### PR TITLE
feat(agent): inject per-turn current time via ephemeral system tail (post-#102117 refit)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -40,6 +40,7 @@ from agent.message_sanitization import (
     _repair_tool_call_arguments,
 )
 from agent.reasoning_summaries import separate_glued_reasoning_blocks
+from agent.prompt_builder import compose_effective_system_tail
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 from tools.terminal_tool import is_persistent_env
 from utils import base_url_host_matches, base_url_hostname, env_float, env_int
@@ -2371,9 +2372,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 agent._sanitize_tool_calls_for_strict_api(api_msg, model=_sanitize_model)
             api_messages.append(api_msg)
 
-        effective_system = agent._cached_system_prompt or ""
-        if agent.ephemeral_system_prompt:
-            effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+        effective_system = compose_effective_system_tail(agent, agent._cached_system_prompt or "")
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
         if agent.prefill_messages:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -29,7 +29,7 @@ from agent.error_classifier import (FailoverReason, PROVIDER_STREAM_NON_JSON_ERR
 from agent.errors import EmptyStreamError
 from agent.chat_completion_stream_monitor import StreamingWaitMonitor
 from agent.fast_mode import effective_request_overrides
-from agent.turn_context import substitute_api_content
+from agent.turn_context import substitute_api_content, compose_effective_system_tail
 from agent.gemini_native_adapter import is_native_gemini_base_url
 # Remote endpoints must never be fingerprinted: the probe waterfall is only valid for local/LM-Studio/Ollama
 # boxes. Non-Ollama remotes (sglang, vLLM, OpenAI-compat) expose Ollama-compat endpoints that can
@@ -1972,9 +1972,7 @@ def _iteration_summary_api_messages(agent, messages: list) -> list:
             agent._sanitize_tool_calls_for_strict_api(api_msg, model=sanitize_model)
         api_messages.append(api_msg)
 
-    effective_system = agent._cached_system_prompt or ""
-    if agent.ephemeral_system_prompt:
-        effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+    effective_system = compose_effective_system_tail(agent, agent._cached_system_prompt or "")
     if effective_system:
         api_messages = [{"role": "system", "content": effective_system}] + api_messages
     for idx, pfm in enumerate(agent.prefill_messages or ()):

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -74,6 +74,7 @@ from agent.model_metadata import (
     save_context_length,
 )
 from agent.process_bootstrap import _install_safe_stdio
+from agent.prompt_builder import compose_effective_system_tail
 from agent.prompt_caching import (
     build_prompt_cache_plan,
     strip_anthropic_cache_control,
@@ -1044,15 +1045,7 @@ def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     if not isinstance(sp, str) or not sp:
         return active_system_prompt
     if api_messages and api_messages[0].get("role") == "system":
-        effective = sp
-        _ephemeral_parts = []
-        _ts = getattr(agent, "_current_turn_timestamp", "") or ""
-        if _ts:
-            _ephemeral_parts.append(_ts)
-        if agent.ephemeral_system_prompt:
-            _ephemeral_parts.append(agent.ephemeral_system_prompt)
-        if _ephemeral_parts:
-            effective = (effective + "\n\n" + "\n\n".join(_ephemeral_parts)).strip()
+        effective = compose_effective_system_tail(agent, sp)
         if not _rewrite_system_content_blocks(api_messages[0], effective):
             api_messages[0]["content"] = effective
     return sp
@@ -1799,20 +1792,7 @@ def run_conversation(
         # every turn. ``apply_anthropic_cache_control`` may split its stable
         # prefix into content blocks on the wire, but the stored string and
         # its byte-stability remain unchanged.
-        effective_system = active_system_prompt or ""
-        # Per-turn timestamp + persistent ephemeral prompt, both appended
-        # AFTER the cached prefix so the byte-stable system prompt is
-        # untouched. The timestamp is a transient per-turn attribute set in
-        # run_conversation (never persisted, never stacked on the persistent
-        # ephemeral prompt).
-        _ephemeral_parts = []
-        _ts = getattr(agent, "_current_turn_timestamp", "") or ""
-        if _ts:
-            _ephemeral_parts.append(_ts)
-        if agent.ephemeral_system_prompt:
-            _ephemeral_parts.append(agent.ephemeral_system_prompt)
-        if _ephemeral_parts:
-            effective_system = (effective_system + "\n\n" + "\n\n".join(_ephemeral_parts)).strip()
+        effective_system = compose_effective_system_tail(agent, active_system_prompt or "")
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1045,8 +1045,14 @@ def _sync_failover_system_message(agent, api_messages, active_system_prompt):
         return active_system_prompt
     if api_messages and api_messages[0].get("role") == "system":
         effective = sp
+        _ephemeral_parts = []
+        _ts = getattr(agent, "_current_turn_timestamp", "") or ""
+        if _ts:
+            _ephemeral_parts.append(_ts)
         if agent.ephemeral_system_prompt:
-            effective = (effective + "\n\n" + agent.ephemeral_system_prompt).strip()
+            _ephemeral_parts.append(agent.ephemeral_system_prompt)
+        if _ephemeral_parts:
+            effective = (effective + "\n\n" + "\n\n".join(_ephemeral_parts)).strip()
         if not _rewrite_system_content_blocks(api_messages[0], effective):
             api_messages[0]["content"] = effective
     return sp
@@ -1477,6 +1483,23 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
+    # ── Per-turn clock ──
+    # Stamp the current time ONCE per turn as a transient attribute (never
+    # persisted, never cached). The system prompt itself must stay
+    # byte-stable for the provider prefix cache, so the timestamp rides on
+    # the ephemeral system prompt (appended AFTER the cached prefix at
+    # API-call time). Dedicated attribute — do NOT mutate
+    # agent.ephemeral_system_prompt: on a cached gateway agent that would
+    # stack "ts2\nts1\nbase" across turns.
+    try:
+        from hermes_time import now as _hermes_now
+        _ts = _hermes_now()
+        agent._current_turn_timestamp = (
+            f"Current time: {_ts.strftime('%A %Y-%m-%d %H:%M %Z')}"
+        )
+    except Exception:
+        agent._current_turn_timestamp = ""
+
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         _redirect_text = agent._drain_pending_redirect()
         if _redirect_text:
@@ -1777,8 +1800,19 @@ def run_conversation(
         # prefix into content blocks on the wire, but the stored string and
         # its byte-stability remain unchanged.
         effective_system = active_system_prompt or ""
+        # Per-turn timestamp + persistent ephemeral prompt, both appended
+        # AFTER the cached prefix so the byte-stable system prompt is
+        # untouched. The timestamp is a transient per-turn attribute set in
+        # run_conversation (never persisted, never stacked on the persistent
+        # ephemeral prompt).
+        _ephemeral_parts = []
+        _ts = getattr(agent, "_current_turn_timestamp", "") or ""
+        if _ts:
+            _ephemeral_parts.append(_ts)
         if agent.ephemeral_system_prompt:
-            effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+            _ephemeral_parts.append(agent.ephemeral_system_prompt)
+        if _ephemeral_parts:
+            effective_system = (effective_system + "\n\n" + "\n\n".join(_ephemeral_parts)).strip()
         if effective_system:
             api_messages = [{"role": "system", "content": effective_system}] + api_messages
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -32,7 +32,7 @@ from agent.runtime_cwd import resolve_agent_cwd
 from agent.surface_switch import (
     identity_line_value, note_inert_pinned_tools, split_runtime_boundary, stage_surface_switch_note,
 )
-from agent.turn_context import PreflightCompressionTimedOut, build_turn_context
+from agent.turn_context import PreflightCompressionTimedOut, build_turn_context, compose_effective_system_tail
 from agent.turn_retry_state import TurnRetryState
 # Phase helpers of the turn loop, bound at import so a source-tree swap cannot load a
 # skewed phase mid-turn.
@@ -1070,7 +1070,7 @@ def _sync_failover_system_message(agent, api_messages, active_system_prompt):
     if not isinstance(sp, str) or not sp:
         return active_system_prompt
     if api_messages and api_messages[0].get("role") == "system":
-        effective = (sp + "\n\n" + agent.ephemeral_system_prompt).strip() if agent.ephemeral_system_prompt else sp
+        effective = compose_effective_system_tail(agent, sp)
         if not _rewrite_system_content_blocks(api_messages[0], effective):
             api_messages[0]["content"] = effective
     return sp
@@ -1491,6 +1491,23 @@ def _run_conversation_turn(
     agent._ephemeral_reasoning_off = False
     agent._auth_pool_refresh_counts = {}
     agent._last_turn_usage = None
+
+    # ── Per-turn clock ──
+    # Stamp the current time ONCE per turn as a transient attribute (never
+    # persisted, never cached). The system prompt itself must stay
+    # byte-stable for the provider prefix cache, so the timestamp rides on
+    # the ephemeral tail (appended AFTER the cached prefix at API-call
+    # time by compose_effective_system_tail). Dedicated attribute — do NOT
+    # mutate agent.ephemeral_system_prompt: on a cached gateway agent that
+    # would stack "ts2\nts1\nbase" across turns.
+    try:
+        from hermes_time import now as _hermes_now
+        _ts = _hermes_now()
+        agent._current_turn_timestamp = (
+            f"Current time: {_ts.strftime('%A %Y-%m-%d %H:%M %Z')}"
+        )
+    except Exception:
+        agent._current_turn_timestamp = ""
 
     s = _LoopState(
         system_message=system_message, moa_config=moa_config,

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2204,3 +2204,30 @@ def build_context_files_prompt(
     if not sections:
         return ""
     return "# Project Context\n\nThe following project context files have been loaded and should be followed:\n\n" + "\n".join(sections)
+
+
+def compose_effective_system_tail(agent, base_prompt: str) -> str:
+    """Append the per-turn timestamp and persistent ephemeral prompt.
+
+    The one shared composer for every request-only system message
+    assembly.  The base prompt (the byte-stable cached prefix) is always
+    preserved unchanged; the per-turn ``_current_turn_timestamp`` (set
+    once per turn in ``run_conversation``) and the persistent
+    ``ephemeral_system_prompt`` ride after it, in that order, at
+    API-call time.  Mutating the ephemeral prompt itself would stack
+    timestamps on a cached gateway agent (``ts2\\nts1\\nbase``); a
+    dedicated attribute avoids that.
+
+    Sites: the main API build, ``_sync_failover_system_message``, and
+    ``handle_max_iterations``.  Missing timestamp (older agent stubs)
+    and missing ephemeral prompt both degrade to today's behaviour.
+    """
+    parts = []
+    _ts = getattr(agent, "_current_turn_timestamp", "") or ""
+    if _ts:
+        parts.append(_ts)
+    if getattr(agent, "ephemeral_system_prompt", None):
+        parts.append(agent.ephemeral_system_prompt)
+    if not parts:
+        return base_prompt
+    return (base_prompt + "\n\n" + "\n\n".join(parts)).strip()

--- a/agent/temporal_guard.py
+++ b/agent/temporal_guard.py
@@ -1,0 +1,118 @@
+"""Temporal-claim guard: verify the model's clock claims against the stamp.
+
+Companion to the per-turn timestamp feature.  ``run_conversation`` stamps
+the authoritative wall clock (``agent._current_turn_timestamp``) into every
+request-only system message; this module checks the assistant's FINAL
+response text for temporal claims that contradict that stamp, so a model
+that pattern-matches a plausible time instead of reading the stamp shows up
+in the logs instead of silently misleading the user.
+
+Scope (deliberately narrow to keep false positives near zero):
+
+- **now-claims**: explicit "it's <HH:MM>" / "the time is <HH:MM>" phrasing,
+  compared against the stamp within ``tolerance_min``.
+- **anchored recency**: a clock time and a "N minutes/hours ago" phrase in
+  the SAME sentence, where the arithmetic must match (stamp - clock).
+
+Deliberately NOT checked (documented blind spots):
+
+- Unanchored recency ("about 15 minutes ago" with no clock time in the
+  sentence) — there is no reference point to verify against.
+- Event references ("the log at 14:42 shows", "started 23:46:45 last
+  night") — past events, not now-claims.
+- Future/schedule claims ("the watcher fires at 06:45").
+- Times inside fenced/inline code, location-qualified times ("it's 9am in
+  Tokyo"), version numbers, and ISO timestamps.
+
+The guard is log-only: it never mutates the response and never raises.
+"""
+
+from __future__ import annotations
+
+import re
+
+_STAMP_RE = re.compile(r"Current time: (\w+) (\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}) (\w+)")
+_NOW_CLAIM_RE = re.compile(
+    r"(?:it'?s|now|currently|right now)\s+(?:about|around|roughly|~)?\s*"
+    r"(\d{1,2}):(\d{2})(?:\s*(am|pm))?\b",
+    re.IGNORECASE,
+)
+_TIME_IS_RE = re.compile(
+    r"(?:current time|the time|time)\s+is\s+(?:about|around|roughly|~)?\s*"
+    r"(\d{1,2}):(\d{2})(?:\s*(am|pm))?\b",
+    re.IGNORECASE,
+)
+_CLOCK_RE = re.compile(r"\b(\d{1,2}):(\d{2})(?::(\d{2}))?\s*(Z|[A-Z]{2,4})?\b")
+_AGO_RE = re.compile(r"\b(\d+)\s*(min(?:ute)?s?|hour(?:s)?|hrs?|h)\s+ago\b", re.IGNORECASE)
+_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+
+
+def _to_minutes(h: str, m: str, ap: str | None = None) -> int:
+    hh = int(h) % 24
+    if ap:
+        ap = ap.lower()
+        if ap == "pm" and hh < 12:
+            hh += 12
+        if ap == "am" and hh == 12:
+            hh = 0
+    return hh * 60 + int(m)
+
+
+def _wrap_diff(a_min: int, b_min: int) -> int:
+    """Circular-clock distance, so 23:58 vs 00:05 is 7 minutes, not 1433."""
+    raw = abs(a_min - b_min)
+    return min(raw, 24 * 60 - raw)
+
+
+def check_temporal_claims(text: str, stamp: str, tolerance_min: int = 5) -> list[str]:
+    """Return human-readable flags for temporal claims contradicting ``stamp``.
+
+    Empty text, an unparseable stamp, or no contradicting claim all return
+    ``[]``. The check is best-effort; callers should wrap it in try/except
+    and never block a turn on its result.
+    """
+    flags: list[str] = []
+    if not text or not stamp:
+        return flags
+    m = _STAMP_RE.search(stamp)
+    if not m:
+        return flags
+    shh, smm = m.group(3).split(":")
+    stamp_min = int(shh) * 60 + int(smm)
+
+    # Strip code before matching: literal times inside code are not claims.
+    scan_text = _FENCE_RE.sub(" ", text)
+    scan_text = _INLINE_CODE_RE.sub(" ", scan_text)
+
+    # 1. now-claims
+    for rx in (_NOW_CLAIM_RE, _TIME_IS_RE):
+        for cm in rx.finditer(scan_text):
+            tail = scan_text[cm.end() : cm.end() + 30]
+            if re.match(r"\s+(?:in|at)\s+[A-Za-z]", tail):
+                continue  # "it's 9am in Tokyo" — location/timezone, not local now
+            claim_min = _to_minutes(cm.group(1), cm.group(2), cm.group(3))
+            if _wrap_diff(claim_min, stamp_min) > tolerance_min:
+                flags.append(
+                    f"now-claim {cm.group(0)!r} contradicts stamp "
+                    f"{stamp_min // 60:02d}:{stamp_min % 60:02d}"
+                )
+
+    # 2. anchored recency: clock time + "N ... ago" in the same sentence
+    for sent in re.split(r"(?<=[.!?])\s+|\n", scan_text):
+        times = [(tm, _to_minutes(tm.group(1), tm.group(2))) for tm in _CLOCK_RE.finditer(sent)]
+        agos = [(am, int(am.group(1)), am.group(2).lower()) for am in _AGO_RE.finditer(sent)]
+        if not times or not agos:
+            continue
+        for tm, tmin in times:
+            for am, n, unit in agos:
+                claimed = n * (60 if unit.startswith("h") else 1)
+                expected = (stamp_min - tmin) % (24 * 60)
+                if expected > 12 * 60:
+                    continue  # clock wrap: ambiguous, do not guess
+                if abs(expected - claimed) > max(10, claimed * 0.25):
+                    flags.append(
+                        f"recency {am.group(0)!r} at clock {tm.group(0)!r}: "
+                        f"expected {expected}min vs claimed {claimed}min"
+                    )
+    return flags

--- a/agent/temporal_guard.py
+++ b/agent/temporal_guard.py
@@ -1,0 +1,118 @@
+"""Temporal-claim guard: verify the model's clock claims against the stamp.
+
+Companion to the per-turn timestamp feature.  ``_run_conversation_turn`` stamps
+the authoritative wall clock (``agent._current_turn_timestamp``) into every
+request-only system message; this module checks the assistant's FINAL
+response text for temporal claims that contradict that stamp, so a model
+that pattern-matches a plausible time instead of reading the stamp shows up
+in the logs instead of silently misleading the user.
+
+Scope (deliberately narrow to keep false positives near zero):
+
+- **now-claims**: explicit "it's <HH:MM>" / "the time is <HH:MM>" phrasing,
+  compared against the stamp within ``tolerance_min``.
+- **anchored recency**: a clock time and a "N minutes/hours ago" phrase in
+  the SAME sentence, where the arithmetic must match (stamp - clock).
+
+Deliberately NOT checked (documented blind spots):
+
+- Unanchored recency ("about 15 minutes ago" with no clock time in the
+  sentence) — there is no reference point to verify against.
+- Event references ("the log at 14:42 shows", "started 23:46:45 last
+  night") — past events, not now-claims.
+- Future/schedule claims ("the watcher fires at 06:45").
+- Times inside fenced/inline code, location-qualified times ("it's 9am in
+  Tokyo"), version numbers, and ISO timestamps.
+
+The guard is log-only: it never mutates the response and never raises.
+"""
+
+from __future__ import annotations
+
+import re
+
+_STAMP_RE = re.compile(r"Current time: (\w+) (\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}) (\w+)")
+_NOW_CLAIM_RE = re.compile(
+    r"(?:it'?s|now|currently|right now)\s+(?:about|around|roughly|~)?\s*"
+    r"(\d{1,2}):(\d{2})(?:\s*(am|pm))?\b",
+    re.IGNORECASE,
+)
+_TIME_IS_RE = re.compile(
+    r"(?:current time|the time|time)\s+is\s+(?:about|around|roughly|~)?\s*"
+    r"(\d{1,2}):(\d{2})(?:\s*(am|pm))?\b",
+    re.IGNORECASE,
+)
+_CLOCK_RE = re.compile(r"\b(\d{1,2}):(\d{2})(?::(\d{2}))?\s*(Z|[A-Z]{2,4})?\b")
+_AGO_RE = re.compile(r"\b(\d+)\s*(min(?:ute)?s?|hour(?:s)?|hrs?|h)\s+ago\b", re.IGNORECASE)
+_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+
+
+def _to_minutes(h: str, m: str, ap: str | None = None) -> int:
+    hh = int(h) % 24
+    if ap:
+        ap = ap.lower()
+        if ap == "pm" and hh < 12:
+            hh += 12
+        if ap == "am" and hh == 12:
+            hh = 0
+    return hh * 60 + int(m)
+
+
+def _wrap_diff(a_min: int, b_min: int) -> int:
+    """Circular-clock distance, so 23:58 vs 00:05 is 7 minutes, not 1433."""
+    raw = abs(a_min - b_min)
+    return min(raw, 24 * 60 - raw)
+
+
+def check_temporal_claims(text: str, stamp: str, tolerance_min: int = 5) -> list[str]:
+    """Return human-readable flags for temporal claims contradicting ``stamp``.
+
+    Empty text, an unparseable stamp, or no contradicting claim all return
+    ``[]``. The check is best-effort; callers should wrap it in try/except
+    and never block a turn on its result.
+    """
+    flags: list[str] = []
+    if not text or not stamp:
+        return flags
+    m = _STAMP_RE.search(stamp)
+    if not m:
+        return flags
+    shh, smm = m.group(3).split(":")
+    stamp_min = int(shh) * 60 + int(smm)
+
+    # Strip code before matching: literal times inside code are not claims.
+    scan_text = _FENCE_RE.sub(" ", text)
+    scan_text = _INLINE_CODE_RE.sub(" ", scan_text)
+
+    # 1. now-claims
+    for rx in (_NOW_CLAIM_RE, _TIME_IS_RE):
+        for cm in rx.finditer(scan_text):
+            tail = scan_text[cm.end() : cm.end() + 30]
+            if re.match(r"\s+(?:in|at)\s+[A-Za-z]", tail):
+                continue  # "it's 9am in Tokyo" — location/timezone, not local now
+            claim_min = _to_minutes(cm.group(1), cm.group(2), cm.group(3))
+            if _wrap_diff(claim_min, stamp_min) > tolerance_min:
+                flags.append(
+                    f"now-claim {cm.group(0)!r} contradicts stamp "
+                    f"{stamp_min // 60:02d}:{stamp_min % 60:02d}"
+                )
+
+    # 2. anchored recency: clock time + "N ... ago" in the same sentence
+    for sent in re.split(r"(?<=[.!?])\s+|\n", scan_text):
+        times = [(tm, _to_minutes(tm.group(1), tm.group(2))) for tm in _CLOCK_RE.finditer(sent)]
+        agos = [(am, int(am.group(1)), am.group(2).lower()) for am in _AGO_RE.finditer(sent)]
+        if not times or not agos:
+            continue
+        for tm, tmin in times:
+            for am, n, unit in agos:
+                claimed = n * (60 if unit.startswith("h") else 1)
+                expected = (stamp_min - tmin) % (24 * 60)
+                if expected > 12 * 60:
+                    continue  # clock wrap: ambiguous, do not guess
+                if abs(expected - claimed) > max(10, claimed * 0.25):
+                    flags.append(
+                        f"recency {am.group(0)!r} at clock {tm.group(0)!r}: "
+                        f"expected {expected}min vs claimed {claimed}min"
+                    )
+    return flags

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1096,12 +1096,39 @@ def build_api_messages(
     # Final system message = cached prompt + ephemeral additions (API-time only).
     # Plugin/recall context goes into the user message, never the system prompt: the
     # prompt is built ONCE per session and replayed verbatim (stable cache prefix).
-    effective_system = active_system_prompt or ""
-    if agent.ephemeral_system_prompt:
-        effective_system = (effective_system + "\n\n" + agent.ephemeral_system_prompt).strip()
+    effective_system = compose_effective_system_tail(agent, active_system_prompt or "")
     if effective_system:
         api_messages = [{"role": "system", "content": effective_system}] + api_messages
     return api_messages, effective_system
+
+
+def compose_effective_system_tail(agent, base_prompt: str) -> str:
+    """Append the per-turn timestamp and persistent ephemeral prompt.
+
+    The ONE shared composer for every request-only system message
+    assembly.  The base prompt (the byte-stable cached prefix) is always
+    preserved unchanged; the per-turn ``_current_turn_timestamp`` (set
+    once per turn in ``_run_conversation_turn``) and the persistent
+    ``ephemeral_system_prompt`` ride after it, in that order, at
+    API-call time.  Mutating the ephemeral prompt itself would stack
+    timestamps on a cached gateway agent (``ts2\\nts1\\nbase``); a
+    dedicated attribute avoids that.
+
+    Sites: ``build_api_messages`` here, ``_sync_failover_system_message``
+    in ``agent.conversation_loop``, and the max-iterations summary in
+    ``agent.chat_completion_helpers``.  Missing timestamp (older agent
+    stubs) and missing ephemeral prompt both degrade to today's
+    behaviour.
+    """
+    parts = []
+    _ts = getattr(agent, "_current_turn_timestamp", "") or ""
+    if _ts:
+        parts.append(_ts)
+    if getattr(agent, "ephemeral_system_prompt", None):
+        parts.append(agent.ephemeral_system_prompt)
+    if not parts:
+        return base_prompt
+    return (base_prompt + "\n\n" + "\n\n".join(parts)).strip()
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -761,4 +761,18 @@ def finalize_turn(
     agent._turn_preflight_display_snapshot = None
     agent._turn_received_provider_response = False
 
+    # Temporal-claim guard (companion to the per-turn timestamp feature).
+    # The stamp makes "now" authoritative every turn; this check surfaces
+    # model output that contradicts it. Log-only, never mutates the
+    # response, never raises — a checker bug must not break a turn.
+    try:
+        _ts_stamp = getattr(agent, "_current_turn_timestamp", "") or ""
+        if final_response and _ts_stamp:
+            from agent.temporal_guard import check_temporal_claims
+
+            for _flag in check_temporal_claims(final_response, _ts_stamp):
+                logger.warning("Temporal-claim check: %s", _flag)
+    except Exception:
+        pass  # Guard is best-effort observability
+
     return result

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -637,4 +637,19 @@ def finalize_turn(
 
     agent._turn_preflight_display_snapshot = None
     agent._turn_received_provider_response = False
+
+    # Temporal-claim guard (companion to the per-turn timestamp feature).
+    # The stamp makes "now" authoritative every turn; this check surfaces
+    # model output that contradicts it. Log-only, never mutates the
+    # response, never raises — a checker bug must not break a turn.
+    try:
+        _ts_stamp = getattr(agent, "_current_turn_timestamp", "") or ""
+        if final_response and _ts_stamp:
+            from agent.temporal_guard import check_temporal_claims
+
+            for _flag in check_temporal_claims(final_response, _ts_stamp):
+                logger.warning("Temporal-claim check: %s", _flag)
+    except Exception:
+        pass  # Guard is best-effort observability
+
     return result

--- a/tests/agent/test_temporal_guard.py
+++ b/tests/agent/test_temporal_guard.py
@@ -1,0 +1,251 @@
+"""Tests for the temporal-claim guard (agent/temporal_guard.py).
+
+The per-turn timestamp feature stamps ``Current time: ...`` into every
+request; this guard verifies the model's FINAL response does not contradict
+that stamp. Coverage: now-claims, anchored recency arithmetic, the
+documented blind spots (unanchored recency, event references, future
+claims, code blocks, location-qualified times), and the wiring in
+``finalize_turn`` (log-only, never mutates, never raises).
+"""
+
+import pytest
+
+from agent.temporal_guard import check_temporal_claims
+from agent.turn_finalizer import finalize_turn
+
+STAMP = "Current time: Monday 2026-08-03 07:56 BST"
+
+
+class _StubBudget:
+    used = 1
+    max_total = 90
+    remaining = 89
+
+
+class _StubCompressor:
+    last_prompt_tokens = 0
+
+
+class _StubAgent:
+    """Minimal agent surface that ``finalize_turn`` reads from."""
+
+    def __init__(self, stamp=None):
+        self.max_iterations = 90
+        self.iteration_budget = _StubBudget()
+        self.context_compressor = _StubCompressor()
+        self.model = "stub/model"
+        self.provider = "stub"
+        self.base_url = "http://stub"
+        self.session_id = "sess-1"
+        self.quiet_mode = True
+        self.platform = "cli"
+        self._interrupt_requested = False
+        self._interrupt_message = None
+        self._tool_guardrail_halt_decision = None
+        self._response_was_previewed = False
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        for attr in (
+            "session_input_tokens",
+            "session_output_tokens",
+            "session_cache_read_tokens",
+            "session_cache_write_tokens",
+            "session_reasoning_tokens",
+            "session_prompt_tokens",
+            "session_completion_tokens",
+            "session_total_tokens",
+            "session_estimated_cost_usd",
+        ):
+            setattr(self, attr, 0)
+        self.session_cost_status = "ok"
+        self.session_cost_source = "stub"
+        self.persisted_messages = None
+        if stamp is not None:
+            self._current_turn_timestamp = stamp
+
+    def _save_trajectory(self, *a, **k):
+        pass
+
+    def _cleanup_task_resources(self, *a, **k):
+        pass
+
+    def _drop_trailing_empty_response_scaffolding(self, messages):
+        pass
+
+    def _persist_session(self, messages, conversation_history):
+        self.persisted_messages = [dict(m) for m in messages]
+
+    def _emit_status(self, *a, **k):
+        pass
+
+    def _safe_print(self, *a, **k):
+        pass
+
+    def _file_mutation_verifier_enabled(self):
+        return False
+
+    def _turn_completion_explainer_enabled(self):
+        return False
+
+    def _drain_pending_steer(self):
+        return None
+
+    def clear_interrupt(self):
+        pass
+
+    def _sync_external_memory_for_turn(self, **k):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Unit: check_temporal_claims
+# ---------------------------------------------------------------------------
+
+
+class TestCheckTemporalClaims:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Correct claims — silent
+            "it's currently 07:56",
+            "Current time is 07:56 BST",
+            "It is 07:56 right now",
+            # Event references, not now-claims
+            "The reply was posted at 06:02, 23 seconds after I posted it",
+            "gateway started 23:46:45 last night",
+            "the 14:42:07 log line shows the error",
+            "log shows 2026-08-03T05:02:23Z",
+            "Gateway PID 660728, started Aug 2 23:46:45, up 6h19m",
+            # Future/schedule claims
+            "The watcher fires at 06:45",
+            # Versions and durations without clocks
+            "pytest-asyncio==1.3.0 and python-telegram-bot 22.6",
+            "the session ran for 2 hours 15 minutes",
+            # Location/timezone-qualified
+            "it's 9am in Tokyo",
+            "it's 5pm at the office",
+            # Unanchored recency — documented blind spot
+            "it's about 15 minutes ago since the reply",
+            # Code blocks and inline code are not claims
+            "```\nit's 07:45 now\n```",
+            "the docs say `it's 07:45 now`",
+            # Anchored recency that is CORRECT arithmetic
+            "posted at 06:02, about 114 minutes ago",
+            "posted at 06:02, about 2 hours ago",
+            "at 05:02Z, 3h ago",
+        ],
+    )
+    def test_silent_cases(self, text):
+        assert check_temporal_claims(text, STAMP) == []
+
+    @pytest.mark.parametrize(
+        "text, needle",
+        [
+            # Wrong now-claims
+            ("it's 07:45 now", "now-claim"),
+            ("It's 06:45 now", "now-claim"),
+            ("the time is 07:00", "now-claim"),
+            ("it's 7:45 pm", "now-claim"),
+            # Wrong anchored recency arithmetic
+            (
+                "The reply was posted at 06:02, so about 15 minutes ago",
+                "recency",
+            ),
+            (
+                "The reply was posted at 06:02 BST, about 15 minutes ago",
+                "recency",
+            ),
+            ("posted at 06:02, about 45 minutes ago", "recency"),
+        ],
+    )
+    def test_flag_cases(self, text, needle):
+        flags = check_temporal_claims(text, STAMP)
+        assert flags, f"expected a flag for: {text}"
+        assert any(needle in f for f in flags), flags
+
+    def test_empty_text_or_stamp(self):
+        assert check_temporal_claims("", STAMP) == []
+        assert check_temporal_claims("it's 07:45", "") == []
+
+    def test_malformed_stamp(self):
+        assert check_temporal_claims("it's 07:45", "Current time: ???") == []
+
+    def test_tolerance_boundary(self):
+        # exactly tolerance_min away: silent; one minute more: flagged
+        assert check_temporal_claims("it's 07:51", STAMP) == []
+        assert check_temporal_claims("it's 07:50", STAMP) != []
+
+    def test_am_pm_matches_stamp(self):
+        # stamp is 07:56 AM; an explicit am claim matches
+        assert check_temporal_claims("it's 7:56 am", STAMP) == []
+
+    def test_clock_wrap_distance(self):
+        night_stamp = "Current time: Monday 2026-08-03 00:05 BST"
+        assert check_temporal_claims("it's 00:02", night_stamp) == []
+        assert check_temporal_claims("it's 23:59", night_stamp) != []
+
+
+# ---------------------------------------------------------------------------
+# Integration: finalize_turn wiring
+# ---------------------------------------------------------------------------
+
+
+def _finalize(agent, final_response, *, interrupted=False):
+    messages = [
+        {"role": "user", "content": "what time is it?"},
+        {"role": "assistant", "content": final_response},
+    ]
+    return finalize_turn(
+        agent,
+        final_response=final_response,
+        api_call_count=1,
+        interrupted=interrupted,
+        failed=False,
+        messages=messages,
+        conversation_history=None,
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="what time is it?",
+        original_user_message="what time is it?",
+        _should_review_memory=False,
+        _turn_exit_reason="ok",
+    )
+
+
+class TestFinalizeTurnGuardWiring:
+    def test_wrong_now_claim_logged(self, monkeypatch):
+        from agent import conversation_loop
+
+        warnings = []
+        monkeypatch.setattr(conversation_loop.logger, "warning", lambda *a: warnings.append(a))
+        agent = _StubAgent(stamp=STAMP)
+        _finalize(agent, "it's 07:45 now, so about 11 minutes have passed.")
+        assert any("Temporal-claim check" in str(a) for a in warnings), warnings
+
+    def test_clean_response_silent(self, monkeypatch):
+        from agent import conversation_loop
+
+        warnings = []
+        monkeypatch.setattr(conversation_loop.logger, "warning", lambda *a: warnings.append(a))
+        agent = _StubAgent(stamp=STAMP)
+        _finalize(agent, "Current time is 07:56 BST.")
+        assert not any("Temporal-claim check" in str(a) for a in warnings)
+
+    def test_no_stamp_silent(self, monkeypatch):
+        from agent import conversation_loop
+
+        warnings = []
+        monkeypatch.setattr(conversation_loop.logger, "warning", lambda *a: warnings.append(a))
+        agent = _StubAgent(stamp=None)
+        _finalize(agent, "it's 07:45 now")
+        assert not any("Temporal-claim check" in str(a) for a in warnings)
+
+    def test_result_unchanged(self, monkeypatch):
+        from agent import conversation_loop
+
+        monkeypatch.setattr(conversation_loop.logger, "warning", lambda *a: None)
+        agent = _StubAgent(stamp=STAMP)
+        result = _finalize(agent, "it's 07:45 now")
+        # Guard must not touch the returned transcript or response text.
+        assert result["final_response"] == "it's 07:45 now"
+        assert result["messages"][-1]["content"] == "it's 07:45 now"

--- a/tests/agent/test_timestamp_injection.py
+++ b/tests/agent/test_timestamp_injection.py
@@ -1,0 +1,169 @@
+"""Per-turn timestamp injection tests.
+
+The per-turn clock stamp (``_current_turn_timestamp``) rides on the
+ephemeral system prompt, appended AFTER the byte-stable cached prefix at
+API-call time. One shared composer
+(``agent.prompt_builder.compose_effective_system_tail``) serves all three
+request-only system assemblies: the main API build, the failover sync, and
+the max-iterations summary request. These tests pin that contract so a
+future refactor cannot silently drop the stamp from one site.
+"""
+
+from types import SimpleNamespace
+
+from agent.chat_completion_helpers import (
+    handle_max_iterations,
+    rewrite_prompt_model_identity,
+)
+from agent.conversation_loop import _sync_failover_system_message
+from agent.prompt_builder import compose_effective_system_tail
+
+_TS = "Current time: Sunday 2026-08-02 14:42 BST"
+
+
+def _agent_with_timestamp(prompt="SYS\nModel: gpt-5.4-mini\nProvider: openai-codex", ephemeral=None):
+    return SimpleNamespace(
+        _cached_system_prompt=prompt,
+        ephemeral_system_prompt=ephemeral,
+        _current_turn_timestamp=_TS,
+    )
+
+
+class TestComposeEffectiveSystemTail:
+    """The shared composer: base prompt preserved byte-identically, stamp
+    and ephemeral prompt appended after it, in that order."""
+
+    def test_timestamp_and_ephemeral_after_base(self):
+        agent = _agent_with_timestamp(ephemeral="EPHEMERAL")
+        out = compose_effective_system_tail(agent, "SYS")
+        assert out == "SYS\n\nCurrent time: Sunday 2026-08-02 14:42 BST\n\nEPHEMERAL"
+
+    def test_timestamp_alone(self):
+        agent = _agent_with_timestamp(ephemeral=None)
+        assert compose_effective_system_tail(agent, "SYS") == "SYS\n\nCurrent time: Sunday 2026-08-02 14:42 BST"
+
+    def test_ephemeral_without_timestamp_preserves_legacy_layout(self):
+        agent = SimpleNamespace(
+            _cached_system_prompt="SYS", ephemeral_system_prompt="EPHEMERAL"
+        )
+        assert compose_effective_system_tail(agent, "SYS") == "SYS\n\nEPHEMERAL"
+
+    def test_neither_appends_nothing(self):
+        agent = SimpleNamespace(_cached_system_prompt="SYS", ephemeral_system_prompt=None)
+        assert compose_effective_system_tail(agent, "SYS") == "SYS"
+
+    def test_base_prompt_untouched_verbatim(self):
+        """The byte-stable cached prefix must never be mutated — the
+        provider prefix cache depends on it."""
+        agent = _agent_with_timestamp(ephemeral="EPHEMERAL")
+        base = "PRECISE\nBYTES\nLINE"
+        out = compose_effective_system_tail(agent, base)
+        assert base in out
+        assert out.startswith(base)
+
+    def test_empty_base_with_stamp(self):
+        agent = _agent_with_timestamp(ephemeral=None)
+        assert compose_effective_system_tail(agent, "") == _TS
+
+
+class TestTimestampThroughFailoverSync:
+    """_sync_failover_system_message rewrites the in-flight system message
+    after provider failover; the stamp must survive that rewrite."""
+
+    def test_stamp_preserved_after_failover_rewrite(self):
+        agent = _agent_with_timestamp()
+        rewrite_prompt_model_identity(agent, "gemma4:e2b-mlx", "custom")
+        api_messages = [
+            {"role": "system", "content": agent._cached_system_prompt},
+            {"role": "user", "content": "what model are you?"},
+        ]
+        _sync_failover_system_message(agent, api_messages, agent._cached_system_prompt)
+        content = api_messages[0]["content"]
+        assert _TS in content
+        assert "Model: gemma4:e2b-mlx" in content
+        # rewrite_prompt_model_identity updates the cached prompt in place
+        # (that is its contract); the stamp must ride the rewritten copy.
+        assert "Model: gemma4:e2b-mlx" in agent._cached_system_prompt
+
+
+class TestTimestampThroughMaxIterationsSummary:
+    """handle_max_iterations builds its own system message for the forced
+    summary request. It must carry the same per-turn stamp as the main
+    loop, or the timestamp disappears exactly when the loop ends."""
+
+    def test_summary_request_includes_timestamp(self):
+        from unittest.mock import patch
+
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._cached_system_prompt = "SYS"
+        agent._current_turn_timestamp = _TS
+
+        captured = {}
+
+        class _Completions:
+            def create(self, **kwargs):
+                captured.update(kwargs)
+                return "RAW-RESPONSE"
+
+        client = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+        transport = SimpleNamespace(
+            normalize_response=lambda _r: SimpleNamespace(content="SUMMARY")
+        )
+
+        messages = [{"role": "user", "content": "q1"}]
+        with patch.object(
+            agent, "_ensure_primary_openai_client", return_value=client
+        ), patch.object(agent, "_get_transport", return_value=transport):
+            out = handle_max_iterations(agent, messages, 5)
+
+        assert out == "SUMMARY"
+        system = [m for m in captured["messages"] if m.get("role") == "system"]
+        assert system, "summary request must carry a system message"
+        assert _TS in system[0]["content"]
+        assert system[0]["content"].startswith("SYS")
+
+    def test_summary_without_timestamp_still_works(self):
+        """Older agent stubs (no _current_turn_timestamp attribute) must
+        behave exactly as before — stamp degrades gracefully."""
+        from unittest.mock import patch
+
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._cached_system_prompt = "SYS"
+        # No _current_turn_timestamp set.
+
+        captured = {}
+
+        class _Completions:
+            def create(self, **kwargs):
+                captured.update(kwargs)
+                return "RAW-RESPONSE"
+
+        client = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+        transport = SimpleNamespace(
+            normalize_response=lambda _r: SimpleNamespace(content="SUMMARY")
+        )
+
+        with patch.object(
+            agent, "_ensure_primary_openai_client", return_value=client
+        ), patch.object(agent, "_get_transport", return_value=transport):
+            out = handle_max_iterations(agent, [{"role": "user", "content": "q1"}], 5)
+
+        assert out == "SUMMARY"
+        system = [m for m in captured["messages"] if m.get("role") == "system"]
+        assert system[0]["content"] == "SYS"

--- a/tests/agent/test_timestamp_injection.py
+++ b/tests/agent/test_timestamp_injection.py
@@ -1,0 +1,169 @@
+"""Per-turn timestamp injection tests.
+
+The per-turn clock stamp (``_current_turn_timestamp``) rides on the
+ephemeral system tail, appended AFTER the byte-stable cached prefix at
+API-call time. One shared composer
+(``agent.turn_context.compose_effective_system_tail``) serves all three
+request-only system assemblies: the main API build, the failover sync, and
+the max-iterations summary request. These tests pin that contract so a
+future refactor cannot silently drop the stamp from one site.
+"""
+
+from types import SimpleNamespace
+
+from agent.chat_completion_helpers import (
+    handle_max_iterations,
+    rewrite_prompt_model_identity,
+)
+from agent.conversation_loop import _sync_failover_system_message
+from agent.turn_context import compose_effective_system_tail
+
+_TS = "Current time: Sunday 2026-08-02 14:42 BST"
+
+
+def _agent_with_timestamp(prompt="SYS\nModel: gpt-5.4-mini\nProvider: openai-codex", ephemeral=None):
+    return SimpleNamespace(
+        _cached_system_prompt=prompt,
+        ephemeral_system_prompt=ephemeral,
+        _current_turn_timestamp=_TS,
+    )
+
+
+class TestComposeEffectiveSystemTail:
+    """The shared composer: base prompt preserved byte-identically, stamp
+    and ephemeral prompt appended after it, in that order."""
+
+    def test_timestamp_and_ephemeral_after_base(self):
+        agent = _agent_with_timestamp(ephemeral="EPHEMERAL")
+        out = compose_effective_system_tail(agent, "SYS")
+        assert out == "SYS\n\nCurrent time: Sunday 2026-08-02 14:42 BST\n\nEPHEMERAL"
+
+    def test_timestamp_alone(self):
+        agent = _agent_with_timestamp(ephemeral=None)
+        assert compose_effective_system_tail(agent, "SYS") == "SYS\n\nCurrent time: Sunday 2026-08-02 14:42 BST"
+
+    def test_ephemeral_without_timestamp_preserves_legacy_layout(self):
+        agent = SimpleNamespace(
+            _cached_system_prompt="SYS", ephemeral_system_prompt="EPHEMERAL"
+        )
+        assert compose_effective_system_tail(agent, "SYS") == "SYS\n\nEPHEMERAL"
+
+    def test_neither_appends_nothing(self):
+        agent = SimpleNamespace(_cached_system_prompt="SYS", ephemeral_system_prompt=None)
+        assert compose_effective_system_tail(agent, "SYS") == "SYS"
+
+    def test_base_prompt_untouched_verbatim(self):
+        """The byte-stable cached prefix must never be mutated — the
+        provider prefix cache depends on it."""
+        agent = _agent_with_timestamp(ephemeral="EPHEMERAL")
+        base = "PRECISE\nBYTES\nLINE"
+        out = compose_effective_system_tail(agent, base)
+        assert base in out
+        assert out.startswith(base)
+
+    def test_empty_base_with_stamp(self):
+        agent = _agent_with_timestamp(ephemeral=None)
+        assert compose_effective_system_tail(agent, "") == _TS
+
+
+class TestTimestampThroughFailoverSync:
+    """_sync_failover_system_message rewrites the in-flight system message
+    after provider failover; the stamp must survive that rewrite."""
+
+    def test_stamp_preserved_after_failover_rewrite(self):
+        agent = _agent_with_timestamp()
+        rewrite_prompt_model_identity(agent, "gemma4:e2b-mlx", "custom")
+        api_messages = [
+            {"role": "system", "content": agent._cached_system_prompt},
+            {"role": "user", "content": "what model are you?"},
+        ]
+        _sync_failover_system_message(agent, api_messages, agent._cached_system_prompt)
+        content = api_messages[0]["content"]
+        assert _TS in content
+        assert "Model: gemma4:e2b-mlx" in content
+        # rewrite_prompt_model_identity updates the cached prompt in place
+        # (that is its contract); the stamp must ride the rewritten copy.
+        assert "Model: gemma4:e2b-mlx" in agent._cached_system_prompt
+
+
+class TestTimestampThroughMaxIterationsSummary:
+    """handle_max_iterations builds its own system message for the forced
+    summary request. It must carry the same per-turn stamp as the main
+    loop, or the timestamp disappears exactly when the loop ends."""
+
+    def test_summary_request_includes_timestamp(self):
+        from unittest.mock import patch
+
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._cached_system_prompt = "SYS"
+        agent._current_turn_timestamp = _TS
+
+        captured = {}
+
+        class _Completions:
+            def create(self, **kwargs):
+                captured.update(kwargs)
+                return "RAW-RESPONSE"
+
+        client = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+        transport = SimpleNamespace(
+            normalize_response=lambda _r: SimpleNamespace(content="SUMMARY")
+        )
+
+        messages = [{"role": "user", "content": "q1"}]
+        with patch.object(
+            agent, "_ensure_primary_openai_client", return_value=client
+        ), patch.object(agent, "_get_transport", return_value=transport):
+            out = handle_max_iterations(agent, messages, 5)
+
+        assert out == "SUMMARY"
+        system = [m for m in captured["messages"] if m.get("role") == "system"]
+        assert system, "summary request must carry a system message"
+        assert _TS in system[0]["content"]
+        assert system[0]["content"].startswith("SYS")
+
+    def test_summary_without_timestamp_still_works(self):
+        """Older agent stubs (no _current_turn_timestamp attribute) must
+        behave exactly as before — stamp degrades gracefully."""
+        from unittest.mock import patch
+
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._cached_system_prompt = "SYS"
+        # No _current_turn_timestamp set.
+
+        captured = {}
+
+        class _Completions:
+            def create(self, **kwargs):
+                captured.update(kwargs)
+                return "RAW-RESPONSE"
+
+        client = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+        transport = SimpleNamespace(
+            normalize_response=lambda _r: SimpleNamespace(content="SUMMARY")
+        )
+
+        with patch.object(
+            agent, "_ensure_primary_openai_client", return_value=client
+        ), patch.object(agent, "_get_transport", return_value=transport):
+            out = handle_max_iterations(agent, [{"role": "user", "content": "q1"}], 5)
+
+        assert out == "SUMMARY"
+        system = [m for m in captured["messages"] if m.get("role") == "system"]
+        assert system[0]["content"] == "SYS"

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -432,10 +432,12 @@ class TestHTTP413Compression:
         assert result["completed"] is True
         assert len(request_payloads) == 2
         assert len(request_payloads[1]["messages"]) < len(request_payloads[0]["messages"])
-        assert request_payloads[1]["messages"][0] == {
-            "role": "system",
-            "content": "compressed prompt",
-        }
+        # Contract, not clock bytes: the compressed prompt stays the byte-stable
+        # base and the per-turn stamp rides after it (composer appends it after
+        # the base on the retry, exactly as on the first attempt).
+        assert request_payloads[1]["messages"][0]["role"] == "system"
+        assert request_payloads[1]["messages"][0]["content"].startswith("compressed prompt")
+        assert "Current time: " in request_payloads[1]["messages"][0]["content"]
         assert request_payloads[1]["messages"][1] == {
             "role": "user",
             "content": "compressed summary",

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2799,18 +2799,21 @@ class TestRunConversation:
         assert result["completed"] is True
         system = agent.client.chat.completions.create.call_args.kwargs["messages"][0]
         assert system["role"] == "system"
-        assert system["content"] == [
-            {
-                "type": "text",
-                "text": "stable instructions",
-                "cache_control": {"type": "ephemeral"},
-            },
-            {
-                "type": "text",
-                "text": "\n\nsession context",
-                "cache_control": {"type": "ephemeral"},
-            },
-        ]
+        # The static prefix block stays byte-identical (its cache entry
+        # stays warm); the volatile tail carries the per-turn stamp, which
+        # belongs after the breakpoint, not in the cached prefix. The stamp
+        # comes from the live clock (run_conversation stamps per turn), so
+        # assert the contract, not exact clock bytes.
+        blocks = system["content"]
+        assert blocks[0] == {
+            "type": "text",
+            "text": "stable instructions",
+            "cache_control": {"type": "ephemeral"},
+        }, f"static prefix block changed: {blocks[0]}"
+        assert blocks[1]["type"] == "text"
+        assert blocks[1]["text"].startswith("\n\nsession context\n\nCurrent time: ")
+        assert blocks[1].get("cache_control") == {"type": "ephemeral"}
+        assert len(blocks) == 2
 
     def test_codex_content_filter_incomplete_routes_to_policy_fallback(self, agent):
         self._setup_agent(agent)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3110,18 +3110,23 @@ class TestRunConversation:
         assert result["completed"] is True
         system = agent.client.chat.completions.create.call_args.kwargs["messages"][0]
         assert system["role"] == "system"
-        assert system["content"] == [
-            {
-                "type": "text",
-                "text": "stable instructions",
-                "cache_control": {"type": "ephemeral"},
-            },
-            {
-                "type": "text",
-                "text": "\n\nsession context",
-                "cache_control": {"type": "ephemeral"},
-            },
-        ]
+        # Contract, not clock bytes: the static prefix block stays byte-identical
+        # (provider prefix cache stays warm) and the volatile tail block carries
+        # the per-turn stamp followed by the session context. Both blocks keep
+        # their ephemeral cache marks exactly as before the feature landed.
+        assert isinstance(system["content"], list)
+        assert system["content"][0] == {
+            "type": "text",
+            "text": "stable instructions",
+            "cache_control": {"type": "ephemeral"},
+        }
+        tail = system["content"][1]
+        assert tail["type"] == "text"
+        assert tail["cache_control"] == {"type": "ephemeral"}
+        # Tail = base remainder (session context) + the per-turn stamp, in that
+        # order: the composer appends the stamp after the byte-stable base.
+        assert tail["text"].startswith("\n\nsession context")
+        assert "Current time: " in tail["text"]
 
     def test_codex_content_filter_incomplete_routes_to_policy_fallback(self, agent):
         self._setup_agent(agent)


### PR DESCRIPTION
## What does this PR do?

Stamps the wall clock once per turn into every request-only system message, appended after the byte-stable cached prefix at API-call time. The model sees `Current time: <weekday> <date> <time> <zone>` for the whole episode, the provider prefix cache stays warm, and nothing is persisted or mutated.

This is a re-fit of an earlier attempt against the #102117 decomposition. That branch no longer merged, because every request path it touched had been split into phase helpers, so the feature is re-implemented in the same spirit against the current layout.

## Related Issue

Fixes #54686

Related, still open: #49198, #10421, #68026. Alternative approach under discussion in #40252.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/turn_context.py`: `compose_effective_system_tail`, one composer for every request-only system assembly. Preserves the base prompt byte-identically, appends the stamp then the ephemeral prompt, degrades to current behaviour when either is missing.
- `agent/conversation_loop.py`: sets `_current_turn_timestamp` once per turn in `_run_conversation_turn`'s per-turn state block; `_sync_failover_system_message` routes through the composer.
- `agent/chat_completion_helpers.py`: the max-iterations summary assembly (`_iteration_summary_api_messages`) routes through the composer, so the stamp survives the iteration-limit path.
- `agent/temporal_guard.py`: log-only check of the final response for now-claims and anchored-recency arithmetic that contradict the stamp. Never mutates, never raises. Wired at the single post-loop choke point in `turn_finalizer.finalize_turn`.
- `tests/agent/test_timestamp_injection.py`, `tests/agent/test_temporal_guard.py`: new. Layout assertions added to `tests/run_agent/test_run_agent.py` and `tests/run_agent/test_413_compression.py`.

## How to Test

1. `pytest tests/agent/test_timestamp_injection.py tests/agent/test_temporal_guard.py tests/run_agent/test_run_agent.py tests/run_agent/test_413_compression.py -q` → 360 passed on `e60edfa95`.
2. Live: start the gateway, send a message, inspect `messages[0]` in the request. The base prompt bytes are unchanged and the tail carries the `Current time:` line.
3. For the guard: prompt something that invites a time claim and watch the log for `Temporal-claim check:`.
4. Full `tests/agent` and `tests/run_agent` on this branch: 8822 passed, 45 failed, 33 skipped. A clean-main worktree fails the identical 45 node ids (compared via `.pytest_cache` `lastfailed` sets), so they are pre-existing on this host, not from this branch.

## Checklist

- [x] Read the contributing guide
- [x] Conventional Commits (`feat(agent): ...`)
- [x] Searched for existing PRs. #40252 covers the same ground with per-call semantics; see below
- [x] Only changes related to this feature
- [x] Tests added for the feature
- [x] Tested on Linux (Debian 13, Python 3.13)

## Relation to #40252

Both PRs inject a wall-clock line through the ephemeral prompt path and append it after the byte-stable prefix, so both keep the prefix cache warm. They differ on one axis: how often the stamp changes. This PR stamps once per turn; #40252 stamps per API call.

A turn is one reasoning episode, and the loop usually makes several API calls inside it, one per tool result. A stamp that moves mid-episode lets the model report two different times within a single turn with no way for the reader to tell which came first. Per-call freshness also buys nothing for caching, since the appended tail is outside the cached region in either design.

If per-call semantics is the decision, I'll rebuild this PR that way rather than keep two open PRs racing. Maintainer's call.
