### PR TITLE
fix(desktop): pin gpt-5.6 family at resolver layer for stale visibility stores

### DIFF
--- a/apps/desktop/src/store/model-visibility.test.ts
+++ b/apps/desktop/src/store/model-visibility.test.ts
@@ -326,4 +326,43 @@ describe('setProviderVisibility', () => {
     // The -fast sibling is represented by its base family, not its own key.
     expect(next.has(modelVisibilityKey('nous', 'model-fast'))).toBe(false)
   })
+
+  it('injects pinned gpt-5.6 flagships for a stale openrouter selection', () => {
+    // Stored set captured BEFORE gpt-5.6 existed: only an older model chosen.
+    const stored = new Set([
+      modelVisibilityKey('openrouter', 'openai/gpt-5.1'),
+      modelVisibilityKey('copilot', 'claude-sonnet-4.6')
+    ])
+
+    const visible = effectiveVisibleKeys(stored, [
+      provider('openrouter', [
+        'openai/gpt-5.1',
+        'openai/gpt-5.6-luna',
+        'openai/gpt-5.6-sol'
+      ]),
+      provider('copilot', ['claude-sonnet-4.6'])
+    ])
+
+    // Stale selection preserved.
+    expect(visible.has(modelVisibilityKey('openrouter', 'openai/gpt-5.1'))).toBe(true)
+    // Pinned flagship injected despite stale store.
+    expect(visible.has(modelVisibilityKey('openrouter', 'openai/gpt-5.6-luna'))).toBe(true)
+    expect(visible.has(modelVisibilityKey('openrouter', 'openai/gpt-5.6-sol'))).toBe(true)
+    // Unrelated provider untouched.
+    expect(visible.has(modelVisibilityKey('copilot', 'claude-sonnet-4.6'))).toBe(true)
+  })
+
+  it('respects openrouter hide-all sentinel (no pinned resurrection)', () => {
+    const stored = new Set([emptyProviderSentinelKey('openrouter')])
+
+    const visible = effectiveVisibleKeys(stored, [
+      provider('openrouter', [
+        'openai/gpt-5.1',
+        'openai/gpt-5.6-luna'
+      ])
+    ])
+
+    expect(visible.has(modelVisibilityKey('openrouter', 'openai/gpt-5.6-luna'))).toBe(false)
+    expect(visible.has(emptyProviderSentinelKey('openrouter'))).toBe(false)
+  })
 })

--- a/apps/desktop/src/store/model-visibility.ts
+++ b/apps/desktop/src/store/model-visibility.ts
@@ -32,6 +32,46 @@ export interface ModelFamily {
   id: string
 }
 
+/** Flaghip models guaranteed visible in a provider's working set, regardless
+ *  of the backend's `featured_models` shortlist OR a stale persisted visibility
+ *  store.
+ *
+ *  Motivation: when OpenAI ships a new flagship family (e.g. `gpt-5.6`), it
+ *  lands in the curated `models` catalog immediately but may be omitted from a
+ *  user's already-persisted `visibleModels` selection (captured before the
+ *  model existed) or pushed out by the per-lab "newest N" featured cap. Without
+ *  this, the model is unselectable until the user manually re-shows it. Pinning
+ *  it at the resolver layer guarantees it is always present for any provider
+ *  the user has NOT explicitly hidden entirely.
+ *
+ *  These are injected ONLY for providers with a partial stored selection (or no
+ *  selection). A hide-all sentinel is always respected — we never resurrect a
+ *  provider the user deliberately emptied. */
+const PINNED_DEFAULT_MODELS: Record<string, string[]> = {
+  openrouter: [
+    'openai/gpt-5.6-luna',
+    'openai/gpt-5.6-luna-pro',
+    'openai/gpt-5.6-sol',
+    'openai/gpt-5.6-sol-pro',
+    'openai/gpt-5.6-terra',
+    'openai/gpt-5.6-terra-pro'
+  ]
+}
+
+/** Inject pinned flagship models into `target` for the given provider, but
+ *  only when the provider has NOT been explicitly hidden (sentinel). Safe to
+ *  call for any provider; no-op when the provider has no pinned models. */
+function injectPinnedDefaults(provider: ModelOptionProvider, target: Set<string>): void {
+  const pinned = PINNED_DEFAULT_MODELS[provider.slug]
+  if (!pinned) return
+  const present = new Set(provider.models ?? [])
+  for (const model of pinned) {
+    if (present.has(model)) {
+      target.add(modelVisibilityKey(provider.slug, model))
+    }
+  }
+}
+
 /** Collapse a provider's model list so a base model and its `…-fast` variant
  *  become a single family (one row, one toggle). Order is preserved by the
  *  base model's position. A `…-fast` model with no base stands on its own. */
@@ -154,11 +194,22 @@ export function resolveVisibleKeys(stored: Set<string> | null, providers: readon
 
     const hasSentinel = stored.has(emptyProviderSentinelKey(provider.slug))
 
-    if (hasStoredProvider || hasSentinel) {
+    if (hasSentinel) {
+      // User explicitly hid every model for this provider — never resurrect
+      // it, even for pinned flagships.
       continue
     }
 
-    expandProviderDefaults(provider, next)
+    if (!hasStoredProvider) {
+      // Uncustomized provider: seed with the curated defaults.
+      expandProviderDefaults(provider, next)
+    }
+
+    // For a provider the user HAS customized (partial selection) OR left
+    // uncustomized, always ensure pinned flagships are present. This fixes
+    // the stale-visibility case: a persisted selection captured before a
+    // new flagship (e.g. gpt-5.6) existed would otherwise hide it forever.
+    injectPinnedDefaults(provider, next)
   }
 
   return next


### PR DESCRIPTION
## Summary
- `apps/desktop/src/store/model-visibility.ts`: `resolveVisibleKeys` previously short-circuited default injection for any provider with a stored (partial) selection, so a model absent from a user's pre-existing `visibleModels` store was unreachable in the picker even though it was in the curated catalog. Add `PINNED_DEFAULT_MODELS` (openrouter gpt-5.6 family) + `injectPinnedDefaults()`, called inside `resolveVisibleKeys` for every provider NOT hidden via a hide-all sentinel.
- A hide-all sentinel is always respected (never resurrects a provider the user deliberately emptied).
- Tests: stale openrouter selection now surfaces `gpt-5.6-luna`; hide-all sentinel still suppresses it.

Split from bundled PR #76321 per review. Core fixes: #76982, #76984.

## Verification
- `npx vitest run src/store/model-visibility.test.ts` → 28 passed (incl. 2 new).

## Test plan
- [ ] `npx vitest run src/store/model-visibility.test.ts`