### PR TITLE
fix(agent): suppress Gemini interim narration on tool-call turns

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3024,6 +3024,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         model_name = None
         role = "assistant"
         reasoning_parts: list = []
+        # #76997: Vertex's OpenAI-compat layer for Gemini 3.x emits the model's
+        # pre-tool narration ("Locating Files", ...) as ordinary delta.content
+        # (native Gemini classifies it as reasoning). Buffer pre-tool-call content
+        # for Gemini-family models on the OpenAI-compat path; when the turn turns
+        # out to carry tool calls the narration is routed to reasoning instead of
+        # streaming as normal assistant content / persisting into history.
+        _gemini_turn = (
+            "gemini" in str(agent.model or "").lower()
+            or "gemma" in str(agent.model or "").lower()
+        ) and not is_native_gemini_base_url(agent.base_url)
+        _gemini_pending: list = []
         usage_obj = None
         _diag = agent._stream_diag_init()
         request_client_holder["diag"] = _diag
@@ -3214,31 +3225,49 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
 
             # Accumulate text content — fire callback only when no tool calls
             if delta and delta.content:
-                content_parts.append(delta.content)
-                if not tool_calls_acc:
-                    _fire_first_delta()
-                    agent._fire_stream_delta(delta.content)
-                    deltas_were_sent["yes"] = True
-                # Tool calls suppress regular content streaming (avoids
-                # displaying chatty "I'll use the tool..." text alongside
-                # tool calls).  But reasoning tags embedded in suppressed
-                # content should still reach the display — otherwise the
-                # reasoning box only appears as a post-response fallback,
-                # rendering it confusingly after the already-streamed
-                # response.  Route suppressed content through the stream
-                # delta callback so its tag extraction can fire the
-                # reasoning display.  Non-reasoning text is harmlessly
-                # suppressed by the CLI's _stream_delta when the stream
-                # box is already closed (tool boundary flush).
-                elif agent.stream_delta_callback:
-                    try:
-                        agent.stream_delta_callback(delta.content)
-                        agent._record_streamed_assistant_text(delta.content)
-                    except Exception:
-                        pass
+                if _gemini_turn and not tool_calls_acc:
+                    # #76997: Gemini via Vertex OpenAI-compat narrates BEFORE the
+                    # first tool_call delta, so tool_calls_acc is still empty here
+                    # and the narration would stream as normal content. Buffer it;
+                    # the first tool-call delta routes it to reasoning instead.
+                    _gemini_pending.append(delta.content)
+                else:
+                    content_parts.append(delta.content)
+                    if not tool_calls_acc:
+                        _fire_first_delta()
+                        agent._fire_stream_delta(delta.content)
+                        deltas_were_sent["yes"] = True
+                    # Tool calls suppress regular content streaming (avoids
+                    # displaying chatty "I'll use the tool..." text alongside
+                    # tool calls).  But reasoning tags embedded in suppressed
+                    # content should still reach the display — otherwise the
+                    # reasoning box only appears as a post-response fallback,
+                    # rendering it confusingly after the already-streamed
+                    # response.  Route suppressed content through the stream
+                    # delta callback so its tag extraction can fire the
+                    # reasoning display.  Non-reasoning text is harmlessly
+                    # suppressed by the CLI's _stream_delta when the stream
+                    # box is already closed (tool boundary flush).
+                    elif agent.stream_delta_callback:
+                        try:
+                            agent.stream_delta_callback(delta.content)
+                            agent._record_streamed_assistant_text(delta.content)
+                        except Exception:
+                            pass
 
             # Accumulate tool call deltas — notify display on first name
             if delta and delta.tool_calls:
+                # #76997: first tool-call delta of a Gemini OpenAI-compat turn —
+                # the buffered pre-tool narration is interim progress, not answer
+                # content. Route it to reasoning so it stays out of the visible
+                # response and out of persisted history.
+                if _gemini_pending:
+                    _pending_text = "".join(_gemini_pending)
+                    _gemini_pending.clear()
+                    if _pending_text:
+                        reasoning_parts.append(_pending_text)
+                        _fire_first_delta()
+                        agent._fire_reasoning_delta(_pending_text)
                 for tc_delta in delta.tool_calls:
                     raw_idx = tc_delta.index if tc_delta.index is not None else 0
                     delta_id = tc_delta.id or ""
@@ -3319,6 +3348,18 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 usage_obj = chunk.usage
 
         _close_managed_stream()
+
+        # #76997: Gemini OpenAI-compat turn ended with buffered narration but NO
+        # tool calls — the buffered text was the real answer; release it as
+        # content (and stream it) instead of dropping it.
+        if _gemini_pending:
+            _pending_text = "".join(_gemini_pending)
+            _gemini_pending.clear()
+            if _pending_text:
+                content_parts.append(_pending_text)
+                _fire_first_delta()
+                agent._fire_stream_delta(_pending_text)
+                deltas_were_sent["yes"] = True
 
         if _stream_attempt_was_cancelled(stream_attempt_id):
             raise _httpx.RemoteProtocolError(

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -757,6 +757,25 @@ class ChatCompletionsTransport(ProviderTransport):
                 if finish_reason in (None, "stop"):
                     finish_reason = "content_filter"
 
+        # #76997: Vertex's OpenAI-compat layer for Gemini 3.x puts the model's
+        # pre-tool narration ("Locating Files", ...) in plain ``content`` on
+        # tool-call turns (native Gemini classifies it as reasoning). Relocate it
+        # to ``reasoning_content`` so it is neither delivered as normal assistant
+        # content nor persisted into session history.
+        if (
+            content
+            and tool_calls
+            and _model_consumes_thought_signature(
+                kwargs.get("model") or getattr(response, "model", None)
+            )
+        ):
+            if isinstance(reasoning_content, str) and reasoning_content:
+                reasoning_content = reasoning_content + str(content)
+            else:
+                reasoning_content = str(content)
+            provider_data["reasoning_content"] = reasoning_content
+            content = None
+
         return NormalizedResponse(
             content=content,
             tool_calls=tool_calls,

--- a/tests/agent/transports/test_chat_completions_gemini_narration.py
+++ b/tests/agent/transports/test_chat_completions_gemini_narration.py
@@ -1,0 +1,98 @@
+"""Tests for issue #76997: non-streaming Gemini tool-turn narration relocation.
+
+Vertex's OpenAI-compat layer for Gemini 3.x returns the model's pre-tool
+narration in plain ``content`` on tool-call turns. ``normalize_response``
+relocates it to ``reasoning_content`` so it is neither delivered as normal
+assistant content nor persisted into session history.
+"""
+
+from types import SimpleNamespace
+
+from agent.transports.chat_completions import ChatCompletionsTransport
+
+
+def _make_choice(message, finish_reason="tool_calls"):
+    return SimpleNamespace(index=0, message=message, finish_reason=finish_reason)
+
+
+def _make_tool_call(name="read_file", arguments='{"path":"/tmp/a"}'):
+    return SimpleNamespace(
+        id="call_1",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _make_message(content, tool_calls):
+    return SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning=None,
+        reasoning_content=None,
+        model_extra=None,
+        refusal=None,
+    )
+
+
+def test_gemini_tool_turn_content_relocated_to_reasoning():
+    transport = ChatCompletionsTransport()
+    msg = _make_message("Locating Files", [_make_tool_call()])
+    response = SimpleNamespace(
+        choices=[_make_choice(msg)],
+        model="gemini-3.5-flash",
+        usage=None,
+    )
+
+    normalized = transport.normalize_response(response, model="gemini-3.5-flash")
+
+    assert normalized.content is None
+    assert normalized.tool_calls is not None
+    assert normalized.provider_data.get("reasoning_content") == "Locating Files"
+
+
+def test_gemini_tool_turn_reasoning_merged():
+    """Existing reasoning_content is preserved and narration appended."""
+    transport = ChatCompletionsTransport()
+    msg = _make_message("Locating Files", [_make_tool_call()])
+    msg.reasoning_content = "previous thought"
+    response = SimpleNamespace(
+        choices=[_make_choice(msg)],
+        model="gemini-3.5-flash",
+        usage=None,
+    )
+
+    normalized = transport.normalize_response(response, model="gemini-3.5-flash")
+
+    assert normalized.content is None
+    assert normalized.provider_data.get("reasoning_content") == "previous thoughtLocating Files"
+
+
+def test_non_gemini_tool_turn_unchanged():
+    transport = ChatCompletionsTransport()
+    msg = _make_message("Reading file...", [_make_tool_call()])
+    response = SimpleNamespace(
+        choices=[_make_choice(msg)],
+        model="gpt-5.5",
+        usage=None,
+    )
+
+    normalized = transport.normalize_response(response, model="gpt-5.5")
+
+    assert normalized.content == "Reading file..."
+    assert normalized.tool_calls is not None
+    assert normalized.provider_data is None or "reasoning_content" not in normalized.provider_data
+
+
+def test_gemini_text_turn_unchanged():
+    """No tool calls -> content is the real answer; never relocated."""
+    transport = ChatCompletionsTransport()
+    msg = _make_message("Here is the answer.", None)
+    response = SimpleNamespace(
+        choices=[_make_choice(msg, finish_reason="stop")],
+        model="gemini-3.5-flash",
+        usage=None,
+    )
+
+    normalized = transport.normalize_response(response, model="gemini-3.5-flash")
+
+    assert normalized.content == "Here is the answer."

--- a/tests/run_agent/test_gemini_narration_suppression.py
+++ b/tests/run_agent/test_gemini_narration_suppression.py
@@ -1,0 +1,157 @@
+"""Tests for issue #76997: Vertex Gemini interim narration suppression.
+
+Vertex's OpenAI-compat layer for Gemini 3.x emits the model's pre-tool
+narration ("Locating Files", ...) as ordinary ``delta.content``. The fix
+buffers that content for Gemini-family models on the OpenAI-compat path and
+routes it to reasoning when the turn carries tool calls, so it is neither
+streamed as normal assistant content nor persisted into history. Native Gemini
+and non-Gemini providers keep the previous behavior.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _make_stream_chunk(content=None, tool_calls=None, finish_reason=None, model=None):
+    delta = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    choice = SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model=model, usage=None)
+
+
+def _make_tool_call_delta(index=0, tc_id=None, name=None, arguments=None):
+    func = SimpleNamespace(name=name, arguments=arguments)
+    return SimpleNamespace(index=index, id=tc_id, function=func)
+
+
+def _build_agent(model, base_url, provider=None):
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url=base_url,
+        model=model,
+        provider=provider or "openai",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    return agent
+
+
+_VERTEX_OPENAI_COMPAT_URL = (
+    "https://us-central1-aiplatform.googleapis.com/v1beta1/"
+    "projects/p/locations/us-central1/endpoints/openapi"
+)
+
+
+@patch("run_agent.AIAgent._create_request_openai_client")
+@patch("run_agent.AIAgent._close_request_openai_client")
+def test_gemini_vertex_narration_routed_to_reasoning(mock_close, mock_create):
+    """Pre-tool narration on Vertex Gemini is not visible content nor persisted."""
+    chunks = [
+        _make_stream_chunk(content="Locating Files", model="gemini-3.5-flash"),
+        _make_stream_chunk(content="Exploring", model="gemini-3.5-flash"),
+        _make_stream_chunk(
+            tool_calls=[_make_tool_call_delta(0, "call_1", "read_file", '{"path":"/tmp/a"}')],
+            model="gemini-3.5-flash",
+        ),
+        _make_stream_chunk(finish_reason="tool_calls", model="gemini-3.5-flash"),
+    ]
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = iter(chunks)
+    mock_create.return_value = mock_client
+
+    agent = _build_agent("gemini-3.5-flash", _VERTEX_OPENAI_COMPAT_URL, provider="vertex")
+
+    response = agent._interruptible_streaming_api_call({})
+    msg = response.choices[0].message
+
+    # Narration must NOT appear as visible/persisted content...
+    assert not msg.content or "Locating" not in msg.content
+    assert not msg.content or "Exploring" not in msg.content
+    # ...but IS preserved as reasoning.
+    assert msg.reasoning_content and "Locating Files" in msg.reasoning_content
+    assert "Exploring" in msg.reasoning_content
+    # Tool call intact.
+    assert msg.tool_calls is not None
+    assert msg.tool_calls[0].function.name == "read_file"
+
+
+@patch("run_agent.AIAgent._create_request_openai_client")
+@patch("run_agent.AIAgent._close_request_openai_client")
+def test_gemini_vertex_plain_text_answer_released(mock_close, mock_create):
+    """A Gemini OpenAI-compat turn WITHOUT tool calls keeps its content."""
+    chunks = [
+        _make_stream_chunk(content="The answer", model="gemini-3.5-flash"),
+        _make_stream_chunk(content=" is 42.", finish_reason="stop", model="gemini-3.5-flash"),
+    ]
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = iter(chunks)
+    mock_create.return_value = mock_client
+
+    agent = _build_agent("gemini-3.5-flash", _VERTEX_OPENAI_COMPAT_URL, provider="vertex")
+
+    response = agent._interruptible_streaming_api_call({})
+    assert response.choices[0].message.content == "The answer is 42."
+    assert response.choices[0].message.tool_calls is None
+
+
+@patch("run_agent.AIAgent._create_request_openai_client")
+@patch("run_agent.AIAgent._close_request_openai_client")
+def test_native_gemini_streaming_unchanged(mock_close, mock_create):
+    """Native Gemini path (no OpenAI-compat) keeps token-by-token content."""
+    chunks = [
+        _make_stream_chunk(content="Locating Files", model="gemini-3.5-flash"),
+        _make_stream_chunk(
+            tool_calls=[_make_tool_call_delta(0, "call_1", "read_file", '{"path":"/tmp/a"}')],
+            model="gemini-3.5-flash",
+        ),
+        _make_stream_chunk(finish_reason="tool_calls", model="gemini-3.5-flash"),
+    ]
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = iter(chunks)
+    mock_create.return_value = mock_client
+
+    agent = _build_agent(
+        "gemini-3.5-flash",
+        "https://generativelanguage.googleapis.com/v1beta",
+        provider="gemini",
+    )
+
+    response = agent._interruptible_streaming_api_call({})
+    msg = response.choices[0].message
+    # Native path is not buffered: narration remains content (pre-existing shape).
+    assert msg.content and "Locating Files" in msg.content
+    assert msg.tool_calls is not None
+
+
+@patch("run_agent.AIAgent._create_request_openai_client")
+@patch("run_agent.AIAgent._close_request_openai_client")
+def test_non_gemini_vertex_behavior_unchanged(mock_close, mock_create):
+    """Non-Gemini models on the same OpenAI-compat path keep current behavior."""
+    chunks = [
+        _make_stream_chunk(content="Reading file...", model="gpt-5.5"),
+        _make_stream_chunk(
+            tool_calls=[_make_tool_call_delta(0, "call_1", "read_file", '{"path":"/tmp/a"}')],
+            model="gpt-5.5",
+        ),
+        _make_stream_chunk(finish_reason="tool_calls", model="gpt-5.5"),
+    ]
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = iter(chunks)
+    mock_create.return_value = mock_client
+
+    agent = _build_agent("gpt-5.5", _VERTEX_OPENAI_COMPAT_URL, provider="vertex")
+
+    response = agent._interruptible_streaming_api_call({})
+    msg = response.choices[0].message
+    # Pre-tool text remains as content (current behavior for non-Gemini).
+    assert msg.content and "Reading file..." in msg.content
+    assert msg.tool_calls is not None


### PR DESCRIPTION
## Summary
Vertex's OpenAI-compat layer for Gemini 3.x emits the model's pre-tool narration ("Locating Files", "Exploring Attachment Patterns", ...) as ordinary `delta.content`. This fix buffers that narration on the OpenAI-compat path and routes it to reasoning when the turn carries tool calls, so it is no longer displayed as normal assistant content, read aloud by TTS, or persisted into session history.

## Root Cause
The Vertex provider path is pure auth — requests flow through the generic OpenAI-compat Chat Completions transport (`agent/chat_completion_helpers.py` streaming loop + `agent/transports/chat_completions.py` `normalize_response`). Vertex's OpenAI-compat layer emits Gemini's pre-tool narration as plain `delta.content` **before** the first `delta.tool_calls` chunk, so the existing tool-call suppression (`tool_calls_acc` empty at that point) never engages and the text streams as a normal assistant turn. The native Gemini path classifies the same text as reasoning, which is why AI Studio shows no interim narration.

## Change
- `agent/chat_completion_helpers.py`: for Gemini-family models on the OpenAI-compat path (native Gemini base URLs excluded), pre-tool-call `delta.content` is buffered. When the first tool-call delta arrives, the buffered narration is routed to `reasoning_parts` / `_fire_reasoning_delta` (collapsed reasoning UI) instead of `_fire_stream_delta`. If the turn ends with **no** tool calls, the buffer is released as normal content (it was the real answer).
- `agent/transports/chat_completions.py`: `normalize_response` relocates Gemini tool-turn `content` into `reasoning_content` (merged with any existing reasoning) so non-streaming and replayed history stay clean.
- New tests: `tests/run_agent/test_gemini_narration_suppression.py` (Vertex narration → reasoning; plain-text turn preserved; native Gemini and non-Gemini paths unchanged) and `tests/agent/transports/test_chat_completions_gemini_narration.py` (normalizer relocation + merge + no-op cases).

## Verification
- New suites: 8 passed
- Related suites: `tests/run_agent/test_streaming.py`, `tests/agent/transports/test_chat_completions.py`, `tests/agent/test_gemini_native_adapter.py`, `tests/agent/test_vertex_adapter.py`, `tests/hermes_cli/test_vertex_provider.py` → 84 passed, 0 failed

Closes #76997
