### PR TITLE
fix(gateway): align Windows running status marker

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -1452,7 +1452,10 @@ def status(deep: bool = False) -> None:
         print("✗ Gateway service not installed")
 
     if pids:
-        print(f"✓ Gateway process running (PID: {', '.join(map(str, pids))})")
+        # Keep the positive liveness marker consistent with the manual status
+        # path in hermes_cli.gateway.  Health checks and operators should not
+        # need a Windows-only phrase to recognize the same gateway state.
+        print(f"✓ Gateway is running (PID: {', '.join(map(str, pids))})")
     else:
         print("✗ No gateway process detected")
 

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -24,6 +24,22 @@ def test_schtasks_encoding_falls_back_to_utf8(monkeypatch):
     assert gateway_windows._schtasks_encoding() == "utf-8"
 
 
+def test_status_uses_shared_gateway_running_marker(monkeypatch, capsys):
+    """Windows status must expose the same positive marker as manual status."""
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "get_task_name", lambda: "Hermes_Gateway")
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: True)
+    monkeypatch.setattr(gateway_windows, "is_startup_entry_installed", lambda: False)
+    monkeypatch.setattr(gateway_windows, "query_task_status", lambda: {})
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [12345])
+
+    gateway_windows.status()
+
+    output = capsys.readouterr().out
+    assert "Gateway is running (PID: 12345)" in output
+
+
 
 
 def test_build_gateway_argv_keeps_venv_console_python_for_uv_venv(monkeypatch, tmp_path):
@@ -245,7 +261,6 @@ def test_gateway_vbs_script_is_console_less(monkeypatch):
 # the gateway's marker-watcher thread to drain + exit cleanly, then escalates
 # to taskkill if drain times out.
 # ---------------------------------------------------------------------------
-
 
 
 


### PR DESCRIPTION
## Summary
- use the shared `Gateway is running` liveness marker in Windows service status output
- add a regression test for the Windows status line

## Why
Windows previously emitted `Gateway process running`, while the manual status path emitted `Gateway is running`. Health checks consuming the established marker could report a false startup failure even when process discovery returned a live PID.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_windows.py -q` — 8 passed
- CodeRabbit CLI round 1 — completed, 0 findings
- live Windows gateway deep status — PID file, runtime lock, PID liveness, and runtime state all PASS

## Broader test note
The 13-file `tests/hermes_cli/test_gateway*.py` run reached 113 passed / 9 failed. The failures are unrelated pre-existing native-Windows assumptions in POSIX-only systemd, FIFO, and shell-script-path tests; the changed Windows test file passed in that run.