### PR TITLE
fix(browser): add browser.viewport config for CDP backends

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -378,6 +378,16 @@ DEFAULT_CONFIG = {
         # website/docs/developer-guide/browser-supervisor.md.
         "dialog_policy": "must_respond",  # must_respond | auto_dismiss | auto_accept
         "dialog_timeout_s": 300,  # Safety auto-dismiss after N seconds under must_respond
+        # Viewport applied via Emulation.setDeviceMetricsOverride when the CDP
+        # supervisor attaches to a page (browser.cdp_url / /browser connect).
+        # Defaults match Chrome's headless window size so existing users see no
+        # change unless they opt in.
+        "viewport": {
+            "width": 1280,
+            "height": 720,
+            "device_scale_factor": 1,
+            "mobile": False,
+        },
         "camofox": {
             # When true, Hermes sends a stable profile-scoped userId to Camofox
             # so the server maps it to a persistent Firefox profile automatically.

--- a/tests/tools/test_browser_supervisor_healthcheck.py
+++ b/tests/tools/test_browser_supervisor_healthcheck.py
@@ -68,11 +68,20 @@ def stub_cdp_supervisor(monkeypatch):
     created: list[SimpleNamespace] = []
 
     class _StubSupervisor:
-        def __init__(self, *, task_id, cdp_url, dialog_policy, dialog_timeout_s):
+        def __init__(
+            self,
+            *,
+            task_id,
+            cdp_url,
+            dialog_policy,
+            dialog_timeout_s,
+            viewport=None,
+        ):
             self.task_id = task_id
             self.cdp_url = cdp_url
             self.dialog_policy = dialog_policy
             self.dialog_timeout_s = dialog_timeout_s
+            self.viewport = dict(viewport or {})
             # Healthy by default — real thread, running "loop".
             hold = threading.Event()
             self._thread = threading.Thread(target=hold.wait, daemon=True)

--- a/tests/tools/test_browser_supervisor_viewport.py
+++ b/tests/tools/test_browser_supervisor_viewport.py
@@ -1,0 +1,326 @@
+"""Unit tests for the CDP supervisor viewport override (browser.viewport).
+
+Covers:
+  * ``CDPSupervisor._apply_viewport_override`` — builds the right
+    ``Emulation.setDeviceMetricsOverride`` payload from config, falls back to
+    built-in defaults for missing/invalid values, and never raises.
+  * ``CDPSupervisor._attach_initial_page`` — applies the override on the page
+    session during attach.
+  * ``browser_tool._get_viewport_config`` — config reading/normalization.
+  * ``browser_tool._ensure_cdp_supervisor`` — forwards the viewport to the
+    supervisor registry.
+
+These are pure unit tests (mocked ``_cdp``, no real Chrome).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.browser_supervisor import (
+    CDPSupervisor,
+    DEFAULT_VIEWPORT_DEVICE_SCALE_FACTOR,
+    DEFAULT_VIEWPORT_HEIGHT,
+    DEFAULT_VIEWPORT_MOBILE,
+    DEFAULT_VIEWPORT_WIDTH,
+)
+
+
+def _make_supervisor(viewport):
+    """Build a CDPSupervisor without a real WS connection.
+
+    ``_cdp`` is replaced by a recording fake; ``_page_session_id`` is set to a
+    fixed value so ``_apply_viewport_override`` exercises the send path.
+    """
+    sup = object.__new__(CDPSupervisor)
+    sup._state_lock = threading.Lock()
+    sup._active = True
+    sup._page_session_id = "sess-1"
+    sup.viewport = dict(viewport or {})
+
+    loop = asyncio.new_event_loop()
+
+    def _runner():
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    thread = threading.Thread(target=_runner, daemon=True)
+    thread.start()
+
+    calls = []
+
+    async def _fake_cdp(method, params=None, *, session_id=None, timeout=10.0):
+        calls.append((method, params, session_id))
+        return {"result": {}}
+
+    sup._cdp = _fake_cdp  # type: ignore[method-assign]
+    sup._loop = loop
+    sup._thread = thread
+    return sup, calls
+
+
+def _stop_supervisor(sup):
+    sup._loop.call_soon_threadsafe(sup._loop.stop)
+    sup._thread.join(timeout=2)
+
+
+def _run_async(coro):
+    return asyncio.run(coro)
+
+
+class TestApplyViewportOverride:
+    def test_sends_custom_viewport(self):
+        sup, calls = _make_supervisor(
+            {"width": 1920, "height": 1080, "device_scale_factor": 1, "mobile": False}
+        )
+        try:
+            _run_async(sup._apply_viewport_override())
+        finally:
+            _stop_supervisor(sup)
+
+        assert calls == [
+            (
+                "Emulation.setDeviceMetricsOverride",
+                {"width": 1920, "height": 1080, "deviceScaleFactor": 1, "mobile": False},
+                "sess-1",
+            )
+        ]
+
+    def test_mobile_viewport_passes_mobile_true(self):
+        sup, calls = _make_supervisor(
+            {"width": 390, "height": 844, "device_scale_factor": 3, "mobile": True}
+        )
+        try:
+            _run_async(sup._apply_viewport_override())
+        finally:
+            _stop_supervisor(sup)
+
+        assert calls == [
+            (
+                "Emulation.setDeviceMetricsOverride",
+                {"width": 390, "height": 844, "deviceScaleFactor": 3, "mobile": True},
+                "sess-1",
+            )
+        ]
+
+    def test_empty_viewport_uses_defaults(self):
+        sup, calls = _make_supervisor({})
+        try:
+            _run_async(sup._apply_viewport_override())
+        finally:
+            _stop_supervisor(sup)
+
+        assert calls == [
+            (
+                "Emulation.setDeviceMetricsOverride",
+                {
+                    "width": DEFAULT_VIEWPORT_WIDTH,
+                    "height": DEFAULT_VIEWPORT_HEIGHT,
+                    "deviceScaleFactor": DEFAULT_VIEWPORT_DEVICE_SCALE_FACTOR,
+                    "mobile": DEFAULT_VIEWPORT_MOBILE,
+                },
+                "sess-1",
+            )
+        ]
+
+    def test_partial_viewport_fills_missing_keys_from_defaults(self):
+        sup, calls = _make_supervisor({"width": 1440})
+        try:
+            _run_async(sup._apply_viewport_override())
+        finally:
+            _stop_supervisor(sup)
+
+        assert calls == [
+            (
+                "Emulation.setDeviceMetricsOverride",
+                {
+                    "width": 1440,
+                    "height": DEFAULT_VIEWPORT_HEIGHT,
+                    "deviceScaleFactor": DEFAULT_VIEWPORT_DEVICE_SCALE_FACTOR,
+                    "mobile": DEFAULT_VIEWPORT_MOBILE,
+                },
+                "sess-1",
+            )
+        ]
+
+    def test_invalid_values_fall_back_to_defaults(self):
+        sup, calls = _make_supervisor(
+            {"width": "wide", "height": -5, "device_scale_factor": 0, "mobile": "yes"}
+        )
+        try:
+            _run_async(sup._apply_viewport_override())
+        finally:
+            _stop_supervisor(sup)
+
+        assert calls == [
+            (
+                "Emulation.setDeviceMetricsOverride",
+                {
+                    "width": DEFAULT_VIEWPORT_WIDTH,
+                    "height": DEFAULT_VIEWPORT_HEIGHT,
+                    "deviceScaleFactor": DEFAULT_VIEWPORT_DEVICE_SCALE_FACTOR,
+                    "mobile": DEFAULT_VIEWPORT_MOBILE,
+                },
+                "sess-1",
+            )
+        ]
+
+    def test_cdp_failure_is_swallowed(self):
+        sup, _ = _make_supervisor({"width": 1280, "height": 720})
+
+        async def _boom(method, params=None, *, session_id=None, timeout=10.0):
+            raise RuntimeError("websocket closed")
+
+        sup._cdp = _boom  # type: ignore[method-assign]
+        try:
+            # Must not raise — the supervisor is a non-fatal enhancement.
+            _run_async(sup._apply_viewport_override())
+        finally:
+            _stop_supervisor(sup)
+
+    def test_no_page_session_is_noop(self):
+        sup, calls = _make_supervisor({"width": 1280, "height": 720})
+        sup._page_session_id = None
+        try:
+            _run_async(sup._apply_viewport_override())
+        finally:
+            _stop_supervisor(sup)
+
+        assert calls == []
+
+
+class TestAttachInitialPageAppliesViewport:
+    def test_emulation_override_sent_on_page_session(self):
+        sup, calls = _make_supervisor({"width": 1920, "height": 1080})
+        # _attach_initial_page finds its own page target and attach result.
+        sup._page_session_id = None
+
+        async def _fake_cdp(method, params=None, *, session_id=None, timeout=10.0):
+            calls.append((method, params, session_id))
+            if method == "Target.getTargets":
+                return {
+                    "result": {
+                        "targetInfos": [{"type": "page", "targetId": "tgt-1"}]
+                    }
+                }
+            if method == "Target.attachToTarget":
+                return {"result": {"sessionId": "sess-1"}}
+            return {"result": {}}
+
+        sup._cdp = _fake_cdp  # type: ignore[method-assign]
+        try:
+            _run_async(sup._attach_initial_page())
+        finally:
+            _stop_supervisor(sup)
+
+        emulation_calls = [
+            c for c in calls if c[0] == "Emulation.setDeviceMetricsOverride"
+        ]
+        assert len(emulation_calls) == 1
+        method, params, session_id = emulation_calls[0]
+        assert session_id == "sess-1"
+        assert params["width"] == 1920
+        assert params["height"] == 1080
+        assert params["deviceScaleFactor"] == 1
+        assert params["mobile"] is False
+
+
+class TestGetViewportConfig:
+    def _import_module(self):
+        import tools.browser_tool as browser_tool
+
+        return browser_tool
+
+    def test_returns_configured_viewport(self):
+        browser_tool = self._import_module()
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={
+                "browser": {
+                    "viewport": {
+                        "width": 1920,
+                        "height": 1080,
+                        "device_scale_factor": 1,
+                        "mobile": False,
+                    }
+                }
+            },
+        ):
+            assert browser_tool._get_viewport_config() == {
+                "width": 1920,
+                "height": 1080,
+                "device_scale_factor": 1,
+                "mobile": False,
+            }
+
+    def test_missing_viewport_returns_empty(self):
+        browser_tool = self._import_module()
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"browser": {"dialog_policy": "must_respond"}},
+        ):
+            assert browser_tool._get_viewport_config() == {}
+
+    def test_no_browser_section_returns_empty(self):
+        browser_tool = self._import_module()
+        with patch("hermes_cli.config.read_raw_config", return_value={}):
+            assert browser_tool._get_viewport_config() == {}
+
+    def test_non_dict_viewport_returns_empty(self):
+        browser_tool = self._import_module()
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            return_value={"browser": {"viewport": "1920x1080"}},
+        ):
+            assert browser_tool._get_viewport_config() == {}
+
+    def test_config_read_failure_returns_empty(self):
+        browser_tool = self._import_module()
+        with patch(
+            "hermes_cli.config.read_raw_config",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert browser_tool._get_viewport_config() == {}
+
+
+class TestEnsureSupervisorForwardsViewport:
+    def test_viewport_passed_to_registry(self):
+        import tools.browser_tool as browser_tool
+        import tools.browser_supervisor as browser_supervisor
+
+        fake_registry = MagicMock()
+        fake_registry.get_or_start.return_value = object()
+        viewport = {"width": 1920, "height": 1080}
+
+        with patch.object(
+            browser_tool, "_get_cdp_override", return_value="ws://127.0.0.1:9222/devtools"
+        ), patch.object(
+            browser_tool, "_get_viewport_config", return_value=viewport
+        ), patch.object(
+            browser_supervisor, "SUPERVISOR_REGISTRY", fake_registry
+        ):
+            browser_tool._ensure_cdp_supervisor(task_id="test-viewport-task")
+
+        fake_registry.get_or_start.assert_called_once()
+        kwargs = fake_registry.get_or_start.call_args.kwargs
+        assert kwargs["viewport"] == viewport
+        assert kwargs["task_id"] == "test-viewport-task"
+        assert kwargs["cdp_url"] == "ws://127.0.0.1:9222/devtools"
+
+    def test_no_cdp_url_skips_registry(self):
+        import tools.browser_tool as browser_tool
+        import tools.browser_supervisor as browser_supervisor
+
+        fake_registry = MagicMock()
+        with patch.object(
+            browser_tool, "_get_cdp_override", return_value=""
+        ), patch.object(
+            browser_supervisor, "SUPERVISOR_REGISTRY", fake_registry
+        ):
+            browser_tool._ensure_cdp_supervisor(task_id="test-viewport-task")
+
+        fake_registry.get_or_start.assert_not_called()

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -77,6 +77,15 @@ _VALID_POLICIES = frozenset(
 DEFAULT_DIALOG_POLICY = DIALOG_POLICY_MUST_RESPOND
 DEFAULT_DIALOG_TIMEOUT_S = 300.0
 
+# Viewport applied via ``Emulation.setDeviceMetricsOverride`` when the
+# supervisor attaches to a page. Defaults match Chrome's headless window size
+# (1280x720 at 1x scale, desktop mode) so existing users see no change unless
+# they opt in via ``browser.viewport`` in config.yaml.
+DEFAULT_VIEWPORT_WIDTH = 1280
+DEFAULT_VIEWPORT_HEIGHT = 720
+DEFAULT_VIEWPORT_DEVICE_SCALE_FACTOR = 1
+DEFAULT_VIEWPORT_MOBILE = False
+
 # Snapshot caps for frame_tree — keep payloads bounded on ad-heavy pages.
 FRAME_TREE_MAX_ENTRIES = 30
 FRAME_TREE_MAX_OOPIF_DEPTH = 2
@@ -310,6 +319,7 @@ class CDPSupervisor:
         *,
         dialog_policy: str = DEFAULT_DIALOG_POLICY,
         dialog_timeout_s: float = DEFAULT_DIALOG_TIMEOUT_S,
+        viewport: Optional[Dict[str, Any]] = None,
     ) -> None:
         if dialog_policy not in _VALID_POLICIES:
             raise ValueError(
@@ -320,6 +330,10 @@ class CDPSupervisor:
         self.cdp_url = cdp_url
         self.dialog_policy = dialog_policy
         self.dialog_timeout_s = float(dialog_timeout_s)
+        # Raw ``browser.viewport`` config (width/height/device_scale_factor/
+        # mobile). Empty dict = user hasn't opted in; the supervisor then
+        # applies the built-in defaults in ``_apply_viewport_override``.
+        self.viewport: Dict[str, Any] = dict(viewport or {})
 
         # State protected by ``_state_lock`` for cross-thread reads.
         self._state_lock = threading.Lock()
@@ -761,11 +775,63 @@ class CDPSupervisor:
             {"autoAttach": True, "waitForDebuggerOnStart": False, "flatten": True},
             session_id=self._page_session_id,
         )
+        # Apply the configured viewport (Emulation.setDeviceMetricsOverride)
+        # for the lifetime of this session — screenshots and browser_vision
+        # then respect browser.viewport instead of Chrome's headless default.
+        await self._apply_viewport_override()
         # Install the dialog bridge — overrides native alert/confirm/prompt with
         # a synchronous XHR we intercept via Fetch domain. This is how we make
         # dialog response work on Browserbase (whose CDP proxy auto-dismisses
         # real native dialogs before we can call handleJavaScriptDialog).
         await self._install_dialog_bridge(self._page_session_id)
+
+    async def _apply_viewport_override(self) -> None:
+        """Apply ``browser.viewport`` via ``Emulation.setDeviceMetricsOverride``.
+
+        Best-effort: a failure to set the viewport must not break the attach
+        (the supervisor is a non-fatal enhancement on top of the browser
+        session). Missing or invalid values fall back to the built-in defaults
+        (1280x720, 1x scale, desktop), so existing users see no change unless
+        they opt in via config.
+        """
+        if not self._page_session_id:
+            return
+        vp = self.viewport
+        try:
+            width = int(vp.get("width") or DEFAULT_VIEWPORT_WIDTH)
+            height = int(vp.get("height") or DEFAULT_VIEWPORT_HEIGHT)
+            dsf = float(
+                vp.get("device_scale_factor") or DEFAULT_VIEWPORT_DEVICE_SCALE_FACTOR
+            )
+            mobile = bool(vp.get("mobile", DEFAULT_VIEWPORT_MOBILE))
+            if width <= 0 or height <= 0 or dsf <= 0:
+                raise ValueError("viewport dimensions must be positive")
+        except (TypeError, ValueError):
+            logger.debug(
+                "viewport override: invalid browser.viewport=%r; using defaults",
+                vp,
+            )
+            width = DEFAULT_VIEWPORT_WIDTH
+            height = DEFAULT_VIEWPORT_HEIGHT
+            dsf = DEFAULT_VIEWPORT_DEVICE_SCALE_FACTOR
+            mobile = DEFAULT_VIEWPORT_MOBILE
+        try:
+            await self._cdp(
+                "Emulation.setDeviceMetricsOverride",
+                {
+                    "width": width,
+                    "height": height,
+                    "deviceScaleFactor": dsf,
+                    "mobile": mobile,
+                },
+                session_id=self._page_session_id,
+                timeout=5.0,
+            )
+        except Exception as e:
+            logger.debug(
+                "viewport override failed on sid=%s: %s",
+                (self._page_session_id or "")[:16], e,
+            )
 
     async def _install_dialog_bridge(self, session_id: str) -> None:
         """Install the dialog-bridge init script + Fetch interceptor on a session.
@@ -1445,6 +1511,7 @@ class _SupervisorRegistry:
         *,
         dialog_policy: str = DEFAULT_DIALOG_POLICY,
         dialog_timeout_s: float = DEFAULT_DIALOG_TIMEOUT_S,
+        viewport: Optional[Dict[str, Any]] = None,
         start_timeout: float = 15.0,
     ) -> CDPSupervisor:
         """Idempotently ensure a supervisor is running for ``(task_id, cdp_url)``.
@@ -1471,6 +1538,7 @@ class _SupervisorRegistry:
             cdp_url=cdp_url,
             dialog_policy=dialog_policy,
             dialog_timeout_s=dialog_timeout_s,
+            viewport=viewport,
         )
         supervisor.start(timeout=start_timeout)
         with self._lock:
@@ -1506,6 +1574,10 @@ __all__ = [
     "ConsoleEvent",
     "DEFAULT_DIALOG_POLICY",
     "DEFAULT_DIALOG_TIMEOUT_S",
+    "DEFAULT_VIEWPORT_DEVICE_SCALE_FACTOR",
+    "DEFAULT_VIEWPORT_HEIGHT",
+    "DEFAULT_VIEWPORT_MOBILE",
+    "DEFAULT_VIEWPORT_WIDTH",
     "DIALOG_POLICY_AUTO_ACCEPT",
     "DIALOG_POLICY_AUTO_DISMISS",
     "DIALOG_POLICY_MUST_RESPOND",

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -591,6 +591,29 @@ def _get_dialog_policy_config() -> Tuple[str, float]:
         return DEFAULT_DIALOG_POLICY, DEFAULT_DIALOG_TIMEOUT_S
 
 
+def _get_viewport_config() -> Dict[str, Any]:
+    """Read ``browser.viewport`` from config for the CDP supervisor.
+
+    Returns a normalized dict with keys ``width``, ``height``,
+    ``device_scale_factor`` and ``mobile``, or ``{}`` when the user has not
+    configured a viewport — the supervisor then applies its built-in defaults
+    (1280x720 at 1x scale, desktop), preserving today's behavior.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config()
+        browser_cfg = cfg.get("browser", {}) if isinstance(cfg, dict) else {}
+        if not isinstance(browser_cfg, dict):
+            return {}
+        vp = browser_cfg.get("viewport") or {}
+        if not isinstance(vp, dict):
+            return {}
+        return dict(vp)
+    except Exception:
+        return {}
+
+
 def _ensure_cdp_supervisor(task_id: str) -> None:
     """Start a CDP supervisor for ``task_id`` if an endpoint is reachable.
 
@@ -625,11 +648,13 @@ def _ensure_cdp_supervisor(task_id: str) -> None:
         from tools.browser_supervisor import SUPERVISOR_REGISTRY  # type: ignore[import-not-found]
 
         policy, timeout_s = _get_dialog_policy_config()
+        viewport = _get_viewport_config()
         SUPERVISOR_REGISTRY.get_or_start(
             task_id=task_id,
             cdp_url=cdp_url,
             dialog_policy=policy,
             dialog_timeout_s=timeout_s,
+            viewport=viewport,
         )
     except Exception as exc:
         logger.debug(

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2029,6 +2029,14 @@ browser:
   # browser via /browser connect). Ignored on Camofox and default local agent-browser mode.
   dialog_policy: must_respond    # must_respond | auto_dismiss | auto_accept
   dialog_timeout_s: 300          # Safety auto-dismiss under must_respond (seconds)
+  # Viewport applied via Emulation.setDeviceMetricsOverride when the CDP
+  # supervisor attaches to a page (browser.cdp_url / /browser connect).
+  # Defaults match Chrome's headless window size (1280x720, 1x, desktop).
+  viewport:
+    width: 1280
+    height: 720
+    device_scale_factor: 1
+    mobile: false
   camofox:
     managed_persistence: false   # When true, Camofox sessions persist cookies/logins across restarts
     user_id: ""                  # Optional externally managed Camofox userId
@@ -2041,6 +2049,8 @@ browser:
 - `must_respond` (default) — capture the dialog, surface it in `browser_snapshot.pending_dialogs`, and wait for the agent to call `browser_dialog(action=...)`. After `dialog_timeout_s` seconds with no response, the dialog is auto-dismissed to prevent the page's JS thread from stalling forever.
 - `auto_dismiss` — capture, dismiss immediately. The agent still sees the dialog record in `browser_snapshot.recent_dialogs` with `closed_by="auto_policy"` after the fact.
 - `auto_accept` — capture, accept immediately. Useful for pages with aggressive `beforeunload` prompts.
+
+**CDP viewport:** when a CDP backend is attached (`browser.cdp_url` or `/browser connect`), `browser.viewport` sets the effective viewport for the session via `Emulation.setDeviceMetricsOverride`. This fixes screenshots and `browser_vision` capturing at Chrome's headless default (780×493 px) on desktop sites. Keys: `width`, `height`, `device_scale_factor`, `mobile`. Defaults are 1280×720 at 1× scale, desktop mode, so existing users see no change unless they opt in.
 
 See the [browser feature page](./features/browser.md#browser_dialog) for the full dialog workflow.
 

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -526,6 +526,8 @@ Raw Chrome DevTools Protocol passthrough — the escape hatch for browser operat
 
 **Only available when a CDP endpoint is reachable at session start** — meaning `/browser connect` has attached to a running Chrome, Brave, Chromium, or Edge browser, or `browser.cdp_url` is set in `config.yaml`. The default local agent-browser mode, Camofox, and cloud providers (Browserbase, Browser Use, Firecrawl) do not currently expose CDP to this tool — cloud providers have per-session CDP URLs but live-session routing is a follow-up.
 
+When a CDP endpoint is attached, the supervisor applies `browser.viewport` (`width`, `height`, `device_scale_factor`, `mobile`; default 1280×720 at 1× scale, desktop) via `Emulation.setDeviceMetricsOverride` on the page session — so screenshots and `browser_vision` render at your chosen size instead of Chrome's headless default (780×493 px). See [configuration](../configuration.md#browser).
+
 **CDP method reference:** https://chromedevtools.github.io/devtools-protocol/ — the agent can `web_extract` a specific method's page to look up parameters and return shape.
 
 Common patterns:


### PR DESCRIPTION
## Summary
Adds a `browser.viewport` config block (`width`, `height`, `device_scale_factor`, `mobile`) so CDP-based browser backends are no longer stuck at Chrome's headless default (780×493). The CDP supervisor now applies `Emulation.setDeviceMetricsOverride` when a page session attaches.

## Root Cause
`browser_supervisor.py` never called `Emulation.setDeviceMetricsOverride` on connection, so screenshots and `browser_vision` always rendered at Chrome's headless default viewport regardless of the site's layout — looking like a mobile view on desktop sites. The Camofox backend had a viewport option (PR #38526), but the CDP path had no equivalent.

## Change
- `hermes_cli/config_defaults.py`: `browser.viewport` defaults — `1280×720`, `device_scale_factor: 1`, `mobile: false` (existing users see no change).
- `tools/browser_supervisor.py`: viewport param on `CDPSupervisor`/registry, `_apply_viewport_override()` sends `Emulation.setDeviceMetricsOverride` on the page session (best-effort, falls back to defaults on invalid values), wired into `_attach_initial_page`.
- `tools/browser_tool.py`: reads `browser.viewport` via `read_raw_config` and forwards it to the supervisor registry.
- Docs updated (`configuration.md`, `features/browser.md`).
- New test suite: `tests/tools/test_browser_supervisor_viewport.py` (15 tests).

## Verification
- `pytest tests/tools/test_browser_supervisor_viewport.py` → 15 passed
- `pytest tests/tools/test_browser*.py` → 344 passed, 7 deselected (integration tests opt-in)
- `load_config()` smoke test confirms merged `browser.viewport` defaults flow through.

Closes #77044
