### PR TITLE
fix(web): warn on unknown security.website_blocklist keys (#76946)

### DIFF
--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -106,6 +106,73 @@ def test_load_website_blocklist_wraps_shared_file_read_errors(tmp_path, monkeypa
     assert result["rules"] == []  # shared file rules skipped
 
 
+def test_load_website_blocklist_warns_on_unknown_keys(tmp_path, caplog):
+    """Unknown security.website_blocklist keys must log a warning.
+
+    A typo such as ``shared_file`` (instead of ``shared_files``) is otherwise
+    carried into the policy dict by ``update()`` and never read, making the
+    policy look deployed while fencing nothing.
+    """
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": {
+                        "enabled": True,
+                        "domains": ["example.com"],
+                        "shared_file": "/etc/blocked-hosts",  # typo
+                        "allowed": ["example.org"],           # invented
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("WARNING", logger="tools.website_policy"):
+        policy = load_website_blocklist(config_path)
+
+    assert policy["enabled"] is True
+    assert {rule["pattern"] for rule in policy["rules"]} == {"example.com"}
+
+    warning = next(
+        (rec.message for rec in caplog.records if "Unknown security.website_blocklist keys" in rec.message),
+        None,
+    )
+    assert warning is not None
+    assert "allowed" in warning and "shared_file" in warning
+
+
+def test_load_website_blocklist_no_warning_for_known_keys(tmp_path, caplog):
+    """A fully-known key set must not log an unknown-keys warning."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": {
+                        "enabled": True,
+                        "domains": ["example.com"],
+                        "shared_files": [],
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("WARNING", logger="tools.website_policy"):
+        load_website_blocklist(config_path)
+
+    assert not any(
+        "Unknown security.website_blocklist keys" in rec.message
+        for rec in caplog.records
+    )
+
+
 def test_check_website_access_blocks_scheme_less_urls(tmp_path):
     config_path = tmp_path / "config.yaml"
     config_path.write_text(

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -28,6 +28,12 @@ _DEFAULT_WEBSITE_BLOCKLIST = {
     "shared_files": [],
 }
 
+# Keys load_website_blocklist actually reads. Anything else in
+# security.website_blocklist is silently ignored by policy.update() — warn so
+# a typo (e.g. shared_file vs shared_files) can't look deployed while
+# fencing nothing.
+_KNOWN_KEYS = {"enabled", "domains", "shared_files"}
+
 # Cache: parsed policy + timestamp.  Avoids re-reading config.yaml on every
 # URL check (a multi-URL extract with 50 pages would otherwise mean 51 YAML parses).
 _CACHE_TTL_SECONDS = 30.0
@@ -125,6 +131,13 @@ def _load_policy_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
 
     policy = dict(_DEFAULT_WEBSITE_BLOCKLIST)
     policy.update(website_blocklist)
+
+    unknown = set(website_blocklist) - _KNOWN_KEYS
+    if unknown:
+        logger.warning(
+            "Unknown security.website_blocklist keys ignored: %s",
+            ", ".join(sorted(unknown)),
+        )
     return policy
 
 


### PR DESCRIPTION
## Summary

`security.website_blocklist` silently accepted unknown keys: `_load_policy_config()` merged the user's mapping over the defaults with `policy.update(website_blocklist)`, and `load_website_blocklist()` only reads three keys — `enabled`, `domains`, `shared_files`. Any other key was carried into the dict and never looked at, so a misspelled key (e.g. `shared_file` instead of `shared_files`) produced **no error, no warning, and no effect** — the operator believes a blocklist file is loaded while nothing is fenced.

This PR adds a `logger.warning` for unrecognized keys in `_load_policy_config()`.

## Root Cause

```python
policy = dict(_DEFAULT_WEBSITE_BLOCKLIST)
policy.update(website_blocklist)  # unknown keys silently carried in
```

`load_website_blocklist()` then reads exactly `enabled`, `domains`, `shared_files`. Everything else stays in the dict unread. Since this is a security control, the failure mode is the worst kind: indistinguishable from success.

## Change

- Added module constant `_KNOWN_KEYS = {"enabled", "domains", "shared_files"}`.
- In `_load_policy_config()`, after the merge, warn on any key outside `_KNOWN_KEYS`:

```python
unknown = set(website_blocklist) - _KNOWN_KEYS
if unknown:
    logger.warning(
        "Unknown security.website_blocklist keys ignored: %s",
        ", ".join(sorted(unknown)),
    )
```

A warning (not a raise) is the right severity: it cannot break an existing config, and it turns a silent misconfiguration into a visible one. `WebsitePolicyError` remains available if a stricter mode is ever wanted.

## Verification

- `PYTHONPATH=. python3 -m pytest tests/tools/test_website_policy.py -v` → **12 passed** (10 existing + 2 new).
- New tests:
  - `test_load_website_blocklist_warns_on_unknown_keys` — a config with `shared_file` (typo) and `allowed` (invented) loads successfully, applies only the real `domains` rules, and logs a warning naming both unknown keys.
  - `test_load_website_blocklist_no_warning_for_known_keys` — a fully-known key set logs no warning.
- `PYTHONPATH=. python3 -m pytest tests/tools/test_vision_tools.py -q` → **32 passed** (also consumes `website_policy`).

## Closes

Closes #76946
