### PR TITLE
fix(gateway): reap orphans on stop_profile_gateway (#75936)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1504,7 +1504,7 @@ def kill_gateway_processes(
     return killed
 
 
-def _reap_unsupervised_gateway_orphans() -> bool:
+def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool:
     """Kill no-supervisor gateway orphans the pidfile/runtime record can't see.
 
     On WSL/no-systemd hosts the manual restart fallback runs the gateway
@@ -1517,6 +1517,10 @@ def _reap_unsupervised_gateway_orphans() -> bool:
     running gateway — gating on ``supports_systemd_services()`` keeps the
     orphan-aware scan from killing live management processes there.
 
+    Args:
+        extra_exclude: Additional PIDs to skip (e.g. a PID already killed by
+            the caller so the sweep doesn't send a redundant SIGTERM/SIGKILL).
+
     Returns True if at least one orphan was reaped.
     """
     try:
@@ -1528,6 +1532,8 @@ def _reap_unsupervised_gateway_orphans() -> bool:
     from gateway.status import _pid_exists, write_planned_stop_marker
 
     own = {os.getpid()}
+    if extra_exclude:
+        own |= extra_exclude
     try:
         # find_gateway_pids() includes no-supervisor `gateway restart` runtimes
         # for the current profile when no systemd supervisor is present.
@@ -1628,11 +1634,13 @@ def stop_profile_gateway() -> bool:
         remove_pid_file()
 
     # Also reap any orphans from prior restarts whose PIDs were overwritten
-    # in the pid file before they exited (#75936).
+    # in the pid file before they exited (#75936).  Exclude the PID we just
+    # killed so the sweep doesn't double-kill a process that's still tearing
+    # down — _reap_unsupervised_gateway_orphans already excludes our own PID.
     try:
-        _reap_unsupervised_gateway_orphans()
-    except Exception:
-        pass
+        _reap_unsupervised_gateway_orphans(extra_exclude={pid} if pid else None)
+    except Exception as exc:
+        logger.debug("orphan reap after stop_profile_gateway failed: %s", exc)
 
     return True
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1583,6 +1583,12 @@ def stop_profile_gateway() -> bool:
     a live orphan still holds the webhook port. In that case fall back to the
     orphan-aware process scan so the replacement reaps the prior instance
     instead of stacking a duplicate on the same port (#51325).
+
+    Even when the pid file is valid and points to the current gateway, older
+    orphans may linger from prior restarts that overwrote the pid file before
+    the old process exited. After killing the recorded PID, also sweep for
+    any remaining orphans so each restart produces at most one live gateway
+    (#75936).
     """
     try:
         from gateway.status import get_running_pid, remove_pid_file
@@ -1620,6 +1626,14 @@ def stop_profile_gateway() -> bool:
 
     if get_running_pid() is None:
         remove_pid_file()
+
+    # Also reap any orphans from prior restarts whose PIDs were overwritten
+    # in the pid file before they exited (#75936).
+    try:
+        _reap_unsupervised_gateway_orphans()
+    except Exception:
+        pass
+
     return True
 
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -369,7 +369,7 @@ class TestWaitForGatewayExit:
 
 class TestStopProfileGateway:
     def test_stop_profile_gateway_keeps_pid_file_when_process_still_running(self, monkeypatch):
-        calls = {"kill": 0, "alive_probes": 0, "remove": 0}
+        calls = {"kill": 0, "alive_probes": 0, "remove": 0, "reap_calls": 0}
 
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: 12345)
         # Post-#21561: the stop loop sends one SIGTERM via ``os.kill`` then
@@ -389,11 +389,42 @@ class TestStopProfileGateway:
             "gateway.status.remove_pid_file",
             lambda: calls.__setitem__("remove", calls["remove"] + 1),
         )
+        # Mock the orphan reap so it doesn't scan for real gateway processes
+        # (#75936 — stop_profile_gateway now calls _reap_unsupervised_gateway_orphans
+        # after killing the pid-file PID).
+        monkeypatch.setattr(
+            gateway,
+            "_reap_unsupervised_gateway_orphans",
+            lambda extra_exclude=None: calls.__setitem__("reap_calls", calls["reap_calls"] + 1) or False,
+        )
 
         assert gateway.stop_profile_gateway() is True
         assert calls["kill"] == 1          # one SIGTERM
         assert calls["alive_probes"] == 20 # 20 liveness polls over the 2s window
         assert calls["remove"] == 0
+        assert calls["reap_calls"] == 1    # orphan sweep ran after kill
+
+    def test_stop_profile_gateway_excludes_killed_pid_from_orphan_reap(self, monkeypatch):
+        """The PID we killed must be excluded from the orphan sweep (#75936)."""
+        killed_pid = 99999
+        reap_extra_excludes = []
+
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: killed_pid)
+        monkeypatch.setattr(gateway.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+        monkeypatch.setattr("time.sleep", lambda _: None)
+        monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+
+        def fake_reap(extra_exclude=None):
+            if extra_exclude:
+                reap_extra_excludes.append(extra_exclude)
+            return False
+
+        monkeypatch.setattr(gateway, "_reap_unsupervised_gateway_orphans", fake_reap)
+
+        assert gateway.stop_profile_gateway() is True
+        assert len(reap_extra_excludes) == 1
+        assert killed_pid in reap_extra_excludes[0]
 
 
 def test_module_has_logger():


### PR DESCRIPTION
## Summary
`stop_profile_gateway()` now sweeps lingering orphan gateway processes after killing the pid-file PID, so repeated `hermes gateway restart` on macOS no longer stacks multiple live gateways (each processing every Discord message N times).

## Changes
- `hermes_cli/gateway.py`: Added `_reap_unsupervised_gateway_orphans()` call after the PID kill sequence in `stop_profile_gateway()`. Added `extra_exclude` param to `_reap_unsupervised_gateway_orphans()` so the just-killed PID is excluded from the sweep (prevents double-kill). Replaced bare `except: pass` with `logger.debug`.
- `tests/hermes_cli/test_gateway.py`: Fixed existing test (mock the reap so it doesn't scan real processes). Added regression test asserting the killed PID is excluded from the orphan sweep.

## Root cause
`stop_profile_gateway()` only killed the single PID from the pid file. On each restart, the new process overwrites the pid file before the old one exits, making older instances invisible. `_reap_unsupervised_gateway_orphans()` existed but was only called when the pid file was missing/stale — never when it was valid but only tracked the newest of several instances.

## Validation
| | Before | After |
|---|---|---|
| `test_stop_profile_gateway_keeps_pid_file...` | FAIL (5 kills instead of 1 — unmocked reap scans real processes) | PASS (1 kill, reap mocked) |
| `test_stop_profile_gateway_excludes_killed_pid...` | N/A (new test) | PASS (killed PID in extra_exclude) |
| Full `test_gateway.py` (15 tests) | — | 15 passed |

Salvage of #75991 by @RelaxJonh — cherry-picked with authorship preserved, fixes applied on top.

Closes #75936
