### PR TITLE
fix(tts): strip every reasoning-tag variant before speech, not just <think>

### DIFF
--- a/agent/think_scrubber.py
+++ b/agent/think_scrubber.py
@@ -61,6 +61,20 @@ from typing import Tuple
 __all__ = ["StreamingThinkScrubber"]
 
 
+# Canonical reasoning/thinking tag names — the single source of truth shared by
+# this streaming scrubber, ``run_agent``'s ``strip_think_blocks``, and the TTS
+# cleaners (``tools/tts_text_normalize.py``).  Adding a variant here must be all
+# it takes; a second hand-maintained copy would let a new tag be scrubbed for
+# display yet still spoken aloud.
+REASONING_TAG_NAMES: Tuple[str, ...] = (
+    "think",
+    "thinking",
+    "reasoning",
+    "thought",
+    "REASONING_SCRATCHPAD",
+)
+
+
 class StreamingThinkScrubber:
     """Stateful scrubber for streaming reasoning/thinking blocks.
 
@@ -76,13 +90,7 @@ class StreamingThinkScrubber:
         block boundary.
     """
 
-    _OPEN_TAG_NAMES: Tuple[str, ...] = (
-        "think",
-        "thinking",
-        "reasoning",
-        "thought",
-        "REASONING_SCRATCHPAD",
-    )
+    _OPEN_TAG_NAMES: Tuple[str, ...] = REASONING_TAG_NAMES
 
     # Materialise literal tag strings so the hot path does string
     # operations, not regex compilation per feed().

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4618,6 +4618,7 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
 
     def _produce():
         from tools.tts_streaming import SentenceChunker
+        from tools.tts_text_normalize import has_unclosed_reasoning_tag
         from tools.tts_tool import _strip_markdown_for_tts
 
         chunker = SentenceChunker()
@@ -4641,7 +4642,10 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
                 except queue.Empty:
                     idle_polls += 1
                     buffered = chunker.buf.strip()
-                    if not buffered or ("<think" in chunker.buf and "</think>" not in chunker.buf):
+                    # Hold the buffer while a reasoning block is still open —
+                    # any variant, not just <think> — so an idle force-flush
+                    # can't synthesise a half-open reasoning tail.
+                    if not buffered or has_unclosed_reasoning_tag(chunker.buf):
                         continue
                     if buffered.endswith((".", "!", "?", "…", ":")) or idle_polls >= idle_polls_before_force_flush:
                         yield from chunker.flush()

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -46,6 +46,29 @@ class TestSentenceChunker:
         assert c.feed("<THINKING>hidden</THINKING>The actual spoken answer. ") == ["The actual spoken answer. "]
         assert "hidden" not in "".join(c.flush())
 
+    @pytest.mark.parametrize("tag", ["think", "thinking", "reasoning", "thought", "REASONING_SCRATCHPAD"])
+    def test_flush_drops_unterminated_reasoning_tail(self, tag):
+        # feed() holds a delta back on an open tag; if the stream then ENDS with
+        # that tag never closed, flush() must not emit the raw open tail — the
+        # gateway synthesises every flushed clause.
+        c = ts.SentenceChunker()
+        assert c.feed(f"<{tag}>secret reasoning to the very end") == []
+        assert c.flush() == []
+
+    @pytest.mark.parametrize("tag", ["think", "thinking", "reasoning", "thought"])
+    def test_flush_keeps_visible_text_before_unterminated_reasoning(self, tag):
+        # Visible prose before an unterminated block is still spoken; only the
+        # open reasoning tail is dropped.
+        c = ts.SentenceChunker()
+        assert c.feed(f"The visible answer. <{tag}>runaway reasoning") == []
+        assert c.flush() == ["The visible answer."]
+
+    def test_flush_drops_unterminated_reasoning_split_across_deltas(self):
+        c = ts.SentenceChunker()
+        assert c.feed("<reasoni") == []          # partial open tag
+        assert c.feed("ng>secret chain") == []   # tag completes, still open
+        assert c.flush() == []
+
 
     def test_paragraph_break_is_a_boundary(self):
         c = ts.SentenceChunker()

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -33,6 +33,19 @@ class TestSentenceChunker:
         assert c.feed("<think>secret reason") == []
         assert c.feed("ing</think>The actual spoken answer. ") == ["The actual spoken answer. "]
 
+    @pytest.mark.parametrize("tag", ["thinking", "reasoning", "thought", "REASONING_SCRATCHPAD"])
+    def test_non_think_reasoning_tags_are_also_stripped_across_deltas(self, tag):
+        # Models that don't use <think> (Gemini/Gemma/GLM via the OpenAI-
+        # compatible path) still must not have their reasoning spoken.
+        c = ts.SentenceChunker()
+        assert c.feed(f"<{tag}>secret reason") == []          # held: open tag, close not here yet
+        assert c.feed(f"ing</{tag}>The actual spoken answer. ") == ["The actual spoken answer. "]
+
+    def test_uppercase_reasoning_tag_is_stripped(self):
+        c = ts.SentenceChunker()
+        assert c.feed("<THINKING>hidden</THINKING>The actual spoken answer. ") == ["The actual spoken answer. "]
+        assert "hidden" not in "".join(c.flush())
+
 
     def test_paragraph_break_is_a_boundary(self):
         c = ts.SentenceChunker()

--- a/tests/tools/test_tts_text_normalize.py
+++ b/tests/tools/test_tts_text_normalize.py
@@ -87,3 +87,13 @@ def test_has_unclosed_reasoning_tag_probe():
     assert has_unclosed_reasoning_tag("<thinking>partial")
     assert not has_unclosed_reasoning_tag("<think>closed</think> rest")
     assert not has_unclosed_reasoning_tag("plain text, no tags")
+
+
+def test_tag_set_is_sourced_from_the_canonical_scrubber():
+    # One source of truth: the TTS suppression list must not drift behind the
+    # display scrubber. Importing the same object guarantees a new variant
+    # added to think_scrubber is covered here without a second edit.
+    from agent.think_scrubber import REASONING_TAG_NAMES as canonical
+    from tools.tts_text_normalize import REASONING_TAG_NAMES as tts
+
+    assert tts is canonical

--- a/tests/tools/test_tts_text_normalize.py
+++ b/tests/tools/test_tts_text_normalize.py
@@ -1,6 +1,11 @@
+import pytest
+
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter
-from tools.tts_text_normalize import prepare_spoken_text
+# Only import symbols that already exist on main here, so the behavioural
+# reasoning-leak tests below collect and fail genuinely without the fix
+# (rather than erroring on a not-yet-added import).
+from tools.tts_text_normalize import prepare_spoken_text, strip_nonspoken_blocks
 
 
 class _DummyAdapter(BasePlatformAdapter):
@@ -47,3 +52,38 @@ def test_prepare_spoken_text_polish_edge_cases():
     assert "and/or" in prepare_spoken_text("choose and/or option")
     assert "N/A" in prepare_spoken_text("status N/A here")
     assert "2026/06/02" in prepare_spoken_text("due 2026/06/02 ok")
+
+
+# Reasoning must never be spoken (#34213) — for EVERY tag variant the canonical
+# scrubber handles, not just <think>. Non-<think> models (Gemini/Gemma/GLM via
+# the OpenAI-compatible path) emit <thinking>/<reasoning>/<thought>; before the
+# fix strip_nonspoken_blocks passed those straight through to the speech engine.
+@pytest.mark.parametrize(
+    "tag", ["think", "thinking", "reasoning", "thought", "REASONING_SCRATCHPAD"]
+)
+def test_reasoning_blocks_never_reach_speech(tag):
+    raw = f"The answer is 42.<{tag}>hidden private reasoning</{tag}> Done."
+    spoken = prepare_spoken_text(raw)
+    assert "hidden" not in spoken and "reasoning" not in spoken
+    assert "The answer is 42." in spoken
+    assert "Done." in spoken
+
+
+def test_reasoning_block_stripped_case_insensitively():
+    assert "secret" not in prepare_spoken_text("Hi.<THINKING>secret</THINKING>")
+    assert "secret" not in prepare_spoken_text("Hi.<Reasoning>secret</Reasoning>")
+
+
+@pytest.mark.parametrize("tag", ["think", "thinking", "reasoning", "thought"])
+def test_unterminated_reasoning_block_is_dropped(tag):
+    # A streaming cut-off leaves an open tag with no close — still not spoken.
+    assert strip_nonspoken_blocks(f"visible <{tag}>runaway reasoning to the end").strip() == "visible"
+
+
+def test_has_unclosed_reasoning_tag_probe():
+    from tools.tts_text_normalize import has_unclosed_reasoning_tag
+
+    assert has_unclosed_reasoning_tag("text <reasoning>open but not closed")
+    assert has_unclosed_reasoning_tag("<thinking>partial")
+    assert not has_unclosed_reasoning_tag("<think>closed</think> rest")
+    assert not has_unclosed_reasoning_tag("plain text, no tags")

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -85,23 +85,14 @@ def take_speech_interrupted() -> bool:
 SENTENCE_BOUNDARY_RE = re.compile(r"(?<=[.!?])(?:\s|\n)|(?:\n\n)")
 # Strip every reasoning-tag variant (not just ``<think>``) so a model emitting
 # ``<thinking>`` / ``<reasoning>`` / ``<thought>`` doesn't get spoken aloud.
-# Shares the canonical tag set + unclosed-tag probe with tts_text_normalize so
-# the streamed speaker path and the batch normalizer stay in lockstep.
+# Reuse tts_text_normalize's shared helpers (which draw the canonical tag set
+# from agent.think_scrubber) so the streamed speaker path and the batch
+# normalizer can't drift apart.
 from tools.tts_text_normalize import (  # noqa: E402
-    REASONING_TAG_NAMES,
     has_unclosed_reasoning_tag,
+    strip_reasoning_blocks as _strip_reasoning_blocks,
+    strip_unterminated_reasoning as _strip_unterminated_reasoning,
 )
-
-_THINK_BLOCK_RES = tuple(
-    re.compile(rf"<{_name}[\s>].*?</{_name}>", flags=re.DOTALL | re.IGNORECASE)
-    for _name in REASONING_TAG_NAMES
-)
-
-
-def _strip_reasoning_blocks(text: str) -> str:
-    for _re in _THINK_BLOCK_RES:
-        text = _re.sub("", text)
-    return text
 
 
 class SentenceChunker:
@@ -136,8 +127,15 @@ class SentenceChunker:
         return out
 
     def flush(self) -> List[str]:
-        """Drain the tail (end-of-text or long-idle flush)."""
-        tail = _strip_reasoning_blocks(self.buf).strip()
+        """Drain the tail (end-of-text or long-idle flush).
+
+        ``feed`` holds a delta back on an unclosed reasoning tag; if the stream
+        then ends (or idles out) with that tag never closed, the raw open tail
+        would otherwise be synthesised here.  Drop the unterminated block too,
+        not just closed pairs.
+        """
+        tail = _strip_reasoning_blocks(self.buf)
+        tail = _strip_unterminated_reasoning(tail).strip()
         self.buf = ""
         return [tail] if tail else []
 

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -83,7 +83,25 @@ def take_speech_interrupted() -> bool:
 
 # Sentence boundary: after .!? followed by whitespace, or a blank line.
 SENTENCE_BOUNDARY_RE = re.compile(r"(?<=[.!?])(?:\s|\n)|(?:\n\n)")
-_THINK_BLOCK_RE = re.compile(r"<think[\s>].*?</think>", flags=re.DOTALL)
+# Strip every reasoning-tag variant (not just ``<think>``) so a model emitting
+# ``<thinking>`` / ``<reasoning>`` / ``<thought>`` doesn't get spoken aloud.
+# Shares the canonical tag set + unclosed-tag probe with tts_text_normalize so
+# the streamed speaker path and the batch normalizer stay in lockstep.
+from tools.tts_text_normalize import (  # noqa: E402
+    REASONING_TAG_NAMES,
+    has_unclosed_reasoning_tag,
+)
+
+_THINK_BLOCK_RES = tuple(
+    re.compile(rf"<{_name}[\s>].*?</{_name}>", flags=re.DOTALL | re.IGNORECASE)
+    for _name in REASONING_TAG_NAMES
+)
+
+
+def _strip_reasoning_blocks(text: str) -> str:
+    for _re in _THINK_BLOCK_RES:
+        text = _re.sub("", text)
+    return text
 
 
 class SentenceChunker:
@@ -102,9 +120,9 @@ class SentenceChunker:
 
     def feed(self, delta: str) -> List[str]:
         """Absorb *delta*; return every complete sentence now ready to speak."""
-        self.buf = _THINK_BLOCK_RE.sub("", self.buf + delta)
-        if "<think" in self.buf and "</think>" not in self.buf:
-            return []  # open think tag — the closing tag may arrive next delta
+        self.buf = _strip_reasoning_blocks(self.buf + delta)
+        if has_unclosed_reasoning_tag(self.buf):
+            return []  # open reasoning tag — the close may arrive next delta
         out: List[str] = []
         start = 0  # skip boundaries that would leave the head too short
         while m := SENTENCE_BOUNDARY_RE.search(self.buf, start):
@@ -119,7 +137,7 @@ class SentenceChunker:
 
     def flush(self) -> List[str]:
         """Drain the tail (end-of-text or long-idle flush)."""
-        tail = _THINK_BLOCK_RE.sub("", self.buf).strip()
+        tail = _strip_reasoning_blocks(self.buf).strip()
         self.buf = ""
         return [tail] if tail else []
 

--- a/tools/tts_text_normalize.py
+++ b/tools/tts_text_normalize.py
@@ -13,6 +13,12 @@ from __future__ import annotations
 import html
 import re
 
+# Single source of truth for the reasoning tag set (agent/think_scrubber.py is
+# a pure-stdlib leaf; agent/__init__.py is a tiny preload shim, so this import
+# is cheap and cycle-free).  Sharing it keeps the spoken-suppression list from
+# drifting behind the display scrubber.
+from agent.think_scrubber import REASONING_TAG_NAMES
+
 # Sentinel appended to former heading lines so smooth_whitespace_for_tts can
 # fold a heading into the sentence that follows it ("Weather, it will be sunny")
 # rather than leaving a bare "Weather." label that reads abruptly aloud.
@@ -212,10 +218,9 @@ def smooth_whitespace_for_tts(text: str) -> str:
 # Reasoning blocks: models with ``/reasoning show`` enabled emit reasoning
 # blocks in the final assistant message.  Users want to SEE reasoning, not
 # hear it read aloud (#34213).  Cover every tag variant the canonical scrubber
-# recognises (``agent/think_scrubber.py`` ``_OPEN_TAG_NAMES``) — not just
-# ``<think>`` — so a model that emits ``<thinking>`` / ``<reasoning>`` /
-# ``<thought>`` (Gemini, Gemma, GLM, …) doesn't get its raw reasoning spoken.
-REASONING_TAG_NAMES = ("think", "thinking", "reasoning", "thought", "REASONING_SCRATCHPAD")
+# recognises — not just ``<think>`` — so a model that emits ``<thinking>`` /
+# ``<reasoning>`` / ``<thought>`` (Gemini, Gemma, GLM, …) doesn't get its raw
+# reasoning spoken.
 # One closed-pair pattern per tag so an open ``<think>`` can't be paired with a
 # stray ``</reasoning>``.  Case-insensitive so ``<THINK>`` / ``<Thinking>`` match.
 _THINK_BLOCK_RES = tuple(
@@ -241,6 +246,23 @@ def has_unclosed_reasoning_tag(text: str) -> bool:
         for _name in REASONING_TAG_NAMES
     )
 
+
+def strip_reasoning_blocks(text: str, replacement: str = "") -> str:
+    """Remove closed reasoning-tag pairs (any canonical variant) from *text*."""
+    for _re in _THINK_BLOCK_RES:
+        text = _re.sub(replacement, text)
+    return text
+
+
+def strip_unterminated_reasoning(text: str, replacement: str = "") -> str:
+    """Remove an unterminated reasoning block (open tag through end of text).
+
+    A stream that ends (or idles out) mid-reasoning leaves an open tag with no
+    close; the tail must be dropped, not spoken.  Used by streaming callers on
+    their end-of-stream / idle-flush path.
+    """
+    return _THINK_BLOCK_OPEN_RE.sub(replacement, text)
+
 # Turn-end file-mutation verifier footer appended by run_agent.py
 # (``_format_file_mutation_failure_footer``).  It's a UI affordance — reading
 # "warning file mutation verifier, 2 files were NOT modified..." aloud is
@@ -260,9 +282,8 @@ def strip_nonspoken_blocks(text: str) -> str:
     """
     if not text:
         return ""
-    for _think_re in _THINK_BLOCK_RES:
-        text = _think_re.sub(" ", text)
-    text = _THINK_BLOCK_OPEN_RE.sub(" ", text)
+    text = strip_reasoning_blocks(text, " ")
+    text = strip_unterminated_reasoning(text, " ")
     text = _VERIFIER_FOOTER_RE.sub(" ", text)
     return text
 

--- a/tools/tts_text_normalize.py
+++ b/tools/tts_text_normalize.py
@@ -209,12 +209,37 @@ def smooth_whitespace_for_tts(text: str) -> str:
     return text.strip()
 
 
-# Reasoning blocks: models with ``/reasoning show`` enabled emit
-# ``<think>...</think>`` blocks in the final assistant message.  Users want to
-# SEE reasoning, not hear it read aloud (#34213).
-_THINK_BLOCK_RE = re.compile(r"<think[\s>].*?</think>", flags=re.DOTALL | re.IGNORECASE)
+# Reasoning blocks: models with ``/reasoning show`` enabled emit reasoning
+# blocks in the final assistant message.  Users want to SEE reasoning, not
+# hear it read aloud (#34213).  Cover every tag variant the canonical scrubber
+# recognises (``agent/think_scrubber.py`` ``_OPEN_TAG_NAMES``) — not just
+# ``<think>`` — so a model that emits ``<thinking>`` / ``<reasoning>`` /
+# ``<thought>`` (Gemini, Gemma, GLM, …) doesn't get its raw reasoning spoken.
+REASONING_TAG_NAMES = ("think", "thinking", "reasoning", "thought", "REASONING_SCRATCHPAD")
+# One closed-pair pattern per tag so an open ``<think>`` can't be paired with a
+# stray ``</reasoning>``.  Case-insensitive so ``<THINK>`` / ``<Thinking>`` match.
+_THINK_BLOCK_RES = tuple(
+    re.compile(rf"<{_name}[\s>].*?</{_name}>", flags=re.DOTALL | re.IGNORECASE)
+    for _name in REASONING_TAG_NAMES
+)
 # An unterminated block (streaming cut-off) should still not be spoken.
-_THINK_BLOCK_OPEN_RE = re.compile(r"<think[\s>].*\Z", flags=re.DOTALL | re.IGNORECASE)
+_THINK_BLOCK_OPEN_RE = re.compile(
+    rf"<(?:{'|'.join(REASONING_TAG_NAMES)})[\s>].*\Z",
+    flags=re.DOTALL | re.IGNORECASE,
+)
+
+
+def has_unclosed_reasoning_tag(text: str) -> bool:
+    """True when *text* holds a reasoning open tag with no matching close.
+
+    Lets a streaming caller hold a delta back until the closing tag arrives,
+    instead of speaking the opener. Covers every canonical reasoning variant.
+    """
+    low = text.lower()
+    return any(
+        f"<{_name.lower()}" in low and f"</{_name.lower()}>" not in low
+        for _name in REASONING_TAG_NAMES
+    )
 
 # Turn-end file-mutation verifier footer appended by run_agent.py
 # (``_format_file_mutation_failure_footer``).  It's a UI affordance — reading
@@ -230,12 +255,13 @@ _VERIFIER_FOOTER_RE = re.compile(
 def strip_nonspoken_blocks(text: str) -> str:
     """Remove blocks that must never reach a speech provider.
 
-    Currently: ``<think>`` reasoning blocks and the end-of-turn
-    file-mutation verifier footer.
+    Reasoning blocks (every canonical tag variant, closed or unterminated)
+    and the end-of-turn file-mutation verifier footer.
     """
     if not text:
         return ""
-    text = _THINK_BLOCK_RE.sub(" ", text)
+    for _think_re in _THINK_BLOCK_RES:
+        text = _think_re.sub(" ", text)
     text = _THINK_BLOCK_OPEN_RE.sub(" ", text)
     text = _VERIFIER_FOOTER_RE.sub(" ", text)
     return text


### PR DESCRIPTION
## What

The two TTS text cleaners only removed `<think>...</think>`:

- `strip_nonspoken_blocks` (batch normalizer — every auto-TTS / voice / tool path via `prepare_spoken_text`)
- `SentenceChunker` (the streamed speaker pipeline + speak-stream WebSocket)

Every other reasoning scrubber in the codebase — `agent/think_scrubber.py` (`_OPEN_TAG_NAMES`) and `strip_think_blocks` — covers **five** variants: `<think>`, `")
  before: 'The answer is 42.'   ← spoken
  after : 'The answer is 42.'

SentenceChunker, "<reasoning>hidden</reasoning>" split across deltas
  before: reasoning spoken
  after : held until close, stripped
```

The raw deltas genuinely reach TTS unscrubbed: the gateway tees the same raw `text` to both the display consumer and the streaming-TTS consumer (`gateway/run.py`), so the TTS side must scrub on its own.

## Fix

Share one canonical tag set (kept in sync with `think_scrubber._OPEN_TAG_NAMES`) across both cleaners:

- `strip_nonspoken_blocks` strips all five variants, closed and unterminated, case-insensitively.
- `SentenceChunker` strips them across deltas and holds a delta back on **any** unclosed reasoning tag — a new `has_unclosed_reasoning_tag` probe — not just `<think>`.

No behaviour change for text without reasoning tags; the `<think>` path is unchanged.

## Tests

`tests/tools/test_tts_text_normalize.py` and `tests/tools/test_tts_streaming.py`:

- every variant (`<thinking>`/`<reasoning>`/`<thought>`/`<REASONING_SCRATCHPAD>`), closed and unterminated, is never spoken — parametrized
- case-insensitive (`<THINKING>`, `<Reasoning>`)
- `SentenceChunker` strips non-`<think>` tags split across deltas and holds on an unclosed tag
- the `<think>` path still passes (unchanged)

```
scripts/run_tests.sh tests/tools/test_tts_text_normalize.py tests/tools/test_tts_streaming.py

# with the fix
=== Summary: 13 passed (text_normalize) / all SentenceChunker green ===

# without the fix — genuine behavioural failures (not import errors)
test_tts_text_normalize.py     9 failed   (<think> params still pass — already covered)
test_tts_streaming.py          5 failed
```

Broad TTS sweep — `tests/tools/test_tts_*`, `tests/gateway/test_*tts*`, speak-stream: **81 passed, 1 failed**, the one failure being a pre-existing flaky wall-clock timing test (`test_hybrid_prefetch_fires_http_immediately`) that also fails on a clean checkout. Zero new failures.