### PR TITLE
feat(terminal): echo cwd in result when a command changes the working directory

### DIFF
--- a/tests/tools/test_terminal_cwd_echo.py
+++ b/tests/tools/test_terminal_cwd_echo.py
@@ -1,0 +1,68 @@
+"""Tests for the terminal result cwd echo (feat/terminal-cwd-echo).
+
+When a command changes the session working directory, the tool result
+gains a "cwd" field so the model stops prefixing every command with
+'cd X && ' (60% of production terminal calls) and stops running pwd
+diagnostics after directory changes.
+"""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from tools.terminal_tool import terminal_tool
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    return tmp_path
+
+
+class TestCwdEcho:
+    def test_cd_reports_new_cwd(self, isolated_home, tmp_path):
+        target = tmp_path / "projdir"
+        target.mkdir()
+        r = json.loads(terminal_tool(f"cd {target}", task_id="t-cwd-1"))
+        assert r["exit_code"] == 0
+        assert "cwd" in r
+        assert os.path.realpath(r["cwd"]) == os.path.realpath(str(target))
+
+    def test_non_cd_command_has_no_cwd_field(self, isolated_home):
+        r = json.loads(terminal_tool("echo hello", task_id="t-cwd-2"))
+        assert r["exit_code"] == 0
+        assert "cwd" not in r
+
+    def test_cwd_persists_and_stops_reporting_when_stable(self, isolated_home, tmp_path):
+        target = tmp_path / "stable"
+        target.mkdir()
+        r1 = json.loads(terminal_tool(f"cd {target}", task_id="t-cwd-3"))
+        assert "cwd" in r1
+        # Next command runs IN the new cwd without changing it: no echo.
+        r2 = json.loads(terminal_tool("pwd", task_id="t-cwd-3"))
+        assert "cwd" not in r2
+        assert os.path.realpath(r2["output"].strip()) == os.path.realpath(str(target))
+
+    def test_cd_within_chain_reports_final_dir(self, isolated_home, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir(); b.mkdir()
+        r = json.loads(terminal_tool(f"cd {a} && cd {b} && echo done", task_id="t-cwd-4"))
+        assert r["exit_code"] == 0
+        assert os.path.realpath(r.get("cwd", "")) == os.path.realpath(str(b))
+
+    def test_workdir_override_does_not_echo(self, isolated_home, tmp_path):
+        # Per-command workdir is transient by contract; it must not surface
+        # a cwd field (the session cwd did not change).
+        sub = tmp_path / "transient"
+        sub.mkdir()
+        r = json.loads(terminal_tool("echo hi", workdir=str(sub), task_id="t-cwd-5"))
+        assert r["exit_code"] == 0
+        assert "cwd" not in r
+
+    def test_failed_cd_no_echo(self, isolated_home):
+        r = json.loads(terminal_tool("cd /nonexistent_dir_zzz_42", task_id="t-cwd-6"))
+        assert r["exit_code"] != 0
+        assert "cwd" not in r

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1072,7 +1072,7 @@ Background: Set background=true to get a session_id. Almost always pair with not
 For servers/watchers, do NOT use shell-level background wrappers (nohup/disown/setsid/trailing '&') in foreground mode. Use background=true so Hermes can track lifecycle and output.
 After starting a server, verify readiness with a health check or log signal, then run tests in a separate terminal() call. Avoid blind sleep loops.
 Use process(action="poll") for progress checks, process(action="wait") to block until done.
-Working directory: Use 'workdir' for per-command cwd.
+Working directory: Use 'workdir' for per-command cwd. When a command changes the session cwd (cd, pushd), the result includes a "cwd" field with the directory you ended in — trust it instead of prefixing every command with 'cd'.
 PTY mode: Set pty=true for interactive CLI tools (Codex, Claude Code, Python REPL).
 
 Do NOT use vim/nano/interactive tools without pty=true — they hang without a pseudo-terminal. Pipe git output to cat if it might page.
@@ -3055,6 +3055,18 @@ def terminal_tool(
                 "exit_code": returncode,
                 "error": None,
             }
+            # cwd echo: when the command changed the session's working
+            # directory (cd, pushd, ...), tell the model where it ended up.
+            # Production mining shows 60% of terminal calls carry a
+            # defensive 'cd X && ' prefix because the model can't see cwd
+            # state; echoing it on change removes the guesswork (pattern
+            # borrowed from crush's <cwd> injection).
+            try:
+                post_cwd = getattr(env, "cwd", None)
+                if post_cwd and command_cwd and os.path.realpath(str(post_cwd)) != os.path.realpath(str(command_cwd)):
+                    result_dict["cwd"] = str(post_cwd)
+            except Exception:
+                pass
             try:
                 from agent.verification_evidence import record_terminal_result
 


### PR DESCRIPTION
## Summary
Terminal results now include a `cwd` field whenever a command changes the session working directory, so the model can trust session cwd state instead of defensively prefixing `cd X && ` onto most commands.

Root cause: the model cannot observe cwd state between calls. Production mining (400k-msg window) shows 60.2% of 104,507 terminal calls carry a `cd X && ` prefix (~925k tokens of pure prefix), 2,462 failed calls led with `cd`, and directory changes are routinely followed by `pwd`/`ls` verification turns.

## Changes
- `tools/terminal_tool.py`: after a foreground command, if the session cwd differs from the cwd the command started in (realpath compare — symlink-safe), the result gains `"cwd": <dir>`. Stable-cwd commands are byte-identical to before (no field). Per-command `workdir` overrides remain transient by contract and never echo. Defensive wrapping: a backend without `.cwd` can never break the result path.
- Schema: one sentence added to the Working-directory line — result includes `cwd` on change; trust it instead of prefixing.
- `tests/tools/test_terminal_cwd_echo.py`: 6 tests — cd echo, non-cd silence, persistence without re-echo, chained `cd a && cd b` reports final dir, workdir-override silence, failed cd silence.

Pattern borrowed from crush's `<cwd>` injection (agent-codebase survey).

## Validation
| Check | Result |
|---|---|
| Hermetic runner (new + terminal suites) | 25/25 passed |
| Live E2E through real `terminal_tool()` | cd echoes; `ls` after cd silent + runs in new dir; relative `cd inner && touch` echoes final dir; stable command has no field |
| Bench battery (term_state, git_flow, diag_fail × 2, ATOF-traced) | 6/6 ok, no regression vs baseline (llm 26 vs baseline 28 for same tasks) |

## Infographic

![terminal cwd echo](https://v3b.fal.media/files/b/0aa4c124/kM7EvRikoaa1hVhuMjWVT_Tzjesaph.png)
