### PR TITLE
test(doctor): pin container detection in the Vercel diagnostics test

### DIFF
--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -194,6 +194,12 @@ def test_doctor_reports_vercel_backend_diagnostics(monkeypatch, tmp_path):
     monkeypatch.delenv("VERCEL_PROJECT_ID", raising=False)
     monkeypatch.setenv("VERCEL_TEAM_ID", "team")
     monkeypatch.setattr(doctor_mod.importlib.util, "find_spec", lambda name: object() if name == "vercel" else None)
+    # Pin container detection to False: doctor.py's run_doctor() imports
+    # is_container locally and, when True, overrides TERMINAL_ENV to "local"
+    # (skipping the Vercel section entirely). On container-like hosts (WSL,
+    # CI containers) is_container() is True, so this test's Vercel assertions
+    # only passed on bare-metal machines — a host-dependent failure.
+    monkeypatch.setattr("hermes_constants.is_container", lambda: False)
 
     fake_model_tools = types.SimpleNamespace(
         check_tool_availability=lambda *a, **kw: ([], []),


### PR DESCRIPTION
## What does this PR do?

Pin hermes_constants.is_container to False in test_doctor_reports_vercel_backend_diagnostics. run_doctor() overrides TERMINAL_ENV to 'local' when is_container() is True (WSL/container hosts), skipping the Vercel section — the test failed on every container-like host and only passed on bare metal. Same host-dependent test-isolation class as the credential-pool and WSL-voice fixes.

## Related Issue

No GitHub issue — discovered via code review and reproduced live (see below). Happy to file one first if preferred.

## Changes Made

- `fix/doctor-vercel-test-isolation` — 1 file(s) changed vs base:
  - `tests/hermes_cli/test_doctor.py`

## How to Test

Validation completed (recorded by prp):
1. Sabotage check: not applicable to this change class (non-pytest) — manual verification recorded: host-dependent test-isolation bug: prp's clean worktree has is_container()=False so the base leg cannot reproduce. Verified directly on this WSL host (is_container()=True): removing the hermes_constants.is_container pin fails test_doctor_reports_vercel_backend_diagnostics ('Vercel runtime' missing — run_doctor overrides TERMINAL_ENV to local in containers); with the pin it passes. Proven by patching is_container to False: the test passes, confirming the container-detection dependency.
2. Suite `tests/hermes_cli/test_doctor.py`: branch 49 passed / 0 failed vs baseline 48 passed / 1 failed — zero branch-only failures.
3. The full repo-wide suite was not run for this change; GitHub CI owns full-suite validation.

## Logs

Sabotage verification:

```
# not applicable to this change class (non-pytest).
# Manual verification performed: host-dependent test-isolation bug: prp's clean worktree has is_container()=False so the base leg cannot reproduce. Verified directly on this WSL host (is_container()=True): removing the hermes_constants.is_container pin fails test_doctor_reports_vercel_backend_diagnostics ('Vercel runtime' missing — run_doctor overrides TERMINAL_ENV to local in containers); with the pin it passes. Proven by patching is_container to False: the test passes, confirming the container-detection dependency.
```
