### PR TITLE
feat: add DeepSeek web search provider backend

### DIFF
--- a/plugins/web/deepseek/__init__.py
+++ b/plugins/web/deepseek/__init__.py
@@ -1,0 +1,14 @@
+"""DeepSeek web search plugin — bundled, auto-loaded.
+
+Mirrors the ``plugins/web/xai/`` layout: ``provider.py`` holds the
+provider class, ``__init__.py::register(ctx)`` registers an instance.
+"""
+
+from __future__ import annotations
+
+from plugins.web.deepseek.provider import DeepSeekWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the DeepSeek Web Search provider with the plugin context."""
+    ctx.register_web_search_provider(DeepSeekWebSearchProvider())

--- a/plugins/web/deepseek/plugin.yaml
+++ b/plugins/web/deepseek/plugin.yaml
@@ -1,0 +1,9 @@
+name: web-deepseek
+version: 1.0.0
+description: "DeepSeek Web Search — server-side web_search via DeepSeek's Anthropic-compatible endpoint. Requires DEEPSEEK_API_KEY."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - deepseek
+requires_env:
+  - DEEPSEEK_API_KEY

--- a/plugins/web/deepseek/provider.py
+++ b/plugins/web/deepseek/provider.py
@@ -1,0 +1,279 @@
+"""DeepSeek Web Search — bundled Hermes web backend plugin.
+
+Routes ``web_search`` tool calls through DeepSeek's server-side
+``web_search`` tool on the Anthropic-compatible endpoint
+(``https://api.deepseek.com/anthropic``). DeepSeek runs the actual
+searching and page-reading server-side (usage reports
+``server_tool_use.web_search_requests``); the final assistant text block
+is a server-side synthesis of the fetched pages, which we surface to the
+main model as ``data.summary`` alongside the standard ``data.web`` rows.
+
+Reference: DeepSeek API docs — "Integrate with Agent Tools" / Web Search
+via the Anthropic endpoint. Tool declaration:
+``{"type": "web_search_20250305", "name": "web_search"}``.
+
+Config keys this provider responds to::
+
+    web:
+      search_backend: "deepseek"    # explicit per-capability
+      backend: "deepseek"           # shared fallback
+
+Optional knobs (under ``web.deepseek`` in ``config.yaml``)::
+
+    web:
+      deepseek:
+        model: "deepseek-v4-flash"  # default deepseek-v4-flash
+        base_url: "https://api.deepseek.com/anthropic"
+        max_tokens: 1024            # cap on the synthesis text
+        timeout: 120                # seconds (default 120)
+
+Auth: ``DEEPSEEK_API_KEY``, resolved via :func:`get_provider_env` (checks
+``os.environ`` first, then ``~/.hermes/.env``).
+
+Trust model
+-----------
+Like the bundled xAI backend, this is an LLM in a trench coat: DeepSeek
+decides which URLs to surface and writes the titles itself, influenced by
+the *content of the query*. Callers that pipe untrusted text directly
+into ``web_search`` should treat returned URLs as model-generated links —
+validate before fetching.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+from agent.web_search_provider import WebSearchProvider, get_provider_env
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "deepseek-v4-flash"
+DEFAULT_BASE_URL = "https://api.deepseek.com/anthropic"
+DEFAULT_MAX_TOKENS = 1024
+DEFAULT_TIMEOUT = 120
+
+# Anthropic server-side web search tool, as implemented by DeepSeek's
+# Anthropic-compatible endpoint. Verified live: without the ``name`` field
+# the endpoint rejects the request ("missing field `name`").
+SEARCH_TOOL = {"type": "web_search_20250305", "name": "web_search"}
+
+
+def _load_cfg() -> Dict[str, Any]:
+    """Read ``web.deepseek`` from config.yaml (returns {} on miss)."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        web_section = cfg.get("web") if isinstance(cfg, dict) else None
+        section = web_section.get("deepseek") if isinstance(web_section, dict) else None
+        return section if isinstance(section, dict) else {}
+    except Exception as exc:  # noqa: BLE001 — config layer is best-effort
+        logger.debug("Could not load web.deepseek config: %s", exc)
+        return {}
+
+
+class DeepSeekWebSearchProvider(WebSearchProvider):
+    """Search-only provider backed by DeepSeek's server-side web search.
+
+    No extract capability — pair with Firecrawl / Tavily / Exa for
+    ``web_extract`` if you need raw page content.
+    """
+
+    @property
+    def name(self) -> str:
+        return "deepseek"
+
+    @property
+    def display_name(self) -> str:
+        return "DeepSeek Web Search (原生联网搜索)"
+
+    def is_available(self) -> bool:
+        """Cheap availability probe — DEEPSEEK_API_KEY present.
+
+        Uses :func:`get_provider_env` so keys living in ``~/.hermes/.env``
+        (loaded by the config layer, not the process env) are honored.
+        Never touches the network — safe for every ``hermes tools`` paint.
+        """
+        return bool(get_provider_env("DEEPSEEK_API_KEY"))
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    # -- Search -----------------------------------------------------------
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute a DeepSeek-native web search.
+
+        Returns ``{"success": True, "data": {"web": [{title, url,
+        description, position}, ...], "summary": str}}`` on success,
+        ``{"success": False, "error": str}`` on failure.
+
+        ``data.summary`` is DeepSeek's own synthesis of the searched pages
+        — the main model gets the search-engine rows *and* the server-side
+        summary, which is what makes this backend feel like Claude Code's
+        Web Search.
+        """
+        api_key = get_provider_env("DEEPSEEK_API_KEY")
+        if not api_key:
+            return {
+                "success": False,
+                "error": (
+                    "No DEEPSEEK_API_KEY found. Set it in ~/.hermes/.env "
+                    "or export it in the environment."
+                ),
+            }
+
+        # Clamp limit to the range the caller (web_search_tool) accepts.
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            limit = 5
+        limit = max(1, min(limit, 100))
+
+        cfg = _load_cfg()
+        model = str(cfg.get("model") or DEFAULT_MODEL).strip() or DEFAULT_MODEL
+        base_url = str(cfg.get("base_url") or DEFAULT_BASE_URL).strip().rstrip("/")
+        base_url = base_url or DEFAULT_BASE_URL
+        try:
+            max_tokens = int(cfg.get("max_tokens", DEFAULT_MAX_TOKENS))
+        except (TypeError, ValueError):
+            max_tokens = DEFAULT_MAX_TOKENS
+        try:
+            timeout = float(cfg.get("timeout", DEFAULT_TIMEOUT))
+        except (TypeError, ValueError):
+            timeout = DEFAULT_TIMEOUT
+
+        payload = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "messages": [{"role": "user", "content": query}],
+            "tools": [SEARCH_TOOL],
+        }
+        headers = {
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        }
+
+        try:
+            import httpx
+        except ImportError:
+            return {
+                "success": False,
+                "error": "httpx is not installed (required for DeepSeek web search)",
+            }
+
+        logger.info(
+            "DeepSeek web search via %s: '%s' (limit=%d, model=%s)",
+            base_url, query, limit, model,
+        )
+
+        try:
+            resp = httpx.post(
+                f"{base_url}/v1/messages",
+                headers=headers,
+                json=payload,
+                timeout=timeout,
+            )
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code if exc.response is not None else 0
+            body = ""
+            try:
+                body = exc.response.text[:300] if exc.response is not None else ""
+            except Exception:  # noqa: BLE001
+                body = ""
+            logger.warning("DeepSeek web search HTTP %d: %s", status, body)
+            return {
+                "success": False,
+                "error": f"DeepSeek web search returned HTTP {status}: {body}".rstrip(),
+            }
+        except httpx.RequestError as exc:
+            logger.warning("DeepSeek web search request error: %s", exc)
+            return {"success": False, "error": f"Could not reach DeepSeek: {exc}"}
+
+        try:
+            data = resp.json()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("DeepSeek web search bad JSON: %s", exc)
+            return {
+                "success": False,
+                "error": "Could not parse DeepSeek reply as JSON",
+            }
+
+        results, summary = self._parse_reply(data)
+        envelope: Dict[str, Any] = {"web": results[:limit], "summary": summary}
+        return {"success": True, "data": envelope}
+
+    # -- Parsing ----------------------------------------------------------
+
+    @classmethod
+    def _parse_reply(cls, data: Any) -> tuple[List[Dict[str, Any]], str]:
+        """Walk ``content`` blocks for search rows and the synthesis text.
+
+        Block types seen in the wild (DeepSeek Anthropic endpoint):
+        ``thinking``, ``server_tool_use`` (search calls), ``text`` (final
+        synthesis), and ``web_search_tool_result`` whose ``content`` holds
+        ``web_search_result`` items with ``title`` / ``url`` /
+        ``encrypted_content`` / ``page_age``. Only title+url are usable
+        client-side; the page content lives inside the server.
+        """
+        results: List[Dict[str, Any]] = []
+        summary_parts: List[str] = []
+        if not isinstance(data, dict):
+            return results, ""
+        content = data.get("content")
+        if not isinstance(content, list):
+            return results, "\n".join(summary_parts)
+
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "web_search_tool_result":
+                items = block.get("content")
+                if not isinstance(items, list):
+                    continue
+                for item in items:
+                    if not isinstance(item, dict) or item.get("type") != "web_search_result":
+                        continue
+                    url = str(item.get("url", "")).strip()
+                    if not url:
+                        continue
+                    results.append(
+                        {
+                            "title": str(item.get("title", "")).strip(),
+                            "url": url,
+                            "description": "",
+                            # Renumber from kept rows so a dropped malformed
+                            # item leaves no gap in positions.
+                            "position": len(results) + 1,
+                        }
+                    )
+            elif btype == "text":
+                text = str(block.get("text", "")).strip()
+                if text:
+                    summary_parts.append(text)
+
+        return results, "\n".join(summary_parts)
+
+    # -- hermes tools picker ----------------------------------------------
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        """Expose the API-key prompt in the ``hermes tools`` picker."""
+        return {
+            "name": "DeepSeek Web Search",
+            "badge": "paid",
+            "tag": "Server-side web search via DeepSeek's Anthropic-compatible endpoint — per-token pricing.",
+            "env_vars": [
+                {
+                    "key": "DEEPSEEK_API_KEY",
+                    "prompt": "DeepSeek API key",
+                    "url": "https://platform.deepseek.com/api_keys",
+                },
+            ],
+        }

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -23,6 +23,8 @@ import inspect
 
 import pytest
 
+from plugins.web.deepseek.provider import DeepSeekWebSearchProvider
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -42,6 +44,7 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
         "FIRECRAWL_GATEWAY_URL",
+        "DEEPSEEK_API_KEY",
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
         "XAI_API_KEY",
@@ -68,9 +71,9 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All eight bundled web plugins discover and register correctly."""
+    """All nine bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_bundled_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -78,6 +81,7 @@ class TestBundledPluginsRegister:
         assert names == [
             "brave-free",
             "ddgs",
+            "deepseek",
             "exa",
             "firecrawl",
             "parallel",
@@ -91,6 +95,8 @@ class TestBundledPluginsRegister:
         [
             ("brave-free", True, False),
             ("ddgs", True, False),
+            # deepseek: search-only via DeepSeek's server-side web_search tool.
+            ("deepseek", True, False),
             ("searxng", True, False),
             ("exa", True, True),
             ("parallel", True, True),
@@ -116,7 +122,17 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        [
+            "brave-free",
+            "ddgs",
+            "deepseek",
+            "searxng",
+            "exa",
+            "parallel",
+            "tavily",
+            "firecrawl",
+            "xai",
+        ],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -230,6 +246,22 @@ class TestIsAvailable:
         monkeypatch.setenv("XAI_API_KEY", "real")
         assert p.is_available() is True
 
+    def test_deepseek_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """DeepSeek needs DEEPSEEK_API_KEY (shared with the inference path)."""
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("deepseek")
+        assert p is not None
+        # Empty string in os.environ shadows any key in ~/.hermes/.env
+        # (get_env_value returns the environ value — even "" — before
+        # falling through to the .env file), keeping the test hermetic
+        # on dev machines that have a real key in .env.
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "")
+        assert p.is_available() is False
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "real")
+        assert p.is_available() is True
+
 
 # ---------------------------------------------------------------------------
 # Registry resolution semantics (Option B — conservative smart fallback)
@@ -310,5 +342,89 @@ class TestAsyncExtractDispatch:
 
 class TestErrorResponseShapes:
     """When credentials are missing, plugins return typed errors, not raises."""
+
+
+# ---------------------------------------------------------------------------
+# DeepSeek reply parsing (pure function — no network)
+# ---------------------------------------------------------------------------
+
+
+class TestDeepSeekParseReply:
+    """``_parse_reply`` extracts web rows + synthesis text from replies."""
+
+    @staticmethod
+    def _provider() -> "DeepSeekWebSearchProvider":
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+        from plugins.web.deepseek.provider import DeepSeekWebSearchProvider
+
+        p = get_provider("deepseek")
+        assert isinstance(p, DeepSeekWebSearchProvider)
+        return p
+
+    def test_parses_search_results_and_summary(self) -> None:
+        p = self._provider()
+        assert p is not None
+        data = {
+            "content": [
+                {"type": "thinking", "thinking": "irrelevant"},
+                {"type": "server_tool_use", "name": "web_search", "input": {"query": "q"}},
+                {
+                    "type": "web_search_tool_result",
+                    "tool_use_id": "call_0",
+                    "content": [
+                        {
+                            "type": "web_search_result",
+                            "title": "T1",
+                            "url": "https://a.example/1",
+                            "page_age": None,
+                        },
+                        {
+                            "type": "web_search_result",
+                            "title": "T2",
+                            "url": "https://a.example/2",
+                        },
+                        # Non-result items must be skipped, not crash.
+                        {"type": "web_search_result", "title": "no-url"},
+                        {"type": "something_else", "url": "https://skip.example"},
+                    ],
+                },
+                {"type": "text", "text": "synthesis text"},
+            ]
+        }
+        rows, summary = p._parse_reply(data)
+        assert rows == [
+            {"title": "T1", "url": "https://a.example/1", "description": "", "position": 1},
+            {"title": "T2", "url": "https://a.example/2", "description": "", "position": 2},
+        ]
+        assert summary == "synthesis text"
+
+    def test_positions_renumber_after_dropped_rows(self) -> None:
+        p = self._provider()
+        assert p is not None
+        data = {
+            "content": [
+                {
+                    "type": "web_search_tool_result",
+                    "tool_use_id": "call_0",
+                    "content": [
+                        {"type": "web_search_result", "title": "", "url": ""},
+                        {"type": "web_search_result", "title": "T", "url": "https://a.example"},
+                    ],
+                }
+            ]
+        }
+        rows, summary = p._parse_reply(data)
+        assert len(rows) == 1
+        assert rows[0]["position"] == 1  # renumbered, no gap
+        assert summary == ""
+
+    def test_empty_and_malformed_replies(self) -> None:
+        p = self._provider()
+        assert p is not None
+        for data in ({}, {"content": None}, {"content": "nope"}, None):
+            rows, summary = p._parse_reply(data)
+            assert rows == []
+            assert summary == ""
 
 

--- a/website/docs/developer-guide/web-search-provider-plugin.md
+++ b/website/docs/developer-guide/web-search-provider-plugin.md
@@ -6,7 +6,7 @@ description: "How to build a web-search/extract/crawl backend plugin for Hermes 
 
 # Building a Web Search Provider Plugin
 
-Web-search provider plugins register a backend that services `web_search`, `web_extract`, and (optionally) deep-crawl tool calls. Built-in providers — Firecrawl, SearXNG, Tavily, Exa, Parallel, Brave Search (free tier), xAI, and DDGS — all ship as plugins under `plugins/web/<name>/`. You can add a new one, or override a bundled one, by dropping a directory next to them.
+Web-search provider plugins register a backend that services `web_search`, `web_extract`, and (optionally) deep-crawl tool calls. Built-in providers — Firecrawl, SearXNG, Tavily, Exa, Parallel, Brave Search (free tier), xAI, DeepSeek, and DDGS — all ship as plugins under `plugins/web/<name>/`. You can add a new one, or override a bundled one, by dropping a directory next to them.
 
 :::tip
 Web search is one of several **backend plugins** Hermes supports. The others (with their own ABCs) are [Image Generation Provider Plugins](/developer-guide/image-gen-provider-plugin), [Video Generation Provider Plugins](/developer-guide/video-gen-provider-plugin), [Memory Provider Plugins](/developer-guide/memory-provider-plugin), [Context Engine Plugins](/developer-guide/context-engine-plugin), and [Model Provider Plugins](/developer-guide/model-provider-plugin). General tool/hook/CLI plugins live in [Build a Hermes Plugin](/developer-guide/plugins).
@@ -242,6 +242,7 @@ If your provider wraps a third-party SDK (like DDGS does with the `ddgs` package
 - **`plugins/web/firecrawl/`** — full multi-capability provider (search + extract + crawl) with multiple format modes.
 - **`plugins/web/searxng/`** — self-hosted, URL-configured backend with no auth.
 - **`plugins/web/xai/`** — LLM-backed search via Grok's server-side `web_search` tool. Shows how to reuse an existing OAuth/env-var credential surface (`tools/xai_http.py`) without adding new env vars, and how to write a cheap `is_available()` that honors the no-network contract.
+- **`plugins/web/deepseek/`** — LLM-backed search via DeepSeek's server-side `web_search` tool on the Anthropic-compatible endpoint (the OpenAI-compatible endpoint rejects the tool type). Shows how a provider can surface extra server-side context (the synthesis text) as an additional `data.summary` key — the tool wrapper serializes the whole envelope back to the model.
 
 ## Distribute via pip
 

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -26,8 +26,9 @@ Both are configured through a single backend selection. Providers are chosen via
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | 1 000 searches/mo |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | Paid |
 | **xAI (Grok)** | `XAI_API_KEY` or `hermes auth add xai-oauth` | ✔ | — | Paid (SuperGrok or per-token) |
+| **DeepSeek** | `DEEPSEEK_API_KEY` | ✔ | — | Paid (per-token) |
 
-Brave Search, DDGS, and xAI are **search-only** — pair any of them with Firecrawl/Tavily/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below).
+Brave Search, DDGS, DeepSeek, and xAI are **search-only** — pair any of them with Firecrawl/Tavily/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below). DeepSeek runs its server-side `web_search` tool on DeepSeek's Anthropic-compatible endpoint — it searches, reads, and synthesizes the pages server-side (each search costs one extra DeepSeek API call), and the provider surfaces that synthesis as a `summary` alongside the result rows (see the [trust-model caveat](#deepseek) below).
 
 **Per-capability split:** you can use different providers for search and extract independently — for example SearXNG (free) for search and Firecrawl for extract. See [Per-capability configuration](#per-capability-configuration) below.
 
@@ -315,6 +316,40 @@ web:
 Unlike index-backed providers (Brave, Tavily, Exa) which return verbatim search-engine results, xAI is an LLM choosing which URLs to surface and writing the titles and descriptions itself. The *content* of the query influences the output, so a maliciously crafted query (e.g. injected via untrusted upstream input the agent picked up) can in principle steer Grok into emitting attacker-chosen URLs. Treat returned URLs the same way you'd treat any model-generated link — validate before fetching, especially if the query came from untrusted input.
 :::
 
+### DeepSeek {#deepseek}
+
+Routes `web_search` through DeepSeek's server-side `web_search` tool on the [Anthropic-compatible endpoint](https://api-docs.deepseek.com/). DeepSeek runs the searching *and* the page-reading server-side — the final answer text is a server-side synthesis of the fetched pages, and the provider surfaces that synthesis to the agent as a `summary` alongside the standard result rows.
+
+```bash
+# ~/.hermes/.env
+DEEPSEEK_API_KEY=«redacted:sk-…»
+```
+
+Then select DeepSeek as the search backend:
+
+```yaml
+# ~/.hermes/config.yaml
+web:
+  backend: "deepseek"
+```
+
+**Optional knobs:**
+
+```yaml
+web:
+  backend: "deepseek"
+  deepseek:
+    model: deepseek-v4-flash        # default
+    max_tokens: 1024                # cap on the server-side synthesis text
+    timeout: 120                    # seconds (default)
+```
+
+**Search-only** — pair with Firecrawl / Tavily / Exa / Parallel if you also need `web_extract`. DeepSeek's web search is a server-side tool on the Anthropic-compatible endpoint: the OpenAI-compatible endpoint rejects the `web_search` tool type (`unknown variant 'web_search'`). Each search costs one extra DeepSeek API call (the server-side summary pass is billed as model tokens), and the model decides how many search rounds to run — the returned result count is not directly controllable via the tool's `limit` argument.
+
+:::caution Trust model
+Same as xAI: DeepSeek is an LLM choosing which URLs to surface and writing the titles itself. The *content* of the query influences the output, so a maliciously crafted query (e.g. injected via untrusted upstream input the agent picked up) can in principle steer DeepSeek into emitting attacker-chosen URLs. Treat returned URLs the same way you'd treat any model-generated link — validate before fetching, especially if the query came from untrusted input.
+:::
+
 ---
 
 ## Configuration
@@ -326,7 +361,7 @@ Set one provider for all web capabilities:
 ```yaml
 # ~/.hermes/config.yaml
 web:
-  backend: "searxng"   # firecrawl | searxng | brave-free | ddgs | tavily | exa | parallel | xai
+  backend: "searxng"   # firecrawl | searxng | brave-free | ddgs | deepseek | tavily | exa | parallel | xai
 ```
 
 ### Per-capability configuration
@@ -362,6 +397,8 @@ If no backend is explicitly configured, Hermes picks the first available one bas
 | `ddgs` package importable | ddgs |
 
 xAI Web Search is **not** in the auto-detection chain — having `XAI_API_KEY` set (or being signed in via xAI Grok OAuth) does not automatically route web traffic through xAI, since those credentials are also used for inference / TTS / image gen and the user may want a different backend for web. Opt in explicitly with `web.backend: "xai"`.
+
+DeepSeek Web Search is also **not** in the auto-detection chain — `DEEPSEEK_API_KEY` is the inference credential, so having it set does not route web traffic through DeepSeek. Opt in explicitly with `web.backend: "deepseek"`.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds a `deepseek` web search backend plugin that routes `web_search` through DeepSeek's **server-side** `web_search` tool on the Anthropic-compatible endpoint (`https://api.deepseek.com/anthropic`). DeepSeek runs the searching, page-reading, and synthesis server-side — the provider surfaces the synthesis as `data.summary` alongside the standard `{title, url, description, position}` rows, matching the Claude Code + DeepSeek Web Search experience.

Key findings that shaped the implementation:

- The OpenAI-compatible endpoint **rejects** the `web_search` tool type (`unknown variant 'web_search'`, only `function` allowed). The Anthropic-compatible endpoint accepts `{"type": "web_search_20250305", "name": "web_search"}` (the `name` field is required — verified live).
- Responses carry `server_tool_use` / `web_search_tool_result` blocks; page content arrives as client-unreadable `encrypted_content`, so the provider returns title/url rows plus the model's synthesis text.
- The model decides how many search rounds to run (`usage.server_tool_use.web_search_requests`) — the tool's `limit` only truncates the returned rows.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/web/deepseek/` — bundled backend plugin (`kind: backend`), knobs via `web.deepseek.model` / `max_tokens` / `timeout`; reuses `DEEPSEEK_API_KEY` (the inference credential)
- `tests/plugins/web/test_web_search_provider_plugins.py` — registry listing (9 providers), capability flags, `is_available()` gating, reply-parsing coverage for `web_search_tool_result` blocks
- `website/docs/user-guide/features/web-search.md` — backend table, setup section, trust-model caveat, auto-detection exclusion note
- `website/docs/developer-guide/web-search-provider-plugin.md` — provider list + reference implementation note

## How to Test

1. `hermes plugins list` — `web-deepseek` appears; `hermes tools` shows the DeepSeek row with the `DEEPSEEK_API_KEY` prompt
2. Set `DEEPSEEK_API_KEY`, then `hermes config set web.search_backend deepseek`
3. In a new session, ask a current-events question — `web_search` calls log `DeepSeek web search via https://api.deepseek.com/anthropic`, and the answer includes dated, sourced results
4. `pytest tests/plugins/web/test_web_search_provider_plugins.py -q` — 34 passed
5. `ruff check plugins/web/deepseek/ tests/plugins/web/test_web_search_provider_plugins.py` — clean

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit message follows Conventional Commits (`feat: add DeepSeek web search provider backend`)
- [x] Searched for existing PRs — no duplicate found
- [x] PR contains only changes related to this feature
- [x] `pytest` passes: 46 passed (web plugin suite + plugin scanner regression)
- [x] Tests added for the new provider
- [x] Tested on: CachyOS Linux (KDE Wayland)
- [x] Docs updated (user guide + developer guide)
- [x] `cli-config.yaml.example` — N/A (no new core config keys; provider knobs live under `web.deepseek`)
- [x] Cross-platform: pure Python stdlib + httpx, no platform-specific code

Note: `TestParallelClientConfig` fails on this machine due to a missing `parallel` SDK — verified pre-existing via `git stash` (unrelated to this PR).
