### PR TITLE
feat: enforce cross-profile execution provenance

### DIFF
--- a/docs/execution-provenance.md
+++ b/docs/execution-provenance.md
@@ -1,0 +1,47 @@
+# Cross-Profile Execution Provenance
+
+> **Audience:** Gateway operators and contributors
+> **Source files:** `hermes_cli/execution_provenance.py`, `hermes_cli/main.py`, `hermes_cli/kanban_db.py`, `gateway/slash_commands.py`
+
+## Purpose
+
+Hermes profiles isolate memory, configuration, and runtime state. A noninteractive agent process that selects a different profile can otherwise look like an ordinary human `hermes -p <profile>` invocation. The profile entry-point gate distinguishes those paths, rejects cross-profile agent work without bounded authority, and writes accepted launches to one shared provenance ledger.
+
+This is a **same-user policy boundary**, not hostile-process isolation. A process running as the same operating-system user can alter its environment and files. The gate prevents untracked Hermes launch paths and provides auditable provenance; it does not provide a cryptographic trust boundary.
+
+## Behavior
+
+- Same-profile commands remain unchanged.
+- Read-only administrative inspection, such as `gateway status`, remains available across profiles.
+- Human profile selection remains available when stdin is an interactive terminal and no noninteractive prompt flag is present.
+- Noninteractive cross-profile agent execution fails closed unless it has either:
+  - live matching Kanban task/run/claim custody; or
+  - a bounded, expiring, one-shot direct-authority record.
+- Prompt bodies and conventionally sensitive command-line values are redacted before ledger storage.
+- One-shot execution IDs are atomically consumed in durable marker files before the ledger row is appended. Replays are rejected even if a later ledger write fails.
+
+Kanban source labels are audit context only. Authorization is established by read-only verification of the live canonical Kanban database: assignee, active run, claim lock, claim expiry, status, and worker PID compatibility must agree.
+
+## Internal execution contract
+
+The launcher and Kanban dispatcher pass authority and custody fields to the child process through internal environment variables. These variables are an execution transport contract, **not user configuration** and must not be placed in `.env` or documented as operator-set feature flags.
+
+The normal operator interface remains `hermes -p <profile> ...`. Behavioral configuration remains in `config.yaml`.
+
+## Ledger and visibility
+
+The ledger is stored at:
+
+```text
+<canonical Hermes root>/execution-provenance.jsonl
+```
+
+Named profile homes therefore fan into the same root ledger. Accepted records include source, authority class/reference, target, redacted execution path, Kanban tracking, scope, one-shot/expiry fields, evidence, terminal condition, PID, start time, and observed state.
+
+Recent bounded records appear in gateway `/status` output. Status reads only a bounded tail of the ledger, ignores oversized rows, sanitizes control characters, and applies per-field, per-line, record-count, and total-size bounds so malformed or oversized ledger values cannot break platform status delivery.
+
+The ledger is append-only in this implementation. There is no automatic retention or migration policy; operators may archive it while no launch is being recorded. Malformed JSONL rows are ignored by status readers and cause new authority consumption to fail closed until the audit history is repaired.
+
+## Failure behavior
+
+The gate exits with code `77` when authority is missing, malformed, expired, mismatched, replayed, or not backed by live Kanban custody. It also fails closed when the custody database or cross-process locking facility is unavailable.

--- a/docs/profile-routing.md
+++ b/docs/profile-routing.md
@@ -2,7 +2,7 @@
 
 > **Audience:** Gateway operators and contributors
 > **Source files:** `gateway/profile_routing.py`, `gateway/run.py` (`_profile_name_for_source`), `gateway/platforms/base.py` (`build_source`), `gateway/config.py`
-> **Related:** [Session Lifecycle](session-lifecycle.md), `docs/design/profile-builder.md`
+> **Related:** [Session Lifecycle](session-lifecycle.md), [Cross-Profile Execution Provenance](execution-provenance.md), `docs/design/profile-builder.md`
 
 ## Overview
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -710,6 +710,17 @@ class GatewaySlashCommandsMixin:
             t("gateway.status.platforms", platforms=', '.join(connected_platforms)),
         ])
 
+        # Include shared cross-profile execution custody so direct/untracked
+        # work cannot disappear behind this profile-local status view.
+        try:
+            from hermes_cli.execution_provenance import format_execution_status
+
+            execution_lines = format_execution_status()
+        except Exception:
+            execution_lines = ["Execution provenance unavailable"]
+        if execution_lines:
+            lines.extend(["", "Cross-profile executions:", *execution_lines])
+
         return "\n".join(lines)
 
     @staticmethod

--- a/hermes_cli/execution_provenance.py
+++ b/hermes_cli/execution_provenance.py
@@ -1,0 +1,611 @@
+"""Structured provenance and visibility for bounded cross-profile executions.
+
+This is a same-user policy boundary, not hostile-process isolation. A process
+running as the same OS user can alter its environment or the ledger. The
+module provides fail-closed Hermes entry-point enforcement and an auditable
+record, but does not claim cryptographic authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import shlex
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+import psutil
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - non-Windows
+    msvcrt = None
+
+_REQUIRED_DIRECT_FIELDS = {
+    "authority_class",
+    "authority_reference",
+    "source",
+    "target",
+    "scope",
+    "one_shot",
+    "expires_at",
+    "execution_id",
+    "evidence",
+    "terminal_condition",
+}
+_READ_ONLY_FORMS = {
+    ("gateway", "status"),
+    ("gateway", "health"),
+    ("profile", "list"),
+    ("kanban", "list"),
+    ("kanban", "show"),
+    ("kanban", "log"),
+    ("kanban", "stats"),
+    ("session", "list"),
+    ("session", "search"),
+}
+_PROMPT_FLAGS = {"-q", "--query", "-z", "--oneshot", "--prompt"}
+_AGENT_MODE_FLAGS = _PROMPT_FLAGS | {"-c", "--continue", "-r", "--resume", "--tui"}
+_TOP_LEVEL_VALUE_FLAGS = {
+    "-p",
+    "--profile",
+    "-m",
+    "--model",
+    "--provider",
+    "--reasoning",
+    "-t",
+    "--toolsets",
+    "-s",
+    "--skills",
+    "--usage-file",
+}
+_SENSITIVE_ARG_TERMS = {
+    "authorization",
+    "cookie",
+    "credential",
+    "credentials",
+    "passphrase",
+    "passwd",
+    "password",
+    "secret",
+    "token",
+}
+_SENSITIVE_KEY_PREFIXES = {
+    "access",
+    "api",
+    "auth",
+    "authentication",
+    "client",
+    "encryption",
+    "private",
+    "secret",
+    "signing",
+    "webhook",
+}
+_EXACT_SENSITIVE_OPTIONS = {
+    "--authority",
+    "--body",
+    "--content",
+    "--message",
+    "--system-prompt",
+}
+
+
+class ExecutionAuthorityError(RuntimeError):
+    """Raised when a cross-profile execution lacks valid bounded authority."""
+
+
+def _ledger_path() -> Path:
+    from hermes_constants import get_default_hermes_root
+
+    return get_default_hermes_root() / "execution-provenance.jsonl"
+
+
+def _kanban_db_path() -> Path:
+    from hermes_constants import get_default_hermes_root
+
+    return get_default_hermes_root() / "kanban.db"
+
+
+def _command_and_args(argv: list[str]) -> tuple[str | None, list[str]]:
+    """Return the real top-level command without treating values as commands."""
+    args = list(argv[1:])
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        option = arg.split("=", 1)[0]
+        if option in _AGENT_MODE_FLAGS:
+            return "__agent__", []
+        if option in _TOP_LEVEL_VALUE_FLAGS:
+            index += 1 if "=" in arg else 2
+            continue
+        if arg.startswith("-"):
+            index += 1
+            continue
+        return arg, args[index + 1 :]
+    return None, []
+
+
+def is_read_only_invocation(argv: list[str]) -> bool:
+    command, args = _command_and_args(argv)
+    return command is not None and bool(args) and (command, args[0]) in _READ_ONLY_FORMS
+
+
+def is_agent_invocation(argv: list[str]) -> bool:
+    command, _args = _command_and_args(argv)
+    return command in {None, "__agent__", "chat"}
+
+
+def _is_noninteractive(argv: list[str]) -> bool:
+    return any(
+        arg in _PROMPT_FLAGS or arg.startswith(("--query=", "--oneshot=", "--prompt="))
+        for arg in argv[1:]
+    )
+
+
+def _is_sensitive_option(arg: str) -> bool:
+    """Return whether a long option name conventionally carries secret material."""
+    if not arg.startswith("--"):
+        return False
+    option = arg.split("=", 1)[0]
+    if option in _EXACT_SENSITIVE_OPTIONS:
+        return True
+    name = option[2:].lower().replace("_", "-")
+    terms = [term for term in name.split("-") if term]
+    if not terms:
+        return False
+    if terms[-1] in _SENSITIVE_ARG_TERMS:
+        return True
+    return terms[-1] == "key" and any(
+        term in _SENSITIVE_KEY_PREFIXES for term in terms[:-1]
+    )
+
+
+def _redacted_execution_path(argv: list[str]) -> str:
+    safe = list(argv)
+    redact_next = False
+    for index, arg in enumerate(safe):
+        if redact_next:
+            safe[index] = "[REDACTED]"
+            redact_next = False
+            continue
+        option, separator, _value = arg.partition("=")
+        if option in _PROMPT_FLAGS or _is_sensitive_option(option):
+            if separator:
+                safe[index] = option + "=[REDACTED]"
+            elif index + 1 < len(safe):
+                redact_next = True
+    return shlex.join(safe)
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    return bool(psutil.pid_exists(pid))
+
+
+_STATUS_MAX_BYTES = 256 * 1024
+_STATUS_MAX_ROWS = 50
+_STATUS_MAX_LINE_BYTES = 16 * 1024
+
+
+def _load_rows(
+    path: Path,
+    *,
+    max_bytes: int = _STATUS_MAX_BYTES,
+    max_rows: int = _STATUS_MAX_ROWS,
+    max_line_bytes: int = _STATUS_MAX_LINE_BYTES,
+) -> list[dict[str, Any]]:
+    """Read a bounded tail of the ledger for synchronous status rendering."""
+    try:
+        size = path.stat().st_size
+        start = max(0, size - max_bytes)
+        with path.open("rb") as handle:
+            handle.seek(start)
+            data = handle.read(max_bytes)
+    except OSError:
+        return []
+    if start:
+        separator = data.find(b"\n")
+        if separator < 0:
+            return []
+        data = data[separator + 1 :]
+
+    rows: list[dict[str, Any]] = []
+    for raw_line in data.splitlines()[-max_rows:]:
+        if not raw_line or len(raw_line) > max_line_bytes:
+            continue
+        try:
+            value = json.loads(raw_line.decode("utf-8", errors="replace"))
+        except (json.JSONDecodeError, UnicodeError):
+            continue
+        if isinstance(value, dict):
+            rows.append(value)
+    return rows
+
+
+def _write_all(fd: int, data: bytes) -> None:
+    """Write every byte or fail; os.write is permitted to short-write."""
+    offset = 0
+    while offset < len(data):
+        written = os.write(fd, data[offset:])
+        if written <= 0:
+            raise OSError("zero-length ledger write")
+        offset += written
+
+
+def _fsync_directory(path: Path) -> None:
+    """Persist directory entries on POSIX after creating audit artifacts."""
+    if (
+        os.name == "nt"
+    ):  # File fsync persists NTFS file metadata; directories cannot be os.open'ed.
+        return
+    directory_fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def _consumption_marker_path(path: Path, execution_id: str) -> Path:
+    digest = hashlib.sha256(execution_id.encode("utf-8")).hexdigest()
+    return path.with_name(path.name + ".consumed") / digest
+
+
+def _append_row_once(path: Path, row: dict[str, Any], *, reject_replay: bool) -> None:
+    """Persist an audit row while atomically consuming one-shot IDs."""
+    try:
+        payload = (json.dumps(row, sort_keys=True, allow_nan=False) + "\n").encode(
+            "utf-8"
+        )
+    except (TypeError, ValueError) as exc:
+        raise ExecutionAuthorityError("execution record is not finite JSON") from exc
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ledger_existed = path.exists()
+    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+    windows_lock_fd: int | None = None
+    marker_fd: int | None = None
+    locked = False
+    original_size = 0
+    append_started = False
+    try:
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            locked = True
+        elif msvcrt is not None:  # pragma: no cover - Windows
+            lock_path = path.with_name(path.name + ".lock")
+            windows_lock_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+            if os.fstat(windows_lock_fd).st_size == 0:
+                _write_all(windows_lock_fd, b"\0")
+            os.lseek(windows_lock_fd, 0, os.SEEK_SET)
+            getattr(msvcrt, "locking")(windows_lock_fd, getattr(msvcrt, "LK_LOCK"), 1)
+            locked = True
+        else:  # pragma: no cover - unsupported Python platform
+            raise ExecutionAuthorityError("cross-process ledger locking is unavailable")
+
+        original_size = os.fstat(fd).st_size
+        execution_id = str(row.get("execution_id"))
+        marker_path: Path | None = None
+        if reject_replay:
+            marker_path = _consumption_marker_path(path, execution_id)
+            if marker_path.exists():
+                raise ExecutionAuthorityError("one-shot execution ID already used")
+
+            # Preserve compatibility with ledgers written before durable marker
+            # files existed and fail closed on ambiguous/corrupt audit history.
+            with os.fdopen(os.dup(fd), "rb") as prior_handle:
+                prior_handle.seek(0)
+                while prior_handle.tell() < original_size:
+                    raw_line = prior_handle.readline(_STATUS_MAX_LINE_BYTES + 1)
+                    if len(raw_line) > _STATUS_MAX_LINE_BYTES or not raw_line.endswith(
+                        b"\n"
+                    ):
+                        raise ExecutionAuthorityError(
+                            "execution ledger integrity check failed"
+                        )
+                    if not raw_line.strip():
+                        continue
+                    try:
+                        value = json.loads(raw_line.decode("utf-8", errors="strict"))
+                    except (json.JSONDecodeError, UnicodeError) as exc:
+                        raise ExecutionAuthorityError(
+                            "execution ledger integrity check failed"
+                        ) from exc
+                    if (
+                        isinstance(value, dict)
+                        and str(value.get("execution_id")) == execution_id
+                    ):
+                        raise ExecutionAuthorityError(
+                            "one-shot execution ID already used"
+                        )
+
+            marker_directory = marker_path.parent
+            marker_directory_existed = marker_directory.exists()
+            marker_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+            if not marker_directory_existed:
+                _fsync_directory(marker_directory.parent)
+            try:
+                marker_fd = os.open(
+                    marker_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600
+                )
+            except FileExistsError as exc:
+                raise ExecutionAuthorityError(
+                    "one-shot execution ID already used"
+                ) from exc
+            _write_all(marker_fd, (execution_id + "\n").encode("utf-8"))
+            os.fsync(marker_fd)
+            os.close(marker_fd)
+            marker_fd = None
+            _fsync_directory(marker_directory)
+
+        os.lseek(fd, 0, os.SEEK_END)
+        append_started = True
+        _write_all(fd, payload)
+        os.fsync(fd)
+        if not ledger_existed:
+            _fsync_directory(path.parent)
+    except OSError as exc:
+        if append_started:
+            try:
+                os.ftruncate(fd, original_size)
+                os.fsync(fd)
+            except OSError:
+                pass
+        raise ExecutionAuthorityError("execution record persistence failed") from exc
+    finally:
+        if marker_fd is not None:
+            os.close(marker_fd)
+        if locked and fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        elif (
+            locked and msvcrt is not None and windows_lock_fd is not None
+        ):  # pragma: no cover
+            os.lseek(windows_lock_fd, 0, os.SEEK_SET)
+            getattr(msvcrt, "locking")(windows_lock_fd, getattr(msvcrt, "LK_UNLCK"), 1)
+        if windows_lock_fd is not None:
+            os.close(windows_lock_fd)
+        os.close(fd)
+
+
+def _is_finite_future(value: Any, now: float) -> bool:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
+    return math.isfinite(numeric) and numeric > now
+
+
+def _validate_kanban_custody(
+    *,
+    source: str,
+    target: str,
+    task_id: str,
+    run_id: str,
+    claim_lock: str,
+    db_path: Path,
+    pid: int,
+) -> None:
+    del source  # Source labels are audit context; live custody is authoritative.
+    if not db_path.is_file():
+        raise ExecutionAuthorityError("Kanban custody database is unavailable")
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        task = conn.execute(
+            "SELECT assignee, status, claim_lock, claim_expires, current_run_id, worker_pid "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        run = conn.execute(
+            "SELECT task_id, profile, status, claim_lock, claim_expires, worker_pid "
+            "FROM task_runs WHERE id = ?",
+            (int(run_id),),
+        ).fetchone()
+        conn.close()
+    except (OSError, sqlite3.Error, TypeError, ValueError) as exc:
+        raise ExecutionAuthorityError("Kanban custody lookup failed closed") from exc
+    now = time.time()
+    valid = (
+        task is not None
+        and run is not None
+        and task["assignee"] == target
+        and run["profile"] == target
+        and task["status"] == "running"
+        and run["status"] == "running"
+        and str(task["current_run_id"]) == str(run_id)
+        and run["task_id"] == task_id
+        and task["claim_lock"] == claim_lock
+        and run["claim_lock"] == claim_lock
+        and _is_finite_future(task["claim_expires"], now)
+        and _is_finite_future(run["claim_expires"], now)
+        and all(
+            value in (None, pid) for value in (task["worker_pid"], run["worker_pid"])
+        )
+    )
+    if not valid:
+        raise ExecutionAuthorityError(
+            "Kanban custody does not match the active assigned run"
+        )
+
+
+def authorize_profile_execution(
+    *,
+    source: str,
+    target: str,
+    argv: list[str],
+    authority_json: str | None,
+    interactive: bool = False,
+    ledger_path: Path | None = None,
+    kanban_task: str | None = None,
+    kanban_run: str | None = None,
+    kanban_claim_lock: str | None = None,
+    kanban_db_path: Path | None = None,
+    pid: int | None = None,
+) -> dict[str, Any] | None:
+    """Authorize and record a cross-profile agent execution."""
+    source = str(source or "").strip()
+    target = str(target or "").strip()
+    if (
+        not source
+        or not target
+        or source == target
+        or not is_agent_invocation(argv)
+        or is_read_only_invocation(argv)
+    ):
+        return None
+    if interactive and not _is_noninteractive(argv):
+        return None
+
+    path = ledger_path or _ledger_path()
+    now = time.time()
+    if kanban_task and kanban_run and kanban_claim_lock:
+        db_path = kanban_db_path or Path(
+            os.environ.get("HERMES_KANBAN_DB") or _kanban_db_path()
+        )
+        _validate_kanban_custody(
+            source=source,
+            target=target,
+            task_id=kanban_task,
+            run_id=kanban_run,
+            claim_lock=kanban_claim_lock,
+            db_path=db_path,
+            pid=int(pid or os.getpid()),
+        )
+        record: dict[str, Any] = {
+            "authority_class": "kanban_dispatch",
+            "authority_reference": f"kanban:{kanban_task}:run:{kanban_run}",
+            "source": source,
+            "target": target,
+            "scope": f"assigned Kanban task {kanban_task}",
+            "one_shot": True,
+            "expires_at": None,
+            "execution_id": f"kanban-{kanban_task}-run-{kanban_run}",
+            "evidence": f"kanban:{kanban_task}",
+            "terminal_condition": "Kanban terminal action or worker exit",
+        }
+    else:
+        if not authority_json:
+            raise ExecutionAuthorityError(
+                f"cross-profile execution {source}->{target} requires structured authority"
+            )
+        try:
+            parsed = json.loads(authority_json)
+        except json.JSONDecodeError as exc:
+            raise ExecutionAuthorityError(
+                "structured authority is not valid JSON"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise ExecutionAuthorityError("structured authority must be a JSON object")
+        missing = sorted(_REQUIRED_DIRECT_FIELDS - parsed.keys())
+        if missing:
+            raise ExecutionAuthorityError(
+                f"structured authority missing: {', '.join(missing)}"
+            )
+        record = dict(parsed)
+        for field in _REQUIRED_DIRECT_FIELDS - {"one_shot", "expires_at"}:
+            if not str(record[field]).strip():
+                raise ExecutionAuthorityError(
+                    f"authority field {field} must not be empty"
+                )
+        if record["authority_class"] != "direct_one_shot":
+            raise ExecutionAuthorityError("authority class must be direct_one_shot")
+        if record["source"] != source:
+            raise ExecutionAuthorityError("authority source mismatch")
+        if record["target"] != target:
+            raise ExecutionAuthorityError("authority target mismatch")
+        if record["one_shot"] is not True:
+            raise ExecutionAuthorityError("direct exception must be one-shot")
+        try:
+            expires_at = float(record["expires_at"])
+        except (TypeError, ValueError) as exc:
+            raise ExecutionAuthorityError(
+                "authority expiry must be a Unix timestamp"
+            ) from exc
+        if not math.isfinite(expires_at):
+            raise ExecutionAuthorityError("authority expiry must be finite")
+        if expires_at <= now:
+            raise ExecutionAuthorityError("structured authority expired")
+
+    record.update({
+        "execution_path": _redacted_execution_path(argv),
+        "kanban_tracked": bool(kanban_task and kanban_run),
+        "pid": int(pid or os.getpid()),
+        "started_at": now,
+        "state": "running",
+    })
+    _append_row_once(path, record, reject_replay=True)
+    return record
+
+
+def _coerce_number(value: Any, *, integer: bool = False) -> int | float:
+    try:
+        numeric = int(value) if integer else float(value)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+    if not integer and not math.isfinite(numeric):
+        return 0
+    return numeric
+
+
+def list_execution_status(*, ledger_path: Path | None = None) -> list[dict[str, Any]]:
+    rows = _load_rows(ledger_path or _ledger_path())
+    for row in rows:
+        if row.get("state") == "running" and not _pid_alive(
+            int(_coerce_number(row.get("pid"), integer=True))
+        ):
+            row["state"] = "terminal"
+    return sorted(
+        rows,
+        key=lambda row: float(_coerce_number(row.get("started_at"))),
+        reverse=True,
+    )
+
+
+def _bounded_status_value(value: Any, *, max_chars: int = 32) -> str:
+    """Render one ledger field as bounded, single-line, printable status text."""
+    text = " ".join(str(value).split())
+    text = "".join(char for char in text if char.isprintable()) or "unknown"
+    if len(text) > max_chars:
+        return text[: max_chars - 1] + "…"
+    return text
+
+
+def format_execution_status(
+    *, ledger_path: Path | None = None, limit: int = 10, max_total_chars: int = 1200
+) -> list[str]:
+    """Return bounded status lines safe to append to gateway status responses."""
+    lines: list[str] = []
+    total_chars = 0
+    for row in list_execution_status(ledger_path=ledger_path)[: max(0, min(limit, 10))]:
+        tracked = "yes" if row.get("kanban_tracked") else "no"
+        line = (
+            "Execution "
+            f"{_bounded_status_value(row.get('execution_id', 'unknown'))}: "
+            f"source={_bounded_status_value(row.get('source', 'unknown'))} "
+            f"authority={_bounded_status_value(row.get('authority_class', 'unknown'))}/"
+            f"{_bounded_status_value(row.get('authority_reference', 'unknown'))} "
+            f"target={_bounded_status_value(row.get('target', 'unknown'))} "
+            f"path={_bounded_status_value(row.get('execution_path', 'unknown'), max_chars=64)} "
+            f"kanban={tracked} scope={_bounded_status_value(row.get('scope', 'unknown'))} "
+            f"one_shot={_bounded_status_value(row.get('one_shot', 'unknown'))} "
+            f"expires={_bounded_status_value(row.get('expires_at', 'none'))} "
+            f"evidence={_bounded_status_value(row.get('evidence', 'unknown'))} "
+            f"terminal={_bounded_status_value(row.get('terminal_condition', 'unknown'))} "
+            f"state={_bounded_status_value(row.get('state', 'unknown'))}"
+        )
+        line = line[:600]
+        added_chars = len(line) + (1 if lines else 0)
+        if total_chars + added_chars > max_total_chars:
+            break
+        lines.append(line)
+        total_chars += added_chars
+    return lines

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8996,6 +8996,17 @@ def _default_spawn(
     for key in _VAR_MAP:
         env.pop(key, None)
 
+    # Preserve the actual dispatcher's profile before HERMES_PROFILE is changed
+    # to the worker assignee below. Source labels are audit context; live
+    # Kanban custody remains the authorization boundary.
+    from hermes_cli.profiles import get_active_profile_name, resolve_profile_env
+
+    env["HERMES_DISPATCH_SOURCE_PROFILE"] = (
+        os.environ.get("HERMES_PROFILE")
+        or get_active_profile_name()
+        or "default"
+    )
+
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml
     # (fallback_providers, toolsets, agent settings, etc.) instead of the root
     # config.  Without this, `env = dict(os.environ)` copies only the parent's
@@ -9005,7 +9016,6 @@ def _default_spawn(
     # back to Path.home() / ".hermes" (the DEFAULT profile root), ignoring the
     # profile-specific config entirely.  Fixes profile-scoped fallback_providers
     # being invisible to kanban workers.
-    from hermes_cli.profiles import resolve_profile_env
     try:
         env["HERMES_HOME"] = resolve_profile_env(profile_arg)
     except FileNotFoundError:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -514,6 +514,45 @@ _ensure_project_root_on_path_fast()
 # The flag is stripped from sys.argv so argparse never sees it.
 # Falls back to ~/.hermes/active_profile for sticky default.
 # ---------------------------------------------------------------------------
+def _profile_name_from_home(value: str | None) -> str:
+    """Return a profile identity from a profile-scoped HERMES_HOME."""
+    if not value:
+        return ""
+    path = Path(value)
+    if path.parent.name == "profiles":
+        return path.name
+    return "default" if path.name == ".hermes" else ""
+
+
+def _enforce_cross_profile_execution(target: str) -> None:
+    """Fail closed on unproven cross-profile agent launches and record valid ones."""
+    source = (
+        os.environ.get("HERMES_DISPATCH_SOURCE_PROFILE", "").strip()
+        or os.environ.get("HERMES_PROFILE", "").strip()
+        or _profile_name_from_home(os.environ.get("HERMES_HOME"))
+        or "external"
+    )
+    from hermes_cli.execution_provenance import (
+        ExecutionAuthorityError,
+        authorize_profile_execution,
+    )
+
+    try:
+        authorize_profile_execution(
+            source=source,
+            target=target,
+            argv=list(sys.argv),
+            authority_json=os.environ.get("HERMES_EXECUTION_AUTHORITY"),
+            interactive=sys.stdin.isatty(),
+            kanban_task=os.environ.get("HERMES_KANBAN_TASK"),
+            kanban_run=os.environ.get("HERMES_KANBAN_RUN_ID"),
+            kanban_claim_lock=os.environ.get("HERMES_KANBAN_CLAIM_LOCK"),
+        )
+    except ExecutionAuthorityError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(77) from exc
+
+
 def _apply_profile_override() -> None:
     """Pre-parse --profile/-p and set HERMES_HOME before imports."""
     argv = sys.argv[1:]
@@ -632,6 +671,7 @@ def _apply_profile_override() -> None:
     hermes_home_env = os.environ.get("HERMES_HOME", "")
     if profile_name is None and hermes_home_env:
         if Path(hermes_home_env).parent.name == "profiles":
+            _enforce_cross_profile_execution(Path(hermes_home_env).name)
             return
 
     # 2. If no flag, check active_profile in the hermes root.
@@ -661,6 +701,7 @@ def _apply_profile_override() -> None:
 
     # 3. If we found a profile, resolve and set HERMES_HOME
     if profile_name is not None:
+        _enforce_cross_profile_execution(profile_name)
         try:
             from hermes_cli.profiles import resolve_profile_env
 

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -11,10 +11,14 @@ active_profile (child-process inheritance contract).
 
 from __future__ import annotations
 
+import json
 import os
 import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
+
+import pytest
 
 
 def _run_apply_profile_override(
@@ -105,12 +109,107 @@ class TestApplyProfileOverrideHermesHomeGuard:
         monkeypatch.setattr(pwd, "getpwnam", lambda name: SimpleNamespace(pw_dir=str(user_home)))
 
         from hermes_cli.main import _apply_profile_override
+
         _apply_profile_override()
 
         assert os.environ.get("HERMES_HOME") == str(profile_dir)
         assert sys.argv == ["hermes", "gateway", "install", "--system"]
 
+    def test_unauthorized_external_noninteractive_profile_launch_is_rejected(
+        self, tmp_path, monkeypatch
+    ):
+        """An external unattended launch cannot cross profiles without authority."""
+        monkeypatch.delenv("HERMES_DISPATCH_SOURCE_PROFILE", raising=False)
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
 
+        with pytest.raises(SystemExit) as exc_info:
+            _run_apply_profile_override(
+                tmp_path,
+                monkeypatch,
+                hermes_home=None,
+                active_profile="coder",
+                argv=["hermes", "chat", "-p", "coder", "-q", "hello"],
+            )
+
+        assert exc_info.value.code == 77
+        assert sys.argv == ["hermes", "chat", "-p", "coder", "-q", "hello"]
+
+    def test_non_tty_interactive_form_still_fails_closed(
+        self, tmp_path, monkeypatch
+    ):
+        """A subprocess cannot bypass authority by omitting query flags."""
+        monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: False))
+        monkeypatch.delenv("HERMES_DISPATCH_SOURCE_PROFILE", raising=False)
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            _run_apply_profile_override(
+                tmp_path,
+                monkeypatch,
+                hermes_home=None,
+                active_profile="coder",
+                argv=["hermes", "chat", "-p", "coder"],
+            )
+
+        assert exc_info.value.code == 77
+
+    def test_human_interactive_profile_after_chat_is_consumed(
+        self, tmp_path, monkeypatch
+    ):
+        """Interactive profile selection remains intentional and consumes -p."""
+        monkeypatch.setattr(sys, "stdin", SimpleNamespace(isatty=lambda: True))
+        result = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile="coder",
+            argv=["hermes", "chat", "-p", "coder"],
+        )
+
+        assert result is not None
+        assert result.endswith("coder")
+        assert sys.argv == ["hermes", "chat"]
+
+    def test_direct_one_shot_noninteractive_profile_launch_records_redacted_prompt(
+        self, tmp_path, monkeypatch
+    ):
+        """Bounded direct authority permits the launch and records no prompt."""
+        sentinel = "DIRECT-PROMPT-SENTINEL"
+        authority = {
+            "authority_class": "direct_one_shot",
+            "authority_reference": "DEC-TEST-PROFILE-001",
+            "source": "external",
+            "target": "coder",
+            "scope": "one bounded profile integration test",
+            "one_shot": True,
+            "expires_at": time.time() + 300,
+            "execution_id": "profile-integration-exec-001",
+            "evidence": "test_apply_profile_override",
+            "terminal_condition": "test call returns",
+        }
+        monkeypatch.delenv("HERMES_DISPATCH_SOURCE_PROFILE", raising=False)
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+        monkeypatch.setenv("HERMES_EXECUTION_AUTHORITY", json.dumps(authority))
+
+        result = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile="coder",
+            argv=["hermes", "chat", "-p", "coder", "-q", sentinel],
+        )
+
+        ledger = tmp_path / ".hermes" / "execution-provenance.jsonl"
+        row = json.loads(ledger.read_text(encoding="utf-8").strip())
+        assert result is not None
+        assert result.endswith("coder")
+        assert sys.argv == ["hermes", "chat", "-q", sentinel]
+        assert row["authority_class"] == "direct_one_shot"
+        assert row["source"] == "external"
+        assert row["target"] == "coder"
+        assert sentinel not in row["execution_path"]
+        assert sentinel not in ledger.read_text(encoding="utf-8")
+        assert "[REDACTED]" in row["execution_path"]
 
 
 class TestSupervisedChildIgnoresStickyProfile:

--- a/tests/hermes_cli/test_execution_provenance.py
+++ b/tests/hermes_cli/test_execution_provenance.py
@@ -1,0 +1,835 @@
+"""Tests for bounded cross-profile execution provenance."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sqlite3
+import stat
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import hermes_cli.execution_provenance as provenance
+from hermes_cli.execution_provenance import (
+    ExecutionAuthorityError,
+    _ledger_path,
+    _redacted_execution_path,
+    authorize_profile_execution,
+    format_execution_status,
+    is_agent_invocation,
+    is_read_only_invocation,
+    list_execution_status,
+)
+
+
+def _authority(**overrides):
+    data = {
+        "authority_class": "direct_one_shot",
+        "authority_reference": "DEC-TEST-001",
+        "source": "csm",
+        "target": "s6",
+        "scope": "one bounded test",
+        "one_shot": True,
+        "expires_at": time.time() + 300,
+        "execution_id": "exec-test-001",
+        "evidence": "kanban:t_test",
+        "terminal_condition": "process exits",
+    }
+    data.update(overrides)
+    return data
+
+
+def _kanban_db(path: Path, *, assignee="s6", run_id=9, claim="claim-1", expiry=None):
+    conn = sqlite3.connect(path)
+    conn.executescript("""
+        CREATE TABLE tasks (id TEXT PRIMARY KEY, assignee TEXT, status TEXT,
+            claim_lock TEXT, claim_expires INTEGER, current_run_id INTEGER,
+            worker_pid INTEGER);
+        CREATE TABLE task_runs (id INTEGER PRIMARY KEY, task_id TEXT,
+            profile TEXT, status TEXT, claim_lock TEXT, claim_expires INTEGER,
+            worker_pid INTEGER);
+    """)
+    expiry = int(time.time()) + 300 if expiry is None else expiry
+    conn.execute(
+        "INSERT INTO tasks VALUES (?, ?, 'running', ?, ?, ?, NULL)",
+        ("t_1", assignee, claim, expiry, run_id),
+    )
+    conn.execute(
+        "INSERT INTO task_runs VALUES (?, 't_1', ?, 'running', ?, ?, NULL)",
+        (run_id, assignee, claim, expiry),
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def test_exact_direct_exception_is_recorded(tmp_path):
+    ledger = tmp_path / "executions.jsonl"
+    record = authorize_profile_execution(
+        source="csm",
+        target="s6",
+        argv=["hermes", "-p", "s6", "chat", "-q", "work"],
+        authority_json=json.dumps(_authority()),
+        ledger_path=ledger,
+        pid=os.getpid(),
+    )
+    assert record["authority_class"] == "direct_one_shot"
+    assert record["authority_reference"] == "DEC-TEST-001"
+    assert record["source"] == "csm"
+    assert record["target"] == "s6"
+    assert record["execution_path"] == "hermes -p s6 chat -q '[REDACTED]'"
+    assert record["kanban_tracked"] is False
+    assert record["state"] == "running"
+    assert (
+        list_execution_status(ledger_path=ledger)[0]["execution_id"] == "exec-test-001"
+    )
+
+
+def test_cli_subprocess_fails_closed_for_admin_token_prompt(tmp_path):
+    root = tmp_path / ".hermes"
+    (root / "profiles" / "coder").mkdir(parents=True)
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(root)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    for key in (
+        "HERMES_PROFILE",
+        "HERMES_DISPATCH_SOURCE_PROFILE",
+        "HERMES_EXECUTION_AUTHORITY",
+        "HERMES_KANBAN_TASK",
+        "HERMES_KANBAN_RUN_ID",
+        "HERMES_KANBAN_CLAIM_LOCK",
+    ):
+        env.pop(key, None)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "-p",
+            "coder",
+            "chat",
+            "-q",
+            "gateway",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode == 77
+    assert "requires structured authority" in completed.stderr
+
+
+def test_independent_cross_profile_chat_is_rejected(tmp_path):
+    with pytest.raises(ExecutionAuthorityError, match="structured authority"):
+        authorize_profile_execution(
+            source="csm",
+            target="s6",
+            argv=["python", "-m", "hermes_cli.main", "chat"],
+            authority_json=None,
+            ledger_path=tmp_path / "executions.jsonl",
+        )
+
+
+def test_mismatched_expired_and_replayed_authority_are_rejected(tmp_path):
+    ledger = tmp_path / "executions.jsonl"
+    with pytest.raises(ExecutionAuthorityError, match="target mismatch"):
+        authorize_profile_execution(
+            source="csm",
+            target="s7",
+            argv=["hermes", "chat"],
+            authority_json=json.dumps(_authority()),
+            ledger_path=ledger,
+        )
+    with pytest.raises(ExecutionAuthorityError, match="expired"):
+        authorize_profile_execution(
+            source="csm",
+            target="s6",
+            argv=["hermes", "chat"],
+            authority_json=json.dumps(_authority(expires_at=time.time() - 1)),
+            ledger_path=ledger,
+        )
+    payload = json.dumps(_authority())
+    authorize_profile_execution(
+        source="csm",
+        target="s6",
+        argv=["hermes", "chat"],
+        authority_json=payload,
+        ledger_path=ledger,
+    )
+    with pytest.raises(ExecutionAuthorityError, match="already used"):
+        authorize_profile_execution(
+            source="csm",
+            target="s6",
+            argv=["hermes", "chat"],
+            authority_json=payload,
+            ledger_path=ledger,
+        )
+
+
+@pytest.mark.parametrize("expires_at", [float("nan"), float("inf"), float("-inf")])
+def test_direct_authority_rejects_non_finite_expiry(tmp_path, expires_at):
+    with pytest.raises(ExecutionAuthorityError, match="finite"):
+        authorize_profile_execution(
+            source="csm",
+            target="s6",
+            argv=["hermes", "chat"],
+            authority_json=json.dumps(_authority(expires_at=expires_at)),
+            ledger_path=tmp_path / "executions.jsonl",
+        )
+
+
+def test_short_writes_are_completed_and_replay_stays_rejected(tmp_path, monkeypatch):
+    ledger = tmp_path / "executions.jsonl"
+    real_write = provenance.os.write
+
+    def short_write(fd, data):
+        return real_write(fd, data[: max(1, min(7, len(data)))])
+
+    monkeypatch.setattr(provenance.os, "write", short_write)
+    payload = json.dumps(_authority())
+    assert (
+        authorize_profile_execution(
+            source="csm",
+            target="s6",
+            argv=["hermes", "chat"],
+            authority_json=payload,
+            ledger_path=ledger,
+        )
+        is not None
+    )
+    assert (
+        json.loads(ledger.read_text(encoding="utf-8"))["execution_id"]
+        == "exec-test-001"
+    )
+    with pytest.raises(ExecutionAuthorityError, match="already used"):
+        authorize_profile_execution(
+            source="csm",
+            target="s6",
+            argv=["hermes", "chat"],
+            authority_json=payload,
+            ledger_path=ledger,
+        )
+
+
+def test_failed_ledger_append_still_consumes_one_shot_id(tmp_path, monkeypatch):
+    ledger = tmp_path / "executions.jsonl"
+    real_write_all = provenance._write_all
+
+    def fail_ledger_payload(fd, data):
+        if data.startswith(b"{"):
+            raise OSError("forced ledger append failure")
+        return real_write_all(fd, data)
+
+    monkeypatch.setattr(provenance, "_write_all", fail_ledger_payload)
+    payload = json.dumps(_authority())
+    with pytest.raises(ExecutionAuthorityError, match="persistence failed"):
+        authorize_profile_execution(
+            source="csm",
+            target="s6",
+            argv=["hermes", "chat"],
+            authority_json=payload,
+            ledger_path=ledger,
+        )
+    assert ledger.read_bytes() == b""
+    assert len(list(ledger.with_name(ledger.name + ".consumed").iterdir())) == 1
+    with pytest.raises(ExecutionAuthorityError, match="already used"):
+        authorize_profile_execution(
+            source="csm",
+            target="s6",
+            argv=["hermes", "chat"],
+            authority_json=payload,
+            ledger_path=ledger,
+        )
+
+
+def test_consumption_marker_directory_entries_are_fsynced(tmp_path, monkeypatch):
+    if os.name == "nt":
+        pytest.skip("POSIX directory fsync assertion")
+    ledger = tmp_path / "executions.jsonl"
+    real_fsync = provenance.os.fsync
+    fsync_modes: list[int] = []
+
+    def recording_fsync(fd):
+        fsync_modes.append(provenance.os.fstat(fd).st_mode)
+        return real_fsync(fd)
+
+    monkeypatch.setattr(provenance.os, "fsync", recording_fsync)
+    assert (
+        authorize_profile_execution(
+            source="csm",
+            target="s6",
+            argv=["hermes", "chat"],
+            authority_json=json.dumps(_authority()),
+            ledger_path=ledger,
+        )
+        is not None
+    )
+
+    assert sum(stat.S_ISDIR(mode) for mode in fsync_modes) >= 2
+
+
+def test_kanban_dispatch_is_allowed_and_visible(tmp_path):
+    ledger = tmp_path / "executions.jsonl"
+    record = authorize_profile_execution(
+        source="dispatcher",
+        target="s6",
+        argv=["hermes", "-p", "s6", "chat", "-q", "work kanban task t_1"],
+        authority_json=None,
+        ledger_path=ledger,
+        kanban_task="t_1",
+        kanban_run="9",
+        kanban_claim_lock="claim-1",
+        kanban_db_path=_kanban_db(tmp_path / "kanban.db"),
+    )
+    assert record is not None
+    assert record["authority_class"] == "kanban_dispatch"
+    assert record["authority_reference"] == "kanban:t_1:run:9"
+    assert record["kanban_tracked"] is True
+
+
+@pytest.mark.parametrize(
+    "target,run,claim",
+    [
+        ("s7", "9", "claim-1"),
+        ("s6", "8", "claim-1"),
+        ("s6", "9", "wrong"),
+    ],
+)
+def test_forged_or_inherited_kanban_custody_is_rejected(tmp_path, target, run, claim):
+    with pytest.raises(ExecutionAuthorityError):
+        authorize_profile_execution(
+            source="untrusted-label",
+            target=target,
+            argv=["hermes", "-p", target, "chat", "-q", "work"],
+            authority_json=None,
+            ledger_path=tmp_path / "ledger.jsonl",
+            kanban_task="t_1",
+            kanban_run=run,
+            kanban_claim_lock=claim,
+            kanban_db_path=_kanban_db(tmp_path / "kanban.db"),
+        )
+
+
+@pytest.mark.parametrize("expiry", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_kanban_claim_expiry_fails_closed(tmp_path, expiry):
+    with pytest.raises(ExecutionAuthorityError, match="custody"):
+        authorize_profile_execution(
+            source="dispatcher",
+            target="s6",
+            argv=["hermes", "-p", "s6", "chat", "-q", "work"],
+            authority_json=None,
+            ledger_path=tmp_path / "ledger.jsonl",
+            kanban_task="t_1",
+            kanban_run="9",
+            kanban_claim_lock="claim-1",
+            kanban_db_path=_kanban_db(tmp_path / "kanban.db", expiry=expiry),
+        )
+
+
+def test_live_kanban_custody_not_source_label_is_authoritative(tmp_path):
+    record = authorize_profile_execution(
+        source="untrusted-label",
+        target="s6",
+        argv=["hermes", "-p", "s6", "chat", "-q", "work"],
+        authority_json=None,
+        ledger_path=tmp_path / "ledger.jsonl",
+        kanban_task="t_1",
+        kanban_run="9",
+        kanban_claim_lock="claim-1",
+        kanban_db_path=_kanban_db(tmp_path / "kanban.db"),
+    )
+    assert record is not None
+    assert record["authority_class"] == "kanban_dispatch"
+    assert record["source"] == "untrusted-label"
+
+
+def test_kanban_run_execution_id_cannot_be_replayed(tmp_path):
+    ledger = tmp_path / "ledger.jsonl"
+    db_path = _kanban_db(tmp_path / "kanban.db")
+    kwargs = {
+        "source": "dispatcher",
+        "target": "s6",
+        "argv": ["hermes", "-p", "s6", "chat", "-q", "work"],
+        "authority_json": None,
+        "ledger_path": ledger,
+        "kanban_task": "t_1",
+        "kanban_run": "9",
+        "kanban_claim_lock": "claim-1",
+        "kanban_db_path": db_path,
+    }
+    assert authorize_profile_execution(**kwargs) is not None
+    with pytest.raises(ExecutionAuthorityError, match="already used"):
+        authorize_profile_execution(**kwargs)
+
+
+def test_concurrent_kanban_prebinding_race_accepts_one_execution(tmp_path):
+    ledger = tmp_path / "ledger.jsonl"
+    db_path = _kanban_db(tmp_path / "kanban.db")
+    barrier = threading.Barrier(16)
+    accepted: list[bool] = []
+
+    def attempt():
+        barrier.wait()
+        try:
+            authorize_profile_execution(
+                source="dispatcher",
+                target="s6",
+                argv=["hermes", "-p", "s6", "chat", "-q", "work"],
+                authority_json=None,
+                ledger_path=ledger,
+                kanban_task="t_1",
+                kanban_run="9",
+                kanban_claim_lock="claim-1",
+                kanban_db_path=db_path,
+            )
+            accepted.append(True)
+        except ExecutionAuthorityError:
+            pass
+
+    threads = [threading.Thread(target=attempt) for _ in range(16)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(accepted) == 1
+    rows = [json.loads(line) for line in ledger.read_text().splitlines()]
+    assert [row["execution_id"] for row in rows] == ["kanban-t_1-run-9"]
+
+
+def test_missing_kanban_database_fails_closed(tmp_path):
+    with pytest.raises(ExecutionAuthorityError, match="Kanban custody"):
+        authorize_profile_execution(
+            source="dispatcher",
+            target="s6",
+            argv=["hermes", "-p", "s6", "chat", "-q", "work"],
+            authority_json=None,
+            ledger_path=tmp_path / "ledger.jsonl",
+            kanban_task="t_1",
+            kanban_run="9",
+            kanban_claim_lock="claim-1",
+            kanban_db_path=tmp_path / "missing.db",
+        )
+
+
+def test_noninteractive_rejects_but_human_tty_selection_is_intentional(tmp_path):
+    with pytest.raises(ExecutionAuthorityError, match="structured authority"):
+        authorize_profile_execution(
+            source="external",
+            target="s6",
+            argv=["hermes", "-p", "s6", "chat", "-q", "secret prompt"],
+            authority_json=None,
+            ledger_path=tmp_path / "ledger.jsonl",
+        )
+    with pytest.raises(ExecutionAuthorityError, match="structured authority"):
+        authorize_profile_execution(
+            source="default",
+            target="s6",
+            argv=["hermes", "-p", "s6"],
+            authority_json=None,
+            interactive=False,
+            ledger_path=tmp_path / "ledger.jsonl",
+        )
+    assert (
+        authorize_profile_execution(
+            source="default",
+            target="s6",
+            argv=["hermes", "-p", "s6"],
+            authority_json=None,
+            interactive=True,
+            ledger_path=tmp_path / "ledger.jsonl",
+        )
+        is None
+    )
+
+
+_ADMIN_PROMPT_WORDS = [
+    "config",
+    "cron",
+    "doctor",
+    "gateway",
+    "kanban",
+    "mcp",
+    "message",
+    "profile",
+    "session",
+    "skills",
+    "tools",
+    "version",
+]
+
+
+@pytest.mark.parametrize("prompt", _ADMIN_PROMPT_WORDS)
+@pytest.mark.parametrize(
+    "argv_factory",
+    [
+        lambda prompt: ["hermes", "-p", "s6", "-q", prompt],
+        lambda prompt: ["hermes", f"--query={prompt}", "-p", "s6"],
+        lambda prompt: ["hermes", "-p", "s6", "-z", prompt],
+        lambda prompt: ["hermes", f"--oneshot={prompt}", "-p", "s6"],
+    ],
+)
+def test_prompt_words_cannot_masquerade_as_admin_commands(
+    tmp_path, prompt, argv_factory
+):
+    argv = argv_factory(prompt)
+    assert is_agent_invocation(argv)
+    assert not is_read_only_invocation(argv)
+    with pytest.raises(ExecutionAuthorityError, match="structured authority"):
+        authorize_profile_execution(
+            source="external",
+            target="s6",
+            argv=argv,
+            authority_json=None,
+            ledger_path=tmp_path / "ledger.jsonl",
+        )
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["hermes", "-p", "s6", "-z", "ONESHOT-SECRET"],
+        ["hermes", "-p", "s6", "--oneshot", "ONESHOT-SECRET"],
+        ["hermes", "--oneshot=ONESHOT-SECRET", "-p", "s6"],
+    ],
+)
+def test_oneshot_is_enforced_and_redacted(tmp_path, argv):
+    sentinel = "ONESHOT-SECRET"
+    assert is_agent_invocation(argv)
+    assert not is_read_only_invocation(argv)
+    with pytest.raises(ExecutionAuthorityError, match="structured authority"):
+        authorize_profile_execution(
+            source="external",
+            target="s6",
+            argv=argv,
+            authority_json=None,
+            ledger_path=tmp_path / "ledger.jsonl",
+        )
+    execution_path = _redacted_execution_path(argv)
+    assert sentinel not in execution_path
+    assert "[REDACTED]" in execution_path
+
+
+def test_direct_execution_id_is_consumed_atomically(tmp_path):
+    ledger = tmp_path / "ledger.jsonl"
+    payload = json.dumps(_authority())
+    barrier = threading.Barrier(16)
+    accepted = []
+
+    def attempt():
+        barrier.wait()
+        try:
+            authorize_profile_execution(
+                source="csm",
+                target="s6",
+                argv=["hermes", "chat"],
+                authority_json=payload,
+                ledger_path=ledger,
+            )
+            accepted.append(True)
+        except ExecutionAuthorityError:
+            pass
+
+    threads = [threading.Thread(target=attempt) for _ in range(16)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert len(accepted) == 1
+    assert (
+        sum(
+            json.loads(line)["execution_id"] == "exec-test-001"
+            for line in ledger.read_text().splitlines()
+        )
+        == 1
+    )
+
+
+def test_prompt_payload_is_redacted_from_ledger(tmp_path):
+    ledger = tmp_path / "ledger.jsonl"
+    record = authorize_profile_execution(
+        source="csm",
+        target="s6",
+        argv=["hermes", "-p", "s6", "chat", "-q", "TOP SECRET BODY"],
+        authority_json=json.dumps(_authority()),
+        ledger_path=ledger,
+    )
+    assert "TOP SECRET BODY" not in record["execution_path"]
+    assert "[REDACTED]" in record["execution_path"]
+    assert "TOP SECRET BODY" not in ledger.read_text()
+
+
+@pytest.mark.parametrize(
+    ("argv", "secret"),
+    [
+        (["hermes", "chat", "--api-key", "sk-live"], "sk-live"),
+        (["hermes", "chat", "--access_token=opaque-token"], "opaque-token"),
+        (["hermes", "chat", "--client-secret", "oauth-secret"], "oauth-secret"),
+        (["hermes", "chat", "--password=hunter2"], "hunter2"),
+        (["hermes", "chat", "--authorization", "Bearer abc123"], "Bearer abc123"),
+        (["hermes", "chat", "--cookie=session=private"], "session=private"),
+        (["hermes", "chat", "--signing_key", "private-material"], "private-material"),
+        (["hermes", "chat", "--webhook-token=hook-secret"], "hook-secret"),
+    ],
+)
+def test_sensitive_named_arguments_are_redacted_generically(argv, secret):
+    execution_path = _redacted_execution_path(argv)
+    assert secret not in execution_path
+    assert "[REDACTED]" in execution_path
+
+
+@pytest.mark.parametrize(
+    "option",
+    ["--body", "--message", "--content", "--authority", "--system-prompt"],
+)
+@pytest.mark.parametrize("form", ["separate", "equals"])
+def test_explicit_sensitive_options_are_redacted_in_both_forms(option, form):
+    secret = f"SENTINEL-{option[2:].upper()}-SECRET"
+    argv = (
+        ["hermes", "chat", option, secret]
+        if form == "separate"
+        else ["hermes", "chat", f"{option}={secret}"]
+    )
+
+    execution_path = _redacted_execution_path(argv)
+
+    assert secret not in execution_path
+    assert "[REDACTED]" in execution_path
+
+
+def test_non_sensitive_lookalike_arguments_remain_visible():
+    argv = [
+        "hermes",
+        "chat",
+        "--token-count",
+        "4096",
+        "--password-policy",
+        "strict",
+        "--secret-santa",
+        "enabled",
+        "--cookie-file-count",
+        "2",
+        "--body-format",
+        "markdown",
+        "--message-count",
+        "3",
+        "--content-type",
+        "application/json",
+        "--authority-level",
+        "staff",
+        "--system-prompt-mode",
+        "inherit",
+    ]
+    execution_path = _redacted_execution_path(argv)
+    assert "[REDACTED]" not in execution_path
+    assert execution_path == shlex.join(argv)
+
+
+def test_default_ledger_is_shared_across_profile_home_overlay(monkeypatch, tmp_path):
+    root = tmp_path / "custom-hermes-root"
+    monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / "s6"))
+
+    assert _ledger_path() == root / "execution-provenance.jsonl"
+
+
+def test_module_imports_when_fcntl_is_unavailable():
+    module_file = sys.modules[authorize_profile_execution.__module__].__file__
+    assert module_file is not None
+    module_path = Path(module_file)
+    script = f"""
+import builtins
+import runpy
+real_import = builtins.__import__
+def portable_import(name, globals=None, *args, **kwargs):
+    if (
+        name in {{'fcntl', 'msvcrt'}}
+        and globals
+        and globals.get('__file__') == {str(module_path)!r}
+    ):
+        raise ImportError(name)
+    return real_import(name, globals, *args, **kwargs)
+builtins.__import__ = portable_import
+namespace = runpy.run_path({str(module_path)!r})
+assert namespace['fcntl'] is None
+assert namespace['msvcrt'] is None
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_status_output_is_bounded_single_line_and_field_complete(tmp_path):
+    ledger = tmp_path / "ledger.jsonl"
+    oversized = "X" * 500 + "\nINJECTED"
+    rows = []
+    for index in range(10):
+        rows.append({
+            **_authority(
+                execution_id=f"exec-{index}-{oversized}",
+                authority_reference=oversized,
+                scope=oversized,
+                evidence=oversized,
+                terminal_condition=oversized,
+            ),
+            "execution_path": oversized,
+            "kanban_tracked": False,
+            "pid": 99999999,
+            "started_at": time.time() - index,
+            "state": oversized,
+        })
+    ledger.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+
+    lines = format_execution_status(ledger_path=ledger)
+
+    assert lines
+    assert len("\n".join(lines)) <= 1200
+    assert all("\n" not in line and len(line) <= 600 for line in lines)
+    for field in (
+        "source=",
+        "authority=",
+        "target=",
+        "path=",
+        "kanban=",
+        "scope=",
+        "one_shot=",
+        "expires=",
+        "evidence=",
+        "terminal=",
+        "state=",
+    ):
+        assert field in lines[0]
+    assert "INJECTED" not in lines[0]
+
+
+def test_status_reader_contains_malformed_rows_without_crashing(tmp_path):
+    ledger = tmp_path / "ledger.jsonl"
+    ledger.write_text(
+        "not-json\n"
+        + json.dumps({
+            "execution_id": "malformed",
+            "pid": {"not": "a pid"},
+            "started_at": "not-a-number",
+            "state": "running",
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+
+    rows = list_execution_status(ledger_path=ledger)
+    lines = format_execution_status(ledger_path=ledger)
+
+    assert len(rows) == 1
+    assert rows[0]["state"] == "terminal"
+    assert lines and "Execution malformed" in lines[0]
+
+
+def test_pid_liveness_uses_cross_platform_psutil(monkeypatch):
+    observed: list[int] = []
+
+    def pid_exists(pid):
+        observed.append(pid)
+        return pid == 42
+
+    monkeypatch.setattr(provenance.psutil, "pid_exists", pid_exists)
+    monkeypatch.setattr(
+        provenance.os,
+        "kill",
+        lambda *_args: pytest.fail("os.kill must not be used for liveness"),
+    )
+
+    assert provenance._pid_alive(42)
+    assert not provenance._pid_alive(43)
+    assert not provenance._pid_alive(0)
+    assert observed == [42, 43]
+
+
+def test_status_reader_only_materializes_bounded_tail(tmp_path):
+    ledger = tmp_path / "ledger.jsonl"
+    ledger.write_text(
+        "".join(
+            json.dumps({
+                "execution_id": f"exec-{index}",
+                "pid": 99999999,
+                "started_at": index,
+                "state": "running",
+            })
+            + "\n"
+            for index in range(200)
+        ),
+        encoding="utf-8",
+    )
+
+    rows = list_execution_status(ledger_path=ledger)
+
+    assert len(rows) == 50
+    assert {row["execution_id"] for row in rows} == {
+        f"exec-{index}" for index in range(150, 200)
+    }
+
+
+def test_status_reader_skips_oversized_tail_without_materializing_it(tmp_path):
+    ledger = tmp_path / "ledger.jsonl"
+    ledger.write_text(
+        json.dumps({"execution_id": "oversized", "value": "X" * 300_000}) + "\n",
+        encoding="utf-8",
+    )
+
+    assert list_execution_status(ledger_path=ledger) == []
+    assert format_execution_status(ledger_path=ledger) == []
+
+
+def test_same_profile_and_read_only_inspection_need_no_authority(tmp_path):
+    ledger = tmp_path / "executions.jsonl"
+    assert (
+        authorize_profile_execution(
+            source="csm",
+            target="csm",
+            argv=["hermes", "chat"],
+            authority_json=None,
+            ledger_path=ledger,
+        )
+        is None
+    )
+    assert (
+        authorize_profile_execution(
+            source="csm",
+            target="s6",
+            argv=["hermes", "-p", "s6", "gateway", "status"],
+            authority_json=None,
+            ledger_path=ledger,
+        )
+        is None
+    )
+    assert not ledger.exists()
+
+
+def test_untracked_process_visibility_and_terminal_state(tmp_path):
+    ledger = tmp_path / "executions.jsonl"
+    ledger.write_text(
+        json.dumps({
+            **_authority(execution_id="exec-dead"),
+            "execution_path": "HERMES_HOME=/tmp/s6 python -m hermes_cli.main chat",
+            "kanban_tracked": False,
+            "pid": 99999999,
+            "started_at": time.time() - 10,
+            "state": "running",
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+    row = list_execution_status(ledger_path=ledger)[0]
+    assert row["kanban_tracked"] is False
+    assert row["state"] == "terminal"

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -255,6 +255,10 @@ class TestWorkerSpawnEnv:
             return FakeProc()
 
         monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        dispatcher_home = fresh_home / "profiles" / "dispatcher"
+        dispatcher_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(dispatcher_home))
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
         kb.create_board("spawntest")
 
         task = kb.Task(
@@ -278,6 +282,7 @@ class TestWorkerSpawnEnv:
         kb._default_spawn(task, str(fresh_home / "ws"), board="spawntest")
 
         env = captured["env"]
+        assert env["HERMES_DISPATCH_SOURCE_PROFILE"] == "dispatcher"
         assert env["HERMES_KANBAN_BOARD"] == "spawntest"
         assert env["HERMES_KANBAN_TASK"] == "t_abc"
         # DB path should match the per-board DB, not the legacy default.


### PR DESCRIPTION
## Summary

- fail closed on noninteractive cross-profile agent launches unless backed by live Kanban custody or bounded one-shot direct authority
- record accepted launches in a shared canonical-root JSONL provenance ledger with prompt/sensitive-argument redaction and atomic replay prevention
- expose bounded, sanitized recent execution custody in gateway `/status`
- preserve human TTY profile selection, same-profile commands, and read-only cross-profile inspection
- propagate the actual Kanban dispatcher profile rather than a hardcoded source label
- support POSIX and Windows ledger locking and custom/Docker Hermes roots
- use cross-platform `psutil.pid_exists()` for pre-worker claim liveness; no `os.kill(pid, 0)` Windows footgun

## Security model

This is a same-user policy and audit boundary, not hostile-process or cryptographic isolation. Source labels are audit context only. Kanban authorization is determined from live read-only task/run/claim custody in the canonical database. Direct authority is bounded, expiring, and one-shot.

The new `HERMES_*` values are internal parent-to-child execution transport, not user-facing configuration and not `.env` settings. Behavioral configuration remains in `config.yaml`.

## Final reviewed tree

- head: `5376104d59190ddba6afe921bdc7fb77e9d48945`
- clean upstream base: `a6defd4f1549da3fe1d08d6f746fc645c64543f0`
- exact-tree security review: PASS
- exact-tree integration review: PASS
- stable patch ID across the final no-drift rebase: `876d267df208e6cdb7c11813b638fb27aba5468d`

## Test plan and results

- provenance/profile/Kanban focused suite: **132 passed, 0 failed**
- adjacent gateway status suite: **14 passed, 0 failed**
- exact-tree integration review suites:
  - **159 passed** across provenance, profile override, gateway status, CLI status/time formatting, session browsing, and Kanban boards
  - **177 passed** across all 36 Kanban-related test files
- control-plane regression harness: **29/29 PASS**
- repository Windows-footgun checker: **912 files scanned, no findings**
- current-base differential:
  - candidate `tests/hermes_cli/test_kanban_boards.py`: **21 passed**
  - clean upstream: **21 passed**
- Ruff, compile, and `git diff --check`: PASS
- real CLI subprocess fail-closed test with an admin-command token as prompt text
- mixed `-q`/`--query`/`-z`/`--oneshot` ordering and redaction cases
- concurrent direct and Kanban one-shot replay tests, including the pre-worker-PID binding window
- forced short-write and post-marker ledger-failure replay tests with file and directory fsync durability
- simulated import without direct `fcntl`/`msvcrt`, plus portable locking fallback
- custom canonical-root/profile-overlay ledger tests
- malformed/oversized/large-ledger status containment tests
- actual dispatcher-profile propagation from a named `HERMES_HOME`
- Windows PID-liveness regression explicitly fails if `os.kill` is invoked

## Notes

- the ledger is append-only; status readers ignore malformed JSONL rows and bound input and rendered output
- no gateway restart, runtime promotion, deployment, merge, or live activation is part of this PR
