### PR TITLE
fix(desktop): route messaging settings to active profile

### DIFF
--- a/apps/desktop/src/hermes-profile-scope.test.ts
+++ b/apps/desktop/src/hermes-profile-scope.test.ts
@@ -5,13 +5,16 @@ import {
   getActionStatus,
   getElevenLabsVoices,
   getMemoryProviderConfig,
+  getMessagingPlatforms,
   getStatus,
   restartGateway,
   saveMemoryProviderConfig,
   setApiRequestProfile,
   speakText,
+  testMessagingPlatform,
   transcribeAudio,
-  updateHermes
+  updateHermes,
+  updateMessagingPlatform
 } from './hermes'
 
 // Contract: every backend-targeted action helper must carry the active gateway
@@ -79,5 +82,19 @@ describe('backend action helpers are profile-scoped', () => {
     for (const call of api.mock.calls) {
       expect(call[0].profile).toBe('jarvis')
     }
+  })
+
+  it('forwards the active profile to every messaging-platform request', () => {
+    setApiRequestProfile('jeeves')
+
+    void getMessagingPlatforms()
+    void updateMessagingPlatform('weixin', { enabled: true })
+    void testMessagingPlatform('weixin')
+
+    expect(api.mock.calls.map(([request]) => [request.path, request.profile])).toEqual([
+      ['/api/messaging/platforms', 'jeeves'],
+      ['/api/messaging/platforms/weixin', 'jeeves'],
+      ['/api/messaging/platforms/weixin/test', 'jeeves']
+    ])
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1147,6 +1147,7 @@ export function grantComputerUsePermissions(): Promise<ActionResponse> {
 
 export function getMessagingPlatforms(): Promise<MessagingPlatformsResponse> {
   return window.hermesDesktop.api<MessagingPlatformsResponse>({
+    ...profileScoped(),
     path: '/api/messaging/platforms'
   })
 }
@@ -1156,6 +1157,7 @@ export function updateMessagingPlatform(
   body: MessagingPlatformUpdate
 ): Promise<{ ok: boolean; platform: string }> {
   return window.hermesDesktop.api<{ ok: boolean; platform: string }>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}`,
     method: 'PUT',
     body
@@ -1164,6 +1166,7 @@ export function updateMessagingPlatform(
 
 export function testMessagingPlatform(platformId: string): Promise<MessagingPlatformTestResponse> {
   return window.hermesDesktop.api<MessagingPlatformTestResponse>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}/test`,
     method: 'POST'
   })


### PR DESCRIPTION
## What does this PR do?

Desktop Messaging Platforms settings were the one settings surface still dropping the active profile when calling the gateway. As a result, a user editing a non-primary profile could read, save, or test the primary profile while the adjacent restart action correctly targeted the selected one.

This routes the list, update, and connectivity-test helpers through the existing `profileScoped()` request seam. Single-profile users keep the existing omitted-profile behavior, while multi-profile users now send every messaging-platform operation to the selected backend.

## Related Issue

Fixes #76899

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Regression tests included with the bug fix

## Changes Made

- `apps/desktop/src/hermes.ts`: attach the active profile to `getMessagingPlatforms()`, `updateMessagingPlatform()`, and `testMessagingPlatform()`.
- `apps/desktop/src/hermes-profile-scope.test.ts`: assert the exact read, update, and test paths all forward the selected profile.

## How to Test

1. `npm exec eslint -- src/hermes.ts src/hermes-profile-scope.test.ts` (from `apps/desktop`) -> passed.
2. `npm exec prettier -- --check src/hermes.ts src/hermes-profile-scope.test.ts` (from `apps/desktop`) -> passed.
3. `npm run test:ui -- src/hermes-profile-scope.test.ts src/app/messaging/index.test.tsx` (from `apps/desktop`) -> 2 files, 12 tests passed.
4. `npm run typecheck` (from `apps/desktop`) -> renderer, Electron, and E2E TypeScript checks passed.
5. `scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/76899` -> all blocking gates passed; existing repository-wide ty diagnostics remain advisory only.

## Checklist

### Code

- [x] Read the current Contributing Guide and project policy files.
- [x] Commit message follows Conventional Commits (`fix(desktop): ...`).
- [x] Searched and reviewed semantic PR candidates; each reviewed candidate is recorded as non-competing in the worklog.
- [x] The branch contains only the two files required for this fix.
- [x] Ran the focused profile-scope and Messaging Platforms UI tests plus the touched-package TypeScript checks.
- [x] Added regression tests for read, update, and connectivity-test profile routing.
- [x] Tested on macOS arm64 with Node/npm and Python 3.11.15 project tooling.

### Documentation & Housekeeping

- [x] No README or standalone documentation change is needed; this is an internal request-routing correction.
- [x] No configuration keys, schemas, or dependencies were added or changed.
- [x] No backend or architecture contract changed.
- [x] Considered single-profile compatibility: `profileScoped()` still omits the field when no profile is active.
- [x] No tool descriptions or generated schemas changed.