### PR TITLE
fix(background-review): preserve gateway prompt context

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -745,6 +745,13 @@ def _run_review_in_thread(
             # _cached_system_prompt below.
             if not _routed:
                 _fork_kwargs["reasoning_config"] = getattr(agent, "reasoning_config", None)
+                # Gateway session context is appended to the parent's cached
+                # system prompt at API-call time through this field.  Preserve
+                # it on same-model forks so the complete effective system
+                # prompt remains byte-identical and can reuse the warm prefix.
+                _fork_kwargs["ephemeral_system_prompt"] = getattr(
+                    agent, "ephemeral_system_prompt", None
+                )
             review_agent = AIAgent(
                 model=_rt.get("model") or agent.model,
                 max_iterations=16,

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -33,6 +33,9 @@ def _make_agent_stub(agent_cls):
         "PARENT-SYSTEM-PROMPT-BYTES — must be inherited verbatim "
         "for prefix-cache parity"
     )
+    agent.ephemeral_system_prompt = (
+        "WebUI session context:\n- Pinned per-request gateway context"
+    )
     import datetime as _dt
     agent.session_start = _dt.datetime(2026, 1, 1, 12, 0, 0)
     agent._MEMORY_REVIEW_PROMPT = "review memory"
@@ -88,6 +91,7 @@ def _make_recorder_class(captured=None, record_on_run=()):
             self.suppress_status_output = None
             self.session_start = None
             self.session_id = None
+            self.ephemeral_system_prompt = kwargs.get("ephemeral_system_prompt")
 
         def run_conversation(self, *args, **kwargs):
             if captured is not None:
@@ -150,6 +154,44 @@ def test_review_fork_inherits_parent_cached_system_prompt():
         f"Got {captured['written_prompt']!r}, expected {parent_prompt!r}. "
         "This breaks Anthropic/OpenRouter prefix-cache parity (#25322)."
     )
+
+
+def test_review_fork_inherits_parent_ephemeral_system_prompt():
+    """The fork must send the parent's complete effective system prompt.
+
+    Gateway session context is appended through ``ephemeral_system_prompt`` at
+    API-call time, outside ``_cached_system_prompt``.  Copying only the cached
+    base therefore makes every background review diverge at the gateway block
+    and miss the parent's warm prefix cache.
+    """
+    import run_agent
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    captured = {}
+    _Recorder = _make_recorder_class(
+        captured,
+        record_on_run=("_cached_system_prompt", "ephemeral_system_prompt"),
+    )
+
+    with patch.object(run_agent, "AIAgent", _Recorder), \
+         patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    parent_effective = (
+        getattr(agent, "_cached_system_prompt")
+        + "\n\n"
+        + getattr(agent, "ephemeral_system_prompt")
+    ).strip()
+    fork_effective = (
+        captured["_cached_system_prompt"]
+        + "\n\n"
+        + captured["ephemeral_system_prompt"]
+    ).strip()
+    assert fork_effective == parent_effective
 
 
 def test_review_fork_pins_session_start_and_session_id():


### PR DESCRIPTION
## Summary

- carry the parent agent's pinned `ephemeral_system_prompt` into same-model background-review forks
- preserve the complete effective system-prompt bytes, including gateway/WebUI session context, so review requests can reuse the parent's warm prefix cache
- keep routed auxiliary-model reviews unchanged to avoid forwarding parent-only context across providers when cache parity is unavailable

## Root cause

The review fork copied `_cached_system_prompt`, but gateway session context is appended separately at API-call time through `ephemeral_system_prompt`. The fork therefore diverged from the parent at the gateway context block despite sharing the cached base prompt.

## Test plan

- RED: `scripts/run_tests.sh tests/run_agent/test_background_review_cache_parity.py -k inherits_parent_ephemeral_system_prompt -v`
- GREEN: same command
- regression suite: `scripts/run_tests.sh tests/run_agent/test_background_review*.py tests/test_background_review*.py tests/agent/test_compression_concurrent_fork.py tests/tui_gateway/test_review_summary_callback.py` (73 passed)

Fixes #76938
