### PR TITLE
test(tools): gate POSIX-only file-operation tests on Windows

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -4,6 +4,7 @@ import os
 import re
 import pytest
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -423,6 +424,16 @@ class TestSearchPathValidation:
         assert "search failed" in result.error.lower() or "Search error" in result.error
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "drives a real POSIX sh script: the fallback shells out to POSIX "
+        "`find`, and `_has_command` probes with `command -v`. "
+        "make_real_subprocess_env runs it through subprocess shell=True, "
+        "which is cmd.exe here, where `find` resolves to the unrelated "
+        "string-search find.exe"
+    ),
+)
 class TestSearchFilesFallbackHiddenPaths:
     def _make_env(self):
         return make_real_subprocess_env("/")
@@ -574,6 +585,10 @@ class _DeletedTestGitBaselineCheck:
 # Atomic write: umask-default permissions for new files
 # =========================================================================
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="POSIX file modes are not enforced on NTFS, and os.umask has no effect there",
+)
 class TestAtomicWriteNewFilePermissions:
     """_atomic_write should apply umask-default perms to new files (not 0600)."""
 
@@ -617,6 +632,10 @@ class TestAtomicWriteNewFilePermissions:
         assert dest.stat().st_mode & 0o777 == 0o755
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Symlinks require elevated privileges on Windows",
+)
 class TestAtomicWriteThroughSymlink:
     """_atomic_write must edit a symlink's target, not replace the link.
 


### PR DESCRIPTION
## What does this PR do?

Eight tests in `tests/tools/test_file_operations.py` fail on native Windows. All three
failing classes drive `make_real_subprocess_env`, whose `execute()` runs the generated
script through `subprocess.run(..., shell=True)` — `/bin/sh` on POSIX, **cmd.exe** on
Windows. The scripts `ShellFileOperations` emits are POSIX `sh`, so they cannot do anything
useful there.

```
FAILED TestSearchFilesFallbackHiddenPaths::test_hidden_root_with_hidden_ancestor_includes_files
FAILED TestSearchFilesFallbackHiddenPaths::test_normal_root_still_excludes_hidden_descendants
FAILED TestAtomicWriteNewFilePermissions::test_new_file_gets_umask_default_permissions[18]
FAILED TestAtomicWriteNewFilePermissions::test_new_file_gets_umask_default_permissions[2]
FAILED TestAtomicWriteNewFilePermissions::test_new_file_gets_umask_default_permissions[63]
FAILED TestAtomicWriteNewFilePermissions::test_overwrite_still_preserves_existing_mode
FAILED TestAtomicWriteThroughSymlink::test_write_follows_symlink_and_preserves_link
FAILED TestAtomicWriteThroughSymlink::test_write_through_broken_symlink_falls_back
8 failed, 38 passed
```

## Why each one fails

**`TestSearchFilesFallbackHiddenPaths`** — the fallback shells out to POSIX `find`, and
`_has_command` probes availability with `command -v`. Under cmd.exe, `find` resolves to
`C:\Windows\System32\find.exe` — a *string-search* utility, not a file finder — so the
search returns an empty set instead of the two visible files:

```
>       assert set(result.files) == {str(visible_file), str(visible_nested_file)}
E       AssertionError: assert set() == {'...\agent.log', '...\nested\visible.log'}
```

The class also passes `"/"` as the environment cwd, which has no meaning on Windows.

**`TestAtomicWriteNewFilePermissions`** — asserts
`dest.stat().st_mode & 0o777 == 0o666 & ~umask` after `os.umask()`. CONTRIBUTING's
cross-platform rules already say POSIX file modes are not enforced on NTFS and that such
assertions must skip on Windows.

**`TestAtomicWriteThroughSymlink`** — calls `Path.symlink_to()`, which needs elevated
privileges on Windows unless Developer Mode is on. CONTRIBUTING prescribes a `skipif` for
exactly this case; the reason string here is the one from the guide.

## The change

A `skipif` per class with its **specific** reason, rather than one blanket module marker,
so the 38 tests in this file that are genuinely platform-independent keep running on
Windows. No test logic or assertion is touched. On POSIX the markers are inert — behaviour
is unchanged.

## How to test

On native Windows:

```powershell
python -m pytest tests/tools/test_file_operations.py -q
```

**Before:** `8 failed, 38 passed`
**After:** `38 passed, 8 skipped` (exit 0)

On Linux/macOS the file behaves exactly as before — all 46 tests still run.

## Why CI never caught this

All CI jobs run on `ubuntu-latest`; the only other runner in the tree is
`ubuntu-24.04-arm` (`docker.yml`). There is no Windows runner, so `shell=True` is always
`/bin/sh` in CI and these tests can never take the cmd.exe path.

## Platforms tested

Native Windows 11 Home, build 26200 · Python 3.11.6.

## Related

- #48986 — Windows-native baseline failures. This clears the `file-handle`/path cluster in
  `test_file_operations.py`; the ACP and CRLF clusters listed there are untouched.
- No open PR I could find targets `tests/tools/test_file_operations.py` for Windows.