### PR TITLE
fix(browser): avoid EFTYPE spawn on Windows ARM64 agent-browser

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -20,7 +20,11 @@ from hermes_cli.config import (
 )
 from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
-from hermes_constants import agent_browser_runnable
+from hermes_constants import (
+    agent_browser_runnable,
+    prefer_agent_browser_native_binary,
+    resolve_agent_browser_native_binary,
+)
 
 PROJECT_ROOT = get_project_root()
 HERMES_HOME = get_hermes_home()
@@ -1909,25 +1913,41 @@ def run_doctor(args):
             or _which_in(HERMES_HOME / "node")
         )
         _legacy_ab = _which_in(HERMES_HOME / "node_modules" / ".bin")
-        if agent_browser_path.exists():
-            check_ok("agent-browser (Node.js)", "(browser automation)")
+        # Prefer a packaged native binary (esp. win32-x64 on Windows ARM64 —
+        # issue #77051) over "node_modules/agent-browser exists".
+        _native_ab = resolve_agent_browser_native_binary(
+            _which_ab or _managed_ab or _legacy_ab,
+            search_roots=[
+                PROJECT_ROOT,
+                HERMES_HOME,
+                HERMES_HOME / "node",
+                agent_browser_path,
+            ],
+        )
+        _probe_candidates = [
+            _native_ab,
+            prefer_agent_browser_native_binary(_which_ab) if _which_ab else None,
+            prefer_agent_browser_native_binary(_managed_ab) if _managed_ab else None,
+            prefer_agent_browser_native_binary(_legacy_ab) if _legacy_ab else None,
+        ]
+        _runnable_ab = next(
+            (c for c in _probe_candidates if c and agent_browser_runnable(c)),
+            None,
+        )
+        if _runnable_ab:
+            if agent_browser_path.exists():
+                check_ok("agent-browser (Node.js)", "(browser automation)")
+            else:
+                check_ok("agent-browser", "(browser automation)")
             agent_browser_ok = True
-        elif _which_ab and agent_browser_runnable(_which_ab):
-            check_ok("agent-browser", "(browser automation)")
-            agent_browser_ok = True
-        elif _managed_ab and agent_browser_runnable(_managed_ab):
-            check_ok("agent-browser", "(browser automation)")
-            agent_browser_ok = True
-        elif _legacy_ab and agent_browser_runnable(_legacy_ab):
-            check_ok("agent-browser", "(browser automation)")
-            agent_browser_ok = True
-        elif _which_ab:
-            # Found on PATH but won't run — almost always a dangling global
-            # symlink left behind by agent-browser's npm postinstall after a
-            # `hermes update` wiped node_modules (issue #48521).
+        elif agent_browser_path.exists() or _which_ab or _managed_ab or _legacy_ab:
+            # Package/shim present but won't run — common on Windows ARM64
+            # when only a 0-byte win32-arm64 stub exists (#77051), or a
+            # dangling global symlink after `hermes update` (#48521).
+            broken_at = _which_ab or _managed_ab or _legacy_ab or str(agent_browser_path)
             check_warn(
                 "agent-browser found but not runnable",
-                f"(broken symlink at {_which_ab}? run: npm install)",
+                f"(broken install at {broken_at}? run: npm install -g agent-browser)",
             )
         elif _is_termux():
             check_info("agent-browser is not installed (expected in the tested Termux path)")

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -904,9 +904,16 @@ def agent_browser_runnable(path: str | None) -> bool:
     # never even spawn a subprocess for the broken-link case.
     if not os.path.exists(probe) or not os.access(probe, os.X_OK):
         return False
-    # Reject empty PE stubs without paying for a spawn (Windows ARM64).
+    # Reject empty PE stubs without paying for a spawn — Windows ARM64 only.
+    # Short POSIX shell wrappers are often <<1KB and must still reach --version.
     try:
-        if Path(probe).is_file() and Path(probe).stat().st_size < 1024:
+        probe_path = Path(probe)
+        if (
+            is_windows_arm64()
+            and probe_path.is_file()
+            and probe_path.suffix.lower() == ".exe"
+            and probe_path.stat().st_size < 1024
+        ):
             return False
     except OSError:
         return False

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -679,6 +679,193 @@ def with_hermes_node_path(env: dict[str, str] | None = None) -> dict[str, str]:
     return merged
 
 
+def is_windows_arm64() -> bool:
+    """Return True when this process is running on a Windows ARM64 host/ABI.
+
+    Used to pick the published ``agent-browser-win32-x64.exe`` build: the npm
+    package has no ``win32-arm64`` binary, and the Node wrapper still looks for
+    one (issue #77051 / vercel-labs/agent-browser#1256).
+    """
+    if sys.platform != "win32":
+        return False
+    import platform as _platform
+
+    for raw in (
+        os.environ.get("PROCESSOR_ARCHITEW6432"),
+        os.environ.get("PROCESSOR_ARCHITECTURE"),
+        _platform.machine(),
+    ):
+        arch = (raw or "").strip().upper()
+        if arch in ("ARM64", "AARCH64"):
+            return True
+    return False
+
+
+def _agent_browser_native_binary_usable(path: Path) -> bool:
+    """True when *path* looks like a real packaged agent-browser native binary.
+
+    Rejects missing files and the 0-byte Windows ARM64 stubs left by older
+    ``agent-browser`` postinstall downloads (vercel-labs/agent-browser#1256).
+    """
+    try:
+        return path.is_file() and path.stat().st_size >= 1024
+    except OSError:
+        return False
+
+
+def agent_browser_native_binary_names(*, windows_arm64: bool | None = None) -> tuple[str, ...]:
+    """Ordered native binary filenames to try for the current platform.
+
+    When *windows_arm64* is passed explicitly (including ``False``), Windows
+    naming is used regardless of ``sys.platform`` so unit tests can exercise
+    the Windows ARM64 ladder on other hosts.
+    """
+    if windows_arm64 is not None or sys.platform == "win32":
+        if windows_arm64 is None:
+            windows_arm64 = is_windows_arm64()
+        if windows_arm64:
+            # Only win32-x64 is published; an arm64-named file is often a
+            # 0-byte stub that spawns as EFTYPE under arm64 Node.
+            return ("agent-browser-win32-x64.exe", "agent-browser-win32-arm64.exe")
+        return ("agent-browser-win32-x64.exe",)
+
+    import platform as _platform
+
+    machine = (_platform.machine() or "").lower()
+    if machine in ("aarch64", "arm64"):
+        arch = "arm64"
+    elif machine in ("x86_64", "amd64", "x64"):
+        arch = "x64"
+    else:
+        return ()
+
+    if sys.platform == "darwin":
+        return (f"agent-browser-darwin-{arch}",)
+    if sys.platform.startswith("linux"):
+        # Prefer glibc build; musl variant is a secondary candidate.
+        return (
+            f"agent-browser-linux-{arch}",
+            f"agent-browser-linux-musl-{arch}",
+        )
+    return ()
+
+
+def iter_agent_browser_package_bin_dirs(cli_path: str | None) -> list[Path]:
+    """Return package ``bin/`` directories adjacent to a resolved CLI/shim path."""
+    if not cli_path or " " in cli_path:
+        return []
+    try:
+        path = Path(cli_path).resolve()
+    except OSError:
+        path = Path(cli_path)
+
+    dirs: list[Path] = []
+    seen: set[str] = set()
+
+    def _add(candidate: Path) -> None:
+        key = str(candidate)
+        if key not in seen:
+            seen.add(key)
+            dirs.append(candidate)
+
+    # Already pointing at bin/agent-browser.js or a native exe in bin/
+    if path.parent.name.lower() == "bin":
+        _add(path.parent)
+    # node_modules/.bin/agent-browser{.cmd,.ps1,}
+    if path.parent.name == ".bin":
+        _add(path.parent.parent / "agent-browser" / "bin")
+    # npm --prefix shim: <prefix>/agent-browser.cmd
+    _add(path.parent / "node_modules" / "agent-browser" / "bin")
+    return dirs
+
+
+def resolve_agent_browser_native_binary(
+    cli_path: str | None = None,
+    *,
+    search_roots: list[Path] | None = None,
+    windows_arm64: bool | None = None,
+) -> str | None:
+    """Locate a packaged native agent-browser binary near *cli_path* or *search_roots*.
+
+    On Windows ARM64 this prefers ``agent-browser-win32-x64.exe`` so callers can
+    bypass the npm JS wrapper, which still requests a non-existent / 0-byte
+    ``win32-arm64`` build and fails with ``spawn EFTYPE`` (issue #77051).
+    """
+    names = agent_browser_native_binary_names(windows_arm64=windows_arm64)
+    if not names:
+        return None
+
+    bin_dirs: list[Path] = []
+    seen: set[str] = set()
+
+    def _add_dir(candidate: Path) -> None:
+        key = str(candidate)
+        if key not in seen:
+            seen.add(key)
+            bin_dirs.append(candidate)
+
+    for directory in iter_agent_browser_package_bin_dirs(cli_path):
+        _add_dir(directory)
+    for root in search_roots or []:
+        root_path = Path(root)
+        _add_dir(root_path / "node_modules" / "agent-browser" / "bin")
+        if root_path.name == "agent-browser":
+            _add_dir(root_path / "bin")
+        if root_path.name == "bin" and root_path.parent.name == "agent-browser":
+            _add_dir(root_path)
+
+    for directory in bin_dirs:
+        for name in names:
+            candidate = directory / name
+            if _agent_browser_native_binary_usable(candidate):
+                return str(candidate)
+    return None
+
+
+def prefer_agent_browser_native_binary(cli_path: str | None) -> str | None:
+    """Return a native binary path when it should replace an npm shim/JS wrapper.
+
+    Passes through ``None`` / the ``npx agent-browser`` sentinel unchanged.
+    """
+    if not cli_path:
+        return cli_path
+    if " " in cli_path and cli_path.split()[0].endswith("npx"):
+        return cli_path
+    native = resolve_agent_browser_native_binary(cli_path)
+    return native or cli_path
+
+
+def heal_agent_browser_windows_arm64_stub(
+    package_bin_dir: Path | str,
+    *,
+    windows_arm64: bool | None = None,
+) -> str | None:
+    """Replace a 0-byte ``win32-arm64`` stub with the published x64 binary.
+
+    Returns the usable native binary path, or ``None`` when healing is
+    impossible. Safe no-op on non-Windows / non-ARM64 hosts.
+    """
+    if windows_arm64 is None:
+        windows_arm64 = is_windows_arm64()
+    if not windows_arm64:
+        return None
+
+    bin_dir = Path(package_bin_dir)
+    x64 = bin_dir / "agent-browser-win32-x64.exe"
+    arm64 = bin_dir / "agent-browser-win32-arm64.exe"
+    if not _agent_browser_native_binary_usable(x64):
+        return None
+    try:
+        if not _agent_browser_native_binary_usable(arm64):
+            # Copy so npx / the JS wrapper (which still asks for arm64) can
+            # spawn a real PE instead of EFTYPE on a 0-byte stub.
+            arm64.write_bytes(x64.read_bytes())
+    except OSError:
+        # Still usable via direct x64 invocation even if the stub copy fails.
+        return str(x64)
+    return str(x64)
+
+
 def agent_browser_runnable(path: str | None) -> bool:
     """Return True only when *path* is an agent-browser CLI that actually runs.
 
@@ -695,6 +882,10 @@ def agent_browser_runnable(path: str | None) -> bool:
     (exit 0) run, so a dead/wrong-arch/hung binary is rejected and the caller
     can fall through to the next resolution candidate.
 
+    On Windows ARM64, prefers the packaged ``win32-x64`` native binary over the
+    npm JS wrapper, which otherwise spawns a missing/0-byte ``win32-arm64``
+    image and fails with ``EFTYPE`` (issue #77051).
+
     Special cases:
       * ``None`` / empty → False.
       * The ``"npx agent-browser"`` fallback form (contains a space, not a real
@@ -706,17 +897,27 @@ def agent_browser_runnable(path: str | None) -> bool:
     # The npx fallback is a two-token command string, not a filesystem path.
     if " " in path and path.split()[0].endswith("npx"):
         return True
+
+    probe = prefer_agent_browser_native_binary(path) or path
+
     # exists() follows symlinks — a dangling link returns False here, so we
     # never even spawn a subprocess for the broken-link case.
-    if not os.path.exists(path) or not os.access(path, os.X_OK):
+    if not os.path.exists(probe) or not os.access(probe, os.X_OK):
         return False
+    # Reject empty PE stubs without paying for a spawn (Windows ARM64).
+    try:
+        if Path(probe).is_file() and Path(probe).stat().st_size < 1024:
+            return False
+    except OSError:
+        return False
+
     import subprocess
 
     try:
         from hermes_cli._subprocess_compat import windows_hide_flags
 
         result = subprocess.run(
-            [path, "--version"],
+            [probe, "--version"],
             capture_output=True,
             timeout=10,
             env=with_hermes_node_path(),

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -393,6 +393,32 @@ function Install-AgentBrowser {
     }
     Remove-Item $npmLog -Force -ErrorAction SilentlyContinue
 
+    # --ignore-scripts skips agent-browser's postinstall, which normally
+    # (a) downloads the platform binary and (b) rewrites Windows shims to
+    # invoke the native .exe. The tarball already ships
+    # agent-browser-win32-x64.exe, but on Windows ARM64 the Node wrapper
+    # still looks for win32-arm64 and will spawn a 0-byte stub as EFTYPE
+    # (#77051 / vercel-labs/agent-browser#1256). Heal that here.
+    $abPkgBin = Join-Path $prefixDir "node_modules\agent-browser\bin"
+    $abX64 = Join-Path $abPkgBin "agent-browser-win32-x64.exe"
+    $abArm64 = Join-Path $abPkgBin "agent-browser-win32-arm64.exe"
+    if (Test-Path $abX64) {
+        $nativeArch = Get-WindowsArch
+        if ($nativeArch -eq "arm64") {
+            $arm64Len = 0
+            if (Test-Path $abArm64) { $arm64Len = (Get-Item $abArm64).Length }
+            if ($arm64Len -lt 1024) {
+                Copy-Item -Path $abX64 -Destination $abArm64 -Force
+                Write-Info "Healed agent-browser Windows ARM64 stub (using win32-x64 via emulation)"
+            }
+        }
+        # Point the prefix shim at the native exe so Chromium install and
+        # later hermes browser tools skip the broken JS wrapper path.
+        $cmdShim = Join-Path $prefixDir "agent-browser.cmd"
+        $shimBody = "@echo off`r`n`"%~dp0node_modules\agent-browser\bin\agent-browser-win32-x64.exe`" %*`r`n"
+        Set-Content -Path $cmdShim -Value $shimBody -Encoding ASCII
+    }
+
     if (-not $SkipChromium) {
         $sysBrowser = Find-SystemBrowser
         if ($sysBrowser) {
@@ -400,6 +426,9 @@ function Install-AgentBrowser {
             Write-Info "Explicit browser override set -- skipping bundled Chromium download"
         } else {
             $abExe = Join-Path $prefixDir "agent-browser.cmd"
+            if (-not (Test-Path $abExe) -and (Test-Path $abX64)) {
+                $abExe = $abX64
+            }
             if (Test-Path $abExe) {
                 Write-Info "Installing Chromium via agent-browser install..."
                 $abLog = [System.IO.Path]::GetTempFileName()

--- a/tests/tools/test_browser_windows_arm64_resolution.py
+++ b/tests/tools/test_browser_windows_arm64_resolution.py
@@ -1,0 +1,160 @@
+"""Windows ARM64 agent-browser resolution (issue #77051).
+
+agent-browser ships only ``agent-browser-win32-x64.exe``. On Windows ARM64 the
+npm JS wrapper still looks for ``win32-arm64``, and a 0-byte stub left by older
+postinstalls spawns as ``EFTYPE``. Hermes must prefer the x64 PE (or fail with
+an actionable error) instead of routing through that wrapper.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import hermes_constants as hc
+import tools.browser_tool as bt
+
+
+@pytest.fixture(autouse=True)
+def _clear_browser_caches():
+    bt._cached_agent_browser = None
+    bt._agent_browser_resolved = False
+    yield
+    bt._cached_agent_browser = None
+    bt._agent_browser_resolved = False
+
+
+def _write_fake_exe(path: Path, *, size: int = 4096) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"MZ" + b"\0" * (size - 2))
+    return path
+
+
+def _shim_with_package(tmp_path: Path, *, empty_arm64: bool = True) -> tuple[Path, Path]:
+    pkg_bin = tmp_path / "node_modules" / "agent-browser" / "bin"
+    native = _write_fake_exe(pkg_bin / "agent-browser-win32-x64.exe", size=8192)
+    if empty_arm64:
+        (pkg_bin / "agent-browser-win32-arm64.exe").write_bytes(b"")
+    shim = tmp_path / "node_modules" / ".bin" / "agent-browser.cmd"
+    shim.parent.mkdir(parents=True, exist_ok=True)
+    shim.write_text("@echo off\n")
+    return shim, native
+
+
+class TestNativeBinaryNameSelection:
+    def test_windows_arm64_prefers_x64_then_arm64_name(self):
+        names = hc.agent_browser_native_binary_names(windows_arm64=True)
+        assert names[0] == "agent-browser-win32-x64.exe"
+        assert "agent-browser-win32-arm64.exe" in names
+
+    def test_windows_x64_only_lists_x64(self, monkeypatch):
+        monkeypatch.setattr(hc.sys, "platform", "win32")
+        names = hc.agent_browser_native_binary_names(windows_arm64=False)
+        assert names == ("agent-browser-win32-x64.exe",)
+
+
+class TestResolveAndHeal:
+    def test_resolve_prefers_usable_x64_over_empty_arm64_stub(self, tmp_path):
+        shim, native = _shim_with_package(tmp_path)
+        resolved = hc.resolve_agent_browser_native_binary(
+            str(shim), windows_arm64=True
+        )
+        assert resolved == str(native)
+
+    def test_resolve_from_prefix_shim(self, tmp_path):
+        pkg_bin = tmp_path / "node_modules" / "agent-browser" / "bin"
+        native = _write_fake_exe(pkg_bin / "agent-browser-win32-x64.exe", size=8192)
+        shim = tmp_path / "agent-browser.cmd"
+        shim.write_text("@echo off\n")
+        assert (
+            hc.resolve_agent_browser_native_binary(str(shim), windows_arm64=True)
+            == str(native)
+        )
+
+    def test_heal_copies_x64_over_empty_arm64_stub(self, tmp_path):
+        pkg_bin = tmp_path / "bin"
+        x64 = _write_fake_exe(pkg_bin / "agent-browser-win32-x64.exe", size=4096)
+        arm64 = pkg_bin / "agent-browser-win32-arm64.exe"
+        arm64.write_bytes(b"")
+
+        healed = hc.heal_agent_browser_windows_arm64_stub(
+            pkg_bin, windows_arm64=True
+        )
+        assert healed == str(x64)
+        assert arm64.stat().st_size == x64.stat().st_size
+
+    def test_heal_noop_when_not_windows_arm64(self, tmp_path):
+        pkg_bin = tmp_path / "bin"
+        _write_fake_exe(pkg_bin / "agent-browser-win32-x64.exe")
+        assert (
+            hc.heal_agent_browser_windows_arm64_stub(pkg_bin, windows_arm64=False)
+            is None
+        )
+
+    def test_reject_empty_native_binary(self, tmp_path):
+        stub = tmp_path / "agent-browser-win32-arm64.exe"
+        stub.write_bytes(b"")
+        assert hc._agent_browser_native_binary_usable(stub) is False
+
+    def test_prefer_replaces_shim_with_native(self, tmp_path):
+        shim, native = _shim_with_package(tmp_path)
+        with patch.object(hc, "is_windows_arm64", return_value=True):
+            assert hc.prefer_agent_browser_native_binary(str(shim)) == str(native)
+
+    def test_prefer_passes_through_npx_sentinel(self):
+        assert (
+            hc.prefer_agent_browser_native_binary("npx agent-browser")
+            == "npx agent-browser"
+        )
+
+
+class TestFindAgentBrowserWinArm64:
+    def test_coerce_heals_stub_and_returns_x64(self, tmp_path, monkeypatch):
+        shim, native = _shim_with_package(tmp_path)
+        arm64 = tmp_path / "node_modules" / "agent-browser" / "bin" / (
+            "agent-browser-win32-arm64.exe"
+        )
+        monkeypatch.setattr(hc, "is_windows_arm64", lambda: True)
+        monkeypatch.setattr(bt.sys, "platform", "win32")
+
+        coerced = bt._coerce_agent_browser_cmd(str(shim))
+        assert coerced == str(native)
+        assert arm64.stat().st_size >= 1024
+
+    def test_find_returns_native_x64_from_path_shim(self, tmp_path, monkeypatch):
+        shim, native = _shim_with_package(tmp_path)
+        monkeypatch.setattr(hc, "is_windows_arm64", lambda: True)
+        monkeypatch.setattr(bt.sys, "platform", "win32")
+        monkeypatch.setattr(bt, "get_hermes_home", lambda: tmp_path / "empty-home")
+        (tmp_path / "empty-home").mkdir()
+
+        with patch(
+            "tools.browser_tool.shutil.which",
+            side_effect=lambda cmd, path=None: str(shim) if cmd == "agent-browser" else None,
+        ), patch(
+            "tools.browser_tool.agent_browser_runnable", return_value=True
+        ), patch(
+            "tools.browser_tool._merge_browser_path", return_value=""
+        ):
+            assert bt._find_agent_browser() == str(native)
+
+    def test_find_raises_actionable_error_when_x64_missing(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(hc, "is_windows_arm64", lambda: True)
+        monkeypatch.setattr(bt.sys, "platform", "win32")
+        monkeypatch.setattr(bt, "get_hermes_home", lambda: tmp_path)
+
+        with patch("tools.browser_tool.shutil.which", return_value=None), patch(
+            "tools.browser_tool._merge_browser_path", return_value=""
+        ), patch(
+            "tools.browser_tool.resolve_agent_browser_native_binary",
+            return_value=None,
+        ), patch(
+            "hermes_cli.dep_ensure.ensure_dependency",
+            return_value=False,
+        ):
+            with pytest.raises(FileNotFoundError, match="Windows ARM64"):
+                bt._find_agent_browser()

--- a/tests/tools/test_browser_windows_arm64_resolution.py
+++ b/tests/tools/test_browser_windows_arm64_resolution.py
@@ -98,10 +98,13 @@ class TestResolveAndHeal:
         stub.write_bytes(b"")
         assert hc._agent_browser_native_binary_usable(stub) is False
 
-    def test_prefer_replaces_shim_with_native(self, tmp_path):
+    def test_prefer_replaces_shim_with_native(self, tmp_path, monkeypatch):
         shim, native = _shim_with_package(tmp_path)
-        with patch.object(hc, "is_windows_arm64", return_value=True):
-            assert hc.prefer_agent_browser_native_binary(str(shim)) == str(native)
+        # Filename selection keys off sys.platform; is_windows_arm64 alone is
+        # not enough on Linux CI (would pick linux-* names and miss the .exe).
+        monkeypatch.setattr(hc, "is_windows_arm64", lambda: True)
+        monkeypatch.setattr(hc.sys, "platform", "win32")
+        assert hc.prefer_agent_browser_native_binary(str(shim)) == str(native)
 
     def test_prefer_passes_through_npx_sentinel(self):
         assert (

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -69,6 +69,9 @@ from hermes_constants import (
     agent_browser_runnable,
     get_hermes_home,
     get_hermes_home_override,
+    heal_agent_browser_windows_arm64_stub,
+    prefer_agent_browser_native_binary,
+    resolve_agent_browser_native_binary,
 )
 from utils import env_int, is_truthy_value
 from hermes_cli.config import DEFAULT_CONFIG, cfg_get
@@ -2288,7 +2291,43 @@ def _agent_browser_candidate_present(path: str | None) -> bool:
         return False
     if " " in path and path.split()[0].endswith("npx"):
         return True
-    return os.path.exists(path) and (os.name == "nt" or os.access(path, os.X_OK))
+    coerced = prefer_agent_browser_native_binary(path) or path
+    return os.path.exists(coerced) and (os.name == "nt" or os.access(coerced, os.X_OK))
+
+
+def _coerce_agent_browser_cmd(path: str | None) -> str | None:
+    """Prefer a packaged native binary over the npm JS wrapper when available.
+
+    On Windows ARM64 the published artifact is ``agent-browser-win32-x64.exe``;
+    the Node wrapper still looks for ``win32-arm64`` and can spawn a 0-byte
+    stub as ``EFTYPE`` (issue #77051). Invoking the x64 PE directly preserves
+    the feature under Windows' x64 emulation.
+    """
+    if not path:
+        return path
+    if " " in path and path.split()[0].endswith("npx"):
+        return path
+    try:
+        native = resolve_agent_browser_native_binary(path)
+        if native:
+            # Best-effort: heal a 0-byte arm64 stub so any residual npx/JS
+            # path in the same package also works.
+            heal_agent_browser_windows_arm64_stub(Path(native).parent)
+            return native
+    except OSError:
+        pass
+    return prefer_agent_browser_native_binary(path) or path
+
+
+def _windows_arm64_agent_browser_error() -> str:
+    return (
+        "agent-browser has no native Windows ARM64 build; the published "
+        "agent-browser-win32-x64.exe binary was not found or is unusable "
+        "(empty/corrupt). Reinstall with: npm install -g agent-browser "
+        "(or re-run hermes setup / the Windows installer), then retry. "
+        "If spawn still fails with EFTYPE, invoke the win32-x64 executable "
+        "directly or use a cloud/CDP browser backend. See issue #77051."
+    )
 
 
 def _find_agent_browser(*, validate: bool = True) -> str:
@@ -2328,30 +2367,39 @@ def _find_agent_browser(*, validate: bool = True) -> str:
     # the next working resolution (extended PATH → local .bin → npx) instead of
     # caching the broken one and silently killing every browser tool.
 
+    def _accept(candidate: str | None) -> str | None:
+        if not candidate:
+            return None
+        coerced = _coerce_agent_browser_cmd(candidate)
+        if not coerced:
+            return None
+        ok = (
+            agent_browser_runnable(coerced)
+            if validate
+            else _agent_browser_candidate_present(coerced)
+        )
+        return coerced if ok else None
+
     # Check if it's in PATH (global install)
-    which_result = shutil.which("agent-browser")
-    if which_result and (
-        agent_browser_runnable(which_result) if validate else _agent_browser_candidate_present(which_result)
-    ):
+    accepted = _accept(shutil.which("agent-browser"))
+    if accepted:
         if not validate:
-            return which_result
-        _cached_agent_browser = which_result
+            return accepted
+        _cached_agent_browser = accepted
         _agent_browser_resolved = True
-        return which_result
+        return accepted
 
     # Build an extended search PATH including Hermes-managed Node, macOS
     # versioned Homebrew installs, and fallback system dirs like Termux.
     extended_path = _merge_browser_path("")
     if extended_path:
-        which_result = shutil.which("agent-browser", path=extended_path)
-        if which_result and (
-            agent_browser_runnable(which_result) if validate else _agent_browser_candidate_present(which_result)
-        ):
+        accepted = _accept(shutil.which("agent-browser", path=extended_path))
+        if accepted:
             if not validate:
-                return which_result
-            _cached_agent_browser = which_result
+                return accepted
+            _cached_agent_browser = accepted
             _agent_browser_resolved = True
-            return which_result
+            return accepted
 
     # Check local node_modules/.bin/ (npm install in repo root).
     # On Windows, npm drops three shims in .bin: an extensionless POSIX shell
@@ -2362,28 +2410,57 @@ def _find_agent_browser(*, validate: bool = True) -> str:
     # `.cmd` shim instead. `shutil.which` consults PATHEXT, so we delegate to it
     # with an explicit path so POSIX hosts still pick the extensionless shim.
     repo_root = Path(__file__).parent.parent
+    hermes_home = get_hermes_home()
+    search_roots = [
+        repo_root,
+        hermes_home,
+        hermes_home / "node",
+    ]
+    # Direct native-binary probe before npx: on Windows ARM64, npx routes
+    # through agent-browser.js which still requests win32-arm64 (#77051).
+    native_direct = resolve_agent_browser_native_binary(search_roots=search_roots)
+    if native_direct:
+        heal_agent_browser_windows_arm64_stub(Path(native_direct).parent)
+        if (not validate) or agent_browser_runnable(native_direct):
+            if not validate:
+                return native_direct
+            _cached_agent_browser = native_direct
+            _agent_browser_resolved = True
+            return native_direct
+
     local_bin_dir = repo_root / "node_modules" / ".bin"
     if local_bin_dir.is_dir():
-        local_which = shutil.which("agent-browser", path=str(local_bin_dir))
-        if local_which and (
-            agent_browser_runnable(local_which) if validate else _agent_browser_candidate_present(local_which)
-        ):
+        accepted = _accept(shutil.which("agent-browser", path=str(local_bin_dir)))
+        if accepted:
             if not validate:
-                return local_which
-            _cached_agent_browser = local_which
+                return accepted
+            _cached_agent_browser = accepted
             _agent_browser_resolved = True
-            return _cached_agent_browser
+            return accepted
 
     # Check common npx locations (also search the extended fallback PATH)
     npx_path = shutil.which("npx")
     if not npx_path and extended_path:
         npx_path = shutil.which("npx", path=extended_path)
     if npx_path:
-        if not validate:
-            return "npx agent-browser"
-        _cached_agent_browser = "npx agent-browser"
-        _agent_browser_resolved = True
-        return _cached_agent_browser
+        # Avoid caching a known-broken npx→JS→win32-arm64 path when we can
+        # already see the package tree but its native binary is unusable.
+        if sys.platform == "win32":
+            from hermes_constants import is_windows_arm64
+
+            if is_windows_arm64() and not resolve_agent_browser_native_binary(
+                search_roots=search_roots, windows_arm64=True
+            ):
+                if not validate:
+                    raise FileNotFoundError(_windows_arm64_agent_browser_error())
+                # Fall through to lazy install / final error with the ARM64 hint.
+                npx_path = None
+        if npx_path:
+            if not validate:
+                return "npx agent-browser"
+            _cached_agent_browser = "npx agent-browser"
+            _agent_browser_resolved = True
+            return _cached_agent_browser
 
     if not validate:
         raise FileNotFoundError("agent-browser CLI not found")
@@ -2400,14 +2477,25 @@ def _find_agent_browser(*, validate: bool = True) -> str:
                 shutil.which("agent-browser", path=str(get_hermes_home() / "node")),
             ]
             for recheck in candidates:
-                if recheck and agent_browser_runnable(recheck):
-                    _cached_agent_browser = recheck
+                accepted = _accept(recheck)
+                if accepted:
+                    _cached_agent_browser = accepted
                     _agent_browser_resolved = True
-                    return recheck
+                    return accepted
+            native_after = resolve_agent_browser_native_binary(search_roots=search_roots)
+            if native_after and agent_browser_runnable(native_after):
+                _cached_agent_browser = native_after
+                _agent_browser_resolved = True
+                return native_after
     except Exception:
         pass
 
     _agent_browser_resolved = True
+    if sys.platform == "win32":
+        from hermes_constants import is_windows_arm64
+
+        if is_windows_arm64():
+            raise FileNotFoundError(_windows_arm64_agent_browser_error())
     raise FileNotFoundError(
         "agent-browser CLI not found. Install it with: "
         f"{_browser_install_hint()}\n"


### PR DESCRIPTION
## Summary
- On Windows ARM64, prefer the published `agent-browser-win32-x64.exe` native binary (and heal empty `win32-arm64` stubs) instead of routing through the npm JS wrapper that still requests a missing/0-byte arm64 build and fails with `spawn EFTYPE`.
- Teach `hermes doctor` to require a runnable agent-browser (not just a present `node_modules` tree), and harden `install.ps1` after `--ignore-scripts` installs so the prefix shim points at the x64 PE.
- Add unit coverage for native binary selection, stub healing, shim coercion, and the actionable missing-binary error path.

Fixes #77051

## Test plan
- [x] `uv run --with pytest pytest tests/tools/test_browser_windows_arm64_resolution.py -v` (12 passed)
- [x] Related browser/doctor/constants suite mostly green; 2 unrelated env/platform failures on this Windows host (`HOME`/Termux path mock, `get_default_hermes_root` LocalAppData)
- [ ] On a Windows ARM64 (Snapdragon) host with Hermes desktop / arm64 Node: `browser_navigate` to `example.com` succeeds without EFTYPE
- [ ] `hermes doctor` reports agent-browser runnable when only `win32-x64.exe` is present
- [ ] Fresh `install.ps1` browser stage leaves a working `agent-browser.cmd` shim on win-arm64
