### PR TITLE
fix(dashboard): offload /api/messaging/platforms build to a worker thread

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9196,6 +9196,8 @@ async def get_messaging_platforms(profile: Optional[str] = None):
     # load_env() honors the HERMES_HOME contextvar override; the gateway
     # status readers do NOT (they resolve process-level paths), so the
     # profile directory is passed explicitly for those (#71211).
+    from starlette.concurrency import run_in_threadpool
+
     with _profile_scope(profile) as scoped_dir:
         env_on_disk = load_env()
         runtime = (
@@ -9203,10 +9205,15 @@ async def get_messaging_platforms(profile: Optional[str] = None):
             if scoped_dir is not None
             else read_runtime_status()
         )
-        return {
-            "env_path": str(get_env_path()),
-            "gateway_start_command": _gateway_display_command(profile, "start"),
-            "platforms": [
+        # The per-platform payload builder performs synchronous liveness
+        # probes (PID/process-table probing + file I/O via
+        # resolve_gateway_liveness) for every catalog entry — ~32 on a stock
+        # install. Running that on the event-loop thread starves the loop for
+        # 6-12s and trips Desktop's readiness timeout (event-loop-stalled
+        # warnings in errors.log). Mirror the /api/status topology pattern
+        # and run the whole synchronous build in a worker thread.
+        def _build_payloads() -> list[dict[str, Any]]:
+            return [
                 _messaging_platform_payload(
                     entry,
                     env_on_disk,
@@ -9216,6 +9223,12 @@ async def get_messaging_platforms(profile: Optional[str] = None):
                 )
                 for entry in _messaging_platform_catalog()
             ]
+
+        platforms = await run_in_threadpool(_build_payloads)
+        return {
+            "env_path": str(get_env_path()),
+            "gateway_start_command": _gateway_display_command(profile, "start"),
+            "platforms": platforms,
         }
 
 

--- a/tests/hermes_cli/test_web_server_messaging_profiles.py
+++ b/tests/hermes_cli/test_web_server_messaging_profiles.py
@@ -267,3 +267,40 @@ class TestMultiplexPortBindingGuard:
             )
             assert resp.status_code == 200
 
+
+
+class TestMessagingPlatformsThreadOffload:
+    """Regression (#77048): the per-platform liveness probes must be offloaded
+    from the FastAPI event-loop thread.
+
+    Each catalog entry's payload builder calls resolve_gateway_liveness()
+    (PID probing + file I/O); running ~32 of those synchronously on the
+    event-loop thread starved the loop for 6-12s and tripped Desktop's
+    15s readiness timeout. The endpoint must delegate the synchronous build
+    through run_in_threadpool — mirroring the /api/status topology pattern.
+    """
+
+    def test_payload_build_is_offloaded_via_threadpool(self, client, monkeypatch):
+        import threading
+
+        from starlette.concurrency import run_in_threadpool
+
+        from hermes_cli import web_server
+
+        captured = []
+
+        async def _spy_threadpool(fn, *a, **kw):
+            captured.append(threading.current_thread())
+            return fn(*a, **kw)
+
+        # The endpoint imports run_in_threadpool inside the function body, so
+        # patch at the source module the local import binds to.
+        import starlette.concurrency
+        monkeypatch.setattr(starlette.concurrency, "run_in_threadpool", _spy_threadpool)
+        # Real catalog + real payload builder: exercises the actual code path.
+        resp = client.get("/api/messaging/platforms")
+        assert resp.status_code == 200
+        platforms = resp.json()["platforms"]
+        assert platforms, "expected at least one platform payload"
+        # The endpoint must delegate through run_in_threadpool (spy captured it).
+        assert captured, "get_messaging_platforms did not delegate through run_in_threadpool"


### PR DESCRIPTION
## What does this PR do?

Offload the /api/messaging/platforms payload build (per-platform liveness probes) to a worker thread via run_in_threadpool, matching the /api/status topology pattern. Response unchanged; the event loop is no longer starved.

## Related Issue

Fixes #77048. Reported by tmycgn: GET /api/messaging/platforms blocks the FastAPI event loop for 6-12s (32 synchronous liveness probes on the loop thread), tripping Desktop's 15s readiness timeout. Fix mirrors the /api/status topology pattern: run the payload build through run_in_threadpool.

## Changes Made

- `fix/messaging-platforms-threadpool` — 2 file(s) changed vs base:
  - `hermes_cli/web_server.py`
  - `tests/hermes_cli/test_web_server_messaging_profiles.py`

## How to Test

Validation completed (recorded by prp):
1. Sabotage check: pre-fix code fails the regression tests (1 failed), with the fix all pass (8 passed, 0 failed) — target `tests/hermes_cli/test_web_server_messaging_profiles.py`.
2. The full repo-wide suite was not run for this change; GitHub CI owns full-suite validation.

## Logs

Sabotage verification output:

```
# base leg (pre-fix code + branch tests):
#   tests: 7 passed, 1 failed
# head leg (with fix):
#   tests: 8 passed, 0 failed
```
