### PR TITLE
perf(state): stop selecting full message content in session search

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1242,7 +1242,6 @@ class SessionSearchMixin:
                 m.session_id,
                 m.role,
                 snippet({table}, -1, '>>>', '<<<', '...', 40) AS snippet,
-                m.content,
                 m.timestamp,
                 m.tool_name,
                 s.source,
@@ -1435,7 +1434,6 @@ class SessionSearchMixin:
                 m.session_id,
                 m.role,
                 snippet(messages_fts, -1, '>>>', '<<<', '...', 40) AS snippet,
-                m.content,
                 m.timestamp,
                 m.tool_name,
                 s.source,
@@ -1524,7 +1522,6 @@ class SessionSearchMixin:
                         m.session_id,
                         m.role,
                         snippet(messages_fts_cjk, -1, '>>>', '<<<', '...', 40) AS snippet,
-                        m.content,
                         m.timestamp,
                         m.tool_name,
                         s.source,
@@ -1613,7 +1610,6 @@ class SessionSearchMixin:
                         m.session_id,
                         m.role,
                         snippet(messages_fts_trigram, -1, '>>>', '<<<', '...', 40) AS snippet,
-                        m.content,
                         m.timestamp,
                         m.tool_name,
                         s.source,
@@ -1706,7 +1702,7 @@ class SessionSearchMixin:
                            substr(m.content,
                                   max(1, instr(m.content, ?) - 40),
                                   120) AS snippet,
-                           m.content, m.timestamp, m.tool_name,
+                           m.timestamp, m.tool_name,
                            s.source, s.model, s.started_at AS session_started
                     FROM messages m
                     JOIN sessions s ON s.id = m.session_id
@@ -1884,10 +1880,11 @@ class SessionSearchMixin:
             except Exception:
                 match["context"] = []
 
-        # Remove full content from result (snippet is enough, saves tokens)
-        for match in matches:
-            match.pop("content", None)
-
+        # Full message content is never selected above: every route returns
+        # snippet + metadata only (saves I/O on multi-MB tool rows and the
+        # tokens a content column would cost downstream). The context loop
+        # re-fetches the 3-message window by id, so nothing reads content
+        # from the match rows themselves.
         return matches
 
     def _search_unindexed_gap(
@@ -1950,7 +1947,7 @@ class SessionSearchMixin:
                    substr(m.content,
                           max(1, instr(m.content, ?) - 40),
                           120) AS snippet,
-                   m.content, m.timestamp, m.tool_name,
+                   m.timestamp, m.tool_name,
                    s.source, s.model, s.started_at AS session_started
             FROM messages m
             JOIN sessions s ON s.id = m.session_id

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -372,6 +372,7 @@ class TestSessionLifecycle:
             results = db.search_messages("大别山")
             assert len(results) == 1
             # Note: search_messages strips 'content' from results; use 'snippet'.
+            assert "content" not in results[0]
             assert "大别山" in results[0]["snippet"]
         finally:
             db.close()
@@ -638,6 +639,8 @@ class TestFTS5Search:
         # At least one result should mention docker
         snippets = [r.get("snippet", "") for r in results]
         assert any("docker" in s.lower() or "Docker" in s for s in snippets)
+        # Results never carry full content; snippet + metadata only.
+        assert all("content" not in r for r in results)
 
 
 


### PR DESCRIPTION
## What does this PR do?

`SessionDB.search_messages()` selected the full `m.content` column for every match on every search route, then popped it unread before returning. On state DBs with multi-MB tool rows, a default 20-hit search read and materialized tens of MB to hand back a few KB of snippets.

The content-free result contract was intentional from the original session-store commit (440c244ca, "snippet is enough, saves tokens"). The waste is accidental: snippets come from `snippet()` / `substr()` in SQL, the context window is re-fetched by message id, and no code path has ever read `match["content"]` (verified with `git log -S` across full history).

This drops `m.content` from all six SELECT lists (main FTS, CJK bigram, trigram x2, LIKE fallback, rebuild-gap supplement) and removes the now-dead pop loop. Returned dicts, snippets, context previews, ranking, and filters are unchanged.

Compatibility note: #63389 (skip unused context enrichment) touches the same result tail but keeps the pop and adds its projection after it. If it lands first, this PR rebases to a one-line removal; if this lands first, its projection just drops the pop line. The two are complementary: this one stops reading the bytes, that one skips the enrichment queries.

## Related Issue

Fixes #77033

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_state_search.py`: drop `m.content` from the six search SELECT lists in `_search_messages_impl`, `_run_trigram_search`, and `_search_unindexed_gap`; remove the dead `match.pop("content", None)` loop and document the contract at the return site.

## How to Test

1. `scripts/run_tests.sh tests/test_hermes_state.py tests/test_fts_cjk_bigram.py tests/test_session_db_read_path_split.py tests/state/test_fts_runtime_rebuild.py tests/test_search_slow_query_log.py tests/hermes_cli/test_web_server_session_search.py -q`
   - 172 passed, 0 failed
2. `scripts/run_tests.sh tests/tools/test_session_search.py tests/tools/test_search_budget_truncation.py tests/acp/test_session.py -q`
   - passed
3. Contract check: `tests/test_hermes_state.py` already documents "search_messages strips 'content' from results; use 'snippet'" and passes unchanged. Result dicts have identical keys before and after, since the pop ran before return on main.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the search/state suites above and they pass. Full `pytest tests/ -q` not re-run here. Change is isolated to session search SQL + result tail.
- [x] I've added tests for my changes - N/A, behavior is pinned by the existing search suites and the returned dict shape is unchanged
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A (comment at the return site only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - pure SQL column-list change, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A (tool results unchanged)

## Screenshots / Logs

```shell
# Before: every route returned full content, popped at the tail
SELECT m.id, m.session_id, m.role, snippet(...) AS snippet,
       m.content, m.timestamp, ...
...
match.pop("content", None)  # never read between SELECT and pop

# After: content never leaves the database
SELECT m.id, m.session_id, m.role, snippet(...) AS snippet,
       m.timestamp, ...
```
