### PR TITLE
fix(security): warn on unknown keys in website_blocklist config

### DIFF
--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -301,3 +301,38 @@ def test_check_website_access_fails_open_on_malformed_config(tmp_path, monkeypat
     # With default path, errors are caught and fail open
     result = check_website_access("https://example.com")
     assert result is None  # allowed, not crashed
+
+
+def test_unknown_keys_with_non_string_yaml_values(tmp_path, caplog):
+    """YAML mapping keys can be non-string (int, bool, etc.).
+
+    ``sorted(unknown)`` would raise ``TypeError`` when mixing str and int
+    keys.  This regression test ensures the warning log uses ``str()`` on
+    every key before sorting.
+    """
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": {
+                        "enabled": True,
+                        "domains": ["example.com"],
+                        1: "not-a-valid-key",
+                        True: "also-not-valid",
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        policy = load_website_blocklist(config_path)
+
+    assert policy["enabled"] is True
+    assert "Unknown keys" in caplog.text
+    # Verify no TypeError was raised and the warning logged successfully

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -131,7 +131,7 @@ def _load_policy_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
     if unknown:
         logger.warning(
             "Unknown keys in security.website_blocklist (ignored): %s",
-            ", ".join(sorted(unknown)),
+            ", ".join(sorted(str(k) for k in unknown)),
         )
 
     policy.update(website_blocklist)

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -28,6 +28,8 @@ _DEFAULT_WEBSITE_BLOCKLIST = {
     "shared_files": [],
 }
 
+_KNOWN_BLOCKLIST_KEYS = frozenset(_DEFAULT_WEBSITE_BLOCKLIST)
+
 # Cache: parsed policy + timestamp.  Avoids re-reading config.yaml on every
 # URL check (a multi-URL extract with 50 pages would otherwise mean 51 YAML parses).
 _CACHE_TTL_SECONDS = 30.0
@@ -124,6 +126,14 @@ def _load_policy_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
         raise WebsitePolicyError("security.website_blocklist must be a mapping")
 
     policy = dict(_DEFAULT_WEBSITE_BLOCKLIST)
+
+    unknown = set(website_blocklist) - _KNOWN_BLOCKLIST_KEYS
+    if unknown:
+        logger.warning(
+            "Unknown keys in security.website_blocklist (ignored): %s",
+            ", ".join(sorted(unknown)),
+        )
+
     policy.update(website_blocklist)
     return policy
 


### PR DESCRIPTION
## Root Cause

`tools/website_policy.py:126-127` — `_load_policy_config()` merges the user's `security.website_blocklist` mapping over defaults with `policy.update(website_blocklist)`. `load_website_blocklist()` then reads exactly three keys — `enabled`, `domains`, `shared_files` — and silently ignores everything else.

A misspelled or invented key produces **no error, no warning, and no effect**. The `shared_file` typo (missing trailing `s`) is the worst case: the operator believes a whole blocklist file is loaded, the config parses cleanly, tools start without error, and URLs are checked against a policy that is missing most of itself.

This matters more than a normal config-validation gap because the thing being configured is a **security control**. Every other failure mode in this module is loud (WebsitePolicyError, logger.warning for missing shared files). This one is indistinguishable from success.

## Fix

Add a set-difference check in `_load_policy_config()` after the `update()` call. Unknown keys are logged at WARNING level. The warning approach is correct here:

- **Cannot break existing configs** — unknown keys still get carried through (backward compatible)
- **Surfaces the `shared_file` typo immediately** — operator sees the warning in logs
- **Minimal change** — 8 lines added, no behavioral change for valid configs

The `_KNOWN_BLOCKLIST_KEYS` constant is derived from `_DEFAULT_WEBSITE_BLOCKLIST` keys so it stays in sync automatically.

## Verification

The fix was verified against the exact scenario from the issue:

```yaml
security:
  website_blocklist:
    enabled: true
    domains: [webhook.site]
    shared_file: /etc/blocked-hosts     # typo: shared_files
    allowed: [example.com]              # invented
```

Before: silent success, `shared_file` ignored.
After: `WARNING: Unknown keys in security.website_blocklist (ignored): allowed, shared_file`

The warning fires once per config load (cached with 30s TTL) so there is no log spam.
