### PR TITLE
feat(patch): whitespace-visualized diagnosis on residual no-match errors

### DIFF
--- a/tests/tools/test_patch_ws_diagnosis.py
+++ b/tests/tools/test_patch_ws_diagnosis.py
@@ -1,0 +1,64 @@
+"""Tests for whitespace-visualized mismatch diagnosis in patch no-match hints."""
+
+import json
+
+import pytest
+
+from tools.fuzzy_match import (
+    _visualize_whitespace,
+    find_closest_lines,
+    fuzzy_find_and_replace,
+)
+
+
+class TestVisualizeWhitespace:
+    def test_spaces_and_tabs_visualized(self):
+        assert _visualize_whitespace("\t    x = 1") == "→····x = 1"
+
+    def test_interior_whitespace_untouched(self):
+        assert _visualize_whitespace("  a  b") == "··a  b"
+
+    def test_no_leading_ws(self):
+        assert _visualize_whitespace("plain") == "plain"
+
+
+class TestWhitespaceDiagnosis:
+    def test_whitespace_shaped_miss_shows_both_lines(self):
+        # File uses tabs; the model sends 4 spaces AND a wrong second line so
+        # every fuzzy strategy misses (content mismatch), but line 1 is a
+        # whitespace-only difference worth diagnosing.
+        content = "def f():\n\tvalue = compute_thing()\n\treturn value\n"
+        old = "    value = compute_thing()\n    return wrong_name"
+        hint = find_closest_lines(old, content)
+        assert "Whitespace difference detected" in hint
+        assert "→value = compute_thing()" in hint
+        assert "····value = compute_thing()" in hint
+
+    def test_content_miss_has_no_whitespace_block(self):
+        content = "alpha = 1\nbeta = 2\n"
+        old = "alpha = 999"
+        hint = find_closest_lines(old, content)
+        assert "Whitespace difference detected" not in hint
+
+    def test_exact_line_present_no_ws_block(self):
+        # anchor matches raw -> no whitespace diagnosis needed
+        content = "  x = 1\n  y = 2\n"
+        old = "  x = 1\n  z = 3"
+        hint = find_closest_lines(old, content)
+        assert "Whitespace difference detected" not in hint
+
+
+class TestEndToEndHint:
+    def test_no_match_error_carries_ws_diagnosis(self):
+        # Second line's CONTENT differs (wrong call name) so all 9 fuzzy
+        # strategies genuinely miss; first line differs only in whitespace,
+        # so the hint should include the whitespace diagnosis.
+        content = "class A:\n\tdef run(self):\n\t\tstart_engine()\n\t\treturn 1\n"
+        old = "    def run(self):\n        boot_engine_wrong()\n        return 2"
+        new = "    def run(self):\n        start_engine()\n        return 3"
+        _c, count, _s, err = fuzzy_find_and_replace(content, old, new)
+        assert count == 0
+        from tools.fuzzy_match import format_no_match_hint
+        hint = format_no_match_hint(err, count, old, content)
+        assert "Did you mean" in hint
+        assert "Whitespace difference detected" in hint

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -941,6 +941,20 @@ def _map_normalized_positions(original: str, normalized: str,
     return original_matches
 
 
+def _visualize_whitespace(line: str) -> str:
+    """Render leading whitespace visibly (→ = tab, · = space).
+
+    Only the leading run is visualized — interior spacing is rarely the
+    culprit and full visualization makes lines unreadable.
+    """
+    i = 0
+    prefix = []
+    while i < len(line) and line[i] in (" ", "\t"):
+        prefix.append("→" if line[i] == "\t" else "·")
+        i += 1
+    return "".join(prefix) + line[i:]
+
+
 def find_closest_lines(old_string: str, content: str, context_lines: int = 2, max_results: int = 3) -> str:
     """Find lines in content most similar to old_string for "did you mean?" feedback.
 
@@ -1000,7 +1014,23 @@ def find_closest_lines(old_string: str, content: str, context_lines: int = 2, ma
     if not parts:
         return ""
 
-    return "\n---\n".join(parts)
+    result = "\n---\n".join(parts)
+
+    # Whitespace diagnosis (pattern from crush's diagnoseMismatch): when the
+    # best candidate line matches the anchor after stripping but differs in
+    # raw text, the failure is whitespace-shaped. Show BOTH lines with
+    # leading whitespace made visible so the model can copy the file's
+    # exact indentation instead of guessing again.
+    best_line = content_lines[top[0][1]]
+    if best_line.strip() == anchor and best_line != old_lines[0]:
+        result += (
+            "\n\nWhitespace difference detected (→ = tab, · = space):\n"
+            f"  file has: {_visualize_whitespace(best_line)}\n"
+            f"  you sent: {_visualize_whitespace(old_lines[0])}\n"
+            "Use the exact whitespace shown in 'file has'."
+        )
+
+    return result
 
 
 def format_no_match_hint(error: Optional[str], match_count: int,


### PR DESCRIPTION
## Summary
Residual patch no-match errors (the ones that survive all 9 fuzzy strategies) now diagnose whitespace-shaped failures explicitly: the hint shows the file's line and the sent line side by side with leading whitespace made visible (`→` = tab, `·` = space), turning a dead-end error into a one-turn fix.

Root cause: after the fuzzy cascade and the existing did-you-mean hint, the surviving failure class is tabs-vs-spaces / indent-depth drift combined with a content difference — the model sees the right lines in the hint but can't see WHY its old_string missed, so it guesses again. Pattern ported from crush's `diagnoseMismatch` (agent-codebase survey), the best-in-class version of this recovery.

## Changes
- `tools/fuzzy_match.py`:
  - `_visualize_whitespace()`: renders the leading whitespace run visibly; interior spacing untouched for readability.
  - `find_closest_lines()`: when the best candidate matches the anchor after stripping but differs raw, append the two-line diagnosis + "Use the exact whitespace shown in 'file has'". Content-shaped misses and raw-exact candidates unchanged.
- `tests/tools/test_patch_ws_diagnosis.py`: 7 tests (glyph rendering, whitespace-shaped vs content-shaped gating, end-to-end through `fuzzy_find_and_replace` + `format_no_match_hint`).

## Validation
| Check | Result |
|---|---|
| Hermetic runner (new + fuzzy_match + patch_parser + file_operations) | 127/127 passed |
| Live E2E via real `patch_tool()` on a tab-indented file with space-indented old_string | error carries numbered did-you-mean block AND the `→def` vs `····def` diagnosis |

## Infographic

![whitespace diagnosis](https://v3b.fal.media/files/b/0aa4c1ce/ABpfEew7bOFn7H6WVI5kZ_yuokNNYu.png)
