### PR TITLE
fix(install): symlink hermes-acp alongside hermes

### DIFF
--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -354,6 +354,17 @@ mkdir -p "$COMMAND_LINK_DIR"
 ln -sf "$HERMES_BIN" "$COMMAND_LINK_DIR/hermes"
 echo -e "${GREEN}✓${NC} Symlinked hermes → $COMMAND_LINK_DISPLAY_DIR/hermes"
 
+# The `acp` extra is part of the standard install (see _ALL_EXTRAS above),
+# so venv/bin/hermes-acp exists on nearly every setup. Symlink it out too —
+# ACP-speaking editors/clients (Zed, VS Code, Buzz, etc.) look for
+# `hermes-acp` on PATH and otherwise report Hermes as "not installed" even
+# though the adapter is already present.
+HERMES_ACP_BIN="$SCRIPT_DIR/venv/bin/hermes-acp"
+if [ -f "$HERMES_ACP_BIN" ]; then
+    ln -sf "$HERMES_ACP_BIN" "$COMMAND_LINK_DIR/hermes-acp"
+    echo -e "${GREEN}✓${NC} Symlinked hermes-acp → $COMMAND_LINK_DISPLAY_DIR/hermes-acp"
+fi
+
 if is_termux; then
     export PATH="$COMMAND_LINK_DIR:$PATH"
     echo -e "${GREEN}✓${NC} $COMMAND_LINK_DISPLAY_DIR is already on PATH in Termux"

--- a/tests/hermes_cli/test_setup_hermes_script.py
+++ b/tests/hermes_cli/test_setup_hermes_script.py
@@ -18,3 +18,78 @@ def test_setup_hermes_script_has_termux_path():
     assert ".[termux]" in content
     assert "constraints-termux.txt" in content
     assert "$PREFIX/bin" in content
+
+
+def _extract_shell_region(start_pattern: str, end_pattern: str) -> str:
+    """Pull a region out of setup-hermes.sh by awk-matching comment/code
+    anchors rather than hardcoded line numbers, so the extraction survives
+    unrelated edits to the script."""
+    result = subprocess.run(
+        [
+            "awk",
+            f"/{start_pattern}/{{p=1}} p{{if(/{end_pattern}/) exit; print}}",
+            str(SETUP_SCRIPT),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _run_symlink_block(tmp_path: Path, create_acp_bin: bool) -> Path:
+    """Run just setup-hermes.sh's command-link functions plus the PATH-setup
+    symlink block (not the whole script — that does a full venv + all-extras
+    install and takes minutes) against a fake SCRIPT_DIR/HOME, and return the
+    fake HOME's ~/.local/bin dir for the caller to inspect."""
+    repo_dir = tmp_path / "repo"
+    home_dir = tmp_path / "home"
+    venv_bin = repo_dir / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    (venv_bin / "hermes").write_text("#!/bin/sh\n")
+    if create_acp_bin:
+        (venv_bin / "hermes-acp").write_text("#!/bin/sh\n")
+
+    functions = _extract_shell_region(r"^is_termux\(\) \{", r"^get_command_link_display_dir\(\) \{")
+    # The end-pattern above stops one function short (it's also a start
+    # anchor), so pull get_command_link_display_dir separately and append it.
+    display_dir_fn = _extract_shell_region(r"^get_command_link_display_dir\(\) \{", r"^\}$")
+    functions += display_dir_fn + "}\n"
+
+    symlink_block = _extract_shell_region(
+        r"# PATH setup — symlink hermes into a user-facing bin dir", r"^if is_termux; then$"
+    )
+
+    fragment = "#!/bin/bash\nset -e\n" + functions + f'\nSCRIPT_DIR="{repo_dir}"\n' + symlink_block
+    script_path = tmp_path / "symlink_block.sh"
+    script_path.write_text(fragment)
+
+    env = {"HOME": str(home_dir), "PATH": "/usr/bin:/bin"}
+    result = subprocess.run(
+        ["bash", str(script_path)], capture_output=True, text=True, env=env
+    )
+    assert result.returncode == 0, result.stderr
+
+    return home_dir / ".local" / "bin"
+
+
+def test_setup_hermes_script_symlinks_hermes_acp_when_present(tmp_path):
+    command_link_dir = _run_symlink_block(tmp_path, create_acp_bin=True)
+
+    hermes_link = command_link_dir / "hermes"
+    acp_link = command_link_dir / "hermes-acp"
+
+    assert hermes_link.is_symlink()
+    assert acp_link.is_symlink()
+    assert acp_link.resolve() == (tmp_path / "repo" / "venv" / "bin" / "hermes-acp").resolve()
+
+
+def test_setup_hermes_script_skips_hermes_acp_when_absent(tmp_path):
+    command_link_dir = _run_symlink_block(tmp_path, create_acp_bin=False)
+
+    hermes_link = command_link_dir / "hermes"
+    acp_link = command_link_dir / "hermes-acp"
+
+    assert hermes_link.is_symlink()
+    assert not acp_link.exists()
+    assert not acp_link.is_symlink()


### PR DESCRIPTION
## Summary
- `venv/bin/hermes-acp` already exists after a standard install (the `acp` extra is part of `_ALL_EXTRAS`), but `setup-hermes.sh` only symlinks the main `hermes` CLI into `~/.local/bin`.
- ACP-speaking clients (Zed, VS Code, Buzz, etc.) look for `hermes-acp` on `PATH` and report Hermes as not installed even though the adapter is already present.
- This adds the same symlink treatment for `hermes-acp`, guarded by an existence check.

## Test plan
- [x] Ran `setup-hermes.sh` against unmodified `main` with an isolated `HOME` — confirmed only `hermes` gets symlinked into `~/.local/bin`, `hermes-acp` is not, even though `venv/bin/hermes-acp` exists.
- [x] Ran `setup-hermes.sh` from this branch with an isolated `HOME` — confirmed `~/.local/bin/hermes-acp -> venv/bin/hermes-acp` is created and `hermes-acp --check` passes.
- [x] Added isolated behavioral tests (`tests/hermes_cli/test_setup_hermes_script.py`) that extract the symlink-creation logic and verify the launcher is created/skipped based on whether `venv/bin/hermes-acp` exists; confirmed they fail against the pre-fix script and pass against the fix.
- [x] `scripts/run_tests.sh tests/hermes_cli/test_setup_hermes_script.py` — 4/4 passing under the hermetic CI-matching runner.
- [x] `scripts/check-windows-footguns.py --diff origin/main` — clean.

## Platforms tested
- macOS (Apple Silicon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)