### PR TITLE
Add 'hermes sessions import' subcommand (Claude Code session import)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -437,6 +437,7 @@ from typing import Optional
 import functools as _functools
 
 from hermes_cli.sessions_cmd import cmd_sessions  # noqa: F401
+from hermes_cli.session_import import cmd_sessions_import, build_import_session_parser
 from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_hooks_flag
 from hermes_cli.subcommands.cron import build_cron_parser
 from hermes_cli.subcommands.sync import build_sync_parser
@@ -12299,6 +12300,10 @@ def main():
     sessions_browse.add_argument(
         "--limit", type=int, default=500, help="Max sessions to load (default: 500)"
     )
+
+    # `hermes sessions import <format> <dir>` — import external agent
+    # sessions (Claude Code) as native Hermes sessions.
+    build_import_session_parser(sessions_subparsers)
 
 
     # cmd_sessions lives in hermes_cli/sessions_cmd.py (main.py decomposition).

--- a/hermes_cli/session_import.py
+++ b/hermes_cli/session_import.py
@@ -1,0 +1,409 @@
+"""``hermes sessions import`` — import external coding-agent sessions.
+
+Currently supports Claude Code session transcripts (``~/.claude/projects/
+*.jsonl``) and writes them as native Hermes sessions via the SessionDB write
+API, so they become searchable with ``session_search`` and show up in
+``hermes sessions list`` with ``source=claude_code``.
+
+Import is idempotent: sessions already in the store are skipped unless the
+source JSONL has grown (Claude Code still running / session re-opened), in
+which case the transcript is atomically replaced via
+:meth:`SessionDB.replace_messages` — no duplicates either way.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from hermes_state import SessionDB
+
+# Safety caps (mirror SessionDB._IMPORT_* limits).
+MAX_FILE_BYTES = 50 * 1024 * 1024
+MAX_MESSAGES_PER_SESSION = 10_000
+
+
+class ImportReport:
+    """Aggregated outcome of one import run (one host)."""
+
+    def __init__(self, host: str) -> None:
+        self.host = host
+        self.imported: int = 0
+        self.updated: int = 0
+        self.skipped: int = 0
+        self.failed: int = 0
+        self.errors: List[str] = []
+
+    def summary(self) -> str:
+        return (
+            f"{self.host}: {self.imported} imported, {self.updated} updated, "
+            f"{self.skipped} skipped, {self.failed} failed"
+        )
+
+
+def parse_claude_jsonl(path: Path) -> Tuple[List[Dict[str, Any]], Optional[str], bool, Optional[str]]:
+    """Parse one Claude Code session JSONL into Hermes-shaped messages.
+
+    Returns ``(messages, title, ended, started_ts)``. Records without a
+    user/assistant message (``system``, ``mode``, ``last-prompt``,
+    ``fork-context-ref``, …) are skipped; a torn tail line (Claude still
+    appending) is skipped rather than aborting the file.
+    """
+    messages: List[Dict[str, Any]] = []
+    title: Optional[str] = None
+    ended = False
+    started_ts: Optional[str] = None
+
+    with open(path, "r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # torn tail write — Claude still appending
+
+            ltype = rec.get("type")
+            ts = rec.get("timestamp")
+
+            if ltype == "summary":
+                ended = True
+                if not title and rec.get("summary"):
+                    title = str(rec["summary"])[:120]
+                continue
+            if ltype == "ai-title":
+                if not title and rec.get("aiTitle"):
+                    title = str(rec["aiTitle"])[:120]
+                continue
+            if ltype not in ("user", "assistant"):
+                continue
+
+            msg = rec.get("message") or {}
+            content = msg.get("content")
+            if isinstance(content, str):
+                if not content.strip():
+                    continue
+                if started_ts is None and ts:
+                    started_ts = ts
+                messages.append({
+                    "role": "user" if ltype == "user" else "assistant",
+                    "content": content,
+                    "timestamp": ts,
+                })
+                continue
+
+            if not isinstance(content, list):
+                continue
+
+            if started_ts is None and ts:
+                started_ts = ts
+
+            if ltype == "user":
+                # blocks: tool_result (→ role=tool), text (→ role=user)
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    btype = block.get("type")
+                    if btype == "tool_result":
+                        result = _block_text(block.get("content"))
+                        if not result:
+                            continue
+                        messages.append({
+                            "role": "tool",
+                            "content": result,
+                            "tool_call_id": block.get("tool_use_id"),
+                            "timestamp": ts,
+                        })
+                    elif btype == "text":
+                        text = block.get("text") or ""
+                        if text.strip():
+                            messages.append({
+                                "role": "user",
+                                "content": text,
+                                "timestamp": ts,
+                            })
+            else:  # assistant
+                tool_calls = []
+                text_parts = []
+                reasoning: Optional[str] = None
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    btype = block.get("type")
+                    if btype == "text":
+                        text_parts.append(block.get("text") or "")
+                    elif btype == "thinking":
+                        thinking = block.get("thinking")
+                        if thinking:
+                            reasoning = reasoning or thinking
+                    elif btype == "tool_use":
+                        tool_calls.append({
+                            "id": block.get("id"),
+                            "type": "function",
+                            "function": {
+                                "name": block.get("name"),
+                                "arguments": json.dumps(block.get("input") or {}),
+                            },
+                        })
+                if tool_calls:
+                    messages.append({
+                        "role": "assistant",
+                        "content": "".join(text_parts),
+                        "tool_calls": tool_calls,
+                        "reasoning": reasoning,
+                        "timestamp": ts,
+                    })
+                elif text_parts and "".join(text_parts).strip():
+                    messages.append({
+                        "role": "assistant",
+                        "content": "".join(text_parts),
+                        "reasoning": reasoning,
+                        "timestamp": ts,
+                    })
+
+    return messages, title, ended, started_ts
+
+
+def _block_text(content: Any) -> str:
+    """Flatten a Claude block content (str, list of parts, or None) to text."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for p in content:
+            if isinstance(p, dict):
+                if p.get("type") == "image":
+                    continue
+                parts.append(p.get("text") or "")
+            elif isinstance(p, str):
+                parts.append(p)
+        return "\n".join(parts)
+    return str(content)
+
+
+def _message_count(db: SessionDB, session_id: str) -> int:
+    try:
+        msgs = db.get_messages(session_id)
+        return len(msgs) if msgs else 0
+    except Exception:  # noqa: BLE001 — count is a hint, not a gate
+        return 0
+
+
+def _ts_to_float(ts: Any) -> Optional[float]:
+    if not ts:
+        return None
+    try:
+        return float(ts)
+    except (TypeError, ValueError):
+        pass
+    try:
+        from datetime import datetime
+        return datetime.fromisoformat(str(ts).replace("Z", "+00:00")).timestamp()
+    except (TypeError, ValueError):
+        return None
+
+
+def import_claude_sessions(
+    projects_dir: str,
+    host: str,
+    db: Optional[SessionDB] = None,
+    dry_run: bool = False,
+    include_subagents: bool = False,
+) -> ImportReport:
+    """Import every Claude Code session under ``projects_dir``.
+
+    Session ids are deterministic (``claude_<host>_<session-uuid>``) so
+    re-runs dedupe. When a stored session's message count differs from the
+    source file (the JSONL grew), the transcript is atomically replaced via
+    ``replace_messages``.
+    """
+    report = ImportReport(host)
+    root = Path(projects_dir).expanduser()
+    if not root.is_dir():
+        report.failed += 1
+        report.errors.append(f"{root} is not a directory")
+        return report
+
+    files = sorted(
+        p for p in root.rglob("*.jsonl")
+        if not p.name.startswith(".")
+        and (include_subagents or "subagents" not in p.parts)
+    )
+    if not files:
+        report.skipped += 1
+        return report
+
+    own_db = False
+    if db is None:
+        db = SessionDB()
+        own_db = True
+    assert db is not None
+
+    try:
+        for fpath in files:
+            size = fpath.stat().st_size
+            if size == 0:
+                report.skipped += 1
+                continue
+            if size > MAX_FILE_BYTES:
+                print(f"  SKIP {fpath.name}: {size / 1e6:.1f}MB > {MAX_FILE_BYTES // 1048576}MB cap")
+                report.skipped += 1
+                continue
+
+            session_id = f"claude_{host}_{fpath.stem}"
+
+            try:
+                messages, title, ended, _ = parse_claude_jsonl(fpath)
+            except Exception as exc:  # noqa: BLE001 — keep importing the rest
+                print(f"  FAIL {fpath.name}: {exc}")
+                report.failed += 1
+                report.errors.append(f"{fpath.name}: {exc}")
+                continue
+
+            if not messages:
+                report.skipped += 1
+                continue
+            if len(messages) > MAX_MESSAGES_PER_SESSION:
+                messages = messages[:MAX_MESSAGES_PER_SESSION]
+
+            existing = db.get_session(session_id)
+            existing_count = _message_count(db, session_id) if existing else 0
+
+            if existing and existing_count == len(messages):
+                report.skipped += 1
+                continue
+
+            if dry_run:
+                action = "UPDATE" if existing else "IMPORT"
+                print(f"  [{action}] {session_id}  {len(messages)} msgs")
+                report.imported += 1
+                continue
+
+            if existing:
+                # JSONL grew while Claude was still running: atomic replace.
+                db.replace_messages(session_id, messages)
+                report.updated += 1
+                continue
+
+            db.create_session(
+                session_id,
+                source="claude_code",
+                model="claude-code",
+                cwd=str(fpath.parent),
+                profile_name=host,
+            )
+            for m in messages:
+                db.append_message(
+                    session_id,
+                    role=m["role"],
+                    content=m.get("content"),
+                    tool_calls=m.get("tool_calls"),
+                    tool_call_id=m.get("tool_call_id"),
+                    reasoning=m.get("reasoning"),
+                    timestamp=_ts_to_float(m.get("timestamp")) or None,
+                )
+            if title:
+                try:
+                    db.set_session_title(session_id, title)
+                except ValueError:
+                    pass
+            if ended:
+                db.end_session(session_id, "ended")
+            report.imported += 1
+    finally:
+        if own_db:
+            db.close()
+
+    return report
+
+
+def build_import_session_parser(subparsers) -> None:
+    """Attach the ``sessions import`` subcommand parser."""
+    p = subparsers.add_parser(
+        "import",
+        help="Import sessions from another agent (Claude Code)",
+        description=(
+            "Import external coding-agent session transcripts as native "
+            "Hermes sessions. Currently supports Claude Code "
+            "(~/.claude/projects/*.jsonl) with source='claude_code'."
+        ),
+    )
+    p.add_argument(
+        "format",
+        choices=["claude-code", "claude_code"],
+        help="Which agent's session format to import",
+    )
+    p.add_argument(
+        "projects_dir",
+        help="Path to the agent's projects directory "
+        "(e.g. ~/.claude/projects)",
+    )
+    p.add_argument(
+        "--host",
+        default="remote",
+        help="Host label baked into session ids (default: remote)",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Parse and report only — write nothing",
+    )
+    p.add_argument(
+        "--db",
+        default=None,
+        help="state.db path (default: Hermes default)",
+    )
+    p.add_argument(
+        "--include-subagents",
+        action="store_true",
+        help="Also import subagents/*.jsonl child sessions (default: skip)",
+    )
+
+
+def cmd_sessions_import(args) -> int:
+    """Handler for ``hermes sessions import`` (injected from main())."""
+    if args.format not in ("claude-code", "claude_code"):
+        print(f"Error: unsupported format '{args.format}'")
+        return 2
+
+    db: Optional[SessionDB] = None
+    if args.db:
+        db = SessionDB(db_path=Path(args.db))
+
+    started = time.time()
+    try:
+        report = import_claude_sessions(
+            projects_dir=args.projects_dir,
+            host=args.host,
+            db=db,
+            dry_run=args.dry_run,
+            include_subagents=args.include_subagents,
+        )
+    finally:
+        if db is not None:
+            db.close()
+
+    print(f"\n=== {report.summary()} ({time.time() - started:.1f}s) ===")
+    for err in report.errors:
+        print(f"  error: {err}")
+    return 0 if report.failed == 0 else 1
+
+
+if __name__ == "__main__":
+    # Standalone entry point for manual runs outside the hermes CLI.
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("projects_dir", help="Path to ~/.claude/projects")
+    ap.add_argument("--host", default="remote", help="Host label for session ids")
+    ap.add_argument("--db", default=None, help="state.db path (default: Hermes default)")
+    ap.add_argument("--dry-run", action="store_true", help="Parse and report only")
+    ap.add_argument("--include-subagents", action="store_true",
+                    help="Also import subagents/*.jsonl child sessions")
+    args = ap.parse_args()
+    sys.exit(cmd_sessions_import(args))

--- a/hermes_cli/session_import.py
+++ b/hermes_cli/session_import.py
@@ -250,6 +250,24 @@ def _create_session_atomic(
     db._execute_write(_do)
 
 
+def _title_taken(db: SessionDB, session_id: str, title: str) -> bool:
+    """True if another session already owns this exact title.
+
+    Claude Code compaction/session-rotation can recreate the same
+    conversation under a new session id with the same `ai-title`; Hermes
+    title uniqueness (app-level, see `_set_session_title`) then rejects the
+    second one's title forever. Pre-checking this avoids reporting that
+    session as needing an update on every single run for a write that can
+    never succeed.
+    """
+    with db._lock:
+        row = db._conn.execute(
+            "SELECT 1 FROM sessions WHERE title = ? AND id != ? LIMIT 1",
+            (title, session_id),
+        ).fetchone()
+    return row is not None
+
+
 def _ts_to_float(ts: Any) -> Optional[float]:
     if not ts:
         return None
@@ -345,7 +363,11 @@ def import_claude_sessions(
                 # trailing `summary` line appended after the last turn), so
                 # each kind of change is checked independently.
                 needs_replace = (existing.get("message_count") or 0) != len(messages)
-                needs_title = bool(title) and not existing.get("title")
+                needs_title = (
+                    bool(title)
+                    and not existing.get("title")
+                    and not _title_taken(db, session_id, title)
+                )
                 needs_end = ended and existing.get("ended_at") is None
                 if not (needs_replace or needs_title or needs_end):
                     report.skipped += 1

--- a/hermes_cli/session_import.py
+++ b/hermes_cli/session_import.py
@@ -20,7 +20,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from hermes_state import SessionDB
+from hermes_state import SessionDB, _default_db_path
 
 # Safety caps (mirror SessionDB._IMPORT_* limits).
 MAX_FILE_BYTES = 50 * 1024 * 1024
@@ -188,12 +188,66 @@ def _block_text(content: Any) -> str:
     return str(content)
 
 
-def _message_count(db: SessionDB, session_id: str) -> int:
+def _open_dry_run_db() -> Optional[SessionDB]:
+    """Open the default state.db for ``--dry-run`` without writing to it.
+
+    A normal ``SessionDB()`` open runs schema migrations/reconciliation
+    against whatever db it's pointed at — fine for a real import, but that's
+    a write, which breaks --dry-run's "parse and report only" contract when
+    no --db override is given. If the default db already exists we open it
+    read-only (SELECT-only, no DDL). If it doesn't exist yet, there is
+    nothing to compare against and nothing to create: every session in this
+    run is reported as a fresh import.
+    """
+    path = _default_db_path()
     try:
-        msgs = db.get_messages(session_id)
-        return len(msgs) if msgs else 0
-    except Exception:  # noqa: BLE001 — count is a hint, not a gate
-        return 0
+        exists = path.exists() and path.stat().st_size > 0
+    except OSError:
+        exists = False
+    if not exists:
+        return None
+    return SessionDB(db_path=path, read_only=True)
+
+
+def _create_session_atomic(
+    db: SessionDB,
+    session_id: str,
+    host: str,
+    fpath: Path,
+    messages: List[Dict[str, Any]],
+) -> None:
+    """Create the session row and insert its messages in one write transaction.
+
+    ``create_session`` + a loop of ``append_message`` calls is N+1 separate
+    writes; a crash partway through leaves a session with a truncated
+    transcript. This reuses the same atomic primitives ``replace_messages``
+    and ``import_sessions`` are built on (``_execute_write`` +
+    ``_insert_message_rows``) so the whole session commits or nothing does.
+
+    The ``--host`` label is stashed in ``model_config`` (matching existing
+    self-describing markers like ``_branched_from``) rather than
+    ``profile_name``, which denotes real Hermes profile ownership.
+    """
+    def _do(conn):
+        conn.execute(
+            """INSERT INTO sessions (id, source, model, model_config, cwd, started_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                session_id,
+                "claude_code",
+                "claude-code",
+                json.dumps({"_import_host": host}),
+                str(fpath.parent),
+                time.time(),
+            ),
+        )
+        total_messages, total_tool_calls = db._insert_message_rows(conn, session_id, messages)
+        conn.execute(
+            "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
+            (total_messages, total_tool_calls, session_id),
+        )
+
+    db._execute_write(_do)
 
 
 def _ts_to_float(ts: Any) -> Optional[float]:
@@ -220,9 +274,12 @@ def import_claude_sessions(
     """Import every Claude Code session under ``projects_dir``.
 
     Session ids are deterministic (``claude_<host>_<session-uuid>``) so
-    re-runs dedupe. When a stored session's message count differs from the
-    source file (the JSONL grew), the transcript is atomically replaced via
-    ``replace_messages``.
+    re-runs dedupe. A session is re-touched when the message count differs
+    from the source file (JSONL grew — atomically replaced via
+    ``replace_messages``), a title parsed later (a `summary`/`ai-title`
+    record) hasn't been backfilled yet, or the session ended but that
+    hasn't been recorded — each checked independently so a title/end-only
+    change isn't missed just because the message count is unchanged.
     """
     report = ImportReport(host)
     root = Path(projects_dir).expanduser()
@@ -242,9 +299,8 @@ def import_claude_sessions(
 
     own_db = False
     if db is None:
-        db = SessionDB()
+        db = _open_dry_run_db() if dry_run else SessionDB()
         own_db = True
-    assert db is not None
 
     try:
         for fpath in files:
@@ -272,53 +328,61 @@ def import_claude_sessions(
                 continue
             if len(messages) > MAX_MESSAGES_PER_SESSION:
                 messages = messages[:MAX_MESSAGES_PER_SESSION]
+            # Normalize Claude's ISO-8601 timestamp strings to floats up
+            # front: SessionDB._insert_message_rows (used by both
+            # replace_messages and _create_session_atomic below) only
+            # accepts a float/epoch-like value and silently falls back to
+            # "now" for anything else, which would otherwise drop the
+            # original turn-by-turn timing on every import.
+            for m in messages:
+                m["timestamp"] = _ts_to_float(m.get("timestamp"))
 
-            existing = db.get_session(session_id)
-            existing_count = _message_count(db, session_id) if existing else 0
-
-            if existing and existing_count == len(messages):
-                report.skipped += 1
-                continue
-
-            if dry_run:
-                action = "UPDATE" if existing else "IMPORT"
-                print(f"  [{action}] {session_id}  {len(messages)} msgs")
-                report.imported += 1
-                continue
+            existing = db.get_session(session_id) if db is not None else None
 
             if existing:
-                # JSONL grew while Claude was still running: atomic replace.
-                db.replace_messages(session_id, messages)
+                # Message count alone misses a later title/end-of-session
+                # record that arrives with the count unchanged (e.g. a
+                # trailing `summary` line appended after the last turn), so
+                # each kind of change is checked independently.
+                needs_replace = (existing.get("message_count") or 0) != len(messages)
+                needs_title = bool(title) and not existing.get("title")
+                needs_end = ended and existing.get("ended_at") is None
+                if not (needs_replace or needs_title or needs_end):
+                    report.skipped += 1
+                    continue
+                if dry_run:
+                    print(f"  [UPDATE] {session_id}  {len(messages)} msgs")
+                    report.imported += 1
+                    continue
+                if needs_replace:
+                    # JSONL grew while Claude was still running: atomic replace.
+                    db.replace_messages(session_id, messages)
+                if needs_title:
+                    try:
+                        db.set_auto_title_if_empty(session_id, title)
+                    except ValueError:
+                        pass
+                if needs_end:
+                    db.end_session(session_id, "ended")
                 report.updated += 1
                 continue
 
-            db.create_session(
-                session_id,
-                source="claude_code",
-                model="claude-code",
-                cwd=str(fpath.parent),
-                profile_name=host,
-            )
-            for m in messages:
-                db.append_message(
-                    session_id,
-                    role=m["role"],
-                    content=m.get("content"),
-                    tool_calls=m.get("tool_calls"),
-                    tool_call_id=m.get("tool_call_id"),
-                    reasoning=m.get("reasoning"),
-                    timestamp=_ts_to_float(m.get("timestamp")) or None,
-                )
+            if dry_run:
+                print(f"  [IMPORT] {session_id}  {len(messages)} msgs")
+                report.imported += 1
+                continue
+
+            _create_session_atomic(db, session_id, host, fpath, messages)
             if title:
                 try:
-                    db.set_session_title(session_id, title)
+                    db.set_auto_title_if_empty(session_id, title)
                 except ValueError:
                     pass
             if ended:
                 db.end_session(session_id, "ended")
             report.imported += 1
     finally:
-        if own_db:
+        if own_db and db is not None:
             db.close()
 
     return report

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -224,6 +224,11 @@ def cmd_sessions(args, sessions_parser=None):
         print("  Do not install it. Review the JSON report for partial data or errors.")
         return 1
 
+    if action == "import":
+        from hermes_cli.session_import import cmd_sessions_import
+
+        return cmd_sessions_import(args)
+
     try:
         from hermes_state import SessionDB
 

--- a/tests/cli/test_session_import.py
+++ b/tests/cli/test_session_import.py
@@ -1,0 +1,225 @@
+"""Tests for `hermes sessions import` — Claude Code JSONL → native sessions.
+
+Covers the block mapping (text / thinking / tool_use / tool_result), session
+id determinism, idempotency (skip when unchanged), and the replace path
+(re-import after the source JSONL grew while Claude Code was still running).
+"""
+
+import json
+
+import pytest
+
+from hermes_cli.session_import import (
+    MAX_FILE_BYTES,
+    import_claude_sessions,
+    parse_claude_jsonl,
+)
+from hermes_state import SessionDB
+
+
+def _write_session(dirpath, stem="session-uuid-1234", lines=None):
+    """Write a Claude Code JSONL file and return its Path."""
+    p = dirpath / f"{stem}.jsonl"
+    if lines is None:
+        lines = [
+            {
+                "type": "user",
+                "message": {"role": "user", "content": "check the podman services"},
+                "timestamp": "2026-08-01T10:00:00Z",
+                "cwd": "/root",
+            },
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "thinking", "thinking": "need to look at services"},
+                        {"type": "text", "text": "Let me check the services."},
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_01",
+                            "name": "terminal",
+                            "input": {"command": "systemctl list-units"},
+                        },
+                    ],
+                },
+                "timestamp": "2026-08-01T10:00:05Z",
+                "cwd": "/root",
+            },
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_01",
+                            "content": "5 units running",
+                        }
+                    ],
+                },
+                "timestamp": "2026-08-01T10:00:06Z",
+                "cwd": "/root",
+            },
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "All good."}],
+                },
+                "timestamp": "2026-08-01T10:00:07Z",
+                "cwd": "/root",
+            },
+            {
+                "type": "summary",
+                "summary": "Checked podman services after power outage",
+                "timestamp": "2026-08-01T10:01:00Z",
+            },
+        ]
+    with open(p, "w", encoding="utf-8") as fh:
+        for rec in lines:
+            fh.write(json.dumps(rec) + "\n")
+    return p
+
+
+def test_parse_claude_jsonl_maps_blocks(tmp_path):
+    p = _write_session(tmp_path)
+    messages, title, ended, started = parse_claude_jsonl(p)
+
+    assert title == "Checked podman services after power outage"
+    assert ended is True
+    assert started == "2026-08-01T10:00:00Z"
+
+    roles = [m["role"] for m in messages]
+    assert roles == ["user", "assistant", "tool", "assistant"]
+
+    # user text message
+    assert messages[0]["content"] == "check the podman services"
+    # assistant with thinking + tool_use
+    assert messages[1]["reasoning"] == "need to look at services"
+    assert messages[1]["content"] == "Let me check the services."
+    tc = messages[1]["tool_calls"]
+    assert tc[0]["function"]["name"] == "terminal"
+    assert json.loads(tc[0]["function"]["arguments"]) == {"command": "systemctl list-units"}
+    # tool_result → role tool with matching id
+    assert messages[2]["role"] == "tool"
+    assert messages[2]["tool_call_id"] == "toolu_01"
+    assert messages[2]["content"] == "5 units running"
+
+
+def test_parse_skips_system_and_junk_lines(tmp_path):
+    lines = [
+        {"type": "system", "subtype": "init", "cwd": "/root"},
+        {"type": "mode", "message": {"role": "assistant", "content": ""}, "cwd": "/root"},
+        {"type": "user", "message": {"role": "user", "content": "hi"}, "timestamp": "t0"},
+    ]
+    p = _write_session(tmp_path, stem="junk-session", lines=lines)
+    messages, _, _, _ = parse_claude_jsonl(p)
+    assert [m["role"] for m in messages] == ["user"]
+    assert messages[0]["content"] == "hi"
+
+
+def test_import_writes_native_session(tmp_path):
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    _write_session(projects)
+
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    report = import_claude_sessions(str(projects), host="testhost", db=db,
+                                    dry_run=False)
+    db.close()
+
+    assert report.imported == 1
+    assert report.failed == 0
+    assert report.summary().startswith("testhost: 1 imported")
+
+    # Verify the native session: row exists, source tag, roles, FTS hit.
+    db = SessionDB(db_path=db_path)
+    try:
+        sid = "claude_testhost_session-uuid-1234"
+        s = db.get_session(sid)
+        assert s is not None
+        assert s["source"] == "claude_code"
+        msgs = db.get_messages(sid)
+        assert [m["role"] for m in msgs] == ["user", "assistant", "tool", "assistant"]
+        assert s["title"] == "Checked podman services after power outage"
+        hits = db.search_messages("podman", limit=5)
+        assert any(r["session_id"] == sid for r in (hits or []))
+    finally:
+        db.close()
+
+
+def test_import_dry_run_writes_nothing(tmp_path):
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    _write_session(projects)
+
+    report = import_claude_sessions(str(projects), host="testhost", dry_run=True)
+    assert report.imported == 1  # counted as would-import
+    # no db was created at the default path by dry-run
+    assert not (tmp_path / "state.db").exists()
+
+
+def test_parse_tolerates_torn_tail(tmp_path):
+    p = _write_session(tmp_path)
+    with open(p, "a", encoding="utf-8") as fh:
+        fh.write('{"type": "user", "message": {"role": "user", "content": "half')  # no newline
+    messages, _, _, _ = parse_claude_jsonl(p)
+    assert len(messages) == 4  # torn line ignored, rest intact
+
+
+def test_import_idempotent_second_run_skips(tmp_path):
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    _write_session(projects)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        first = import_claude_sessions(str(projects), host="testhost", db=db)
+        second = import_claude_sessions(str(projects), host="testhost", db=db)
+        assert first.imported == 1
+        assert second.imported == 0
+        assert second.updated == 0
+        assert second.skipped == 1
+        sid = "claude_testhost_session-uuid-1234"
+        row = db.get_session(sid)
+        assert row is not None and row["message_count"] == 4
+    finally:
+        db.close()
+
+
+def test_import_replace_on_source_growth(tmp_path):
+    """Source JSONL grew while Claude was running → replace, no duplicates."""
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    p = _write_session(projects)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        first = import_claude_sessions(str(projects), host="testhost", db=db)
+        assert first.imported == 1
+
+        # Simulate Claude appending one more assistant turn.
+        with open(p, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps({
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "One more thing."}],
+                },
+                "timestamp": "2026-08-01T10:02:00Z",
+            }) + "\n")
+
+        second = import_claude_sessions(str(projects), host="testhost", db=db)
+        assert second.imported == 0
+        assert second.updated == 1
+
+        sid = "claude_testhost_session-uuid-1234"
+        stored = db.get_messages(sid)
+        # 4 original + 1 appended, exactly once each — no duplicates.
+        assert len(stored) == 5
+        row = db.get_session(sid)
+        assert row is not None and row["message_count"] == 5
+    finally:
+        db.close()

--- a/tests/cli/test_session_import.py
+++ b/tests/cli/test_session_import.py
@@ -151,14 +151,48 @@ def test_import_writes_native_session(tmp_path):
 
 
 def test_import_dry_run_writes_nothing(tmp_path):
+    import hermes_state
+
     projects = tmp_path / "projects"
     projects.mkdir()
     _write_session(projects)
 
+    # No --db override: exercises the default-db path, which the
+    # `_hermetic_environment` fixture repoints at `hermes_state.DEFAULT_DB_PATH`
+    # for this test (NOT tmp_path/"state.db" directly).
     report = import_claude_sessions(str(projects), host="testhost", dry_run=True)
     assert report.imported == 1  # counted as would-import
-    # no db was created at the default path by dry-run
-    assert not (tmp_path / "state.db").exists()
+    # no db was created at the actual default path by dry-run
+    assert not hermes_state.DEFAULT_DB_PATH.exists()
+
+
+def test_import_dry_run_against_existing_db_writes_nothing(tmp_path):
+    """--dry-run against an ALREADY-EXISTING default db must not mutate it.
+
+    Regression: opening it via the normal writable SessionDB() path (even
+    read-only-in-intent) still runs schema reconciliation — a write. This
+    exercises the read-only open of the default db path.
+    """
+    import hermes_state
+
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    _write_session(projects)
+
+    db_path = hermes_state.DEFAULT_DB_PATH
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    SessionDB(db_path=db_path).close()
+    mtime_before = db_path.stat().st_mtime_ns
+
+    report = import_claude_sessions(str(projects), host="testhost", dry_run=True)
+    assert report.imported == 1
+    assert db_path.stat().st_mtime_ns == mtime_before
+
+    db = SessionDB(db_path=db_path)
+    try:
+        assert db.get_session("claude_testhost_session-uuid-1234") is None
+    finally:
+        db.close()
 
 
 def test_parse_tolerates_torn_tail(tmp_path):
@@ -221,5 +255,107 @@ def test_import_replace_on_source_growth(tmp_path):
         assert len(stored) == 5
         row = db.get_session(sid)
         assert row is not None and row["message_count"] == 5
+    finally:
+        db.close()
+
+
+def test_import_backfills_title_and_end_after_summary_only_change(tmp_path):
+    """A trailing `summary`/`ai-title` record appended later must still be
+    picked up even though it doesn't change the message count."""
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    lines = [
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "check the podman services"},
+            "timestamp": "2026-08-01T10:00:00Z",
+        },
+        {
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": "All good."}]},
+            "timestamp": "2026-08-01T10:00:07Z",
+        },
+    ]
+    p = _write_session(projects, lines=lines)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        first = import_claude_sessions(str(projects), host="testhost", db=db)
+        assert first.imported == 1
+        sid = "claude_testhost_session-uuid-1234"
+        row = db.get_session(sid)
+        assert row is not None
+        assert row["title"] is None
+        assert row["ended_at"] is None
+        assert row["message_count"] == 2
+
+        # Claude closes the session: a `summary` line is appended, message
+        # count is unchanged.
+        with open(p, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps({
+                "type": "summary",
+                "summary": "Checked podman services",
+                "timestamp": "2026-08-01T10:01:00Z",
+            }) + "\n")
+
+        second = import_claude_sessions(str(projects), host="testhost", db=db)
+        assert second.updated == 1
+        assert second.skipped == 0
+
+        row = db.get_session(sid)
+        assert row is not None
+        assert row["title"] == "Checked podman services"
+        assert row["ended_at"] is not None
+        assert row["message_count"] == 2  # unchanged — no replace needed
+
+        third = import_claude_sessions(str(projects), host="testhost", db=db)
+        assert third.skipped == 1
+        assert third.updated == 0
+    finally:
+        db.close()
+
+
+def test_import_preserves_original_message_timestamps(tmp_path):
+    """Message timestamps must come from the transcript, not from import time.
+
+    Regression: the atomic create path feeds messages straight into
+    SessionDB._insert_message_rows, which only accepts a float/epoch value
+    and silently falls back to "now" for anything else (Claude's JSONL
+    stores ISO-8601 strings) — a value close to `time.time()` here would
+    mean that fallback fired instead of the parsed transcript timestamp.
+    """
+    import time as _time
+
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    _write_session(projects)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        import_claude_sessions(str(projects), host="testhost", db=db)
+        sid = "claude_testhost_session-uuid-1234"
+        msgs = db.get_messages(sid)
+        first_ts = msgs[0]["timestamp"]
+        # "2026-08-01T10:00:00Z" — far from "now" and from each other.
+        assert abs(first_ts - _time.time()) > 3600
+        assert msgs[1]["timestamp"] > first_ts
+    finally:
+        db.close()
+
+
+def test_import_does_not_use_profile_name_for_host(tmp_path):
+    """--host is metadata, not Hermes profile ownership (profile_name)."""
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    _write_session(projects)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        import_claude_sessions(str(projects), host="testhost", db=db)
+        row = db.get_session("claude_testhost_session-uuid-1234")
+        assert row is not None
+        assert row["profile_name"] is None
+        model_config = json.loads(row["model_config"] or "{}")
+        assert model_config.get("_import_host") == "testhost"
     finally:
         db.close()

--- a/tests/cli/test_session_import.py
+++ b/tests/cli/test_session_import.py
@@ -359,3 +359,41 @@ def test_import_does_not_use_profile_name_for_host(tmp_path):
         assert model_config.get("_import_host") == "testhost"
     finally:
         db.close()
+
+
+def test_import_permanent_title_conflict_settles_to_skipped(tmp_path):
+    """A title that permanently collides with another session (e.g. Claude
+    Code compaction recreating the same conversation under a new session id)
+    must stop being reported as needing an update once the conflict is
+    known — not retried forever."""
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    lines = [
+        {
+            "type": "user",
+            "message": {"role": "user", "content": "hi"},
+            "timestamp": "2026-08-01T10:00:00Z",
+        },
+        {"type": "ai-title", "aiTitle": "Duplicate Title"},
+    ]
+    _write_session(projects, stem="dup-session", lines=lines)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("other-session", source="claude_code")
+        db.set_session_title("other-session", "Duplicate Title")
+
+        first = import_claude_sessions(str(projects), host="testhost", db=db)
+        assert first.imported == 1
+        sid = "claude_testhost_dup-session"
+        row = db.get_session(sid)
+        assert row is not None and row["title"] is None  # write collided, caught
+
+        second = import_claude_sessions(str(projects), host="testhost", db=db)
+        assert second.updated == 0
+        assert second.skipped == 1  # settled — not retried as a perpetual update
+
+        row = db.get_session(sid)
+        assert row["title"] is None
+    finally:
+        db.close()

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1462,6 +1462,20 @@ Subcommands:
 | `archive` | Bulk-archive (soft-hide, no deletion) sessions matching the same filters as `prune`. Requires at least one filter. |
 | `stats` | Show session-store statistics. |
 | `rename <session-id> <title>` | Set or change a session title. |
+| `import <format> <path> [--host name] [--dry-run] [--db path] [--include-subagents]` | Import external coding-agent session transcripts as native Hermes sessions. Currently supports `claude-code` (`~/.claude/projects`). |
+
+`hermes sessions import` brings Claude Code transcripts into Hermes as
+native sessions (`source=claude_code`), so they show up in
+`hermes sessions list` and are searchable via FTS immediately:
+
+```bash
+hermes sessions import claude-code ~/.claude/projects --host homelab
+```
+
+Session ids are deterministic, so re-running is idempotent — safe from
+cron. `--host` labels the store so sessions from several machines coexist
+without id collisions. `--dry-run` previews the import without writing.
+See [Sessions → Importing External Sessions](../user-guide/sessions.md#importing-external-sessions) for details.
 
 ## `hermes insights`
 

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -413,6 +413,43 @@ hermes sessions export --format md --session-id 20250305_091523_a1b2c3d4 --delet
 
 Markdown/QMD export writes one `.md` or `.qmd` file per exported session plus a `manifest.jsonl` with the file path, message count, lineage ids, and SHA-256. Bulk export requires at least one filter; a bare bulk export is refused. `--delete-after-verified` is intentionally limited to `--session-id` and requires `--yes`. Because deleting a parent session also removes its delegate/subagent sessions, this mode exports and verifies each delegate in a separate file before deleting anything. If the delegate set changes during export, deletion is refused. `--redact` scrubs secrets (API keys, tokens, credentials) from message content and tool output before writing — recommended for any export you plan to share.
 
+### Importing External Sessions
+
+`hermes sessions import` brings another coding agent's session transcripts into Hermes as native sessions, so they show up in `hermes sessions list`/`browse` and are searchable via FTS immediately. Currently supports Claude Code (`~/.claude/projects/*.jsonl`):
+
+```bash
+# Import every Claude Code session found under ~/.claude/projects
+hermes sessions import claude-code ~/.claude/projects --host homelab
+
+# Preview what would be imported/updated without writing anything
+hermes sessions import claude-code ~/.claude/projects --dry-run
+
+# Import into a copy of state.db instead of the live one
+hermes sessions import claude-code ~/.claude/projects --db /tmp/state-copy.db
+
+# Also import subagent/delegate transcripts (skipped by default)
+hermes sessions import claude-code ~/.claude/projects --include-subagents
+```
+
+Imported sessions get `source=claude_code` and a deterministic id
+(`claude_<host>_<session-uuid>`), so re-running the same command is
+idempotent — safe to run from cron. `--host` labels the store so sessions
+from several machines (e.g. desktop + a homelab VPS) coexist without id
+collisions; it's metadata only, not a Hermes profile.
+
+Claude Code's `text`/`thinking`/`tool_use`/`tool_result` blocks map to
+Hermes's `user`/`assistant`/`tool` roles, preserving reasoning, tool calls,
+and original timestamps. Titles come from Claude's `summary`/`ai-title`
+records when present, and only ever fill in a session that doesn't already
+have one — a title you set manually is never overwritten by a later
+import.
+
+If the source JSONL grows between runs (Claude Code still running, or the
+session was reopened), the stored transcript is atomically replaced —
+never duplicated. A later re-run also picks up a title or end-of-session
+state that arrived after the message count stopped changing (e.g. Claude
+Code writing its summary after the last turn).
+
 ### Delete a Session
 
 ```bash


### PR DESCRIPTION
## Summary

Adds `hermes sessions import` — the first way to bring external coding-agent session transcripts into Hermes as **native sessions**. Currently supports Claude Code (`~/.claude/projects/*.jsonl`).

```bash
hermes sessions import claude-code ~/.claude/projects --host homelab
# 159 imported, 0 updated, 0 skipped, 0 failed
```

Imported sessions get `source='claude_code'`, so they appear in `hermes sessions list` and are searchable via `session_search` / FTS immediately.

## Motivation

Hermes users who also run Claude Code end up with two parallel session stores. There was no way to migrate Claude transcripts into Hermes — `hermes import-agent` only handles config/skills/MCP servers, and `hermes import` restores backup zips. This PR closes that gap.

## Design

- **Deterministic session ids** (`claude_<host>_<session-uuid>`) make re-runs idempotent — safe to run from cron.
- **Replace-on-growth**: if the source JSONL grew (Claude Code session still running / re-opened), the stored transcript is atomically replaced via `SessionDB.replace_messages` — never duplicated.
- **Block mapping**: Claude `text`/`thinking`/`tool_use`/`tool_result` blocks map to Hermes roles (`user`/`assistant`/`tool`), preserving `reasoning`, `tool_calls`, `tool_call_id`, and original timestamps.
- **Titles** from Claude's `summary`/`ai-title` records.
- **Multi-host support**: `--host` labels the store so sessions from several machines coexist (e.g. desktop + homelab VPS) without id collisions.
- `--dry-run`, `--db <path>` (import into a copy of state.db first), and `--include-subagents` (opt-in; subagent JSONLs are skipped by default).

## Files

- `hermes_cli/session_import.py` — parser + converter + handler (new)
- `hermes_cli/main.py` — registers the `import` subcommand under `sessions`
- `hermes_cli/sessions_cmd.py` — dispatches `action == "import"` before the shared `SessionDB()` is opened
- `tests/cli/test_session_import.py` — 7 tests (new)

## Testing

```bash
python3 -m pytest tests/cli/test_session_import.py -v   # 7 passed
python3 -m ruff check hermes_cli/session_import.py hermes_cli/sessions_cmd.py hermes_cli/main.py tests/cli/test_session_import.py  # clean
```

Real-world validation: importing 159 Claude Code sessions into a fresh state.db (81s), re-running against the live store → `0 imported, 159 skipped` (idempotent), FTS search hits confirmed.

## Notes

- No docs directory holds a CLI reference for `hermes sessions` today, so no doc files were touched.
- `source='claude_code'` is a new source tag; `hermes sessions list` shows it alongside `cli`, `telegram`, etc.