### PR TITLE
feat: add ontology-context-layer MCP skill (optional)

### DIFF
--- a/optional-skills/mcp/ontology-context-layer/SKILL.md
+++ b/optional-skills/mcp/ontology-context-layer/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: ontology-context-layer
+description: Give Hermes a knowledge graph + business rules for explainable decisions.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [ontology, knowledge-graph, MCP, context, rules, explainability]
+    related_skills: [hermes-agent, fastmcp, mcporter]
+prerequisites:
+  commands: [python3]
+---
+
+# Ontology Context Layer
+
+A local, ontology-based semantic context layer for Hermes, delivered as an MCP server. It combines a knowledge graph (entities + typed relationships) with a business-rule engine so the agent can retrieve reliable context, validate facts against business logic, and explain decisions with evidence — without any cloud dependency.
+
+## When to Use
+
+Use this skill when the task is to:
+
+- install or re-connect the ontology MCP server (`hermes mcp add` → tools appear as `ontology_*`)
+- seed demo data and verify the server works end to end
+- define entities, relationships, or business rules (see `references/rules-dsl.md`)
+- teach the agent to look up context before answering (`ontology_query`, `ontology_get_entity`, `ontology_traverse`)
+- validate a fact or proposed action against business rules (`ontology_validate`) and justify the outcome (`ontology_explain`)
+- back up or migrate the ontology store (`ontology_export` / `ontology_import`)
+
+Use `fastmcp` when building a *new* MCP server from scratch. Use `mcporter` for ad-hoc CLI access to an existing MCP server. Use this skill when the goal is an ontology/graph + rules context layer specifically.
+
+## Included Files
+
+- `scripts/ontology_mcp_server.py` — the MCP server (stdio transport, FastMCP)
+- `scripts/test_mcp.py` — protocol smoke test (list tools, ingest, rule, validate, export)
+- `references/rules-dsl.md` — full rules DSL reference with worked examples
+
+## Install
+
+The server ships in this skill; register it with Hermes' native MCP client:
+
+```bash
+hermes mcp add ontology --command python --args "<path-to>/scripts/ontology_mcp_server.py"
+```
+
+Then **start a new session** (MCP tools have no hot-reload). The 11 tools appear as `ontology_*` in every conversation. Verify with:
+
+```bash
+hermes mcp list
+python "<path-to>/scripts/test_mcp.py"     # protocol smoke test
+python "<path-to>/scripts/ontology_mcp_server.py" --seed   # optional demo data
+```
+
+The store is a JSON file at `$HERMES_HOME/ontology_store.json` (default `~/.hermes/`); override with the `ONTOLOGY_STORE` env var. No network, no external services.
+
+## Data Model
+
+- **Entity** — a thing the agent should know: `{id, type, name, properties{...}, source, confidence, verified}`. `verified=false` marks unconfirmed facts so downstream rules can flag them.
+- **Relation** — a typed link: `{from, to, type}` (e.g. `jane_doe --works_at--> acme_corp`).
+- **Rule** — business logic: `{name, if:[conditions], then, severity, mode}`. Validation runs every rule against an entity and reports per-condition PASS/FAIL reasons.
+
+## Tool Reference
+
+| Tool | Purpose |
+|---|---|
+| `ontology_ingest_entity` | Add/update an entity (upsert by id or slugified name) |
+| `ontology_add_relationship` | Link two entities with a type |
+| `ontology_query` | Search entities by type, keyword, or property |
+| `ontology_get_entity` | One entity + its relationships |
+| `ontology_traverse` | BFS graph traversal along relationship types |
+| `ontology_add_rule` | Add/upsert a business rule by name |
+| `ontology_validate` | Run all rules against an entity → PASS/FAIL + reasons |
+| `ontology_explain` | Entity state + rule outcomes + evidence (confidence, source) |
+| `ontology_stats` | Graph statistics |
+| `ontology_export` / `ontology_import` | JSON backup / restore |
+
+## Usage Patterns
+
+### 1. Install and smoke-test
+
+```bash
+hermes mcp add ontology --command python --args "$(pwd)/scripts/ontology_mcp_server.py"
+python scripts/test_mcp.py
+```
+
+Completion criterion: `ALL SMOKE TESTS PASSED` and `hermes mcp list` shows `ontology ... ✓ enabled`.
+
+### 2. Build context before answering
+
+When the user asks about an entity the agent knows, query the graph first, then answer from verified entities. Ingest new facts as they surface, marking unconfirmed ones `verified=false`.
+
+### 3. Validate and explain a decision
+
+```text
+ontology_validate(entity_id="acme_corp")   → overall PASS/FAIL + per-rule reasons
+ontology_explain(entity_id="acme_corp")    → entity + rule evidence + confidence/source
+```
+
+Completion criterion: every claim in the final answer traces to a PASS rule or a cited entity property.
+
+### 4. Backup before migrating
+
+Call `ontology_export`, save the JSON, `ontology_import` on the target machine.
+
+## Common Pitfalls
+
+1. **Forgetting to restart Hermes after `hermes mcp add`.** MCP servers load at session start — tools stay invisible until a new session.
+2. **Rules can't see nested properties.** A condition checks `properties.<key>` first, then top-level entity fields (`verified`, `confidence`, `source`, `id`, `type`, `name`). Store rule-relevant facts at the top level of `properties` or as entity fields.
+3. **Hardcoding the store path.** The store is `$HERMES_HOME/ontology_store.json`; always read `ontology_stats` (it reports the path) instead of assuming `~/.hermes`.
+4. **Ingesting unverified facts as truth.** Leave `verified=false` for uncertain data so `ontology_validate` can flag it; set `verified_only=true` in queries when the answer must be confirmed.
+5. **Rule conditions are AND by default.** Use `"mode": "any"` when at least one condition should satisfy the rule.
+6. **Traversal depth limit.** `ontology_traverse` caps at 5 hops by design — use `ontology_query` for broad searches instead of deep walks.
+
+## Verification Checklist
+
+- [ ] `python scripts/test_mcp.py` → `ALL SMOKE TESTS PASSED`
+- [ ] `hermes mcp list` shows the server with status `✓ enabled`
+- [ ] Tools appear in a fresh session as `ontology_*` (new session required after add)
+- [ ] A rule with a top-level field (`verified`) and a rule with a `properties` field both evaluate correctly
+- [ ] `ontology_stats` shows the expected store path and counts
+- [ ] `ontology_export` output round-trips through `ontology_import`

--- a/optional-skills/mcp/ontology-context-layer/references/rules-dsl.md
+++ b/optional-skills/mcp/ontology-context-layer/references/rules-dsl.md
@@ -1,0 +1,100 @@
+# Rules DSL Reference
+
+Rules are plain JSON, stored in the ontology store and upserted by `ontology_add_rule` (matched on `name`).
+
+## Rule Shape
+
+```json
+{
+  "name": "Large deal needs approval",
+  "description": "Deals over $10k need manager sign-off.",
+  "if": [
+    {"property": "value", "op": "gt", "value": 10000}
+  ],
+  "then": "requires_manager_approval",
+  "severity": "warning",
+  "mode": "all"
+}
+```
+
+| Field | Default | Meaning |
+|---|---|---|
+| `name` | — (required) | Unique; adding a rule with an existing name replaces it |
+| `if` | — (required) | One condition dict, or a list of condition dicts |
+| `then` | `"ok"` | Machine-readable action/outcome label returned on PASS |
+| `severity` | `"info"` | `info` \| `warning` \| `error` — display hint |
+| `mode` | `"all"` | `all` = every condition must pass; `any` = at least one |
+| `description` | `""` | Human explanation surfaced in validation output |
+
+## Property Conditions
+
+Conditions check `properties.<key>` first, then top-level entity fields (`verified`, `confidence`, `source`, `id`, `type`, `name`).
+
+| op | Behavior | Example |
+|---|---|---|
+| `eq` | equality | `{"property":"status","op":"eq","value":"Won"}` |
+| `ne` | inequality | `{"property":"status","op":"ne","value":"Lost"}` |
+| `gt` / `gte` | numeric greater (or equal) | `{"property":"value","op":"gt","value":10000}` |
+| `lt` / `lte` | numeric less (or equal) | `{"property":"age","op":"lt","value":18}` |
+| `in` | value in a list | `{"property":"status","op":"in","value":["Scheduled","In Progress"]}` |
+| `contains` | substring in value | `{"property":"email","op":"contains","value":"@acme.test"}` |
+| `exists` | field present and non-empty | `{"property":"email","op":"exists"}` |
+| `not_exists` | field absent or empty | `{"property":"datePaidInFull","op":"not_exists"}` |
+
+## Relationship Conditions
+
+Count a specific relationship type from the entity, optionally filtered by the target's type:
+
+```json
+{"relationship": "works_at", "target_type": "Company", "count_op": "gte", "count": 1}
+```
+
+This passes when the entity has ≥1 outgoing `works_at` relation pointing at a `Company`.
+
+## Worked Examples
+
+**Approval gate — reject deals over $10k without manager sign-off:**
+
+```json
+{
+  "name": "Approval gate",
+  "if": [
+    {"property": "value", "op": "gt", "value": 10000},
+    {"property": "approved_by_manager", "op": "eq", "value": true}
+  ],
+  "then": "ok",
+  "severity": "error"
+}
+```
+
+**Follow-up required — unverified entity with no recent touch:**
+
+```json
+{
+  "name": "Follow-up required",
+  "if": [
+    {"property": "verified", "op": "eq", "value": false},
+    {"property": "lastTouchDate", "op": "not_exists"}
+  ],
+  "then": "call_today",
+  "severity": "warning"
+}
+```
+
+**Any-mode — blocked by price OR timing:**
+
+```json
+{
+  "name": "Objection detected",
+  "mode": "any",
+  "if": [
+    {"property": "objection", "op": "eq", "value": "Price"},
+    {"property": "objection", "op": "eq", "value": "Timing"}
+  ],
+  "then": "handle_objection"
+}
+```
+
+## Validation Output
+
+`ontology_validate(entity_id)` returns per-rule results; each carries `passed`, `mode`, per-condition `reasons` (`PASS`/`FAIL` lines with the evaluated detail), plus `then`, `severity`, and `description`. `overall` is `PASS` only when every rule passes.

--- a/optional-skills/mcp/ontology-context-layer/scripts/ontology_mcp_server.py
+++ b/optional-skills/mcp/ontology-context-layer/scripts/ontology_mcp_server.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""
+Ontology Context Layer — a lightweight MCP server for Hermes Agent.
+
+A local, ontology-based semantic context layer: it gives the agent a structured
+knowledge graph (entities + relationships) plus a business-rule engine, so it can
+retrieve reliable context, validate facts against business logic, and explain
+decisions with evidence.
+
+Data model:
+  - Entity:   {id, type, name, properties{...}, source, confidence, verified}
+  - Relation: {from, to, type, properties{...}}
+  - Rule:     {name, if[...], then, severity, mode}
+
+Rules DSL (JSON, see references/rules-dsl.md in this skill):
+  {
+    "name": "High-value account",
+    "if": [{"property": "annual_revenue", "op": "gt", "value": 100000}],
+    "then": "qualified",
+    "severity": "info",
+    "mode": "all"
+  }
+  ops: eq, ne, gt, gte, lt, lte, in, contains, exists, not_exists
+  conditions may also check relationships:
+  {"relationship": "works_at", "target_type": "Company", "count_op": "gte", "count": 1}
+
+Storage: JSON file at $HERMES_HOME/ontology_store.json (default ~/.hermes/).
+Override with the ONTOLOGY_STORE env var. No network, no external services.
+
+Usage:
+  python ontology_mcp_server.py            # stdio MCP server (connect via `hermes mcp add`)
+  python ontology_mcp_server.py --seed     # seed demo data, then serve
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+# ---------------------------------------------------------------------------
+# Storage layer
+# ---------------------------------------------------------------------------
+
+DEFAULT_STORE = os.path.join(
+    os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")),
+    "ontology_store.json",
+)
+STORE_PATH = os.environ.get("ONTOLOGY_STORE", DEFAULT_STORE)
+
+
+def _empty_store() -> dict[str, Any]:
+    return {"entities": {}, "relations": [], "rules": [], "meta": {"created": time.time()}}
+
+
+def load_store() -> dict[str, Any]:
+    p = Path(STORE_PATH)
+    if p.exists():
+        try:
+            return json.loads(p.read_text(encoding="utf-8"))
+        except Exception:
+            return _empty_store()
+    return _empty_store()
+
+
+def save_store(store: dict[str, Any]) -> None:
+    Path(STORE_PATH).parent.mkdir(parents=True, exist_ok=True)
+    Path(STORE_PATH).write_text(json.dumps(store, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def _eid() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+# ---------------------------------------------------------------------------
+# Rule engine
+# ---------------------------------------------------------------------------
+
+def _eval_op(op: str, actual: Any, expected: Any) -> tuple[bool, str]:
+    if op == "eq":
+        return actual == expected, f"expected == {expected!r}"
+    if op == "ne":
+        return actual != expected, f"expected != {expected!r}"
+    if op in ("gt", "gte", "lt", "lte"):
+        try:
+            a, e = float(actual), float(expected)
+        except (TypeError, ValueError):
+            return False, f"'{actual}' not numeric"
+        table = {"gt": a > e, "gte": a >= e, "lt": a < e, "lte": a <= e}
+        return table[op], f"expected {op} {expected}"
+    if op == "in":
+        return actual in expected, f"expected one of {expected}"
+    if op == "contains":
+        return expected in actual, f"expected to contain {expected!r}"
+    if op == "exists":
+        return actual is not None and actual != "", "expected to exist"
+    if op == "not_exists":
+        return actual is None or actual == "", "expected to be absent"
+    return False, f"unknown op {op}"
+
+
+def _rule_condition_satisfied(
+    condition: dict[str, Any], entity: dict[str, Any], store: dict[str, Any]
+) -> tuple[bool, str]:
+    """Evaluate one rule condition against an entity."""
+    if "property" in condition:
+        prop = condition["property"]
+        # properties first, then top-level entity fields (verified, confidence, source...)
+        if prop in entity.get("properties", {}):
+            actual = entity["properties"][prop]
+        else:
+            actual = entity.get(prop)
+        return _eval_op(condition.get("op", "eq"), actual, condition.get("value"))
+    if "relationship" in condition:
+        rel_type = condition["relationship"]
+        matches = [r for r in store["relations"] if r["from"] == entity["id"] and r["type"] == rel_type]
+        if condition.get("target_type"):
+            matches = [
+                r for r in matches
+                if store["entities"].get(r["to"], {}).get("type") == condition["target_type"]
+            ]
+        return _eval_op(condition.get("count_op", "gte"), len(matches), condition.get("count", 1))
+    return False, "condition missing 'property' or 'relationship'"
+
+
+def evaluate_rule(rule: dict[str, Any], entity: dict[str, Any], store: dict[str, Any]) -> dict[str, Any]:
+    """Evaluate a rule against an entity. Returns pass/fail with per-condition reasons."""
+    conditions = rule.get("if")
+    if not conditions:
+        return {"rule": rule.get("name", "?"), "passed": True, "reasons": [], "then": rule.get("then", "ok")}
+    if isinstance(conditions, dict):
+        conditions = [conditions]
+    mode = rule.get("mode", "all")  # all | any
+    satisfied = 0
+    reasons: list[str] = []
+    for cond in conditions:
+        ok, detail = _rule_condition_satisfied(cond, entity, store)
+        label = cond.get("property") or f"relationship:{cond.get('relationship')}"
+        reasons.append(f"{'PASS' if ok else 'FAIL'} {label} {detail}")
+        if ok:
+            satisfied += 1
+    passed = satisfied == len(conditions) if mode == "all" else satisfied > 0
+    return {
+        "rule": rule.get("name", "?"),
+        "passed": passed,
+        "mode": mode,
+        "reasons": reasons,
+        "then": rule.get("then", "ok"),
+        "severity": rule.get("severity", "info"),
+        "description": rule.get("description", ""),
+    }
+
+
+# ---------------------------------------------------------------------------
+# MCP server
+# ---------------------------------------------------------------------------
+
+mcp = FastMCP(
+    "hermes-ontology",
+    instructions=(
+        "Semantic context layer: manage entities, relationships and business rules; "
+        "query the knowledge graph; validate facts against rules; explain decisions. "
+        "Use ontology_query before answering factual questions about known entities, "
+        "ontology_validate to check facts against business logic, and ontology_explain "
+        "to show why a decision passed or failed."
+    ),
+)
+
+
+@mcp.tool()
+def ontology_ingest_entity(
+    type: str,
+    name: str,
+    properties: dict[str, Any] = {},
+    source: str = "manual",
+    confidence: float = 1.0,
+    verified: bool = True,
+    entity_id: str = "",
+) -> dict[str, Any]:
+    """Add or update an entity (a 'thing' the agent should know about) in the ontology graph."""
+    store = load_store()
+    eid = entity_id or name.lower().replace(" ", "_")[:64]
+    if eid in store["entities"]:
+        existing = store["entities"][eid]
+        existing["properties"] = {**existing.get("properties", {}), **properties}
+        existing.update({
+            "name": name, "type": type, "source": source,
+            "confidence": confidence, "verified": verified, "updated": time.time(),
+        })
+        action = "updated"
+    else:
+        store["entities"][eid] = {
+            "id": eid, "type": type, "name": name, "properties": dict(properties),
+            "source": source, "confidence": confidence, "verified": verified,
+            "created": time.time(), "updated": time.time(),
+        }
+        action = "created"
+    save_store(store)
+    return {"action": action, "id": eid, "entity": store["entities"][eid]}
+
+
+@mcp.tool()
+def ontology_add_relationship(
+    from_entity: str, to_entity: str, type: str, properties: dict[str, Any] = {}
+) -> dict[str, Any]:
+    """Link two entities with a typed relationship (e.g. from=acme_corp, to=jane_doe, type='employs')."""
+    store = load_store()
+    if from_entity not in store["entities"] or to_entity not in store["entities"]:
+        missing = [e for e in (from_entity, to_entity) if e not in store["entities"]]
+        return {"error": f"Unknown entities: {missing}. Ingest them first."}
+    rel = {
+        "id": _eid(), "from": from_entity, "to": to_entity, "type": type,
+        "properties": dict(properties),
+    }
+    store["relations"].append(rel)
+    save_store(store)
+    return {"action": "added", "relationship": rel}
+
+
+@mcp.tool()
+def ontology_query(
+    query: str = "",
+    type: str = "",
+    property_name: str = "",
+    property_value: Any = None,
+    verified_only: bool = False,
+    limit: int = 20,
+) -> dict[str, Any]:
+    """Search entities by type, name keyword, or property. Use to look up context before answering."""
+    store = load_store()
+    results = []
+    q = query.lower().strip()
+    for e in store["entities"].values():
+        if type and e["type"].lower() != type.lower():
+            continue
+        if verified_only and not e.get("verified", False):
+            continue
+        if property_name and e["properties"].get(property_name) != property_value:
+            continue
+        if q:
+            hay = (e.get("name", "") + " " + json.dumps(e.get("properties", {}))).lower()
+            if q not in hay:
+                continue
+        results.append(e)
+    return {"count": len(results), "results": results[:limit]}
+
+
+@mcp.tool()
+def ontology_get_entity(entity_id: str) -> dict[str, Any]:
+    """Get one entity by ID, including its outgoing relationships."""
+    store = load_store()
+    e = store["entities"].get(entity_id)
+    if not e:
+        return {"error": f"Entity '{entity_id}' not found. Use ontology_query to search."}
+    rels = [r for r in store["relations"] if r["from"] == entity_id or r["to"] == entity_id]
+    return {"entity": e, "relationships": rels}
+
+
+@mcp.tool()
+def ontology_traverse(
+    entity_id: str, relationship_type: str = "", max_depth: int = 1
+) -> dict[str, Any]:
+    """Traverse the knowledge graph from an entity along relationship types (BFS, max_depth hops)."""
+    store = load_store()
+    if entity_id not in store["entities"]:
+        return {"error": f"Entity '{entity_id}' not found."}
+    visited = {entity_id}
+    frontier = [entity_id]
+    levels: list[dict[str, Any]] = []
+    for _ in range(max(1, min(max_depth, 5))):
+        level: dict[str, Any] = {}
+        nxt = []
+        for cur in frontier:
+            for r in store["relations"]:
+                if r["from"] == cur and (not relationship_type or r["type"] == relationship_type):
+                    target = store["entities"].get(r["to"])
+                    if target and r["to"] not in visited:
+                        visited.add(r["to"])
+                        nxt.append(r["to"])
+                        level.setdefault(cur, []).append({
+                            "relationship": r["type"], "to": r["to"],
+                            "name": target.get("name"), "type": target.get("type"),
+                        })
+        if not level:
+            break
+        levels.append({"depth": len(levels) + 1, "connections": level})
+        frontier = nxt
+    return {"root": entity_id, "relationship_type": relationship_type or "any", "levels": levels}
+
+
+@mcp.tool()
+def ontology_add_rule(
+    name: str,
+    if_conditions: list[dict[str, Any]] | dict[str, Any],
+    then: str = "ok",
+    severity: str = "info",
+    description: str = "",
+    mode: str = "all",
+) -> dict[str, Any]:
+    """Add a business rule. Ops: eq,ne,gt,gte,lt,lte,in,contains,exists,not_exists over entity
+    properties, or {'relationship': type, 'count_op': 'gte', 'count': N} over relations."""
+    store = load_store()
+    rule = {
+        "name": name, "if": if_conditions, "then": then, "severity": severity,
+        "description": description, "mode": mode, "created": time.time(),
+    }
+    store["rules"] = [r for r in store["rules"] if r["name"] != name]  # upsert by name
+    store["rules"].append(rule)
+    save_store(store)
+    return {"action": "added", "rule": rule, "total_rules": len(store["rules"])}
+
+
+@mcp.tool()
+def ontology_validate(entity_id: str) -> dict[str, Any]:
+    """Validate an entity against ALL business rules. Returns pass/fail per rule with reasons."""
+    store = load_store()
+    e = store["entities"].get(entity_id)
+    if not e:
+        return {"error": f"Entity '{entity_id}' not found."}
+    if not store["rules"]:
+        return {"entity_id": entity_id, "note": "No rules defined yet. Use ontology_add_rule.", "results": []}
+    results = [evaluate_rule(r, e, store) for r in store["rules"]]
+    return {
+        "entity_id": entity_id,
+        "entity_name": e.get("name"),
+        "entity_type": e.get("type"),
+        "overall": "PASS" if all(r["passed"] for r in results) else "FAIL",
+        "results": results,
+    }
+
+
+@mcp.tool()
+def ontology_explain(entity_id: str) -> dict[str, Any]:
+    """Explain the current state of an entity: what's known, what rules pass/fail and why."""
+    store = load_store()
+    e = store["entities"].get(entity_id)
+    if not e:
+        return {"error": f"Entity '{entity_id}' not found."}
+    rels = [r for r in store["relations"] if r["from"] == entity_id]
+    validation = ontology_validate(entity_id)
+    return {
+        "entity": e,
+        "outgoing_relationships": [
+            {"type": r["type"], "to": r["to"], "name": store["entities"].get(r["to"], {}).get("name")}
+            for r in rels
+        ],
+        "rule_check": validation.get("overall", "no rules"),
+        "rule_details": validation.get("results", []),
+        "confidence": e.get("confidence"),
+        "verified": e.get("verified"),
+        "source": e.get("source"),
+    }
+
+
+@mcp.tool()
+def ontology_stats() -> dict[str, Any]:
+    """Show ontology graph statistics: entity counts by type, relation counts, rule count."""
+    store = load_store()
+    by_type: dict[str, int] = {}
+    for e in store["entities"].values():
+        by_type[e.get("type", "?")] = by_type.get(e.get("type", "?"), 0) + 1
+    rel_types: dict[str, int] = {}
+    for r in store["relations"]:
+        rel_types[r.get("type", "?")] = rel_types.get(r.get("type", "?"), 0) + 1
+    return {
+        "entities": len(store["entities"]),
+        "by_type": by_type,
+        "relations": len(store["relations"]),
+        "by_relationship_type": rel_types,
+        "rules": len(store["rules"]),
+        "store_path": STORE_PATH,
+    }
+
+
+@mcp.tool()
+def ontology_export() -> str:
+    """Export the full ontology store as JSON (for backup / sharing)."""
+    return json.dumps(load_store(), indent=2, ensure_ascii=False)
+
+
+@mcp.tool()
+def ontology_import(json_blob: str) -> dict[str, Any]:
+    """Replace the ontology store from a JSON blob produced by ontology_export."""
+    try:
+        data = json.loads(json_blob)
+    except Exception as exc:
+        return {"error": f"Invalid JSON: {exc}"}
+    if "entities" not in data or "relations" not in data or "rules" not in data:
+        return {"error": "Not a valid ontology export (missing entities/relations/rules)."}
+    save_store(data)
+    return {"action": "imported", "entities": len(data["entities"]), "relations": len(data["relations"]), "rules": len(data["rules"])}
+
+
+def seed_demo(store: dict[str, Any]) -> dict[str, Any]:
+    """Load a small demo knowledge graph so the tools are immediately useful."""
+    now = time.time()
+    store["entities"] = {
+        "acme_corp": {"id": "acme_corp", "type": "Company", "name": "Acme Corp",
+                      "properties": {"annual_revenue": 250000, "industry": "Construction", "region": "ON"},
+                      "source": "seed", "confidence": 1.0, "verified": True, "created": now, "updated": now},
+        "jane_doe": {"id": "jane_doe", "type": "Person", "name": "Jane Doe",
+                     "properties": {"role": "CFO", "email": "jane@acme.test"},
+                     "source": "seed", "confidence": 1.0, "verified": True, "created": now, "updated": now},
+        "bob_smith": {"id": "bob_smith", "type": "Person", "name": "Bob Smith",
+                      "properties": {"role": "Procurement", "email": "bob@acme.test"},
+                      "source": "seed", "confidence": 0.9, "verified": True, "created": now, "updated": now},
+        "proj_fence": {"id": "proj_fence", "type": "Project", "name": "Fence Replacement",
+                       "properties": {"value": 4500, "status": "Proposal", "deposit_paid": False},
+                       "source": "seed", "confidence": 1.0, "verified": True, "created": now, "updated": now},
+    }
+    store["relations"] = [
+        {"id": _eid(), "from": "jane_doe", "to": "acme_corp", "type": "works_at", "properties": {}},
+        {"id": _eid(), "from": "bob_smith", "to": "acme_corp", "type": "works_at", "properties": {}},
+        {"id": _eid(), "from": "proj_fence", "to": "acme_corp", "type": "sold_to", "properties": {}},
+    ]
+    store["rules"] = [
+        {"name": "Large deal needs approval",
+         "if": [{"property": "value", "op": "gt", "value": 10000}],
+         "then": "requires_manager_approval", "severity": "warning",
+         "description": "Deals over $10k need manager sign-off.", "mode": "all"},
+        {"name": "Deposit required before work",
+         "if": [{"property": "status", "op": "in", "value": ["Scheduled", "In Progress"]},
+                {"property": "deposit_paid", "op": "eq", "value": True}],
+         "then": "ok", "severity": "info",
+         "description": "Scheduled projects must have deposit paid.", "mode": "all"},
+        {"name": "Enterprise customer",
+         "if": [{"property": "annual_revenue", "op": "gt", "value": 100000}],
+         "then": "enterprise_tier", "severity": "info",
+         "description": "Revenue over $100k = enterprise tier.", "mode": "all"},
+    ]
+    return store
+
+
+if __name__ == "__main__":
+    if "--seed" in sys.argv:
+        st = load_store()
+        if not st["entities"]:
+            save_store(seed_demo(st))
+            print(f"[hermes-ontology] demo data seeded to {STORE_PATH}", file=sys.stderr)
+    mcp.run(transport="stdio")

--- a/optional-skills/mcp/ontology-context-layer/scripts/test_mcp.py
+++ b/optional-skills/mcp/ontology-context-layer/scripts/test_mcp.py
@@ -1,0 +1,63 @@
+"""Smoke test for the ontology-context-layer MCP server (stdio transport).
+
+Run: python scripts/test_mcp.py
+Requires: pip install mcp  (the Hermes venv already has it)
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+SERVER = Path(__file__).resolve().parent / "ontology_mcp_server.py"
+
+
+async def main() -> None:
+    params = StdioServerParameters(command=sys.executable, args=[str(SERVER)])
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            tools = await session.list_tools()
+            names = sorted(t.name for t in tools.tools)
+            assert "ontology_ingest_entity" in names, "missing ingest tool"
+            assert "ontology_validate" in names, "missing validate tool"
+            print(f"[OK] discovered {len(names)} tools: {', '.join(names)}")
+
+            r = await session.call_tool(
+                "ontology_ingest_entity",
+                {"type": "Company", "name": "GreenLeaf Landscaping",
+                 "properties": {"annual_revenue": 85000}, "source": "test", "verified": False},
+            )
+            assert "created" in r.content[0].text, "ingest failed"
+            print("[OK] ingested entity")
+
+            r = await session.call_tool(
+                "ontology_add_rule",
+                {"name": "Prospect needs call",
+                 "if_conditions": [{"property": "verified", "op": "eq", "value": False}],
+                 "then": "follow_up_required"},
+            )
+            assert "added" in r.content[0].text, "rule add failed"
+            print("[OK] added rule")
+
+            r = await session.call_tool(
+                "ontology_validate", {"entity_id": "greenleaf_landscaping"}
+            )
+            assert '"overall": "PASS"' in r.content[0].text, f"validate failed: {r.content[0].text}"
+            print("[OK] validation PASS")
+
+            r = await session.call_tool("ontology_stats", {})
+            assert "entities" in r.content[0].text, "stats failed"
+            print("[OK] stats")
+
+            r = await session.call_tool("ontology_export", {})
+            assert "entities" in r.content[0].text, "export failed"
+            print("[OK] export")
+
+            print("\nALL SMOKE TESTS PASSED")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## What does this PR do?

Adds `ontology-context-layer` — an optional skill under `optional-skills/mcp/` that ships a local, ontology-based semantic context layer for Hermes as an MCP server. It combines a knowledge graph (entities + typed relationships) with a business-rule engine so the agent can retrieve reliable context, validate facts against business logic, and explain decisions with evidence — zero cloud dependency.

The bundled FastMCP server exposes 11 tools:
- **Build:** `ontology_ingest_entity`, `ontology_add_relationship`
- **Retrieve:** `ontology_query`, `ontology_get_entity`, `ontology_traverse`
- **Validate:** `ontology_add_rule`, `ontology_validate`, `ontology_explain`
- **Ops:** `ontology_stats`, `ontology_export`, `ontology_import`

It registers via Hermes' native MCP client (`hermes mcp add ontology --command python --args <path>`), stores data in a JSON file under `$HERMES_HOME` (override with `ONTOLOGY_STORE`), and ships a protocol smoke test plus a rules-DSL reference.

## Related Issue

No existing issue — this is a new capability. Placement rationale: per CONTRIBUTING.md, specialized-but-official skills belong in `optional-skills/`; the `optional-skills/mcp/` category already hosts peer MCP skills (`fastmcp`, `mcporter`).

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/mcp/ontology-context-layer/SKILL.md` — skill definition: install steps, data model, tool reference, usage patterns, pitfalls, verification checklist
- `optional-skills/mcp/ontology-context-layer/scripts/ontology_mcp_server.py` — the MCP server (stdio, FastMCP); entities/relations/rules store + rule engine with per-condition PASS/FAIL reasoning
- `optional-skills/mcp/ontology-context-layer/scripts/test_mcp.py` — protocol smoke test (discovers tools, ingests, adds rule, validates, exports)
- `optional-skills/mcp/ontology-context-layer/references/rules-dsl.md` — rules DSL reference with worked examples

## How to Test

1. `python scripts/test_mcp.py` from the skill directory → prints `ALL SMOKE TESTS PASSED`
2. `hermes mcp add ontology --command python --args "<skill>/scripts/ontology_mcp_server.py"` → `hermes mcp list` shows the server `✓ enabled`
3. Start a new session; the 11 `ontology_*` tools are available
4. `python scripts/ontology_mcp_server.py --seed` → demo graph (Acme Corp, Jane Doe, 3 rules), then `ontology_validate(entity_id="acme_corp")` returns per-rule PASS/FAIL with reasons
5. `ONTOLOGY_STORE=/tmp/test.json` isolates the store for testing

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (optional skill; no core code touched; smoke test provided instead)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — protocol smoke test included
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — server uses stdlib + `mcp` package only, no OS-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — placed in `optional-skills/` since it is specialized; not bundled/activated by default
- [x] SKILL.md follows the standard format (frontmatter, trigger conditions, steps, pitfalls, verification checklist)
- [x] No external dependencies that aren't already available — stdlib + `mcp` package (Hermes already vendors/uses it for its native MCP client)
- [x] I've tested the skill end-to-end: smoke test + `hermes mcp add` verified locally
