### PR TITLE
fix(gateway): recover final delivery and bound state DB fds

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -219,17 +219,42 @@ def mark_delivered(obligation_id: str) -> None:
     _update_state(obligation_id, "delivered")
 
 
-def mark_failed(obligation_id: str, error: str = "") -> None:
-    _update_state(obligation_id, "failed", error=error)
+def mark_failed(
+    obligation_id: str,
+    error: str = "",
+    *,
+    recoverable: bool = False,
+) -> None:
+    _update_state(
+        obligation_id,
+        "failed",
+        error=error,
+        release_owner=recoverable,
+    )
 
 
-def _update_state(obligation_id: str, state: str, error: str = "") -> None:
+def _update_state(
+    obligation_id: str,
+    state: str,
+    error: str = "",
+    *,
+    release_owner: bool = False,
+) -> None:
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
             """UPDATE delivery_obligations
-               SET state=?, updated_at=?, last_error=?
+               SET state=?, updated_at=?, last_error=?,
+                   owner_pid=CASE WHEN ? THEN NULL ELSE owner_pid END,
+                   owner_started_at=CASE WHEN ? THEN NULL ELSE owner_started_at END
                WHERE obligation_id=?""",
-            (state, time.time(), error[:500] if error else None, obligation_id),
+            (
+                state,
+                time.time(),
+                error[:500] if error else None,
+                release_owner,
+                release_owner,
+                obligation_id,
+            ),
         )
 
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2509,6 +2509,11 @@ _RETRYABLE_ERROR_PATTERNS = (
     "connectionreset",
     "connectionrefused",
     "connecttimeout",
+    "cannot connect to host",
+    "nodename nor servname",
+    "name or service not known",
+    "temporary failure in name resolution",
+    "getaddrinfo failed",
     "network",
     "broken pipe",
     "remotedisconnected",
@@ -4959,6 +4964,20 @@ class BasePlatformAdapter(ABC):
         return any(pat in lowered for pat in _RETRYABLE_ERROR_PATTERNS)
 
     @staticmethod
+    def _is_reconnectable_delivery_failure(result: "SendResult") -> bool:
+        """Return True only for transport failures a reconnect can repair."""
+        error = str(getattr(result, "error", "") or "")
+        return BasePlatformAdapter._is_retryable_error(error)
+
+    async def _promote_retryable_delivery_failure(self, result: "SendResult") -> None:
+        """Move an exhausted network send onto the existing reconnect path."""
+        error = str(getattr(result, "error", "") or "")
+        if not self._is_reconnectable_delivery_failure(result):
+            return
+        self._set_fatal_error("outbound_network_error", error, retryable=True)
+        await self._notify_fatal_error()
+
+    @staticmethod
     def _is_timeout_error(error: Optional[str]) -> bool:
         """Return True if the error string indicates a read/write timeout.
 
@@ -6088,11 +6107,17 @@ class BasePlatformAdapter(ABC):
                                 mark_failed(
                                     _obligation_id,
                                     str(getattr(result, "error", "") or ""),
+                                    recoverable=(
+                                        delivery_adapter
+                                        ._is_reconnectable_delivery_failure(result)
+                                    ),
                                 )
                         except Exception:
                             logger.debug(
                                 "delivery ledger update failed", exc_info=True
                             )
+                    if not getattr(result, "success", False):
+                        await delivery_adapter._promote_retryable_delivery_failure(result)
 
                     # Schedule auto-deletion on the adapter that owns the new
                     # message ID, which may be the reconnect replacement.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10060,7 +10060,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 exc_info=(type(exc), exc, exc.__traceback__),
             )
 
-    async def _redeliver_pending_obligations(self) -> int:
+    async def _redeliver_pending_obligations(
+        self,
+        *,
+        platform: Optional[Platform] = None,
+    ) -> int:
         """Redeliver final responses recorded in the delivery ledger by a
         previous (now dead) gateway process.
 
@@ -10091,7 +10095,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # holds a platform only after its connect() succeeded, and each
             # claim spends one of the row's three redelivery attempts.
             _deliverable = {
-                getattr(p, "value", str(p)) for p in self.adapters
+                getattr(p, "value", str(p))
+                for p in self.adapters
+                if platform is None or p == platform
             }
             claimed = await asyncio.to_thread(
                 sweep_recoverable, None, deliverable_platforms=_deliverable
@@ -10124,7 +10130,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 {"thread_id": row["thread_id"]} if row.get("thread_id") else None
             )
             try:
-                result = await adapter.send(
+                result = await adapter._send_with_retry(
                     chat_id=row["chat_id"],
                     content=content,
                     metadata=metadata,
@@ -10135,8 +10141,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     row["obligation_id"], send_err,
                 )
                 result = None
-            try:
-                if result is not None and getattr(result, "success", False):
+            if result is not None and getattr(result, "success", False):
+                try:
                     mark_delivered(row["obligation_id"])
                     redelivered += 1
                     logger.info(
@@ -10145,13 +10151,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         row["platform"], row["chat_id"],
                         row["obligation_id"], row["attempts"],
                     )
-                else:
+                except Exception:
+                    logger.debug("delivery ledger update failed", exc_info=True)
+            else:
+                reconnectable = bool(
+                    result is not None
+                    and adapter._is_reconnectable_delivery_failure(result)
+                )
+                try:
                     mark_failed(
                         row["obligation_id"],
                         str(getattr(result, "error", "") or "send failed"),
+                        recoverable=reconnectable,
                     )
-            except Exception:
-                logger.debug("delivery ledger update failed", exc_info=True)
+                except Exception:
+                    logger.debug("delivery ledger update failed", exc_info=True)
+                if result is not None:
+                    try:
+                        await adapter._promote_retryable_delivery_failure(result)
+                    except Exception:
+                        logger.debug(
+                            "delivery reconnect promotion failed", exc_info=True
+                        )
 
             # The answer reached (or was owed to) this session — don't ALSO
             # re-run the turn via the resume path.
@@ -11935,6 +11956,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             error_message=None,
                         )
                         logger.info("✓ %s reconnected successfully", platform.value)
+
+                        try:
+                            await self._redeliver_pending_obligations(platform=platform)
+                        except Exception:
+                            logger.debug(
+                                "delivery redelivery after %s reconnect failed",
+                                platform.value,
+                                exc_info=True,
+                            )
+                        if self.adapters.get(platform) is not adapter:
+                            continue
 
                         # Rebuild channel directory with the new adapter
                         try:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1853,11 +1853,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # read-only connections so they never queue behind writer flushes on
         # self._lock. See _read_ctx().
         self._read_local = threading.local()
-        # Strong set of all live read connections across all threads.  We
+        # Strong map of open read connections and their last owner threads. We
         # hold a reference so short-lived reader threads' connections are
-        # not GC'd without close() — that would leak tracked fds in
-        # _live_connections.  close() drains this set.
-        self._read_conns: "set[sqlite3.Connection]" = set()
+        # reassigned on the next checkout instead of accumulating until shutdown.
+        self._read_conns: "dict[sqlite3.Connection, threading.Thread]" = {}
         self._read_conns_lock = threading.Lock()
         # Set when close() begins.  _get_read_conn checks this under the
         # lock so a reader that finishes opening after the drain finds the
@@ -2111,11 +2110,24 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return conn
         if getattr(self._read_local, "failed", False):
             return None
+        current_thread = threading.current_thread()
+        with self._read_conns_lock:
+            if self._read_conns_closed:
+                self._read_local.failed = True
+                return None
+            # Reuse rather than close: POSIX close() cancels this process's
+            # SQLite locks on the same file, including an in-flight writer.
+            for pooled_conn, owner in self._read_conns.items():
+                if not owner.is_alive():
+                    self._read_conns[pooled_conn] = current_thread
+                    self._read_local.conn = pooled_conn
+                    return pooled_conn
         try:
             conn = _connect_tracked_db(
                 f"file:{self.db_path}?mode=ro",
                 tracking_path=self.db_path,
                 uri=True,
+                check_same_thread=False,
                 timeout=5.0,
                 isolation_level=None,
             )
@@ -2133,7 +2145,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     conn.close()
                     self._read_local.failed = True
                     return None
-                self._read_conns.add(conn)
+                self._read_conns[conn] = current_thread
         except sqlite3.Error:
             # Mark this thread failed so we don't retry the open on every
             # query; the locked writer connection still serves reads.
@@ -2670,8 +2682,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # Close all read-only connections across all threads.  Per-thread
         # connections live in threading.local() and would otherwise be GC'd
         # without calling close(), leaking tracked fds in _live_connections.
-        # The strong set holds references so short-lived reader threads'
-        # connections survive until close() drains them.  Setting the closed
+        # The strong map holds references so short-lived reader threads'
+        # connections can be reused until close() drains them. Setting the closed
         # flag under the lock prevents a reader from registering a new
         # connection after the drain.
         with self._read_conns_lock:

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -83,6 +83,22 @@ class TestSweep:
         _record()  # owner = this (live) process
         assert dl.sweep_recoverable() == []
 
+    def test_failed_live_owner_row_is_recoverable(self):
+        _record()
+        dl.mark_failed("ob-1", "dns unavailable", recoverable=True)
+
+        claimed = dl.sweep_recoverable(deliverable_platforms={"slack"})
+
+        assert len(claimed) == 1
+        assert claimed[0]["needs_marker"] is True
+
+    def test_permanent_failed_live_owner_row_is_not_recoverable(self):
+        _record()
+        dl.mark_failed("ob-1", "invalid payload")
+
+        assert dl.sweep_recoverable(deliverable_platforms={"slack"}) == []
+        assert _row("ob-1")["owner_pid"] is not None
+
     def test_dead_owner_pending_claimed_without_marker(self):
         _record()
         _orphan("ob-1")
@@ -134,7 +150,7 @@ class TestGatewayRedeliverySweep:
     @staticmethod
     def _adapter(success=True):
         adapter = MagicMock()
-        adapter.send = AsyncMock(
+        adapter._send_with_retry = AsyncMock(
             return_value=MagicMock(success=success, error="" if success else "nope")
         )
         return adapter
@@ -149,7 +165,7 @@ class TestGatewayRedeliverySweep:
         n = await runner._redeliver_pending_obligations()
 
         assert n == 1
-        sent = adapter.send.call_args.kwargs
+        sent = adapter._send_with_retry.call_args.kwargs
         assert sent["content"] == "the final answer"  # no marker
         assert sent["metadata"] == {"thread_id": "171.001"}
         assert _row("ob-1")["state"] == "delivered"
@@ -167,9 +183,33 @@ class TestGatewayRedeliverySweep:
 
         await runner._redeliver_pending_obligations()
 
-        sent = adapter.send.call_args.kwargs
+        sent = adapter._send_with_retry.call_args.kwargs
         assert sent["content"].startswith(dl.RECOVERED_MARKER)
         assert sent["content"].endswith("the final answer")
+
+    @pytest.mark.asyncio
+    async def test_ledger_failure_does_not_block_reconnect_promotion(self):
+        _record()
+        _orphan("ob-1")
+        result = MagicMock(
+            success=False,
+            error="Cannot connect to host discord.com:443",
+        )
+        adapter = self._adapter()
+        adapter._send_with_retry.return_value = result
+        adapter._is_reconnectable_delivery_failure = MagicMock(return_value=True)
+        adapter._promote_retryable_delivery_failure = AsyncMock()
+        runner = self._runner(adapter)
+
+        with patch.object(dl, "mark_failed", side_effect=OSError("fd exhausted")) as failed:
+            await runner._redeliver_pending_obligations()
+
+        failed.assert_called_once_with(
+            "ob-1",
+            "Cannot connect to host discord.com:443",
+            recoverable=True,
+        )
+        adapter._promote_retryable_delivery_failure.assert_awaited_once_with(result)
 
 
 class TestAttemptsOnlySpentOnRealSends:

--- a/tests/gateway/test_delivery_ledger_producer.py
+++ b/tests/gateway/test_delivery_ledger_producer.py
@@ -96,6 +96,50 @@ class TestProducerHook:
         assert len(rows) == 1
         assert rows[0][1] == "failed"
 
+    @pytest.mark.asyncio
+    async def test_dns_send_failure_promotes_adapter_to_reconnect(self):
+        adapter = _Adapter()
+        adapter.send = AsyncMock(
+            return_value=SendResult(
+                success=False,
+                error=(
+                    "ClientConnectorDNSError: Cannot connect to host discord.com:443 "
+                    "[nodename nor servname provided, or not known]"
+                ),
+            )
+        )
+        fatal_handler = AsyncMock()
+        adapter.set_fatal_error_handler(fatal_handler)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _run(adapter, _event())
+
+        assert adapter.has_fatal_error
+        assert adapter.fatal_error_retryable
+        fatal_handler.assert_awaited_once_with(adapter)
+        claimed = dl.sweep_recoverable(deliverable_platforms={"slack"})
+        assert len(claimed) == 1
+
+    @pytest.mark.asyncio
+    async def test_retryable_rate_limit_does_not_reconnect(self):
+        adapter = _Adapter()
+        adapter.send = AsyncMock(
+            return_value=SendResult(
+                success=False,
+                error="rate_limited",
+                retryable=True,
+            )
+        )
+        fatal_handler = AsyncMock()
+        adapter.set_fatal_error_handler(fatal_handler)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _run(adapter, _event())
+
+        assert not adapter.has_fatal_error
+        fatal_handler.assert_not_awaited()
+        assert dl.sweep_recoverable(deliverable_platforms={"slack"}) == []
+
 
     @pytest.mark.asyncio
     async def test_crash_between_attempting_and_ack_is_recoverable(self):

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -215,7 +215,10 @@ class TestPlatformReconnectWatcher:
         )
 
     @pytest.mark.asyncio
-    async def test_reconnect_retries_resume_pending_for_platform(self):
+    @pytest.mark.parametrize("redelivery_disconnects", [False, True])
+    async def test_reconnect_retries_resume_pending_for_platform(
+        self, redelivery_disconnects
+    ):
         """A successful reconnect retries the startup auto-resume scoped to
         that platform.
 
@@ -227,6 +230,12 @@ class TestPlatformReconnectWatcher:
         """
         runner = _make_runner()
         runner._sync_voice_mode_state_to_adapter = MagicMock()
+        async def redeliver(**_kwargs):
+            if redelivery_disconnects:
+                runner.adapters.pop(Platform.TELEGRAM, None)
+            return 1
+
+        runner._redeliver_pending_obligations = AsyncMock(side_effect=redeliver)
         runner._schedule_resume_pending_sessions = MagicMock(return_value=1)
 
         platform_config = PlatformConfig(enabled=True, token="test")
@@ -257,10 +266,17 @@ class TestPlatformReconnectWatcher:
 
                 await run_one_iteration()
 
-        assert Platform.TELEGRAM in runner.adapters
-        runner._schedule_resume_pending_sessions.assert_called_once_with(
-            platform=Platform.TELEGRAM
+        runner._redeliver_pending_obligations.assert_awaited_once_with(
+            platform=Platform.TELEGRAM,
         )
+        if redelivery_disconnects:
+            assert Platform.TELEGRAM not in runner.adapters
+            runner._schedule_resume_pending_sessions.assert_not_called()
+        else:
+            assert Platform.TELEGRAM in runner.adapters
+            runner._schedule_resume_pending_sessions.assert_called_once_with(
+                platform=Platform.TELEGRAM,
+            )
 
 
     @pytest.mark.asyncio

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -44,6 +44,37 @@ def test_read_conn_reused_within_thread(db):
 
 
 @pytest.mark.requires_wal
+def test_dead_thread_read_connections_are_reused(db):
+    conns = []
+    ready = threading.Barrier(7)
+    release = threading.Event()
+
+    def grab():
+        conns.append(db._get_read_conn())
+        ready.wait()
+        release.wait()
+
+    threads = [threading.Thread(target=grab) for _ in range(6)]
+    for thread in threads:
+        thread.start()
+    try:
+        ready.wait(timeout=5)
+        assert all(conn is not None for conn in conns)
+        assert len(db._read_conns) == 6
+    finally:
+        release.set()
+        for thread in threads:
+            thread.join()
+
+    assert db.get_session("s1")["id"] == "s1"
+
+    assert len(db._read_conns) == 6
+    assert db._get_read_conn() in conns
+    for conn in conns:
+        assert conn.execute("SELECT 1").fetchone()[0] == 1
+
+
+@pytest.mark.requires_wal
 def test_reads_do_not_take_writer_lock(db):
     """Reads must complete while another thread holds self._lock."""
     acquired = db._lock.acquire()

--- a/tests/tools/test_react_to_message.py
+++ b/tests/tools/test_react_to_message.py
@@ -1,0 +1,20 @@
+from tools import react_to_message_tool as reactions
+
+
+def test_owned_session_db_closes_on_early_return(monkeypatch):
+    class DB:
+        closed = 0
+
+        def latest_message_row_id(self, *args, **kwargs):
+            return None
+
+        def close(self):
+            self.closed += 1
+
+    db = DB()
+    monkeypatch.setattr(reactions, "get_session_env", lambda *args: "session-1")
+    monkeypatch.setattr(reactions, "_open_session_db", lambda: db)
+
+    reactions.react_to_message_tool("👍")
+
+    assert db.closed == 1

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -29,6 +29,45 @@ def db(tmp_path):
     return SessionDB(tmp_path / "state.db")
 
 
+class TestOwnedDbCleanup:
+    @staticmethod
+    def _track_close(monkeypatch, db):
+        closed = []
+        close = db.close
+
+        def tracked_close():
+            closed.append(True)
+            close()
+
+        monkeypatch.setattr(db, "close", tracked_close)
+        return closed
+
+    def test_closes_default_db_it_opens(self, tmp_path, monkeypatch):
+        owned = SessionDB(tmp_path / "owned.db")
+        owned.create_session("owned", source="cli")
+        closed = self._track_close(monkeypatch, owned)
+        monkeypatch.setattr("hermes_state.SessionDB", lambda: owned)
+
+        result = json.loads(session_search())
+
+        assert result["success"] is True
+        assert closed == [True]
+
+    def test_closes_profile_db_but_not_injected_db(self, db, tmp_path, monkeypatch):
+        owned = SessionDB(tmp_path / "profile.db", read_only=False)
+        owned.create_session("profile", source="cli")
+        closed = self._track_close(monkeypatch, owned)
+        monkeypatch.setattr(
+            "tools.session_search_tool._resolve_profile_db", lambda _profile: owned
+        )
+
+        result = json.loads(session_search(db=db, profile="other"))
+
+        assert result["success"] is True
+        assert closed == [True]
+        assert db._conn.execute("SELECT 1").fetchone()[0] == 1
+
+
 def _seed_modpack_sessions(db):
     """Create three sessions about a modpack so FTS5 has hits to dedupe."""
     now = int(time.time())

--- a/tools/react_to_message_tool.py
+++ b/tools/react_to_message_tool.py
@@ -45,48 +45,54 @@ def react_to_message_tool(emoji: str, message_row_id=None, messages_back=None) -
     if db is None:
         return tool_error("Session storage is unavailable.")
 
-    row_id = message_row_id
-    target_role = "user"
-    if row_id is None:
-        # Default target: the latest user message. `messages_back` steps to
-        # earlier user turns (1 = the one before, etc.) for retroactive
-        # reactions — quoting text would be ambiguous, ids aren't visible to
-        # the model, but "two messages ago" is how a person thinks about it.
-        back = max(0, int(messages_back or 0))
-        row_id = db.latest_message_row_id(session_key, role="user", offset=back)
+    try:
+        row_id = message_row_id
+        target_role = "user"
         if row_id is None:
-            return tool_error(
-                f"No user message found {back} back." if back else "No user message to react to yet."
+            # Default target: the latest user message. `messages_back` steps to
+            # earlier user turns (1 = the one before, etc.) for retroactive
+            # reactions — quoting text would be ambiguous, ids aren't visible to
+            # the model, but "two messages ago" is how a person thinks about it.
+            back = max(0, int(messages_back or 0))
+            row_id = db.latest_message_row_id(session_key, role="user", offset=back)
+            if row_id is None:
+                return tool_error(
+                    f"No user message found {back} back."
+                    if back
+                    else "No user message to react to yet."
+                )
+        else:
+            row = db.get_message_role(session_key, int(row_id))
+            target_role = row or "user"
+
+        try:
+            reactions = db.set_message_reaction(
+                session_key, int(row_id), emoji or None, author="agent"
             )
-    else:
-        row = db.get_message_role(session_key, int(row_id))
-        target_role = row or "user"
+        except Exception as exc:
+            return tool_error(f"Failed to set the reaction: {exc}")
 
-    try:
-        reactions = db.set_message_reaction(
-            session_key, int(row_id), emoji or None, author="agent"
+        if reactions is None:
+            return tool_error(f"Message {row_id} is not part of this conversation.")
+
+        # Paint it live. A missing bridge (non-desktop surface) is not an error —
+        # the reaction is persisted either way and shows on the next load.
+        # `role` lets the renderer match a live message that doesn't know its
+        # durable row id yet (it only learns rowId on resume).
+        try:
+            desktop_ui.emit(
+                "message.reaction",
+                {"row_id": int(row_id), "reactions": reactions, "role": target_role},
+            )
+        except Exception:
+            pass
+
+        return json.dumps(
+            {"success": True, "row_id": int(row_id), "reactions": reactions},
+            ensure_ascii=False,
         )
-    except Exception as exc:
-        return tool_error(f"Failed to set the reaction: {exc}")
-
-    if reactions is None:
-        return tool_error(f"Message {row_id} is not part of this conversation.")
-
-    # Paint it live. A missing bridge (non-desktop surface) is not an error —
-    # the reaction is persisted either way and shows on the next load.
-    # `role` lets the renderer match a live message that doesn't know its
-    # durable row id yet (it only learns rowId on resume).
-    try:
-        desktop_ui.emit(
-            "message.reaction",
-            {"row_id": int(row_id), "reactions": reactions, "role": target_role},
-        )
-    except Exception:
-        pass
-
-    return json.dumps(
-        {"success": True, "row_id": int(row_id), "reactions": reactions}, ensure_ascii=False
-    )
+    finally:
+        db.close()
 
 
 def check_react_requirements() -> bool:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -840,6 +840,7 @@ def session_search(
     sort: str = None,
     # Cross-profile (any shape)
     profile: str = None,
+    _profile_db_resolved: bool = False,
 ) -> str:
     """Single-shape tool. Mode inferred from which args are set.
 
@@ -855,11 +856,27 @@ def session_search(
     if db is None:
         try:
             from hermes_state import SessionDB
-            db = SessionDB()
+            owned_db = SessionDB()
         except Exception:
             logging.debug("SessionDB unavailable for session_search", exc_info=True)
             from hermes_state import format_session_db_unavailable
             return tool_error(format_session_db_unavailable(), success=False)
+        try:
+            return session_search(
+                query=query,
+                role_filter=role_filter,
+                limit=limit,
+                db=owned_db,
+                current_session_id=current_session_id,
+                session_id=session_id,
+                around_message_id=around_message_id,
+                window=window,
+                sort=sort,
+                profile=profile,
+                _profile_db_resolved=_profile_db_resolved,
+            )
+        finally:
+            owned_db.close()
 
     # Normalise a raw `@session:<profile>/<id>` link value passed as session_id.
     # Session ids never contain "/", so a slash unambiguously means profile/id —
@@ -876,14 +893,28 @@ def session_search(
     # Cross-profile read: swap in the named profile's DB (read-only) for every
     # shape below. The current-session-lineage guards no longer apply across
     # profiles, but they key off ids that won't collide, so they stay inert.
-    if profile is not None and str(profile).strip():
+    if profile is not None and str(profile).strip() and not _profile_db_resolved:
         try:
             profile_db = _resolve_profile_db(profile)
         except Exception as e:
             return tool_error(f"profile '{profile}': {e}", success=False)
         if profile_db is not None:
-            db = profile_db
-            current_session_id = None
+            try:
+                return session_search(
+                    query=query,
+                    role_filter=role_filter,
+                    limit=limit,
+                    db=profile_db,
+                    current_session_id="",
+                    session_id=session_id,
+                    around_message_id=around_message_id,
+                    window=window,
+                    sort=sort,
+                    profile=profile,
+                    _profile_db_resolved=True,
+                )
+            finally:
+                profile_db.close()
 
     # Scroll shape takes precedence — explicit anchor beats any query.
     if (isinstance(session_id, str) and session_id.strip()) and around_message_id is not None:


### PR DESCRIPTION
## What does this PR do?

Prevents generated gateway replies from being stranded after transient outbound DNS/connection failures, and bounds `state.db` file descriptors retained by long-lived `SessionDB` instances.

The incident that motivated this change had two coupled failure modes:

- short-lived reader threads accumulated per-thread SQLite connections until the process reached its FD limit;
- the final Discord REST delivery then failed during DNS resolution, but the durable obligation was not replayed because the WebSocket itself had remained connected.

This reuses the existing delivery ledger and platform reconnect lifecycle; it does not add a new queue, poller, or daemon.

## Related Issue

No existing issue or PR found after searching both delivery-replay and `SessionDB` FD-leak terms.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Record recoverable delivery failures durably and replay only transient DNS/transport failures; permanent payload/config failures remain terminal.
- Wake the existing reconnect lifecycle after outbound REST transport failure, even when the platform WebSocket did not disconnect.
- Replay only the reconnecting platform, through the adapter's normal retry path, before resuming sessions.
- Keep ledger-state writes independent from reconnect promotion so a SQLite write failure cannot suppress the reconnect signal.
- Avoid treating generic retryable outcomes such as Slack HTTP 429 as connection failures.
- Close tool-owned `SessionDB` instances on every return/error path while preserving injected-DB ownership.
- Reassign dead reader-thread SQLite connections to later readers instead of accumulating one FD per historical thread. Connections stay open until `SessionDB.close()` to avoid POSIX process-wide record-lock cancellation caused by intermediate `close()` calls.

## How to Test

1. Run the focused regression suite:
   ```bash
   scripts/run_tests.sh -j 2 \
     tests/gateway/test_delivery_ledger.py \
     tests/gateway/test_delivery_ledger_fd_leak.py \
     tests/gateway/test_delivery_ledger_producer.py \
     tests/gateway/test_platform_reconnect.py \
     tests/gateway/test_send_retry.py \
     tests/gateway/test_platform_base.py \
     tests/gateway/test_async_session_db.py \
     tests/test_session_db_read_path_split.py \
     tests/test_sqlite_lock_safe_inspection.py \
     tests/tools/test_session_search.py \
     tests/tools/test_react_to_message.py -q
   ```
2. Run Ruff on the 12 changed Python files.
3. Run the 200-iteration short-lived-reader stress probe described below.

Local exact-head result: **190 passed, 0 failed**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused 190-test regression suite passed; full suite left to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration or API added
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; existing lifecycle reused
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — connection reuse uses existing thread/SQLite primitives; POSIX lock-safety rationale is documented
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; ownership cleanup only

## Screenshots / Logs

Focused suite:

```text
=== Summary: 11 files, 190 tests passed, 0 failed (100% complete) ===
```

Short-lived reader stress probe:

```json
{"iterations": 200, "peak_tracked_readers": 1, "tracked_after_reuse": 1, "fd_delta_while_open": 2, "fd_delta_after_close": -3}
```
