### PR TITLE
fix(acp): forward resolved credential pool into ACP-created agents

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -640,6 +640,7 @@ class SessionManager:
                     "api_mode": api_mode or runtime.get("api_mode"),
                     "base_url": base_url or runtime.get("base_url"),
                     "api_key": runtime.get("api_key"),
+                    "credential_pool": runtime.get("credential_pool"),
                     "command": runtime.get("command"),
                     "args": list(runtime.get("args") or []),
                 }

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -66,7 +66,9 @@ class TestCreateSession:
         assert fetched is state
 
 
-    def test_make_agent_stamps_session_cwd_for_codex_runtime(self, monkeypatch):
+    def test_make_agent_stamps_cwd_and_forwards_runtime_credential_pool(self, monkeypatch):
+        sentinel_pool = object()
+
         class FakeAgent:
             model = "fake-model"
 
@@ -102,6 +104,7 @@ class TestCreateSession:
                 "api_mode": "codex_app_server",
                 "base_url": "https://example.invalid",
                 "api_key": "test-key",
+                "credential_pool": sentinel_pool,
             },
         )
         monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda task_id, cwd: None)
@@ -109,8 +112,7 @@ class TestCreateSession:
         state = SessionManager(db=None).create_session(cwd="/tmp/project")
 
         assert state.agent.session_cwd == "/tmp/project"
-
-
+        assert state.agent.kwargs["credential_pool"] is sentinel_pool
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
ACP-created AIAgent instances were missing the resolved `credential_pool`, preventing long-lived OpenAI Codex ACP sessions from using Hermes' in-process OAuth 401 refresh/rotation path.

## Changes
- `acp_adapter/session.py`: Forward `runtime["credential_pool"]` into ACP-created AIAgent instances (parity with gateway's `_resolve_runtime_agent_kwargs`)
- `tests/acp/test_session.py`: Extend construction regression to assert the pool is retained

## Validation
- 15 ACP session tests pass
- E2E: verified AIAgent.__init__ accepts credential_pool, runtime_provider returns it, gateway already forwards it (this brings ACP to parity)

Credits @stefanpieter for the original fix.
