### PR TITLE
test(search): guard zero-match hint wiring on both engines

### DIFF
--- a/tests/tools/test_search_zero_match_and_multipath.py
+++ b/tests/tools/test_search_zero_match_and_multipath.py
@@ -93,3 +93,69 @@ class TestMultiPathRecovery:
         assert "error" not in r
         blob = json.dumps(r)
         assert "a.py" in blob
+
+
+class TestZeroMatchProbeEngineParity:
+    """The hint must be attached on BOTH search engines' code paths.
+
+    The probe block originally lived inline after the grep call. Three minutes
+    later a separate commit (auto-multiline) added an early ``return result`` to
+    the ripgrep branch, which orphaned the block: the entire zero-match
+    steering tier was unreachable for every user with rg installed, while the
+    feature's own tests reported the absence as a plain assertion failure.
+    Fixed in 794d6c434e; these tests pin the wiring per engine so a future
+    early return can't silently orphan it again.
+
+    The probe itself shells out to rg (by design: bounded, count-only), so a
+    grep-only host gets no hints even with correct wiring. The probe is
+    therefore stubbed to a sentinel here — this isolates the *wiring* rather
+    than the probe's own dependency, and a naive parity test asserting real
+    hint text would fail on the grep leg for an unrelated reason.
+    """
+
+    @pytest.mark.parametrize("engine", ["rg", "grep"])
+    def test_hint_is_attached_on_each_search_engine(self, proj, monkeypatch, engine):
+        from tools.file_tools import _get_file_ops
+
+        ops = _get_file_ops(task_id=f"t-parity-{engine}")
+        if not ops._has_command(engine):
+            pytest.skip(f"{engine} not installed")
+        real = ops._has_command
+
+        def only(cmd, _real=real, _keep=engine):
+            # Forces which engine `search` picks; other lookups pass through.
+            if cmd in ("rg", "grep"):
+                return _real(cmd) if cmd == _keep else False
+            return _real(cmd)
+
+        monkeypatch.setattr(ops, "_has_command", only)
+        monkeypatch.setattr(ops, "_zero_match_probe", lambda *a, **k: "SENTINEL_HINT")
+        r = ops.search("token_alpha", path=str(proj / "proj"), target="content")
+        assert r.total_count == 0
+        assert "SENTINEL_HINT" in (r.warning or ""), (
+            f"zero-match hint not wired on the {engine} path: warning={r.warning!r}"
+        )
+
+    def test_hint_not_attached_when_matches_exist(self, proj, monkeypatch):
+        from tools.file_tools import _get_file_ops
+
+        ops = _get_file_ops(task_id="t-parity-hit")
+        monkeypatch.setattr(ops, "_zero_match_probe", lambda *a, **k: "SENTINEL_HINT")
+        r = ops.search("TOKEN_ALPHA", path=str(proj / "proj"), target="content")
+        assert r.total_count > 0
+        assert "SENTINEL_HINT" not in (r.warning or "")
+
+    def test_rg_path_still_skips_line_oriented_newline_warning(self, proj):
+        """The early return existed to skip a grep-only warning — keep that.
+
+        rg auto-enables --multiline for ``\\n`` patterns, so the line-oriented
+        explanation must not be attached on the rg path. A fix that merely
+        deleted the early return would regress this.
+        """
+        from tools.file_tools import _get_file_ops
+
+        ops = _get_file_ops(task_id="t-parity-nl")
+        if not ops._has_command("rg"):
+            pytest.skip("rg not installed")
+        r = ops.search("TOKEN_ALPHA\\nother", path=str(proj / "proj"), target="content")
+        assert "line-oriented" not in (r.warning or "")


### PR DESCRIPTION
## Summary
The zero-match search steering tier now has a regression guard: reintroducing the early return that killed it turns 4 tests red instead of shipping silently.

Follow-up to #77128, which fixed the orphaned code path but shipped no tests — so a fourth commit could re-orphan it exactly the same way.

## Background
Three commits landed within three minutes on Aug 2:

```
15:10  5797b50288  feat(search): zero-match probes and multi-path recovery      <- probe block added
15:10  e7aa06c3a6  feat(search): hidden/gitignored probe on zero-match results
15:13  1cefabc8af  feat(search): auto-enable multiline mode for newline patterns <- added early return
```

The last one added `return result` to the ripgrep branch of `_search_content`, which orphaned the probe block sitting after the grep call. Result: the entire zero-match steering tier was unreachable for every user with ripgrep installed — a bare `{"total_count": 0}` with no hint, reproducible on a pristine `origin/main` worktree. The feature's own three tests were reporting its absence as plain assertion failures.

## Changes
- `tests/tools/test_search_zero_match_and_multipath.py`: new `TestZeroMatchProbeEngineParity` — 4 tests.
  - Hint wiring is asserted **per search engine** (parametrized rg / grep), with `_zero_match_probe` stubbed to a sentinel. This isolates the wiring rather than the probe's own dependency: the probe shells out to rg by design (bounded, count-only), so a grep-only host gets no hints even when wiring is correct, and a naive parity test asserting real hint text fails on the grep leg for an unrelated reason.
  - Negative case: no hint attached when matches exist.
  - The rg path must still skip the line-oriented `\n` warning — that skip is *why* the early return existed, so a fix that merely deleted it would regress. Guarded explicitly.

## Validation
| | Result |
|---|---|
| Suite on merged #77128 | 15/15 pass |
| Sabotage: restore the early return | 4 tests RED |
| Sabotage: naive fix (drop early return AND the rg newline guard) | 1 test RED |
| Sabotage: attach hint even when matches exist | 2 tests RED |

No production code touched.

## Infographic

![zero-match probe regression guard](https://v3b.fal.media/files/b/0aa4c706/_oCc2pK_I6wW9pbIpBmQU_W9HSp0Ek.png)
