### PR TITLE
chore: add contributor email mapping for JeffStone69

### DIFF
--- a/contributors/emails/116476090+JeffStone69@users.noreply.github.com
+++ b/contributors/emails/116476090+JeffStone69@users.noreply.github.com
@@ -1,0 +1,1 @@
+JeffStone69


### PR DESCRIPTION
Attribution mapping for @JeffStone69, needed by the #66016 salvage.