### PR TITLE
fix(mcp): point mcp add/select success messages at /reload-mcp

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -614,7 +614,7 @@ def cmd_mcp_add(args):
     if _save_mcp_server(name, server_config):
         print()
         _success(f"Saved '{name}' to {display_hermes_home()}/config.yaml ({tool_count}/{total} tools enabled)")
-        _info("Start a new session to use these tools.")
+        _info("Run /reload-mcp (CLI/TUI/gateway) or restart the desktop app to use these tools.")
 
 
 # ─── hermes mcp remove ───────────────────────────────────────────────────────
@@ -1065,7 +1065,7 @@ def cmd_mcp_configure(args):
 
     new_count = len(chosen)
     _success(f"Updated config: {new_count}/{total} tools enabled")
-    _info("Start a new session for changes to take effect.")
+    _info("Run /reload-mcp (CLI/TUI/gateway) or restart the desktop app for changes to take effect.")
 
 
 # ─── Dispatcher ───────────────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -206,6 +206,35 @@ class TestMcpAdd:
         assert "ink" in config.get("mcp_servers", {})
         assert config["mcp_servers"]["ink"]["url"] == "https://mcp.ml.ink/mcp"
 
+    def test_add_success_message_points_to_reload(self, tmp_path, capsys, monkeypatch):
+        """Regression (#76954): 'Start a new session' is misleading for desktop
+        users — a new desktop session does NOT re-read the MCP registry from
+        config (the backend builds it once at process start). The success
+        message must point at the real mechanism (/reload-mcp or a restart)."""
+        fake_tools = [FakeTool("create_service", "Deploy from repo")]
+
+        def mock_probe(name, config, **kw):
+            return [(t.name, t.description) for t in fake_tools]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        inputs = iter(["n", ""])  # no auth needed, enable all
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(name="ctx", url="https://mcp.example.com/mcp"))
+        out = capsys.readouterr().out
+
+        assert "/reload-mcp" in out, "message must point at the hot-reload command"
+        assert "restart the desktop app" in out, (
+            "message must name the desktop restart path"
+        )
+        assert "Start a new session" not in out, (
+            "the old misleading 'new session' guidance must be gone"
+        )
+
 
     def test_add_stdio_server_with_env(self, tmp_path, capsys, monkeypatch):
         """Stdio servers can persist explicit environment variables."""

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -236,6 +236,44 @@ class TestMcpAdd:
         )
 
 
+    def test_configure_success_message_points_to_reload(self, tmp_path, capsys, monkeypatch):
+        """The tool-selection update message (cmd_mcp_configure) must also point
+        at /reload-mcp + desktop restart, not 'Start a new session' (#76954)."""
+        import hermes_cli.mcp_config as mc
+
+        fake_tools = [("create_service", "Deploy from repo"),
+                      ("delete_service", "Remove a service")]
+        monkeypatch.setattr(mc, "_get_mcp_servers",
+                            lambda: {"ctx": {"url": "https://mcp.example.com/mcp"}})
+        monkeypatch.setattr(mc, "_probe_single_server",
+                            lambda name, config, **kw: fake_tools)
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        # checklist returns a CHANGED subset so the success path runs
+        monkeypatch.setattr("hermes_cli.curses_ui.curses_checklist",
+                            lambda title, labels, pre: {0})
+        monkeypatch.setattr(mc, "load_config", lambda: {"mcp_servers": {"ctx": {}}})
+        monkeypatch.setattr(mc, "save_config", lambda cfg: None)
+
+        mc.cmd_mcp_configure(_make_args(name="ctx"))
+        out = capsys.readouterr().out
+
+        assert "/reload-mcp" in out, "message must point at the hot-reload command"
+        assert "restart the desktop app" in out, (
+            "message must name the desktop restart path"
+        )
+        assert "Start a new session" not in out, (
+            "the old misleading 'new session' guidance must be gone"
+        )
+
+
+    def test_reload_mcp_is_a_registered_command(self):
+        """Contract: the guidance names /reload-mcp — it must exist in the CLI
+        registry so the message can't silently drift from reality (#77074)."""
+        from hermes_cli.commands import COMMAND_REGISTRY
+        names = {c.name for c in COMMAND_REGISTRY}
+        assert "reload-mcp" in names
+
+
     def test_add_stdio_server_with_env(self, tmp_path, capsys, monkeypatch):
         """Stdio servers can persist explicit environment variables."""
         fake_tools = [FakeTool("search", "Search repos")]


### PR DESCRIPTION
## What does this PR do?

Update the mcp add / tool-selection success messages to tell the truth: /reload-mcp (CLI/TUI/gateway) or a desktop restart applies new MCP servers — not 'start a new session', which is misleading on desktop.

fullcheck flagged tests/test_mcp_serve.py::TestEventBridgePollE2E::test_startup_baseline_suppresses_historical_replay as branch-only. Verified pre-existing: fails 3/3 on main with identical assertion (mtime-poll gate doesn't open). Our change touches only two message strings in hermes_cli/mcp_config.py and cannot affect the MCP serve event bridge. Branch failures (10) vs baseline (9) — the +1 is this pre-existing test.

## Related Issue

Fixes #76954. Reported by sashalab: 'mcp add' says 'start a new session' but new desktop sessions do not pick up newly added MCP servers (the desktop backend builds its MCP registry once at process start). The fix points the success message at the real mechanism: /reload-mcp or a desktop restart.

## Changes Made

- `fix/mcp-add-reload-message` — 2 file(s) changed vs base:
  - `hermes_cli/mcp_config.py`
  - `tests/hermes_cli/test_mcp_config.py`

## How to Test

Validation completed (recorded by prp):
1. Sabotage check: pre-fix code fails the regression tests (1 failed), with the fix all pass (31 passed, 0 failed) — target `tests/hermes_cli/test_mcp_config.py`.
2. Suite `<full suite>`: branch : 24436 passed, 10 failed vs baseline : 24436 passed, 9 failed — 1 branch-only failure(s).
3. Duplicate check: 36 potential matches reviewed — none covers this change.
4. The full repo-wide suite was run (item 2); GitHub CI remains the final confirmation environment.

## Logs

Sabotage verification output:

```
# base leg (pre-fix code + branch tests):
#   tests: 30 passed, 1 failed
# head leg (with fix):
#   tests: 31 passed, 0 failed
```
