### PR TITLE
test(tools): pin the WSL2 PowerShell TTS fallback in voice tests

### DIFF
--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -207,6 +207,11 @@ class TestDetectAudioEnvironment:
         monkeypatch.setattr("tools.voice_mode._pulse_socket_reachable", lambda: False)
         monkeypatch.setattr("tools.voice_mode._import_audio",
                             lambda: (MagicMock(), MagicMock()))
+        # Pin the WSL2 PowerShell TTS fallback: without this the no-forwarding
+        # block depends on whether powershell.exe + ffmpeg exist on the host
+        # (a WSL machine with both sees available=True via the fallback and
+        # this test flakes). The fallback path is covered by its own test.
+        monkeypatch.setattr("tools.voice_mode._wsl_powershell_tts_available", lambda: False)
 
         proc_version = tmp_path / "proc_version"
         proc_version.write_text("Linux 5.15.0-microsoft-standard-WSL2")

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -212,6 +212,12 @@ class TestDetectAudioEnvironment:
         # (a WSL machine with both sees available=True via the fallback and
         # this test flakes). The fallback path is covered by its own test.
         monkeypatch.setattr("tools.voice_mode._wsl_powershell_tts_available", lambda: False)
+        # Also pin container detection: on container-like hosts (WSL, CI
+        # containers) is_container() is True, which diverts the diagnostic to
+        # the "container" branch — the warning then says "container", not
+        # "WSL", failing assert any("WSL" in w ...). Deterministic on every
+        # host requires pinning both detection paths.
+        monkeypatch.setattr("hermes_constants.is_container", lambda: False)
 
         proc_version = tmp_path / "proc_version"
         proc_version.write_text("Linux 5.15.0-microsoft-standard-WSL2")

--- a/tests/tools/test_voice_wsl_pipewire.py
+++ b/tests/tools/test_voice_wsl_pipewire.py
@@ -63,21 +63,7 @@ def test_wsl_without_forwarding_still_blocks(monkeypatch):
     assert any("WSL" in w for w in res["warnings"])
 
 
-def test_wsl_without_forwarding_but_powershell_fallback_allows_tts(monkeypatch):
-    """The WSL2 PowerShell TTS fallback relaxes the no-forwarding block for
-    OUTPUT (TTS playback) while keeping recording guidance visible.
-
-    Regression for the stale-test bug: this path was added by the PowerShell
-    fallback feature but never unit-tested, so a WSL host with powershell.exe
-    and ffmpeg (the fallback's only preconditions) flipped the no-forwarding
-    test from pass to fail depending on the machine.
-    """
-    _base(monkeypatch)
-    _force_wsl(monkeypatch)  # no PULSE_SERVER, no PIPEWIRE_REMOTE
-    from tools.voice_mode import detect_audio_environment
-    monkeypatch.setattr("tools.voice_mode._wsl_powershell_tts_available", lambda: True)
-    res = detect_audio_environment()
-    # TTS playback works via Media.SoundPlayer on the Windows host, so voice
-    # mode is available — but the WSL guidance notice must still surface.
-    assert res["available"] is True
-    assert any("WSL" in w for w in res["notices"])
+# Note: the positive PowerShell-fallback path (probe True, voice available,
+# recording guidance surfaced) is covered by
+# TestWSLAudioEnvironmentGate::test_wsl_no_pulse_but_powershell_available_not_hard_blocked
+# in tests/tools/test_voice_mode.py — do not re-add it here.

--- a/tests/tools/test_voice_wsl_pipewire.py
+++ b/tests/tools/test_voice_wsl_pipewire.py
@@ -28,6 +28,11 @@ def _base(monkeypatch):
     monkeypatch.delenv("PIPEWIRE_REMOTE", raising=False)
     monkeypatch.setattr("hermes_constants.is_container", lambda: False)
     monkeypatch.setattr("tools.voice_mode._pulse_socket_reachable", lambda: False)
+    # The WSL2 PowerShell TTS fallback makes the no-forwarding path host-
+    # dependent (powershell.exe + ffmpeg on PATH). Pin it so these tests are
+    # deterministic on any machine: the fallback is only exercised by the
+    # dedicated test that mocks it to True.
+    monkeypatch.setattr("tools.voice_mode._wsl_powershell_tts_available", lambda: False)
     sd = MagicMock(); sd.query_devices.return_value = [{"name": "dev"}]
     monkeypatch.setattr("tools.voice_mode._import_audio", lambda: (sd, MagicMock()))
 
@@ -56,3 +61,23 @@ def test_wsl_without_forwarding_still_blocks(monkeypatch):
     res = detect_audio_environment()
     assert res["available"] is False
     assert any("WSL" in w for w in res["warnings"])
+
+
+def test_wsl_without_forwarding_but_powershell_fallback_allows_tts(monkeypatch):
+    """The WSL2 PowerShell TTS fallback relaxes the no-forwarding block for
+    OUTPUT (TTS playback) while keeping recording guidance visible.
+
+    Regression for the stale-test bug: this path was added by the PowerShell
+    fallback feature but never unit-tested, so a WSL host with powershell.exe
+    and ffmpeg (the fallback's only preconditions) flipped the no-forwarding
+    test from pass to fail depending on the machine.
+    """
+    _base(monkeypatch)
+    _force_wsl(monkeypatch)  # no PULSE_SERVER, no PIPEWIRE_REMOTE
+    from tools.voice_mode import detect_audio_environment
+    monkeypatch.setattr("tools.voice_mode._wsl_powershell_tts_available", lambda: True)
+    res = detect_audio_environment()
+    # TTS playback works via Media.SoundPlayer on the Windows host, so voice
+    # mode is available — but the WSL guidance notice must still surface.
+    assert res["available"] is True
+    assert any("WSL" in w for w in res["notices"])


### PR DESCRIPTION
## What does this PR do?

Pin the WSL2 PowerShell TTS fallback in the WSL voice-detection tests so they pass/fail deterministically on any host. The no-forwarding tests previously depended on whether powershell.exe + ffmpeg exist on the machine (a WSL2 host with both flipped them to fail).

## Related Issue

No direct issue — discovered via code review and reproduced live (see below).


## Follow-up (complete fix)

Added the missing container-detection pin to test_wsl_without_pulse_blocks_voice: on container-like hosts (WSL, CI containers) is_container() is True, which diverts the diagnostic to the "container" branch — the warning says "container", not "WSL", failing assert any("WSL" in w ...). Both detection paths (PowerShell-TTS fallback + container detection) are now pinned, making the test deterministic on every host. Verified on a real WSL host (both pins required; either alone still flakes).
