### PR TITLE
feat(security): mask opaque credential values in log output

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -1045,4 +1045,13 @@ class RedactingFormatter(logging.Formatter):
         # exact-value pass so opaque credential values with no recognizable
         # prefix (e.g. MY_SERVICE_TOKEN=abc123randomstring, BWS_ACCESS_TOKEN)
         # are masked from log output too.
-        return _mask_known_env_values(redact_sensitive_text(original))
+        redacted = redact_sensitive_text(original)
+        # The exact-value pass must honor the same global opt-out as
+        # redact_sensitive_text: with `security.redact_secrets: false` (or
+        # HERMES_REDACT_SECRETS=false) the documented contract is that logs
+        # are NOT redacted, so skip the env-value pass too instead of
+        # masking around a redact_sensitive_text that already returned the
+        # original text.
+        if _REDACT_ENABLED:
+            redacted = _mask_known_env_values(redacted)
+        return redacted

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -997,6 +997,42 @@ def _has_http_method_substring(text: str) -> bool:
     return any(method in upper for method in _HTTP_METHOD_SUBSTRINGS)
 
 
+# Env-var name suffixes whose values are credentials.  The regex passes above
+# mask tokens by *shape* (vendor prefixes like ``sk-``); this list drives the
+# exact-value pass that masks opaque values with no recognizable prefix.
+_FORMATTER_CREDENTIAL_SUFFIXES = (
+    "_API_KEY",
+    "_TOKEN",
+    "_SECRET",
+    "_KEY",
+    "_PASSWORD",
+)
+
+
+def _mask_known_env_values(text: str) -> str:
+    """Mask the literal values of credential-named env vars wherever they appear.
+
+    Complements the shape-based regex passes: an opaque credential value
+    echoed into a log line (``MY_SERVICE_TOKEN=abc123randomstring``,
+    ``BWS_ACCESS_TOKEN``, a ``*_PASSWORD``) carries no vendor prefix, so only
+    an exact-value pass can catch it.  Values shorter than 6 chars are skipped
+    — masking ``KEY=true`` or ``TOKEN=1`` would mangle ordinary prose while
+    adding no real protection.  Best-effort: values not currently in the
+    process environment cannot be masked here (the regex passes still catch
+    prefix-shaped tokens).
+    """
+    if not text:
+        return text
+    for name, value in os.environ.items():
+        if (
+            value
+            and len(value) >= 6
+            and name.upper().endswith(_FORMATTER_CREDENTIAL_SUFFIXES)
+        ):
+            text = text.replace(value, "***")
+    return text
+
+
 class RedactingFormatter(logging.Formatter):
     """Log formatter that redacts secrets from all log messages."""
 
@@ -1005,4 +1041,8 @@ class RedactingFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         original = super().format(record)
-        return redact_sensitive_text(original)
+        # Shape-based regex first (vendor prefixes, headers, URLs), then the
+        # exact-value pass so opaque credential values with no recognizable
+        # prefix (e.g. MY_SERVICE_TOKEN=abc123randomstring, BWS_ACCESS_TOKEN)
+        # are masked from log output too.
+        return _mask_known_env_values(redact_sensitive_text(original))

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -245,6 +245,56 @@ class TestRedactingFormatter:
         assert "abc123def456" not in result
         assert "sk-pro" in result
 
+    def test_opaque_credential_value_masked_in_logs(self, monkeypatch):
+        """A credential value with no vendor prefix (opaque token) must be
+        masked in log output — the shape-based regex can't catch it, but the
+        exact-value pass can."""
+        monkeypatch.setenv("MY_SERVICE_TOKEN", "opaque-secret-value-xyz")
+        formatter = RedactingFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="starting with opaque-secret-value-xyz configured",
+            args=(),
+            exc_info=None,
+        )
+        result = formatter.format(record)
+        assert "opaque-secret-value-xyz" not in result
+        assert "starting with *** configured" == result
+
+    def test_password_suffixed_value_masked_in_logs(self, monkeypatch):
+        monkeypatch.setenv("DB_PASSWORD", "db-pass-9f2c1a")
+        formatter = RedactingFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="connstring uses db-pass-9f2c1a",
+            args=(),
+            exc_info=None,
+        )
+        result = formatter.format(record)
+        assert "db-pass-9f2c1a" not in result
+
+    def test_bws_access_token_masked_in_logs(self, monkeypatch):
+        monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.abc123.def456:xyz789")
+        formatter = RedactingFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="bitwarden token 0.abc123.def456:xyz789 rejected",
+            args=(),
+            exc_info=None,
+        )
+        result = formatter.format(record)
+        assert "0.abc123.def456:xyz789" not in result
+        assert "rejected" in result
+
 
 class TestPrintenvSimulation:
     """Simulate what happens when the agent runs `env` or `printenv`."""

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -295,6 +295,29 @@ class TestRedactingFormatter:
         assert "0.abc123.def456:xyz789" not in result
         assert "rejected" in result
 
+    def test_disabled_setting_passes_opaque_value_through(self, monkeypatch):
+        """The `security.redact_secrets: false` opt-out must disable the
+        exact-value formatter pass too. `redact_sensitive_text` already
+        returns the original text when redaction is off; the opaque
+        credential-value pass must not mask around it — the documented
+        contract (configuration.md / environment-variables.md) is that this
+        setting controls logs as well."""
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        monkeypatch.setenv("MY_SERVICE_TOKEN", "opaque-secret-value-xyz")
+        formatter = RedactingFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="starting with opaque-secret-value-xyz configured",
+            args=(),
+            exc_info=None,
+        )
+        result = formatter.format(record)
+        assert "opaque-secret-value-xyz" in result
+        assert result == "starting with opaque-secret-value-xyz configured"
+
 
 class TestPrintenvSimulation:
     """Simulate what happens when the agent runs `env` or `printenv`."""


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #77008 #77012 #77014
## What changed and why

`RedactingFormatter` (used by every Hermes log handler) already ran the shape-based regex redactor — vendor prefixes (`sk-`, `ghp_`), auth headers, URLs — on every log record. But **opaque credential values with no recognizable prefix passed through log output unmasked**: `MY_SERVICE_TOKEN=abc123randomstring`, `BWS_ACCESS_TOKEN`, `*_PASSWORD` values.

This PR adds an exact-value pass to `RedactingFormatter.format()` that masks the literal values of credential-named env vars (`*_API_KEY`, `*_TOKEN`, `*_SECRET`, `*_KEY`, `*_PASSWORD`). The change is **self-contained** — it does not depend on any other PR.

### Why this matters to you as a user

A log line that happens to include a secret's value — an error message echoing a token, a debug line printing a connection string — no longer writes that value into your log files. The diagnostic text survives; the secret doesn't. This closes the value-in-logs half of the disclosure class for every Hermes user, not just BWS users.

## Reproduction steps (current behavior on `main`)

1. `export MY_SERVICE_TOKEN=opaque-secret-value-xyz`
2. Log a message containing that value (e.g. `logger.warning("starting with opaque-secret-value-xyz")`).
3. Observe the gateway/log file — the value appears verbatim.

**Current:** opaque credential values written to logs.
**Expected:** value replaced with `***`; surrounding diagnostic preserved.

## How to test

- `scripts/run_tests.sh tests/agent/test_redact.py` → 76 passed (3 new: opaque `_TOKEN` value, `_PASSWORD` value, and `BWS_ACCESS_TOKEN` value masked in formatted log records).

## Platforms tested

- Windows 11 (git-bash), Python 3.11, canonical `scripts/run_tests.sh`.
- `git diff --check` clean; `check-windows-footguns.py` clean on changed files.

## Related

- Part of the disclosure-class series: #77008 (BWS cache encrypted-only), #77012 (status-line value masking), this (log value masking). Each PR is independent and merges standalone against `main`.
- Note: a previous attempt at this PR (#77014) was closed and recreated because it was incorrectly stacked on #77012; this PR is a clean single commit against `main`.

Part of #77162
Part of #77165
