### PR TITLE
feat(agent): add autonomous turn-budget metadata hook

### DIFF
--- a/agent/autonomous_task_hooks.py
+++ b/agent/autonomous_task_hooks.py
@@ -1,0 +1,129 @@
+"""Metadata-only autonomous-task lifecycle hooks.
+
+These hooks give profile/runtime integrations a deterministic signal when an
+agent turn is near or at the tool/turn budget boundary. The payload is
+intentionally tiny and metadata-only so hook consumers can update external DOD
+or continuation state without receiving prompts, transcript text, tool outputs,
+credentials, environment dumps, or customer data.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+HOOK_NAME = "autonomous_task_turn_budget"
+PREEMPTIVE_TURN_BUDGET_THRESHOLD = 70
+ALLOWED_FIELDS = frozenset({"event", "turns_used", "max_turns", "session_id"})
+FORBIDDEN_PAYLOAD_FIELDS = frozenset(
+    {
+        "prompts",
+        "messages",
+        "conversation_history",
+        "tool_outputs",
+        "secrets",
+        "cookies",
+        "customer_data",
+        "environment",
+        "full_environment",
+    }
+)
+
+
+def _coerce_non_negative_int(value: Any) -> int:
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, number)
+
+
+def build_turn_budget_metadata(
+    *,
+    event: str,
+    turns_used: Any,
+    max_turns: Any,
+    session_id: Any,
+    **extra: Any,
+) -> dict[str, Any]:
+    """Return the exact metadata-only payload allowed for the hook.
+
+    ``extra`` is accepted defensively so call sites cannot accidentally widen
+    the hook by passing transcript/tool/secret-bearing objects. Known forbidden
+    keys and all other non-contract keys are ignored rather than forwarded.
+    """
+
+    del extra  # never forward non-contract payloads
+    metadata = {
+        "event": str(event or ""),
+        "turns_used": _coerce_non_negative_int(turns_used),
+        "max_turns": _coerce_non_negative_int(max_turns),
+        "session_id": str(session_id or ""),
+    }
+    assert set(metadata) <= ALLOWED_FIELDS
+    return metadata
+
+
+def notify_turn_budget_or_closeout(
+    *,
+    event: str,
+    turns_used: Any,
+    max_turns: Any,
+    session_id: Any,
+    **extra: Any,
+) -> bool:
+    """Invoke the lifecycle hook with metadata only, fail-open.
+
+    Returns ``True`` when hook dispatch completed, ``False`` when a consumer or
+    lifecycle import failed. Failures are logged but must never block final
+    response delivery or session persistence.
+    """
+
+    # Deliberately build from the allowlist, not from caller kwargs.
+    metadata = build_turn_budget_metadata(
+        event=event,
+        turns_used=turns_used,
+        max_turns=max_turns,
+        session_id=session_id,
+        **extra,
+    )
+    try:
+        from hermes_cli.lifecycle import invoke_hook
+
+        invoke_hook(HOOK_NAME, **metadata)
+        return True
+    except Exception:
+        logger.warning("autonomous task turn-budget hook failed", exc_info=True)
+        return False
+
+
+def event_for_turn_budget(
+    *,
+    turns_used: Any,
+    max_turns: Any,
+    iteration_limit_fallback: bool = False,
+    budget_exhausted: bool = False,
+    threshold: int = PREEMPTIVE_TURN_BUDGET_THRESHOLD,
+) -> str | None:
+    """Classify whether this turn should emit an autonomous-task hook event."""
+
+    used = _coerce_non_negative_int(turns_used)
+    maximum = _coerce_non_negative_int(max_turns)
+    if iteration_limit_fallback or budget_exhausted or (maximum and used >= maximum):
+        return "max_turn_or_tool_iteration_closeout"
+    if used >= threshold:
+        return "preemptive_turn_budget_threshold"
+    return None
+
+
+__all__ = [
+    "ALLOWED_FIELDS",
+    "FORBIDDEN_PAYLOAD_FIELDS",
+    "HOOK_NAME",
+    "PREEMPTIVE_TURN_BUDGET_THRESHOLD",
+    "build_turn_budget_metadata",
+    "event_for_turn_budget",
+    "notify_turn_budget_or_closeout",
+]

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -141,6 +141,28 @@ def finalize_turn(
         final_response = agent._handle_max_iterations(messages, api_call_count)
         iteration_limit_fallback = True
 
+    try:
+        from agent.autonomous_task_hooks import (
+            event_for_turn_budget,
+            notify_turn_budget_or_closeout,
+        )
+
+        _autonomous_event = event_for_turn_budget(
+            turns_used=api_call_count,
+            max_turns=agent.max_iterations,
+            iteration_limit_fallback=iteration_limit_fallback,
+            budget_exhausted=budget_exhausted,
+        )
+        if _autonomous_event:
+            notify_turn_budget_or_closeout(
+                event=_autonomous_event,
+                turns_used=api_call_count,
+                max_turns=agent.max_iterations,
+                session_id=agent.session_id,
+            )
+    except Exception:
+        logger.warning("autonomous task turn-budget notification failed", exc_info=True)
+
     if iteration_limit_fallback:
         # If running as a kanban worker, signal the dispatcher that the
         # worker could not complete (rather than treating it as a

--- a/tests/agent/test_autonomous_task_hooks.py
+++ b/tests/agent/test_autonomous_task_hooks.py
@@ -1,0 +1,183 @@
+import logging
+import sys
+from types import ModuleType, SimpleNamespace
+
+from agent.turn_finalizer import finalize_turn
+
+
+def _install_lightweight_conversation_loop(monkeypatch):
+    module = ModuleType("agent.conversation_loop")
+    setattr(module, "logger", logging.getLogger("test.conversation_loop"))
+    setattr(module, "_notify_context_engine_turn_complete", lambda *args, **kwargs: None)
+    monkeypatch.setitem(sys.modules, "agent.conversation_loop", module)
+
+
+def _agent_for_finalize(max_iterations=90):
+    return SimpleNamespace(
+        max_iterations=max_iterations,
+        iteration_budget=SimpleNamespace(remaining=20, used=70, max_total=max_iterations),
+        quiet_mode=True,
+        model="test-model",
+        provider="test-provider",
+        base_url="https://example.invalid",
+        session_id="session-123",
+        context_compressor=SimpleNamespace(last_prompt_tokens=0),
+        _tool_guardrail_halt_decision=None,
+        _response_was_previewed=False,
+        _turn_failed_file_mutations={},
+        session_input_tokens=0,
+        session_output_tokens=0,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_reasoning_tokens=0,
+        session_prompt_tokens=0,
+        session_completion_tokens=0,
+        session_total_tokens=0,
+        session_estimated_cost_usd=0.0,
+        session_cost_status="ok",
+        session_cost_source="test",
+        request_overrides={},
+        clear_interrupt=lambda: None,
+        _drain_pending_steer=lambda: None,
+        _save_trajectory=lambda *args, **kwargs: None,
+        _cleanup_task_resources=lambda *args, **kwargs: None,
+        _drop_trailing_empty_response_scaffolding=lambda messages: None,
+        _apply_persist_user_message_override=lambda messages: None,
+        _persist_session=lambda *args, **kwargs: None,
+        _file_mutation_verifier_enabled=lambda: False,
+        _turn_completion_explainer_enabled=lambda: False,
+        _handle_max_iterations=lambda messages, api_call_count: "budget summary",
+        _emit_status=lambda *args, **kwargs: None,
+        _skill_nudge_interval=0,
+        _iters_since_skill=0,
+        valid_tool_names=set(),
+        _trigger_review_background=lambda *args, **kwargs: None,
+        _sync_external_memory_for_turn=lambda *args, **kwargs: None,
+        _spawn_background_review=lambda *args, **kwargs: None,
+        _interrupt_message=None,
+        platform="test",
+    )
+
+
+def test_autonomous_task_hook_allows_only_metadata_fields(monkeypatch):
+    from agent.autonomous_task_hooks import notify_turn_budget_or_closeout
+
+    captured = {}
+
+    def fake_invoke(hook_name, **kwargs):
+        captured["hook_name"] = hook_name
+        captured["kwargs"] = kwargs
+        return []
+
+    monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", fake_invoke)
+
+    notify_turn_budget_or_closeout(
+        event="max_turn_or_tool_iteration_closeout",
+        turns_used=90,
+        max_turns=90,
+        session_id="session-123",
+        messages=[{"role": "user", "content": "must not leak"}],
+        tool_outputs=["must not leak"],
+        secrets={"token": "must not leak"},
+    )
+
+    assert captured == {
+        "hook_name": "autonomous_task_turn_budget",
+        "kwargs": {
+            "event": "max_turn_or_tool_iteration_closeout",
+            "turns_used": 90,
+            "max_turns": 90,
+            "session_id": "session-123",
+        },
+    }
+
+
+def test_autonomous_task_hook_is_fail_open(monkeypatch):
+    from agent.autonomous_task_hooks import notify_turn_budget_or_closeout
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("hook consumer failed")
+
+    monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", boom)
+
+    assert notify_turn_budget_or_closeout(
+        event="preemptive_turn_budget_threshold",
+        turns_used=70,
+        max_turns=90,
+        session_id="session-123",
+    ) is False
+
+
+def test_turn_finalizer_emits_preemptive_metadata_only_hook(monkeypatch):
+    calls = []
+
+    def fake_notify(**kwargs):
+        calls.append(kwargs)
+        return True
+
+    _install_lightweight_conversation_loop(monkeypatch)
+    monkeypatch.setattr("agent.autonomous_task_hooks.notify_turn_budget_or_closeout", fake_notify)
+    agent = _agent_for_finalize(max_iterations=90)
+    result = finalize_turn(
+        agent,
+        final_response="Done.",
+        api_call_count=70,
+        interrupted=False,
+        failed=False,
+        messages=[{"role": "user", "content": "do work"}, {"role": "assistant", "content": "Done."}],
+        conversation_history=[],
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="do work",
+        original_user_message="do work",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    assert result["completed"] is True
+    assert calls == [
+        {
+            "event": "preemptive_turn_budget_threshold",
+            "turns_used": 70,
+            "max_turns": 90,
+            "session_id": "session-123",
+        }
+    ]
+
+
+def test_turn_finalizer_emits_max_turn_metadata_only_hook(monkeypatch):
+    calls = []
+
+    def fake_notify(**kwargs):
+        calls.append(kwargs)
+        return True
+
+    _install_lightweight_conversation_loop(monkeypatch)
+    monkeypatch.setattr("agent.autonomous_task_hooks.notify_turn_budget_or_closeout", fake_notify)
+    agent = _agent_for_finalize(max_iterations=90)
+    agent.iteration_budget = SimpleNamespace(remaining=0, used=90, max_total=90)
+    result = finalize_turn(
+        agent,
+        final_response=None,
+        api_call_count=90,
+        interrupted=False,
+        failed=False,
+        messages=[{"role": "user", "content": "do work"}],
+        conversation_history=[],
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="do work",
+        original_user_message="do work",
+        _should_review_memory=False,
+        _turn_exit_reason="budget_exhausted",
+    )
+
+    assert result["final_response"] == "budget summary"
+    assert calls == [
+        {
+            "event": "max_turn_or_tool_iteration_closeout",
+            "turns_used": 90,
+            "max_turns": 90,
+            "session_id": "session-123",
+        }
+    ]


### PR DESCRIPTION
## Summary
- add a metadata-only `autonomous_task_turn_budget` lifecycle hook for preemptive/max-turn closeout signals
- emit the hook from the turn finalizer at the preemptive threshold and at budget exhaustion
- keep the payload allowlisted to `event`, `turns_used`, `max_turns`, and `session_id`; hook failures are fail-open and never block final response delivery

## Motivation
Mission Control IN-715 needs a native Hermes Agent signal so external DOD/continuation watchdogs can update durable autonomous-task contracts before a session hits the 90/90 turn/tool ceiling. This avoids treating max-turn/context-compression stops as terminal while preserving prompt-cache and transcript privacy boundaries.

## Safety
- No model tool schema changes
- No prompt/system-message mutation
- No transcript, tool output, secret, cookie, customer-data, or environment payload is passed to the hook
- Hook consumer failure is logged and fail-open

## Verification
- RED: `pytest tests/agent/test_autonomous_task_hooks.py -q` failed with `ModuleNotFoundError: No module named 'agent.autonomous_task_hooks'`
- GREEN: `uv run --extra dev pytest tests/agent/test_autonomous_task_hooks.py -q` → `4 passed`
- Related: `uv run --extra dev --extra anthropic pytest tests/run_agent/test_run_agent.py::TestHandleMaxIterations tests/run_agent/test_run_agent.py::TestAnthropicInterruptHandler::test_interruptible_anthropic_interrupt_never_closes_shared_client -q` → `10 passed`
- Broader: `uv run --extra dev --extra anthropic pytest tests/agent/test_autonomous_task_hooks.py tests/run_agent/test_run_agent.py -q` → `233 passed, 1 warning`
