### PR TITLE
fix(process): wait timeout result reads as status, not failure

### DIFF
--- a/tests/tools/test_process_wait_clarity.py
+++ b/tests/tools/test_process_wait_clarity.py
@@ -1,0 +1,64 @@
+"""Tests for process wait timeout-result clarity (not-an-error semantics)."""
+
+import pytest
+
+from tools.process_registry import ProcessRegistry
+
+
+@pytest.fixture
+def registry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    return ProcessRegistry()
+
+
+def _spawn_sleeper(registry, notify=False):
+    session = registry.spawn_local("sleep 30", cwd="/tmp", task_id="t-waitclar")
+    session.notify_on_complete = notify
+    return session.id
+
+
+class TestWaitTimeoutClarity:
+    def test_wait_timeout_marks_process_running(self, registry):
+        sid = _spawn_sleeper(registry)
+        try:
+            r = registry.wait(sid, timeout=1)
+            assert r["status"] == "timeout"
+            assert r["process_running"] is True
+            assert "not an error" in r["timeout_note"]
+            assert "Uptime" in r["timeout_note"]
+        finally:
+            registry.kill_process(sid)
+
+    def test_wait_timeout_suggests_notify_when_unset(self, registry):
+        sid = _spawn_sleeper(registry, notify=False)
+        try:
+            r = registry.wait(sid, timeout=1)
+            assert "notify_on_complete=true" in r["timeout_note"]
+        finally:
+            registry.kill_process(sid)
+
+    def test_wait_timeout_defers_to_notify_when_set(self, registry):
+        sid = _spawn_sleeper(registry, notify=True)
+        try:
+            r = registry.wait(sid, timeout=1)
+            assert "you will be notified on exit" in r["timeout_note"]
+        finally:
+            registry.kill_process(sid)
+
+    def test_clamped_wait_keeps_clamp_note_and_running_semantics(self, registry, monkeypatch):
+        monkeypatch.setenv("TERMINAL_TIMEOUT", "1")
+        sid = _spawn_sleeper(registry)
+        try:
+            r = registry.wait(sid, timeout=600)
+            assert r["status"] == "timeout"
+            assert "clamped" in r["timeout_note"]
+            assert "not an error" in r["timeout_note"]
+            assert r["process_running"] is True
+        finally:
+            registry.kill_process(sid)
+
+    def test_exited_process_unaffected(self, registry):
+        session = registry.spawn_local("true", cwd="/tmp", task_id="t-waitclar")
+        r = registry.wait(session.id, timeout=10)
+        assert r["status"] == "exited"
+        assert "process_running" not in r

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1598,11 +1598,32 @@ class ProcessRegistry:
             "status": "timeout",
             "command": session.command,
             "output": strip_ansi(session.output_buffer[-1000:]),
+            # A wait window elapsing is NOT a failure — 511 exact-duplicate
+            # process calls in a production window show models re-issuing
+            # identical waits after misreading this result as an error.
+            "process_running": True,
         }
-        if timeout_note:
-            result["timeout_note"] = timeout_note
+        uptime = time.time() - session.started_at if session.started_at else None
+        base_note = (
+            f"Wait window of {effective_timeout}s elapsed — the process is "
+            "still running. This is not an error."
+        )
+        if uptime is not None:
+            base_note += f" Uptime: {int(uptime)}s."
+        if session.notify_on_complete:
+            base_note += (
+                " notify_on_complete is set: you will be notified on exit — "
+                "do more work instead of waiting again."
+            )
         else:
-            result["timeout_note"] = f"Waited {effective_timeout}s, process still running"
+            base_note += (
+                " Poll again later or use terminal(background=true, "
+                "notify_on_complete=true) next time for automatic notification."
+            )
+        if timeout_note:
+            result["timeout_note"] = f"{timeout_note}. {base_note}"
+        else:
+            result["timeout_note"] = base_note
         return result
 
     def kill_process(


### PR DESCRIPTION
## Summary
A `process(action='wait')` that hits its window now says explicitly that the process is still running and this is not an error — with a machine-readable `process_running: true` and the correct next step — instead of a terse timeout note that models read as failure and answered with identical re-waits.

Root cause: `process` is the #1 exact-duplicate tool call in production (511 dupes in a 400k-msg window; `wait` is 57% of process actions, 1,536 calls). The old result (`status: "timeout"`, `"Waited 60s, process still running"`) looked like an error, so the standard response was another identical wait.

## Changes
- `tools/process_registry.py` (`wait()` timeout branch):
  - `process_running: true` field.
  - Note rewritten: "Wait window of Ns elapsed — the process is still running. This is not an error. Uptime: Ms." + notify-aware guidance: with `notify_on_complete` set → "you will be notified on exit — do more work instead of waiting again"; without → pointer to `notify_on_complete=true` for next time.
  - The clamp note (requested > configured max) now composes with the status note instead of replacing it.
  - Exited/interrupted results unchanged.
- `tests/tools/test_process_wait_clarity.py`: 5 tests (running semantics, notify-set/unset variants, clamp composition, exited unaffected).

## Validation
| Check | Result |
|---|---|
| Hermetic runner (new + process_registry suites) | 59/59 passed |
| Live E2E (real bg `sleep` via terminal_tool → `_handle_process` wait/kill) | `status: timeout`, `process_running: true`, full note with uptime + notify pointer; kill clean |

## Infographic

![process wait clarity](https://v3b.fal.media/files/b/0aa4c164/KnhKQK2XOMpgILl8ufl_X_TGVXXmhD.png)
