### PR TITLE
feat(tools): add per-tool usage analytics and prune suggestion

### DIFF
--- a/contributors/emails/tugrulgunr@gmail.com
+++ b/contributors/emails/tugrulgunr@gmail.com
@@ -1,0 +1,2 @@
+tugrulguner
+# PR #77061 — per-tool usage analytics

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -7,9 +7,6 @@ verbatim from hermes_cli/config.py. Must not import from hermes_cli.config.
 DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
-    "tools": {
-        "analytics": False,
-    },
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
@@ -2271,6 +2268,7 @@ DEFAULT_CONFIG = {
     # See tools/tool_search.py for full design notes and the
     # openclaw-tool-search-report PDF in this PR for the rationale.
     "tools": {
+        "analytics": False,
         "tool_search": {
             # Tiered disclosure: any deferrable (MCP/plugin) tool activates
             # the bridge; the listing then scales with catalog size.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -7,6 +7,9 @@ verbatim from hermes_cli/config.py. Must not import from hermes_cli.config.
 DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
+    "tools": {
+        "analytics": False,
+    },
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -7,9 +7,6 @@ verbatim from hermes_cli/config.py. Must not import from hermes_cli.config.
 DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
-    "tools": {
-        "analytics": False,
-    },
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
@@ -2639,6 +2636,7 @@ DEFAULT_CONFIG = {
     # See tools/tool_search.py for full design notes and the
     # openclaw-tool-search-report PDF in this PR for the rationale.
     "tools": {
+        "analytics": False,
         "tool_search": {
             # Tiered disclosure: any deferrable (MCP/plugin) tool activates
             # the bridge; the listing then scales with catalog size.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11007,6 +11007,14 @@ def cmd_tools(args):
         from hermes_cli.tools_config import run_post_setup_command
 
         sys.exit(run_post_setup_command(args))
+    elif action == "analytics":
+        from tools.tool_usage import cmd_analytics
+
+        cmd_analytics(args)
+    elif action == "prune":
+        from tools.tool_usage import cmd_prune
+
+        cmd_prune(args)
     else:
         _require_tty("tools")
         from hermes_cli.tools_config import tools_command

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11997,6 +11997,14 @@ def cmd_tools(args):
         from hermes_cli.tools_config import run_post_setup_command
 
         sys.exit(run_post_setup_command(args))
+    elif action == "analytics":
+        from tools.tool_usage import cmd_analytics
+
+        cmd_analytics(args)
+    elif action == "prune":
+        from tools.tool_usage import cmd_prune
+
+        cmd_prune(args)
     else:
         _require_tty("tools")
         from hermes_cli.tools_config import tools_command

--- a/hermes_cli/subcommands/tools.py
+++ b/hermes_cli/subcommands/tools.py
@@ -93,3 +93,26 @@ def build_tools_parser(subparsers, *, cmd_tools: Callable) -> None:
         help="Post-setup hook key (e.g. agent_browser, camofox, kittentts)",
     )
     tools_parser.set_defaults(func=cmd_tools)
+
+    # hermes tools analytics [--verbose]
+    tools_analytics_p = tools_sub.add_parser(
+        "analytics",
+        help="Show per-tool usage analytics",
+        description=(
+            "Aggregate report of tool call counts, success rates, "
+            "and estimated token cost per tool. Requires tools.analytics: true."
+        ),
+    )
+    tools_analytics_p.add_argument(
+        "--verbose", action="store_true", help="Show detailed per-tool breakdown",
+    )
+
+    # hermes tools prune
+    tools_prune_p = tools_sub.add_parser(
+        "prune",
+        help="Suggest rarely-used tools to disable",
+        description=(
+            "Analyze tool usage across sessions and suggest toolsets that are "
+            "cold enough to disable, saving tokens on every API call."
+        ),
+    )

--- a/model_tools.py
+++ b/model_tools.py
@@ -31,6 +31,7 @@ from typing import Dict, Any, List, Optional, Tuple
 
 from tools.registry import discover_builtin_tools, registry, tool_error
 from toolsets import resolve_toolset, validate_toolset
+from tools.tool_usage import record_call
 
 logger = logging.getLogger(__name__)
 
@@ -1411,11 +1412,27 @@ def handle_function_call(
         except Exception as _hook_err:
             logger.debug("transform_tool_result hook error: %s", _hook_err)
 
+        # Tool usage recording (opt-in, gated by tools.analytics config key).
+        record_call(
+            function_name,
+            success=True,
+            token_est=0,
+            session_id=session_id,
+            turn_id=turn_id,
+        )
+
         return result
 
     except Exception as e:
         error_msg = f"Error executing {function_name}: {str(e)}"
         logger.exception(error_msg)
+        record_call(
+            function_name,
+            success=False,
+            token_est=0,
+            session_id=session_id,
+            turn_id=turn_id,
+        )
         return tool_error(_sanitize_tool_error(error_msg))
 
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -1415,8 +1415,7 @@ def handle_function_call(
         # Tool usage recording (opt-in, gated by tools.analytics config key).
         record_call(
             function_name,
-            success=True,
-            token_est=0,
+            result=result,
             session_id=session_id,
             turn_id=turn_id,
         )
@@ -1429,7 +1428,7 @@ def handle_function_call(
         record_call(
             function_name,
             success=False,
-            token_est=0,
+            result=f"[TOOL_ERROR] {error_msg}",
             session_id=session_id,
             turn_id=turn_id,
         )

--- a/model_tools.py
+++ b/model_tools.py
@@ -39,6 +39,7 @@ from tools.registry import (
     tool_error,
 )
 from toolsets import resolve_toolset, validate_toolset
+from tools.tool_usage import record_call
 
 logger = logging.getLogger(__name__)
 
@@ -1583,6 +1584,15 @@ def handle_function_call(
         except Exception as _hook_err:
             logger.debug("transform_tool_result hook error: %s", _hook_err)
 
+        # Tool usage recording (opt-in, gated by tools.analytics config key).
+        record_call(
+            function_name,
+            success=True,
+            token_est=0,
+            session_id=session_id,
+            turn_id=turn_id,
+        )
+
         return result
 
     except Exception as e:
@@ -1608,6 +1618,13 @@ def handle_function_call(
             error_type=type(e).__name__,
             error_message=str(e),
             middleware_trace=list(_tool_middleware_trace),
+        )
+        record_call(
+            function_name,
+            success=False,
+            token_est=0,
+            session_id=session_id,
+            turn_id=turn_id,
         )
         return result
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -1587,8 +1587,7 @@ def handle_function_call(
         # Tool usage recording (opt-in, gated by tools.analytics config key).
         record_call(
             function_name,
-            success=True,
-            token_est=0,
+            result=result,
             session_id=session_id,
             turn_id=turn_id,
         )
@@ -1622,7 +1621,7 @@ def handle_function_call(
         record_call(
             function_name,
             success=False,
-            token_est=0,
+            result=f"[TOOL_ERROR] {error_msg}",
             session_id=session_id,
             turn_id=turn_id,
         )

--- a/tests/tools/test_tool_usage.py
+++ b/tests/tools/test_tool_usage.py
@@ -30,7 +30,7 @@ def _set_analytics_on(hermes_home, enabled=True):
 def _record_calls(hermes_home, count=5, tool="web_search"):
     from tools.tool_usage import record_call
     for i in range(count):
-        record_call(tool, success=True, token_est=100 + i * 10)
+        record_call(tool, result='{"ok": true}', session_id="sess-1")
 
 
 def test_disabled_by_default(hermes_home):
@@ -97,6 +97,22 @@ def test_analytics_report_with_data(hermes_home):
 
 def test_record_call_no_effect_when_disabled(hermes_home):
     from tools.tool_usage import record_call, tool_summary
-    record_call("terminal", success=True, token_est=100)
+    record_call("terminal", result='{"ok": true}')
     summary = tool_summary()
     assert summary["total_calls"] == 0
+
+
+def test_record_call_detects_failure_from_result(hermes_home):
+    _set_analytics_on(hermes_home, True)
+    from tools.tool_usage import record_call, tool_summary
+    record_call("web_search", result='{"error": "rate limited"}', session_id="sess-1")
+    record_call("browser", result="[TOOL_ERROR] crashed", session_id="sess-1")
+    record_call("read_file", result='{"ok": true}', session_id="sess-1")
+    summary = tool_summary()
+    assert summary["total_calls"] == 3
+    web = next(t for t in summary["tools"] if t["tool_name"] == "web_search")
+    browser = next(t for t in summary["tools"] if t["tool_name"] == "browser")
+    read = next(t for t in summary["tools"] if t["tool_name"] == "read_file")
+    assert web["successes"] == 0
+    assert browser["successes"] == 0
+    assert read["successes"] == 1

--- a/tests/tools/test_tool_usage.py
+++ b/tests/tools/test_tool_usage.py
@@ -1,0 +1,102 @@
+"""Tests for the opt-in per-tool usage tracker (tools/tool_usage.py)."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import shutil
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(monkeypatch):
+    d = tempfile.mkdtemp(prefix="hermes_tool_usage_test_")
+    home = os.path.join(d, ".hermes")
+    os.makedirs(home)
+    monkeypatch.setenv("HERMES_HOME", home)
+    yield home
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def _set_analytics_on(hermes_home, enabled=True):
+    import hermes_cli.config as cfg
+    c = cfg.load_config()
+    c.setdefault("tools", {})["analytics"] = enabled
+    cfg.save_config(c)
+
+
+def _record_calls(hermes_home, count=5, tool="web_search"):
+    from tools.tool_usage import record_call
+    for i in range(count):
+        record_call(tool, success=True, token_est=100 + i * 10)
+
+
+def test_disabled_by_default(hermes_home):
+    from tools.tool_usage import is_enabled
+    assert is_enabled() is False
+
+
+def test_enabled_after_config(hermes_home):
+    _set_analytics_on(hermes_home, True)
+    from tools.tool_usage import is_enabled
+    assert is_enabled() is True
+
+
+def test_record_call_stores_data(hermes_home):
+    _set_analytics_on(hermes_home, True)
+    _record_calls(hermes_home, 3, "terminal")
+    from tools.tool_usage import tool_summary
+    summary = tool_summary()
+    assert summary["total_calls"] == 3
+    assert len(summary["tools"]) == 1
+    assert summary["tools"][0]["tool_name"] == "terminal"
+    assert summary["tools"][0]["total"] == 3
+
+
+def test_tool_summary_multiple_tools(hermes_home):
+    _set_analytics_on(hermes_home, True)
+    _record_calls(hermes_home, 4, "web_search")
+    _record_calls(hermes_home, 2, "read_file")
+    from tools.tool_usage import tool_summary
+    summary = tool_summary()
+    assert summary["total_calls"] == 6
+    assert len(summary["tools"]) == 2
+
+
+def test_cost_summary(hermes_home):
+    _set_analytics_on(hermes_home, True)
+    _record_calls(hermes_home, 2, "terminal")
+    from tools.tool_usage import cost_summary
+    costs = cost_summary()
+    assert costs["total_tokens"] > 0
+
+
+def test_suggest_prune_empty_when_no_data(hermes_home):
+    from tools.tool_usage import suggest_prune
+    assert suggest_prune() == []
+
+
+def test_analytics_report_empty(hermes_home):
+    _set_analytics_on(hermes_home, True)
+    from tools.tool_usage import analytics_report
+    report = analytics_report()
+    assert "No tool usage data" in report
+
+
+def test_analytics_report_with_data(hermes_home):
+    _set_analytics_on(hermes_home, True)
+    _record_calls(hermes_home, 5, "web_search")
+    from tools.tool_usage import analytics_report
+    report = analytics_report()
+    assert "web_search" in report
+    assert "5 calls" in report
+    assert "100%" in report
+
+
+def test_record_call_no_effect_when_disabled(hermes_home):
+    from tools.tool_usage import record_call, tool_summary
+    record_call("terminal", success=True, token_est=100)
+    summary = tool_summary()
+    assert summary["total_calls"] == 0

--- a/tools/tool_usage.py
+++ b/tools/tool_usage.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Opt-in local per-tool usage tracker and analytics.
+
+Records every tool call (name, timestamp, success, estimated token cost) in a
+sidecar SQLite store under ``<HERMES_HOME>/tool_usage.db``.  All data stays
+local — no outbound telemetry.
+
+Enable via ``tools.analytics: true`` in config.yaml (default off).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import threading
+import time
+from collections import Counter, defaultdict
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+_CONFIG_KEY = "tools.analytics"
+_DB_NAME = "tool_usage.db"
+_PRUNE_THRESHOLD = 10  # sessions with zero calls before suggesting disable
+
+# ---------------------------------------------------------------------------
+# Schema & DB management
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS tool_calls (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    tool_name   TEXT NOT NULL,
+    ts          REAL NOT NULL,
+    success     INTEGER NOT NULL DEFAULT 1,
+    token_est   INTEGER NOT NULL DEFAULT 0,
+    session_id  TEXT,
+    turn_id     TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_tool_calls_tool ON tool_calls(tool_name);
+CREATE INDEX IF NOT EXISTS idx_tool_calls_ts   ON tool_calls(ts);
+CREATE TABLE IF NOT EXISTS call_counts (
+    tool_name   TEXT PRIMARY KEY,
+    total       INTEGER NOT NULL DEFAULT 0,
+    successes   INTEGER NOT NULL DEFAULT 0,
+    last_used   REAL
+);
+"""
+
+_local = threading.local()
+
+
+def _db_path() -> Path:
+    return get_hermes_home() / _DB_NAME
+
+
+@contextmanager
+def _connect() -> Iterator[sqlite3.Connection]:
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_SCHEMA)
+    try:
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Recording
+# ---------------------------------------------------------------------------
+
+def record_call(
+    tool_name: str,
+    success: bool,
+    token_est: int = 0,
+    session_id: Optional[str] = None,
+    turn_id: Optional[str] = None,
+) -> None:
+    """Record one tool call in the local store."""
+    if not is_enabled():
+        return
+    try:
+        with _connect() as conn:
+            now = time.time()
+            conn.execute(
+                "INSERT INTO tool_calls (tool_name, ts, success, token_est, session_id, turn_id) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (tool_name, now, 1 if success else 0, token_est, session_id, turn_id),
+            )
+            conn.execute(
+                "INSERT INTO call_counts (tool_name, total, successes, last_used) "
+                "VALUES (?, 1, ?, ?) "
+                "ON CONFLICT(tool_name) DO UPDATE SET "
+                "total = total + 1, "
+                "successes = successes + ?, "
+                "last_used = MAX(last_used, ?)",
+                (tool_name, 1 if success else 0, now, 1 if success else 0, now),
+            )
+    except Exception:
+        logger.warning("tool_usage: failed to record call to %s", tool_name, exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Queries
+# ---------------------------------------------------------------------------
+
+def _dict_row(row: sqlite3.Row) -> Dict[str, Any]:
+    return dict(zip(row.keys(), row))
+
+
+def tool_summary() -> Dict[str, Any]:
+    """Return per-tool aggregate stats."""
+    if not _db_path().exists():
+        return {"tools": [], "total_calls": 0}
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT tool_name, total, successes, "
+            "ROUND(CAST(successes AS REAL) / MAX(total, 1) * 100, 1) AS success_pct, "
+            "last_used "
+            "FROM call_counts ORDER BY total DESC"
+        ).fetchall()
+        total = conn.execute("SELECT COUNT(*) AS c FROM tool_calls").fetchone()["c"]
+    return {"tools": [_dict_row(r) for r in rows], "total_calls": total}
+
+
+def cost_summary() -> Dict[str, Any]:
+    """Return per-tool estimated token cost breakdown."""
+    if not _db_path().exists():
+        return {"tools": [], "total_tokens": 0}
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT tool_name, COUNT(*) AS calls, "
+            "SUM(token_est) AS total_tokens, "
+            "ROUND(AVG(token_est), 1) AS avg_tokens "
+            "FROM tool_calls GROUP BY tool_name ORDER BY total_tokens DESC"
+        ).fetchall()
+        total = conn.execute("SELECT COALESCE(SUM(token_est), 0) AS t FROM tool_calls").fetchone()["t"]
+    return {"tools": [_dict_row(r) for r in rows], "total_tokens": total}
+
+
+def session_tool_counts(min_sessions: int = 1) -> Dict[str, int]:
+    """Return how many unique sessions each tool was called in."""
+    if not _db_path().exists():
+        return {}
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT tool_name, COUNT(DISTINCT session_id) AS sessions FROM tool_calls "
+            "WHERE session_id IS NOT NULL AND session_id != '' "
+            "GROUP BY tool_name"
+        ).fetchall()
+    return {r["tool_name"]: r["sessions"] for r in rows}
+
+
+# ---------------------------------------------------------------------------
+# Prune suggestions
+# ---------------------------------------------------------------------------
+
+def suggest_prune() -> List[Dict[str, Any]]:
+    """Return tools/toolsets used so rarely they could be disabled.
+
+    A tool is a prune candidate when it has been called in fewer than
+    ``_PRUNE_THRESHOLD`` distinct sessions.  Returns a list sorted by
+    increasing session count (coldest first).
+    """
+    per_tool = session_tool_counts(min_sessions=1)
+    if not per_tool:
+        return []
+    candidates = [
+        {"tool_name": name, "sessions": count}
+        for name, count in sorted(per_tool.items(), key=lambda kv: kv[1])
+        if count < _PRUNE_THRESHOLD
+    ]
+    return candidates
+
+
+def generate_prune_diff() -> Dict[str, Any]:
+    """Generate a suggested ``tools.<platform>.disabled`` diff."""
+    candidates = suggest_prune()
+    if not candidates:
+        return {"suggestions": [], "message": "All tools are actively used across sessions."}
+    disabled = [c["tool_name"] for c in candidates]
+    return {
+        "suggestions": candidates,
+        "diff_hint": (
+            "Consider adding to your config.yaml under the relevant platform:\n"
+            "  tools.cli.disabled:\n"
+            + "\n".join(f"    - {name}" for name in disabled)
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Analytics report (plain text for CLI / gateway)
+# ---------------------------------------------------------------------------
+
+def analytics_report(verbose: bool = False) -> str:
+    """Build a human-readable analytics report string."""
+    summary = tool_summary()
+    costs = cost_summary()
+    prune = generate_prune_diff()
+
+    if summary["total_calls"] == 0:
+        return "No tool usage data recorded yet. Enable `tools.analytics: true` in config.yaml."
+
+    lines = [f"Tool Usage Analytics ({summary['total_calls']} total calls)", "=" * 50]
+
+    lines.append("")
+    lines.append("Top tools by call count:")
+    for t in summary["tools"][:15]:
+        lines.append(
+            f"  {t['tool_name']:<30s}  {t['total']:>5d} calls  "
+            f"{t['success_pct']:.0f}% success"
+        )
+    if len(summary["tools"]) > 15:
+        lines.append(f"  ... and {len(summary['tools']) - 15} more tools")
+
+    lines.append("")
+    lines.append("Estimated token cost by tool:")
+    for t in costs["tools"][:10]:
+        lines.append(
+            f"  {t['tool_name']:<30s}  {t['total_tokens']:>8,d} tokens  "
+            f"avg {t['avg_tokens']:.0f}/call"
+        )
+    if costs["total_tokens"]:
+        lines.append(f"  {'TOTAL':<30s}  {costs['total_tokens']:>8,d} tokens")
+
+    if prune["suggestions"]:
+        lines.append("")
+        lines.append("Prune suggestions (consider disabling):")
+        for c in prune["suggestions"]:
+            pct = max(1, int(c["sessions"] / max(summary["total_calls"], 1) * 100))
+            lines.append(f"  {c['tool_name']:<30s}  used in {c['sessions']} session(s)")
+    else:
+        lines.append("")
+        lines.append("No prune candidates — all tools are actively used.")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Config gate
+# ---------------------------------------------------------------------------
+
+def is_enabled() -> bool:
+    """Return whether the tool usage tracker is enabled in config."""
+    try:
+        from hermes_cli.config import load_config, cfg_get
+        cfg = load_config()
+        raw = cfg_get(cfg, "tools", "analytics", default=False)
+    except Exception:
+        return False
+    return _normalize(raw)
+
+
+def _normalize(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"on", "true", "yes", "1", "enabled"}
+    return False
+
+
+# ---------------------------------------------------------------------------
+# CLI entry
+# ---------------------------------------------------------------------------
+
+def cmd_analytics(args: Any) -> None:
+    """``hermes tools analytics`` handler."""
+    if not is_enabled():
+        print(
+            "Tool analytics is disabled.\n"
+            "Enable it with:  hermes config set tools.analytics true"
+        )
+        return
+    print(analytics_report(verbose=getattr(args, "verbose", False)))
+
+
+def cmd_prune(args: Any) -> None:
+    """``hermes tools prune`` handler."""
+    if not is_enabled():
+        print(
+            "Tool analytics is disabled.\n"
+            "Enable it with:  hermes config set tools.analytics true"
+        )
+        return
+    result = generate_prune_diff()
+    if result["suggestions"]:
+        print(f"Prune candidates ({len(result['suggestions'])} found):\n")
+        for c in result["suggestions"]:
+            print(f"  {c['tool_name']}  (used in {c['sessions']} session(s))")
+        print("")
+        print(result["diff_hint"])
+    else:
+        print(result["message"])
+
+
+def cmd_record_stats() -> str:
+    """Return a brief stats line for status displays."""
+    summary = tool_summary()
+    if summary["total_calls"] == 0:
+        return "No tool usage data."
+    return f"Tool usage: {summary['total_calls']} calls across {len(summary['tools'])} tools."

--- a/tools/tool_usage.py
+++ b/tools/tool_usage.py
@@ -85,14 +85,28 @@ def _connect() -> Iterator[sqlite3.Connection]:
 
 def record_call(
     tool_name: str,
-    success: bool,
+    success: bool | None = None,
+    *,
     token_est: int = 0,
-    session_id: Optional[str] = None,
-    turn_id: Optional[str] = None,
+    result: str | None = None,
+    session_id: str | None = None,
+    turn_id: str | None = None,
 ) -> None:
-    """Record one tool call in the local store."""
+    """Record one tool call in the local store.
+
+    Args:
+        tool_name: Name of the tool called.
+        success: Whether the call succeeded. If None, derived from result.
+        token_est: Estimated token cost. If 0, estimated from result length.
+        result: The raw result string from the tool dispatch. Used to derive
+            success when not explicitly provided and to estimate token cost.
+    """
     if not is_enabled():
         return
+    if success is None and result is not None:
+        success = _is_successful(result)
+    if token_est == 0 and result is not None:
+        token_est = _estimate_tokens(result)
     try:
         with _connect() as conn:
             now = time.time()
@@ -112,6 +126,27 @@ def record_call(
             )
     except Exception:
         logger.warning("tool_usage: failed to record call to %s", tool_name, exc_info=True)
+
+
+def _is_successful(result: str) -> bool:
+    """Determine if a tool call succeeded based on its result string."""
+    if result.startswith("[TOOL_ERROR]"):
+        return False
+    try:
+        parsed = json.loads(result)
+        if isinstance(parsed, dict):
+            if parsed.get("error"):
+                return False
+            if parsed.get("success") is False:
+                return False
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return True
+
+
+def _estimate_tokens(result: str) -> int:
+    """Rough token estimate from result length (~4 chars per token)."""
+    return max(1, len(result) // 4)
 
 
 # ---------------------------------------------------------------------------
@@ -197,7 +232,9 @@ def generate_prune_diff() -> Dict[str, Any]:
         "suggestions": candidates,
         "diff_hint": (
             "Consider adding to your config.yaml under the relevant platform:\n"
-            "  tools.cli.disabled:\n"
+            "  platform_toolsets.cli:\n"
+            "    - hermes-cli\n"
+            "  platform_toolsets.cli.disabled:\n"
             + "\n".join(f"    - {name}" for name in disabled)
         ),
     }


### PR DESCRIPTION
Closes #77057

## Summary

Adds an opt-in per-tool usage tracker that records every tool call (name, timestamp, success, estimated token cost) in a local SQLite store. Data stays purely local — no outbound telemetry.

## Changes

### `tools/tool_usage.py` (new)
- Local SQLite store under `<HERMES_HOME>/tool_usage.db`
- `record_call()` — records one tool call (gated by `tools.analytics: true`)
- `tool_summary()` / `cost_summary()` — per-tool aggregate reports
- `suggest_prune()` / `generate_prune_diff()` — identifies tools used in <10 sessions
- `analytics_report()` — human-readable plain-text report
- `cmd_analytics()` / `cmd_prune()` — CLI entry points

### `model_tools.py`
- Import `record_call` and call it in `handle_function_call` on both success and error paths (gated by the tracker's own config check)

### CLI
- `hermes_cli/main.py` — dispatch `analytics` and `prune` subcommands in `cmd_tools()`
- `hermes_cli/subcommands/tools.py` — add `analytics [--verbose]` and `prune` parser entries

### Config
- `hermes_cli/config_defaults.py` — default `tools.analytics: false`

### Tests
- `tests/tools/test_tool_usage.py` — 9 tests: disabled gate, enabled gate, recording, summaries, reports, empty state

## Usage

```
hermes config set tools.analytics true
# ... use Hermes normally for a while ...
hermes tools analytics          # show per-tool call counts + token estimates
hermes tools prune              # suggest cold toolsets to disable
```

## Scope
- No new dependencies (stdlib only)
- Default off — zero overhead until opted in
- Follows `skill_usage.py` pattern for local-only opt-in telemetry