### PR TITLE
fix(tools): keep invalid UTF-8 boundaries binary

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -682,6 +682,24 @@ class TestReadNonUtf8IsBinary:
 class TestReadUtf8SampleBoundary:
     """A byte sample must not split a valid UTF-8 character."""
 
+    @pytest.mark.parametrize("reader", ["read_file", "read_file_raw"])
+    def test_read_paths_accept_dense_cjk_at_sample_boundary(
+        self, tmp_path, reader
+    ):
+        """Dense CJK text remains readable when the 1000-byte cut splits a glyph."""
+        ops = ShellFileOperations(
+            make_real_subprocess_env(str(tmp_path), errors="replace")
+        )
+        path = tmp_path / "cjk-boundary.md"
+        prefix = "界" * 333  # 999 UTF-8 bytes: the next glyph starts at byte 1000.
+        path.write_bytes((prefix + "語\ntext\n").encode("utf-8"))
+
+        result = getattr(ops, reader)(str(path))
+
+        assert result.is_binary is False
+        assert result.error is None
+        assert "語" in result.content
+
     def test_read_file_accepts_multibyte_character_at_sample_boundary(self, tmp_path):
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path), errors="replace"))
         path = tmp_path / "boundary.md"

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -723,3 +723,45 @@ class TestReadUtf8SampleBoundary:
 
         assert result.is_binary is True
         assert result.error is not None
+
+    def test_read_file_rejects_invalid_byte_at_extended_sample_boundary(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path), errors="replace"))
+        path = tmp_path / "invalid-at-extended-boundary.md"
+        path.write_bytes(b"a" * 999 + "ç".encode("utf-8") + b"ab\xfftail\n")
+
+        result = ops.read_file(str(path))
+
+        assert result.is_binary is True
+        assert result.error is not None
+
+    def test_read_file_raw_rejects_invalid_byte_at_extended_sample_boundary(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path), errors="replace"))
+        path = tmp_path / "invalid-at-extended-boundary.md"
+        path.write_bytes(b"a" * 999 + "ç".encode("utf-8") + b"ab\xfftail\n")
+
+        result = ops.read_file_raw(str(path))
+
+        assert result.is_binary is True
+        assert result.error is not None
+
+    def test_read_file_accepts_valid_character_split_by_extended_sample_boundary(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path), errors="replace"))
+        path = tmp_path / "extended-boundary.md"
+        path.write_bytes(b"a" * 999 + "🧪é\ntext\n".encode("utf-8"))
+
+        result = ops.read_file(str(path))
+
+        assert result.is_binary is False
+        assert result.error is None
+        assert "🧪é" in result.content
+
+    def test_read_file_raw_accepts_valid_character_split_by_extended_sample_boundary(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path), errors="replace"))
+        path = tmp_path / "extended-boundary.md"
+        path.write_bytes(b"a" * 999 + "🧪é\ntext\n".encode("utf-8"))
+
+        result = ops.read_file_raw(str(path))
+
+        assert result.is_binary is False
+        assert result.error is None
+        assert "🧪é" in result.content

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -242,7 +242,9 @@ def file_ops(mock_env):
     return ShellFileOperations(mock_env)
 
 
-def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMock:
+def make_real_subprocess_env(
+    cwd: str, include_stderr: bool = False, errors: str = "strict"
+) -> MagicMock:
     """Mock env whose execute() runs the command in a real subprocess.
 
     For tests that need the generated shell scripts to actually run
@@ -250,6 +252,7 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
     intercepted by a bare MagicMock.  ``include_stderr`` folds stderr
     into ``output`` for tests that surface shell error text; leave it
     off for tests that parse structured stdout (e.g. find results).
+    ``errors`` mirrors the terminal backend's subprocess decoding policy.
     """
     env = MagicMock()
     env.cwd = cwd
@@ -261,6 +264,7 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
             text=True,
             capture_output=True,
             input=kwargs.get("stdin_data"),
+            errors=errors,
         )
         output = completed.stdout
         if include_stderr:
@@ -673,3 +677,49 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+
+class TestReadUtf8SampleBoundary:
+    """A byte sample must not split a valid UTF-8 character."""
+
+    def test_read_file_accepts_multibyte_character_at_sample_boundary(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path), errors="replace"))
+        path = tmp_path / "boundary.md"
+        path.write_bytes(b"a" * 999 + "ç\ntext\n".encode("utf-8"))
+
+        result = ops.read_file(str(path))
+
+        assert result.is_binary is False
+        assert result.error is None
+        assert "ç" in result.content
+
+    def test_read_file_raw_accepts_multibyte_character_at_sample_boundary(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path), errors="replace"))
+        path = tmp_path / "boundary.md"
+        path.write_bytes(b"a" * 999 + "ç\ntext\n".encode("utf-8"))
+
+        result = ops.read_file_raw(str(path))
+
+        assert result.is_binary is False
+        assert result.error is None
+        assert "ç" in result.content
+
+    def test_invalid_bytes_at_sample_boundary_remain_binary(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path), errors="replace"))
+        path = tmp_path / "invalid.bin"
+        path.write_bytes(b"a" * 999 + b"\xff\n")
+
+        result = ops.read_file(str(path))
+
+        assert result.is_binary is True
+        assert result.error is not None
+
+    def test_invalid_boundary_byte_is_not_hidden_by_a_following_split_character(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path), errors="replace"))
+        path = tmp_path / "invalid-with-boundary.md"
+        path.write_bytes(b"a" * 999 + b"\xff" + "🧪\ntext\n".encode("utf-8"))
+
+        result = ops.read_file(str(path))
+
+        assert result.is_binary is True
+        assert result.error is not None

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -887,6 +887,40 @@ class ShellFileOperations(FileOperations):
             self._command_cache[cmd] = result.stdout.strip() == 'yes'
         return self._command_cache[cmd]
     
+    def _binary_sample(self, path: str, file_size: int) -> str:
+        """Return a UTF-8-safe sample for binary detection.
+
+        Terminal backends decode command output with ``errors="replace"``.
+        A byte sample that ends halfway through a valid multibyte character
+        therefore produces a trailing U+FFFD even though the file is valid
+        UTF-8. Only extend samples with that exact boundary signal. Any
+        replacement character that remains inside the extended sample still
+        represents undecodable input and remains fail-closed.
+        """
+        sample_limit = 1000
+        sample_cmd = f"head -c {sample_limit} {self._escape_shell_arg(path)} 2>/dev/null"
+        sample_result = self._exec(sample_cmd)
+        sample = _strip_terminal_fence_leaks(sample_result.stdout)
+
+        if not sample.endswith("\ufffd") or file_size <= sample_limit:
+            return sample
+
+        extended_limit = sample_limit + 4
+        extended_result = self._exec(
+            f"head -c {extended_limit} {self._escape_shell_arg(path)} 2>/dev/null"
+        )
+        extended = _strip_terminal_fence_leaks(extended_result.stdout)
+        if not extended.endswith("\ufffd"):
+            return extended
+
+        # The extended probe can itself end in a newly split character. Do
+        # not let that second boundary hide an undecodable replacement from
+        # the original 1000-byte window. If the file ends within the probe,
+        # retain the replacement: it is truncated/invalid file content.
+        if file_size <= extended_limit or extended.count("\ufffd") != 1:
+            return extended
+        return extended[:-1]
+
     def _is_likely_binary(self, path: str, content_sample: str = None) -> bool:
         """
         Check if a file is likely binary.
@@ -1194,9 +1228,7 @@ class ShellFileOperations(FileOperations):
             )
         
         # Read a sample to check for binary content
-        sample_cmd = f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null"
-        sample_result = self._exec(sample_cmd)
-        sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
+        sample_output = self._binary_sample(path, file_size)
         
         if self._is_likely_binary(path, sample_output):
             return ReadResult(
@@ -1312,8 +1344,7 @@ class ShellFileOperations(FileOperations):
             file_size = 0
         if self._is_image(path):
             return ReadResult(is_image=True, is_binary=True, file_size=file_size)
-        sample_result = self._exec(f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null")
-        sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
+        sample_output = self._binary_sample(path, file_size)
         if self._is_likely_binary(path, sample_output):
             return ReadResult(
                 is_binary=True, file_size=file_size,

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -886,6 +886,39 @@ class ShellFileOperations(FileOperations):
             result = self._exec(f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'")
             self._command_cache[cmd] = result.stdout.strip() == 'yes'
         return self._command_cache[cmd]
+
+    def _sample_ends_with_incomplete_utf8(self, path: str, sample_limit: int) -> bool:
+        """Prove that a raw sample ends with an incomplete valid UTF-8 sequence.
+
+        The terminal stream may replace undecodable bytes before this class
+        sees them, so the decoded U+FFFD at the sample boundary is ambiguous.
+        ``od`` keeps this probe bounded and emits ASCII hex, allowing strict
+        decoding of the original bytes without sending binary data through
+        the terminal stream. If the probe is unavailable or malformed, fail
+        closed and leave the replacement character intact.
+        """
+        if not self._has_command("od"):
+            return False
+
+        raw_result = self._exec(
+            f"od -An -v -tx1 -N {sample_limit} "
+            f"{self._escape_shell_arg(path)} 2>/dev/null"
+        )
+        if raw_result.exit_code != 0:
+            return False
+
+        try:
+            raw_sample = bytes.fromhex(raw_result.stdout)
+        except ValueError:
+            return False
+        if len(raw_sample) != sample_limit:
+            return False
+
+        try:
+            raw_sample.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            return exc.reason == "unexpected end of data" and exc.end == len(raw_sample)
+        return False
     
     def _binary_sample(self, path: str, file_size: int) -> str:
         """Return a UTF-8-safe sample for binary detection.
@@ -916,9 +949,16 @@ class ShellFileOperations(FileOperations):
         # The extended probe can itself end in a newly split character. Do
         # not let that second boundary hide an undecodable replacement from
         # the original 1000-byte window. If the file ends within the probe,
-        # retain the replacement: it is truncated/invalid file content.
-        if file_size <= extended_limit or extended.count("\ufffd") != 1:
-            return extended
+        # retain the replacement: it is truncated/invalid file content. A
+        # raw-byte probe is required before removing any replacement; a real
+        # invalid byte at this boundary must remain fail-closed. Return the
+        # original sample on an unproven path so its boundary U+FFFD remains
+        # inside the 1000-character binary-detection window.
+        if (
+            file_size <= extended_limit
+            or not self._sample_ends_with_incomplete_utf8(path, extended_limit)
+        ):
+            return sample
         return extended[:-1]
 
     def _is_likely_binary(self, path: str, content_sample: str = None) -> bool:


### PR DESCRIPTION
## What does this PR do?

`read_file` and `read_file_raw` sample the first 1000 bytes through a terminal stream decoded with `errors="replace"`. When that boundary splits a valid UTF-8 character, the lossy sample contains U+FFFD and the file is incorrectly rejected as binary. This is reproducible with ordinary UTF-8 notes containing Turkish, CJK, or other multibyte text.

The shared binary-detection sampler now performs a small boundary-only extension when the first sample ends with U+FFFD. It accepts valid UTF-8 at the boundary only after a bounded raw-byte probe proves that the replacement is an incomplete sequence; genuine undecodable bytes and truncated content remain fail-closed.

Two contemporaneous direct fixes remain open as [#76924](https://github.com/NousResearch/hermes-agent/pull/76924) and [#76925](https://github.com/NousResearch/hermes-agent/pull/76925); the later duplicate [#81711](https://github.com/NousResearch/hermes-agent/pull/81711) was closed in favor of this PR. This branch is materially stronger for the shared backend surface: it keeps the existing shell abstraction, performs one bounded optional `od` probe only for the boundary signal, fails closed when that probe is unavailable, and tests the adversarial case where a real invalid byte sits exactly at the extended boundary. That guard is absent from #76925's unconditional trailing-character exemption, while #76924 pays for repeated raw-byte shell probes instead of this single bounded validation.

## Related Issue

Fixes #76886; fixes #80308

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Regression tests included with the bug fix

## Changes Made

- `tools/file_operations.py`: centralize the 1000-byte binary sample, retry only when the decoded sample ends at a possible UTF-8 boundary, strictly validate the bounded raw bytes before removing a replacement, and retain the original boundary signal on every unproven path.
- `tests/tools/test_file_operations.py`: exercise paginated and raw reads with valid multibyte characters at the initial and extended boundaries, add a dense CJK boundary regression for both public paths, and verify invalid bytes at both boundaries remain blocked.

## How to Test

1. On the selected base (`4983c576b`), a real `errors="replace"` subprocess probe classified 999 ASCII bytes followed by a valid UTF-8 `ç` as `is_binary=True`.
2. `scripts/run_tests.sh tests/tools/test_file_operations.py -q` -> 56 passed.
3. `.venv/bin/ruff check tools/file_operations.py tests/tools/test_file_operations.py` -> passed.
4. Local final head `9179af050` is rebased onto current `origin/main` `3d7dda4cf`; the canonical changed-file gate passes with 56 tests, Ruff, `uv lock --check`, and `git diff --check`. Existing repository-wide ty diagnostics remain advisory only.
5. A post-fix real subprocess probe accepted both paginated and raw reads, while invalid `0xff` bytes at the initial and extended sample boundaries remained binary for both public read paths.

## Checklist

### Code

- [x] Read the current Contributing Guide and project policy files.
- [x] Commit message follows Conventional Commits (`fix(tools): ...`).
- [x] Searched and reviewed semantic PR candidates; PDF-only and unrelated voice-stack PRs are recorded as non-competing in the worklog.
- [x] The branch contains only the two files required for this fix.
- [x] Ran the focused file-operations suite and all canonical local blocking gates; release verification passed before publication.
- [x] Added regression tests for both public read paths and for fail-closed invalid bytes.
- [x] Tested on macOS arm64 with Python 3.11.15.

### Documentation & Housekeeping

- [x] No README or standalone documentation change is needed; this is an internal sampling correction.
- [x] No configuration keys, schemas, or dependencies were added or changed.
- [x] No architecture or workflow policy changed.
- [x] Considered cross-platform terminal decoding: the fix uses the existing shell sampling path, invokes one bounded optional raw-byte probe only on the replacement-character boundary signal, and falls back fail-closed when `od` is unavailable or cannot prove the boundary.
- [x] No tool descriptions or generated schemas changed.