### PR TITLE
feat(telegram): add configurable commentary preview mode

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1324,6 +1324,14 @@ display:
   #   false: Only keep/send the final response
   interim_assistant_messages: true
 
+  # Gateway commentary delivery shape. "separate" preserves the default of
+  # one message per completed update. Telegram can opt into one temporary
+  # editable preview with:
+  #   display.platforms.telegram.interim_assistant_message_mode: preview
+  # The final answer remains separate; its successful delivery removes the
+  # preview, while failed or cancelled turns retain it as a breadcrumb.
+  interim_assistant_message_mode: separate
+
   # Gateway-only long-running status heartbeats.
   # When false, the platform does not receive periodic "⏳ Working — N min"
   # notifications even if agent.gateway_notify_interval is non-zero. The

--- a/contributors/emails/david@scalingforever.com
+++ b/contributors/emails/david@scalingforever.com
@@ -1,0 +1,2 @@
+Git-on-my-level
+# PR #76943

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -45,6 +45,10 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     # Gateway-only assistant/status chatter controls. These default on for
     # back-compat, but mobile platforms can opt down to final-answer-first.
     "interim_assistant_messages": True,
+    # Delivery shape for completed interim assistant commentary.  ``preview``
+    # is honored by the gateway only on Telegram; all other platforms retain
+    # legacy separate-message delivery.
+    "interim_assistant_message_mode": "separate",
     "long_running_notifications": True,
     "busy_ack_detail": True,
     # Whether busy_input_mode=steer sends a visible "Steered into current run"
@@ -266,6 +270,13 @@ def _normalise(setting: str, value: Any) -> Any:
         if val in {"true", "1", "yes", "on"}:
             return "all"
         return val if val in {"off", "new", "all", "verbose", "log"} else "all"
+    if setting == "interim_assistant_message_mode":
+        if isinstance(value, str):
+            val = value.strip().lower()
+            if val == "preview":
+                return "preview"
+            return "separate"
+        return "separate"
     if setting in {
         "show_reasoning",
         "streaming",

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2805,6 +2805,10 @@ class BasePlatformAdapter(ABC):
         # deliveries generation-aware and avoid stale runs clearing callbacks
         # registered by a fresher run for the same session.
         self._post_delivery_callbacks: Dict[str, Any] = {}
+        # One-shot callbacks that require a confirmed successful main-response
+        # platform ACK. Unlike the legacy callbacks above, these are discarded
+        # without firing on failed delivery, exceptions, or cancellation.
+        self._post_successful_delivery_callbacks: Dict[str, Any] = {}
         self._expected_cancelled_tasks: set[asyncio.Task] = set()
         self._busy_session_handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]] = None
         # Optional authorization check, registered by GatewayRunner. Used by
@@ -4889,6 +4893,79 @@ class BasePlatformAdapter(ABC):
         self._post_delivery_callbacks.pop(session_key, None)
         return entry if callable(entry) else None
 
+    def register_post_successful_delivery_callback(
+        self,
+        session_key: str,
+        callback: Callable,
+        *,
+        generation: int | None = None,
+    ) -> None:
+        """Register work that may run only after a confirmed final-delivery ACK."""
+        if not session_key or not callable(callback):
+            return
+        existing = self._post_successful_delivery_callbacks.get(session_key)
+        if existing is not None:
+            if isinstance(existing, tuple) and len(existing) == 2:
+                existing_gen, existing_cb = existing
+            else:
+                existing_gen, existing_cb = None, existing
+            if (
+                existing_gen is not None
+                and generation is not None
+                and int(generation) < int(existing_gen)
+            ):
+                return
+            if callable(existing_cb) and (
+                existing_gen is None
+                or generation is None
+                or int(existing_gen) == int(generation)
+            ):
+                previous = existing_cb
+                new = callback
+
+                async def _chained_success() -> None:
+                    for cb in (previous, new):
+                        try:
+                            result = cb()
+                            if inspect.isawaitable(result):
+                                await result
+                        except Exception:
+                            logger.debug(
+                                "Successful-delivery callback failed", exc_info=True
+                            )
+
+                callback = _chained_success
+        if generation is None:
+            self._post_successful_delivery_callbacks[session_key] = callback
+        else:
+            self._post_successful_delivery_callbacks[session_key] = (
+                int(generation),
+                callback,
+            )
+
+    def pop_post_successful_delivery_callback(
+        self,
+        session_key: str,
+        *,
+        generation: int | None = None,
+    ) -> Callable | None:
+        """Pop success-gated work, optionally requiring generation ownership."""
+        if not session_key:
+            return None
+        entry = self._post_successful_delivery_callbacks.get(session_key)
+        if entry is None:
+            return None
+        if isinstance(entry, tuple) and len(entry) == 2:
+            entry_generation, callback = entry
+            if generation is not None and int(entry_generation) != int(generation):
+                return None
+            self._post_successful_delivery_callbacks.pop(session_key, None)
+            return callback if callable(callback) else None
+        if generation is not None:
+            return None
+        self._post_successful_delivery_callbacks.pop(session_key, None)
+        return entry if callable(entry) else None
+
     # ── Processing lifecycle hooks ──────────────────────────────────────────
     # Subclasses override these to react to message processing events
     # (e.g. Discord adds 👀/✅/❌ reactions).
@@ -6379,6 +6456,23 @@ class BasePlatformAdapter(ABC):
                     if inspect.isawaitable(_post_result):
                         await asyncio.wait_for(
                             _post_result,
+                            timeout=_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS,
+                        )
+                except (asyncio.TimeoutError, Exception):
+                    pass
+            # Success-only callbacks are always popped at this terminal
+            # boundary so stale cleanup cannot leak into a later turn, but fire
+            # only when the main-response send produced a positive platform ACK.
+            _success_cb = self.pop_post_successful_delivery_callback(
+                session_key,
+                generation=_callback_generation,
+            )
+            if delivery_succeeded and callable(_success_cb):
+                try:
+                    _success_result = _success_cb()
+                    if inspect.isawaitable(_success_result):
+                        await asyncio.wait_for(
+                            _success_result,
                             timeout=_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS,
                         )
                 except (asyncio.TimeoutError, Exception):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4350,6 +4350,7 @@ class TurnRunner:
                         self._runner._build_stream_consumer_config(
                             ctx.source, _scfg, _adapter,
                             on_missing_cursor="raise",
+                            commentary_mode=ctx.interim_assistant_messages_mode,
                         )
                     )
                     _stream_consumer = GatewayStreamConsumer(
@@ -22968,6 +22969,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter: Any,
         *,
         on_missing_cursor: str,
+        commentary_mode: str = "separate",
     ) -> "tuple[Any, Optional[Callable[[], None]]]":
         """Build the shared ``StreamConsumerConfig`` and the optional
         Telegram pause-typing closure used by both agent-run paths.
@@ -23027,6 +23029,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             fresh_final_after_seconds=_fresh_final_secs,
             transport=scfg.transport or "edit",
             chat_type=getattr(source, "chat_type", "") or "",
+            commentary_mode=(
+                commentary_mode
+                if source.platform == Platform.TELEGRAM
+                else "separate"
+            ),
         )
         return _consumer_cfg, _pause_typing_before_finalize
 
@@ -23632,14 +23639,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Natural assistant status messages are intentionally independent from
         # tool progress and token streaming. Users can keep tool_progress quiet
         # in chat platforms while opting into concise mid-turn updates.
-        interim_assistant_messages_mode = _display_surface_mode(
+        _interim_visibility = _display_surface_mode(
             "interim_assistant_messages",
             default=True,
             require_platform_override_for={Platform.MATTERMOST},
         )
+        interim_assistant_messages_mode = str(
+            resolve_display_setting(
+                user_config,
+                platform_key,
+                "interim_assistant_message_mode",
+                "separate",
+            )
+            or "separate"
+        ).strip().lower()
+        if interim_assistant_messages_mode not in {"separate", "preview"}:
+            interim_assistant_messages_mode = "separate"
+        # Preview compaction is intentionally Telegram-only.  A misplaced
+        # preview value on another platform retains legacy separate delivery.
+        if (
+            interim_assistant_messages_mode == "preview"
+            and source.platform != Platform.TELEGRAM
+        ):
+            interim_assistant_messages_mode = "separate"
         interim_assistant_messages_enabled = (
             source.platform != Platform.WEBHOOK
-            and interim_assistant_messages_mode != "off"
+            and _interim_visibility != "off"
         )
         # thinking_progress is independent — if enabled, we need the progress
         # queue even when tool_progress is off (thinking relay uses same infra).
@@ -23742,6 +23767,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             disabled_toolsets=disabled_toolsets,
             log_mode_enabled=log_mode_enabled,
             interim_assistant_messages_enabled=interim_assistant_messages_enabled,
+            interim_assistant_messages_mode=interim_assistant_messages_mode,
             needs_progress_queue=needs_progress_queue,
             _voice_ack_fired=_voice_ack_fired,
             _voice_ack_guild=_voice_ack_guild,
@@ -24744,7 +24770,65 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         merge_pending_message_event(adapter._pending_messages, session_key, pending_event)
                     elif adapter and hasattr(adapter, 'queue_message'):
                         adapter.queue_message(session_key, pending)
-                    return result_holder[0] or {"final_response": response, "messages": history}
+                    # This early return hands the completed response back to
+                    # Base for normal final delivery, bypassing the cleanup
+                    # registration below. Snapshot preview IDs now and attach
+                    # their deletion to Base's successful final ACK.
+                    _depth_sc = stream_consumer_holder[0]
+                    if _depth_sc and stream_task:
+                        try:
+                            await asyncio.wait_for(stream_task, timeout=5.0)
+                        except (asyncio.TimeoutError, asyncio.CancelledError):
+                            stream_task.cancel()
+                            try:
+                                await stream_task
+                            except asyncio.CancelledError:
+                                pass
+                        except Exception as e:
+                            logger.debug(
+                                "Stream consumer wait at interrupt-depth cap failed: %s",
+                                e,
+                            )
+                    _depth_preview_ids = tuple(
+                        getattr(_depth_sc, "commentary_preview_message_ids", ()) or ()
+                    )
+                    _depth_response = result_holder[0] or {
+                        "final_response": response,
+                        "messages": history,
+                    }
+                    if (
+                        adapter
+                        and source.platform == Platform.TELEGRAM
+                        and _depth_preview_ids
+                        and isinstance(_depth_response, dict)
+                        and not _depth_response.get("failed")
+                        and not _depth_response.get("interrupted")
+                        and (_depth_response.get("final_response") or "").strip()
+                        and hasattr(
+                            adapter,
+                            "register_post_successful_delivery_callback",
+                        )
+                        and getattr(type(adapter), "delete_message", None)
+                        is not BasePlatformAdapter.delete_message
+                    ):
+                        _depth_chat_id = source.chat_id
+
+                        async def _delete_depth_previews() -> None:
+                            for _depth_preview_id in _depth_preview_ids:
+                                try:
+                                    await adapter.delete_message(
+                                        _depth_chat_id,
+                                        _depth_preview_id,
+                                    )
+                                except Exception:
+                                    pass
+
+                        adapter.register_post_successful_delivery_callback(
+                            session_key,
+                            _delete_depth_previews,
+                            generation=run_generation,
+                        )
+                    return _depth_response
 
                 was_interrupted = result.get("interrupted")
                 if not was_interrupted:
@@ -24776,6 +24860,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         first_response,
                         previewed=_previewed,
                     )
+                    _queued_final_delivery_succeeded = _already_streamed
                     # Apply the same predicate as the normal completed-turn path.
                     # This direct queued-send branch predates intentional-silence
                     # filtering, so without this check it leaks the literal marker.
@@ -24797,10 +24882,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",
                                 session_key or "?",
                             )
-                            await adapter.send(
+                            _queued_final_result = await adapter.send(
                                 source.chat_id,
                                 first_response,
+                                reply_to=event_message_id,
                                 metadata=_status_thread_metadata,
+                            )
+                            _queued_final_delivery_succeeded = bool(
+                                getattr(_queued_final_result, "success", False)
                             )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
@@ -24809,6 +24898,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Queued follow-up for session %s: skipping resend because final streamed delivery was confirmed.",
                             session_key or "?",
                         )
+                    # This branch recurses before the normal post-run cleanup
+                    # registration below. Clean the completed first turn's
+                    # preview here, strictly after its explicit final ACK.
+                    _queued_preview_ids = tuple(
+                        getattr(_sc, "commentary_preview_message_ids", ()) or ()
+                    )
+                    if (
+                        _queued_final_delivery_succeeded
+                        and source.platform == Platform.TELEGRAM
+                        and _queued_preview_ids
+                    ):
+                        _queued_delete = getattr(type(adapter), "delete_message", None)
+                        if (
+                            _queued_delete is not None
+                            and _queued_delete is not BasePlatformAdapter.delete_message
+                        ):
+                            for _queued_preview_id in _queued_preview_ids:
+                                try:
+                                    await adapter.delete_message(
+                                        source.chat_id,
+                                        _queued_preview_id,
+                                    )
+                                except Exception:
+                                    pass
                     # Release deferred bg-review notifications now that the
                     # first response has been delivered.  Pop from the
                     # adapter's callback dict (prevents double-fire in
@@ -25021,6 +25134,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # final answer.  Suppressing delivery here leaves the user staring
         # at silence.  (#10xxx — "agent stops after web search")
         _sc = stream_consumer_holder[0]
+        _explicit_final_delivery_succeeded = False
         if isinstance(response, dict) and not response.get("failed"):
             _final = response.get("final_response") or ""
             _is_empty_sentinel = not _final or _final == "(empty)"
@@ -25096,6 +25210,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                         if getattr(_reconcile_res, "success", True):
                             response["already_sent"] = True
+                            _explicit_final_delivery_succeeded = True
                             logger.info(
                                 "Reconciled stale streamed finalize for session %s: edited message %s with the complete response (#71643).",
                                 session_key or "?", _sc_msg_id,
@@ -25122,22 +25237,86 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _sc_msg_id = _sc.message_id
                 if _sc_msg_id:
                     try:
-                        await _sc.adapter.edit_message(
+                        _transformed_result = await _sc.adapter.edit_message(
                             chat_id=source.chat_id,
                             message_id=_sc_msg_id,
                             content=response["final_response"],
                             finalize=True,
                         )
-                        response["already_sent"] = True
-                        logger.info(
-                            "Edited streamed message %s for session %s to include plugin-transformed content.",
-                            _sc_msg_id, session_key or "?",
-                        )
+                        if getattr(_transformed_result, "success", False):
+                            response["already_sent"] = True
+                            _explicit_final_delivery_succeeded = True
+                            logger.info(
+                                "Edited streamed message %s for session %s to include plugin-transformed content.",
+                                _sc_msg_id, session_key or "?",
+                            )
+                        else:
+                            logger.warning(
+                                "Failed to edit streamed message %s for session %s to include plugin-transformed content; normal final delivery remains enabled.",
+                                _sc_msg_id,
+                                session_key or "?",
+                            )
                     except Exception as _edit_err:
                         logger.warning(
                             "Failed to edit streamed message for session %s: %s",
                             session_key or "?", _edit_err,
                         )
+
+        # Commentary preview cleanup is stricter than legacy progress cleanup:
+        # it runs only after a confirmed final platform ACK. Streamed finals are
+        # already acknowledged here; commentary-only turns defer to the base
+        # adapter's success-gated delivery callback.
+        _commentary_preview_ids = tuple(
+            getattr(_sc, "commentary_preview_message_ids", ()) or ()
+        )
+        if (
+            _commentary_preview_ids
+            and source.platform == Platform.TELEGRAM
+            and isinstance(response, dict)
+            and not response.get("failed")
+            and not response.get("interrupted")
+            and (response.get("final_response") or "").strip()
+        ):
+            _commentary_adapter = getattr(_sc, "adapter", None)
+            _commentary_delete = (
+                getattr(type(_commentary_adapter), "delete_message", None)
+                if _commentary_adapter is not None
+                else None
+            )
+            if (
+                _commentary_adapter is not None
+                and _commentary_delete is not None
+                and _commentary_delete is not BasePlatformAdapter.delete_message
+            ):
+                _commentary_chat_id = source.chat_id
+
+                async def _delete_commentary_previews() -> None:
+                    for _preview_id in _commentary_preview_ids:
+                        try:
+                            await _commentary_adapter.delete_message(
+                                _commentary_chat_id,
+                                _preview_id,
+                            )
+                        except Exception:
+                            pass
+
+                _final_text = response.get("final_response") or ""
+                _previewed = bool(response.get("response_previewed"))
+                if _explicit_final_delivery_succeeded or _stream_confirmed_final_delivery(
+                    _sc,
+                    _final_text,
+                    previewed=_previewed,
+                ):
+                    await _delete_commentary_previews()
+                elif session_key and hasattr(
+                    _commentary_adapter,
+                    "register_post_successful_delivery_callback",
+                ):
+                    _commentary_adapter.register_post_successful_delivery_callback(
+                        session_key,
+                        _delete_commentary_previews,
+                        generation=run_generation,
+                    )
 
         # Schedule deletion of tracked temporary progress bubbles after the
         # final response lands. Failed runs skip this so bubbles remain as

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -151,6 +151,11 @@ class StreamConsumerConfig:
     # "group", "supergroup", "forum").  Used to gate native draft streaming,
     # which is platform-specific (Telegram drafts are DM-only).
     chat_type: str = ""
+    # Completed interim assistant commentary delivery:
+    #   "separate" — one normal message per commentary item (legacy/default)
+    #   "preview"  — one editable preview bubble, currently enabled by the
+    #                gateway only for Telegram.
+    commentary_mode: str = "separate"
 
 
 class GatewayStreamConsumer:
@@ -314,6 +319,13 @@ class GatewayStreamConsumer:
         # this response and route through edit-based for graceful degradation.
         self._draft_failures = 0
         self._before_finalize_notified = False
+        # Commentary-preview state is deliberately separate from streamed final
+        # response state.  In particular, it must never touch ``_message_id`` or
+        # ``_already_sent`` because commentary is not the turn-final answer.
+        self._commentary_preview_message_ids: list[str] = []
+        self._commentary_preview_message_id: Optional[str] = None
+        self._commentary_preview_last_text = ""
+        self._commentary_preview_edit_supported = True
 
     def _metadata_for_send(
         self,
@@ -355,6 +367,35 @@ class GatewayStreamConsumer:
     def message_id(self) -> str | None:
         """The Discord/chat message ID of the last-sent or edited message."""
         return self._message_id
+
+    @property
+    def commentary_preview_message_ids(self) -> tuple[str, ...]:
+        """Telegram preview bubbles eligible for post-final cleanup."""
+        return tuple(self._commentary_preview_message_ids)
+
+    @staticmethod
+    def _commentary_message_ids_from_result(result: Any) -> tuple[str, ...]:
+        """Return every concrete message ID exposed by a send/edit result."""
+        ids: list[str] = []
+        candidates = [getattr(result, "message_id", None)]
+        candidates.extend(getattr(result, "continuation_message_ids", None) or ())
+        raw = getattr(result, "raw_response", None) or {}
+        if isinstance(raw, dict):
+            candidates.extend(raw.get("message_ids") or ())
+        for message_id in candidates:
+            if message_id and str(message_id) != "__no_edit__":
+                normalized = str(message_id)
+                if normalized not in ids:
+                    ids.append(normalized)
+        return tuple(ids)
+
+    def _track_commentary_preview_result(self, result: Any) -> tuple[str, ...]:
+        """Track every preview bubble created by an adapter fallback/split."""
+        message_ids = self._commentary_message_ids_from_result(result)
+        for message_id in message_ids:
+            if message_id not in self._commentary_preview_message_ids:
+                self._commentary_preview_message_ids.append(message_id)
+        return message_ids
 
     @property
     def final_content_delivered(self) -> bool:
@@ -1758,11 +1799,90 @@ class GatewayStreamConsumer:
         text = self._clean_for_display(text)
         if not text.strip():
             return False
+
+        preview_mode = (
+            str(getattr(self.cfg, "commentary_mode", "separate")).lower()
+            == "preview"
+        )
+        preview_delivery = preview_mode
+        if preview_mode:
+            # Telegram measures the editable-message limit in UTF-16 code
+            # units.  Content that cannot fit in one editable bubble must use
+            # the adapter's existing full-content send/split path; never clip
+            # completed commentary merely to keep it editable.
+            limit = getattr(self.adapter, "MAX_MESSAGE_LENGTH", 4096)
+            len_fn: "Callable[[str], int]" = len
+            if isinstance(self.adapter, _BasePlatformAdapter):
+                try:
+                    limit = self.adapter.max_message_length_for_chat(self.chat_id)
+                    len_fn = self.adapter.message_len_fn_for_chat(self.chat_id)
+                except Exception:
+                    pass
+            safe_limit = max(1, int(limit) - 100)
+            if len_fn(text) > safe_limit:
+                preview_delivery = False
+                self._commentary_preview_message_id = None
+                self._commentary_preview_edit_supported = False
+
+            if (
+                preview_delivery
+                and self._commentary_preview_message_id
+                and self._commentary_preview_edit_supported
+            ):
+                if text == self._commentary_preview_last_text:
+                    return True
+                try:
+                    kwargs: dict[str, Any] = {
+                        "chat_id": self.chat_id,
+                        "message_id": self._commentary_preview_message_id,
+                        "content": text,
+                        # Completed commentary should retain Telegram formatting
+                        # (rich -> MarkdownV2 -> plain fallback), not use the raw
+                        # progressive-edit path.
+                        "finalize": True,
+                    }
+                    metadata = self._metadata_for_send(expect_edits=True)
+                    if metadata:
+                        try:
+                            params = inspect.signature(self.adapter.edit_message).parameters
+                            if "metadata" in params or any(
+                                param.kind is inspect.Parameter.VAR_KEYWORD
+                                for param in params.values()
+                            ):
+                                kwargs["metadata"] = metadata
+                        except (TypeError, ValueError):
+                            pass
+                    result = await self.adapter.edit_message(**kwargs)
+                    if getattr(result, "success", False):
+                        updated_ids = self._track_commentary_preview_result(result)
+                        if len(updated_ids) == 1:
+                            self._commentary_preview_message_id = updated_ids[0]
+                        elif len(updated_ids) > 1:
+                            # Overflow created multiple visible messages, so no
+                            # single bubble can represent the preview anymore.
+                            self._commentary_preview_message_id = None
+                            self._commentary_preview_edit_supported = False
+                        self._commentary_preview_last_text = text
+                        return True
+                except Exception as e:
+                    logger.debug("Commentary preview edit failed: %s", e)
+
+                # Preserve the old bubble as a breadcrumb and degrade this
+                # update to a fresh send.  A successful fresh send becomes the
+                # next editable preview; all created IDs remain cleanup-eligible.
+                self._commentary_preview_edit_supported = False
+                self._commentary_preview_message_id = None
+
         try:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
-                metadata=self.metadata,
+                reply_to=self._initial_reply_to_id if preview_delivery else None,
+                metadata=(
+                    self._metadata_for_send(expect_edits=True)
+                    if preview_delivery
+                    else self.metadata
+                ),
             )
             # Note: do NOT set _already_sent = True here.
             # Commentary messages are interim status updates (e.g. "Using browser
@@ -1770,6 +1890,17 @@ class GatewayStreamConsumer:
             # the final response to be incorrectly suppressed when there are
             # multiple tool calls. See: https://github.com/NousResearch/hermes-agent/issues/10454
             if result.success:
+                if preview_delivery:
+                    message_ids = self._track_commentary_preview_result(result)
+                    if len(message_ids) == 1:
+                        self._commentary_preview_message_id = message_ids[0]
+                        self._commentary_preview_edit_supported = True
+                        self._commentary_preview_last_text = text
+                    else:
+                        # No ID (or multiple IDs from an adapter split) means
+                        # later commentary must stay on the safe fresh-send path.
+                        self._commentary_preview_message_id = None
+                        self._commentary_preview_edit_supported = False
                 # Commentary counts as fresh content — close off any
                 # stale tool bubble above it so the next tool starts a
                 # new bubble below.
@@ -1777,7 +1908,11 @@ class GatewayStreamConsumer:
                 # Record the exact delivered text so run.py can confirm whether
                 # an interim "preview" actually carried the final response, vs.
                 # unrelated commentary delivered during a session split (#14238).
-                self._delivered_commentary_texts.append(text)
+                # In preview mode commentary is never final-delivery evidence,
+                # even if it happens to equal the final text.  The mode's final
+                # answer must always be delivered separately.
+                if not preview_mode:
+                    self._delivered_commentary_texts.append(text)
             return result.success
         except Exception as e:
             logger.error("Commentary send error: %s", e)

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -96,6 +96,7 @@ class TurnContext:
     disabled_toolsets: Any = None
     log_mode_enabled: bool = False
     interim_assistant_messages_enabled: bool = False
+    interim_assistant_messages_mode: str = "separate"
     needs_progress_queue: bool = False
 
     # --- lazy-imported callables captured from the outer body -------------

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1157,6 +1157,9 @@ DEFAULT_CONFIG = {
             "last_lines": 2,
         },
         "interim_assistant_messages": True,  # Gateway: send natural mid-turn assistant status messages. Desktop: keep mid-turn narration between tool calls instead of collapsing to the final message.
+        # Gateway delivery shape for completed interim commentary. ``preview``
+        # is a Telegram-only opt-in; other platforms retain separate messages.
+        "interim_assistant_message_mode": "separate",
         # Codex Responses models narrate progress in a dedicated commentary
         # channel. When true (default), completed commentary messages are
         # delivered as visible mid-turn updates via the interim message path.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -822,6 +822,17 @@ def _timezone_options() -> List[str]:
 
 
 _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
+    "display.interim_assistant_message_mode": {
+        "type": "select",
+        "description": "Default interim commentary delivery shape",
+        "options": ["separate", "preview"],
+    },
+    "display.platforms.telegram.interim_assistant_message_mode": {
+        "type": "select",
+        "description": "Telegram interim commentary delivery shape",
+        "options": ["separate", "preview"],
+        "category": "display",
+    },
     "timezone": {
         "type": "select",
         "description": "IANA timezone (e.g. America/New_York). Blank uses the system timezone.",
@@ -1096,6 +1107,13 @@ for _k, _v in CONFIG_SCHEMA.items():
     if _k == "model":
         _ordered_schema["model_context_length"] = _mcl_entry
 CONFIG_SCHEMA = _ordered_schema
+
+# Per-platform display overrides are intentionally sparse in DEFAULT_CONFIG:
+# materializing a Telegram value there would shadow the global value after
+# deep-merge. Expose this supported override as a virtual dashboard field.
+CONFIG_SCHEMA["display.platforms.telegram.interim_assistant_message_mode"] = (
+    _SCHEMA_OVERRIDES["display.platforms.telegram.interim_assistant_message_mode"]
+)
 
 
 def _is_command_provider_block(value: Any) -> bool:

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -227,6 +227,56 @@ class TestStreamingPerPlatform:
 
 
 # ---------------------------------------------------------------------------
+# Interim commentary delivery mode
+# ---------------------------------------------------------------------------
+
+
+class TestInterimAssistantMessageMode:
+    def test_default_is_backward_compatible_separate(self):
+        from gateway.display_config import resolve_display_setting
+
+        assert (
+            resolve_display_setting({}, "telegram", "interim_assistant_message_mode")
+            == "separate"
+        )
+
+    def test_platform_override_wins_and_is_scoped(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "interim_assistant_message_mode": "separate",
+                "platforms": {
+                    "telegram": {"interim_assistant_message_mode": "preview"},
+                },
+            }
+        }
+        assert (
+            resolve_display_setting(
+                config, "telegram", "interim_assistant_message_mode"
+            )
+            == "preview"
+        )
+        assert (
+            resolve_display_setting(
+                config, "discord", "interim_assistant_message_mode"
+            )
+            == "separate"
+        )
+
+    def test_invalid_mode_falls_back_to_separate(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"interim_assistant_message_mode": "unknown"}}
+        assert (
+            resolve_display_setting(
+                config, "telegram", "interim_assistant_message_mode"
+            )
+            == "separate"
+        )
+
+
+# ---------------------------------------------------------------------------
 # cleanup_progress — opt-in deletion of temporary progress bubbles
 # ---------------------------------------------------------------------------
 
@@ -300,5 +350,3 @@ class TestLiveStatusSetting:
         from gateway.display_config import resolve_display_setting
 
         assert resolve_display_setting({}, "slack", "live_status") == "full"
-
-

--- a/tests/gateway/test_post_delivery_callback_chaining.py
+++ b/tests/gateway/test_post_delivery_callback_chaining.py
@@ -17,7 +17,14 @@ import inspect
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+from gateway.session import SessionSource
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
 
 
 class _MinAdapter(BasePlatformAdapter):
@@ -102,3 +109,101 @@ class TestPostDeliveryCallbackAsyncChaining:
         _invoke(cb)
         assert fired == ["sync", "async"]
 
+
+class _DeliveryOutcomeAdapter(_MinAdapter):
+    def __init__(self, *, succeeds: bool):
+        super().__init__(PlatformConfig(enabled=True), Platform.TELEGRAM)
+        self.succeeds = succeeds
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=self.succeeds, message_id="final-1" if self.succeeds else None)
+
+
+def _event():
+    return MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="chat", chat_type="dm"),
+        message_id="user-1",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("succeeds", [True, False])
+async def test_success_only_callback_follows_final_delivery_ack(succeeds):
+    adapter = _DeliveryOutcomeAdapter(succeeds=succeeds)
+    fired = []
+
+    async def handler(event):
+        return "final answer"
+
+    adapter.set_message_handler(handler)
+    adapter.register_post_successful_delivery_callback(
+        "session",
+        lambda: fired.append("cleanup"),
+    )
+
+    await adapter._process_message_background(_event(), "session")
+
+    assert fired == (["cleanup"] if succeeds else [])
+    assert "session" not in adapter._post_successful_delivery_callbacks
+
+
+@pytest.mark.asyncio
+async def test_success_only_callback_is_discarded_on_cancellation():
+    adapter = _DeliveryOutcomeAdapter(succeeds=True)
+    fired = []
+
+    async def handler(event):
+        raise asyncio.CancelledError
+
+    adapter.set_message_handler(handler)
+    adapter.register_post_successful_delivery_callback(
+        "session",
+        lambda: fired.append("cleanup"),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._process_message_background(_event(), "session")
+
+    assert fired == []
+    assert "session" not in adapter._post_successful_delivery_callbacks
+
+
+@pytest.mark.asyncio
+async def test_cancelled_turn_retains_created_commentary_preview():
+    adapter = _DeliveryOutcomeAdapter(succeeds=True)
+    adapter.deleted = []
+
+    async def delete_message(chat_id, message_id):
+        adapter.deleted.append((chat_id, message_id))
+        return True
+
+    adapter.delete_message = delete_message
+
+    async def handler(event):
+        consumer = GatewayStreamConsumer(
+            adapter,
+            event.source.chat_id,
+            StreamConsumerConfig(commentary_mode="preview"),
+            initial_reply_to_id=event.message_id,
+        )
+        consumer.on_commentary("Work was interrupted.")
+        consumer.finish()
+        await consumer.run()
+        preview_ids = consumer.commentary_preview_message_ids
+
+        async def cleanup():
+            for message_id in preview_ids:
+                await adapter.delete_message(event.source.chat_id, message_id)
+
+        adapter.register_post_successful_delivery_callback("session", cleanup)
+        raise asyncio.CancelledError
+
+    adapter.set_message_handler(handler)
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._process_message_background(_event(), "session")
+
+    assert adapter.deleted == []
+    assert "session" not in adapter._post_successful_delivery_callbacks

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -115,6 +115,86 @@ class MetadataEditProgressCaptureAdapter(ProgressCaptureAdapter):
         return SendResult(success=True, message_id=message_id)
 
 
+class CommentaryPreviewCaptureAdapter(ProgressCaptureAdapter):
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform)
+        self.deleted = []
+        self._next_id = 0
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self._next_id += 1
+        message_id = f"message-{self._next_id}"
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
+
+    async def edit_message(
+        self,
+        chat_id,
+        message_id,
+        content,
+        *,
+        finalize=False,
+        metadata=None,
+    ) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "finalize": finalize,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
+
+    async def delete_message(self, chat_id, message_id) -> bool:
+        self.deleted.append({"chat_id": chat_id, "message_id": message_id})
+        return True
+
+
+class CommentaryDeleteFailureAdapter(CommentaryPreviewCaptureAdapter):
+    async def delete_message(self, chat_id, message_id) -> bool:
+        self.deleted.append({"chat_id": chat_id, "message_id": message_id})
+        raise RuntimeError("delete unavailable")
+
+
+class CommentaryFinalDeliveryAdapter(CommentaryPreviewCaptureAdapter):
+    def __init__(self, platform=Platform.TELEGRAM, *, final_succeeds=True):
+        super().__init__(platform=platform)
+        self.final_succeeds = final_succeeds
+        self.delivery_events = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.delivery_events.append(("send", content))
+        if "Final answer." in content and not self.final_succeeds:
+            self.sent.append(
+                {
+                    "chat_id": chat_id,
+                    "content": content,
+                    "reply_to": reply_to,
+                    "metadata": metadata,
+                }
+            )
+            return SendResult(success=False, error="final delivery rejected")
+        return await super().send(chat_id, content, reply_to=reply_to, metadata=metadata)
+
+    async def delete_message(self, chat_id, message_id) -> bool:
+        self.delivery_events.append(("delete", message_id))
+        return await super().delete_message(chat_id, message_id)
+
+
+class CommentaryQueuedFinalFailureAdapter(CommentaryFinalDeliveryAdapter):
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform, final_succeeds=False)
+
+
 class RetryableFirstEditProgressCaptureAdapter(ProgressCaptureAdapter):
     """Fail one progress edit transiently, then accept later edits."""
 
@@ -513,6 +593,30 @@ class CommentaryAgent:
         }
 
 
+class CommentaryBurstAgent:
+    def __init__(self, **kwargs):
+        self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.interim_assistant_callback:
+            self.interim_assistant_callback("Checking the repo.", already_streamed=False)
+            self.interim_assistant_callback("Running targeted tests.", already_streamed=False)
+        return {
+            "final_response": "Final answer.",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class FailedCommentaryBurstAgent(CommentaryBurstAgent):
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        result = super().run_conversation(message, conversation_history, task_id)
+        result["failed"] = True
+        result["error"] = "provider failed"
+        return result
+
+
 class PreviewedResponseAgent:
     def __init__(self, **kwargs):
         self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
@@ -675,6 +779,7 @@ async def _run_with_agent(
     chat_type="group",
     thread_id="17585",
     adapter_cls=ProgressCaptureAdapter,
+    event_message_id=None,
 ):
     if config_data:
         import yaml
@@ -720,8 +825,277 @@ async def _run_with_agent(
         source=source,
         session_id=session_id,
         session_key=session_key,
+        event_message_id=event_message_id,
     )
     return adapter, result
+
+
+@pytest.mark.asyncio
+async def test_run_agent_telegram_preview_mode_uses_editable_commentary_and_defers_cleanup(
+    monkeypatch,
+    tmp_path,
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryBurstAgent,
+        session_id="sess-commentary-preview",
+        config_data={
+            "display": {
+                "interim_assistant_messages": True,
+                "platforms": {
+                    "telegram": {"interim_assistant_message_mode": "preview"},
+                },
+            }
+        },
+        adapter_cls=CommentaryPreviewCaptureAdapter,
+        event_message_id="user-42",
+    )
+
+    assert result.get("already_sent") is not True
+    assert [call["content"] for call in adapter.sent] == ["Checking the repo."]
+    assert [call["content"] for call in adapter.edits] == ["Running targeted tests."]
+    assert adapter.sent[0]["reply_to"] == "user-42"
+    assert adapter.sent[0]["metadata"]["expect_edits"] is True
+    assert adapter.sent[0]["metadata"]["thread_id"] == "17585"
+    assert adapter.edits[0]["message_id"] == "message-1"
+    assert adapter.edits[0]["finalize"] is True
+    session_key = "agent:main:telegram:group:-1001:17585"
+    cleanup = adapter.pop_post_successful_delivery_callback(session_key)
+    assert callable(cleanup)
+    await cleanup()
+    assert adapter.deleted == [{"chat_id": "-1001", "message_id": "message-1"}]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_commentary_delete_failure_does_not_fail_final_result(
+    monkeypatch,
+    tmp_path,
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryBurstAgent,
+        session_id="sess-commentary-delete-failure",
+        config_data={
+            "display": {
+                "platforms": {
+                    "telegram": {"interim_assistant_message_mode": "preview"},
+                },
+            }
+        },
+        adapter_cls=CommentaryDeleteFailureAdapter,
+    )
+
+    session_key = "agent:main:telegram:group:-1001:17585"
+    cleanup = adapter.pop_post_successful_delivery_callback(session_key)
+    assert callable(cleanup)
+    await cleanup()
+
+    assert result["final_response"] == "Final answer."
+    assert result.get("already_sent") is not True
+    assert adapter.deleted == [{"chat_id": "-1001", "message_id": "message-1"}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("final_succeeds", [True, False])
+async def test_base_delivery_sends_independent_final_then_conditionally_cleans_preview(
+    monkeypatch,
+    tmp_path,
+    final_succeeds,
+):
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "display": {
+                    "platforms": {
+                        "telegram": {
+                            "interim_assistant_message_mode": "preview",
+                        },
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = CommentaryBurstAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = CommentaryFinalDeliveryAdapter(final_succeeds=final_succeeds)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***"},
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+    event = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="user-42",
+    )
+    session_key = "agent:main:telegram:group:-1001:17585"
+
+    async def handler(inbound):
+        result = await runner._run_agent(
+            message=inbound.text,
+            context_prompt="",
+            history=[],
+            source=inbound.source,
+            session_id=f"sess-final-ack-{final_succeeds}",
+            session_key=session_key,
+            event_message_id=inbound.message_id,
+        )
+        assert result.get("already_sent") is not True
+        return result["final_response"]
+
+    adapter.set_message_handler(handler)
+    await adapter._process_message_background(event, session_key)
+
+    assert adapter.sent[0]["content"] == "Checking the repo."
+    assert any("Final answer." in call["content"] for call in adapter.sent[1:])
+    assert [call["content"] for call in adapter.edits] == [
+        "Running targeted tests.",
+    ]
+    if final_succeeds:
+        assert adapter.deleted == [
+            {"chat_id": "-1001", "message_id": "message-1"},
+        ]
+        assert adapter.delivery_events == [
+            ("send", "Checking the repo."),
+            ("send", "Final answer."),
+            ("delete", "message-1"),
+        ]
+    else:
+        assert adapter.deleted == []
+        assert all(kind != "delete" for kind, _ in adapter.delivery_events)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("adapter_cls", "expected_deleted"),
+    [
+        (CommentaryFinalDeliveryAdapter, True),
+        (CommentaryQueuedFinalFailureAdapter, False),
+    ],
+)
+async def test_queued_followup_cleans_first_preview_only_after_first_final_ack(
+    monkeypatch,
+    tmp_path,
+    adapter_cls,
+    expected_deleted,
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryBurstAgent,
+        session_id=f"sess-commentary-queued-{expected_deleted}",
+        pending_text="queued follow-up",
+        config_data={
+            "display": {
+                "platforms": {
+                    "telegram": {"interim_assistant_message_mode": "preview"},
+                },
+            }
+        },
+        adapter_cls=adapter_cls,
+        event_message_id="user-42",
+    )
+
+    assert result["final_response"] == "Final answer."
+    assert ("send", "Final answer.") in adapter.delivery_events
+    if expected_deleted:
+        assert adapter.delivery_events.index(("send", "Final answer.")) < (
+            adapter.delivery_events.index(("delete", "message-1"))
+        )
+        assert adapter.deleted == [
+            {"chat_id": "-1001", "message_id": "message-1"},
+        ]
+    else:
+        assert adapter.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_run_agent_default_and_nontelegram_preview_keep_separate_commentary(
+    monkeypatch,
+    tmp_path,
+):
+    telegram, telegram_result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryBurstAgent,
+        session_id="sess-commentary-default",
+        config_data={"display": {"interim_assistant_messages": True}},
+        adapter_cls=CommentaryPreviewCaptureAdapter,
+    )
+    assert telegram_result.get("already_sent") is not True
+    assert [call["content"] for call in telegram.sent] == [
+        "Checking the repo.",
+        "Running targeted tests.",
+    ]
+    assert telegram.edits == []
+
+    discord, discord_result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryBurstAgent,
+        session_id="sess-commentary-discord-preview",
+        config_data={
+            "display": {
+                "interim_assistant_messages": True,
+                "platforms": {
+                    "discord": {"interim_assistant_message_mode": "preview"},
+                },
+            }
+        },
+        platform=Platform.DISCORD,
+        chat_id="dm-1",
+        chat_type="dm",
+        thread_id=None,
+        adapter_cls=CommentaryPreviewCaptureAdapter,
+    )
+    assert discord_result.get("already_sent") is not True
+    assert [call["content"] for call in discord.sent] == [
+        "Checking the repo.",
+        "Running targeted tests.",
+    ]
+    assert discord.edits == []
+
+
+@pytest.mark.asyncio
+async def test_run_agent_failed_turn_retains_commentary_preview(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        FailedCommentaryBurstAgent,
+        session_id="sess-commentary-preview-failed",
+        config_data={
+            "display": {
+                "platforms": {
+                    "telegram": {"interim_assistant_message_mode": "preview"},
+                },
+            }
+        },
+        adapter_cls=CommentaryPreviewCaptureAdapter,
+    )
+
+    assert result["failed"] is True
+    assert adapter.deleted == []
+    assert adapter._post_successful_delivery_callbacks == {}
 
 
 @pytest.mark.asyncio
@@ -1316,5 +1690,3 @@ class TestSlackReplyInThreadProgressRouting:
             event_message_id="1700000000.000100",
             reply_in_thread=False,
         ) is None
-
-

--- a/tests/gateway/test_stream_consumer_commentary_preview.py
+++ b/tests/gateway/test_stream_consumer_commentary_preview.py
@@ -1,0 +1,192 @@
+"""Focused contracts for editable interim-commentary previews."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+def _consumer(adapter, **kwargs):
+    return GatewayStreamConsumer(
+        adapter,
+        "chat",
+        StreamConsumerConfig(
+            edit_interval=0.01,
+            buffer_threshold=1,
+            commentary_mode="preview",
+        ),
+        metadata={"thread_id": "topic-7"},
+        initial_reply_to_id="reply-42",
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_preview_first_send_then_repeated_edits_keep_one_message_id():
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.send = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id="preview-1")
+    )
+    adapter.edit_message = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id="preview-1")
+    )
+    consumer = _consumer(adapter)
+
+    consumer.on_commentary("Checking the repo.")
+    consumer.on_commentary("Running targeted tests.")
+    consumer.on_commentary("Reviewing the diff.")
+    consumer.finish()
+    await consumer.run()
+
+    adapter.send.assert_awaited_once_with(
+        chat_id="chat",
+        content="Checking the repo.",
+        reply_to="reply-42",
+        metadata={
+            "thread_id": "topic-7",
+            "reply_to_message_id": "reply-42",
+            "expect_edits": True,
+        },
+    )
+    assert [call.kwargs["message_id"] for call in adapter.edit_message.await_args_list] == [
+        "preview-1",
+        "preview-1",
+    ]
+    assert all(call.kwargs["finalize"] is True for call in adapter.edit_message.await_args_list)
+    assert consumer.commentary_preview_message_ids == ("preview-1",)
+    assert consumer.already_sent is False
+    assert consumer.final_response_sent is False
+
+
+@pytest.mark.asyncio
+async def test_preview_edit_failure_falls_back_and_tracks_every_breadcrumb():
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.send = AsyncMock(
+        side_effect=[
+            SimpleNamespace(success=True, message_id="preview-1"),
+            SimpleNamespace(success=True, message_id="preview-2"),
+        ]
+    )
+    adapter.edit_message = AsyncMock(
+        side_effect=[
+            SimpleNamespace(success=False, message_id="preview-1", error="not editable"),
+            SimpleNamespace(success=True, message_id="preview-2"),
+        ]
+    )
+    consumer = _consumer(adapter)
+
+    consumer.on_commentary("First.")
+    consumer.on_commentary("Second survives failed edit.")
+    consumer.on_commentary("Third edits the fallback.")
+    consumer.finish()
+    await consumer.run()
+
+    assert [call.kwargs["content"] for call in adapter.send.await_args_list] == [
+        "First.",
+        "Second survives failed edit.",
+    ]
+    assert adapter.edit_message.await_args_list[-1].kwargs["message_id"] == "preview-2"
+    assert consumer.commentary_preview_message_ids == ("preview-1", "preview-2")
+    assert consumer.already_sent is False
+
+
+@pytest.mark.asyncio
+async def test_preview_edit_exception_falls_back_to_fresh_editable_message():
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.send = AsyncMock(
+        side_effect=[
+            SimpleNamespace(success=True, message_id="preview-1"),
+            SimpleNamespace(success=True, message_id="preview-2"),
+        ]
+    )
+    adapter.edit_message = AsyncMock(side_effect=RuntimeError("edit unavailable"))
+    consumer = _consumer(adapter)
+
+    consumer.on_commentary("First.")
+    consumer.on_commentary("Second survives the exception.")
+    consumer.finish()
+    await consumer.run()
+
+    assert [call.kwargs["content"] for call in adapter.send.await_args_list] == [
+        "First.",
+        "Second survives the exception.",
+    ]
+    assert consumer.commentary_preview_message_ids == ("preview-1", "preview-2")
+
+
+@pytest.mark.asyncio
+async def test_preview_tracks_all_adapter_result_ids_and_stops_ambiguous_edits():
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.send = AsyncMock(
+        side_effect=[
+            SimpleNamespace(
+                success=True,
+                message_id="preview-2",
+                continuation_message_ids=("preview-1", "preview-2"),
+            ),
+            SimpleNamespace(success=True, message_id="preview-3"),
+        ]
+    )
+    adapter.edit_message = AsyncMock()
+    consumer = _consumer(adapter)
+
+    consumer.on_commentary("First split by the adapter.")
+    consumer.on_commentary("Second uses a fresh message.")
+    consumer.finish()
+    await consumer.run()
+
+    assert adapter.edit_message.await_count == 0
+    assert consumer.commentary_preview_message_ids == (
+        "preview-2",
+        "preview-1",
+        "preview-3",
+    )
+
+
+@pytest.mark.asyncio
+async def test_overlong_preview_uses_full_content_send_instead_of_clipping():
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 140
+    adapter.send = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id="separate-1")
+    )
+    adapter.edit_message = AsyncMock()
+    consumer = _consumer(adapter)
+    commentary = "A" * 80
+
+    consumer.on_commentary(commentary)
+    consumer.finish()
+    await consumer.run()
+
+    adapter.send.assert_awaited_once_with(
+        chat_id="chat",
+        content=commentary,
+        reply_to=None,
+        metadata={"thread_id": "topic-7"},
+    )
+    assert consumer.commentary_preview_message_ids == ()
+    assert consumer.has_delivered_text(commentary) is False
+
+
+@pytest.mark.asyncio
+async def test_preview_equal_to_final_is_not_final_delivery_evidence():
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.send = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id="preview-1")
+    )
+    consumer = _consumer(adapter)
+
+    consumer.on_commentary("The final answer.")
+    consumer.finish()
+    await consumer.run()
+
+    assert consumer.has_delivered_text("The final answer.") is False
+    assert consumer.already_sent is False
+    assert consumer.final_content_delivered is False

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -950,6 +950,35 @@ class TestInterimAssistantMessageConfig:
 
     def test_default_config_enables_interim_assistant_messages(self):
         assert DEFAULT_CONFIG["display"]["interim_assistant_messages"] is True
+        assert DEFAULT_CONFIG["display"]["interim_assistant_message_mode"] == "separate"
+        assert "interim_assistant_message_mode" not in DEFAULT_CONFIG["display"][
+            "platforms"
+        ]["telegram"]
+
+    def test_loaded_global_commentary_mode_is_not_shadowed_by_platform_defaults(
+        self,
+        tmp_path,
+    ):
+        from gateway.display_config import resolve_display_setting
+
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump(
+                {"display": {"interim_assistant_message_mode": "preview"}}
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            loaded = load_config()
+
+        assert (
+            resolve_display_setting(
+                loaded,
+                "telegram",
+                "interim_assistant_message_mode",
+            )
+            == "preview"
+        )
 
     def test_migrate_to_v15_adds_interim_assistant_message_gate(self, tmp_path):
         config_path = tmp_path / "config.yaml"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1577,6 +1577,13 @@ class TestBuildSchemaFromConfig:
         assert "node24" in runtime_entry["options"]
         assert "python3.13" in runtime_entry["options"]
         assert len(runtime_entry["options"]) >= 3
+        for path in (
+            "display.interim_assistant_message_mode",
+            "display.platforms.telegram.interim_assistant_message_mode",
+        ):
+            commentary_entry = CONFIG_SCHEMA[path]
+            assert commentary_entry["type"] == "select"
+            assert set(commentary_entry["options"]) == {"separate", "preview"}
 
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1583,6 +1583,7 @@ display:
   focus_view: false       # CLI focus view (/focus) — reduced output, display-only
   platforms: {}           # Per-platform display overrides (see below)
   interim_assistant_messages: true  # Gateway: send natural mid-turn assistant updates as separate messages
+  interim_assistant_message_mode: separate  # Gateway: separate | preview (Telegram-only preview)
   show_commentary: true   # Codex models: deliver commentary-channel progress narration as visible mid-turn updates
   skin: default           # Built-in or custom CLI skin (see user-guide/features/skins)
   personality: ""         # Legacy cosmetic field still surfaced in some summaries
@@ -1741,6 +1742,17 @@ Platforms without an override fall back to the global `tool_progress` value. Val
 Signal is listed as a valid platform key because the setting can be saved per platform, but the current Signal adapter cannot edit sent messages and does not render tool-progress bubbles. Keep Signal `tool_progress` set to `off`; use the CLI or an editing-capable messaging platform if you need to watch each tool call live.
 
 `interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
+
+Telegram can opt into a single editable commentary preview while keeping that visibility gate enabled:
+
+```yaml
+display:
+  platforms:
+    telegram:
+      interim_assistant_message_mode: preview
+```
+
+The default mode is `separate`. In `preview` mode, the first completed commentary sends one editable Telegram message and later commentary edits it. The final answer is always a separate delivery; after Telegram confirms that final delivery, Hermes deletes every preview bubble created during the turn. Agent failure, cancellation, or a failed final send keeps the preview as a breadcrumb. Edit failures fall back to fresh commentary messages, and delete failures never affect the final answer. The mode is Telegram-only; a `preview` value on another platform degrades to `separate`.
 
 `show_commentary` (default `true`) controls Codex Responses models' commentary channel — the polished progress narration these models produce alongside their private reasoning. When enabled, each completed commentary message is delivered as a visible mid-turn update (on the gateway this also requires `interim_assistant_messages`). Set it to `false` if the extra narration annoys you: commentary then falls back to the reasoning channel and is only shown when `show_reasoning` is enabled.
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -738,6 +738,7 @@ Telegram is usually a mobile inbox, so the defaults are tuned for that surface:
 - **`tool_progress`** defaults to **`off`** — no per-tool breadcrumb stream filling up the chat.
 - **`busy_ack_detail`** defaults to **`off`** — busy-state acknowledgments and long-running heartbeats stay terse (no `iteration 21/60` debug detail).
 - **`interim_assistant_messages`** stays **on** — real mid-turn assistant commentary (the model literally telling you what it's about to do) is signal, not noise.
+- **`interim_assistant_message_mode`** defaults to **`separate`** — opt Telegram into `preview` to edit one temporary commentary bubble instead.
 - **`long_running_notifications`** stays **on** — a single edit-in-place "⏳ Working — N min" bubble updates every few minutes so you have a heartbeat instead of staring at `typing…` for half an hour.
 
 Opt out of either of the kept-on defaults or opt back into verbose progress per platform:
@@ -753,7 +754,11 @@ display:
       # Or quiet them entirely
       interim_assistant_messages: false
       long_running_notifications: false
+      # Or compact completed commentary into one temporary editable bubble
+      interim_assistant_message_mode: preview
 ```
+
+Telegram preview mode never reuses the final-response message. The final answer is delivered separately, then the temporary preview is deleted only after a successful final delivery. Failed or cancelled turns retain it as a breadcrumb. Telegram formatting, topic/reply routing, and length limits still apply; edit failures safely fall back to fresh commentary messages, and deletion is best-effort.
 
 ### Progress bubble cleanup (opt-in)
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1309,6 +1309,19 @@ Unknown values log a warning and fall back to `important`.
 
 The Telegram adapter routes recurring agent status callbacks (e.g. "Compressing context…", "Calling tool…") through `send_or_update_status()`, which keeps a `{(chat_id, status_key) → message_id}` cache and **edits the existing bubble** on subsequent emits instead of appending a new one each time. Distinct `status_key` values get their own messages; distinct chats never collide. If the edit fails (e.g. the user deleted the message, or it's older than Telegram allows for edits), the cache entry is dropped and the next emit posts a fresh message and re-caches its ID. No config required — this is the default Telegram behavior. Other adapters that don't implement `send_or_update_status` fall through to plain `send()` unchanged.
 
+### Commentary preview mode
+
+Completed assistant commentary uses separate messages by default. To keep long turns compact, opt Telegram into one temporary editable preview:
+
+```yaml
+display:
+  platforms:
+    telegram:
+      interim_assistant_message_mode: preview
+```
+
+The first commentary sends a normal bot message and later commentary edits that same message. The final answer remains an independent message and is never suppressed merely because commentary was visible. Hermes deletes commentary previews only after Telegram acknowledges the final response; failed or cancelled turns retain them as breadcrumbs. Topic/reply metadata and Telegram's MarkdownV2/rich-to-plain fallbacks are preserved. If an edit is rejected, too old, or rate-limited, Hermes falls back to a fresh preview message. Commentary too long for one editable message uses Telegram's existing full-content send/split path instead of clipping the text. Cleanup deletion is best-effort and cannot remove or delay the final answer.
+
 ## Pin incoming user message during agent turn
 
 When a user sends a message that triggers an agent turn, the Telegram adapter pins that incoming message for the duration of the turn and unpins it when the response is finished — a lightweight visual indicator that the bot is actively working on the message rather than ignoring it. The pin uses `disable_notification=true` to avoid extra pings. No config required.


### PR DESCRIPTION
## Summary

- add `display.interim_assistant_message_mode: separate | preview`, with per-platform precedence and a backward-compatible `separate` default
- compact completed Telegram commentary into one editable preview while keeping final delivery completely independent
- delete preview bubbles only after a confirmed final ACK; retain them on failure, cancellation, interruption, or failed final delivery
- preserve reply/topic metadata, editable seed metadata (`expect_edits: true`), formatted-edit fallbacks, Telegram length semantics, and safe edit/delete degradation
- add gateway/Base integration coverage, config/dashboard coverage, and user documentation

## Configuration

```yaml
display:
  platforms:
    telegram:
      interim_assistant_message_mode: preview
```

`interim_assistant_messages` remains the visibility gate. `preview` changes only the Telegram delivery shape; non-Telegram platforms remain on separate commentary messages.

## Relationship to existing work

This supersedes the fixed `compact_commentary` approach in #41337 with an explicit opt-in mode, editable seed metadata, final-ACK-gated deletion, failure/cancellation breadcrumbs, full-content length fallback, and broader lifecycle tests. It was implemented independently against current `NousResearch/main` rather than copying the conflicted branch.

Fork counterpart against `Git-on-my-level/prod`: https://github.com/Git-on-my-level/hermes-agent/pull/24

The fork and upstream baselines have diverged substantially, so the same reviewed commits were ported onto each real base and the only `gateway/run.py` conflict was resolved by retaining the fork's older final-reconciliation shape. No upstream history was merged into `prod`.

## Verification

- `scripts/run_tests.sh tests/gateway/test_stream_consumer_commentary_preview.py tests/gateway/test_run_progress_topics.py tests/gateway/test_post_delivery_callback_chaining.py tests/gateway/test_display_config.py tests/hermes_cli/test_config.py tests/hermes_cli/test_web_server.py -q` — **256 passed**
- `scripts/run_tests.sh tests/gateway/test_stream_consumer.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_run_cleanup_progress.py -q` — **94 passed**
- `.venv/bin/ruff check <all changed Python files>` — **passed**
- `git diff --check upstream/main...HEAD` — **passed**

## Limitations and boundary

- Telegram only; the upstream default remains `separate`.
- Commentary too large for one editable message uses the adapter's existing full-content send/split path instead of clipping.
- Edit failures create a fresh preview; deletion is best-effort and never blocks or suppresses the final answer.
- The local Docusaurus toolchain was not installed, so documentation was source-reviewed but not site-built locally.
- This PR is authorized for review only. Do **not** merge, release, deploy, restart a gateway, or change credentials as part of this work.
