### PR TITLE
fix(tools): cache the disk-usage warning scan (salvage #22166)

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -189,8 +189,24 @@ def _check_vercel_sandbox_requirements(config: dict[str, Any]) -> bool:
     return False
 
 
+# Cache for disk usage warning to avoid full rglob scan on every call.
+# The check is advisory-only — staleness for up to 5 minutes is acceptable.
+_disk_usage_cache: dict = {"timestamp": 0.0, "result": False}
+_DISK_USAGE_CACHE_TTL = 300.0  # seconds
+
+
 def _check_disk_usage_warning():
-    """Check if total disk usage exceeds warning threshold."""
+    """Check if total disk usage exceeds warning threshold.
+
+    Result is cached for :data:`_DISK_USAGE_CACHE_TTL` seconds (default:
+    5 minutes) to avoid an expensive recursive filesystem scan on every
+    terminal command.  The check is advisory-only so a stale result is
+    harmless.
+    """
+    import time as _time_mod
+    now = _time_mod.monotonic()
+    if now - _disk_usage_cache["timestamp"] < _DISK_USAGE_CACHE_TTL:
+        return _disk_usage_cache["result"]
     try:
         scratch_dir = _get_scratch_dir()
 
@@ -207,14 +223,16 @@ def _check_disk_usage_warning():
         
         total_gb = total_bytes / (1024 ** 3)
         
-        if total_gb > DISK_USAGE_WARNING_THRESHOLD_GB:
+        exceeded = total_gb > DISK_USAGE_WARNING_THRESHOLD_GB
+        if exceeded:
             logger.warning("Disk usage (%.1fGB) exceeds threshold (%.0fGB). Consider running cleanup_all_environments().",
                            total_gb, DISK_USAGE_WARNING_THRESHOLD_GB)
-            return True
-        
-        return False
+        _disk_usage_cache["timestamp"] = _time_mod.monotonic()
+        _disk_usage_cache["result"] = exceeded
+        return exceeded
     except Exception as e:
         logger.debug("Disk usage warning check failed: %s", e, exc_info=True)
+        # Don't update cache on error so the next call retries.
         return False
 
 


### PR DESCRIPTION
Salvages #22166 by @amathxbt — commit cherry-picked to preserve authorship, rebased onto current main.

## Context

`_check_disk_usage_warning()` runs an O(N) recursive `rglob('*')` across all `hermes-*` scratch directories on **every terminal command**. This caches the advisory result for 5 minutes: first call scans, subsequent calls within the TTL return the cached result; errors don't populate the cache so the next call retries. Staleness is harmless — the check is advisory-only (a log warning suggesting cleanup).

## Why a salvage instead of merging #22166 directly

The original is a fork PR based ~12,400 commits back; its stale-base CI can't satisfy current main's required checks and the branch can't be updated without workflow-scope pushes to the fork. Content is unchanged — verified premise on current main (the rglob still runs unconditionally at tools/terminal_tool.py:190) and behavior-probed on a scratch merge: call 1 scans, call 2 within TTL returns cached without touching the filesystem.

## Verification

- `tests/tools/test_file_tools_container_config.py`: 2 passed (the only suite touching the seam; it patches the function away, so no breakage)
- Behavioral probe: scan-once-then-cached confirmed; error path leaves cache unpopulated
- ruff clean; monkeypatch-seam sweep clean

Closes #22166 (superseded by this salvage — original author credited via cherry-pick authorship).
