### PR TITLE
fix(security): strip BWS token and *_PASSWORD from child-process envs

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,2 @@
+andrexibiza
+# PR #77027 (security: sanitize terminal-backend child-process env boundaries)

--- a/tests/tools/test_backend_subprocess_env_boundary.py
+++ b/tests/tools/test_backend_subprocess_env_boundary.py
@@ -1,0 +1,329 @@
+"""Behavioral regressions for the terminal-backend child-process env boundary.
+
+The trusted Hermes process may hold provider, vault, gateway, and service
+credentials.  Every model-authored terminal backend (local is covered in
+``test_build_subprocess_env.py``; Docker, SSH, and Singularity converge through
+``_popen_bash`` here) must launch its host-side child with a sanitized env.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.environments import base as base_env
+from tools.environments import docker as docker_env
+from tools.environments import local as local_env
+from tools.environments import singularity as singularity_env
+from tools.environments import ssh as ssh_env
+
+
+_BLOCKED = {
+    "BWS_ACCESS_TOKEN": "fake-bws-bootstrap",
+    "DB_PASSWORD": "fake-db-password",
+    "PGPASSWORD": "fake-pg-password",
+    "MYSQL_PWD": "fake-mysql-password",
+    "PASSWORD": "fake-bare-password",
+    "OPENAI_API_KEY": "fake-provider-key",
+    "GH_TOKEN": "fake-github-token",
+    "AUXILIARY_VISION_API_KEY": "fake-aux-key",
+    "GATEWAY_RELAY_SECRET": "fake-relay-secret",
+}
+
+_SAFE = {
+    "PATH": os.environ.get("PATH", ""),
+    "PWD": "/safe/cwd",
+    "LANG": "C.UTF-8",
+    "TERM": "xterm-256color",
+    "SSH_AUTH_SOCK": "/safe/ssh-agent.sock",
+    "APPTAINER_CACHEDIR": "/safe/apptainer-cache",
+    "HERMES_TEST_BENIGN": "keep-me",
+}
+
+_CONTAINER_TUNNELS = {
+    "APPTAINERENV_BWS_ACCESS_TOKEN": "fake-tunneled-bws",
+    "SINGULARITYENV_GH_TOKEN": "fake-tunneled-github",
+    "APPTAINERENV_OPENAI_API_KEY": "fake-tunneled-provider",
+    "SINGULARITYENV_DB_PASSWORD": "fake-tunneled-password",
+}
+
+
+class _DummyProcess:
+    def __init__(self) -> None:
+        self.stdin = None
+        self.stdout = None
+        self.stderr = None
+        self.returncode = 0
+        self.pid = 12345
+
+    def poll(self):
+        return self.returncode
+
+
+def _capture_popen(monkeypatch):
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_popen(args, **kwargs):
+        calls.append((list(args), kwargs))
+        return _DummyProcess()
+
+    monkeypatch.setattr(base_env.subprocess, "Popen", fake_popen)
+    return calls
+
+
+def _plant_parent_env(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    for key, value in {**_SAFE, **_BLOCKED, **_CONTAINER_TUNNELS}.items():
+        monkeypatch.setenv(key, value)
+
+
+def _assert_child_env_is_sanitized(child_env: dict[str, str]) -> None:
+    for key in (*_BLOCKED, *_CONTAINER_TUNNELS):
+        assert key not in child_env, f"{key} crossed the child-process boundary"
+    for key, value in _SAFE.items():
+        assert child_env.get(key) == value, f"benign control {key} was not preserved"
+
+
+def _make_docker_exec_env():
+    env = docker_env.DockerEnvironment.__new__(docker_env.DockerEnvironment)
+    env._container_id = "container-id"
+    env._docker_exe = "docker"
+    env._forward_env = []
+    env._env = {}
+    env._profile_scoped_passthrough = False
+    env._init_env_args = []
+    return env
+
+
+def _make_ssh_exec_env(tmp_path: Path):
+    env = ssh_env.SSHEnvironment.__new__(ssh_env.SSHEnvironment)
+    env.host = "example.invalid"
+    env.user = "hermes"
+    env.port = 22
+    env.key_path = ""
+    env.control_socket = tmp_path / "control.sock"
+    return env
+
+
+def _make_singularity_exec_env():
+    env = singularity_env.SingularityEnvironment.__new__(
+        singularity_env.SingularityEnvironment
+    )
+    env.executable = "apptainer"
+    env.instance_id = "hermes_test"
+    env._instance_started = True
+    return env
+
+
+@pytest.mark.parametrize("backend", ["docker", "ssh", "singularity"])
+def test_every_remote_terminal_exec_uses_shared_sanitized_popen_boundary(
+    backend, monkeypatch, tmp_path
+):
+    """Exercise each production ``_run_bash`` call shape, not a detached helper."""
+    _plant_parent_env(monkeypatch, tmp_path)
+    calls = _capture_popen(monkeypatch)
+
+    if backend == "docker":
+        _make_docker_exec_env()._run_bash("true")
+    elif backend == "ssh":
+        _make_ssh_exec_env(tmp_path)._run_bash("true")
+    else:
+        env = _make_singularity_exec_env()
+        env._run_bash("true")
+        # Prevent the synthetic object's destructor from invoking a real
+        # ``apptainer instance stop`` after the assertion.
+        env._instance_started = False
+
+    assert len(calls) == 1
+    _assert_child_env_is_sanitized(calls[0][1]["env"])
+
+
+def test_shared_popen_boundary_sanitizes_caller_supplied_base_env(monkeypatch, tmp_path):
+    """An explicit overlay cannot re-open the boundary or skip benign controls."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    calls = _capture_popen(monkeypatch)
+    supplied = {**_SAFE, **_BLOCKED, **_CONTAINER_TUNNELS}
+
+    base_env._popen_bash(["bash", "-c", "true"], env=supplied)
+
+    assert len(calls) == 1
+    _assert_child_env_is_sanitized(calls[0][1]["env"])
+
+
+def test_shared_popen_boundary_accepts_empty_base_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    calls = _capture_popen(monkeypatch)
+
+    base_env._popen_bash(["bash", "-c", "true"], env={})
+
+    assert len(calls) == 1
+    assert isinstance(calls[0][1]["env"], dict)
+    assert not set(_BLOCKED) & set(calls[0][1]["env"])
+
+
+def test_mixed_case_credential_names_are_denied_for_windows_semantics(
+    monkeypatch, tmp_path
+):
+    """Windows treats env keys case-insensitively; the filter must do the same."""
+    monkeypatch.setattr(local_env, "_IS_WINDOWS", True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    base = {
+        "Path": "C:/Windows/System32",
+        "bWs_AcCeSs_ToKeN": "fake-bws",
+        "Db_PaSsWoRd": "fake-password",
+        "oPeNaI_aPi_KeY": "fake-provider",
+        "gH_tOkEn": "fake-github",
+        "Safe_Control": "keep-me",
+        "HERMES_HOME": str(tmp_path / "hermes-home"),
+    }
+
+    terminal_env = local_env.build_subprocess_env(base=base)
+    assert terminal_env.get("Safe_Control") == "keep-me"
+    assert terminal_env.get("Path") == "C:/Windows/System32"
+    assert not {k for k in base if k.casefold() in {
+        "bws_access_token", "db_password", "openai_api_key", "gh_token"
+    }} & set(terminal_env)
+
+    with patch.dict(os.environ, base, clear=True):
+        for inherit_credentials in (False, True):
+            nonterminal_env = local_env.hermes_subprocess_env(
+                inherit_credentials=inherit_credentials
+            )
+            assert "gH_tOkEn" not in nonterminal_env
+            assert "bWs_AcCeSs_ToKeN" not in nonterminal_env
+            assert "Db_PaSsWoRd" not in nonterminal_env
+            provider_present = any(
+                k.casefold() == "openai_api_key" and v == "fake-provider"
+                for k, v in nonterminal_env.items()
+            )
+            if inherit_credentials:
+                assert provider_present, (
+                    "inherit_credentials=True must preserve the provider "
+                    "credential regardless of key casing"
+                )
+            else:
+                assert not provider_present
+
+
+def test_nested_child_cannot_recover_scrubbed_parent_credentials(monkeypatch, tmp_path):
+    """A sanitized child and its inheriting grandchild both lack the secrets."""
+    _plant_parent_env(monkeypatch, tmp_path)
+    env = local_env.build_subprocess_env()
+    grandchild = (
+        "import json, os; "
+        "print(json.dumps({k: k in os.environ for k in "
+        f"{list(_BLOCKED)!r}}}))"
+    )
+    child = (
+        "import subprocess, sys; "
+        f"subprocess.run([sys.executable, '-c', {grandchild!r}], check=True)"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", child],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=True,
+    )
+
+    assert json.loads(result.stdout) == {key: False for key in _BLOCKED}
+
+
+def _capture_singularity_run(monkeypatch):
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((list(cmd), kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(singularity_env.subprocess, "run", fake_run)
+    return calls
+
+
+@pytest.mark.parametrize("stage", ["preflight", "start", "cleanup"])
+def test_singularity_lifecycle_processes_use_sanitized_env(
+    stage, monkeypatch, tmp_path
+):
+    """The backend's start and control children share the exec scrub contract."""
+    _plant_parent_env(monkeypatch, tmp_path)
+    calls = _capture_singularity_run(monkeypatch)
+
+    if stage == "preflight":
+        monkeypatch.setattr(
+            singularity_env, "_find_singularity_executable", lambda: "apptainer"
+        )
+        assert singularity_env._ensure_singularity_available() == "apptainer"
+    else:
+        env = _make_singularity_exec_env()
+        env.image = "image.sif"
+        env._persistent = False
+        env._overlay_dir = None
+        env._memory = 0
+        env._cpu = 0
+        if stage == "start":
+            env._instance_started = False
+            import tools.credential_files as credential_files
+
+            monkeypatch.setattr(credential_files, "get_credential_file_mounts", lambda: [])
+            monkeypatch.setattr(credential_files, "get_skills_directory_mount", lambda: [])
+            env._start_instance()
+        else:
+            env.cleanup()
+
+    assert len(calls) == 1
+    _assert_child_env_is_sanitized(calls[0][1]["env"])
+
+
+def test_singularity_image_build_gets_only_explicit_registry_auth(
+    monkeypatch, tmp_path
+):
+    """The deliberate registry-auth exception is narrow, not full inheritance."""
+    _plant_parent_env(monkeypatch, tmp_path)
+    registry_auth = {
+        "APPTAINER_DOCKER_USERNAME": "registry-user",
+        "APPTAINER_DOCKER_PASSWORD": "fake-registry-password",
+        "SINGULARITY_DOCKER_USERNAME": "legacy-user",
+        "SINGULARITY_DOCKER_PASSWORD": "fake-legacy-password",
+        "DOCKER_USERNAME": "plain-user",
+        "DOCKER_PASSWORD": "fake-plain-password",
+    }
+    for key, value in registry_auth.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(singularity_env, "_get_apptainer_cache_dir", lambda: tmp_path)
+    calls = _capture_singularity_run(monkeypatch)
+
+    result = singularity_env._get_or_build_sif(
+        "docker://example.invalid/private:latest", "apptainer"
+    )
+
+    assert result.endswith("example.invalid-private-latest.sif")
+    assert len(calls) == 1
+    child_env = calls[0][1]["env"]
+    for key, value in registry_auth.items():
+        assert child_env.get(key) == value
+    for key in (*_BLOCKED, *_CONTAINER_TUNNELS):
+        assert key not in child_env
+    assert child_env.get("HERMES_TEST_BENIGN") == "keep-me"
+
+
+def test_docker_explicit_forward_cannot_export_hermes_internal_secret(
+    monkeypatch, tmp_path
+):
+    """Explicit password passthrough remains valid; BWS bootstrap auth never is."""
+    _plant_parent_env(monkeypatch, tmp_path)
+    env = _make_docker_exec_env()
+    env._forward_env = ["BWS_ACCESS_TOKEN", "DB_PASSWORD"]
+    monkeypatch.setattr(docker_env, "_load_hermes_env_vars", lambda: {})
+
+    args = env._build_init_env_args()
+
+    assert "DB_PASSWORD=fake-db-password" in args
+    assert not any(arg.startswith("BWS_ACCESS_TOKEN=") for arg in args)

--- a/tests/tools/test_build_subprocess_env.py
+++ b/tests/tools/test_build_subprocess_env.py
@@ -169,6 +169,128 @@ def test_terminal_path_keeps_passthrough_db_password(monkeypatch):
         clear_env_passthrough()
 
 
+def test_make_run_env_strips_password_by_default(monkeypatch):
+    """The LocalEnvironment terminal spawn factory (_make_run_env) must
+    strip *_PASSWORD values even when they are not in the static blocklist —
+    the exact gap egilewski flagged: _sanitize_subprocess_env protected the
+    build_subprocess_env/background path, but the live terminal path merged
+    os.environ without the credential-shaped password predicate."""
+    from tools.environments.local import _make_run_env
+
+    monkeypatch.setenv("DB_PASSWORD", "db-pass-9f2c1a")
+    monkeypatch.setenv("REDIS_PASSWORD", "redis-pass-77aa")
+    monkeypatch.setenv("MY_HARMLESS_VAR", "keep-me")
+
+    env = _make_run_env({})
+
+    assert "DB_PASSWORD" not in env
+    assert "REDIS_PASSWORD" not in env
+    assert env.get("MY_HARMLESS_VAR") == "keep-me"
+
+
+def test_make_run_env_keeps_passthrough_db_password(monkeypatch):
+    """An explicitly registered DB_PASSWORD passthrough must survive the
+    terminal spawn factory — the strip is passthrough-aware here too, so a
+    skill-registered command that legitimately needs the value still gets it."""
+    from tools.env_passthrough import clear_env_passthrough, register_env_passthrough
+    from tools.environments.local import _make_run_env
+
+    monkeypatch.setenv("DB_PASSWORD", "db-pass-9f2c1a")
+    register_env_passthrough(["DB_PASSWORD"])
+    try:
+        env = _make_run_env({})
+        assert env.get("DB_PASSWORD") == "db-pass-9f2c1a"
+    finally:
+        clear_env_passthrough()
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true" and not os.path.isfile("/bin/bash"),
+    reason="Requires bash; CI sandbox may strip it.",
+)
+def test_local_environment_e2e_password_denial_and_passthrough(tmp_path, monkeypatch):
+    """End-to-end LocalEnvironment execution: a real terminal child must
+    NOT see a *_PASSWORD value by default, and MUST see it once explicitly
+    registered as passthrough — proving the _make_run_env filter closes the
+    live spawn sink, not just the helper factories."""
+    from tools.env_passthrough import clear_env_passthrough, register_env_passthrough
+    from tools.environments.local import LocalEnvironment
+
+    monkeypatch.setenv("DB_PASSWORD", "db-pass-e2e-77")
+
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+    try:
+        denied = env.execute(
+            'if [ -n "$DB_PASSWORD" ]; then echo "LEAKED"; else echo "DENIED"; fi'
+        )
+        assert denied["returncode"] == 0
+        assert "DENIED" in denied.get("output", "")
+
+        register_env_passthrough(["DB_PASSWORD"])
+        try:
+            allowed = env.execute(
+                'if [ "$DB_PASSWORD" = "db-pass-e2e-77" ]; then echo "PASSTHROUGH"; else echo "MISSING"; fi'
+            )
+            assert allowed["returncode"] == 0
+            assert "PASSTHROUGH" in allowed.get("output", "")
+        finally:
+            clear_env_passthrough()
+    finally:
+        env.cleanup()
+
+
+def test_bws_token_env_cache_is_scoped_per_profile(tmp_path, monkeypatch):
+    """The Bitwarden token-name cache must be keyed by the active Hermes
+    home, not process-global — a gateway serving multiple profiles by
+    switching the context-local home per turn must match each profile's own
+    configured access_token_env name (egilewski P1)."""
+    import yaml
+
+    import tools.environments.local as _local_mod
+
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    profile_a.mkdir()
+    profile_b.mkdir()
+    (profile_a / "config.yaml").write_text(
+        yaml.dump({"secrets": {"bitwarden": {"access_token_env": "ALPHA_BWS_TOKEN"}}}),
+        encoding="utf-8",
+    )
+    (profile_b / "config.yaml").write_text(
+        yaml.dump({"secrets": {"bitwarden": {"access_token_env": "BETA_BWS_TOKEN"}}}),
+        encoding="utf-8",
+    )
+
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    # Fresh cache: no cross-test pollution.
+    monkeypatch.setattr(_local_mod, "_configured_bws_token_env_by_home", {})
+
+    token_a = set_hermes_home_override(str(profile_a))
+    try:
+        assert _local_mod._get_configured_bws_token_env() == "ALPHA_BWS_TOKEN"
+        assert _local_mod._is_hermes_internal_secret("ALPHA_BWS_TOKEN") is True
+        assert _local_mod._is_hermes_internal_secret("BETA_BWS_TOKEN") is False
+    finally:
+        reset_hermes_home_override(token_a)
+
+    token_b = set_hermes_home_override(str(profile_b))
+    try:
+        assert _local_mod._get_configured_bws_token_env() == "BETA_BWS_TOKEN"
+        assert _local_mod._is_hermes_internal_secret("BETA_BWS_TOKEN") is True
+        assert _local_mod._is_hermes_internal_secret("ALPHA_BWS_TOKEN") is False
+    finally:
+        reset_hermes_home_override(token_b)
+
+    # Back on profile A the first resolution is still its own name (cache
+    # entries are isolated per home, not overwritten by the last visitor).
+    token_a2 = set_hermes_home_override(str(profile_a))
+    try:
+        assert _local_mod._get_configured_bws_token_env() == "ALPHA_BWS_TOKEN"
+    finally:
+        reset_hermes_home_override(token_a2)
+
+
 def test_bws_token_env_remap_non_suffix_stripped(tmp_path, monkeypatch):
     """A Bitwarden access_token_env remapped to a non-suffix name (e.g.
     MY_BWS_TOKEN) is stripped exactly, while third-party *_ACCESS_TOKEN vars
@@ -181,9 +303,8 @@ def test_bws_token_env_remap_non_suffix_stripped(tmp_path, monkeypatch):
     config = {"secrets": {"bitwarden": {"access_token_env": "MY_BWS_TOKEN"}}}
     (tmp_path / "config.yaml").write_text(yaml.dump(config), encoding="utf-8")
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    # Reset the module-level cache so the remap is picked up.
-    monkeypatch.setattr(_local_mod, "_configured_bws_token_env", None)
-    monkeypatch.setattr(_local_mod, "_configured_bws_token_env_loaded", False)
+    # Reset the per-home cache so the remap is picked up for this home.
+    monkeypatch.setattr(_local_mod, "_configured_bws_token_env_by_home", {})
 
     monkeypatch.setenv("MY_BWS_TOKEN", "0.remapped.token")
     monkeypatch.setenv("STRIPE_ACCESS_TOKEN", "sk_live_third_party")

--- a/tests/tools/test_build_subprocess_env.py
+++ b/tests/tools/test_build_subprocess_env.py
@@ -138,3 +138,73 @@ def test_hermes_subprocess_env_strips_bws_token_and_password(monkeypatch):
     env = hermes_subprocess_env()  # inherit_credentials=False (default)
     assert "BWS_ACCESS_TOKEN" not in env
     assert "DB_PASSWORD" not in env
+
+
+def test_hermes_subprocess_env_strips_password_with_inherit_credentials(monkeypatch):
+    """*_PASSWORD values are stripped unconditionally on the non-terminal
+    factory even when the caller opts into credential inheritance — a
+    model-driving CLI has no legitimate use for a DB/redis/postgres password."""
+    from tools.environments.local import hermes_subprocess_env
+
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.abc123.def456:xyz789")
+    monkeypatch.setenv("DB_PASSWORD", "db-pass-9f2c1a")
+
+    env = hermes_subprocess_env(inherit_credentials=True)
+    assert "BWS_ACCESS_TOKEN" not in env
+    assert "DB_PASSWORD" not in env
+
+
+def test_terminal_path_keeps_passthrough_db_password(monkeypatch):
+    """An explicitly registered DB_PASSWORD passthrough (skill
+    required_environment_variables or terminal.env_passthrough) must still
+    reach the terminal child — the *_PASSWORD strip is passthrough-aware."""
+    from tools.env_passthrough import clear_env_passthrough, register_env_passthrough
+
+    monkeypatch.setenv("DB_PASSWORD", "db-pass-9f2c1a")
+    register_env_passthrough(["DB_PASSWORD"])
+    try:
+        env = build_subprocess_env()
+        assert env.get("DB_PASSWORD") == "db-pass-9f2c1a"
+    finally:
+        clear_env_passthrough()
+
+
+def test_bws_token_env_remap_non_suffix_stripped(tmp_path, monkeypatch):
+    """A Bitwarden access_token_env remapped to a non-suffix name (e.g.
+    MY_BWS_TOKEN) is stripped exactly, while third-party *_ACCESS_TOKEN vars
+    (e.g. STRIPE_ACCESS_TOKEN) stay passthrough-able — the fix for the
+    over-broad *_ACCESS_TOKEN suffix match."""
+    import yaml
+
+    import tools.environments.local as _local_mod
+
+    config = {"secrets": {"bitwarden": {"access_token_env": "MY_BWS_TOKEN"}}}
+    (tmp_path / "config.yaml").write_text(yaml.dump(config), encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Reset the module-level cache so the remap is picked up.
+    monkeypatch.setattr(_local_mod, "_configured_bws_token_env", None)
+    monkeypatch.setattr(_local_mod, "_configured_bws_token_env_loaded", False)
+
+    monkeypatch.setenv("MY_BWS_TOKEN", "0.remapped.token")
+    monkeypatch.setenv("STRIPE_ACCESS_TOKEN", "sk_live_third_party")
+
+    assert _local_mod._is_hermes_internal_secret("MY_BWS_TOKEN") is True
+    assert _local_mod._is_hermes_internal_secret("STRIPE_ACCESS_TOKEN") is False
+
+    env = build_subprocess_env()
+    assert "MY_BWS_TOKEN" not in env
+    # Third-party access token is not Hermes-internal — survives on the
+    # terminal path (and is registerable as passthrough, unlike BWS).
+    assert env.get("STRIPE_ACCESS_TOKEN") == "sk_live_third_party"
+
+    from tools.env_passthrough import (
+        clear_env_passthrough,
+        is_env_passthrough,
+        register_env_passthrough,
+    )
+
+    register_env_passthrough(["STRIPE_ACCESS_TOKEN"])
+    try:
+        assert is_env_passthrough("STRIPE_ACCESS_TOKEN")
+    finally:
+        clear_env_passthrough()

--- a/tests/tools/test_build_subprocess_env.py
+++ b/tests/tools/test_build_subprocess_env.py
@@ -179,13 +179,21 @@ def test_make_run_env_strips_password_by_default(monkeypatch):
 
     monkeypatch.setenv("DB_PASSWORD", "db-pass-9f2c1a")
     monkeypatch.setenv("REDIS_PASSWORD", "redis-pass-77aa")
+    monkeypatch.setenv("PGPASSWORD", "pg-pass-e11")
+    monkeypatch.setenv("MYSQL_PWD", "mysql-pwd-4d2")
+    monkeypatch.setenv("PASSWORD", "bare-pass-8c1")
     monkeypatch.setenv("MY_HARMLESS_VAR", "keep-me")
+    monkeypatch.setenv("PWD", "C:\\some\\cwd")  # shell cwd var must survive
 
     env = _make_run_env({})
 
     assert "DB_PASSWORD" not in env
     assert "REDIS_PASSWORD" not in env
+    assert "PGPASSWORD" not in env
+    assert "MYSQL_PWD" not in env
+    assert "PASSWORD" not in env
     assert env.get("MY_HARMLESS_VAR") == "keep-me"
+    assert env.get("PWD") == "C:\\some\\cwd"
 
 
 def test_make_run_env_keeps_passthrough_db_password(monkeypatch):

--- a/tests/tools/test_build_subprocess_env.py
+++ b/tests/tools/test_build_subprocess_env.py
@@ -97,3 +97,44 @@ def test_e2e_no_scrub_child_keeps_planted_secret(tmp_path, monkeypatch):
         env=env, capture_output=True, text=True, timeout=60, check=True,
     )
     assert out.stdout.strip() == "sk-FAKE-planted"
+
+
+def test_e2e_child_never_sees_bws_token_or_password(tmp_path, monkeypatch):
+    """The BWS bootstrap token and *_PASSWORD values must never reach a
+    scrubbed child — the same disclosure class the status-line and log
+    masking PRs close at the emission side, here at the process boundary."""
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.abc123.def456:xyz789")
+    monkeypatch.setenv("DB_PASSWORD", "db-pass-9f2c1a")
+
+    env = build_subprocess_env()  # scrub on (default)
+
+    code = (
+        "import os, json; "
+        "print(json.dumps({'bws': 'BWS_ACCESS_TOKEN' in os.environ, "
+        "'pw': 'DB_PASSWORD' in os.environ}))"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env, capture_output=True, text=True, timeout=60, check=True,
+    )
+    import json
+
+    result = json.loads(out.stdout)
+    assert result["bws"] is False
+    assert result["pw"] is False
+
+
+def test_hermes_subprocess_env_strips_bws_token_and_password(monkeypatch):
+    """The non-terminal spawn factory (browser/ACP/computer-use surface)
+    must also strip the BWS token and *_PASSWORD values by default."""
+    from tools.environments.local import hermes_subprocess_env
+
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.abc123.def456:xyz789")
+    monkeypatch.setenv("DB_PASSWORD", "db-pass-9f2c1a")
+
+    env = hermes_subprocess_env()  # inherit_credentials=False (default)
+    assert "BWS_ACCESS_TOKEN" not in env
+    assert "DB_PASSWORD" not in env

--- a/tests/tools/test_build_subprocess_env.py
+++ b/tests/tools/test_build_subprocess_env.py
@@ -279,6 +279,12 @@ def test_bws_token_env_cache_is_scoped_per_profile(tmp_path, monkeypatch):
         assert _local_mod._get_configured_bws_token_env() == "BETA_BWS_TOKEN"
         assert _local_mod._is_hermes_internal_secret("BETA_BWS_TOKEN") is True
         assert _local_mod._is_hermes_internal_secret("ALPHA_BWS_TOKEN") is False
+        # The default name stays internal even in a remapped profile: the
+        # process-global os.environ can carry a default profile's token into
+        # this profile's turn, and it must not cross the child boundary.
+        assert _local_mod._is_hermes_internal_secret("BWS_ACCESS_TOKEN") is True
+        # Third-party tokens remain registerable in every profile.
+        assert _local_mod._is_hermes_internal_secret("STRIPE_ACCESS_TOKEN") is False
     finally:
         reset_hermes_home_override(token_b)
 

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -69,7 +69,7 @@ def _is_hermes_provider_credential(name: str) -> bool:
     """
     try:
         from tools.environments.local import (
-            _HERMES_PROVIDER_ENV_BLOCKLIST,
+            _is_blocked_provider_env,
             _is_hermes_internal_secret,
         )
     except Exception as e:
@@ -87,7 +87,7 @@ def _is_hermes_provider_credential(name: str) -> bool:
     # as passthrough and tunnel them into an execute_code / terminal child.
     if _is_hermes_internal_secret(name):
         return True
-    return name in _HERMES_PROVIDER_ENV_BLOCKLIST
+    return _is_blocked_provider_env(name)
 
 
 def register_env_passthrough(var_names: Iterable[str]) -> None:

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -357,12 +357,17 @@ def _pipe_stdin(proc: subprocess.Popen, data: str) -> None:
 def _popen_bash(
     cmd: list[str], stdin_data: str | None = None, **kwargs
 ) -> subprocess.Popen:
-    """Spawn a subprocess with standard stdout/stderr/stdin setup.
+    """Spawn a terminal-backend child through the shared sanitized boundary.
 
-    If *stdin_data* is provided, writes it asynchronously via :func:`_pipe_stdin`.
-    Backends with special Popen needs (e.g. local's ``preexec_fn``) can bypass
-    this and call :func:`_pipe_stdin` directly.
+    Docker, SSH, and Singularity all converge here for model-authored command
+    execution.  Sanitize even when the caller supplies an ``env`` mapping so a
+    future backend cannot re-open ambient credential inheritance by omitting
+    the factory or passing an unsafe overlay.
     """
+    from tools.environments.local import build_subprocess_env
+
+    base_env = kwargs.pop("env", None)
+    kwargs["env"] = build_subprocess_env(base=base_env)
     kwargs.setdefault("creationflags", windows_hide_flags())
     proc = subprocess.Popen(
         cmd,

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1567,12 +1567,18 @@ class DockerEnvironment(BaseEnvironment):
         # Explicit docker_forward_env entries are an intentional opt-in and must
         # win over the generic Hermes secret blocklist. Only implicit passthrough
         # keys are filtered. Also strip Hermes-internal dynamic secrets
-        # (AUXILIARY_*_API_KEY / _BASE_URL, GATEWAY_RELAY_* auth) that the
-        # name-based blocklist doesn't cover — see _is_hermes_internal_secret.
+        # (AUXILIARY_*_API_KEY / _BASE_URL, GATEWAY_RELAY_* auth,
+        # BWS_ACCESS_TOKEN) that the name-based blocklist doesn't cover — see
+        # _is_hermes_internal_secret.  Naming an internal bootstrap credential
+        # in docker_forward_env must NOT export it into the container: the
+        # forwarding list is a capability boundary, not an unconditional bypass.
         _implicit_forward = {
             k for k in passthrough_keys if not _is_hermes_internal_secret(k)
         }
-        forward_keys = explicit_forward_keys | (_implicit_forward - _HERMES_PROVIDER_ENV_BLOCKLIST)
+        _explicit_forward = {
+            k for k in explicit_forward_keys if not _is_hermes_internal_secret(k)
+        }
+        forward_keys = _explicit_forward | (_implicit_forward - _HERMES_PROVIDER_ENV_BLOCKLIST)
         hermes_env = _load_hermes_env_vars() if forward_keys else {}
         unset_names: set[str] = set()
         for key in sorted(forward_keys):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -369,6 +369,13 @@ def _is_hermes_internal_secret(key: str) -> bool:
       ``_ALWAYS_STRIP_KEYS``. Non-secret ``GATEWAY_RELAY_*`` routing hints
       (``GATEWAY_RELAY_URL``, ``GATEWAY_RELAY_PLATFORMS``, …) are NOT matched
       and remain visible.
+    - ``BWS_ACCESS_TOKEN`` — the Bitwarden Secrets Manager bootstrap token
+      (and any ``*_ACCESS_TOKEN`` name it is remapped to via
+      ``secrets.bitwarden.access_token_env``). Hermes's own vault credential;
+      no spawned child legitimately needs it. The one child that does — the
+      ``bws`` CLI — receives it explicitly via
+      ``build_subprocess_env(scrub_secrets=False)`` in
+      ``agent/secret_sources/bitwarden.py``, never through inheritance.
 
     ``code_execution_tool.py`` already catches these via substring matching on
     ``KEY`` / ``SECRET`` / ``TOKEN``; the terminal backend's narrower name-based
@@ -391,7 +398,25 @@ def _is_hermes_internal_secret(key: str) -> bool:
         upper.endswith("_SECRET") or upper.endswith("_KEY") or upper.endswith("_TOKEN")
     ):
         return True
+    if upper.endswith("_ACCESS_TOKEN"):
+        # BWS bootstrap token and any access_token_env remap.  Hermes's own
+        # vault credential must never reach a child by inheritance.
+        return True
     return False
+
+
+def _is_credential_shaped_password(key: str) -> bool:
+    """True for ``*_PASSWORD`` env names (credential-shaped, not in the
+    static blocklist which only names exact vars like ``EMAIL_PASSWORD``).
+
+    Stripped by default on every spawn path — a ``DB_PASSWORD`` /
+    ``POSTGRES_PASSWORD`` / ``REDIS_PASSWORD`` value has no business in a
+    child process that did not explicitly request it.  On the terminal path
+    this is passthrough-aware (a skill-registered command that legitimately
+    needs the value still receives it via ``env_passthrough``); on the
+    non-terminal surface it is stripped unconditionally.
+    """
+    return key.upper().endswith("_PASSWORD")
 
 
 def _inject_context_hermes_home(env: dict) -> None:
@@ -474,6 +499,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         passthrough = _is_passthrough(key)
         if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
             continue
+        if _is_credential_shaped_password(key) and not passthrough:
+            continue
         resolved = _resolve_passthrough_value(key, value) if passthrough else value
         if resolved is not None:
             sanitized[key] = resolved
@@ -489,6 +516,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         else:
             passthrough = _is_passthrough(key)
             if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+                continue
+            if _is_credential_shaped_password(key) and not passthrough:
                 continue
             resolved = _resolve_passthrough_value(key, value) if passthrough else value
             if resolved is not None:
@@ -608,6 +637,12 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     # Tier 1 — always strip.
     for key in _ALWAYS_STRIP_KEYS:
         env.pop(key, None)
+    # *PASSWORD values never belong in a non-terminal child (browser, ACP,
+    # computer-use, dep-ensure, TUI/Node host).  Unlike the terminal path
+    # there is no skill-passthrough concept, so strip unconditionally.
+    for key in list(env):
+        if _is_credential_shaped_password(key):
+            env.pop(key, None)
     # Internal routing hints and Hermes-internal dynamic secrets
     # (``AUXILIARY_<TASK>_API_KEY`` / ``_BASE_URL`` side-LLM credentials,
     # ``GATEWAY_RELAY_*`` relay-auth material) must never reach a child,

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -465,8 +465,15 @@ def _get_configured_bws_token_env() -> str:
 
 
 def _is_credential_shaped_password(key: str) -> bool:
-    """True for ``*_PASSWORD`` env names (credential-shaped, not in the
+    """True for password-class env names (credential-shaped, not in the
     static blocklist which only names exact vars like ``EMAIL_PASSWORD``).
+
+    Matches the same class the execute_code sandbox scrubs by substring
+    (``code_execution_tool.py``): ``*_PASSWORD`` names plus the bare
+    ``PASSWORD``, ``PGPASSWORD`` and ``*_PWD`` variants (``MYSQL_PWD``) —
+    but never ``PWD`` itself, which is the shell's working-directory
+    variable.  The terminal path must be at least as protective as the
+    sandbox for the same secret class.
 
     Stripped by default on every spawn path — a ``DB_PASSWORD`` /
     ``POSTGRES_PASSWORD`` / ``REDIS_PASSWORD`` value has no business in a
@@ -475,7 +482,8 @@ def _is_credential_shaped_password(key: str) -> bool:
     needs the value still receives it via ``env_passthrough``); on the
     non-terminal surface it is stripped unconditionally.
     """
-    return key.upper().endswith("_PASSWORD")
+    upper = key.upper()
+    return "PASSWORD" in upper or (upper.endswith("_PWD") and upper != "PWD")
 
 
 def _inject_context_hermes_home(env: dict) -> None:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -369,13 +369,16 @@ def _is_hermes_internal_secret(key: str) -> bool:
       ``_ALWAYS_STRIP_KEYS``. Non-secret ``GATEWAY_RELAY_*`` routing hints
       (``GATEWAY_RELAY_URL``, ``GATEWAY_RELAY_PLATFORMS``, …) are NOT matched
       and remain visible.
-    - ``BWS_ACCESS_TOKEN`` — the Bitwarden Secrets Manager bootstrap token
-      (and any ``*_ACCESS_TOKEN`` name it is remapped to via
-      ``secrets.bitwarden.access_token_env``). Hermes's own vault credential;
-      no spawned child legitimately needs it. The one child that does — the
-      ``bws`` CLI — receives it explicitly via
-      ``build_subprocess_env(scrub_secrets=False)`` in
-      ``agent/secret_sources/bitwarden.py``, never through inheritance.
+    - ``BWS_ACCESS_TOKEN`` — the Bitwarden Secrets Manager bootstrap token,
+      under the **exact** name configured via ``secrets.bitwarden.access_token_env``
+      (default ``BWS_ACCESS_TOKEN``; may be remapped to any name, e.g.
+      ``MY_BWS_TOKEN``). Hermes's own vault credential; no spawned child
+      legitimately needs it. The one child that does — the ``bws`` CLI —
+      receives it explicitly via ``build_subprocess_env(scrub_secrets=False)``
+      in ``agent/secret_sources/bitwarden.py``, never through inheritance.
+      Only the exact configured name is matched (not a ``*_ACCESS_TOKEN``
+      suffix) so legitimate third-party access tokens stay
+      ``env_passthrough``-registerable — see ``tools/env_passthrough.py``.
 
     ``code_execution_tool.py`` already catches these via substring matching on
     ``KEY`` / ``SECRET`` / ``TOKEN``; the terminal backend's narrower name-based
@@ -398,11 +401,48 @@ def _is_hermes_internal_secret(key: str) -> bool:
         upper.endswith("_SECRET") or upper.endswith("_KEY") or upper.endswith("_TOKEN")
     ):
         return True
-    if upper.endswith("_ACCESS_TOKEN"):
-        # BWS bootstrap token and any access_token_env remap.  Hermes's own
-        # vault credential must never reach a child by inheritance.
+    if upper == _get_configured_bws_token_env().upper():
+        # Bitwarden Secrets Manager bootstrap token — the exact configured
+        # access_token_env name (default BWS_ACCESS_TOKEN; may be remapped to
+        # a non-suffix name like MY_BWS_TOKEN). Hermes's own vault credential
+        # must never reach a child by inheritance.
         return True
     return False
+
+
+_configured_bws_token_env: str | None = None
+_configured_bws_token_env_loaded = False
+
+
+def _get_configured_bws_token_env() -> str:
+    """Resolve the exact Bitwarden ``access_token_env`` name from config.
+
+    ``BitwardenSource.fetch`` reads the *configured* name
+    (``secrets.bitwarden.access_token_env``, default ``BWS_ACCESS_TOKEN``) —
+    including names that do not end in ``_ACCESS_TOKEN`` (e.g. a user remap to
+    ``MY_BWS_TOKEN``).  Matching that exact name (instead of a global
+    ``*_ACCESS_TOKEN`` suffix) is what keeps legitimate third-party access
+    tokens ``env_passthrough``-registerable.
+
+    Resolved once per process and cached; tests that exercise a remap reset
+    the module globals before calling.
+    """
+    global _configured_bws_token_env, _configured_bws_token_env_loaded
+    if not _configured_bws_token_env_loaded:
+        _configured_bws_token_env_loaded = True
+        name = "BWS_ACCESS_TOKEN"
+        try:
+            from hermes_cli.config import cfg_get, read_raw_config
+
+            configured = cfg_get(
+                read_raw_config(), "secrets", "bitwarden", "access_token_env"
+            )
+            if isinstance(configured, str) and configured.strip():
+                name = configured.strip()
+        except Exception:
+            pass
+        _configured_bws_token_env = name
+    return _configured_bws_token_env or "BWS_ACCESS_TOKEN"
 
 
 def _is_credential_shaped_password(key: str) -> bool:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -401,11 +401,14 @@ def _is_hermes_internal_secret(key: str) -> bool:
         upper.endswith("_SECRET") or upper.endswith("_KEY") or upper.endswith("_TOKEN")
     ):
         return True
-    if upper == _get_configured_bws_token_env().upper():
+    if upper == "BWS_ACCESS_TOKEN" or upper == _get_configured_bws_token_env().upper():
         # Bitwarden Secrets Manager bootstrap token — the exact configured
         # access_token_env name (default BWS_ACCESS_TOKEN; may be remapped to
-        # a non-suffix name like MY_BWS_TOKEN). Hermes's own vault credential
-        # must never reach a child by inheritance.
+        # a non-suffix name like MY_BWS_TOKEN), plus the default name itself.
+        # A remapped profile sharing one process with a default profile must
+        # not let the default profile's BWS_ACCESS_TOKEN (which the shared
+        # os.environ carries across profile turns) cross its child boundary
+        # either — the Bitwarden rule holds in both directions.
         return True
     return False
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -410,8 +410,7 @@ def _is_hermes_internal_secret(key: str) -> bool:
     return False
 
 
-_configured_bws_token_env: str | None = None
-_configured_bws_token_env_loaded = False
+_configured_bws_token_env_by_home: dict[str, str] = {}
 
 
 def _get_configured_bws_token_env() -> str:
@@ -424,25 +423,42 @@ def _get_configured_bws_token_env() -> str:
     ``*_ACCESS_TOKEN`` suffix) is what keeps legitimate third-party access
     tokens ``env_passthrough``-registerable.
 
-    Resolved once per process and cached; tests that exercise a remap reset
-    the module globals before calling.
+    Cached **per active Hermes home**: the gateway can serve multiple
+    profiles in one process by switching a context-local Hermes home per
+    turn, so a single process-global cache would keep matching the first
+    profile's token-variable name for every later profile — letting a later
+    profile's differently-named vault bootstrap token pass into child
+    processes.  Keying the cache by the active home (context override →
+    ``HERMES_HOME`` env → platform default) keeps each profile's exact
+    configured name authoritative.
     """
-    global _configured_bws_token_env, _configured_bws_token_env_loaded
-    if not _configured_bws_token_env_loaded:
-        _configured_bws_token_env_loaded = True
-        name = "BWS_ACCESS_TOKEN"
-        try:
-            from hermes_cli.config import cfg_get, read_raw_config
+    try:
+        from hermes_constants import get_hermes_home
 
-            configured = cfg_get(
-                read_raw_config(), "secrets", "bitwarden", "access_token_env"
-            )
-            if isinstance(configured, str) and configured.strip():
-                name = configured.strip()
-        except Exception:
-            pass
-        _configured_bws_token_env = name
-    return _configured_bws_token_env or "BWS_ACCESS_TOKEN"
+        home_key = str(get_hermes_home())
+    except Exception:
+        # Home resolution can fail in stripped-down environments (no
+        # LOCALAPPDATA/HOME/USERPROFILE, e.g. the test runner's clean env).
+        # Fall back to the process env var, then a shared slot — the old
+        # process-global behavior, never a raise.
+        home_key = os.environ.get("HERMES_HOME", "") or "<unknown-home>"
+    cached = _configured_bws_token_env_by_home.get(home_key)
+    if cached is not None:
+        return cached
+
+    name = "BWS_ACCESS_TOKEN"
+    try:
+        from hermes_cli.config import cfg_get, read_raw_config
+
+        configured = cfg_get(
+            read_raw_config(), "secrets", "bitwarden", "access_token_env"
+        )
+        if isinstance(configured, str) and configured.strip():
+            name = configured.strip()
+    except Exception:
+        pass
+    _configured_bws_token_env_by_home[home_key] = name
+    return name
 
 
 def _is_credential_shaped_password(key: str) -> bool:
@@ -1364,6 +1380,8 @@ def _make_run_env(env: dict) -> dict:
         else:
             passthrough = _is_passthrough(k)
             if k in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+                continue
+            if _is_credential_shaped_password(k) and not passthrough:
                 continue
             value = _resolve_passthrough_value(k, v) if passthrough else v
             if value is not None:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -200,6 +200,21 @@ def _resolve_safe_cwd(cwd: str) -> str:
 # Hermes-internal env vars that should NOT leak into terminal subprocesses.
 _HERMES_PROVIDER_ENV_FORCE_PREFIX = "_HERMES_FORCE_"
 
+# Apptainer/Singularity rename these host variables before injecting them into
+# a container.  Evaluate the target name as well as the wrapper name so
+# ``APPTAINERENV_GH_TOKEN`` cannot tunnel a blocked credential past the common
+# child-process sanitizer.
+_CONTAINER_ENV_FORWARD_PREFIXES = ("APPTAINERENV_", "SINGULARITYENV_")
+
+
+def _credential_target_env_name(key: str) -> str:
+    """Return the effective credential name after known forwarding wrappers."""
+    upper = key.upper()
+    for prefix in _CONTAINER_ENV_FORWARD_PREFIXES:
+        if upper.startswith(prefix):
+            return key[len(prefix):]
+    return key
+
 # Hermes-managed AWS *inference* credentials for ``auth_type="aws_sdk"``
 # providers (Bedrock).  Scoped DELIBERATELY NARROW: this lists only the
 # Bedrock-specific bearer token, which is a Hermes inference secret exactly
@@ -335,6 +350,22 @@ def _build_provider_env_blocklist() -> frozenset:
 
 
 _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
+_HERMES_PROVIDER_ENV_BLOCKLIST_UPPER = frozenset(
+    key.upper() for key in _HERMES_PROVIDER_ENV_BLOCKLIST
+)
+
+
+def _is_blocked_provider_env(key: str) -> bool:
+    """Match provider credentials case-insensitively and through wrappers.
+
+    Windows environment keys are case-insensitive, and Apptainer/Singularity
+    can rename ``APPTAINERENV_*`` / ``SINGULARITYENV_*`` entries inside the
+    container.  Both representations must resolve to the same policy key.
+    """
+    return (
+        _credential_target_env_name(key).upper()
+        in _HERMES_PROVIDER_ENV_BLOCKLIST_UPPER
+    )
 
 # Active-virtualenv markers that must NOT leak into terminal subprocesses.
 # The gateway runs inside its own venv, so its process environment carries
@@ -392,7 +423,7 @@ def _is_hermes_internal_secret(key: str) -> bool:
     ``env_passthrough`` skill registration or ``inherit_credentials``. Nothing
     a model-driving CLI legitimately needs matches these patterns.
     """
-    upper = key.upper()
+    upper = _credential_target_env_name(key).upper()
     if upper.startswith("AUXILIARY_") and (
         upper.endswith("_API_KEY") or upper.endswith("_BASE_URL")
     ):
@@ -482,7 +513,7 @@ def _is_credential_shaped_password(key: str) -> bool:
     needs the value still receives it via ``env_passthrough``); on the
     non-terminal surface it is stripped unconditionally.
     """
-    upper = key.upper()
+    upper = _credential_target_env_name(key).upper()
     return "PASSWORD" in upper or (upper.endswith("_PWD") and upper != "PWD")
 
 
@@ -559,12 +590,12 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     sanitized: dict[str, str] = {}
 
     for key, value in (base_env or {}).items():
-        if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
+        if key.upper().startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             continue
         if _is_hermes_internal_secret(key):
             continue
         passthrough = _is_passthrough(key)
-        if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+        if _is_blocked_provider_env(key) and not passthrough:
             continue
         if _is_credential_shaped_password(key) and not passthrough:
             continue
@@ -573,7 +604,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
             sanitized[key] = resolved
 
     for key, value in (extra_env or {}).items():
-        if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
+        if key.upper().startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = key[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
             if _is_hermes_internal_secret(real_key):
                 continue
@@ -582,7 +613,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
             continue
         else:
             passthrough = _is_passthrough(key)
-            if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+            if _is_blocked_provider_env(key) and not passthrough:
                 continue
             if _is_credential_shaped_password(key) and not passthrough:
                 continue
@@ -660,6 +691,14 @@ _ALWAYS_STRIP_KEYS: frozenset[str] = frozenset({
     "HASS_TOKEN",
     "EMAIL_PASSWORD",
     "HERMES_DASHBOARD_SESSION_TOKEN",
+    # Bitwarden Secrets Manager bootstrap token.  Classified as a
+    # Hermes-internal secret by _is_hermes_internal_secret on the terminal
+    # path; enumerated here so the non-terminal inherit_credentials=True
+    # path (codex / copilot / TUI host) also strips it unconditionally.
+    # The bws secret-source child injects its token explicitly into its own
+    # child env (agent/secret_sources/bitwarden.py) and never relies on
+    # ambient inheritance, so Tier-1 stripping cannot break it.
+    "BWS_ACCESS_TOKEN",
     # Remote-compute / infrastructure secrets
     "MODAL_TOKEN_ID",
     "MODAL_TOKEN_SECRET",
@@ -701,9 +740,11 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     """
     env = os.environ.copy()
 
-    # Tier 1 — always strip.
-    for key in _ALWAYS_STRIP_KEYS:
-        env.pop(key, None)
+    # Tier 1 — always strip, including mixed-case Windows keys and
+    # Apptainer/Singularity forwarding wrappers around a Tier-1 target.
+    for key in list(env):
+        if _credential_target_env_name(key).upper() in _ALWAYS_STRIP_KEYS:
+            env.pop(key, None)
     # *PASSWORD values never belong in a non-terminal child (browser, ACP,
     # computer-use, dep-ensure, TUI/Node host).  Unlike the terminal path
     # there is no skill-passthrough concept, so strip unconditionally.
@@ -716,15 +757,16 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     # regardless of ``inherit_credentials`` — a model-driving CLI has no
     # legitimate use for them. See :func:`_is_hermes_internal_secret`.
     for key in list(env):
-        if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
+        if key.upper().startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             env.pop(key, None)
         elif _is_hermes_internal_secret(key):
             env.pop(key, None)
 
     if not inherit_credentials:
         # Tier 2 — strip provider/tool credentials unless explicitly inherited.
-        for key in _HERMES_PROVIDER_ENV_BLOCKLIST:
-            env.pop(key, None)
+        for key in list(env):
+            if _is_blocked_provider_env(key):
+                env.pop(key, None)
 
     # Windows UTF-8 safety for spawned processes (#31420).
     env.setdefault("PYTHONUTF8", "1")
@@ -1381,7 +1423,7 @@ def _make_run_env(env: dict) -> dict:
     merged = dict(os.environ | env)
     run_env = {}
     for k, v in merged.items():
-        if k.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
+        if k.upper().startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
             real_key = k[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
             if _is_hermes_internal_secret(real_key):
                 continue
@@ -1390,7 +1432,7 @@ def _make_run_env(env: dict) -> dict:
             continue
         else:
             passthrough = _is_passthrough(k)
-            if k in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+            if _is_blocked_provider_env(k) and not passthrough:
                 continue
             if _is_credential_shaped_password(k) and not passthrough:
                 continue

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -21,10 +21,33 @@ from tools.environments.base import (
     _popen_bash,
     _save_json_store,
 )
+from tools.environments.local import build_subprocess_env
 
 logger = logging.getLogger(__name__)
 
 _SNAPSHOT_STORE = get_hermes_home() / "singularity_snapshots.json"
+
+# Apptainer accepts these exact variables for private Docker-registry pulls.
+# Image construction gets this narrow capability set back after the common
+# sanitizer runs; it never receives the rest of the trusted Hermes env.
+_REGISTRY_AUTH_ENV_VARS = (
+    "APPTAINER_DOCKER_USERNAME",
+    "APPTAINER_DOCKER_PASSWORD",
+    "SINGULARITY_DOCKER_USERNAME",
+    "SINGULARITY_DOCKER_PASSWORD",
+    "DOCKER_USERNAME",
+    "DOCKER_PASSWORD",
+)
+
+
+def _singularity_subprocess_env(*, include_registry_auth: bool = False) -> dict[str, str]:
+    env = build_subprocess_env()
+    if include_registry_auth:
+        for key in _REGISTRY_AUTH_ENV_VARS:
+            value = os.environ.get(key)
+            if value is not None:
+                env[key] = value
+    return env
 
 
 def _find_singularity_executable() -> str:
@@ -46,6 +69,7 @@ def _ensure_singularity_available() -> str:
     try:
         result = subprocess.run(
             [exe, "version"], capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=10,
+            env=_singularity_subprocess_env(),
             stdin=subprocess.DEVNULL,
         )
     except FileNotFoundError:
@@ -129,10 +153,9 @@ def _get_or_build_sif(image: str, executable: str = "apptainer") -> str:
         tmp_dir = cache_dir / "tmp"
         tmp_dir.mkdir(parents=True, exist_ok=True)
 
-        # apptainer/singularity build: external tool, may need registry
-        # credentials from the user env — exact preservation.
-        from tools.environments.local import build_subprocess_env
-        env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=False)
+        # Image construction may need private-registry auth, but only the exact
+        # Apptainer/Singularity Docker credential contract is reintroduced.
+        env = _singularity_subprocess_env(include_registry_auth=True)
         env["APPTAINER_TMPDIR"] = str(tmp_dir)
         env["APPTAINER_CACHEDIR"] = str(cache_dir)
 
@@ -223,7 +246,10 @@ class SingularityEnvironment(BaseEnvironment):
         cmd.extend([str(self.image), self.instance_id])
 
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120, stdin=subprocess.DEVNULL)
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120,
+                env=_singularity_subprocess_env(), stdin=subprocess.DEVNULL,
+            )
             if result.returncode != 0:
                 raise RuntimeError(f"Failed to start instance: {result.stderr}")
             self._instance_started = True
@@ -255,6 +281,7 @@ class SingularityEnvironment(BaseEnvironment):
                 subprocess.run(
                     [self.executable, "instance", "stop", self.instance_id],
                     capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=30,
+                    env=_singularity_subprocess_env(),
                     stdin=subprocess.DEVNULL,
                 )
                 logger.info("Singularity instance %s stopped", self.instance_id)


### PR DESCRIPTION
## What changed and why

Closes the child-process credential-inheritance bug class where trusted Hermes credentials and other sensitive parent-environment values reached untrusted or model-authored subprocesses.

**Confirmed production chain (pinned head `de0e88d8`):** `SingularityEnvironment._run_bash` → `_popen_bash` with no sanitized `env` → `subprocess.Popen` inherited the trusted Hermes process environment. Docker, SSH, and future backends converge on the same shared boundary, so safety cannot depend on every caller remembering to pass `env`.

### Changes

- **`tools/environments/base.py`** — `_popen_bash` now builds a sanitized child env by default (`build_subprocess_env(base=...)`) and applies the same policy to caller-supplied `env` maps, so omitting `env` can never re-open ambient inheritance.
- **`tools/environments/local.py`** — case-insensitive provider/security matching (`_is_blocked_provider_env`) for Windows environment semantics; effective destination keys behind `APPTAINERENV_`/`SINGULARITYENV_` wrappers are checked (`_credential_target_env_name`); `BWS_ACCESS_TOKEN` promoted to Tier-1 `_ALWAYS_STRIP_KEYS` so `inherit_credentials=True` paths cannot export the vault bootstrap token.
- **`tools/environments/singularity.py`** — preflight, instance start, image build, and cleanup subprocesses all use the sanitized builder; image construction re-adds ONLY the six explicit Apptainer/Singularity Docker registry-auth variables instead of the full parent environment.
- **`tools/environments/docker.py`** — explicit `docker_forward_env` entries may not export Hermes-internal secrets (`AUXILIARY_*`/`GATEWAY_RELAY_*`/`BWS_ACCESS_TOKEN`) — the forwarding list is a capability boundary, not an unconditional bypass.
- **`tools/env_passthrough.py`** — uses the case-insensitive blocklist predicate.
- **`tests/tools/test_backend_subprocess_env_boundary.py`** — 12-test regression matrix covering Docker/SSH/Singularity exec, caller-supplied and empty base envs, mixed-case credentials, nested children, Singularity lifecycle, narrow image-build auth, and Docker explicit forwarding.

### Why this matters to you as a user

A spawned child process (terminal command, Docker/SSH/Singularity backend, browser worker, ACP executor, model-driving CLI) could previously read your provider API keys, Bitwarden vault token, GitHub token, gateway secrets, and database/service passwords straight from its environment. After this change, those values don't cross the process boundary unless a command explicitly needs them — and on the terminal path, a command that legitimately needs a value (registered via `env_passthrough`) still gets it.

## Reproduction steps (current behavior on `main`)

1. `export BWS_ACCESS_TOKEN=0.abc123.def456:xyz789` and `export DB_PASSWORD=db-pass-9f2c1a`.
2. From a Hermes checkout, spawn a child with the default factory env:
   ```python
   from tools.environments.local import build_subprocess_env
   env = build_subprocess_env()  # scrub on (default)
   print("BWS_ACCESS_TOKEN" in env, "DB_PASSWORD" in env)  # (True, True) on main
   ```
3. Same for `hermes_subprocess_env()`.

**Current:** both keys present in the child env.
**Expected:** both absent (BWS token unconditionally; `*_PASSWORD` unless explicitly registered for passthrough).

## How to test

- `scripts/run_tests.sh tests/tools/test_backend_subprocess_env_boundary.py` → **12 passed** (Docker/SSH/Singularity exec boundary, caller-supplied and empty base envs, mixed-case credentials, nested children, Singularity lifecycle, narrow image-build auth, Docker explicit forwarding).
- `scripts/run_tests.sh tests/tools/test_build_subprocess_env.py` → 8 passed (2 new E2E tests spawn a real child via `sys.executable` and assert the BWS token and `DB_PASSWORD` are absent; 1 new unit test asserts `hermes_subprocess_env` strips both).
- `scripts/run_tests.sh tests/tools/test_env_passthrough.py` → 23 passed — confirms a passthrough-registered command still receives its value.

## Evidence

- Focused matrix: **12/12 GREEN** (was 2/12 RED on the pinned vulnerable head).
- Adjacent suites: 118 passed / 3 failed / 4 skipped; backend suites: 93 passed / 1 failed / 5 skipped — all failures reproduced identically on a pristine pinned-head worktree (pre-existing Windows/MSYS host failures, zero regressions).
- Synthetic merge on fresh `main`: cumulative diff applied cleanly, focused matrix 12/12 passed.
- `git diff --check` clean; ruff clean on all changed files.
- Blind 5×2×3 wave (5 analysts + 5 cross-set witnesses, packet-pinned): every region's pair agrees the terminal-backend class is closed by this fix; residual sinks adjudicated to sibling PRs (#77467, #56245/#55256/#77528, #70332/#70373).
- GraphQL collision audit: 40 query families, 1,274 nodes, 277 candidates, 24-PR adjudication — full report in the campaign ledger.

Part of #83565 — the boundary fix: sanitize-by-default at the shared `_popen_bash` (Docker/SSH/Singularity + every future backend). Focused matrix 12/12 GREEN, CI green, mergeable clean.