### PR TITLE
fix(buzz): refresh access policy at runtime

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -868,12 +868,10 @@ class GatewayAuthorizationMixin:
         3. Explicit global ``unauthorized_dm_behavior`` in config — wins for
            chat-shaped platforms when no per-platform override is set.
         4. When an adapter-level DM policy opts into pairing or silent drop, honor it.
-        5. When an allowlist (``PLATFORM_ALLOWED_USERS``,
-           ``PLATFORM_GROUP_ALLOWED_USERS`` / ``PLATFORM_GROUP_ALLOWED_CHATS``,
-           or ``GATEWAY_ALLOWED_USERS``) is configured, default to ``"ignore"`` —
-           the allowlist signals that the owner has deliberately restricted
-           access; spamming unknown contacts with pairing codes is both noisy
-           and a potential info-leak. (#9337)
+        5. When a core-platform or plugin-provided allowlist is configured,
+           default to ``"ignore"`` — the allowlist signals that the owner has
+           deliberately restricted access; spamming unknown contacts with
+           pairing codes is both noisy and a potential info-leak. (#9337)
         6. No allowlist and no explicit config → ``"pair"`` (open-gateway default).
         """
         config = getattr(self, "config", None)
@@ -920,6 +918,32 @@ class GatewayAuthorizationMixin:
         # if any allowlist is configured for this platform, silently drop
         # unauthorized messages instead of sending pairing codes.
         if platform:
+            # Plugin platforms can supply both env-backed gates and a live,
+            # profile-scoped config policy.  Apply the same absent-vs-empty env
+            # precedence used by _is_user_authorized: an explicit env value
+            # overrides config, including an explicitly empty value.
+            try:
+                from gateway.platform_registry import platform_registry
+
+                plugin_entry = platform_registry.get(platform.value)
+                if plugin_entry is not None:
+                    allowlist_present, plugin_allowlist = (
+                        _platform_gate_env_present(plugin_entry.allowed_users_env)
+                    )
+                    if plugin_allowlist:
+                        return "ignore"
+                    if (
+                        not allowlist_present
+                        and plugin_entry.authorization_config_fn is not None
+                    ):
+                        resolved = plugin_entry.authorization_config_fn(profile)
+                        if isinstance(resolved, dict) and _coerce_allow_set(
+                            resolved.get("allowed_users")
+                        ):
+                            return "ignore"
+            except Exception:
+                pass
+
             platform_env_map = {
                 Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
                 Platform.DISCORD:  "DISCORD_ALLOWED_USERS",

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -857,6 +857,7 @@ class GatewayAuthorizationMixin:
         platform: Optional[Platform],
         *,
         profile: Optional[str] = None,
+        source: Optional[SessionSource] = None,
     ) -> str:
         """Return how unauthorized DMs should be handled for a platform.
 
@@ -875,6 +876,11 @@ class GatewayAuthorizationMixin:
         6. No allowlist and no explicit config → ``"pair"`` (open-gateway default).
         """
         config = getattr(self, "config", None)
+        policy_profile = (
+            self._adapter_profile_for_source(source)
+            if source is not None
+            else profile
+        )
 
         # Check for an explicit per-platform override first.
         if config and hasattr(config, "get_unauthorized_dm_behavior") and platform:
@@ -903,7 +909,7 @@ class GatewayAuthorizationMixin:
         # Prefer the profile-scoped live adapter's resolved policy in multiplex
         # mode; fall back to the default profile's config.extra.
         if platform:
-            dm_policy = self._adapter_dm_policy(platform, profile=profile)
+            dm_policy = self._adapter_dm_policy(platform, profile=policy_profile)
             if not dm_policy and config and hasattr(config, "platforms"):
                 platform_cfg = config.platforms.get(platform)
                 extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
@@ -936,13 +942,24 @@ class GatewayAuthorizationMixin:
                         not allowlist_present
                         and plugin_entry.authorization_config_fn is not None
                     ):
-                        resolved = plugin_entry.authorization_config_fn(profile)
+                        resolved = plugin_entry.authorization_config_fn(policy_profile)
                         if isinstance(resolved, dict) and _coerce_allow_set(
                             resolved.get("allowed_users")
                         ):
                             return "ignore"
-            except Exception:
-                pass
+            except Exception as exc:
+                # Central authorization also denies when a plugin policy cannot
+                # be resolved. Never turn that fail-closed denial into an
+                # externally visible pairing response.
+                from gateway.run import logger
+
+                logger.warning(
+                    "Failed to resolve runtime authorization policy for %s; "
+                    "ignoring unauthorized DM: %s",
+                    platform.value,
+                    exc,
+                )
+                return "ignore"
 
             platform_env_map = {
                 Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -72,6 +72,37 @@ def _platform_gate_env(name: str, default: str = "") -> str:
     return (os.getenv(name) or default).strip()
 
 
+def _platform_gate_env_present(name: str) -> tuple[bool, str]:
+    """Read a platform gate while preserving absent-vs-explicit-empty.
+
+    Under multiplex, the active profile secret scope is authoritative and a
+    missing key must not fall through to another profile's process env.
+    """
+    if not name:
+        return False, ""
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        scope = current_secret_scope()
+        multiplex = is_multiplex_active()
+        if scope is not None:
+            if name in scope:
+                value = scope.get(name)
+                return True, "" if value is None else str(value).strip()
+            if multiplex:
+                return False, ""
+        elif multiplex:
+            # Fail closed: process env may belong to another profile.
+            return False, ""
+    except Exception:
+        # Authorization isolation failures must never fall through to process
+        # environment values that may belong to another profile.
+        return False, ""
+    if name not in os.environ:
+        return False, ""
+    return True, str(os.environ[name]).strip()
+
+
 def _coerce_allow_set(raw) -> set[str]:
     """Parse allowlist values from config or env var into a set of strings.
 
@@ -552,22 +583,36 @@ class GatewayAuthorizationMixin:
             Platform.YUANBAO: "YUANBAO_ALLOW_ALL_USERS",
         }
 
-        # Plugin platforms: check the registry for auth env var names
+        plugin_authorization: dict = {}
+        plugin_entry = None
+
+        # Plugin platforms: check the registry for auth env var names and an
+        # optional live config-backed policy resolver.
         if source.platform not in platform_env_map:
             try:
                 from gateway.platform_registry import platform_registry
-                entry = platform_registry.get(source.platform.value)
-                if entry:
-                    if entry.allowed_users_env:
-                        platform_env_map[source.platform] = entry.allowed_users_env
-                    if entry.allow_all_env:
-                        platform_allow_all_map[source.platform] = entry.allow_all_env
+
+                plugin_entry = platform_registry.get(source.platform.value)
+                if plugin_entry:
+                    if plugin_entry.allowed_users_env:
+                        platform_env_map[source.platform] = plugin_entry.allowed_users_env
+                    if plugin_entry.allow_all_env:
+                        platform_allow_all_map[source.platform] = plugin_entry.allow_all_env
+                    if plugin_entry.authorization_config_fn is not None:
+                        resolved = plugin_entry.authorization_config_fn(adapter_profile)
+                        if isinstance(resolved, dict):
+                            plugin_authorization = resolved
             except Exception:
                 pass
 
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
         platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
-        if platform_allow_all_var and _auth_env(platform_allow_all_var).lower() in {"true", "1", "yes"}:
+        allow_all_present, allow_all_value = _platform_gate_env_present(
+            platform_allow_all_var
+        )
+        if not allow_all_present and "allow_all_users" in plugin_authorization:
+            allow_all_value = str(plugin_authorization["allow_all_users"]).strip()
+        if allow_all_value.lower() in {"true", "1", "yes"}:
             return True
 
         # Adapter-verified role auth: the Discord adapter already confirmed the
@@ -598,7 +643,14 @@ class GatewayAuthorizationMixin:
             return True
 
         # Check platform-specific and global allowlists
-        platform_allowlist = _auth_env(platform_env_map.get(source.platform, ""))
+        platform_allowlist_var = platform_env_map.get(source.platform, "")
+        allowlist_present, platform_allowlist = _platform_gate_env_present(
+            platform_allowlist_var
+        )
+        if not allowlist_present and "allowed_users" in plugin_authorization:
+            platform_allowlist = ",".join(
+                sorted(_coerce_allow_set(plugin_authorization["allowed_users"]))
+            )
         group_user_allowlist = ""
         group_chat_allowlist = ""
         if source.chat_type in {"group", "forum"}:
@@ -736,7 +788,21 @@ class GatewayAuthorizationMixin:
         # allowlist and still works everywhere for backward compatibility.
         allowed_ids = set()
         if platform_allowlist:
-            allowed_ids.update(uid.strip() for uid in platform_allowlist.split(",") if uid.strip())
+            platform_allowed_ids = {
+                uid.strip() for uid in platform_allowlist.split(",") if uid.strip()
+            }
+            normalizer = (
+                plugin_entry.authorization_user_normalizer
+                if plugin_entry is not None
+                else None
+            )
+            if normalizer is not None:
+                platform_allowed_ids = {
+                    normalized
+                    for value in platform_allowed_ids
+                    if (normalized := normalizer(value))
+                }
+            allowed_ids.update(platform_allowed_ids)
         if group_user_allowlist:
             allowed_ids.update(uid.strip() for uid in group_user_allowlist.split(",") if uid.strip())
         if global_allowlist:
@@ -748,6 +814,10 @@ class GatewayAuthorizationMixin:
             return True
 
         check_ids = {user_id}
+        if plugin_entry is not None and plugin_entry.authorization_user_normalizer:
+            normalized_user_id = plugin_entry.authorization_user_normalizer(user_id)
+            if normalized_user_id:
+                check_ids.add(normalized_user_id)
         if "@" in user_id:
             check_ids.add(user_id.split("@")[0])
 

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -158,6 +158,18 @@ class PlatformEntry:
     # targets when the gateway is not co-resident with the cron process.
     standalone_sender_fn: Optional[Callable[..., Awaitable[dict]]] = None
 
+    # Optional live authorization hooks for config-backed plugin policies.
+    # Appended to preserve the positional constructor ABI for existing plugins.
+    # The resolver receives the transport-owning profile name (None means the
+    # default profile) and returns optional ``allowed_users`` /
+    # ``allow_all_users`` keys.
+    authorization_config_fn: Optional[
+        Callable[[Optional[str]], Optional[dict]]
+    ] = None
+    authorization_user_normalizer: Optional[
+        Callable[[str], Optional[str]]
+    ] = None
+
 
 class PlatformRegistry:
     """Central registry of platform adapters.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13897,6 +13897,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 and self._get_unauthorized_dm_behavior(
                     source.platform,
                     profile=source.profile,
+                    source=source,
                 )
                 == "pair"
             ):

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1257,28 +1257,26 @@ class BuzzAdapter(BasePlatformAdapter):
                 return True, os.environ.get(name, "")
             return False, ""
 
-        allowed_env_present, allowed_env = explicit_value("BUZZ_ALLOWED_USERS")
-        allow_all_env_present, allow_all_env = explicit_value(
+        policy = _load_runtime_authorization_config(profile)
+
+        allow_all_present, allow_all_value = explicit_value(
             "BUZZ_ALLOW_ALL_USERS"
         )
-        if allowed_env_present or allow_all_env_present:
-            allow_all = allow_all_env.strip().lower() in {
-                "true",
-                "1",
-                "yes",
-                "on",
-            }
+        if not allow_all_present and "allow_all_users" in policy:
+            allow_all_value = str(policy["allow_all_users"])
+        if allow_all_value.strip().lower() in {"true", "1", "yes", "on"}:
+            return True
+
+        allowed_present, allowed_value = explicit_value("BUZZ_ALLOWED_USERS")
+        if allowed_present:
             allowed = {
                 normalized
-                for raw in allowed_env.split(",")
+                for raw in allowed_value.split(",")
                 if (normalized := _normalize_user_ref(raw))
             }
-            return bool(allow_all or (sender and sender in allowed))
-
-        policy = _load_runtime_authorization_config(profile)
-        if policy.get("allow_all_users") is True:
-            return True
-        return bool(sender and sender in policy.get("allowed_users", []))
+        else:
+            allowed = set(policy.get("allowed_users", []))
+        return bool(sender and sender in allowed)
 
     async def _dispatch_message(
         self,
@@ -1313,7 +1311,7 @@ class BuzzAdapter(BasePlatformAdapter):
         await self.handle_message(event)
         
         # Acknowledgements are cosmetic only; central authorization remains
-        # the enforcement point.  Keep unauthorized group traffic silent.
+        # the enforcement point. Keep unauthorized traffic silent.
         if self._should_ack_sender(user_id, getattr(source, "profile", None)):
             try:
                 await self.send_reaction(chat_id, message_id, "👀")

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1239,6 +1239,47 @@ class BuzzAdapter(BasePlatformAdapter):
             state["seen"][event_id] = None
             self._trim_seen(state)
 
+    @staticmethod
+    def _should_ack_sender(user_id: str, profile: Optional[str] = None) -> bool:
+        """Return whether the live Buzz policy admits a cosmetic acknowledgement."""
+        sender = _normalize_user_ref(user_id)
+
+        def explicit_value(name: str) -> Tuple[bool, str]:
+            from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+            scope = current_secret_scope()
+            if scope is not None and name in scope:
+                value = scope.get(name)
+                return True, "" if value is None else str(value)
+            if is_multiplex_active():
+                return False, ""
+            if name in os.environ:
+                return True, os.environ.get(name, "")
+            return False, ""
+
+        allowed_env_present, allowed_env = explicit_value("BUZZ_ALLOWED_USERS")
+        allow_all_env_present, allow_all_env = explicit_value(
+            "BUZZ_ALLOW_ALL_USERS"
+        )
+        if allowed_env_present or allow_all_env_present:
+            allow_all = allow_all_env.strip().lower() in {
+                "true",
+                "1",
+                "yes",
+                "on",
+            }
+            allowed = {
+                normalized
+                for raw in allowed_env.split(",")
+                if (normalized := _normalize_user_ref(raw))
+            }
+            return bool(allow_all or (sender and sender in allowed))
+
+        policy = _load_runtime_authorization_config(profile)
+        if policy.get("allow_all_users") is True:
+            return True
+        return bool(sender and sender in policy.get("allowed_users", []))
+
     async def _dispatch_message(
         self,
         text: str,
@@ -1271,12 +1312,17 @@ class BuzzAdapter(BasePlatformAdapter):
 
         await self.handle_message(event)
         
-        # Add a "seen" reaction after dispatching — signals to the user that
-        # their message was received and is being processed.
-        try:
-            await self.send_reaction(chat_id, message_id, "👀")
-        except Exception:
-            logger.debug("Buzz: reaction failed for message %s", message_id[:12], exc_info=True)
+        # Acknowledgements are cosmetic only; central authorization remains
+        # the enforcement point.  Keep unauthorized group traffic silent.
+        if self._should_ack_sender(user_id, getattr(source, "profile", None)):
+            try:
+                await self.send_reaction(chat_id, message_id, "👀")
+            except Exception:
+                logger.debug(
+                    "Buzz: reaction failed for message %s",
+                    message_id[:12],
+                    exc_info=True,
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -320,6 +320,75 @@ def _parse_json_list(stdout: str) -> List[dict]:
     return [item for item in data if isinstance(item, dict)]
 
 
+def _load_runtime_authorization_config(profile: Optional[str] = None) -> dict:
+    """Resolve the live, profile-scoped Buzz access policy from config.yaml."""
+    from hermes_cli.config import load_config_readonly
+
+    if profile:
+        from hermes_cli.profiles import get_profile_dir
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        token = set_hermes_home_override(str(get_profile_dir(profile)))
+        try:
+            config = load_config_readonly()
+        finally:
+            reset_hermes_home_override(token)
+    else:
+        config = load_config_readonly()
+    merged: Dict[str, Any] = {}
+
+    def _merge(candidate: Any) -> None:
+        if not isinstance(candidate, dict):
+            return
+        merged.update(
+            {
+                key: value
+                for key, value in candidate.items()
+                if key
+                not in {"enabled", "token", "home_channel", "home_channels", "extra"}
+            }
+        )
+        extra = candidate.get("extra")
+        if isinstance(extra, dict):
+            merged.update(extra)
+
+    if isinstance(config, dict):
+        gateway = config.get("gateway")
+        gateway_platforms = (
+            gateway.get("platforms") if isinstance(gateway, dict) else None
+        )
+        if isinstance(gateway_platforms, dict):
+            _merge(gateway_platforms.get("buzz"))
+
+        platforms = config.get("platforms")
+        if isinstance(platforms, dict):
+            _merge(platforms.get("buzz"))
+
+        if isinstance(gateway, dict):
+            _merge(gateway.get("buzz"))
+        _merge(config.get("buzz"))
+
+    policy: dict = {}
+    if "allowed_users" in merged:
+        raw_allowed = merged["allowed_users"]
+        if isinstance(raw_allowed, str):
+            raw_allowed = raw_allowed.split(",")
+        if not isinstance(raw_allowed, (list, tuple)):
+            raw_allowed = []
+        policy["allowed_users"] = [
+            normalized
+            for entry in raw_allowed
+            if isinstance(entry, str)
+            and (normalized := _normalize_user_ref(entry))
+        ]
+    if "allow_all_users" in merged:
+        policy["allow_all_users"] = merged["allow_all_users"]
+    return policy
+
+
 # ---------------------------------------------------------------------------
 # Buzz Adapter
 # ---------------------------------------------------------------------------
@@ -376,16 +445,6 @@ class BuzzAdapter(BasePlatformAdapter):
             os.getenv("BUZZ_TRANSPORT") or str(extra.get("transport", "auto") or "auto")
         ).strip().lower()
         self.transport = _transport if _transport in ("auto", "websocket", "poll") else "auto"
-
-        # Auth: entries may be hex pubkeys or npubs; normalized to hex
-        raw_allowed = os.getenv("BUZZ_ALLOWED_USERS") or extra.get("allowed_users", [])
-        if isinstance(raw_allowed, str):
-            raw_allowed = raw_allowed.split(",")
-        self._allowed_pubkeys: set = {
-            normalized
-            for entry in raw_allowed
-            if isinstance(entry, str) and (normalized := _normalize_user_ref(entry))
-        }
 
         # Secret — resolved lazily (never at import/registration time and
         # never logged).  connect() re-resolves it to fail fast with a clear
@@ -1012,12 +1071,6 @@ class BuzzAdapter(BasePlatformAdapter):
         if not is_dm and self.require_mention and not self._is_mentioned(content):
             return
 
-        # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
-        # BUZZ_ALLOW_ALL_USERS centrally as well; empty list = no filter here).
-        if self._allowed_pubkeys and pubkey not in self._allowed_pubkeys:
-            logger.debug("Buzz: ignoring message from unauthorized pubkey %s…", pubkey[:8])
-            return
-
         # Strip a leading @mention so slash commands (@Chip /whoami ->
         # /whoami) and clean prompts are recognized. DM messages often still
         # open with "@Chip" even though no mention is required there, so the
@@ -1283,13 +1336,6 @@ def _apply_yaml_config(yaml_cfg: dict, buzz_cfg: dict) -> Optional[dict]:
         if isinstance(channels, (list, tuple)):
             channels = ",".join(str(c) for c in channels)
         os.environ["BUZZ_CHANNELS"] = str(channels)
-    allowed = extra.get("allowed_users")
-    if allowed is not None and not os.getenv("BUZZ_ALLOWED_USERS"):
-        if isinstance(allowed, (list, tuple)):
-            allowed = ",".join(str(a) for a in allowed)
-        os.environ["BUZZ_ALLOWED_USERS"] = str(allowed)
-    if "allow_all_users" in extra and not os.getenv("BUZZ_ALLOW_ALL_USERS"):
-        os.environ["BUZZ_ALLOW_ALL_USERS"] = str(extra["allow_all_users"]).lower()
     if "require_mention" in extra and not os.getenv("BUZZ_REQUIRE_MENTION"):
         os.environ["BUZZ_REQUIRE_MENTION"] = str(extra["require_mention"]).lower()
     return None
@@ -1486,9 +1532,11 @@ def register(ctx):
         # cron jobs fail with "No live adapter" when cron runs separately
         # from the gateway.
         standalone_sender_fn=_standalone_send,
-        # Auth env vars for _is_user_authorized() integration
+        # Auth env vars and live config resolver for central authorization.
         allowed_users_env="BUZZ_ALLOWED_USERS",
         allow_all_env="BUZZ_ALLOW_ALL_USERS",
+        authorization_config_fn=_load_runtime_authorization_config,
+        authorization_user_normalizer=_normalize_user_ref,
         # Display
         emoji="🐝",
         # Buzz identities are pubkeys, not phone numbers

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1264,7 +1264,7 @@ class BuzzAdapter(BasePlatformAdapter):
         )
         if not allow_all_present and "allow_all_users" in policy:
             allow_all_value = str(policy["allow_all_users"])
-        if allow_all_value.strip().lower() in {"true", "1", "yes", "on"}:
+        if allow_all_value.strip().lower() in {"true", "1", "yes"}:
             return True
 
         allowed_present, allowed_value = explicit_value("BUZZ_ALLOWED_USERS")

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -492,6 +492,34 @@ class TestAcknowledgementAuthorization:
         adapter.send_reaction.assert_awaited_once_with(CHANNEL, "e1", "👀")
 
     @pytest.mark.asyncio
+    async def test_noncanonical_allow_all_env_does_not_ack_sender(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("BUZZ_ALLOW_ALL_USERS", "on")
+        (tmp_path / "config.yaml").write_text(
+            "buzz:\n  extra:\n    allow_all_users: false\n",
+            encoding="utf-8",
+        )
+        adapter = _make_adapter()
+        adapter._message_handler = AsyncMock()
+        adapter.handle_message = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+
+        await adapter._dispatch_message(
+            text="test",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="Other",
+            message_id="e1",
+            created_at=10,
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        adapter.send_reaction.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_explicit_empty_allowlist_env_keeps_runtime_allow_all_reaction(
         self, monkeypatch, tmp_path
     ):

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -142,6 +142,158 @@ class TestBuzzAdapterInit:
         adapter = BuzzAdapter(PlatformConfig(enabled=True, extra={"relay_url": "https://cfg.relay"}))
         assert adapter.relay_url == "https://env.relay"
 
+    def test_runtime_authorization_config_normalizes_buzz_identities(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "buzz:\n"
+            "  extra:\n"
+            f"    allowed_users: [{SELF_NPUB}, {OTHER_PUBKEY.upper()}]\n"
+            "    allow_all_users: false\n",
+            encoding="utf-8",
+        )
+
+        policy = _buzz_mod._load_runtime_authorization_config()
+
+        assert policy == {
+            "allowed_users": [SELF_PUBKEY, OTHER_PUBKEY],
+            "allow_all_users": False,
+        }
+
+    def test_runtime_authorization_config_supports_gateway_buzz_path(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "gateway:\n"
+            "  buzz:\n"
+            "    extra:\n"
+            f"      allowed_users: [{SELF_NPUB}]\n"
+            "      allow_all_users: true\n",
+            encoding="utf-8",
+        )
+
+        assert _buzz_mod._load_runtime_authorization_config() == {
+            "allowed_users": [SELF_PUBKEY],
+            "allow_all_users": True,
+        }
+
+    def test_runtime_authorization_config_uses_gateway_precedence(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    buzz:\n"
+            "      extra:\n"
+            f"        allowed_users: [{OTHER_PUBKEY}]\n"
+            "  buzz:\n"
+            "    extra:\n"
+            "      allow_all_users: true\n"
+            "platforms:\n"
+            "  buzz:\n"
+            "    extra:\n"
+            "      allow_all_users: false\n"
+            "buzz:\n"
+            "  extra:\n"
+            f"    allowed_users: [{SELF_NPUB}]\n",
+            encoding="utf-8",
+        )
+
+        assert _buzz_mod._load_runtime_authorization_config() == {
+            "allowed_users": [SELF_PUBKEY],
+            "allow_all_users": True,
+        }
+
+    def test_runtime_authorization_config_retains_last_valid_policy(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "buzz:\n"
+            "  extra:\n"
+            f"    allowed_users: [{SELF_NPUB}]\n",
+            encoding="utf-8",
+        )
+        expected = {"allowed_users": [SELF_PUBKEY]}
+        assert _buzz_mod._load_runtime_authorization_config() == expected
+
+        config_path.write_text("buzz: [not: valid", encoding="utf-8")
+
+        assert _buzz_mod._load_runtime_authorization_config() == expected
+
+        config_path.write_text(
+            "buzz:\n"
+            "  extra:\n"
+            f"    allowed_users: [{OTHER_PUBKEY}]\n",
+            encoding="utf-8",
+        )
+        assert _buzz_mod._load_runtime_authorization_config() == {
+            "allowed_users": [OTHER_PUBKEY]
+        }
+
+        config_path.write_text("buzz:\n  extra: {}\n", encoding="utf-8")
+        assert _buzz_mod._load_runtime_authorization_config() == {}
+
+        config_path.unlink()
+        assert _buzz_mod._load_runtime_authorization_config() == {}
+
+    def test_runtime_authorization_config_honors_managed_overlay(
+        self, monkeypatch, tmp_path
+    ):
+        from hermes_cli import managed_scope
+
+        home = tmp_path / "home"
+        managed = tmp_path / "managed"
+        home.mkdir()
+        managed.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+        (home / "config.yaml").write_text(
+            "buzz:\n"
+            "  extra:\n"
+            f"    allowed_users: [{OTHER_PUBKEY}]\n"
+            "    allow_all_users: true\n",
+            encoding="utf-8",
+        )
+        (managed / "config.yaml").write_text(
+            "buzz:\n"
+            "  extra:\n"
+            f"    allowed_users: [{SELF_NPUB}]\n"
+            "    allow_all_users: false\n",
+            encoding="utf-8",
+        )
+        managed_scope.invalidate_managed_cache()
+
+        assert _buzz_mod._load_runtime_authorization_config() == {
+            "allowed_users": [SELF_PUBKEY],
+            "allow_all_users": False,
+        }
+
+    def test_runtime_authorization_config_reads_requested_profile(
+        self, monkeypatch, tmp_path
+    ):
+        from hermes_cli.profiles import get_profile_dir
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            f"buzz:\n  extra:\n    allowed_users: [{OTHER_PUBKEY}]\n",
+            encoding="utf-8",
+        )
+        secondary = get_profile_dir("secondary")
+        secondary.mkdir(parents=True)
+        (secondary / "config.yaml").write_text(
+            f"buzz:\n  extra:\n    allowed_users: [{SELF_NPUB}]\n",
+            encoding="utf-8",
+        )
+
+        assert _buzz_mod._load_runtime_authorization_config("secondary") == {
+            "allowed_users": [SELF_PUBKEY]
+        }
+
 
 # ── CLI error contract ────────────────────────────────────────────────────
 
@@ -245,10 +397,10 @@ class TestMentionGating:
 
 
     @pytest.mark.asyncio
-    async def test_allowlist_blocks_unauthorized(self, adapter):
+    async def test_access_policy_is_deferred_to_central_authorization(self, adapter):
         adapter._allowed_pubkeys = {"b" * 64}
         await self._poll_with(adapter, _event("e1", content="@Chip hello", created_at=10))
-        assert adapter._dispatched == []
+        assert [item["message_id"] for item in adapter._dispatched] == ["e1"]
 
 
 # ── DM classification via p-tags (issue #68871) ──────────────────────────
@@ -505,6 +657,8 @@ class TestBuzzPluginRegistration:
         assert kwargs["cron_deliver_env_var"] == "BUZZ_HOME_CHANNEL"
         assert kwargs["allowed_users_env"] == "BUZZ_ALLOWED_USERS"
         assert kwargs["allow_all_env"] == "BUZZ_ALLOW_ALL_USERS"
+        assert callable(kwargs["authorization_config_fn"])
+        assert callable(kwargs["authorization_user_normalizer"])
         assert callable(kwargs["standalone_sender_fn"])
         assert callable(kwargs["env_enablement_fn"])
         assert set(kwargs["required_env"]) == {"BUZZ_RELAY_URL", "BUZZ_PRIVATE_KEY"}

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -492,7 +492,7 @@ class TestAcknowledgementAuthorization:
         adapter.send_reaction.assert_awaited_once_with(CHANNEL, "e1", "👀")
 
     @pytest.mark.asyncio
-    async def test_explicit_empty_env_suppresses_runtime_seen_reaction(
+    async def test_explicit_empty_allowlist_env_keeps_runtime_allow_all_reaction(
         self, monkeypatch, tmp_path
     ):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -516,8 +516,36 @@ class TestAcknowledgementAuthorization:
             created_at=10,
         )
 
-        adapter.handle_message.assert_awaited_once()
-        adapter.send_reaction.assert_not_awaited()
+        adapter.send_reaction.assert_awaited_once_with(CHANNEL, "e1", "👀")
+
+    @pytest.mark.asyncio
+    async def test_explicit_allow_all_env_keeps_runtime_allowlist_reaction(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("BUZZ_ALLOW_ALL_USERS", "false")
+        (tmp_path / "config.yaml").write_text(
+            "buzz:\n"
+            "  extra:\n"
+            f"    allowed_users: [{OTHER_PUBKEY}]\n",
+            encoding="utf-8",
+        )
+        adapter = _make_adapter()
+        adapter._message_handler = AsyncMock()
+        adapter.handle_message = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+
+        await adapter._dispatch_message(
+            text="test",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="Other",
+            message_id="e1",
+            created_at=10,
+        )
+
+        adapter.send_reaction.assert_awaited_once_with(CHANNEL, "e1", "👀")
 
     @pytest.mark.asyncio
     async def test_multiplex_ack_uses_active_profile_scope(self, monkeypatch, tmp_path):

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -403,6 +403,154 @@ class TestMentionGating:
         assert [item["message_id"] for item in adapter._dispatched] == ["e1"]
 
 
+class TestAcknowledgementAuthorization:
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_sender_gets_no_seen_reaction(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "buzz:\n"
+            "  extra:\n"
+            f"    allowed_users: [{SELF_NPUB}]\n"
+            "    allow_all_users: false\n",
+            encoding="utf-8",
+        )
+        adapter = _make_adapter()
+        adapter._message_handler = AsyncMock()
+        adapter.handle_message = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+
+        await adapter._dispatch_message(
+            text="test",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="Other",
+            message_id="e1",
+            created_at=10,
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        adapter.send_reaction.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_allowlisted_sender_keeps_seen_reaction(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "buzz:\n"
+            "  extra:\n"
+            f"    allowed_users: [{OTHER_PUBKEY.upper()}]\n"
+            "    allow_all_users: false\n",
+            encoding="utf-8",
+        )
+        adapter = _make_adapter()
+        adapter._message_handler = AsyncMock()
+        adapter.handle_message = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+
+        await adapter._dispatch_message(
+            text="test",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="Other",
+            message_id="e1",
+            created_at=10,
+        )
+
+        adapter.send_reaction.assert_awaited_once_with(CHANNEL, "e1", "👀")
+
+    @pytest.mark.asyncio
+    async def test_explicit_env_allowlist_controls_seen_reaction(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("BUZZ_ALLOWED_USERS", OTHER_PUBKEY.upper())
+        (tmp_path / "config.yaml").write_text(
+            "buzz:\n  extra:\n    allow_all_users: false\n",
+            encoding="utf-8",
+        )
+        adapter = _make_adapter()
+        adapter._message_handler = AsyncMock()
+        adapter.handle_message = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+
+        await adapter._dispatch_message(
+            text="test",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="Other",
+            message_id="e1",
+            created_at=10,
+        )
+
+        adapter.send_reaction.assert_awaited_once_with(CHANNEL, "e1", "👀")
+
+    @pytest.mark.asyncio
+    async def test_explicit_empty_env_suppresses_runtime_seen_reaction(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("BUZZ_ALLOWED_USERS", "")
+        (tmp_path / "config.yaml").write_text(
+            "buzz:\n  extra:\n    allow_all_users: true\n",
+            encoding="utf-8",
+        )
+        adapter = _make_adapter()
+        adapter._message_handler = AsyncMock()
+        adapter.handle_message = AsyncMock()
+        adapter.send_reaction = AsyncMock(return_value=True)
+
+        await adapter._dispatch_message(
+            text="test",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="Other",
+            message_id="e1",
+            created_at=10,
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        adapter.send_reaction.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_multiplex_ack_uses_active_profile_scope(self, monkeypatch, tmp_path):
+        from agent import secret_scope
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("BUZZ_ALLOW_ALL_USERS", "true")
+        (tmp_path / "config.yaml").write_text("buzz:\n  extra: {}\n", encoding="utf-8")
+        token = secret_scope.set_secret_scope({"BUZZ_ALLOWED_USERS": SELF_PUBKEY})
+        secret_scope.set_multiplex_active(True)
+        try:
+            adapter = _make_adapter()
+            adapter._message_handler = AsyncMock()
+            adapter.handle_message = AsyncMock()
+            adapter.send_reaction = AsyncMock(return_value=True)
+
+            await adapter._dispatch_message(
+                text="test",
+                chat_id=CHANNEL,
+                chat_type="group",
+                user_id=OTHER_PUBKEY,
+                user_name="Other",
+                message_id="e1",
+                created_at=10,
+            )
+
+            adapter.handle_message.assert_awaited_once()
+            adapter.send_reaction.assert_not_awaited()
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(False)
+
+
 # ── DM classification via p-tags (issue #68871) ──────────────────────────
 #
 # `buzz dms list` returns [] on some hosted relays, so DM conversations leak

--- a/tests/gateway/test_plugin_runtime_access_policy.py
+++ b/tests/gateway/test_plugin_runtime_access_policy.py
@@ -1,0 +1,203 @@
+"""Tests for plugin-provided runtime authorization configuration."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.authz_mixin import GatewayAuthorizationMixin
+from gateway.config import Platform
+from gateway.platform_registry import PlatformEntry, platform_registry
+from gateway.session import SessionSource
+
+
+PLATFORM_NAME = "runtime_auth_test"
+AUTH_ENV_VARS = (
+    "RUNTIME_AUTH_TEST_ALLOWED_USERS",
+    "RUNTIME_AUTH_TEST_ALLOW_ALL_USERS",
+    "GATEWAY_ALLOWED_USERS",
+    "GATEWAY_ALLOW_ALL_USERS",
+)
+
+
+class _Runner(GatewayAuthorizationMixin):
+    def __init__(self):
+        self.adapters = {}
+        self._profile_adapters = {}
+        self.pairing_store = None
+        self.pairing_stores = {}
+        self.config = SimpleNamespace(platforms={})
+
+
+def _source(user_id: str, *, profile=None) -> SessionSource:
+    source = SessionSource(
+        platform=Platform(PLATFORM_NAME),
+        user_id=user_id,
+        chat_id="test-chat",
+        user_name=user_id,
+        chat_type="dm",
+    )
+    source.profile = profile
+    return source
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry_and_env(monkeypatch):
+    for name in AUTH_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    platform_registry.unregister(PLATFORM_NAME)
+    yield
+    platform_registry.unregister(PLATFORM_NAME)
+
+
+def _register_runtime_policy(policy, *, normalizer=None, resolver=None):
+    platform_registry.register(
+        PlatformEntry(
+            name=PLATFORM_NAME,
+            label="Runtime auth test",
+            adapter_factory=lambda _cfg: None,
+            check_fn=lambda: True,
+            allowed_users_env="RUNTIME_AUTH_TEST_ALLOWED_USERS",
+            allow_all_env="RUNTIME_AUTH_TEST_ALLOW_ALL_USERS",
+            authorization_config_fn=resolver or (lambda _profile: policy),
+            authorization_user_normalizer=normalizer,
+        )
+    )
+
+
+def test_plugin_runtime_allowlist_is_applied_by_central_authorization():
+    policy = {"allowed_users": ["alice"], "allow_all_users": False}
+    _register_runtime_policy(policy)
+    runner = _Runner()
+
+    assert runner._is_user_authorized(_source("alice")) is True
+    assert runner._is_user_authorized(_source("bob")) is False
+
+    policy["allowed_users"] = ["bob"]
+
+    assert runner._is_user_authorized(_source("alice")) is False
+    assert runner._is_user_authorized(_source("bob")) is True
+
+
+def test_plugin_runtime_allow_all_can_be_revoked():
+    policy = {"allowed_users": [], "allow_all_users": False}
+    _register_runtime_policy(policy)
+    runner = _Runner()
+
+    assert runner._is_user_authorized(_source("alice")) is False
+    policy["allow_all_users"] = True
+    assert runner._is_user_authorized(_source("alice")) is True
+    policy.pop("allow_all_users")
+    assert runner._is_user_authorized(_source("alice")) is False
+
+
+def test_explicit_plugin_env_overrides_runtime_policy(monkeypatch):
+    _register_runtime_policy(
+        {"allowed_users": ["yaml-user"], "allow_all_users": True}
+    )
+    monkeypatch.setenv("RUNTIME_AUTH_TEST_ALLOWED_USERS", "env-user")
+    monkeypatch.setenv("RUNTIME_AUTH_TEST_ALLOW_ALL_USERS", "false")
+    runner = _Runner()
+
+    assert runner._is_user_authorized(_source("env-user")) is True
+    assert runner._is_user_authorized(_source("yaml-user")) is False
+
+
+def test_explicit_empty_plugin_env_suppresses_runtime_allowlist(monkeypatch):
+    _register_runtime_policy(
+        {"allowed_users": ["yaml-user"], "allow_all_users": False}
+    )
+    monkeypatch.setenv("RUNTIME_AUTH_TEST_ALLOWED_USERS", "")
+    runner = _Runner()
+
+    assert runner._is_user_authorized(_source("yaml-user")) is False
+
+
+def test_multiplex_profile_env_does_not_fall_through_to_process_env(monkeypatch):
+    from agent import secret_scope
+
+    _register_runtime_policy(
+        {"allowed_users": ["yaml-user"], "allow_all_users": False}
+    )
+    monkeypatch.setenv("RUNTIME_AUTH_TEST_ALLOWED_USERS", "other-profile-user")
+    token = secret_scope.set_secret_scope(
+        {"RUNTIME_AUTH_TEST_ALLOWED_USERS": "active-profile-user"}
+    )
+    secret_scope.set_multiplex_active(True)
+    try:
+        runner = _Runner()
+        assert runner._is_user_authorized(_source("active-profile-user")) is True
+        assert runner._is_user_authorized(_source("other-profile-user")) is False
+        assert runner._is_user_authorized(_source("yaml-user")) is False
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(False)
+
+
+def test_multiplex_missing_profile_keys_do_not_use_process_env(monkeypatch):
+    from agent import secret_scope
+
+    _register_runtime_policy({})
+    monkeypatch.setenv("RUNTIME_AUTH_TEST_ALLOWED_USERS", "other-profile-user")
+    monkeypatch.setenv("RUNTIME_AUTH_TEST_ALLOW_ALL_USERS", "true")
+    token = secret_scope.set_secret_scope({})
+    secret_scope.set_multiplex_active(True)
+    try:
+        runner = _Runner()
+        assert runner._is_user_authorized(_source("other-profile-user")) is False
+        assert runner._is_user_authorized(_source("any-user")) is False
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(False)
+
+
+def test_multiplex_unscoped_authorization_does_not_use_process_env(monkeypatch):
+    from agent import secret_scope
+
+    _register_runtime_policy({})
+    monkeypatch.setenv("RUNTIME_AUTH_TEST_ALLOW_ALL_USERS", "true")
+    secret_scope.set_multiplex_active(True)
+    try:
+        assert _Runner()._is_user_authorized(_source("any-user")) is False
+    finally:
+        secret_scope.set_multiplex_active(False)
+
+
+def test_runtime_resolver_receives_source_profile():
+    profiles = []
+
+    def resolve(profile):
+        profiles.append(profile)
+        return {"allowed_users": ["alice"]}
+
+    _register_runtime_policy({}, resolver=resolve)
+
+    assert _Runner()._is_user_authorized(
+        _source("alice", profile="secondary")
+    ) is True
+    assert profiles == ["secondary"]
+
+
+def test_plugin_normalizer_applies_to_explicit_env_allowlist(monkeypatch):
+    from plugins.platforms.buzz.adapter import hex_to_npub, _normalize_user_ref
+
+    pubkey = "a" * 64
+    npub = hex_to_npub(pubkey)
+    assert npub is not None
+    _register_runtime_policy({}, normalizer=_normalize_user_ref)
+    monkeypatch.setenv("RUNTIME_AUTH_TEST_ALLOWED_USERS", npub)
+
+    assert _Runner()._is_user_authorized(_source(pubkey)) is True
+
+    monkeypatch.setenv("RUNTIME_AUTH_TEST_ALLOWED_USERS", pubkey.upper())
+    assert _Runner()._is_user_authorized(_source(pubkey)) is True
+
+
+def test_runtime_hooks_are_appended_to_platform_entry_abi():
+    fields = list(PlatformEntry.__dataclass_fields__)
+
+    assert fields.index("authorization_config_fn") > fields.index(
+        "standalone_sender_fn"
+    )
+    assert fields.index("authorization_user_normalizer") > fields.index(
+        "standalone_sender_fn"
+    )

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -296,6 +296,62 @@ async def test_signal_with_allowlist_ignores_unauthorized_dm(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_buzz_config_allowlist_ignores_unauthorized_dm(monkeypatch, tmp_path):
+    """A config-only Buzz allowlist must not leak a pairing response."""
+    from gateway.platform_registry import PlatformEntry, platform_registry
+    from plugins.platforms.buzz.adapter import (
+        _load_runtime_authorization_config,
+        _normalize_user_ref,
+    )
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("BUZZ_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("BUZZ_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    allowed_pubkey = "a" * 64
+    unauthorized_pubkey = "b" * 64
+    (tmp_path / "config.yaml").write_text(
+        "buzz:\n"
+        "  extra:\n"
+        f"    allowed_users: [{allowed_pubkey}]\n"
+        "    allow_all_users: false\n",
+        encoding="utf-8",
+    )
+
+    buzz = Platform("buzz")
+    previous_entry = platform_registry.get("buzz")
+    platform_registry.register(
+        PlatformEntry(
+            name="buzz",
+            label="Buzz",
+            adapter_factory=lambda _cfg: None,
+            check_fn=lambda: True,
+            allowed_users_env="BUZZ_ALLOWED_USERS",
+            allow_all_env="BUZZ_ALLOW_ALL_USERS",
+            authorization_config_fn=_load_runtime_authorization_config,
+            authorization_user_normalizer=_normalize_user_ref,
+        )
+    )
+    try:
+        config = GatewayConfig(
+            platforms={buzz: PlatformConfig(enabled=True)},
+        )
+        runner, adapter = _make_runner(buzz, config)
+
+        result = await runner._handle_message(
+            _make_event(buzz, unauthorized_pubkey, "unauthorized-dm")
+        )
+
+        assert result is None
+        runner.pairing_store.generate_code.assert_not_called()
+        adapter.send.assert_not_awaited()
+    finally:
+        platform_registry.unregister("buzz")
+        if previous_entry is not None:
+            platform_registry.register(previous_entry)
+
+
+@pytest.mark.asyncio
 async def test_telegram_with_allowlist_ignores_unauthorized_dm(monkeypatch):
     """Same behavior for Telegram: allowlist ⟹ ignore unauthorized DMs."""
     _clear_auth_env(monkeypatch)

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -1,3 +1,4 @@
+import weakref
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -296,8 +297,10 @@ async def test_signal_with_allowlist_ignores_unauthorized_dm(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_buzz_config_allowlist_ignores_unauthorized_dm(monkeypatch, tmp_path):
-    """A config-only Buzz allowlist must not leak a pairing response."""
+async def test_buzz_config_allowlist_uses_transport_profile_and_ignores_unauthorized_dm(
+    monkeypatch, tmp_path
+):
+    """A routed Buzz DM must use its transport profile and remain silent."""
     from gateway.platform_registry import PlatformEntry, platform_registry
     from plugins.platforms.buzz.adapter import (
         _load_runtime_authorization_config,
@@ -338,9 +341,17 @@ async def test_buzz_config_allowlist_ignores_unauthorized_dm(monkeypatch, tmp_pa
         )
         runner, adapter = _make_runner(buzz, config)
 
-        result = await runner._handle_message(
-            _make_event(buzz, unauthorized_pubkey, "unauthorized-dm")
-        )
+        class _TransportAdapter:
+            pass
+
+        transport_adapter = _TransportAdapter()
+        transport_adapter.send = adapter.send
+        runner.adapters[buzz] = transport_adapter
+        event = _make_event(buzz, unauthorized_pubkey, "unauthorized-dm")
+        event.source.profile = "routed-runtime"
+        event.source._transport_adapter_ref = weakref.ref(transport_adapter)
+
+        result = await runner._handle_message(event)
 
         assert result is None
         runner.pairing_store.generate_code.assert_not_called()
@@ -349,6 +360,50 @@ async def test_buzz_config_allowlist_ignores_unauthorized_dm(monkeypatch, tmp_pa
         platform_registry.unregister("buzz")
         if previous_entry is not None:
             platform_registry.register(previous_entry)
+
+
+@pytest.mark.asyncio
+async def test_plugin_runtime_policy_error_ignores_unauthorized_dm(monkeypatch):
+    """Policy lookup failures must deny silently, never offer pairing."""
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    _clear_auth_env(monkeypatch)
+    platform_name = "runtime-policy-error-test"
+    allowed_env = "RUNTIME_POLICY_ERROR_TEST_ALLOWED_USERS"
+    allow_all_env = "RUNTIME_POLICY_ERROR_TEST_ALLOW_ALL_USERS"
+    monkeypatch.delenv(allowed_env, raising=False)
+    monkeypatch.delenv(allow_all_env, raising=False)
+
+    def _raise_policy_error(_profile):
+        raise RuntimeError("config unavailable")
+
+    platform_registry.register(
+        PlatformEntry(
+            name=platform_name,
+            label="Runtime policy error test",
+            adapter_factory=lambda _cfg: None,
+            check_fn=lambda: True,
+            allowed_users_env=allowed_env,
+            allow_all_env=allow_all_env,
+            authorization_config_fn=_raise_policy_error,
+        )
+    )
+    platform = Platform(platform_name)
+    try:
+        runner, adapter = _make_runner(
+            platform,
+            GatewayConfig(platforms={platform: PlatformConfig(enabled=True)}),
+        )
+
+        result = await runner._handle_message(
+            _make_event(platform, "unknown-user", "unauthorized-dm")
+        )
+
+        assert result is None
+        runner.pairing_store.generate_code.assert_not_called()
+        adapter.send.assert_not_awaited()
+    finally:
+        platform_registry.unregister(platform_name)
 
 
 @pytest.mark.asyncio

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -33,7 +33,8 @@ gateway:
         poll_interval: 4           # seconds between inbound poll sweeps
         cli_path: ""               # buzz binary (default: PATH, then ~/bin/buzz)
         credentials_file: ""       # JSON file with the nsec (BUZZ_PRIVATE_KEY fallback)
-        allowed_users: []          # empty = allow all; hex pubkeys or npubs
+        allowed_users: []          # public hex pubkeys or npubs
+        allow_all_users: false     # secure default: deny unlisted senders
 ```
 
 Plus, in `~/.hermes/.env`:
@@ -103,7 +104,11 @@ gateway:
 
 ## Access control
 
-By default the allow-list is empty, which means every community member who mentions the agent gets a response only if `BUZZ_ALLOW_ALL_USERS=true`; otherwise restrict access by listing npubs or hex pubkeys in `BUZZ_ALLOWED_USERS` (or `allowed_users` in config.yaml). Community membership itself is enforced by the relay — only members can post.
+By default, `allowed_users` is empty and `allow_all_users` is false, so no unlisted community member is authorized. Add public npubs or 64-character hex pubkeys to `allowed_users`, or explicitly enable `allow_all_users` for community-wide access. Npubs and uppercase or lowercase hex identities are normalized before comparison. Community membership itself is enforced by the relay — only members can post.
+
+Saved `allowed_users` and `allow_all_users` changes take effect on the next authorization check; the gateway does not need to restart. Removing an entry revokes that sender, and removing `allow_all_users: true`, its containing Buzz section, or the config file revokes community-wide access. If a config edit is malformed, Hermes retains the last valid policy until the file is corrected.
+
+Legacy `BUZZ_ALLOWED_USERS` and `BUZZ_ALLOW_ALL_USERS` environment values override the corresponding `config.yaml` key independently, including explicit empty values. `BUZZ_ALLOW_ALL_USERS` accepts `true`, `1`, or `yes` (case-insensitive) as true; all other values are false. Environment changes still require the gateway process environment to be reloaded. Unauthorized messages are rejected silently without an acknowledgement reaction.
 
 Cron jobs and notifications (`deliver=buzz`) are delivered to the **home channel** — `BUZZ_HOME_CHANNEL` if set, otherwise the first watched channel — and work even when cron runs outside the gateway process.
 


### PR DESCRIPTION
## What does this PR do?

Buzz currently snapshots `allowed_users` during adapter startup and bridges saved access-control settings into process-global environment variables. As a result, saved policy changes can remain stale until the gateway restarts and can leak across profiles in multiplex mode.

This PR moves Buzz authorization to the gateway’s central authorization boundary and resolves the effective Buzz policy on each authorization check. Changes to `allowed_users` and `allow_all_users` therefore take effect without restarting the gateway.

The implementation:

- Uses Hermes’s managed-overlay-aware, profile-aware, last-known-good configuration loader.
- Preserves explicit per-key environment precedence, including explicitly empty values.
- Revokes access when allowlist entries, `allow_all_users`, or the Buzz policy section are removed.
- Supports the accepted Buzz configuration layouts.
- Normalizes both `npub` and 64-character hexadecimal identities.
- Keeps unauthorized traffic silent by suppressing cosmetic acknowledgement reactions.
- Preserves `PlatformEntry` positional compatibility by appending the optional authorization hooks.

## Related Issue

N/A — no issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platform_registry.py`
  - Adds optional runtime authorization configuration and identity-normalization hooks for plugin platforms.
  - Appends the hooks after existing dataclass fields to preserve positional API compatibility.
- `gateway/authz_mixin.py`
  - Evaluates plugin-provided policy at the central authorization boundary.
  - Preserves absent-versus-explicit-empty environment semantics.
  - Prevents process-environment fallthrough across multiplexed profiles.
  - Applies platform-specific identity normalization to explicit environment allowlists.
- `plugins/platforms/buzz/adapter.py`
  - Resolves live Buzz policy through `load_config_readonly()`.
  - Supports `gateway.platforms.buzz`, `platforms.buzz`, `gateway.buzz`, and top-level `buzz` configuration.
  - Removes the stale adapter-level authorization snapshot and duplicate inbound gate.
  - Stops bridging Buzz access policy into process-global environment variables.
  - Suppresses acknowledgement reactions for unauthorized senders.
  - Aligns acknowledgement policy precedence and accepted allow-all literals with central authorization.
- `tests/gateway/test_buzz_adapter.py`
  - Adds coverage for hot reload, policy deletion, malformed-config fallback, managed overlays, supported configuration paths, profile selection, identity normalization, and acknowledgement behavior.
- `tests/gateway/test_plugin_runtime_access_policy.py`
  - Adds central authorization regressions covering policy mutation, revocation, explicit-empty overrides, multiplex isolation, profile routing, normalization, and registry compatibility.
- `website/docs/user-guide/messaging/buzz.md`
  - Documents secure default-deny behavior, live policy refresh and revocation, identity normalization, malformed-config fallback, per-key legacy environment precedence, and silent rejection.

## How to Test

1. Configure Buzz with an explicit `allowed_users` list and confirm an allowlisted sender is accepted.
2. Remove that sender from `allowed_users` without restarting the gateway; confirm the sender receives neither a response nor an acknowledgement reaction.
3. Re-add the sender without restarting; confirm access returns.
4. Enable `allow_all_users`; confirm an unlisted sender is accepted.
5. Disable or remove `allow_all_users`; confirm the unlisted sender is rejected immediately.
6. Run the focused regression suite:

   ```bash
   scripts/run_tests.sh \
     tests/gateway/test_buzz_adapter.py \
     tests/gateway/test_plugin_runtime_access_policy.py \
     tests/gateway/test_config_driven_access_policy.py \
     tests/gateway/test_plugin_platform_interface.py
   ```

   Result: **69 tests passed, 0 failed**.

7. Run static checks:

   ```bash
   ruff check \
     gateway/authz_mixin.py \
     gateway/platform_registry.py \
     plugins/platforms/buzz/adapter.py \
     tests/gateway/test_buzz_adapter.py \
     tests/gateway/test_plugin_runtime_access_policy.py

   git diff --check upstream/main...HEAD
   ```

   Result: all checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04 LTS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the Buzz messaging guide
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: no configuration keys were added or changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Python-only gateway behavior with no platform-specific paths or subprocesses
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification on the rebased branch:

```text
69 tests passed, 0 failed
Ruff: passed
Python compilation: passed
git diff --check: passed
```

A live Buzz smoke test on Ubuntu 26.04 confirmed that an unauthorized sender receives neither an acknowledgement reaction nor a response after the saved allowlist is changed.