### PR TITLE
fix: recover malformed tool calls safely

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -49,6 +49,7 @@ from agent.runtime_cwd import resolve_agent_cwd
 from agent.message_sanitization import (
     close_interrupted_tool_sequence,
     _repair_tool_call_arguments,
+    parse_tool_arguments,
     _sanitize_messages_non_ascii,
     _sanitize_messages_surrogates,
     _sanitize_structure_non_ascii,
@@ -2457,7 +2458,7 @@ def run_conversation(
                     else:
                         interrupted = True
                     break
-                
+
                 api_duration = time.time() - api_start_time
                 
                 # Stop thinking spinner silently -- the response box or tool
@@ -5996,9 +5997,8 @@ def run_conversation(
                     if not args or not args.strip():
                         tc.function.arguments = "{}"
                         continue
-                    try:
-                        json.loads(args)
-                    except json.JSONDecodeError as e:
+                    _parsed_args, parse_error = parse_tool_arguments(args)
+                    if parse_error is not None:
                         if (
                             _mixed_invalid_batch
                             and tc.function.name not in agent.valid_tool_names
@@ -6007,83 +6007,63 @@ def run_conversation(
                             # invalid-name error result below. Don't let its
                             # broken args trigger the whole-turn JSON retry.
                             continue
-                        invalid_json_args.append((tc.function.name, str(e)))
+                        invalid_json_args.append((tc, parse_error))
                 
                 if invalid_json_args:
-                    # Check if the invalid JSON is due to truncation rather
-                    # than a model formatting mistake.  Routers sometimes
-                    # rewrite finish_reason from "length" to "tool_calls",
-                    # hiding the truncation from the length handler above.
-                    # Detect truncation: args that don't end with } or ]
-                    # (after stripping whitespace) are cut off mid-stream.
-                    _truncated = any(
-                        not (tc.function.arguments or "").rstrip().endswith(("}", "]"))
-                        for tc in assistant_message.tool_calls
-                        if tc.function.name in {n for n, _ in invalid_json_args}
+                    # Preserve the assistant/tool-call pairing and give the
+                    # model one deterministic, model-visible parse error per
+                    # call ID. Retrying the same response without feedback
+                    # just replays deterministic providers; coercing malformed
+                    # arguments to {} risks invoking a tool with invented
+                    # intent. No malformed call reaches the executor here.
+                    invalid_by_id = {
+                        tc.id: error for tc, error in invalid_json_args
+                    }
+                    first_tc, error_msg = invalid_json_args[0]
+                    tool_name = first_tc.function.name
+                    agent._buffer_vprint(f"⚠️  Invalid JSON in tool call arguments for '{tool_name}': {error_msg}")
+                    agent._buffer_vprint("⚠️  Injecting recovery tool results for invalid JSON...")
+                    agent._invalid_json_retries += 1
+
+                    recovery_assistant = agent._build_assistant_message(
+                        assistant_message, finish_reason,
                     )
-                    if _truncated:
-                        agent._vprint(
-                            f"{agent.log_prefix}⚠️  Truncated tool call arguments detected "
-                            f"(finish_reason={finish_reason!r}) — refusing to execute.",
-                            force=True,
+                    messages.append(recovery_assistant)
+
+                    for tc in assistant_message.tool_calls:
+                        if tc.id in invalid_by_id:
+                            err = invalid_by_id[tc.id]
+                            tool_result = (
+                                f"Error: Invalid JSON arguments. {err}. "
+                                "The tool was not executed. Please retry with valid JSON."
+                            )
+                        else:
+                            tool_result = (
+                                "Skipped: another tool call in this response had invalid JSON."
+                            )
+                        messages.append({
+                            "role": "tool",
+                            "name": tc.function.name,
+                            "tool_call_id": tc.id,
+                            "content": tool_result,
+                        })
+                    if agent._invalid_json_retries > 1:
+                        final_response = (
+                            "Invalid JSON tool call arguments after regeneration attempt"
                         )
-                        agent._invalid_json_retries = 0
                         agent._cleanup_task_resources(effective_task_id)
-                        _final_response = "Response truncated due to output length limit"
-                        # Same tool-tail close as interrupt / invalid-tool
-                        # exhaustion — this path never reaches finalize_turn.
-                        close_interrupted_tool_sequence(messages, _final_response)
+                        close_interrupted_tool_sequence(messages, final_response)
                         agent._persist_session(messages, conversation_history)
                         return {
-                            "final_response": _final_response,
+                            "final_response": final_response,
                             "messages": messages,
                             "api_calls": api_call_count,
                             "completed": False,
                             "partial": True,
-                            "error": _final_response,
+                            "error": final_response,
                         }
+                    continue
 
-                    # Track retries for invalid JSON arguments
-                    agent._invalid_json_retries += 1
-
-                    tool_name, error_msg = invalid_json_args[0]
-                    agent._buffer_vprint(f"⚠️  Invalid JSON in tool call arguments for '{tool_name}': {error_msg}")
-
-                    if agent._invalid_json_retries < 3:
-                        agent._buffer_vprint(f"🔄 Retrying API call ({agent._invalid_json_retries}/3)...")
-                        # Don't add anything to messages, just retry the API call
-                        continue
-                    else:
-                        # Instead of returning partial, inject tool error results so the model can recover.
-                        # Using tool results (not user messages) preserves role alternation.
-                        agent._buffer_vprint("⚠️  Injecting recovery tool results for invalid JSON...")
-                        agent._invalid_json_retries = 0  # Reset for next attempt
-                        
-                        # Append the assistant message with its (broken) tool_calls
-                        recovery_assistant = agent._build_assistant_message(assistant_message, finish_reason)
-                        messages.append(recovery_assistant)
-                        
-                        # Respond with tool error results for each tool call
-                        invalid_names = {name for name, _ in invalid_json_args}
-                        for tc in assistant_message.tool_calls:
-                            if tc.function.name in invalid_names:
-                                err = next(e for n, e in invalid_json_args if n == tc.function.name)
-                                tool_result = (
-                                    f"Error: Invalid JSON arguments. {err}. "
-                                    f"For tools with no required parameters, use an empty object: {{}}. "
-                                    f"Please retry with valid JSON."
-                                )
-                            else:
-                                tool_result = "Skipped: other tool call in this response had invalid JSON."
-                            messages.append({
-                                "role": "tool",
-                                "name": tc.function.name,
-                                "tool_call_id": tc.id,
-                                "content": tool_result,
-                            })
-                        continue
-                
-                # Reset retry counter on successful JSON validation
                 agent._invalid_json_retries = 0
 
                 # ── Post-call guardrails ──────────────────────────

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -280,6 +280,25 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     return "{}"
 
 
+def parse_tool_arguments(raw_arguments: Any) -> tuple[dict, str | None]:
+    """Parse model-emitted arguments as the JSON object tools require."""
+    try:
+        arguments = json.loads(raw_arguments)
+    except (json.JSONDecodeError, TypeError):
+        arguments = None
+    if isinstance(arguments, dict):
+        return arguments, None
+    return {}, json.dumps(
+        {
+            "error": "Invalid tool arguments",
+            "message": (
+                "Tool arguments must be a valid JSON object; tool was not executed."
+            ),
+        },
+        ensure_ascii=False,
+    )
+
+
 def close_interrupted_tool_sequence(messages: list, final_response: Any = None) -> bool:
     """Append a synthetic assistant turn when an interrupted tail is a tool result.
 
@@ -470,6 +489,7 @@ __all__ = [
     "_sanitize_messages_surrogates",
     "_escape_invalid_chars_in_json_strings",
     "_repair_tool_call_arguments",
+    "parse_tool_arguments",
     "_strip_non_ascii",
     "_sanitize_messages_non_ascii",
     "_sanitize_tools_non_ascii",

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -32,6 +32,7 @@ from agent.display import (
     redact_tool_args_for_display as _redact_tool_args_for_display,
     _detect_tool_failure,
 )
+from agent.message_sanitization import parse_tool_arguments
 from agent.tool_dispatch_helpers import (
     _is_destructive_command,
     _is_multimodal_tool_result,
@@ -96,25 +97,6 @@ _MAX_TOOL_WORKERS = 8
 # Keep this above the stock auxiliary.web_extract timeout (360s) so the batch
 # guard does not preempt a slow-but-valid summarization attempt.
 _DEFAULT_CONCURRENT_TOOL_TIMEOUT_S = 420.0
-
-
-def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
-    """Parse model-emitted arguments without repairing or coercing them."""
-    try:
-        arguments = json.loads(raw_arguments)
-    except (json.JSONDecodeError, TypeError):
-        arguments = None
-    if isinstance(arguments, dict):
-        return arguments, None
-    return {}, json.dumps(
-        {
-            "error": "Invalid tool arguments",
-            "message": (
-                "Tool arguments must be a valid JSON object; tool was not executed."
-            ),
-        },
-        ensure_ascii=False,
-    )
 
 
 def _resolve_concurrent_tool_timeout() -> float | None:
@@ -667,7 +649,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     for tool_call in tool_calls:
         function_name = tool_call.function.name
 
-        function_args, malformed_args_result = _parse_tool_arguments(
+        function_args, malformed_args_result = parse_tool_arguments(
             tool_call.function.arguments
         )
 
@@ -1369,7 +1351,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         function_name = tool_call.function.name
 
-        function_args, malformed_args_result = _parse_tool_arguments(
+        function_args, malformed_args_result = parse_tool_arguments(
             tool_call.function.arguments
         )
         if malformed_args_result is not None:

--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -450,7 +450,7 @@ fi
 # after first-boot seeding and before supervised gateway services start.
 # Set HERMES_SKIP_CONFIG_MIGRATION=1 for controlled/manual migrations.
 if [ -f "$HERMES_HOME/config.yaml" ]; then
-    s6-setuidgid hermes "$INSTALL_DIR/.venv/bin/python" "$INSTALL_DIR/scripts/docker_config_migrate.py" \
+    as_hermes "$INSTALL_DIR/.venv/bin/python" "$INSTALL_DIR/scripts/docker_config_migrate.py" \
         || echo "[stage2] Warning: docker_config_migrate.py failed; continuing"
 fi
 

--- a/tests/docker/conftest.py
+++ b/tests/docker/conftest.py
@@ -175,6 +175,7 @@ def start_container(
     name: str,
     *env: str,
     cmd: str = "sleep infinity",
+    user: str | None = None,
     timeout: int = 60,
 ) -> str:
     """Start a detached container and wait for cont-init to finish.
@@ -185,12 +186,15 @@ def start_container(
             typically handled by the ``container_name`` fixture).
         env: Env vars as ``KEY=VALUE`` strings, each passed via ``-e``.
         cmd: Container CMD (default ``sleep infinity``).
+        user: Optional Docker ``--user`` value for non-root startup tests.
         timeout: ``docker run`` subprocess timeout.
 
     Returns the container name. Raises on ``docker run`` failure or if
     the container never finishes cont-init within 30s.
     """
     args = ["docker", "run", "-d", "--name", name]
+    if user is not None:
+        args.extend(["--user", user])
     for e in env:
         args.extend(["-e", e])
     args.extend([image, *cmd.split()])

--- a/tests/docker/test_config_migration.py
+++ b/tests/docker/test_config_migration.py
@@ -6,6 +6,8 @@ user.
 """
 from __future__ import annotations
 
+import subprocess
+
 from tests.docker.conftest import docker_exec, docker_exec_sh, start_container
 
 
@@ -50,3 +52,19 @@ def test_config_migration_runs_on_boot(
     )
 
 
+def test_config_migration_runs_when_container_starts_as_hermes(
+    built_image: str, container_name: str,
+) -> None:
+    """The migration must not attempt a second privilege drop at UID 10000."""
+    start_container(built_image, container_name, user="10000:10000")
+
+    logs = subprocess.run(
+        ["docker", "logs", container_name],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert logs.returncode == 0
+    combined_logs = logs.stdout + logs.stderr
+    assert "docker_config_migrate.py failed" not in combined_logs
+    assert "unable to set supplementary group list" not in combined_logs

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2792,6 +2792,90 @@ class TestRunConversation:
         assert mock_handle_function_call.call_args.kwargs["tool_call_id"] == "c1"
         assert mock_handle_function_call.call_args.kwargs["session_id"] == agent.session_id
 
+    @pytest.mark.parametrize(
+        "arguments",
+        [
+            '{"name":"hindsight_recall","arguments":{"query":"unfinished',
+            '{"name":"hindsight_recall","arguments":{"query":"say "hello""}}',
+        ],
+        ids=["truncated-deferred-call", "unescaped-quotes"],
+    )
+    def test_malformed_tool_call_emits_one_error_result_without_dispatch(
+        self, agent, arguments,
+    ):
+        """Malformed calls become one model-visible parse error immediately."""
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("tool_call")
+        tc = _mock_tool_call(name="tool_call", arguments=arguments, call_id="bad-call")
+        malformed = _mock_response(
+            content="", finish_reason="tool_calls", tool_calls=[tc],
+        )
+        recovered = _mock_response(content="Recovered", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [malformed, recovered]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="must not run") as dispatch,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("recall something")
+
+        assert result["final_response"] == "Recovered"
+        assert result["api_calls"] == 2
+        dispatch.assert_not_called()
+        second_request = agent.client.chat.completions.create.call_args_list[1].kwargs["messages"]
+        error_results = [
+            message for message in second_request
+            if message.get("role") == "tool"
+            and message.get("tool_call_id") == "bad-call"
+        ]
+        assert len(error_results) == 1
+        assert "Invalid JSON arguments" in error_results[0]["content"]
+        assert "Please retry with valid JSON" in error_results[0]["content"]
+
+    def test_second_consecutive_malformed_tool_call_returns_closed_partial(
+        self, agent,
+    ):
+        """Only one regeneration opportunity is allowed per malformed streak."""
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("tool_call")
+        first = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(
+                name="tool_call", arguments='{"name":"one"', call_id="bad-1",
+            )],
+        )
+        second = _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call(
+                name="tool_call", arguments='{"name":"two"', call_id="bad-2",
+            )],
+        )
+        agent.client.chat.completions.create.side_effect = [first, second]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="must not run") as dispatch,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("recall something")
+
+        assert result["partial"] is True
+        assert result["completed"] is False
+        assert result["api_calls"] == 2
+        dispatch.assert_not_called()
+        assert result["messages"][-1]["role"] == "assistant"
+        assert "invalid json" in result["messages"][-1]["content"].lower()
+        assert [
+            message["tool_call_id"]
+            for message in result["messages"]
+            if message.get("role") == "tool"
+        ] == ["bad-1", "bad-2"]
+
 
     def test_request_scoped_api_hooks_fire_for_each_api_call(self, agent):
         self._setup_agent(agent)
@@ -3811,8 +3895,8 @@ class TestRunConversation:
         assert result["final_response"] == "Done!"
 
 
-    def test_truncated_tool_json_after_tool_batch_closes_tool_tail(self, agent):
-        """finish_reason=tool_calls + truncated args after a real tool must close tool→user."""
+    def test_truncated_tool_json_after_tool_batch_requests_regeneration(self, agent):
+        """A malformed call after a real tool receives one paired parse error."""
         self._setup_agent(agent)
         agent.valid_tool_names.add("write_file")
         good_tc = _mock_tool_call(
@@ -3831,21 +3915,34 @@ class TestRunConversation:
         bad_resp = _mock_response(
             content="", finish_reason="tool_calls", tool_calls=[bad_tc],
         )
-        agent.client.chat.completions.create.side_effect = [good_resp, bad_resp]
+        recovered_resp = _mock_response(content="Recovered", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [
+            good_resp, bad_resp, recovered_resp,
+        ]
 
         with (
-            patch("run_agent.handle_function_call", return_value='{"success":true}'),
+            patch(
+                "run_agent.handle_function_call",
+                return_value='{"success":true}',
+            ) as dispatch,
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
             patch.object(agent, "_cleanup_task_resources"),
         ):
             result = agent.run_conversation("write then truncate")
 
-        assert result.get("partial") is True
+        assert result["final_response"] == "Recovered"
+        assert dispatch.call_count == 1
         msgs = result.get("messages") or []
         assert msgs[-1].get("role") == "assistant"
-        assert "truncated" in (msgs[-1].get("content") or "").lower()
-        assert any(isinstance(m, dict) and m.get("role") == "tool" for m in msgs)
+        malformed_results = [
+            message for message in msgs
+            if isinstance(message, dict)
+            and message.get("role") == "tool"
+            and message.get("tool_call_id") == "c_bad"
+        ]
+        assert len(malformed_results) == 1
+        assert "tool was not executed" in malformed_results[0]["content"].lower()
 
 
     def test_kanban_block_called_on_iteration_exhaustion(self, agent, monkeypatch):
@@ -5804,5 +5901,3 @@ class TestMemoryContextSanitization:
         assert "memory-context" not in result.lower()
         assert "stale observation" not in result
         assert "how is the honcho working" in result
-
-


### PR DESCRIPTION
## Summary

- Parse and validate tool-call arguments through one shared sanitizer before execution.
- Give malformed tool JSON one regeneration opportunity, then return a structurally closed partial response without dispatching a tool.
- Make the Docker state migration work both as root and as the container's runtime UID without unnecessary privilege dropping.

## Testing

- 231 focused conversation and execution tests
- 65 sanitizer and canonical message tests
- Docker migration tests as root and `--user 10000:10000`
- Ruff, ShellCheck, and `git diff --check`

The broader `test_run_agent` collection still has one environment-only collection failure because the optional `anthropic` dependency is not installed in this checkout.

## Post-Deploy Monitoring & Validation

- After the next image release, watch sanitizer warnings and tool dispatch counts for malformed argument responses.
- Confirm malformed calls never execute with `{}` and that a second malformed response returns a closed assistant/tool sequence.
- Verify startup migration logs are clean for both root-started and UID 10000 containers.
- Roll back to the prior image tag if tool dispatch or startup migration regresses.

Owner: Jonathan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
