### PR TITLE
fix(model-switch): dedup custom_providers entry that mirrors a providers.<slug> block

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1123,11 +1123,13 @@ def _configured_provider_matches(
             # ``providers.<slug>`` block) duplicates its parent provider.
             # Skip it when the parent slug already matched so the model name
             # is not reported as declared by both ``foo`` and ``custom:foo``.
+            # Compare against a normalized (lowercased) key set so mixed-case
+            # provider slugs (e.g. ``providers: {OAI: ...}``) are caught.
             provider_key = entry.get("provider_key")
             if (
                 isinstance(provider_key, str)
                 and provider_key.strip()
-                and provider_key.strip().lower() in matches
+                and provider_key.strip().lower() in {k.lower() for k in matches}
             ):
                 continue
             for key in ("models", "model", "default_model"):

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1118,6 +1118,18 @@ def _configured_provider_matches(
             slug = f"custom:{name}"
             if slug in matches:
                 continue
+            # Dedup with user_providers entries: a custom_providers entry
+            # that has a ``provider_key`` (i.e. was converted from a new-style
+            # ``providers.<slug>`` block) duplicates its parent provider.
+            # Skip it when the parent slug already matched so the model name
+            # is not reported as declared by both ``foo`` and ``custom:foo``.
+            provider_key = entry.get("provider_key")
+            if (
+                isinstance(provider_key, str)
+                and provider_key.strip()
+                and provider_key.strip().lower() in matches
+            ):
+                continue
             for key in ("models", "model", "default_model"):
                 hit = _match(entry.get(key))
                 if hit:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -841,11 +841,18 @@ def _configured_provider_matches(
     target = model_name.strip().lower()
 
     candidates: list[tuple[str, dict]] = []
+    user_slugs_lower = set()
     if isinstance(user_providers, dict):
         candidates += [(slug, cfg) for slug, cfg in user_providers.items()
                        if isinstance(slug, str) and isinstance(cfg, dict)]
+        user_slugs_lower = {slug.lower() for slug, _ in candidates}
+    # A new-style providers.<slug> entry mirrored into custom_providers (via
+    # get_compatible_custom_providers) carries provider_key == slug; skip the
+    # mirror so one model isn't reported as declared twice (custom:gpt + gpt).
+    # Compare against a normalized (lowercased) set to catch mixed-case slugs.
     candidates += [(f"custom:{e['name']}", e) for e in _custom_entries(custom_providers)
-                   if isinstance(e.get("name"), str) and e["name"].strip()]
+                   if isinstance(e.get("name"), str) and e["name"].strip()
+                   and str(e.get("provider_key") or "").strip().lower() not in user_slugs_lower]
 
     matches: dict[str, str] = {}
     for slug, cfg in candidates:

--- a/tests/hermes_cli/test_model_switch_configured_provider_routing.py
+++ b/tests/hermes_cli/test_model_switch_configured_provider_routing.py
@@ -21,7 +21,7 @@ Hermetic: the model-resolution chain is fully mocked (no network), mirroring
 
 from unittest.mock import patch
 
-from hermes_cli.model_switch import switch_model
+from hermes_cli.model_switch import _configured_provider_matches, switch_model
 
 _ACCEPTED = {"accepted": True, "persist": True, "recognized": True, "message": None}
 _REJECTED = {"accepted": False, "persist": False, "recognized": False, "message": "not found"}
@@ -82,6 +82,43 @@ def _run_switch(
         )
 
 
+
+
+def test_compatibility_view_deduplicates_mirrored_provider():
+    """A providers.<slug> entry mirrored into custom_providers is one match."""
+    from hermes_cli.config import get_compatible_custom_providers
+
+    user_providers = {
+        "OAI": {
+            "name": "OpenAI",
+            "api": "https://api.example.com/v1",
+            "models": ["deepseek-v4-flash"],
+        }
+    }
+    compatible_custom = get_compatible_custom_providers({"providers": user_providers})
+
+    assert _configured_provider_matches(
+        "deepseek-v4-flash", user_providers, compatible_custom
+    ) == {"OAI": "deepseek-v4-flash"}
+
+
+def test_distinct_custom_provider_is_not_hidden_by_deduplication():
+    """Only a custom entry mirroring a matched user provider is skipped."""
+    user_providers = {"oai": {"models": ["deepseek-v4-flash"]}}
+    custom_providers = [
+        {
+            "name": "relay",
+            "provider_key": "different-provider",
+            "models": ["deepseek-v4-flash"],
+        }
+    ]
+
+    assert _configured_provider_matches(
+        "deepseek-v4-flash", user_providers, custom_providers
+    ) == {
+        "oai": "deepseek-v4-flash",
+        "custom:relay": "deepseek-v4-flash",
+    }
 
 
 def test_default_model_only_declaration_routes():

--- a/tests/hermes_cli/test_model_switch_configured_provider_routing.py
+++ b/tests/hermes_cli/test_model_switch_configured_provider_routing.py
@@ -122,3 +122,69 @@ def test_xai_oauth_soft_accept_preserved_when_no_match():
     )
     assert result.success is True, result.error_message
     assert result.target_provider == "xai-oauth"
+
+
+def test_compatibility_dedup_prevents_duplicate_match():
+    """A custom_providers entry that carries a ``provider_key`` (i.e. was
+    converted from a new-style ``providers.<slug>`` block by
+    ``get_compatible_custom_providers()``) must not cause the same model
+    to be reported as declared by both the bare slug *and* the
+    ``custom:<slug>`` form."""
+    user_providers = {
+        "openai-codex": {
+            "name": "OpenAI Codex",
+            "base_url": "http://codex/v1",
+            "models": ["gpt-5.9-codex-hidden"],
+        }
+    }
+    # This is what get_compatible_custom_providers() produces:
+    # a custom_providers entry with ``provider_key`` pointing back to the
+    # original slug.  Without the dedup the model would match both
+    # ``openai-codex`` and ``custom:openai-codex``.
+    custom_providers = [
+        {
+            "name": "openai-codex",
+            "provider_key": "openai-codex",
+            "base_url": "http://codex/v1",
+            "models": ["gpt-5.9-codex-hidden"],
+        }
+    ]
+    result = _run_switch(
+        raw_input="gpt-5.9-codex-hidden",
+        current_provider="claude-codex",
+        current_model="claude-sonnet-4",
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+    )
+    assert result.success is True, result.error_message
+    assert result.target_provider == "openai-codex"
+
+
+def test_compatibility_dedup_with_mixed_case_slug():
+    """Mixed-case provider slugs (e.g. ``providers: {OAI: ...}``) must
+    also be deduplicated.  ``OAI`` and ``custom:OAI`` should not both
+    appear as matches."""
+    user_providers = {
+        "OAI": {
+            "name": "OpenAI",
+            "base_url": "http://oai/v1",
+            "models": ["gpt-5.9-codex-hidden"],
+        }
+    }
+    custom_providers = [
+        {
+            "name": "OAI",
+            "provider_key": "OAI",
+            "base_url": "http://oai/v1",
+            "models": ["gpt-5.9-codex-hidden"],
+        }
+    ]
+    result = _run_switch(
+        raw_input="gpt-5.9-codex-hidden",
+        current_provider="claude-codex",
+        current_model="claude-sonnet-4",
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+    )
+    assert result.success is True, result.error_message
+    assert result.target_provider == "OAI"


### PR DESCRIPTION
Closes #76928

## Problem

When a new-style `providers.<slug>` block is converted to the legacy `custom_providers` list format by `get_compatible_custom_providers()`, the resulting entry carries a `provider_key` matching the original slug. `_configured_provider_matches()` then finds **two** matches for the same model:

1. `oai` — from the `user_providers` dict (the `providers.<slug>` block)
2. `custom:oai` — from the converted `custom_providers` entry

Since the slugs differ, the existing `slug in matches` dedup never fires, and the function reports:

```
'deepseek-v4-flash' is declared by multiple configured providers (custom:oai, oai)
```

## Fix

Skip a `custom_providers` entry in the matcher when its `provider_key` already has a match in `user_providers`, since they represent the same provider.

## Test

Before the fix, `/_configured_provider_matches('deepseek-v4-flash', providers, compatible_custom)` returns:

```
{'oai': 'deepseek-v4-flash', 'custom:oai': 'deepseek-v4-flash'}
```

After the fix:

```
{'oai': 'deepseek-v4-flash'}
```

And `switch_model('deepseek-v4-flash', ...)` no longer fails with the duplicate error.