### PR TITLE
fix(tools): stop delegated-child marker leaking into shared bash snapshot

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1675,18 +1675,6 @@ def _clear_planned_restart_notification() -> None:
 # knows not to clobber TERMINAL_CWD if lazily imported.
 os.environ["_HERMES_GATEWAY"] = "1"
 
-# A gateway is never a delegate_task child, even when the process that
-# spawned it was one (e.g. a desktop session launched from a subagent, or
-# a terminal session that inherited the marker from a delegated context).
-# HERMES_DELEGATED_CHILD_CONTEXT is a lineage marker for subagent
-# subprocesses; inherited here it makes the kanban dispatcher's own
-# connect()/migration write_txn fail with "delegate_task child contexts
-# cannot mutate Kanban tasks or boards" on every tick. The gateway IS the
-# trusted dispatcher host, so strip the stale marker. The in-process
-# ContextVar guard still protects real delegated children (that signal is
-# per-execution-context and never survives a process boundary).
-os.environ.pop("HERMES_DELEGATED_CHILD_CONTEXT", None)
-
 _ensure_ssl_certs()
 
 # Add parent directory to path

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1675,6 +1675,18 @@ def _clear_planned_restart_notification() -> None:
 # knows not to clobber TERMINAL_CWD if lazily imported.
 os.environ["_HERMES_GATEWAY"] = "1"
 
+# A gateway is never a delegate_task child, even when the process that
+# spawned it was one (e.g. a desktop session launched from a subagent, or
+# a terminal session that inherited the marker from a delegated context).
+# HERMES_DELEGATED_CHILD_CONTEXT is a lineage marker for subagent
+# subprocesses; inherited here it makes the kanban dispatcher's own
+# connect()/migration write_txn fail with "delegate_task child contexts
+# cannot mutate Kanban tasks or boards" on every tick. The gateway IS the
+# trusted dispatcher host, so strip the stale marker. The in-process
+# ContextVar guard still protects real delegated children (that signal is
+# per-execution-context and never survives a process boundary).
+os.environ.pop("HERMES_DELEGATED_CHILD_CONTEXT", None)
+
 _ensure_ssl_certs()
 
 # Add parent directory to path

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -62,14 +62,18 @@ def test_export_snippet_shape():
     assert snippet.rstrip().endswith("> /tmp/snap.tmp.$BASHPID")
 
 
-def test_real_snapshot_excludes_delegated_child_marker(tmp_path):
+def test_real_snapshot_excludes_delegated_child_marker(tmp_path, monkeypatch):
     """Real regression: when the marker is live in the env, the produced
     snapshot must NOT export it after the unset runs.
 
     Exercises the actual dump path (not just the regex) with
-    HERMES_DELEGATED_CHILD_CONTEXT=1 set, then evaluates the snippet in a
-    real POSIX shell to prove the marker is gone from the captured env.
-    Skips where no bash is available (pure Windows cmd).
+    HERMES_DELEGATED_CHILD_CONTEXT=1 set via monkeypatch (so any prior value
+    is preserved and restored), then evaluates the snippet in a real POSIX
+    shell to prove the marker is gone from the captured snapshot. Uses a
+    unique tmp_path-derived output so parallel test runs never collide, and
+    asserts the capture/read commands succeed.
+
+    Skips where no POSIX shell is available (pure Windows cmd).
     """
     import shutil
     import stat
@@ -83,36 +87,38 @@ def test_real_snapshot_excludes_delegated_child_marker(tmp_path):
     if bash is None:
         pytest.skip("no POSIX shell available to evaluate snapshot snippet")
 
-    os.environ["HERMES_DELEGATED_CHILD_CONTEXT"] = "1"
-    try:
-        # git-bash on Windows only honors POSIX-style paths for the `>`
-        # redirect target inside the snippet, so use /tmp (mapped to the
-        # git-bash root) rather than the Windows-style tmp_path fixture.
-        snap_posix = "/tmp/hermes_snap_test.out"
-        snippet = _export_dump_excluding_session_vars(snap_posix)
-        # Evaluate the snippet in a real POSIX shell. The brace group writes
-        # `export -p` (post-unset) to snap_posix, so the captured snapshot
-        # must NOT contain the delegated-child marker.
-        script = tmp_path / "run_snapshot.sh"
-        script.write_text(snippet + "\n")
-        script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
-        out = subprocess.run(
-            [bash, str(script)],
-            capture_output=True, text=True, timeout=30,
-        )
-        assert out.returncode == 0, f"snapshot snippet failed: {out.stderr!r}"
-        # Read the captured snapshot back through bash (it wrote to the
-        # POSIX /tmp path inside the git-bash root).
-        cat = subprocess.run(
-            [bash, "-c", f"cat {snap_posix}"],
-            capture_output=True, text=True, timeout=30,
-        )
-        captured_text = cat.stdout
-        assert "HERMES_DELEGATED_CHILD_CONTEXT" not in captured_text, (
-            f"delegated-child marker leaked into snapshot: {captured_text!r}"
-        )
-    finally:
-        os.environ.pop("HERMES_DELEGATED_CHILD_CONTEXT", None)
+    # Set the marker via monkeypatch: preserves any prior value and restores
+    # it after the test (the snippet's unset must not leak into our process).
+    monkeypatch.setenv("HERMES_DELEGATED_CHILD_CONTEXT", "1")
+
+    # git-bash on Windows only honors POSIX-style paths for the `>` redirect
+    # target, so map tmp_path (Windows) to a git-bash root path under /tmp.
+    snap_posix = f"/tmp/hermes_snap_{os.getpid()}_{id(tmp_path)}.out"
+    snippet = _export_dump_excluding_session_vars(snap_posix)
+
+    script = tmp_path / "run_snapshot.sh"
+    script.write_text(snippet + "\n")
+    script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    run = subprocess.run([bash, str(script)], capture_output=True, text=True, timeout=30)
+    assert run.returncode == 0, f"snapshot snippet failed: {run.stderr!r}"
+
+    # Read the captured snapshot back through bash (it wrote to the POSIX path
+    # inside the git-bash root). Assert the command itself succeeded.
+    cat = subprocess.run(
+        [bash, "-c", f"cat {snap_posix}"],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert cat.returncode == 0, f"snapshot read failed: {cat.stderr!r}"
+    captured_text = cat.stdout
+    assert "HERMES_DELEGATED_CHILD_CONTEXT" not in captured_text, (
+        f"delegated-child marker leaked into snapshot: {captured_text!r}"
+    )
+
+    # The marker must NOT have been removed from our own process env.
+    assert os.environ.get("HERMES_DELEGATED_CHILD_CONTEXT") == "1", (
+        "test mutated the process-global env instead of only the snapshot"
+    )
 
 
 

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -40,7 +40,6 @@ def test_regex_matches_bridged_session_vars():
         line = f'declare -x {name}="whatever"'
         assert rx.search(line), f"{name} should be excluded from the snapshot"
 
-
 def test_export_snippet_shape():
     snippet = _export_dump_excluding_session_vars("/tmp/snap.tmp.$BASHPID")
     assert "export -p" in snippet
@@ -50,6 +49,7 @@ def test_export_snippet_shape():
     assert "${!HERMES_SESSION_*}" in snippet
     assert "${!HERMES_CRON_AUTO_DELIVER_*}" in snippet
     assert "HERMES_UI_SESSION_ID" in snippet
+    assert "HERMES_DELEGATED_CHILD_CONTEXT" in snippet
     assert "grep -vE" not in snippet
     assert "/tmp/snap.tmp.$BASHPID" in snippet
     # The redirection must be attached to a brace group wrapping the dump,
@@ -60,6 +60,60 @@ def test_export_snippet_shape():
     assert snippet.lstrip().startswith("{ ")
     assert "|| true; }" in snippet
     assert snippet.rstrip().endswith("> /tmp/snap.tmp.$BASHPID")
+
+
+def test_real_snapshot_excludes_delegated_child_marker(tmp_path):
+    """Real regression: when the marker is live in the env, the produced
+    snapshot must NOT export it after the unset runs.
+
+    Exercises the actual dump path (not just the regex) with
+    HERMES_DELEGATED_CHILD_CONTEXT=1 set, then evaluates the snippet in a
+    real POSIX shell to prove the marker is gone from the captured env.
+    Skips where no bash is available (pure Windows cmd).
+    """
+    import shutil
+    import stat
+    import subprocess
+
+    bash = (
+        shutil.which("git-bash")
+        or shutil.which("bash")
+        or shutil.which("wsl")
+    )
+    if bash is None:
+        pytest.skip("no POSIX shell available to evaluate snapshot snippet")
+
+    os.environ["HERMES_DELEGATED_CHILD_CONTEXT"] = "1"
+    try:
+        # git-bash on Windows only honors POSIX-style paths for the `>`
+        # redirect target inside the snippet, so use /tmp (mapped to the
+        # git-bash root) rather than the Windows-style tmp_path fixture.
+        snap_posix = "/tmp/hermes_snap_test.out"
+        snippet = _export_dump_excluding_session_vars(snap_posix)
+        # Evaluate the snippet in a real POSIX shell. The brace group writes
+        # `export -p` (post-unset) to snap_posix, so the captured snapshot
+        # must NOT contain the delegated-child marker.
+        script = tmp_path / "run_snapshot.sh"
+        script.write_text(snippet + "\n")
+        script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        out = subprocess.run(
+            [bash, str(script)],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert out.returncode == 0, f"snapshot snippet failed: {out.stderr!r}"
+        # Read the captured snapshot back through bash (it wrote to the
+        # POSIX /tmp path inside the git-bash root).
+        cat = subprocess.run(
+            [bash, "-c", f"cat {snap_posix}"],
+            capture_output=True, text=True, timeout=30,
+        )
+        captured_text = cat.stdout
+        assert "HERMES_DELEGATED_CHILD_CONTEXT" not in captured_text, (
+            f"delegated-child marker leaked into snapshot: {captured_text!r}"
+        )
+    finally:
+        os.environ.pop("HERMES_DELEGATED_CHILD_CONTEXT", None)
+
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -408,8 +408,19 @@ def _cwd_marker(session_id: str) -> str:
 # with one of these prefixes (or is HERMES_UI_SESSION_ID). Used by unit tests
 # as the Python-side contract for the exclusion set; the dump path unsets by
 # name/prefix instead of grepping declare lines (see below / issue #71296).
+#
+# HERMES_DELEGATED_CHILD_CONTEXT is excluded too: it is a Hermes-internal
+# lineage marker (set by agent.delegation_context.scrub_kanban_env on
+# subprocesses of delegate_task children), NOT user shell state. Persisting it
+# into the shared snapshot makes every LATER session source a stale
+# "delegated child" flag — a session that was never delegated then trips
+# kanban_db._assert_not_delegated_child_mutation and other delegated-child
+# guards (the gateway's own dispatcher failed every tick with exactly this
+# leak). Per-command Popen env scrubbing re-applies the marker when a
+# delegated child actually runs a command, so dropping it from the snapshot is
+# safe and matches the session-identity exclusion above.
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
-    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_)"
+    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_|HERMES_DELEGATED_CHILD_CONTEXT)"
 )
 _SHELL_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -453,7 +464,7 @@ def _export_dump_excluding_session_vars(
     return (
         "{ ( "
         "unset ${!HERMES_SESSION_*} ${!HERMES_CRON_AUTO_DELIVER_*} "
-        f"HERMES_UI_SESSION_ID{extra_unset} 2>/dev/null; "
+        "HERMES_UI_SESSION_ID HERMES_DELEGATED_CHILD_CONTEXT 2>/dev/null; "
         "export -p; "
         ") || true; } "
         f"> {tmp_path}"


### PR DESCRIPTION
## Summary
- `tools/environments/base.py`: exclude `HERMES_DELEGATED_CHILD_CONTEXT` from the shared bash session snapshot (the root cause). The marker leaked into `cache/terminal/hermes-snap-*.sh` and poisoned every later session's env; a session that was never delegated then tripped `kanban_db._assert_not_delegated_child_mutation` (the gateway's own dispatcher failed every 60s tick) and other delegated-child guards. Per-command Popen scrubbing re-applies the marker for real delegated children, so dropping it from the snapshot is safe.

## Scope change (addressed reviewer feedback)
- Dropped the earlier module-level `os.environ.pop("HERMES_DELEGATED_CHILD_CONTEXT")` in `gateway/run.py`. A delegated subprocess that imports `gateway.run` relies on that marker for the kanban mutation guard (it survives where a ContextVar cannot cross a subprocess boundary), so the pop was a trust-boundary regression. The snapshot exclusion alone prevents the leak.

## Tests
- `tests/tools/test_snapshot_session_id_leak.py`: `test_real_snapshot_excludes_delegated_child_marker` sets the marker via `monkeypatch` (preserves/restores prior value), uses a unique tmp_path-derived output, asserts the capture/read subprocesses succeed and the process env is untouched. (Replaces the previous unconditional-remove + shared /tmp path.)
- `pytest tests/tools/test_snapshot_session_id_leak.py` → 3 passed, 1 skipped (POSIX-only integration test skips on Windows).

## Test plan
- [ ] `pytest tests/tools/test_snapshot_session_id_leak.py`