### PR TITLE
feat: prefix hindsight recall results with freshness timestamp

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -565,6 +565,19 @@ def _event_timestamp() -> str:
     return event_time.isoformat(timespec="seconds")
 
 
+def _fmt_memory(r) -> str:
+    """Format a recall result with a freshness timestamp prefix.
+
+    Prepends [YYYY-MM-DD] when the memory carries a time anchor, so the agent
+    can judge how old a recalled memory is (local hit != already searched).
+    mentioned_at (write time) is the freshness signal and is populated in
+    practice; occurred_start (event time) and occurred_at (explicit anchor) are fallbacks that are usually empty.
+    """
+    t = getattr(r, "mentioned_at", None) or getattr(r, "occurred_start", None) or getattr(r, "occurred_at", None) or ""
+    ts = t[:10] if t else ""
+    return f"[{ts}] {r.text}" if ts else r.text
+
+
 def _embedded_profile_name(config: dict[str, Any]) -> str:
     """Return the Hindsight embedded profile name for this Hermes config."""
     profile = config.get("profile", "hermes")
@@ -1905,7 +1918,7 @@ class HindsightMemoryProvider(MemoryProvider):
             resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
             num_results = len(resp.results) if resp.results else 0
             logger.debug("Recall: returned %d results", num_results)
-            text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+            text = "\n".join(_fmt_memory(r) for r in resp.results if r.text) if resp.results else ""
             return _RecallResult(text, num_results)
         except Exception as e:
             logger.debug("Hindsight recall failed: %s", e, exc_info=True)
@@ -2249,7 +2262,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 logger.debug("Tool hindsight_recall: %d results", num_results)
                 if not resp.results:
                     return json.dumps({"result": "No relevant memories found."})
-                lines = [f"{i}. {r.text}" for i, r in enumerate(resp.results, 1)]
+                lines = [f"{i}. {_fmt_memory(r)}" for i, r in enumerate(resp.results, 1)]
                 return json.dumps({"result": "\n".join(lines)})
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -493,6 +493,19 @@ def _utc_timestamp() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
+def _fmt_memory(r) -> str:
+    """Format a recall result with a freshness timestamp prefix.
+
+    Prepends [YYYY-MM-DD] when the memory carries a time anchor, so the agent
+    can judge how old a recalled memory is (local hit != already searched).
+    mentioned_at (write time) is the freshness signal and is populated in
+    practice; occurred_start (event time) is a fallback that is usually empty.
+    """
+    t = getattr(r, "mentioned_at", None) or getattr(r, "occurred_start", None) or ""
+    ts = t[:10] if t else ""
+    return f"[{ts}] {r.text}" if ts else r.text
+
+
 def _embedded_profile_name(config: dict[str, Any]) -> str:
     """Return the Hindsight embedded profile name for this Hermes config."""
     profile = config.get("profile", "hermes")
@@ -1568,7 +1581,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
                     num_results = len(resp.results) if resp.results else 0
                     logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+                    text = "\n".join(_fmt_memory(r) for r in resp.results if r.text) if resp.results else ""
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text
@@ -1799,7 +1812,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 logger.debug("Tool hindsight_recall: %d results", num_results)
                 if not resp.results:
                     return json.dumps({"result": "No relevant memories found."})
-                lines = [f"{i}. {r.text}" for i, r in enumerate(resp.results, 1)]
+                lines = [f"{i}. {_fmt_memory(r)}" for i, r in enumerate(resp.results, 1)]
                 return json.dumps({"result": "\n".join(lines)})
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -32,6 +32,7 @@ from plugins.memory.hindsight import (
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
+    _fmt_memory,
 )
 
 
@@ -225,6 +226,34 @@ def test_normalize_retain_tags_accepts_csv_and_dedupes():
 # ---------------------------------------------------------------------------
 # Schema tests
 # ---------------------------------------------------------------------------
+
+
+class TestFmtMemory:
+    def test_uses_mentioned_at_when_present(self):
+        r = SimpleNamespace(
+            text="memory", mentioned_at="2026-07-20T08:30:00Z", occurred_start="2026-07-19T00:00:00Z"
+        )
+        assert _fmt_memory(r) == "[2026-07-20] memory"
+
+    def test_falls_back_to_occurred_start(self):
+        r = SimpleNamespace(
+            text="memory", mentioned_at=None, occurred_start="2026-06-15T12:00:00Z"
+        )
+        assert _fmt_memory(r) == "[2026-06-15] memory"
+
+    def test_bare_text_when_no_timestamp(self):
+        r = SimpleNamespace(text="memory", mentioned_at=None, occurred_start=None)
+        assert _fmt_memory(r) == "memory"
+
+    def test_truncates_timestamp_to_date_only(self):
+        r = SimpleNamespace(
+            text="memory", mentioned_at="2026-07-20T08:30:00.123456Z", occurred_start=None
+        )
+        assert _fmt_memory(r) == "[2026-07-20] memory"
+
+    def test_missing_attributes_do_not_raise(self):
+        r = SimpleNamespace(text="memory")
+        assert _fmt_memory(r) == "memory"
 
 
 class TestSchemas:
@@ -509,6 +538,37 @@ class TestToolHandlers:
         assert "Memory 2" in result["result"]
 
 
+    def test_recall_prefixes_freshness_timestamp(self, provider):
+        """_fmt_memory must prepend [YYYY-MM-DD] from mentioned_at, fall back
+        to occurred_start, and leave bare memories untouched."""
+        provider._client.arecall.return_value = SimpleNamespace(
+            results=[
+                SimpleNamespace(
+                    text="Old memory",
+                    mentioned_at="2026-07-20T08:30:00Z",
+                    occurred_start=None,
+                ),
+                SimpleNamespace(
+                    text="Event memory",
+                    mentioned_at=None,
+                    occurred_start="2026-06-15T12:00:00Z",
+                ),
+                SimpleNamespace(
+                    text="No timestamp memory",
+                    mentioned_at=None,
+                    occurred_start=None,
+                ),
+            ]
+        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "old"}
+        ))
+        lines = result["result"].split("\n")
+        assert "[2026-07-20] Old memory" in lines[0]
+        assert "[2026-06-15] Event memory" in lines[1]
+        assert lines[2] == "3. No timestamp memory"
+
+
     def test_reflect_success(self, provider):
         result = json.loads(provider.handle_tool_call(
             "hindsight_reflect", {"query": "summarize"}
@@ -554,6 +614,29 @@ class TestToolHandlers:
 class TestPrefetch:
     def test_prefetch_returns_empty_when_no_result(self, provider):
         assert provider.prefetch("test") == ""
+
+
+    def test_prefetch_prefixes_freshness_timestamp(self, provider):
+        """Auto-prefetch injection must apply the same _fmt_memory timestamp
+        prefixing as the explicit recall tool."""
+        provider._client.arecall.return_value = SimpleNamespace(
+            results=[
+                SimpleNamespace(
+                    text="Prefetched old memory",
+                    mentioned_at="2026-07-18T09:00:00Z",
+                    occurred_start=None,
+                ),
+                SimpleNamespace(
+                    text="Prefetched bare memory",
+                    mentioned_at=None,
+                    occurred_start=None,
+                ),
+            ]
+        )
+        provider.queue_prefetch("old")
+        provider._prefetch_thread.join(timeout=5.0)
+        assert "[2026-07-18] Prefetched old memory" in provider._prefetch_result
+        assert "Prefetched bare memory" in provider._prefetch_result
 
 
     def test_recall_sync_defaults_off(self, provider):

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -29,6 +29,7 @@ from plugins.memory.hindsight import (
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
+    _fmt_memory,
 )
 
 
@@ -217,6 +218,39 @@ def test_normalize_retain_tags_accepts_csv_and_dedupes():
         "agent:fakeassistantname",
         "source_system:hermes-agent",
     ]
+
+
+# ---------------------------------------------------------------------------
+# _fmt_memory tests
+# ---------------------------------------------------------------------------
+
+
+class TestFmtMemory:
+    def test_uses_mentioned_at_when_present(self):
+        r = SimpleNamespace(
+            text="memory", mentioned_at="2026-07-20T08:30:00Z", occurred_start="2026-07-19T00:00:00Z"
+        )
+        assert _fmt_memory(r) == "[2026-07-20] memory"
+
+    def test_falls_back_to_occurred_start(self):
+        r = SimpleNamespace(
+            text="memory", mentioned_at=None, occurred_start="2026-06-15T12:00:00Z"
+        )
+        assert _fmt_memory(r) == "[2026-06-15] memory"
+
+    def test_bare_text_when_no_timestamp(self):
+        r = SimpleNamespace(text="memory", mentioned_at=None, occurred_start=None)
+        assert _fmt_memory(r) == "memory"
+
+    def test_truncates_timestamp_to_date_only(self):
+        r = SimpleNamespace(
+            text="memory", mentioned_at="2026-07-20T08:30:00.123456Z", occurred_start=None
+        )
+        assert _fmt_memory(r) == "[2026-07-20] memory"
+
+    def test_missing_attributes_do_not_raise(self):
+        r = SimpleNamespace(text="memory")
+        assert _fmt_memory(r) == "memory"
 
 
 # ---------------------------------------------------------------------------
@@ -447,6 +481,36 @@ class TestToolHandlers:
         assert "Memory 1" in result["result"]
         assert "Memory 2" in result["result"]
 
+    def test_recall_prefixes_freshness_timestamp(self, provider):
+        """_fmt_memory must prepend [YYYY-MM-DD] from mentioned_at, fall back
+        to occurred_start, and leave bare memories untouched."""
+        provider._client.arecall.return_value = SimpleNamespace(
+            results=[
+                SimpleNamespace(
+                    text="Old memory",
+                    mentioned_at="2026-07-20T08:30:00Z",
+                    occurred_start=None,
+                ),
+                SimpleNamespace(
+                    text="Event memory",
+                    mentioned_at=None,
+                    occurred_start="2026-06-15T12:00:00Z",
+                ),
+                SimpleNamespace(
+                    text="No timestamp memory",
+                    mentioned_at=None,
+                    occurred_start=None,
+                ),
+            ]
+        )
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "old"}
+        ))
+        lines = result["result"].split("\n")
+        assert "[2026-07-20] Old memory" in lines[0]
+        assert "[2026-06-15] Event memory" in lines[1]
+        assert lines[2] == "3. No timestamp memory"
+
 
     def test_reflect_success(self, provider):
         result = json.loads(provider.handle_tool_call(
@@ -500,6 +564,28 @@ class TestPrefetch:
         p.queue_prefetch("test")
         # Should not start a thread
         assert p._prefetch_thread is None
+
+    def test_prefetch_prefixes_freshness_timestamp(self, provider):
+        """Auto-prefetch injection must apply the same _fmt_memory timestamp
+        prefixing as the explicit recall tool."""
+        provider._client.arecall.return_value = SimpleNamespace(
+            results=[
+                SimpleNamespace(
+                    text="Prefetched old memory",
+                    mentioned_at="2026-07-18T09:00:00Z",
+                    occurred_start=None,
+                ),
+                SimpleNamespace(
+                    text="Prefetched bare memory",
+                    mentioned_at=None,
+                    occurred_start=None,
+                ),
+            ]
+        )
+        provider.queue_prefetch("old")
+        provider._prefetch_thread.join(timeout=5.0)
+        assert "[2026-07-18] Prefetched old memory" in provider._prefetch_result
+        assert "Prefetched bare memory" in provider._prefetch_result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Prefix recalled hindsight memories with a `[YYYY-MM-DD]` freshness timestamp so the agent can judge how old an auto-injected memory is — instead of trusting a snapshot blindly.

## Motivation

Hindsight auto-injects recalled memories into context. The `RecallResult` already carries `mentioned_at` (write time) and `occurred_start` (event time), but both the prefetch injection and the `hindsight_recall` tool discard them, keeping only `.text`. Without a time anchor the agent cannot tell whether a recalled memory is current or stale (`local hit != already searched`).

## Changes

Add `_fmt_memory(r)` helper that prepends `[YYYY-MM-DD]` from `mentioned_at` (fallback `occurred_start`) when present, and use it in:

- prefetch injection (`queue_prefetch`)
- `hindsight_recall` tool result formatting

## Notes

- `mentioned_at` (write time) is the freshness signal and is populated in practice; `occurred_start` (event time) is a fallback that is usually empty.
- Falls back to bare text when no time field is present — no behaviour change for untimestamped memories.
