### PR TITLE
fix(search): restore zero-match probes on the rg engine after auto-multiline early-return

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2475,12 +2475,11 @@ class ShellFileOperations(FileOperations):
                         limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
         """Search for content inside files (grep-like)."""
         # Try ripgrep first (fast), fallback to grep (slower but works)
+        used_rg = False
         if self._has_command('rg'):
+            used_rg = True
             result = self._search_with_rg(pattern, path, file_glob, limit, offset,
                                           output_mode, context)
-            # rg auto-enables --multiline for \n patterns, so the line-
-            # oriented warning below no longer applies to this engine.
-            return result
         elif self._has_command('grep'):
             result = self._search_with_grep(pattern, path, file_glob, limit, offset,
                                             output_mode, context)
@@ -2492,8 +2491,9 @@ class ShellFileOperations(FileOperations):
             )
 
         # Zero-match steering: a 0-match result with no guidance is a dead
-        # turn. Probe cheaply for near-misses (wrong casing, unescaped regex
-        # metacharacters) and attach the finding as a warning.
+        # turn. Probe cheaply for near-misses (wrong casing, hidden-only
+        # matches, unescaped regex metacharacters) and attach the finding
+        # as a warning. Runs for BOTH engines.
         if (not result.error and result.total_count == 0
                 and not result.matches and not result.files and not result.counts):
             try:
@@ -2503,6 +2503,10 @@ class ShellFileOperations(FileOperations):
             if hint:
                 result.warning = hint if not result.warning else f"{result.warning} {hint}"
 
+        # rg auto-enables --multiline for \n patterns, so the line-oriented
+        # explanation only applies to the grep fallback engine.
+        if used_rg:
+            return result
         return _maybe_warn_line_oriented_newline_pattern(result, pattern)
     
     def _search_with_rg(self, pattern: str, path: str, file_glob: Optional[str],


### PR DESCRIPTION
## Summary
Restores the #77011 zero-match steering probes (case-insensitive / hidden-file / literal-vs-regex) on the ripgrep engine — #77102's early return, added to skip the legacy line-oriented `\n` warning for rg, was also skipping the probe block.

Root cause: an integration regression between two individually-green PRs. #77011 attached the probes after the engine dispatch in `_search_content`; #77102 later added `return result` directly after the rg call so the grep-era line-oriented explanation wouldn't fire on an engine that now auto-multilines. That return bypassed the probes on the primary engine. Caught by #77001's rebased CI (its branch was the first to carry both features together).

## Changes
- `tools/file_operations.py` (`_search_content`): probes run for BOTH engines; only the legacy line-oriented `\n` warning is rg-exempt (rg auto-enables `--multiline`; the grep fallback keeps the explanation).

## Validation
| Check | Result |
|---|---|
| Hermetic runner (zero-match+multipath, auto-multiline, file_operations, file_tools) | 109/109 passed |
| Live E2E via real `search_tool()` | case probe fires; hidden probe fires; `\n` pattern still multiline-matches with mode note |

## Infographic

![probe restore](https://v3b.fal.media/files/b/0aa4c6d7/BHc2bbPsFztXwc1Ie5PHV_jxyFpdep.png)
