### PR TITLE
Add fifty50 MCP catalog entry

### DIFF
--- a/optional-mcps/fifty50/manifest.yaml
+++ b/optional-mcps/fifty50/manifest.yaml
@@ -1,0 +1,43 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: fifty50
+description: Find a co-founder and split equity fairly — partnership analysis, vesting recommendations, and a co-founder marketplace.
+source: https://frederickandsons.xyz/fifty50/developers
+
+# Fifty50 ships a public, unauthenticated remote MCP server over Streamable
+# HTTP — nothing to install locally, no API key. The same endpoint any AI
+# agent can add by URL (see README).
+transport:
+  type: http
+  url: https://frederickandsons.xyz/fifty50/mcp
+
+auth:
+  type: none
+
+# Tool selection at install time:
+# Fifty50 exposes 9 tools. The 4 that create or mutate stored data
+# (create_partnership, add_contribution, record_outcome, post_listing) are
+# pruned from the default so a user who installs casually gets a
+# read-mostly safe surface — same reasoning n8n's catalog entry uses for its
+# workflow activate/deactivate tools. None are destructive (no delete
+# capability exists on the API), but an equity platform's write paths still
+# deserve an explicit opt-in rather than being on by default.
+tools:
+  default_enabled:
+    - get_attribution
+    - forecast_equity
+    - recommend_vesting
+    - browse_marketplace
+    - ask_assistant
+
+post_install: |
+  No credentials needed — the endpoint is public and unauthenticated.
+
+  create_partnership returns a one-time owner_token the caller must store
+  to manage that partnership later; Fifty50 has no way to recover a lost
+  token. Read-only tools (get_attribution, forecast_equity,
+  recommend_vesting, browse_marketplace, ask_assistant) need no token.
+
+  Full API reference: https://frederickandsons.xyz/fifty50/developers


### PR DESCRIPTION
## What

Adds `optional-mcps/fifty50/manifest.yaml` for [Fifty50](https://frederickandsons.xyz/fifty50/) — a co-founder equity-split analysis tool + co-founder marketplace by Frederick & Sons.

## About the server

- **Public, unauthenticated remote MCP** over Streamable HTTP: `https://frederickandsons.xyz/fifty50/mcp` — no install, no API key, add by URL.
- **9 tools**: `create_partnership`, `add_contribution`, `get_attribution`, `forecast_equity`, `recommend_vesting`, `record_outcome`, `browse_marketplace`, `post_listing`, `ask_assistant`.
- **5 read-only tools enabled by default** (`get_attribution`, `forecast_equity`, `recommend_vesting`, `browse_marketplace`, `ask_assistant`); the 4 tools that create or mutate stored data require an explicit opt-in at install time, same reasoning the existing `n8n` entry uses for its mutating tools.
- Full API docs: https://frederickandsons.xyz/fifty50/developers

## Verification

Checked directly against the live server immediately before opening this PR (not just against the source code):
- `tools/list` over the real MCP endpoint returns exactly the 9 tools named in this manifest, with matching names.
- The endpoint requires no authentication (confirmed no API key is checked anywhere in the proxy).
- `source:` and `transport.url` both return 200 / a valid MCP `initialize` response.
- Service uptime checked (stable, 0 errors in the preceding 24h) before submitting.

Manifest validated as syntactically correct YAML and checked field-by-field against the schema used by the existing `n8n` and `linear`/`figma` entries (the latter two as the closest precedent, since Fifty50 is also `transport.type: http` with no local install step).