### PR TITLE
feat: statusline provider usage + session workspace actions SDK

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -46,6 +46,41 @@ class AccountUsageSnapshot:
         return bool(self.windows or self.details) and not self.unavailable_reason
 
 
+def _datetime_to_utc_iso(value: Optional[datetime]) -> Optional[str]:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().removesuffix("+00:00") + "Z"
+
+
+def account_usage_snapshot_to_dict(
+    snapshot: Optional[AccountUsageSnapshot],
+) -> Optional[dict[str, Any]]:
+    """Serialize an account-usage snapshot using only credential-free JSON fields."""
+    if snapshot is None:
+        return None
+    return {
+        "provider": snapshot.provider,
+        "source": snapshot.source,
+        "fetched_at": _datetime_to_utc_iso(snapshot.fetched_at),
+        "title": snapshot.title,
+        "plan": snapshot.plan,
+        "available": snapshot.available,
+        "windows": [
+            {
+                "label": window.label,
+                "used_percent": window.used_percent,
+                "reset_at": _datetime_to_utc_iso(window.reset_at),
+                "detail": window.detail,
+            }
+            for window in snapshot.windows
+        ],
+        "details": list(snapshot.details),
+        "unavailable_reason": snapshot.unavailable_reason,
+    }
+
+
 def _title_case_slug(value: Optional[str]) -> Optional[str]:
     cleaned = str(value or "").strip()
     if not cleaned:

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -70,7 +70,7 @@ def account_usage_snapshot_to_dict(
         "windows": [
             {
                 "label": window.label,
-                "used_percent": window.used_percent,
+                "used_percent": float(window.used_percent) if _is_finite_num(window.used_percent) else None,
                 "reset_at": _datetime_to_utc_iso(window.reset_at),
                 "detail": window.detail,
             }

--- a/agent/rate_limit_tracker.py
+++ b/agent/rate_limit_tracker.py
@@ -23,6 +23,7 @@ Header schema (12 headers total):
 from __future__ import annotations
 
 import math
+import re
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -128,11 +129,27 @@ def _safe_int(value: Any, default: int = 0) -> int:
         return default
 
 
-def _safe_float(value: Any, default: float = 0.0) -> float:
+_DURATION_PART_RE = re.compile(r"(\d+(?:\.\d+)?)(ms|s|m|h)")
+_DURATION_MULTIPLIERS = {"ms": 0.001, "s": 1.0, "m": 60.0, "h": 3600.0}
+
+
+def _parse_reset_seconds(value: Any, *, now: float) -> float:
+    text = str(value or "").strip().lower()
+    if not text:
+        return 0.0
     try:
-        return float(value)
-    except (TypeError, ValueError):
-        return default
+        numeric = float(text)
+    except ValueError:
+        parts = list(_DURATION_PART_RE.finditer(text))
+        if not parts or "".join(part.group(0) for part in parts) != text:
+            return 0.0
+        return sum(float(part.group(1)) * _DURATION_MULTIPLIERS[part.group(2)] for part in parts)
+    if not math.isfinite(numeric):
+        return 0.0
+    # Providers use both relative seconds and Unix timestamps on the wire.
+    if numeric >= 1_000_000_000:
+        return max(0.0, numeric - now)
+    return max(0.0, numeric)
 
 
 def parse_rate_limit_headers(
@@ -161,7 +178,7 @@ def parse_rate_limit_headers(
         return RateLimitBucket(
             limit=_safe_int(lowered.get(f"x-ratelimit-limit-{tag}")),
             remaining=_safe_int(lowered.get(f"x-ratelimit-remaining-{tag}")),
-            reset_seconds=_safe_float(lowered.get(f"x-ratelimit-reset-{tag}")),
+            reset_seconds=_parse_reset_seconds(lowered.get(f"x-ratelimit-reset-{tag}"), now=now),
             captured_at=now,
         )
 

--- a/agent/rate_limit_tracker.py
+++ b/agent/rate_limit_tracker.py
@@ -22,8 +22,10 @@ Header schema (12 headers total):
 
 from __future__ import annotations
 
+import math
 import time
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any, Mapping, Optional
 
 
@@ -73,6 +75,50 @@ class RateLimitState:
         if not self.has_data:
             return float("inf")
         return time.time() - self.captured_at
+
+
+def _timestamp_to_utc_iso(value: float) -> Optional[str]:
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or not math.isfinite(value) or value <= 0:
+        return None
+    return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _bucket_to_dict(bucket: RateLimitBucket) -> dict[str, Any]:
+    reset_at = (
+        bucket.captured_at + bucket.reset_seconds
+        if math.isfinite(bucket.captured_at)
+        and bucket.captured_at > 0
+        and math.isfinite(bucket.reset_seconds)
+        and bucket.reset_seconds >= 0
+        else 0.0
+    )
+    used_percent = bucket.usage_pct
+    return {
+        "limit": int(bucket.limit),
+        "remaining": int(bucket.remaining),
+        "used": int(bucket.used),
+        "used_percent": float(used_percent) if math.isfinite(used_percent) else None,
+        "reset_at": _timestamp_to_utc_iso(reset_at),
+    }
+
+
+def rate_limit_state_to_dict(state: Optional[RateLimitState]) -> Optional[dict[str, Any]]:
+    """Serialize captured provider limits without response headers or credentials."""
+    if state is None:
+        return None
+    age_seconds = state.age_seconds
+    return {
+        "provider": str(state.provider or ""),
+        "captured_at": _timestamp_to_utc_iso(state.captured_at),
+        "age_seconds": max(0.0, float(age_seconds)) if math.isfinite(age_seconds) else None,
+        "available": state.has_data,
+        "buckets": {
+            "requests_min": _bucket_to_dict(state.requests_min),
+            "requests_hour": _bucket_to_dict(state.requests_hour),
+            "tokens_min": _bucket_to_dict(state.tokens_min),
+            "tokens_hour": _bucket_to_dict(state.tokens_hour),
+        },
+    }
 
 
 def _safe_int(value: Any, default: int = 0) -> int:

--- a/apps/desktop/src/app/chat/sidebar/session-actions-contrib.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-contrib.ts
@@ -21,6 +21,7 @@ export function isSessionActionContributionData(value: unknown): value is Sessio
   if (!value || typeof value !== 'object') {
     return false
   }
+
   const data = value as Partial<SessionActionContributionData>
 
   return (typeof data.label === 'string' || typeof data.label === 'function') && typeof data.onSelect === 'function'

--- a/apps/desktop/src/app/chat/sidebar/session-actions-contrib.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-contrib.ts
@@ -1,0 +1,27 @@
+import type { ActionItemSpec } from '@/components/ui/actions-menu'
+
+export const SESSION_ACTIONS_AREA = 'session.actions'
+
+export interface SessionActionContext {
+  sessionId: string
+  title: string
+  profile?: string
+  cwd?: string | null
+  surface: 'row' | 'tab'
+}
+
+export interface SessionActionContributionData {
+  label: string | ((context: SessionActionContext) => string)
+  icon?: ActionItemSpec['icon']
+  disabled?: boolean | ((context: SessionActionContext) => boolean)
+  onSelect: (context: SessionActionContext) => void | Promise<void>
+}
+
+export function isSessionActionContributionData(value: unknown): value is SessionActionContributionData {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const data = value as Partial<SessionActionContributionData>
+
+  return (typeof data.label === 'string' || typeof data.label === 'function') && typeof data.onSelect === 'function'
+}

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -4,7 +4,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { SessionActionsMenu } from './session-actions-menu'
 
-afterEach(cleanup)
+const contributedAction = vi.hoisted(() => vi.fn())
+
+afterEach(() => {
+  cleanup()
+  contributedAction.mockReset()
+})
 
 // Exercises the real SessionActionsMenu end-to-end (no DropdownMenu mock) so
 // a broken asChild composition on the kebab trigger fails here — the menu
@@ -15,6 +20,19 @@ vi.mock('@/components/pane-shell/tree/store', () => ({
   closeOtherTreeTabs: vi.fn(),
   closeTreeTabsToRight: vi.fn(),
   treeTabCloseTargets: vi.fn(() => null)
+}))
+vi.mock('@/contrib/react/use-contributions', () => ({
+  useContributions: () => [
+    {
+      area: 'session.actions',
+      id: 'test:change-workspace',
+      data: {
+        icon: 'folder-opened',
+        label: 'Change workspace…',
+        onSelect: contributedAction
+      }
+    }
+  ]
 }))
 vi.mock('@/hermes', () => ({ renameSession: vi.fn() }))
 vi.mock('@/i18n', () => ({
@@ -73,7 +91,7 @@ vi.mock('@/store/windows', () => ({
 
 function renderMenu() {
   return render(
-    <SessionActionsMenu sessionId="s1" title="My session">
+    <SessionActionsMenu cwd="/work/project" profile="work" sessionId="s1" title="My session">
       <button aria-label="Session actions" type="button">
         ⋮
       </button>
@@ -99,5 +117,26 @@ describe('SessionActionsMenu', () => {
     expect(await screen.findByRole('menu')).toBeTruthy()
     expect(screen.getByRole('menuitem', { name: /rename/i })).toBeTruthy()
     expect(screen.getByRole('menuitem', { name: /archive/i })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: /change workspace/i })).toBeTruthy()
+  })
+
+  it('invokes a contributed session action with durable row context', async () => {
+    renderMenu()
+    const trigger = screen.getByRole('button', { name: 'Session actions' })
+
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(trigger)
+    fireEvent.click(await screen.findByRole('menuitem', { name: /change workspace/i }))
+
+    await vi.waitFor(() =>
+      expect(contributedAction).toHaveBeenCalledWith({
+        cwd: '/work/project',
+        profile: 'work',
+        sessionId: 's1',
+        surface: 'row',
+        title: 'My session'
+      })
+    )
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -22,6 +22,7 @@ import { ColorSwatches } from '@/components/ui/color-swatches'
 import { CopyButton } from '@/components/ui/copy-button'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { useContributions } from '@/contrib/react/use-contributions'
 import { renameSession } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
@@ -42,6 +43,12 @@ import { $sessionTiles } from '@/store/session-states'
 import { canOpenSessionWindow } from '@/store/windows'
 
 import type { SessionTitleResponse } from '../../types'
+
+import {
+  isSessionActionContributionData,
+  SESSION_ACTIONS_AREA,
+  type SessionActionContext
+} from './session-actions-contrib'
 
 // Rename a session, preferring the gateway's session.title RPC over REST.
 //
@@ -93,6 +100,7 @@ interface SessionActions {
   title: string
   pinned?: boolean
   profile?: string
+  cwd?: string | null
   onPin?: () => void
   onBranch?: () => void
   onArchive?: () => void
@@ -137,6 +145,7 @@ function useSessionActions({
   title,
   pinned = false,
   profile,
+  cwd,
   onPin,
   onBranch,
   onArchive,
@@ -151,6 +160,42 @@ function useSessionActions({
   const [renameOpen, setRenameOpen] = useState(false)
   const tiles = useStore($sessionTiles)
   const selectedStoredSessionId = useStore($selectedStoredSessionId)
+  const sessionActionContributions = useContributions(SESSION_ACTIONS_AREA)
+
+  const actionContext: SessionActionContext = { sessionId, title, profile, cwd, surface }
+
+  const contributedItems: ActionItemSpec[] = sessionActionContributions.flatMap(contribution => {
+    if (!isSessionActionContributionData(contribution.data)) {
+      return []
+    }
+    const data = contribution.data
+    let label: string
+    let disabled: boolean
+
+    try {
+      label = typeof data.label === 'function' ? data.label(actionContext) : data.label
+      disabled = typeof data.disabled === 'function' ? data.disabled(actionContext) : Boolean(data.disabled)
+    } catch (error) {
+      console.warn(`session action contribution ${contribution.id} failed to resolve`, error)
+
+      return []
+    }
+
+    return [
+      {
+        disabled: !sessionId || disabled,
+        icon: data.icon,
+        key: contribution.id,
+        label,
+        onSelect: () => {
+          triggerHaptic('selection')
+          void Promise.resolve()
+            .then(() => data.onSelect(actionContext))
+            .catch(error => notifyError(error, label))
+        }
+      }
+    ]
+  })
 
   // Already showing as a tab somewhere (a tile, or loaded in main — main IS
   // a tab): offering "Open in new tab" again is noise.
@@ -342,6 +387,12 @@ function useSessionActions({
       />
       <kit.Separator />
       {workItems.map(item => renderActionItem(kit, item))}
+      {contributedItems.length > 0 && (
+        <>
+          <kit.Separator />
+          {contributedItems.map(item => renderActionItem(kit, item))}
+        </>
+      )}
       {tabCloseItems.length > 0 && (
         <>
           <kit.Separator />

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -168,6 +168,7 @@ function useSessionActions({
     if (!isSessionActionContributionData(contribution.data)) {
       return []
     }
+
     const data = contribution.data
     let label: string
     let disabled: boolean

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -92,6 +92,7 @@ function SidebarSessionRowImpl({
 
   return (
     <SessionContextMenu
+      cwd={session.cwd}
       onArchive={onArchive}
       onBranch={onBranch}
       onDelete={onDelete}
@@ -110,6 +111,7 @@ function SidebarSessionRowImpl({
               </span>
             )}
             <SessionActionsMenu
+              cwd={session.cwd}
               onArchive={onArchive}
               onBranch={onBranch}
               onDelete={onDelete}

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -23,7 +23,8 @@ import { atom, type ReadableAtom } from 'nanostores'
 import { $narrowViewport } from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
 import { getLogs, getStatus } from '@/hermes'
-import { $gateway } from '@/store/gateway'
+import { selectDesktopPaths } from '@/lib/desktop-fs'
+import { $gateway, requestGatewayForProfile } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $activeSessionId, $currentCwd, $currentModel, $gatewayState } from '@/store/session'
@@ -53,6 +54,19 @@ if (typeof window !== 'undefined') {
   const refresh = () => $viewport.set(readViewport())
   window.addEventListener('resize', refresh)
   $narrowViewport.listen(refresh)
+}
+
+export interface SessionWorkspaceChange {
+  sessionId: string
+  cwd: string
+  profile?: string
+}
+
+export interface SessionWorkspaceResult {
+  session_id: string
+  cwd: string
+  profile?: string
+  live: boolean
 }
 
 export const host = {
@@ -98,6 +112,24 @@ export const host = {
   /** One-shot system status snapshot (platforms, versions, …). */
   status: async () => getStatus(),
 
+  /** Select one local or remote workspace directory through Desktop's native picker. */
+  selectWorkspaceDirectory: async (defaultPath?: string): Promise<string | null> => {
+    const paths = await selectDesktopPaths({
+      defaultPath: defaultPath || undefined,
+      directories: true,
+      multiple: false
+    })
+
+    return paths[0] ?? null
+  },
+
+  /** Persist a stored session's workspace without foregrounding its profile. */
+  setSessionWorkspace: async (change: SessionWorkspaceChange): Promise<SessionWorkspaceResult> =>
+    requestGatewayForProfile<SessionWorkspaceResult>(change.profile, 'session.workspace.set', {
+      session_id: change.sessionId,
+      cwd: change.cwd
+    }),
+
   /** Gateway JSON-RPC — sessions, config, skills, cron, kanban, everything
    *  the app itself uses. Lazy: resolves the LIVE socket per call. */
   request: async <T>(method: string, params: Record<string, unknown> = {}): Promise<T> => {
@@ -120,6 +152,11 @@ export { COMPOSER_AREAS, type ComposerAttachmentProvider, type ComposerMiddlewar
 
 // -- ui: the design language --------------------------------------------------
 
+export {
+  SESSION_ACTIONS_AREA,
+  type SessionActionContext,
+  type SessionActionContributionData
+} from '@/app/chat/sidebar/session-actions-contrib'
 export { PALETTE_AREA, type PaletteContribution } from '@/app/command-palette/contrib'
 export { type RouteContribution, ROUTES_AREA, SIDEBAR_NAV_AREA, type SidebarNavContribution } from '@/app/routes'
 /** THE model catalog menu — the same searchable, provider-grouped, family-

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -266,6 +266,32 @@ export async function openGatewayForProfile(profile: string): Promise<void> {
   }
 }
 
+/** Request a profile's gateway without changing the foreground profile. */
+export async function requestGatewayForProfile<T>(
+  profile: string | null | undefined,
+  method: string,
+  params: Record<string, unknown> = {}
+): Promise<T> {
+  const key = normKey(profile)
+
+  if (key === g.primaryProfile) {
+    if (!g.primaryGateway) {
+      throw new Error('Hermes gateway unavailable')
+    }
+
+    return g.primaryGateway.request<T>(method, params)
+  }
+
+  await openGatewayForProfile(key)
+  const gateway = g.secondaries.get(key)?.gateway
+
+  if (!gateway) {
+    throw new Error(`Hermes gateway unavailable for profile ${key}`)
+  }
+
+  return gateway.request<T>(method, params)
+}
+
 // Make `profile` the active gateway, lazily opening its socket if needed. The
 // primary is a no-op fast path. Background sockets are never closed here.
 export async function ensureGatewayForProfile(profile: string): Promise<void> {

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -113,6 +113,21 @@ def test_account_usage_snapshot_to_dict_serializes_complete_snapshot():
     json.dumps(result, allow_nan=False)
 
 
+@pytest.mark.parametrize("used_percent", [float("nan"), float("inf"), float("-inf")])
+def test_account_usage_snapshot_to_dict_sanitizes_non_finite_percentages(used_percent):
+    snapshot = account_usage.AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage-api",
+        fetched_at=datetime(2026, 8, 2, tzinfo=timezone.utc),
+        windows=(account_usage.AccountUsageWindow(label="Session", used_percent=used_percent),),
+    )
+
+    result = account_usage.account_usage_snapshot_to_dict(snapshot)
+
+    assert result["windows"][0]["used_percent"] is None
+    json.dumps(result, allow_nan=False)
+
+
 def test_account_usage_snapshot_to_dict_serializes_unavailable_snapshot():
     snapshot = account_usage.AccountUsageSnapshot(
         provider="anthropic",

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -1,3 +1,5 @@
+import json
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -48,6 +50,91 @@ def codex_usage_payload():
         },
         "credits": {"has_credits": False},
     }
+
+
+def test_account_usage_snapshot_to_dict_returns_none_for_none():
+    assert account_usage.account_usage_snapshot_to_dict(None) is None
+
+
+def test_account_usage_snapshot_to_dict_serializes_complete_snapshot():
+    snapshot = account_usage.AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage-api",
+        fetched_at=datetime(
+            2026, 8, 2, 14, 30, 45, tzinfo=timezone(timedelta(hours=2))
+        ),
+        title="Codex limits",
+        plan="Pro",
+        windows=(
+            account_usage.AccountUsageWindow(
+                label="Session",
+                used_percent=12.5,
+                reset_at=datetime(
+                    2026, 8, 3, 1, 15, tzinfo=timezone(timedelta(hours=-5))
+                ),
+                detail="5 hour window",
+            ),
+        ),
+        details=("Credits available", "Priority access"),
+    )
+
+    result = account_usage.account_usage_snapshot_to_dict(snapshot)
+
+    assert result == {
+        "provider": "openai-codex",
+        "source": "usage-api",
+        "fetched_at": "2026-08-02T12:30:45Z",
+        "title": "Codex limits",
+        "plan": "Pro",
+        "available": True,
+        "windows": [
+            {
+                "label": "Session",
+                "used_percent": 12.5,
+                "reset_at": "2026-08-03T06:15:00Z",
+                "detail": "5 hour window",
+            }
+        ],
+        "details": ["Credits available", "Priority access"],
+        "unavailable_reason": None,
+    }
+    assert set(result) == {
+        "provider",
+        "source",
+        "fetched_at",
+        "title",
+        "plan",
+        "available",
+        "windows",
+        "details",
+        "unavailable_reason",
+    }
+    assert set(result["windows"][0]) == {"label", "used_percent", "reset_at", "detail"}
+    json.dumps(result, allow_nan=False)
+
+
+def test_account_usage_snapshot_to_dict_serializes_unavailable_snapshot():
+    snapshot = account_usage.AccountUsageSnapshot(
+        provider="anthropic",
+        source="oauth-usage-api",
+        fetched_at=datetime(2026, 8, 2, tzinfo=timezone.utc),
+        unavailable_reason="Usage endpoint unavailable",
+    )
+
+    result = account_usage.account_usage_snapshot_to_dict(snapshot)
+
+    assert result == {
+        "provider": "anthropic",
+        "source": "oauth-usage-api",
+        "fetched_at": "2026-08-02T00:00:00Z",
+        "title": "Account limits",
+        "plan": None,
+        "available": False,
+        "windows": [],
+        "details": [],
+        "unavailable_reason": "Usage endpoint unavailable",
+    }
+    json.dumps(result, allow_nan=False)
 
 
 def test_codex_usage_prefers_explicit_live_agent_credentials(monkeypatch, codex_usage_payload):

--- a/tests/agent/test_rate_limit_tracker.py
+++ b/tests/agent/test_rate_limit_tracker.py
@@ -1,6 +1,8 @@
 """Tests for agent.rate_limit_tracker — header parsing and formatting."""
-
+import json
 import time
+from datetime import datetime, timezone
+
 import pytest
 from agent.rate_limit_tracker import (
     RateLimitBucket,
@@ -62,6 +64,54 @@ class TestParseHeaders:
 
 
 class TestBucket:
+    def test_snapshot_serialization_is_json_safe(self, monkeypatch):
+        captured_at = 1_700_000_000.0
+        monkeypatch.setattr(time, "time", lambda: captured_at + 15)
+        state = RateLimitState(
+            requests_min=RateLimitBucket(limit=100, remaining=75, reset_seconds=60, captured_at=captured_at),
+            requests_hour=RateLimitBucket(limit=1000, remaining=900, reset_seconds=3600, captured_at=captured_at),
+            captured_at=captured_at,
+            provider="xai-oauth",
+        )
+
+        from agent.rate_limit_tracker import rate_limit_state_to_dict
+
+        payload = rate_limit_state_to_dict(state)
+
+        assert payload is not None
+        assert set(payload) == {"provider", "captured_at", "age_seconds", "available", "buckets"}
+        assert payload["provider"] == "xai-oauth"
+        assert payload["captured_at"] == datetime.fromtimestamp(captured_at, tz=timezone.utc).isoformat().replace(
+            "+00:00", "Z"
+        )
+        assert payload["age_seconds"] == pytest.approx(15)
+        assert payload["available"] is True
+        assert set(payload["buckets"]) == {"requests_min", "requests_hour", "tokens_min", "tokens_hour"}
+        request_bucket = payload["buckets"]["requests_min"]
+        assert set(request_bucket) == {"limit", "remaining", "used", "used_percent", "reset_at"}
+        assert request_bucket == {
+            "limit": 100,
+            "remaining": 75,
+            "used": 25,
+            "used_percent": 25.0,
+            "reset_at": datetime.fromtimestamp(captured_at + 60, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+        }
+        json.dumps(payload, allow_nan=False)
+
+    def test_snapshot_serialization_handles_none_and_non_finite_values(self):
+        from agent.rate_limit_tracker import rate_limit_state_to_dict
+
+        assert rate_limit_state_to_dict(None) is None
+        state = RateLimitState(
+            requests_min=RateLimitBucket(limit=100, remaining=20, reset_seconds=float("inf"), captured_at=1.0),
+            captured_at=1.0,
+            provider="xai",
+        )
+        payload = rate_limit_state_to_dict(state)
+        assert payload["buckets"]["requests_min"]["reset_at"] is None
+        json.dumps(payload, allow_nan=False)
 
     def test_usage_pct(self):
         b = RateLimitBucket(limit=100, remaining=20, reset_seconds=30.0, captured_at=time.time())

--- a/tests/agent/test_rate_limit_tracker.py
+++ b/tests/agent/test_rate_limit_tracker.py
@@ -59,8 +59,42 @@ class TestParseHeaders:
         state = parse_rate_limit_headers({})
         assert state is None
 
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [("1s", 1.0), ("250ms", 0.25), ("1m30s", 90.0), ("2h5m", 7_500.0)],
+    )
+    def test_parses_openai_wire_reset_durations(self, raw, expected):
+        state = parse_rate_limit_headers(
+            {
+                "x-ratelimit-limit-requests": "10",
+                "x-ratelimit-remaining-requests": "9",
+                "x-ratelimit-reset-requests": raw,
+            },
+            provider="xai-oauth",
+        )
+        assert state.requests_min.reset_seconds == pytest.approx(expected)
 
+    def test_parses_epoch_reset_timestamp_as_remaining_seconds(self, monkeypatch):
+        monkeypatch.setattr(time, "time", lambda: 1_700_000_000.0)
+        state = parse_rate_limit_headers(
+            {
+                "x-ratelimit-limit-requests": "10",
+                "x-ratelimit-remaining-requests": "9",
+                "x-ratelimit-reset-requests": "1700000045",
+            },
+            provider="xai-oauth",
+        )
+        assert state.requests_min.reset_seconds == pytest.approx(45.0)
 
+    def test_invalid_reset_value_degrades_to_zero(self):
+        state = parse_rate_limit_headers(
+            {
+                "x-ratelimit-limit-requests": "10",
+                "x-ratelimit-remaining-requests": "9",
+                "x-ratelimit-reset-requests": "not-a-duration",
+            }
+        )
+        assert state.requests_min.reset_seconds == 0.0
 
 
 class TestBucket:

--- a/tests/tui_gateway/test_session_workspace_set.py
+++ b/tests/tui_gateway/test_session_workspace_set.py
@@ -1,0 +1,270 @@
+"""Contract tests for persistent ``session.workspace.set`` workspace mutation.
+
+Unlike ``session.cwd.set`` (which addresses a gateway-local live-session id),
+this RPC addresses the durable SessionDB id.  It must therefore work for both
+live sessions and historical sessions that have no in-memory agent.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_state import SessionDB
+import tools.terminal_tool as terminal_tool
+import tui_gateway.server as server
+
+
+METHOD = "session.workspace.set"
+
+
+def _rpc(**params):
+    return server.handle_request(
+        {"jsonrpc": "2.0", "id": "workspace-set", "method": METHOD, "params": params}
+    )
+
+
+def _assert_error(response, code: int, message: str) -> None:
+    assert response == {
+        "jsonrpc": "2.0",
+        "id": "workspace-set",
+        "error": {"code": code, "message": message},
+    }
+
+
+@pytest.fixture()
+def gateway(tmp_path, monkeypatch):
+    """Use only temp HOME/HERMES_HOME state, including named-profile DBs."""
+    fake_home = tmp_path / "home"
+    hermes_home = fake_home / ".hermes"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(server, "_hermes_home", hermes_home)
+
+    previous_db = server._db
+    server._sessions.clear()
+    db = SessionDB(db_path=hermes_home / "state.db")
+    server._db = db
+    try:
+        yield SimpleNamespace(
+            db=db,
+            fake_home=fake_home,
+            hermes_home=hermes_home,
+        )
+    finally:
+        server._sessions.clear()
+        server._db = previous_db
+        db.close()
+
+
+def test_live_idle_session_uses_set_cwd_semantics_and_emits_info(
+    gateway, tmp_path, monkeypatch
+):
+    durable_id = "20260802_120000_live01"
+    ui_session_id = "live-ui"
+    old_cwd = tmp_path / "old"
+    workspace = gateway.fake_home / "workspace"
+    old_cwd.mkdir()
+    workspace.mkdir()
+    gateway.db.create_session(durable_id, source="desktop", cwd=str(old_cwd))
+
+    live = {
+        "agent": object(),
+        "cwd": str(old_cwd),
+        "cwd_from_settle": True,
+        "explicit_cwd": False,
+        "running": False,
+        "session_key": durable_id,
+    }
+    server._sessions[ui_session_id] = live
+
+    registered = []
+    cleaned = []
+    git_meta = []
+    emitted = []
+    monkeypatch.setattr(
+        terminal_tool,
+        "register_task_env_overrides",
+        lambda session_id, overrides: registered.append((session_id, overrides)),
+    )
+    monkeypatch.setattr(terminal_tool, "cleanup_vm", lambda session_id: cleaned.append(session_id))
+    monkeypatch.setattr(
+        server,
+        "_persist_session_git_meta",
+        lambda session, cwd: git_meta.append((session, cwd)),
+    )
+    expected_info = {
+        "cwd": str(workspace),
+        "branch": "feature/live",
+        "project": {"id": "project-live"},
+        "running": False,
+    }
+    monkeypatch.setattr(server, "_session_info", lambda agent, session: expected_info)
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, session_id, payload=None: emitted.append(
+            (event, session_id, payload)
+        ),
+    )
+
+    response = _rpc(
+        session_id=durable_id,
+        # Exercises both ~ expansion and normalization of a redundant segment.
+        cwd="~/workspace/../workspace",
+    )
+
+    assert response["result"] == expected_info
+    assert live["cwd"] == str(workspace)
+    assert live["explicit_cwd"] is True
+    assert live["cwd_from_settle"] is False
+    assert gateway.db.get_session(durable_id)["cwd"] == str(workspace)
+    assert registered == [(durable_id, {"cwd": str(workspace)})]
+    assert cleaned == [durable_id]
+    assert git_meta == [(live, str(workspace))]
+    assert emitted == [("session.info", ui_session_id, expected_info)]
+
+
+def test_live_busy_session_is_rejected_without_mutation(gateway, tmp_path, monkeypatch):
+    durable_id = "20260802_120001_busy01"
+    old_cwd = tmp_path / "old"
+    requested = tmp_path / "requested"
+    old_cwd.mkdir()
+    requested.mkdir()
+    gateway.db.create_session(durable_id, source="desktop", cwd=str(old_cwd))
+    live = {
+        "agent": object(),
+        "cwd": str(old_cwd),
+        "explicit_cwd": False,
+        "running": True,
+        "session_key": durable_id,
+    }
+    server._sessions["busy-ui"] = live
+    cleaned = []
+    monkeypatch.setattr(terminal_tool, "cleanup_vm", lambda sid: cleaned.append(sid))
+
+    response = _rpc(session_id=durable_id, cwd=str(requested))
+
+    _assert_error(response, 4009, "session busy")
+    assert live["cwd"] == str(old_cwd)
+    assert live["explicit_cwd"] is False
+    assert gateway.db.get_session(durable_id)["cwd"] == str(old_cwd)
+    assert cleaned == []
+
+
+def test_inactive_session_is_updated_in_requested_profile(
+    gateway, tmp_path, monkeypatch
+):
+    durable_id = "20260802_120002_profile01"
+    old_default = tmp_path / "default-old"
+    old_profile = tmp_path / "profile-old"
+    workspace = tmp_path / "profile-workspace"
+    for path in (old_default, old_profile, workspace):
+        path.mkdir()
+
+    # Same durable id in two profiles makes a wrong-profile write observable.
+    gateway.db.create_session(durable_id, source="desktop", cwd=str(old_default))
+    profile_home = gateway.hermes_home / "profiles" / "work"
+    profile_home.mkdir(parents=True)
+    profile_db = SessionDB(db_path=profile_home / "state.db")
+    profile_db.create_session(durable_id, source="desktop", cwd=str(old_profile))
+    profile_db.close()
+
+    update_calls = []
+    original_update = SessionDB.update_session_cwd
+
+    def record_update(self, session_id, cwd, git_branch=None, git_repo_root=None):
+        update_calls.append((session_id, cwd, git_branch, git_repo_root))
+        return original_update(self, session_id, cwd, git_branch, git_repo_root)
+
+    monkeypatch.setattr(SessionDB, "update_session_cwd", record_update)
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda cwd: "feature/profile")
+    monkeypatch.setattr(
+        server,
+        "_project_info_for_cwd",
+        lambda cwd: {"id": "project-profile", "primary_path": cwd},
+    )
+
+    response = _rpc(session_id=durable_id, profile="work", cwd=str(workspace))
+
+    assert response["result"] == {
+        "session_id": durable_id,
+        "cwd": str(workspace),
+        "branch": "feature/profile",
+        "project": {"id": "project-profile", "primary_path": str(workspace)},
+        "lazy": True,
+    }
+    assert update_calls and update_calls[0][:2] == (durable_id, str(workspace))
+    assert gateway.db.get_session(durable_id)["cwd"] == str(old_default)
+    check = SessionDB(db_path=profile_home / "state.db")
+    try:
+        assert check.get_session(durable_id)["cwd"] == str(workspace)
+    finally:
+        check.close()
+
+
+def test_unknown_durable_id_is_stable_error_without_db_mutation(gateway, tmp_path):
+    known_id = "20260802_120003_known01"
+    old_cwd = tmp_path / "old"
+    requested = tmp_path / "requested"
+    old_cwd.mkdir()
+    requested.mkdir()
+    gateway.db.create_session(known_id, source="desktop", cwd=str(old_cwd))
+
+    response = _rpc(session_id="does-not-exist", cwd=str(requested))
+
+    _assert_error(response, 4007, "session not found")
+    assert gateway.db.get_session(known_id)["cwd"] == str(old_cwd)
+
+
+def test_missing_session_id_is_stable_error_without_db_mutation(gateway, tmp_path):
+    known_id = "20260802_120004_known02"
+    old_cwd = tmp_path / "old"
+    requested = tmp_path / "requested"
+    old_cwd.mkdir()
+    requested.mkdir()
+    gateway.db.create_session(known_id, source="desktop", cwd=str(old_cwd))
+
+    response = _rpc(cwd=str(requested))
+
+    _assert_error(response, 4006, "session_id required")
+    assert gateway.db.get_session(known_id)["cwd"] == str(old_cwd)
+
+
+def test_missing_cwd_is_stable_error_without_db_mutation(gateway, tmp_path):
+    durable_id = "20260802_120005_missingcwd"
+    old_cwd = tmp_path / "old"
+    old_cwd.mkdir()
+    gateway.db.create_session(durable_id, source="desktop", cwd=str(old_cwd))
+
+    response = _rpc(session_id=durable_id)
+
+    _assert_error(response, 4016, "cwd required")
+    assert gateway.db.get_session(durable_id)["cwd"] == str(old_cwd)
+
+
+@pytest.mark.parametrize("candidate_kind", ["missing", "file"])
+def test_non_directory_is_stable_error_without_db_mutation(
+    gateway, tmp_path, candidate_kind
+):
+    durable_id = f"20260802_120006_{candidate_kind}"
+    old_cwd = tmp_path / "old"
+    candidate = tmp_path / candidate_kind
+    old_cwd.mkdir()
+    if candidate_kind == "file":
+        candidate.write_text("not a directory\n", encoding="utf-8")
+    gateway.db.create_session(durable_id, source="desktop", cwd=str(old_cwd))
+
+    response = _rpc(session_id=durable_id, cwd=str(candidate))
+
+    _assert_error(
+        response,
+        4017,
+        f"working directory does not exist: {os.fspath(candidate)}",
+    )
+    assert gateway.db.get_session(durable_id)["cwd"] == str(old_cwd)

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -724,6 +724,87 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, info)
 
 
+@method("session.workspace.set")
+def _(rid, params: dict) -> dict:
+    """Persist a workspace by durable SessionDB id, live or inactive."""
+    target = str(params.get("session_id") or "").strip()
+    if not target:
+        return _err(rid, 4006, "session_id required")
+    raw = str(params.get("cwd") or "").strip()
+    if not raw:
+        return _err(rid, 4016, "cwd required")
+
+    profile = (params.get("profile") or "").strip() or None
+    profile_home = _profile_home(profile)
+    with _profile_db(params) as db:
+        if db is None:
+            return _db_unavailable_error(rid, code=5006)
+        if db.get_session(target) is None:
+            return _err(rid, 4007, "session not found")
+
+        live = None
+        with _sessions_lock:
+            for sid, session in _sessions.items():
+                if session.get("_finalized") or session.get("session_key") != target:
+                    continue
+                live_home = session.get("profile_home")
+                if profile_home is None:
+                    same_profile = not live_home
+                else:
+                    same_profile = (
+                        bool(live_home)
+                        and Path(live_home).resolve() == Path(profile_home).resolve()
+                    )
+                if same_profile:
+                    live = sid, session
+                    break
+
+        if live is not None:
+            sid, session = live
+            history_lock = session.get("history_lock")
+            lock = (
+                history_lock if history_lock is not None else contextlib.nullcontext()
+            )
+            with lock:
+                if session.get("running"):
+                    return _err(rid, 4009, "session busy")
+                try:
+                    cwd = _set_session_cwd(session, raw)
+                except ValueError as e:
+                    return _err(rid, 4017, str(e))
+            agent = session.get("agent")
+            info = (
+                _session_info(agent, session)
+                if agent is not None
+                else {
+                    "cwd": cwd,
+                    "branch": _git_branch_for_cwd(cwd),
+                    "project": _project_info_for_cwd(cwd),
+                    "lazy": True,
+                }
+            )
+            _emit("session.info", sid, info)
+            return _ok(rid, info)
+
+        try:
+            cwd = _resolve_session_cwd(raw)
+        except ValueError as e:
+            return _err(rid, 4017, str(e))
+        branch = _git_branch_for_cwd(cwd)
+        repo_root = _git_common_repo_root_for_cwd(cwd)
+        db.update_session_cwd(target, cwd, branch, repo_root)
+        return _ok(
+            rid,
+            {
+                "session_id": target,
+                "cwd": cwd,
+                "branch": branch,
+                "project": _project_info_for_cwd(cwd),
+                "lazy": True,
+            },
+        )
+
+
 @method("session.active_list")
 def _(rid, params: dict) -> dict:
     """Return live TUI sessions in this gateway process.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2776,13 +2776,18 @@ def _persist_session_git_meta(session: dict, cwd: str) -> None:
     threading.Thread(target=_run, name="git-meta", daemon=True).start()
 
 
-def _set_session_cwd(session: dict, cwd: str) -> str:
+def _resolve_session_cwd(cwd: str) -> str:
     from hermes_constants import translate_cwd_for_wsl_backend
 
     cwd = translate_cwd_for_wsl_backend(str(cwd))
     resolved = os.path.abspath(os.path.expanduser(cwd))
     if not os.path.isdir(resolved):
         raise ValueError(f"working directory does not exist: {cwd}")
+    return resolved
+
+
+def _set_session_cwd(session: dict, cwd: str) -> str:
+    resolved = _resolve_session_cwd(cwd)
     session["cwd"] = resolved
     # An explicit user choice — persist it as the workspace (and let a later
     # lazy row creation persist it too, not the launch-dir fallback).

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -200,6 +200,7 @@ Import the area constants from the SDK; each area has its own `data` payload.
 | Full page | `ROUTES_AREA` | `data: { path }` + `render` |
 | Sidebar nav | `SIDEBAR_NAV_AREA` | `data: { path, label, codicon }` |
 | Status bar | `STATUSBAR_AREAS.left` / `.right` | `render` (or `data` as `StatusbarItem`) |
+| Session menu | `SESSION_ACTIONS_AREA` (`'session.actions'`) | `data: SessionActionContributionData` |
 | Title bar | `TITLEBAR_AREAS.left` / `.center` / `.right` | `data` as `TitlebarTool`, or a mount-scoped `<Contribute>` |
 | ⌘K palette | `PALETTE_AREA` | `data: PaletteContribution` |
 | Keybind | `KEYBINDS_AREA` | `data: KeybindContribution` |
@@ -265,6 +266,35 @@ ctx.registerMany([
 
 `codicon` is a [VS Code codicon](https://microsoft.github.io/vscode-codicons/dist/codicon.html)
 id. Navigate to a route from anywhere with `host.navigate('/my-page')`.
+
+### Session actions
+
+Session-action contributions render in both the session row's three-dot menu and
+its context menu. The callback receives the durable stored-session identity, its
+profile, current cwd, title, and surface. Core isolates sync and async callback
+failures and reports them as notifications.
+
+```javascript
+import { host, SESSION_ACTIONS_AREA } from '@hermes/plugin-sdk'
+
+ctx.register({
+  id: 'change-workspace',
+  area: SESSION_ACTIONS_AREA,
+  data: {
+    icon: 'folder-opened',
+    label: 'Change workspace…',
+    async onSelect(session) {
+      const cwd = await host.selectWorkspaceDirectory(session.cwd ?? undefined)
+      if (!cwd) return
+      await host.setSessionWorkspace({ sessionId: session.sessionId, profile: session.profile, cwd })
+    }
+  }
+})
+```
+
+Use the curated picker and workspace mutation above instead of importing Desktop
+filesystem or gateway internals. A busy live session rejects the mutation rather
+than changing its cwd mid-turn.
 
 ### Status bar and title bar
 
@@ -375,6 +405,8 @@ host.onEvent(type, fn)                     // gateway event stream ('*' = all); 
 host.logs(...)                             // tail an app log file
 host.status()                              // one-shot system status snapshot
 host.restartGateway()                      // restart the backend gateway
+host.selectWorkspaceDirectory(defaultPath?) // native local/remote directory picker
+host.setSessionWorkspace({ sessionId, profile?, cwd }) // durable profile-routed mutation
 host.request<T>(method, params?)           // gateway JSON-RPC — the real power
 ```
 
@@ -596,10 +628,10 @@ not treat this pipeline as a trust boundary.
 
 | Category | Exports |
 |----------|---------|
-| Host | `host` (`.state.*`, `.notify`, `.notifyError`, `.navigate`, `.onEvent`, `.logs`, `.status`, `.restartGateway`, `.request`) |
+| Host | `host` (`.state.*`, `.notify`, `.notifyError`, `.navigate`, `.onEvent`, `.logs`, `.status`, `.restartGateway`, `.selectWorkspaceDirectory`, `.setSessionWorkspace`, `.request`) |
 | Plugin contract | `HermesPlugin`, `PluginContext`, `PluginContribution`, `PluginStorage`, `PluginRestOptions`, `Contribution` |
-| Area constants | `PANES_AREA`, `ROUTES_AREA`, `SIDEBAR_NAV_AREA`, `STATUSBAR_AREAS`, `TITLEBAR_AREAS`, `PALETTE_AREA`, `KEYBINDS_AREA`, `THEMES_AREA`, `COMPOSER_AREAS` |
-| Area payloads | `RouteContribution`, `SidebarNavContribution`, `StatusbarItem`, `TitlebarTool`, `PaletteContribution`, `KeybindContribution`, `ComposerMiddleware`, `ComposerAttachmentProvider` |
+| Area constants | `PANES_AREA`, `ROUTES_AREA`, `SIDEBAR_NAV_AREA`, `SESSION_ACTIONS_AREA`, `STATUSBAR_AREAS`, `TITLEBAR_AREAS`, `PALETTE_AREA`, `KEYBINDS_AREA`, `THEMES_AREA`, `COMPOSER_AREAS` |
+| Area payloads | `RouteContribution`, `SidebarNavContribution`, `SessionActionContext`, `SessionActionContributionData`, `StatusbarItem`, `TitlebarTool`, `PaletteContribution`, `KeybindContribution`, `ComposerMiddleware`, `ComposerAttachmentProvider` |
 | React / state | `useValue`, `atom`, `computed`, `useQuery`, `useMutation`, `useQueryClient`, `queryClient`, `Contribute` |
 | UI kit | `Button`, `Input`, `Textarea`, `Select*`, `Switch`, `Checkbox`, `SegmentedControl`, `Tabs*`, `Dialog*`, `ConfirmDialog`, `DropdownMenu*`, `ContextMenu*`, `Popover*`, `Tip`/`Tooltip*`, `Badge`, `Kbd`/`KbdGroup`, `SearchField`, `ScrollArea`, `Separator`, `Skeleton`, `GlyphSpinner`, `Loader`, `EmptyState`, `ErrorState`, `CopyButton`, `StatusDot`, `LogView`, `Codicon`, `DecodeText` |
 | Helpers | `cn`, `icons`, `haptic`, `useI18n`, `profileColor`, `profileColorSoft`, `relativeTime`, `fmtDateTime`, `fmtDayTime`, `coarseElapsed`, `evaluateRuntimeReadiness` |


### PR DESCRIPTION
## Summary
Adds the core/gateway/desktop plumbing needed by the external Desktop plugin [hermes-statusline-workspaces](https://github.com/Codezilla-jpg/hermes-statusline-workspaces):

- JSON-safe, credential-free serialization for provider account usage snapshots
- JSON-safe live rate-limit state serialization + OpenAI-compatible reset duration parsing
- Persistent `session.workspace.set` RPC (durable session id, optional profile, busy-session guard)
- Desktop SDK contribution area `session.actions` plus curated host helpers:
  - `host.selectWorkspaceDirectory`
  - `host.setSessionWorkspace`
- SDK docs updated accordingly

## Companion plugin
- Repo: https://github.com/Codezilla-jpg/hermes-statusline-workspaces
- Release: https://github.com/Codezilla-jpg/hermes-statusline-workspaces/releases/tag/v0.1.0

## Notes / follow-ups
- Gateway RPC `usage.providers` is still a planned follow-up for a single combined account+rate-limit payload.
- Rate-limit overflow/edge-case hardening can still be tightened further.

## Test plan
- [x] `tests/agent/test_account_usage.py` (serializer + account suites)
- [x] `tests/agent/test_rate_limit_tracker.py`
- [x] `tests/tui_gateway/test_session_workspace_set.py` (+ adjacent session/cwd suites)
- [x] Desktop: `session-actions-menu.test.tsx`, typecheck on touched surfaces
- [ ] CI full matrix