### PR TITLE
fix(matrix): bridge cron delivery sends onto the adapter's own event loop

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -809,6 +809,74 @@ class TestMatrixBridgeOnForeignLoop:
             # (legacy direct path) when it cannot inspect the adapter.
             assert _matrix_adapter_loop_matches(BrokenAdapter()) is True
 
+    def test_loop_mismatch_bridge_timeout_returns_error(self):
+        """A send that exceeds the bridge timeout must surface a timed-out
+        error dict and cancel the scheduled future instead of blocking the
+        caller's event loop (review: replace blocking future.result with
+        asyncio.wrap_future + async timeout)."""
+        adapter_loop = asyncio.new_event_loop()
+        adapter = self._adapter_with_loop(
+            adapter_loop, SimpleNamespace(success=True, message_id="$never")
+        )
+        import threading
+        t = threading.Thread(target=adapter_loop.run_forever, daemon=True)
+        t.start()
+        try:
+            # Make the adapter's send block far past the patched 50ms cap.
+            orig_send = adapter.send
+
+            async def slow_send(chat_id, message, metadata=None):
+                await asyncio.sleep(5)
+                return await orig_send(chat_id, message, metadata)
+
+            adapter.send = slow_send
+
+            with patch(
+                "gateway.run._gateway_runner_ref", return_value=self._runner_with(adapter)
+            ), patch("tools.send_message_tool._MATRIX_BRIDGE_TIMEOUT", 0.05):
+                result = asyncio.run(
+                    _send_matrix_via_adapter(
+                        SimpleNamespace(enabled=True, token="tok", extra={}),
+                        "!room:example.com",
+                        "cron report",
+                    )
+                )
+            assert result.get("error") == "Matrix send timed out on adapter loop"
+            assert result.get("success") is not True
+        finally:
+            adapter_loop.call_soon_threadsafe(adapter_loop.stop)
+            t.join(timeout=5)
+            adapter_loop.close()
+
+    def test_loop_mismatch_bridge_schedule_failure_returns_error(self):
+        """If the send cannot be scheduled onto the adapter loop at all
+        (loop closed during a shutdown race), the bridge must return an
+        error dict, not raise."""
+        adapter_loop = asyncio.new_event_loop()
+        adapter = self._adapter_with_loop(
+            adapter_loop, SimpleNamespace(success=True, message_id="$x")
+        )
+        try:
+            with patch(
+                "gateway.run._gateway_runner_ref", return_value=self._runner_with(adapter)
+            ), patch(
+                "agent.async_utils.safe_schedule_threadsafe", return_value=None
+            ):
+                result = asyncio.run(
+                    _send_matrix_via_adapter(
+                        SimpleNamespace(enabled=True, token="tok", extra={}),
+                        "!room:example.com",
+                        "report",
+                    )
+                )
+            assert (
+                result.get("error")
+                == "Matrix send failed: could not schedule send on adapter loop"
+            )
+            assert result.get("success") is not True
+        finally:
+            adapter_loop.close()
+
 
 # ---------------------------------------------------------------------------
 # HTML auto-detection in Telegram send

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -672,6 +672,144 @@ class TestMatrixMediaLiveAdapterReuse:
             ("disconnect",),
         ]
 
+class TestMatrixBridgeOnForeignLoop:
+    """Cron standalone delivery runs asyncio.run() on a fresh loop in the
+    scheduler thread, so the live adapter's aiohttp session lives on a
+    DIFFERENT loop. _send_matrix_via_adapter must bridge the send onto the
+    adapter's own loop instead of awaiting it cross-loop (which makes
+    aiohttp's TimerContext explode) or dropping to an ephemeral adapter
+    (which cannot open the shared crypto store, BAD_ACCOUNT_KEY)."""
+
+    def _adapter_with_loop(self, loop, send_result=None):
+        """Live adapter whose mautrix session reports the given loop."""
+
+        class LiveAdapter:
+            def __init__(self, loop, send_result):
+                self._client = SimpleNamespace(
+                    api=SimpleNamespace(session=SimpleNamespace(_loop=loop))
+                )
+                self._send_result = send_result
+                self.sends = []
+
+            async def send(self, chat_id, message, metadata=None):
+                self.sends.append((chat_id, message, metadata))
+                return self._send_result
+
+        return LiveAdapter(loop, send_result)
+
+    def _runner_with(self, adapter):
+        return SimpleNamespace(adapters={Platform.MATRIX: adapter})
+
+    def test_loop_match_sends_direct(self):
+        """Same-loop call uses the direct send path (no bridge, no
+        connect/disconnect): the normal gateway path stays untouched."""
+        # asyncio.run() always creates a fresh loop, so to test the same-loop
+        # path we must run on the SAME loop that the session reports.
+        loop = asyncio.new_event_loop()
+        try:
+            adapter = self._adapter_with_loop(loop, SimpleNamespace(success=True, message_id="$direct"))
+            with patch("gateway.run._gateway_runner_ref", return_value=self._runner_with(adapter)):
+                result = loop.run_until_complete(
+                    _send_matrix_via_adapter(
+                        SimpleNamespace(enabled=True, token="tok", extra={}),
+                        "!room:example.com",
+                        "hello",
+                    )
+                )
+            assert result["success"] is True
+            assert result["message_id"] == "$direct"
+            assert adapter.sends == [("!room:example.com", "hello", None)]
+        finally:
+            loop.close()
+
+    def test_loop_mismatch_bridges_onto_adapter_loop(self):
+        """Foreign-loop call must schedule the send onto the adapter's own
+        loop (run_coroutine_threadsafe), keep the persistent session, and
+        return the send result."""
+        adapter_loop = asyncio.new_event_loop()
+        adapter = self._adapter_with_loop(adapter_loop, SimpleNamespace(success=True, message_id="$bridged"))
+        import threading
+        t = threading.Thread(target=adapter_loop.run_forever, daemon=True)
+        t.start()
+        try:
+            with patch("gateway.run._gateway_runner_ref", return_value=self._runner_with(adapter)):
+                # Run from a DIFFERENT loop (cron path: fresh asyncio.run)
+                result = asyncio.run(
+                    _send_matrix_via_adapter(
+                        SimpleNamespace(enabled=True, token="tok", extra={}),
+                        "!room:example.com",
+                        "cron report",
+                    )
+                )
+            assert result["success"] is True
+            assert result["message_id"] == "$bridged"
+            assert adapter.sends == [("!room:example.com", "cron report", None)]
+        finally:
+            adapter_loop.call_soon_threadsafe(adapter_loop.stop)
+            t.join(timeout=5)
+            adapter_loop.close()
+
+    def test_loop_mismatch_bridge_send_error_returns_error_dict(self):
+        """A failing send on the adapter's loop must surface as a dict with
+        'error' so cron's standalone delivery path can inspect .get('error')
+        instead of crashing on attribute access."""
+        adapter_loop = asyncio.new_event_loop()
+        adapter = self._adapter_with_loop(
+            adapter_loop, SimpleNamespace(success=False, error="temporary Matrix API stall", message_id=None)
+        )
+        import threading
+        t = threading.Thread(target=adapter_loop.run_forever, daemon=True)
+        t.start()
+        try:
+            with patch("gateway.run._gateway_runner_ref", return_value=self._runner_with(adapter)):
+                result = asyncio.run(
+                    _send_matrix_via_adapter(
+                        SimpleNamespace(enabled=True, token="tok", extra={}),
+                        "!room:example.com",
+                        "report",
+                    )
+                )
+            # _matrix_send_core returns an _error dict ({error: ...}) when the
+            # adapter send fails; the bridge must surface it unchanged so
+            # cron's standalone path can inspect .get('error').
+            assert result.get("error") == "Matrix send failed: temporary Matrix API stall"
+            assert result.get("success") is not True
+        finally:
+            adapter_loop.call_soon_threadsafe(adapter_loop.stop)
+            t.join(timeout=5)
+            adapter_loop.close()
+
+    def test_unknown_session_loop_keeps_legacy_direct_await(self):
+        """When the adapter's loop cannot be determined (session missing or
+        _loop None), detection must not block the happy path: keep the
+        legacy direct await."""
+        adapter = self._adapter_with_loop(None, SimpleNamespace(success=True, message_id="$legacy"))
+        with patch("gateway.run._gateway_runner_ref", return_value=self._runner_with(adapter)):
+            result = asyncio.run(
+                _send_matrix_via_adapter(
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "!room:example.com",
+                    "hello",
+                )
+            )
+        assert result["success"] is True
+        assert result["message_id"] == "$legacy"
+
+    def test_detection_failure_never_blocks_send(self):
+        """A broken adapter (no _client) must not raise out of
+        _matrix_adapter_loop_matches; detection defaults to the safe
+        'keep legacy behaviour' path (True)."""
+        from tools.send_message_tool import _matrix_adapter_loop_matches
+
+        class BrokenAdapter:
+            pass
+
+        with patch("gateway.run._gateway_runner_ref", return_value=self._runner_with(BrokenAdapter())):
+            # Detection itself must not raise, and must report 'matches'
+            # (legacy direct path) when it cannot inspect the adapter.
+            assert _matrix_adapter_loop_matches(BrokenAdapter()) is True
+
+
 # ---------------------------------------------------------------------------
 # HTML auto-detection in Telegram send
 # ---------------------------------------------------------------------------

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -17,6 +17,11 @@ from agent.secret_scope import get_secret
 
 logger = logging.getLogger(__name__)
 
+# Cap for awaiting a send scheduled onto the live Matrix adapter's own event
+# loop (see _matrix_bridge_to_adapter_loop). Mirrors the 90s cap the
+# scheduler's synchronous live-adapter path applies.
+_MATRIX_BRIDGE_TIMEOUT = 90
+
 _TELEGRAM_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+)(?::(\d+))?\s*$")
 _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::([-A-Za-z0-9_]+))?\s*$")
 # Slack conversation IDs: C (public channel), G (private/group channel), D (DM).
@@ -1834,9 +1839,10 @@ async def _matrix_bridge_to_adapter_loop(adapter, chat_id, message, media_files,
     ephemeral adapter cannot open the shared crypto store (BAD_ACCOUNT_KEY)
     and would break encrypted-room delivery.
 
-    Blocks the calling thread until the send completes (or times out), the
-    same contract the scheduler's live-adapter path uses. Returns a dict so
-    cron's standalone delivery path can inspect ``.get("error")``.
+    Awaits the send on the adapter's own loop without blocking the caller's
+    event loop, capped by the same 90s timeout the scheduler's sync
+    live-adapter path uses. Returns a dict so cron's standalone delivery
+    path can inspect ``.get("error")``.
     """
     from agent.async_utils import safe_schedule_threadsafe
 
@@ -1855,7 +1861,14 @@ async def _matrix_bridge_to_adapter_loop(adapter, chat_id, message, media_files,
     if future is None:
         return _error("Matrix send failed: could not schedule send on adapter loop")
     try:
-        result = future.result(timeout=90)
+        # Await the concurrent future without blocking the caller's event
+        # loop. This helper is async and may run on the gateway loop itself,
+        # where future.result(timeout=90) would stall every other task for
+        # up to 90s. wrap_future bridges the concurrent future into this
+        # loop; wait_for applies the same cap the scheduler's sync path uses.
+        result = await asyncio.wait_for(
+            asyncio.wrap_future(future), timeout=_MATRIX_BRIDGE_TIMEOUT
+        )
     except TimeoutError:
         future.cancel()
         return _error("Matrix send timed out on adapter loop")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1794,6 +1794,80 @@ async def _send_signal(extra, chat_id, message, media_files=None):
 # (_send_matrix_via_adapter below stays — it's the native-media upload path.)
 
 
+def _matrix_adapter_loop_matches(adapter) -> bool:
+    """Only reuse a live gateway adapter on its own event loop.
+
+    The gateway-bound adapter's mautrix aiohttp session is created on the
+    gateway loop. When a caller runs the send from a DIFFERENT loop — the
+    cron standalone delivery path does ``asyncio.run()`` on a fresh loop in
+    the scheduler thread — aiohttp's ``TimerContext`` cannot find the current
+    task on the session's loop and every request dies with "Timeout context
+    manager should be used inside a task". Detecting the mismatch lets the
+    caller bridge the send onto the adapter's own loop
+    (``_matrix_bridge_to_adapter_loop``) instead. The persistent-session
+    benefit (#46310) is kept for the normal gateway-loop path.
+    """
+    try:
+        import asyncio
+
+        session = getattr(
+            getattr(getattr(adapter, "_client", None), "api", None), "session", None
+        )
+        session_loop = getattr(session, "_loop", None)
+        if session_loop is None:
+            return True  # unknown loop — keep legacy behaviour
+        return session_loop is asyncio.get_running_loop()
+    except Exception:
+        return True  # a detection failure must never block the happy path
+
+
+async def _matrix_bridge_to_adapter_loop(adapter, chat_id, message, media_files, metadata):
+    """Run ``_matrix_send_core`` on the live adapter's own event loop.
+
+    Called when the current call executes on a DIFFERENT loop than the
+    gateway-bound adapter's session — the cron standalone delivery path runs
+    ``asyncio.run()`` on a fresh loop in the scheduler thread. Awaiting the
+    adapter's send directly in that context makes aiohttp's ``TimerContext``
+    raise "Timeout context manager should be used inside a task", because the
+    session is bound to the gateway loop. Scheduling the send onto the
+    adapter's own loop keeps the persistent E2EE session (#46310) — an
+    ephemeral adapter cannot open the shared crypto store (BAD_ACCOUNT_KEY)
+    and would break encrypted-room delivery.
+
+    Blocks the calling thread until the send completes (or times out), the
+    same contract the scheduler's live-adapter path uses. Returns a dict so
+    cron's standalone delivery path can inspect ``.get("error")``.
+    """
+    from agent.async_utils import safe_schedule_threadsafe
+
+    session = getattr(
+        getattr(getattr(adapter, "_client", None), "api", None), "session", None
+    )
+    loop = getattr(session, "_loop", None)
+    if loop is None:
+        # Cannot determine the adapter's loop — fall back to the legacy
+        # direct await rather than failing the delivery.
+        return await _matrix_send_core(adapter, chat_id, message, media_files, metadata)
+
+    future = safe_schedule_threadsafe(
+        _matrix_send_core(adapter, chat_id, message, media_files, metadata), loop
+    )
+    if future is None:
+        return _error("Matrix send failed: could not schedule send on adapter loop")
+    try:
+        result = future.result(timeout=90)
+    except TimeoutError:
+        future.cancel()
+        return _error("Matrix send timed out on adapter loop")
+    if isinstance(result, dict):
+        return result
+    return {
+        "success": bool(getattr(result, "success", False)),
+        "error": getattr(result, "error", None),
+        "message_id": getattr(result, "message_id", None),
+    }
+
+
 async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, thread_id=None):
     """Send via the Matrix adapter so native Matrix media uploads are preserved.
 
@@ -1841,7 +1915,16 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
         # disconnect it. Correctness here depends on this branch returning
         # before the ephemeral ``adapter`` is constructed below, so the
         # ephemeral ``finally`` disconnect never touches the live session.
-        return await _matrix_send_core(
+        if _matrix_adapter_loop_matches(live_adapter):
+            return await _matrix_send_core(
+                live_adapter, chat_id, message, media_files, metadata
+            )
+        # Loop mismatch (e.g. cron standalone delivery runs ``asyncio.run()``
+        # on a fresh loop in the scheduler thread): bridge the send onto the
+        # adapter's own loop instead of awaiting it here — direct cross-loop
+        # awaits make aiohttp's TimerContext explode, and an ephemeral
+        # adapter cannot open the shared crypto store (BAD_ACCOUNT_KEY).
+        return await _matrix_bridge_to_adapter_loop(
             live_adapter, chat_id, message, media_files, metadata
         )
 


### PR DESCRIPTION
## Summary

Cron jobs that deliver content to Matrix fail with:

```
delivery error: Matrix send failed: Timeout context manager should be used inside a task
```

The same job delivers fine to ntfy and other targets. First seen on
`litellm-spend-daily` (deliver='all'), 2026-08-01.

## Root cause

Cron's standalone delivery path (`cron/scheduler.py`, `_deliver_result`) runs
`asyncio.run(_send_to_platform(...))` on a fresh event loop in the scheduler
thread. `tools/send_message_tool.py::_send_matrix_via_adapter` reuses the
live gateway adapter via `_gateway_runner_ref()`. The mautrix aiohttp session
is bound to the gateway loop. Awaiting it from a different loop makes
aiohttp's `TimerContext` raise that RuntimeError on every request.

The failure is deterministic: a session bound to long-lived loop A, awaited
from fresh loop B, fails every time.

## Fix

`tools/send_message_tool.py`, commit `a70ef23f9`:

- `_matrix_adapter_loop_matches(adapter)`: True when the adapter's session
  loop is the current running loop. The session loop lives at
  `client.api.session._loop` (mautrix `HTTPAPI.session` is the aiohttp
  `ClientSession`). Checking `api._loop` alone returns None, silently falls
  back to the legacy cross-loop await, and reproduces the failure.
- On mismatch, `_matrix_bridge_to_adapter_loop(...)` schedules
  `_matrix_send_core` onto the adapter's own loop via
  `agent.async_utils.safe_schedule_threadsafe` (run_coroutine_threadsafe),
  blocks on `future.result(timeout=90)`, and normalizes the result to a dict
  (SendResult has no `.get()`, and cron's standalone path does
  `result.get("error")`).
- `_send_matrix_via_adapter` gates live-adapter reuse on loop identity.

**Do not fall back to an ephemeral adapter.** An ephemeral
`MatrixAdapter.connect()` cannot open the shared crypto store
(`~/.hermes/platforms/matrix/store/crypto.db`). It computes a different
pickle key with no real device_id and fails with `BAD_ACCOUNT_KEY`. That is
why the existing code reuses the live session (issue #46310).

## Deployment note

The desktop/dashboard backend (`hermes serve`, spawned by the desktop app)
also ticks cron and races the gateway's in-process ticker on the `.tick.lock`
file lock. It caches modules at its own start. Both processes need the new
code; a gateway restart alone does not reload the desktop backend.

## Verification

- `_matrix_adapter_loop_matches`: same loop returns True, foreign loop
  returns False, unknown loop returns True.
- Bridge test against a real `mautrix.api.HTTPAPI` session bound to a
  long-lived loop: the send coroutine runs on the adapter's loop.
- End-to-end requires a gateway restart (modules cached at process start).
  Confirmed live 2026-08-02: `litellm-spend-daily` ran with `last_status:
  ok`, `last_delivery_error: null`, and the report arrived on Matrix.

## Related upstream

- #61495 [open]: "[Bug]: Matrix manual cron delivery fails with \"Timeout
  context manager should be used inside a task\"". Same error string. This
  patch is a candidate fix; attach it to that issue.
- #52202 [open]: "Desktop dashboard cron scheduler races the gateway; when
  it wins a tick it has no live adapter and delivery hangs until
  script_timeout (600s)". Related ticker race, separate defect.