### PR TITLE
fix(mcp): detect same-name tool contract mutations on refresh

### DIFF
--- a/tests/tools/test_mcp_dynamic_discovery.py
+++ b/tests/tools/test_mcp_dynamic_discovery.py
@@ -1,17 +1,22 @@
 """Tests for MCP dynamic tool discovery (notifications/tools/list_changed)."""
 
 import asyncio
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from tools.mcp_tool import MCPServerTask, _register_server_tools
+from tools.mcp_tool import (
+    MCPServerTask,
+    _discover_and_register_server,
+    _register_server_tools,
+)
 from tools.registry import ToolRegistry
 
 
-def _make_mcp_tool(name: str, desc: str = ""):
-    return SimpleNamespace(name=name, description=desc, inputSchema=None)
+def _make_mcp_tool(name: str, desc: str = "", input_schema=None):
+    return SimpleNamespace(name=name, description=desc, inputSchema=input_schema)
 
 
 class TestRegisterServerTools:
@@ -34,6 +39,80 @@ class TestRegisterServerTools:
             assert "mcp__my_srv__my_tool" in mock_registry.get_all_tool_names()
             assert validate_toolset("my_srv") is True
             assert "mcp__my_srv__my_tool" in resolve_toolset("my_srv")
+
+    def test_registration_failure_rolls_back_newly_published_tools(
+        self, mock_registry
+    ):
+        server = MCPServerTask("my_srv")
+        server._tools = [
+            _make_mcp_tool("first", "first behavior"),
+            _make_mcp_tool("second", "second behavior"),
+        ]
+        original_register = mock_registry.register
+        call_count = 0
+
+        def _register(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("injected registration failure")
+            return original_register(**kwargs)
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            patch.object(mock_registry, "register", side_effect=_register),
+            pytest.raises(RuntimeError, match="injected registration failure"),
+        ):
+            _register_server_tools("my_srv", server, {})
+
+        assert mock_registry.get_all_tool_names() == []
+        assert server._last_registered_tool_contracts == {}
+
+    def test_registration_failure_restores_previous_snapshot(self, mock_registry):
+        server = MCPServerTask("my_srv")
+        server._config = {}
+        server._tools = [
+            _make_mcp_tool("first", "original first"),
+            _make_mcp_tool("second", "original second"),
+        ]
+
+        with patch("tools.registry.registry", mock_registry):
+            server._synchronize_registered_tools()
+
+        original_register = mock_registry.register
+        call_count = 0
+
+        def _register(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("injected registration failure")
+            return original_register(**kwargs)
+
+        server._tools = [
+            _make_mcp_tool("first", "changed first"),
+            _make_mcp_tool("second", "changed second"),
+        ]
+        with (
+            patch("tools.registry.registry", mock_registry),
+            patch.object(mock_registry, "register", side_effect=_register),
+            pytest.raises(RuntimeError, match="injected registration failure"),
+        ):
+            server._synchronize_registered_tools()
+
+        assert server._registered_tool_names == [
+            "mcp__my_srv__first",
+            "mcp__my_srv__second",
+        ]
+        assert mock_registry.get_entry("mcp__my_srv__first").schema[
+            "description"
+        ] == "original first"
+        assert mock_registry.get_entry("mcp__my_srv__second").schema[
+            "description"
+        ] == "original second"
+        assert server._last_registered_tool_contracts[
+            "mcp__my_srv__first"
+        ]["description"] == "original first"
 
 
 class TestRefreshTools:
@@ -75,6 +154,1242 @@ class TestRefreshTools:
             assert "mcp__live_srv__new_tool" in resolve_toolset("live_srv")
             assert server._registered_tool_names == ["mcp__live_srv__new_tool"]
 
+    @pytest.mark.asyncio
+    async def test_warns_when_existing_tool_contract_changes(self, mock_registry, caplog):
+        server = MCPServerTask("live_srv")
+        server._refresh_lock = asyncio.Lock()
+        server._config = {}
+        server._tools = [_make_mcp_tool("stable_tool", "original behavior")]
+        server._registered_tool_names = ["mcp__live_srv__stable_tool"]
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                return_value=SimpleNamespace(
+                    tools=[_make_mcp_tool("stable_tool", "changed behavior")]
+                )
+            )
+        )
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            caplog.at_level(logging.WARNING, logger="tools.mcp_tool"),
+        ):
+            await server._refresh_tools()
+
+        assert any(
+            "modified: mcp__live_srv__stable_tool" in record.getMessage()
+            for record in caplog.records
+        )
+        assert any(
+            "MCP rug pull" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_warns_when_existing_tool_input_schema_changes(self, mock_registry, caplog):
+        server = MCPServerTask("live_srv")
+        server._refresh_lock = asyncio.Lock()
+        server._config = {}
+        server._tools = [
+            _make_mcp_tool(
+                "stable_tool",
+                "stable behavior",
+                {"type": "object", "properties": {"path": {"type": "string"}}},
+            )
+        ]
+        server._registered_tool_names = ["mcp__live_srv__stable_tool"]
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                return_value=SimpleNamespace(
+                    tools=[
+                        _make_mcp_tool(
+                            "stable_tool",
+                            "stable behavior",
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "path": {"type": "string"},
+                                    "recursive": {"type": "boolean"},
+                                },
+                            },
+                        )
+                    ]
+                )
+            )
+        )
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            caplog.at_level(logging.WARNING, logger="tools.mcp_tool"),
+        ):
+            await server._refresh_tools()
+
+        assert any(
+            "modified: mcp__live_srv__stable_tool" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_does_not_warn_when_required_order_changes(self, mock_registry, caplog):
+        properties = {
+            "path": {"type": "string"},
+            "recursive": {"type": "boolean"},
+        }
+        server = MCPServerTask("live_srv")
+        server._refresh_lock = asyncio.Lock()
+        server._config = {}
+        server._tools = [
+            _make_mcp_tool(
+                "stable_tool",
+                "stable behavior",
+                {
+                    "type": "object",
+                    "properties": properties,
+                    "required": ["path", "recursive"],
+                },
+            )
+        ]
+        server._registered_tool_names = ["mcp__live_srv__stable_tool"]
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                return_value=SimpleNamespace(
+                    tools=[
+                        _make_mcp_tool(
+                            "stable_tool",
+                            "stable behavior",
+                            {
+                                "type": "object",
+                                "properties": properties,
+                                "required": ["recursive", "path"],
+                            },
+                        )
+                    ]
+                )
+            )
+        )
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            caplog.at_level(logging.WARNING, logger="tools.mcp_tool"),
+        ):
+            await server._refresh_tools()
+
+        assert not any(
+            "modified: mcp__live_srv__stable_tool" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_warns_when_instance_data_required_order_changes(self, mock_registry, caplog):
+        def _schema(required_order):
+            return {
+                "type": "object",
+                "properties": {
+                    "policy": {
+                        "const": {
+                            "type": "object",
+                            "properties": {
+                                "safe": {"type": "string"},
+                                "dangerous": {"type": "string"},
+                            },
+                            "required": required_order,
+                        }
+                    }
+                },
+            }
+
+        server = MCPServerTask("live_srv")
+        server._refresh_lock = asyncio.Lock()
+        server._config = {}
+        server._tools = [
+            _make_mcp_tool(
+                "stable_tool",
+                "stable behavior",
+                _schema(["safe", "dangerous"]),
+            )
+        ]
+        server._registered_tool_names = ["mcp__live_srv__stable_tool"]
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                return_value=SimpleNamespace(
+                    tools=[
+                        _make_mcp_tool(
+                            "stable_tool",
+                            "stable behavior",
+                            _schema(["dangerous", "safe"]),
+                        )
+                    ]
+                )
+            )
+        )
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            caplog.at_level(logging.WARNING, logger="tools.mcp_tool"),
+        ):
+            await server._refresh_tools()
+
+        assert any(
+            "modified: mcp__live_srv__stable_tool" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @pytest.mark.parametrize(
+        ("keyword", "old_value", "new_value"),
+        [
+            ("const", True, 1),
+            ("default", False, 0),
+            ("enum", [True], [1]),
+            ("examples", [False], [0]),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_warns_when_json_instance_value_types_change(
+        self, mock_registry, caplog, keyword, old_value, new_value
+    ):
+        def _schema(value):
+            return {
+                "type": "object",
+                "properties": {
+                    "policy": {keyword: value},
+                },
+            }
+
+        server = MCPServerTask("live_srv")
+        server._config = {}
+        server._tools = [
+            _make_mcp_tool(
+                "stable_tool", "stable behavior", _schema(old_value)
+            )
+        ]
+        server._registered_tool_names = ["mcp__live_srv__stable_tool"]
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                return_value=SimpleNamespace(
+                    tools=[
+                        _make_mcp_tool(
+                            "stable_tool", "stable behavior", _schema(new_value)
+                        )
+                    ]
+                )
+            )
+        )
+
+        with patch("tools.registry.registry", mock_registry):
+            with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+                await server._refresh_tools()
+
+        assert any(
+            "modified: mcp__live_srv__stable_tool" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_warns_when_tool_contract_changes_across_reconnect(
+        self, mock_registry, caplog
+    ):
+        server = MCPServerTask("live_srv")
+        server._ready.set()
+        server._config = {}
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace())
+        )
+        server._tools = [_make_mcp_tool("stable_tool", "original behavior")]
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                return_value=SimpleNamespace(
+                    tools=[_make_mcp_tool("stable_tool", "changed behavior")]
+                )
+            )
+        )
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            caplog.at_level(logging.WARNING, logger="tools.mcp_tool"),
+        ):
+            server._registered_tool_names = _register_server_tools(
+                server.name, server, server._config
+            )
+            await server._discover_tools()
+
+        assert any(
+            "modified after reconnect: mcp__live_srv__stable_tool" in record.getMessage()
+            for record in caplog.records
+        )
+        assert any(
+            "MCP rug pull" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_warns_when_capability_change_replaces_remote_with_utility(
+        self, mock_registry, caplog
+    ):
+        tool_name = "mcp__live_srv__list_resources"
+        server = MCPServerTask("live_srv")
+        server._ready.set()
+        server._config = {}
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace())
+        )
+        server._tools = [
+            _make_mcp_tool("list_resources", "remote list behavior")
+        ]
+        server.session = SimpleNamespace()
+
+        with patch("tools.registry.registry", mock_registry):
+            server._registered_tool_names = _register_server_tools(
+                server.name, server, server._config
+            )
+            remote_handler = mock_registry.get_entry(tool_name).handler
+            server.initialize_result = SimpleNamespace(
+                capabilities=SimpleNamespace(resources=SimpleNamespace())
+            )
+            with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+                await server._discover_tools()
+
+        assert server._registered_tool_names == [
+            "mcp__live_srv__list_resources",
+            "mcp__live_srv__read_resource",
+        ]
+        assert mock_registry.get_entry(tool_name).handler is not remote_handler
+        assert sum(
+            f"modified after reconnect: {tool_name}" in record.getMessage()
+            for record in caplog.records
+        ) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_tools_capability_reconnect_uses_transition_lock(
+        self, mock_registry
+    ):
+        server = MCPServerTask("live_srv")
+        server._ready.set()
+        server._config = {}
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(resources=SimpleNamespace())
+        )
+        server.session = SimpleNamespace()
+
+        with patch("tools.registry.registry", mock_registry):
+            async with server._refresh_lock:
+                discovery_task = asyncio.create_task(server._discover_tools())
+                await asyncio.sleep(0)
+                assert not discovery_task.done()
+            await discovery_task
+
+    @pytest.mark.asyncio
+    async def test_modified_reconnect_deregisters_removed_tool(
+        self, mock_registry
+    ):
+        stable_name = "mcp__live_srv__stable_tool"
+        removed_name = "mcp__live_srv__removed_tool"
+        server = MCPServerTask("live_srv")
+        server._ready.set()
+        server._config = {}
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace())
+        )
+        server._tools = [
+            _make_mcp_tool("stable_tool", "original behavior"),
+            _make_mcp_tool("removed_tool", "removed behavior"),
+        ]
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                return_value=SimpleNamespace(
+                    tools=[_make_mcp_tool("stable_tool", "changed behavior")]
+                )
+            )
+        )
+
+        with patch("tools.registry.registry", mock_registry):
+            server._registered_tool_names = _register_server_tools(
+                server.name, server, server._config
+            )
+            await server._discover_tools()
+
+        assert server._registered_tool_names == [stable_name]
+        assert stable_name in mock_registry.get_all_tool_names()
+        assert removed_name not in mock_registry.get_all_tool_names()
+        assert removed_name in server._last_registered_tool_contracts
+
+    @pytest.mark.asyncio
+    async def test_reconnect_synchronizes_additions_and_removals_without_mutation(
+        self, mock_registry
+    ):
+        stable_name = "mcp__live_srv__stable_tool"
+        removed_name = "mcp__live_srv__removed_tool"
+        added_name = "mcp__live_srv__added_tool"
+        server = MCPServerTask("live_srv")
+        server._ready.set()
+        server._config = {}
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace())
+        )
+        server._tools = [
+            _make_mcp_tool("stable_tool", "stable behavior"),
+            _make_mcp_tool("removed_tool", "removed behavior"),
+        ]
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                return_value=SimpleNamespace(
+                    tools=[
+                        _make_mcp_tool("stable_tool", "stable behavior"),
+                        _make_mcp_tool("added_tool", "added behavior"),
+                    ]
+                )
+            )
+        )
+
+        with patch("tools.registry.registry", mock_registry):
+            server._registered_tool_names = _register_server_tools(
+                server.name, server, server._config
+            )
+            await server._discover_tools()
+
+        assert set(server._registered_tool_names) == {stable_name, added_name}
+        assert stable_name in mock_registry.get_all_tool_names()
+        assert added_name in mock_registry.get_all_tool_names()
+        assert removed_name not in mock_registry.get_all_tool_names()
+        assert removed_name in server._last_registered_tool_contracts
+
+    @pytest.mark.parametrize(
+        ("second_description", "expected_warning_count"),
+        [
+            ("changed behavior", 1),
+            ("original behavior", 2),
+        ],
+    )
+    @pytest.mark.parametrize("parked", [False, True])
+    @pytest.mark.asyncio
+    async def test_serializes_reconnect_discovery_with_dynamic_refresh(
+        self,
+        mock_registry,
+        caplog,
+        second_description,
+        expected_warning_count,
+        parked,
+    ):
+        server = MCPServerTask("live_srv")
+        server._ready.set()
+        server._config = {}
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace())
+        )
+        server._tools = [_make_mcp_tool("stable_tool", "original behavior")]
+
+        first_list_started = asyncio.Event()
+        release_first_list = asyncio.Event()
+        list_call_count = 0
+
+        async def _list_tools():
+            nonlocal list_call_count
+            list_call_count += 1
+            if list_call_count == 1:
+                first_list_started.set()
+                await release_first_list.wait()
+                description = "changed behavior"
+            else:
+                description = second_description
+            return SimpleNamespace(
+                tools=[_make_mcp_tool("stable_tool", description)]
+            )
+
+        server.session = SimpleNamespace(list_tools=_list_tools)
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            caplog.at_level(logging.WARNING, logger="tools.mcp_tool"),
+        ):
+            server._registered_tool_names = _register_server_tools(
+                server.name, server, server._config
+            )
+            if parked:
+                server._deregister_tools()
+
+            discovery_task = asyncio.create_task(server._discover_tools())
+            await first_list_started.wait()
+            refresh_task = asyncio.create_task(server._refresh_tools())
+            await asyncio.sleep(0)
+            release_first_list.set()
+            await asyncio.gather(discovery_task, refresh_task)
+
+        rug_pull_warnings = [
+            record
+            for record in caplog.records
+            if "MCP rug pull" in record.getMessage()
+        ]
+        assert len(rug_pull_warnings) == expected_warning_count
+        assert mock_registry._tools[
+            "mcp__live_srv__stable_tool"
+        ].schema["description"] == second_description
+        assert server._last_registered_tool_contracts[
+            "mcp__live_srv__stable_tool"
+        ]["description"] == second_description
+
+    @pytest.mark.asyncio
+    async def test_serializes_initial_registration_with_dynamic_refresh(
+        self, mock_registry
+    ):
+        tool_name = "mcp__startup_srv__stable_tool"
+        server = MCPServerTask("startup_srv")
+        server._config = {}
+        server._tools = [_make_mcp_tool("stable_tool", "original behavior")]
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace())
+        )
+
+        refresh_list_started = asyncio.Event()
+        release_refresh_list = asyncio.Event()
+        connect_returned = asyncio.Event()
+
+        async def _list_tools():
+            refresh_list_started.set()
+            await release_refresh_list.wait()
+            return SimpleNamespace(
+                tools=[_make_mcp_tool("stable_tool", "changed behavior")]
+            )
+
+        async def _connect_server(_name, _config):
+            connect_returned.set()
+            return server
+
+        server.session = SimpleNamespace(list_tools=_list_tools)
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            patch("tools.mcp_tool._connect_server", _connect_server),
+            patch.dict("tools.mcp_tool._servers", {}, clear=True),
+        ):
+            refresh_task = asyncio.create_task(server._refresh_tools())
+            await refresh_list_started.wait()
+            registration_task = asyncio.create_task(
+                _discover_and_register_server("startup_srv", {})
+            )
+            await connect_returned.wait()
+            for _ in range(3):
+                await asyncio.sleep(0)
+
+            registration_completed_while_refresh_pending = registration_task.done()
+            tool_exposed_while_refresh_pending = (
+                tool_name in mock_registry.get_all_tool_names()
+            )
+
+            release_refresh_list.set()
+            await asyncio.gather(refresh_task, registration_task)
+
+        assert not registration_completed_while_refresh_pending
+        assert not tool_exposed_while_refresh_pending
+        assert mock_registry._tools[tool_name].schema["description"] == (
+            "changed behavior"
+        )
+
+    @pytest.mark.asyncio
+    async def test_startup_refresh_timeout_does_not_leave_cached_server(
+        self, mock_registry
+    ):
+        server = MCPServerTask("startup_srv")
+        server._config = {"connect_timeout": 1}
+        server._tools = [_make_mcp_tool("stable_tool", "original behavior")]
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace())
+        )
+        refresh_list_started = asyncio.Event()
+
+        async def _list_tools():
+            refresh_list_started.set()
+            await asyncio.Event().wait()
+
+        async def _connect_server(_name, _config):
+            return server
+
+        server.session = SimpleNamespace(list_tools=_list_tools)
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            patch("tools.mcp_tool._connect_server", _connect_server),
+            patch.dict("tools.mcp_tool._servers", {}, clear=True) as servers,
+        ):
+            refresh_task = asyncio.create_task(server._refresh_tools())
+            await refresh_list_started.wait()
+            with pytest.raises(asyncio.TimeoutError):
+                await _discover_and_register_server(
+                    "startup_srv", {"connect_timeout": 0.01}
+                )
+            refresh_task.cancel()
+            await asyncio.gather(refresh_task, return_exceptions=True)
+
+        assert "startup_srv" not in servers
+        assert server._registered_tool_names == []
+        assert mock_registry.get_all_tool_names() == []
+
+    @pytest.mark.asyncio
+    async def test_startup_timeout_does_not_wait_for_cancellation_resistant_task(
+        self, mock_registry
+    ):
+        server = MCPServerTask("startup_srv")
+        server._config = {"connect_timeout": 1}
+        server._tools = [_make_mcp_tool("stable_tool", "original behavior")]
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace())
+        )
+        refresh_list_started = asyncio.Event()
+        release_server_task = asyncio.Event()
+
+        async def _list_tools():
+            refresh_list_started.set()
+            await asyncio.Event().wait()
+
+        async def _resist_cancellation():
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                await release_server_task.wait()
+
+        server.session = SimpleNamespace(list_tools=_list_tools)
+        server._task = asyncio.create_task(_resist_cancellation())
+
+        async def _connect_server(_name, _config):
+            return server
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            patch("tools.mcp_tool._connect_server", _connect_server),
+            patch.dict("tools.mcp_tool._servers", {}, clear=True) as servers,
+        ):
+            refresh_task = asyncio.create_task(server._refresh_tools())
+            await refresh_list_started.wait()
+            discovery_task = asyncio.create_task(
+                _discover_and_register_server(
+                    "startup_srv", {"connect_timeout": 0.01}
+                )
+            )
+            done, _ = await asyncio.wait({discovery_task}, timeout=0.1)
+            try:
+                assert discovery_task in done
+                with pytest.raises(asyncio.TimeoutError):
+                    await discovery_task
+                assert "startup_srv" not in servers
+                assert server._registered_tool_names == []
+                assert mock_registry.get_all_tool_names() == []
+            finally:
+                server._task.cancel()
+                release_server_task.set()
+                refresh_task.cancel()
+                await asyncio.gather(
+                    discovery_task,
+                    refresh_task,
+                    server._task,
+                    return_exceptions=True,
+                )
+
+    @pytest.mark.asyncio
+    async def test_refresh_list_timeout_releases_transition_locks(self):
+        server = MCPServerTask("live_srv")
+        server._config = {"connect_timeout": 0.01}
+
+        async def _list_tools():
+            await asyncio.Event().wait()
+
+        server.session = SimpleNamespace(list_tools=_list_tools)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await server._refresh_tools()
+
+        assert not server._refresh_lock.locked()
+        assert not server._rpc_lock.locked()
+
+    @pytest.mark.asyncio
+    async def test_does_not_warn_for_never_exposed_tool_across_reconnect(self, caplog):
+        server = MCPServerTask("live_srv")
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace())
+        )
+        server._tools = [_make_mcp_tool("hidden_tool", "original behavior")]
+        server._registered_tool_names = []
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                return_value=SimpleNamespace(
+                    tools=[_make_mcp_tool("hidden_tool", "changed behavior")]
+                )
+            )
+        )
+
+        with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+            await server._discover_tools()
+
+        assert not any(
+            "modified after reconnect" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_parked_reconnect_ignores_changed_filtered_tool(
+        self, mock_registry, caplog
+    ):
+        visible_name = "mcp__live_srv__visible_tool"
+        hidden_name = "mcp__live_srv__hidden_tool"
+        server = MCPServerTask("live_srv")
+        server._ready.set()
+        server._config = {"tools": {"include": ["visible_tool"]}}
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace())
+        )
+        server._tools = [
+            _make_mcp_tool("visible_tool", "stable behavior"),
+            _make_mcp_tool("hidden_tool", "original hidden behavior"),
+        ]
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                return_value=SimpleNamespace(
+                    tools=[
+                        _make_mcp_tool("visible_tool", "stable behavior"),
+                        _make_mcp_tool("hidden_tool", "changed hidden behavior"),
+                    ]
+                )
+            )
+        )
+
+        with patch("tools.registry.registry", mock_registry):
+            server._registered_tool_names = _register_server_tools(
+                server.name, server, server._config
+            )
+            server._deregister_tools()
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+                await server._discover_tools()
+
+        assert server._registered_tool_names == [visible_name]
+        assert hidden_name not in server._last_registered_tool_contracts
+        assert not any(
+            hidden_name in record.getMessage()
+            or "MCP rug pull" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_warns_when_collided_tool_is_reexposed(self, mock_registry, caplog):
+        tool_name = "mcp__live_srv__stable_tool"
+        server = MCPServerTask("live_srv")
+        server._ready.set()
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace())
+        )
+        server._config = {}
+        server._tools = [_make_mcp_tool("stable_tool", "original behavior")]
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                return_value=SimpleNamespace(
+                    tools=[_make_mcp_tool("stable_tool", "changed behavior")]
+                )
+            )
+        )
+
+        with patch("tools.registry.registry", mock_registry):
+            server._registered_tool_names = _register_server_tools(
+                server.name, server, server._config
+            )
+            server._deregister_tools()
+            mock_registry.register(
+                name=tool_name,
+                toolset="builtin",
+                schema={},
+                handler=lambda _args: None,
+            )
+
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+                await server._discover_tools()
+            assert server._registered_tool_names == []
+            assert not any(
+                "MCP rug pull" in record.getMessage()
+                for record in caplog.records
+            )
+
+            caplog.clear()
+            mock_registry.deregister(tool_name)
+            with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+                await server._discover_tools()
+
+        assert server._registered_tool_names == [tool_name]
+        assert sum(
+            f"modified after reconnect: {tool_name}" in record.getMessage()
+            for record in caplog.records
+        ) == 1
+
+    @pytest.mark.asyncio
+    async def test_dynamic_removal_preserves_new_registry_owner(self, mock_registry):
+        tool_name = "mcp__live_srv__shared_tool"
+        server = MCPServerTask("live_srv")
+        server._ready.set()
+        server._config = {}
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace())
+        )
+        server._tools = [_make_mcp_tool("shared_tool", "remote behavior")]
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(return_value=SimpleNamespace(tools=[]))
+        )
+
+        with patch("tools.registry.registry", mock_registry):
+            server._registered_tool_names = _register_server_tools(
+                server.name, server, server._config
+            )
+            mock_registry.deregister(tool_name)
+            mock_registry.register(
+                name=tool_name,
+                toolset="builtin-owner",
+                schema={
+                    "name": tool_name,
+                    "description": "replacement behavior",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                handler=lambda **_: None,
+            )
+
+            await server._refresh_tools()
+
+        assert mock_registry.get_toolset_for_tool(tool_name) == "builtin-owner"
+        assert server._registered_tool_names == []
+        assert tool_name in server._last_registered_tool_contracts
+
+    def test_deregistration_preserves_new_registry_owner(self, mock_registry):
+        tool_name = "mcp__live_srv__shared_tool"
+        server = MCPServerTask("live_srv")
+        server._registered_tool_names = [tool_name]
+        mock_registry.register(
+            name=tool_name,
+            toolset="builtin-owner",
+            schema={
+                "name": tool_name,
+                "description": "replacement behavior",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda **_: None,
+        )
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            patch.dict(
+                "tools.mcp_tool._mcp_tool_server_names",
+                {tool_name: "live_srv"},
+                clear=True,
+            ) as provenance,
+        ):
+            server._deregister_tools()
+            assert tool_name not in provenance
+
+        assert mock_registry.get_toolset_for_tool(tool_name) == "builtin-owner"
+        assert server._registered_tool_names == []
+
+    @pytest.mark.parametrize("cleanup_path", ["refresh", "deregister"])
+    def test_cleanup_preserves_replacement_mcp_provenance(
+        self, mock_registry, cleanup_path
+    ):
+        """Same-name instance replacement keeps provenance for the live owner.
+
+        Distinct raw server names that sanitize to one tool prefix still map to
+        different toolsets (``mcp-{raw}``). Current registry policy rejects
+        cross-MCP ownership transfer, so this covers same-name instance swap
+        under one raw server name (the realistic reconnect/replace path).
+        """
+        from tools.mcp_tool import (
+            has_registered_mcp_tools,
+            is_mcp_tool_parallel_safe,
+        )
+        import tools.mcp_tool as mcp_tool
+
+        tool_name = "mcp__shared_owner__shared_tool"
+        old_server = MCPServerTask("shared_owner")
+        old_server._config = {}
+        old_server._tools = [_make_mcp_tool("shared_tool", "old behavior")]
+        new_server = MCPServerTask("shared_owner")
+        new_server._config = {"supports_parallel_tool_calls": True}
+        new_server._tools = [_make_mcp_tool("shared_tool", "new behavior")]
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            patch.dict("tools.mcp_tool._mcp_tool_server_names", {}, clear=True),
+            patch("tools.mcp_tool._parallel_safe_servers", {"shared_owner"}),
+            patch.object(mcp_tool, "_servers", {"shared_owner": old_server}),
+        ):
+            old_server._synchronize_registered_tools()
+            mcp_tool._servers["shared_owner"] = new_server
+            new_server._synchronize_registered_tools()
+            assert mock_registry.get_toolset_for_tool(tool_name) == (
+                "mcp-shared_owner"
+            )
+            assert mock_registry.get_entry(tool_name).schema["description"] == (
+                "new behavior"
+            )
+            if cleanup_path == "refresh":
+                old_server._tools = []
+                old_server._synchronize_registered_tools()
+            else:
+                old_server._deregister_tools()
+
+            assert mock_registry.get_toolset_for_tool(tool_name) == (
+                "mcp-shared_owner"
+            )
+            assert mock_registry.get_entry(tool_name).schema["description"] == (
+                "new behavior"
+            )
+            assert has_registered_mcp_tools()
+            assert is_mcp_tool_parallel_safe(tool_name)
+
+    def test_registration_skips_server_name_already_connecting(self):
+        import tools.mcp_tool as mcp_tool
+
+        config = {"same": {"command": "ignored"}}
+        with (
+            patch.object(mcp_tool, "_MCP_AVAILABLE", True),
+            patch.object(
+                mcp_tool,
+                "_filter_suspicious_mcp_servers",
+                return_value=config,
+            ),
+            patch.object(mcp_tool, "_connect_cooldown_active", return_value=False),
+            patch.object(mcp_tool, "_servers", {}),
+            patch.object(mcp_tool, "_server_connecting", {"same"}),
+            patch.object(mcp_tool, "_server_connect_errors", {}),
+            patch.object(mcp_tool, "_parallel_safe_servers", set()),
+            patch.object(mcp_tool, "_ensure_mcp_loop") as ensure_loop,
+            patch.object(mcp_tool, "_run_on_mcp_loop") as run_on_loop,
+            patch.object(
+                mcp_tool,
+                "_existing_tool_names",
+                return_value=["existing"],
+            ),
+        ):
+            registered = mcp_tool.register_mcp_servers(config)
+
+        assert registered == ["existing"]
+        ensure_loop.assert_not_called()
+        run_on_loop.assert_not_called()
+
+    def test_outer_discovery_timeout_releases_connecting_name(self):
+        import tools.mcp_tool as mcp_tool
+
+        config = {"same": {"command": "ignored"}}
+        connecting = set()
+        with (
+            patch.object(mcp_tool, "_MCP_AVAILABLE", True),
+            patch.object(
+                mcp_tool,
+                "_filter_suspicious_mcp_servers",
+                return_value=config,
+            ),
+            patch.object(mcp_tool, "_servers", {}),
+            patch.object(mcp_tool, "_server_connecting", connecting),
+            patch.object(mcp_tool, "_server_connect_errors", {}),
+            patch.object(mcp_tool, "_parallel_safe_servers", set()),
+            patch.object(mcp_tool, "_connect_cooldown_active", return_value=False),
+            patch.object(mcp_tool, "_ensure_mcp_loop"),
+            patch.object(
+                mcp_tool,
+                "_run_on_mcp_loop",
+                side_effect=TimeoutError("outer discovery timed out"),
+            ),
+        ):
+            with pytest.raises(TimeoutError, match="outer discovery timed out"):
+                mcp_tool.register_mcp_servers(config)
+
+        assert connecting == set()
+
+    def test_parallel_safety_uses_raw_owner_across_sanitized_collision(self):
+        import tools.mcp_tool as mcp_tool
+
+        tool_name = "mcp__a_b__shared_tool"
+        config = {
+            "a-b": {
+                "command": "ignored",
+                "supports_parallel_tool_calls": True,
+            },
+            "a_b": {
+                "command": "ignored",
+                "supports_parallel_tool_calls": False,
+            },
+        }
+        parallel_safe_servers = set()
+        provenance = {}
+        with (
+            patch.object(mcp_tool, "_MCP_AVAILABLE", True),
+            patch.object(
+                mcp_tool,
+                "_filter_suspicious_mcp_servers",
+                return_value=config,
+            ),
+            patch.object(mcp_tool, "_servers", {}),
+            patch.object(mcp_tool, "_server_connecting", set()),
+            patch.object(mcp_tool, "_server_connect_errors", {}),
+            patch.object(mcp_tool, "_parallel_safe_servers", parallel_safe_servers),
+            patch.object(mcp_tool, "_mcp_tool_server_names", provenance),
+            patch.object(mcp_tool, "_connect_cooldown_active", return_value=False),
+            patch.object(mcp_tool, "_ensure_mcp_loop"),
+            patch.object(mcp_tool, "_run_on_mcp_loop"),
+            patch.object(mcp_tool, "_existing_tool_names", return_value=[]),
+        ):
+            mcp_tool.register_mcp_servers(config)
+
+            mcp_tool._track_mcp_tool_server(tool_name, "a_b")
+            assert not mcp_tool.is_mcp_tool_parallel_safe(tool_name)
+
+            mcp_tool._track_mcp_tool_server(tool_name, "a-b")
+            assert mcp_tool.is_mcp_tool_parallel_safe(tool_name)
+
+        assert parallel_safe_servers == {"a-b"}
+        assert provenance[tool_name] == "a-b"
+
+    def test_stale_same_name_deregistration_preserves_current_instance(
+        self, mock_registry
+    ):
+        import tools.mcp_tool as mcp_tool
+
+        tool_name = "mcp__same__shared_tool"
+        stale_server = MCPServerTask("same")
+        stale_server._config = {}
+        stale_server._tools = [_make_mcp_tool("shared_tool", "stale behavior")]
+        current_server = MCPServerTask("same")
+        current_server._config = {}
+        current_server._tools = [_make_mcp_tool("shared_tool", "current behavior")]
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            patch.dict("tools.mcp_tool._mcp_tool_server_names", {}, clear=True),
+            patch.object(mcp_tool, "_servers", {"same": stale_server}),
+        ):
+            stale_server._synchronize_registered_tools()
+            mcp_tool._servers["same"] = current_server
+            current_server._synchronize_registered_tools()
+            stale_server._deregister_tools()
+
+            assert mock_registry.get_entry(tool_name).schema["description"] == (
+                "current behavior"
+            )
+            assert mcp_tool._mcp_tool_server_names[tool_name] == "same"
+
+    @pytest.mark.asyncio
+    async def test_cross_mcp_collision_warns_for_visible_contract_change(
+        self, mock_registry, caplog
+    ):
+        """Sanitized-name collisions keep the first owner and warn on drift.
+
+        Current registry policy rejects cross-MCP toolset shadowing, so a
+        second server must not steal the model-visible entry. A differing
+        contract is still a rug-pull signal and must be logged.
+        """
+        tool_name = "mcp__a_b__shared_tool"
+        first_server = MCPServerTask("a-b")
+        first_server._config = {}
+        first_server._tools = [_make_mcp_tool("shared_tool", "A-safe")]
+        second_server = MCPServerTask("a_b")
+        second_server._config = {}
+        second_server._tools = [_make_mcp_tool("shared_tool", "B-dangerous")]
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            patch.dict("tools.mcp_tool._mcp_tool_server_names", {}, clear=True),
+        ):
+            first_server._synchronize_registered_tools()
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+                second_server._synchronize_registered_tools()
+
+        assert mock_registry.get_entry(tool_name).schema["description"] == "A-safe"
+        assert mock_registry.get_toolset_for_tool(tool_name) == "mcp-a-b"
+        assert sum(
+            "MCP rug pull" in record.getMessage()
+            and tool_name in record.getMessage()
+            for record in caplog.records
+        ) == 1
+
+    def test_snapshot_publication_is_atomic_for_registry_readers(
+        self, mock_registry
+    ):
+        import threading
+
+        server = MCPServerTask("atomic")
+        server._config = {}
+        server._tools = [
+            _make_mcp_tool("first", "first behavior"),
+            _make_mcp_tool("second", "second behavior"),
+        ]
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(
+                tools=SimpleNamespace(), resources=None, prompts=None
+            )
+        )
+        first_published = threading.Event()
+        release_publication = threading.Event()
+        reader_finished = threading.Event()
+        observed_names = []
+        register_calls = 0
+        original_register = mock_registry.register
+
+        def blocking_register(**spec):
+            nonlocal register_calls
+            original_register(**spec)
+            register_calls += 1
+            if register_calls == 1:
+                first_published.set()
+                release_publication.wait(timeout=2)
+
+        def publish_snapshot():
+            server._synchronize_registered_tools()
+
+        def read_snapshot():
+            observed_names.extend(
+                mock_registry.get_tool_names_for_toolset("mcp-atomic")
+            )
+            reader_finished.set()
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            patch.object(mock_registry, "register", side_effect=blocking_register),
+            patch.dict("tools.mcp_tool._mcp_tool_server_names", {}, clear=True),
+        ):
+            publisher = threading.Thread(target=publish_snapshot)
+            reader = threading.Thread(target=read_snapshot)
+            publisher.start()
+            assert first_published.wait(timeout=1)
+            reader.start()
+            try:
+                assert not reader_finished.wait(timeout=0.05)
+            finally:
+                release_publication.set()
+                publisher.join(timeout=2)
+                reader.join(timeout=2)
+
+        assert not publisher.is_alive()
+        assert not reader.is_alive()
+        assert observed_names == ["mcp__atomic__first", "mcp__atomic__second"]
+
+    def test_bounds_retained_inactive_contracts_by_count(self, mock_registry):
+        server = MCPServerTask("live_srv")
+        server._config = {}
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            patch("tools.mcp_tool._MAX_RETAINED_INACTIVE_MCP_CONTRACTS", 2),
+        ):
+            for tool_name in ("one", "two", "three", "four"):
+                server._tools = [_make_mcp_tool(tool_name, f"{tool_name} behavior")]
+                server._synchronize_registered_tools()
+
+        assert set(server._last_registered_tool_contracts) == {
+            "mcp__live_srv__two",
+            "mcp__live_srv__three",
+            "mcp__live_srv__four",
+        }
+
+    def test_evicts_oversized_inactive_contract(self, mock_registry):
+        tool_name = "mcp__live_srv__large_tool"
+        server = MCPServerTask("live_srv")
+        server._config = {}
+        server._tools = [_make_mcp_tool("large_tool", "x" * 1024)]
+
+        with (
+            patch("tools.registry.registry", mock_registry),
+            patch("tools.mcp_tool._MAX_RETAINED_INACTIVE_MCP_CONTRACT_BYTES", 128),
+        ):
+            server._synchronize_registered_tools()
+            assert tool_name in server._last_registered_tool_contracts
+            server._deregister_tools()
+
+        assert tool_name not in server._last_registered_tool_contracts
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("refresh_method", ["_refresh_tools", "_discover_tools"])
+    async def test_utility_name_collision_tracks_only_visible_contract(
+        self, refresh_method, mock_registry, caplog
+    ):
+        tool_name = "mcp__live_srv__list_resources"
+        server = MCPServerTask("live_srv")
+        server._ready.set()
+        server._config = {}
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(
+                tools=SimpleNamespace(),
+                resources=SimpleNamespace(),
+                prompts=None,
+            )
+        )
+        server._tools = [_make_mcp_tool("list_resources", "remote behavior A")]
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                return_value=SimpleNamespace(
+                    tools=[
+                        _make_mcp_tool("list_resources", "remote behavior B")
+                    ]
+                )
+            )
+        )
+
+        with patch("tools.registry.registry", mock_registry):
+            server._registered_tool_names = _register_server_tools(
+                server.name, server, server._config
+            )
+            visible_description = mock_registry._tools[tool_name].schema[
+                "description"
+            ]
+            assert server._last_registered_tool_contracts[tool_name][
+                "description"
+            ] == visible_description
+
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+                await getattr(server, refresh_method)()
+
+        assert mock_registry._tools[tool_name].schema["description"] == (
+            visible_description
+        )
+        assert server._last_registered_tool_contracts[tool_name][
+            "description"
+        ] == visible_description
+        assert not any(
+            "MCP rug pull" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_warns_when_removed_tool_is_readded_with_changed_contract(
+        self, mock_registry, caplog
+    ):
+        tool_name = "mcp__live_srv__stable_tool"
+        server = MCPServerTask("live_srv")
+        server._config = {}
+        server._tools = [_make_mcp_tool("stable_tool", "original behavior")]
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace())
+        )
+        server.session = SimpleNamespace(
+            list_tools=AsyncMock(
+                side_effect=[
+                    SimpleNamespace(tools=[]),
+                    SimpleNamespace(
+                        tools=[
+                            _make_mcp_tool("stable_tool", "changed behavior")
+                        ]
+                    ),
+                ]
+            )
+        )
+
+        with patch("tools.registry.registry", mock_registry):
+            server._registered_tool_names = _register_server_tools(
+                server.name, server, server._config
+            )
+            await server._refresh_tools()
+            assert server._registered_tool_names == []
+
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+                await server._refresh_tools()
+
+        assert server._registered_tool_names == [tool_name]
+        assert any(
+            f"modified: {tool_name}" in record.getMessage()
+            for record in caplog.records
+        )
+
 
 class TestMessageHandler:
     """Tests for MCPServerTask._make_message_handler dispatch."""
@@ -112,9 +1427,63 @@ class TestMessageHandler:
             await handler({"jsonrpc": "2.0", "result": "ok"})
             mock_schedule.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_coalesces_rapid_refresh_notifications(self):
+        server = MCPServerTask("notif_srv")
+        refresh_started = asyncio.Event()
+        release_refresh = asyncio.Event()
+        refresh_calls = 0
+
+        async def blocked_refresh(_server):
+            nonlocal refresh_calls
+            refresh_calls += 1
+            if refresh_calls == 1:
+                refresh_started.set()
+                await release_refresh.wait()
+
+        with patch.object(MCPServerTask, "_refresh_tools", new=blocked_refresh):
+            first_task = server._schedule_tools_refresh()
+            await asyncio.wait_for(refresh_started.wait(), timeout=1)
+            scheduled_tasks = [
+                server._schedule_tools_refresh() for _ in range(99)
+            ]
+            try:
+                assert all(task is first_task for task in scheduled_tasks)
+                assert len(server._pending_refresh_tasks) == 1
+            finally:
+                release_refresh.set()
+                await asyncio.gather(
+                    *server._pending_refresh_tasks,
+                    return_exceptions=True,
+                )
+
+        assert refresh_calls == 2
+        assert not server._pending_refresh_tasks
+
 
 class TestDeregister:
     """Tests for ToolRegistry.deregister."""
+
+    def test_preserves_exposed_contracts_for_reconnect_checks(self):
+        server = MCPServerTask("parked_srv")
+        server._config = {}
+        server.initialize_result = SimpleNamespace(
+            capabilities=SimpleNamespace(tools=SimpleNamespace())
+        )
+        server._tools = [
+            _make_mcp_tool("visible_tool", "original behavior")
+        ]
+
+        with patch("tools.registry.registry", ToolRegistry()):
+            server._registered_tool_names = _register_server_tools(
+                server.name, server, server._config
+            )
+            server._deregister_tools()
+
+        assert server._registered_tool_names == []
+        assert server._last_registered_tool_contracts[
+            "mcp__parked_srv__visible_tool"
+        ]["description"] == "original behavior"
 
     def test_removes_tool(self):
         reg = ToolRegistry()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -332,6 +332,8 @@ _MCP_LOG_LEVEL_MAP = {
 
 _DEFAULT_TOOL_TIMEOUT = 300      # seconds for tool calls
 _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
+_MAX_RETAINED_INACTIVE_MCP_CONTRACTS = 256
+_MAX_RETAINED_INACTIVE_MCP_CONTRACT_BYTES = 2 * 1024 * 1024
 _MAX_RECONNECT_RETRIES = 5
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
 _MAX_BACKOFF_SECONDS = 60
@@ -1833,8 +1835,9 @@ class MCPServerTask:
         "_task", "_ready", "_shutdown_event", "_reconnect_event",
         "_tools", "_error", "_config",
         "_sampling", "_elicitation",
-        "_registered_tool_names", "_auth_type", "_refresh_lock",
-        "_rpc_lock", "_pending_refresh_tasks",
+        "_registered_tool_names", "_last_registered_tool_contracts",
+        "_auth_type", "_refresh_lock",
+        "_rpc_lock", "_pending_refresh_tasks", "_tools_refresh_requested",
         "_pending_call_context",
         "_lifecycle_started_at", "_last_tool_call_at",
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
@@ -1861,6 +1864,7 @@ class MCPServerTask:
         self._sampling: Optional[SamplingHandler] = None
         self._elicitation: Optional[ElicitationHandler] = None
         self._registered_tool_names: list[str] = []
+        self._last_registered_tool_contracts: Dict[str, dict] = {}
         self._reconnect_retries: int = 0
         # Rapid-drop budget (#62212): a freshly (re)established session is
         # UNPROVEN until it demonstrates real health — it survived at least
@@ -1884,6 +1888,7 @@ class MCPServerTask:
         # transports for conservative per-server ordering.
         self._rpc_lock = asyncio.Lock()
         self._pending_refresh_tasks: set[asyncio.Task] = set()
+        self._tools_refresh_requested = False
         # contextvars snapshot of the agent task that's currently in
         # session.call_tool(). The MCP recv loop dispatches incoming
         # elicitation/create requests on a SEPARATE asyncio task whose
@@ -1937,6 +1942,12 @@ class MCPServerTask:
             return True
         return getattr(caps, "tools", None) is not None
 
+    def _list_timeout(self) -> float:
+        """Bound control-plane list RPCs with the server connect timeout."""
+        return float(
+            self._config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+        )
+
     def _is_recycled_stdio(self) -> bool:
         """Return True when a stdio server was intentionally recycled."""
         return not self._is_http() and self._recycled_reason is not None
@@ -1987,16 +1998,24 @@ class MCPServerTask:
     # ----- Dynamic tool discovery (notifications/tools/list_changed) -----
 
     async def _refresh_tools_task(self):
-        """Run a dynamic tool refresh and log failures from background tasks."""
-        try:
-            await self._refresh_tools()
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.exception("MCP server '%s': dynamic tool refresh failed", self.name)
+        """Drain coalesced dynamic refresh requests in one background task."""
+        while self._tools_refresh_requested:
+            self._tools_refresh_requested = False
+            try:
+                await self._refresh_tools()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception(
+                    "MCP server '%s': dynamic tool refresh failed", self.name
+                )
 
     def _schedule_tools_refresh(self) -> asyncio.Task:
-        """Schedule a background tool refresh and keep it strongly referenced."""
+        """Schedule one worker while coalescing additional refresh requests."""
+        self._tools_refresh_requested = True
+        for task in self._pending_refresh_tasks:
+            if not task.done():
+                return task
         task = asyncio.create_task(self._refresh_tools_task())
         self._pending_refresh_tasks.add(task)
         task.add_done_callback(self._pending_refresh_tasks.discard)
@@ -2083,12 +2102,11 @@ class MCPServerTask:
         """Re-fetch tools from the server and update the registry.
 
         Called when the server sends ``notifications/tools/list_changed``.
-        The lock prevents overlapping refreshes from rapid-fire notifications.
+        The lock serializes refreshes with reconnect discovery so each
+        transition compares and commits against one exposed baseline.
         After the initial ``await`` (list_tools), all mutations are synchronous
         — atomic from the event loop's perspective.
         """
-        from tools.registry import registry
-
         if not self._advertises_tools():
             # A server that doesn't implement tools/* should never send
             # tools/list_changed, but guard anyway — calling tools/list
@@ -2096,68 +2114,62 @@ class MCPServerTask:
             return
 
         async with self._refresh_lock:
-            # Capture old tool names for change diff
+            # Capture names and model-visible contracts before the server refresh.
             old_tool_names = set(self._registered_tool_names)
+            old_tool_contracts = dict(self._last_registered_tool_contracts)
+            missing_contracts = old_tool_names - old_tool_contracts.keys()
+            if missing_contracts:
+                old_tool_contracts.update(
+                    _mcp_tool_contracts(
+                        self.name, self._tools, missing_contracts
+                    )
+                )
 
             # 1. Fetch current tool list from server (follow nextCursor)
             async with self._rpc_lock:
-                new_mcp_tools = await _paginate_full_list(
-                    self.session.list_tools, "tools", self.name
+                new_mcp_tools = await asyncio.wait_for(
+                    _paginate_full_list(
+                        self.session.list_tools, "tools", self.name
+                    ),
+                    timeout=self._list_timeout(),
                 )
 
-            # 2. Re-register with fresh tool list. Avoid nuke-and-repave for
-            # all names: live agent turns may already have tool-call IDs
-            # pointing at existing handler functions. Replacing entries
-            # in-place is enough for unchanged names and avoids transient
-            # "tool not connected" / stale-handler races during startup
-            # notifications. Tools absent from the fresh list are no longer
-            # callable, so remove only those stale registry entries first.
-            toolset_name = f"mcp-{self.name}"
-            stale_tool_names = old_tool_names - {
-                mcp_prefixed_tool_name(self.name, tool.name)
-                for tool in new_mcp_tools
-            }
-            for tool_name in stale_tool_names:
-                # Never let one server's refresh remove a colliding name that
-                # is currently owned by another server.
-                if registry.get_toolset_for_tool(tool_name) != toolset_name:
-                    continue
-                registry.deregister(tool_name)
-                _forget_mcp_tool_server(tool_name)
-
-            # 3. Re-register with the fresh list. The helper may skip names that
-            # are ambiguous after normalization.
+            # 2. Synchronize the final model-visible snapshot.
             self._tools = new_mcp_tools
-            registered_names = _register_server_tools(
-                self.name, self, self._config
-            )
+            self._synchronize_registered_tools()
 
-            # A previously unique raw name can become ambiguous without changing
-            # its normalized registry name. In that case the pre-pass above does
-            # not consider it stale, so remove any old entry that the final,
-            # collision-checked registration set no longer owns.
-            registered_name_set = set(registered_names)
-            for tool_name in old_tool_names - registered_name_set:
-                if registry.get_toolset_for_tool(tool_name) != toolset_name:
-                    continue
-                registry.deregister(tool_name)
-                _forget_mcp_tool_server(tool_name)
-            self._registered_tool_names = registered_names
-
-            # 4. Log what changed (user-visible notification)
+            # 3. Log what changed (user-visible notification)
             new_tool_names = set(self._registered_tool_names)
+            new_tool_contracts = {
+                tool_name: self._last_registered_tool_contracts[tool_name]
+                for tool_name in new_tool_names
+                if tool_name in self._last_registered_tool_contracts
+            }
             added = new_tool_names - old_tool_names
             removed = old_tool_names - new_tool_names
+            modified = {
+                tool_name
+                for tool_name in old_tool_contracts.keys() & new_tool_contracts.keys()
+                if _mcp_tool_contract_fingerprint(old_tool_contracts[tool_name])
+                != _mcp_tool_contract_fingerprint(new_tool_contracts[tool_name])
+            }
             changes = []
             if added:
                 changes.append(f"added: {', '.join(sorted(added))}")
             if removed:
                 changes.append(f"removed: {', '.join(sorted(removed))}")
+            if modified:
+                changes.append(f"modified: {', '.join(sorted(modified))}")
             if changes:
+                security_note = (
+                    " Same-name contract changes can indicate an MCP rug pull "
+                    "or tool poisoning."
+                    if modified else ""
+                )
                 logger.warning(
                     "MCP server '%s': tools changed dynamically — %s. "
-                    "Verify these changes are expected.",
-                    self.name, "; ".join(changes),
+                    "Verify these changes are expected.%s",
+                    self.name, "; ".join(changes), security_note,
                 )
             else:
                 logger.info(
@@ -3005,49 +3017,107 @@ class MCPServerTask:
         self._ping_unsupported = False
         if self.session is None:
             return
-        if not self._advertises_tools():
-            logger.info(
-                "MCP server '%s': does not advertise 'tools' capability — "
-                "skipping tools/list (prompts/resources remain available)",
-                self.name,
+
+        async with self._refresh_lock:
+            old_tool_contracts = dict(self._last_registered_tool_contracts)
+            missing_contracts = (
+                set(self._registered_tool_names) - old_tool_contracts.keys()
             )
-            self._tools = []
+            if missing_contracts:
+                old_tool_contracts.update(
+                    _mcp_tool_contracts(
+                        self.name, self._tools, missing_contracts
+                    )
+                )
+
+            if self._advertises_tools():
+                async with self._rpc_lock:
+                    new_mcp_tools = await asyncio.wait_for(
+                        _paginate_full_list(
+                            self.session.list_tools, "tools", self.name
+                        ),
+                        timeout=self._list_timeout(),
+                    )
+            else:
+                logger.info(
+                    "MCP server '%s': does not advertise 'tools' capability — "
+                    "skipping tools/list (prompts/resources remain available)",
+                    self.name,
+                )
+                new_mcp_tools = []
+
+            self._tools = new_mcp_tools
             self._register_discovered_tools_if_needed()
-            return
-        async with self._rpc_lock:
-            self._tools = await _paginate_full_list(
-                self.session.list_tools, "tools", self.name
-            )
-        self._register_discovered_tools_if_needed()
+            exposed_contracts = {
+                tool_name: self._last_registered_tool_contracts[tool_name]
+                for tool_name in self._registered_tool_names
+                if tool_name in self._last_registered_tool_contracts
+            }
+            exposed_modified = {
+                tool_name
+                for tool_name in old_tool_contracts.keys() & exposed_contracts.keys()
+                if _mcp_tool_contract_fingerprint(old_tool_contracts[tool_name])
+                != _mcp_tool_contract_fingerprint(exposed_contracts[tool_name])
+            }
+            if exposed_modified:
+                logger.warning(
+                    "MCP server '%s': tool contracts modified after reconnect: %s. "
+                    "Verify these changes are expected. Same-name contract changes "
+                    "can indicate an MCP rug pull or tool poisoning.",
+                    self.name, ", ".join(sorted(exposed_modified)),
+                )
 
     def _register_discovered_tools_if_needed(self) -> None:
-        """Re-register tools after an owned server reconnects if needed.
+        """Synchronize model-visible tools after a post-ready reconnect.
 
         Initial registration is performed by ``_discover_and_register_server``
         after ``start()`` completes. During a later reconnect, outage handling
         may clear ``_ready`` before discovery and may deregister stale tools.
         A managed server can still be identified by its entry in ``_servers``;
-        publish its freshly discovered tools before transport readiness is
-        restored so a successful revival cannot come back with zero tools.
+        synchronize its freshly discovered snapshot before transport readiness
+        is restored so additions, removals, and contract changes are atomic.
         A server retained after a recoverable initial failure is likewise
         registry-owned before its first successful session, so ownership also
         authorizes its first publication.
         """
-        if self._registered_tool_names:
-            return
         if not self._ready.is_set():
             with _lock:
                 if _servers.get(self.name) is not self:
                     return
-        self._registered_tool_names = _register_server_tools(
-            self.name, self, self._config
-        )
+        self._synchronize_registered_tools()
         # A retained initial-failure server that just published tools has
         # recovered: drop its stale connect error so status surfaces stop
         # reporting it as failed.
         with _lock:
-            if _servers.get(self.name) is self:
+            if (
+                _servers.get(self.name) is self
+                and self._registered_tool_names
+            ):
                 _server_connect_errors.pop(self.name, None)
+
+    def _synchronize_registered_tools(self) -> None:
+        """Publish the discovered snapshot and remove only entries still owned."""
+        from tools.registry import registry
+
+        # A superseded same-name instance must not mutate the live registry.
+        with _lock:
+            current_server = _servers.get(self.name)
+        if current_server is not None and current_server is not self:
+            self._registered_tool_names = []
+            _prune_retained_mcp_tool_contracts(self)
+            return
+
+        previous_tool_names = set(self._registered_tool_names)
+        with registry._lock:
+            registered_names = _register_server_tools(
+                self.name, self, self._config
+            )
+            for tool_name in previous_tool_names - set(registered_names):
+                _remove_mcp_tool_registration_if_owned(
+                    self.name, tool_name, registry
+                )
+        self._registered_tool_names = registered_names
+        _prune_retained_mcp_tool_contracts(self)
 
     async def run(self, config: dict):
         """Long-lived coroutine: connect, discover tools, wait, disconnect.
@@ -3490,6 +3560,18 @@ class MCPServerTask:
         self._deregister_tools()
         self.session = None
 
+    def _abort(self) -> None:
+        """Cancel lifecycle work and remove visible state without awaiting teardown."""
+        self._shutdown_event.set()
+        self._reconnect_event.set()
+        if self._task and not self._task.done():
+            self._task.cancel()
+        for task in list(self._pending_refresh_tasks):
+            task.cancel()
+        self._deregister_tools()
+        self.session = None
+
+
     def _deregister_tools(self) -> None:
         """Drop this server's tools from the global registry (idempotent).
 
@@ -3501,10 +3583,20 @@ class MCPServerTask:
         """
         from tools.registry import registry
 
-        for tool_name in list(getattr(self, "_registered_tool_names", [])):
-            registry.deregister(tool_name)
-            _forget_mcp_tool_server(tool_name)
+        with _lock:
+            current_server = _servers.get(self.name)
+        if current_server is not None and current_server is not self:
+            self._registered_tool_names = []
+            _prune_retained_mcp_tool_contracts(self)
+            return
+
+        with registry._lock:
+            for tool_name in list(getattr(self, "_registered_tool_names", [])):
+                _remove_mcp_tool_registration_if_owned(
+                    self.name, tool_name, registry
+                )
         self._registered_tool_names = []
+        _prune_retained_mcp_tool_contracts(self)
 
     async def _wait_for_lazy_reconnect(self) -> None:
         """Wait while an intentionally recycled stdio server is dormant."""
@@ -5544,6 +5636,141 @@ def _convert_mcp_schema(server_name: str, mcp_tool) -> dict:
         "parameters": _normalize_mcp_input_schema(getattr(mcp_tool, "inputSchema", None)),
     }
 
+def _canonicalize_mcp_json_schema(schema):
+    """Normalize order-insensitive JSON Schema fields for comparison."""
+    if not isinstance(schema, dict):
+        return schema
+
+    canonical = {}
+    for keyword, value in schema.items():
+        if keyword == "required" and isinstance(value, list) and all(
+            isinstance(item, str) for item in value
+        ):
+            canonical[keyword] = sorted(value)
+        elif keyword in (
+            "additionalItems",
+            "additionalProperties",
+            "contains",
+            "contentSchema",
+            "else",
+            "if",
+            "items",
+            "not",
+            "propertyNames",
+            "then",
+            "unevaluatedItems",
+            "unevaluatedProperties",
+        ):
+            if keyword == "items" and isinstance(value, list):
+                canonical[keyword] = [
+                    _canonicalize_mcp_json_schema(item) for item in value
+                ]
+            else:
+                canonical[keyword] = _canonicalize_mcp_json_schema(value)
+        elif keyword in ("allOf", "anyOf", "oneOf", "prefixItems") and isinstance(
+            value, list
+        ):
+            canonical[keyword] = [
+                _canonicalize_mcp_json_schema(item) for item in value
+            ]
+        elif keyword in (
+            "$defs",
+            "definitions",
+            "dependentSchemas",
+            "patternProperties",
+            "properties",
+        ) and isinstance(value, dict):
+            canonical[keyword] = {
+                name: _canonicalize_mcp_json_schema(child)
+                for name, child in value.items()
+            }
+        elif keyword == "dependencies" and isinstance(value, dict):
+            canonical[keyword] = {
+                name: (
+                    _canonicalize_mcp_json_schema(child)
+                    if isinstance(child, dict)
+                    else child
+                )
+                for name, child in value.items()
+            }
+        elif keyword == "dependentRequired" and isinstance(value, dict):
+            canonical[keyword] = {
+                name: (
+                    sorted(required)
+                    if isinstance(required, list)
+                    and all(isinstance(item, str) for item in required)
+                    else required
+                )
+                for name, required in value.items()
+            }
+        else:
+            canonical[keyword] = value
+    return canonical
+
+def _canonicalize_mcp_tool_schema(schema: dict) -> dict:
+    return {
+        **schema,
+        "parameters": _canonicalize_mcp_json_schema(schema["parameters"]),
+    }
+
+def _mcp_tool_contract_fingerprint(contract: dict) -> str:
+    """Serialize a contract while preserving JSON scalar type distinctions."""
+    return json.dumps(
+        contract,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+def _mcp_tool_contracts(server_name: str, tools, exposed_names=None) -> Dict[str, dict]:
+    """Return model-visible tool schemas keyed by their registry names."""
+    visible_names = set(exposed_names) if exposed_names is not None else None
+    if visible_names is not None and not visible_names:
+        return {}
+    contracts = {}
+    for tool in tools:
+        schema = _convert_mcp_schema(server_name, tool)
+        if visible_names is None or schema["name"] in visible_names:
+            contracts[schema["name"]] = _canonicalize_mcp_tool_schema(schema)
+    return contracts
+
+def _store_mcp_tool_contract(server: MCPServerTask, tool_name: str, schema: dict) -> None:
+    contracts = server._last_registered_tool_contracts
+    contracts.pop(tool_name, None)
+    contracts[tool_name] = _canonicalize_mcp_tool_schema(schema)
+
+def _prune_retained_mcp_tool_contracts(server: MCPServerTask) -> None:
+    contracts = server._last_registered_tool_contracts
+    active_names = set(server._registered_tool_names)
+    retained_count = 0
+    retained_bytes = 0
+    evicted_names = []
+
+    for tool_name in reversed(contracts):
+        if tool_name in active_names:
+            continue
+        contract_bytes = len(tool_name.encode("utf-8")) + len(
+            _mcp_tool_contract_fingerprint(contracts[tool_name]).encode("utf-8")
+        )
+        if (
+            retained_count >= _MAX_RETAINED_INACTIVE_MCP_CONTRACTS
+            or retained_bytes + contract_bytes
+            > _MAX_RETAINED_INACTIVE_MCP_CONTRACT_BYTES
+        ):
+            evicted_names.append(tool_name)
+            continue
+        retained_count += 1
+        retained_bytes += contract_bytes
+
+    for tool_name in evicted_names:
+        contracts.pop(tool_name, None)
+
+    if evicted_names:
+        logger.debug(
+            "MCP server '%s': evicted %d inactive contract baseline(s)",
+            server.name,
+            len(evicted_names),
+        )
 
 def _build_utility_schemas(server_name: str) -> List[dict]:
     """Build schemas for the MCP utility tools (resources & prompts).
@@ -5726,6 +5953,16 @@ def _forget_mcp_tool_server(tool_name: str) -> None:
     with _lock:
         _mcp_tool_server_names.pop(tool_name, None)
 
+def _remove_mcp_tool_registration_if_owned(
+    server_name: str, tool_name: str, registry
+) -> None:
+    """Remove registry and provenance state unless another MCP server owns it."""
+    current_toolset = registry.get_toolset_for_tool(tool_name)
+    if current_toolset == f"mcp-{server_name}":
+        registry.deregister(tool_name)
+        _forget_mcp_tool_server(tool_name)
+    elif not current_toolset or not current_toolset.startswith("mcp-"):
+        _forget_mcp_tool_server(tool_name)
 
 def _select_utility_schemas(server_name: str, server: MCPServerTask, config: dict) -> List[dict]:
     """Select utility schemas based on config and server capabilities."""
@@ -5826,16 +6063,17 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
     """
     from tools.registry import registry
 
+    with registry._lock:
+        return _register_server_tools_locked(name, server, config, registry)
+
+
+def _register_server_tools_locked(
+    name: str, server: MCPServerTask, config: dict, registry
+) -> List[str]:
+    """Register one complete MCP snapshot while holding the registry lock."""
     registered_names: List[str] = []
     toolset_name = f"mcp-{name}"
 
-    # Selective tool loading: honour include/exclude lists from config.
-    # Rules (matching issue #690 spec, extended with glob support):
-    #   tools.include — whitelist: only matching tool names are registered
-    #   tools.exclude — blacklist: all tools EXCEPT matching ones are registered
-    #   entries may be exact names or fnmatch globs (e.g. "*_radar_*")
-    #   include takes precedence over exclude
-    #   Neither set → register all tools (backward-compatible default)
     tools_filter = config.get("tools") or {}
     include_set = _normalize_name_filter(
         tools_filter.get("include"), f"mcp_servers.{name}.tools.include"
@@ -5852,6 +6090,8 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
         return True
 
     check_fn = _make_check_fn(name)
+    utility_entries = _select_utility_schemas(name, server, config)
+    utility_names = {entry["schema"]["name"] for entry in utility_entries}
     candidates: List[dict] = []
 
     for mcp_tool in server._tools:
@@ -5865,9 +6105,17 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 
         _scan_mcp_description(name, mcp_tool.name, mcp_tool.description or "")
         schema = _convert_mcp_schema(name, mcp_tool)
+        tool_name_prefixed = schema["name"]
+        if tool_name_prefixed in utility_names:
+            logger.warning(
+                "MCP server '%s': remote tool '%s' collides with generated "
+                "utility '%s' — skipping remote tool",
+                name, mcp_tool.name, tool_name_prefixed,
+            )
+            continue
         candidates.append(
             {
-                "registry_name": schema["name"],
+                "registry_name": tool_name_prefixed,
                 "origin": f"tool {mcp_tool.name!r}",
                 "schema": schema,
                 "handler": _make_tool_handler(
@@ -5877,15 +6125,13 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             }
         )
 
-    # Generated resource/prompt utility tools share the same namespace as raw
-    # MCP tools, so they must participate in the same collision preflight.
     handler_factories = {
         "list_resources": _make_list_resources_handler,
         "read_resource": _make_read_resource_handler,
         "list_prompts": _make_list_prompts_handler,
         "get_prompt": _make_get_prompt_handler,
     }
-    for entry in _select_utility_schemas(name, server, config):
+    for entry in utility_entries:
         schema = entry["schema"]
         handler_key = entry["handler_key"]
         candidates.append(
@@ -5900,8 +6146,6 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             }
         )
 
-    # Exact duplicate rows from a server are harmless but should not inflate
-    # counts. Distinct origins that collapse to one normalized name are unsafe.
     unique_candidates: List[dict] = []
     seen_candidates: set[tuple[str, str]] = set()
     origins_by_name: Dict[str, set[str]] = {}
@@ -5937,6 +6181,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             ", ".join(origins),
         )
 
+    registration_specs = []
     for candidate in unique_candidates:
         registry_name = candidate["registry_name"]
         if registry_name in ambiguous_names:
@@ -5944,16 +6189,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 
         existing_toolset = registry.get_toolset_for_tool(registry_name)
         if existing_toolset and existing_toolset != toolset_name:
-            if existing_toolset.startswith("mcp-"):
-                logger.error(
-                    "MCP server '%s': %s normalizes to '%s', already owned by "
-                    "MCP toolset '%s' — skipping to preserve the existing owner",
-                    name,
-                    candidate["origin"],
-                    registry_name,
-                    existing_toolset,
-                )
-            else:
+            if not existing_toolset.startswith("mcp-"):
                 logger.warning(
                     "MCP server '%s': %s (→ '%s') collides with built-in tool "
                     "in toolset '%s' — skipping to preserve built-in",
@@ -5962,38 +6198,116 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
                     registry_name,
                     existing_toolset,
                 )
-            continue
+                continue
 
-        registry.register(
-            name=registry_name,
-            toolset=toolset_name,
-            schema=candidate["schema"],
-            handler=candidate["handler"],
-            check_fn=candidate["check_fn"],
-            is_async=False,
-            description=candidate["schema"]["description"],
+        registration_specs.append(
+            {
+                "name": registry_name,
+                "toolset": toolset_name,
+                "schema": candidate["schema"],
+                "handler": candidate["handler"],
+                "check_fn": candidate["check_fn"],
+                "is_async": False,
+                "description": candidate["schema"]["description"],
+            }
         )
 
-        # The pre-check above is advisory only. Multiple servers connect in
-        # parallel, so ToolRegistry.register() is the atomic ownership gate.
-        if registry.get_toolset_for_tool(registry_name) != toolset_name:
-            logger.error(
-                "MCP server '%s': registration of %s as '%s' was rejected by "
-                "the registry; skipping provenance/count updates",
-                name,
-                candidate["origin"],
-                registry_name,
+    published_entries = []
+    cross_server_contract_changes = []
+    try:
+        for spec in registration_specs:
+            tool_name = spec["name"]
+            previous_entry = registry.get_entry(tool_name)
+            previous_toolset = (
+                previous_entry.toolset if previous_entry is not None else None
             )
-            continue
+            cross_server_contract_changed = (
+                isinstance(previous_toolset, str)
+                and previous_toolset.startswith("mcp-")
+                and previous_toolset != toolset_name
+                and previous_entry is not None
+                and _mcp_tool_contract_fingerprint(
+                    _canonicalize_mcp_tool_schema(previous_entry.schema)
+                )
+                != _mcp_tool_contract_fingerprint(
+                    _canonicalize_mcp_tool_schema(spec["schema"])
+                )
+            )
+            registry.register(**spec)
+            if registry.get_toolset_for_tool(tool_name) != toolset_name:
+                owned = registry.get_toolset_for_tool(tool_name)
+                if (
+                    isinstance(owned, str)
+                    and owned.startswith("mcp-")
+                    and owned != toolset_name
+                ):
+                    logger.error(
+                        "MCP server '%s': registration of '%s' rejected; "
+                        "already owned by MCP toolset '%s'",
+                        name,
+                        tool_name,
+                        owned,
+                    )
+                    if cross_server_contract_changed:
+                        logger.warning(
+                            "MCP server '%s': MCP rug pull warning for '%s': "
+                            "model-visible contract differs from owner '%s' "
+                            "(registration not transferred). Verify this "
+                            "change is expected.",
+                            name,
+                            tool_name,
+                            owned,
+                        )
+                continue
+            published_entries.append((tool_name, previous_entry, spec["schema"]))
+            registered_names.append(tool_name)
+            if cross_server_contract_changed:
+                cross_server_contract_changes.append((tool_name, previous_toolset))
 
-        _track_mcp_tool_server(registry_name, name)
-        registered_names.append(registry_name)
+        if registered_names:
+            registry.register_toolset_alias(name, toolset_name)
+    except BaseException:
+        for tool_name, previous_entry, _schema in reversed(published_entries):
+            if registry.get_toolset_for_tool(tool_name) != toolset_name:
+                continue
+            if previous_entry is None:
+                registry.deregister(tool_name)
+                continue
+            registry.register(
+                name=previous_entry.name,
+                toolset=previous_entry.toolset,
+                schema=previous_entry.schema,
+                handler=previous_entry.handler,
+                check_fn=previous_entry.check_fn,
+                requires_env=previous_entry.requires_env,
+                is_async=previous_entry.is_async,
+                description=previous_entry.description,
+                emoji=previous_entry.emoji,
+                max_result_size_chars=previous_entry.max_result_size_chars,
+                dynamic_schema_overrides=previous_entry.dynamic_schema_overrides,
+            )
+        raise
+
+    for tool_name, _previous_entry, schema in published_entries:
+        _store_mcp_tool_contract(server, tool_name, schema)
+        _track_mcp_tool_server(tool_name, name)
+
+    for tool_name, previous_toolset in cross_server_contract_changes:
+        logger.warning(
+            "MCP server '%s': MCP rug pull warning for '%s': model-visible "
+            "contract changed while ownership moved from '%s' to '%s'. "
+            "Verify this change is expected.",
+            name,
+            tool_name,
+            previous_toolset,
+            toolset_name,
+        )
 
     if registered_names:
-        registry.register_toolset_alias(name, toolset_name)
         # Write-through (#56832): refresh the on-disk schema cache after a
         # live connect so the next startup can lazily register this server
         # without spawning it. Cache failures never break registration.
+        # Toolset alias is already registered inside the publish transaction.
         try:
             from tools.mcp_schema_cache import config_fingerprint, write_cache_entry
 
@@ -6202,8 +6516,28 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
         _server_connect_errors.pop(name, None)
         _servers[name] = server
 
-    registered_names = _register_server_tools(name, server, config)
-    server._registered_tool_names = list(registered_names)
+    async def _commit_registration() -> List[str]:
+        # A startup list-changed refresh may already be queued; registration
+        # is the model-visible baseline commit and must share its transition
+        # lock. Bound the whole commit (including lock wait) so a wedged
+        # refresh cannot leave a half-registered server cached forever.
+        async with server._refresh_lock:
+            names = _register_server_tools(name, server, config)
+            server._registered_tool_names = list(names)
+            _prune_retained_mcp_tool_contracts(server)
+            return names
+
+    try:
+        registered_names = await asyncio.wait_for(
+            _commit_registration(),
+            timeout=float(config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)),
+        )
+    except BaseException:
+        with _lock:
+            if _servers.get(name) is server:
+                _servers.pop(name, None)
+        server._abort()
+        raise
 
     transport_type = "HTTP" if "url" in config else "stdio"
     logger.info(


### PR DESCRIPTION
## What does this PR do?

Hermes already reported tools added or removed during MCP dynamic discovery, but a server could alter an existing tool's description or input schema without changing its name and the refresh log would say "no changes."

This change compares the last-exposed model-visible contract (prefixed name, description, and normalized input parameters) across `notifications/tools/list_changed` refreshes and reconnect discovery. When a same-name tool mutates, Hermes logs a clear warning that the change can indicate an MCP rug pull or tool poisoning, while still allowing legitimate dynamic discovery.

Trust baselines advance only after successful exposure, survive parking/filtering/partial registration, and are bounded for inactive historical names. Snapshot publication is transactional under the registry lock (rollback on failure), startup registration shares the refresh transition lock under the connect-timeout budget, and superseded same-name server instances cannot wipe the live registry owner.

## Related Issue

N/A — proactive security hardening at the MCP trust boundary. No existing open issue or PR covers same-name contract mutation detection (searched open MCP PRs for contract/rug-pull/list_changed ownership).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_tool.py`: retain last-exposed tool contracts; fingerprint description + canonicalized JSON Schema parameters; warn on same-name mutations during refresh/reconnect; coalesce rapid list-changed notifications; bound control-plane list RPCs; transactional registry snapshot publish with rollback; prune inactive baselines by count/bytes; preserve live ownership when a superseded same-name instance cleans up; warn (without transfer) when a sanitized-name collision tries to register a differing contract against another MCP owner.
- `tests/tools/test_mcp_dynamic_discovery.py`: coverage for contract mutation paths, reconnect/refresh races, transactional rollback, atomic reader visibility, bounded inactive baselines, utility collisions, parking/filter retention, and current cross-MCP non-transfer policy.

## How to Test

```bash
export PYTHONPATH="$(pwd)"
python -m pytest tests/tools/test_mcp_dynamic_discovery.py -q --tb=short
```

Expected: `48 passed, 1 skipped`.

Optional related suite (env-dependent; some modules need the `mcp` SDK):

```bash
python -m pytest tests/tools/test_mcp_dynamic_discovery.py tests/tools/test_mcp_circuit_breaker.py tests/tools/test_mcp_stability.py tests/tools/test_mcp_list_pagination.py tests/tools/test_mcp_reconnect_signal.py tests/tools/test_mcp_register_wakes_stale.py tests/tools/test_mcp_parked_self_probe.py tests/tools/test_mcp_rapid_drop_budget.py -q --tb=line
```

Also: `ruff check tools/mcp_tool.py tests/tools/test_mcp_dynamic_discovery.py` and `python -m py_compile tools/mcp_tool.py tests/tools/test_mcp_dynamic_discovery.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (git-bash / Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused module result on this branch tip:

```
48 passed, 1 skipped in 1.22s
```

Ruff clean on touched files; `py_compile` clean; `git diff --check` clean.