### PR TITLE
fix(discord): avoid duplicate codex app-server final replies

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -458,6 +458,7 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
     # item/started and consumed on item/completed so duration is correct
     # even when codex doesn't report durationMs.
     started: dict[str, tuple[str, dict, float]] = {}
+    pending_agent_message: dict[str, Any] | None = None
 
     def _stable_call_id(item: dict, name: str) -> str:
         """Deterministic tool_call id mirroring CodexEventProjector, so a
@@ -586,6 +587,30 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
                 "_emit_interim_assistant_message raised", exc_info=True,
             )
 
+    def _buffer_agent_message_completed(item: dict) -> None:
+        """Hold completed agentMessage text until the next event proves it is
+        commentary, not the turn-final answer.
+
+        Codex app-server emits the final answer as a completed agentMessage too.
+        If the bridge publishes that immediately as interim commentary, Discord
+        sees one reply through the commentary path and then the gateway sends the
+        same final_response normally. A later tool/stream event proves the
+        buffered message was mid-turn commentary, so flush it then; otherwise the
+        normal final-response path owns delivery.
+        """
+        nonlocal pending_agent_message
+        if pending_agent_message is not None:
+            _fire_agent_message_completed(pending_agent_message)
+        pending_agent_message = item
+
+    def _flush_pending_agent_message() -> None:
+        nonlocal pending_agent_message
+        if pending_agent_message is None:
+            return
+        item = pending_agent_message
+        pending_agent_message = None
+        _fire_agent_message_completed(item)
+
     def on_event(note: dict) -> None:
         if not isinstance(note, dict):
             return
@@ -594,6 +619,7 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
         if not isinstance(params, dict):
             params = {}
         if method == "item/agentMessage/delta":
+            _flush_pending_agent_message()
             _fire_text_delta(params)
             return
         if method in {"item/reasoning/delta", "item/reasoning/summaryDelta"}:
@@ -604,13 +630,15 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
             return
         item_type = item.get("type") or ""
         if method == "item/started" and item_type in _CODEX_TOOL_ITEM_TYPES:
+            _flush_pending_agent_message()
             _fire_tool_started(item)
             return
         if method == "item/completed":
             if item_type in _CODEX_TOOL_ITEM_TYPES:
+                _flush_pending_agent_message()
                 _fire_tool_completed(item)
             elif item_type == "agentMessage":
-                _fire_agent_message_completed(item)
+                _buffer_agent_message_completed(item)
 
     return on_event
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -611,6 +611,10 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
         pending_agent_message = None
         _fire_agent_message_completed(item)
 
+    def _clear_pending_agent_message() -> None:
+        nonlocal pending_agent_message
+        pending_agent_message = None
+
     def on_event(note: dict) -> None:
         if not isinstance(note, dict):
             return
@@ -640,7 +644,25 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
             elif item_type == "agentMessage":
                 _buffer_agent_message_completed(item)
 
+    on_event.clear_pending_agent_message = (  # type: ignore[attr-defined]
+        _clear_pending_agent_message
+    )
     return on_event
+
+
+def _clear_codex_app_server_event_bridge_pending(session: Any) -> None:
+    """Discard buffered app-server final-message candidates for turn boundaries."""
+    on_event = getattr(session, "_on_event", None)
+    clear = getattr(on_event, "clear_pending_agent_message", None)
+    if not callable(clear):
+        return
+    try:
+        clear()
+    except Exception:
+        logger.debug(
+            "codex app-server event bridge pending-message clear raised",
+            exc_info=True,
+        )
 
 
 def run_codex_app_server_turn(
@@ -723,8 +745,10 @@ def run_codex_app_server_turn(
     # return reaches us. Do NOT append again — that would duplicate.
 
     try:
+        _clear_codex_app_server_event_bridge_pending(agent._codex_session)
         turn = agent._codex_session.run_turn(user_input=user_message)
     except Exception as exc:
+        _clear_codex_app_server_event_bridge_pending(agent._codex_session)
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn
         # respawns from scratch instead of reusing a dead client.
@@ -760,6 +784,9 @@ def run_codex_app_server_turn(
             ),
             "error": str(exc),
         }
+    finally:
+        if getattr(agent, "_codex_session", None) is not None:
+            _clear_codex_app_server_event_bridge_pending(agent._codex_session)
 
     # This runtime bypasses the normal conversation-loop finalizer. Mirror its
     # interrupt handoff/cleanup so a hard stop cannot poison the next turn and a

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -265,6 +265,24 @@ class TestAgentMessageInterimDispatch:
         }))
         agent._emit_interim_assistant_message.assert_not_called()
 
+    def test_cleared_completed_agent_message_does_not_flush_next_turn(self):
+        """A reused app-server bridge must not carry a final answer into the
+        next turn's first stream/tool event."""
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_completed({
+            "type": "agentMessage",
+            "id": "am-1",
+            "text": "Final answer from the previous turn.",
+        }))
+
+        bridge.clear_pending_agent_message()
+        bridge({"method": "item/agentMessage/delta",
+                "params": {"delta": "New turn starts."}})
+
+        agent._emit_interim_assistant_message.assert_not_called()
+        agent._fire_stream_delta.assert_called_once_with("New turn starts.")
+
     def test_completed_agent_message_flushes_before_tool_event(self):
         agent = _make_stub_agent()
         bridge = make_codex_app_server_event_bridge(agent)
@@ -447,6 +465,95 @@ class TestBridgeWiredInRuntime:
             "id": "wired-1",
             "command": "ls",
         }))
+        agent.tool_progress_callback.assert_called_once()
+        assert agent.tool_progress_callback.call_args.args[0] == "tool.started"
+        assert agent.tool_progress_callback.call_args.args[1] == "exec_command"
+
+    def test_reused_session_clears_buffered_final_answer_between_turns(
+        self, monkeypatch
+    ):
+        from agent import codex_runtime
+        from agent.transports.codex_app_server_session import TurnResult
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                self._on_event = kwargs["on_event"]
+                self.calls = 0
+
+            def run_turn(self, user_input, **_):
+                self.calls += 1
+                if self.calls == 1:
+                    self._on_event(_item_completed({
+                        "type": "agentMessage",
+                        "id": "am-final-1",
+                        "text": "Previous final answer.",
+                    }))
+                    return TurnResult(
+                        final_text="Previous final answer.",
+                        projected_messages=[{
+                            "role": "assistant",
+                            "content": "Previous final answer.",
+                        }],
+                        turn_id="turn-1",
+                        thread_id="thread-1",
+                    )
+
+                self._on_event(_item_started({
+                    "type": "commandExecution",
+                    "id": "exec-2",
+                    "command": "pwd",
+                }))
+                return TurnResult(
+                    final_text="Next final answer.",
+                    projected_messages=[{
+                        "role": "assistant",
+                        "content": "Next final answer.",
+                    }],
+                    turn_id="turn-2",
+                    thread_id="thread-1",
+                )
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerSession",
+            FakeSession,
+        )
+
+        agent = SimpleNamespace(
+            session_cwd=None,
+            _codex_session=None,
+            tool_progress_callback=MagicMock(),
+            _fire_stream_delta=MagicMock(),
+            _fire_reasoning_delta=MagicMock(),
+            _emit_interim_assistant_message=MagicMock(),
+            _iters_since_skill=0,
+            _skill_nudge_interval=0,
+            valid_tool_names=set(),
+            _sync_external_memory_for_turn=lambda **_: None,
+            _spawn_background_review=lambda **_: None,
+            session_api_calls=0,
+            session_prompt_tokens=0,
+            session_completion_tokens=0,
+            session_reasoning_tokens=0,
+            session_cached_tokens=0,
+            session_total_tokens=0,
+            context_compressor=None,
+            event_callback=None,
+            _session_db=None,
+        )
+
+        for text in ("first", "second"):
+            codex_runtime.run_codex_app_server_turn(
+                agent,
+                user_message=text,
+                original_user_message=text,
+                messages=[],
+                effective_task_id="task",
+            )
+
+        agent._emit_interim_assistant_message.assert_not_called()
         agent.tool_progress_callback.assert_called_once()
         assert agent.tool_progress_callback.call_args.args[0] == "tool.started"
         assert agent.tool_progress_callback.call_args.args[1] == "exec_command"

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -250,7 +250,12 @@ class TestToolProgressDispatch:
 
 
 class TestAgentMessageInterimDispatch:
-    def test_completed_agent_message_emits_interim(self):
+    def test_completed_agent_message_alone_is_not_emitted_as_interim(self):
+        """A lone completed agentMessage is usually the final answer.
+
+        Emitting it through the interim path duplicates the gateway's normal
+        final send on Discord when codex_app_server is active.
+        """
         agent = _make_stub_agent()
         bridge = make_codex_app_server_event_bridge(agent)
         bridge(_item_completed({
@@ -258,10 +263,56 @@ class TestAgentMessageInterimDispatch:
             "id": "am-1",
             "text": "I'll check the config first.",
         }))
+        agent._emit_interim_assistant_message.assert_not_called()
+
+    def test_completed_agent_message_flushes_before_tool_event(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_completed({
+            "type": "agentMessage",
+            "id": "am-1",
+            "text": "I'll check the config first.",
+        }))
+        bridge(_item_started({
+            "type": "commandExecution",
+            "id": "exec-1",
+            "command": "ls",
+        }))
         agent._emit_interim_assistant_message.assert_called_once_with(
             {"role": "assistant", "content": "I'll check the config first."}
         )
 
+    def test_completed_agent_message_flushes_before_stream_delta(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_completed({
+            "type": "agentMessage",
+            "id": "am-1",
+            "text": "I'll check the config first.",
+        }))
+        bridge({"method": "item/agentMessage/delta",
+                "params": {"delta": "final"}})
+        agent._emit_interim_assistant_message.assert_called_once_with(
+            {"role": "assistant", "content": "I'll check the config first."}
+        )
+        agent._fire_stream_delta.assert_called_once_with("final")
+
+    def test_second_completed_agent_message_flushes_previous_only(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_completed({
+            "type": "agentMessage",
+            "id": "am-1",
+            "text": "First interim.",
+        }))
+        bridge(_item_completed({
+            "type": "agentMessage",
+            "id": "am-2",
+            "text": "Final answer.",
+        }))
+        agent._emit_interim_assistant_message.assert_called_once_with(
+            {"role": "assistant", "content": "First interim."}
+        )
 
 
     def test_show_commentary_off_suppresses_interim(self):
@@ -274,11 +325,11 @@ class TestAgentMessageInterimDispatch:
         bridge(_item_completed({
             "type": "agentMessage", "id": "am-5", "text": "I'll check config.",
         }))
-        agent._emit_interim_assistant_message.assert_not_called()
-        # Tool progress is unaffected by the commentary toggle.
         bridge(_item_started({
             "type": "commandExecution", "id": "cmd-1", "command": "ls",
         }))
+        agent._emit_interim_assistant_message.assert_not_called()
+        # Tool progress is unaffected by the commentary toggle.
         agent.tool_progress_callback.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- Buffer completed Codex app-server `agentMessage` events until a later tool/stream event proves they are mid-turn commentary.
- Let the gateway normal final-response path own a lone completed `agentMessage`, avoiding duplicate final replies.
- Clear buffered final-answer candidates at app-server turn boundaries so a reused session cannot flush a prior final answer on the next turn.
- Add focused bridge and runtime regression coverage for both duplicate-reply paths.

## Reproduction / diagnosis
- With `codex_app_server` enabled, the event bridge treated a completed final `agentMessage` as interim commentary before the gateway sent `final_response`.
- The change lets the normal final-response path own lone completed final messages, while retaining actual in-turn commentary.
- It also ensures a reused app-server session cannot retain a final-answer candidate across turn boundaries.

## Tests
- `scripts/run_tests.sh tests/agent/test_codex_app_server_event_bridge.py -q`
- `venv/bin/python -m ruff check agent/codex_runtime.py tests/agent/test_codex_app_server_event_bridge.py`
- `git diff --check`