### PR TITLE
fix(browser): use Camofox access key for route auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -313,6 +313,9 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # Set CAMOFOX_URL to route the browser tools through a local Camofox server
 # instead of agent-browser/Browserbase. See docs/user-guide/features/browser.md.
 # CAMOFOX_URL=http://localhost:9377
+# Optional: when the Camofox server is started with CAMOFOX_ACCESS_KEY, set the
+# same key here so Hermes can authenticate browser-route requests.
+# CAMOFOX_ACCESS_KEY=
 
 # Externally managed Camofox sessions — when another app owns the visible
 # Camofox browser, set these so Hermes shares the same userId/profile instead

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3637,8 +3637,17 @@ OPTIONAL_ENV_VARS = {
         "password": False,
         "category": "tool",
     },
+    "CAMOFOX_ACCESS_KEY": {
+        "description": "Optional global bearer token for authenticated Camofox browser routes",
+        "prompt": "Camofox access key",
+        "url": "https://github.com/jo-inc/camofox-browser",
+        "tools": ["browser_navigate", "browser_click"],
+        "password": True,
+        "category": "tool",
+        "advanced": True,
+    },
     "CAMOFOX_API_KEY": {
-        "description": "Optional bearer token sent as Authorization header to a remote/authenticated Camofox server",
+        "description": "Legacy Camofox browser-route bearer fallback; upstream uses this for cookie import only",
         "prompt": "Camofox API key",
         "url": "https://github.com/jo-inc/camofox-browser",
         "tools": ["browser_navigate", "browser_click"],

--- a/tests/tools/test_browser_camofox_auth.py
+++ b/tests/tools/test_browser_camofox_auth.py
@@ -1,4 +1,4 @@
-"""Tests that Camofox browser sends Authorization header when CAMOFOX_API_KEY is set.
+"""Tests that Camofox browser sends Authorization header when a bearer key is set.
 
 Regression test for https://github.com/NousResearch/hermes-agent/issues/20476
 """
@@ -35,20 +35,37 @@ class TestAuthHeaders:
     """Unit tests for _auth_headers() helper."""
 
     def test_empty_when_no_key(self, monkeypatch):
+        monkeypatch.delenv("CAMOFOX_ACCESS_KEY", raising=False)
         monkeypatch.delenv("CAMOFOX_API_KEY", raising=False)
         assert _auth_headers() == {}
 
 
     def test_empty_when_key_blank(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_ACCESS_KEY", "   ")
         monkeypatch.setenv("CAMOFOX_API_KEY", "   ")
         assert _auth_headers() == {}
+
+    def test_access_key_is_global_browser_route_bearer(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_ACCESS_KEY", "access-key")
+        monkeypatch.delenv("CAMOFOX_API_KEY", raising=False)
+        assert _auth_headers() == {"Authorization": "Bearer access-key"}
+
+    def test_access_key_wins_over_legacy_api_key(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_ACCESS_KEY", "access-key")
+        monkeypatch.setenv("CAMOFOX_API_KEY", "legacy-api-key")
+        assert _auth_headers() == {"Authorization": "Bearer access-key"}
+
+    def test_legacy_api_key_still_works_as_fallback(self, monkeypatch):
+        monkeypatch.delenv("CAMOFOX_ACCESS_KEY", raising=False)
+        monkeypatch.setenv("CAMOFOX_API_KEY", "legacy-api-key")
+        assert _auth_headers() == {"Authorization": "Bearer legacy-api-key"}
 
     def test_multiplex_scope_key_wins_over_process_environment(self, monkeypatch):
         from agent import secret_scope
 
-        monkeypatch.setenv("CAMOFOX_API_KEY", "default-profile-key")
+        monkeypatch.setenv("CAMOFOX_ACCESS_KEY", "default-profile-key")
         secret_scope.set_multiplex_active(True)
-        token = secret_scope.set_secret_scope({"CAMOFOX_API_KEY": "secondary-profile-key"})
+        token = secret_scope.set_secret_scope({"CAMOFOX_ACCESS_KEY": "secondary-profile-key"})
         try:
             assert _auth_headers() == {"Authorization": "Bearer secondary-profile-key"}
         finally:
@@ -58,7 +75,7 @@ class TestAuthHeaders:
     def test_multiplex_scope_missing_key_fails_closed(self, monkeypatch):
         from agent import secret_scope
 
-        monkeypatch.setenv("CAMOFOX_API_KEY", "default-profile-key")
+        monkeypatch.setenv("CAMOFOX_ACCESS_KEY", "default-profile-key")
         secret_scope.set_multiplex_active(True)
         token = secret_scope.set_secret_scope({})
         try:
@@ -71,12 +88,12 @@ class TestAuthHeaders:
         from agent import secret_scope
 
         monkeypatch.setenv("CAMOFOX_URL", "https://default.example")
-        monkeypatch.setenv("CAMOFOX_API_KEY", "default-profile-key")
+        monkeypatch.setenv("CAMOFOX_ACCESS_KEY", "default-profile-key")
         secret_scope.set_multiplex_active(True)
         token = secret_scope.set_secret_scope(
             {
                 "CAMOFOX_URL": "https://secondary.example/",
-                "CAMOFOX_API_KEY": "secondary-profile-key",
+                "CAMOFOX_ACCESS_KEY": "secondary-profile-key",
             }
         )
         try:
@@ -90,19 +107,19 @@ class TestAuthHeaders:
 
 
 class TestAuthHeadersSent:
-    """Verify all HTTP call sites include auth headers when CAMOFOX_API_KEY is set."""
+    """Verify all HTTP call sites include auth headers when CAMOFOX_ACCESS_KEY is set."""
 
     @pytest.fixture(autouse=True)
     def _set_key(self, monkeypatch):
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
-        monkeypatch.setenv("CAMOFOX_API_KEY", "my-api-key")
+        monkeypatch.setenv("CAMOFOX_ACCESS_KEY", "my-access-key")
 
     @patch("tools.browser_camofox.requests.post")
     def test_ensure_tab_sends_auth(self, mock_post):
         mock_post.return_value = _mock_response(json_data={"tabId": "t1"})
         camofox_navigate("https://example.com", task_id="auth_test_1")
         _, kwargs = mock_post.call_args
-        assert kwargs["headers"] == {"Authorization": "Bearer my-api-key"}
+        assert kwargs["headers"] == {"Authorization": "Bearer my-access-key"}
 
 
     @patch("tools.browser_camofox.requests.post")
@@ -113,15 +130,16 @@ class TestAuthHeadersSent:
         mock_delete.return_value = _mock_response(json_data={"ok": True})
         camofox_close(task_id="auth_test_4")
         _, kwargs = mock_delete.call_args
-        assert kwargs["headers"] == {"Authorization": "Bearer my-api-key"}
+        assert kwargs["headers"] == {"Authorization": "Bearer my-access-key"}
 
 
-class TestNoAuthHeadersWhenKeyUnset:
-    """Verify HTTP calls send empty headers when CAMOFOX_API_KEY is not set."""
+class TestNoAuthHeadersWhenKeysUnset:
+    """Verify HTTP calls send empty headers when no Camofox bearer key is set."""
 
     @pytest.fixture(autouse=True)
     def _unset_key(self, monkeypatch):
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        monkeypatch.delenv("CAMOFOX_ACCESS_KEY", raising=False)
         monkeypatch.delenv("CAMOFOX_API_KEY", raising=False)
 
     @patch("tools.browser_camofox.requests.post")

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -82,8 +82,16 @@ def _get_command_timeout() -> int:
 
 
 def _auth_headers() -> Dict[str, str]:
-    """Return Authorization header when CAMOFOX_API_KEY is set."""
-    key = (get_secret("CAMOFOX_API_KEY", "") or "").strip()
+    """Return Authorization header for Camofox browser routes.
+
+    Camofox's global route gate uses ``CAMOFOX_ACCESS_KEY``.  Keep
+    ``CAMOFOX_API_KEY`` as a fallback for older Hermes setups that used it as
+    the bearer token before camofox-browser split access-key and API-key auth.
+    """
+    key = (
+        (get_secret("CAMOFOX_ACCESS_KEY", "") or "").strip()
+        or (get_secret("CAMOFOX_API_KEY", "") or "").strip()
+    )
     if key:
         return {"Authorization": f"Bearer {key}"}
     return {}
@@ -948,6 +956,5 @@ def camofox_console(clear: bool = False, task_id: Optional[str] = None) -> str:
         "note": "Console log capture is not available with the Camofox backend. "
                 "Use browser_snapshot or browser_vision to inspect page state.",
     })
-
 
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -149,7 +149,8 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `FIRECRAWL_BROWSER_TTL` | Firecrawl browser session TTL in seconds (default: 300) |
 | `BROWSER_CDP_URL` | Chrome DevTools Protocol URL for local browser (set via `/browser connect`, e.g. `ws://localhost:9222`) |
 | `CAMOFOX_URL` | Camofox local anti-detection browser URL (default: `http://localhost:9377`) |
-| `CAMOFOX_API_KEY` | Optional bearer token sent as Authorization header to a remote/authenticated Camofox server |
+| `CAMOFOX_ACCESS_KEY` | Optional global bearer token sent to authenticated Camofox browser routes |
+| `CAMOFOX_API_KEY` | Legacy Camofox browser-route bearer fallback; upstream uses this for cookie import only |
 | `CAMOFOX_USER_ID` | Optional externally managed Camofox user ID for shared visible sessions |
 | `CAMOFOX_SESSION_KEY` | Optional Camofox session key used when creating tabs for `CAMOFOX_USER_ID` |
 | `CAMOFOX_ADOPT_EXISTING_TAB` | Set to `true` to reuse an existing Camofox tab before creating a new one |

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -183,6 +183,8 @@ Then set in `~/.hermes/.env`:
 
 ```bash
 CAMOFOX_URL=http://localhost:9377
+# Required only when the Camofox server is started with CAMOFOX_ACCESS_KEY.
+CAMOFOX_ACCESS_KEY=your-access-key
 ```
 
 If Camofox is running in Docker and you want it to open web apps served from the host machine, enable loopback rewriting. `CAMOFOX_URL` should still point at the host-published control API, but page URLs such as `http://127.0.0.1:3000` must be opened from inside the container as `http://host.docker.internal:3000`:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
@@ -135,6 +135,8 @@ description: "Hermes Agent 使用的所有环境变量完整参考"
 | `FIRECRAWL_BROWSER_TTL` | Firecrawl 浏览器会话 TTL（秒，默认：300） |
 | `BROWSER_CDP_URL` | 本地浏览器的 Chrome DevTools Protocol（CDP）URL（通过 `/browser connect` 设置，例如 `ws://localhost:9222`） |
 | `CAMOFOX_URL` | Camofox 本地反检测浏览器 URL（默认：`http://localhost:9377`） |
+| `CAMOFOX_ACCESS_KEY` | 发送到已启用认证的 Camofox 浏览器路由的可选全局 Bearer 令牌 |
+| `CAMOFOX_API_KEY` | 旧版 Camofox 浏览器路由 Bearer 备用项；上游仅将其用于 cookie 导入 |
 | `CAMOFOX_USER_ID` | 可选的外部管理 Camofox 用户 ID，用于共享可见会话 |
 | `CAMOFOX_SESSION_KEY` | 为 `CAMOFOX_USER_ID` 创建标签页时使用的可选 Camofox 会话密钥 |
 | `CAMOFOX_ADOPT_EXISTING_TAB` | 设为 `true` 可在创建新标签页前复用现有 Camofox 标签页 |


### PR DESCRIPTION
## Summary

Fixes #77088.

Camofox browser routes are gated upstream by `CAMOFOX_ACCESS_KEY`, not `CAMOFOX_API_KEY`. Hermes was reading only `CAMOFOX_API_KEY` in `tools/browser_camofox.py`, so a Camofox server started with the documented global access key returned `401 Unauthorized` on browser calls.

This changes Hermes to:

- prefer `CAMOFOX_ACCESS_KEY` for Camofox browser-route `Authorization` headers
- keep `CAMOFOX_API_KEY` as a legacy fallback for existing Hermes setups
- add `CAMOFOX_ACCESS_KEY` to optional env metadata and setup docs
- update Camofox auth regression coverage for precedence, multiplex scoping, fallback, and HTTP call sites

## Verification

Verified the upstream Camofox contract against `jo-inc/camofox-browser`:

- `lib/auth.js` global `accessKeyMiddleware()` gates most routes with `CAMOFOX_ACCESS_KEY`
- `requireAuth()` accepts `CAMOFOX_API_KEY` and `CAMOFOX_ACCESS_KEY` as a superkey for API-key routes
- `mcp/lib/tool-contracts.mjs` emits `accessKey` auth for browser tools and `apiKey` auth for cookie import

Tests run:

```bash
pytest tests/tools/test_browser_camofox_auth.py tests/tools/test_browser_camofox.py tests/tools/test_browser_camofox_persistence.py tests/tools/test_browser_camofox_private_page_guard.py tests/tools/test_browser_camofox_ensure_tab.py tests/tools/test_browser_camofox_timeout.py tests/tools/test_browser_camofox_state.py tests/tools/test_local_env_blocklist.py::TestBlocklistCoverage::test_optional_tool_and_messaging_vars_are_in_blocklist
```

Result: `64 passed`.

## Notes

I did not add a new tool or new integration surface. This stays within the existing Camofox backend and preserves compatibility for users who previously configured `CAMOFOX_API_KEY` as the bearer token.
