### PR TITLE
fix(security): fail closed on unrecognized approval outcomes

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -86,6 +86,11 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_API_VERSION = "v20.0"
+
+# Interactive-button payloads predate the approval layer's canonical
+# once/session/always vocabulary. Map the wire value to the canonical one at
+# the edge; buttons already sitting in a user's chat keep working.
+_APPROVAL_WIRE_ALIASES = {"approve": "once"}
 # ``None`` → aiohttp/asyncio ``create_server`` binds one listening socket per
 # address family (IPv4 + IPv6). The old "0.0.0.0" default bound IPv4 ONLY and
 # was unreachable over IPv6-only private networks (e.g. Fly.io 6PN) — same
@@ -1797,7 +1802,15 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             parts = button_id.split(":", 2)
             if len(parts) != 3:
                 return False
-            _, approval_id, choice = parts
+            _, approval_id, raw_choice = parts
+            # The button payload carries "approve"/"deny"; the approval layer's
+            # canonical vocabulary is once/session/always. Validate the wire
+            # value against what this adapter actually emits BEFORE translating,
+            # so the accepted wire vocabulary stays exactly as it was, then
+            # translate so only canonical values cross into the gate.
+            if raw_choice not in ("approve", "deny"):
+                return False
+            choice = _APPROVAL_WIRE_ALIASES.get(raw_choice, raw_choice)
             session_key = self._exec_approval_state.pop(approval_id, None)
             if not session_key:
                 logger.info(
@@ -1805,9 +1818,6 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     "(approval_id=%s) — likely stale; falling back to text",
                     approval_id,
                 )
-                return False
-            if choice not in ("approve", "deny"):
-                self._exec_approval_state[approval_id] = session_key
                 return False
             try:
                 from tools.approval import resolve_gateway_approval
@@ -1829,7 +1839,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             try:
                 if count:
                     confirm_text = (
-                        "✅ Approved." if choice == "approve" else "❌ Denied."
+                        "✅ Approved." if choice == "once" else "❌ Denied."
                     )
                 else:
                     confirm_text = (

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6341,6 +6341,13 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to approve commands.")
                     return
 
+                # Checked after authorization so an unauthorized clicker
+                # cannot use the reply to probe which payloads are valid.
+                from tools.approval import APPROVAL_RESPONSES
+                if choice not in APPROVAL_RESPONSES:
+                    await query.answer(text="Invalid approval data.")
+                    return
+
                 session_key = self._approval_state.pop(approval_id, None)
                 if not session_key:
                     await query.answer(text="This approval has already been resolved.")

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -207,6 +207,65 @@ class TestTelegramApprovalCallback:
 
 
     @pytest.mark.asyncio
+    async def test_unrecognized_choice_is_rejected_without_resolving(self):
+        """A payload the approval layer does not know must resolve nothing.
+
+        The approval state must also survive, so a stale or malformed tap
+        cannot consume a pending approval the user still needs to answer.
+        """
+        adapter = _make_adapter()
+        adapter._approval_state[11] = "agent:main:telegram:group:12345:99"
+
+        query = AsyncMock()
+        query.data = "ea:approve:11"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Norbert"
+        query.from_user.id = "12345"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval") as resolve:
+                await adapter._handle_callback_query(update, context)
+
+        resolve.assert_not_called()
+        assert adapter._approval_state[11] == "agent:main:telegram:group:12345:99"
+        assert "invalid approval" in query.answer.call_args.kwargs["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_is_rejected_before_choice_validation(self):
+        """Authorization is answered first, so the reply is not a payload oracle."""
+        adapter = _make_adapter()
+        adapter._approval_state[12] = "agent:main:telegram:group:12345:99"
+
+        query = AsyncMock()
+        query.data = "ea:bogus:12"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Mallory"
+        query.from_user.id = "99999"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "12345"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval") as resolve:
+                await adapter._handle_callback_query(update, context)
+
+        resolve.assert_not_called()
+        assert "not authorized" in query.answer.call_args.kwargs["text"].lower()
+
+    @pytest.mark.asyncio
     async def test_resume_typing_after_inline_approval(self):
         """Clicking an inline approval button must un-pause the chat's typing.
 

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1121,7 +1121,9 @@ class TestDispatchInteractiveReplyApproval:
         handled = await adapter._dispatch_interactive_reply(raw, {})
 
         assert handled is True
-        assert calls == [("sess-app-1", "approve")]
+        # The "approve" wire value is translated at the edge; only the
+        # canonical vocabulary reaches the approval layer.
+        assert calls == [("sess-app-1", "once")]
         assert "app1" not in adapter._exec_approval_state
         confirm_payload = adapter._http_client.post.call_args.kwargs["json"]
         assert confirm_payload["type"] == "text"
@@ -1204,7 +1206,9 @@ class TestDispatchInteractiveReplyAuthorization:
         handled = await adapter._dispatch_interactive_reply(raw, {})
 
         assert handled is True
-        assert calls == [("sess-app-1", "approve")]
+        # The "approve" wire value is translated at the edge; only the
+        # canonical vocabulary reaches the approval layer.
+        assert calls == [("sess-app-1", "once")]
 
 
 @pytest.mark.usefixtures("authorized_interactive_env")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -37,6 +37,60 @@ def _neuter_agent_prewarm_timer(request, monkeypatch):
     yield
 
 
+def test_approval_respond_unknown_choice_resolves_as_deny(monkeypatch):
+    """A choice the approval layer does not know must arrive as an explicit deny."""
+    monkeypatch.setattr(
+        server, "_sess",
+        lambda _params, _rid: ({"session_key": "rpc-session-key"}, None),
+    )
+
+    with patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve:
+        response = server._methods["approval.respond"](
+            "approval-1",
+            {"session_id": "rpc-session", "choice": "approve"},
+        )
+
+    assert response["result"] == {"resolved": 1}
+    resolve.assert_called_once_with("rpc-session-key", "deny", resolve_all=False)
+
+
+@pytest.mark.parametrize("bad_all", ["no", "false", "0", 0.1, {}, [1], "true"])
+def test_approval_respond_non_bool_all_does_not_resolve_everything(monkeypatch, bad_all):
+    """Only a literal True may widen one approval into approve-all.
+
+    resolve_gateway_approval consumes resolve_all as a bare truthiness test, so
+    a truthy non-bool off the wire would authorize every queued dangerous
+    command in the session from a single response.
+    """
+    monkeypatch.setattr(
+        server, "_sess",
+        lambda _params, _rid: ({"session_key": "rpc-session-key"}, None),
+    )
+
+    with patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve:
+        server._methods["approval.respond"](
+            "approval-1",
+            {"session_id": "rpc-session", "choice": "once", "all": bad_all},
+        )
+
+    assert resolve.call_args.kwargs["resolve_all"] is False
+
+
+def test_approval_respond_all_true_still_resolves_everything(monkeypatch):
+    monkeypatch.setattr(
+        server, "_sess",
+        lambda _params, _rid: ({"session_key": "rpc-session-key"}, None),
+    )
+
+    with patch("tools.approval.resolve_gateway_approval", return_value=3) as resolve:
+        server._methods["approval.respond"](
+            "approval-1",
+            {"session_id": "rpc-session", "choice": "once", "all": True},
+        )
+
+    assert resolve.call_args.kwargs["resolve_all"] is True
+
+
 def test_session_slot_is_claimed_on_first_turn_not_on_create(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1397,3 +1397,237 @@ class TestApprovalPromptRedaction:
         # The script's credential must not appear in the user-facing message.
         assert "sk-proj-abc123xyz4567890abcdef" not in result["message"]
         assert "sk-proj-abc123xyz4567890abcdef" not in result["command"]
+
+
+class TestUnrecognizedApprovalOutcomeFailsClosed:
+    """An approval outcome that is not canonical must never mean consent.
+
+    The approval gate receives its outcome from a prompt, a gateway client, or
+    a platform adapter. A client bug, a stale build, or an undocumented alias
+    can put a value there that the gate does not recognize — and the gate must
+    treat every such value as a denial rather than falling through to approval.
+    """
+
+    # Values a drifted, stale, or buggy caller could realistically supply.
+    UNRECOGNIZED = [
+        "approve",      # undocumented alias (WhatsApp's historical wire value)
+        "yes",
+        "allow",
+        "",
+        "Once",         # right word, wrong case
+        "ALWAYS",
+        "once ",        # trailing whitespace
+        None,           # callback returned nothing
+        42,             # wrong type entirely
+        0,
+        True,           # truthy non-string
+        {"choice": "always"},   # unhashable — must deny, not raise
+        ["always"],
+    ]
+
+    CANONICAL = ["once", "session", "always"]
+
+    @staticmethod
+    def _isolate(monkeypatch):
+        """Force the interactive-CLI branch and firewall persistence.
+
+        'session' and 'always' persist an approval, so without a reset between
+        cases a canonical value would silently approve every case after it —
+        the probe would measure its own side effects instead of the guard.
+        """
+        from tools import approval as mod
+
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setattr(mod, "_get_approval_config", lambda: {"mode": "manual"})
+        monkeypatch.setattr(mod, "save_permanent_allowlist", lambda *_a, **_k: None)
+        monkeypatch.setattr(
+            "tools.tirith_security.check_command_security",
+            lambda _command: {"action": "allow", "findings": [], "summary": ""},
+        )
+        # Replace rather than clear: monkeypatch restores the originals when
+        # the test unwinds, so cleared approval state cannot leak into a later
+        # test file that shares this module-level state.
+        monkeypatch.setattr(mod, "_permanent_approved", set())
+        monkeypatch.setattr(mod, "_session_approved", {})
+        return mod
+
+    @pytest.mark.parametrize("choice", UNRECOGNIZED)
+    def test_check_dangerous_command_denies_unrecognized(self, monkeypatch, choice):
+        mod = self._isolate(monkeypatch)
+        monkeypatch.setattr(mod, "prompt_dangerous_approval",
+                            lambda *_a, **_k: choice)
+
+        result = mod.check_dangerous_command("rm -rf /tmp/target", "local")
+
+        assert result["approved"] is False
+        assert result["outcome"] == "unknown"
+        assert result["user_consent"] is False
+
+    @pytest.mark.parametrize("choice", UNRECOGNIZED)
+    def test_check_all_command_guards_denies_unrecognized(self, monkeypatch, choice):
+        mod = self._isolate(monkeypatch)
+        monkeypatch.setattr(mod, "prompt_dangerous_approval",
+                            lambda *_a, **_k: choice)
+
+        result = mod.check_all_command_guards("rm -rf /tmp/target", "local")
+
+        assert result["approved"] is False
+        assert result["outcome"] == "unknown"
+        assert result["user_consent"] is False
+
+    @pytest.mark.parametrize("choice", CANONICAL)
+    def test_canonical_choices_still_approve(self, monkeypatch, choice):
+        """The guard must deny only what it does not recognize."""
+        mod = self._isolate(monkeypatch)
+        monkeypatch.setattr(mod, "prompt_dangerous_approval",
+                            lambda *_a, **_k: choice)
+
+        assert mod.check_dangerous_command(
+            "rm -rf /tmp/target", "local")["approved"] is True
+
+        self._isolate(monkeypatch)
+        monkeypatch.setattr(mod, "prompt_dangerous_approval",
+                            lambda *_a, **_k: choice)
+        assert mod.check_all_command_guards(
+            "rm -rf /tmp/target", "local")["approved"] is True
+
+    @pytest.mark.parametrize("choice", [{"choice": "always"}, ["always"], {1, 2}])
+    def test_unhashable_outcome_denies_instead_of_raising(self, monkeypatch, choice):
+        """An unhashable outcome must deny, not raise.
+
+        ``choice in APPROVAL_CHOICES`` alone raises TypeError on a dict or a
+        list, which turns the guard meant to deny into a crash — the caller,
+        not the guard, would then decide what happens.
+        """
+        mod = self._isolate(monkeypatch)
+        monkeypatch.setattr(mod, "prompt_dangerous_approval",
+                            lambda *_a, **_k: choice)
+
+        result = mod.check_dangerous_command("rm -rf /tmp/target", "local")
+
+        assert result["approved"] is False
+        assert result["outcome"] == "unknown"
+
+    def test_is_approval_choice_helper(self):
+        from tools.approval import _is_approval_choice
+
+        for good in ("once", "session", "always"):
+            assert _is_approval_choice(good) is True
+        for bad in ("deny", "approve", "", "Once", None, 1, True,
+                    {"a": 1}, ["once"], object()):
+            assert _is_approval_choice(bad) is False
+
+
+class TestUnrecognizedGatewayOutcomeFailsClosed:
+    """The gateway branches must fail closed too.
+
+    The CLI branch and the gateway branch reach their approve path through
+    different code, so covering one proves nothing about the other. These
+    exercise the three gateway-side decision sites: _run_approval_gate (via
+    check_dangerous_command), check_all_command_guards, and
+    check_execute_code_guard.
+    """
+
+    # None is excluded deliberately: upstream's gateway branch already treats a
+    # None outcome as an explicit denial before this guard is reached, so it is
+    # denied as "denied" rather than "unknown". Covered separately below.
+    UNRECOGNIZED = [
+        "approve", "yes", "", "Once", "ALWAYS", 42, True,
+        {"choice": "always"}, ["always"],
+    ]
+
+    @staticmethod
+    def _isolate(monkeypatch, choice):
+        """Force the gateway branch and inject `choice` as the resolved outcome."""
+        from tools import approval as mod
+
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.setattr(mod, "_get_approval_config", lambda: {"mode": "manual"})
+        monkeypatch.setattr(mod, "save_permanent_allowlist", lambda *_a, **_k: None)
+        monkeypatch.setattr(
+            "tools.tirith_security.check_command_security",
+            lambda _command: {"action": "allow", "findings": [], "summary": ""},
+        )
+        monkeypatch.setattr(mod, "_permanent_approved", set())
+        monkeypatch.setattr(mod, "_session_approved", {})
+        # A registered notify callback is what selects the gateway branch.
+        monkeypatch.setattr(
+            mod, "_gateway_notify_cbs",
+            {mod.get_current_session_key(): lambda *_a, **_k: True},
+        )
+        monkeypatch.setattr(
+            mod, "_await_gateway_decision",
+            lambda *_a, **_k: {"resolved": True, "choice": choice,
+                               "reason": None, "notify_failed": False},
+        )
+        return mod
+
+    @pytest.mark.parametrize("choice", UNRECOGNIZED)
+    def test_gateway_dangerous_command_denies_unrecognized(self, monkeypatch, choice):
+        mod = self._isolate(monkeypatch, choice)
+
+        result = mod.check_dangerous_command("rm -rf /tmp/target", "local")
+
+        assert result["approved"] is False
+        assert result["outcome"] == "unknown"
+        assert result["user_consent"] is False
+
+    @pytest.mark.parametrize("choice", UNRECOGNIZED)
+    def test_gateway_all_command_guards_denies_unrecognized(self, monkeypatch, choice):
+        mod = self._isolate(monkeypatch, choice)
+
+        result = mod.check_all_command_guards("rm -rf /tmp/target", "local")
+
+        assert result["approved"] is False
+        assert result["outcome"] == "unknown"
+        assert result["user_consent"] is False
+
+    @pytest.mark.parametrize("choice", UNRECOGNIZED)
+    def test_gateway_execute_code_guard_denies_unrecognized(self, monkeypatch, choice):
+        mod = self._isolate(monkeypatch, choice)
+
+        result = mod.check_execute_code_guard(
+            "import os; os.system('rm -rf /tmp/target')", "local")
+
+        assert result["approved"] is False
+        assert result["outcome"] == "unknown"
+        assert result["user_consent"] is False
+
+    @pytest.mark.parametrize("choice", ["once", "session", "always"])
+    def test_gateway_canonical_choices_still_approve(self, monkeypatch, choice):
+        """The gateway guard must deny only what it does not recognize."""
+        mod = self._isolate(monkeypatch, choice)
+        assert mod.check_dangerous_command(
+            "rm -rf /tmp/target", "local")["approved"] is True
+
+        mod = self._isolate(monkeypatch, choice)
+        assert mod.check_all_command_guards(
+            "rm -rf /tmp/target", "local")["approved"] is True
+
+        mod = self._isolate(monkeypatch, choice)
+        assert mod.check_execute_code_guard(
+            "import os; os.system('rm -rf /tmp/target')", "local")["approved"] is True
+
+    @pytest.mark.parametrize("fn_name,args", [
+        ("check_dangerous_command", ("rm -rf /tmp/target", "local")),
+        ("check_all_command_guards", ("rm -rf /tmp/target", "local")),
+        ("check_execute_code_guard",
+         ("import os; os.system('rm -rf /tmp/target')", "local")),
+    ])
+    def test_gateway_none_outcome_is_denied_as_explicit_denial(
+        self, monkeypatch, fn_name, args,
+    ):
+        """A None outcome is a denial, reported as "denied" not "unknown".
+
+        The gateway branch checks for an unresolved/None outcome before the
+        unrecognized-value guard, so it is classified as an explicit denial.
+        Either way it is not consent, which is what matters.
+        """
+        mod = self._isolate(monkeypatch, None)
+
+        result = getattr(mod, fn_name)(*args)
+
+        assert result["approved"] is False
+        assert result["user_consent"] is False
+        assert result["outcome"] in ("denied", "timeout")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -599,6 +599,42 @@ def _sudo_stdin_block_result(description: str) -> dict:
     }
 
 
+# The only values that mean "the user consented". Anything else — an unknown
+# string, an undocumented alias, None, or a non-string — is not consent.
+APPROVAL_CHOICES = frozenset({"once", "session", "always"})
+# What a client may legitimately send in reply to an approval request:
+# the consent values plus an explicit refusal.
+APPROVAL_RESPONSES = APPROVAL_CHOICES | {"deny"}
+
+
+def _is_approval_choice(choice) -> bool:
+    """Return True only for a canonical approval outcome.
+
+    Type-checks before the membership test: an approval outcome arrives from a
+    prompt, a gateway client, or a platform adapter, so it is not guaranteed to
+    be a string. ``choice in APPROVAL_CHOICES`` alone raises ``TypeError`` on an
+    unhashable value (a dict or list), turning the guard that is supposed to
+    deny into a crash.
+    """
+    return isinstance(choice, str) and choice in APPROVAL_CHOICES
+
+
+def _unrecognized_choice_result(pattern_key: str, description: str,
+                                subject: str = "this action") -> dict:
+    """Build the standard block result for an unrecognized approval outcome."""
+    return {
+        "approved": False,
+        "message": (
+            f"BLOCKED: Approval outcome was not recognized. The user has "
+            f"NOT consented to {subject}. Do NOT retry it."
+        ),
+        "pattern_key": pattern_key,
+        "description": description,
+        "outcome": "unknown",
+        "user_consent": False,
+    }
+
+
 # =========================================================================
 # Dangerous command patterns
 # =========================================================================
@@ -2988,10 +3024,18 @@ def _run_approval_gate(
                         f"do NOT rephrase it, and do NOT attempt the same "
                         f"outcome via a different path.{timeout_addendum}"
                     ),
+                    # Sibling gates already report a structured outcome here;
+                    # without it a caller reading result["outcome"] sees None
+                    # for a gateway denial from this gate but a real value from
+                    # the others.
+                    "outcome": "timeout" if not resolved else "denied",
                     "pattern_key": pattern_key,
                     "description": description,
                     "user_consent": False,
                 }
+
+            if not _is_approval_choice(choice):
+                return _unrecognized_choice_result(pattern_key, description)
 
             if choice == "session":
                 approve_session(session_key, pattern_key)
@@ -3034,6 +3078,9 @@ def _run_approval_gate(
             "pattern_key": pattern_key,
             "description": description,
         }
+
+    if not _is_approval_choice(choice):
+        return _unrecognized_choice_result(pattern_key, description)
 
     if choice == "session":
         approve_session(session_key, pattern_key)
@@ -3719,6 +3766,10 @@ def check_all_command_guards(command: str, env_type: str,
                     "deny_reason": deny_reason,
                 }
 
+            if not _is_approval_choice(choice):
+                return _unrecognized_choice_result(
+                    primary_key, combined_desc, "this command")
+
             # A smart-DENY owner override is always one operation, even if an
             # older client returns "session" or "always". Manual and ESCALATE
             # choices retain their existing persistence semantics.
@@ -3814,6 +3865,10 @@ def check_all_command_guards(command: str, env_type: str,
             "outcome": "denied",
             "user_consent": False,
         }
+
+    if not _is_approval_choice(choice):
+        return _unrecognized_choice_result(
+            primary_key, combined_desc, "this command")
 
     # Smart-DENY owner overrides are one-operation scoped. Preserve existing
     # persistence for manual mode and smart ESCALATE.
@@ -4052,6 +4107,10 @@ def check_execute_code_guard(code: str, env_type: str,
             "deny_reason": deny_reason,
         }
 
+    if not _is_approval_choice(choice):
+        return _unrecognized_choice_result(
+            pattern_key, description, "running this code")
+
     # Never persist a smart-DENY override under the coarse execute_code key;
     # doing so would approve unrelated future scripts. Manual and ESCALATE
     # decisions preserve their existing session/permanent behavior.
@@ -4133,7 +4192,7 @@ def request_elicitation_consent(
         if not decision.get("resolved"):
             return "cancel"
         choice = decision.get("choice")
-        if choice in ("once", "session", "always"):
+        if _is_approval_choice(choice):
             return "accept"
         return "decline"
 
@@ -4152,7 +4211,7 @@ def request_elicitation_consent(
         )
         return "decline"
 
-    if choice in ("once", "session", "always"):
+    if _is_approval_choice(choice):
         return "accept"
     return "decline"
 

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -891,13 +891,32 @@ def _(rid, params: dict) -> dict:
     try:
         from tools.approval import resolve_gateway_approval
 
+        # Both fields come off the wire, so neither can be trusted to have the
+        # shape the resolver expects.
+        #
+        # `choice` is forwarded only when it is one the approval layer knows;
+        # anything else becomes an explicit deny rather than an unrecognized
+        # value the gate has to interpret.
+        from tools.approval import APPROVAL_RESPONSES
+
+        raw_choice = params.get("choice", "deny")
+        choice = (
+            raw_choice
+            if isinstance(raw_choice, str) and raw_choice in APPROVAL_RESPONSES
+            else "deny"
+        )
+        # `all` is consumed as a bare truthiness test by the resolver, so any
+        # truthy non-bool ("false", "no", 0.1, [1]) would silently widen a
+        # single approval into approve-everything-queued. Require True.
+        resolve_all = params.get("all", False) is True
+
         return _ok(
             rid,
             {
                 "resolved": resolve_gateway_approval(
                     session["session_key"],
-                    params.get("choice", "deny"),
-                    resolve_all=params.get("all", False),
+                    choice,
+                    resolve_all=resolve_all,
                 )
             },
         )


### PR DESCRIPTION
## The problem

Hermes asks the user before running a dangerous command. The approval layer has a
canonical vocabulary for the answer: `once`, `session`, `always`, or `deny`.

The gates that act on that answer decided approval by checking whether it was `deny`,
and otherwise falling through to the approve path. So the real rule was not "run this
only if the user said yes" — it was **"run this unless the user said exactly `deny`."**

Those two rules agree only as long as the answer is one of the four expected values.
When it isn't, they disagree in the worst direction. An undocumented alias, a stale
client's wire value, a wrong-cased string, `None`, or a non-string all missed the `deny`
comparison and reached the approve branch — authorizing a command the user never
consented to.

There is also a second, quieter version of the same problem in `approval.respond`'s
`all` flag, which widens a single approval into approving everything queued in the
session. The resolver consumes it as a bare truthiness test, so any truthy non-bool off
the wire — `"false"`, `"no"`, `0.1` — silently widened one "yes" into "yes to all".

## Why it matters

This is the layer whose entire job is to make sure a destructive command has the user
behind it. A gate that fails open is worse than no gate, because the prompt convinces
the user that something is checking.

The values that trigger it are not exotic. Approval outcomes cross process boundaries —
a gateway client, a platform adapter, an RPC caller — so they arrive as whatever the
sender sent, including from clients built against an older vocabulary. One such
mismatch already exists in-tree: the WhatsApp adapter's interactive buttons emit
`approve`, which is not a canonical value, and passed it straight through.

## What this PR does

It inverts the test everywhere the decision is made: **approve only on a recognized
canonical outcome, and treat everything else as a denial.**

Four commits, ordered so each one is safe on its own:

1. **`fix(whatsapp)`** — validate the interactive-button wire value, then translate the
   `approve` alias to canonical `once` at the adapter edge. The accepted wire vocabulary
   is unchanged, so buttons already sitting in a user's chat keep working. This lands
   first on purpose: with the guard in place but this translation missing, every WhatsApp
   approval tap would be denied.

2. **`fix(security)`** — the core change. Adds `APPROVAL_CHOICES`, `APPROVAL_RESPONSES`,
   and an `_is_approval_choice()` helper, applied at five gate sites: `_run_approval_gate`
   (gateway and CLI branches), `check_all_command_guards` (gateway and CLI branches), and
   `check_execute_code_guard`. `check_dangerous_command` and `request_tool_approval` are
   covered transitively, since both delegate to `_run_approval_gate`.

   The helper type-checks *before* the membership test. An approval outcome is not
   guaranteed to be a string, and `choice in {...}` alone raises `TypeError` on an
   unhashable value — turning the guard that exists to deny into a crash whose
   consequences the caller decides. An unrecognized outcome now returns a structured
   denial carrying `outcome="unknown"` and `user_consent=False`.

   This commit also fills in a missing `outcome` key on `_run_approval_gate`'s gateway
   denial return, which every sibling gate already reported.

3. **`fix(gateway)`** — validate both `approval.respond` parameters at the RPC boundary.
   `choice` is forwarded only when the approval layer recognizes it, and becomes an
   explicit `deny` otherwise. `all` must now be literally `True`. That is deliberately
   stricter than the HTTP approval endpoint, which coerces `"true"`/`"1"`/`"yes"` — a
   scope-widening flag seemed worth requiring exactly.

4. **`fix(telegram)`** — reject unrecognized `ea:` button payloads, leaving the pending
   approval in place so the user can still answer it. The check runs *after* the
   authorization check, so an unauthorized clicker gets the authorization refusal rather
   than a reply that reveals which payloads are well-formed.

## Compatibility

Behavior changes strictly in the deny direction. Nothing that previously prompted is now
auto-approved, and no wire format or config format changes.

Every current native adapter was traced: each one emits canonical values, maps its own
wire alias, rejects unknowns, or coerces to denial. No legitimate current producer is
blocked by the stricter checks. A third-party client sending an undocumented value such
as `"approve"` or `"yes"` will now be denied rather than approved — that is the intended
security change, and it is why the WhatsApp alias is translated rather than dropped.

## Testing

- 720 tests pass across the four touched test files.
- New regression coverage for each guarded path: the CLI branch and all three gateway
  branches against malformed outcomes (unknown strings, wrong case, `None`, ints, dicts,
  lists), the RPC boundary against unknown `choice` and non-bool `all`, and both adapter
  callbacks.
- Verified by direct probe that all five guard sites are reached and reject malformed
  values with `approved=False, outcome="unknown"`.
- Confirmed a Smart-DENY owner override with an unrecognized value stays denied and does
  not reset the consecutive-denial tally.
- Rebased on and validated against current `main`.

## Related, deliberately not included

Two adjacent items were left out to keep this PR to one story. Happy to follow up on
either, or fold them in if you'd prefer:

- The sibling `sc:` slash-confirm lane in `plugins/platforms/telegram/adapter.py` decides
  by a `!= "cancel"` fallthrough — the same shape of bug as the one fixed here.
- An unrecognized `choice` at the RPC boundary is coerced to `deny` silently, with no
  error returned to the client. Safe, but a caller gets no signal that its value was
  uninterpretable.
