### PR TITLE
fix(browser): use CAMOFOX_ACCESS_KEY as the global Camofox auth token (#77088)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3637,8 +3637,17 @@ OPTIONAL_ENV_VARS = {
         "password": False,
         "category": "tool",
     },
+    "CAMOFOX_ACCESS_KEY": {
+        "description": "Optional global access key (Bearer token) for a gated Camofox server; gates every route except /health, cookie import, and /stop",
+        "prompt": "Camofox access key",
+        "url": "https://github.com/jo-inc/camofox-browser",
+        "tools": ["browser_navigate", "browser_click"],
+        "password": True,
+        "category": "tool",
+        "advanced": True,
+    },
     "CAMOFOX_API_KEY": {
-        "description": "Optional bearer token sent as Authorization header to a remote/authenticated Camofox server",
+        "description": "Legacy Camofox bearer token; only gates the cookie-import route on the server, kept as a fallback for older deployments",
         "prompt": "Camofox API key",
         "url": "https://github.com/jo-inc/camofox-browser",
         "tools": ["browser_navigate", "browser_click"],

--- a/tests/tools/test_browser_camofox_auth.py
+++ b/tests/tools/test_browser_camofox_auth.py
@@ -36,11 +36,13 @@ class TestAuthHeaders:
 
     def test_empty_when_no_key(self, monkeypatch):
         monkeypatch.delenv("CAMOFOX_API_KEY", raising=False)
+        monkeypatch.delenv("CAMOFOX_ACCESS_KEY", raising=False)
         assert _auth_headers() == {}
 
 
     def test_empty_when_key_blank(self, monkeypatch):
         monkeypatch.setenv("CAMOFOX_API_KEY", "   ")
+        monkeypatch.setenv("CAMOFOX_ACCESS_KEY", "   ")
         assert _auth_headers() == {}
 
     def test_multiplex_scope_key_wins_over_process_environment(self, monkeypatch):
@@ -51,6 +53,38 @@ class TestAuthHeaders:
         token = secret_scope.set_secret_scope({"CAMOFOX_API_KEY": "secondary-profile-key"})
         try:
             assert _auth_headers() == {"Authorization": "Bearer secondary-profile-key"}
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(False)
+
+    def test_access_key_preferred_over_api_key(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_ACCESS_KEY", "global-access-key")
+        monkeypatch.setenv("CAMOFOX_API_KEY", "legacy-api-key")
+        assert _auth_headers() == {"Authorization": "Bearer global-access-key"}
+
+    def test_access_key_alone(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_ACCESS_KEY", "global-access-key")
+        monkeypatch.delenv("CAMOFOX_API_KEY", raising=False)
+        assert _auth_headers() == {"Authorization": "Bearer global-access-key"}
+
+    def test_access_key_blank_falls_back_to_api_key(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_ACCESS_KEY", "   ")
+        monkeypatch.setenv("CAMOFOX_API_KEY", "legacy-api-key")
+        assert _auth_headers() == {"Authorization": "Bearer legacy-api-key"}
+
+    def test_no_keys_sends_empty(self, monkeypatch):
+        monkeypatch.delenv("CAMOFOX_ACCESS_KEY", raising=False)
+        monkeypatch.delenv("CAMOFOX_API_KEY", raising=False)
+        assert _auth_headers() == {}
+
+    def test_multiplex_scope_access_key_wins_over_process_environment(self, monkeypatch):
+        from agent import secret_scope
+
+        monkeypatch.setenv("CAMOFOX_ACCESS_KEY", "default-access-key")
+        secret_scope.set_multiplex_active(True)
+        token = secret_scope.set_secret_scope({"CAMOFOX_ACCESS_KEY": "secondary-access-key"})
+        try:
+            assert _auth_headers() == {"Authorization": "Bearer secondary-access-key"}
         finally:
             secret_scope.reset_secret_scope(token)
             secret_scope.set_multiplex_active(False)

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -82,8 +82,23 @@ def _get_command_timeout() -> int:
 
 
 def _auth_headers() -> Dict[str, str]:
-    """Return Authorization header when CAMOFOX_API_KEY is set."""
-    key = (get_secret("CAMOFOX_API_KEY", "") or "").strip()
+    """Return Authorization header for a gated Camofox server.
+
+    The camofox-browser server distinguishes two keys with different scopes:
+
+    - ``CAMOFOX_ACCESS_KEY`` — global "superkey": when set, every route except
+      ``/health``, cookie import, and ``/stop`` requires
+      ``Authorization: Bearer <ACCESS_KEY>``.
+    - ``CAMOFOX_API_KEY`` — gates **only** the cookie-import route
+      (``POST /sessions/:userId/cookies``).
+
+    Hermes never calls the cookie-import route, so the access key is the
+    correct token for all of its requests. Prefer it, and fall back to the
+    API key so deployments that only configured the legacy key keep working.
+    """
+    access = (get_secret("CAMOFOX_ACCESS_KEY", "") or "").strip()
+    api = (get_secret("CAMOFOX_API_KEY", "") or "").strip()
+    key = access or api
     if key:
         return {"Authorization": f"Bearer {key}"}
     return {}

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -149,7 +149,8 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `FIRECRAWL_BROWSER_TTL` | Firecrawl browser session TTL in seconds (default: 300) |
 | `BROWSER_CDP_URL` | Chrome DevTools Protocol URL for local browser (set via `/browser connect`, e.g. `ws://localhost:9222`) |
 | `CAMOFOX_URL` | Camofox local anti-detection browser URL (default: `http://localhost:9377`) |
-| `CAMOFOX_API_KEY` | Optional bearer token sent as Authorization header to a remote/authenticated Camofox server |
+| `CAMOFOX_ACCESS_KEY` | Global access key (Bearer token) for a gated Camofox server. When set, the server requires it on every route except `/health`, cookie import, and `/stop`. Hermes prefers this key for all browser calls. |
+| `CAMOFOX_API_KEY` | Legacy Camofox bearer token, kept as a fallback for older deployments. On the current server this only gates the cookie-import route; use `CAMOFOX_ACCESS_KEY` for full gating. |
 | `CAMOFOX_USER_ID` | Optional externally managed Camofox user ID for shared visible sessions |
 | `CAMOFOX_SESSION_KEY` | Optional Camofox session key used when creating tabs for `CAMOFOX_USER_ID` |
 | `CAMOFOX_ADOPT_EXISTING_TAB` | Set to `true` to reuse an existing Camofox tab before creating a new one |


### PR DESCRIPTION
## Summary

Fixes #77088 — Hermes could not authenticate against a properly-gated Camofox server.

The camofox-browser server (`jo-inc/camofox-browser`) uses **two keys with different scopes**:

- `CAMOFOX_ACCESS_KEY` → global "superkey": when set, every route except `/health`, cookie import, and `/stop` requires `Authorization: Bearer <ACCESS_KEY>` (`accessKeyMiddleware` in `lib/auth.js`).
- `CAMOFOX_API_KEY` → gates **only** the cookie-import route (`POST /sessions/:userId/cookies`).

Hermes's `_auth_headers()` in `tools/browser_camofox.py` only ever read `CAMOFOX_API_KEY` and sent it as the Bearer token on **all** requests. Consequences:

1. Against a server gated with `CAMOFOX_ACCESS_KEY`, every browser call (navigate/snapshot/click/type/...) fails with `401 Unauthorized` because Hermes sends no valid token.
2. Worse, a user who sets `CAMOFOX_API_KEY` to satisfy Hermes gets cookie import enabled but **all browsing routes stay unauthenticated** — a silent auth bypass for anyone who can reach the port.

## Fix

`_auth_headers()` now prefers `CAMOFOX_ACCESS_KEY` (the global gate) and falls back to `CAMOFOX_API_KEY` for backward compatibility with older deployments. Hermes never calls the cookie-import route, so the access key is the correct token for all of its requests.

Also:
- Added `CAMOFOX_ACCESS_KEY` to `hermes_cli/config_defaults.py` env-var metadata.
- Documented both keys in `website/docs/reference/environment-variables.md`.

## Tests

- `tests/tools/test_browser_camofox_auth.py`: 13 passed (6 new tests covering access-key preference, blank-key fallback, and multiplex scope resolution).
- Full camofox test set: 78 passed, 3 skipped.
- `config_defaults`/`environment_variables` tests: 12 passed, 8 skipped.
