### PR TITLE
feat(file): raise read_file default limit from 500 to 2000 lines

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -278,7 +278,7 @@ class TestShellFileOpsHelpers:
     def test_normalize_read_pagination_clamps_invalid_values(self):
         assert normalize_read_pagination(offset=0, limit=0) == (1, 1)
         assert normalize_read_pagination(offset=-10, limit=-5) == (1, 1)
-        assert normalize_read_pagination(offset="bad", limit="bad") == (1, 500)
+        assert normalize_read_pagination(offset="bad", limit="bad") == (1, 2000)
         assert normalize_read_pagination(offset=2, limit=999999) == (2, 2000)
 
 
@@ -319,7 +319,7 @@ class TestShellFileOpsHelpers:
         assert result.error is None
         assert commands[0] == "wc -c < '/c/Users/alice/notes.txt' 2>/dev/null"
         assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null"
-        assert commands[2] == "sed -n '1,500p' '/c/Users/alice/notes.txt'"
+        assert commands[2] == "sed -n '1,2000p' '/c/Users/alice/notes.txt'"
         assert commands[3] == "wc -l < '/c/Users/alice/notes.txt'"
 
     def test_is_likely_binary_by_extension(self, file_ops):

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -27,7 +27,7 @@ class TestReadFileHandler:
         result = json.loads(read_file_tool("/tmp/test.txt"))
         assert result["content"] == "line1\nline2"
         assert result["total_lines"] == 2
-        mock_ops.read_file.assert_called_once_with("/tmp/test.txt", 1, 500)
+        mock_ops.read_file.assert_called_once_with("/tmp/test.txt", 1, 2000)
 
 
     @patch("tools.file_tools._get_file_ops")

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -341,7 +341,7 @@ _TOOL_STUBS = {
     ),
     "read_file": (
         "read_file",
-        "path: str, offset: int = 1, limit: int = 500",
+        "path: str, offset: int = 1, limit: int = 2000",
         '"""Read a file (1-indexed lines). Returns dict with "content" and "total_lines"."""',
         '{"path": path, "offset": offset, "limit": limit}',
     ),
@@ -1900,7 +1900,7 @@ _TOOL_DOC_LINES = [
      "    Returns {\"results\": [{\"url\", \"title\", \"content\", \"error\"}, ...]} where content is markdown.\n"
      "    No LLM summarization. Pages over char_limit (default 15000) are head+tail truncated; full text stored on disk (path in the content footer)."),
     ("read_file",
-     "  read_file(path: str, offset: int = 1, limit: int = 500) -> dict\n"
+     "  read_file(path: str, offset: int = 1, limit: int = 2000) -> dict\n"
      "    Lines are 1-indexed. Returns {\"content\": \"...\", \"total_lines\": N}"),
     ("write_file",
      "  write_file(path: str, content: str) -> dict\n"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -435,7 +435,7 @@ class FileOperations(ABC):
     """Abstract interface for file operations across terminal backends."""
     
     @abstractmethod
-    def read_file(self, path: str, offset: int = 1, limit: int = 500) -> ReadResult:
+    def read_file(self, path: str, offset: int = 1, limit: int = 2000) -> ReadResult:
         """Read a file with pagination support."""
         ...
 
@@ -711,7 +711,7 @@ MAX_LINES = 2000
 MAX_LINE_LENGTH = 2000
 MAX_FILE_SIZE = 50 * 1024  # 50KB
 DEFAULT_READ_OFFSET = 1
-DEFAULT_READ_LIMIT = 500
+DEFAULT_READ_LIMIT = 2000
 DEFAULT_SEARCH_OFFSET = 0
 DEFAULT_SEARCH_LIMIT = 50
 
@@ -1116,7 +1116,7 @@ class ShellFileOperations(FileOperations):
     # READ Implementation
     # =========================================================================
     
-    def read_file(self, path: str, offset: int = 1, limit: int = 500) -> ReadResult:
+    def read_file(self, path: str, offset: int = 1, limit: int = 2000) -> ReadResult:
         """
         Read a file with pagination, binary detection, and line numbers.
         

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1261,7 +1261,7 @@ def clear_file_ops_cache(task_id: str = None):
             _file_ops_cache.clear()
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = "default") -> str:
+def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default") -> str:
     """Read a file with pagination and line numbers."""
     try:
         offset, limit = normalize_read_pagination(offset, limit)
@@ -2164,7 +2164,7 @@ READ_FILE_SCHEMA = {
         "properties": {
             "path": {"type": "string", "description": "Path to the file to read (absolute, relative, or ~/path)"},
             "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1)", "default": 1, "minimum": 1},
-            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 500, max: 2000)", "default": 500, "maximum": 2000}
+            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 2000, max: 2000). Reads are additionally capped at a ~100K-character budget with a next_offset continuation.", "default": 2000, "maximum": 2000}
         },
         "required": ["path"]
     }


### PR DESCRIPTION
## Summary
`read_file` now defaults to 2000 lines (the existing schema max) instead of 500, making ~44% of previously-truncated first reads complete in a single call while the unchanged ~100K-char budget still bounds worst-case result size.

Root cause: 74.3% of production read_file results were truncated (28.5k-call window), and 22,443 of 22,456 sampled truncations came from the 500-line default rather than the char budget (13). The fallout was 12,229 redundant re-reads, and after a truncated result the model's single most common next move was abandoning read_file for terminal `cat`/`sed` (4,608 times) — a pagination-trust failure.

## Changes
- `tools/file_operations.py`: `DEFAULT_READ_LIMIT` 500→2000; both `read_file()` signatures.
- `tools/file_tools.py`: `read_file_tool` default + schema text (notes the char-budget continuation contract).
- `tools/code_execution_tool.py`: sandbox `read_file` stub signature + docs (2 sites).
- Tests pinning the old default updated (3 assertions).

## Why this is safe
The worst-case result size is unchanged: the per-line cap is 2000 chars and the read budget is ~100K chars, which the old 500-line default could already hit. The char-budget path (`truncated_by: "bytes"` + `next_offset`) remains the hard ceiling — verified live below. Median truncated file is 2,422 total lines (p90 15k), so the second page now covers the p75 file instead of the p25 file.

## Validation
| Check | Result |
|---|---|
| Targeted suites (file_operations, read guards, loop detection, staleness, file_tools) | 149 passed |
| Live E2E: 1,800-line file | complete in one read (was 4 pages) |
| Live E2E: 5,000-line file | truncates at 2000 with `offset=2001` hint |
| Live E2E: 450KB wide file | char budget fires (`truncated_by: bytes`, 99,913 chars, next_offset) — ceiling intact |
| Bench battery (big_file_nav + edit_dedup, 2 reps, ATOF-traced) | 4/4 ok, no regression vs baseline |

## Infographic

![read_file default limit](https://v3b.fal.media/files/b/0aa4c0b5/8UYUZ3t2mFCvN6XLHXJEC_y1bXtnE3.png)
