### PR TITLE
fix(web): add /api/providers/oauth to PROFILE_SCOPED_PREFIXES (#76674)

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -80,6 +80,14 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/model/auxiliary",
   "/api/model/moa",
   "/api/model/options",
+  // Provider Logins OAuth: the backend already accepts ?profile= on
+  // /api/providers/oauth{,/{provider}/start,/submit,/poll/{session_id},/sessions/{session_id}}
+  // (web_server.py _validate_oauth_profile wraps the calls in _profile_scope),
+  // but the SPA helpers in this file forget to forward it. Without the prefix
+  // here, switching management profile to a non-default one (e.g. `coder`) and
+  // then opening Provider Logins still reads/writes the dashboard's launch
+  // profile — a real bug (#76674, root cause: missing prefix).
+  "/api/providers/oauth",
   // A named profile keeps its own pairing whitelist, and its gateway only
   // consults that one — approving into the global store would grant access
   // the running gateway never sees.


### PR DESCRIPTION
## Summary

The dashboard's Provider Logins OAuth card calls `/api/providers/oauth`, `/api/providers/oauth/{provider}/start`, `/submit`, `/poll/{session_id}`, and `/sessions/{session_id}` (cancel) without forwarding the selected management profile. Switching the dashboard to a non-default profile (e.g. `coder`) and then opening Provider Logins still reads/writes the dashboard's launch profile — see issue #76674 for the broken-affected-components diagram.

## Fix

Add `"/api/providers/oauth"` to `PROFILE_SCOPED_PREFIXES` in `web/src/lib/api.ts`. `withManagementProfile(...)` already runs over every URL inside `fetchJSON()`, appending `?profile=<mgmt>` if the path starts with one of the prefixes. Adding the OAuth prefix means every status, start, submit, poll, and cancel call now flows to the right profile without any caller code change.

The backend is already profile-aware: `web_server.py` `list_oauth_providers`, `start_oauth_login`, `submit_oauth_code`, `poll_oauth_session`, and `cancel_oauth_session` all accept `profile: Optional[str] = None` and gate writes with `_validate_oauth_profile()` + `_profile_scope()`. The SPA was the only missing piece.

## Files

- `web/src/lib/api.ts` — one entry added to `PROFILE_SCOPED_PREFIXES` (+8 / -0 including the comment explaining the bug). No callers touched. No public API change. No backend changes.

## Test plan

1. Local: `git diff` shows exactly one prefix added under the right alphabetical slot.
2. Manual: open the dashboard, switch to a non-default profile, open Provider Logins, start OAuth for a provider — the request URL in DevTools Network tab shows `?profile=<selected>`. Backend log shows the same profile name on the rewriting `_profile_scope` enter.
3. Existing tests in `web/src/lib/` (cron, models, etc.) that read the prefix list will continue to pass because the insertion is alphabetical and doesn't reorder existing entries.
4. Vitest coverage of the prefix list itself isn't included; the existing `_managementProfile` flow has unit tests in `apps/desktop/src/lib/` style and the same constant here is exercised by every API call that already passes profile tests. Adding a new test file just for this one line would be heavier than the fix warrants.
