### PR TITLE
fix(tui_gateway,desktop): scope setup.runtime_check and setup.status …

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-status-snapshot.test.ts
+++ b/apps/desktop/src/app/shell/hooks/use-status-snapshot.test.ts
@@ -6,7 +6,8 @@ import { getStatus } from '@/hermes'
 import { useStatusSnapshot } from './use-status-snapshot'
 
 vi.mock('@/hermes', () => ({
-  getStatus: vi.fn()
+  getStatus: vi.fn(),
+  setApiRequestProfile: vi.fn()
 }))
 
 type GatewayRequester = <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
@@ -166,5 +167,26 @@ describe('useStatusSnapshot', () => {
       await vi.advanceTimersByTimeAsync(1)
     })
     expect(requestGatewayMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('forwards active profile to evaluateRuntimeReadiness RPCs', async () => {
+    const calls: Array<{ method: string; params?: Record<string, unknown> }> = []
+
+    const requestGatewayMock = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      return (method === 'setup.runtime_check' ? { ok: true } : { provider_configured: true }) as never
+    })
+
+    const requestGateway = requestGatewayMock as unknown as GatewayRequester
+
+    renderHook(() => useStatusSnapshot('open', requestGateway, 'work'))
+
+    await flushAsync()
+
+    expect(calls).toEqual([
+      { method: 'setup.status', params: { profile: 'work' } },
+      { method: 'setup.runtime_check', params: { profile: 'work' } }
+    ])
   })
 })

--- a/apps/desktop/src/app/shell/hooks/use-status-snapshot.ts
+++ b/apps/desktop/src/app/shell/hooks/use-status-snapshot.ts
@@ -1,7 +1,9 @@
+import { useStore } from '@nanostores/react'
 import { useEffect, useState } from 'react'
 
 import { getStatus } from '@/hermes'
 import { evaluateRuntimeReadiness, type RuntimeReadinessResult } from '@/lib/runtime-readiness'
+import { $activeGatewayProfile } from '@/store/profile'
 import type { StatusResponse } from '@/types/hermes'
 
 // Statusbar health is ambient chrome, not live data — nothing the user acts on
@@ -12,7 +14,13 @@ const REFRESH_MS = 60_000
 
 type GatewayRequester = <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
 
-export function useStatusSnapshot(gatewayState: string | undefined, requestGateway: GatewayRequester) {
+export function useStatusSnapshot(
+  gatewayState: string | undefined,
+  requestGateway: GatewayRequester,
+  profile?: string
+) {
+  const activeProfile = useStore($activeGatewayProfile)
+  const targetProfile = profile ?? activeProfile
   const [statusSnapshot, setStatusSnapshot] = useState<StatusResponse | null>(null)
   const [inferenceStatus, setInferenceStatus] = useState<RuntimeReadinessResult | null>(null)
 
@@ -49,7 +57,9 @@ export function useStatusSnapshot(gatewayState: string | undefined, requestGatew
         // race newer healthy results.
         const [statusResult, inferenceResult] = await Promise.allSettled([
           getStatus(),
-          gatewayState === 'open' ? evaluateRuntimeReadiness(requestGateway) : Promise.resolve(null)
+          gatewayState === 'open'
+            ? evaluateRuntimeReadiness(requestGateway, { profile: targetProfile })
+            : Promise.resolve(null)
         ])
 
         if (cancelled) {
@@ -100,7 +110,7 @@ export function useStatusSnapshot(gatewayState: string | undefined, requestGatew
         window.clearTimeout(timer)
       }
     }
-  }, [gatewayState, requestGateway])
+  }, [gatewayState, requestGateway, targetProfile])
 
   return { inferenceStatus, statusSnapshot }
 }

--- a/apps/desktop/src/lib/runtime-readiness.test.ts
+++ b/apps/desktop/src/lib/runtime-readiness.test.ts
@@ -86,6 +86,31 @@ describe('fetchRuntimeReadinessSignals', () => {
 
     expect(calls).toEqual([{ method: 'setup.status' }, { method: 'setup.runtime_check', params: { provider: 'nous' } }])
   })
+
+  it('forwards profile parameter to both setup.status and setup.runtime_check', async () => {
+    const calls: Array<{ method: string; params?: Record<string, unknown> }> = []
+
+    const requestGateway = async <T = unknown>(method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'setup.status') {
+        return { provider_configured: true } as T
+      }
+
+      if (method === 'setup.runtime_check') {
+        return { ok: true } as T
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    }
+
+    await fetchRuntimeReadinessSignals(requestGateway, 'nous', 'work')
+
+    expect(calls).toEqual([
+      { method: 'setup.status', params: { profile: 'work' } },
+      { method: 'setup.runtime_check', params: { provider: 'nous', profile: 'work' } }
+    ])
+  })
 })
 
 describe('evaluateRuntimeReadiness', () => {
@@ -107,5 +132,31 @@ describe('evaluateRuntimeReadiness', () => {
     const result = await evaluateRuntimeReadiness(requestGateway, { requestedProvider: 'nous' })
 
     expect(result.ready).toBe(true)
+  })
+
+  it('forwards profile to setup.status and setup.runtime_check via options', async () => {
+    const calls: Array<{ method: string; params?: Record<string, unknown> }> = []
+
+    const requestGateway = async <T = unknown>(method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'setup.status') {
+        return { provider_configured: true } as T
+      }
+
+      if (method === 'setup.runtime_check') {
+        return { ok: true } as T
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    }
+
+    const result = await evaluateRuntimeReadiness(requestGateway, { requestedProvider: 'openai', profile: 'dev' })
+
+    expect(result.ready).toBe(true)
+    expect(calls).toEqual([
+      { method: 'setup.status', params: { profile: 'dev' } },
+      { method: 'setup.runtime_check', params: { provider: 'openai', profile: 'dev' } }
+    ])
   })
 })

--- a/apps/desktop/src/lib/runtime-readiness.ts
+++ b/apps/desktop/src/lib/runtime-readiness.ts
@@ -16,6 +16,7 @@ export interface RuntimeReadinessSignals {
 
 export interface RuntimeReadinessOptions {
   defaultReason?: string
+  profile?: string
   requestedProvider?: string
   unknownReady?: boolean
 }
@@ -67,12 +68,24 @@ async function requestWithFallback<T>(
 
 export async function fetchRuntimeReadinessSignals(
   requestGateway: RuntimeReadinessRequester,
-  requestedProvider?: string
+  requestedProvider?: string,
+  profile?: string
 ): Promise<RuntimeReadinessSignals> {
-  const runtimeParams = requestedProvider?.trim() ? { provider: requestedProvider.trim() } : undefined
+  const normProfile = profile?.trim() ? profile.trim() : undefined
+  const normProvider = requestedProvider?.trim() ? requestedProvider.trim() : undefined
+
+  const setupParams = normProfile ? { profile: normProfile } : undefined
+
+  const runtimeParams =
+    normProvider || normProfile
+      ? {
+          ...(normProvider ? { provider: normProvider } : {}),
+          ...(normProfile ? { profile: normProfile } : {})
+        }
+      : undefined
 
   const [setup, runtime] = await Promise.all([
-    requestWithFallback<SetupStatusSnapshot>(requestGateway, 'setup.status'),
+    requestWithFallback<SetupStatusSnapshot>(requestGateway, 'setup.status', setupParams),
     requestWithFallback<RuntimeCheckSnapshot>(requestGateway, 'setup.runtime_check', runtimeParams)
   ])
 
@@ -146,7 +159,7 @@ export async function evaluateRuntimeReadiness(
   requestGateway: RuntimeReadinessRequester,
   options: RuntimeReadinessOptions = {}
 ): Promise<RuntimeReadinessResult> {
-  const signals = await fetchRuntimeReadinessSignals(requestGateway, options.requestedProvider)
+  const signals = await fetchRuntimeReadinessSignals(requestGateway, options.requestedProvider, options.profile)
 
   return interpretRuntimeReadiness(signals, options)
 }

--- a/contributors/emails/StanleyStetson@users.noreply.github.com
+++ b/contributors/emails/StanleyStetson@users.noreply.github.com
@@ -1,0 +1,1 @@
+StanleyStetson

--- a/tests/test_setup_profile_scope.py
+++ b/tests/test_setup_profile_scope.py
@@ -1,0 +1,51 @@
+"""Unit tests verifying setup.status and setup.runtime_check profile scoping (#77006)."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from hermes_constants import get_hermes_home, reset_hermes_home_override, set_hermes_home_override
+from tui_gateway.server import _methods, _profile_scoped
+
+
+def test_setup_status_and_runtime_check_are_profile_scoped(tmp_path, monkeypatch):
+    """Verify setup.status and setup.runtime_check resolve credentials under params['profile']."""
+    # Launch profile dir (empty)
+    launch_home = tmp_path / "launch_profile"
+    launch_home.mkdir()
+
+    # Target profile B dir (has custom config/credentials)
+    profile_b_home = tmp_path / "profiles" / "profile_b"
+    profile_b_home.mkdir(parents=True)
+    (profile_b_home / ".env").write_text("OPENAI_API_KEY=sk-test-key-123\n", encoding="utf-8")
+    (profile_b_home / "config.yaml").write_text("provider: openai-api\nmodel:\n  default: 'openai-api/gpt-4o'\n", encoding="utf-8")
+
+    # Set launch profile as default HERMES_HOME
+    token = set_hermes_home_override(launch_home)
+    try:
+        def mock_get_profile_dir(name):
+            if name == "profile_b":
+                return str(profile_b_home)
+            return str(tmp_path / "profiles" / name)
+
+        with patch("hermes_cli.profiles.get_profile_dir", side_effect=mock_get_profile_dir):
+            setup_status = _methods["setup.status"]
+            setup_runtime_check = _methods["setup.runtime_check"]
+
+            # 1. Without profile param: evaluates launch profile (empty -> not configured / no key)
+            res_status_launch = setup_status(1, {})
+            assert res_status_launch.get("result", {}).get("provider_configured") is False
+
+            res_check_launch = setup_runtime_check(2, {})
+            assert res_check_launch.get("result", {}).get("ok") is False
+
+            # 2. With profile="profile_b": evaluates profile_b context (configured -> ok=True)
+            res_status_b = setup_status(3, {"profile": "profile_b"})
+            assert res_status_b.get("result", {}).get("provider_configured") is True
+
+            res_check_b = setup_runtime_check(4, {"profile": "profile_b"})
+            assert res_check_b.get("result", {}).get("ok") is True
+            assert res_check_b.get("result", {}).get("provider") == "openai-api"
+    finally:
+        reset_hermes_home_override(token)

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -338,6 +338,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("setup.status")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     try:
         from hermes_cli.main import _has_any_provider_configured
@@ -348,6 +349,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("setup.runtime_check")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Strict provider check: does the configured/default model actually resolve to a usable runtime?
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1401,13 +1401,13 @@ def _profile_home(profile: str | None) -> Path | None:
 
 
 def _profile_scoped(handler):
-    """Bind ``params['profile']``'s HERMES_HOME around a pet RPC handler.
+    """Bind ``params['profile']``'s HERMES_HOME and secret scope around an RPC handler.
 
-    Pets are per-profile: ``display.pet.*`` lives in the profile's config.yaml and
-    sprites install under its ``pets/`` dir (both resolve via ``get_hermes_home``).
-    The desktop sends ``profile`` on pet calls so config + pets dir resolve to the
-    focused profile even in app-global remote mode, where one backend serves every
-    profile. No-op for the launch profile (own-profile backends already resolve it).
+    Pets and setup readiness RPCs are per-profile: config.yaml, .env, and assets
+    resolve under the profile's home directory. The desktop sends ``profile`` on
+    these calls so config + secrets resolve to the focused profile even in
+    app-global remote mode, where one backend serves every profile. No-op for the
+    launch profile (own-profile backends already resolve it).
     """
 
     def wrapper(rid, params):
@@ -1415,9 +1415,11 @@ def _profile_scoped(handler):
         if home is None:
             return handler(rid, params)
         token = set_hermes_home_override(home)
+        secret_token = set_secret_scope(build_profile_secret_scope(Path(home)))
         try:
             return handler(rid, params)
         finally:
+            reset_secret_scope(secret_token)
             reset_hermes_home_override(token)
 
     return wrapper


### PR DESCRIPTION
### What does this PR do?
Scopes `setup.runtime_check` and `setup.status` RPC endpoints to the requested session profile when `params['profile']` is specified, and updates the desktop runtime readiness helper (`fetchRuntimeReadinessSignals` / `evaluateRuntimeReadiness`) to forward the active session profile.

### Related Issue
Fixes #77006

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Changes Made
1. **Backend (`tui_gateway`)**: Applied `@_profile_scoped` to `setup.status` and `setup.runtime_check` in `tui_gateway/methods_config.py`, and updated `_profile_scoped` in `server.py` to bind both `HERMES_HOME` and `secret_scope`.
2. **Desktop (`apps/desktop`)**: Updated `RuntimeReadinessOptions`, `fetchRuntimeReadinessSignals`, and `evaluateRuntimeReadiness` in `src/lib/runtime-readiness.ts` to accept and forward `profile` in RPC requests.
3. **Unit Tests**: Added `tests/test_setup_profile_scope.py` and updated `apps/desktop/src/lib/runtime-readiness.test.ts` with profile-forwarding tests.

### Verification
- `pytest tests/test_setup_profile_scope.py` -> 1 passed
- `npx vitest run src/lib/runtime-readiness.test.ts` -> 8 passed
- `python -m py_compile` -> clean