### PR TITLE
fix(auth): read provider keys from live dotenv

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -46,6 +46,7 @@ import httpx
 from hermes_cli.config import (
     get_hermes_home,
     get_config_path,
+    get_env_value_prefer_dotenv,
     read_raw_config,
     require_readable_config_before_write,
 )
@@ -1767,7 +1768,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
         for env_var in pconfig.api_key_env_vars:
             if env_var in _IMPLICIT_ENV_VARS:
                 continue
-            if has_usable_secret(os.getenv(env_var, "")):
+            if has_usable_secret(get_env_value_prefer_dotenv(env_var) or ""):
                 return True
 
     # 4. Check persisted credential-pool entries that came from EXPLICIT flows
@@ -1786,7 +1787,9 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
                 # the user deletes the env var (#55790) — only count it when
                 # the referenced var still resolves to a usable secret NOW.
                 env_var = entry.get("source", "").split(":", 1)[1].strip()
-                if env_var and has_usable_secret(os.getenv(env_var, "")):
+                if env_var and has_usable_secret(
+                    get_env_value_prefer_dotenv(env_var) or ""
+                ):
                     return True
                 continue
             if (

--- a/tests/hermes_cli/test_auth_explicit_provider.py
+++ b/tests/hermes_cli/test_auth_explicit_provider.py
@@ -1,0 +1,24 @@
+"""Regression tests for explicit provider detection."""
+
+
+def test_provider_env_value_is_read_live_from_dotenv(monkeypatch, tmp_path):
+    """Provider pickers see credentials added to .env without a restart."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+
+    assert is_provider_explicitly_configured("anthropic") is False
+
+    (hermes_home / ".env").write_text(
+        "ANTHROPIC_API_KEY=dotenv-key-for-test\n",
+        encoding="utf-8",
+    )
+
+    assert is_provider_explicitly_configured("anthropic") is True


### PR DESCRIPTION
## Summary

- use Hermes's live dotenv resolver when checking explicitly configured provider API keys
- keep persisted `env:` credential-pool entries consistent with the same resolver
- add a regression test covering a key added to `.env` while the process is running

## Test plan

- `uv run --extra dev pytest -q tests/hermes_cli/test_auth_explicit_provider.py`
- `uv run --extra dev ruff check hermes_cli/auth.py tests/hermes_cli/test_auth_explicit_provider.py`

Fixes #77007