### PR TITLE
fix(desktop): avoid repeated pet spritesheet fetches (salvage #60899)

### DIFF
--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -145,7 +145,7 @@ export function FloatingPet() {
     // pet.changed already carries the meta payload — an enabled=false
     // broadcast clears the mascot with zero round-trips, and an unchanged
     // revision (scale-only move still changes the sig) short-circuits below
-    // via samePetRevision.
+    // via hasPetSpriteForMeta + mergePetInfoMeta.
     if (changeEventsAvailable && petChange.tick > 0 && petChange.meta?.enabled === false) {
       setPetInfo({ enabled: false })
 

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -13,7 +13,10 @@ import {
   $petRoam,
   $petRoamDir,
   clearPetUnread,
+  hasPetSpriteForMeta,
+  mergePetInfoMeta,
   type PetInfo,
+  type PetInfoMeta,
   petProfile,
   setPetInfo
 } from '@/store/pet'
@@ -37,25 +40,6 @@ const NOMINAL_PET_PX = 96
 interface Point {
   x: number
   y: number
-}
-
-interface PetInfoMeta {
-  enabled: boolean
-  slug?: string
-  displayName?: string
-  scale?: number
-  spritesheetRevision?: string
-}
-
-function samePetRevision(info: PetInfo, meta: PetInfoMeta): boolean {
-  return (
-    info.enabled &&
-    Boolean(info.spritesheetBase64) &&
-    info.slug === meta.slug &&
-    info.displayName === meta.displayName &&
-    info.scale === meta.scale &&
-    info.spritesheetRevision === meta.spritesheetRevision
-  )
 }
 
 // Keep a w×h box fully inside the viewport. Pre-pet-load callers pass a nominal
@@ -184,7 +168,11 @@ export function FloatingPet() {
               return
             }
 
-            if (samePetRevision($petInfo.get(), meta)) {
+            const current = $petInfo.get()
+
+            if (hasPetSpriteForMeta(current, meta)) {
+              setPetInfo(mergePetInfoMeta(current, meta))
+
               return
             }
           } catch {

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -171,7 +171,10 @@ export function FloatingPet() {
             const current = $petInfo.get()
 
             if (hasPetSpriteForMeta(current, meta)) {
-              setPetInfo(mergePetInfoMeta(current, meta))
+              const merged = mergePetInfoMeta(current, meta)
+              if (merged !== current) {
+                setPetInfo(merged)
+              }
 
               return
             }

--- a/apps/desktop/src/store/pet-gallery.test.ts
+++ b/apps/desktop/src/store/pet-gallery.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $petInfo, setPetInfo } from './pet'
+import { $petGallery, adoptPet, loadPetGallery, resetPetGallery, type GatewayRequest } from './pet-gallery'
+
+function localGallery() {
+  return {
+    enabled: true,
+    active: 'boba',
+    pets: [{ slug: 'boba', displayName: 'Boba', installed: true }]
+  }
+}
+
+describe('pet gallery pet.info sync', () => {
+  beforeEach(() => {
+    resetPetGallery()
+    setPetInfo({ enabled: false })
+  })
+
+  afterEach(() => {
+    resetPetGallery()
+    setPetInfo({ enabled: false })
+    vi.restoreAllMocks()
+  })
+
+  it('uses pet.info.meta and keeps the cached spritesheet when the revision is current', async () => {
+    setPetInfo({
+      enabled: true,
+      slug: 'boba',
+      displayName: 'Old Boba',
+      scale: 0.33,
+      spritesheetBase64: 'large-sprite-payload',
+      spritesheetRevision: '100:2048',
+      frameW: 192,
+      frameH: 208
+    })
+
+    const requestMock = vi.fn(async (method: string) => {
+      if (method === 'pet.gallery') {
+        return localGallery()
+      }
+
+      if (method === 'pet.info.meta') {
+        return {
+          enabled: true,
+          slug: 'boba',
+          displayName: 'Boba',
+          scale: 0.5,
+          spritesheetRevision: '100:2048'
+        }
+      }
+
+      if (method === 'pet.info') {
+        throw new Error('full pet.info should not be called for an unchanged sprite')
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+    const request = requestMock as unknown as GatewayRequest
+
+    await loadPetGallery(request)
+
+    const methods = requestMock.mock.calls.map(([method]) => method)
+    expect(methods).toContain('pet.info.meta')
+    expect(methods).not.toContain('pet.info')
+    expect($petInfo.get()).toMatchObject({
+      enabled: true,
+      slug: 'boba',
+      displayName: 'Boba',
+      scale: 0.5,
+      spritesheetBase64: 'large-sprite-payload',
+      spritesheetRevision: '100:2048',
+      frameW: 192,
+      frameH: 208
+    })
+  })
+
+  it('fetches full pet.info when metadata reports a new spritesheet revision', async () => {
+    setPetInfo({
+      enabled: true,
+      slug: 'boba',
+      displayName: 'Boba',
+      scale: 0.33,
+      spritesheetBase64: 'old-sprite-payload',
+      spritesheetRevision: '100:2048'
+    })
+
+    const requestMock = vi.fn(async (method: string) => {
+      if (method === 'pet.gallery') {
+        return localGallery()
+      }
+
+      if (method === 'pet.info.meta') {
+        return {
+          enabled: true,
+          slug: 'boba',
+          displayName: 'Boba',
+          scale: 0.33,
+          spritesheetRevision: '101:4096'
+        }
+      }
+
+      if (method === 'pet.info') {
+        return {
+          enabled: true,
+          slug: 'boba',
+          displayName: 'Boba',
+          scale: 0.33,
+          spritesheetBase64: 'new-sprite-payload',
+          spritesheetRevision: '101:4096'
+        }
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+    const request = requestMock as unknown as GatewayRequest
+
+    await loadPetGallery(request)
+
+    const methods = requestMock.mock.calls.map(([method]) => method)
+    expect(methods).toContain('pet.info.meta')
+    expect(methods).toContain('pet.info')
+    expect($petInfo.get().spritesheetBase64).toBe('new-sprite-payload')
+    expect($petInfo.get().spritesheetRevision).toBe('101:4096')
+  })
+
+  it('falls back to full pet.info when an older gateway lacks metadata', async () => {
+    const requestMock = vi.fn(async (method: string) => {
+      if (method === 'pet.gallery') {
+        return localGallery()
+      }
+
+      if (method === 'pet.info.meta') {
+        throw new Error('JSON-RPC -32601: Method not found')
+      }
+
+      if (method === 'pet.info') {
+        return {
+          enabled: true,
+          slug: 'boba',
+          displayName: 'Boba from legacy gateway',
+          scale: 0.4,
+          spritesheetBase64: 'legacy-full-payload',
+          spritesheetRevision: '99:1024'
+        }
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+    const request = requestMock as unknown as GatewayRequest
+
+    await loadPetGallery(request)
+
+    const methods = requestMock.mock.calls.map(([method]) => method)
+    expect(methods).toContain('pet.info.meta')
+    expect(methods).toContain('pet.info')
+    expect($petInfo.get()).toMatchObject({
+      enabled: true,
+      slug: 'boba',
+      displayName: 'Boba from legacy gateway',
+      spritesheetBase64: 'legacy-full-payload',
+      spritesheetRevision: '99:1024'
+    })
+  })
+
+  it('keeps mutation sync on metadata when the selected pet sprite is unchanged', async () => {
+    $petGallery.set(localGallery())
+    setPetInfo({
+      enabled: true,
+      slug: 'boba',
+      displayName: 'Boba',
+      scale: 0.33,
+      spritesheetBase64: 'large-sprite-payload',
+      spritesheetRevision: '100:2048'
+    })
+
+    const requestMock = vi.fn(async (method: string) => {
+      if (method === 'pet.select') {
+        return { ok: true, slug: 'boba', displayName: 'Boba' }
+      }
+
+      if (method === 'pet.info.meta') {
+        return {
+          enabled: true,
+          slug: 'boba',
+          displayName: 'Boba',
+          scale: 0.33,
+          spritesheetRevision: '100:2048'
+        }
+      }
+
+      if (method === 'pet.info') {
+        throw new Error('full pet.info should not be called after an unchanged select')
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+    const request = requestMock as unknown as GatewayRequest
+
+    await expect(adoptPet(request, 'boba', 'Could not adopt pet.')).resolves.toBe(true)
+
+    const methods = requestMock.mock.calls.map(([method]) => method)
+    expect(methods).toEqual(['pet.select', 'pet.info.meta'])
+    expect($petInfo.get().spritesheetBase64).toBe('large-sprite-payload')
+  })
+})

--- a/apps/desktop/src/store/pet-gallery.test.ts
+++ b/apps/desktop/src/store/pet-gallery.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $petInfo, setPetInfo } from './pet'
-import { $petGallery, adoptPet, loadPetGallery, resetPetGallery, type GatewayRequest } from './pet-gallery'
+import { $petGallery, adoptPet, loadPetGallery, type GatewayRequest, resetPetGallery } from './pet-gallery'
 
 function localGallery() {
   return {

--- a/apps/desktop/src/store/pet-gallery.test.ts
+++ b/apps/desktop/src/store/pet-gallery.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $petInfo, setPetInfo } from './pet'
-import { $petGallery, adoptPet, loadPetGallery, type GatewayRequest, resetPetGallery } from './pet-gallery'
+import { $petGallery, adoptPet, type GatewayRequest, loadPetGallery, resetPetGallery } from './pet-gallery'
 
 function localGallery() {
   return {

--- a/apps/desktop/src/store/pet-gallery.ts
+++ b/apps/desktop/src/store/pet-gallery.ts
@@ -1,7 +1,15 @@
 import { atom } from 'nanostores'
 
 import { normalize } from '@/lib/text'
-import { $petInfo, type PetInfo, petProfile, setPetInfo } from '@/store/pet'
+import {
+  $petInfo,
+  hasPetSpriteForMeta,
+  mergePetInfoMeta,
+  type PetInfo,
+  type PetInfoMeta,
+  petProfile,
+  setPetInfo
+} from '@/store/pet'
 
 /**
  * Feature store for the petdex gallery picker (Cmd+K "Pets…" + Settings).
@@ -128,9 +136,9 @@ export function loadPetGallery(request: GatewayRequest, options: { force?: boole
     try {
       // Phase 1: local pets only — instant, never blocks on the remote petdex
       // manifest. The user's own/generated pets render right away.
-      const [local, info] = await Promise.all([
+      const [local] = await Promise.all([
         petRpc<PetGallery>(request, 'pet.gallery', { localOnly: true }),
-        petRpc<PetInfo>(request, 'pet.info')
+        syncInfo(request)
       ])
 
       if (local) {
@@ -140,9 +148,6 @@ export function loadPetGallery(request: GatewayRequest, options: { force?: boole
         localOk = true
       }
 
-      if (info) {
-        setPetInfo(info)
-      }
     } catch (e) {
       if (isMissingMethod(e)) {
         $petGalleryStatus.set('stale')
@@ -179,6 +184,42 @@ export function loadPetGallery(request: GatewayRequest, options: { force?: boole
 // network gallery — the floating pet repaints, the picker keeps its cache.
 async function syncInfo(request: GatewayRequest): Promise<void> {
   try {
+    let meta: PetInfoMeta | null = null
+
+    try {
+      meta = await petRpc<PetInfoMeta>(request, 'pet.info.meta')
+    } catch (e) {
+      if (!isMissingMethod(e)) {
+        throw e
+      }
+
+      const info = await petRpc<PetInfo>(request, 'pet.info')
+
+      if (info) {
+        setPetInfo(info)
+      }
+
+      return
+    }
+
+    if (!meta) {
+      return
+    }
+
+    if (!meta.enabled) {
+      setPetInfo({ enabled: false })
+
+      return
+    }
+
+    const current = $petInfo.get()
+
+    if (hasPetSpriteForMeta(current, meta)) {
+      setPetInfo(mergePetInfoMeta(current, meta))
+
+      return
+    }
+
     const info = await petRpc<PetInfo>(request, 'pet.info')
 
     if (info) {

--- a/apps/desktop/src/store/pet-gallery.ts
+++ b/apps/desktop/src/store/pet-gallery.ts
@@ -215,7 +215,10 @@ async function syncInfo(request: GatewayRequest): Promise<void> {
     const current = $petInfo.get()
 
     if (hasPetSpriteForMeta(current, meta)) {
-      setPetInfo(mergePetInfoMeta(current, meta))
+      const merged = mergePetInfoMeta(current, meta)
+      if (merged !== current) {
+        setPetInfo(merged)
+      }
 
       return
     }

--- a/apps/desktop/src/store/pet.test.ts
+++ b/apps/desktop/src/store/pet.test.ts
@@ -7,6 +7,8 @@ import {
   $petState,
   derivePetState,
   flashPetActivity,
+  hasPetSpriteForMeta,
+  mergePetInfoMeta,
   setPetActivity
 } from './pet'
 
@@ -72,6 +74,36 @@ describe('roam motion', () => {
     expect($petState.get()).toBe('idle')
 
     $petActivity.set({})
+  })
+})
+
+describe('pet info metadata cache helpers', () => {
+  it('treats matching slug and spritesheet revision as a reusable sprite payload', () => {
+    const current = {
+      enabled: true,
+      slug: 'boba',
+      displayName: 'Old Boba',
+      scale: 0.33,
+      spritesheetBase64: 'large-sprite-payload',
+      spritesheetRevision: '100:2048'
+    }
+    const meta = {
+      enabled: true,
+      slug: 'boba',
+      displayName: 'Boba',
+      scale: 0.5,
+      spritesheetRevision: '100:2048'
+    }
+
+    expect(hasPetSpriteForMeta(current, meta)).toBe(true)
+    expect(mergePetInfoMeta(current, meta)).toMatchObject({
+      enabled: true,
+      slug: 'boba',
+      displayName: 'Boba',
+      scale: 0.5,
+      spritesheetBase64: 'large-sprite-payload',
+      spritesheetRevision: '100:2048'
+    })
   })
 })
 

--- a/apps/desktop/src/store/pet.test.ts
+++ b/apps/desktop/src/store/pet.test.ts
@@ -9,6 +9,7 @@ import {
   flashPetActivity,
   hasPetSpriteForMeta,
   mergePetInfoMeta,
+  type PetInfo,
   setPetActivity
 } from './pet'
 
@@ -104,6 +105,26 @@ describe('pet info metadata cache helpers', () => {
       spritesheetBase64: 'large-sprite-payload',
       spritesheetRevision: '100:2048'
     })
+  })
+
+  it('returns the same reference when nothing changed to avoid redundant store updates', () => {
+    const current: PetInfo = {
+      enabled: true,
+      slug: 'boba',
+      displayName: 'Boba',
+      scale: 0.33,
+      spritesheetBase64: 'large-sprite-payload',
+      spritesheetRevision: '100:2048'
+    }
+    const meta = {
+      enabled: true,
+      slug: 'boba',
+      displayName: 'Boba',
+      scale: 0.33,
+      spritesheetRevision: '100:2048'
+    }
+
+    expect(mergePetInfoMeta(current, meta)).toBe(current)
   })
 })
 

--- a/apps/desktop/src/store/pet.ts
+++ b/apps/desktop/src/store/pet.ts
@@ -39,6 +39,40 @@ export interface PetInfo {
   stateRows?: string[]
 }
 
+export interface PetInfoMeta {
+  enabled: boolean
+  slug?: string
+  displayName?: string
+  scale?: number
+  spritesheetRevision?: string
+}
+
+export function hasPetSpriteForMeta(info: PetInfo, meta: PetInfoMeta): boolean {
+  return (
+    meta.enabled &&
+    info.enabled &&
+    Boolean(info.spritesheetBase64) &&
+    info.slug === meta.slug &&
+    Boolean(info.spritesheetRevision) &&
+    info.spritesheetRevision === meta.spritesheetRevision
+  )
+}
+
+export function mergePetInfoMeta(info: PetInfo, meta: PetInfoMeta): PetInfo {
+  if (!meta.enabled) {
+    return { enabled: false }
+  }
+
+  return {
+    ...info,
+    enabled: true,
+    slug: meta.slug,
+    displayName: meta.displayName,
+    scale: meta.scale,
+    spritesheetRevision: meta.spritesheetRevision
+  }
+}
+
 export interface PetActivity {
   busy?: boolean
   awaitingInput?: boolean

--- a/apps/desktop/src/store/pet.ts
+++ b/apps/desktop/src/store/pet.ts
@@ -60,7 +60,20 @@ export function hasPetSpriteForMeta(info: PetInfo, meta: PetInfoMeta): boolean {
 
 export function mergePetInfoMeta(info: PetInfo, meta: PetInfoMeta): PetInfo {
   if (!meta.enabled) {
-    return { enabled: false }
+    return info.enabled ? { enabled: false } : info
+  }
+
+  // Fast-path: nothing changed — return the same reference so callers can
+  // skip the store update (nanostores fires on .set() regardless of deep
+  // equality; returning `info` avoids a redundant re-render on every poll).
+  if (
+    info.enabled &&
+    info.slug === meta.slug &&
+    info.displayName === meta.displayName &&
+    info.scale === meta.scale &&
+    info.spritesheetRevision === meta.spritesheetRevision
+  ) {
+    return info
   }
 
   return {


### PR DESCRIPTION
Salvages #60899 by @embwl0x — commit cherry-picked to preserve authorship. Merges clean; no changes to the contribution.

## Context — what this fixes, for whom

Every Desktop user with a pet: opening the pet gallery (and every gallery refresh) fetched the FULL spritesheet base64 payload via `pet.info` even when nothing changed. The lightweight `pet.info.meta` RPC (enabled/slug/displayName/scale/spritesheetRevision — no sprite data) has existed on main for a while and `floating-pet.tsx` already uses it; the gallery's `syncInfo` was the missing consumer.

## What the fix does

`syncInfo` now calls `pet.info.meta` first, keeps the cached spritesheet when the revision matches (`hasPetSpriteForMeta`), merges display metadata without a refetch (`mergePetInfoMeta`), and only falls back to full `pet.info` on revision change, cache miss, or a legacy gateway lacking the method (-32601 handled). The helpers are extracted to `pet.ts` as one source of truth, replacing `floating-pet.tsx`'s private `samePetRevision`. Bonus behavior improvement: a pet rename/rescale now updates display metadata without refetching the whole sprite.

## Verification

- vitest: `pet.test.ts` + `pet-gallery.test.ts` — 13/13 passed on the salvage tree (and previously verified on a test-merge with current main + full 3-tsconfig typecheck)
- Premise re-verified on current main: gallery `syncInfo` still fetches full `pet.info` unconditionally; `pet.info.meta` registered at tui_gateway/methods_session.py:1254
- 5,117-commit staleness checked: touched files not restructured; only benign semantic drift (floating-pet live-sync), merge verified clean at blob level
- Mock seams: tests use the designed GatewayRequest DI seam only — no module mocks

Closes #60899 (superseded by this salvage — original author credited via cherry-pick authorship).
