### PR TITLE
fix(serve): load gateway config off the event loop in get_status (salvage #72720)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2953,6 +2953,20 @@ def _collect_profile_gateway_topology_cached() -> Dict[str, Any]:
         return data
 
 
+def _load_configured_gateway_platforms() -> set[str]:
+    """Load connected platform names away from the asyncio event loop.
+
+    The first ``load_gateway_config()`` call performs platform discovery and
+    can take longer than Desktop's WebSocket connect timeout on Windows.  This
+    helper is synchronous by design; ``get_status`` runs it in Starlette's
+    worker pool so a concurrent ``/api/ws`` handshake can still complete.
+    """
+    from gateway.config import load_gateway_config
+
+    gateway_config = load_gateway_config()
+    return {platform.value for platform in gateway_config.get_connected_platforms()}
+
+
 @app.get("/api/ssh/ownership")
 async def get_ssh_ownership(request: Request):
     _require_token(request)
@@ -3054,12 +3068,9 @@ async def get_status(profile: Optional[str] = None):
         gateway_updated_at = None
         configured_gateway_platforms: set[str] | None = None
         try:
-            from gateway.config import load_gateway_config
-
-            gateway_config = load_gateway_config()
-            configured_gateway_platforms = {
-                platform.value for platform in gateway_config.get_connected_platforms()
-            }
+            configured_gateway_platforms = await run_in_threadpool(
+                _load_configured_gateway_platforms
+            )
         except Exception:
             configured_gateway_platforms = None
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -318,6 +318,39 @@ class TestWebServerEndpoints:
                 monitor.close()
             writer.close()
 
+    def test_get_status_loads_gateway_config_off_event_loop(self, monkeypatch):
+        """Cold gateway config loading must not block the WebSocket loop.
+
+        On Windows the first ``load_gateway_config()`` call imports and
+        discovers platform adapters and can take longer than Desktop's 15s
+        WebSocket timeout.  Running it inline makes a concurrent /api/ws
+        handshake time out before ``gateway.ready`` can be sent.
+        """
+        import gateway.config as gateway_config
+        import hermes_cli.web_server as web_server
+
+        seen = {}
+
+        class _Config:
+            @staticmethod
+            def get_connected_platforms():
+                return []
+
+        def _load():
+            seen["thread"] = threading.get_ident()
+            return _Config()
+
+        monkeypatch.setattr(gateway_config, "load_gateway_config", _load)
+
+        async def _run():
+            event_loop_thread = threading.get_ident()
+            await web_server.get_status()
+            return event_loop_thread
+
+        event_loop_thread = asyncio.run(_run())
+
+        assert seen["thread"] != event_loop_thread
+
     def test_get_sessions_auto_archive_uses_maintenance_writer(self):
         from hermes_cli import web_server
         from hermes_cli.config import load_config, save_config


### PR DESCRIPTION
Salvages #72720 by @wayne1992127 — commit cherry-picked to preserve authorship; conflict resolution was test-placement-only (production hunk merged clean).

## Context — honest premise update

The PR was written against a Windows desktop-boot symptom: cold `load_gateway_config()` inside `get_status` could exceed Desktop's 15s WS connect timeout, starving the `/api/ws` handshake. Since then that boot symptom has been doubly mooted: 23cb26c moved desktop boot readiness to `/api/health`, and a9af49df0 (#73083) made `_warm_gateway_module()` absorb the expensive cold platform-adapter import tree synchronously before the server accepts any request.

The change still carries real value as loop hygiene, which is why we're landing it: `/api/status` is hit continuously outside boot (web sidebar 10s poll, statusbar 60s, Hermes Cloud Portal, remote-connect auth classification, legacy pre-0.19.0 boot fallback), and `load_gateway_config()` is blocking file I/O (yaml.safe_load + gateway.json reads) running inline on the event loop. Offloading it to `run_in_threadpool` matches the endpoint's existing pattern — liveness and topology are already off-loop.

## What the fix does (from #72720, kept verbatim)

Extracts `_load_configured_gateway_platforms()` (10-line helper) and calls it via Starlette's `run_in_threadpool` from `get_status`. Thread-identity test proves the offload.

## Conflict resolution (ours, content-free)

The PR's test anchored before a test that no longer exists on main (file was reorganized). Re-anchored it inside `TestWebServerEndpoints` after the WAL-poll test. No content changes.

## Verification

- `tests/hermes_cli/test_web_server.py`: 121 passed, 1 skipped on current main
- Mutation check: revert web_server.py to main → the offload test fails; restore → passes
- Seam sweep: helper imports `load_gateway_config` at call time from `gateway.config`, so all existing monkeypatch seams keep intercepting
- ruff clean

Closes #72720 (superseded by this salvage — original author credited via cherry-pick authorship).
