### PR TITLE
fix(auth): make is_provider_explicitly_configured dotenv-aware

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1756,6 +1756,11 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     # Exclude CLAUDE_CODE_OAUTH_TOKEN — it's set by Claude Code itself,
     # not by the user explicitly configuring anthropic in Hermes.
     _IMPLICIT_ENV_VARS = {"CLAUDE_CODE_OAUTH_TOKEN"}
+    # Resolve via the live-dotenv-aware resolver so a key added to
+    # ~/.hermes/.env while `hermes serve` is running is picked up
+    # immediately (matches the credential resolver used at runtime;
+    # see get_env_value_prefer_dotenv in hermes_cli.config).
+    from hermes_cli.config import get_env_value_prefer_dotenv
     pconfig = PROVIDER_REGISTRY.get(normalized)
     # Fallback to ProviderDef from models.dev catalog when the provider
     # isn't in the manually-maintained PROVIDER_REGISTRY (e.g. openrouter).
@@ -1767,7 +1772,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
         for env_var in pconfig.api_key_env_vars:
             if env_var in _IMPLICIT_ENV_VARS:
                 continue
-            if has_usable_secret(os.getenv(env_var, "")):
+            if has_usable_secret(get_env_value_prefer_dotenv(env_var)):
                 return True
 
     # 4. Check persisted credential-pool entries that came from EXPLICIT flows
@@ -1786,7 +1791,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
                 # the user deletes the env var (#55790) — only count it when
                 # the referenced var still resolves to a usable secret NOW.
                 env_var = entry.get("source", "").split(":", 1)[1].strip()
-                if env_var and has_usable_secret(os.getenv(env_var, "")):
+                if env_var and has_usable_secret(get_env_value_prefer_dotenv(env_var)):
                     return True
                 continue
             if (

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -98,6 +98,61 @@ def test_stale_env_pool_entry_does_not_count_when_var_unset(tmp_path, monkeypatc
     assert is_provider_explicitly_configured("deepseek") is False
 
 
+def _write_dotenv(tmp_path, payload: dict) -> None:
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    lines = [f"{key}={value}" for key, value in payload.items()]
+    (hermes_home / ".env").write_text("\n".join(lines) + "\n")
+
+
+def test_api_key_in_dotenv_counts_as_explicit_without_restart(tmp_path, monkeypatch):
+    """A provider API key added to ~/.hermes/.env mid-session is picked up by
+    is_provider_explicitly_configured() without a serve restart (#77007).
+
+    The runtime credential resolver (get_env_value_prefer_dotenv) prefers the
+    live .env read over os.environ; the explicit-config gate must agree so the
+    desktop picker and the readiness gate report the same state.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "providers": {},
+        "active_provider": None,
+        "credential_pool": {},
+    })
+    # Key exists ONLY in ~/.hermes/.env — never in the process environment.
+    _write_dotenv(tmp_path, {"DEEPSEEK_API_KEY": "sk-dotenv-only-secret"})
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("deepseek") is True
+
+
+def test_env_pool_entry_counts_when_key_resolves_via_dotenv(tmp_path, monkeypatch):
+    """An env-seeded credential-pool entry resolves through the live dotenv
+    read, not only os.environ (#77007, #55790): rotating the key in .env
+    keeps the provider visible in explicit-only pickers."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "providers": {},
+        "active_provider": None,
+        "credential_pool": {
+            "deepseek": [{
+                "id": "aaa111",
+                "source": "env:DEEPSEEK_API_KEY",
+                "auth_type": "api_key",
+            }],
+        },
+    })
+    _write_dotenv(tmp_path, {"DEEPSEEK_API_KEY": "sk-dotenv-only-secret"})
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("deepseek") is True
+
+
+
 
 
 


### PR DESCRIPTION
## Summary

Fixes the inconsistency where `is_provider_explicitly_configured()` in `hermes_cli/auth.py` only checked API-key environment variables via `os.getenv()`, while the actual runtime credential resolver (`get_env_value_prefer_dotenv()` in `hermes_cli/config.py`) deliberately prefers a live read of `~/.hermes/.env`.

## Root Cause

Adding a key to `~/.hermes/.env` while `hermes serve` is running works for the readiness gate (`setup.runtime_check` uses the live dotenv read), but desktop model pickers — which call `/api/model/options?explicit_only=1`, filtered by `is_provider_explicitly_configured()` — kept hiding the provider until the next serve restart, because the new key was not yet in the process environment. The gate said "ready" while the picker said "not configured".

## Change

In `is_provider_explicitly_configured()`, both env-var resolution paths now route through `get_env_value_prefer_dotenv()` (imported lazily, matching the existing pattern in `hermes_cli/auth.py`):

- Step 3 (provider-specific env vars, e.g. `DEEPSEEK_API_KEY`): `os.getenv(env_var, "")` → `get_env_value_prefer_dotenv(env_var)`
- Step 4 (env-seeded credential-pool entries, #55790 follow-up): `os.getenv(env_var, "")` → `get_env_value_prefer_dotenv(env_var)`

This keeps the `CLAUDE_CODE_OAUTH_TOKEN` exclusion and the stale-pool-entry behavior (unset var ⇒ provider no longer counts as configured) intact, while making the explicit-config gate agree with the live-dotenv credential resolver. Keys added to `.env` mid-session are now picked up immediately, with no serve restart required.

## Verification

- Added 2 regression tests in `tests/hermes_cli/test_auth_provider_gate.py`:
  - `test_api_key_in_dotenv_counts_as_explicit_without_restart` — key present only in `~/.hermes/.env`, never in `os.environ`, provider is reported as explicitly configured.
  - `test_env_pool_entry_counts_when_key_resolves_via_dotenv` — env-seeded pool entry resolves through the live dotenv read.
- `pytest tests/hermes_cli/test_auth_provider_gate.py tests/hermes_cli/test_get_env_value_scope.py` — 11 passed.
- Broader run: `pytest tests/hermes_cli/ -k "auth or provider or credential"` — 1104 passed, 0 failed.

## Closes #77007