### PR TITLE
compression: auto-persist Durable Facts into MemoryStore

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1336,6 +1336,7 @@ class ContextCompressor(ContextEngine):
         self._last_summary_dropped_count = 0
         self._last_summary_fallback_used = False
         self._last_feasibility_skip = False
+        self._last_raw_summary: Optional[str] = None
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
         self._last_compression_savings_pct = 100.0
@@ -1605,6 +1606,7 @@ class ContextCompressor(ContextEngine):
         self._last_summary_dropped_count = 0
         self._last_summary_fallback_used = False
         self._last_feasibility_skip = False
+        self._last_raw_summary: Optional[str] = None
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
         self._last_compression_savings_pct = 100.0
@@ -2342,6 +2344,7 @@ class ContextCompressor(ContextEngine):
         self._last_summary_dropped_count: int = 0
         self._last_summary_fallback_used: bool = False
         self._last_feasibility_skip: bool = False
+        self._last_raw_summary: Optional[str] = None
         # When summary generation fails we now ABORT compression entirely
         # and return the original messages unchanged instead of dropping
         # the middle window with a static placeholder.  Callers inspect
@@ -3631,6 +3634,9 @@ Example:
 2. PATCH config.py:45 — changed `==` to `!=` [tool: patch]
 3. TEST `pytest tests/` — 3/50 failed: test_parse, test_validate, test_edge [tool: terminal]
 Be specific with file paths, commands, line numbers, and results.]
+
+## Durable Facts
+[1-3 concise, durable facts about the user or project that should be remembered across future sessions. These are stable preferences, recurring patterns, architectural conventions, or permanent context — NOT task-tracking items or one-time actions. Format each as a single sentence. Include only information that is likely to still be true and useful weeks from now. Only include facts that are NEW or UPDATED from previous compactions — do not repeat facts that were already recorded in earlier Durable Facts sections. If nothing new or durable was observed in these turns, write "None." Do NOT include API keys, tokens, passwords, or credentials.]
 
 ## Active State
 [Current working state — include:
@@ -5928,6 +5934,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         self._last_summary_dropped_count = 0
         self._last_summary_fallback_used = False
         self._last_feasibility_skip = False
+        self._last_raw_summary = None
         self._last_summary_error = None
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
@@ -6392,6 +6399,10 @@ This compaction should PRIORITISE preserving all information related to the focu
                 reason=None if feasibility_skip else self._last_summary_error,
             )
 
+        # Record the raw summary for downstream consumers (e.g. durable-fact
+        # extraction into persistent memory).
+        self._last_raw_summary = summary
+
         tail_messages: List[Dict[str, Any]] = []
         # Start at tail_start (not compress_end): the restart-decay scan may
         # have advanced it past a summary that sat beyond compress_end
@@ -6706,3 +6717,54 @@ def is_compaction_summary_message(message: Any) -> bool:
     else:
         content = message
     return ContextCompressor._is_context_summary_content(content)
+
+
+# ── Durable Facts Extraction ────────────────────────────────────────────────
+# Compression summaries include a "## Durable Facts" section (1-3 stable facts
+# about the user or project).  This function extracts them so downstream
+# consumers (``compress_context()`` in conversation_compression.py) can
+# persist them into ``MemoryStore`` — closing the gap between compression-time
+# fact recognition and permanent memory storage.
+
+_DURABLE_FACTS_RE = re.compile(
+    r'##\s+Durable\s+Facts\s*\n(.*?)(?=\n##\s+(?:Active State|Blocked|Key Decisions|Goal|Completed|Resolved|Relevant|Critical|[A-Z])|\n\Z)',
+    re.DOTALL,
+)
+
+
+def extract_durable_facts_from_summary(summary_text: str) -> list[str]:
+    """Extract Durable Facts entries from a compression summary.
+
+    The compression summary template includes::
+
+        ## Durable Facts
+        1. First durable fact about the user or project.
+        2. Second durable fact.
+        3. Third durable fact.
+
+    When the summariser writes ``None.`` (no new facts observed), an empty
+    list is returned.  Returned strings have the list-marker prefix stripped
+    and leading/trailing whitespace removed.
+    """
+    if not isinstance(summary_text, str) or not summary_text.strip():
+        return []
+    match = _DURABLE_FACTS_RE.search(summary_text)
+    if not match:
+        return []
+    facts_section = match.group(1).strip()
+    if not facts_section or facts_section.lower() in ("none.", "none"):
+        return []
+    facts: list[str] = []
+    for line in facts_section.split("\n"):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        # Remove list markers: "1. ", "2. ", "- ", "* ", etc.
+        cleaned = re.sub(
+            r'^[\d]+\.\s*|^[-*\u2022]\s*|^\[\s*[\d]+\s*\]\s*',
+            "",
+            stripped,
+        ).strip()
+        if cleaned and cleaned.lower() not in ("none.", "none"):
+            facts.append(cleaned)
+    return facts

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2383,6 +2383,7 @@ def compress_context(
                     if _store is not None:
                         from tools.memory_tool import memory_tool
 
+                        _results: list[tuple[str, dict[str, Any]]] = []
                         _persisted = 0
                         for _fact in _facts:
                             _result_json = memory_tool(
@@ -2393,10 +2394,11 @@ def compress_context(
                             )
                             try:
                                 _result = json.loads(_result_json)
-                                if _result.get("success"):
-                                    _persisted += 1
                             except (json.JSONDecodeError, TypeError):
-                                pass
+                                _result = {}
+                            _results.append((_result_json, _result))
+                            if _result.get("success"):
+                                _persisted += 1
                         if _persisted:
                             logger.info(
                                 "persisted %d durable fact(s) from compression "
@@ -2404,6 +2406,18 @@ def compress_context(
                                 _persisted,
                                 len(_facts) - _persisted,
                             )
+                            # Mirror to external memory providers (Mem0,
+                            # Honcho, etc.) so they see the new facts too.
+                            _manager = getattr(agent, "_memory_manager", None)
+                            if _manager:
+                                for _fact, (_result_json, _) in zip(
+                                    _facts, _results
+                                ):
+                                    _manager.notify_memory_tool_write(
+                                        _result_json,
+                                        {"action": "add", "target": "memory",
+                                         "content": _fact},
+                                    )
         except Exception as _exc:
             logger.debug(
                 "durable facts persistence after compression failed: %s", _exc

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2381,13 +2381,29 @@ def compress_context(
                 if _facts:
                     _store = getattr(agent, "_memory_store", None)
                     if _store is not None:
+                        from tools.memory_tool import memory_tool
+
+                        _persisted = 0
                         for _fact in _facts:
-                            _store.add("memory", _fact)
-                        logger.info(
-                            "persisted %d durable fact(s) from compression "
-                            "summary to memory store",
-                            len(_facts),
-                        )
+                            _result_json = memory_tool(
+                                action="add",
+                                target="memory",
+                                content=_fact,
+                                store=_store,
+                            )
+                            try:
+                                _result = json.loads(_result_json)
+                                if _result.get("success"):
+                                    _persisted += 1
+                            except (json.JSONDecodeError, TypeError):
+                                pass
+                        if _persisted:
+                            logger.info(
+                                "persisted %d durable fact(s) from compression "
+                                "summary to memory store (%d skipped)",
+                                _persisted,
+                                len(_facts) - _persisted,
+                            )
         except Exception as _exc:
             logger.debug(
                 "durable facts persistence after compression failed: %s", _exc

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2365,6 +2365,34 @@ def compress_context(
         except Exception:
             pass
 
+        # Persist durable facts extracted from the compression summary into
+        # the built-in memory store so they survive across sessions.  Only
+        # the LLM-generated summary has a "## Durable Facts" section; static
+        # fallbacks are skipped silently by the extractor.
+        try:
+            _raw_summary = getattr(
+                agent.context_compressor, "_last_raw_summary", None
+            )
+            if _raw_summary:
+                from agent.context_compressor import (
+                    extract_durable_facts_from_summary,
+                )
+                _facts = extract_durable_facts_from_summary(_raw_summary)
+                if _facts:
+                    _store = getattr(agent, "_memory_store", None)
+                    if _store is not None:
+                        for _fact in _facts:
+                            _store.add("memory", _fact)
+                        logger.info(
+                            "persisted %d durable fact(s) from compression "
+                            "summary to memory store",
+                            len(_facts),
+                        )
+        except Exception as _exc:
+            logger.debug(
+                "durable facts persistence after compression failed: %s", _exc
+            )
+
         logger.info(
             "context compression done: session=%s messages=%d->%d rough_tokens=~%s awaiting_real_usage=true",
             agent.session_id or "none", _pre_msg_count, len(compressed),

--- a/tests/agent/test_durable_facts_extraction.py
+++ b/tests/agent/test_durable_facts_extraction.py
@@ -1,0 +1,389 @@
+"""Tests for durable-fact extraction from compression summaries and
+automatic persistence into the built-in MemoryStore.
+
+Covers:
+  1. ``extract_durable_facts_from_summary()`` — pure extraction function
+  2. ``ContextCompressor.compress()`` stores ``_last_raw_summary``
+  3. ``compress_context()`` pipes extracted facts into ``MemoryStore``
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.context_compressor import (
+    ContextCompressor,
+    extract_durable_facts_from_summary,
+)
+from tools.memory_tool import MemoryStore
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _compressor(**kwargs) -> ContextCompressor:
+    """Minimal compressor with a faked context length."""
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=100_000,
+    ):
+        return ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=1,
+            protect_last_n=1,
+            quiet_mode=True,
+            **kwargs,
+        )
+
+
+def _response(content: str) -> MagicMock:
+    """Return a mock OpenAI response whose only text content is *content*."""
+    mock = MagicMock()
+    mock.choices = [MagicMock()]
+    mock.choices[0].message.content = content
+    return mock
+
+
+# ── Unit: extract_durable_facts_from_summary ─────────────────────────────────
+
+
+class TestExtractDurableFacts:
+    """Pure-function tests — no filesystem, no LLM."""
+
+    def test_extracts_numbered_facts(self):
+        summary = (
+            "## Durable Facts\n"
+            "1. User prefers dark mode in all editors.\n"
+            "2. Project uses Python 3.12 minimum.\n"
+            "3. Deployment target is AWS Lambda.\n"
+            "\n"
+            "## Active State\n"
+            "working dir: /src\n"
+        )
+        facts = extract_durable_facts_from_summary(summary)
+        assert facts == [
+            "User prefers dark mode in all editors.",
+            "Project uses Python 3.12 minimum.",
+            "Deployment target is AWS Lambda.",
+        ]
+
+    def test_extracts_bullet_facts(self):
+        summary = (
+            "## Durable Facts\n"
+            "- User prefers concise responses.\n"
+            "* Error handling must never silently fail.\n"
+            "• Tests run with scripts/run_tests.sh.\n"
+            "\n"
+            "## Blocked\n"
+            "nothing\n"
+        )
+        facts = extract_durable_facts_from_summary(summary)
+        assert len(facts) == 3
+        assert "concise responses" in facts[0]
+
+    def test_none_returns_empty(self):
+        assert extract_durable_facts_from_summary(
+            "## Durable Facts\nNone.\n\n## Active State\n..."
+        ) == []
+        assert extract_durable_facts_from_summary(
+            "## Durable Facts\nNone\n"
+        ) == []
+
+    def test_empty_section_returns_empty(self):
+        assert extract_durable_facts_from_summary(
+            "## Durable Facts\n\n\n## Active State\n..."
+        ) == []
+
+    def test_no_durable_facts_section_returns_empty(self):
+        assert extract_durable_facts_from_summary(
+            "## Goal\nBuild the thing.\n\n## Active State\nidle\n"
+        ) == []
+
+    def test_empty_input_returns_empty(self):
+        assert extract_durable_facts_from_summary("") == []
+
+    def test_non_string_returns_empty(self):
+        assert extract_durable_facts_from_summary(None) == []  # type: ignore[arg-type]
+        assert extract_durable_facts_from_summary(123) == []  # type: ignore[arg-type]
+
+    def test_trims_whitespace_and_list_markers(self):
+        summary = (
+            "## Durable Facts\n"
+            "  1.   Trailing spaces trimmed.   \n"
+            "   -   Dashes work too.\n"
+        )
+        facts = extract_durable_facts_from_summary(summary)
+        assert facts == [
+            "Trailing spaces trimmed.",
+            "Dashes work too.",
+        ]
+
+    def test_skips_blank_and_none_lines(self):
+        summary = (
+            "## Durable Facts\n"
+            "1. Only real fact.\n"
+            "\n"
+            "None.\n"
+            "\n"
+            "## Active State\n"
+            "...\n"
+        )
+        facts = extract_durable_facts_from_summary(summary)
+        assert facts == ["Only real fact."]
+
+    def test_excludes_common_header_words_from_fact_match(self):
+        """'Goal', 'Completed' etc. appearing as headings must not trigger
+        false positive section matching."""
+        summary = (
+            "## Durable Facts\n"
+            "1. The goal is to simplify deployment.\n"
+            "2. Completed the migration to PostgreSQL.\n"
+            "\n"
+            "## Completed Actions\n"
+            "...\n"
+        )
+        facts = extract_durable_facts_from_summary(summary)
+        assert len(facts) == 2
+        assert "goal is to simplify" in facts[0]
+        assert "Completed the migration" in facts[1]
+
+    def test_when_section_is_last_section(self):
+        """Durable Facts at the very end of the summary (no trailing `##`)."""
+        summary = (
+            "## Durable Facts\n"
+            "1. Only one durable fact this time.\n"
+        )
+        facts = extract_durable_facts_from_summary(summary)
+        assert facts == ["Only one durable fact this time."]
+
+
+# ── Integration: compress() stores _last_raw_summary ─────────────────────────
+
+
+class TestCompressStoresRawSummary:
+    def test_raw_summary_stored_on_success(self):
+        """After a successful compress(), ``_last_raw_summary`` holds the
+        generated summary text."""
+        c = _compressor()
+        summary_text = (
+            "## Durable Facts\n"
+            "1. CI runs on GitHub Actions.\n"
+            "\n"
+            "## Active State\n"
+            "branch: main\n"
+        )
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "task"},
+        ]
+        # Pad with enough messages to hit the compressible window.
+        for i in range(30):
+            messages.append({"role": "assistant", "content": f"work {i}"})
+            messages.append({"role": "user", "content": f"followup {i}"})
+
+        with patch.object(c, "_generate_summary", return_value=summary_text):
+            c.compress(messages, current_tokens=90_000)
+
+        assert c._last_raw_summary == summary_text
+
+    def test_raw_summary_reset_every_call(self):
+        """Each compress() call resets _last_raw_summary before running."""
+        c = _compressor()
+        # Seed a stale value.
+        c._last_raw_summary = "stale"
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "task"},
+        ]
+        # Not enough messages to trigger compression → early return.
+        result = c.compress(messages, current_tokens=50_000)
+        assert result == messages  # no-op
+        # _last_raw_summary should now be None (reset at call start, never set
+        # because summary wasn't generated).
+        assert c._last_raw_summary is None
+
+    def test_facts_extractable_from_stored_summary(self):
+        """The full pipeline: compress with LLM summary → _last_raw_summary →
+        extract facts."""
+        c = _compressor()
+        summary_text = (
+            "## Durable Facts\n"
+            "1. User prefers `uv` over `pip` for package management.\n"
+            "2. All services use port 8000 internally.\n"
+            "\n"
+            "## Active State\n"
+            "...\n"
+        )
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "start"},
+        ]
+        for i in range(30):
+            messages.append({"role": "assistant", "content": f"work {i}"})
+            messages.append({"role": "user", "content": f"followup {i}"})
+
+        with patch.object(c, "_generate_summary", return_value=summary_text):
+            c.compress(messages, current_tokens=90_000)
+
+        facts = extract_durable_facts_from_summary(c._last_raw_summary)
+        assert len(facts) == 2
+        assert "uv" in facts[0]
+        assert "port 8000" in facts[1]
+
+
+# ── E2E: compress_context → MemoryStore ──────────────────────────────────────
+
+
+class TestCompressContextPersistsToMemory:
+    """Verify that the ``compress_context()`` orchestration function takes the
+    raw summary, extracts facts, and writes them to ``MemoryStore``."""
+
+    def test_facts_written_to_memory_store(self, tmp_path, monkeypatch):
+        """Full pipeline: mock compression + agent → facts land in MEMORY.md."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+
+        # Build a MemoryStore that mirrors what a real agent would have.
+        store = MemoryStore(memory_char_limit=2000)
+        store.load_from_disk()
+
+        # Build a compressor whose compress() returns a summary with facts.
+        c = _compressor()
+        summary_text = (
+            "## Durable Facts\n"
+            "1. Deployment uses Docker Compose v2.\n"
+            "2. Logging goes to CloudWatch.\n"
+            "\n"
+            "## Active State\n"
+            "branch: main\n"
+            "## Completed Actions\n"
+            "1. ...\n"
+        )
+        # Set the raw summary as if compress() just finished.
+        c._last_raw_summary = summary_text
+
+        # Build a minimal mock agent.
+        agent = MagicMock()
+        agent._memory_store = store
+        agent.context_compressor = c
+        agent._memory_enabled = True
+
+        # Simulate the durable-facts persistence block from compress_context().
+        # (This is the literal code path — exercised directly in the test so
+        # the logic under test is the production logic, not a reimplementation.)
+        from agent.context_compressor import extract_durable_facts_from_summary
+
+        _raw_summary = getattr(agent.context_compressor, "_last_raw_summary", None)
+        if _raw_summary:
+            _facts = extract_durable_facts_from_summary(_raw_summary)
+            if _facts:
+                _store = getattr(agent, "_memory_store", None)
+                if _store is not None:
+                    for _fact in _facts:
+                        _store.add("memory", _fact)
+
+        # Verify facts landed on disk.
+        mem_file = tmp_path / "MEMORY.md"
+        assert mem_file.exists()
+        content = mem_file.read_text()
+        assert "Docker Compose v2" in content
+        assert "CloudWatch" in content
+
+        # Verify store is also consistent.
+        assert len(store.memory_entries) == 2
+
+    def test_no_facts_when_none_in_summary(self, tmp_path, monkeypatch):
+        """When the summary's Durable Facts section is ``None.``, nothing is
+        persisted."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+
+        store = MemoryStore()
+        store.load_from_disk()
+
+        c = _compressor()
+        c._last_raw_summary = "## Durable Facts\nNone.\n\n## Active State\n..."
+
+        agent = MagicMock()
+        agent._memory_store = store
+        agent.context_compressor = c
+
+        from agent.context_compressor import extract_durable_facts_from_summary
+
+        _raw_summary = getattr(agent.context_compressor, "_last_raw_summary", None)
+        if _raw_summary:
+            _facts = extract_durable_facts_from_summary(_raw_summary)
+            if _facts:
+                _store = getattr(agent, "_memory_store", None)
+                if _store is not None:
+                    for _fact in _facts:
+                        _store.add("memory", _fact)
+
+        # MEMORY.md should not be created (no facts to write).
+        mem_file = tmp_path / "MEMORY.md"
+        assert not mem_file.exists() or mem_file.read_text().strip() == ""
+
+    def test_no_store_no_crash(self):
+        """When agent has no _memory_store, the block is a no-op (no crash)."""
+        c = _compressor()
+        c._last_raw_summary = (
+            "## Durable Facts\n"
+            "1. A fact that won't be saved.\n"
+            "\n"
+            "## Active State\n"
+            "...\n"
+        )
+
+        agent = MagicMock()
+        agent._memory_store = None
+        agent.context_compressor = c
+
+        from agent.context_compressor import extract_durable_facts_from_summary
+
+        _raw_summary = getattr(agent.context_compressor, "_last_raw_summary", None)
+        if _raw_summary:
+            _facts = extract_durable_facts_from_summary(_raw_summary)
+            if _facts:
+                _store = getattr(agent, "_memory_store", None)
+                if _store is not None:
+                    for _fact in _facts:
+                        _store.add("memory", _fact)
+
+        # Shouldn't crash — that's the entire test.
+        assert True
+
+    def test_duplicate_fact_not_written_twice(self, tmp_path, monkeypatch):
+        """MemoryStore.add() rejects exact duplicates."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+
+        store = MemoryStore()
+        store.load_from_disk()
+        store.add("memory", "Deployment uses Docker Compose v2.")
+
+        c = _compressor()
+        c._last_raw_summary = (
+            "## Durable Facts\n"
+            "1. Deployment uses Docker Compose v2.\n"  # duplicate
+            "2. Logging via structured JSON.\n"  # new
+            "\n"
+            "## Active State\n"
+            "...\n"
+        )
+
+        agent = MagicMock()
+        agent._memory_store = store
+        agent.context_compressor = c
+
+        from agent.context_compressor import extract_durable_facts_from_summary
+
+        _raw_summary = getattr(agent.context_compressor, "_last_raw_summary", None)
+        if _raw_summary:
+            _facts = extract_durable_facts_from_summary(_raw_summary)
+            if _facts:
+                _store = getattr(agent, "_memory_store", None)
+                if _store is not None:
+                    for _fact in _facts:
+                        _store.add("memory", _fact)
+
+        # Only the new fact should be persisted.
+        assert len(store.memory_entries) == 2  # original + new (one duplicate skipped)
+        assert any("structured JSON" in e for e in store.memory_entries)

--- a/tests/agent/test_durable_facts_extraction.py
+++ b/tests/agent/test_durable_facts_extraction.py
@@ -5,9 +5,9 @@ Covers:
   1. ``extract_durable_facts_from_summary()`` — pure extraction function
   2. ``ContextCompressor.compress()`` stores ``_last_raw_summary``
   3. ``compress_context()`` pipes extracted facts into ``MemoryStore``
+     via the gate-aware ``memory_tool()`` path.
 """
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -35,14 +35,6 @@ def _compressor(**kwargs) -> ContextCompressor:
             quiet_mode=True,
             **kwargs,
         )
-
-
-def _response(content: str) -> MagicMock:
-    """Return a mock OpenAI response whose only text content is *content*."""
-    mock = MagicMock()
-    mock.choices = [MagicMock()]
-    mock.choices[0].message.content = content
-    return mock
 
 
 # ── Unit: extract_durable_facts_from_summary ─────────────────────────────────
@@ -73,7 +65,7 @@ class TestExtractDurableFacts:
             "## Durable Facts\n"
             "- User prefers concise responses.\n"
             "* Error handling must never silently fail.\n"
-            "• Tests run with scripts/run_tests.sh.\n"
+            "\u2022 Tests run with scripts/run_tests.sh.\n"
             "\n"
             "## Blocked\n"
             "nothing\n"
@@ -177,7 +169,6 @@ class TestCompressStoresRawSummary:
             {"role": "system", "content": "sys"},
             {"role": "user", "content": "task"},
         ]
-        # Pad with enough messages to hit the compressible window.
         for i in range(30):
             messages.append({"role": "assistant", "content": f"work {i}"})
             messages.append({"role": "user", "content": f"followup {i}"})
@@ -190,21 +181,17 @@ class TestCompressStoresRawSummary:
     def test_raw_summary_reset_every_call(self):
         """Each compress() call resets _last_raw_summary before running."""
         c = _compressor()
-        # Seed a stale value.
         c._last_raw_summary = "stale"
         messages = [
             {"role": "system", "content": "sys"},
             {"role": "user", "content": "task"},
         ]
-        # Not enough messages to trigger compression → early return.
         result = c.compress(messages, current_tokens=50_000)
         assert result == messages  # no-op
-        # _last_raw_summary should now be None (reset at call start, never set
-        # because summary wasn't generated).
         assert c._last_raw_summary is None
 
     def test_facts_extractable_from_stored_summary(self):
-        """The full pipeline: compress with LLM summary → _last_raw_summary →
+        """The full pipeline: compress with LLM summary -> _last_raw_summary ->
         extract facts."""
         c = _compressor()
         summary_text = (
@@ -232,55 +219,89 @@ class TestCompressStoresRawSummary:
         assert "port 8000" in facts[1]
 
 
-# ── E2E: compress_context → MemoryStore ──────────────────────────────────────
+# ── E2E: compress_context -> MemoryStore (via gate-aware memory_tool) ─────────
+
+
+def _summary_with_facts(*facts: str) -> str:
+    """Build a realistic compression summary with a Durable Facts section."""
+    numbered = "\n".join(
+        f"{i}. {fact}" for i, fact in enumerate(facts, start=1)
+    )
+    return (
+        f"## Goal\nTest session.\n\n"
+        f"## Durable Facts\n{numbered}\n\n"
+        f"## Active State\nbranch: main\n\n"
+        f"## Completed Actions\n1. ...\n"
+    )
 
 
 class TestCompressContextPersistsToMemory:
-    """Verify that the ``compress_context()`` orchestration function takes the
-    raw summary, extracts facts, and writes them to ``MemoryStore``."""
+    """Drive the real ``compress_context()`` orchestration function and verify
+    that durable facts are persisted through the gate-aware ``memory_tool()``
+    path."""
 
-    def test_facts_written_to_memory_store(self, tmp_path, monkeypatch):
-        """Full pipeline: mock compression + agent → facts land in MEMORY.md."""
+    def test_facts_persisted_via_compress_context(self, tmp_path, monkeypatch):
+        """End-to-end: compress_context() -> durable facts land in MEMORY.md."""
         monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
 
-        # Build a MemoryStore that mirrors what a real agent would have.
+        summary_text = _summary_with_facts(
+            "Deployment uses Docker Compose v2.",
+            "Logging goes to CloudWatch.",
+        )
+
         store = MemoryStore(memory_char_limit=2000)
         store.load_from_disk()
 
-        # Build a compressor whose compress() returns a summary with facts.
-        c = _compressor()
-        summary_text = (
-            "## Durable Facts\n"
-            "1. Deployment uses Docker Compose v2.\n"
-            "2. Logging goes to CloudWatch.\n"
-            "\n"
-            "## Active State\n"
-            "branch: main\n"
-            "## Completed Actions\n"
-            "1. ...\n"
-        )
-        # Set the raw summary as if compress() just finished.
-        c._last_raw_summary = summary_text
+        compressor = _compressor()
+        compressor._last_raw_summary = summary_text
 
-        # Build a minimal mock agent.
+        # Build enough messages to pass the minimum-count guard.
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "task"},
+        ]
+        for i in range(30):
+            messages.append({"role": "assistant", "content": f"work {i}"})
+            messages.append({"role": "user", "content": f"followup {i}"})
+
+        # Mock the agent just enough for compress_context() to reach the
+        # durable-facts persistence block without real DB / network / locks.
         agent = MagicMock()
+        agent.model = "test/model"
+        agent.platform = "cli"
+        agent.session_id = "test-sid"
+        agent.tools = []
         agent._memory_store = store
-        agent.context_compressor = c
         agent._memory_enabled = True
+        agent._memory_manager = None
+        agent.context_compressor = compressor
+        agent._user_profile_enabled = False
+        agent._compression_feasibility_checked = True
+        agent.log_prefix = ""
+        agent._cached_system_prompt = "cached system prompt"
 
-        # Simulate the durable-facts persistence block from compress_context().
-        # (This is the literal code path — exercised directly in the test so
-        # the logic under test is the production logic, not a reimplementation.)
-        from agent.context_compressor import extract_durable_facts_from_summary
+        # compress_context() calls context_compressor.compress() — return a
+        # shortened list so compression is considered to have made progress,
+        # which lets the function reach the durable-facts persistence block.
+        def _fake_compress(msgs, **kwargs):
+            return msgs[:1] + msgs[-3:]  # drop middle messages
 
-        _raw_summary = getattr(agent.context_compressor, "_last_raw_summary", None)
-        if _raw_summary:
-            _facts = extract_durable_facts_from_summary(_raw_summary)
-            if _facts:
-                _store = getattr(agent, "_memory_store", None)
-                if _store is not None:
-                    for _fact in _facts:
-                        _store.add("memory", _fact)
+        compressor.compress = _fake_compress
+
+        # Session DB lock — must succeed.
+        agent._session_db = MagicMock()
+        agent._session_db.try_acquire_compression_lock.return_value = True
+        agent._session_db.release_compression_lock = MagicMock()
+
+        from agent.conversation_compression import compress_context
+
+        compress_context(
+            agent,
+            messages,
+            system_message="sys",
+            approx_tokens=90_000,
+            force=True,
+        )
 
         # Verify facts landed on disk.
         mem_file = tmp_path / "MEMORY.md"
@@ -288,102 +309,99 @@ class TestCompressContextPersistsToMemory:
         content = mem_file.read_text()
         assert "Docker Compose v2" in content
         assert "CloudWatch" in content
-
-        # Verify store is also consistent.
         assert len(store.memory_entries) == 2
 
-    def test_no_facts_when_none_in_summary(self, tmp_path, monkeypatch):
-        """When the summary's Durable Facts section is ``None.``, nothing is
-        persisted."""
+    def test_none_section_no_write(self, tmp_path, monkeypatch):
+        """When the summary says 'None.', no facts are persisted."""
         monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+
+        summary_text = _summary_with_facts().replace(
+            "## Durable Facts\n",
+            "## Durable Facts\nNone.\n\n## Active State\n",
+        )
 
         store = MemoryStore()
         store.load_from_disk()
 
-        c = _compressor()
-        c._last_raw_summary = "## Durable Facts\nNone.\n\n## Active State\n..."
+        compressor = _compressor()
+        compressor._last_raw_summary = summary_text
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "task"},
+        ]
+        for i in range(30):
+            messages.append({"role": "assistant", "content": f"work {i}"})
+            messages.append({"role": "user", "content": f"followup {i}"})
 
         agent = MagicMock()
+        agent.model = "test/model"
+        agent.platform = "cli"
+        agent.session_id = "test-sid"
+        agent.tools = []
         agent._memory_store = store
-        agent.context_compressor = c
+        agent._memory_enabled = True
+        agent._memory_manager = None
+        agent.context_compressor = compressor
+        agent._user_profile_enabled = False
+        agent._compression_feasibility_checked = True
+        agent.log_prefix = ""
+        agent._cached_system_prompt = "cached system prompt"
 
-        from agent.context_compressor import extract_durable_facts_from_summary
+        compressor.compress = lambda msgs, **kwargs: msgs[:1] + msgs[-3:]
 
-        _raw_summary = getattr(agent.context_compressor, "_last_raw_summary", None)
-        if _raw_summary:
-            _facts = extract_durable_facts_from_summary(_raw_summary)
-            if _facts:
-                _store = getattr(agent, "_memory_store", None)
-                if _store is not None:
-                    for _fact in _facts:
-                        _store.add("memory", _fact)
+        agent._session_db = MagicMock()
+        agent._session_db.try_acquire_compression_lock.return_value = True
+        agent._session_db.release_compression_lock = MagicMock()
 
-        # MEMORY.md should not be created (no facts to write).
+        from agent.conversation_compression import compress_context
+
+        compress_context(
+            agent, messages, system_message="sys", approx_tokens=90_000, force=True,
+        )
+
+        # No MEMORY.md should exist (nothing to write).
         mem_file = tmp_path / "MEMORY.md"
         assert not mem_file.exists() or mem_file.read_text().strip() == ""
 
-    def test_no_store_no_crash(self):
-        """When agent has no _memory_store, the block is a no-op (no crash)."""
-        c = _compressor()
-        c._last_raw_summary = (
-            "## Durable Facts\n"
-            "1. A fact that won't be saved.\n"
-            "\n"
-            "## Active State\n"
-            "...\n"
-        )
-
-        agent = MagicMock()
-        agent._memory_store = None
-        agent.context_compressor = c
-
-        from agent.context_compressor import extract_durable_facts_from_summary
-
-        _raw_summary = getattr(agent.context_compressor, "_last_raw_summary", None)
-        if _raw_summary:
-            _facts = extract_durable_facts_from_summary(_raw_summary)
-            if _facts:
-                _store = getattr(agent, "_memory_store", None)
-                if _store is not None:
-                    for _fact in _facts:
-                        _store.add("memory", _fact)
-
-        # Shouldn't crash — that's the entire test.
-        assert True
-
-    def test_duplicate_fact_not_written_twice(self, tmp_path, monkeypatch):
-        """MemoryStore.add() rejects exact duplicates."""
+    def test_no_store_no_crash(self, tmp_path, monkeypatch):
+        """When agent has no _memory_store, the block is a no-op."""
         monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
 
-        store = MemoryStore()
-        store.load_from_disk()
-        store.add("memory", "Deployment uses Docker Compose v2.")
+        summary_text = _summary_with_facts("A fact that cannot be saved.")
 
-        c = _compressor()
-        c._last_raw_summary = (
-            "## Durable Facts\n"
-            "1. Deployment uses Docker Compose v2.\n"  # duplicate
-            "2. Logging via structured JSON.\n"  # new
-            "\n"
-            "## Active State\n"
-            "...\n"
-        )
+        compressor = _compressor()
+        compressor._last_raw_summary = summary_text
+
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "task"},
+        ]
+        for i in range(30):
+            messages.append({"role": "assistant", "content": f"work {i}"})
+            messages.append({"role": "user", "content": f"followup {i}"})
 
         agent = MagicMock()
-        agent._memory_store = store
-        agent.context_compressor = c
+        agent.model = "test/model"
+        agent.platform = "cli"
+        agent.session_id = "test-sid"
+        agent.tools = []
+        agent._memory_store = None
+        agent._memory_manager = None
+        agent.context_compressor = compressor
+        agent._compression_feasibility_checked = True
+        agent.log_prefix = ""
+        agent._cached_system_prompt = "cached system prompt"
 
-        from agent.context_compressor import extract_durable_facts_from_summary
+        compressor.compress = lambda msgs, **kwargs: msgs[:1] + msgs[-3:]
 
-        _raw_summary = getattr(agent.context_compressor, "_last_raw_summary", None)
-        if _raw_summary:
-            _facts = extract_durable_facts_from_summary(_raw_summary)
-            if _facts:
-                _store = getattr(agent, "_memory_store", None)
-                if _store is not None:
-                    for _fact in _facts:
-                        _store.add("memory", _fact)
+        agent._session_db = MagicMock()
+        agent._session_db.try_acquire_compression_lock.return_value = True
+        agent._session_db.release_compression_lock = MagicMock()
 
-        # Only the new fact should be persisted.
-        assert len(store.memory_entries) == 2  # original + new (one duplicate skipped)
-        assert any("structured JSON" in e for e in store.memory_entries)
+        from agent.conversation_compression import compress_context
+
+        # Must not raise.
+        compress_context(
+            agent, messages, system_message="sys", approx_tokens=90_000, force=True,
+        )


### PR DESCRIPTION
The compression summary template has a '## Durable Facts' section that the aux LLM fills in with 1-3 stable facts about the user or project.  Before this change those facts lived only in the compressed summary text and were lost when the session ended — the summarizer recognized them as durable, but nothing wrote them to persistent memory.

This closes the gap:

- extract_durable_facts_from_summary() parses the section from the raw summary text (handles numbered, bulleted, and None. cases).
- compress() stores the raw summary on _last_raw_summary so callers can inspect it without re-parsing the message list.
- compress_context() extracts facts after a successful compression and feeds them into MemoryStore.add('memory', fact) — dedup is handled by MemoryStore's existing exact-duplicate guard.

No new tools, config keys, or env vars.  The persistence is a best-effort side effect that degrades to a debug log on failure so it never blocks compression.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

