### PR TITLE
fix(tools): don't flag boundary-cut UTF-8 as binary in read_file (#76886)

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -673,3 +673,62 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+    def test_trailing_replacement_char_from_boundary_cut_not_flagged(self, tmp_path):
+        """#76886: `head -c 1000` can slice a multibyte char, and
+        errors="replace" turns the dangling tail into a single U+FFFD at the
+        *end* of the sample. That lone trailing artifact must not condemn a
+        valid UTF-8 file as binary."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # 999 ASCII bytes + the first byte of 'ç' (0xC3) -> one trailing U+FFFD.
+        boundary_sample = ("a" * 999) + "�"
+        assert ops._is_likely_binary("notes.md", boundary_sample) is False
+
+    def test_interior_replacement_char_still_flagged(self, tmp_path):
+        """A trailing-only exemption must not weaken detection of genuinely
+        non-UTF-8 content, whose replacement chars land in the interior."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # U+FFFD before the end (even with a trailing one too) => still binary.
+        assert ops._is_likely_binary("notes.txt", "ab�cd�") is True
+
+    def test_read_file_valid_utf8_across_1000_byte_boundary(self, tmp_path):
+        """End-to-end repro of #76886: a valid UTF-8 file whose non-ASCII
+        character straddles byte 1000 must read as text, not be rejected as
+        binary. Exercises the real `head -c 1000` sample path.
+
+        The env decodes stdout with errors="replace" (as the production
+        terminal backend does, tools/environments/local.py), so the sliced
+        multibyte tail surfaces as a single trailing U+FFFD — the artifact
+        this fix must tolerate."""
+        # 'ç' (0xC3 0xA7) starts at byte 1000: byte 1000 is 0xC3, so the
+        # `head -c 1000` sample ends mid-character.
+        fails = tmp_path / "fails.md"
+        fails.write_bytes(b"a" * 999 + "ç\nx\n".encode("utf-8"))
+
+        env = MagicMock()
+        env.cwd = str(tmp_path)
+
+        def execute(command, **kwargs):
+            completed = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                input=kwargs.get("stdin_data"),
+            )
+            # Mirror the production backend: decode bytes with
+            # errors="replace" so a boundary-sliced multibyte char does not
+            # raise, exactly as tools/environments/local.py does.
+            return {
+                "output": completed.stdout.decode("utf-8", errors="replace"),
+                "returncode": completed.returncode,
+            }
+
+        env.execute = execute
+
+        ops = ShellFileOperations(env)
+        result = ops.read_file(str(fails))
+
+        assert result.is_binary is False, "boundary-cut UTF-8 wrongly flagged binary"
+        assert result.error is None
+        assert "ç" in (result.content or "")
+

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -893,7 +893,19 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            #
+            # Exception (#76886): the sample is taken with `head -c 1000`, so a
+            # file longer than the sample can be sliced in the middle of a
+            # multibyte character. Python's errors="replace" collapses that
+            # dangling, incomplete-but-valid trailing sequence into exactly one
+            # U+FFFD at the very end of the string \u2014 an artifact of the cut, not
+            # of the file's bytes. Ignore a single *trailing* U+FFFD so valid
+            # UTF-8 (Turkish, CJK, emoji \u2026) still reads when a non-ASCII char
+            # straddles the 1000-byte boundary; any U+FFFD in the interior
+            # still marks genuinely non-UTF-8 content.
+            sample = content_sample[:1000]
+            interior = sample[:-1] if sample.endswith("\ufffd") else sample
+            if "\ufffd" in interior:
                 return True
             non_printable = sum(1 for c in content_sample[:1000]
                                if ord(c) < 32 and c not in '\n\r\t')


### PR DESCRIPTION
## What does this PR do?

`read_file` samples the first 1000 bytes with `head -c 1000`, and the terminal environment decodes stdout with `errors="replace"`. When byte 1000 lands in the middle of a multibyte UTF-8 character, that dangling (incomplete-but-valid) tail decodes to a single **U+FFFD at the very end of the sample** — an artifact of where the sample was cut, not a byte that exists in the file. The `_is_likely_binary` U+FFFD guard added in 0.19.1 then rejected the whole file with *"Binary file - cannot display as text"*.

The result: valid UTF-8 files (Turkish `ç/ğ/ı/ö/ş/ü`, CJK, emoji, …) that happen to have a non-ASCII character straddling the 1000-byte boundary stopped opening after the 0.19.1 update. `patch` on the same files works fine, so the classification isn't shared — only `read` refuses them.

**Fix:** ignore a *single trailing* U+FFFD. Only `head -c` truncation can place one there, and `errors="replace"` collapses a cut multibyte sequence into exactly one replacement char (verified across 2-, 3-, and 4-byte lead bytes). Any U+FFFD in the **interior** of the sample still marks genuinely non-UTF-8 content, so the read→edit→write mojibake guard the original check was protecting stays intact.

## Related Issue

Fixes #76886

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations.py` — `_is_likely_binary`: strip one trailing U+FFFD before scanning the sample for replacement chars; interior U+FFFD still returns binary.
- `tests/tools/test_file_operations.py` — added regression coverage under `TestReadNonUtf8IsBinary`:
  - `test_trailing_replacement_char_from_boundary_cut_not_flagged` (trailing artifact → text)
  - `test_interior_replacement_char_still_flagged` (interior U+FFFD → binary, guard preserved)
  - `test_read_file_valid_utf8_across_1000_byte_boundary` (end-to-end: reads a file whose `ç` starts at byte 1000 through the real `head -c 1000` path, env decoding with `errors="replace"` as production does)

## How to Test

Repro from the issue (no dependencies):

```sh
printf 'a%.0s' $(seq 999) > fails.md && printf '\303\247\nx\n' >> fails.md   # 'ç' starts at byte 1000
```

- Before: `read_file fails.md` → `is_binary: true` ("Binary file - cannot display as text").
- After: reads normally, content includes `ç`.

Automated:

```sh
scripts/run_tests.sh tests/tools/test_file_operations.py -q
```

I confirmed the two new boundary tests fail on `main` (reproducing the bug) and pass with this change, while the existing `test_replacement_char_sample_flagged_binary` (interior U+FFFD) stays green. Full `tests/tools/test_file_operations.py` + `test_file_operations_edge_cases.py`: 69 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tools):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (the open PRs touching this file — #43064/#43124 — are about treating PDFs as binary, a separate concern; none address the boundary-cut U+FFFD false positive)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] Documentation — N/A (behavior restored to pre-0.19.1; no doc/config/schema surface changed)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — the fix is pure string logic on the decoded sample; no platform-specific paths
- [x] Tool descriptions/schemas — N/A
