### PR TITLE
fix(config): `hermes config set` cannot create list-of-dicts values (hooks: unreachable via CLI)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -989,6 +989,11 @@ def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
     return missing
 
 
+def _is_index(segment: str) -> bool:
+    """True when a dotted-path segment addresses a list index (``a.0.b``)."""
+    return segment.isdigit()
+
+
 def _set_nested(config, dotted_key: str, value):
     """Set a value at an arbitrarily nested dotted key path.
 
@@ -998,13 +1003,14 @@ def _set_nested(config, dotted_key: str, value):
       _set_nested(c, "providers.1", "x") → c["providers"][1] = "x"
 
     Intermediate dicts are created on demand.  List indices are parsed
-    from numeric path segments; the referenced index must already exist
-    (we do not grow lists — the user is navigating into structure they
-    wrote themselves).  If a segment targets a non-container leaf
-    (scalar), the leaf is replaced with a fresh dict so the write can
-    proceed — this preserves the pre-existing behavior for bare scalar
-    overrides (e.g. setting ``a.b.c`` where ``a.b`` was previously a
-    string).
+    from numeric path segments.  A numeric segment also *creates* the list
+    when the parent key is missing (``hooks.pre_tool_call.0.command`` on an
+    empty config yields a one-element list, not a dict keyed ``"0"`` —
+    #76974), and grows a short list so the index resolves.  If a segment
+    targets a non-container leaf (scalar), the leaf is replaced with a fresh
+    container so the write can proceed — this preserves the pre-existing
+    behavior for bare scalar overrides (e.g. setting ``a.b.c`` where ``a.b``
+    was previously a string).
 
     Guards against #17876: before this fix the code unconditionally
     replaced any non-dict value (including lists) with ``{}``, silently
@@ -1013,7 +1019,7 @@ def _set_nested(config, dotted_key: str, value):
     """
     parts = dotted_key.split(".")
     current = config
-    for part in parts[:-1]:
+    for depth, part in enumerate(parts[:-1]):
         if isinstance(current, list):
             try:
                 idx = int(part)
@@ -1025,10 +1031,20 @@ def _set_nested(config, dotted_key: str, value):
             current = current[idx]
         elif isinstance(current, dict):
             existing = current.get(part)
-            # Preserve dicts and lists; replace missing/scalar with a fresh dict.
+            # Preserve dicts and lists; replace missing/scalar with a fresh
+            # container. Seed a LIST when the next segment is a numeric index,
+            # so creating list-of-dicts config works and not just editing it
+            # (#76974): before this, `hooks.pre_tool_call.0.command` produced
+            # a dict with the string key "0", which the runtime never reads.
             if part not in current or not isinstance(existing, (dict, list)):
-                current[part] = {}
+                current[part] = [] if _is_index(parts[depth + 1]) else {}
             current = current[part]
+            # Grow a seeded/short list so the upcoming index resolves.
+            if isinstance(current, list):
+                nxt = parts[depth + 1]
+                if _is_index(nxt):
+                    while len(current) <= int(nxt):
+                        current.append({})
         else:
             raise TypeError(
                 f"Cannot navigate into {type(current).__name__} at key {dotted_key!r}"

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -723,3 +723,57 @@ class TestMalformedYAMLConfigPreservation:
         assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
         raw = _read_config(_isolated_hermes_home)
         assert raw == self.BROKEN_CONFIG
+
+
+class TestSetNestedListCreation:
+    """`_set_nested` must CREATE list-of-dicts config, not just edit it (#76974).
+
+    Before the fix a numeric segment under a missing key produced a dict with
+    the string key "0", so `hooks:` written via `hermes config set` was never
+    read by the runtime — the CLI reported success and the feature stayed off.
+    """
+
+    def test_numeric_segment_creates_list_not_string_keyed_dict(self):
+        from hermes_cli.config import _set_nested
+
+        cfg = {}
+        _set_nested(cfg, "hooks.pre_tool_call.0.command", "/tmp/hook.py")
+
+        assert isinstance(cfg["hooks"]["pre_tool_call"], list)
+        assert cfg["hooks"]["pre_tool_call"] == [{"command": "/tmp/hook.py"}]
+
+    def test_grows_list_to_reach_index(self):
+        from hermes_cli.config import _set_nested
+
+        cfg = {}
+        _set_nested(cfg, "a.2.k", "v")
+
+        assert isinstance(cfg["a"], list)
+        assert len(cfg["a"]) == 3
+        assert cfg["a"][2] == {"k": "v"}
+
+    def test_editing_an_existing_list_is_unchanged(self):
+        """Regression guard: the pre-existing edit path must keep working."""
+        from hermes_cli.config import _set_nested
+
+        cfg = {"hooks": {"pre_llm_call": [{"command": "/old.py", "timeout": 20}]}}
+        _set_nested(cfg, "hooks.pre_llm_call.0.command", "/new.py")
+
+        assert cfg["hooks"]["pre_llm_call"] == [{"command": "/new.py", "timeout": 20}]
+
+    def test_non_numeric_segment_still_creates_dict(self):
+        from hermes_cli.config import _set_nested
+
+        cfg = {}
+        _set_nested(cfg, "agent.model.name", "x")
+
+        assert cfg == {"agent": {"model": {"name": "x"}}}
+
+    def test_existing_list_is_not_clobbered(self):
+        """#17876 guard must survive: a list under a dotted path is preserved."""
+        from hermes_cli.config import _set_nested
+
+        cfg = {"custom_providers": [{"name": "a"}, {"name": "b"}]}
+        _set_nested(cfg, "custom_providers.1.name", "c")
+
+        assert cfg["custom_providers"] == [{"name": "a"}, {"name": "c"}]


### PR DESCRIPTION
Fixes #76974

### Problem

`_set_nested()` navigated lists only when one **already existed**, so a numeric segment under a missing key created a dict with the string key `"0"`:

```
$ hermes config set hooks.pre_tool_call.0.command /tmp/hook.py
✓ Set hooks.pre_tool_call.0.command = /tmp/hook.py in .../config.yaml
```
```yaml
hooks:
  pre_tool_call:
    '0':                       # dict keyed "0" — not a list
      command: /tmp/hook.py
```

The command exits `0` and prints the normal success line, but the runtime never reads that shape — `hermes hooks list` reports **“No shell hooks configured”**. The documented `hooks:` schema in `website/docs/user-guide/features/hooks.md` was therefore unreachable through the CLI, and the user got a success receipt for a no-op.

The existing docstring already advertised `_set_nested(c, "a.0.b", 1)` → `c["a"][0]["b"]`; that held only when `c["a"]` was already a list.

### Fix

Look ahead at the next path segment. When it parses as a numeric index, seed a **list** instead of a dict, and grow it so the index resolves.

```yaml
hooks:
  pre_tool_call:
    - command: /tmp/hook.py    # after
```

Smallest change that makes the documented syntax work; no new config keys, flags, or parsing modes. The issue also floated JSON-value parsing and loud rejection as alternatives — this PR implements only the path fix, leaving `hermes config set k '[{...}]'` (a string value) as-is, since that syntax was never documented.

### Preserved behaviour

- **Editing an existing list** works exactly as before.
- **#17876 guard holds** — an existing list is never clobbered by a dotted path.
- Non-numeric segments still create dicts.

Each has a dedicated regression test.

### Tests

Added `TestSetNestedListCreation` (5 cases) to `tests/hermes_cli/test_set_config_value.py`. These are behaviour contracts (asserting the container type and resulting structure), not value snapshots.

```
$ .venv/bin/python -m pytest tests/hermes_cli/test_set_config_value.py \
      tests/hermes_cli/test_hooks_cli.py -q
94 passed in 6.43s
```

Verified the tests actually discriminate — reverting just the one-line behaviour change while keeping the tests:

```
2 failed, 3 passed
E  assert False
E   +  where False = isinstance({'0': {'command': '/tmp/hook.py'}}, list)
```

End-to-end through the real CLI entry point against an isolated `HERMES_HOME`, confirming the emitted YAML is a valid list-of-dicts:

```yaml
hooks:
  pre_tool_call:
    - command: ~/.hermes/agent-hooks/x.py
```
`type: list | valid list-of-dicts: True`

Scope note: a broader `tests/hermes_cli/` sweep hit 161 collection errors in my sandbox from `ModuleNotFoundError: httpx` — a missing dependency in the throwaway venv, reproducible on unmodified files (e.g. `test_status.py`) and unrelated to this change. Every test that imports the touched code passes.
