### PR TITLE
fix(desktop): show recorded cost per model in Usage

### DIFF
--- a/apps/desktop/src/app/command-center/index.test.tsx
+++ b/apps/desktop/src/app/command-center/index.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { AnalyticsResponse } from '@/hermes'
+
+import { UsagePanel } from './index'
+
+const usage: AnalyticsResponse = {
+  by_model: [
+    {
+      api_calls: 7,
+      estimated_cost: 0.25,
+      input_tokens: 900_000,
+      model: 'provider/model-a',
+      output_tokens: 100_000,
+      sessions: 2
+    },
+    {
+      api_calls: 3,
+      estimated_cost: 0.006,
+      input_tokens: 45_000,
+      model: 'provider/model-b',
+      output_tokens: 5_000,
+      sessions: 1
+    },
+    {
+      api_calls: 1,
+      estimated_cost: 0.000001,
+      input_tokens: 10,
+      model: 'provider/tiny-cost-model',
+      output_tokens: 0,
+      sessions: 1
+    }
+  ],
+  daily: [],
+  period_days: 30,
+  skills: {
+    summary: {
+      distinct_skills_used: 0,
+      total_skill_actions: 0,
+      total_skill_edits: 0,
+      total_skill_loads: 0
+    },
+    top_skills: []
+  },
+  totals: {
+    total_actual_cost: 0,
+    total_api_calls: 75,
+    total_cache_read: 0,
+    total_estimated_cost: 0.3190519836,
+    total_input: 1_708_111,
+    total_output: 23_204,
+    total_reasoning: 0,
+    total_sessions: 3
+  }
+}
+
+describe('UsagePanel', () => {
+  it('shows each model estimated cost and effective rate over displayed tokens', () => {
+    render(<UsagePanel error="" loading={false} onRefresh={vi.fn()} period={30} usage={usage} />)
+
+    expect(
+      screen.getByText('1M I/O tokens · recorded est. $0.25 · effective $0.25 per 1M displayed I/O tokens')
+    ).toBeTruthy()
+    expect(
+      screen.getByText('50k I/O tokens · recorded est. $0.0060 · effective $0.12 per 1M displayed I/O tokens')
+    ).toBeTruthy()
+    expect(
+      screen.getByText('10 I/O tokens · recorded est. <$0.0001 · effective $0.10 per 1M displayed I/O tokens')
+    ).toBeTruthy()
+  })
+
+  it('does not present unknown or included zero-cost data as a priced estimate', () => {
+    const zeroCostUsage: AnalyticsResponse = {
+      ...usage,
+      by_model: [
+        {
+          api_calls: 1,
+          estimated_cost: 0,
+          input_tokens: 1_000,
+          model: 'provider/zero-cost-model',
+          output_tokens: 100,
+          sessions: 1
+        }
+      ]
+    }
+
+    render(<UsagePanel error="" loading={false} onRefresh={vi.fn()} period={30} usage={zeroCostUsage} />)
+
+    expect(screen.getByText('1.1k I/O tokens')).toBeTruthy()
+    expect(screen.queryByText(/\$0\.00|unavailable/i)).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -47,6 +47,7 @@ const LOG_LEVELS = ['ALL', 'INFO', 'WARNING', 'ERROR'] as const
 
 const USAGE_PERIODS = [7, 30, 90] as const
 type UsagePeriod = (typeof USAGE_PERIODS)[number]
+const MIN_DISPLAYED_USAGE_COST_USD = 0.0001
 
 // Stable empty arrays so the selector returns the same reference when we're
 // not on the Sessions tab — useStoreSelector bails out on Object.is, so the
@@ -75,6 +76,35 @@ function formatTimestamp(value?: number | null): string {
   }
 
   return fmtDateTime.format(date)
+}
+
+function formatUsageCost(value: null | number | undefined, locale: string): string {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return '$0.00'
+  }
+
+  const fractionDigits = value < 0.01 ? 4 : 2
+
+  const formatter = new Intl.NumberFormat(locale, {
+    currency: 'USD',
+    maximumFractionDigits: fractionDigits,
+    minimumFractionDigits: fractionDigits,
+    style: 'currency'
+  })
+
+  if (value < MIN_DISPLAYED_USAGE_COST_USD) {
+    return `<${formatter.format(MIN_DISPLAYED_USAGE_COST_USD)}`
+  }
+
+  return formatter.format(value)
+}
+
+function formatUsageRate(estimatedCost: number, totalTokens: number, locale: string): string {
+  if (!Number.isFinite(totalTokens) || totalTokens <= 0) {
+    return '$0.00'
+  }
+
+  return formatUsageCost((estimatedCost / totalTokens) * 1_000_000, locale)
 }
 
 function useDebouncedValue<T>(value: T, delayMs: number): T {
@@ -521,8 +551,8 @@ interface UsagePanelProps {
   usage: AnalyticsResponse | null
 }
 
-function UsagePanel({ error, loading, onRefresh, period, usage }: UsagePanelProps) {
-  const { t } = useI18n()
+export function UsagePanel({ error, loading, onRefresh, period, usage }: UsagePanelProps) {
+  const { locale, t } = useI18n()
   const cc = t.commandCenter
   const daily = useMemo(() => usage?.daily ?? [], [usage])
   const totals = usage?.totals
@@ -625,14 +655,28 @@ function UsagePanel({ error, loading, onRefresh, period, usage }: UsagePanelProp
         )}
       </section>
 
-      <div className="grid min-h-0 gap-x-8 gap-y-5 pt-1 sm:grid-cols-2">
+      <div className="grid min-h-0 gap-x-8 gap-y-5 pt-1 md:grid-cols-2">
         <UsageList
           emptyLabel={cc.noModelUsage}
-          rows={byModel.slice(0, 6).map(entry => ({
-            key: entry.model,
-            label: entry.model,
-            value: `${compactNumber((entry.input_tokens || 0) + (entry.output_tokens || 0))}`
-          }))}
+          rows={byModel.slice(0, 6).map(entry => {
+            const modelTokens = (entry.input_tokens || 0) + (entry.output_tokens || 0)
+
+            const hasEstimatedRate =
+              Number.isFinite(entry.estimated_cost) && entry.estimated_cost > 0 && modelTokens > 0
+
+            return {
+              key: entry.model,
+              label: entry.model,
+              value: hasEstimatedRate
+                ? cc.modelUsage(
+                    compactNumber(modelTokens),
+                    formatUsageCost(entry.estimated_cost, locale),
+                    formatUsageRate(entry.estimated_cost, modelTokens, locale)
+                  )
+                : cc.modelTokens(compactNumber(modelTokens))
+            }
+          })}
+          stacked
           title={cc.topModels}
         />
         <UsageList
@@ -652,10 +696,12 @@ function UsagePanel({ error, loading, onRefresh, period, usage }: UsagePanelProp
 function UsageList({
   emptyLabel,
   rows,
+  stacked = false,
   title
 }: {
   emptyLabel: string
   rows: Array<{ key: string; label: string; value: string }>
+  stacked?: boolean
   title: string
 }) {
   return (
@@ -670,9 +716,11 @@ function UsageList({
       ) : (
         <ul>
           {rows.map(row => (
-            <li className="flex items-center justify-between gap-2 py-1.5" key={row.key}>
-              <span className="min-w-0 truncate font-mono text-[0.7rem] text-foreground">{row.label}</span>
-              <span className="shrink-0 text-[0.65rem] text-(--ui-text-tertiary)">{row.value}</span>
+            <li className={cn(stacked ? 'py-1.5' : 'flex items-center justify-between gap-2 py-1.5')} key={row.key}>
+              <span className="block min-w-0 truncate font-mono text-[0.7rem] text-foreground">{row.label}</span>
+              <span className={cn('text-[0.65rem] text-(--ui-text-tertiary)', stacked ? 'mt-0.5 block' : 'shrink-0')}>
+                {row.value}
+              </span>
             </li>
           ))}
         </ul>

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1109,6 +1109,9 @@ export const ar = defineLocale({
     noDailyActivity: 'لا يوجد نشاط يومي',
     topModels: 'أكثر النماذج استخداما',
     noModelUsage: 'لا يوجد استخدام نماذج',
+    modelUsage: (tokens, estimatedCost, effectiveRate) =>
+      `${tokens} رمز إدخال/إخراج · تقدير مسجل ${estimatedCost} · معدل تقديري ${effectiveRate} لكل مليون رمز إدخال/إخراج معروض`,
+    modelTokens: tokens => `${tokens} رمز إدخال/إخراج`,
     topSkills: 'أكثر المهارات استخداما',
     noSkillActivity: 'لا يوجد نشاط مهارات',
     actions: count => `${count} إجراء`

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1283,6 +1283,9 @@ export const en: Translations = {
     noDailyActivity: 'No daily activity.',
     topModels: 'Top models',
     noModelUsage: 'No model usage yet.',
+    modelUsage: (tokens, estimatedCost, effectiveRate) =>
+      `${tokens} I/O tokens · recorded est. ${estimatedCost} · effective ${effectiveRate} per 1M displayed I/O tokens`,
+    modelTokens: tokens => `${tokens} I/O tokens`,
     topSkills: 'Top skills',
     noSkillActivity: 'No skill activity yet.',
     actions: count => `${count} actions`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1243,6 +1243,9 @@ export const ja = defineLocale({
     noDailyActivity: '日別アクティビティがありません。',
     topModels: 'よく使うモデル',
     noModelUsage: 'モデルの使用履歴はまだありません。',
+    modelUsage: (tokens, estimatedCost, effectiveRate) =>
+      `${tokens} I/Oトークン · 記録済み推定 ${estimatedCost} · 表示I/Oトークン100万件あたりの実効 ${effectiveRate}`,
+    modelTokens: tokens => `${tokens} I/Oトークン`,
     topSkills: 'よく使うスキル',
     noSkillActivity: 'スキルのアクティビティはまだありません。',
     actions: count => `${count} アクション`

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1128,6 +1128,8 @@ export interface Translations {
     noDailyActivity: string
     topModels: string
     noModelUsage: string
+    modelUsage: (tokens: string, estimatedCost: string, effectiveRate: string) => string
+    modelTokens: (tokens: string) => string
     topSkills: string
     noSkillActivity: string
     actions: (count: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1208,6 +1208,9 @@ export const zhHant = defineLocale({
     noDailyActivity: '暫無每日活動。',
     topModels: '常用模型',
     noModelUsage: '暫無模型使用量。',
+    modelUsage: (tokens, estimatedCost, effectiveRate) =>
+      `${tokens} 輸入/輸出詞元 · 已記錄預估 ${estimatedCost} · 每百萬已顯示輸入/輸出詞元折算 ${effectiveRate}`,
+    modelTokens: tokens => `${tokens} 輸入/輸出詞元`,
     topSkills: '常用技能',
     noSkillActivity: '暫無技能活動。',
     actions: count => `${count} 次動作`

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1479,6 +1479,9 @@ export const zh: Translations = {
     noDailyActivity: '暂无每日活动。',
     topModels: '常用模型',
     noModelUsage: '暂无模型用量。',
+    modelUsage: (tokens, estimatedCost, effectiveRate) =>
+      `${tokens} 输入/输出词元 · 已记录预估 ${estimatedCost} · 每百万已显示输入/输出词元折算 ${effectiveRate}`,
+    modelTokens: tokens => `${tokens} 输入/输出词元`,
     topSkills: '常用技能',
     noSkillActivity: '暂无技能活动。',
     actions: count => `${count} 次操作`,


### PR DESCRIPTION
## What does this PR do?

Shows each model's positive recorded cost estimate and an effective cost per 1M displayed input/output tokens in Desktop → Command Center → Usage.

The backend already returns `estimated_cost` for every `by_model` row, but the desktop discarded it and rendered only the token count. This keeps the change in the renderer, labels the values as recorded estimates rather than provider list prices, and stacks the metrics below the model name so long identifiers remain readable.

Zero-cost rows remain token-only. The analytics contract currently cannot distinguish an included/free route from unknown pricing, so rendering `$0.00` or `Unavailable` would overclaim what the data means.

## Related Issue

There is no open issue that exactly tracks the missing per-model values, so a Before/After screenshot is included in a PR comment.

Related but intentionally **not fixed here**:

- #19469 tracks provider-pricing coverage outside OpenRouter.
- #56091 tracks a models.dev pricing fallback for named providers.

This PR does not change pricing discovery, token accounting, or provider routing. It displays positive estimates already returned by `/api/analytics/usage`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Render per-model recorded estimated cost from the existing analytics response.
- Derive and clearly label an effective rate: `recorded estimated cost / displayed input+output tokens × 1,000,000`.
- Preserve token-only rows when the recorded estimate is zero or missing instead of implying “free” or “unavailable.”
- Render very small positive costs as `<$0.0001` instead of the false zero `$0.0000`.
- Stack model metrics and delay the two-column layout until `md` width for long model names.
- Localize the new copy in English, Arabic, Japanese, Simplified Chinese, and Traditional Chinese.
- Add behavior tests for normal estimates, sub-cent precision, and real numeric-zero analytics data.

## Provider Scope and Verification

- **Live verified:** Windows 11 with OpenRouter, using `deepseek/deepseek-v4-flash` and `minimax/minimax-m3` rows from a real local usage database.
- **Implementation scope:** provider-neutral renderer logic; no OpenRouter-specific branches or model catalog fixtures.
- **Not claimed:** live validation of direct Anthropic, OpenAI, Bedrock, Vertex, or custom endpoints. Reviewers with those providers are invited to verify their positive `by_model[].estimated_cost` rows.
- **Important:** the effective rate is a historical ratio over the displayed I/O tokens, not the provider's published input/output price. Cache billing and incomplete upstream pricing can make those concepts differ.

## How to Test

1. Open Desktop → Command Center → Usage after generating usage with a provider that records positive per-model estimates.
2. Confirm each priced model shows its model ID, displayed I/O token count, recorded estimate, and effective rate.
3. Confirm a zero-cost analytics fixture remains token-only and no `$0.00`/`Unavailable` claim appears.
4. Narrow the window and confirm model names remain readable with metrics stacked beneath them.

Automated checks run locally:

- `npx vitest run --project ui src/app/command-center/index.test.tsx` — 2 tests passed.
- Desktop `npm run typecheck` — passed.
- ESLint on all 8 changed files — passed with zero warnings.
- Production desktop build — passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — renderer-only change; relying on focused desktop checks and CI for the full repository suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no public configuration or API change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer and `Intl` APIs only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before/After screenshots are posted in a PR comment because no exact tracking issue exists.
