### PR TITLE
perf(cli): cap /model picker custom-endpoint probe at 1.5s (salvage #72020)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2702,6 +2702,7 @@ def list_authenticated_providers(
                     live_models = fetch_api_models(
                         api_key,
                         api_url,
+                        timeout=1.5 if for_picker else 5.0,  # picker: fail fast so a slow custom endpoint doesn't block /model
                         headers=_extra_headers_from_config(ep_cfg) or None,
                     )
                     if live_models:
@@ -2769,7 +2770,11 @@ def list_authenticated_providers(
             try:
                 from hermes_cli.models import fetch_api_models
 
-                _live_models = fetch_api_models("", str(current_base_url).strip().rstrip("/"))
+                _live_models = fetch_api_models(
+                    "",
+                    str(current_base_url).strip().rstrip("/"),
+                    timeout=1.5 if for_picker else 5.0,  # picker: fail fast on a slow current endpoint
+                )
                 if _live_models:
                     _models = _live_models
             except Exception:
@@ -3012,6 +3017,7 @@ def list_authenticated_providers(
                     live_models = fetch_api_models(
                         api_key,
                         api_url,
+                        timeout=1.5 if for_picker else 5.0,  # picker: fail fast so a slow custom endpoint doesn't block /model
                         headers=grp.get("extra_headers") or None,
                     )
                     if live_models:

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -640,7 +640,7 @@ def test_custom_providers_uses_live_models_for_multi_model_endpoint(monkeypatch)
 
     assert gateway_prov is not None, "Custom provider group not found in results"
     assert calls == [
-        ("sk-gateway-key", "https://gateway.example.com/v1", {"headers": None})
+        ("sk-gateway-key", "https://gateway.example.com/v1", {"timeout": 5.0, "headers": None})
     ], "fetch_api_models must be called with the custom provider's credentials"
     assert gateway_prov["models"] == [
         "gateway-model-a",

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -158,7 +158,7 @@ def test_list_authenticated_providers_uses_live_models_for_user_provider(monkeyp
     )
 
     assert user_prov is not None
-    assert calls == [("sk-test", "http://127.0.0.1:3000/api/v1", {"headers": None})]
+    assert calls == [("sk-test", "http://127.0.0.1:3000/api/v1", {"timeout": 5.0, "headers": None})]
     assert user_prov["models"] == ["old-configured-model", "new-live-model"]
     assert user_prov["total_models"] == 2
 
@@ -497,7 +497,7 @@ def test_section3_probes_no_key_endpoint_without_explicit_models(monkeypatch):
 
     assert probed.get("called") is True, "no-key bare endpoint should be probed"
     assert probed["api_key"] == ""
-    assert probed["kwargs"] == {"headers": None}
+    assert probed["kwargs"] == {"timeout": 5.0, "headers": None}
     row = next(p for p in providers if p["slug"] == "local-llamacpp")
     assert row["models"] == ["live-model-1", "live-model-2", "live-model-3"]
     assert row["total_models"] == 3


### PR DESCRIPTION
Salvages #72020 by @ZachariahChu — commit cherry-picked to preserve authorship, plus one test-adaptation commit.

## Context — what this fixes, for whom

Anyone with a custom OpenAI-compatible endpoint configured who opens the `/model` picker: each custom endpoint gets a live `/models` probe, and `fetch_api_models`'s default timeout is 5s connect. A slow or unreachable custom endpoint blocks the interactive picker for the full default timeout, per endpoint. This caps the picker-path probes at 1.5s (matching the existing LMStudio picker precedent at `fetch_lmstudio_models`' 1.5s), while non-picker callers keep the 5s default explicitly.

## What the fix does (from #72020, kept verbatim)

Passes `timeout=1.5 if for_picker else 5.0` at all three `fetch_api_models` call sites in `list_authenticated_providers` (custom-endpoint probe, current-endpoint probe, custom-provider-group probe). Verified on current main that all three sites previously passed no timeout.

## Test adaptation (ours)

`test_custom_providers_uses_live_models_for_multi_model_endpoint` (added on main after this PR's base) pins the exact kwargs of the probe call; with the timeout now always explicit the pinned shape gains `timeout: 5.0`. One-line assertion update.

## Verification

- `tests/hermes_cli/test_model_switch_custom_providers.py` + `test_list_picker_providers.py`: 38 passed on current main
- Monkeypatch-seam sweep: all `fetch_api_models` test seams use `**kwargs`-tolerant fakes (`lambda *a, **k` / `def fake(...,**kwargs)`) — no breakage
- ruff clean
- Attribution: contributor mapping for @ZachariahChu landed via #76921

Closes #72020 (superseded by this salvage — original author credited via cherry-pick authorship).
