### PR TITLE
fix(security): warn on unknown website blocklist keys

### DIFF
--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -181,6 +181,37 @@ def test_browser_navigate_allows_when_shared_file_missing(monkeypatch, tmp_path)
     assert result is None
 
 
+def test_load_website_blocklist_warns_on_unknown_keys(tmp_path, caplog):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": {
+                        "enabled": True,
+                        "domains": ["example.com"],
+                        "shared_file": "/tmp/typo.txt",
+                        1: "non-string-key",
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("WARNING", logger="tools.website_policy"):
+        policy = load_website_blocklist(config_path)
+
+    assert policy["rules"] == [
+        {"pattern": "example.com", "source": "config"},
+    ]
+    blocked = check_website_access("https://example.com", config_path=config_path)
+    assert blocked is not None
+    assert blocked["rule"] == "example.com"
+    assert "Unknown security.website_blocklist keys ignored: 1, shared_file" in caplog.text
+
+
 class TestWebToolPolicy:
     """Tests that exercise web_extract_tool with website-policy gates.
 

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -123,6 +123,13 @@ def _load_policy_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
     if not isinstance(website_blocklist, dict):
         raise WebsitePolicyError("security.website_blocklist must be a mapping")
 
+    unknown_keys = set(website_blocklist) - set(_DEFAULT_WEBSITE_BLOCKLIST)
+    if unknown_keys:
+        logger.warning(
+            "Unknown security.website_blocklist keys ignored: %s",
+            ", ".join(sorted(map(str, unknown_keys))),
+        )
+
     policy = dict(_DEFAULT_WEBSITE_BLOCKLIST)
     policy.update(website_blocklist)
     return policy


### PR DESCRIPTION
## Summary

- warn when `security.website_blocklist` contains unknown keys
- preserve the existing fail-open behavior and valid policy parsing
- add regression coverage for a misspelled `shared_files` key

## Test plan

- `uv run --extra dev pytest -q tests/tools/test_website_policy.py`
- `uv run --extra dev ruff check tools/website_policy.py tests/tools/test_website_policy.py`

Fixes #76946