### PR TITLE
fix(docker): skip redundant stage2 chown walks (salvage #62419)

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -220,6 +220,11 @@ chown_hermes_tree() {
         echo "[stage2] Warning: chown $target failed (rootless container?) — continuing"
 }
 
+tree_has_non_hermes_owner() {
+    target="$1"
+    find "$target" \( ! -user hermes -o ! -group hermes \) -print -quit 2>/dev/null | grep -q .
+}
+
 needs_chown=false
 if [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; then
     needs_chown=true
@@ -243,7 +248,7 @@ if [ "$needs_chown" = true ]; then
     # created and managed exclusively by hermes (see the s6-setuidgid mkdir
     # -p block below for the canonical list).
     for sub in cron sessions logs hooks memories skills skins plans workspace home profiles pairing platforms/pairing lazy-packages; do
-        if [ -e "$HERMES_HOME/$sub" ]; then
+        if [ -e "$HERMES_HOME/$sub" ] && tree_has_non_hermes_owner "$HERMES_HOME/$sub"; then
             chown_hermes_tree "$HERMES_HOME/$sub"
         fi
     done
@@ -273,9 +278,10 @@ fi
 # are invoked via `docker exec <container> hermes …` (which defaults
 # to root unless `-u` is passed), and that breaks the cont-init
 # reconciler (02-reconcile-profiles) which runs as hermes and walks
-# the profiles dir. Idempotent; skipped on rootless containers where
-# chown would fail.
-if [ -d "$HERMES_HOME/profiles" ]; then
+# the profiles dir. Skip the recursive walk when the tree is already
+# owned correctly so warm boots do not rescan huge profile caches.
+# Idempotent; skipped on rootless containers where chown would fail.
+if [ -d "$HERMES_HOME/profiles" ] && tree_has_non_hermes_owner "$HERMES_HOME/profiles"; then
     chown_hermes_tree "$HERMES_HOME/profiles"
 fi
 

--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -288,8 +288,10 @@ fi
 # Always reset ownership of $HERMES_HOME/cron on every boot for the same
 # docker-exec/root-write reason as profiles/. The cron scheduler state
 # (jobs.json) must stay readable by the unprivileged hermes runtime even
-# after root-context maintenance commands or scheduler writes.
-if [ -d "$HERMES_HOME/cron" ]; then
+# after root-context maintenance commands or scheduler writes. Skip the
+# recursive walk when the tree is already owned correctly (same warm-boot
+# gate as profiles/).
+if [ -d "$HERMES_HOME/cron" ] && tree_has_non_hermes_owner "$HERMES_HOME/cron"; then
     chown_hermes_tree "$HERMES_HOME/cron"
 fi
 
@@ -315,13 +317,14 @@ fi
 # silently leaving the approved user unauthorized (#10270). The targeted
 # data-volume chown above only runs when the top-level $HERMES_HOME is
 # mis-owned, so warm boots skip it — this block makes a container restart
-# self-heal. Tiny directory (a handful of small JSON files), so the cost
-# is negligible.
-if [ -d "$HERMES_HOME/platforms/pairing" ]; then
+# self-heal. Tiny directory (a handful of small JSON files), so even the
+# ownership pre-scan is negligible; gated for consistency with profiles/
+# and cron/.
+if [ -d "$HERMES_HOME/platforms/pairing" ] && tree_has_non_hermes_owner "$HERMES_HOME/platforms/pairing"; then
     chown_hermes_tree "$HERMES_HOME/platforms/pairing"
 fi
 # Legacy location (pre-consolidated layout).
-if [ -d "$HERMES_HOME/pairing" ]; then
+if [ -d "$HERMES_HOME/pairing" ] && tree_has_non_hermes_owner "$HERMES_HOME/pairing"; then
     chown_hermes_tree "$HERMES_HOME/pairing"
 fi
 

--- a/tests/tools/test_stage2_hook_symlink_chown.py
+++ b/tests/tools/test_stage2_hook_symlink_chown.py
@@ -122,3 +122,7 @@ def test_stage2_skips_recursive_repairs_when_tree_is_already_owned(
     assert "tree_has_non_hermes_owner() {" in stage2_text
     assert 'if [ -e "$HERMES_HOME/$sub" ] && tree_has_non_hermes_owner "$HERMES_HOME/$sub"; then' in stage2_text
     assert 'if [ -d "$HERMES_HOME/profiles" ] && tree_has_non_hermes_owner "$HERMES_HOME/profiles"; then' in stage2_text
+    # Sibling every-boot chown blocks carry the same warm-boot gate.
+    assert 'if [ -d "$HERMES_HOME/cron" ] && tree_has_non_hermes_owner "$HERMES_HOME/cron"; then' in stage2_text
+    assert 'if [ -d "$HERMES_HOME/platforms/pairing" ] && tree_has_non_hermes_owner "$HERMES_HOME/platforms/pairing"; then' in stage2_text
+    assert 'if [ -d "$HERMES_HOME/pairing" ] && tree_has_non_hermes_owner "$HERMES_HOME/pairing"; then' in stage2_text

--- a/tests/tools/test_stage2_hook_symlink_chown.py
+++ b/tests/tools/test_stage2_hook_symlink_chown.py
@@ -114,3 +114,11 @@ def test_stage2_skips_top_level_chown_for_symlinked_hermes_home(
     stage2_text: str,
 ) -> None:
     assert 'refuse_symlinked_path "chown" "$HERMES_HOME"' in stage2_text
+
+
+def test_stage2_skips_recursive_repairs_when_tree_is_already_owned(
+    stage2_text: str,
+) -> None:
+    assert "tree_has_non_hermes_owner() {" in stage2_text
+    assert 'if [ -e "$HERMES_HOME/$sub" ] && tree_has_non_hermes_owner "$HERMES_HOME/$sub"; then' in stage2_text
+    assert 'if [ -d "$HERMES_HOME/profiles" ] && tree_has_non_hermes_owner "$HERMES_HOME/profiles"; then' in stage2_text


### PR DESCRIPTION
Salvages #62419 by @LeonSGP43 — commit cherry-picked to preserve authorship, plus one whole-bug-class follow-up commit.

## Context — what this fixes, for whom

Every Docker/hosted Hermes user pays recursive `chown -R` walks at container boot: the stage2 hook unconditionally re-chowns `profiles/`, `cron/`, and pairing dirs on **every** boot (defense against root-owned files dropped by `docker exec`). On warm boots with large profile caches this rescans and rewrites ownership on tens of thousands of inodes that are already correct — pure wasted boot time, plus inode ctime churn.

## What the fix does (from #62419, kept verbatim)

Adds `tree_has_non_hermes_owner()` — `find "$target" \( ! -user hermes -o ! -group hermes \) -print -quit` — and gates the cold-boot subdir loop and the `profiles/` every-boot block behind it. A clean tree pays one read-only walk (no writes, no audit/ctime churn) instead of a full `chown -R`; a dirty tree short-circuits at the first mismatch — and since `find` evaluates the top directory first (verified empirically), a mis-owned tree top returns in O(1). This approach correctly handles the nested-root-file case (`docker exec` writes deep in a hermes-owned tree) that a top-level-only stat check would miss — the reason this PR won over #62233.

## Follow-up commit (ours) — whole-bug-class

The same every-boot cost class existed in three sibling blocks the PR didn't gate: `cron/` (materially valuable — scheduler state grows), `platforms/pairing`, and legacy `pairing/`. Same one-line gate on each, comments updated, and the PR's test extended to pin all five gated call sites.

## Verification

- `tests/tools/test_stage2_hook_symlink_chown.py`: 6 passed (incl. the extended gate assertions)
- `sh -n` and `dash -n` syntax-clean; behavioral probe of `tree_has_non_hermes_owner` under `dash -c 'set -eu'`: clean tree → 1 (skip), dirty tree → 0 (chown), no `set -e` trip; first `-print` output is the top dir itself (confirms the built-in O(1) top-dir short-circuit)
- Container base is debian:13 (GNU findutils; `-quit` fine — and busybox ≥1.24 supports it anyway)
- Fail-safe audit: if `find` errors, output is empty → gate returns 1 → chown skipped — identical net behavior to the existing rootless-container fallback where chown fails silently

Note for @webtecnica (from the #62233 closure): the explicit top-level `stat` fast path turned out to be mostly redundant — `find` already stats the starting directory first and `-quit`s on mismatch, so the O(1) short-circuit you wanted exists inherently. A stat pre-check would only save one process spawn; still welcome as a micro-optimization on top if you'd like to send it.

Closes #62419 (superseded by this salvage — original author credited via cherry-pick authorship).
