### PR TITLE
test(agent): isolate ~/.claude in credential pool routing tests

### DIFF
--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -371,6 +371,16 @@ class TestFailureAttribution:
 
     def _make_pool(self, tmp_path, monkeypatch, entries):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+        # Keep the dev machine's live ~/.claude credentials from seeding a
+        # claude_code singleton entry into this pool (same isolation as the
+        # other anthropic pool tests in test_credential_pool.py). Without it,
+        # load_pool() auto-seeds a second entry from ~/.claude/.credentials.json
+        # on developer machines, silently changing the pool size the tests
+        # assume (e.g. test_unmatched_key_does_not_retry_only_pool_entry
+        # expects a single-entry pool) and making the suite host-dependent.
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+        )
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir(parents=True, exist_ok=True)
         (hermes_home / "auth.json").write_text(


### PR DESCRIPTION
## What does this PR do?

Isolate ~/.claude credentials in the credential-pool routing tests. load_pool() auto-seeds a claude_code singleton entry from the dev machine's ~/.claude/.credentials.json, changing the pool size the tests assume and making the suite host-dependent (fails on any machine with Claude Code installed, passes only on clean CI). Mirrors the isolation already used in test_credential_pool.py.

## Related Issue

No GitHub issue — discovered via code review and reproduced live (see below). Happy to file one first if preferred.

## Changes Made

- `fix/credential-pool-test-isolation` — 1 file(s) changed vs base:
  - `tests/agent/test_credential_pool_routing.py`

## How to Test

Validation completed (recorded by prp):
1. Sabotage check: not applicable to this change class (non-pytest) — manual verification recorded: host-dependent test-isolation bug: prp's clean worktree has no ~/.claude, so the base leg cannot reproduce it. Verified directly on this host (which HAS ~/.claude/.credentials.json): removing the read_claude_code_credentials isolation fails test_unmatched_key_does_not_retry_only_pool_entry (load_pool seeds a 2nd claude_code entry, pool no longer single-entry); with the isolation all 15 pass. Also proven by isolating HOME: the test passes on a clean HOME.
2. Suite `tests/agent/test_credential_pool_routing.py`: branch 15 passed / 0 failed vs baseline 14 passed / 1 failed — zero branch-only failures.
3. The full repo-wide suite was not run for this change; GitHub CI owns full-suite validation.

## Logs

Sabotage verification:

```
# not applicable to this change class (non-pytest).
# Manual verification performed: host-dependent test-isolation bug: prp's clean worktree has no ~/.claude, so the base leg cannot reproduce it. Verified directly on this host (which HAS ~/.claude/.credentials.json): removing the read_claude_code_credentials isolation fails test_unmatched_key_does_not_retry_only_pool_entry (load_pool seeds a 2nd claude_code entry, pool no longer single-entry); with the isolation all 15 pass. Also proven by isolating HOME: the test passes on a clean HOME.
```
