### PR TITLE
perf(run-agent): reuse Anthropic request-local client instead of rebuilding per call

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4043,6 +4043,10 @@ class AIAgent:
             self._close_cached_request_openai_client(reason="cache_evict")
         except Exception:
             pass
+        try:
+            self._close_cached_request_anthropic_client(reason="cache_evict")
+        except Exception:
+            pass
 
     def close(self) -> None:
         """Release all resources held by this agent instance.
@@ -4117,6 +4121,10 @@ class AIAgent:
         # sequential LLM calls; see _create_request_openai_client).
         try:
             self._close_cached_request_openai_client(reason="agent_close")
+        except Exception:
+            pass
+        try:
+            self._close_cached_request_anthropic_client(reason="agent_close")
         except Exception:
             pass
 
@@ -4965,8 +4973,31 @@ class AIAgent:
                 exc,
             )
 
+    def _request_anthropic_client_cache_ref(self) -> dict:
+        # Lazy init — tests build agents via AIAgent.__new__ without __init__.
+        cache = getattr(self, "_request_anthropic_client_cache", None)
+        if cache is None:
+            cache = {"client": None, "key": None, "poisoned": False, "in_use": False}
+            self._request_anthropic_client_cache = cache
+        return cache
+
+    def _request_anthropic_client_key(self) -> tuple:
+        """Cache key covering everything that forces a fresh client: credential
+        rotation, base URL / region changes, timeout changes (model switch),
+        and the 1M-context beta flag."""
+        if getattr(self, "provider", None) == "bedrock":
+            region = getattr(self, "_bedrock_region", "us-east-1") or "us-east-1"
+            return ("bedrock", region)
+        return (
+            "direct",
+            self._anthropic_api_key,
+            getattr(self, "_anthropic_base_url", None),
+            get_provider_request_timeout(self.provider, self.model),
+            bool(getattr(self, "_oauth_1m_beta_disabled", False)),
+        )
+
     def _create_request_anthropic_client(self, *, reason: str) -> Any:
-        """Build a request-local Anthropic client for one in-flight call.
+        """Build (or reuse) a request-local Anthropic client for one in-flight call.
 
         The shared ``_anthropic_client`` stays the long-lived primary, but the
         stale/interrupt watchdog runs on the poll thread and must never call
@@ -4978,24 +5009,56 @@ class AIAgent:
         worker performs the SDK-level close from its own context — the same
         ownership contract the OpenAI-wire path already uses.
 
+        Also mirrors the OpenAI-wire path's single-slot cache
+        (``_create_request_openai_client``): building ``anthropic.Anthropic``
+        means a fresh httpx pool and TCP+TLS handshake per call, so the client
+        is kept warm across sequential calls whose cache key (credentials,
+        base URL/region, timeout, 1M-beta flag) hasn't changed. ``in_use``
+        keeps a second concurrent call from sharing one pool's close/abort
+        lifecycle — it gets a fresh untracked client instead.
+
         Mirrors ``_rebuild_anthropic_client`` construction (direct + Bedrock,
-        1M-beta drop) but returns a fresh client instead of swapping the shared
-        one.
+        1M-beta drop) but returns a fresh/cached client instead of swapping
+        the shared one.
         """
         if self.api_mode == "anthropic_messages":
             self._try_refresh_anthropic_client_credentials()
-        _drop_1m = bool(getattr(self, "_oauth_1m_beta_disabled", False))
-        if getattr(self, "provider", None) == "bedrock":
+        key = self._request_anthropic_client_key()
+
+        stale = None
+        with self._openai_client_lock():
+            cache = self._request_anthropic_client_cache_ref()
+            cached = cache["client"]
+            if cached is not None and not cache["in_use"]:
+                if (
+                    not cache["poisoned"]
+                    and cache["key"] == key
+                    and not self._is_openai_client_closed(cached)
+                ):
+                    cache["in_use"] = True
+                    return cached
+                # Key changed (credential rotation, base URL/region, timeout,
+                # 1M-beta flip), poisoned by a cross-thread abort, or
+                # externally closed — never reuse; discard and rebuild below.
+                stale = cached
+                cache["client"] = None
+                cache["key"] = None
+                cache["poisoned"] = False
+        if stale is not None:
+            # Safe to close from this thread: in_use was False, so no worker
+            # thread owns the pool's FDs (same #29507 reasoning as OpenAI).
+            self._close_request_anthropic_client(stale, reason=f"reuse_evict:{reason}")
+
+        if key[0] == "bedrock":
             from agent.anthropic_adapter import build_anthropic_bedrock_client
-            region = getattr(self, "_bedrock_region", "us-east-1") or "us-east-1"
-            client = build_anthropic_bedrock_client(region)
+            client = build_anthropic_bedrock_client(key[1])
         else:
             from agent.anthropic_adapter import build_anthropic_client
             client = build_anthropic_client(
                 self._anthropic_api_key,
                 getattr(self, "_anthropic_base_url", None),
                 timeout=get_provider_request_timeout(self.provider, self.model),
-                drop_context_1m_beta=_drop_1m,
+                drop_context_1m_beta=key[4],
             )
         logger.debug(
             "Anthropic request client created (%s, shared=False) provider=%s model=%s",
@@ -5003,17 +5066,41 @@ class AIAgent:
             getattr(self, "provider", None),
             getattr(self, "model", None),
         )
+        with self._openai_client_lock():
+            cache = self._request_anthropic_client_cache_ref()
+            if cache["client"] is None:
+                cache["client"] = client
+                cache["key"] = key
+                cache["poisoned"] = False
+                cache["in_use"] = True
+            # else: a concurrent call holds the slot — hand this client out
+            # untracked; _close_request_anthropic_client fully closes
+            # untracked clients, preserving the per-request lifecycle.
         return client
 
     def _close_request_anthropic_client(self, client: Any, *, reason: str) -> None:
-        """Owner-thread full close of a request-local Anthropic client.
+        """Owner-thread close of a request-local Anthropic client.
 
-        Force-closes the pool's TCP sockets first (CLOSE-WAIT hygiene, parity
-        with ``_close_openai_client``), then does the graceful SDK close. Safe
+        On a clean finish (``reason`` in ``_REQUEST_CLIENT_REUSE_REASONS``)
+        the pool is kept warm in the cache slot for the next sequential call,
+        mirroring ``_close_request_openai_client``. Any other outcome
+        (error / kill / abort / stale-slot eviction) force-closes the pool's
+        TCP sockets first (CLOSE-WAIT hygiene, parity with
+        ``_close_openai_client``), then does the graceful SDK close. Safe
         because the caller owns the connection.
         """
         if client is None:
             return
+        with self._openai_client_lock():
+            cache = self._request_anthropic_client_cache_ref()
+            if cache["client"] is client:
+                if reason in self._REQUEST_CLIENT_REUSE_REASONS and not cache["poisoned"]:
+                    cache["in_use"] = False
+                    return
+                cache["client"] = None
+                cache["key"] = None
+                cache["poisoned"] = False
+                cache["in_use"] = False
         try:
             self._force_close_tcp_sockets(client)
             client.close()
@@ -5032,6 +5119,30 @@ class AIAgent:
                 exc,
             )
 
+    def _close_cached_request_anthropic_client(self, *, reason: str) -> None:
+        """Teardown hook: really close the cached per-request Anthropic client."""
+        with self._openai_client_lock():
+            cache = getattr(self, "_request_anthropic_client_cache", None)
+            client = cache["client"] if cache else None
+            in_use = bool(cache["in_use"]) if cache else False
+            if cache is not None:
+                cache["client"] = None
+                cache["key"] = None
+                cache["poisoned"] = False
+                cache["in_use"] = False
+        if client is None:
+            return
+        if in_use:
+            # A worker thread has this client checked out for an in-flight
+            # request — same #29507 reasoning as the OpenAI teardown hook.
+            self._abort_request_anthropic_client(client, reason=f"{reason}_in_flight")
+            return
+        try:
+            self._force_close_tcp_sockets(client)
+            client.close()
+        except Exception:
+            pass
+
     def _abort_request_anthropic_client(self, client: Any, *, reason: str) -> None:
         """Cross-thread abort for request-local Anthropic clients.
 
@@ -5043,6 +5154,13 @@ class AIAgent:
         """
         if client is None:
             return
+        # A pool whose sockets were shut down from a stranger thread must
+        # never be reused: poison the cache slot so the owner-thread close
+        # discards it and the next create builds a fresh client.
+        with self._openai_client_lock():
+            cache = self._request_anthropic_client_cache_ref()
+            if cache["client"] is client:
+                cache["poisoned"] = True
         try:
             shutdown_count = self._force_close_tcp_sockets(client)
             # Same visibility contract as the OpenAI abort path (#72975):

--- a/tests/agent/test_anthropic_request_client_reuse.py
+++ b/tests/agent/test_anthropic_request_client_reuse.py
@@ -1,0 +1,157 @@
+"""Per-request Anthropic wire client reuse across sequential LLM calls.
+
+Mirrors ``tests/agent/test_request_client_reuse.py`` (the OpenAI-wire cache)
+for the Anthropic request-local client. Before this cache existed,
+``_create_request_anthropic_client`` built a fresh ``anthropic.Anthropic``
+(and its httpx pool) on every single LLM call and ``_close_request_anthropic_client``
+always fully closed it — no reuse across a turn's sequential tool-loop calls,
+unlike the OpenAI-wire path.
+
+- identical cache key (credentials, base URL, timeout, 1M-beta flag) → same
+  client object handed back (the reuse win);
+- key changes (credential rotation, base URL change) → evict + rebuild;
+- cross-thread abort poisons the slot → the owner-thread close does a real
+  close and the next create rebuilds;
+- non-reuse close reasons (error cleanups, stale/interrupt kills) discard —
+  only request_complete / stream_request_complete reuse;
+- teardown (release_clients / close) really closes the cached client, or
+  detaches it to the in-flight worker's own close when checked out.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+class _StubClient:
+    """Minimal non-Mock client: _is_openai_client_closed reads ``is_closed``."""
+
+    def __init__(self):
+        self.is_closed = False
+
+    def close(self):
+        self.is_closed = True
+
+
+def _make_agent(provider="anthropic", base_url="https://api.anthropic.com", model="claude-sonnet-5"):
+    agent = AIAgent.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.api_mode = "anthropic_messages"
+    agent._anthropic_api_key = "sk-ant-test"
+    agent._anthropic_base_url = base_url
+    agent._oauth_1m_beta_disabled = False
+    # Real credential-refresh reaches auth/network state we don't need here;
+    # the cache logic under test is agnostic to it.
+    agent._try_refresh_anthropic_client_credentials = MagicMock(return_value=False)
+    return agent
+
+
+class _Harness:
+    """Patch the Anthropic client build/socket seams and record calls."""
+
+    def __init__(self, agent):
+        self.agent = agent
+        self.built = []  # reason
+        self._patchers = []
+
+    def __enter__(self):
+        def _fake_build(*a, **k):
+            self.built.append(k.get("drop_context_1m_beta"))
+            return _StubClient()
+
+        self._patchers = [
+            patch("agent.anthropic_adapter.build_anthropic_client", side_effect=_fake_build),
+            patch.object(self.agent, "_force_close_tcp_sockets", return_value=0),
+        ]
+        for p in self._patchers:
+            p.start()
+        return self
+
+    def __exit__(self, *exc):
+        for p in self._patchers:
+            p.stop()
+
+
+def test_reuse_on_identical_key_same_object():
+    agent = _make_agent()
+    with _Harness(agent) as h:
+        a = agent._create_request_anthropic_client(reason="chat_completion_request")
+        agent._close_request_anthropic_client(a, reason="request_complete")
+        assert not a.is_closed  # kept for reuse, not really closed
+
+        b = agent._create_request_anthropic_client(reason="chat_completion_request")
+        assert b is a
+        assert len(h.built) == 1
+
+
+def test_rebuild_on_credential_rotation():
+    agent = _make_agent()
+    with _Harness(agent):
+        a = agent._create_request_anthropic_client(reason="r")
+        agent._close_request_anthropic_client(a, reason="request_complete")
+
+        agent._anthropic_api_key = "sk-ant-rotated"
+        b = agent._create_request_anthropic_client(reason="r")
+        assert b is not a
+        assert a.is_closed  # stale slot really closed on eviction
+
+        agent._close_request_anthropic_client(b, reason="request_complete")
+        c = agent._create_request_anthropic_client(reason="r")
+        assert c is b
+
+
+def test_non_reuse_reason_discards_client():
+    agent = _make_agent()
+    with _Harness(agent):
+        a = agent._create_request_anthropic_client(reason="r")
+        agent._close_request_anthropic_client(a, reason="request_error_cleanup")
+        assert a.is_closed
+
+        b = agent._create_request_anthropic_client(reason="r")
+        assert b is not a
+
+
+def test_cross_thread_abort_poisons_slot():
+    agent = _make_agent()
+    with _Harness(agent):
+        a = agent._create_request_anthropic_client(reason="r")
+        agent._abort_request_anthropic_client(a, reason="interrupt")
+        # Owner thread's close now sees the poisoned slot and really closes.
+        agent._close_request_anthropic_client(a, reason="request_complete")
+        assert a.is_closed
+
+        b = agent._create_request_anthropic_client(reason="r")
+        assert b is not a
+
+
+def test_concurrent_call_gets_untracked_client():
+    agent = _make_agent()
+    with _Harness(agent):
+        a = agent._create_request_anthropic_client(reason="r")
+        # Slot still checked out (in_use=True) — a second concurrent call
+        # must not share it.
+        b = agent._create_request_anthropic_client(reason="r")
+        assert b is not a
+
+        # Finishing the untracked one does a real close, not a slot release.
+        agent._close_request_anthropic_client(b, reason="request_complete")
+        assert b.is_closed
+        # The tracked slot is unaffected and still reusable.
+        agent._close_request_anthropic_client(a, reason="request_complete")
+        c = agent._create_request_anthropic_client(reason="r")
+        assert c is a
+
+
+def test_agent_close_closes_cached_request_client():
+    agent = _make_agent()
+    with _Harness(agent):
+        a = agent._create_request_anthropic_client(reason="r")
+        agent._close_request_anthropic_client(a, reason="request_complete")
+        assert not a.is_closed
+
+        agent._close_cached_request_anthropic_client(reason="agent_close")
+        assert a.is_closed
+
+        # Idempotent: a second teardown must not error or double-act.
+        agent._close_cached_request_anthropic_client(reason="agent_close")


### PR DESCRIPTION
## Summary

- Fixes #77142: `_create_request_anthropic_client()` built a fresh `anthropic.Anthropic` client (new httpx pool, new TCP+TLS handshake) on **every single Anthropic-wire LLM call**, and `_close_request_anthropic_client()` always fully closed it right after — unlike the OpenAI-wire path, which caches and reuses one warm client across sequential calls.
- Adds the same single-slot cache to the Anthropic-wire path, keyed on credentials, base URL / Bedrock region, per-model timeout, and the 1M-context-beta flag — mirroring `_create_request_openai_client`'s `in_use` / `poisoned` / kwargs-key contract exactly.
- Reuse only fires on `request_complete` / `stream_request_complete` (the existing `_REQUEST_CLIENT_REUSE_REASONS` set already shared with the OpenAI path); any other outcome (error, kill, abort, stale-slot eviction) does a real close, preserving the #29507/#67142 cross-thread-close safety contract this code exists for.
- Wires a `_close_cached_request_anthropic_client` teardown hook into `release_clients()` (LRU/idle eviction) and `close()` (hard session teardown), mirroring `_close_cached_request_openai_client`.
- Adds `tests/agent/test_anthropic_request_client_reuse.py` (6 tests) covering reuse, credential-rotation rebuild, non-reuse close reasons, cross-thread abort poisoning, concurrent-call isolation, and teardown.

## Root cause diagram

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
flowchart TD
    A["LLM Call #1 (Anthropic)"] --> B["build_anthropic_client() - fresh httpx pool, TCP+TLS handshake"]
    B --> C["Request completes"]
    C --> D["_close_request_anthropic_client() - full close (before fix)"]
    D --> E["LLM Call #2 (same turn, same credentials)"]
    E --> F["build_anthropic_client() again - handshake repeats"]
    F --> G["Request completes"]
    G --> H["Full close again"]
    H --> I["... repeats every call in the tool loop"]

    subgraph Fix["After Fix: Single-Slot Cache"]
        J["LLM Call #1"] --> K["Cache miss - build client, store in slot"]
        K --> L["request_complete - keep slot warm"]
        L --> M["LLM Call #2 - same key - reuse cached client"]
        M --> N["Only rebuilds on credential/URL/timeout/beta-flag change or poisoned slot"]
    end
```
## Infographic:
<img width="1024" height="1024" alt="infographic" src="https://github.com/user-attachments/assets/9301d7d0-88f0-4bbf-84ab-da5eb4f983bf" />


## Test plan

- [x] `pytest tests/agent/test_anthropic_request_client_reuse.py tests/agent/test_request_client_reuse.py -v` — 10 passed (6 new Anthropic-cache tests + 4 existing OpenAI-cache tests, confirming parity and no cross-path regression).
- [x] `pytest tests/run_agent/test_70773_shared_client_fd_corruption.py tests/run_agent/test_request_client_reuse_abort_races.py tests/agent/test_cascading_interrupt_6600.py tests/agent/test_anthropic_kwargs_sanitize.py` — 15 passed, 1 skipped (cross-thread abort / FD-corruption regression coverage for #29507/#67142 unaffected).
- [x] `pytest tests/run_agent/test_run_agent.py tests/run_agent/test_streaming.py tests/run_agent/test_28161_anthropic_stream_pool_cleanup.py tests/run_agent/test_stream_stale_circuit_breaker.py` — 266 passed, 3 failed; verified by stashing this change and re-running on a clean `origin/main` base that the 3 failures (`TestConcurrentToolExecution.*`, `AttributeError: 'DaemonThreadPoolExecutor' object has no attribute '_initializer'`) are pre-existing on `main` (Python 3.14 stdlib `ThreadPoolExecutor` incompatibility in `tools/daemon_pool.py`) and unrelated to this change.
