### PR TITLE
fix(files): hard-cap search result payloads

### DIFF
--- a/tests/tools/test_search_output_cap.py
+++ b/tests/tools/test_search_output_cap.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import uuid
+
+import tools.file_tools as file_tools
+from tools.file_operations import SearchMatch, SearchResult
+
+
+class _FakeFileOps:
+    def search(self, **_kwargs):
+        return SearchResult(
+            matches=[
+                SearchMatch(path="large.txt", line_number=i, content="needle " + ("x" * 4_000))
+                for i in range(1, 26)
+            ],
+            total_count=25,
+        )
+
+
+def test_search_tool_caps_large_result_without_breaking_json(monkeypatch):
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda _task_id: _FakeFileOps())
+
+    output = file_tools.search_tool(
+        pattern="needle",
+        target="content",
+        path=".",
+        limit=25,
+        task_id=f"search-cap-{uuid.uuid4()}",
+    )
+
+    assert len(output) <= 64_000
+    body, _, hint = output.partition("\n\n[Hint:")
+    parsed = json.loads(body)
+    assert parsed["truncated"] is True
+    assert parsed["limit_reason"] == "output_size"
+    assert hint

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1839,6 +1839,41 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         return tool_error(str(e))
 
 
+_SEARCH_RESULT_JSON_CHAR_CAP = 63_500
+
+
+def _cap_search_result_dict(result_dict: dict) -> dict:
+    """Keep serialized search output below 64K while preserving valid JSON."""
+    if len(json.dumps(result_dict, ensure_ascii=False)) <= _SEARCH_RESULT_JSON_CHAR_CAP:
+        return result_dict
+
+    result_dict["truncated"] = True
+    result_dict["limit_reason"] = "output_size"
+    marker = "\n[Search output truncated at the 64K result cap.]"
+
+    dense = result_dict.get("matches_text")
+    if isinstance(dense, str):
+        low, high = 0, len(dense)
+        while low < high:
+            mid = (low + high + 1) // 2
+            result_dict["matches_text"] = dense[:mid] + marker
+            if len(json.dumps(result_dict, ensure_ascii=False)) <= _SEARCH_RESULT_JSON_CHAR_CAP:
+                low = mid
+            else:
+                high = mid - 1
+        result_dict["matches_text"] = dense[:low] + marker
+        return result_dict
+
+    for key in ("matches", "files"):
+        values = result_dict.get(key)
+        while isinstance(values, list) and values and len(json.dumps(result_dict, ensure_ascii=False)) > _SEARCH_RESULT_JSON_CHAR_CAP:
+            values.pop()
+    counts = result_dict.get("counts")
+    while isinstance(counts, dict) and counts and len(json.dumps(result_dict, ensure_ascii=False)) > _SEARCH_RESULT_JSON_CHAR_CAP:
+        counts.pop(next(reversed(counts)))
+    return result_dict
+
+
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,
@@ -1911,6 +1946,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 "The results have not changed. Use the information you already have."
             )
 
+        result_dict = _cap_search_result_dict(result_dict)
         result_json = json.dumps(result_dict, ensure_ascii=False)
         # Hint when results were truncated — explicit next offset is clearer
         # than relying on the model to infer it from total_count vs match count.


### PR DESCRIPTION
## Summary
- cap serialized `search_files` JSON below 64K
- preserve valid JSON and mark size truncation explicitly
- add regression coverage for oversized dense results

## Verification
- `uv run ruff check tools/file_tools.py tests/tools/test_search_output_cap.py`
- `uv run pytest -q tests/tools/test_search_output_cap.py tests/tools/test_tool_result_storage.py` (27 passed)