### PR TITLE
fix: recover Slack files from app mention blocks

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -480,6 +480,63 @@ def _extract_text_from_slack_blocks(blocks: list) -> str:
     return "\n".join(parts)
 
 
+def _extract_file_ids_from_slack_blocks(blocks: list) -> list[str]:
+    """Return structured Slack file IDs embedded anywhere in Block Kit.
+
+    Slack can deliver the same authored message as both ``message`` and
+    ``app_mention`` events.  The latter may omit the top-level ``files`` array
+    while retaining ``rich_text`` elements of type ``file``.  Recovering the
+    IDs from the structured blocks lets the normal, authorization-gated
+    ``files.info`` path hydrate and download those attachments before the
+    richer duplicate event is suppressed.
+    """
+    found: list[str] = []
+    seen: set[str] = set()
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            if node.get("type") == "file":
+                file_id = node.get("file_id")
+                if (
+                    isinstance(file_id, str)
+                    and re.fullmatch(r"F[A-Z0-9]+", file_id)
+                    and file_id not in seen
+                ):
+                    seen.add(file_id)
+                    found.append(file_id)
+            for value in node.values():
+                _walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                _walk(value)
+
+    _walk(blocks or [])
+    return found
+
+
+def _slack_file_is_shared_in_message(
+    file_obj: dict, *, channel_id: str, message_ts: str
+) -> bool:
+    """Prove a hydrated block-only file reference belongs to this message."""
+    shares = file_obj.get("shares")
+    if not isinstance(shares, dict) or not channel_id or not message_ts:
+        return False
+
+    for visibility in ("public", "private"):
+        by_channel = shares.get(visibility)
+        if not isinstance(by_channel, dict):
+            continue
+        channel_shares = by_channel.get(channel_id)
+        if not isinstance(channel_shares, list):
+            continue
+        if any(
+            isinstance(share, dict) and str(share.get("ts") or "") == message_ts
+            for share in channel_shares
+        ):
+            return True
+    return False
+
+
 def _extract_text_from_slack_attachments(attachments: list) -> str:
     """Extract readable text from legacy Slack message ``attachments``.
 
@@ -5282,6 +5339,31 @@ class SlackAdapter(BasePlatformAdapter):
                 normalized_event["_slack_changed_event_ts"] = changed_event_ts
             event = normalized_event
 
+        # ``app_mention`` duplicates can omit top-level files[] even though the
+        # rich-text blocks still carry structured file elements.  Recover only
+        # those structured IDs (never regex arbitrary message text) as Slack
+        # Connect-style stubs.  The existing attachment loop resolves them via
+        # files.info *after* the adapter-side authorization gate below.
+        recovered_block_file_ids: set[str] = set()
+        block_file_ids = _extract_file_ids_from_slack_blocks(event.get("blocks") or [])
+        if block_file_ids:
+            files = list(event.get("files") or [])
+            existing_file_ids = {
+                file_obj.get("id")
+                for file_obj in files
+                if isinstance(file_obj, dict) and file_obj.get("id")
+            }
+            missing_file_ids = [
+                file_id for file_id in block_file_ids if file_id not in existing_file_ids
+            ]
+            if missing_file_ids:
+                recovered_block_file_ids.update(missing_file_ids)
+                event = dict(event)
+                event["files"] = files + [
+                    {"id": file_id, "file_access": "check_file_info"}
+                    for file_id in missing_file_ids
+                ]
+
         # Dedup: Slack Socket Mode can redeliver events after reconnects (#4777)
         # Scope the dedup id by workspace: Slack event ts values are only
         # unique within one workspace, so two teams' events with the same ts
@@ -5918,6 +6000,8 @@ class SlackAdapter(BasePlatformAdapter):
         attachment_notices: List[str] = []
         files = event.get("files", [])
         for f in files:
+            file_id = f.get("id") if isinstance(f, dict) else None
+            recovered_from_block = file_id in recovered_block_file_ids
             # Slack Connect channels return stub file objects with
             # file_access="check_file_info" and no URL fields. We must
             # call files.info to retrieve the full object (including url_private_download)
@@ -5933,6 +6017,19 @@ class SlackAdapter(BasePlatformAdapter):
                     ).files_info(file=file_id)
                     if info_resp.get("ok"):
                         f = info_resp["file"]
+                        if recovered_from_block and not _slack_file_is_shared_in_message(
+                            f,
+                            channel_id=channel_id,
+                            message_ts=str(ts or ""),
+                        ):
+                            logger.warning(
+                                "[Slack] Refusing block-only file reference %s: "
+                                "files.info does not show it shared in channel %s at %s",
+                                file_id,
+                                channel_id,
+                                ts,
+                            )
+                            continue
                     else:
                         detail = self._describe_slack_api_error(info_resp, file_obj=f)
                         if detail:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2563,6 +2563,141 @@ class TestIncomingDocumentHandling:
         assert "# Title" in msg_event.text
 
     @pytest.mark.asyncio
+    async def test_app_mention_file_block_resolves_document_when_files_array_is_missing(
+        self, adapter
+    ):
+        """Slack app_mention variants can omit files[] but retain a rich-text file block."""
+        content = b"# X Playwright Attended Canary\nImplement this plan"
+        file_id = "F0BMF4381RC"
+        adapter._app.client.files_info = AsyncMock(
+            return_value={
+                "ok": True,
+                "file": {
+                    "id": file_id,
+                    "mimetype": "text/plain",
+                    "filetype": "markdown",
+                    "name": "x-playwright-attended-canary.md",
+                    "url_private_download": "https://files.slack.com/canary.md",
+                    "size": len(content),
+                    "file_access": "visible",
+                    "shares": {
+                        "private": {
+                            "D123": [{"ts": "1234567890.000001"}],
+                        }
+                    },
+                },
+            }
+        )
+        event = self._make_event(
+            text=f"<@U_BOT> {file_id} proceed to implement",
+            files=[],
+            blocks=[
+                {
+                    "type": "rich_text",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {"type": "user", "user_id": "U_BOT"},
+                                {"type": "text", "text": " "},
+                                {
+                                    "type": "file",
+                                    "file_id": file_id,
+                                    "url": "https://workspace.slack.com/files/U_USER/F0BMF4381RC/file.md",
+                                },
+                                {"type": "text", "text": " proceed to implement"},
+                            ],
+                        }
+                    ],
+                }
+            ],
+        )
+        event["type"] = "app_mention"
+        event.pop("files")
+
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as download:
+            download.return_value = content
+            await adapter._handle_slack_message(event)
+
+            # Slack also emits the richer generic message event for the same
+            # timestamp. It must be deduplicated after the app_mention has
+            # recovered and delivered the attachment.
+            duplicate = self._make_event(
+                text=event["text"],
+                files=[adapter._app.client.files_info.return_value["file"]],
+                blocks=event["blocks"],
+            )
+            duplicate["type"] = "message"
+            await adapter._handle_slack_message(duplicate)
+
+        adapter._app.client.files_info.assert_awaited_once_with(file=file_id)
+        download.assert_awaited_once_with(
+            "https://files.slack.com/canary.md", team_id=""
+        )
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert "[Content of x-playwright-attended-canary.md]" in msg_event.text
+        assert "# X Playwright Attended Canary" in msg_event.text
+        assert "proceed to implement" in msg_event.text
+        assert msg_event.message_type == MessageType.DOCUMENT
+        assert adapter.handle_message.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_file_block_recovery_rejects_file_not_shared_in_trigger_message(
+        self, adapter
+    ):
+        """A structured block cannot pull an unrelated file visible to the bot token."""
+        file_id = "FOTHER123"
+        adapter._app.client.files_info = AsyncMock(
+            return_value={
+                "ok": True,
+                "file": {
+                    "id": file_id,
+                    "mimetype": "text/plain",
+                    "name": "unrelated.txt",
+                    "url_private_download": "https://files.slack.com/unrelated.txt",
+                    "size": 12,
+                    "shares": {
+                        "private": {
+                            "D_OTHER": [{"ts": "999.000001"}],
+                        }
+                    },
+                },
+            }
+        )
+        event = self._make_event(
+            text=f"<@U_BOT> {file_id} read this",
+            files=[],
+            blocks=[
+                {
+                    "type": "rich_text",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [
+                                {"type": "user", "user_id": "U_BOT"},
+                                {"type": "file", "file_id": file_id},
+                                {"type": "text", "text": " read this"},
+                            ],
+                        }
+                    ],
+                }
+            ],
+        )
+        event.pop("files")
+
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as download:
+            await adapter._handle_slack_message(event)
+
+        adapter._app.client.files_info.assert_awaited_once_with(file=file_id)
+        download.assert_not_awaited()
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.message_type == MessageType.TEXT
+
+    @pytest.mark.asyncio
     async def test_json_snippet_injects_content(self, adapter):
         """A .json snippet should be treated as a text document and injected."""
         content = b'{"hello": "world", "count": 2}'


### PR DESCRIPTION
## Summary

- recover structured Slack file IDs from rich-text `file` elements when `app_mention` omits the top-level `files[]` array
- hydrate those references through the existing authorization-gated `files.info` path before duplicate `message` events are suppressed
- require `files.info.shares` to prove the recovered file belongs to the exact triggering channel/message before download

## Reproduction

Slack can emit both `app_mention` and `message` for a file-bearing mention. If the `app_mention` arrives first without `files[]`, Hermes handles only the text/file ID and then deduplicates away the richer `message` event with the attachment. The agent therefore asks the user to upload or paste the file again.

## Verification

- regression test replays `app_mention` first (no `files` key, structured file block), then the duplicate `message` event with the same timestamp; asserts one metadata lookup, one download, and one agent delivery
- security regression rejects a structured file ID whose Slack share metadata does not match the triggering channel/message
- `uv run --extra dev --extra slack pytest tests/gateway/test_slack.py -q -o addopts=` → 429 passed
- `uv run --extra dev ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py` → passed
- `git diff --check` → passed

The existing test suite emits 28 pre-existing AsyncMock RuntimeWarnings.