### PR TITLE
fix(mcp): keepalive false-positive kills long tool calls; teardown orphans in-flight RPCs

### DIFF
--- a/tests/tools/test_mcp_inflight_call_abort.py
+++ b/tests/tools/test_mcp_inflight_call_abort.py
@@ -1,0 +1,179 @@
+"""Session teardown must abort in-flight tool calls, not orphan them.
+
+Companion to test_mcp_keepalive_rpc_lock_guard.py (both from the
+deleg_e8af57bc investigation, 2026-08-02). When a transport genuinely
+dies mid-call, the dying session's teardown never cancels foreign
+awaiters: before the fix the pending ``session.call_tool`` hung forever
+holding ``_rpc_lock``, starving every later call to that server (a
+read-only status call queued 403s behind a dead wait) until an outer
+watchdog interrupted the agent. Teardown now cancels registered
+in-flight calls so they fail fast with ``McpCallAbortedError`` and
+release the lock.
+"""
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+
+def _install_server(name, call_tool):
+    """Register a real MCPServerTask backed by a stub session."""
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    mcp_tool._ensure_mcp_loop()
+
+    class _Session:
+        pass
+
+    session = _Session()
+    session.call_tool = call_tool
+
+    server = MCPServerTask(name)
+    server._config = {"command": "x"}
+    server.session = session
+    mcp_tool._servers[name] = server
+    mcp_tool._server_error_counts.pop(name, None)
+    return server
+
+
+def _run_handler_in_thread(handler):
+    box = {}
+
+    def _target():
+        box["result"] = handler({})
+
+    thread = threading.Thread(target=_target, daemon=True)
+    thread.start()
+    return thread, box
+
+
+def _wait_for(predicate, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def test_teardown_aborts_inflight_call_and_releases_lock():
+    """An aborted call returns a verify-first error and frees _rpc_lock."""
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    async def _never_answers(tool_name, arguments=None):
+        await asyncio.Event().wait()
+
+    server = _install_server("abort-srv", _never_answers)
+    handler = _make_tool_handler("abort-srv", "slow_tool", tool_timeout=30)
+    thread, box = _run_handler_in_thread(handler)
+
+    assert _wait_for(lambda: server._inflight_calls), "call never registered"
+    mcp_tool._mcp_loop.call_soon_threadsafe(server._abort_inflight_calls)
+
+    thread.join(timeout=10)
+    assert not thread.is_alive(), "handler still blocked after abort"
+    assert "connection was reset" in box["result"]
+    assert "read-only" in box["result"]
+    assert not server._rpc_lock.locked(), "_rpc_lock leaked after abort"
+
+
+def test_next_call_proceeds_after_abort():
+    """The lock released by an abort must admit the next queued caller."""
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    state = {"calls": 0}
+
+    async def _first_hangs(tool_name, arguments=None):
+        state["calls"] += 1
+        if state["calls"] == 1:
+            await asyncio.Event().wait()
+
+        class _Result:
+            isError = False
+            content = []
+            structuredContent = {"ok": True}
+
+        return _Result()
+
+    server = _install_server("abort-then-ok", _first_hangs)
+    handler = _make_tool_handler("abort-then-ok", "tool", tool_timeout=30)
+
+    first_thread, first_box = _run_handler_in_thread(handler)
+    assert _wait_for(lambda: server._inflight_calls)
+
+    second_thread, second_box = _run_handler_in_thread(handler)
+    assert _wait_for(lambda: server._rpc_lock.locked())
+
+    mcp_tool._mcp_loop.call_soon_threadsafe(server._abort_inflight_calls)
+
+    first_thread.join(timeout=10)
+    second_thread.join(timeout=10)
+    assert "connection was reset" in first_box["result"]
+    assert second_box["result"] == '{"result": {"ok": true}}'
+
+
+def test_lifecycle_exit_aborts_inflight_calls():
+    """Every _wait_for_lifecycle_event exit path sweeps in-flight calls."""
+    from tools.mcp_tool import MCPServerTask
+
+    async def _scenario():
+        server = MCPServerTask("srv")
+        server._config = {"command": "x", "keepalive_interval": 30}
+        server.session = object()
+
+        inner = asyncio.ensure_future(asyncio.Event().wait())
+        server._inflight_calls.add(inner)
+
+        server._shutdown_event.set()
+        result = await asyncio.wait_for(
+            server._wait_for_lifecycle_event(), timeout=5
+        )
+        assert result == "shutdown"
+        with pytest.raises(asyncio.CancelledError):
+            await inner
+
+    asyncio.run(_scenario())
+
+
+def test_user_interrupt_keeps_semantics_and_cancels_rpc(monkeypatch):
+    """A user interrupt must keep its semantics: the handler returns the
+    interrupted-call result (not McpCallAbortedError), and the detached
+    RPC task is cancelled rather than left running holding resources."""
+    import tools.interrupt as interrupt_mod
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    state = {"rpc_cancelled": False, "started": False, "interrupted": False}
+
+    async def _hangs_until_cancelled(tool_name, arguments=None):
+        state["started"] = True
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            state["rpc_cancelled"] = True
+            raise
+
+    server = _install_server("interrupt-srv", _hangs_until_cancelled)
+    monkeypatch.setattr(
+        interrupt_mod, "is_interrupted", lambda *a, **kw: state["interrupted"]
+    )
+
+    handler = _make_tool_handler("interrupt-srv", "tool", tool_timeout=30)
+    thread, box = _run_handler_in_thread(handler)
+
+    assert _wait_for(lambda: state["started"])
+    state["interrupted"] = True
+
+    thread.join(timeout=10)
+    assert not thread.is_alive(), "handler did not honor the interrupt"
+    assert "interrupted" in box["result"]
+    assert "connection was reset" not in box["result"]
+    assert _wait_for(lambda: state["rpc_cancelled"]), (
+        "RPC task left running after interrupt"
+    )
+    assert not server._rpc_lock.locked()

--- a/tests/tools/test_mcp_keepalive_rpc_lock_guard.py
+++ b/tests/tools/test_mcp_keepalive_rpc_lock_guard.py
@@ -1,0 +1,71 @@
+"""Keepalive must not probe while an RPC is in flight (``_rpc_lock`` held).
+
+A single-threaded stdio server (e.g. the mac_worker facade) reads one
+message, dispatches it, and only then reads the next — so it cannot
+answer ``ping`` while executing a long tool call. Probing mid-call
+guarantees a false-positive reconnect that tears down the transport and
+kills the very call it blames (delegation deleg_e8af57bc, 2026-08-02: a
+240s ``mac_worker_wait`` was destroyed at t+48s and its completion
+receipt never reached the Pi). The in-flight round-trip is itself the
+liveness signal; its success path marks the session proven.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def test_keepalive_skips_probe_while_rpc_in_flight(monkeypatch):
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    monkeypatch.setattr(mcp_tool, "_MIN_KEEPALIVE_INTERVAL", 0.01)
+
+    async def _scenario():
+        server = MCPServerTask("srv")
+        server._config = {"command": "x", "keepalive_interval": 0.02}
+        ping = AsyncMock(return_value=None)
+        server.session = AsyncMock()
+        server.session.send_ping = ping
+
+        async with server._rpc_lock:
+            lifecycle = asyncio.ensure_future(server._wait_for_lifecycle_event())
+            # Many keepalive intervals elapse while the RPC is in flight.
+            await asyncio.sleep(0.3)
+            assert ping.await_count == 0, (
+                f"probe fired {ping.await_count}x while _rpc_lock was held"
+            )
+            assert not server._reconnect_event.is_set()
+            assert not lifecycle.done()
+
+        # Lock released — probing must resume.
+        await asyncio.sleep(0.3)
+        assert ping.await_count > 0, "probe never resumed after lock release"
+        assert not server._reconnect_event.is_set()
+
+        server._shutdown_event.set()
+        assert await asyncio.wait_for(lifecycle, timeout=5) == "shutdown"
+
+    asyncio.run(_scenario())
+
+
+def test_keepalive_still_reconnects_on_real_ping_failure(monkeypatch):
+    """The guard must not mask genuine idle-session death."""
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    monkeypatch.setattr(mcp_tool, "_MIN_KEEPALIVE_INTERVAL", 0.01)
+
+    async def _scenario():
+        server = MCPServerTask("srv")
+        server._config = {"command": "x", "keepalive_interval": 0.02}
+        server.session = AsyncMock()
+        server.session.send_ping = AsyncMock(side_effect=ConnectionError("dead"))
+
+        result = await asyncio.wait_for(
+            server._wait_for_lifecycle_event(), timeout=5
+        )
+        assert result == "reconnect"
+
+    asyncio.run(_scenario())

--- a/tests/tools/test_mcp_resource_content.py
+++ b/tests/tools/test_mcp_resource_content.py
@@ -178,7 +178,9 @@ class TestErrorPathResourceText:
         from tools import mcp_tool
 
         fake_session = MagicMock()
-        fake_server = SimpleNamespace(session=fake_session, _rpc_lock=None)
+        fake_server = SimpleNamespace(
+            session=fake_session, _rpc_lock=None, _inflight_calls=set()
+        )
 
         def _fake_run_on_mcp_loop(coro_or_factory, timeout=30):
             coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory

--- a/tests/tools/test_mcp_structured_content.py
+++ b/tests/tools/test_mcp_structured_content.py
@@ -56,7 +56,11 @@ def _patch_mcp_server():
     # `_rpc_lock` is acquired by _make_tool_handler's call path (mcp_tool.py
     # ~L2008) to serialize JSON-RPC against the server — build it inside the
     # fresh loop that _fake_run_on_mcp_loop spins up, not at fixture import.
-    fake_server = SimpleNamespace(session=fake_session, _rpc_lock=None)
+    # `_inflight_calls` is the teardown-abort registry the call path adds
+    # each RPC task to (mirrors MCPServerTask; see _abort_inflight_calls).
+    fake_server = SimpleNamespace(
+        session=fake_session, _rpc_lock=None, _inflight_calls=set()
+    )
     with patch.dict(mcp_tool._servers, {"test-server": fake_server}), \
          patch("tools.mcp_tool._run_on_mcp_loop", side_effect=_fake_run_on_mcp_loop):
         yield fake_session

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2301,6 +2301,16 @@ class MCPServerTask:
                 # tool-capable server that doesn't implement it answers -32601;
                 # in that case fall back to the pre-ping ``list_tools`` probe
                 # for the rest of this connection rather than reconnect-looping.
+                #
+                # Never probe while an RPC is in flight (``_rpc_lock`` held): a
+                # single-threaded stdio server can't answer ping mid-dispatch,
+                # so the probe would time out and tear down a healthy transport,
+                # killing the very call it blames — the in-flight round-trip is
+                # itself the liveness signal, and its success path marks the
+                # session proven. The stdio recycle checks above already skip
+                # under the same condition.
+                if self.session and self._rpc_lock.locked():
+                    continue
                 if self.session:
                     try:
                         await self._keepalive_probe()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -962,6 +962,20 @@ class InvalidMcpUrlError(ValueError):
     """
 
 
+class McpCallAbortedError(RuntimeError):
+    """Raised when a session teardown aborts an in-flight ``tools/call``.
+
+    The response streams a pending call awaits on are owned by the dying
+    session's task group, and that teardown never cancels foreign awaiters —
+    without an explicit abort the call would hang holding ``_rpc_lock``,
+    starving every later call to the same server until an outer watchdog
+    fires (deleg_e8af57bc, 2026-08-02: 1225s hang on a 240s wait). The
+    server-side operation may still have completed; only the response was
+    lost, so callers must verify with a read-only call before retrying
+    anything with side effects.
+    """
+
+
 class NonMcpEndpointError(ConnectionError):
     """Raised when an HTTP MCP URL serves a non-MCP response.
 
@@ -1835,7 +1849,7 @@ class MCPServerTask:
         "_sampling", "_elicitation",
         "_registered_tool_names", "_auth_type", "_refresh_lock",
         "_rpc_lock", "_pending_refresh_tasks",
-        "_pending_call_context",
+        "_pending_call_context", "_inflight_calls",
         "_lifecycle_started_at", "_last_tool_call_at",
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported",
@@ -1883,6 +1897,7 @@ class MCPServerTask:
         # client-initiated RPCs per server. The lock is also applied to HTTP
         # transports for conservative per-server ordering.
         self._rpc_lock = asyncio.Lock()
+        self._inflight_calls: set[asyncio.Task] = set()
         self._pending_refresh_tasks: set[asyncio.Task] = set()
         # contextvars snapshot of the agent task that's currently in
         # session.call_tool(). The MCP recv loop dispatches incoming
@@ -1944,6 +1959,20 @@ class MCPServerTask:
     def mark_tool_call(self) -> None:
         """Record that a user-visible MCP operation is starting."""
         self._last_tool_call_at = time.monotonic()
+
+    def _abort_inflight_calls(self) -> None:
+        """Cancel tool calls still awaiting a response on a dying session.
+
+        Their response streams belong to the session being torn down, so no
+        answer can ever arrive; cancelling converts each into an immediate
+        :class:`McpCallAbortedError` (see the ``_call`` await site) and
+        releases ``_rpc_lock`` for the next caller. Synchronous on purpose —
+        it runs from ``finally`` blocks that may themselves be unwinding a
+        cancellation.
+        """
+        for task in tuple(self._inflight_calls):
+            task.cancel()
+        self._inflight_calls.clear()
 
     def _mark_lifecycle_started(self) -> None:
         now = time.monotonic()
@@ -2328,6 +2357,13 @@ class MCPServerTask:
                     # Clear the rapid-drop budget (#62212).
                     self._mark_session_proven()
         finally:
+            # This method only exits when the session it guards is being
+            # abandoned (shutdown / reconnect / recycle) or the transport
+            # crashed out from under it. Either way, a tools/call still
+            # awaiting a response on this session can never be answered —
+            # abort it now so it fails fast and releases _rpc_lock instead
+            # of hanging until an outer watchdog fires.
+            self._abort_inflight_calls()
             for t in (shutdown_task, reconnect_task):
                 if not t.done():
                     t.cancel()
@@ -4861,9 +4897,40 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # task, which doesn't inherit our contextvars) can replay
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
+                # Run the RPC as a child task registered on the server so a
+                # session teardown (_abort_inflight_calls) can cancel it.
+                # The response streams belong to the session's task group,
+                # and teardown never cancels foreign awaiters — an inline
+                # await here would strand forever holding _rpc_lock.
+                call_task = asyncio.create_task(
+                    server.session.call_tool(tool_name, arguments=args)
+                )
+                server._inflight_calls.add(call_task)
                 try:
-                    result = await server.session.call_tool(tool_name, arguments=args)
+                    result = await call_task
+                except asyncio.CancelledError:
+                    current = asyncio.current_task()
+                    cancelling = getattr(current, "cancelling", None)
+                    outer_cancelled = bool(cancelling and cancelling())
+                    if call_task.cancelled() and not outer_cancelled:
+                        # The teardown aborted the RPC; this coroutine itself
+                        # was not cancelled, so surface a real error rather
+                        # than propagating a cancellation nobody requested.
+                        raise McpCallAbortedError(
+                            f"MCP server '{server.name}' connection was reset "
+                            f"while this call was in flight; the response was "
+                            f"lost. The server-side operation may still have "
+                            f"completed — verify with a read-only status/"
+                            f"result call before retrying anything with side "
+                            f"effects."
+                        ) from None
+                    # Caller-driven cancellation (user interrupt, outer
+                    # timeout): propagate it into the RPC task too so it
+                    # doesn't keep running detached.
+                    call_task.cancel()
+                    raise
                 finally:
+                    server._inflight_calls.discard(call_task)
                     server._pending_call_context = None
             # The RPC round-trip completed — the session is demonstrably
             # healthy at the transport level (even if the tool itself
@@ -4968,6 +5035,15 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             return result
         except InterruptedError:
             return _interrupted_call_result()
+        except McpCallAbortedError as exc:
+            # Transport teardown aborted the call. Not a new failure signal
+            # (whatever killed the transport already drove the reconnect
+            # machinery), so no breaker strike — return the guidance so the
+            # model verifies server-side state instead of blind-retrying.
+            logger.warning(
+                "MCP tool %s/%s aborted by session teardown", server_name, tool_name,
+            )
+            return tool_error(str(exc))
         except Exception as exc:
             # Auth-specific recovery path: consult the manager, signal
             # reconnect if viable, retry once. Returns None to fall


### PR DESCRIPTION
## Problem

A single-threaded stdio MCP server (read one message → dispatch → write → repeat) cannot answer `ping` while it executes a long tool call. The MCP client's keepalive loop probes on its fixed cadence regardless of an in-flight RPC, with a 30s ping timeout — so any tool call that straddles a ping tick is guaranteed to be declared a dead server. The resulting reconnect tears down the transport and kills the very call it blamed.

Worse, the teardown never cancels the in-flight `session.call_tool` awaiter: its response streams belong to the dying session's task group, so the caller strands forever holding the per-server `_rpc_lock`, starving every subsequent call to that server until an outer watchdog fires.

Observed in production (2026-08-02): a worker-owned 240s wait call was killed 48s in by a keepalive false-positive; the caller hung 1225s until a delegation watchdog interrupted it, and a read-only status call queued 403s behind the leaked lock. The remote work had completed successfully 3 minutes into the hang — the receipt was simply never carried back.

## Fixes (one commit each)

1. **Skip the keepalive probe while `_rpc_lock` is held.** An in-flight round-trip is itself the liveness signal, and its success path already marks the session proven. The stdio recycle checks used this exact guard; the probe now matches.
2. **Abort in-flight calls on session teardown.** Each RPC runs as a cancellable child task registered on the server; every `_wait_for_lifecycle_event` exit path (reconnect, recycle, shutdown, transport crash unwinding through it) cancels them. Aborted calls fail fast with `McpCallAbortedError` and a verify-before-retry message instead of hanging; no circuit-breaker strike, since whatever killed the transport already drove the reconnect machinery. User-interrupt/timeout cancellation keeps its semantics and now also cancels the detached RPC task.

## Testing

- 6 new regression tests (`test_mcp_keepalive_rpc_lock_guard.py`, `test_mcp_inflight_call_abort.py`): no probe while an RPC is in flight, genuine idle-session death still reconnects, teardown abort releases the lock and admits the next caller, lifecycle sweep, interrupt semantics.
- Full MCP suite passes (422 passed, 2 skipped).
- Live-verified on a Raspberry Pi gateway driving a remote worker over a single-threaded stdio facade: two end-to-end runs (240s+ server-owned waits crossing keepalive ticks) completed cleanly with zero false reconnects, versus a reproducible kill at ~44s before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)