### PR TITLE
fix(installer): require npm with node

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1206,6 +1206,22 @@ function Test-NodeVersionOk {
     return ($v.Major -gt 22)
 }
 
+function Test-NpmAvailable {
+    # Prefer the cmd shim so PowerShell execution policy cannot reject npm.ps1.
+    $npmCmd = Get-Command npm.cmd -ErrorAction SilentlyContinue
+    if (-not $npmCmd) {
+        $npmCmd = Get-Command npm -ErrorAction SilentlyContinue
+    }
+    if (-not $npmCmd) { return $false }
+
+    try {
+        & $npmCmd.Source --version *> $null
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    }
+}
+
 function Test-Node {
     Write-Info "Checking Node.js (for browser tools)..."
 
@@ -1213,11 +1229,15 @@ function Test-Node {
         $version = node --version
         if (Test-NodeVersionOk $version) {
             Ensure-NodeExeOnPath | Out-Null
-            Write-Success "Node.js $version found"
-            $script:HasNode = $true
-            return $true
+            if (Test-NpmAvailable) {
+                Write-Success "Node.js $version found"
+                $script:HasNode = $true
+                return $true
+            }
+            Write-Warn "Node.js $version has no usable npm on PATH -- installing Hermes-managed Node $NodeVersion instead..."
+        } else {
+            Write-Warn "Node.js $version is too old (Hermes requires Node >=26)"
         }
-        Write-Warn "Node.js $version is too old (Hermes requires Node >=26)"
     }
 
     # Prefer a Hermes-managed Node from a previous run over a too-old system one.
@@ -1226,13 +1246,16 @@ function Test-Node {
         $version = & $managedNode --version
         $env:Path = "$HermesHome\node;$env:Path"
         Set-ManagedNodeFirstOnUserPath "$HermesHome\node"
-        Write-Success "Node.js $version found (Hermes-managed)"
-        # A tree from an older install still has that Node major's bundled
-        # npm, which is below the current engines.npm floor. No-ops when the
-        # npm is already in range, so reruns cost one --version probe.
-        Update-ManagedNpm "$HermesHome\node" | Out-Null
-        $script:HasNode = $true
-        return $true
+        if (Test-NpmAvailable) {
+            Write-Success "Node.js $version found (Hermes-managed)"
+            # A tree from an older install still has that Node major's bundled
+            # npm, which is below the current engines.npm floor. No-ops when the
+            # npm is already in range, so reruns cost one --version probe.
+            Update-ManagedNpm "$HermesHome\node" | Out-Null
+            $script:HasNode = $true
+            return $true
+        }
+        Write-Warn "Hermes-managed Node.js $version has no usable npm -- reinstalling it..."
     }
 
     Write-Info "Installing Hermes-managed Node.js $NodeVersion LTS..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -830,13 +830,21 @@ check_node() {
     # bad-band npm (see npm_supports_npmrc) fails `npm ci` outright, and the
     # managed Node we install instead bundles one that works.
     if command -v node &> /dev/null && node_satisfies_build "$(node --version)"; then
-        if ! command -v npm &> /dev/null || npm_supports_npmrc "$(npm --version 2>/dev/null)"; then
+        local npm_version=""
+        if command -v npm &> /dev/null; then
+            npm_version="$(npm --version 2>/dev/null || true)"
+        fi
+        if [ -n "$npm_version" ] && npm_supports_npmrc "$npm_version"; then
             log_success "Node.js $(node --version) found"
             HAS_NODE=true
             return 0
         fi
-        log_warn "npm $(npm --version) cannot honor this repo's .npmrc (npm 11.10-11.16 ignore"
-        log_warn "min-release-age-exclude) — installing Hermes-managed Node $NODE_VERSION instead..."
+        if [ -n "$npm_version" ]; then
+            log_warn "npm $npm_version cannot honor this repo's .npmrc (npm 11.10-11.16 ignore"
+            log_warn "min-release-age-exclude) — installing Hermes-managed Node $NODE_VERSION instead..."
+        else
+            log_warn "Node.js $(node --version) has no usable npm on PATH — installing Hermes-managed Node $NODE_VERSION instead..."
+        fi
         install_node
         return
     fi
@@ -2288,10 +2296,11 @@ install_node_deps() {
         cd "$INSTALL_DIR"
         # Time-boxed: a stalled registry fetch would otherwise hang here with no
         # progress (same #39219 stall class as the desktop build below).
-        run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent || {
+        if run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent; then
+            log_success "Node.js dependencies installed"
+        else
             log_warn "npm install failed or timed out (browser tools may not work)"
-        }
-        log_success "Node.js dependencies installed"
+        fi
 
         # Install Playwright browser + system dependencies.
         # Playwright's --with-deps only supports apt-based systems natively.
@@ -2390,10 +2399,11 @@ install_node_deps() {
         log_info "Installing TUI dependencies..."
         cd "$INSTALL_DIR/ui-tui"
         # Time-boxed: a stalled registry fetch would otherwise hang here (#39219).
-        run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent || {
+        if run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent; then
+            log_success "TUI dependencies installed"
+        else
             log_warn "TUI npm install failed or timed out (hermes --tui may not work)"
-        }
-        log_success "TUI dependencies installed"
+        fi
     fi
 
     # Keep the checkout clean so `hermes update` doesn't autostash every run.

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -165,6 +165,8 @@ _nb_ensure_bundled_npm_range() {
 
 _nb_have_modern_node() {
     command -v node >/dev/null 2>&1 || return 1
+    command -v npm >/dev/null 2>&1 || return 1
+    npm --version >/dev/null 2>&1 || return 1
     [ "$(_nb_node_major)" -ge "$HERMES_NODE_MIN_VERSION" ]
 }
 

--- a/tests/test_install_sh_node_toolchain.py
+++ b/tests/test_install_sh_node_toolchain.py
@@ -1,0 +1,158 @@
+"""Behavioral coverage for installer Node/npm toolchain detection."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+NODE_BOOTSTRAP_SH = REPO_ROOT / "scripts" / "lib" / "node-bootstrap.sh"
+BASH = shutil.which("bash") or ""
+
+pytestmark = [
+    pytest.mark.live_system_guard_bypass,
+    pytest.mark.skipif(not BASH, reason="needs bash"),
+    pytest.mark.skipif(sys.platform == "win32", reason="tests POSIX installers"),
+]
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _fake_toolchain(
+    tmp_path: Path,
+    *,
+    with_npm: bool,
+    npm_install_exit: int = 0,
+) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "node",
+        'if [ "${1:-}" = "--version" ]; then echo "v22.22.2"; fi',
+    )
+    _write_executable(
+        bin_dir / "uname",
+        'case "${1:-}" in -s) echo Darwin ;; -m) echo test-unsupported ;; *) echo Darwin ;; esac',
+    )
+    _write_executable(bin_dir / "sleep", "exit 0")
+
+    # The sourceable bootstrap helper parses node's version with these tools.
+    for name in ("sed", "cut", "tr"):
+        resolved = shutil.which(name)
+        assert resolved is not None
+        _write_executable(bin_dir / name, f'exec "{resolved}" "$@"')
+
+    if with_npm:
+        _write_executable(
+            bin_dir / "npm",
+            (
+                'if [ "${1:-}" = "--version" ]; then echo "10.9.0"; exit 0; fi\n'
+                f"exit {npm_install_exit}"
+            ),
+        )
+    return bin_dir
+
+
+def _env(bin_dir: Path, tmp_path: Path) -> dict[str, str]:
+    return os.environ | {
+        "HOME": str(tmp_path / "home"),
+        "HERMES_HOME": str(tmp_path / "hermes-home"),
+        "PATH": str(bin_dir),
+    }
+
+
+def test_ensure_node_rejects_node_without_npm(tmp_path: Path) -> None:
+    bin_dir = _fake_toolchain(tmp_path, with_npm=False)
+
+    result = subprocess.run(
+        [BASH, str(INSTALL_SH), "--ensure", "node"],
+        env=_env(bin_dir, tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "has no usable npm on PATH" in result.stdout
+    assert "Node.js v22.22.2 found" not in result.stdout
+
+
+def test_ensure_node_accepts_complete_toolchain(tmp_path: Path) -> None:
+    bin_dir = _fake_toolchain(tmp_path, with_npm=True)
+
+    result = subprocess.run(
+        [BASH, str(INSTALL_SH), "--ensure", "node"],
+        env=_env(bin_dir, tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Node.js v22.22.2 found" in result.stdout
+    assert "test-unsupported" not in result.stdout
+
+
+def test_sourceable_bootstrap_requires_npm_with_node(tmp_path: Path) -> None:
+    bin_dir = _fake_toolchain(tmp_path, with_npm=False)
+
+    result = subprocess.run(
+        [BASH, "-c", 'source "$1"; _nb_have_modern_node', "_", str(NODE_BOOTSTRAP_SH)],
+        env=_env(bin_dir, tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode != 0
+
+
+@pytest.mark.parametrize(
+    ("package_dir", "failure_message", "false_success"),
+    [
+        (".", "npm install failed or timed out", "Node.js dependencies installed"),
+        ("ui-tui", "TUI npm install failed or timed out", "TUI dependencies installed"),
+    ],
+)
+def test_node_deps_does_not_claim_success_after_npm_failure(
+    tmp_path: Path,
+    package_dir: str,
+    failure_message: str,
+    false_success: str,
+) -> None:
+    bin_dir = _fake_toolchain(tmp_path, with_npm=True, npm_install_exit=1)
+    install_dir = tmp_path / "checkout"
+    target = install_dir if package_dir == "." else install_dir / package_dir
+    target.mkdir(parents=True)
+    (target / "package.json").write_text("{}\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            BASH,
+            str(INSTALL_SH),
+            "--stage",
+            "node-deps",
+            "--dir",
+            str(install_dir),
+            "--skip-browser",
+            "--non-interactive",
+        ],
+        env=_env(bin_dir, tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert failure_message in result.stdout
+    assert false_success not in result.stdout


### PR DESCRIPTION
## What does this PR do?

Fixes a bootstrap false positive where a modern `node` executable without a usable `npm` was accepted as a complete Node.js toolchain. The installer then reached the dependency and desktop stages with no runnable npm, while the node-deps stage could still print success after its npm commands failed.

The root cause in `install.sh` was an inverted availability condition: `! command -v npm || npm_supports_npmrc(...)` treated a missing npm as success. The sourceable Node bootstrap similarly checked only the Node version. The Windows installer had the same Node-only acceptance path.

After this change:

- POSIX and Windows installers accept a system/managed Node only when npm resolves and `npm --version` succeeds.
- An incomplete system toolchain falls through to the existing Hermes-managed Node installation path.
- The sourceable Node bootstrap applies the same invariant.
- Browser-tool and TUI dependency stages only print their success messages when the corresponding `npm install` exits successfully.

This keeps the existing remediation behavior while preventing the misleading partial install reported in #77003.

## Related Issue

Fixes #77003

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/install.sh`: require a usable npm alongside a compatible Node and make dependency success logs conditional on the npm exit status.
- `scripts/install.ps1`: mirror the complete-toolchain check for system and Hermes-managed Node installations.
- `scripts/lib/node-bootstrap.sh`: require `npm --version` in the sourceable bootstrap's healthy-toolchain predicate.
- `tests/test_install_sh_node_toolchain.py`: exercise the real POSIX installer stages with isolated toolchains, including node-without-npm and failed root/TUI installs.

## How to Test

1. Put a compatible `node` on `PATH` without npm and run `bash scripts/install.sh --ensure node`. It should warn that npm is unusable and attempt the managed-Node fallback instead of reporting `Node.js ... found`.
2. Run a `node-deps` stage with an npm shim that exits non-zero. The warning should remain, but the matching dependency-success message must not be printed.
3. Run the focused validation:

```bash
scripts/run_tests.sh \
  tests/test_install_sh_node_toolchain.py \
  tests/test_install_sh_node_global_prefix.py \
  tests/test_install_sh_browser_install.py \
  tests/test_install_ps1_node_path_for_npm.py -q
# 18 passed

ruff check tests/test_install_sh_node_toolchain.py
bash -n scripts/install.sh
bash -n scripts/lib/node-bootstrap.sh
python3 scripts/check-windows-footguns.py --diff origin/main
git diff --check origin/main...HEAD
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused installer suites were run through `scripts/run_tests.sh`; the full repository suite is left to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing interface changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); `install.ps1` mirrors the detection change
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before, an isolated PATH containing only Node produced:

```text
✓ Node.js v22.22.2 found
```

After, the same toolchain produces:

```text
⚠ Node.js v22.22.2 has no usable npm on PATH — installing Hermes-managed Node 22 instead...
```
