### PR TITLE
fix(process_registry): unify elapsed-time formatting across surfaces

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -17,6 +17,8 @@ from tools.process_registry import (
     FINISHED_TTL_SECONDS,
     MAX_PROCESSES,
     MAX_ACTIVE_PROCESS_AGE,
+    _format_age,
+    format_uptime_short,
 )
 
 
@@ -1534,3 +1536,25 @@ class TestReaderLoopOrphanedPipe:
             except (ProcessLookupError, PermissionError):
                 pass
 
+
+
+class TestElapsedFormatConsistency:
+    """The two elapsed-time formatters must render the same value identically.
+
+    _format_age (delegation completion text) and format_uptime_short (/proc
+    and /agents surfaces) previously produced different shapes for the same
+    input ('1m5s' vs '1m 5s', '2h' vs '2h 0m'), so a session's age could
+    read differently depending on which surface printed it. _format_age now
+    delegates to format_uptime_short; this pins the cross-surface contract.
+    """
+
+    @pytest.mark.parametrize("seconds", [0, 5, 59, 60, 65, 90, 3599, 3600, 3661, 7200, 7325, 86399, 86400])
+    def test_age_matches_uptime_short(self, seconds):
+        assert _format_age(seconds) == format_uptime_short(seconds)
+
+    def test_age_keeps_defensive_fallback(self):
+        assert _format_age(None) == "?"
+        assert _format_age("not-a-number") == "?"
+
+    def test_age_clamps_negative(self):
+        assert _format_age(-10) == "0s"

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2172,18 +2172,19 @@ process_registry = ProcessRegistry()
 
 
 def _format_age(seconds: float) -> str:
-    """Human-friendly elapsed string ('18m', '2h3m', '45s')."""
+    """Human-friendly elapsed string, consistent with ``format_uptime_short``.
+
+    The delegation completion text and the /proc-style uptime surfaces must
+    render the same elapsed value the same way — previously ``_format_age``
+    produced a different shape ('1m5s', '2h') than ``format_uptime_short``
+    ('1m 5s', '2h 0m') for the same input, so a session's age could read
+    differently depending on which surface printed it. One canonical
+    formatter; this wrapper only keeps the defensive non-numeric fallback.
+    """
     try:
-        s = int(max(0, seconds))
+        return format_uptime_short(int(max(0, seconds)))
     except (TypeError, ValueError):
         return "?"
-    if s < 60:
-        return f"{s}s"
-    m, s = divmod(s, 60)
-    if m < 60:
-        return f"{m}m" if s == 0 else f"{m}m{s}s"
-    h, m = divmod(m, 60)
-    return f"{h}h" if m == 0 else f"{h}h{m}m"
 
 
 def _format_async_delegation(evt: dict) -> str:


### PR DESCRIPTION
## What does this PR do?

Unify elapsed-time rendering: _format_age now delegates to the canonical format_uptime_short, so the same duration reads identically across every surface.

## Related Issue

Cross-surface elapsed-time formatting inconsistency: the /proc and /agents uptime columns (format_uptime_short) and the delegation completion text (_format_age) rendered the same duration differently ('1m 5s' vs '1m5s', '2h 0m' vs '2h').

## Changes Made

- `fix/unify-elapsed-format` — 2 file(s) changed vs base:
  - `tests/tools/test_process_registry.py`
  - `tools/process_registry.py`

## How to Test

Validation completed (recorded by prp):
1. Sabotage check: pre-fix code fails the regression tests (10 failed), with the fix all pass (69 passed, 0 failed) — target `tests/tools/test_process_registry.py`.
2. Suite `<full suite>`: branch 22185 passed / 1906 failed vs baseline 22197 passed / 1911 failed — zero branch-only failures.
3. Duplicate check: 37 potential matches reviewed — none covers this change.
4. The full repo-wide suite was run (item 2); GitHub CI remains the final confirmation environment.

## Logs

Sabotage verification output:

```
# base leg (pre-fix code + branch tests):
#   tests: 59 passed, 10 failed
# head leg (with fix):
#   tests: 69 passed, 0 failed
```
