### PR TITLE
fix(gateway): keep Telegram topic binding in sync on /resume

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -16,6 +16,7 @@ call time (run.py fully loaded by then), avoiding an import cycle.
 from __future__ import annotations
 
 import asyncio
+import copy
 import dataclasses
 import hashlib
 import inspect
@@ -4434,12 +4435,63 @@ class GatewaySlashCommandsMixin:
         if current_entry.session_id == target_id:
             return t("gateway.resume.already_on", name=name)
 
+        # Telegram DM topics keep a second durable topic -> session binding,
+        # and the normal-message path treats that binding as authoritative.
+        # Move it first so uniqueness/DB failures leave the generic route and
+        # session lifecycle untouched; if the generic switch then fails, put
+        # the binding back before reporting failure.
+        is_topic_lane = getattr(self, "_is_telegram_topic_lane", None)
+        record_topic_binding = getattr(self, "_record_telegram_topic_binding", None)
+        topic_binding_moved = False
+        if callable(is_topic_lane) and await asyncio.to_thread(is_topic_lane, source):
+            if not callable(record_topic_binding):
+                return t("gateway.resume.switch_failed")
+            target_entry = copy.copy(current_entry)
+            target_entry.session_id = target_id
+            try:
+                await asyncio.to_thread(record_topic_binding, source, target_entry)
+                topic_binding_moved = True
+            except Exception:
+                logger.warning(
+                    "Failed to rebind Telegram topic before /resume",
+                    exc_info=True,
+                )
+                return t("gateway.resume.switch_failed")
+
         # Clear any running agent for this session key
         self._release_running_agent_state(session_key)
 
-        # Switch the session entry to point at the old session
-        new_entry = await self.async_session_store.switch_session(session_key, target_id)
+        async def _restore_topic_binding_after_switch_failure() -> None:
+            if not topic_binding_moved or not callable(record_topic_binding):
+                return
+            try:
+                await asyncio.to_thread(
+                    record_topic_binding, source, current_entry
+                )
+            except Exception:
+                logger.error(
+                    "Failed to restore Telegram topic binding after /resume "
+                    "session switch failed: key=%s target=%s previous=%s",
+                    session_key, target_id, current_entry.session_id,
+                    exc_info=True,
+                )
+
+        # Switch the session entry to point at the old session. Both a falsey
+        # return and an exception are failures; either must restore the binding
+        # before the command reports failure.
+        try:
+            new_entry = await self.async_session_store.switch_session(
+                session_key, target_id
+            )
+        except Exception:
+            logger.warning(
+                "Session route switch raised after Telegram topic rebind",
+                exc_info=True,
+            )
+            await _restore_topic_binding_after_switch_failure()
+            return t("gateway.resume.switch_failed")
         if not new_entry:
+            await _restore_topic_binding_after_switch_failure()
             return t("gateway.resume.switch_failed")
 
         # Conversation boundary: clear ALL conversation-scoped per-session

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -4,6 +4,7 @@ Tests the _handle_resume_command handler (switch to a previously-named session)
 across gateway messenger platforms.
 """
 
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -175,6 +176,216 @@ class TestHandleResumeCommand:
         runner.session_store.switch_session.assert_called_once()
         call_args = runner.session_store.switch_session.call_args
         assert call_args[0][1] == "old_session_abc"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_in_telegram_topic_updates_durable_topic_binding(self, tmp_path):
+        """A resumed topic must not be snapped back to its previously bound session.
+
+        Telegram topic lanes have a second durable topic->session binding.  If
+        /resume only updates the generic routing entry, the next normal message
+        reloads the stale topic binding and silently undoes the resume.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.enable_telegram_topic_mode(chat_id="67890", user_id="12345")
+        db.create_session(
+            "old_session_abc", "telegram", user_id="12345", chat_id="67890",
+            thread_id="9496",
+        )
+        db.set_session_title("old_session_abc", "My Project")
+        db.create_session(
+            "current_session_001", "telegram", user_id="12345", chat_id="67890",
+            thread_id="9496",
+        )
+
+        event = _make_event(text="/resume My Project")
+        event.source = replace(event.source, thread_id="9496")
+        session_key = build_session_key(event.source)
+        db.bind_telegram_topic(
+            chat_id="67890",
+            thread_id="9496",
+            user_id="12345",
+            session_key=session_key,
+            session_id="current_session_001",
+        )
+        runner = _make_runner(
+            session_db=db, current_session_id="current_session_001", event=event,
+        )
+        resumed_entry = SimpleNamespace(
+            session_id="old_session_abc",
+            session_key=session_key,
+        )
+        runner.session_store.switch_session = MagicMock(return_value=resumed_entry)
+        runner._is_telegram_topic_lane = MagicMock(return_value=True)
+
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        binding = db.get_telegram_topic_binding(chat_id="67890", thread_id="9496")
+        assert binding is not None
+        assert binding["session_id"] == "old_session_abc"
+        assert binding["session_key"] == session_key
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_in_telegram_topic_fails_closed_when_binding_write_fails(self, tmp_path):
+        """Never report a successful resume when the topic binding did not move."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(
+            "old_session_abc", "telegram", user_id="12345", chat_id="67890",
+            thread_id="9496",
+        )
+        db.set_session_title("old_session_abc", "My Project")
+        db.create_session(
+            "current_session_001", "telegram", user_id="12345", chat_id="67890",
+            thread_id="9496",
+        )
+
+        event = _make_event(text="/resume My Project")
+        event.source = replace(event.source, thread_id="9496")
+        runner = _make_runner(
+            session_db=db, current_session_id="current_session_001", event=event,
+        )
+        session_key = build_session_key(event.source)
+        resumed_entry = SimpleNamespace(
+            session_id="old_session_abc", session_key=session_key,
+        )
+        runner.session_store.switch_session = MagicMock(return_value=resumed_entry)
+        runner._is_telegram_topic_lane = MagicMock(return_value=True)
+        runner._record_telegram_topic_binding = MagicMock(
+            side_effect=ValueError("session is already linked to another Telegram topic")
+        )
+
+        result = await runner._handle_resume_command(event)
+
+        assert "Failed to switch session" in result
+        assert "Resumed" not in result
+        runner.session_store.switch_session.assert_not_called()
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_in_telegram_topic_restores_binding_when_route_switch_fails(self, tmp_path):
+        """Restore the prior topic binding if the generic route cannot switch."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.enable_telegram_topic_mode(chat_id="67890", user_id="12345")
+        db.create_session(
+            "old_session_abc", "telegram", user_id="12345", chat_id="67890",
+            thread_id="9496",
+        )
+        db.set_session_title("old_session_abc", "My Project")
+        db.create_session(
+            "current_session_001", "telegram", user_id="12345", chat_id="67890",
+            thread_id="9496",
+        )
+
+        event = _make_event(text="/resume My Project")
+        event.source = replace(event.source, thread_id="9496")
+        session_key = build_session_key(event.source)
+        db.bind_telegram_topic(
+            chat_id="67890", thread_id="9496", user_id="12345",
+            session_key=session_key, session_id="current_session_001",
+        )
+        runner = _make_runner(
+            session_db=db, current_session_id="current_session_001", event=event,
+        )
+        runner.session_store.switch_session = MagicMock(return_value=None)
+        runner._is_telegram_topic_lane = MagicMock(return_value=True)
+
+        result = await runner._handle_resume_command(event)
+
+        assert "Failed to switch session" in result
+        assert "Resumed" not in result
+        binding = db.get_telegram_topic_binding(chat_id="67890", thread_id="9496")
+        assert binding is not None
+        assert binding["session_id"] == "current_session_001"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_in_telegram_topic_restores_binding_when_route_switch_raises(self, tmp_path):
+        """A raised route-switch error must restore the prior topic binding."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.enable_telegram_topic_mode(chat_id="67890", user_id="12345")
+        db.create_session(
+            "old_session_abc", "telegram", user_id="12345", chat_id="67890",
+            thread_id="9496",
+        )
+        db.set_session_title("old_session_abc", "My Project")
+        db.create_session(
+            "current_session_001", "telegram", user_id="12345", chat_id="67890",
+            thread_id="9496",
+        )
+        event = _make_event(text="/resume My Project")
+        event.source = replace(event.source, thread_id="9496")
+        session_key = build_session_key(event.source)
+        db.bind_telegram_topic(
+            chat_id="67890", thread_id="9496", user_id="12345",
+            session_key=session_key, session_id="current_session_001",
+        )
+        runner = _make_runner(
+            session_db=db, current_session_id="current_session_001", event=event,
+        )
+        runner.session_store.switch_session = MagicMock(
+            side_effect=RuntimeError("routing persistence failed")
+        )
+        runner._is_telegram_topic_lane = MagicMock(return_value=True)
+
+        result = await runner._handle_resume_command(event)
+
+        assert "Failed to switch session" in result
+        assert "Resumed" not in result
+        binding = db.get_telegram_topic_binding(chat_id="67890", thread_id="9496")
+        assert binding is not None
+        assert binding["session_id"] == "current_session_001"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_route_failure_does_not_claim_success_if_binding_restore_fails(self, tmp_path):
+        """Even failed compensation must never produce a false success response."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(
+            "old_session_abc", "telegram", user_id="12345", chat_id="67890",
+            thread_id="9496",
+        )
+        db.set_session_title("old_session_abc", "My Project")
+        db.create_session(
+            "current_session_001", "telegram", user_id="12345", chat_id="67890",
+            thread_id="9496",
+        )
+        event = _make_event(text="/resume My Project")
+        event.source = replace(event.source, thread_id="9496")
+        runner = _make_runner(
+            session_db=db, current_session_id="current_session_001", event=event,
+        )
+        session_key = build_session_key(event.source)
+        target_entry = SimpleNamespace(
+            session_id="old_session_abc", session_key=session_key,
+        )
+        calls = []
+
+        def record_binding(_source, entry):
+            calls.append(entry.session_id)
+            if entry.session_id == "current_session_001":
+                raise OSError("restore failed")
+
+        runner.session_store.switch_session = MagicMock(return_value=None)
+        runner._is_telegram_topic_lane = MagicMock(return_value=True)
+        runner._record_telegram_topic_binding = MagicMock(side_effect=record_binding)
+
+        result = await runner._handle_resume_command(event)
+
+        assert "Failed to switch session" in result
+        assert "Resumed" not in result
+        assert calls == [target_entry.session_id, "current_session_001"]
         db.close()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes manual `/resume` and `/sessions <session-id>` inside Telegram DM topics so the restored session remains attached to the topic on the next message.

Telegram topic mode has two durable routing records:

- the generic gateway `session_key -> session_id` route;
- the Telegram-specific `(chat_id, thread_id) -> session_id` binding.

Before this change, `_handle_resume_command()` updated only the generic route. The next normal message treated the still-stale Telegram binding as authoritative and switched the route back, even though the command had already replied `Conversation restored`.

Observed failure shape:

```text
/sessions <old-session-id>
↻ Resumed session ... Conversation restored.

# next user message
conversation turn: session=<fresh-session> history=0
```

The fix coordinates both records in the shared `/resume` handler (which also covers `/sessions <target>`):

1. validate and update the Telegram topic binding first;
2. then switch the generic session route;
3. if the binding write fails, leave the generic route/session lifecycle untouched and report failure;
4. if the generic switch returns falsey or raises, restore the previous topic binding and report failure;
5. never acknowledge a successful resume while the two durable routes disagree.

This stays scoped to Telegram DM topic lanes. Other platforms, ordinary Telegram DMs, and the General/root lobby keep their existing behavior.

## Related Issue

N/A — no existing issue or PR was found for the manual `/resume` command path.

Related but distinct work consulted:

- #19206 — introduced Telegram DM topic sessions and fixed stale bindings after `/new`;
- #34409 — keeps bindings aligned after compression-created session children;
- #51013 — open PR for auto-reset topic continuity;
- #30030 — open PR for restart/automatic resume recovery;
- #76487 — open PR for profile namespacing of Telegram topic state.

None of these updates the Telegram topic binding when the user explicitly runs `/resume` or `/sessions <target>`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/slash_commands.py`
  - coordinate Telegram topic binding updates with the generic `/resume` route switch;
  - fail closed on binding uniqueness/SQLite errors;
  - compensate by restoring the previous binding when the generic route switch returns falsey or raises;
  - keep the logic off the event loop with `asyncio.to_thread()`.

- `tests/gateway/test_resume_command.py`
  - verify the real SQLite topic binding moves to the resumed session;
  - verify a binding-write failure does not mutate the generic route or claim success;
  - verify the previous binding is restored when the generic switch returns `None`;
  - verify the previous binding is restored when the generic switch raises;
  - verify failed compensation still never produces a false success response.

## How to Test

### Reproduction before the fix

1. Enable Telegram DM topic mode and use a topic with an existing bound session.
2. Run `/resume <older-session-id>` or `/sessions <older-session-id>` in that topic.
3. Observe that Hermes replies `Conversation restored`.
4. Send a normal follow-up message.
5. Before the fix, the stale `(chat_id, thread_id)` binding switches the gateway route back to the previously bound session; the restored history is not used.

The regression test fails on the old code with:

```text
assert binding["session_id"] == "old_session_abc"
AssertionError:
  actual:   current_session_001
  expected: old_session_abc
```

### Automated verification

```bash
uv run --with pytest --with pytest-asyncio python -m pytest \
  tests/gateway/test_resume_command.py \
  tests/gateway/test_telegram_topic_mode.py \
  tests/gateway/test_telegram_prune_stale_topic_binding_31501.py \
  -q
```

Development checkout: **120 passed**. Applied to current upstream `main` (8defb9fd): **48 passed**, no conflicts.

Additional checks: `py_compile` passed, `git diff --check` passed, added-line security scan: no findings.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched existing open, closed, and merged PRs for duplicate work
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — focused affected suites pass on both the development checkout and current upstream
- [x] I've added tests for the success path and relevant failure/compensation paths
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] User-facing docs: N/A — this restores the documented `/resume` behavior
- [x] `cli-config.yaml.example`: N/A — no configuration changes
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no contributor workflow or architecture change
- [x] Cross-platform impact considered — pure Python/SQLite routing logic, no OS-specific behavior
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Production evidence from the reported failure:

```text
inbound message: msg='前面聊了什么'
conversation turn:
  session=20260730_185828_aeb11a52
  history=0
```

The requested restored session still had two user messages and its full assistant/tool history in `state.db`; the failure occurred in gateway routing before model invocation.

## AI assistance disclosure

This bug investigation, patch development, test design, and PR draft were performed with AI assistance. The final change was validated with reproducible SQLite regression tests, focused gateway test suites, and an application check against current upstream `main`.
