### PR TITLE
fix(dashboard): add native OAuth provider chooser

### DIFF
--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -22,8 +22,11 @@ class name MUST NOT change without updating
 from __future__ import annotations
 
 import html
+from typing import Iterable
+from urllib.parse import urlencode
 
 from hermes_cli.dashboard_auth import list_session_providers
+from hermes_cli.dashboard_auth.base import DashboardAuthProvider
 
 # Inline minimal CSS. The dashboard's full skin lives in the React
 # bundle, which we deliberately do NOT load here — the login page must
@@ -498,6 +501,39 @@ def render_login_html(*, next_path: str = "") -> str:
     return _LOGIN_HTML_TEMPLATE.format(
         provider_buttons="\n".join(buttons),
         password_script=script,
+    )
+
+
+def render_native_provider_choice_html(
+    *,
+    providers: Iterable[DashboardAuthProvider],
+    authorize_path: str,
+    code_challenge: str,
+    code_challenge_method: str,
+    redirect_uri: str,
+    state: str,
+) -> str:
+    """Render a native OAuth provider chooser preserving desktop PKCE state."""
+    buttons = []
+    common_params = {
+        "code_challenge": code_challenge,
+        "code_challenge_method": code_challenge_method,
+        "redirect_uri": redirect_uri,
+        "state": state,
+    }
+
+    for provider in providers:
+        query = urlencode({**common_params, "provider": provider.name})
+        href = html.escape(f"{authorize_path}?{query}", quote=True)
+        label = html.escape(provider.display_name)
+        buttons.append(f'  <a class="provider-btn" href="{href}">Sign in with {label}</a>')
+
+    if not buttons:
+        return _EMPTY_HTML
+
+    return _LOGIN_HTML_TEMPLATE.format(
+        provider_buttons="\n".join(buttons),
+        password_script="",
     )
 
 

--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -22,8 +22,11 @@ class name MUST NOT change without updating
 from __future__ import annotations
 
 import html
+from typing import Iterable
+from urllib.parse import urlencode
 
 from hermes_cli.dashboard_auth import list_session_providers
+from hermes_cli.dashboard_auth.base import DashboardAuthProvider
 
 # Inline minimal CSS. The dashboard's full skin lives in the React
 # bundle, which we deliberately do NOT load here — the login page must
@@ -495,6 +498,39 @@ def render_login_html(*, next_path: str = "") -> str:
     return _LOGIN_HTML_TEMPLATE.format(
         provider_buttons="\n".join(buttons),
         password_script=script,
+    )
+
+
+def render_native_provider_choice_html(
+    *,
+    providers: Iterable[DashboardAuthProvider],
+    authorize_path: str,
+    code_challenge: str,
+    code_challenge_method: str,
+    redirect_uri: str,
+    state: str,
+) -> str:
+    """Render a native OAuth provider chooser preserving desktop PKCE state."""
+    buttons = []
+    common_params = {
+        "code_challenge": code_challenge,
+        "code_challenge_method": code_challenge_method,
+        "redirect_uri": redirect_uri,
+        "state": state,
+    }
+
+    for provider in providers:
+        query = urlencode({**common_params, "provider": provider.name})
+        href = html.escape(f"{authorize_path}?{query}", quote=True)
+        label = html.escape(provider.display_name)
+        buttons.append(f'  <a class="provider-btn" href="{href}">Sign in with {label}</a>')
+
+    if not buttons:
+        return _EMPTY_HTML
+
+    return _LOGIN_HTML_TEMPLATE.format(
+        provider_buttons="\n".join(buttons),
+        password_script="",
     )
 
 

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -46,7 +46,10 @@ from hermes_cli.dashboard_auth.cookies import (
     set_pkce_cookie,
     set_session_cookies,
 )
-from hermes_cli.dashboard_auth.login_page import render_login_html
+from hermes_cli.dashboard_auth.login_page import (
+    render_login_html,
+    render_native_provider_choice_html,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -323,6 +326,26 @@ async def auth_native_authorize(
         sess_providers = list_session_providers()
         if len(sess_providers) == 1:
             p = sess_providers[0]
+        else:
+            native_providers = [
+                candidate
+                for candidate in sess_providers
+                if not getattr(candidate, "supports_password", False)
+            ]
+            if len(native_providers) == 1:
+                p = native_providers[0]
+            elif len(native_providers) > 1:
+                return HTMLResponse(
+                    render_native_provider_choice_html(
+                        providers=native_providers,
+                        authorize_path=f"{_prefix(request)}/auth/native/authorize",
+                        code_challenge=code_challenge,
+                        code_challenge_method=code_challenge_method,
+                        redirect_uri=redirect_uri,
+                        state=state,
+                    ),
+                    headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
+                )
     if p is None:
         raise HTTPException(
             status_code=404, detail=f"Unknown provider: {provider!r}"

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -47,7 +47,10 @@ from hermes_cli.dashboard_auth.cookies import (
     set_pkce_cookie,
     set_session_cookies,
 )
-from hermes_cli.dashboard_auth.login_page import render_login_html
+from hermes_cli.dashboard_auth.login_page import (
+    render_login_html,
+    render_native_provider_choice_html,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -361,6 +364,18 @@ async def auth_native_authorize(
         ]
         if len(native_eligible) == 1:
             p = native_eligible[0]
+        elif len(native_eligible) > 1:
+            return HTMLResponse(
+                render_native_provider_choice_html(
+                    providers=native_eligible,
+                    authorize_path=f"{_prefix(request)}/auth/native/authorize",
+                    code_challenge=code_challenge,
+                    code_challenge_method=code_challenge_method,
+                    redirect_uri=redirect_uri,
+                    state=state,
+                ),
+                headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
+            )
         elif not native_eligible:
             # No brokerable provider at all. Preserve the old behaviour of
             # selecting a lone password provider so the explicit 400 below

--- a/tests/hermes_cli/test_dashboard_auth_native_flow.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_flow.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import hashlib
 import base64
 import time
+from html.parser import HTMLParser
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -33,6 +34,29 @@ from hermes_cli.dashboard_auth import (
 from hermes_cli.dashboard_auth import native_flow
 from hermes_cli.dashboard_auth.base import Session
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+
+class NousStubAuthProvider(StubAuthProvider):
+    name = "nous"
+    display_name = "Nous Research"
+
+
+class SelfHostedOidcStubAuthProvider(StubAuthProvider):
+    name = "self-hosted"
+    display_name = "Self-Hosted OIDC"
+
+
+class ProviderLinkParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hrefs: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = dict(attrs)
+        if tag == "a" and "provider-btn" in (values.get("class") or "").split():
+            href = values.get("href")
+            if href:
+                self.hrefs.append(href)
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +185,85 @@ def _walk_native_login(client, *, redirect_uri, challenge, state="cli-state"):
         f"native callback must NOT set a session cookie; got {set_cookie!r}"
     )
     return loop_qs["code"][0], loop_qs["state"][0]
+
+
+def test_native_authorize_auto_selects_single_provider(gated_client):
+    _verifier, challenge = _make_pkce()
+    response = gated_client.get(
+        "/auth/native/authorize",
+        params={
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "redirect_uri": "http://127.0.0.1:53999/cb",
+            "state": "single-provider-state",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("https://fly-app.fly.dev/auth/callback?")
+
+
+def test_native_authorize_renders_multi_provider_chooser(gated_client):
+    clear_providers()
+    register_provider(NousStubAuthProvider())
+    register_provider(SelfHostedOidcStubAuthProvider())
+    _verifier, challenge = _make_pkce()
+    redirect_uri = "http://127.0.0.1:53999/cb"
+    state = 'state-with-unsafe-chars-"&<>'
+
+    response = gated_client.get(
+        "/auth/native/authorize",
+        params={
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "redirect_uri": redirect_uri,
+            "state": state,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store, no-cache, must-revalidate"
+    assert "Nous Research" in response.text
+    assert "Self-Hosted OIDC" in response.text
+
+    parser = ProviderLinkParser()
+    parser.feed(response.text)
+    assert len(parser.hrefs) == 2
+
+    links_by_provider = {}
+    for href in parser.hrefs:
+        parsed = urlparse(href)
+        query = parse_qs(parsed.query)
+        links_by_provider[query["provider"][0]] = (parsed, query)
+
+    assert set(links_by_provider) == {"nous", "self-hosted"}
+    for parsed, query in links_by_provider.values():
+        assert parsed.path == "/auth/native/authorize"
+        assert query["code_challenge"] == [challenge]
+        assert query["code_challenge_method"] == ["S256"]
+        assert query["redirect_uri"] == [redirect_uri]
+        assert query["state"] == [state]
+
+    for href in parser.hrefs:
+        selected = gated_client.get(href)
+        assert selected.status_code == 302
+
+
+def test_native_authorize_without_registered_provider_fails_closed(gated_client):
+    clear_providers()
+    _verifier, challenge = _make_pkce()
+    response = gated_client.get(
+        "/auth/native/authorize",
+        params={
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "redirect_uri": "http://127.0.0.1:53999/cb",
+            "state": "no-provider-state",
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Unknown provider: ''"
 
 
 

--- a/tests/hermes_cli/test_dashboard_auth_native_flow.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_flow.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import hashlib
 import base64
 import time
+from html.parser import HTMLParser
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -33,6 +34,29 @@ from hermes_cli.dashboard_auth import (
 from hermes_cli.dashboard_auth import native_flow
 from hermes_cli.dashboard_auth.base import Session
 from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+
+class NousStubAuthProvider(StubAuthProvider):
+    name = "nous"
+    display_name = "Nous Research"
+
+
+class SelfHostedOidcStubAuthProvider(StubAuthProvider):
+    name = "self-hosted"
+    display_name = "Self-Hosted OIDC"
+
+
+class ProviderLinkParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hrefs: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = dict(attrs)
+        if tag == "a" and "provider-btn" in (values.get("class") or "").split():
+            href = values.get("href")
+            if href:
+                self.hrefs.append(href)
 
 
 # ---------------------------------------------------------------------------
@@ -256,17 +280,53 @@ def test_native_authorize_empty_provider_auto_selects_single_oauth(gated_client)
     assert "code=stub_code" in r.headers["location"]
 
 
-def test_native_authorize_empty_provider_ambiguous_multiple_oauth_404(gated_client):
-    """Two brokerable providers: the empty-provider convenience cannot pick
-    unambiguously, so the request still fails — the desktop must pass
-    ``?provider=`` explicitly."""
-    register_provider(_SecondStubProvider())
+def test_native_authorize_renders_multi_provider_chooser(gated_client):
+    """Multiple brokerable providers: empty provider returns a 200 chooser HTML
+    page preserving PKCE parameters so the user can choose between e.g. Nous
+    vs Self-Hosted OIDC."""
+    clear_providers()
+    register_provider(NousStubAuthProvider())
+    register_provider(SelfHostedOidcStubAuthProvider())
     _verifier, challenge = _make_pkce()
-    r = gated_client.get(
+    redirect_uri = "http://127.0.0.1:53999/cb"
+    state = 'state-with-unsafe-chars-"&<>'
+
+    response = gated_client.get(
         "/auth/native/authorize",
-        params=_native_authorize_params(challenge),
+        params={
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "redirect_uri": redirect_uri,
+            "state": state,
+        },
     )
-    assert r.status_code == 404
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store, no-cache, must-revalidate"
+    assert "Nous Research" in response.text
+    assert "Self-Hosted OIDC" in response.text
+
+    parser = ProviderLinkParser()
+    parser.feed(response.text)
+    assert len(parser.hrefs) == 2
+
+    links_by_provider = {}
+    for href in parser.hrefs:
+        parsed = urlparse(href)
+        query = parse_qs(parsed.query)
+        links_by_provider[query["provider"][0]] = (parsed, query)
+
+    assert set(links_by_provider) == {"nous", "self-hosted"}
+    for parsed, query in links_by_provider.values():
+        assert parsed.path == "/auth/native/authorize"
+        assert query["code_challenge"] == [challenge]
+        assert query["code_challenge_method"] == ["S256"]
+        assert query["redirect_uri"] == [redirect_uri]
+        assert query["state"] == [state]
+
+    for href in parser.hrefs:
+        selected = gated_client.get(href)
+        assert selected.status_code == 302
 
 
 def test_native_authorize_empty_provider_password_only_brokers_to_login(


### PR DESCRIPTION
## What does this PR do?

Fixes native Desktop sign-in when a remote gateway registers more than one redirect-capable session provider.

Hermes Desktop intentionally omits `provider` from `/auth/native/authorize` so the gateway owns provider selection. The gateway currently auto-selects only when exactly one session provider exists; with both Nous and self-hosted OIDC configured, it returns `404 {"detail":"Unknown provider: ''"}` before authentication begins.

When `provider` is omitted, this change now:

- auto-selects the sole native-capable provider;
- renders a server-side provider chooser when multiple native-capable providers exist;
- preserves the PKCE challenge, method, loopback redirect URI, and CSRF state in each choice;
- excludes password-only providers, which current `main` rejects for native OAuth;
- keeps zero-provider behavior fail-closed.

The chooser stays in the RFC 8252 system browser flow and works with existing Desktop builds; the Desktop does not need provider names or a new IPC contract.

## Related Issue

No dedicated issue was opened because this is a reproduced bug fix.

- Related to #75045. That PR resolves a sole redirect-capable provider in the Desktop and falls back to the embedded chooser when multiple OAuth providers remain. This PR covers the distinct multi-OAuth case while retaining the system browser and supporting already-released Desktop clients.
- Related to #75808, which proposes native password-provider support and overlaps `routes.py`. This PR reflects current `main`, where password providers are not native-login capable.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/dashboard_auth/routes.py`: select one native provider or render the chooser before registering the pending authorization.
- `hermes_cli/dashboard_auth/login_page.py`: render escaped, URL-encoded provider links while preserving all native OAuth parameters.
- `tests/hermes_cli/test_dashboard_auth_native_flow.py`: cover one, two, and zero providers plus click-through for both Nous and self-hosted OIDC.

## How to Test

1. Configure a gated dashboard with both `nous` and `self-hosted` session providers.
2. In Hermes Desktop, connect to the remote gateway.
3. Confirm the system browser shows both provider choices instead of a 404 response.
4. Complete sign-in with each provider and confirm Desktop receives the loopback callback and connects.

Automated validation on rebased commit `caf637502`:

```text
scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_*.py
127 passed, 0 failed

ruff check hermes_cli/dashboard_auth/login_page.py hermes_cli/dashboard_auth/routes.py tests/hermes_cli/test_dashboard_auth_native_flow.py
All checks passed

git diff upstream/main...HEAD --check
passed
```

## Real behavior proof

- **Setup:** Windows 11 Enterprise build 26200, Hermes Desktop, remote gated dashboard with `nous` and `self-hosted` OIDC providers.
- **Before:** Connect Remote Gateway opened `/auth/native/authorize` in the system browser and returned `404 {"detail":"Unknown provider: ''"}`.
- **After:** Restarted the patched dashboard; the browser displayed Nous and OIDC choices. The operator completed both sign-in paths successfully and Desktop connected in both cases.
- **Not tested:** macOS Desktop UI and Linux Desktop UI. A local complete-suite attempt on pre-rebase upstream `26e0b1c12` exposed environment/baseline failures, seven of which reproduced on the unchanged parent. After rebasing, upstream PR CI completed successfully on the current tip: all 8 Python slices, Python e2e, lint, Windows footguns, OSV, supply-chain, and Docker checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs and documented the related overlapping proposals
- [x] My PR contains only changes related to this fix
- [x] Full upstream Python CI passed (8/8 slices plus Python e2e); local environment limitations are disclosed above
- [x] I've added tests for my changes
- [x] I've tested on Windows 11 Enterprise with the automated suite running under WSL2

### Documentation & Housekeeping

- [x] Documentation update is N/A; this restores the documented native OAuth behavior without changing configuration or public API
- [x] Tool descriptions/schemas are N/A

## Screenshots / Logs

The production verification results are included in **Real behavior proof**. No secrets, tokens, PKCE verifiers, or session cookies are included.
