### PR TITLE
fix(gateway): keep busy photo followups silent

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8678,6 +8678,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if getattr(event, "internal", False):
             return False
 
+        # Photo bursts and mixed caption+photo payloads can arrive as a media
+        # completion while the session guard is still active.  Defer them to
+        # BasePlatformAdapter.handle_message(), which already merges PHOTO
+        # follow-ups into the pending turn without interrupting the active run
+        # or emitting a user-facing busy acknowledgment.
+        if event.message_type == MessageType.PHOTO:
+            return False
+
         _busy_state = self._peek_session_state(session_key)
         running_agent = _busy_state.turn.agent if _busy_state else None
 

--- a/tests/gateway/test_internal_event_never_interrupts_busy_session.py
+++ b/tests/gateway/test_internal_event_never_interrupts_busy_session.py
@@ -64,6 +64,23 @@ def _make_internal_event(text: str = "[async delegation completed]") -> MessageE
     )
 
 
+def _make_photo_event() -> MessageEvent:
+    source = SessionSource(
+        platform=MagicMock(value="photon"),
+        chat_id="any;-;+31600000000",
+        chat_type="private",
+        user_id="+31600000000",
+    )
+    return MessageEvent(
+        text="What is in this image?",
+        message_type=MessageType.PHOTO,
+        source=source,
+        message_id="photo-msg",
+        media_urls=["/tmp/photo.heic"],
+        media_types=["image/heic"],
+    )
+
+
 def _make_runner() -> GatewayRunner:
     runner = object.__new__(GatewayRunner)
     runner._running_agents = {}
@@ -124,6 +141,25 @@ async def test_internal_event_does_not_interrupt_busy_session() -> None:
     # The active turn must survive.
     parent.interrupt.assert_not_called()
     # No "⚡ Interrupting current task" (or any) ack for a synthetic event.
+    adapter._send_with_retry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_photo_followup_defers_to_silent_base_queue() -> None:
+    """Photo completions must use the base adapter's no-interrupt media path."""
+    runner = _make_runner()
+    runner._busy_input_mode = "interrupt"
+    adapter = _make_adapter()
+    event = _make_photo_event()
+    sk = build_session_key(event.source)
+    parent = _make_running_parent()
+    runner._running_agents[sk] = parent
+    runner.adapters[event.source.platform] = adapter
+
+    handled = await runner._handle_active_session_busy_message(event, sk)
+
+    assert handled is False
+    parent.interrupt.assert_not_called()
     adapter._send_with_retry.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

- let busy `PHOTO` events fall through to `BasePlatformAdapter.handle_message`
- preserve the existing silent photo-burst/pending-media merge contract
- prevent the gateway from interrupting the active turn and emitting a user-facing `Interrupting current task` acknowledgment for a photo completion

## Root cause

`BasePlatformAdapter.handle_message` already has a dedicated busy-session branch for `MessageType.PHOTO`: it merges the event into the pending turn and returns without interrupting.

However, the runner's `_handle_active_session_busy_message` executes first. It consumed the PHOTO event under the default interrupt mode, called `running_agent.interrupt(...)`, sent the busy acknowledgment, and returned `True`, making the base PHOTO branch unreachable.

Mixed caption+photo payloads can surface this when the media completion arrives while the session guard is still active. The final vision response is correct, but the user sees an internal busy-state message first.

## Fix

Return `False` for `MessageType.PHOTO` after the existing drain, approval, clarify, and internal-event handling. `False` means “not consumed by the runner”; the base adapter then applies its existing silent PHOTO merge path.

This is platform-agnostic and does not change ordinary TEXT interruption.

## Verification

- strict RED: regression test failed with `assert True is False`
- GREEN: focused regression file: `2 passed`
- relevant gateway/CLI suites: `19 passed`
- Ruff: PASS
- `py_compile`: PASS
- `git diff --check`: PASS
- independent review: no security concerns or logic errors

Tested suites:

```text
tests/gateway/test_internal_event_never_interrupts_busy_session.py
tests/gateway/test_session_race_guard.py
tests/gateway/test_queue_command.py
tests/cli/test_busy_input_mode_command.py
```

## Behavioral boundaries

- PHOTO media is not dropped: returning `False` reaches the base adapter's existing `merge_pending_message_event` branch.
- Clarify handling remains before the runner busy handler.
- Plain-text approval handling remains before the PHOTO fall-through.
- Internal synthetic events retain their existing early return.
- TEXT busy-interrupt behavior is unchanged.
- No runtime configuration or platform-specific special case is added.
