### PR TITLE
fix(kanban): expose current run id in task JSON

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -79,6 +79,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "model_override": t.model_override,
         "provider_override": t.provider_override,
         "session_id": t.session_id,
+        "current_run_id": t.current_run_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
     }

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -50,11 +50,24 @@ def test_kanban_list_json_includes_session_id(kanban_home):
         )
     raw = kc.run_slash("list --json")
     payload = json.loads(raw)
-    assert any(
-        row.get("title") == "acp task"
-        and row.get("session_id") == "acp-x"
-        for row in payload
-    )
+    task = next(row for row in payload if row.get("title") == "acp task")
+    assert task["session_id"] == "acp-x"
+    assert task["current_run_id"] is None
+
+
+def test_kanban_show_json_includes_authoritative_current_run_id(kanban_home):
+    """JSON show exposes the task pointer needed to reject stale run snapshots."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="active task", assignee="alice")
+        kb.recompute_ready(conn)
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        expected_run_id = claimed.current_run_id
+
+    payload = json.loads(kc.run_slash(f"show {tid} --json"))
+
+    assert type(payload["task"]["current_run_id"]) is int
+    assert payload["task"]["current_run_id"] == expected_run_id
 
 
 def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch):


### PR DESCRIPTION
## Summary

Expose the authoritative `Task.current_run_id` through the shared Kanban CLI task JSON serializer.

The shared serializer is used by `create --json`, `list --json`, and `show --json`:

- active task: exact integer run pointer;
- task without an active run: JSON `null`.

## Motivation

External Kanban clients can inspect historical runs but currently cannot determine whether a candidate run is still the task's authoritative current run. Without this pointer, a fail-closed client must either act on a stale run snapshot or suppress the operation as indeterminate.

## Scope

- one additive JSON property;
- behavior-contract tests for active integer and inactive null semantics;
- no DB/schema migration, dependency, tool, configuration, or environment variable.

## Verification

- focused CLI tests: 4 passed
- broader Kanban DB/core/tool tests: 81 passed
- Ruff on both changed files: pass
- `git diff --check`: pass

`ruff format --check` and `ty check` retain pre-existing diagnostics on the touched files; this change intentionally avoids unrelated whole-file formatting.

## Compatibility

Low risk. This exposes an existing optional integer dataclass/DB field. Consumers should tolerate additive JSON properties.
