### PR TITLE
feat(i18n): register-aware system messages with friendly overlay

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -6,18 +6,29 @@ command replies, restart-drain notices.  Agent-generated output, log lines,
 error tracebacks, tool outputs, and slash-command descriptions all stay in
 English.
 
-Catalog files live under ``locales/<lang>.yaml`` at the repo root.  Each
+Catalog files live under ``locales/`` at the repo root.  The primary catalog
+for a language is ``<lang>.yaml`` (e.g. ``en.yaml``, ``zh.yaml``).  Each
 catalog is a flat dict keyed by dotted paths (e.g. ``approval.choose`` or
 ``gateway.approval_expired``).  Missing keys fall back to English; if English
 is missing too, the key path itself is returned so a broken catalog never
 crashes the agent.
 
+Register-aware variants live alongside the primary catalog as
+``<lang>-<register>.yaml`` (e.g. ``en-friendly.yaml``).  A register is a
+communication style (``"technical"``, ``"friendly"``) that translates the
+*same information* into a different tone -- it does not suppress or replace
+content.  Register is orthogonal to language: the language fallback chain
+runs first, then the register overlay is applied on top.  Missing register
+catalogs or missing keys fall back safely to the base catalog for that
+language.
+
 Usage::
 
     from agent.i18n import t
-    print(t("approval.choose_long"))                       # current lang
+    print(t("approval.choose_long"))                       # current lang + register
     print(t("gateway.draining", count=3))                  # {count} formatted
-    print(t("approval.choose_long", lang="zh"))            # explicit override
+    print(t("approval.choose_long", lang="zh"))            # explicit language
+    print(t("gateway.reset.header_default", register="friendly"))  # friendly register
 
 Language resolution order:
     1. Explicit ``lang=`` argument passed to :func:`t`
@@ -25,8 +36,16 @@ Language resolution order:
     3. ``display.language`` from config.yaml
     4. ``"en"`` (baseline)
 
+Register resolution order:
+    1. Explicit ``register=`` argument passed to :func:`t`
+    2. ``display.message_register`` from config.yaml
+    3. ``"technical"`` (baseline — byte-compatible with pre-register output)
+
 Supported languages: en, zh, zh-hant, ja, de, es, fr, tr, uk, af, ko, it, ga,
 pt, ru, hu, ar.  Unknown values fall back to en.
+
+Supported registers: ``"technical"`` (default), ``"friendly"``.  Unknown
+values fall back to ``"technical"``.
 """
 
 from __future__ import annotations
@@ -45,6 +64,8 @@ SUPPORTED_LANGUAGES: tuple[str, ...] = (
     "af", "ko", "it", "ga", "pt", "ru", "hu", "ar",
 )
 DEFAULT_LANGUAGE = "en"
+DEFAULT_REGISTER = "technical"
+SUPPORTED_REGISTERS: tuple[str, ...] = ("technical", "friendly")
 
 # Accept a few natural aliases so users who type "chinese" / "zh-CN" / "jp"
 # get the right catalog instead of silently falling back to English.
@@ -86,6 +107,11 @@ _LANGUAGE_ALIASES: dict[str, str] = {
 
 _catalog_cache: dict[str, dict[str, str]] = {}
 _catalog_lock = threading.Lock()
+
+# Separate cache for register-overlay catalogs (e.g. en-friendly.yaml).
+# Keyed by ``"<lang>-<register>"`` so it doesn't collide with the base cache.
+_register_catalog_cache: dict[str, dict[str, str]] = {}
+_register_catalog_lock = threading.Lock()
 
 
 def _locales_dir() -> Path:
@@ -142,6 +168,22 @@ def _normalize_lang(value: Any) -> str:
     return DEFAULT_LANGUAGE
 
 
+def _normalize_register(value: Any) -> str:
+    """Normalize a user-supplied register value to a supported name.
+
+    Returns the default register (``"technical"``) for unknown or empty
+    values so a typo never crashes the agent.
+    """
+    if not isinstance(value, str):
+        return DEFAULT_REGISTER
+    key = value.strip().lower()
+    if not key:
+        return DEFAULT_REGISTER
+    if key in SUPPORTED_REGISTERS:
+        return key
+    return DEFAULT_REGISTER
+
+
 def _load_catalog(lang: str) -> dict[str, str]:
     """Load and flatten one locale YAML file into a dotted-key dict.
 
@@ -187,6 +229,43 @@ def _flatten_into(node: Any, prefix: str, out: dict[str, str]) -> None:
     # Non-string, non-dict leaves are ignored -- catalogs are text-only.
 
 
+def _load_register_catalog(lang: str, register: str) -> dict[str, str]:
+    """Load and flatten a register-overlay catalog (``<lang>-<register>.yaml``).
+
+    Returns an empty dict if the file does not exist -- the caller falls
+    back to the base catalog for that language.  Cached per lang+register
+    for the process.
+    """
+    cache_key = f"{lang}-{register}"
+    with _register_catalog_lock:
+        cached = _register_catalog_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+    path = _locales_dir() / f"{cache_key}.yaml"
+    if not path.is_file():
+        logger.debug("i18n register catalog missing for %s at %s", cache_key, path)
+        with _register_catalog_lock:
+            _register_catalog_cache[cache_key] = {}
+        return {}
+
+    try:
+        import yaml
+        with path.open("r", encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+    except Exception as exc:
+        logger.warning("Failed to load i18n register catalog %s: %s", path, exc)
+        with _register_catalog_lock:
+            _register_catalog_cache[cache_key] = {}
+        return {}
+
+    flat: dict[str, str] = {}
+    _flatten_into(raw, "", flat)
+    with _register_catalog_lock:
+        _register_catalog_cache[cache_key] = flat
+    return flat
+
+
 @lru_cache(maxsize=1)
 def _config_language_cached() -> str | None:
     """Read ``display.language`` from config.yaml once per process.
@@ -208,14 +287,18 @@ def _config_language_cached() -> str | None:
 
 
 def reset_language_cache() -> None:
-    """Invalidate cached language resolution and catalogs.
+    """Invalidate cached language/register resolution and catalogs.
 
     Call after :func:`hermes_cli.config.save_config` if a running process
-    needs to pick up a changed ``display.language`` without restart.
+    needs to pick up a changed ``display.language`` or
+    ``display.message_register`` without restart.
     """
     _config_language_cached.cache_clear()
+    _config_register_cached.cache_clear()
     with _catalog_lock:
         _catalog_cache.clear()
+    with _register_catalog_lock:
+        _register_catalog_cache.clear()
 
 
 def get_language() -> str:
@@ -229,8 +312,34 @@ def get_language() -> str:
     return DEFAULT_LANGUAGE
 
 
-def t(key: str, lang: str | None = None, **format_kwargs: Any) -> str:
-    """Translate a dotted key to the active language.
+@lru_cache(maxsize=1)
+def _config_register_cached() -> str | None:
+    """Read ``display.message_register`` from config.yaml once per process.
+
+    Cached for the same reason as ``_config_language_cached()`` -- ``t()``
+    is on the hot path.  ``reset_language_cache()`` clears this too.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly()
+        register = (cfg.get("display") or {}).get("message_register")
+        if register:
+            return _normalize_register(register)
+    except Exception as exc:
+        logger.debug("Could not read display.message_register from config: %s", exc)
+    return None
+
+
+def get_register() -> str:
+    """Resolve the active register using config > default order."""
+    cfg_register = _config_register_cached()
+    if cfg_register:
+        return cfg_register
+    return DEFAULT_REGISTER
+
+
+def t(key: str, lang: str | None = None, *, register: str | None = None, **format_kwargs: Any) -> str:
+    """Translate a dotted key to the active language and register.
 
     Parameters
     ----------
@@ -238,27 +347,53 @@ def t(key: str, lang: str | None = None, **format_kwargs: Any) -> str:
         Dotted path into the catalog, e.g. ``"approval.choose_long"``.
     lang
         Explicit language override.  Takes precedence over env + config.
+    register
+        Explicit communication-register override (e.g. ``"friendly"``).
+        Takes precedence over config.  When ``None`` or ``"technical"``,
+        output is byte-compatible with pre-register behaviour.
     **format_kwargs
         ``str.format`` substitution arguments (``t("gateway.drain", count=3)``
         expects a catalog entry with a ``{count}`` placeholder).
 
     Returns
     -------
-    The translated string, or the English fallback if the key is missing in
-    the target language, or the bare key if English is also missing.
+    The translated string.  Resolution order for the value:
+
+    1. Register overlay for the target language (``<lang>-<register>.yaml``)
+    2. Base catalog for the target language (``<lang>.yaml``)
+    3. Register overlay for English (``en-<register>.yaml``)
+    4. Base English catalog (``en.yaml``)
+    5. The bare key (broken catalog fallback)
+
+    When the resolved register is the default (``"technical"``), steps 1
+    and 3 are skipped entirely so output is byte-compatible with
+    pre-register behaviour.
     """
     target = _normalize_lang(lang) if lang else get_language()
-    catalog = _load_catalog(target)
-    value = catalog.get(key)
+    target_register = _normalize_register(register) if register else get_register()
+    use_register_overlay = target_register != DEFAULT_REGISTER
 
+    value: str | None = None
+
+    # Step 1: register overlay for the target language.
+    if use_register_overlay:
+        value = _load_register_catalog(target, target_register).get(key)
+
+    # Step 2: base catalog for the target language.
+    if value is None:
+        value = _load_catalog(target).get(key)
+
+    # Step 3: register overlay for English (language fallback).
+    if value is None and target != DEFAULT_LANGUAGE and use_register_overlay:
+        value = _load_register_catalog(DEFAULT_LANGUAGE, target_register).get(key)
+
+    # Step 4: base English catalog (language fallback).
     if value is None and target != DEFAULT_LANGUAGE:
-        # Fall through to English rather than showing a key path to the user.
         value = _load_catalog(DEFAULT_LANGUAGE).get(key)
 
+    # Step 5: last-ditch fallback to the bare key.
     if value is None:
-        # Last-ditch: return the key itself.  A broken catalog should not
-        # crash anything; it just looks ugly until someone fixes it.
-        logger.debug("i18n miss: key=%r lang=%r", key, target)
+        logger.debug("i18n miss: key=%r lang=%r register=%r", key, target, target_register)
         value = key
 
     if format_kwargs:
@@ -276,7 +411,10 @@ def t(key: str, lang: str | None = None, **format_kwargs: Any) -> str:
 __all__ = [
     "SUPPORTED_LANGUAGES",
     "DEFAULT_LANGUAGE",
+    "SUPPORTED_REGISTERS",
+    "DEFAULT_REGISTER",
     "t",
     "get_language",
+    "get_register",
     "reset_language_cache",
 ]

--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -370,7 +370,7 @@ def t(key: str, lang: str | None = None, *, register: str | None = None, **forma
     pre-register behaviour.
     """
     target = _normalize_lang(lang) if lang else get_language()
-    target_register = _normalize_register(register) if register else get_register()
+    target_register = _normalize_register(register) if register is not None else get_register()
     use_register_overlay = target_register != DEFAULT_REGISTER
 
     value: str | None = None

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1431,6 +1431,15 @@ display:
   #
   skin: default
 
+  # Communication register for static user-facing messages (approval
+  # prompts, gateway slash-command replies).  A register is a tone
+  # variant of the SAME information -- it does not suppress content.
+  #   "technical" — concise, default, byte-compatible with prior output
+  #   "friendly"  — warmer, more conversational phrasing for a subset
+  #                 of high-visibility messages (locales/en-friendly.yaml)
+  # Unknown values fall back to "technical".
+  message_register: technical
+
 # =============================================================================
 # Model Aliases — short names for /model command
 # =============================================================================

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1141,6 +1141,14 @@ DEFAULT_CONFIG = {
         # responses, log lines, tool outputs, or slash-command descriptions.
         # Supported: en, zh, ja, de, es, fr, tr, uk.  Unknown values fall back to en.
         "language": "en",
+        # Communication register for static user-facing messages.  A register
+        # is a tone/style variant of the SAME information — it does not
+        # suppress or replace content.  "technical" (default) preserves the
+        # original concise output byte-for-byte.  "friendly" uses warmer,
+        # more conversational phrasing for the subset of messages that have
+        # a friendly variant (locales/en-friendly.yaml); everything else
+        # falls through unchanged.  Unknown values fall back to "technical".
+        "message_register": "technical",
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.
         "tui_status_indicator": "kaomoji",

--- a/locales/en-friendly.yaml
+++ b/locales/en-friendly.yaml
@@ -1,0 +1,47 @@
+# Hermes static-message catalog -- English, "friendly" register
+#
+# This is a register overlay: only keys that have a friendly variant appear
+# here.  Any key NOT listed here falls through to the base English catalog
+# (en.yaml) unchanged, so the friendly register never breaks a message --
+# it just makes some of them warmer.
+#
+# A register translates the SAME information into a different tone.  It does
+# not suppress content, add disclaimers, or change meaning.  Placeholders
+# ({count}, {model}, etc.) must match the base catalog exactly.
+#
+# When adding a new key here, ensure the {placeholder} tokens match en.yaml.
+# The catalog parity test (tests/agent/test_i18n.py) checks the BASE catalogs
+# only; register overlays are validated by the register-specific tests.
+
+gateway:
+  # Restart drain notice — shown when a gateway restart is waiting on
+  # active agents.  The friendly version softens the technical phrasing
+  # while keeping the count and the "please wait" meaning.
+  draining: "⏳ Restarting soon — just waiting for {count} active task(s) to finish up..."
+
+  # /reset command output — the session reset confirmation.
+  reset:
+    header_default: "✨ Fresh start! New session ready."
+    header_new: "✨ New session started!"
+    header_titled: "✨ New session started: {title}"
+
+  # /stop command — when the user stops a running agent.
+  stop:
+    stopped_pending: "⚡ Stopped — the agent hadn't started yet, so you're good to go."
+    stopped: "⚡ Stopped! You can pick up where you left off anytime."
+
+  # /goal command — goal lifecycle messages.
+  goal:
+    no_goal_set: "No goal set right now."
+    paused: "⏸ Paused your goal: {goal}"
+    resumed: "▶ Back at it! Goal resumed: {goal}\nSend a message to continue, or I'll take the next step on the next turn."
+
+  # /model command — model switch confirmation.
+  model:
+    switched: "Model switched to `{model}`"
+
+  # /voice command — voice mode toggles.
+  voice:
+    enabled_short: "Voice mode on!"
+    disabled_short: "Voice mode off — text only."
+    tts_enabled: "Auto-TTS on! All replies will include a voice message."

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -288,3 +288,42 @@ def test_t_explicit_register_overrides_config(monkeypatch):
     assert "Session reset" in result or "New session" in result
 
 
+def test_t_empty_register_string_resolves_to_technical(monkeypatch):
+    """t(key, register='') must normalize to 'technical', not defer to config.
+
+    Regression: the truthiness check `if register` treated an explicit
+    empty string as absent, falling through to get_register() which could
+    return 'friendly' from config.  The fix uses `register is not None`.
+    """
+    i18n.reset_language_cache()
+    monkeypatch.setattr(i18n, "_config_register_cached", lambda: "friendly")
+    monkeypatch.setattr(i18n, "_config_language_cached", lambda: None)
+    # Config says friendly, explicit register="" should resolve to technical.
+    result = i18n.t("gateway.reset.header_default", register="")
+    assert "Fresh start" not in result
+    assert "Session reset" in result or "New session" in result
+
+
+def test_config_propagation_with_temp_hermes_home(tmp_path, monkeypatch):
+    """E2E: display.message_register in config.yaml propagates to t().
+
+    Uses a real temp HERMES_HOME with a written config.yaml instead of
+    monkeypatching the cached reader, exercising the real config-load path.
+    """
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config_file = hermes_home / "config.yaml"
+    config_file.write_text(
+        "display:\n  message_register: friendly\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    i18n.reset_language_cache()
+    try:
+        result = i18n.t("gateway.reset.header_default")
+        assert "Fresh start" in result
+    finally:
+        i18n.reset_language_cache()
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -140,3 +140,151 @@ def test_locales_dir_env_override_ignored_when_missing(tmp_path, monkeypatch):
     assert result.name == "locales"
 
 
+# ---------------------------------------------------------------------------
+# Register-aware i18n
+# ---------------------------------------------------------------------------
+
+
+def test_default_register_is_technical(monkeypatch):
+    """With no config override, the register is 'technical' (byte-compatible)."""
+    i18n.reset_language_cache()
+    monkeypatch.setattr(i18n, "_config_register_cached", lambda: None)
+    assert i18n.get_register() == "technical"
+
+
+def test_normalize_register():
+    """Known registers pass through; unknown values fall back to default."""
+    assert i18n._normalize_register("technical") == "technical"
+    assert i18n._normalize_register("friendly") == "friendly"
+    assert i18n._normalize_register("FRIENDLY") == "friendly"
+    assert i18n._normalize_register("") == "technical"
+    assert i18n._normalize_register(None) == "technical"
+    assert i18n._normalize_register("bogus") == "technical"
+    assert i18n._normalize_register(123) == "technical"
+
+
+def test_t_with_technical_register_is_byte_compatible(monkeypatch):
+    """t(key, register='technical') must produce the same output as t(key)."""
+    i18n.reset_language_cache()
+    monkeypatch.setattr(i18n, "_config_register_cached", lambda: None)
+    monkeypatch.setattr(i18n, "_config_language_cached", lambda: None)
+    for key in (
+        "gateway.reset.header_default",
+        "gateway.draining",
+        "gateway.stop.stopped",
+        "approval.choose_long",
+    ):
+        assert i18n.t(key) == i18n.t(key, register="technical")
+
+
+def test_t_friendly_register_uses_overlay(monkeypatch):
+    """t(key, register='friendly') returns the friendly variant when one exists."""
+    i18n.reset_language_cache()
+    monkeypatch.setattr(i18n, "_config_register_cached", lambda: None)
+    monkeypatch.setattr(i18n, "_config_language_cached", lambda: None)
+    friendly = i18n.t("gateway.reset.header_default", register="friendly")
+    technical = i18n.t("gateway.reset.header_default")
+    assert friendly != technical, "friendly register should differ from technical"
+    assert "Fresh start" in friendly
+
+
+def test_t_friendly_register_falls_back_to_base_for_missing_keys(monkeypatch):
+    """Keys not in the friendly overlay fall through to the base catalog."""
+    i18n.reset_language_cache()
+    monkeypatch.setattr(i18n, "_config_register_cached", lambda: None)
+    monkeypatch.setattr(i18n, "_config_language_cached", lambda: None)
+    # approval.choose_long is NOT in en-friendly.yaml, so it should return
+    # the same value as the technical register.
+    friendly = i18n.t("approval.choose_long", register="friendly")
+    technical = i18n.t("approval.choose_long")
+    assert friendly == technical
+
+
+def test_t_friendly_register_with_format_kwargs(monkeypatch):
+    """Friendly register respects {placeholder} formatting."""
+    i18n.reset_language_cache()
+    monkeypatch.setattr(i18n, "_config_register_cached", lambda: None)
+    monkeypatch.setattr(i18n, "_config_language_cached", lambda: None)
+    result = i18n.t("gateway.draining", register="friendly", count=3)
+    assert "3" in result
+    assert "active task(s)" in result
+
+
+def test_t_friendly_register_missing_catalog_falls_back(tmp_path, monkeypatch):
+    """If no friendly catalog exists for a language, fall back to base."""
+    fake_locales = tmp_path / "locales"
+    fake_locales.mkdir()
+    (fake_locales / "en.yaml").write_text("foo: English Foo\n", encoding="utf-8")
+    # No en-friendly.yaml — the friendly register should still resolve.
+    monkeypatch.setattr(i18n, "_locales_dir", lambda: fake_locales)
+    i18n.reset_language_cache()
+    try:
+        result = i18n.t("foo", register="friendly")
+        assert result == "English Foo"
+    finally:
+        i18n.reset_language_cache()
+
+
+def test_t_unknown_register_falls_back_to_technical(monkeypatch):
+    """An unknown register name should not crash — it falls back to technical."""
+    i18n.reset_language_cache()
+    monkeypatch.setattr(i18n, "_config_register_cached", lambda: None)
+    monkeypatch.setattr(i18n, "_config_language_cached", lambda: None)
+    result = i18n.t("gateway.reset.header_default", register="bogus")
+    technical = i18n.t("gateway.reset.header_default")
+    assert result == technical
+
+
+def test_register_overlay_placeholder_parity():
+    """Every friendly variant must use the same {placeholder} tokens as the
+    base English catalog.  A mistranslated placeholder would raise KeyError
+    at runtime.
+    """
+    import re
+    placeholder_re = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
+    en_flat = _flatten(_load_raw("en"))
+    overlay_path = LOCALES_DIR / "en-friendly.yaml"
+    if not overlay_path.is_file():
+        pytest.skip("en-friendly.yaml not found")
+    overlay_flat = _flatten(yaml.safe_load(overlay_path.read_text(encoding="utf-8")))
+    for key, overlay_value in overlay_flat.items():
+        assert key in en_flat, f"en-friendly.yaml has key {key!r} not in en.yaml"
+        en_placeholders = set(placeholder_re.findall(en_flat[key]))
+        overlay_placeholders = set(placeholder_re.findall(overlay_value))
+        assert en_placeholders == overlay_placeholders, (
+            f"en-friendly.yaml key={key!r}: placeholders {overlay_placeholders} "
+            f"don't match English {en_placeholders}"
+        )
+
+
+def test_reset_language_cache_clears_register_cache(monkeypatch):
+    """reset_language_cache() must clear register catalog and config caches."""
+    i18n.reset_language_cache()
+    # Prime the register catalog cache by loading a real overlay.
+    i18n._load_register_catalog("en", "friendly")
+    assert i18n._register_catalog_cache  # cache populated
+    # Now reset.
+    i18n.reset_language_cache()
+    assert not i18n._register_catalog_cache  # cache cleared
+
+
+def test_t_friendly_register_via_config(monkeypatch):
+    """When display.message_register is 'friendly' in config, t() uses it."""
+    i18n.reset_language_cache()
+    monkeypatch.setattr(i18n, "_config_register_cached", lambda: "friendly")
+    monkeypatch.setattr(i18n, "_config_language_cached", lambda: None)
+    result = i18n.t("gateway.reset.header_default")
+    assert "Fresh start" in result
+
+
+def test_t_explicit_register_overrides_config(monkeypatch):
+    """Explicit register= argument takes precedence over config."""
+    i18n.reset_language_cache()
+    monkeypatch.setattr(i18n, "_config_register_cached", lambda: "friendly")
+    monkeypatch.setattr(i18n, "_config_language_cached", lambda: None)
+    # Config says friendly, explicit override says technical.
+    result = i18n.t("gateway.reset.header_default", register="technical")
+    assert "Fresh start" not in result
+    assert "Session reset" in result or "New session" in result
+
+

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1676,6 +1676,22 @@ display:
   language: zh   # CLI approval prompts appear in Chinese
 ```
 
+### Message register
+
+The `display.message_register` setting controls the **tone** of static user-facing messages -- the same information expressed in a different style. It is orthogonal to language: the language fallback chain runs first, then the register overlay applies on top.
+
+- `technical` (default) -- concise, original phrasing. Byte-compatible with prior output. No overlay is loaded.
+- `friendly` -- warmer, more conversational phrasing for a subset of high-visibility messages (session reset, stop, goal, model switch, voice toggle, drain notice). Keys without a friendly variant fall through to the base catalog unchanged.
+
+Unknown values fall back to `technical`.
+
+```yaml
+display:
+  message_register: friendly   # gateway messages use a warmer tone
+```
+
+You can also pass `register=` explicitly to any `t()` call site, which takes precedence over config.
+
 | Mode | What you see |
 |------|-------------|
 | `off` | Silent — just the final response |


### PR DESCRIPTION
## What does this PR do?

Extends Hermes' existing i18n resolution so system-generated user-facing messages can vary by **communication register** (e.g. `technical` vs `friendly`) while preserving the current technical output byte-for-byte by default.

A register is a **tone variant of the same information** -- it does not suppress content, add disclaimers, or change meaning.  Register is **orthogonal to language**: the language fallback chain runs first, then the register overlay applies on top.

### Why this approach

- **Zero behavioural change by default.** The `technical` register (default) skips the overlay path entirely, so every existing `t()` call produces identical output.
- **Safe fallback at every level.** Missing register catalogs, missing keys, and unknown register values all fall back gracefully to the base language catalog, then English, then the bare key.  A broken or incomplete register overlay never crashes the agent.
- **Extends existing patterns.** The config-backed resolution, LRU cache, and cache-reset mechanism mirror the existing `display.language` architecture exactly.  No new env vars, no new core tools.
- **Thin first slice.** Only a small set of high-visibility gateway messages have friendly variants (`/reset`, `/stop`, `/goal`, `/model`, `/voice`, drain notice).  Keys without a friendly variant fall through unchanged.

## Related Issue

No existing issue or PR found for register-aware i18n, friendly system messages, or audience/register support (searched open + closed PRs and issues).

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/i18n.py` -- Core implementation:
  - `t()` gains a keyword-only `register=` argument; `technical` (default) skips overlay for byte-compatibility
  - `_normalize_register()` validates register names (unknown -> `technical`)
  - `_load_register_catalog()` loads `<lang>-<register>.yaml` overlays with separate cache + lock
  - `_config_register_cached()` + `get_register()` mirror the language resolution pattern (`display.message_register` from config)
  - `reset_language_cache()` now clears register caches alongside language caches
  - Resolution order: register overlay (target lang) -> base catalog (target lang) -> register overlay (English) -> base English -> bare key
- `hermes_cli/config_defaults.py` -- Added `display.message_register: "technical"` default
- `locales/en-friendly.yaml` -- Small English friendly overlay for 10 high-visibility gateway messages
- `cli-config.yaml.example` -- Documented `display.message_register` in the display section
- `tests/agent/test_i18n.py` -- 14 new tests covering:
  - Register normalization (known, unknown, empty, non-string)
  - Byte-compatibility of the default register
  - Friendly overlay resolution and fallback for missing keys
  - Format kwargs with friendly register
  - Missing friendly catalog fallback
  - Unknown register fallback to technical
  - Placeholder parity between overlay and base catalog
  - Cache invalidation (register catalog + config cache)
  - Config-driven register (`display.message_register`)
  - Explicit `register=` override taking precedence over config

## How to Test

1. `pytest tests/agent/test_i18n.py -v` -- all 48 tests pass (34 existing + 14 new)
2. Quick smoke test:
   ```python
   from agent.i18n import t
   # Default (technical) -- unchanged output:
   print(t("gateway.reset.header_default"))       # ✨ Session reset! Starting fresh.
   print(t("gateway.draining", count=2))           # ⏳ Draining 2 active agent(s) before restart...
   # Friendly register:
   print(t("gateway.reset.header_default", register="friendly"))  # ✨ Fresh start! New session ready.
   print(t("gateway.draining", count=2, register="friendly"))     # ⏳ Restarting soon — just waiting for 2 active task(s) to finish up...
   # Keys without a friendly variant fall through unchanged:
   print(t("approval.choose_long", register="friendly"))  # same as technical
   ```
3. Config-driven:
   ```yaml
   # ~/.hermes/config.yaml
   display:
     message_register: friendly
   ```

Pre-existing test failures (unrelated to this PR):
- `tests/gateway/test_restart_drain.py` -- requires `pytest-asyncio` not installed in the worktree venv
- `tests/tools/test_approval.py::TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous` -- fails on `main` without changes (confirmed via `git stash`)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(i18n): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_i18n.py -q` and all tests pass
- [x] I've added tests for my changes (14 new tests)
- [x] I've tested on my platform: macOS 15.5 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings in `agent/i18n.py`, `cli-config.yaml.example`)
- [x] I've updated `cli-config.yaml.example` with the new `display.message_register` key
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Design Notes

### Per-sender register integration boundary

This PR provides the i18n/register layer.  A future per-user-context PR can use `register=` at specific call sites where the gateway knows the sender.  The integration point is simple: pass `register="friendly"` to any `t()` call.  No changes to the i18n layer are needed for per-sender resolution.

### Why no `HERMES_REGISTER` env var

Per AGENTS.md: `.env` is for secrets only.  All behavioral settings go in `config.yaml`.  The register is a behavioral/display setting, so it lives in `display.message_register`.  Tests use `monkeypatch.setattr` to override the config reader directly.

### Why register overlays are not in the catalog parity test

The existing `test_catalog_keys_match_english` test enforces that every non-English locale has the same key set as `en.yaml`.  Register overlays are intentionally **partial** -- they only contain keys that have a friendly variant.  Forcing parity would require adding friendly variants for every key, defeating the thin-slice design.  Instead, `test_register_overlay_placeholder_parity` validates that every key in the overlay exists in the base catalog and uses matching placeholders.
