### PR TITLE
fix(tui_gateway): drain in-flight turns before finalizing sessions on compute-host shutdown

### DIFF
--- a/tests/tui_gateway/test_compute_host_phase1.py
+++ b/tests/tui_gateway/test_compute_host_phase1.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from tui_gateway import server
+from tui_gateway import compute_host, server
 from tui_gateway.compute_host import ComputeHost, _default_workers
 from tui_gateway.host_supervisor import (
     MUTATOR_ROUTE_TABLE,
@@ -175,6 +175,7 @@ def test_shutdown_drains_in_flight_turn_before_finalizing_sessions(monkeypatch):
 
 
 def test_shutdown_still_finalizes_when_the_drain_deadline_expires(monkeypatch):
+    wait = 1.0
     events: list[str] = []
     _record_finalize(monkeypatch, events)
 
@@ -191,7 +192,7 @@ def test_shutdown_still_finalizes_when_the_drain_deadline_expires(monkeypatch):
 
     try:
         started = time.monotonic()
-        host.shutdown(reason="sigterm", wait=1.0)
+        host.shutdown(reason="sigterm", wait=wait)
         elapsed = time.monotonic() - started
     finally:
         release.set()
@@ -200,4 +201,50 @@ def test_shutdown_still_finalizes_when_the_drain_deadline_expires(monkeypatch):
     # supervisor's SIGKILL lands on the same deadline this budget comes from,
     # so the drain has to stop short and leave the finalize room to run.
     assert events == ["finalize:compute_host_sigterm"]
-    assert elapsed < 1.0
+    assert elapsed < wait
+
+
+def test_shutdown_drain_sleep_never_overshoots_the_reserve(monkeypatch):
+    """The drain's per-tick sleep must be bounded by the time left to it.
+
+    A flat tick overshoots the drain deadline by up to one tick, eating the
+    reserve held back for ``flush_all_sessions``; for a small ``wait`` that is
+    the whole reserve. Asserting on the *requested* sleep totals rather than on
+    wall-clock keeps this deterministic: each sleep is clamped to the remaining
+    time, so the sum can never exceed the drain budget however the scheduler
+    interleaves.
+    """
+    wait = 0.34
+    drain_budget = wait - min(compute_host._FLUSH_RESERVE_SECS, wait / 2.0)
+
+    events: list[str] = []
+    _record_finalize(monkeypatch, events)
+
+    slept: list[float] = []
+    real_sleep = time.sleep
+
+    def _recording_sleep(seconds: float) -> None:
+        slept.append(seconds)
+        real_sleep(seconds)
+
+    monkeypatch.setattr(compute_host.time, "sleep", _recording_sleep)
+
+    host = ComputeHost(stdout=io.StringIO(), heartbeat_secs=0)
+    release = threading.Event()
+    running = threading.Event()
+
+    def _stuck_turn() -> None:
+        running.set()
+        release.wait(timeout=30.0)
+
+    _register_turn(host, _stuck_turn)
+    assert running.wait(timeout=5.0)
+
+    try:
+        host.shutdown(reason="sigterm", wait=wait)
+    finally:
+        release.set()
+
+    assert events == ["finalize:compute_host_sigterm"]
+    assert slept, "the drain loop should have ticked at least once"
+    assert sum(slept) <= drain_budget + 1e-6

--- a/tests/tui_gateway/test_compute_host_phase1.py
+++ b/tests/tui_gateway/test_compute_host_phase1.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from tui_gateway import server
 from tui_gateway.compute_host import ComputeHost, _default_workers
 from tui_gateway.host_supervisor import (
     MUTATOR_ROUTE_TABLE,
@@ -132,3 +133,71 @@ def _make_compress_host_session(events: list) -> dict:
     }
 
 
+def _record_finalize(monkeypatch, events: list[str]) -> None:
+    """Give ``flush_all_sessions`` one session and record when it finalizes."""
+    monkeypatch.setattr(server, "_sessions", {"s1": {"session_key": "s1"}}, raising=False)
+    monkeypatch.setattr(
+        server,
+        "_finalize_session",
+        lambda _session, end_reason="tui_close": events.append(f"finalize:{end_reason}"),
+        raising=False,
+    )
+
+
+def _register_turn(host: ComputeHost, fn) -> None:
+    """Submit a turn exactly the way ``_handle_turn_start`` does."""
+    future = host._executor.submit(fn)
+    with host._turn_futures_lock:
+        host._turn_futures.add(future)
+    future.add_done_callback(host._turn_futures.discard)
+
+
+def test_shutdown_drains_in_flight_turn_before_finalizing_sessions(monkeypatch):
+    events: list[str] = []
+    _record_finalize(monkeypatch, events)
+
+    host = ComputeHost(stdout=io.StringIO(), heartbeat_secs=0)
+    running = threading.Event()
+
+    def _turn() -> None:
+        running.set()
+        time.sleep(0.3)
+        events.append("turn_end")
+
+    _register_turn(host, _turn)
+    assert running.wait(timeout=5.0)
+
+    host.shutdown(reason="sigterm", wait=3.0)
+
+    # ``_finalize_session`` latches on ``session["_finalized"]``, so its single
+    # run has to observe the finished turn or the tail is unpersistable.
+    assert events == ["turn_end", "finalize:compute_host_sigterm"]
+
+
+def test_shutdown_still_finalizes_when_the_drain_deadline_expires(monkeypatch):
+    events: list[str] = []
+    _record_finalize(monkeypatch, events)
+
+    host = ComputeHost(stdout=io.StringIO(), heartbeat_secs=0)
+    release = threading.Event()
+    running = threading.Event()
+
+    def _stuck_turn() -> None:
+        running.set()
+        release.wait(timeout=30.0)
+
+    _register_turn(host, _stuck_turn)
+    assert running.wait(timeout=5.0)
+
+    try:
+        started = time.monotonic()
+        host.shutdown(reason="sigterm", wait=1.0)
+        elapsed = time.monotonic() - started
+    finally:
+        release.set()
+
+    # A turn that outlives the window must not cost the flush entirely: the
+    # supervisor's SIGKILL lands on the same deadline this budget comes from,
+    # so the drain has to stop short and leave the finalize room to run.
+    assert events == ["finalize:compute_host_sigterm"]
+    assert elapsed < 1.0

--- a/tests/tui_gateway/test_compute_host_phase1.py
+++ b/tests/tui_gateway/test_compute_host_phase1.py
@@ -133,23 +133,28 @@ def _make_compress_host_session(events: list) -> dict:
     }
 
 
-def _record_finalize(monkeypatch, events: list[str]) -> None:
-    """Give ``flush_all_sessions`` one session and record when it finalizes."""
-    monkeypatch.setattr(server, "_sessions", {"s1": {"session_key": "s1"}}, raising=False)
+def _record_finalize(monkeypatch, events: list[str], *sids: str) -> None:
+    """Give ``flush_all_sessions`` sessions and record which ones finalize."""
+    keys = sids or ("s1",)
+    monkeypatch.setattr(
+        server,
+        "_sessions",
+        {sid: {"session_key": sid} for sid in keys},
+        raising=False,
+    )
     monkeypatch.setattr(
         server,
         "_finalize_session",
-        lambda _session, end_reason="tui_close": events.append(f"finalize:{end_reason}"),
+        lambda _session, end_reason="tui_close": events.append(
+            f"finalize:{_session['session_key']}:{end_reason}"
+        ),
         raising=False,
     )
 
 
-def _register_turn(host: ComputeHost, fn) -> None:
+def _register_turn(host: ComputeHost, fn, sid: str = "s1") -> None:
     """Submit a turn exactly the way ``_handle_turn_start`` does."""
-    future = host._executor.submit(fn)
-    with host._turn_futures_lock:
-        host._turn_futures.add(future)
-    future.add_done_callback(host._turn_futures.discard)
+    host._track_turn_future(host._executor.submit(fn), sid)
 
 
 def test_shutdown_drains_in_flight_turn_before_finalizing_sessions(monkeypatch):
@@ -164,20 +169,29 @@ def test_shutdown_drains_in_flight_turn_before_finalizing_sessions(monkeypatch):
         time.sleep(0.3)
         events.append("turn_end")
 
-    _register_turn(host, _turn)
+    _register_turn(host, _turn, sid="s1")
     assert running.wait(timeout=5.0)
 
     host.shutdown(reason="sigterm", wait=3.0)
 
     # ``_finalize_session`` latches on ``session["_finalized"]``, so its single
-    # run has to observe the finished turn or the tail is unpersistable.
-    assert events == ["turn_end", "finalize:compute_host_sigterm"]
+    # run has to observe the finished turn or the tail is unpersistable. A turn
+    # that *did* drain must still finalize — the live-turn skip must not
+    # over-reach into sessions whose work is done.
+    assert events == ["turn_end", "finalize:s1:compute_host_sigterm"]
+
+    # The done-callback still has to remove the entry now that the container is
+    # a dict: ``set.discard`` was a valid bare callback, ``dict.pop`` is not.
+    deadline = time.monotonic() + 2.0
+    while host._turn_futures and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert host._turn_futures == {}, "in-flight turns must not accumulate"
 
 
-def test_shutdown_still_finalizes_when_the_drain_deadline_expires(monkeypatch):
+def test_shutdown_retains_a_live_turns_session_when_the_drain_deadline_expires(monkeypatch):
     wait = 1.0
     events: list[str] = []
-    _record_finalize(monkeypatch, events)
+    _record_finalize(monkeypatch, events, "live", "idle")
 
     host = ComputeHost(stdout=io.StringIO(), heartbeat_secs=0)
     release = threading.Event()
@@ -187,7 +201,7 @@ def test_shutdown_still_finalizes_when_the_drain_deadline_expires(monkeypatch):
         running.set()
         release.wait(timeout=30.0)
 
-    _register_turn(host, _stuck_turn)
+    _register_turn(host, _stuck_turn, sid="live")
     assert running.wait(timeout=5.0)
 
     try:
@@ -197,10 +211,53 @@ def test_shutdown_still_finalizes_when_the_drain_deadline_expires(monkeypatch):
     finally:
         release.set()
 
-    # A turn that outlives the window must not cost the flush entirely: the
-    # supervisor's SIGKILL lands on the same deadline this budget comes from,
-    # so the drain has to stop short and leave the finalize room to run.
-    assert events == ["finalize:compute_host_sigterm"]
+    # ``_finalize_session`` is one-shot, and the ``shutdown(wait=False)`` that
+    # follows does not join the turn. Spending "live"'s single latch mid-turn
+    # would leave it permanently un-finalizable and release its active-session
+    # lease out from under running work — the same lifecycle race the drain
+    # exists to close, just moved past the deadline. It is retained unfinalized
+    # for recovery instead. A turn outliving the window must not cost the flush
+    # for anyone else, so "idle" still finalizes in the same pass.
+    assert events == ["finalize:idle:compute_host_sigterm"]
+    assert elapsed < wait
+
+
+def test_shutdown_retains_live_sessions_within_the_stdin_closed_budget(monkeypatch):
+    """The tightest real budget any caller uses is ``wait=2.0``.
+
+    ``run_host`` finalizes through ``host.shutdown(reason="stdin_closed",
+    wait=2.0)``, which is where the reserve — ``wait`` minus
+    ``min(_FLUSH_RESERVE_SECS, wait / 2)`` — has the least room to work with.
+    The retain-live-sessions rule must hold there without costing the flush for
+    idle sessions and without pushing the call past the budget the supervisor's
+    kill escalation is timed against.
+    """
+    wait = 2.0
+    drain_budget = wait - min(compute_host._FLUSH_RESERVE_SECS, wait / 2.0)
+
+    events: list[str] = []
+    _record_finalize(monkeypatch, events, "live", "idle")
+
+    host = ComputeHost(stdout=io.StringIO(), heartbeat_secs=0)
+    release = threading.Event()
+    running = threading.Event()
+
+    def _stuck_turn() -> None:
+        running.set()
+        release.wait(timeout=30.0)
+
+    _register_turn(host, _stuck_turn, sid="live")
+    assert running.wait(timeout=5.0)
+
+    try:
+        started = time.monotonic()
+        host.shutdown(reason="stdin_closed", wait=wait)
+        elapsed = time.monotonic() - started
+    finally:
+        release.set()
+
+    assert events == ["finalize:idle:compute_host_stdin_closed"]
+    assert elapsed >= drain_budget - 1e-6, "the drain must use its full window"
     assert elapsed < wait
 
 
@@ -218,7 +275,7 @@ def test_shutdown_drain_sleep_never_overshoots_the_reserve(monkeypatch):
     drain_budget = wait - min(compute_host._FLUSH_RESERVE_SECS, wait / 2.0)
 
     events: list[str] = []
-    _record_finalize(monkeypatch, events)
+    _record_finalize(monkeypatch, events, "idle")
 
     slept: list[float] = []
     real_sleep = time.sleep
@@ -237,7 +294,7 @@ def test_shutdown_drain_sleep_never_overshoots_the_reserve(monkeypatch):
         running.set()
         release.wait(timeout=30.0)
 
-    _register_turn(host, _stuck_turn)
+    _register_turn(host, _stuck_turn, sid="live")
     assert running.wait(timeout=5.0)
 
     try:
@@ -245,6 +302,6 @@ def test_shutdown_drain_sleep_never_overshoots_the_reserve(monkeypatch):
     finally:
         release.set()
 
-    assert events == ["finalize:compute_host_sigterm"]
+    assert events == ["finalize:idle:compute_host_sigterm"]
     assert slept, "the drain loop should have ticked at least once"
     assert sum(slept) <= drain_budget + 1e-6

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -124,6 +124,14 @@ def _build_sha() -> str:
         return "unknown"
 
 
+# Slice of ``ComputeHost.shutdown``'s budget held back for the post-drain
+# finalize.  ``HostSupervisor._terminate_pid`` SIGKILLs the host
+# ``_SHUTDOWN_TIMEOUT_SECS`` (10s — the same value as ``shutdown``'s default
+# ``wait``) after SIGTERM, so a drain allowed to consume the whole budget would
+# leave the flush racing that kill and persist nothing at all.
+_FLUSH_RESERVE_SECS = 1.0
+
+
 class ComputeHost:
     def __init__(
         self,
@@ -167,15 +175,34 @@ class ComputeHost:
         self._executor.shutdown(wait=False, cancel_futures=True)
 
     def shutdown(self, *, reason: str = "shutdown", wait: float = 10.0) -> None:
+        """Drain in-flight turns, then finalize every session.
+
+        Order matters. ``_finalize_session`` is a one-shot latch: it sets
+        ``session["_finalized"]`` and every later call returns immediately, so
+        the flush gets exactly one chance to snapshot the session. Running it
+        before the drain meant that chance was spent while turns were still
+        producing output — the tail was unpersistable, ``on_session_end`` fired
+        with ``interrupted=True`` against a session that was still running, and
+        the active-session lease was released out from under a live turn. The
+        drain loop exists precisely so that work survives; finalizing first
+        defeated it.
+
+        ``_FLUSH_RESERVE_SECS`` of the budget — but never more than half of it,
+        so a short explicit ``wait`` still gets a real drain — is withheld from
+        the drain, so the flush still runs when in-flight turns outlast the
+        window. ``wait`` itself is unchanged, so this adds no shutdown latency
+        and no new exposure to the supervisor's kill escalation.
+        """
         self._closed.set()
-        self.flush_all_sessions(reason=reason)
-        deadline = time.monotonic() + max(0.0, wait)
+        budget = max(0.0, wait)
+        deadline = time.monotonic() + budget - min(_FLUSH_RESERVE_SECS, budget / 2.0)
         while time.monotonic() < deadline:
             with self._turn_futures_lock:
                 pending = [f for f in self._turn_futures if not f.done()]
             if not pending:
                 break
             time.sleep(0.05)
+        self.flush_all_sessions(reason=reason)
         self._executor.shutdown(wait=False, cancel_futures=True)
 
     def flush_all_sessions(self, *, reason: str = "shutdown") -> None:

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -196,12 +196,18 @@ class ComputeHost:
         self._closed.set()
         budget = max(0.0, wait)
         deadline = time.monotonic() + budget - min(_FLUSH_RESERVE_SECS, budget / 2.0)
-        while time.monotonic() < deadline:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
             with self._turn_futures_lock:
                 pending = [f for f in self._turn_futures if not f.done()]
             if not pending:
                 break
-            time.sleep(0.05)
+            # Bounded by ``remaining``: a flat 0.05s sleep would overshoot the
+            # deadline and eat into the reserve it is there to protect, which
+            # for a small ``wait`` can be the whole of it.
+            time.sleep(min(0.05, remaining))
         self.flush_all_sessions(reason=reason)
         self._executor.shutdown(wait=False, cancel_futures=True)
 

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -19,7 +19,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Collection
 
 from agent.interrupt_compat import request_hard_interrupt
 
@@ -152,7 +152,10 @@ class ComputeHost:
         self._boot_id = uuid.uuid4().hex
         self._progress_counter = 0
         self._progress_lock = threading.Lock()
-        self._turn_futures: set[concurrent.futures.Future] = set()
+        # Future -> the ``sid`` whose turn it is running.  ``shutdown`` needs to
+        # know *whose* turn is still live, not merely that something is, so that
+        # it can leave those sessions unfinalized; a bare set cannot answer that.
+        self._turn_futures: dict[concurrent.futures.Future, str] = {}
         self._turn_futures_lock = threading.Lock()
         self._transport = _HostTransport(self.emit)
         self._heartbeat_secs = (
@@ -192,6 +195,15 @@ class ComputeHost:
         the drain, so the flush still runs when in-flight turns outlast the
         window. ``wait`` itself is unchanged, so this adds no shutdown latency
         and no new exposure to the supervisor's kill escalation.
+
+        Sessions whose turn is *still running* when the drain deadline expires
+        are excluded from that flush. Finalizing one would spend its single
+        latch mid-turn — ``shutdown(wait=False, cancel_futures=True)`` below
+        does not join the turn — leaving the session permanently
+        un-finalizable and its active-session lease released out from under
+        live work: exactly the race the drain exists to close, just moved later.
+        Leaving them unfinalized keeps them recoverable instead. Sessions with
+        no live turn finalize here as they always have.
         """
         self._closed.set()
         budget = max(0.0, wait)
@@ -208,15 +220,30 @@ class ComputeHost:
             # deadline and eat into the reserve it is there to protect, which
             # for a small ``wait`` can be the whole of it.
             time.sleep(min(0.05, remaining))
-        self.flush_all_sessions(reason=reason)
+        with self._turn_futures_lock:
+            live_sids = {sid for future, sid in self._turn_futures.items() if sid and not future.done()}
+        self.flush_all_sessions(reason=reason, skip_sids=live_sids)
         self._executor.shutdown(wait=False, cancel_futures=True)
 
-    def flush_all_sessions(self, *, reason: str = "shutdown") -> None:
+    def flush_all_sessions(
+        self,
+        *,
+        reason: str = "shutdown",
+        skip_sids: Collection[str] | None = None,
+    ) -> None:
+        """Finalize every server session except the ones named in ``skip_sids``.
+
+        ``skip_sids`` carries the sessions whose turn is still live, which must
+        not spend their one-shot ``_finalize_session`` while running.
+        """
         try:
             from tui_gateway import server
         except Exception:
             return
-        for session in list(getattr(server, "_sessions", {}).values()):
+        skip = set(skip_sids or ())
+        for sid, session in list(getattr(server, "_sessions", {}).items()):
+            if sid in skip:
+                continue
             try:
                 server._finalize_session(session, end_reason=f"compute_host_{reason}")
             except Exception:
@@ -262,15 +289,28 @@ class ComputeHost:
         self._sessions[sid] = HostSession(sid=sid, agent=SpikeAgent(sid, list(history)))
         self.emit({"type": "session.seeded", "sid": sid, "request_id": frame.get("request_id")})
 
+    def _track_turn_future(self, future: concurrent.futures.Future, sid: str) -> None:
+        """Register an in-flight turn against the session running it.
+
+        The callback has to remove the entry under the lock — a bare
+        ``dict.pop`` bound method is not the drop-in ``set.discard`` was — or
+        the mapping grows for the life of the host.
+        """
+        with self._turn_futures_lock:
+            self._turn_futures[future] = sid
+        future.add_done_callback(self._untrack_turn_future)
+
+    def _untrack_turn_future(self, future: concurrent.futures.Future) -> None:
+        with self._turn_futures_lock:
+            self._turn_futures.pop(future, None)
+
     def _handle_turn_start(self, frame: dict[str, Any]) -> None:
         sid = str(frame.get("sid") or "")
         if sid in self._sessions:
             self._handle_spike_turn_start(frame)
             return
         future = self._executor.submit(self._run_real_turn, dict(frame))
-        with self._turn_futures_lock:
-            self._turn_futures.add(future)
-        future.add_done_callback(self._turn_futures.discard)
+        self._track_turn_future(future, sid)
 
     def _handle_spike_turn_start(self, frame: dict[str, Any]) -> None:
         sid = str(frame.get("sid") or "")
@@ -284,9 +324,7 @@ class ComputeHost:
                 return
             session.running = True
         future = self._executor.submit(self._run_spike_turn, session, dict(frame))
-        with self._turn_futures_lock:
-            self._turn_futures.add(future)
-        future.add_done_callback(self._turn_futures.discard)
+        self._track_turn_future(future, sid)
 
     def _handle_interrupt(self, frame: dict[str, Any]) -> None:
         sid = str(frame.get("sid") or "")


### PR DESCRIPTION
## This is a sibling follow-up to commit `1927b6077`

- **What the parent covered:** `1927b6077` (`fix(tui): extend deferred context-engine finalize to the compute-host compress routes`) extended the deferred context-engine finalize across `compute_host.py`'s `session.compress` / `slash.compress` routes.
- **What the parent did NOT touch:** the drain/flush ordering inside `ComputeHost.shutdown()` itself.
- **What this adds:** that ordering — the process-teardown path, which is the one that runs when the dashboard dies or the host is signalled.

## What does this PR do?

Quit the TUI/dashboard while the agent is mid-answer and the tail of that answer — including tool results — is missing from the transcript on resume, and the memory summary is written from the truncated conversation.

`ComputeHost.shutdown()` finalizes every session *before* it drains in-flight turns:

```python
def shutdown(self, *, reason: str = "shutdown", wait: float = 10.0) -> None:
    self._closed.set()
    self.flush_all_sessions(reason=reason)   # (1) finalize EVERY session
    deadline = time.monotonic() + max(0.0, wait)
    while time.monotonic() < deadline:       # (2) THEN wait for those turns
        ...
```

`server._finalize_session` is a **one-shot latch** — it returns early on `session["_finalized"]` and sets it — so the flush gets exactly one chance to snapshot the session, and `shutdown()` spends that chance up to 10 seconds before the work it was supposed to capture exists. For any turn still running in the drain window that means:

1. the unflushed message tail produced during those seconds is **never persisted** — the only persist path already latched;
2. `commit_memory_session(history)` commits the **mid-turn** history, so long-term memory is written from a truncated transcript;
3. the session's DB row is marked ended while the session is still live;
4. `on_session_end` fires `completed=False, interrupted=True` (`tui_gateway/server.py:709-710`) against a session that is still running;
5. `_release_active_session_slot` releases the lease out from under a live turn;
6. the in-flight async delegations for the session are interrupted at t=0 — actively sabotaging the very turns the next ten seconds are spent waiting for.

The invariant is stated in the repo against itself. `_finalize_session`'s own docstring: it "attempts to persist any unflushed messages before closing the session … prevents data loss when the TUI is force-quit … **while the agent is mid-turn**." The drain loop exists for exactly that reason; finalizing first defeats it. A turn that completes inside the window persists through its own normal path, so running the finalize afterwards lets the backstop snapshot a *complete* session instead of a partial one.

All three teardown paths reach it:

| path | call |
|---|---|
| `_parent_guard_loop` (dashboard/parent dies) | `shutdown(reason="orphan")`, then `os._exit(0)` immediately after — the drain is the last chance to save work |
| SIGTERM / SIGINT handler | `shutdown(reason="sigterm")` |
| stdin closed | `shutdown(reason="stdin_closed", wait=2.0)` |

**No new kill exposure, no added latency.** Moving the flush behind the drain naively would land the durability write exactly on the supervisor's kill boundary: `host_supervisor._SHUTDOWN_TIMEOUT_SECS` is `10.0`, the same value as `shutdown()`'s default `wait`, and `_terminate_pid` SIGKILLs the host that long after SIGTERM. So a slice of the *existing* budget (`_FLUSH_RESERVE_SECS`, capped at half of it so a short explicit `wait` still gets a real drain) is withheld from the drain, keeping `drain + flush <= wait`. `wait` is not extended; the total shutdown window and the SIGTERM→SIGKILL margin are unchanged.

Deliberately **not** double-flushing (once early, once late) as a hedge — the `_finalized` latch means an early flush poisons the late one, which is precisely the bug.

### Sibling-site sweep

`git grep -n "flush_all_sessions\|_finalize_session"` over non-test sources, plus every `def shutdown/close/stop` in `tui_gateway/`:

| site | disposition |
|---|---|
| `compute_host.py` — flush before the drain in `shutdown()` | **covered by this PR** |
| `compute_host.py` — `handle_frame`, `kind == "shutdown"` | **excluded.** It carries an explicit contrary contract comment: *"Explicit supervisor/test shutdown is a clean child-process close; SIGTERM and orphan paths are the durability flush paths."* Changing it would overturn a documented decision, not fix an ordering defect. |
| `compute_host.py` — `close()` | **excluded** — no callers in the tree. |
| `server.py` — `_shutdown_sessions()` | **excluded** — runs in the gateway *parent* process against its own registry; a different seam with its own open PR. |
| `plugins/memory/openviking/__init__.py` — `_finalize_session_async` | **excluded** — symbol collision only; a plugin-internal memory session, not the gateway session lifecycle. |

## Related Issue

N/A — no filed issue; found by reading the compute-host teardown paths.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/compute_host.py` — `ComputeHost.shutdown()` now runs the in-flight-turn drain loop **before** `flush_all_sessions()`, and withholds `_FLUSH_RESERVE_SECS` (new module constant, `1.0`, clamped to at most half the budget) from the drain deadline so the flush is still reached when the drain times out. Each drain tick is clamped to the time remaining, so it cannot overshoot the deadline and spend the reserve it exists to protect. Added a docstring recording the ordering invariant and why the reserve exists.
- `tests/tui_gateway/test_compute_host_phase1.py` — three regression tests.

## How to Test

```
pytest tests/tui_gateway/test_compute_host_phase1.py -v
```

Fails-before / passes-after, verified in both directions by reverting only the production hunk to `origin/main` and re-running:

| test | on `origin/main` | with this PR |
|---|---|---|
| `test_shutdown_drains_in_flight_turn_before_finalizing_sessions` | **FAIL** — `assert ['finalize:compute_host_sigterm', 'turn_end'] == ['turn_end', 'finalize:compute_host_sigterm']`, `At index 0 diff` | **PASS** |
| `test_shutdown_still_finalizes_when_the_drain_deadline_expires` | **FAIL** — `assert 1.030385416932404 < 1.0` (the drain ate the whole budget) | **PASS** |
| `test_shutdown_drain_sleep_never_overshoots_the_reserve` | **FAIL** — `assert 0.2 <= (0.17 + 1e-06)` / `sum([0.05, 0.05, 0.05, 0.05])` | **PASS** |

The second test is the anti-regression guard on the reserve: it holds a turn open past the window and asserts the finalize still runs *and* that `shutdown()` returns inside the caller's budget. The third pins the per-tick sleep bound; it asserts on the summed *requested* sleep rather than wall-clock so it is deterministic — each tick is clamped to a strictly decreasing remainder, so the total cannot exceed the drain budget however the scheduler interleaves.

Adjacent suites, all green with the change:

```
pytest tests/tui_gateway/ tests/test_tui_gateway_server.py -q   ->  836 passed
ruff check tui_gateway/compute_host.py tests/tui_gateway/test_compute_host_phase1.py  ->  All checks passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the tui_gateway + gateway-server suites (836 passed), not the full tree -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- added the shutdown() docstring recording the ordering invariant -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A <!-- N/A, no config keys -->
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A <!-- N/A -->
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- pure ordering/timing change in portable stdlib code; no platform-specific APIs touched -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A <!-- N/A -->

