### PR TITLE
fix(cron): finalize kanban worker sessions with ended_at (#76914)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1344,6 +1344,13 @@ def _finalize_single_query(cli) -> None:
     try:
         _notify_single_query_session_finalize(cli)
         _run_cleanup(notify_session_finalize=False)
+        # The quiet path never enters run()'s interactive loop, whose finally
+        # closes the SQLite session. Without agent.close() here, kanban
+        # workers / cron pipes / `hermes chat -q` exit with ended_at NULL.
+        agent = getattr(cli, "agent", None)
+        close = getattr(agent, "close", None)
+        if callable(close):
+            close()
     finally:
         cli._release_active_session()
 


### PR DESCRIPTION
## Summary
Kanban worker sessions completed their tasks but left `sessions.ended_at` NULL in `state.db` (reproduced 2/2 runs). The worker exits via the quiet single-query CLI path, which never finalized the SQLite session.

## Root Cause
Kanban workers are spawned as `hermes -p <profile> --cli chat -q "work kanban task <id>"` (`hermes_cli/kanban_db.py:8964`). The quiet path in `cli.py` (`_finalize_single_query`, ~L1342) only notifies session-finalize hooks and runs cleanup — it **never calls `agent.close()`**, which is what invokes `session_db.end_session(session_id, "agent_close")` (`run_agent.py:4150-4157`, gated by `_end_session_on_close`, default `True`).

The interactive `run()` loop closes the session in its `finally` block (`cli.py:17718-17721`), but the quiet path bypasses it entirely. Compare `hermes_cli/oneshot.py:461-481` (`hermes -z` calls `agent.close()` in its own finally) and `cron/scheduler.py:3829-3832` (`end_session(..., "cron_complete")` explicitly).

## Change
`cli.py` — `_finalize_single_query` now calls `agent.close()` (defensively, via `getattr`/`callable` so stub agents in tests are unaffected) before releasing the active session lease. `close()` is idempotent in the run loop path and triggers `end_session` → `ended_at` set.

## Verification
- `pytest tests/cli/test_single_query_session_finalize.py tests/cli/test_chat_q_exit_clear.py` — 9 passed
- `pytest tests/hermes_cli/test_kanban_lifecycle_hooks.py::test_claim_fires_hook tests/hermes_cli/test_kanban_write_guard.py` — 4 passed
- 7 kanban-collection failures on the full `-k kanban` run reproduce on unpatched `upstream/main` (pre-existing order-dependent flakes, not caused by this change)

Closes #76914