### PR TITLE
fix(gateway): prevent startup-restore flood control deadlock

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -309,12 +309,24 @@ def sweep_recoverable(
 def _prune(now: Optional[float] = None) -> None:
     now = now if now is not None else time.time()
     cutoff = now - _RETENTION_SECONDS
+    # Failed obligations are pruned more aggressively: they are retried by
+    # sweep_recoverable on every boot, which can re-trigger flood control on
+    # a platform that is already rate-limited. A failed obligation older
+    # than 1 hour is stale by definition — the original response is gone and
+    # redelivery would just fail again. Prune them so they stop poisoning
+    # the startup restore path.
+    _failed_cutoff = now - 3600  # 1 hour
     try:
         with _transaction() as conn:
             conn.execute(
                 """DELETE FROM delivery_obligations
                    WHERE state IN ('delivered', 'abandoned') AND updated_at < ?""",
                 (cutoff,),
+            )
+            conn.execute(
+                """DELETE FROM delivery_obligations
+                   WHERE state = 'failed' AND updated_at < ?""",
+                (_failed_cutoff,),
             )
             total = conn.execute(
                 "SELECT COUNT(*) FROM delivery_obligations"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1671,6 +1671,47 @@ def _clear_planned_restart_notification() -> None:
     _planned_restart_notification_path().unlink(missing_ok=True)
 
 
+# Stale marker cleanup: if the gateway was killed before it could send a
+# startup notification, the marker file lingers forever. On the next boot
+# the gateway tries to send the old notification again, which re-triggers
+# flood control and perpetuates the startup-restore block loop. Prune
+# markers older than the threshold before the startup notification path runs.
+_STALE_MARKER_MAX_AGE_SECONDS = 600  # 10 minutes
+
+
+def _prune_stale_startup_markers() -> int:
+    """Remove startup notification marker files older than the threshold.
+
+    Returns the number of files pruned. Safe to call before the startup
+    notification path — if the markers are recent, they're left alone so the
+    normal notification flow runs.
+    """
+    import time
+    marker_paths = [
+        _hermes_home / ".restart_pending.json",
+        _hermes_home / ".restart_notify.json",
+        _hermes_home / ".update_pending.json",
+        _hermes_home / ".update_pending.claimed.json",
+    ]
+    pruned = 0
+    now = time.time()
+    for path in marker_paths:
+        try:
+            if not path.exists():
+                continue
+            age = now - path.stat().st_mtime
+            if age > _STALE_MARKER_MAX_AGE_SECONDS:
+                path.unlink(missing_ok=True)
+                pruned += 1
+                logger.info(
+                    "Pruned stale startup marker %s (age %.0fs > %.0fs)",
+                    path.name, age, _STALE_MARKER_MAX_AGE_SECONDS,
+                )
+        except Exception:
+            pass
+    return pruned
+
+
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
 # knows not to clobber TERMINAL_CWD if lazily imported.
 os.environ["_HERMES_GATEWAY"] = "1"
@@ -6058,6 +6099,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
+        # Track redelivery tasks spawned during startup restore so they're
+        # not garbage-collected mid-send (same pattern as _background_tasks).
+        self._spawned_redelivery_tasks: set = set()
 
         # Event-loop liveness heartbeat (#66892): rewritten every 30s while
         # the loop is dispatching. External supervisors use the file mtime /
@@ -10075,7 +10119,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Crash-ambiguity contract (see gateway/delivery_ledger.py):
         rows that were mid-send or previously rejected carry a visible
         recovered-reply marker so a possible duplicate is labeled, never
-        silent. Returns the number of redeliveries attempted.
+        silent. Returns the number of redeliveries attempted (claimed but
+        not necessarily delivered yet — sends run as background tasks).
         """
         try:
             from gateway.delivery_ledger import (
@@ -10103,6 +10148,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not claimed:
             return 0
 
+        # Fire each redelivery as a background task instead of awaiting
+        # sequentially. A single send that hits flood control can block for
+        # the full retry_after duration (sometimes 30+ minutes), which
+        # blocks _finish_startup_restore and traps all inbound messages in
+        # the startup queue. Background tasks let startup restore complete
+        # immediately; redeliveries land whenever the platform accepts them.
         redelivered = 0
         for row in claimed:
             try:
@@ -10118,54 +10169,76 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Platform not connected this boot — leave the row claimed;
                 # attempts cap + stale cutoff bound the retries on later boots.
                 continue
-            content = row["content"]
-            if row.get("needs_marker"):
-                content = RECOVERED_MARKER + content
-            metadata = (
-                {"thread_id": row["thread_id"]} if row.get("thread_id") else None
+            task = asyncio.create_task(
+                self._redeliver_one_obligation(row, adapter)
             )
-            try:
-                result = await adapter.send(
-                    chat_id=row["chat_id"],
-                    content=content,
-                    metadata=metadata,
-                )
-            except Exception as send_err:
-                logger.warning(
-                    "obligation %s: redelivery send raised: %s",
-                    row["obligation_id"], send_err,
-                )
-                result = None
-            try:
-                if result is not None and getattr(result, "success", False):
-                    mark_delivered(row["obligation_id"])
-                    redelivered += 1
-                    logger.info(
-                        "Redelivered recovered final response to %s:%s "
-                        "(obligation %s, attempt %d)",
-                        row["platform"], row["chat_id"],
-                        row["obligation_id"], row["attempts"],
-                    )
-                else:
-                    mark_failed(
-                        row["obligation_id"],
-                        str(getattr(result, "error", "") or "send failed"),
-                    )
-            except Exception:
-                logger.debug("delivery ledger update failed", exc_info=True)
-
-            # The answer reached (or was owed to) this session — don't ALSO
-            # re-run the turn via the resume path.
-            session_key = row.get("session_key") or ""
-            if session_key:
-                try:
-                    await self.async_session_store.clear_resume_pending(session_key)
-                except Exception:
-                    logger.debug(
-                        "clear_resume_pending failed for %s", session_key,
-                        exc_info=True,
-                    )
+            self._spawned_redelivery_tasks.add(task)
+            task.add_done_callback(
+                lambda t, _set=self._spawned_redelivery_tasks: _set.discard(t)
+            )
+            redelivered += 1
+        if redelivered:
+            logger.info(
+                "Scheduled %d delivery obligation redeliver(ies) as background tasks",
+                redelivered,
+            )
         return redelivered
+
+    async def _redeliver_one_obligation(self, row, adapter) -> None:
+        """Send a single delivery-obligation row in the background and update
+        its ledger state. Isolated from the startup restore path so a flood
+        control sleep on one send cannot block inbound message dispatch."""
+        from gateway.delivery_ledger import (
+            RECOVERED_MARKER,
+            mark_delivered,
+            mark_failed,
+        )
+        content = row["content"]
+        if row.get("needs_marker"):
+            content = RECOVERED_MARKER + content
+        metadata = (
+            {"thread_id": row["thread_id"]} if row.get("thread_id") else None
+        )
+        try:
+            result = await adapter.send(
+                chat_id=row["chat_id"],
+                content=content,
+                metadata=metadata,
+            )
+        except Exception as send_err:
+            logger.warning(
+                "obligation %s: redelivery send raised: %s",
+                row["obligation_id"], send_err,
+            )
+            result = None
+        try:
+            if result is not None and getattr(result, "success", False):
+                mark_delivered(row["obligation_id"])
+                logger.info(
+                    "Redelivered recovered final response to %s:%s "
+                    "(obligation %s, attempt %d)",
+                    row["platform"], row["chat_id"],
+                    row["obligation_id"], row["attempts"],
+                )
+            else:
+                mark_failed(
+                    row["obligation_id"],
+                    str(getattr(result, "error", "") or "send failed"),
+                )
+        except Exception:
+            logger.debug("delivery ledger update failed", exc_info=True)
+
+        # The answer reached (or was owed to) this session — don't ALSO
+        # re-run the turn via the resume path.
+        session_key = row.get("session_key") or ""
+        if session_key:
+            try:
+                await self.async_session_store.clear_resume_pending(session_key)
+            except Exception:
+                logger.debug(
+                    "clear_resume_pending failed for %s", session_key,
+                    exc_info=True,
+                )
 
     def _schedule_resume_pending_sessions(self, platform=None) -> int:
         """Auto-continue fresh restart-interrupted sessions after startup.
@@ -11103,6 +11176,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.info("Channel directory built: %d target(s)", ch_count)
         except Exception as e:
             logger.warning("Channel directory build failed: %s", e)
+        
+        # Prune stale startup notification markers before the notification
+        # path runs. If the previous gateway was killed before sending a
+        # notification, the marker file lingers and re-triggers a send
+        # (and flood control) on every subsequent boot.
+        try:
+            _pruned = _prune_stale_startup_markers()
+            if _pruned:
+                logger.info(
+                    "Pruned %d stale startup marker(s) before notification path",
+                    _pruned,
+                )
+        except Exception:
+            logger.debug("Stale marker prune failed", exc_info=True)
         
         # Check if we're restarting after a /update command. If the update is
         # still running, keep watching so we notify once it actually finishes.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2528,6 +2528,26 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
                     continue
                 raise
+            except SystemError as exc:
+                # CPython raises SystemError ("<...> returned NULL without
+                # setting an exception") when a sqlite3 C-extension function
+                # fails (typically SQLITE_NOMEM under memory pressure on a
+                # large state.db) but does not set a Python-level exception.
+                # This is transient: the allocation succeeds on retry once
+                # the memory pressure clears (in-progress VACUUM finishes, a
+                # sibling WAL checkpoint releases its buffers, the OS page
+                # cache recycles). Treat it like a locked/busy error and
+                # retry within the patience budget rather than destroying the
+                # caller's turn — the database itself is healthy.
+                logger.warning(
+                    "Transient SystemError during state.db write "
+                    "(session=%s): %s — retrying",
+                    getattr(self, "_current_session_id", "unknown"),
+                    exc,
+                )
+                if self._sleep_before_write_retry(deadline, patience_s):
+                    continue
+                raise
 
     def _sleep_before_write_retry(
         self, deadline: float, patience_s: float

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4672,6 +4672,28 @@ class TelegramAdapter(BasePlatformAdapter):
                             if _send_attempt < 2:
                                 wait = float(retry_after) if retry_after is not None else 1.0
                                 safe_send_error = _redact_telegram_error_text(send_err)
+                                # Cap the inline flood control sleep. Telegram
+                                # sometimes demands waits of 30+ minutes; honouring
+                                # that inside the send coroutine blocks the caller
+                                # (often the startup restore drain) for the whole
+                                # duration, which prevents the gateway from
+                                # processing any inbound messages. If the wait
+                                # exceeds the cap, raise immediately so the caller
+                                # can mark the send as failed and move on (the
+                                # delivery ledger + redelivery path handle retries
+                                # on the next boot). See #flood-control-block-cap.
+                                _FLOOD_SLEEP_CAP = 30.0
+                                if wait > _FLOOD_SLEEP_CAP:
+                                    logger.warning(
+                                        "[%s] Telegram flood control on send (attempt %d/3), "
+                                        "wait %.1fs exceeds cap %.0fs — raising instead of sleeping: %s",
+                                        self.name,
+                                        _send_attempt + 1,
+                                        wait,
+                                        _FLOOD_SLEEP_CAP,
+                                        safe_send_error,
+                                    )
+                                    raise
                                 logger.warning(
                                     "[%s] Telegram flood control on send (attempt %d/3), retrying in %.1fs: %s",
                                     self.name,


### PR DESCRIPTION
## Problem

When the Telegram bot hits flood control (429), the adapter sleeps for the full `retry_after` duration (sometimes 30+ minutes) inside the send coroutine. During startup restore, this blocks `_redeliver_pending_obligations` and `_finish_startup_restore`, trapping **all inbound messages from all platforms** in the startup queue until the sleep completes. If the gateway is killed and restarted during the sleep, the cycle repeats indefinitely.

Observed in production: a `/update` command created `.update_pending.claimed.json`. The gateway was killed mid-send. On every subsequent boot (8+ hours), the stale marker triggered a send to Telegram, which hit flood control, which blocked startup restore for 30+ minutes. Discord messages were received but trapped in the queue.

A separate but related failure: `session_persistence_failed` errors ("session storage could not be written") destroyed turns when SQLite hit OOM under memory pressure on a 3.3 GB state.db with 84 MB free RAM on a 2.5 GB VPS. The misleading "free disk space" error message sent the operator hunting disk space when the actual problem was transient memory pressure during FTS5 index sync.

## Root cause chain

1. **Uncapped flood sleep**: `asyncio.sleep(retry_after)` in the Telegram send path has no cap. Telegram can demand waits of 30+ minutes.
2. **Stale markers**: `.restart_pending.json` and `.update_pending.claimed.json` survive indefinitely if the gateway is killed before the notification send completes.
3. **Failed obligations retried forever**: `sweep_recoverable()` claims rows in `('pending', 'attempting', 'failed')` states, but `_prune()` only deletes `delivered` and `abandoned` rows.
4. **Sequential redelivery**: `_redeliver_pending_obligations()` awaits each `adapter.send()` sequentially. A single flood-controlled send blocks the entire startup restore path.
5. **SystemError from SQLite OOM not caught**: CPython raises `SystemError` ("returned NULL without setting an exception") when a sqlite3 C-extension function fails under memory pressure (SQLITE_NOMEM). `SystemError` is NOT a subclass of `sqlite3.Error`, so the existing `except sqlite3.OperationalError` / `sqlite3.DatabaseError` / `sqlite3.Error` handlers never catch it. It propagates to the conversation loop's generic `except Exception`, which sets `session_persistence_failed` and destroys the turn.

## Fix (5 layers)

### 1. Cap flood control inline sleep at 30s (`telegram/adapter.py`)
If Telegram demands a wait > 30s, raise immediately instead of sleeping. The caller already catches the exception and marks the obligation as failed. Short waits (< 30s) still retry inline as before.

### 2. Prune stale startup notification markers (`gateway/run.py`)
Added `_prune_stale_startup_markers()` that removes `.restart_pending.json`, `.restart_notify.json`, `.update_pending.json`, and `.update_pending.claimed.json` files older than 10 minutes, before the startup notification path runs.

### 3. Prune failed delivery obligations after 1 hour (`delivery_ledger.py`)
Added aggressive pruning of `failed` rows older than 1 hour in `_prune()`. This prevents failed obligations from being swept and retried on every boot, which re-triggers flood control.

### 4. Make redelivery non-blocking (`gateway/run.py`)
`_redeliver_pending_obligations()` now fires each send as a background task (`asyncio.create_task`) instead of awaiting sequentially. Startup restore completes immediately, freeing the inbound queue drain. Redeliveries land whenever the platform accepts them.

### 5. Retry SystemError from SQLite C-extension OOM (`hermes_state.py`)
Add an `except SystemError` handler in `_execute_write` that retries within the same patience budget as locked/busy errors. `SystemError` is raised by CPython when a sqlite3 C function returns NULL without setting a Python exception (typically SQLITE_NOMEM under memory pressure). The error is transient: the allocation succeeds on retry once memory pressure clears. Without this fix, a transient OOM destroys the entire turn with a misleading "free disk space" message.

## Test plan

- [ ] Gateway starts with no obligations, startup restore completes immediately
- [ ] Gateway starts with obligations to flood-controlled platform, redelivery as background tasks, startup restore completes immediately
- [ ] Stale markers (mtime > 10 min) pruned before notification path
- [ ] Fresh markers (mtime < 10 min) NOT pruned
- [ ] Failed obligations > 1 hour pruned
- [ ] Flood control retry_after < 30s retries inline
- [ ] Flood control retry_after > 30s raises immediately
- [ ] SystemError from sqlite3 C-extension is caught and retried within patience budget
- [ ] SystemError that persists beyond patience budget is re-raised
- [ ] Transient OOM during FTS5 index sync does not destroy the turn