### PR TITLE
fix(buzz): deliver documents through native upload

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -344,6 +344,24 @@ def _cli_retryable(raw: str, exit_code: int) -> bool:
     return exit_code == 2
 
 
+_MAX_DOCUMENT_RECEIPT_ERROR_CHARS = 900
+
+
+def _document_receipt_error(data: Dict[str, Any], local: Path) -> str:
+    """Return useful, bounded detail for an invalid document-send receipt."""
+    message = data.get("message")
+    if isinstance(message, str) and message.strip():
+        detail = message.strip()
+    elif data.get("accepted") is False:
+        detail = "Buzz CLI rejected the document"
+    else:
+        detail = "Incomplete response from Buzz CLI"
+    detail = detail.replace(str(local), local.name)
+    if len(detail) > _MAX_DOCUMENT_RECEIPT_ERROR_CHARS:
+        detail = f"{detail[: _MAX_DOCUMENT_RECEIPT_ERROR_CHARS - 3]}..."
+    return detail
+
+
 def _parse_json_list(stdout: str) -> List[dict]:
     """Parse CLI stdout expected to be a JSON array of objects."""
     try:
@@ -714,12 +732,14 @@ class BuzzAdapter(BasePlatformAdapter):
         if not isinstance(data, dict):
             return SendResult(success=False, error="Invalid response from Buzz CLI")
         event_id = data.get("event_id")
-        if data.get("accepted") is not True or not isinstance(event_id, str) or not event_id:
-            error = str(data.get("message") or "Incomplete response from Buzz CLI")
+        if (
+            data.get("accepted") is not True
+            or not isinstance(event_id, str)
+            or not event_id.strip()
+        ):
             return SendResult(
                 success=False,
-                error=error.replace(str(local), local.name),
-                raw_response=data,
+                error=_document_receipt_error(data, local),
             )
         self._mark_seen(str(chat_id), event_id)
         return SendResult(

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -320,24 +320,35 @@ async def _exec_buzz(
 _MAX_CLI_MESSAGE_CHARS = 900
 
 
-def _bounded_cli_message(message: str) -> str:
+def _bounded_cli_message(message: str, redact_path: Optional[Path] = None) -> str:
+    if redact_path is not None:
+        message = message.replace(str(redact_path), redact_path.name)
     if len(message) <= _MAX_CLI_MESSAGE_CHARS:
         return message
     return f"{message[: _MAX_CLI_MESSAGE_CHARS - 3]}..."
 
 
-def _cli_error_message(stderr: str, returncode: int) -> str:
+def _cli_error_message(
+    stderr: str,
+    returncode: int,
+    *,
+    redact_path: Optional[Path] = None,
+) -> str:
     """Extract a bounded human-readable message from the CLI error contract."""
     text = (stderr or "").strip()
     try:
         data = json.loads(text)
         if isinstance(data, dict) and data.get("message"):
             return _bounded_cli_message(
-                f"{data.get('error', 'error')}: {data['message']} (exit {returncode})"
+                f"{data.get('error', 'error')}: {data['message']} (exit {returncode})",
+                redact_path,
             )
     except ValueError:
         pass
-    return _bounded_cli_message(text or f"buzz CLI failed with exit code {returncode}")
+    return _bounded_cli_message(
+        text or f"buzz CLI failed with exit code {returncode}",
+        redact_path,
+    )
 
 
 def _cli_retryable(raw: str, exit_code: int) -> bool:
@@ -726,7 +737,7 @@ class BuzzAdapter(BasePlatformAdapter):
             args += ["--reply-to", str(reply_target)]
         code, out, err = await self._run_cli(args, input_text=caption or "")
         if code != 0:
-            error = _cli_error_message(err, code).replace(str(local), local.name)
+            error = _cli_error_message(err, code, redact_path=local)
             return SendResult(
                 success=False,
                 error=error,

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -333,6 +333,17 @@ def _cli_error_message(stderr: str, returncode: int) -> str:
     return text or f"buzz CLI failed with exit code {returncode}"
 
 
+def _cli_retryable(raw: str, exit_code: int) -> bool:
+    """Honor structured CLI retry guidance, with legacy exit-code fallback."""
+    try:
+        payload = json.loads((raw or "").strip())
+    except (TypeError, ValueError):
+        payload = None
+    if isinstance(payload, dict) and isinstance(payload.get("retryable"), bool):
+        return payload["retryable"]
+    return exit_code == 2
+
+
 def _parse_json_list(stdout: str) -> List[dict]:
     """Parse CLI stdout expected to be a JSON array of objects."""
     try:
@@ -663,6 +674,59 @@ class BuzzAdapter(BasePlatformAdapter):
             )
             return False
         return True
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Upload a local document through the Buzz CLI."""
+        local = Path(file_path).expanduser()
+        if not local.is_file():
+            return SendResult(success=False, error="Attachment file is unavailable")
+
+        args = [
+            "messages", "send",
+            "--channel", str(chat_id),
+            "--file", str(local),
+            "--content", "-",
+        ]
+        reply_target = reply_to or (metadata or {}).get("thread_id")
+        if reply_target:
+            args += ["--reply-to", str(reply_target)]
+        code, out, err = await self._run_cli(args, input_text=caption or "")
+        if code != 0:
+            error = _cli_error_message(err, code).replace(str(local), local.name)
+            return SendResult(
+                success=False,
+                error=error,
+                retryable=_cli_retryable(err, code),
+            )
+        try:
+            data = json.loads(out or "")
+        except ValueError:
+            data = None
+        if not isinstance(data, dict):
+            return SendResult(success=False, error="Invalid response from Buzz CLI")
+        event_id = data.get("event_id")
+        if data.get("accepted") is not True or not isinstance(event_id, str) or not event_id:
+            error = str(data.get("message") or "Incomplete response from Buzz CLI")
+            return SendResult(
+                success=False,
+                error=error.replace(str(local), local.name),
+                raw_response=data,
+            )
+        self._mark_seen(str(chat_id), event_id)
+        return SendResult(
+            success=True,
+            message_id=event_id,
+            raw_response=data,
+        )
 
     async def send_image(
         self,

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -317,20 +317,27 @@ async def _exec_buzz(
     )
 
 
-def _cli_error_message(stderr: str, returncode: int) -> str:
-    """Extract the human-readable message from the CLI's JSON error contract.
+_MAX_CLI_MESSAGE_CHARS = 900
 
-    stderr is ``{"error": "<category>", "message": "<detail>"}`` on failure;
-    fall back to the raw (stripped) stderr when it isn't JSON.
-    """
+
+def _bounded_cli_message(message: str) -> str:
+    if len(message) <= _MAX_CLI_MESSAGE_CHARS:
+        return message
+    return f"{message[: _MAX_CLI_MESSAGE_CHARS - 3]}..."
+
+
+def _cli_error_message(stderr: str, returncode: int) -> str:
+    """Extract a bounded human-readable message from the CLI error contract."""
     text = (stderr or "").strip()
     try:
         data = json.loads(text)
         if isinstance(data, dict) and data.get("message"):
-            return f"{data.get('error', 'error')}: {data['message']} (exit {returncode})"
+            return _bounded_cli_message(
+                f"{data.get('error', 'error')}: {data['message']} (exit {returncode})"
+            )
     except ValueError:
         pass
-    return text or f"buzz CLI failed with exit code {returncode}"
+    return _bounded_cli_message(text or f"buzz CLI failed with exit code {returncode}")
 
 
 def _cli_retryable(raw: str, exit_code: int) -> bool:

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -470,6 +470,27 @@ class TestBuzzAdapterSend:
         assert args[args.index("--reply-to") + 1] == "metadata-root"
 
     @pytest.mark.asyncio
+    async def test_send_document_explicit_reply_overrides_metadata_thread(self, tmp_path):
+        document = tmp_path / "handoff.txt"
+        document.write_text("safe handoff", encoding="utf-8")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-explicit"})
+        adapter._run_cli = cli
+
+        result = await adapter.send_document(
+            CHANNEL,
+            str(document),
+            reply_to="explicit-root",
+            metadata={"thread_id": "metadata-root"},
+        )
+
+        assert result.success is True
+        args, _stdin_text = cli.calls[0]
+        assert args.count("--reply-to") == 1
+        assert args[args.index("--reply-to") + 1] == "explicit-root"
+
+    @pytest.mark.asyncio
     async def test_send_document_sanitizes_cli_error_path(self, tmp_path):
         document = tmp_path / "private" / "handoff.txt"
         document.parent.mkdir()

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -528,6 +528,41 @@ class TestBuzzAdapterSend:
         assert "handoff.txt" in result.error
 
     @pytest.mark.asyncio
+    async def test_send_document_redacts_long_path_before_bounding(self, tmp_path):
+        parent = tmp_path
+        private_parts = []
+        for index in range(6):
+            part = f"private-{index}-" + ("x" * 150)
+            private_parts.append(part)
+            parent = parent / part
+            parent.mkdir()
+        document = parent / "handoff.txt"
+        document.write_text("safe handoff", encoding="utf-8")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=2,
+            stderr=json.dumps(
+                {
+                    "error": "network",
+                    "message": f"upload failed for {document}: " + ("z" * 1_000),
+                    "retryable": True,
+                }
+            ),
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send_document(CHANNEL, str(document))
+
+        assert result.success is False
+        assert all(part not in result.error for part in private_parts)
+        assert "handoff.txt" in result.error
+        assert len(result.error) <= 900
+
+    @pytest.mark.asyncio
     async def test_send_document_honors_non_retryable_cli_error(self, tmp_path):
         document = tmp_path / "handoff.txt"
         document.write_text("safe handoff", encoding="utf-8")

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -573,6 +573,86 @@ class TestBuzzAdapterSend:
         assert result.retryable is False
         assert "response" in result.error.lower()
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "receipt",
+        [
+            [],
+            {},
+            {"event_id": "evt-without-acceptance"},
+            {"accepted": True},
+            {"accepted": True, "event_id": ""},
+            {"accepted": True, "event_id": "   "},
+            {"accepted": 1, "event_id": "evt-non-boolean-acceptance"},
+        ],
+        ids=[
+            "non-dict",
+            "missing-accepted-and-id",
+            "missing-accepted",
+            "missing-event-id",
+            "empty-event-id",
+            "blank-event-id",
+            "non-boolean-accepted",
+        ],
+    )
+    async def test_send_document_rejects_invalid_zero_exit_receipt(self, tmp_path, receipt):
+        document = tmp_path / "handoff.txt"
+        document.write_text("safe handoff", encoding="utf-8")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", receipt)
+        adapter._run_cli = cli
+
+        result = await adapter.send_document(CHANNEL, str(document))
+
+        assert result.success is False
+        assert result.message_id is None
+        assert result.retryable is False
+
+    @pytest.mark.asyncio
+    async def test_send_document_rejection_is_useful_and_bounded(self, tmp_path):
+        document = tmp_path / "handoff.txt"
+        document.write_text("safe handoff", encoding="utf-8")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        external_message = "relay rejected: " + ("x" * 100_000)
+        cli.script(
+            "messages",
+            "send",
+            {
+                "accepted": False,
+                "event_id": "evt-rejected",
+                "message": external_message,
+                "external": "y" * 100_000,
+            },
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send_document(CHANNEL, str(document))
+
+        assert result.success is False
+        assert result.message_id is None
+        assert result.retryable is False
+        assert result.error.startswith("relay rejected:")
+        assert len(result.error) <= 1_024
+        assert result.raw_response is None
+
+    @pytest.mark.asyncio
+    async def test_send_document_valid_receipt_preserves_success_payload(self, tmp_path):
+        document = tmp_path / "handoff.txt"
+        document.write_text("safe handoff", encoding="utf-8")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        receipt = {"accepted": True, "event_id": "evt-valid", "message": "delivered"}
+        cli.script("messages", "send", receipt)
+        adapter._run_cli = cli
+
+        result = await adapter.send_document(CHANNEL, str(document))
+
+        assert result.success is True
+        assert result.message_id == "evt-valid"
+        assert result.raw_response == receipt
+
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -152,8 +152,16 @@ class TestCliErrorContract:
         msg = _cli_error_message('{"error":"relay_error","message":"boom","retryable":false}', 2)
         assert "relay_error" in msg and "boom" in msg and "exit 2" in msg
 
+    def test_bounds_untrusted_nonzero_cli_error(self):
+        msg = _cli_error_message(
+            json.dumps({"error": "relay_error", "message": "x" * 100_000}),
+            2,
+        )
+        assert msg.startswith("relay_error:")
+        assert len(msg) <= 900
 
-# ── Seeding / high-water mark / de-dupe ───────────────────────────────────
+
+# ── Seeding / high-water mark / de-dupe ────────────────────────────────────
 
 
 class TestPollingDedupe:

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -421,6 +421,137 @@ class TestBuzzAdapterSend:
         args, _stdin = cli.calls[0]
         assert args[args.index("--file") + 1] == str(img)
 
+    @pytest.mark.asyncio
+    async def test_send_document_uploads_file_with_caption_and_reply(self, tmp_path):
+        document = tmp_path / "handoff.txt"
+        document.write_text("safe handoff", encoding="utf-8")
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-document"})
+        adapter._run_cli = cli
+
+        result = await adapter.send_document(
+            CHANNEL,
+            str(document),
+            caption="handoff",
+            reply_to="root-event",
+        )
+
+        assert result.success is True
+        assert result.message_id == "evt-document"
+        args, stdin_text = cli.calls[0]
+        assert args[:2] == ["messages", "send"]
+        assert args[args.index("--channel") + 1] == CHANNEL
+        assert args[args.index("--file") + 1] == str(document)
+        assert args[args.index("--content") + 1] == "-"
+        assert args[args.index("--reply-to") + 1] == "root-event"
+        assert stdin_text == "handoff"
+        assert "handoff" not in args
+        assert "evt-document" in adapter._channel_state[CHANNEL]["seen"]
+
+    @pytest.mark.asyncio
+    async def test_send_document_uses_metadata_thread_when_reply_omitted(self, tmp_path):
+        document = tmp_path / "handoff.txt"
+        document.write_text("safe handoff", encoding="utf-8")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-thread"})
+        adapter._run_cli = cli
+
+        result = await adapter.send_document(
+            CHANNEL,
+            str(document),
+            metadata={"thread_id": "metadata-root"},
+        )
+
+        assert result.success is True
+        args, _stdin_text = cli.calls[0]
+        assert args[args.index("--reply-to") + 1] == "metadata-root"
+
+    @pytest.mark.asyncio
+    async def test_send_document_sanitizes_cli_error_path(self, tmp_path):
+        document = tmp_path / "private" / "handoff.txt"
+        document.parent.mkdir()
+        document.write_text("safe handoff", encoding="utf-8")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=2,
+            stderr=json.dumps(
+                {
+                    "error": "network",
+                    "message": f"upload failed for {document}: relay unavailable",
+                    "retryable": True,
+                }
+            ),
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send_document(CHANNEL, str(document))
+
+        assert result.success is False
+        assert result.retryable is True
+        assert str(document) not in result.error
+        assert "handoff.txt" in result.error
+
+    @pytest.mark.asyncio
+    async def test_send_document_honors_non_retryable_cli_error(self, tmp_path):
+        document = tmp_path / "handoff.txt"
+        document.write_text("safe handoff", encoding="utf-8")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=2,
+            stderr=json.dumps(
+                {
+                    "error": "delivery_unknown",
+                    "message": "relay may already have accepted the event",
+                    "retryable": False,
+                }
+            ),
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send_document(CHANNEL, str(document))
+
+        assert result.success is False
+        assert result.retryable is False
+
+    @pytest.mark.asyncio
+    async def test_send_document_rejects_missing_path_without_cli(self, tmp_path):
+        missing = tmp_path / "private" / "missing.txt"
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        adapter._run_cli = cli
+
+        result = await adapter.send_document(CHANNEL, str(missing))
+
+        assert result.success is False
+        assert str(missing) not in result.error
+        assert cli.calls == []
+
+    @pytest.mark.asyncio
+    async def test_send_document_rejects_malformed_success_output(self, tmp_path):
+        document = tmp_path / "handoff.txt"
+        document.write_text("safe handoff", encoding="utf-8")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", "not-json")
+        adapter._run_cli = cli
+
+        result = await adapter.send_document(CHANNEL, str(document))
+
+        assert result.success is False
+        assert result.retryable is False
+        assert "response" in result.error.lower()
+
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

The Buzz adapter inherited `BasePlatformAdapter.send_document()`. When Hermes tried to deliver a local document, the base fallback posted “Couldn't deliver the file attachment” instead of uploading the file.

This adds a focused Buzz `send_document()` implementation using the adapter's existing argv-based `buzz messages send --file` path. Captions travel over stdin, explicit replies take precedence over `metadata.thread_id`, and a delivery is reported successful only when the CLI explicitly returns `accepted: true` with a non-empty event ID.

Failure handling is fail-closed: missing files never invoke the CLI, absolute local paths are removed from surfaced CLI errors, and structured `retryable` guidance is honored before falling back to the CLI's legacy exit-code contract.

## Related Issue

No dedicated Hermes issue exists for this adapter gap.

Related work:

- block/buzz#3641 adds generic-file upload and correct document-link rendering to the Buzz CLI.
- #74999 is the complementary draft for local **image** delivery through `send_image_file()`; this PR intentionally limits itself to documents and does not duplicate that override.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add native Buzz document uploads through `messages send --file`.
- Preserve captions and reply/thread targeting.
- Require an explicit accepted response and event ID before reporting success.
- Mark successful outbound event IDs as seen for echo suppression.
- Sanitize local paths from recipient-visible errors and honor structured retry guidance.
- Add regression coverage for success, thread metadata, missing files, malformed responses, path redaction, and ambiguous non-retryable outcomes.

## How to Test

1. Run:
   ```bash
   PYTHONPATH="$PWD" python -m pytest \
     tests/gateway/test_buzz_adapter.py \
     tests/gateway/test_mixed_attachment_routing.py \
     tests/cron/test_scheduler.py -q
   ```
2. Confirm all 95 selected tests pass.
3. With a Buzz CLI that supports generic files (for example block/buzz#3641), send a local document through Hermes and confirm the recipient receives a downloadable file under the intended reply root.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — the canonical `scripts/run_tests.sh -j 2` suite exited successfully; the focused 95-test selection also passes locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; adapter behavior only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses `pathlib.Path` and argv-based subprocess arguments
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
95 passed, 3 pre-existing warnings in 9.23s
ruff: All checks passed
py_compile: passed
git diff --check: passed
```
