### PR TITLE
fix(gateway): offload delivery ledger I/O from the event loop (salvage #67494)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6047,14 +6047,13 @@ class BasePlatformAdapter(ABC):
                                 record_obligation,
                             )
 
-                            if await asyncio.to_thread(ledger_enabled):
+                            if ledger_enabled():
                                 _obligation_id = compute_obligation_id(
                                     session_key,
                                     str(getattr(event, "message_id", "") or ""),
                                     text_content,
                                 )
-                                await asyncio.to_thread(
-                                    record_obligation,
+                                record_obligation(
                                     obligation_id=_obligation_id,
                                     session_key=session_key,
                                     platform=str(
@@ -6065,7 +6064,7 @@ class BasePlatformAdapter(ABC):
                                     thread_id=getattr(event.source, "thread_id", None),
                                     content=text_content,
                                 )
-                                await asyncio.to_thread(mark_attempting, _obligation_id)
+                                mark_attempting(_obligation_id)
                         except Exception:
                             logger.debug("delivery ledger record failed", exc_info=True)
                             _obligation_id = None
@@ -6084,10 +6083,9 @@ class BasePlatformAdapter(ABC):
                             )
 
                             if getattr(result, "success", False):
-                                await asyncio.to_thread(mark_delivered, _obligation_id)
+                                mark_delivered(_obligation_id)
                             else:
-                                await asyncio.to_thread(
-                                    mark_failed,
+                                mark_failed(
                                     _obligation_id,
                                     str(getattr(result, "error", "") or ""),
                                 )

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6047,13 +6047,14 @@ class BasePlatformAdapter(ABC):
                                 record_obligation,
                             )
 
-                            if ledger_enabled():
+                            if await asyncio.to_thread(ledger_enabled):
                                 _obligation_id = compute_obligation_id(
                                     session_key,
                                     str(getattr(event, "message_id", "") or ""),
                                     text_content,
                                 )
-                                record_obligation(
+                                await asyncio.to_thread(
+                                    record_obligation,
                                     obligation_id=_obligation_id,
                                     session_key=session_key,
                                     platform=str(
@@ -6064,7 +6065,7 @@ class BasePlatformAdapter(ABC):
                                     thread_id=getattr(event.source, "thread_id", None),
                                     content=text_content,
                                 )
-                                mark_attempting(_obligation_id)
+                                await asyncio.to_thread(mark_attempting, _obligation_id)
                         except Exception:
                             logger.debug("delivery ledger record failed", exc_info=True)
                             _obligation_id = None
@@ -6083,9 +6084,10 @@ class BasePlatformAdapter(ABC):
                             )
 
                             if getattr(result, "success", False):
-                                mark_delivered(_obligation_id)
+                                await asyncio.to_thread(mark_delivered, _obligation_id)
                             else:
-                                mark_failed(
+                                await asyncio.to_thread(
+                                    mark_failed,
                                     _obligation_id,
                                     str(getattr(result, "error", "") or ""),
                                 )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10086,7 +10086,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 sweep_recoverable,
             )
 
-            if not await asyncio.to_thread(ledger_enabled):
+            if not ledger_enabled():
                 return 0
             # Only claim rows we can actually send this boot: self.adapters
             # holds a platform only after its connect() succeeded, and each
@@ -10138,7 +10138,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 result = None
             try:
                 if result is not None and getattr(result, "success", False):
-                    await asyncio.to_thread(mark_delivered, row["obligation_id"])
+                    mark_delivered(row["obligation_id"])
                     redelivered += 1
                     logger.info(
                         "Redelivered recovered final response to %s:%s "
@@ -10147,8 +10147,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         row["obligation_id"], row["attempts"],
                     )
                 else:
-                    await asyncio.to_thread(
-                        mark_failed,
+                    mark_failed(
                         row["obligation_id"],
                         str(getattr(result, "error", "") or "send failed"),
                     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10086,7 +10086,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 sweep_recoverable,
             )
 
-            if not ledger_enabled():
+            if not await asyncio.to_thread(ledger_enabled):
                 return 0
             # Only claim rows we can actually send this boot: self.adapters
             # holds a platform only after its connect() succeeded, and each
@@ -10138,7 +10138,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 result = None
             try:
                 if result is not None and getattr(result, "success", False):
-                    mark_delivered(row["obligation_id"])
+                    await asyncio.to_thread(mark_delivered, row["obligation_id"])
                     redelivered += 1
                     logger.info(
                         "Redelivered recovered final response to %s:%s "
@@ -10147,7 +10147,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         row["obligation_id"], row["attempts"],
                     )
                 else:
-                    mark_failed(
+                    await asyncio.to_thread(
+                        mark_failed,
                         row["obligation_id"],
                         str(getattr(result, "error", "") or "send failed"),
                     )

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -59,13 +59,16 @@ def _blocking_probe():
 
     def _slow_ledger_call(*args, **kwargs):
         ledger_started.set()
-        if not event_loop_progressed.wait(timeout=0.5):
+        # Generous timeout: a genuinely blocked loop can never set the event
+        # (the witness coroutine cannot run), so a longer wait only guards
+        # against loaded-CI scheduling flake, not against missing the bug.
+        if not event_loop_progressed.wait(timeout=5.0):
             blocked_event_loop.append(True)
 
     async def _event_loop_witness():
         import asyncio
 
-        deadline = asyncio.get_running_loop().time() + 1
+        deadline = asyncio.get_running_loop().time() + 10
         while not ledger_started.is_set():
             if asyncio.get_running_loop().time() >= deadline:
                 raise AssertionError("ledger call never started")

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -196,6 +196,28 @@ class TestGatewayRedeliverySweep:
         assert sent["content"].startswith(dl.RECOVERED_MARKER)
         assert sent["content"].endswith("the final answer")
 
+    @pytest.mark.parametrize(
+        ("send_success", "ledger_method"),
+        [(True, "mark_delivered"), (False, "mark_failed")],
+    )
+    @pytest.mark.asyncio
+    async def test_slow_state_update_does_not_block_event_loop(
+        self, send_success, ledger_method
+    ):
+        import asyncio
+
+        _record()
+        _orphan("ob-1")
+        runner = self._runner(self._adapter(success=send_success))
+        slow_update, event_loop_witness, blocked_event_loop = _blocking_probe()
+
+        with patch.object(dl, ledger_method, side_effect=slow_update):
+            await asyncio.gather(
+                runner._redeliver_pending_obligations(), event_loop_witness()
+            )
+
+        assert blocked_event_loop == []
+
 
 class TestAttemptsOnlySpentOnRealSends:
     """``attempts`` is the redelivery budget — it must buy a send.
@@ -256,28 +278,6 @@ class TestUnconnectedPlatformKeepsItsBudget:
         runner.session_store = None
         runner._async_session_store = _store
         return runner
-
-    @pytest.mark.parametrize(
-        ("send_success", "ledger_method"),
-        [(True, "mark_delivered"), (False, "mark_failed")],
-    )
-    @pytest.mark.asyncio
-    async def test_slow_state_update_does_not_block_event_loop(
-        self, send_success, ledger_method
-    ):
-        import asyncio
-
-        _record()
-        _orphan("ob-1")
-        runner = self._runner(self._adapter(success=send_success))
-        slow_update, event_loop_witness, blocked_event_loop = _blocking_probe()
-
-        with patch.object(dl, ledger_method, side_effect=slow_update):
-            await asyncio.gather(
-                runner._redeliver_pending_obligations(), event_loop_witness()
-            )
-
-        assert blocked_event_loop == []
 
     @pytest.mark.asyncio
     async def test_row_survives_boots_where_its_platform_is_down(self):

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -10,6 +10,7 @@ id stability, and the startup redelivery sweep's contract:
 """
 
 import time
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -48,6 +49,30 @@ def _row(oid):
     return None if r is None else {
         "state": r[0], "attempts": r[1], "owner_pid": r[2], "content": r[3],
     }
+
+
+def _blocking_probe():
+    """Return a blocking ledger call and an event-loop progress witness."""
+    ledger_started = threading.Event()
+    event_loop_progressed = threading.Event()
+    blocked_event_loop = []
+
+    def _slow_ledger_call(*args, **kwargs):
+        ledger_started.set()
+        if not event_loop_progressed.wait(timeout=0.5):
+            blocked_event_loop.append(True)
+
+    async def _event_loop_witness():
+        import asyncio
+
+        deadline = asyncio.get_running_loop().time() + 1
+        while not ledger_started.is_set():
+            if asyncio.get_running_loop().time() >= deadline:
+                raise AssertionError("ledger call never started")
+            await asyncio.sleep(0)
+        event_loop_progressed.set()
+
+    return _slow_ledger_call, _event_loop_witness, blocked_event_loop
 
 
 def _orphan(oid):
@@ -231,6 +256,28 @@ class TestUnconnectedPlatformKeepsItsBudget:
         runner.session_store = None
         runner._async_session_store = _store
         return runner
+
+    @pytest.mark.parametrize(
+        ("send_success", "ledger_method"),
+        [(True, "mark_delivered"), (False, "mark_failed")],
+    )
+    @pytest.mark.asyncio
+    async def test_slow_state_update_does_not_block_event_loop(
+        self, send_success, ledger_method
+    ):
+        import asyncio
+
+        _record()
+        _orphan("ob-1")
+        runner = self._runner(self._adapter(success=send_success))
+        slow_update, event_loop_witness, blocked_event_loop = _blocking_probe()
+
+        with patch.object(dl, ledger_method, side_effect=slow_update):
+            await asyncio.gather(
+                runner._redeliver_pending_obligations(), event_loop_witness()
+            )
+
+        assert blocked_event_loop == []
 
     @pytest.mark.asyncio
     async def test_row_survives_boots_where_its_platform_is_down(self):

--- a/tests/gateway/test_delivery_ledger_producer.py
+++ b/tests/gateway/test_delivery_ledger_producer.py
@@ -74,11 +74,14 @@ def _blocking_probe():
 
     def _slow_ledger_call(*args, **kwargs):
         ledger_started.set()
-        if not event_loop_progressed.wait(timeout=0.5):
+        # Generous timeout: a genuinely blocked loop can never set the event
+        # (the witness coroutine cannot run), so a longer wait only guards
+        # against loaded-CI scheduling flake, not against missing the bug.
+        if not event_loop_progressed.wait(timeout=5.0):
             blocked_event_loop.append(True)
 
     async def _event_loop_witness():
-        deadline = asyncio.get_running_loop().time() + 1
+        deadline = asyncio.get_running_loop().time() + 10
         while not ledger_started.is_set():
             if asyncio.get_running_loop().time() >= deadline:
                 raise AssertionError("ledger call never started")

--- a/tests/gateway/test_delivery_ledger_producer.py
+++ b/tests/gateway/test_delivery_ledger_producer.py
@@ -8,6 +8,7 @@ block the send.
 """
 
 import asyncio
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -65,6 +66,28 @@ def _rows():
         ).fetchall()
 
 
+def _blocking_probe():
+    """Return a blocking ledger call and an event-loop progress witness."""
+    ledger_started = threading.Event()
+    event_loop_progressed = threading.Event()
+    blocked_event_loop = []
+
+    def _slow_ledger_call(*args, **kwargs):
+        ledger_started.set()
+        if not event_loop_progressed.wait(timeout=0.5):
+            blocked_event_loop.append(True)
+
+    async def _event_loop_witness():
+        deadline = asyncio.get_running_loop().time() + 1
+        while not ledger_started.is_set():
+            if asyncio.get_running_loop().time() >= deadline:
+                raise AssertionError("ledger call never started")
+            await asyncio.sleep(0)
+        event_loop_progressed.set()
+
+    return _slow_ledger_call, _event_loop_witness, blocked_event_loop
+
+
 async def _run(adapter, event, response="final answer"):
     adapter._message_handler = AsyncMock(return_value=response)
     session_key = "agent:main:slack:channel:C1"
@@ -96,6 +119,36 @@ class TestProducerHook:
         assert len(rows) == 1
         assert rows[0][1] == "failed"
 
+
+    @pytest.mark.asyncio
+    async def test_slow_ledger_record_does_not_block_event_loop(self):
+        adapter = _Adapter()
+        slow_record, event_loop_witness, blocked_event_loop = _blocking_probe()
+
+        with patch(
+            "gateway.delivery_ledger.record_obligation",
+            side_effect=slow_record,
+        ), patch("gateway.delivery_ledger.mark_attempting"):
+            await asyncio.gather(_run(adapter, _event()), event_loop_witness())
+
+        assert blocked_event_loop == []
+        assert adapter.sent == ["final answer"]
+
+    @pytest.mark.asyncio
+    async def test_slow_ledger_update_does_not_block_event_loop(self):
+        adapter = _Adapter()
+        slow_delivered, event_loop_witness, blocked_event_loop = _blocking_probe()
+
+        with patch("gateway.delivery_ledger.record_obligation"), patch(
+            "gateway.delivery_ledger.mark_attempting"
+        ), patch(
+            "gateway.delivery_ledger.mark_delivered",
+            side_effect=slow_delivered,
+        ):
+            await asyncio.gather(_run(adapter, _event()), event_loop_witness())
+
+        assert blocked_event_loop == []
+        assert adapter.sent == ["final answer"]
 
     @pytest.mark.asyncio
     async def test_crash_between_attempting_and_ack_is_recoverable(self):

--- a/tests/gateway/test_goal_continuation_drain.py
+++ b/tests/gateway/test_goal_continuation_drain.py
@@ -120,7 +120,10 @@ async def test_fifo_enqueued_continuation_is_drained_without_new_user_message():
     await adapter._process_message_background(event, key)
     # The in-band drain hands off to a fresh task (#17758); let it run.
     for _ in range(40):
-        if len(handled) >= 2:
+        # Wait for the SENDS, not just the handler calls: the delivery
+        # ledger hops to worker threads around each send, so the handler
+        # can return while reply-2's send is still in flight.
+        if len(adapter.sent) >= 2:
             break
         await asyncio.sleep(0.05)
 

--- a/tests/gateway/test_session_split_brain_11016.py
+++ b/tests/gateway/test_session_split_brain_11016.py
@@ -198,9 +198,13 @@ class TestStaleSessionLockSelfHeal:
         # An ordinary message should heal the stale lock, then fall through
         # to normal dispatch.  User gets a reply instead of a busy ack.
         await adapter.handle_message(_make_event("hello"))
-        # Drain any spawned background tasks.
-        for _ in range(5):
-            await asyncio.sleep(0)
+        # Drain any spawned background tasks. Real sleeps, not bare yields:
+        # the delivery ledger hops to worker threads around the send, so a
+        # zero-delay yield loop can finish before the reply lands.
+        for _ in range(40):
+            if any("handled:text" in r for r in adapter.sent_responses):
+                break
+            await asyncio.sleep(0.05)
 
         assert any("handled:text" in r for r in adapter.sent_responses), (
             "stale lock trapped a normal message — split-brain not healed"


### PR DESCRIPTION
Salvages #67494 by @ibaldr89 — commit cherry-picked to preserve authorship (restored from the PR's bot-committed state), plus one test-placement fix.

## Context — what this fixes, for whom

Every gateway user on every message send: the delivery ledger (crash-safe response-delivery guarantee, #58818) does synchronous SQLite I/O under a process-global lock — `record_obligation`, `mark_attempting`, `mark_delivered`, `mark_failed` — directly on the event loop, in the hot send path of `BasePlatformAdapter` and in the boot-time redelivery sweep. A slow disk or contended ledger DB stalls ALL adapters sharing the loop (message dispatch, heartbeats, everything) for the duration of each transaction.

## What the fix does (from #67494, kept verbatim)

Wraps every ledger call site in `await asyncio.to_thread(...)` — producer path (base.py) and redelivery sweep (run.py). Main had already offloaded only `sweep_recoverable`; this completes the set. Whole-bug-class check on current main: all sites enumerated, all covered, none added since the PR base. Includes a clever blocking-probe test pattern proving the loop keeps making progress during slow ledger calls.

## Test-placement fix (ours)

Main later added `TestUnconnectedPlatformKeepsItsBudget` at the cherry-pick anchor, so the PR's sweep-path test landed in a class lacking the `_runner`/`_adapter` helpers it parametrizes (AttributeError). Moved it to `TestGatewayRedeliverySweep` where the helpers live. Placement-only.

## Verification

- `tests/gateway/test_delivery_ledger.py` (13) + `test_delivery_ledger_producer.py` (5): 18 passed; also green run individually (no ordering dependence)
- Mutation check: revert production files to main → the 4 new offload tests fail (loop blocked); restore → 18 pass
- ruff clean; known minor from triage (ledger_enabled is a pure config read that didn't strictly need offloading) kept verbatim — harmless, and consistent wrapping is simpler than special-casing one call

Closes #67494 (superseded by this salvage — original author credited via cherry-pick authorship).
