### PR TITLE
fix(buzz): keep progress messages in thread

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -688,7 +688,7 @@ def _resolve_progress_thread_id(
         return str(source_thread_id) if source_thread_id else None
     if source_thread_id:
         return str(source_thread_id)
-    if platform_key in {"slack", "mattermost"} and event_message_id:
+    if platform_key in {"slack", "mattermost", "buzz"} and event_message_id:
         return str(event_message_id)
     return None
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -407,6 +407,22 @@ class TestBuzzAdapterSend:
         # Our own event id is marked seen for echo suppression
         assert "evt123" in adapter._channel_state[CHANNEL]["seen"]
 
+    @pytest.mark.asyncio
+    async def test_send_metadata_thread_id_uses_reply_to_flag(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt124", "message": ""})
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "working",
+            metadata={"thread_id": "buzz-event-123"},
+        )
+
+        assert result.success is True
+        args, _stdin = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "buzz-event-123"
 
     @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):

--- a/tests/gateway/test_buzz_progress_thread_routing.py
+++ b/tests/gateway/test_buzz_progress_thread_routing.py
@@ -1,0 +1,15 @@
+"""Buzz progress/status thread-routing regressions."""
+
+from gateway.run import _resolve_progress_thread_id
+
+
+def test_buzz_progress_without_source_thread_uses_triggering_event():
+    """Progress for a Buzz reply must inherit the triggering event anchor."""
+    assert (
+        _resolve_progress_thread_id(
+            "buzz",
+            source_thread_id=None,
+            event_message_id="buzz-event-123",
+        )
+        == "buzz-event-123"
+    )

--- a/tests/gateway/test_buzz_progress_thread_routing.py
+++ b/tests/gateway/test_buzz_progress_thread_routing.py
@@ -13,3 +13,14 @@ def test_buzz_progress_without_source_thread_uses_triggering_event():
         )
         == "buzz-event-123"
     )
+
+
+def test_buzz_progress_preserves_explicit_source_thread():
+    assert (
+        _resolve_progress_thread_id(
+            "buzz",
+            source_thread_id="explicit-thread-root",
+            event_message_id="buzz-event-123",
+        )
+        == "explicit-thread-root"
+    )

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -2,7 +2,7 @@
 
 The Buzz adapter connects Hermes to a [Buzz](https://github.com/block/buzz) community — Block's open-source human+agent collaboration platform built on the Nostr protocol — and relays messages between Buzz channels (or DMs) and the agent. Outbound traffic shells out to the `buzz` CLI binary ("JSON in, JSON out"); inbound uses a native Nostr WebSocket subscription (via the already-bundled `websockets` package) with CLI polling as fallback. **No extra Python packages are required** — just the `buzz` binary.
 
-Buzz renders markdown, so agent replies keep their formatting. Images are delivered as uploads (local files) or links (URLs). Replies can thread onto an existing message via its event id.
+Buzz renders markdown, so agent replies keep their formatting. Images are delivered as uploads (local files) or links (URLs). Replies can thread onto an existing message via its event id. When progress or status messages are enabled, they inherit the triggering Buzz event as their reply anchor instead of appearing as unrelated top-level channel posts.
 
 Inbound messages arrive over a persistent NIP-42-authenticated Nostr WebSocket subscription by default (near-instant delivery), with automatic fallback to CLI polling when the WebSocket can't be established. Outbound messages always go through the `buzz` CLI. Control it with `transport` / `BUZZ_TRANSPORT`: `auto` (default), `websocket` (require WS, fail otherwise), or `poll`. If your relay membership uses NIP-OA owner attestation, set `BUZZ_AUTH_TAG` to the four-string auth tag JSON.
 


### PR DESCRIPTION
## What does this PR do?

Keeps Buzz progress and status messages in the same conversation as the event that triggered the agent run.

Buzz inbound events do not populate `source.thread_id`. Normal final replies still carry the triggering event ID, but the generic progress-routing helper only synthesized that fallback for Slack and Mattermost. Consequently, enabled progress, heartbeat, and interim status messages were sent without a reply anchor and appeared as unrelated top-level Buzz channel posts.

This change gives Buzz the same triggering-event fallback. The existing Buzz adapter then sends the event ID through `--reply-to`, while an explicit source thread ID continues to take precedence.

## Related Issue

No linked issue. Reproduced against current `main` and verified on a hosted Buzz gateway.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - Include Buzz in `_resolve_progress_thread_id()`'s triggering-event fallback.
- `tests/gateway/test_buzz_progress_thread_routing.py`
  - Verify a missing Buzz source thread falls back to the triggering event ID.
  - Verify an explicit Buzz source thread remains authoritative.
- `website/docs/user-guide/messaging/buzz.md`
  - Document progress/status reply anchoring.
- `tests/gateway/test_buzz_adapter.py`
  - Verify `thread_id` metadata is translated into the Buzz CLI `--reply-to` flag.

## How to Test

1. Run:
   ```bash
   pytest -q tests/gateway/test_buzz_progress_thread_routing.py tests/gateway/test_buzz_adapter.py tests/gateway/test_mattermost.py tests/gateway/relay/test_relay_slack_prompt_dm_root.py
   ```
2. Confirm all 74 tests pass.
3. Enable Buzz progress/interim feedback, trigger a long-running agent turn from a Buzz thread, and confirm progress/status events contain a reply anchor and remain in that thread.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04 LTS (x86_64)

The focused cross-platform progress-routing and Buzz adapter suites pass: **74 passed**. The full repository suite was not run for this focused four-file change.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated the canonical Buzz guide
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no configuration keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the change is platform-key routing with no OS-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool changed

## Screenshots / Logs

```text
74 passed in 1.75s
All checks passed!
```

Live verification on a hosted Buzz gateway confirmed that progress and interim feedback remained in the originating thread after deployment and restart.