### PR TITLE
chore: contributor email mapping for FixItFoundry

### DIFF
--- a/contributors/emails/jesse.casco@gmail.com
+++ b/contributors/emails/jesse.casco@gmail.com
@@ -1,0 +1,1 @@
+FixItFoundry


### PR DESCRIPTION
Maps jesse.casco@gmail.com -> FixItFoundry for release attribution. Needed by the #68157 salvage.