### PR TITLE
fix(desktop): allow updater-managed gateway through preflight

### DIFF
--- a/apps/desktop/electron/venv-blocker-scan.test.ts
+++ b/apps/desktop/electron/venv-blocker-scan.test.ts
@@ -15,8 +15,10 @@ import path from 'node:path'
 import { describe, it } from 'vitest'
 
 import {
+  filterUpdaterManagedBlockers,
   formatBlockerMessage,
   formatProbeFailedMessage,
+  isUpdaterManagedGatewayBlocker,
   parseVenvBlockerScanOutput,
   resolveVenvPython,
   scanVenvBlockers
@@ -147,6 +149,55 @@ describe('parseVenvBlockerScanOutput', () => {
   })
 })
 
+describe('updater-managed gateway filtering', () => {
+  const gateway = {
+    pid: 37748,
+    name: 'python.exe',
+    cmdline: 'C:\\Hermes\\venv\\Scripts\\python.exe -m hermes_cli.main gateway run'
+  }
+
+  it('recognizes Python module and Hermes shim gateway commands', () => {
+    assert.equal(isUpdaterManagedGatewayBlocker(gateway), true)
+    assert.equal(
+      isUpdaterManagedGatewayBlocker({
+        pid: 2,
+        name: 'hermes.exe',
+        cmdline: 'C:\\Hermes\\venv\\Scripts\\hermes.exe -p default gateway run'
+      }),
+      true
+    )
+  })
+
+  it('does not exempt other Hermes processes', () => {
+    assert.equal(
+      isUpdaterManagedGatewayBlocker({
+        pid: 3,
+        name: 'python.exe',
+        cmdline: 'python.exe -m hermes_cli.main serve --host 0.0.0.0'
+      }),
+      false
+    )
+  })
+
+  it('clears a gateway-only scan because the CLI updater owns its lifecycle', () => {
+    assert.deepEqual(
+      filterUpdaterManagedBlockers({ kind: 'blocked', result: { blocked: true, processes: [gateway] } }),
+      { kind: 'clear', result: { blocked: false, processes: [] } }
+    )
+  })
+
+  it('preserves unrelated blockers while removing the managed gateway', () => {
+    const serve = { pid: 4, name: 'python.exe', cmdline: 'python.exe -m hermes_cli.main serve' }
+    assert.deepEqual(
+      filterUpdaterManagedBlockers({
+        kind: 'blocked',
+        result: { blocked: true, processes: [gateway, serve] }
+      }),
+      { kind: 'blocked', result: { blocked: true, processes: [serve] } }
+    )
+  })
+})
+
 // ---------------------------------------------------------------------------
 // scanVenvBlockers — subprocess with injection
 // ---------------------------------------------------------------------------
@@ -180,6 +231,22 @@ describe('scanVenvBlockers', () => {
 
   it('blocked scan returns blocked', async () => {
     assert.equal((await scanVenvBlockers('/r', execReturn(blockedJson), stubVenv)).kind, 'blocked')
+  })
+
+  it('gateway-only scan returns clear so the CLI updater can stop it', async () => {
+    const gatewayJson = JSON.stringify({
+      ok: true,
+      blocked: true,
+      processes: [
+        {
+          pid: 37748,
+          name: 'python.exe',
+          cmdline: 'C:\\Hermes\\venv\\Scripts\\python.exe -m hermes_cli.main gateway run'
+        }
+      ]
+    })
+
+    assert.equal((await scanVenvBlockers('/r', execReturn(gatewayJson), stubVenv)).kind, 'clear')
   })
 
   it('non-zero exit is probe-failure', async () => {

--- a/apps/desktop/electron/venv-blocker-scan.ts
+++ b/apps/desktop/electron/venv-blocker-scan.ts
@@ -34,6 +34,31 @@ export type ScanOutcome =
   | { kind: 'blocked'; result: VenvBlockerScanResult }
   | { kind: 'probe-failure'; error: string }
 
+/**
+ * The CLI updater owns the messaging gateway lifecycle: it stops enabled
+ * gateway profiles before replacing the venv and restarts them afterwards.
+ * Desktop's earlier preflight must not reject that managed process before the
+ * CLI updater gets a chance to stop it.
+ */
+export function isUpdaterManagedGatewayBlocker(proc: VenvBlockerProcess): boolean {
+  const cmdline = proc.cmdline.replace(/["']/g, ' ')
+
+  return (
+    /(?:^|\s)-m\s+hermes_cli\.main\s+(?:-p\s+\S+\s+)?gateway\s+run(?:\s|$)/i.test(cmdline) ||
+    /(?:^|\s)(?:\S*[\\/])?hermes(?:\.exe)?\s+(?:-p\s+\S+\s+)?gateway\s+run(?:\s|$)/i.test(cmdline)
+  )
+}
+
+export function filterUpdaterManagedBlockers(outcome: ScanOutcome): ScanOutcome {
+  if (outcome.kind !== 'blocked') return outcome
+
+  const processes = outcome.result.processes.filter((proc) => !isUpdaterManagedGatewayBlocker(proc))
+
+  return processes.length > 0
+    ? { kind: 'blocked', result: { blocked: true, processes } }
+    : { kind: 'clear', result: { blocked: false, processes: [] } }
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -148,7 +173,7 @@ export async function scanVenvBlockers(
     return { kind: 'probe-failure', error: diag.join('; ') }
   }
 
-  return parseVenvBlockerScanOutput(stdout)
+  return filterUpdaterManagedBlockers(parseVenvBlockerScanOutput(stdout))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Allow the Hermes messaging gateway through Desktop's early venv blocker preflight.
- Leave all unrelated venv holders fail-closed.
- Let the CLI updater perform its existing stop/restart lifecycle for gateway profiles.

## Reproduction

On Windows, a running `python.exe -m hermes_cli.main gateway run` inside the managed venv caused Desktop to abort before launching the CLI updater. The CLI updater already stops and restarts this gateway safely, but could never be reached.

## Tests

- `venv-blocker-scan.test.ts`: 25 passed, including gateway-only and mixed-blocker regressions.
- Updater test sweep: 72 passed; one unrelated Windows-only `update-relaunch.test.ts` path assertion fails because its POSIX fixture is normalized with Windows `path.join`.
- Real Windows Desktop update completed from `710b026` to `d0b87da`, rebuilt/relaunched, and restored the gateway.
