### PR TITLE
feat(telegram): make processing reactions configurable

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9783,6 +9783,14 @@ class TelegramAdapter(BasePlatformAdapter):
 
     # ── Message reactions (processing lifecycle) ──────────────────────────
 
+    def _processing_reaction(self, name: str, default: str) -> str:
+        """Return a configured processing reaction emoji, or its default."""
+        extra = getattr(getattr(self, "config", None), "extra", None) or {}
+        value = extra.get(name, default)
+        if value is None or str(value).strip().lower() in {"", "clear", "none"}:
+            return ""
+        return str(value)
+
     def _reactions_enabled(self) -> bool:
         """Check if message reactions are enabled via config/env."""
         return os.getenv("TELEGRAM_REACTIONS", "false").lower() not in {"false", "0", "no"}
@@ -9830,7 +9838,9 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if chat_id and message_id:
-            await self._set_reaction(chat_id, message_id, "\U0001f440")
+            reaction = self._processing_reaction("reactions_on_receive", "\U0001f440")
+            if reaction:
+                await self._set_reaction(chat_id, message_id, reaction)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Swap the in-progress reaction for a final success/failure reaction.
@@ -9854,11 +9864,14 @@ class TelegramAdapter(BasePlatformAdapter):
         if outcome == ProcessingOutcome.CANCELLED:
             await self._clear_reactions(chat_id, message_id)
         else:
-            await self._set_reaction(
-                chat_id,
-                message_id,
+            reaction = self._processing_reaction(
+                "reactions_on_success" if outcome == ProcessingOutcome.SUCCESS else "reactions_on_failure",
                 "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
             )
+            if reaction:
+                await self._set_reaction(chat_id, message_id, reaction)
+            else:
+                await self._clear_reactions(chat_id, message_id)
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -10,12 +10,12 @@ from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
 from gateway.session import SessionSource
 
 
-def _make_adapter(**extra_env):
+def _make_adapter(extra=None, **extra_env):
     from plugins.platforms.telegram.adapter import TelegramAdapter
 
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
-    adapter.config = PlatformConfig(enabled=True, token="fake-token")
+    adapter.config = PlatformConfig(enabled=True, token="fake-token", extra=extra or {})
     adapter._bot = AsyncMock()
     adapter._bot.set_message_reaction = AsyncMock()
     return adapter
@@ -92,7 +92,61 @@ async def test_on_processing_start_handles_missing_ids(monkeypatch):
     adapter._bot.set_message_reaction.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_on_processing_start_uses_configured_reaction(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter(extra={"reactions_on_receive": "🔧"})
+
+    await adapter.on_processing_start(_make_event())
+
+    adapter._bot.set_message_reaction.assert_awaited_once_with(
+        chat_id=123,
+        message_id=456,
+        reaction="🔧",
+    )
+
+
+@pytest.mark.parametrize("suppressed", ["", "clear"])
+@pytest.mark.asyncio
+async def test_on_processing_start_can_be_suppressed(monkeypatch, suppressed):
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter(extra={"reactions_on_receive": suppressed})
+
+    await adapter.on_processing_start(_make_event())
+
+    adapter._bot.set_message_reaction.assert_not_awaited()
+
+
 # ── on_processing_complete ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_processing_complete_uses_configured_success_reaction(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter(extra={"reactions_on_success": "✅"})
+
+    await adapter.on_processing_complete(_make_event(), ProcessingOutcome.SUCCESS)
+
+    adapter._bot.set_message_reaction.assert_awaited_once_with(
+        chat_id=123,
+        message_id=456,
+        reaction="✅",
+    )
+
+
+@pytest.mark.parametrize("suppressed", ["", "clear", "none"])
+@pytest.mark.asyncio
+async def test_on_processing_complete_clears_suppressed_failure_reaction(monkeypatch, suppressed):
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter(extra={"reactions_on_failure": suppressed})
+
+    await adapter.on_processing_complete(_make_event(), ProcessingOutcome.FAILURE)
+
+    adapter._bot.set_message_reaction.assert_awaited_once_with(
+        chat_id=123,
+        message_id=456,
+        reaction=None,
+    )
 
 
 @pytest.mark.asyncio

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1199,8 +1199,8 @@ This covers the custom fallback transport layer that Hermes uses for Telegram co
 The bot can add emoji reactions to messages as visual processing feedback:
 
 - 👀 when the bot starts processing your message
-- ✅ when the response is delivered successfully
-- ❌ if an error occurs during processing
+- 👍 when processing succeeds
+- 👎 if processing fails
 
 Reactions are **disabled by default**. Enable them in `config.yaml`:
 
@@ -1209,7 +1209,23 @@ telegram:
   reactions: true
 ```
 
-Or via environment variable:
+You can customize or suppress each lifecycle reaction under the Telegram
+platform's `extra` settings:
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      reactions_on_receive: "👀"
+      reactions_on_success: "👍"
+      reactions_on_failure: "👎"
+```
+
+Use `""`, `clear`, or `none` to suppress an individual reaction. When a
+completion reaction is suppressed, Hermes clears the in-progress reaction so
+it does not remain stuck on the message.
+
+Or enable reactions via environment variable:
 
 ```bash
 TELEGRAM_REACTIONS=true


### PR DESCRIPTION
## Summary

- allow Telegram processing reaction emojis to be configured under `platforms.telegram.extra`
- support separate receive, success, and failure reactions
- allow an empty value to suppress an individual reaction while preserving cancellation cleanup
- add regression coverage for custom and suppressed reactions

Supported keys:

```yaml
platforms:
  telegram:
    extra:
      reactions_on_receive: "👀"
      reactions_on_success: "👍"
      reactions_on_failure: "👎"
```

## Test plan

- `uv run --extra dev --extra messaging pytest -q tests/gateway/test_telegram_reactions.py`
- `uv run --extra dev --extra messaging ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_reactions.py`

Fixes #49570