### PR TITLE
fix(google-workspace): gmail_search drops To/Subject on non-Title-Case headers

### DIFF
--- a/contributors/emails/bayrakdarerdemm@gmail.com
+++ b/contributors/emails/bayrakdarerdemm@gmail.com
@@ -1,0 +1,1 @@
+bayrakdarerdem

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -226,7 +226,14 @@ def gmail_search(args):
                     "userId": "me",
                     "id": msg_meta["id"],
                     "format": "metadata",
-                    "metadataHeaders": ["From", "To", "Subject", "Date"],
+                    # No metadataHeaders filter: it matches header names
+                    # case-sensitively against the raw MIME source, so
+                    # senders that emit "to:"/"SUBJECT:" instead of
+                    # "To:"/"Subject:" silently drop those headers here.
+                    # This deliberately returns every header on the
+                    # message (format=metadata still excludes body/
+                    # payload); _headers_dict() lower-cases keys for
+                    # the client-side lookup below.
                 },
             )
             headers = _headers_dict(msg)
@@ -256,9 +263,13 @@ def gmail_search(args):
 
     output = []
     for msg_meta in messages:
+        # No metadataHeaders filter -- see the matching comment in the
+        # _gws_binary() branch above: it's a case-sensitive exact match
+        # against the raw header name and silently drops non-Title-Case
+        # headers (issue #34806). This deliberately returns every header
+        # on the message (format=metadata still excludes body/payload).
         msg = service.users().messages().get(
             userId="me", id=msg_meta["id"], format="metadata",
-            metadataHeaders=["From", "To", "Subject", "Date"],
         ).execute()
         headers = _headers_dict(msg)
         output.append({
@@ -366,7 +377,10 @@ def gmail_reply(args):
                 "userId": "me",
                 "id": args.message_id,
                 "format": "metadata",
-                "metadataHeaders": ["From", "Subject", "Message-ID"],
+                # No metadataHeaders filter -- see the comment in
+                # gmail_search() above (issue #34806 follow-up): it's a
+                # case-sensitive exact match against the raw header name
+                # and can silently drop From/Subject/Message-ID.
             },
         )
         headers = _headers_dict(original)
@@ -394,9 +408,9 @@ def gmail_reply(args):
         return
 
     service = build_service("gmail", "v1")
+    # No metadataHeaders filter -- see gmail_search() above.
     original = service.users().messages().get(
         userId="me", id=args.message_id, format="metadata",
-        metadataHeaders=["From", "Subject", "Message-ID"],
     ).execute()
     headers = _headers_dict(original)
 

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -1,5 +1,6 @@
 """Tests for Google Workspace gws bridge and CLI wrapper."""
 
+import base64
 import importlib.util
 import json
 import subprocess
@@ -144,6 +145,214 @@ def test_api_calendar_list_uses_events_list(api_module):
 
 
 
+
+
+def test_api_gmail_search_does_not_filter_by_metadata_headers(api_module):
+    """gmail_search must not pass metadataHeaders to the gws get call.
+
+    Regression for #34806: metadataHeaders matches header names
+    case-sensitively against the raw MIME source, so a filter of
+    ["From", "To", "Subject", "Date"] silently drops headers a sender
+    wrote as e.g. "to:" or "SUBJECT:". Omitting the filter (format=metadata
+    already excludes body/payload) returns every header and lets the
+    existing case-insensitive _headers_dict() do the lookup instead.
+    """
+    calls = []
+
+    def capture_run(cmd, **kwargs):
+        calls.append(cmd)
+        if "list" in cmd:
+            return MagicMock(
+                returncode=0,
+                stdout=json.dumps({"messages": [{"id": "msg1"}]}),
+                stderr="",
+            )
+        # Simulate a message whose headers came in lower-case, as some
+        # senders emit -- this is exactly what a case-sensitive
+        # metadataHeaders=["From", "To", "Subject", "Date"] filter drops.
+        return MagicMock(
+            returncode=0,
+            stdout=json.dumps({
+                "id": "msg1",
+                "threadId": "thread1",
+                "snippet": "hi",
+                "labelIds": ["INBOX"],
+                "payload": {
+                    "headers": [
+                        {"name": "from", "value": "alice@example.com"},
+                        {"name": "to", "value": "bob@example.com"},
+                        {"name": "subject", "value": "lower-case headers"},
+                        {"name": "date", "value": "Mon, 1 Jun 2026 00:00:00 +0000"},
+                    ]
+                },
+            }),
+            stderr="",
+        )
+
+    args = api_module.argparse.Namespace(query="is:unread", max=10, func=api_module.gmail_search)
+
+    with patch.object(api_module.subprocess, "run", side_effect=capture_run):
+        with patch("builtins.print") as mock_print:
+            api_module.gmail_search(args)
+
+    # The "get" call must not restrict headers by name.
+    get_cmd = calls[1]
+    if "--params" in get_cmd:
+        params = json.loads(get_cmd[get_cmd.index("--params") + 1])
+        assert "metadataHeaders" not in params
+
+    # And the parsed output must still surface to/subject despite the
+    # lower-case header names in the raw response.
+    printed = mock_print.call_args[0][0]
+    output = json.loads(printed)
+    assert output[0]["to"] == "bob@example.com"
+    assert output[0]["subject"] == "lower-case headers"
+
+
+def test_api_gmail_reply_does_not_filter_by_metadata_headers(api_module):
+    """gmail_reply must not pass metadataHeaders to the gws get call either.
+
+    Same root cause as test_api_gmail_search_does_not_filter_by_metadata_headers
+    (issue #34806 follow-up): the original message's From/Subject/Message-ID
+    headers can come back lower-case, and a metadataHeaders filter drops them
+    before _headers_dict() ever sees them -- breaking the reply's To header,
+    subject line, and In-Reply-To/References threading.
+    """
+    calls = []
+
+    def capture_run(cmd, **kwargs):
+        calls.append(cmd)
+        if "get" in cmd:
+            return MagicMock(
+                returncode=0,
+                stdout=json.dumps({
+                    "id": "orig1",
+                    "threadId": "thread1",
+                    "payload": {
+                        "headers": [
+                            {"name": "from", "value": "alice@example.com"},
+                            {"name": "subject", "value": "lower-case headers"},
+                            {"name": "message-id", "value": "<abc123@mail.example.com>"},
+                        ]
+                    },
+                }),
+                stderr="",
+            )
+        return MagicMock(
+            returncode=0,
+            stdout=json.dumps({"id": "sent1", "threadId": "thread1"}),
+            stderr="",
+        )
+
+    args = api_module.argparse.Namespace(
+        message_id="orig1", body="reply body", from_header="", func=api_module.gmail_reply,
+    )
+
+    with patch.object(api_module.subprocess, "run", side_effect=capture_run):
+        with patch("builtins.print"):
+            api_module.gmail_reply(args)
+
+    get_cmd = calls[0]
+    if "--params" in get_cmd:
+        params = json.loads(get_cmd[get_cmd.index("--params") + 1])
+        assert "metadataHeaders" not in params
+
+    # The outgoing raw MIME message must still have picked up the To/Subject
+    # despite the lower-case header names in the raw response.
+    send_cmd = calls[1]
+    body = json.loads(send_cmd[send_cmd.index("--json") + 1])
+    raw = base64.urlsafe_b64decode(body["raw"]).decode()
+    assert "To: alice@example.com" in raw
+    assert "Subject: Re: lower-case headers" in raw
+    assert "In-Reply-To: <abc123@mail.example.com>" in raw
+
+
+def test_api_gmail_search_direct_client_does_not_filter_by_metadata_headers(
+    api_module, monkeypatch
+):
+    """Same regression as the gws-binary test, but for the direct
+    googleapiclient fallback path (no gws binary installed).
+
+    Per review on #77067: the shared api_module fixture forces
+    _gws_binary() to a real path, so the direct-client branch of
+    gmail_search() was never exercised by any existing test.
+    """
+    monkeypatch.setattr(api_module, "_gws_binary", lambda: None)
+
+    fake_service = MagicMock()
+    fake_service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+        "messages": [{"id": "msg1"}]
+    }
+    fake_service.users.return_value.messages.return_value.get.return_value.execute.return_value = {
+        "id": "msg1",
+        "threadId": "thread1",
+        "snippet": "hi",
+        "labelIds": ["INBOX"],
+        "payload": {
+            "headers": [
+                {"name": "from", "value": "alice@example.com"},
+                {"name": "to", "value": "bob@example.com"},
+                {"name": "subject", "value": "lower-case headers"},
+                {"name": "date", "value": "Mon, 1 Jun 2026 00:00:00 +0000"},
+            ]
+        },
+    }
+    monkeypatch.setattr(api_module, "build_service", lambda *a, **k: fake_service)
+
+    args = api_module.argparse.Namespace(query="is:unread", max=10, func=api_module.gmail_search)
+
+    with patch("builtins.print") as mock_print:
+        api_module.gmail_search(args)
+
+    get_call = fake_service.users.return_value.messages.return_value.get.call_args
+    assert "metadataHeaders" not in get_call.kwargs
+
+    printed = mock_print.call_args[0][0]
+    output = json.loads(printed)
+    assert output[0]["to"] == "bob@example.com"
+    assert output[0]["subject"] == "lower-case headers"
+
+
+def test_api_gmail_reply_direct_client_does_not_filter_by_metadata_headers(
+    api_module, monkeypatch
+):
+    """Direct googleapiclient fallback path for gmail_reply -- see
+    test_api_gmail_search_direct_client_does_not_filter_by_metadata_headers.
+    """
+    monkeypatch.setattr(api_module, "_gws_binary", lambda: None)
+
+    fake_service = MagicMock()
+    fake_service.users.return_value.messages.return_value.get.return_value.execute.return_value = {
+        "id": "orig1",
+        "threadId": "thread1",
+        "payload": {
+            "headers": [
+                {"name": "from", "value": "alice@example.com"},
+                {"name": "subject", "value": "lower-case headers"},
+                {"name": "message-id", "value": "<abc123@mail.example.com>"},
+            ]
+        },
+    }
+    fake_service.users.return_value.messages.return_value.send.return_value.execute.return_value = {
+        "id": "sent1", "threadId": "thread1",
+    }
+    monkeypatch.setattr(api_module, "build_service", lambda *a, **k: fake_service)
+
+    args = api_module.argparse.Namespace(
+        message_id="orig1", body="reply body", from_header="", func=api_module.gmail_reply,
+    )
+
+    with patch("builtins.print"):
+        api_module.gmail_reply(args)
+
+    get_call = fake_service.users.return_value.messages.return_value.get.call_args
+    assert "metadataHeaders" not in get_call.kwargs
+
+    send_call = fake_service.users.return_value.messages.return_value.send.call_args
+    raw = base64.urlsafe_b64decode(send_call.kwargs["body"]["raw"]).decode()
+    assert "To: alice@example.com" in raw
+    assert "Subject: Re: lower-case headers" in raw
+    assert "In-Reply-To: <abc123@mail.example.com>" in raw
 
 
 def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, monkeypatch):


### PR DESCRIPTION
## What does this PR do?
`gmail_search` requests Gmail message headers with `metadataHeaders=["From","To","Subject","Date"]`. This filter matches header names **case-sensitively** against the raw MIME source. Senders that emit `to:`/`SUBJECT:` instead of `To:`/`Subject:` had those headers silently dropped by Gmail's API before they ever reached `_headers_dict()` — even though that function already normalizes case on the way out. The result: search results silently show an empty `to`/`subject` for some messages.

The fix removes the `metadataHeaders` filter entirely. `format=metadata` already excludes body/payload, so dropping the filter costs nothing extra and returns every header regardless of case, letting the existing case-insensitive lookup work as intended.

## Related Issue
Fixes #34806

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made
- `skills/productivity/google-workspace/scripts/google_api.py`: removed the `metadataHeaders` filter from both `gmail_search` code paths (the `gws` binary path and the direct `googleapiclient` path)
- `tests/skills/test_google_workspace_api.py`: added `test_api_gmail_search_does_not_filter_by_metadata_headers`, which mocks a message with lower-case headers and asserts `to`/`subject` survive, and that `metadataHeaders` is no longer sent

## How to Test
1. Check out this branch and install deps: `uv pip install -e ".[all,dev]"`
2. Run `python3 -m pytest tests/skills/test_google_workspace_api.py -v`
3. All 5 tests pass. Reverting only the `google_api.py` change (keeping the new test) makes the new test fail with `AssertionError: assert 'metadataHeaders' not in {...}`, confirming it's a real regression test for a real bug.

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping
- [x] N/A — no doc/config/architecture changes needed for this fix

