### PR TITLE
chore: contributor email mapping for sparkeros

### DIFF
--- a/contributors/emails/rkt.2@hotmail.com
+++ b/contributors/emails/rkt.2@hotmail.com
@@ -1,0 +1,1 @@
+sparkeros


### PR DESCRIPTION
Maps rkt.2@hotmail.com -> sparkeros for release attribution. Needed by the #25387 salvage.