### PR TITLE
fix(agent): serialize skill-command scans under an RLock

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+import threading
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -22,6 +23,12 @@ logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
+# Guards scan_skill_commands() against concurrent startup scans (gateway
+# run loop, webhook platform, tool-registry scan all call it at boot).
+# Without it two threads race: seen_names is call-local while
+# _skill_commands is process-global and gets reset+repopulated, so the
+# second scanner logs "already claimed by itself" for every skill.
+_scan_lock = threading.RLock()
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
@@ -377,6 +384,17 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     Returns:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
+    with _scan_lock:
+        return _scan_skill_commands_locked()
+
+
+def _scan_skill_commands_locked() -> Dict[str, Dict[str, Any]]:
+    """Scan skill dirs and rebuild the slash-command map.
+
+    Caller MUST hold ``_scan_lock``. Kept separate from
+    ``scan_skill_commands`` so ``get_skill_commands`` can check-then-scan
+    atomically without recursive locking surprises.
+    """
     global _skill_commands, _skill_commands_platform
     _skill_commands_platform = _resolve_skill_commands_platform()
     _skill_commands = {}
@@ -474,11 +492,12 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     process serving Telegram and Discord concurrently) so each platform
     sees its own ``skills.platform_disabled`` view (#14536).
     """
-    if (
-        not _skill_commands
-        or _skill_commands_platform != _resolve_skill_commands_platform()
-    ):
-        scan_skill_commands()
+    with _scan_lock:
+        if (
+            not _skill_commands
+            or _skill_commands_platform != _resolve_skill_commands_platform()
+        ):
+            _scan_skill_commands_locked()
     return _skill_commands
 
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -15,6 +15,57 @@ from agent.skill_commands import (
 )
 
 
+def test_concurrent_scan_no_duplicate_warnings():
+    """Concurrent startup scans must not race and log "already claimed".
+
+    Regression for the boot-time log spam where two threads called
+    scan_skill_commands() at once: seen_names is call-local while
+    _skill_commands is process-global and gets reset+repopulated, so the
+    second scanner saw the first's entries and warned for every skill.
+    The RLock in scan_skill_commands() / get_skill_commands() serializes
+    them; this test proves the warning is gone under contention.
+    """
+    import logging
+    import threading
+
+    from agent import skill_commands as sc
+
+    with patch.object(
+        sc, "_resolve_skill_commands_platform", return_value="cli"
+    ):
+        # Force a rescan path so each call re-runs the full scan.
+        sc._skill_commands = {}
+        sc._skill_commands_platform = None
+
+        warnings = []
+        handler = logging.Handler()
+        handler.emit = lambda record: warnings.append(record.getMessage())
+        logger = logging.getLogger("agent.skill_commands")
+        logger.addHandler(handler)
+        try:
+            barrier = threading.Barrier(6)
+
+            def worker():
+                barrier.wait()
+                sc.get_skill_commands()
+
+            threads = [threading.Thread(target=worker) for _ in range(6)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+        finally:
+            logger.removeHandler(handler)
+
+        dup_warnings = [
+            w for w in warnings
+            if "already claimed" in w
+        ]
+        assert not dup_warnings, (
+            f"concurrent scan produced {len(dup_warnings)} duplicate warnings: "
+            f"{dup_warnings[:3]}"
+        )
+
 def _make_skill(
     skills_dir, name, frontmatter_extra="", body="Do the thing.", category=None
 ):


### PR DESCRIPTION
## Summary
- `agent/skill_commands.py`: `scan_skill_commands()` raced between startup threads (gateway run loop, webhook platform, tool-registry scan all call it at boot). `seen_names` is call-local while `_skill_commands` is process-global and gets reset+repopulated, so the second concurrent scanner saw the first's entries and logged "already claimed by itself" for every skill (~200 warnings per boot). Split the scan body into `_scan_skill_commands_locked()` and hold an `RLock` in both `scan_skill_commands()` and `get_skill_commands()` so check-then-scan is atomic.
- `tests/agent/test_skill_commands.py`: add `test_concurrent_scan_no_duplicate_warnings` — 6 threads behind a `threading.Barrier` call `get_skill_commands()` concurrently and assert zero "already claimed" warnings.

This is split out from the previously-bundled PR #76321 per review (the Core snapshot fix is #76982; the Desktop visibility change is a separate follow-up).

## Verification
- `pytest tests/agent/test_skill_commands.py::test_concurrent_scan_no_duplicate_warnings` → PASSED

## Test plan
- [ ] `pytest tests/agent/test_skill_commands.py`