### PR TITLE
fix(desktop): reconcile named custom provider so live reasoning edits apply

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -54,20 +54,20 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-function renderPanel(onSelectModel = vi.fn()) {
+function renderPanel(onSelectModel = vi.fn(), requestGateway = vi.fn()) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
 
   const content = render(
     <QueryClientProvider client={client}>
       <DropdownMenu open>
         <DropdownMenuContent>
-          <ModelMenuPanel onSelectModel={onSelectModel} requestGateway={vi.fn() as never} />
+          <ModelMenuPanel onSelectModel={onSelectModel} requestGateway={requestGateway as never} />
         </DropdownMenuContent>
       </DropdownMenu>
     </QueryClientProvider>
   )
 
-  return { onSelectModel, content }
+  return { onSelectModel, requestGateway, content }
 }
 
 describe('ModelMenuPanel MoA presets', () => {
@@ -141,6 +141,40 @@ describe('ModelMenuPanel current selection', () => {
 
     expect(currentRow?.querySelector('.codicon-check')).not.toBeNull()
     expect(staleRow?.querySelector('.codicon-check')).toBeNull()
+  })
+
+  it('pushes Thinking edits onto a named custom provider session', async () => {
+    const model = 'DeepSeek-V4-Flash-0731'
+    $currentProvider.set('custom')
+    $currentModel.set(model)
+    getGlobalModelOptions.mockResolvedValue({
+      model,
+      provider: 'custom:deepseek-v4-flash-0731',
+      providers: [
+        {
+          capabilities: { [model]: { reasoning: true } },
+          is_current: true,
+          models: [model],
+          name: model,
+          slug: 'deepseek-v4-flash-0731'
+        }
+      ]
+    })
+
+    const { content, requestGateway } = renderPanel()
+    const row = (await content.findByText('DeepSeek V4 Flash 0731')).closest('[role="menuitem"]')
+
+    expect(row?.querySelector('.codicon-check')).not.toBeNull()
+    fireEvent.pointerMove(row as Element, { pointerType: 'mouse' })
+    fireEvent.click(await screen.findByRole('switch'))
+
+    await vi.waitFor(() => {
+      expect(requestGateway).toHaveBeenCalledWith('config.set', {
+        key: 'reasoning',
+        session_id: 'runtime-1',
+        value: 'none'
+      })
+    })
   })
 })
 

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -58,6 +58,27 @@ describe('model-status-label', () => {
       expect(currentPickerSelection(store, options)).toEqual(store)
     })
 
+    it('recovers a named custom provider from the current catalog row', () => {
+      const model = 'DeepSeek-V4-Flash-0731'
+
+      expect(
+        currentPickerSelection(
+          { model, provider: 'custom' },
+          {
+            model,
+            provider: 'custom:deepseek-v4-flash-0731',
+            providers: [
+              {
+                is_current: true,
+                models: [model],
+                slug: 'deepseek-v4-flash-0731'
+              }
+            ]
+          }
+        )
+      ).toEqual({ model, provider: 'deepseek-v4-flash-0731' })
+    })
+
     it('falls back to options when the store is empty', () => {
       expect(currentPickerSelection({ model: '', provider: '' }, options)).toEqual(options)
     })

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -7,7 +7,15 @@ import { DEFAULT_REASONING_EFFORT, reasoningEffortLabel } from '@/lib/reasoning-
  *  a model is never shown under a different provider. */
 export function currentPickerSelection(
   store: { model: string; provider: string },
-  options?: { model?: string; provider?: string }
+  options?: {
+    model?: string
+    provider?: string
+    providers?: ReadonlyArray<{
+      is_current?: boolean
+      models?: readonly string[]
+      slug?: string
+    }>
+  }
 ): { model: string; provider: string } {
   const storeSelection = {
     model: String(store.model || ''),
@@ -20,6 +28,23 @@ export function currentPickerSelection(
   }
 
   if (storeSelection.model && storeSelection.provider) {
+    // A named custom provider resolves to the billing/runtime class `custom`
+    // inside AIAgent, so SessionView cannot identify which configured picker
+    // row owns the model. The session-scoped model.options response can: its
+    // current row carries the exact slug the menu renders. Recover only when
+    // the model agrees, preserving the sticky SessionView pair when options
+    // are stale or belong to another session.
+    if (storeSelection.provider.toLowerCase() === 'custom' && optionsSelection.model === storeSelection.model) {
+      const currentRow = options?.providers?.find(
+        provider => provider.is_current === true && provider.models?.includes(storeSelection.model)
+      )
+      const currentProvider = String(currentRow?.slug || '')
+
+      if (currentProvider) {
+        return { model: storeSelection.model, provider: currentProvider }
+      }
+    }
+
     return storeSelection
   }
 


### PR DESCRIPTION
## Bug Description

For a named `providers:` custom provider (e.g. `deepseek-v4-flash-0731`), AISessionView exposes the runtime/billing class `custom`, while the model picker's catalog row uses the bare configured slug. Because `ModelCatalogMenu` only marks a row active when the provider slug **strictly** equals the current provider, the real row was treated as inactive. As a result, changing Thinking or reasoning effort on a live session only updated the remembered visual preset — `model-menu-panel.tsx` returned before issuing session-scoped `config.set`, so the change never reached the running agent (no persisted `reasoning_config`, no reasoning in the response), despite the menu *appearing* to accept the new setting.

## Root Cause

Three provider identities that should align instead differed:

| Layer | Value |
|---|---|
| `session.info.provider` (AISessionView) | `custom` |
| `model.options.provider` (picker context) | `custom:<name>` |
| catalog row `slug` | `<name>` |

`currentPickerSelection()` returned the session pair verbatim, which never matched the catalog slug, so the active-row comparison failed for bare `custom`.

## Fix

In `apps/desktop/src/lib/model-status-label.ts::currentPickerSelection()`, reconcile **only** an ambiguous bare `custom` provider: when the drift-`options` model equals the session model, resolve the identity through the `is_current` provider row that contains that exact model and return that row's real slug. Behavior is otherwise unchanged:

- Named/built-in providers keep their sticky SessionView pair untouched.
- Stale or cross-session `model.options` still fall through to the sticky pair (guarded by the model-match check).
- Backend routing identities are not rewritten; only Desktop's active-row comparison is corrected.

## How to Verify

1. Add a `providers:` custom provider (e.g. `deepseek-v4-flash-0731` → `DeepSeek-V4-Flash-0731`).
2. Open a session with that model, then change Thinking/effort to High or Max **after** the session has started.
3. Confirm the menu row shows the check (active) and a session-scoped `config.set` with `key: reasoning` is sent.

Manual live verification confirmed: the persisted session `model_config.reasoning_config` updated to `{enabled:true, effort:"high"/"max"}`, the transport sent `thinking:true` + `reasoning_effort=high|max`, and reasoning streamed back and persisted in `state.db`.

## Test Plan

- [x] Regression test in `model-status-label.test.ts` — bare `custom` resolves through the `is_current` catalog row for the exact model
- [x] Integration test in `model-menu-panel.test.tsx` — resolved row is active and its Thinking switch issues session-scoped `config.set`
- [x] Focused suites pass (32/32)
- [x] Typecheck passes
- [x] ESLint passes
- [x] Manual end-to-end verified in Desktop

## Risk Assessment

**Low** — The reconciliation fires only for the ambiguous bare `custom` provider and only when the session model matches the `model.options` model; every other path returns the exact prior pair. Backend routing/provider identities are untouched.