### PR TITLE
fix(gateway): close order-dependency + missing-verb gap in launchctl lifecycle guards

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -92,12 +92,48 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
 _SHELL_LINE_CONTINUATION = re.compile(r"\\\r?\n[ \t]*")
 
 
+# Branch B only catches `launchctl <verb> ... hermes[.-]?gateway` when the
+# label literally appears AFTER the verb in the same `[^\n]*` span, and its
+# verb list is missing `bootout`/`kill`/`disable`/`remove` entirely (2026-08-02
+# incident). `bootout` is the one that actually unloads a job's registration
+# — worse than `stop`/`kickstart`, which just bounce a still-registered job.
+#
+# A shell loop that builds the label from a list defined EARLIER in the same
+# command — `for item in 'ai.hermes.gateway-apollo:...' 'ai.hermes.gateway:...';
+# do label=${item%%:*}; launchctl bootout "gui/$uid/$label"; done` — puts the
+# literal label text in a different `;`-separated segment than the verb, so
+# no amount of same-segment tokenization sees it: the token next to `bootout`
+# is the unexpanded variable `$label`, not the string "hermes.gateway". This
+# incident command evaded Branch B on both counts (missing verb AND order)
+# and unloaded all 4 profiles' launchd jobs with zero approval.
+#
+# Unlike `submit`/`bootstrap` (handled separately, fully label-independent,
+# because a NEW job's label is attacker-chosen), these verbs act on an
+# EXISTING job, so anchoring to the hermes-gateway label is still correct —
+# `test_safe_commands` requires unrelated-label ops (e.g. `launchctl unload
+# ai.hermes.update-checker.plist`) to stay unblocked. The fix is checking
+# "verb anywhere AND label anywhere", not "label right after verb".
+_LAUNCHCTL_LIFECYCLE_VERBS_RE = re.compile(
+    r"(?i)\blaunchctl\s+(?:kickstart|unload|load|stop|restart|bootout|kill|disable|remove)\b"
+)
+_HERMES_GATEWAY_LABEL_RE = re.compile(r"(?i)\bhermes[.\-]?gateway\b")
+
+
+def _contains_launchctl_gateway_lifecycle(normalized_text: str) -> bool:
+    """Order-independent companion to Branch B — see comment above."""
+    return bool(_LAUNCHCTL_LIFECYCLE_VERBS_RE.search(normalized_text)) and bool(
+        _HERMES_GATEWAY_LABEL_RE.search(normalized_text)
+    )
+
+
 def contains_gateway_lifecycle_command(text: str) -> bool:
     """Return True if *text* contains a gateway lifecycle command pattern."""
     if not text:
         return False
     normalized = _SHELL_LINE_CONTINUATION.sub(" ", text)
-    return bool(_GATEWAY_LIFECYCLE_PATTERN.search(normalized))
+    return bool(_GATEWAY_LIFECYCLE_PATTERN.search(normalized)) or _contains_launchctl_gateway_lifecycle(
+        normalized
+    )
 
 
 _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -56,6 +56,32 @@ class TestGatewayLifecyclePattern:
     def test_launchctl_submit_bootstrap_commands(self, text):
         assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
 
+    def test_launchctl_bootout_verb_is_caught(self):
+        """`bootout` was missing from Branch B's verb list entirely — the
+        2026-08-02 incident command used exactly this verb (it deregisters
+        the job outright, unlike stop/kickstart) and slipped past both this
+        check and the missing-verb rule in tools/approval.py."""
+        assert _contains_gateway_lifecycle_command(
+            "launchctl bootout gui/501/ai.hermes.gateway"
+        )
+
+    def test_label_defined_before_verb_is_caught(self):
+        """2026-08-02 incident reproduction: the label comes from a shell
+        for-loop list defined BEFORE the launchctl call, in an earlier `;`
+        -separated segment, referenced only via `$label` at the point of the
+        verb. Branch B's `[^\\n]*` sequential match requires the literal
+        label text to appear AFTER the verb IN THE SAME SEGMENT and never
+        sees it — restarted 4 gateways with zero approval."""
+        cmd = (
+            "uid=$(id -u); for item in 'ai.hermes.gateway-apollo:/a.plist' "
+            "'ai.hermes.gateway-cronus:/c.plist' 'ai.hermes.gateway-plutus:/p.plist' "
+            "'ai.hermes.gateway:/Users/botuser/Library/LaunchAgents/ai.hermes.gateway.plist'; "
+            "do label=${item%%:*}; plist=${item#*:}; "
+            'launchctl bootout "gui/$uid/$label"; '
+            'launchctl bootstrap "gui/$uid" "$plist"; done'
+        )
+        assert _contains_gateway_lifecycle_command(cmd)
+
     def test_line_continuation_does_not_bridge_unrelated_lines(self):
         # A backslash-newline is only normalized when it's a real shell
         # continuation. Two genuinely separate lines of a longer prompt

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -849,6 +849,23 @@ class TestLaunchctlGatewayLifecycle:
             dangerous, _, _ = detect_dangerous_command(cmd)
             assert dangerous is False, cmd
 
+    def test_label_built_before_verb_detected(self):
+        """2026-08-02 incident: the label was defined in a shell for-loop
+        BEFORE the `launchctl bootout` call, referenced only via a `$label`
+        variable at the point of the verb. The old sequential regex required
+        "hermes"/"ai.hermes" to appear AFTER the verb and missed this
+        entirely, restarting 4 gateways with zero approval."""
+        cmd = (
+            "uid=$(id -u); for item in 'ai.hermes.gateway-apollo:/a.plist' "
+            "'ai.hermes.gateway:/Users/botuser/Library/LaunchAgents/ai.hermes.gateway.plist'; "
+            "do label=${item%%:*}; plist=${item#*:}; "
+            'launchctl bootout "gui/$uid/$label"; '
+            'launchctl bootstrap "gui/$uid" "$plist"; done'
+        )
+        dangerous, _, desc = detect_dangerous_command(cmd)
+        assert dangerous is True, cmd
+        assert "launchd" in desc.lower()
+
 
 class TestGitDestructiveOps:
     """git reset --hard, push --force, clean -f, branch -D can destroy

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -775,7 +775,22 @@ DANGEROUS_PATTERNS = [
     # the `hermes gateway stop|restart` pattern above by driving launchd
     # directly against the service label (commonly `ai.hermes.gateway`).
     # Catch the operations that stop, restart, or unload it.
-    (r'\blaunchctl\s+(stop|kickstart|bootout|unload|kill|disable|remove)\b.*\b(hermes|ai\.hermes)\b', "stop/restart hermes launchd service (kills running agents)"),
+    #
+    # Order-independent (2026-08-02 incident): the previous version required
+    # "hermes"/"ai.hermes" to appear AFTER the launchctl verb in the same
+    # string (`.*` only scans forward). A shell for-loop that builds the
+    # label from a list defined earlier in the command — e.g. `for item in
+    # 'ai.hermes.gateway-apollo:...' ...; do label=${item%%:*}; launchctl
+    # bootout "$label"; done` — never has the literal text "hermes" appear
+    # after "bootout" (only the expanded variable does), so it slipped past
+    # undetected and restarted 4 gateways with zero approval. Two
+    # independent lookaheads instead of one sequential match: both
+    # substrings must appear SOMEWHERE in the command, in either order.
+    # This is intentionally broader (a launchctl-verb command anywhere near
+    # an unrelated "hermes" mention now also matches) — for an approval gate
+    # that's the correct direction to err: an extra approval prompt is
+    # cheap, a missed one took down the whole gateway fleet.
+    (r'(?=[\s\S]*\blaunchctl\s+(?:stop|kickstart|bootout|unload|kill|disable|remove)\b)(?=[\s\S]*\b(?:hermes|ai\.hermes)\b)', "stop/restart hermes launchd service (kills running agents)"),
     # File copy/move/edit into sensitive system paths (/etc/ and macOS
     # /private/etc/ mirror).
     (rf'\b(cp|mv|install)\b.*\s{_SYSTEM_CONFIG_PATH}', "copy/move file into system config path"),


### PR DESCRIPTION
## Summary

Both `launchctl`-lifecycle guards — `cron/lifecycle_guard.py` Branch B (the unconditional hard-block used by cron creation and the terminal tool when `_HERMES_GATEWAY=1`) and `tools/approval.py`'s launchctl rule — matched `launchctl <verb> ... hermes[.-]?gateway` as a single sequential regex, requiring the hermes-gateway label to appear literally *after* the verb. A shell command that builds the label earlier in the string (e.g. a `for` loop reading labels from a list defined before the actual `launchctl` call) defeats that ordering entirely, since the label text never appears after the verb — only an unexpanded `$label` variable does.

`cron/lifecycle_guard.py`'s verb list also didn't include `bootout` at all, even though it's present in `tools/approval.py`'s list and that file's own test suite explicitly asserts `launchctl bootout ai.hermes.gateway` should be flagged dangerous — this looks like list drift between the two guards rather than an intentional exclusion. `bootout` is the verb that actually deregisters a launchd job (unlike `kickstart`/`stop`, which just bounce a still-registered one), so a command using it evades both guards and removes the service from launchd entirely, with no supervisor left to bring it back.

## How we hit this

A gateway self-restart (triggered by a chat request to change the default model) used a raw terminal `launchctl bootout`/`bootstrap` loop across 4 launchd labels instead of the normal `hermes gateway restart` path:

```bash
uid=$(id -u); for item in 'ai.hermes.gateway-apollo:...' 'ai.hermes.gateway:...'; do
  label=${item%%:*}; plist=${item#*:}
  launchctl bootout "gui/$uid/$label"
  launchctl bootstrap "gui/$uid" "$plist"
done
```

This slipped past both guards, the self-bootout killed the gateway process mid-drain before its own follow-up `bootstrap` could run, and all 4 gateway profiles ended up fully deregistered from launchd with **zero user approval** (`approvals.mode: manual` was configured) until someone manually re-bootstrapped them.

## Fix

Both guards now check "a launchctl lifecycle verb appears somewhere AND a hermes-gateway label appears somewhere", independent of order, instead of one sequential match. `cron/lifecycle_guard.py`'s verb list gains `bootout`/`kill`/`disable`/`remove` to match `tools/approval.py`'s existing set.

Internal recovery code (`hermes_cli/gateway.py`'s own `subprocess.run(["launchctl", "bootout", ...])` calls) is unaffected — these guards only scan shell-command strings composed by the agent's terminal/cron tools, never the CLI's trusted internal subprocess argument lists.

## Test plan

- [x] Added regression tests in both `tests/hermes_cli/test_gateway_restart_loop.py` and `tests/tools/test_approval.py` reproducing the exact incident command (label built in an earlier for-loop segment, referenced only via `$label` at the point of the verb).
- [x] Full `tests/hermes_cli/test_gateway_restart_loop.py` + `tests/tools/test_approval.py` pass (171/172; the one pre-existing failure, `TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`, reproduces on a clean `main` checkout and is unrelated to this change).
- [x] Verified existing safe-command cases stay unblocked (`launchctl unload ai.hermes.update-checker.plist`, `launchctl restart ai.hermes.daemon`, `launchctl print system/com.apple.WindowServer`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)