### PR TITLE
fix(stt): keep requirements probes from lazy-installing faster-whisper

### DIFF
--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -273,7 +273,10 @@ class TestCheckVoiceRequirements:
         monkeypatch.setattr("tools.voice_mode._audio_available", lambda: True)
         monkeypatch.setattr("tools.voice_mode.detect_audio_environment",
                             lambda: {"available": True, "warnings": []})
-        monkeypatch.setattr("tools.transcription_tools._get_provider", lambda cfg: "openai")
+        monkeypatch.setattr(
+            "tools.transcription_tools._get_provider",
+            lambda cfg, *, install=True: "openai",
+        )
 
         from tools.voice_mode import check_voice_requirements
 

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -146,6 +146,51 @@ def test_tts_ready_is_a_probe_never_an_installer(monkeypatch):
     assert ww._tts_ready() is True
 
 
+def test_stt_ready_is_a_probe_never_an_installer(monkeypatch):
+    """_stt_ready must NOT trigger lazy pip installs from a status poll.
+
+    Regression: _get_provider resolved an explicit 'local' provider by
+    lazy-installing faster-whisper (lazy_deps.ensure → pip install), which
+    froze the TUI's wake.start handshake — and wake.status — for the length
+    of a pip install. Uninstalled-but-lazy-installable counts as ready
+    WITHOUT calling _try_lazy_install_stt / ensure.
+    """
+    monkeypatch.setattr(
+        ww, "_stt_ready", ww.__dict__["_stt_ready"]
+    )  # use the real implementation
+    install_seen: list = []
+
+    def _fake_get_provider(cfg, *, install=True):
+        install_seen.append(install)
+        # faster-whisper absent, no cloud keys → resolves to nothing
+        return "none"
+
+    fake_stt = types.SimpleNamespace(
+        _get_provider=_fake_get_provider,
+        _load_stt_config=lambda: {"enabled": True, "provider": "local"},
+        is_stt_enabled=lambda cfg: bool(cfg.get("enabled")),
+    )
+    monkeypatch.setitem(sys.modules, "tools.transcription_tools", fake_stt)
+
+    # Deps missing + lazy installs allowed → ready (installs at first use),
+    # and the probe must never pass install=True into the resolver.
+    monkeypatch.setattr("tools.lazy_deps._allow_lazy_installs", lambda: True)
+    assert ww._stt_ready() is True
+    assert install_seen == [False]
+
+    # Deps missing + lazy installs disabled → not ready.
+    monkeypatch.setattr("tools.lazy_deps._allow_lazy_installs", lambda: False)
+    assert ww._stt_ready() is False
+
+    # A cloud provider resolves → ready without needing the lazy install.
+    fake_stt._get_provider = lambda cfg, *, install=True: "groq"
+    assert ww._stt_ready() is True
+
+    # STT disabled → never ready.
+    fake_stt._load_stt_config = lambda: {"enabled": False, "provider": "local"}
+    assert ww._stt_ready() is False
+
+
 def test_requirements_fresh_install_lazy_allowed(monkeypatch):
     """Deps missing + lazy installs allowed → available, so /wake on can
     reach the engine constructor's ``lazy_deps.ensure()`` call.

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -965,12 +965,18 @@ def _transcribe_command_stt(
     }
 
 
-def _get_provider(stt_config: dict) -> str:
+def _get_provider(stt_config: dict, *, install: bool = True) -> str:
     """Determine which STT provider to use.
 
     When ``stt.provider`` is explicitly set in config, that choice is
     honoured — no silent cloud fallback.  When no provider is configured,
     auto-detect tries: local > groq (free) > openai (paid).
+
+    ``install`` controls whether resolving an uninstalled ``local`` provider
+    may trigger a lazy faster-whisper install.  Probe callers (wake-word and
+    voice requirements checks) pass ``install=False`` so a slow pip install
+    can never freeze a startup handshake or status poll — the install then
+    happens lazily at first real transcription instead.
     """
     if not is_stt_enabled(stt_config):
         return "none"
@@ -986,8 +992,9 @@ def _get_provider(stt_config: dict) -> str:
                 return "local"
             if _has_local_command():
                 return "local_command"
-            # Try lazy-install before giving up
-            if _try_lazy_install_stt():
+            # Try lazy-install before giving up (probe callers skip this —
+            # an uninstalled local provider is resolved lazily at first use)
+            if install and _try_lazy_install_stt():
                 return "local"
             logger.warning(
                 "STT provider 'local' configured but unavailable "
@@ -1073,7 +1080,8 @@ def _get_provider(stt_config: dict) -> str:
     if _has_local_command():
         return "local_command"
     # Try lazy-install before falling through to cloud providers
-    if _try_lazy_install_stt():
+    # (probe callers skip this — uninstalled local resolves lazily at first use)
+    if install and _try_lazy_install_stt():
         return "local"
     if _HAS_OPENAI and _resolve_provider_key("GROQ_API_KEY", "groq"):
         logger.info("No local STT available, using Groq Whisper API")

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -2189,7 +2189,10 @@ def check_voice_requirements() -> Dict[str, Any]:
     )
     stt_config = _load_stt_config()
     stt_enabled = is_stt_enabled(stt_config)
-    stt_provider = _get_provider(stt_config)
+    # install=False: this is a status probe, not a transcription path — a
+    # lazy faster-whisper install here would freeze /voice status (and the
+    # TUI's voice.toggle status RPC) for the length of a pip install.
+    stt_provider = _get_provider(stt_config, install=False)
     native_stt_available = stt_provider in {
         "local",
         "local_command",

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -739,12 +739,33 @@ def _stt_ready() -> bool:
     A wake without STT arms the mic but every captured utterance dies at
     transcription — a useless (and confusing) experience. Same standard as
     voice mode's ``check_voice_requirements``: enabled + a real provider.
+
+    PROBE, not an installer: ``_get_provider`` resolves an explicit
+    ``local`` provider by lazy-installing faster-whisper via
+    ``lazy_deps.ensure`` — running that inside the wake.start handshake /
+    wake.status froze the TUI for the length of a pip install. We resolve
+    with ``install=False``; an uninstalled-but-installable local provider
+    still counts as ready ("installs at first transcription"), mirroring
+    ``_tts_ready``.
     """
     try:
+        from tools import lazy_deps
         from tools.transcription_tools import _get_provider, _load_stt_config, is_stt_enabled
 
         stt_config = _load_stt_config()
-        return is_stt_enabled(stt_config) and _get_provider(stt_config) != "none"
+        if not is_stt_enabled(stt_config):
+            return False
+
+        provider = _get_provider(stt_config, install=False)
+        if provider != "none":
+            return True
+
+        # Explicit local / local_command that isn't installed yet: ready iff
+        # a lazy install is permitted — the pip fetch happens at first
+        # transcription, never from a status poll / startup handshake.
+        if "provider" in stt_config and stt_config.get("provider") in ("local", "local_command"):
+            return lazy_deps._allow_lazy_installs()
+        return False
     except Exception:
         return False
 


### PR DESCRIPTION
## Bug Description

Starting `hermes --tui` on a machine with `stt.provider: local` and
faster-whisper not yet installed hangs on the `forging session…` screen
for minutes (or until killed).

The TUI startup handshake (`wake.start`) calls
`check_wake_word_requirements()` → `_stt_ready()` → `_get_provider()`, and
`_get_provider` resolves an uninstalled explicit `local` provider by
running a **synchronous lazy pip install**
(`lazy_deps.ensure("stt.faster_whisper")` → `uv pip install
faster-whisper`, up to 300s for the ~200MB ctranslate2 wheel). The
handshake is handled on the gateway's main thread, so the Ink frontend
never receives a ready event and sits on `forging session…` until the
install finishes, times out, or the process is killed.

`check_voice_requirements()` (used by the TUI's `/voice status` RPC) has
the same freeze.

## Root Cause

`tools/transcription_tools.py::_get_provider` calls
`_try_lazy_install_stt()` from both the explicit-`local` branch and the
auto-detect branch. Any caller that merely wants to *probe* STT readiness
(resolve which provider would be used) therefore triggers a real,
synchronous, multi-minute pip install.

The TTS path already solved this exact problem:
`_tts_ready()` in `tools/wake_word.py` is documented as
"PROBE, not an installer" — it never touches pip from a status poll, and
treats uninstalled-but-lazy-installable providers as ready (installed at
first real use). STT never got the same treatment.

## Fix

- `_get_provider(stt_config, *, install=True)` — new keyword-only
  `install` switch (default `True`, fully backward compatible). When
  `False`, an uninstalled `local` provider is *not* pip-installed; the
  resolver just falls through to `local_command` / cloud providers /
  `"none"`.
- `_stt_ready()` now resolves with `install=False` and, mirroring
  `_tts_ready`, treats an explicit `local`/`local_command` provider that
  isn't installed yet as ready **iff** lazy installs are permitted — the
  actual fetch happens lazily at first real transcription, never from a
  startup handshake or status poll.
- `check_voice_requirements()` resolves with `install=False` too (same
  freeze via the TUI `/voice status` RPC).

## How to Verify

1. Set `stt.enabled: true` / `stt.provider: local` with faster-whisper
   absent from the venv.
2. `hermes --tui` — the UI should reach the main screen immediately
   instead of hanging on `forging session…`.
3. `/wake status` and `/voice status` return promptly (no pip install
   freeze).

## Test Plan

- [x] Added regression test
      `test_stt_ready_is_a_probe_never_an_installer` (mirrors the existing
      `test_tts_ready_is_a_probe_never_an_installer`), asserting the probe
      never passes `install=True` into the resolver
- [x] `tests/tools/test_wake_word.py` — 23 passed
- [x] `tests/tools/test_voice_mode.py` + `tests/tools/test_transcription_tools.py`
      — 61 passed (1 pre-existing WSL audio-env failure, reproduced on
      clean `main` with the changes stashed)
- [x] `tests/test_tui_gateway_server.py` wake tests — 3 passed
- [x] Manual: `check_wake_word_requirements()` returns in ~0.14s with
      faster-whisper absent and lazy installs allowed (previously hung
      for the full 300s pip timeout)

## Risk Assessment

Low — only the probe callers change (`install=False`); the real
transcription path keeps `install=True` and behaves exactly as before.
The new parameter is keyword-only with a `True` default, so existing
call sites are unaffected.
