### PR TITLE
fix(security): write BWS disk cache encrypted-only, migrate legacy plaintext

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -91,11 +91,12 @@ _CACHE: Dict[_CacheKey, _CachedFetch] = {}
 # ~380ms `bws secret list` tax. The in-process _CACHE above only saves repeated
 # fetches WITHIN one process; this saves repeated fetches ACROSS processes.
 #
-# Layout: one JSON object per cache key, written atomically with mode 0600 in
-# <hermes_home>/cache/bws_cache.json. The file holds only the secret VALUES,
-# never the access token. It's plaintext-equivalent to ~/.hermes/.env (which
-# we already accept) but kept out of the .env file so users editing it won't
-# accidentally commit BSM-sourced secrets. The atomic-write/0600/TTL mechanics
+# Layout: one AES-GCM encrypted JSON object per cache key, written atomically
+# with mode 0600 in <hermes_home>/cache/bws_cache.enc.json.  The file holds
+# only the secret VALUES, never the access token (the token only derives the
+# local encryption key).  Plaintext is never written: a legacy plaintext
+# bws_cache.json from an older Hermes is re-encrypted and removed on first
+# read (_migrate_legacy_plaintext_cache). The atomic-write/0600/TTL mechanics
 # live in agent.secret_sources._cache.DiskCache, shared with the other backends.
 _DISK_CACHE_BASENAME = "bws_cache.json"
 _ENCRYPTED_CACHE_BASENAME = "bws_cache.enc.json"
@@ -493,6 +494,43 @@ def _read_encrypted_disk_cache(
         return None
 
 
+def _migrate_legacy_plaintext_cache(
+    *,
+    cache_key: _CacheKey,
+    access_token: str,
+    max_age_seconds: float,
+    home_path: Optional[Path] = None,
+) -> Optional[_CachedFetch]:
+    """Re-encrypt a legacy plaintext cache entry and return it.
+
+    Older Hermes versions persisted the cross-process cache as plaintext
+    ``bws_cache.json``.  With the encrypted-only policy, a leftover
+    plaintext file is migrated on first read: the entry is read from the
+    legacy DiskCache (honoring ``max_age_seconds``), written to the
+    encrypted cache — whose writer removes the plaintext file on success
+    (see ``_write_encrypted_disk_cache``) — and returned to the caller so
+    the cached values are served without a live fetch.
+
+    Returns None when there is no legacy plaintext entry for ``cache_key``
+    (or it is outside ``max_age_seconds``); the caller then falls through
+    to a live fetch.  Best-effort by design: a migration failure is
+    treated as a plain cache miss and never raises.
+    """
+    try:
+        legacy = _DISK_CACHE.read(cache_key, max_age_seconds, home_path)
+        if legacy is None:
+            return None
+        _write_encrypted_disk_cache(
+            cache_key=cache_key,
+            access_token=access_token,
+            entry=legacy,
+            home_path=home_path,
+        )
+        return legacy
+    except Exception:  # noqa: BLE001 — migration must never block startup
+        return None
+
+
 def fetch_bitwarden_secrets(
     *,
     access_token: str,
@@ -502,7 +540,7 @@ def fetch_bitwarden_secrets(
     use_cache: bool = True,
     server_url: str = "",
     home_path: Optional[Path] = None,
-    encrypted_cache_enabled: bool = False,
+    encrypted_cache_enabled: bool = True,
     encrypted_cache_max_stale_seconds: float = 0,
 ) -> Tuple[Dict[str, str], List[str]]:
     """Pull the secrets for ``project_id`` from Bitwarden Secrets Manager.
@@ -515,13 +553,15 @@ def fetch_bitwarden_secrets(
     (``https://vault.bitwarden.com``, US Cloud).  This is plumbed into
     the subprocess as ``BWS_SERVER_URL``.
 
-    ``cache_ttl_seconds`` controls the normal fresh cache.  When
-    ``encrypted_cache_enabled`` is true, fresh cache entries are written as
-    AES-GCM encrypted JSON instead of plaintext, and a last-good encrypted
-    entry may be used after NETWORK/TIMEOUT failures for up to
-    ``encrypted_cache_max_stale_seconds``.  This stale fallback is separate
-    from the fresh-cache TTL so operators can set ``cache_ttl_seconds: 0``
-    while still keeping an encrypted break-glass cache for offline startup.
+    ``cache_ttl_seconds`` controls the normal fresh cache.  The disk cache is
+    ALWAYS AES-GCM encrypted (``encrypted_cache_enabled`` defaults to True):
+    secret values are never persisted as plaintext.  A legacy plaintext
+    ``bws_cache.json`` from an older Hermes is re-encrypted and removed on
+    first read.  On NETWORK/TIMEOUT failures, a last-good encrypted entry may
+    be used for up to ``encrypted_cache_max_stale_seconds``.  This stale
+    fallback is separate from the fresh-cache TTL so operators can set
+    ``cache_ttl_seconds: 0`` while still keeping an encrypted break-glass
+    cache for offline startup.
 
     Raises :class:`RuntimeError` for fatal conditions (missing binary,
     auth failure, unparseable output).  Callers in the env_loader path
@@ -539,6 +579,12 @@ def fetch_bitwarden_secrets(
         if cached and cached.is_fresh(cache_ttl_seconds):
             return cached.secrets, []
         # L2: disk cache. ~5ms on cache hit vs ~380ms for `bws secret list`.
+        # Encrypted-only storage policy: with encryption enabled (the
+        # default) we read the encrypted cache; a legacy plaintext entry
+        # from an older Hermes is migrated (re-encrypted + removed) on
+        # the way out.  With encryption disabled there is NO disk read at
+        # all — plaintext is never consulted.
+        disk_cached = None
         if encrypted_cache_enabled:
             disk_cached = _read_encrypted_disk_cache(
                 cache_key=cache_key,
@@ -546,8 +592,13 @@ def fetch_bitwarden_secrets(
                 max_age_seconds=cache_ttl_seconds,
                 home_path=home_path,
             )
-        else:
-            disk_cached = _DISK_CACHE.read(cache_key, cache_ttl_seconds, home_path)
+            if disk_cached is None:
+                disk_cached = _migrate_legacy_plaintext_cache(
+                    cache_key=cache_key,
+                    access_token=access_token,
+                    max_age_seconds=cache_ttl_seconds,
+                    home_path=home_path,
+                )
         if disk_cached is not None:
             # Promote into in-process cache so subsequent fetches in the
             # same process skip the disk read too.
@@ -574,43 +625,45 @@ def fetch_bitwarden_secrets(
         # fallback a fleet of bots sharing one BWS project all stop working
         # on a single network blip.
         #
-        # Two fallback tiers share the transport-only gate:
-        # * encrypted cache (opt-in) — AES-GCM payload keyed off the
-        #   bootstrap token, with its own max_stale_seconds window.  When
-        #   enabled it is the ONLY fallback consulted: the whole point is
-        #   that the at-rest payload is never plaintext, so we don't
-        #   quietly serve the plaintext file alongside it.
-        # * plaintext disk cache (default) — the ordinary DiskCache file.
-        #   `cache_ttl_seconds <= 0` means the caller opted out of caching
-        #   entirely (DiskCache.read/write both short-circuit on it) —
-        #   honor that on the fallback path too.  `ttl_seconds=inf` on the
-        #   read bypasses freshness (we explicitly want a stale hit); the
-        #   caller's real TTL gates whether we even attempt the read.
+        # The encrypted cache is the ONLY fallback tier: the whole point is
+        # that the at-rest payload is never plaintext, so we never quietly
+        # serve a plaintext file.  When encryption is disabled there is no
+        # disk fallback at all — plaintext is never consulted.  `ttl_seconds
+        # =inf` on the stale read bypasses freshness (we explicitly want a
+        # stale hit); max_stale_seconds gates whether we attempt it.
         kind = _classify_bws_error(str(exc))
         if use_cache and kind in (ErrorKind.NETWORK, ErrorKind.TIMEOUT):
-            if encrypted_cache_enabled:
-                stale = _read_encrypted_disk_cache(
-                    cache_key=cache_key,
-                    access_token=access_token,
-                    max_age_seconds=encrypted_cache_max_stale_seconds,
-                    home_path=home_path,
-                )
-                if stale is not None:
-                    age = max(0.0, time.time() - stale.fetched_at)
-                    _CACHE[cache_key] = stale
-                    return stale.secrets, [
-                        f"bws live fetch failed ({exc}); falling back to "
-                        f"stale ENCRYPTED disk cache ({int(age)}s old)"
-                    ]
-            elif cache_ttl_seconds > 0:
-                stale = _DISK_CACHE.read(cache_key, float("inf"), home_path)
-                if stale is not None:
-                    age = max(0.0, time.time() - stale.fetched_at)
-                    _CACHE[cache_key] = stale
-                    return stale.secrets, [
-                        f"bws live fetch failed ({exc}); "
-                        f"falling back to stale disk cache ({int(age)}s old)"
-                    ]
+            if not encrypted_cache_enabled:
+                raise
+            stale = _read_encrypted_disk_cache(
+                cache_key=cache_key,
+                access_token=access_token,
+                max_age_seconds=encrypted_cache_max_stale_seconds,
+                home_path=home_path,
+            )
+            if stale is not None:
+                age = max(0.0, time.time() - stale.fetched_at)
+                _CACHE[cache_key] = stale
+                return stale.secrets, [
+                    f"bws live fetch failed ({exc}); falling back to "
+                    f"stale ENCRYPTED disk cache ({int(age)}s old)"
+                ]
+            # A legacy plaintext cache (written by an older Hermes) is
+            # migrated — re-encrypted + removed — then served, so the
+            # plaintext file does not survive the upgrade.
+            stale = _migrate_legacy_plaintext_cache(
+                cache_key=cache_key,
+                access_token=access_token,
+                max_age_seconds=float("inf"),
+                home_path=home_path,
+            )
+            if stale is not None:
+                age = max(0.0, time.time() - stale.fetched_at)
+                _CACHE[cache_key] = stale
+                return stale.secrets, [
+                    f"bws live fetch failed ({exc}); falling back to "
+                    f"stale disk cache ({int(age)}s old)"
+                ]
         raise
     entry = _CachedFetch(secrets=secrets, fetched_at=time.time())
     if use_cache:
@@ -618,16 +671,14 @@ def fetch_bitwarden_secrets(
             _CACHE[cache_key] = entry
         if encrypted_cache_enabled:
             # Encryption is the storage policy; max_stale_seconds only controls
-            # whether an outage may consume the last-good entry.  Never fall
-            # back to the plaintext cache just because stale fallback is off.
+            # whether an outage may consume the last-good entry.  Plaintext is
+            # never written to disk — there is no plaintext write branch.
             _write_encrypted_disk_cache(
                 cache_key=cache_key,
                 access_token=access_token,
                 entry=entry,
                 home_path=home_path,
             )
-        elif cache_ttl_seconds > 0:
-            _DISK_CACHE.write(cache_key, entry, cache_ttl_seconds, home_path)
     return secrets, warnings
 
 
@@ -761,7 +812,7 @@ def apply_bitwarden_secrets(
     auto_install: bool = True,
     server_url: str = "",
     home_path: Optional[Path] = None,
-    encrypted_cache_enabled: bool = False,
+    encrypted_cache_enabled: bool = True,
     encrypted_cache_max_stale_seconds: float = 0,
 ) -> FetchResult:
     """Pull secrets from BSM and set them on ``os.environ``.
@@ -889,9 +940,15 @@ class BitwardenSource(SecretSource):
                 "default": 300,
             },
             "encrypted_cache": {
-                "description": "Encrypted last-good cache for network/timeout fallback",
+                "description": (
+                    "Encrypted-only disk cache.  Enabled by default: secret "
+                    "values are persisted ONLY as AES-GCM ciphertext, never "
+                    "plaintext.  Set enabled: false to skip disk persistence "
+                    "entirely (memory cache only) — plaintext is never an "
+                    "option."
+                ),
                 "default": {
-                    "enabled": False,
+                    "enabled": True,
                     "max_stale_seconds": 0,
                 },
             },
@@ -950,7 +1007,7 @@ class BitwardenSource(SecretSource):
 
         encrypted_cfg = cfg.get("encrypted_cache")
         encrypted_cfg = encrypted_cfg if isinstance(encrypted_cfg, dict) else {}
-        encrypted_enabled = bool(encrypted_cfg.get("enabled", False))
+        encrypted_enabled = bool(encrypted_cfg.get("enabled", True))
         try:
             encrypted_max_stale = float(encrypted_cfg.get("max_stale_seconds", 0))
         except (TypeError, ValueError):

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -390,11 +390,15 @@ def _write_encrypted_disk_cache(
     access_token: str,
     entry: _CachedFetch,
     home_path: Optional[Path] = None,
-) -> None:
+) -> bool:
     """Persist an encrypted last-good cache entry atomically.
 
     Best-effort by design: cache write failure must never block a fresh BWS
     fetch.  The raw BWS access token is not stored; it only derives the AES key.
+
+    Returns True when the encrypted write (and legacy-plaintext removal on
+    success) completed; False when a non-fatal error was swallowed so callers
+    can decide whether to trust the migration.
     """
     path = _encrypted_disk_cache_path(home_path)
     try:
@@ -438,6 +442,7 @@ def _write_encrypted_disk_cache(
                 pass
             except OSError:
                 pass
+            return True
         except BaseException:
             try:
                 os.unlink(tmp)
@@ -445,7 +450,7 @@ def _write_encrypted_disk_cache(
                 pass
             raise
     except Exception:  # noqa: BLE001 — best-effort cache only
-        return
+        return False
 
 
 def _read_encrypted_disk_cache(
@@ -520,15 +525,31 @@ def _migrate_legacy_plaintext_cache(
         legacy = _DISK_CACHE.read(cache_key, max_age_seconds, home_path)
         if legacy is None:
             return None
-        _write_encrypted_disk_cache(
+        if _write_encrypted_disk_cache(
             cache_key=cache_key,
             access_token=access_token,
             entry=legacy,
             home_path=home_path,
-        )
-        return legacy
+        ):
+            return legacy
+        return None
     except Exception:  # noqa: BLE001 — migration must never block startup
         return None
+
+
+def _remove_legacy_plaintext_cache(home_path: Optional[Path] = None) -> None:
+    """Delete the legacy plaintext bws_cache.json if it exists.
+
+    Best-effort: never raises.  Called when encryption is explicitly
+    disabled to ensure a pre-upgrade plaintext cache does not survive
+    the encrypted-only policy.
+    """
+    try:
+        _disk_cache_path(home_path).unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
 
 
 def fetch_bitwarden_secrets(
@@ -583,7 +604,9 @@ def fetch_bitwarden_secrets(
         # default) we read the encrypted cache; a legacy plaintext entry
         # from an older Hermes is migrated (re-encrypted + removed) on
         # the way out.  With encryption disabled there is NO disk read at
-        # all — plaintext is never consulted.
+        # all — plaintext is never consulted.  The legacy plaintext file
+        # is still removed so it does not survive the upgrade even when
+        # the user explicitly opted out of disk persistence.
         disk_cached = None
         if encrypted_cache_enabled:
             disk_cached = _read_encrypted_disk_cache(
@@ -599,6 +622,10 @@ def fetch_bitwarden_secrets(
                     max_age_seconds=cache_ttl_seconds,
                     home_path=home_path,
                 )
+        else:
+            # Memory-only mode: the legacy plaintext cache must still be
+            # removed so a pre-upgrade bws_cache.json does not survive.
+            _remove_legacy_plaintext_cache(home_path)
         if disk_cached is not None:
             # Promote into in-process cache so subsequent fetches in the
             # same process skip the disk read too.
@@ -634,6 +661,10 @@ def fetch_bitwarden_secrets(
         kind = _classify_bws_error(str(exc))
         if use_cache and kind in (ErrorKind.NETWORK, ErrorKind.TIMEOUT):
             if not encrypted_cache_enabled:
+                # Memory-only mode: the legacy plaintext cache is never
+                # consulted, but it must still be removed so it does not
+                # survive the upgrade.
+                _remove_legacy_plaintext_cache(home_path)
                 raise
             stale = _read_encrypted_disk_cache(
                 cache_key=cache_key,
@@ -650,11 +681,13 @@ def fetch_bitwarden_secrets(
                 ]
             # A legacy plaintext cache (written by an older Hermes) is
             # migrated — re-encrypted + removed — then served, so the
-            # plaintext file does not survive the upgrade.
+            # plaintext file does not survive the upgrade.  The same
+            # max_stale_seconds bound applies: arbitrarily old plaintext
+            # must not be served when a stale limit is configured.
             stale = _migrate_legacy_plaintext_cache(
                 cache_key=cache_key,
                 access_token=access_token,
-                max_age_seconds=float("inf"),
+                max_age_seconds=encrypted_cache_max_stale_seconds,
                 home_path=home_path,
             )
             if stale is not None:

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -436,12 +436,15 @@ def _write_encrypted_disk_cache(
             os.replace(tmp, path)
             # A successful encrypted write completes migration; remove the
             # legacy plaintext cache so stale secrets cannot remain on disk.
+            # If the legacy file cannot be removed, the migration is NOT
+            # complete — report failure so callers never serve a value whose
+            # plaintext copy is still at rest.
             try:
                 _disk_cache_path(home_path).unlink()
             except FileNotFoundError:
                 pass
             except OSError:
-                pass
+                return False
             return True
         except BaseException:
             try:
@@ -661,10 +664,6 @@ def fetch_bitwarden_secrets(
         kind = _classify_bws_error(str(exc))
         if use_cache and kind in (ErrorKind.NETWORK, ErrorKind.TIMEOUT):
             if not encrypted_cache_enabled:
-                # Memory-only mode: the legacy plaintext cache is never
-                # consulted, but it must still be removed so it does not
-                # survive the upgrade.
-                _remove_legacy_plaintext_cache(home_path)
                 raise
             stale = _read_encrypted_disk_cache(
                 cache_key=cache_key,
@@ -697,6 +696,11 @@ def fetch_bitwarden_secrets(
                     f"bws live fetch failed ({exc}); falling back to "
                     f"stale disk cache ({int(age)}s old)"
                 ]
+        if not encrypted_cache_enabled:
+            # Memory-only mode: the legacy plaintext cache is never consulted,
+            # but it must still be removed so it does not survive the upgrade —
+            # independently of cache TTL / use-cache settings.
+            _remove_legacy_plaintext_cache(home_path)
         raise
     entry = _CachedFetch(secrets=secrets, fetched_at=time.time())
     if use_cache:
@@ -712,6 +716,11 @@ def fetch_bitwarden_secrets(
                 entry=entry,
                 home_path=home_path,
             )
+    # The encrypted-only policy removes a pre-upgrade plaintext cache
+    # independently of cache TTL / use-cache settings: even a zero TTL or a
+    # fully bypassed cache must not leave bws_cache.json at rest after a
+    # successful live fetch.
+    _remove_legacy_plaintext_cache(home_path)
     return secrets, warnings
 
 

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -393,11 +393,15 @@ def _write_encrypted_disk_cache(
     access_token: str,
     entry: _CachedFetch,
     home_path: Optional[Path] = None,
-) -> None:
+) -> bool:
     """Persist an encrypted last-good cache entry atomically.
 
     Best-effort by design: cache write failure must never block a fresh BWS
     fetch.  The raw BWS access token is not stored; it only derives the AES key.
+
+    Returns True when the encrypted write (and legacy-plaintext removal on
+    success) completed; False when a non-fatal error was swallowed so callers
+    can decide whether to trust the migration.
     """
     path = _encrypted_disk_cache_path(home_path)
     try:
@@ -443,6 +447,7 @@ def _write_encrypted_disk_cache(
                 pass
             except OSError:
                 pass
+            return True
         except BaseException:
             try:
                 os.unlink(tmp)
@@ -450,7 +455,7 @@ def _write_encrypted_disk_cache(
                 pass
             raise
     except Exception:  # noqa: BLE001 — best-effort cache only
-        return
+        return False
 
 
 def _read_encrypted_disk_cache(
@@ -527,15 +532,31 @@ def _migrate_legacy_plaintext_cache(
         legacy = _DISK_CACHE.read(cache_key, max_age_seconds, home_path)
         if legacy is None:
             return None
-        _write_encrypted_disk_cache(
+        if _write_encrypted_disk_cache(
             cache_key=cache_key,
             access_token=access_token,
             entry=legacy,
             home_path=home_path,
-        )
-        return legacy
+        ):
+            return legacy
+        return None
     except Exception:  # noqa: BLE001 — migration must never block startup
         return None
+
+
+def _remove_legacy_plaintext_cache(home_path: Optional[Path] = None) -> None:
+    """Delete the legacy plaintext bws_cache.json if it exists.
+
+    Best-effort: never raises.  Called when encryption is explicitly
+    disabled to ensure a pre-upgrade plaintext cache does not survive
+    the encrypted-only policy.
+    """
+    try:
+        _disk_cache_path(home_path).unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
 
 
 def fetch_bitwarden_secrets(
@@ -590,7 +611,9 @@ def fetch_bitwarden_secrets(
         # default) we read the encrypted cache; a legacy plaintext entry
         # from an older Hermes is migrated (re-encrypted + removed) on
         # the way out.  With encryption disabled there is NO disk read at
-        # all — plaintext is never consulted.
+        # all — plaintext is never consulted.  The legacy plaintext file
+        # is still removed so it does not survive the upgrade even when
+        # the user explicitly opted out of disk persistence.
         disk_cached = None
         if encrypted_cache_enabled:
             disk_cached = _read_encrypted_disk_cache(
@@ -606,6 +629,10 @@ def fetch_bitwarden_secrets(
                     max_age_seconds=cache_ttl_seconds,
                     home_path=home_path,
                 )
+        else:
+            # Memory-only mode: the legacy plaintext cache must still be
+            # removed so a pre-upgrade bws_cache.json does not survive.
+            _remove_legacy_plaintext_cache(home_path)
         if disk_cached is not None:
             # Promote into in-process cache so subsequent fetches in the
             # same process skip the disk read too.
@@ -641,6 +668,10 @@ def fetch_bitwarden_secrets(
         kind = _classify_bws_error(str(exc))
         if use_cache and kind in (ErrorKind.NETWORK, ErrorKind.TIMEOUT):
             if not encrypted_cache_enabled:
+                # Memory-only mode: the legacy plaintext cache is never
+                # consulted, but it must still be removed so it does not
+                # survive the upgrade.
+                _remove_legacy_plaintext_cache(home_path)
                 raise
             stale = _read_encrypted_disk_cache(
                 cache_key=cache_key,
@@ -657,11 +688,13 @@ def fetch_bitwarden_secrets(
                 ]
             # A legacy plaintext cache (written by an older Hermes) is
             # migrated — re-encrypted + removed — then served, so the
-            # plaintext file does not survive the upgrade.
+            # plaintext file does not survive the upgrade.  The same
+            # max_stale_seconds bound applies: arbitrarily old plaintext
+            # must not be served when a stale limit is configured.
             stale = _migrate_legacy_plaintext_cache(
                 cache_key=cache_key,
                 access_token=access_token,
-                max_age_seconds=float("inf"),
+                max_age_seconds=encrypted_cache_max_stale_seconds,
                 home_path=home_path,
             )
             if stale is not None:

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -441,12 +441,15 @@ def _write_encrypted_disk_cache(
             os.replace(tmp, path)
             # A successful encrypted write completes migration; remove the
             # legacy plaintext cache so stale secrets cannot remain on disk.
+            # If the legacy file cannot be removed, the migration is NOT
+            # complete — report failure so callers never serve a value whose
+            # plaintext copy is still at rest.
             try:
                 _disk_cache_path(home_path).unlink()
             except FileNotFoundError:
                 pass
             except OSError:
-                pass
+                return False
             return True
         except BaseException:
             try:
@@ -668,10 +671,6 @@ def fetch_bitwarden_secrets(
         kind = _classify_bws_error(str(exc))
         if use_cache and kind in (ErrorKind.NETWORK, ErrorKind.TIMEOUT):
             if not encrypted_cache_enabled:
-                # Memory-only mode: the legacy plaintext cache is never
-                # consulted, but it must still be removed so it does not
-                # survive the upgrade.
-                _remove_legacy_plaintext_cache(home_path)
                 raise
             stale = _read_encrypted_disk_cache(
                 cache_key=cache_key,
@@ -704,6 +703,11 @@ def fetch_bitwarden_secrets(
                     f"bws live fetch failed ({exc}); falling back to "
                     f"stale disk cache ({int(age)}s old)"
                 ]
+        if not encrypted_cache_enabled:
+            # Memory-only mode: the legacy plaintext cache is never consulted,
+            # but it must still be removed so it does not survive the upgrade —
+            # independently of cache TTL / use-cache settings.
+            _remove_legacy_plaintext_cache(home_path)
         raise
     entry = _CachedFetch(secrets=secrets, fetched_at=time.time())
     if use_cache:
@@ -719,6 +723,11 @@ def fetch_bitwarden_secrets(
                 entry=entry,
                 home_path=home_path,
             )
+    # The encrypted-only policy removes a pre-upgrade plaintext cache
+    # independently of cache TTL / use-cache settings: even a zero TTL or a
+    # fully bypassed cache must not leave bws_cache.json at rest after a
+    # successful live fetch.
+    _remove_legacy_plaintext_cache(home_path)
     return secrets, warnings
 
 

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -87,11 +87,12 @@ _CACHE: Dict[_CacheKey, _CachedFetch] = {}
 # ~380ms `bws secret list` tax. The in-process _CACHE above only saves repeated
 # fetches WITHIN one process; this saves repeated fetches ACROSS processes.
 #
-# Layout: one JSON object per cache key, written atomically with mode 0600 in
-# <hermes_home>/cache/bws_cache.json. The file holds only the secret VALUES,
-# never the access token. It's plaintext-equivalent to ~/.hermes/.env (which
-# we already accept) but kept out of the .env file so users editing it won't
-# accidentally commit BSM-sourced secrets. The atomic-write/0600/TTL mechanics
+# Layout: one AES-GCM encrypted JSON object per cache key, written atomically
+# with mode 0600 in <hermes_home>/cache/bws_cache.enc.json.  The file holds
+# only the secret VALUES, never the access token (the token only derives the
+# local encryption key).  Plaintext is never written: a legacy plaintext
+# bws_cache.json from an older Hermes is re-encrypted and removed on first
+# read (_migrate_legacy_plaintext_cache). The atomic-write/0600/TTL mechanics
 # live in agent.secret_sources._cache.DiskCache, shared with the other backends.
 _DISK_CACHE_BASENAME = "bws_cache.json"
 _ENCRYPTED_CACHE_BASENAME = "bws_cache.enc.json"
@@ -500,6 +501,43 @@ def _read_encrypted_disk_cache(
         return None
 
 
+def _migrate_legacy_plaintext_cache(
+    *,
+    cache_key: _CacheKey,
+    access_token: str,
+    max_age_seconds: float,
+    home_path: Optional[Path] = None,
+) -> Optional[_CachedFetch]:
+    """Re-encrypt a legacy plaintext cache entry and return it.
+
+    Older Hermes versions persisted the cross-process cache as plaintext
+    ``bws_cache.json``.  With the encrypted-only policy, a leftover
+    plaintext file is migrated on first read: the entry is read from the
+    legacy DiskCache (honoring ``max_age_seconds``), written to the
+    encrypted cache — whose writer removes the plaintext file on success
+    (see ``_write_encrypted_disk_cache``) — and returned to the caller so
+    the cached values are served without a live fetch.
+
+    Returns None when there is no legacy plaintext entry for ``cache_key``
+    (or it is outside ``max_age_seconds``); the caller then falls through
+    to a live fetch.  Best-effort by design: a migration failure is
+    treated as a plain cache miss and never raises.
+    """
+    try:
+        legacy = _DISK_CACHE.read(cache_key, max_age_seconds, home_path)
+        if legacy is None:
+            return None
+        _write_encrypted_disk_cache(
+            cache_key=cache_key,
+            access_token=access_token,
+            entry=legacy,
+            home_path=home_path,
+        )
+        return legacy
+    except Exception:  # noqa: BLE001 — migration must never block startup
+        return None
+
+
 def fetch_bitwarden_secrets(
     *,
     access_token: str,
@@ -509,7 +547,7 @@ def fetch_bitwarden_secrets(
     use_cache: bool = True,
     server_url: str = "",
     home_path: Optional[Path] = None,
-    encrypted_cache_enabled: bool = False,
+    encrypted_cache_enabled: bool = True,
     encrypted_cache_max_stale_seconds: float = 0,
 ) -> Tuple[Dict[str, str], List[str]]:
     """Pull the secrets for ``project_id`` from Bitwarden Secrets Manager.
@@ -522,13 +560,15 @@ def fetch_bitwarden_secrets(
     (``https://vault.bitwarden.com``, US Cloud).  This is plumbed into
     the subprocess as ``BWS_SERVER_URL``.
 
-    ``cache_ttl_seconds`` controls the normal fresh cache.  When
-    ``encrypted_cache_enabled`` is true, fresh cache entries are written as
-    AES-GCM encrypted JSON instead of plaintext, and a last-good encrypted
-    entry may be used after NETWORK/TIMEOUT failures for up to
-    ``encrypted_cache_max_stale_seconds``.  This stale fallback is separate
-    from the fresh-cache TTL so operators can set ``cache_ttl_seconds: 0``
-    while still keeping an encrypted break-glass cache for offline startup.
+    ``cache_ttl_seconds`` controls the normal fresh cache.  The disk cache is
+    ALWAYS AES-GCM encrypted (``encrypted_cache_enabled`` defaults to True):
+    secret values are never persisted as plaintext.  A legacy plaintext
+    ``bws_cache.json`` from an older Hermes is re-encrypted and removed on
+    first read.  On NETWORK/TIMEOUT failures, a last-good encrypted entry may
+    be used for up to ``encrypted_cache_max_stale_seconds``.  This stale
+    fallback is separate from the fresh-cache TTL so operators can set
+    ``cache_ttl_seconds: 0`` while still keeping an encrypted break-glass
+    cache for offline startup.
 
     Raises :class:`RuntimeError` for fatal conditions (missing binary,
     auth failure, unparseable output).  Callers in the env_loader path
@@ -546,6 +586,12 @@ def fetch_bitwarden_secrets(
         if cached and cached.is_fresh(cache_ttl_seconds):
             return cached.secrets, []
         # L2: disk cache. ~5ms on cache hit vs ~380ms for `bws secret list`.
+        # Encrypted-only storage policy: with encryption enabled (the
+        # default) we read the encrypted cache; a legacy plaintext entry
+        # from an older Hermes is migrated (re-encrypted + removed) on
+        # the way out.  With encryption disabled there is NO disk read at
+        # all — plaintext is never consulted.
+        disk_cached = None
         if encrypted_cache_enabled:
             disk_cached = _read_encrypted_disk_cache(
                 cache_key=cache_key,
@@ -553,8 +599,13 @@ def fetch_bitwarden_secrets(
                 max_age_seconds=cache_ttl_seconds,
                 home_path=home_path,
             )
-        else:
-            disk_cached = _DISK_CACHE.read(cache_key, cache_ttl_seconds, home_path)
+            if disk_cached is None:
+                disk_cached = _migrate_legacy_plaintext_cache(
+                    cache_key=cache_key,
+                    access_token=access_token,
+                    max_age_seconds=cache_ttl_seconds,
+                    home_path=home_path,
+                )
         if disk_cached is not None:
             # Promote into in-process cache so subsequent fetches in the
             # same process skip the disk read too.
@@ -581,43 +632,45 @@ def fetch_bitwarden_secrets(
         # fallback a fleet of bots sharing one BWS project all stop working
         # on a single network blip.
         #
-        # Two fallback tiers share the transport-only gate:
-        # * encrypted cache (opt-in) — AES-GCM payload keyed off the
-        #   bootstrap token, with its own max_stale_seconds window.  When
-        #   enabled it is the ONLY fallback consulted: the whole point is
-        #   that the at-rest payload is never plaintext, so we don't
-        #   quietly serve the plaintext file alongside it.
-        # * plaintext disk cache (default) — the ordinary DiskCache file.
-        #   `cache_ttl_seconds <= 0` means the caller opted out of caching
-        #   entirely (DiskCache.read/write both short-circuit on it) —
-        #   honor that on the fallback path too.  `ttl_seconds=inf` on the
-        #   read bypasses freshness (we explicitly want a stale hit); the
-        #   caller's real TTL gates whether we even attempt the read.
+        # The encrypted cache is the ONLY fallback tier: the whole point is
+        # that the at-rest payload is never plaintext, so we never quietly
+        # serve a plaintext file.  When encryption is disabled there is no
+        # disk fallback at all — plaintext is never consulted.  `ttl_seconds
+        # =inf` on the stale read bypasses freshness (we explicitly want a
+        # stale hit); max_stale_seconds gates whether we attempt it.
         kind = _classify_bws_error(str(exc))
         if use_cache and kind in (ErrorKind.NETWORK, ErrorKind.TIMEOUT):
-            if encrypted_cache_enabled:
-                stale = _read_encrypted_disk_cache(
-                    cache_key=cache_key,
-                    access_token=access_token,
-                    max_age_seconds=encrypted_cache_max_stale_seconds,
-                    home_path=home_path,
-                )
-                if stale is not None:
-                    age = max(0.0, time.time() - stale.fetched_at)
-                    _CACHE[cache_key] = stale
-                    return stale.secrets, [
-                        f"bws live fetch failed ({exc}); falling back to "
-                        f"stale ENCRYPTED disk cache ({int(age)}s old)"
-                    ]
-            elif cache_ttl_seconds > 0:
-                stale = _DISK_CACHE.read(cache_key, float("inf"), home_path)
-                if stale is not None:
-                    age = max(0.0, time.time() - stale.fetched_at)
-                    _CACHE[cache_key] = stale
-                    return stale.secrets, [
-                        f"bws live fetch failed ({exc}); "
-                        f"falling back to stale disk cache ({int(age)}s old)"
-                    ]
+            if not encrypted_cache_enabled:
+                raise
+            stale = _read_encrypted_disk_cache(
+                cache_key=cache_key,
+                access_token=access_token,
+                max_age_seconds=encrypted_cache_max_stale_seconds,
+                home_path=home_path,
+            )
+            if stale is not None:
+                age = max(0.0, time.time() - stale.fetched_at)
+                _CACHE[cache_key] = stale
+                return stale.secrets, [
+                    f"bws live fetch failed ({exc}); falling back to "
+                    f"stale ENCRYPTED disk cache ({int(age)}s old)"
+                ]
+            # A legacy plaintext cache (written by an older Hermes) is
+            # migrated — re-encrypted + removed — then served, so the
+            # plaintext file does not survive the upgrade.
+            stale = _migrate_legacy_plaintext_cache(
+                cache_key=cache_key,
+                access_token=access_token,
+                max_age_seconds=float("inf"),
+                home_path=home_path,
+            )
+            if stale is not None:
+                age = max(0.0, time.time() - stale.fetched_at)
+                _CACHE[cache_key] = stale
+                return stale.secrets, [
+                    f"bws live fetch failed ({exc}); falling back to "
+                    f"stale disk cache ({int(age)}s old)"
+                ]
         raise
     entry = _CachedFetch(secrets=secrets, fetched_at=time.time())
     if use_cache:
@@ -625,16 +678,14 @@ def fetch_bitwarden_secrets(
             _CACHE[cache_key] = entry
         if encrypted_cache_enabled:
             # Encryption is the storage policy; max_stale_seconds only controls
-            # whether an outage may consume the last-good entry.  Never fall
-            # back to the plaintext cache just because stale fallback is off.
+            # whether an outage may consume the last-good entry.  Plaintext is
+            # never written to disk — there is no plaintext write branch.
             _write_encrypted_disk_cache(
                 cache_key=cache_key,
                 access_token=access_token,
                 entry=entry,
                 home_path=home_path,
             )
-        elif cache_ttl_seconds > 0:
-            _DISK_CACHE.write(cache_key, entry, cache_ttl_seconds, home_path)
     return secrets, warnings
 
 
@@ -768,7 +819,7 @@ def apply_bitwarden_secrets(
     auto_install: bool = True,
     server_url: str = "",
     home_path: Optional[Path] = None,
-    encrypted_cache_enabled: bool = False,
+    encrypted_cache_enabled: bool = True,
     encrypted_cache_max_stale_seconds: float = 0,
 ) -> FetchResult:
     """Pull secrets from BSM and set them on ``os.environ``.
@@ -896,9 +947,15 @@ class BitwardenSource(SecretSource):
                 "default": 300,
             },
             "encrypted_cache": {
-                "description": "Encrypted last-good cache for network/timeout fallback",
+                "description": (
+                    "Encrypted-only disk cache.  Enabled by default: secret "
+                    "values are persisted ONLY as AES-GCM ciphertext, never "
+                    "plaintext.  Set enabled: false to skip disk persistence "
+                    "entirely (memory cache only) — plaintext is never an "
+                    "option."
+                ),
                 "default": {
-                    "enabled": False,
+                    "enabled": True,
                     "max_stale_seconds": 0,
                 },
             },
@@ -957,7 +1014,7 @@ class BitwardenSource(SecretSource):
 
         encrypted_cfg = cfg.get("encrypted_cache")
         encrypted_cfg = encrypted_cfg if isinstance(encrypted_cfg, dict) else {}
-        encrypted_enabled = bool(encrypted_cfg.get("enabled", False))
+        encrypted_enabled = bool(encrypted_cfg.get("enabled", True))
         try:
             encrypted_max_stale = float(encrypted_cfg.get("max_stale_seconds", 0))
         except (TypeError, ValueError):

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1639,9 +1639,9 @@ updates:
 #     project_id: ""                       # UUID of the BSM project to sync
 #     server_url: ""                       # "" = US Cloud; EU/self-hosted URL otherwise
 #     cache_ttl_seconds: 300               # 0 disables fresh caching
-#     encrypted_cache:                     # optional encrypted stale fallback
-#       enabled: false
-#       max_stale_seconds: 0               # 0 disables stale fallback
+#     encrypted_cache:                     # encrypted-only disk cache (enabled by default)
+#       enabled: true
+#       max_stale_seconds: 0               # 0 disables stale fallback; set >0 for offline resilience
 #     override_existing: true              # BSM values win over existing env
 #     auto_install: true                   # lazy-download bws into ~/.hermes/bin
 #

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1853,9 +1853,9 @@ updates:
 #     project_id: ""                       # UUID of the BSM project to sync
 #     server_url: ""                       # "" = US Cloud; EU/self-hosted URL otherwise
 #     cache_ttl_seconds: 300               # 0 disables fresh caching
-#     encrypted_cache:                     # optional encrypted stale fallback
-#       enabled: false
-#       max_stale_seconds: 0               # 0 disables stale fallback
+#     encrypted_cache:                     # encrypted-only disk cache (enabled by default)
+#       enabled: true
+#       max_stale_seconds: 0               # 0 disables stale fallback; set >0 for offline resilience
 #     override_existing: true              # BSM values win over existing env
 #     auto_install: true                   # lazy-download bws into ~/.hermes/bin
 #

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2861,13 +2861,15 @@ DEFAULT_CONFIG = {
             # Seconds to reuse a fresh disk/memory cache entry before contacting
             # Bitwarden again. 0 disables normal fresh-cache reuse.
             "cache_ttl_seconds": 300,
-            # Optional encrypted last-good fallback for network/timeout outages.
-            # When enabled, successful BWS fetches write AES-GCM encrypted cache
-            # material under ~/.hermes/cache/. If a later startup cannot reach
-            # Bitwarden due to NETWORK/TIMEOUT, Hermes may use this encrypted
-            # cache for up to max_stale_seconds. Auth failures do not fall back.
+            # Encrypted-only disk cache.  Enabled by default: BWS values are
+            # persisted ONLY as AES-GCM ciphertext under ~/.hermes/cache/,
+            # never plaintext.  A legacy plaintext bws_cache.json from an
+            # older Hermes is re-encrypted and removed on first read.
+            # max_stale_seconds: on NETWORK/TIMEOUT failures, use the
+            # last-good encrypted cache for up to this many seconds.  Auth
+            # failures never fall back.
             "encrypted_cache": {
-                "enabled": False,
+                "enabled": True,
                 "max_stale_seconds": 0,
             },
             # When True, BSM values overwrite existing env vars.  Default

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3172,13 +3172,15 @@ DEFAULT_CONFIG = {
             # Seconds to reuse a fresh disk/memory cache entry before contacting
             # Bitwarden again. 0 disables normal fresh-cache reuse.
             "cache_ttl_seconds": 300,
-            # Optional encrypted last-good fallback for network/timeout outages.
-            # When enabled, successful BWS fetches write AES-GCM encrypted cache
-            # material under ~/.hermes/cache/. If a later startup cannot reach
-            # Bitwarden due to NETWORK/TIMEOUT, Hermes may use this encrypted
-            # cache for up to max_stale_seconds. Auth failures do not fall back.
+            # Encrypted-only disk cache.  Enabled by default: BWS values are
+            # persisted ONLY as AES-GCM ciphertext under ~/.hermes/cache/,
+            # never plaintext.  A legacy plaintext bws_cache.json from an
+            # older Hermes is re-encrypted and removed on first read.
+            # max_stale_seconds: on NETWORK/TIMEOUT failures, use the
+            # last-good encrypted cache for up to this many seconds.  Auth
+            # failures never fall back.
             "encrypted_cache": {
-                "enabled": False,
+                "enabled": True,
                 "max_stale_seconds": 0,
             },
             # When True, BSM values overwrite existing env vars.  Default

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -434,6 +434,120 @@ def test_encrypted_cache_falls_back_on_network_error(monkeypatch, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Encrypted-only storage policy (default) + legacy plaintext migration
+# ---------------------------------------------------------------------------
+
+
+def test_default_cache_storage_is_encrypted_only(monkeypatch, tmp_path):
+    """With the default config (no encrypted_cache section), secrets are
+    persisted ONLY in the encrypted cache file — the plaintext bws_cache.json
+    must never be written."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("", encoding="utf-8")
+    payload = _fake_bws_payload([{"key": "K1", "value": "secret-value"}])
+
+    monkeypatch.setattr(
+        bw.subprocess,
+        "run",
+        lambda *a, **kw: mock.Mock(returncode=0, stdout=payload, stderr=""),
+    )
+    bw._reset_cache_for_tests(home)
+
+    secrets, warnings = bw.fetch_bitwarden_secrets(
+        access_token="0.t", project_id="proj-1", binary=fake_binary,
+        cache_ttl_seconds=300, home_path=home,
+    )
+
+    assert secrets == {"K1": "secret-value"}
+    assert warnings == []
+    # Plaintext file must not exist at all under the default policy.
+    assert not bw._disk_cache_path(home).exists()
+    enc_path = bw._encrypted_disk_cache_path(home)
+    assert enc_path.exists()
+    assert "secret-value" not in enc_path.read_text(encoding="utf-8")
+
+
+def test_legacy_plaintext_cache_migrated_to_encrypted(monkeypatch, tmp_path):
+    """A pre-existing plaintext bws_cache.json (written by an older Hermes)
+    is re-encrypted and removed on the first default-config fetch.  The
+    migrated value is served without a live fetch (a cache hit is a cache
+    hit), and the plaintext file is deleted."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("", encoding="utf-8")
+    bw._reset_cache_for_tests(home)
+
+    # Simulate a plaintext cache written by an older Hermes version.
+    legacy_key = (bw._token_fingerprint("0.t"), "proj-1", "")
+    bw._DISK_CACHE.write(
+        legacy_key,
+        bw._CachedFetch(secrets={"K1": "legacy"}, fetched_at=time.time()),
+        300,
+        home,
+    )
+    assert bw._disk_cache_path(home).exists()
+
+    # No live bws call should happen — the migrated entry is served directly.
+    monkeypatch.setattr(
+        bw.subprocess, "run",
+        lambda *a, **kw: (_ for _ in ()).throw(
+            AssertionError("live bws call should not run when a fresh "
+                           "migrated cache entry is served")),
+    )
+
+    secrets, warnings = bw.fetch_bitwarden_secrets(
+        access_token="0.t", project_id="proj-1", binary=fake_binary,
+        cache_ttl_seconds=300, home_path=home,
+    )
+    assert secrets == {"K1": "legacy"}
+    assert warnings == []
+    # Legacy plaintext file is gone; only the encrypted cache remains.
+    assert not bw._disk_cache_path(home).exists()
+    enc_path = bw._encrypted_disk_cache_path(home)
+    assert enc_path.exists()
+    assert "legacy" not in enc_path.read_text(encoding="utf-8")
+
+
+def test_legacy_plaintext_cache_served_and_migrated_on_offline_start(
+    monkeypatch, tmp_path
+):
+    """When the live fetch fails (offline start) and only a stale legacy
+    plaintext cache exists, the stale value is served AND re-encrypted so the
+    plaintext file is removed."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("", encoding="utf-8")
+    bw._reset_cache_for_tests(home)
+
+    # Stale legacy plaintext: fetched an hour ago, TTL is 300s.
+    _seed_stale_disk_cache(home, secrets={"K1": "legacy"}, age_seconds=3600)
+    assert bw._disk_cache_path(home).exists()
+
+    def fail_run(*a, **kw):
+        return mock.Mock(returncode=1, stdout="",
+                         stderr="Error: network is unreachable")
+    monkeypatch.setattr(bw.subprocess, "run", fail_run)
+
+    secrets, warnings = bw.fetch_bitwarden_secrets(
+        access_token="0.t", project_id="proj-1", binary=fake_binary,
+        cache_ttl_seconds=300, encrypted_cache_max_stale_seconds=604800,
+        home_path=home,
+    )
+    assert secrets == {"K1": "legacy"}
+    assert len(warnings) == 1
+    assert "stale disk cache" in warnings[0]
+    # The legacy plaintext was migrated: file removed, encrypted cache written.
+    assert not bw._disk_cache_path(home).exists()
+    enc_path = bw._encrypted_disk_cache_path(home)
+    assert enc_path.exists()
+    assert "legacy" not in enc_path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
 # Stale disk cache fallback when live bws fetch fails
 # ---------------------------------------------------------------------------
 

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -547,6 +547,127 @@ def test_legacy_plaintext_cache_served_and_migrated_on_offline_start(
     assert "legacy" not in enc_path.read_text(encoding="utf-8")
 
 
+def test_migration_skips_legacy_when_encrypted_write_fails(
+    monkeypatch, tmp_path
+):
+    """When the encrypted write/removal fails, _migrate_legacy_plaintext_cache
+    must return None — treat it as a cache miss — so the caller falls through
+    to a live fetch rather than serving a value whose plaintext file may still
+    be on disk."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    bw._reset_cache_for_tests(home)
+
+    # Seed a fresh legacy plaintext cache.
+    legacy_key = (bw._token_fingerprint("0.t"), "proj-1", "")
+    bw._DISK_CACHE.write(
+        legacy_key,
+        bw._CachedFetch(secrets={"K1": "legacy"}, fetched_at=time.time()),
+        300,
+        home,
+    )
+    assert bw._disk_cache_path(home).exists()
+
+    # Simulate an encrypted write that fails (disk full, permission, etc.).
+    monkeypatch.setattr(
+        bw, "_write_encrypted_disk_cache", lambda **kw: False,
+    )
+
+    # Direct unit test: even with a valid DiskCache entry, migration
+    # returns None when _write_encrypted_disk_cache returns False.
+    result = bw._migrate_legacy_plaintext_cache(
+        cache_key=legacy_key,
+        access_token="0.t",
+        max_age_seconds=300,
+        home_path=home,
+    )
+    assert result is None
+    assert bw._disk_cache_path(home).exists()  # plaintext still on disk
+
+
+def test_legacy_plaintext_offline_fallback_respects_stale_bound(
+    monkeypatch, tmp_path
+):
+    """Offline fallback for legacy plaintext must honor
+    encrypted_cache_max_stale_seconds, not float('inf').  A legacy entry
+    older than the configured bound must NOT be served."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("", encoding="utf-8")
+    bw._reset_cache_for_tests(home)
+
+    # Seed a very stale legacy plaintext cache (25 hours old).
+    _seed_stale_disk_cache(home, secrets={"K1": "ancient"}, age_seconds=90000)
+    assert bw._disk_cache_path(home).exists()
+
+    def fail_run(*a, **kw):
+        return mock.Mock(returncode=1, stdout="",
+                         stderr="Error: network is unreachable")
+    monkeypatch.setattr(bw.subprocess, "run", fail_run)
+
+    # max_stale_seconds=0 means NO stale fallback should serve anything.
+    with pytest.raises(RuntimeError):
+        bw.fetch_bitwarden_secrets(
+            access_token="0.t", project_id="proj-1", binary=fake_binary,
+            cache_ttl_seconds=300, encrypted_cache_max_stale_seconds=0,
+            home_path=home,
+        )
+
+    # With a generous bound, the stale legacy entry IS migrated and served.
+    bw._reset_cache_for_tests(home)
+    _seed_stale_disk_cache(home, secrets={"K1": "ancient"}, age_seconds=90000)
+    assert bw._disk_cache_path(home).exists()
+
+    secrets, warnings = bw.fetch_bitwarden_secrets(
+        access_token="0.t", project_id="proj-1", binary=fake_binary,
+        cache_ttl_seconds=300, encrypted_cache_max_stale_seconds=999999,
+        home_path=home,
+    )
+    assert secrets == {"K1": "ancient"}
+    assert len(warnings) == 1
+    assert "stale disk cache" in warnings[0]
+    assert not bw._disk_cache_path(home).exists()
+
+
+def test_legacy_plaintext_removed_when_encryption_disabled(
+    monkeypatch, tmp_path
+):
+    """With encrypted_cache_enabled=False, the legacy plaintext cache is never
+    consulted — but it must still be removed so a pre-upgrade bws_cache.json
+    does not survive the encrypted-only policy."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("", encoding="utf-8")
+    payload = _fake_bws_payload([{"key": "K1", "value": "live-value"}])
+
+    bw._reset_cache_for_tests(home)
+
+    # Seed a legacy plaintext cache from a prior version.
+    _seed_stale_disk_cache(home, secrets={"K1": "legacy"}, age_seconds=100)
+    assert bw._disk_cache_path(home).exists()
+
+    monkeypatch.setattr(
+        bw.subprocess, "run",
+        lambda *a, **kw: mock.Mock(returncode=0, stdout=payload, stderr=""),
+    )
+
+    secrets, warnings = bw.fetch_bitwarden_secrets(
+        access_token="0.t", project_id="proj-1", binary=fake_binary,
+        cache_ttl_seconds=300, encrypted_cache_enabled=False,
+        home_path=home,
+    )
+    # The live fetch succeeded; legacy plaintext is gone even though
+    # encryption was disabled (the removal happens before the live fetch).
+    assert secrets == {"K1": "live-value"}
+    assert warnings == []
+    assert not bw._disk_cache_path(home).exists()
+    # No encrypted cache written either — encryption is off.
+    enc_path = bw._encrypted_disk_cache_path(home)
+    assert not enc_path.exists()
+
+
 # ---------------------------------------------------------------------------
 # Stale disk cache fallback when live bws fetch fails
 # ---------------------------------------------------------------------------

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -713,7 +713,8 @@ def test_stale_disk_cache_returned_when_bws_fails(monkeypatch, tmp_path):
 
     secrets, warnings = bw.fetch_bitwarden_secrets(
         access_token="0.t", project_id="proj-1", binary=fake_binary,
-        cache_ttl_seconds=300, home_path=home,
+        cache_ttl_seconds=300, encrypted_cache_max_stale_seconds=7200,
+        home_path=home,
     )
     assert secrets == {"OPENAI_API_KEY": "sk-old"}
     assert len(warnings) == 1

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -668,6 +668,118 @@ def test_legacy_plaintext_removed_when_encryption_disabled(
     assert not enc_path.exists()
 
 
+def test_legacy_unlink_failure_blocks_migration(monkeypatch, tmp_path):
+    """When the legacy plaintext file cannot be removed, the encrypted write
+    must NOT report success and migration must NOT serve the legacy value —
+    the plaintext copy is still at rest (P2: unlink-error probe)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    bw._reset_cache_for_tests(home)
+
+    # Seed a fresh legacy plaintext cache.
+    legacy_key = (bw._token_fingerprint("0.t"), "proj-1", "")
+    bw._DISK_CACHE.write(
+        legacy_key,
+        bw._CachedFetch(secrets={"K1": "legacy"}, fetched_at=time.time()),
+        300,
+        home,
+    )
+    assert bw._disk_cache_path(home).exists()
+
+    # The legacy file refuses to be unlinked (permissions, AV lock, ...).
+    def _refuse_unlink(*a, **kw):
+        raise OSError(13, "Permission denied")
+    monkeypatch.setattr(
+        bw, "_disk_cache_path",
+        lambda home_path=None: mock.Mock(unlink=_refuse_unlink),
+    )
+
+    ok = bw._write_encrypted_disk_cache(
+        cache_key=legacy_key,
+        access_token="0.t",
+        entry=bw._CachedFetch(secrets={"K1": "legacy"}, fetched_at=time.time()),
+        home_path=home,
+    )
+    assert ok is False
+
+    # Migration must not serve the legacy value while the plaintext file
+    # may still be on disk.
+    migrated = bw._migrate_legacy_plaintext_cache(
+        cache_key=legacy_key,
+        access_token="0.t",
+        max_age_seconds=300,
+        home_path=home,
+    )
+    assert migrated is None
+
+
+@pytest.mark.parametrize(
+    "fetch_kwargs",
+    [
+        {"cache_ttl_seconds": 0},
+        {"use_cache": False},
+    ],
+)
+def test_legacy_plaintext_removed_after_successful_fetch_without_disk_cache(
+    monkeypatch, tmp_path, fetch_kwargs
+):
+    """A successful live fetch must remove a pre-upgrade plaintext cache even
+    when the disk cache is disabled (zero TTL) or bypassed (use_cache=False)
+    with encryption disabled — cleanup is independent of cache settings
+    (P2: zero-TTL / use-cache bypass probes)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("", encoding="utf-8")
+    payload = _fake_bws_payload([{"key": "K1", "value": "live-value"}])
+
+    bw._reset_cache_for_tests(home)
+    _seed_stale_disk_cache(home, secrets={"K1": "legacy"}, age_seconds=100)
+    assert bw._disk_cache_path(home).exists()
+
+    monkeypatch.setattr(
+        bw.subprocess, "run",
+        lambda *a, **kw: mock.Mock(returncode=0, stdout=payload, stderr=""),
+    )
+
+    secrets, warnings = bw.fetch_bitwarden_secrets(
+        access_token="0.t", project_id="proj-1", binary=fake_binary,
+        encrypted_cache_enabled=False, home_path=home, **fetch_kwargs,
+    )
+    assert secrets == {"K1": "live-value"}
+    assert warnings == []
+    assert not bw._disk_cache_path(home).exists()
+
+
+def test_legacy_plaintext_removed_when_fetch_fails_and_cache_bypassed(
+    monkeypatch, tmp_path
+):
+    """Even when the live fetch fails, a pre-upgrade plaintext cache must be
+    removed when disk persistence is disabled — the cleanup runs regardless
+    of use_cache, not only in the transport-error cache branch."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("", encoding="utf-8")
+    bw._reset_cache_for_tests(home)
+
+    _seed_stale_disk_cache(home, secrets={"K1": "legacy"}, age_seconds=100)
+    assert bw._disk_cache_path(home).exists()
+
+    def fail_run(*a, **kw):
+        return mock.Mock(returncode=1, stdout="",
+                         stderr="Error: network is unreachable")
+    monkeypatch.setattr(bw.subprocess, "run", fail_run)
+
+    with pytest.raises(RuntimeError):
+        bw.fetch_bitwarden_secrets(
+            access_token="0.t", project_id="proj-1", binary=fake_binary,
+            use_cache=False, encrypted_cache_enabled=False,
+            home_path=home,
+        )
+    assert not bw._disk_cache_path(home).exists()
+
+
 # ---------------------------------------------------------------------------
 # Stale disk cache fallback when live bws fetch fails
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/secrets/bitwarden.md
+++ b/website/docs/user-guide/secrets/bitwarden.md
@@ -106,7 +106,7 @@ secrets:
     server_url: ""
     cache_ttl_seconds: 300
     encrypted_cache:
-      enabled: false
+      enabled: true
       max_stale_seconds: 0
     override_existing: true
     auto_install: true
@@ -119,8 +119,8 @@ secrets:
 | `project_id` | `""` | UUID of the project to sync from. |
 | `server_url` | `""` | Bitwarden region or self-hosted endpoint. Empty = `bws` default (US Cloud, `https://vault.bitwarden.com`). Set to `https://vault.bitwarden.eu` for EU Cloud, or your own URL for self-hosted. Plumbed into the `bws` subprocess as `BWS_SERVER_URL`. |
 | `cache_ttl_seconds` | `300` | How long an in-process or disk fetch result is reused. Set to `0` to disable fresh-cache reuse. |
-| `encrypted_cache.enabled` | `false` | Store the last successful fetch in an AES-GCM encrypted cache at `~/.hermes/cache/bws_cache.enc.json`. |
-| `encrypted_cache.max_stale_seconds` | `0` | When encrypted caching is enabled, allow that cache to be used only after network/timeout failures, up to this age. Authentication failures never use stale secrets. A successful encrypted write removes the legacy plaintext `cache/bws_cache.json`. |
+| `encrypted_cache.enabled` | `true` | Encrypted-only disk cache (AES-GCM) at `~/.hermes/cache/bws_cache.enc.json`. Enabled by default: secret values are never persisted as plaintext. Set to `false` for memory-only mode (no disk persistence). |
+| `encrypted_cache.max_stale_seconds` | `0` | On network/timeout failures, use the last-good encrypted cache for up to this many seconds. Auth failures never fall back. Set to a positive value for offline-startup resilience. A successful encrypted write removes the legacy plaintext `cache/bws_cache.json`. |
 | `override_existing` | `true` | When true, Bitwarden values overwrite anything already in env (so rotation in the web app actually takes effect). Flip to `false` if you want `.env` / shell exports to win locally. |
 | `auto_install` | `true` | When true, `bws` is auto-downloaded into `~/.hermes/bin/` on first use. |
 


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #60295 #69054
## What changed and why

The Bitwarden Secrets Manager disk cache used to persist **every fetched secret value in plaintext** at `<hermes_home>/cache/bws_cache.json`. The encrypted AES-GCM cache (`bws_cache.enc.json`) already existed but was opt-in and **off by default** — so every user of the built-in BWS integration had their full set of provider keys sitting readable on disk.

This PR makes encryption the default and the only storage policy:

- `encrypted_cache.enabled` now defaults to `true` (config defaults + source schema + function signatures).
- The plaintext write/read/fallback branches in `fetch_bitwarden_secrets` are **removed entirely**. There is no config value that writes plaintext again. With encryption explicitly disabled, the disk cache is skipped (memory-only) rather than falling back to plaintext.
- A legacy plaintext `bws_cache.json` from an older Hermes is **re-encrypted and removed on first read** (`_migrate_legacy_plaintext_cache`), so existing users are migrated automatically — no plaintext cache survives the upgrade.

### Why this matters to you as a user

Today, every API key you keep in Bitwarden Secrets Manager is copied to a plain-text file on your computer so Hermes doesn't have to re-fetch it on every launch. Anyone with access to your machine, a backup, or a cloud-synced folder can open that file and see all your keys. After this change, that file is encrypted — your keys are unreadable to anyone without the right access, even if the file itself leaks. No action needed from you; it happens automatically when you upgrade.

## Reproduction steps (current behavior on `main`)

1. Configure BWS in `config.yaml`:
   ```yaml
   secrets:
     bitwarden:
       enabled: true
       project_id: "<your-bws-project-id>"
       access_token_env: "BWS_ACCESS_TOKEN"
   ```
2. Export `BWS_ACCESS_TOKEN`, start Hermes once.
3. Observe `<hermes_home>/cache/bws_cache.json` — contains your secret **values in plaintext** (e.g. `"value": "sk-..."`).

**Current:** plaintext `bws_cache.json` written by default.
**Expected:** only `bws_cache.enc.json` (AES-GCM ciphertext) exists; plaintext is never written, and any pre-existing plaintext file is re-encrypted and removed on first read.

## How to test

- `scripts/run_tests.sh tests/test_bitwarden_secrets.py` → 19 passed (3 new regression tests: encrypted-only default, legacy migration, offline-start migration).
- Manual: after upgrading with a pre-existing `bws_cache.json`, start Hermes once and confirm the file is gone and `bws_cache.enc.json` exists with no plaintext substrings.

## Platforms tested

- Windows 11 (git-bash), Python 3.11 — full file ran; two pre-existing Windows-only failures unrelated to this change (`test_install_bws_happy_path` fixture zip member naming, `chmod 0o600` not enforced on Windows — both fail on pristine `main` too).
- CI-parity runner `scripts/run_tests.sh` used; `git diff --check` clean; `check-windows-footguns.py` clean on changed files.

## Related

- Follow-up to the merged secret-name disclosure fix (#60295 / #69054) — this closes the value-at-rest half of the same disclosure class.
- Config default change intentionally breaks the old plaintext-cache behavior; migration tolerates legacy format for one read then converts (see "What changed").

Part of #77165
