### PR TITLE
feat(patch): list match locations in ambiguous old_string errors

### DIFF
--- a/tests/tools/test_patch_multimatch_locations.py
+++ b/tests/tools/test_patch_multimatch_locations.py
@@ -1,0 +1,64 @@
+"""Tests for multi-match location listing in patch ambiguity errors."""
+
+import json
+
+from tools.fuzzy_match import fuzzy_find_and_replace, _format_match_locations
+
+
+class TestFormatMatchLocations:
+    def test_lists_line_numbers_and_snippets(self):
+        content = "alpha = 1\nvalue = compute()\nbeta = 2\nvalue = compute()\n"
+        matches = [(10, 27), (38, 55)]
+        out = _format_match_locations(content, matches)
+        assert "L2: value = compute()" in out
+        assert "L4: value = compute()" in out
+
+    def test_caps_at_five_with_overflow_note(self):
+        line = "x = do_thing()\n"
+        content = line * 9
+        matches = []
+        pos = 0
+        for _ in range(9):
+            matches.append((pos, pos + len(line) - 1))
+            pos += len(line)
+        out = _format_match_locations(content, matches)
+        assert out.count("L") == 5
+        assert "... and 4 more" in out
+
+    def test_long_lines_truncated(self):
+        content = "y = " + "z" * 200 + "\n"
+        out = _format_match_locations(content, [(0, 5)])
+        assert "..." in out
+        assert len(out.splitlines()[0]) < 100
+
+
+class TestMultiMatchErrorIncludesLocations:
+    def test_ambiguous_replace_lists_locations(self):
+        content = (
+            "def block_a(v):\n    value = value + 1\n    return v\n\n"
+            "def block_b(v):\n    value = value + 1\n    return v\n"
+        )
+        _new, count, _strategy, error = fuzzy_find_and_replace(
+            content, "    value = value + 1", "    value = value + 2"
+        )
+        assert count == 0
+        assert "Found 2 matches" in error
+        assert "L2:" in error
+        assert "L6:" in error
+
+    def test_replace_all_unaffected(self):
+        content = "a = old_value_here\nb = old_value_here\n"
+        new, count, _strategy, error = fuzzy_find_and_replace(
+            content, "old_value_here", "new_value_here", replace_all=True
+        )
+        assert error is None
+        assert count == 2
+        assert "old_value_here" not in new
+
+    def test_unique_match_unaffected(self):
+        content = "only_one = special_marker_line\nother = thing\n"
+        new, count, _strategy, error = fuzzy_find_and_replace(
+            content, "special_marker_line", "replacement_marker"
+        )
+        assert error is None
+        assert count == 1

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -91,6 +91,31 @@ def is_already_applied(content: str, old_string: str, new_string: str) -> bool:
     return old_string not in content
 
 
+def _format_match_locations(content: str, matches: List[Tuple[int, int]],
+                            cap: int = 5) -> str:
+    """Render up to ``cap`` match positions as 'L<line>: <snippet>' rows.
+
+    Gives the model the information it needs to disambiguate an ambiguous
+    old_string in ONE follow-up (add neighboring context, or choose
+    replace_all) instead of re-reading the file to find the occurrences.
+    """
+    rows = []
+    for start, _end in matches[:cap]:
+        line_no = content.count("\n", 0, start) + 1
+        line_start = content.rfind("\n", 0, start) + 1
+        line_end = content.find("\n", line_start)
+        if line_end == -1:
+            line_end = len(content)
+        snippet = content[line_start:line_end].strip()
+        if len(snippet) > 80:
+            snippet = snippet[:77] + "..."
+        rows.append(f"  L{line_no}: {snippet}")
+    extra = len(matches) - cap
+    if extra > 0:
+        rows.append(f"  ... and {extra} more")
+    return "\n".join(rows)
+
+
 def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
                             replace_all: bool = False) -> Tuple[str, int, Optional[str], Optional[str]]:
     """
@@ -146,9 +171,11 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
         if matches:
             # Found matches with this strategy
             if len(matches) > 1 and not replace_all:
+                locations = _format_match_locations(content, matches)
                 return content, 0, None, (
                     f"Found {len(matches)} matches for old_string. "
-                    f"Provide more context to make it unique, or use replace_all=True."
+                    f"Provide more context to make it unique, or use replace_all=True. "
+                    f"Matches:\n{locations}"
                 )
 
             # replace_all with a similarity-based strategy would overwrite


### PR DESCRIPTION
## Summary
Ambiguous `old_string` patch errors now list where the matches are (`L<line>: <snippet>`, up to 5), so the model disambiguates in one follow-up instead of re-reading the file to locate the occurrences.

Root cause: `Found N matches for old_string` (190+ occurrences in a 250k-call production window) reported only the count. The standard recovery was read_file → find occurrences → retry with more context: two extra turns for information the tool already had in hand.

## Changes
- `tools/fuzzy_match.py`: new `_format_match_locations()` (line number + stripped 80-char snippet per match, cap 5 with `... and N more`); wired into the multi-match error branch of `fuzzy_find_and_replace` — shared by both patch modes (replace + V4A).
- `tests/tools/test_patch_multimatch_locations.py`: 6 tests — formatting, cap/overflow, long-line truncation, end-to-end ambiguity error content, replace_all and unique-match paths unaffected.

## Validation
| Check | Result |
|---|---|
| Targeted suites (new + fuzzy_match + patch_parser) | 80 passed |
| Live E2E via real `patch_tool()` on a 3-duplicate file | error now carries `L2/L6/L10: value = value + 1` rows |
| Bench battery (edit_dedup ×3, ATOF-traced) | 3/3 ok, turn counts unchanged vs baseline |

## Infographic

![multimatch locations](https://v3b.fal.media/files/b/0aa4c102/f47iKkT2TlJvPZtYXgPRb_GmkJYufe.png)
