### PR TITLE
feat(kanban): add all-board stats

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -759,6 +759,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_stats = sub.add_parser(
         "stats", help="Per-status + per-assignee counts + oldest-ready age",
     )
+    p_stats.add_argument(
+        "--all",
+        action="store_true",
+        help="Show every non-archived board regardless of --board",
+    )
     p_stats.add_argument("--json", action="store_true")
 
     # --- notify subscribe / list / remove ---
@@ -2730,12 +2735,8 @@ def _cmd_watch(args: argparse.Namespace) -> int:
         return 0
 
 
-def _cmd_stats(args: argparse.Namespace) -> int:
-    with kb.connect_closing() as conn:
-        stats = kb.board_stats(conn)
-    if getattr(args, "json", False):
-        print(json.dumps(stats, indent=2, ensure_ascii=False))
-        return 0
+def _print_stats(stats: dict[str, Any]) -> None:
+    """Print one board's stats in the established human-readable layout."""
     print("By status:")
     for k in ("triage", "todo", "scheduled", "ready", "running", "blocked", "done"):
         print(f"  {k:8s}  {stats['by_status'].get(k, 0)}")
@@ -2747,6 +2748,38 @@ def _cmd_stats(args: argparse.Namespace) -> int:
     age = stats["oldest_ready_age_seconds"]
     if age is not None:
         print(f"\nOldest ready task age: {int(age)}s")
+
+
+def _cmd_stats(args: argparse.Namespace) -> int:
+    if getattr(args, "all", False):
+        boards: list[dict[str, Any]] = []
+        for board in kb.list_boards(include_archived=False):
+            slug = board["slug"]
+            with kb.connect_closing(board=slug) as conn:
+                stats = kb.board_stats(conn)
+            boards.append({
+                "slug": slug,
+                "name": board.get("name"),
+                "archived": bool(board.get("archived")),
+                "stats": stats,
+            })
+        if getattr(args, "json", False):
+            print(json.dumps({"boards": boards}, indent=2, ensure_ascii=False))
+            return 0
+        for index, board in enumerate(boards):
+            if index:
+                print()
+            name = f" ({board['name']})" if board["name"] else ""
+            print(f"Board: {board['slug']}{name}")
+            _print_stats(board["stats"])
+        return 0
+
+    with kb.connect_closing() as conn:
+        stats = kb.board_stats(conn)
+    if getattr(args, "json", False):
+        print(json.dumps(stats, indent=2, ensure_ascii=False))
+        return 0
+    _print_stats(stats)
     return 0
 
 

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -104,12 +104,41 @@ def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch
 
 
 # ---------------------------------------------------------------------------
-# Integration with the COMMAND_REGISTRY
+# stats across boards
 # ---------------------------------------------------------------------------
 
 
+def test_run_slash_stats_all_reports_each_board(kanban_home):
+    """`/kanban stats --all` reports isolated per-board stats."""
+    kb.create_board("alpha")
+    kb.create_board("beta")
 
+    with kb.connect_closing(board="alpha") as conn:
+        first = kb.create_task(conn, title="alpha done", assignee="alice")
+        kb.complete_task(conn, first, result="done")
+    with kb.connect_closing(board="beta") as conn:
+        kb.create_task(conn, title="beta ready", assignee="bob")
 
+    raw = kc.run_slash("stats --all --json")
+    payload = json.loads(raw)
+    assert set(payload) == {"boards"}
+    by_slug = {board["slug"]: board for board in payload["boards"]}
+    assert set(by_slug["alpha"]) == {"slug", "name", "archived", "stats"}
+
+    assert by_slug["alpha"]["stats"]["by_status"]["done"] == 1
+    assert by_slug["alpha"]["stats"]["by_assignee"]["alice"]["done"] == 1
+    assert by_slug["beta"]["stats"]["by_status"]["ready"] == 1
+    assert by_slug["beta"]["stats"]["by_status"].get("done", 0) == 0
+
+    single_board = json.loads(kc.run_slash("stats --json"))
+    assert "boards" not in single_board
+    assert single_board["by_status"] == {}
+
+    all_from_alpha = json.loads(kc.run_slash("--board alpha stats --all --json"))
+    assert {board["slug"] for board in all_from_alpha["boards"]} == {"default", "alpha", "beta"}
+
+    assert "Board: alpha" in kc.run_slash("stats --all")
+    assert "Board: beta" in kc.run_slash("stats --all")
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -729,7 +729,7 @@ hermes kanban dispatch [--dry-run] [--max N]           # one-shot pass
         [--failure-limit N] [--json]
 hermes kanban daemon --force                           # DEPRECATED — standalone dispatcher (use `hermes gateway start` instead)
         [--failure-limit N] [--pidfile PATH] [-v]
-hermes kanban stats [--json]                           # per-status + per-assignee counts
+hermes kanban stats [--all] [--json]                   # current board, or every non-archived board (--all ignores --board)
 hermes kanban log <id> [--tail BYTES]                  # worker log from ~/.hermes/kanban/logs/
 hermes kanban notify-subscribe <id>                    # gateway bridge hook (used by /kanban in the gateway)
         --platform <name> --chat-id <id> [--thread-id <id>] [--user-id <id>]

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
@@ -547,7 +547,7 @@ hermes kanban dispatch [--dry-run] [--max N]           # 单次扫描
         [--failure-limit N] [--json]
 hermes kanban daemon --force                           # 已弃用 —— 独立调度器（改用 `hermes gateway start`）
         [--failure-limit N] [--pidfile PATH] [-v]
-hermes kanban stats [--json]                           # 每状态 + 每受让人计数
+hermes kanban stats [--all] [--json]                   # 当前看板，或每个未归档看板（--all 忽略 --board）的每状态 + 每受让人计数
 hermes kanban log <id> [--tail BYTES]                  # 来自 ~/.hermes/kanban/logs/ 的 worker 日志
 hermes kanban notify-subscribe <id>                    # gateway 桥接钩子（由 gateway 中的 /kanban 使用）
         --platform <name> --chat-id <id> [--thread-id <id>] [--user-id <id>]


### PR DESCRIPTION
## Summary
- add `/kanban stats --all` to report each non-archived board
- preserve existing single-board text and JSON output; all-board JSON is `{ "boards": [...] }`
- clarify that `--all` ignores `--board`, and document the command in English and Chinese

## Validation
- TDD: the new slash/CLI test failed first because `--all` was unrecognized, then passed after implementation
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_core_functionality.py -q` (28 passed)
- direct multi-board slash/JSON verification, including `--board alpha stats --all` and legacy JSON compatibility

## Review
- independent review: no blocking findings; strengthened JSON/isolation/precedence regression coverage in response.