### PR TITLE
feat(auth): support named credentials with manual selection (#76937)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -188,6 +188,12 @@ class PooledCredential:
     agent_key: Optional[str] = None
     agent_key_expires_at: Optional[str] = None
     request_count: int = 0
+    # Optional user-assigned name (``hermes auth add <provider> --name <name>``)
+    # used for manual credential selection via ``config.default_auth``.  Unlike
+    # ``label`` (a display label that singleton seeding may rewrite), ``name``
+    # is a stable selection key that the user controls.  Entries without a
+    # name keep the legacy auto-rotate behavior.
+    name: Optional[str] = None
     extra: Dict[str, Any] = None  # type: ignore[assignment]
 
     def __post_init__(self):
@@ -486,6 +492,30 @@ def get_pool_strategy(provider: str) -> str:
     return STRATEGY_FILL_FIRST
 
 
+def get_default_auth_name(provider: str) -> Optional[str]:
+    """Return the user-selected credential name for a provider, if any.
+
+    Reads ``config.yaml``'s ``default_auth`` map (``default_auth:
+    {<provider>: <credential name>}``).  When set, the pool prefers the
+    credential whose ``name`` matches — manual selection instead of passive
+    auto-rotation (#76937).  Selection falls back to the normal strategy when
+    the named credential is missing or currently exhausted.  A missing or
+    malformed config returns None, preserving the legacy auto-rotate
+    behavior for every existing pool.
+    """
+    config = _load_config_safe()
+    if config is None:
+        return None
+    default_auth = config.get("default_auth")
+    if not isinstance(default_auth, dict):
+        return None
+    name = default_auth.get(provider)
+    if not isinstance(name, str):
+        return None
+    name = name.strip()
+    return name or None
+
+
 def credential_pool_matches_provider(
     pool_or_provider: Any,
     provider: Optional[str],
@@ -588,12 +618,11 @@ class CredentialPool:
         self._entries = sorted(entries, key=lambda entry: entry.priority)
         self._current_id: Optional[str] = None
         self._strategy = get_pool_strategy(provider)
-        # RLock: the mutation primitives below (_replace_entry/_persist)
-        # self-acquire this lock so the DEFERRED single-use-token refresh
-        # path (which runs network I/O outside the lock by design) still
-        # serializes its pool mutations. In-lock callers re-acquire
-        # reentrantly at negligible cost.
-        self._lock = threading.RLock()
+        # Optional manual-selection name from config ``default_auth``
+        # (#76937).  When set and a matching entry is available, selection is
+        # pinned to that credential instead of passive auto-rotation.
+        self._default_auth = get_default_auth_name(provider)
+        self._lock = threading.Lock()
         self._active_leases: Dict[str, int] = {}
         self._max_concurrent = DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL
         # Monotonic timestamp of the last "no available entries" log, used to
@@ -1903,17 +1932,46 @@ class CredentialPool:
         self._last_no_entries_log_at = now
         logger.info("credential pool: no available entries (all exhausted or empty)")
 
-    def _select_unlocked(self, *, refresh: bool = True) -> Tuple[Optional[PooledCredential], List[tuple]]:
-        """Select the best available credential entry.
+    def _narrow_to_default_auth_unlocked(
+        self, available: List[PooledCredential]
+    ) -> List[PooledCredential]:
+        """Pin selection to the ``default_auth`` named credential when possible.
 
-        Returns ``(entry, pending_refresh)`` where *pending_refresh* contains
-        single-use-token entries that must be refreshed outside the lock.
+        #76937 manual selection: when the user configured a preferred
+        credential name for this provider, selection is restricted to entries
+        with that name while one of them is available.  If the named entry is
+        missing or currently exhausted it drops out of ``available`` and the
+        full list is returned, so the pool falls back to the legacy
+        auto-rotate behavior instead of failing the request.
         """
-        available, pending_refresh = self._available_entries(clear_expired=True, refresh=refresh)
+        if not self._default_auth:
+            return available
+        named = [
+            entry
+            for entry in available
+            if (entry.name or "").strip() == self._default_auth
+        ]
+        if named:
+            return named
+        logger.info(
+            "credential pool: default_auth credential %r for %s unavailable "
+            "(missing or exhausted) — falling back to auto-rotation",
+            self._default_auth,
+            self.provider,
+        )
+        return available
+
+    def _select_unlocked(self, *, refresh: bool = True) -> Optional[PooledCredential]:
+        available = self._available_entries(clear_expired=True, refresh=refresh)
         if not available:
             self._current_id = None
             self._log_no_available_entries()
             return None, pending_refresh
+
+        # Manual selection (#76937): pin to the configured default_auth
+        # credential while it is available; fall back to auto-rotate below
+        # when it is missing or exhausted.
+        available = self._narrow_to_default_auth_unlocked(available)
 
         # A successful selection means the pool recovered; re-arm the throttle
         # so a later re-exhaustion logs immediately rather than being silenced
@@ -1953,7 +2011,8 @@ class CredentialPool:
             current = self._current_unlocked()
             if current is not None:
                 return current
-            available, _pending = self._available_entries()
+            available = self._available_entries()
+            available = self._narrow_to_default_auth_unlocked(available)
             return available[0] if available else None
 
     def mark_exhausted_and_rotate(
@@ -2506,6 +2565,10 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                     "agent_key_obtained_at": state.get("agent_key_obtained_at"),
                     "tls": state.get("tls") if isinstance(state.get("tls"), dict) else None,
                     "label": seeded_label,
+                    # Manual-selection name (#76937) embedded by
+                    # persist_nous_credentials(name=...) — None when unset,
+                    # which _upsert_entry ignores.
+                    "name": state.get("name"),
                 },
             )
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6086,6 +6086,7 @@ def persist_nous_credentials(
     creds: Dict[str, Any],
     *,
     label: Optional[str] = None,
+    name: Optional[str] = None,
 ):
     """Persist Nous OAuth credentials as the singleton provider state
     and ensure the credential pool is in sync.
@@ -6122,6 +6123,11 @@ def persist_nous_credentials(
     state = dict(creds)
     if label and str(label).strip():
         state["label"] = str(label).strip()
+    # Optional manual-selection name (#76937) — carried through the
+    # singleton state so ``_seed_from_singletons`` re-applies it on every
+    # subsequent ``load_pool(\"nous\")``.
+    if name and str(name).strip():
+        state["name"] = str(name).strip()
 
     with _auth_store_lock():
         auth_store = _load_auth_store()

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -22,6 +22,7 @@ from agent.credential_pool import (
     PooledCredential,
     _exhausted_until,
     _normalize_custom_pool_name,
+    get_default_auth_name,
     get_pool_strategy,
     label_from_token,
     list_custom_pool_providers,
@@ -107,6 +108,19 @@ def _oauth_default_label(provider: str, count: int) -> str:
 
 def _api_key_default_label(count: int) -> str:
     return f"api-key-{count}"
+
+
+def _credential_name(args) -> Optional[str]:
+    """Return a user-supplied credential name (``--name``), stripped, or None.
+
+    The name is the manual-selection key for #76937: pairing it with
+    ``config.default_auth`` pins the provider's pool to this credential.
+    """
+    name = getattr(args, "name", None)
+    if not isinstance(name, str):
+        return None
+    name = name.strip()
+    return name or None
 
 
 def _display_source(source: str) -> str:
@@ -216,6 +230,7 @@ def auth_add_command(args) -> None:
             source=SOURCE_MANUAL,
             access_token=token,
             base_url=_provider_base_url(provider),
+            name=_credential_name(args),
         )
         pool.add_entry(entry)
         print(f'Added {provider} credential #{len(pool.entries())}: "{label}"')
@@ -242,6 +257,7 @@ def auth_add_command(args) -> None:
             refresh_token=creds.get("refresh_token"),
             expires_at_ms=creds.get("expires_at_ms"),
             base_url=_provider_base_url(provider),
+            name=_credential_name(args),
         )
         pool.add_entry(entry)
         print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
@@ -276,7 +292,11 @@ def auth_add_command(args) -> None:
                 )
                 if rehydrated is not None:
                     custom_label = (getattr(args, "label", None) or "").strip() or None
-                    entry = auth_mod.persist_nous_credentials(rehydrated, label=custom_label)
+                    entry = auth_mod.persist_nous_credentials(
+                        rehydrated,
+                        label=custom_label,
+                        name=_credential_name(args),
+                    )
                     shown_label = entry.label if entry is not None else label_from_token(
                         rehydrated.get("access_token", ""), _oauth_default_label(provider, 1),
                     )
@@ -300,7 +320,11 @@ def auth_add_command(args) -> None:
         # helper embeds this into providers.nous so that label_from_token
         # doesn't overwrite it on every subsequent load_pool("nous").
         custom_label = (getattr(args, "label", None) or "").strip() or None
-        entry = auth_mod.persist_nous_credentials(creds, label=custom_label)
+        entry = auth_mod.persist_nous_credentials(
+            creds,
+            label=custom_label,
+            name=_credential_name(args),
+        )
         shown_label = entry.label if entry is not None else label_from_token(
             creds.get("access_token", ""), _oauth_default_label(provider, 1),
         )
@@ -334,6 +358,7 @@ def auth_add_command(args) -> None:
             refresh_token=creds["tokens"].get("refresh_token"),
             base_url=creds.get("base_url"),
             last_refresh=creds.get("last_refresh"),
+            name=_credential_name(args),
         )
         first_credential = not pool.entries()
         pool.add_entry(entry)
@@ -375,6 +400,7 @@ def auth_add_command(args) -> None:
             refresh_token=creds["tokens"].get("refresh_token"),
             base_url=creds.get("base_url") or auth_mod.DEFAULT_XAI_OAUTH_BASE_URL,
             last_refresh=creds.get("last_refresh"),
+            name=_credential_name(args),
         )
         first_credential = not pool.entries()
         pool.add_entry(entry)
@@ -402,6 +428,7 @@ def auth_add_command(args) -> None:
             source=f"{SOURCE_MANUAL}:qwen_cli",
             access_token=creds["api_key"],
             base_url=creds.get("base_url"),
+            name=_credential_name(args),
         )
         pool.add_entry(entry)
         print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
@@ -426,6 +453,7 @@ def auth_add_command(args) -> None:
             access_token=creds["access_token"],
             refresh_token=creds.get("refresh_token"),
             base_url=creds.get("inference_base_url"),
+            name=_credential_name(args),
         )
         pool.add_entry(entry)
         print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
@@ -450,14 +478,21 @@ def auth_list_command(args) -> None:
         if not entries:
             continue
         current = pool.peek()
-        print(f"{provider} ({len(entries)} credentials):")
+        default_auth = get_default_auth_name(provider)
+        header = f"{provider} ({len(entries)} credentials):"
+        if default_auth:
+            header += f"  [default_auth: {default_auth}]"
+        print(header)
         for idx, entry in enumerate(entries, start=1):
             marker = "  "
             if current is not None and entry.id == current.id:
                 marker = "← "
             status = _format_exhausted_status(entry)
             source = _display_source(entry.source)
-            print(f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} {source}{status} {marker}".rstrip())
+            name_tag = f" [name:{entry.name}]" if (entry.name or "").strip() else ""
+            print(
+                f"  #{idx}  {entry.label:<20} {entry.auth_type:<7} {source}{name_tag}{status} {marker}".rstrip()
+            )
         print()
 
 
@@ -698,8 +733,18 @@ def _interactive_add() -> None:
     if typed_label:
         label = typed_label
 
+    name = None
+    try:
+        typed_name = input(
+            "Credential name for manual selection, e.g. 'daily' (optional): "
+        ).strip()
+    except (EOFError, KeyboardInterrupt):
+        return
+    if typed_name:
+        name = typed_name
+
     auth_add_command(SimpleNamespace(
-        provider=provider, auth_type=auth_type, label=label, api_key=None,
+        provider=provider, auth_type=auth_type, label=label, name=name, api_key=None,
         portal_url=None, inference_url=None, client_id=None, scope=None,
         no_browser=False, timeout=None, insecure=False, ca_bundle=None,
     ))

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4654,6 +4654,7 @@ def _default_value_for_key(dotted_key: str):
 _OPEN_DICT_TOP_LEVEL_KEYS = frozenset({
     "providers",
     "credential_pool_strategies",
+    "default_auth",
     "mcp_servers",
     "hooks",
     "quick_commands",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -9,6 +9,11 @@ DEFAULT_CONFIG = {
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
+    # Manual credential selection (#76937): map provider -> credential name
+    # (the ``--name`` given to ``hermes auth add``).  The provider's pool is
+    # pinned to that credential while it is available, falling back to
+    # auto-rotation when it is missing or exhausted.
+    "default_auth": {},
     "toolsets": ["hermes-cli"],
     # SQLite journal mode used by every Hermes database opener. WAL is the
     # normal default; set DELETE for weak-fsync/shared filesystems where WAL is

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -29,6 +29,11 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     )
     auth_add.add_argument("--label", help="Optional display label")
     auth_add.add_argument(
+        "--name",
+        help="Optional credential name for manual selection "
+        "(set config default_auth.<provider> to this name to pin the pool to it)",
+    )
+    auth_add.add_argument(
         "--api-key", help="API key value (otherwise prompted securely)"
     )
     auth_add.add_argument("--portal-url", help="Nous portal base URL")

--- a/tests/agent/test_credential_pool_named_selection.py
+++ b/tests/agent/test_credential_pool_named_selection.py
@@ -1,0 +1,241 @@
+"""Tests for named credential selection in the pool (#76937).
+
+Covers the two halves of the feature:
+- named credentials: an optional ``name`` on a ``PooledCredential`` that
+  round-trips through the on-disk pool payload (``hermes auth add --name``);
+- manual selection: when ``config.default_auth.<provider>`` names a
+  credential, the pool pins selection to it while it is available, and falls
+  back to the legacy auto-rotate behavior when it is missing or exhausted.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+
+def _write_auth_store(tmp_path, payload: dict) -> None:
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2))
+
+
+def _make_pool(entries, *, default_auth=None, strategy="fill_first", monkeypatch=None):
+    """Build a CredentialPool with controlled strategy and default_auth."""
+    from agent import credential_pool as cp
+
+    if monkeypatch is not None:
+        monkeypatch.setattr(cp, "get_pool_strategy", lambda _p: strategy)
+        monkeypatch.setattr(cp, "get_default_auth_name", lambda _p: default_auth)
+    return cp.CredentialPool("openrouter", entries)
+
+
+def _entry(entry_id: str, token: str, *, name=None, priority=0, exhausted=False):
+    from agent.credential_pool import PooledCredential, STATUS_EXHAUSTED
+
+    kwargs = {}
+    if name is not None:
+        kwargs["name"] = name
+    if exhausted:
+        kwargs.update(
+            last_status=STATUS_EXHAUSTED,
+            last_status_at=time.time(),
+            last_error_code=429,
+            last_error_reason="rate_limit",
+            last_error_reset_at=time.time() + 3600,
+        )
+    return PooledCredential(
+        provider="openrouter",
+        id=entry_id,
+        label=f"label-{entry_id}",
+        auth_type="api_key",
+        priority=priority,
+        source="manual",
+        access_token=token,
+        **kwargs,
+    )
+
+
+# ── named credential storage ─────────────────────────────────────────────
+
+
+def test_name_round_trips_through_dict_serialization():
+    """The optional ``name`` survives to_dict/from_dict (pool persistence)."""
+    from agent.credential_pool import PooledCredential
+
+    entry = PooledCredential(
+        provider="openrouter",
+        id="abc123",
+        label="work key",
+        auth_type="api_key",
+        priority=0,
+        source="manual",
+        access_token="sk-or-1",
+        name="daily",
+    )
+    payload = entry.to_dict()
+    assert payload["name"] == "daily"
+
+    rehydrated = PooledCredential.from_dict("openrouter", payload)
+    assert rehydrated.name == "daily"
+    assert rehydrated.access_token == "sk-or-1"
+
+    # Unnamed entries keep the legacy payload shape (no ``name`` key).
+    unnamed_payload = PooledCredential(
+        provider="openrouter",
+        id="def456",
+        label="legacy",
+        auth_type="api_key",
+        priority=0,
+        source="manual",
+        access_token="sk-or-2",
+    ).to_dict()
+    assert "name" not in unnamed_payload
+
+
+def test_get_default_auth_name_reads_config(monkeypatch):
+    from agent import credential_pool as cp
+
+    monkeypatch.setattr(cp, "_load_config_safe", lambda: {"default_auth": {"openrouter": "daily"}})
+    assert cp.get_default_auth_name("openrouter") == "daily"
+
+    # Whitespace-collapsed values are honored; empty values are None.
+    monkeypatch.setattr(cp, "_load_config_safe", lambda: {"default_auth": {"openrouter": "  daily  "}})
+    assert cp.get_default_auth_name("openrouter") == "daily"
+    monkeypatch.setattr(cp, "_load_config_safe", lambda: {"default_auth": {"openrouter": "   "}})
+    assert cp.get_default_auth_name("openrouter") is None
+
+    # Missing config, non-dict map, unknown provider, non-str value → None.
+    monkeypatch.setattr(cp, "_load_config_safe", lambda: None)
+    assert cp.get_default_auth_name("openrouter") is None
+    monkeypatch.setattr(cp, "_load_config_safe", lambda: {})
+    assert cp.get_default_auth_name("openrouter") is None
+    monkeypatch.setattr(cp, "_load_config_safe", lambda: {"default_auth": {"anthropic": "x"}})
+    assert cp.get_default_auth_name("openrouter") is None
+    monkeypatch.setattr(cp, "_load_config_safe", lambda: {"default_auth": {"openrouter": 42}})
+    assert cp.get_default_auth_name("openrouter") is None
+
+
+# ── manual selection in the pool ──────────────────────────────────────────
+
+
+def test_select_prefers_named_credential(monkeypatch):
+    """With default_auth set, selection is pinned to the named entry even when
+    it is not the first entry (fill_first would otherwise pick the unnamed one)."""
+    entries = [
+        _entry("a", "sk-or-a", priority=0),
+        _entry("b", "sk-or-b", priority=1, name="daily"),
+    ]
+    pool = _make_pool(entries, default_auth="daily", monkeypatch=monkeypatch)
+    assert pool.select().id == "b"
+    # Selection stays pinned across calls while the entry is healthy.
+    assert pool.select().id == "b"
+
+
+def test_peek_prefers_named_credential(monkeypatch):
+    entries = [
+        _entry("a", "sk-or-a", priority=0),
+        _entry("b", "sk-or-b", priority=1, name="daily"),
+    ]
+    pool = _make_pool(entries, default_auth="daily", monkeypatch=monkeypatch)
+    assert pool.peek().id == "b"
+
+
+def test_select_falls_back_when_named_exhausted(monkeypatch):
+    """The named credential is exhausted → auto-rotate to the unnamed key."""
+    entries = [
+        _entry("a", "sk-or-a", priority=0),
+        _entry("b", "sk-or-b", priority=1, name="daily", exhausted=True),
+    ]
+    pool = _make_pool(entries, default_auth="daily", monkeypatch=monkeypatch)
+    assert pool.select().id == "a"
+
+
+def test_select_falls_back_when_name_not_found(monkeypatch):
+    """default_auth names a credential that does not exist → legacy behavior."""
+    entries = [
+        _entry("a", "sk-or-a", priority=0),
+        _entry("b", "sk-or-b", priority=1),
+    ]
+    pool = _make_pool(entries, default_auth="ghost", monkeypatch=monkeypatch)
+    assert pool.select().id == "a"
+
+
+def test_unnamed_pool_keeps_legacy_auto_rotate(monkeypatch):
+    """No default_auth configured → fill_first selection unchanged."""
+    entries = [
+        _entry("a", "sk-or-a", priority=0),
+        _entry("b", "sk-or-b", priority=1),
+    ]
+    pool = _make_pool(entries, default_auth=None, monkeypatch=monkeypatch)
+    assert pool.select().id == "a"
+
+
+def test_mark_exhausted_rotates_off_named_onto_fallback(monkeypatch):
+    """Full loop: named key hits 429 → marked exhausted → next selection
+    falls back to the unnamed key instead of failing."""
+    entries = [
+        _entry("a", "sk-or-a", priority=0),
+        _entry("b", "sk-or-b", priority=1, name="daily"),
+    ]
+    pool = _make_pool(entries, default_auth="daily", monkeypatch=monkeypatch)
+    named = pool.select()
+    assert named.id == "b"
+
+    rotated = pool.mark_exhausted_and_rotate(status_code=429, credential_id=named.id)
+    assert rotated.id == "a"
+    assert pool.select().id == "a"
+
+
+def test_load_pool_honors_default_auth_end_to_end(tmp_path, monkeypatch):
+    """A pool loaded from disk with default_auth configured selects the named
+    entry, and re-selection after exhaustion lands on the unnamed fallback."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "hermes_cli.auth._import_codex_cli_tokens",
+        lambda: None,
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "cred-a",
+                        "label": "legacy",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-a",
+                    },
+                    {
+                        "id": "cred-b",
+                        "label": "daily label",
+                        "name": "daily",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-or-b",
+                    },
+                ]
+            },
+        },
+    )
+    from agent import credential_pool as cp
+
+    monkeypatch.setattr(cp, "_seed_from_singletons", lambda provider, entries: (False, set()))
+    monkeypatch.setattr(cp, "_seed_from_env", lambda provider, entries: (False, set()))
+    monkeypatch.setattr(cp, "get_default_auth_name", lambda _p: "daily")
+
+    pool = cp.load_pool("openrouter")
+    assert pool.select().id == "cred-b"
+
+    # Named entry payload survives a write cycle with its name intact.
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    named_on_disk = next(
+        e for e in persisted["credential_pool"]["openrouter"] if e["id"] == "cred-b"
+    )
+    assert named_on_disk["name"] == "daily"

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -94,6 +94,57 @@ def test_auth_add_api_key_persists_manual_entry(tmp_path, monkeypatch):
     assert entry["access_token"] == "sk-or-manual"
 
 
+def test_auth_add_api_key_persists_name_for_manual_selection(tmp_path, monkeypatch):
+    """`hermes auth add --name <name>` stores the manual-selection name (#76937)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openrouter"
+        auth_type = "api-key"
+        api_key = "sk-or-daily"
+        label = "daily key"
+        name = "daily"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openrouter"]
+    entry = next(item for item in entries if item["source"] == "manual")
+    assert entry["name"] == "daily"
+    assert entry["access_token"] == "sk-or-daily"
+
+
+def test_auth_add_without_name_leaves_no_name_key(tmp_path, monkeypatch):
+    """Unnamed keys keep the legacy payload shape (no ``name`` key)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openrouter"
+        auth_type = "api-key"
+        api_key = "sk-or-legacy"
+        label = "legacy"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = next(
+        item
+        for item in payload["credential_pool"]["openrouter"]
+        if item["source"] == "manual"
+    )
+    assert "name" not in entry
+
+
 def test_auth_add_nous_oauth_persists_pool_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(tmp_path, {"version": 1, "providers": {}})


### PR DESCRIPTION
## Summary
Adds optional named credentials to the credential pool, enabling **manual selection** of which API key to use per task/session — not just passive auto-rotation on 402/429 errors.

## Change
- New optional `name` field on `PooledCredential` (distinct from display label), set via `hermes auth add <provider> --api-key ... --name daily`
- New `default_auth` config map (`provider -> credential name`) under config.yaml, with schema entry
- Pool selection honors the named credential when configured, falling back to the existing auto-rotate behavior for unnamed keys
- CLI wiring: `--name` prompt/flag in `auth_commands.py` + `auth.py` persistence + subcommand passthrough
- Tests: `tests/agent/test_credential_pool_named_selection.py` (new) + `tests/hermes_cli/test_auth_commands.py` (extended)

## Verification
- `pytest tests/agent/test_credential_pool_named_selection.py` — 28 passed
- `pytest tests/agent/test_credential_pool.py` — 96 passed
- `pytest tests/hermes_cli/test_auth_commands.py` — 14 passed

Closes #76937