### PR TITLE
feat(security): mask opaque credential values in log output

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -1043,4 +1043,8 @@ class RedactingFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         original = super().format(record)
-        return redact_sensitive_text(original)
+        # Shape-based regex first (vendor prefixes, headers, URLs), then the
+        # exact-value pass so opaque credential values with no recognizable
+        # prefix (e.g. MY_SERVICE_TOKEN=abc123randomstring, BWS_ACCESS_TOKEN)
+        # are masked from log output too.
+        return mask_known_secret_values(redact_sensitive_text(original))

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -997,6 +997,44 @@ def _has_http_method_substring(text: str) -> bool:
     return any(method in upper for method in _HTTP_METHOD_SUBSTRINGS)
 
 
+# Env-var name suffixes that mark a value as a credential.  The regex passes
+# above mask tokens by *shape* (vendor prefixes like ``sk-``); this suffix
+# list drives the exact-value pass below, which masks opaque values that
+# carry no recognizable prefix (e.g. ``MY_SERVICE_TOKEN=abc123randomstring``).
+_CREDENTIAL_VALUE_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET", "_KEY", "_PASSWORD")
+
+
+def _known_secret_values() -> set[str]:
+    """Return the exact values of credential-named env vars, when non-trivial.
+
+    Used by :func:`mask_known_secret_values` to strip a secret's literal
+    value out of text even when it has no recognizable vendor prefix.  Values
+    shorter than 6 chars are skipped — masking ``KEY=true`` or ``TOKEN=1``
+    would mangle ordinary prose while adding no real protection.
+    """
+    values: set[str] = set()
+    for name, value in os.environ.items():
+        if value and len(value) >= 6 and name.upper().endswith(_CREDENTIAL_VALUE_SUFFIXES):
+            values.add(value)
+    return values
+
+
+def mask_known_secret_values(text: str) -> str:
+    """Mask the exact values of known credential env vars wherever they appear.
+
+    Complements the shape-based regex passes: a secret value echoed into a
+    status line, warning, or error message is replaced with ``***`` even when
+    it doesn't match any vendor prefix.  Best-effort — if a value is not
+    currently known to the process it cannot be masked here (the regex passes
+    still catch prefix-shaped tokens).
+    """
+    if not text:
+        return text
+    for value in _known_secret_values():
+        text = text.replace(value, "***")
+    return text
+
+
 class RedactingFormatter(logging.Formatter):
     """Log formatter that redacts secrets from all log messages."""
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -635,14 +635,43 @@ def _apply_external_secret_sources(home_path: Path) -> None:
                 file=sys.stderr,
             )
         if src.result.error:
-            print(f"  {src.label}: {src.result.error}", file=sys.stderr)
+            print(
+                f"  {src.label}: {_mask_secret_text(src.result.error)}",
+                file=sys.stderr,
+            )
             hint = _remediation_hint(src.name, src.result.error_kind, cfg)
             if hint:
-                print(f"  {src.label}: → {hint}", file=sys.stderr)
+                print(
+                    f"  {src.label}: → {_mask_secret_text(hint)}",
+                    file=sys.stderr,
+                )
         for warn in src.result.warnings:
-            print(f"  {src.label}: {warn}", file=sys.stderr)
+            print(f"  {src.label}: {_mask_secret_text(warn)}", file=sys.stderr)
     for conflict in report.conflicts:
-        print(f"  Secret sources: {conflict}", file=sys.stderr)
+        print(f"  Secret sources: {_mask_secret_text(conflict)}", file=sys.stderr)
+
+
+def _mask_secret_text(text: str) -> str:
+    """Mask known secret values out of status text before it reaches stderr.
+
+    Uses the exact values applied from external secret sources this process
+    (``_SECRET_SOURCE_VALUES_BY_HOME`` — the authoritative set for what the
+    status line is about) plus the generic credential-env scan in
+    ``agent.redact``.  Error, hint, warning, and conflict lines can carry a
+    secret *value* (a backend echoing it, a remediation hint quoting it);
+    names are already suppressed on the applied-count line.  Best-effort:
+    never raises, never blocks startup.
+    """
+    if not text:
+        return text
+    from agent.redact import mask_known_secret_values
+
+    masked = text
+    for snapshot in _SECRET_SOURCE_VALUES_BY_HOME.values():
+        for value in snapshot.values():
+            if value and len(value) >= 6 and value in masked:
+                masked = masked.replace(value, "***")
+    return mask_known_secret_values(masked)
 
 
 def _remediation_hint(source_name: str, error_kind, secrets_cfg: dict) -> str:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -245,6 +245,56 @@ class TestRedactingFormatter:
         assert "abc123def456" not in result
         assert "sk-pro" in result
 
+    def test_opaque_credential_value_masked_in_logs(self, monkeypatch):
+        """A credential value with no vendor prefix (opaque token) must be
+        masked in log output — the shape-based regex can't catch it, but the
+        exact-value pass can."""
+        monkeypatch.setenv("MY_SERVICE_TOKEN", "opaque-secret-value-xyz")
+        formatter = RedactingFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="starting with opaque-secret-value-xyz configured",
+            args=(),
+            exc_info=None,
+        )
+        result = formatter.format(record)
+        assert "opaque-secret-value-xyz" not in result
+        assert "starting with *** configured" == result
+
+    def test_password_suffixed_value_masked_in_logs(self, monkeypatch):
+        monkeypatch.setenv("DB_PASSWORD", "db-pass-9f2c1a")
+        formatter = RedactingFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="connstring uses db-pass-9f2c1a",
+            args=(),
+            exc_info=None,
+        )
+        result = formatter.format(record)
+        assert "db-pass-9f2c1a" not in result
+
+    def test_bws_access_token_masked_in_logs(self, monkeypatch):
+        monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.abc123.def456:xyz789")
+        formatter = RedactingFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="bitwarden token 0.abc123.def456:xyz789 rejected",
+            args=(),
+            exc_info=None,
+        )
+        result = formatter.format(record)
+        assert "0.abc123.def456:xyz789" not in result
+        assert "rejected" in result
+
 
 class TestPrintenvSimulation:
     """Simulate what happens when the agent runs `env` or `printenv`."""

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -361,6 +361,81 @@ def test_apply_external_secret_sources_status_line_suppresses_secret_names(
     assert "LEAK_THIS_TOKEN" not in err
 
 
+def test_status_warning_with_secret_value_is_masked(tmp_path, monkeypatch, capsys):
+    """A source warning that echoes a secret VALUE must be masked in stderr —
+    the merged name-suppression fix covers names, but values are the
+    exfiltration risk."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.test-token")
+    monkeypatch.delenv("LEAK_THIS_API_KEY", raising=False)
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: test-project\n"
+        "    access_token_env: BWS_ACCESS_TOKEN\n",
+        encoding="utf-8",
+    )
+
+    import agent.secret_sources.bitwarden as bw_module
+
+    monkeypatch.setattr(bw_module, "find_bws", lambda **_kw: Path("/fake/bws"))
+    monkeypatch.setattr(
+        bw_module,
+        "fetch_bitwarden_secrets",
+        lambda **_kw: (
+            {"LEAK_THIS_API_KEY": "sk-super-secret-value-123"},
+            ["bws returned suspicious value sk-super-secret-value-123"],
+        ),
+    )
+
+    from agent.secret_sources import registry as reg_module
+
+    reg_module._reset_registry_for_tests()
+
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    err = capsys.readouterr().err
+    assert "applied 1 secret" in err
+    assert "sk-super-secret-value-123" not in err
+
+
+def test_status_error_with_secret_value_is_masked(tmp_path, monkeypatch, capsys):
+    """A source error that embeds a known secret VALUE must be masked."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.test-token")
+    # The value is known to Hermes (applied in a prior run / .env) and the
+    # backend error echoes it.
+    monkeypatch.setenv("LEAK_THIS_API_KEY", "sk-error-value-456")
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: test-project\n"
+        "    access_token_env: BWS_ACCESS_TOKEN\n",
+        encoding="utf-8",
+    )
+
+    import agent.secret_sources.bitwarden as bw_module
+
+    monkeypatch.setattr(bw_module, "find_bws", lambda **_kw: Path("/fake/bws"))
+
+    def _raise_with_value(**_kw):
+        raise RuntimeError("Bitwarden rejected token sk-error-value-456")
+
+    monkeypatch.setattr(bw_module, "fetch_bitwarden_secrets", _raise_with_value)
+
+    from agent.secret_sources import registry as reg_module
+
+    reg_module._reset_registry_for_tests()
+
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    err = capsys.readouterr().err
+    assert "Bitwarden rejected token" in err  # diagnostic preserved
+    assert "sk-error-value-456" not in err
+
+
 def test_external_secret_values_are_isolated_between_homes(tmp_path, monkeypatch):
     """A later apply for the same key must not mutate an earlier home snapshot."""
     from agent.secret_scope import build_profile_secret_scope


### PR DESCRIPTION
## What changed and why

`RedactingFormatter` (used by every Hermes log handler) already ran the shape-based regex redactor — vendor prefixes (`sk-`, `ghp_`), auth headers, URLs — on every log record. But **opaque credential values with no recognizable prefix passed through log output unmasked**: `MY_SERVICE_TOKEN=abc123randomstring`, `BWS_ACCESS_TOKEN`, `*_PASSWORD` values.

This PR wires the exact-value pass (`mask_known_secret_values`) into `RedactingFormatter.format()`, so every log record also masks the literal values of credential-named env vars.

### Why this matters to you as a user

A log line that happens to include a secret's value — an error message echoing a token, a debug line printing a connection string — no longer writes that value into your log files. The diagnostic text survives; the secret doesn't. This closes the value-in-logs half of the disclosure class for every Hermes user, not just BWS users.

## Reproduction steps (current behavior on `main`)

1. `export MY_SERVICE_TOKEN=opaque-secret-value-xyz`
2. Log a message containing that value (e.g. `logger.warning("starting with opaque-secret-value-xyz")`).
3. Observe the gateway/log file — the value appears verbatim.

**Current:** opaque credential values written to logs.
**Expected:** value replaced with `***`; surrounding diagnostic preserved.

## How to test

- `scripts/run_tests.sh tests/agent/test_redact.py` → 76 passed (3 new: opaque `_TOKEN` value, `_PASSWORD` value, and `BWS_ACCESS_TOKEN` value masked in formatted log records).

## Platforms tested

- Windows 11 (git-bash), Python 3.11, canonical `scripts/run_tests.sh`.
- `git diff --check` clean; `check-windows-footguns.py` clean on changed files.

## Stacking note (important)

This PR is **stacked on #77012** (`fix(security): mask secret values in secret-source status lines`), which introduces `mask_known_secret_values` in `agent/redact.py`. Because the fork-based base branch isn't addressable upstream, this PR currently targets `main` and therefore includes #77012's commit in its diff. Please review/merge **#77012 first**, then this one — after #77012 lands on main, this PR can be rebased and its diff shrinks to exactly the formatter wiring + tests. The formatter change itself does not depend on anything else.

## Related

- Disclosure-class series: #77008 (BWS cache encrypted-only), #77012 (status-line value masking), this (log value masking).
