### PR TITLE
feat(execute_code): recovery hints for known sandbox failure classes

### DIFF
--- a/tests/tools/test_sandbox_failure_hints.py
+++ b/tests/tools/test_sandbox_failure_hints.py
@@ -1,0 +1,66 @@
+"""Tests for execute_code sandbox failure hints."""
+
+import json
+
+import pytest
+
+from tools.code_execution_tool import _sandbox_failure_hint, execute_code
+
+
+class TestSandboxFailureHint:
+    def test_unavailable_tool_import_lists_available(self):
+        err = ("Traceback (most recent call last):\n  File \"script.py\", line 1\n"
+               "ImportError: cannot import name 'browser_navigate' from 'hermes_tools'")
+        h = _sandbox_failure_hint(err, enabled_tools={"terminal", "read_file"})
+        assert "browser_navigate" in h
+        assert "read_file" in h and "terminal" in h
+        assert "normal tool call" in h
+
+    def test_builtin_helper_import_redirects(self):
+        err = "ImportError: cannot import name 'json_parse' from 'hermes_tools'"
+        h = _sandbox_failure_hint(err)
+        assert "BUILT-IN" in h
+        assert "no import" in h.lower()
+
+    def test_missing_third_party_module(self):
+        err = "ModuleNotFoundError: No module named 'matplotlib'"
+        h = _sandbox_failure_hint(err)
+        assert "matplotlib" in h
+        assert "stdlib" in h
+
+    def test_dict_vs_string_confusion(self):
+        err = "TypeError: string indices must be integers"
+        h = _sandbox_failure_hint(err)
+        assert "DICTS" in h
+
+    def test_unknown_failure_no_hint(self):
+        assert _sandbox_failure_hint("ZeroDivisionError: division by zero") is None
+
+    def test_empty_stderr_no_hint(self):
+        assert _sandbox_failure_hint("") is None
+
+
+class TestLiveSandboxHint:
+    def test_bad_import_produces_hint_field(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        r = json.loads(execute_code(
+            "from hermes_tools import totally_fake_tool\nprint('unreachable')",
+            task_id="t-sbhint",
+        ))
+        assert r["status"] == "error"
+        assert "hint" in r
+        assert "totally_fake_tool" in r["hint"]
+
+    def test_missing_module_produces_hint(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        r = json.loads(execute_code(
+            "import nonexistent_pkg_zzz\n", task_id="t-sbhint",
+        ))
+        assert r["status"] == "error"
+        assert "not installed in the sandbox" in r.get("hint", "")
+
+    def test_successful_script_has_no_hint(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        r = json.loads(execute_code("print('fine')", task_id="t-sbhint"))
+        assert r["status"] == "success"
+        assert "hint" not in r

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -34,6 +34,7 @@ import json
 import logging
 import os
 import platform
+import re
 import secrets
 import shlex
 import socket
@@ -370,6 +371,61 @@ _TOOL_STUBS = {
         '{"command": command, "timeout": timeout, "workdir": workdir}',
     ),
 }
+
+
+def _sandbox_failure_hint(stderr_text: str, enabled_tools=None) -> Optional[str]:
+    """Map well-known sandbox script failures to one actionable recovery hint.
+
+    Production mining (state.db): the top execute_code failure classes are
+    hermes_tools import misuse (importing tools that aren't in the sandbox,
+    23x in one window), calling the built-in helpers via import, treating
+    tool results as strings instead of dicts, and importing third-party
+    packages that don't exist in the sandbox interpreter. Bounded scan,
+    first match wins, never raises.
+    """
+    if not stderr_text:
+        return None
+    window = stderr_text[:4000]
+    try:
+        m = re.search(
+            r"cannot import name '(\w+)' from 'hermes_tools'", window
+        )
+        if m:
+            missing = m.group(1)
+            available = sorted(SANDBOX_ALLOWED_TOOLS & set(enabled_tools or SANDBOX_ALLOWED_TOOLS))
+            builtin = {"json_parse", "shell_quote", "retry"}
+            if missing in builtin:
+                return (
+                    f"{missing} is a BUILT-IN helper in the sandbox — no import "
+                    f"needed. Remove it from the import line and call {missing}(...) directly."
+                )
+            return (
+                f"'{missing}' is not available inside the execute_code sandbox. "
+                f"Importable tools here: {', '.join(available)}. For anything "
+                "else, use the normal tool call instead of execute_code."
+            )
+        m = re.search(r"NameError: name '(json_parse|shell_quote|retry)' is not defined", window)
+        if m:
+            return (
+                f"{m.group(1)} is built into the generated sandbox module — "
+                "call it directly at module scope without importing it."
+            )
+        m = re.search(r"ModuleNotFoundError: No module named '([\w.]+)'", window)
+        if m:
+            return (
+                f"'{m.group(1)}' is not installed in the sandbox interpreter. "
+                "Use Python stdlib inside execute_code, or run the code via "
+                "terminal() with the project venv's python instead."
+            )
+        if re.search(r"TypeError: string indices must be integers|AttributeError: 'str' object has no attribute 'get'", window):
+            return (
+                "Tool functions in the sandbox return DICTS (already parsed) — "
+                "do not json.loads() them or index them like strings. "
+                "Example: read_file(path)['content']."
+            )
+    except Exception:
+        return None
+    return None
 
 
 def generate_hermes_tools_module(enabled_tools: List[str],
@@ -1626,6 +1682,12 @@ def execute_code(
             # Include stderr in output so the LLM sees the traceback
             if stderr_text:
                 result["output"] = stdout_text + "\n--- stderr ---\n" + stderr_text
+            # Known-failure-class recovery hint (import misuse, missing
+            # module, dict-vs-string result handling) so the model fixes
+            # the script on the next attempt instead of re-diagnosing.
+            hint = _sandbox_failure_hint(stderr_text, enabled_tools=sandbox_tools)
+            if hint:
+                result["hint"] = hint
 
         return json.dumps(result, ensure_ascii=False)
 


### PR DESCRIPTION
## Summary
Failed `execute_code` scripts now carry one actionable `hint` for the known sandbox-contract failure classes — wrong `hermes_tools` imports, built-in-helper imports, missing third-party modules, and dict-vs-string result confusion — so the model fixes the script on the next attempt instead of re-diagnosing from a bare traceback.

Root cause (production mining): the top execute_code failure shapes are contract confusions, not logic bugs — `cannot import name X from 'hermes_tools'` (23× in one window, including importing the built-in helpers), `ModuleNotFoundError: matplotlib` (6×, sandbox is stdlib-only), and `TypeError: string indices` from json.loads-ing results that are already dicts.

## Changes
- `tools/code_execution_tool.py`: `_sandbox_failure_hint(stderr, enabled_tools)` — 4 pattern classes, first match wins, bounded 4KB scan, never raises. Wired into the exit≠0 branch of the local result assembly; the unavailable-import hint lists the tools actually importable in the CURRENT session (intersection with enabled toolset). Successful scripts, timeouts, and unknown failures untouched.
- `tests/tools/test_sandbox_failure_hints.py`: 9 tests — per-class hints, session-aware tool list, no-hint negatives, plus live sandbox E2E (real `execute_code` runs: bad import → hint with the missing name; missing module → stdlib hint; success → no hint field).

## Validation
| Check | Result |
|---|---|
| Hermetic runner (new + code_execution suites) | 67/67 passed |
| Live sandbox E2E (real UDS child process) | `from hermes_tools import totally_fake_tool` → error + hint naming it; `import nonexistent_pkg` → stdlib hint; clean script → no hint |

## Infographic

![sandbox failure hints](https://v3b.fal.media/files/b/0aa4c5b7/2Cl3fiQZOOg9NT6cP4Ns3_csQ5d2px.png)
