### PR TITLE
fix(agent): fail fast on custom-provider /models auth errors (salvage #69983)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1185,8 +1185,22 @@ def fetch_endpoint_model_metadata(
 
     for candidate in candidates:
         url = candidate.rstrip("/") + "/models"
+        response = None
         try:
-            response = requests.get(url, headers=headers, timeout=(5, 10), verify=_resolve_requests_verify())
+            response = requests.get(
+                url,
+                headers=headers,
+                timeout=(5, 10),
+                verify=_resolve_requests_verify(),
+                stream=True,
+            )
+            if response.status_code in (401, 403):
+                logger.debug(
+                    "Model metadata probe received HTTP %s from %s; stopping candidate probing",
+                    response.status_code,
+                    url,
+                )
+                break
             response.raise_for_status()
             payload = response.json()
             cache: Dict[str, Dict[str, Any]] = {}
@@ -1236,6 +1250,9 @@ def fetch_endpoint_model_metadata(
             return cache
         except Exception as exc:
             last_error = exc
+        finally:
+            if response is not None:
+                response.close()
 
     if last_error:
         logger.debug("Failed to fetch model metadata from %s/models: %s", normalized, last_error)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -490,6 +490,79 @@ class TestCodexOAuthContextLength:
 
 
 # =========================================================================
+# Custom endpoint model metadata
+# =========================================================================
+
+class TestFetchEndpointModelMetadata:
+    def setup_method(self):
+        import agent.model_metadata as mm
+        mm._endpoint_model_metadata_cache.clear()
+        mm._endpoint_model_metadata_cache_time.clear()
+
+    @pytest.mark.parametrize("status_code", [401, 403])
+    def test_auth_failure_stops_after_first_candidate(self, status_code):
+        import agent.model_metadata as mm
+
+        response = MagicMock()
+        response.status_code = status_code
+        response.raise_for_status.side_effect = RuntimeError(str(status_code))
+
+        with patch("agent.model_metadata.requests.get", return_value=response) as mock_get:
+            result = mm.fetch_endpoint_model_metadata("https://custom.example/v1")
+
+        assert result == {}
+        mock_get.assert_called_once()
+        assert mock_get.call_args.kwargs["stream"] is True
+        response.raise_for_status.assert_not_called()
+        response.json.assert_not_called()
+        response.close.assert_called_once()
+
+    def test_auth_failure_empty_result_is_cached(self):
+        import agent.model_metadata as mm
+
+        response = MagicMock()
+        response.status_code = 401
+        response.raise_for_status.side_effect = RuntimeError("401")
+
+        with patch("agent.model_metadata.requests.get", return_value=response) as mock_get:
+            first = mm.fetch_endpoint_model_metadata("https://custom.example/v1")
+            second = mm.fetch_endpoint_model_metadata("https://custom.example/v1")
+
+        assert first == second == {}
+        mock_get.assert_called_once()
+        response.close.assert_called_once()
+
+    def test_not_found_still_tries_alternate_candidate(self):
+        import agent.model_metadata as mm
+
+        not_found = MagicMock()
+        not_found.status_code = 404
+        not_found.raise_for_status.side_effect = RuntimeError("404")
+        success = MagicMock()
+        success.status_code = 200
+        success.json.return_value = {
+            "data": [{"id": "test/model", "context_length": 32768}]
+        }
+
+        with patch(
+            "agent.model_metadata.requests.get",
+            side_effect=[not_found, success],
+        ) as mock_get:
+            result = mm.fetch_endpoint_model_metadata("https://custom.example/v1")
+
+        assert result["test/model"]["context_length"] == 32768
+        assert mock_get.call_count == 2
+        assert [call.args[0] for call in mock_get.call_args_list] == [
+            "https://custom.example/v1/models",
+            "https://custom.example/models",
+        ]
+        assert all(call.kwargs["stream"] is True for call in mock_get.call_args_list)
+        not_found.json.assert_not_called()
+        not_found.close.assert_called_once()
+        success.close.assert_called_once()
+
+
+# =========================================================================
 # Nous Portal context-window resolution (provider="nous")
 # =========================================================================
 


### PR DESCRIPTION
Salvages #69983 by @bounce12340 — commit cherry-picked to preserve authorship, rebased onto current main.

## Context

A custom OpenAI-compatible endpoint with a bad API key made `fetch_endpoint_model_metadata` waste a full second candidate probe: 401/403 raised via `raise_for_status()`, was caught, and the loop tried the alternate URL with the same dead key — up to another 5s connect + 10s read against the same host, plus an eagerly downloaded error body. This PR: (1) `stream=True` on the probe so error bodies are never downloaded, (2) a 401/403 `break` before `raise_for_status()` (no exception-as-control-flow) with a dedicated debug log, (3) robust `finally`-based `response.close()` on all paths. 73 lines of tests cover 401/403 short-circuit, 404 fall-through, stream=True on every call, close on all paths, and empty-result caching.

This is the canonical implementation of the pair — #69971 was closed as its functional duplicate earlier.

## Why a salvage instead of merging #69983 directly

The original is a fork PR based ~3,000 commits back; its stale-base CI can't satisfy current main's required checks and the branch can't be updated without workflow-scope pushes to the fork. Content is unchanged — verified on current main: the candidate loop still does a plain `requests.get` with no short-circuit, and the only drift in the function since the PR's base is an added `_ensure_requests()` line (main's disk-L2 probe cache never touches the candidate loop).

## Verification

- `tests/agent/test_model_metadata.py` + `test_model_metadata_local_ctx.py`: 84 passed on current main (incl. the PR's 4 new tests)
- ruff clean; monkeypatch-seam sweep clean

Closes #69983 (superseded by this salvage — original author credited via cherry-pick authorship).
