### PR TITLE
fix(agent): probe container honors docker_network egress control (#76906)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1084,6 +1084,13 @@ def _probe_remote_backend(env_type: str) -> str | None:
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                 "docker_extra_args": config.get("docker_extra_args", []),
                 "docker_shm_size": config.get("docker_shm_size", "1g"),
+                # #76906: the probe must honor the operator's egress control.
+                # Omitting this let docker_network fall through to the True
+                # default in _create_environment, so the backend-probe
+                # container came up networked (on `bridge`) even under
+                # docker_network: false / TERMINAL_DOCKER_NETWORK=false —
+                # while carrying the same docker_volumes as the agent shell.
+                "docker_network": config.get("docker_network", True),
                 "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
                 "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
             }

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -767,6 +767,46 @@ class TestEnvironmentHints:
         assert "root" in line
 
 
+    def test_probe_remote_backend_honors_docker_network_false(self, monkeypatch):
+        """Regression for #76906: the backend probe built its own
+        ``container_config`` and omitted ``docker_network``, so the key fell
+        through to the ``True`` default in ``_create_environment`` and the
+        ``prompt-backend-probe`` container came up networked even when the
+        operator set ``docker_network: false`` / ``TERMINAL_DOCKER_NETWORK=false``
+        as an egress control — while inheriting the agent's ``docker_volumes``.
+        The probe must forward the operator's setting."""
+        import agent.prompt_builder as _pb
+
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_DOCKER_NETWORK", "false")
+        _pb._clear_backend_probe_cache()
+
+        captured = {}
+
+        class _FakeEnv:
+            def execute(self, cmd, timeout=None):
+                return {
+                    "returncode": 0,
+                    "output": "os=Linux\nkernel=6.8.0\nhome=/root\ncwd=/workspace\nuser=root\n",
+                }
+
+        def _fake_create_environment(*, env_type, container_config=None, **kwargs):
+            captured["container_config"] = container_config
+            return _FakeEnv()
+
+        import tools.terminal_tool as _tt
+        monkeypatch.setattr(_tt, "_create_environment", _fake_create_environment)
+
+        _pb._probe_remote_backend("docker")
+
+        cc = captured.get("container_config")
+        assert cc is not None, "probe must pass a container_config for docker"
+        assert cc.get("docker_network") is False, (
+            "probe container_config must forward docker_network so the "
+            "operator's egress control applies to the probe container too"
+        )
+
+
     def test_environment_hint_from_env_var_is_appended(self, monkeypatch):
         """HERMES_ENVIRONMENT_HINT lets an embedder describe the runtime env."""
         import agent.prompt_builder as _pb


### PR DESCRIPTION
## What does this PR do?

`_probe_remote_backend()` in `agent/prompt_builder.py` runs a tiny introspection command inside the configured terminal backend to describe it in the system prompt. For container backends it assembles its **own** `container_config` dict — but it omits `docker_network`. That key then falls through to the `True` default in `_create_environment`, so the `prompt-backend-probe` container comes up on `bridge` **even when the operator has set `docker_network: false` / `TERMINAL_DOCKER_NETWORK=false`** as an egress control.

The agent's own shell container is air-gapped correctly (the live terminal path in `tools/terminal_tool.py` passes `docker_network`); this second probe container is not, and it inherits the same `docker_volumes` — so whatever the operator mounts for the agent (document trees, credential files) is present in a container with unrestricted egress. The setting is silently half-applied.

**Fix:** forward `config.get("docker_network", True)` into the probe's `container_config`, exactly as the live terminal path already does. One-line behavioral change; the probe now honors the same egress toggle as the agent shell.

## Related Issue

Fixes #76906

## Type of Change

- [x] 🔒 Security fix

(Bounded today — `_resolve_container_task_id` collapses everything to `default` and the probe runs a fixed `printf`/`uname` with no untrusted input — but it defeats an operator's egress control and mounts the same volumes in a networked container, so it's a real hardening gap.)

## Changes Made

- `agent/prompt_builder.py` — `_probe_remote_backend`: add `"docker_network": config.get("docker_network", True)` to the probe's `container_config`, mirroring `tools/terminal_tool.py`.
- `tests/agent/test_prompt_builder.py` — `test_probe_remote_backend_honors_docker_network_false`: with `TERMINAL_DOCKER_NETWORK=false`, patch the real `_create_environment` and assert the probe's `container_config` carries `docker_network=False`.

## How to Test

1. Configure a docker terminal backend with `docker_network: false` (or `TERMINAL_DOCKER_NETWORK=false`) and a `docker_volumes` mount.
2. Trigger the backend probe (start a session so the system prompt is built).
3. Before: `docker ps` shows two containers; `docker inspect <probe> --format '{{.HostConfig.NetworkMode}}'` is `bridge` (`default`). After: the probe container's `NetworkMode` is `none`, matching the agent shell.

Automated:

```sh
scripts/run_tests.sh tests/agent/test_prompt_builder.py -q
```

I confirmed the new test fails on `main` (probe `container_config` has no `docker_network`) and passes with this change. Full `tests/agent/test_prompt_builder.py`: 56 passed, 1 skipped.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (no open PR addresses the probe's missing `docker_network`)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] Documentation — N/A (no new config key; `docker_network` already documented, this makes the probe honor it)
- [x] `cli-config.yaml.example` — N/A (no new/changed keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — Docker-backend config only; no OS-specific code paths
- [x] Tool descriptions/schemas — N/A
