### PR TITLE
fix: display sub-cent model prices with extended precision instead of $0.00

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1695,13 +1695,19 @@ def _format_price_per_mtok(per_token_str: str) -> str:
     Always uses 2 decimal places so that prices align vertically when
     right-justified in a column (the decimal point stays in the same position).
 
+    Sub-cent prices (e.g. deep-discount cache-hit promos) extend precision
+    instead of collapsing to "$0.00": the smallest decimal place that makes
+    the value non-zero is found, then one extra digit is kept and trailing
+    zeros trimmed.
+
     Examples:
-        "0.000003"   → "$3.00"      (per million tokens)
-        "0.00003"    → "$30.00"
-        "0.00000015" → "$0.15"
-        "0.0000001"  → "$0.10"
-        "0.00018"    → "$180.00"
-        "0"          → "free"
+        "0.000003"        → "$3.00"      (per million tokens)
+        "0.00003"         → "$30.00"
+        "0.00000015"      → "$0.15"
+        "0.0000001"       → "$0.10"
+        "0.00018"         → "$180.00"
+        "0.0000000018"    → "$0.0018"    (promo: $0.0018/Mtok)
+        "0"               → "free"
     """
     try:
         val = float(per_token_str)
@@ -1710,7 +1716,15 @@ def _format_price_per_mtok(per_token_str: str) -> str:
     if val == 0:
         return "free"
     per_m = val * 1_000_000
-    return f"${per_m:.2f}"
+    text = f"{per_m:.2f}"
+    if per_m < 0.01:
+        # Non-zero price below one cent per Mtok — widen precision until the
+        # value shows, keep one extra significant digit, trim trailing zeros.
+        prec = 3
+        while prec < 12 and round(per_m, prec) == 0:
+            prec += 1
+        text = f"{per_m:.{min(prec + 1, 12)}f}".rstrip("0").rstrip(".")
+    return f"${text}"
 
 
 def compute_sale_discount(

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -448,3 +448,38 @@ class TestClaudeSonnet5InCuratedLists:
         assert "claude-sonnet-5" in _PROVIDER_MODELS["anthropic"]
 
 
+
+
+class TestFormatPricePerMtok:
+    """_format_price_per_mtok: sub-cent prices must not collapse to 'free'/'$0.00'."""
+
+    def test_standard_prices_keep_two_decimals(self):
+        from hermes_cli.models import _format_price_per_mtok
+        assert _format_price_per_mtok("0.000003") == "$3.00"
+        assert _format_price_per_mtok("0.00003") == "$30.00"
+        assert _format_price_per_mtok("0.00000015") == "$0.15"
+        assert _format_price_per_mtok("0.00018") == "$180.00"
+
+    def test_zero_is_free(self):
+        from hermes_cli.models import _format_price_per_mtok
+        assert _format_price_per_mtok("0") == "free"
+        assert _format_price_per_mtok("0.0") == "free"
+
+    def test_invalid_is_question_mark(self):
+        from hermes_cli.models import _format_price_per_mtok
+        assert _format_price_per_mtok("garbage") == "?"
+        assert _format_price_per_mtok(None) == "?"
+
+    def test_sub_cent_price_extends_precision(self):
+        from hermes_cli.models import _format_price_per_mtok
+        # DeepSeek V4 Flash 0731 promo cache-hit rate: $0.0018/Mtok.
+        assert _format_price_per_mtok("0.0000000018") == "$0.0018"
+        assert _format_price_per_mtok("0.000000001") == "$0.001"
+        assert _format_price_per_mtok("0.0000000049") == "$0.0049"
+        assert _format_price_per_mtok("0.000000005") == "$0.005"
+        # Tiny but non-zero must never render as free or $0.00.
+        assert _format_price_per_mtok("0.00000000001") == "$0.00001"
+
+    def test_one_cent_boundary_stays_two_decimals(self):
+        from hermes_cli.models import _format_price_per_mtok
+        assert _format_price_per_mtok("0.00000001") == "$0.01"


### PR DESCRIPTION
## Summary
Sub-cent per-Mtok prices now render with extended precision instead of collapsing to "$0.00"/free — Nous Portal's DeepSeek V4 Flash 0731 promo cache-hit rate ($0.0018/Mtok) previously displayed as free in the model picker and price listings.

Root cause: `_format_price_per_mtok` hard-formatted every non-zero price with `:.2f`, so anything under one cent per Mtok printed as `$0.00`.

## Changes
- `hermes_cli/models.py`: prices below $0.01/Mtok widen precision to the first significant digit plus one, trimming trailing zeros (`0.0000000018`/tok → `$0.0018`). Standard prices keep the aligned two-decimal format; exact zero still renders `free`. All consumers (auth.py picker, inventory.py GUI payload) inherit the fix through the shared helper.
- `tests/hermes_cli/test_models.py`: new `TestFormatPricePerMtok` covering standard prices, zero→free, invalid→`?`, the promo price, and the one-cent boundary.

## Validation
| Input (per token) | Before | After |
|---|---|---|
| `0.0000000018` | `$0.00` | `$0.0018` |
| `0.00000000001` | `$0.00` | `$0.00001` |
| `0.00000001` | `$0.01` | `$0.01` |
| `0.000003` | `$3.00` | `$3.00` |
| `0` | `free` | `free` |

`scripts/run_tests.sh tests/hermes_cli/test_models.py`: 30/30 passed.

## Infographic

![Sub-cent price precision fix](https://v3b.fal.media/files/b/0aa4c088/F0MpyHGsq7vgdJLOXrpCm_La80xuiM.png)
