### PR TITLE
feat(providers): support generic external ACP plugins

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -706,8 +706,7 @@ def init_agent(
     if (
         api_mode is None
         and agent.api_mode == "chat_completions"
-        and agent.provider != "copilot-acp"
-        and not str(agent.base_url or "").lower().startswith("acp://copilot")
+        and not str(agent.base_url or "").lower().startswith("acp://")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
         and (
@@ -1133,7 +1132,7 @@ def init_agent(
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
             if _provider_timeout is not None:
                 client_kwargs["timeout"] = _provider_timeout
-            if agent.provider == "copilot-acp":
+            if str(base_url or "").lower().startswith("acp://"):
                 client_kwargs["command"] = agent.acp_command
                 client_kwargs["args"] = agent.acp_args
             effective_base = base_url

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2016,12 +2016,12 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     httpx_verify = resolve_httpx_verify(ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify_cfg)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
-    if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
+    if str(client_kwargs.get("base_url", "")).startswith("acp://"):
         from agent.copilot_acp_client import CopilotACPClient
 
         client = CopilotACPClient(**client_kwargs)
         _ra().logger.info(
-            "Copilot ACP client created (%s, shared=%s) %s",
+            "External ACP client created (%s, shared=%s) %s",
             reason,
             shared,
             agent._client_log_context(),

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2017,9 +2017,17 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
     if str(client_kwargs.get("base_url", "")).startswith("acp://"):
-        from agent.copilot_acp_client import CopilotACPClient
+        from agent.copilot_acp_client import ExternalACPClient
 
-        client = CopilotACPClient(**client_kwargs)
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(agent.provider)
+        client = ExternalACPClient(
+            **client_kwargs,
+            provider_name=agent.provider,
+            display_name=(profile.display_name if profile else agent.provider),
+            model_arg=(profile.external_model_arg if profile else ""),
+        )
         _ra().logger.info(
             "External ACP client created (%s, shared=%s) %s",
             reason,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5775,39 +5775,33 @@ def resolve_provider_client(
             or _read_main_model_for_aux(),
             provider,
         )
-        if provider == "copilot-acp":
-            api_key = str(creds.get("api_key", "")).strip()
-            base_url = str(creds.get("base_url", "")).strip()
-            command = str(creds.get("command", "")).strip() or None
-            args = list(creds.get("args") or [])
-            if not final_model:
-                logger.warning(
-                    "resolve_provider_client: copilot-acp requested but no model "
-                    "was provided or configured"
-                )
-                return None, None
-            if not api_key or not base_url:
-                logger.warning(
-                    "resolve_provider_client: copilot-acp requested but external "
-                    "process credentials are incomplete"
-                )
-                return None, None
-            from agent.copilot_acp_client import CopilotACPClient
-
-            client = CopilotACPClient(
-                api_key=api_key,
-                base_url=base_url,
-                command=command,
-                args=args,
+        api_key = str(creds.get("api_key", "")).strip()
+        base_url = str(creds.get("base_url", "")).strip()
+        command = str(creds.get("command", "")).strip() or None
+        args = list(creds.get("args") or [])
+        if not final_model:
+            logger.warning(
+                "resolve_provider_client: external ACP provider requested but no model "
+                "was provided or configured"
             )
-            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
-            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
-                    else (client, final_model))
-        if provider not in _LOGGED_UNSUPPORTED_EXTPROC_KEYS:
-            _LOGGED_UNSUPPORTED_EXTPROC_KEYS.add(provider)
-            logger.debug("resolve_provider_client: external-process provider %s not "
-                         "directly supported", provider)
-        return None, None
+            return None, None
+        if not api_key or not base_url:
+            logger.warning(
+                "resolve_provider_client: external ACP provider requested but external "
+                "process credentials are incomplete"
+            )
+            return None, None
+        from agent.copilot_acp_client import CopilotACPClient
+
+        client = CopilotACPClient(
+            api_key=api_key,
+            base_url=base_url,
+            command=command,
+            args=args,
+        )
+        logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
 
     elif pconfig.auth_type == "vertex":
         # Google Vertex AI — Gemini via the OpenAI-compatible endpoint with an

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1735,8 +1735,8 @@ def _maybe_wrap_anthropic(
     except ImportError:
         pass
     try:
-        from agent.copilot_acp_client import CopilotACPClient
-        if _safe_isinstance(client_obj, CopilotACPClient):
+        from agent.copilot_acp_client import ExternalACPClient
+        if _safe_isinstance(client_obj, ExternalACPClient):
             return client_obj
     except ImportError:
         pass
@@ -5068,8 +5068,8 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     except ImportError:
         pass
     try:
-        from agent.copilot_acp_client import CopilotACPClient
-        if isinstance(sync_client, CopilotACPClient):
+        from agent.copilot_acp_client import ExternalACPClient
+        if isinstance(sync_client, ExternalACPClient):
             return sync_client, model
     except ImportError:
         pass
@@ -5779,6 +5779,7 @@ def resolve_provider_client(
         base_url = str(creds.get("base_url", "")).strip()
         command = str(creds.get("command", "")).strip() or None
         args = list(creds.get("args") or [])
+        model_arg = str(creds.get("model_arg", "")).strip() or None
         if not final_model:
             logger.warning(
                 "resolve_provider_client: external ACP provider requested but no model "
@@ -5791,13 +5792,19 @@ def resolve_provider_client(
                 "process credentials are incomplete"
             )
             return None, None
-        from agent.copilot_acp_client import CopilotACPClient
+        from agent.copilot_acp_client import ExternalACPClient
+        from providers import get_provider_profile
 
-        client = CopilotACPClient(
+        profile = get_provider_profile(provider)
+
+        client = ExternalACPClient(
             api_key=api_key,
             base_url=base_url,
             command=command,
             args=args,
+            provider_name=provider,
+            display_name=(profile.display_name if profile else provider),
+            model_arg=model_arg,
         )
         logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2206,8 +2206,7 @@ def run_conversation(
                 # stream.  Mirror the ACP exclusion used for Responses
                 # API upgrade (lines ~1083-1085).
                 elif (
-                    agent.provider in {"copilot-acp"}
-                    or str(agent.base_url or "").lower().startswith("acp://copilot")
+                    str(agent.base_url or "").lower().startswith("acp://")
                     or str(agent.base_url or "").lower().startswith("acp+tcp://")
                 ):
                     _use_streaming = False

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -1,9 +1,9 @@
-"""OpenAI-compatible shim that forwards Hermes requests to `copilot --acp`.
+"""OpenAI-compatible shim that forwards Hermes requests to an ACP process.
 
-This adapter lets Hermes treat the GitHub Copilot ACP server as a chat-style
-backend. Each request starts a short-lived ACP session, sends the formatted
-conversation as a single prompt, collects text chunks, and converts the result
-back into the minimal shape Hermes expects from an OpenAI client.
+Each request starts a short-lived ACP session, sends the formatted conversation
+as a single prompt, collects text chunks, and converts the result back into the
+minimal shape Hermes expects from an OpenAI client. ``CopilotACPClient`` remains
+as a compatibility alias for third-party imports.
 """
 
 from __future__ import annotations
@@ -381,7 +381,7 @@ def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:
 
 
 class _ACPChatCompletions:
-    def __init__(self, client: "CopilotACPClient"):
+    def __init__(self, client: "ExternalACPClient"):
         self._client = client
 
     def create(self, **kwargs: Any) -> Any:
@@ -389,12 +389,12 @@ class _ACPChatCompletions:
 
 
 class _ACPChatNamespace:
-    def __init__(self, client: "CopilotACPClient"):
+    def __init__(self, client: "ExternalACPClient"):
         self.completions = _ACPChatCompletions(client)
 
 
-class CopilotACPClient:
-    """Minimal OpenAI-client-compatible facade for Copilot ACP."""
+class ExternalACPClient:
+    """Minimal OpenAI-client-compatible facade for a local ACP process."""
 
     def __init__(
         self,
@@ -407,6 +407,9 @@ class CopilotACPClient:
         acp_cwd: str | None = None,
         command: str | None = None,
         args: list[str] | None = None,
+        provider_name: str | None = None,
+        display_name: str | None = None,
+        model_arg: str | None = None,
         **_: Any,
     ):
         self.api_key = api_key or "copilot-acp"
@@ -414,6 +417,10 @@ class CopilotACPClient:
         self._default_headers = dict(default_headers or {})
         self._acp_command = acp_command or command or _resolve_command()
         self._acp_args = list(acp_args or args or _resolve_args())
+        self._provider_name = (provider_name or self.api_key or "external-acp").strip()
+        default_display = "Copilot" if self._provider_name == "copilot-acp" else self._provider_name
+        self._display_name = (display_name or default_display or "External").strip()
+        self._model_arg = (model_arg or "").strip()
         self._acp_cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self.chat = _ACPChatNamespace(self)
         self.is_closed = False
@@ -436,6 +443,12 @@ class CopilotACPClient:
                 proc.kill()
             except Exception:
                 pass
+
+    def _build_process_args(self, model: str | None = None) -> list[str]:
+        process_args = [self._acp_command, *self._acp_args]
+        if self._model_arg and model:
+            process_args.extend((self._model_arg, model))
+        return process_args
 
     def _create_chat_completion(
         self,
@@ -473,6 +486,7 @@ class CopilotACPClient:
         response_text, reasoning_text = self._run_prompt(
             prompt_text,
             timeout_seconds=_effective_timeout,
+            model=model,
         )
 
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
@@ -495,20 +509,26 @@ class CopilotACPClient:
         completion = SimpleNamespace(
             choices=[choice],
             usage=usage,
-            model=model or "copilot-acp",
+            model=model or self._provider_name,
         )
         if stream:
             return _completion_to_stream_chunks(completion)
         return completion
 
-    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+    def _run_prompt(
+        self,
+        prompt_text: str,
+        *,
+        timeout_seconds: float,
+        model: str | None = None,
+    ) -> tuple[str, str]:
         try:
             # Hide the console the CLI child would otherwise flash on Windows
             # (#56747). Hide-only — stdio pipes stay intact for the ACP wire.
             from hermes_cli._subprocess_compat import windows_hide_flags
 
             proc = subprocess.Popen(
-                [self._acp_command] + self._acp_args,
+                self._build_process_args(model),
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -520,13 +540,13 @@ class CopilotACPClient:
             )
         except FileNotFoundError as exc:
             raise RuntimeError(
-                f"Could not start Copilot ACP command '{self._acp_command}'. "
-                "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+                f"Could not start {self._display_name} ACP command "
+                f"'{self._acp_command}'."
             ) from exc
 
         if proc.stdin is None or proc.stdout is None:
             proc.kill()
-            raise RuntimeError("Copilot ACP process did not expose stdin/stdout pipes.")
+            raise RuntimeError(f"{self._display_name} ACP process did not expose stdin/stdout pipes.")
 
         self.is_closed = False
         with self._active_process_lock:
@@ -593,7 +613,7 @@ class CopilotACPClient:
                 if "error" in msg:
                     err = msg.get("error") or {}
                     raise RuntimeError(
-                        f"Copilot ACP {method} failed: {err.get('message') or err}"
+                        f"{self._display_name} ACP {method} failed: {err.get('message') or err}"
                     )
                 return msg.get("result")
 
@@ -614,8 +634,8 @@ class CopilotACPClient:
                         "directly with a Copilot subscription token) via `hermes setup`.\n\n"
                         f"Original error:\n{stderr_text}"
                     )
-                raise RuntimeError(f"Copilot ACP process exited early: {stderr_text}")
-            raise TimeoutError(f"Timed out waiting for Copilot ACP response to {method}.")
+                raise RuntimeError(f"{self._display_name} ACP process exited early: {stderr_text}")
+            raise TimeoutError(f"Timed out waiting for {self._display_name} ACP response to {method}.")
 
         try:
             _request(
@@ -644,7 +664,7 @@ class CopilotACPClient:
             ) or {}
             session_id = str(session.get("sessionId") or "").strip()
             if not session_id:
-                raise RuntimeError("Copilot ACP did not return a sessionId.")
+                raise RuntimeError(f"{self._display_name} ACP did not return a sessionId.")
 
             text_parts: list[str] = []
             reasoning_parts: list[str] = []
@@ -754,3 +774,8 @@ class CopilotACPClient:
         process.stdin.write(json.dumps(response) + "\n")
         process.stdin.flush()
         return True
+
+
+# Backward compatibility for callers importing the historical provider-specific
+# name. New code should use ``ExternalACPClient``.
+CopilotACPClient = ExternalACPClient

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6807,6 +6807,7 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     command = command or (getattr(profile, "external_command", "") if profile else "") or "copilot"
     raw_args = os.getenv(args_env, "").strip() if args_env else ""
     args = shlex.split(raw_args) if raw_args else list(getattr(profile, "external_args", ()) or ("--acp", "--stdio"))
+    model_arg = str(getattr(profile, "external_model_arg", "") or "").strip() if profile else ""
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
@@ -6831,6 +6832,7 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
         "name": pconfig.name,
         "command": command,
         "args": args,
+        "model_arg": model_arg,
         "resolved_command": resolved_command,
         "base_url": base_url,
         "logged_in": logged_in,
@@ -7047,6 +7049,7 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     command = command or (getattr(profile, "external_command", "") if profile else "") or "copilot"
     raw_args = os.getenv(args_env, "").strip() if args_env else ""
     args = shlex.split(raw_args) if raw_args else list(getattr(profile, "external_args", ()) or ("--acp", "--stdio"))
+    model_arg = str(getattr(profile, "external_model_arg", "") or "").strip() if profile else ""
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
         raise AuthError(
@@ -7061,6 +7064,7 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,
+        "model_arg": model_arg,
         "source": "process",
     }
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -455,13 +455,23 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
     ),
 }
 
-# Auto-extend PROVIDER_REGISTRY with any api-key provider registered in
+# Auto-extend PROVIDER_REGISTRY with plugin providers registered in
 # providers/ that is not already declared above.  New providers only need a
 # plugins/model-providers/<name>/ plugin — no edits to this file required.
 try:
     from providers import list_providers as _list_providers_for_registry
     for _pp in _list_providers_for_registry():
         if _pp.name in PROVIDER_REGISTRY:
+            continue
+        if _pp.auth_type == "external_process":
+            PROVIDER_REGISTRY[_pp.name] = ProviderConfig(
+                id=_pp.name,
+                name=_pp.display_name or _pp.name,
+                auth_type="external_process",
+                inference_base_url=_pp.base_url,
+            )
+            for _alias in _pp.aliases:
+                PROVIDER_REGISTRY.setdefault(_alias, PROVIDER_REGISTRY[_pp.name])
             continue
         if _pp.auth_type != "api_key" or not _pp.env_vars:
             continue
@@ -6787,18 +6797,34 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    from providers import get_provider_profile
+    profile = get_provider_profile(provider_id)
+    command_env = getattr(profile, "external_command_env", "") if profile else ""
+    args_env = getattr(profile, "external_args_env", "") if profile else ""
+    command = (os.getenv(command_env, "").strip() if command_env else "")
+    if not command and provider_id == "copilot-acp":
+        command = os.getenv("COPILOT_CLI_PATH", "").strip()
+    command = command or (getattr(profile, "external_command", "") if profile else "") or "copilot"
+    raw_args = os.getenv(args_env, "").strip() if args_env else ""
+    args = shlex.split(raw_args) if raw_args else list(getattr(profile, "external_args", ()) or ("--acp", "--stdio"))
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 
     resolved_command = shutil.which(command) if command else None
+    logged_in = bool(resolved_command or base_url.startswith("acp+tcp://"))
+    auth_args = list(getattr(profile, "external_auth_args", ()) or ()) if profile else []
+    if resolved_command and auth_args:
+        try:
+            logged_in = subprocess.run(
+                [resolved_command, *auth_args],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+                check=False,
+            ).returncode == 0
+        except Exception:
+            logged_in = False
     return {
         "configured": bool(resolved_command or base_url.startswith("acp+tcp://")),
         "provider": provider_id,
@@ -6807,7 +6833,7 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
         "args": args,
         "resolved_command": resolved_command,
         "base_url": base_url,
-        "logged_in": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "logged_in": logged_in,
     }
 
 
@@ -6816,6 +6842,7 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
     target = (provider_id or get_active_provider() or "").strip().lower()
     if not target:
         return {"logged_in": False}
+    pconfig = PROVIDER_REGISTRY.get(target)
     if target == "spotify":
         return get_spotify_auth_status()
     if target == "nous":
@@ -6828,12 +6855,11 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_qwen_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
+    if pconfig and pconfig.auth_type == "external_process":
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
     # API-key providers
-    pconfig = PROVIDER_REGISTRY.get(target)
     if pconfig and pconfig.auth_type == "api_key":
         return get_api_key_provider_status(target)
     # AWS SDK providers (Bedrock) — check via boto3 credential chain
@@ -7011,25 +7037,27 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    from providers import get_provider_profile
+    profile = get_provider_profile(provider_id)
+    command_env = getattr(profile, "external_command_env", "") if profile else ""
+    args_env = getattr(profile, "external_args_env", "") if profile else ""
+    command = (os.getenv(command_env, "").strip() if command_env else "")
+    if not command and provider_id == "copilot-acp":
+        command = os.getenv("COPILOT_CLI_PATH", "").strip()
+    command = command or (getattr(profile, "external_command", "") if profile else "") or "copilot"
+    raw_args = os.getenv(args_env, "").strip() if args_env else ""
+    args = shlex.split(raw_args) if raw_args else list(getattr(profile, "external_args", ()) or ("--acp", "--stdio"))
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            f"Could not find the external ACP command '{command}' for provider '{provider_id}'.",
             provider=provider_id,
-            code="missing_copilot_cli",
+            code="missing_external_process",
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": provider_id,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2075,6 +2075,45 @@ def list_authenticated_providers(
             live = [current_model]
         curated["lmstudio"] = live
 
+    # External ACP provider plugins own their local authentication and model
+    # catalogs. Surface every authenticated plugin here without adding its
+    # slug to a Hermes-maintained overlay table.
+    try:
+        from providers import list_providers as _list_provider_profiles
+        from hermes_cli.auth import get_auth_status as _get_auth_status
+
+        for _profile in _list_provider_profiles():
+            if _profile.auth_type != "external_process":
+                continue
+            _slug = _profile.name
+            if _slug.lower() in seen_slugs or _slug.lower() in _excluded:
+                continue
+            _status = _get_auth_status(_slug)
+            if not _status.get("logged_in"):
+                continue
+            try:
+                _ids = _profile.fetch_models(timeout=8.0) or []
+            except Exception:
+                _ids = []
+            if not _ids:
+                _ids = list(_profile.fallback_models or curated.get(_slug, []))
+            _ids = list(dict.fromkeys(str(item) for item in _ids if item))
+            _total = len(_ids)
+            _top = _ids[:max_models] if max_models is not None else _ids
+            results.append({
+                "slug": _slug,
+                "name": _profile.display_name or _slug,
+                "is_current": _slug == current_provider,
+                "is_user_defined": True,
+                "models": _top,
+                "total_models": _total,
+                "source": "plugin",
+            })
+            seen_slugs.add(_slug.lower())
+            _record_builtin_endpoint(_slug)
+    except Exception:
+        logger.debug("external ACP provider discovery failed", exc_info=True)
+
     # --- 1. Check Hermes-mapped providers ---
     from hermes_cli.models import _AGGREGATOR_PROVIDERS as _AGG_PROVIDERS
     from hermes_cli.providers import ALIASES as _PROVIDER_ALIAS_TABLE

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1124,7 +1124,7 @@ try:
     for _pp in _list_providers_for_canonical():
         if _pp.name in _canonical_slugs:
             continue
-        if _pp.auth_type in {"oauth_device_code", "oauth_external", "external_process", "aws_sdk", "copilot", "vertex"}:
+        if _pp.auth_type in {"oauth_device_code", "oauth_external", "aws_sdk", "copilot", "vertex"}:
             continue  # non-api-key flows need bespoke picker UX; skip auto-inject
         _label = _pp.display_name or _pp.name
         _desc = _pp.description or f"{_label} (direct API)"

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1987,10 +1987,11 @@ def resolve_runtime_provider(
                 "requested_provider": requested_provider,
             }
 
-    if provider == "copilot-acp":
+    _provider_cfg = PROVIDER_REGISTRY.get(provider)
+    if _provider_cfg and _provider_cfg.auth_type == "external_process":
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/plugins/model-providers/copilot-acp/__init__.py
+++ b/plugins/model-providers/copilot-acp/__init__.py
@@ -30,6 +30,10 @@ copilot_acp = CopilotACPProfile(
     env_vars=(),  # Managed by ACP subprocess
     base_url="acp://copilot",  # ACP internal scheme
     auth_type="external_process",
+    external_command="copilot",
+    external_args=("--acp", "--stdio"),
+    external_command_env="HERMES_COPILOT_ACP_COMMAND",
+    external_args_env="HERMES_COPILOT_ACP_ARGS",
 )
 
 register_provider(copilot_acp)

--- a/providers/base.py
+++ b/providers/base.py
@@ -56,6 +56,15 @@ class ProviderProfile:
     auth_type: str = "api_key"   # api_key|oauth_device_code|oauth_external|copilot|aws_sdk
     supports_health_check: bool = True  # False → doctor skips /models probe for this provider
 
+    # External ACP process transport. These fields let third-party plugins
+    # reuse the generic ACP shim without adding provider-name branches to the
+    # Hermes core. Environment variables are optional per-user overrides.
+    external_command: str = ""
+    external_args: tuple[str, ...] = ()
+    external_command_env: str = ""
+    external_args_env: str = ""
+    external_auth_args: tuple[str, ...] = ()
+
     # ── Vision support ────────────────────────────────────────
     # True when the provider's API accepts image content inside
     # tool-result messages natively.  Set on providers that expose

--- a/providers/base.py
+++ b/providers/base.py
@@ -64,6 +64,10 @@ class ProviderProfile:
     external_command_env: str = ""
     external_args_env: str = ""
     external_auth_args: tuple[str, ...] = ()
+    # Optional CLI flag used to bind each ACP process to the model selected in
+    # Hermes (for example ``--model``). Empty means the ACP server owns model
+    # selection and the requested model remains only an ACP prompt hint.
+    external_model_arg: str = ""
 
     # ── Vision support ────────────────────────────────────────
     # True when the provider's API accepts image content inside

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -105,7 +105,12 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
     def test_timeout_object_is_coerced_for_streaming_requests(self) -> None:
         captured: dict[str, float] = {}
 
-        def fake_run_prompt(prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        def fake_run_prompt(
+            prompt_text: str,
+            *,
+            timeout_seconds: float,
+            model: str | None = None,
+        ) -> tuple[str, str]:
             captured["timeout"] = timeout_seconds
             return "ok", ""
 

--- a/tests/providers/test_external_acp_provider.py
+++ b/tests/providers/test_external_acp_provider.py
@@ -1,0 +1,60 @@
+from types import SimpleNamespace
+
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    ProviderConfig,
+    get_external_process_provider_status,
+    resolve_external_process_provider_credentials,
+)
+
+
+def test_external_acp_profile_controls_command_and_auth(monkeypatch):
+    profile = SimpleNamespace(
+        external_command="python",
+        external_args=("-m", "example_acp"),
+        external_command_env="TEST_ACP_COMMAND",
+        external_args_env="TEST_ACP_ARGS",
+        external_auth_args=("-c", "raise SystemExit(0)"),
+    )
+    config = ProviderConfig(
+        id="test-acp",
+        name="Test ACP",
+        auth_type="external_process",
+        inference_base_url="acp://test",
+    )
+    monkeypatch.setitem(PROVIDER_REGISTRY, "test-acp", config)
+    monkeypatch.setattr("providers.get_provider_profile", lambda _: profile)
+
+    status = get_external_process_provider_status("test-acp")
+    credentials = resolve_external_process_provider_credentials("test-acp")
+
+    assert status["logged_in"] is True
+    assert status["args"] == ["-m", "example_acp"]
+    assert credentials["provider"] == "test-acp"
+    assert credentials["api_key"] == "test-acp"
+    assert credentials["base_url"] == "acp://test"
+    assert credentials["args"] == ["-m", "example_acp"]
+
+
+def test_external_acp_environment_overrides_profile(monkeypatch):
+    profile = SimpleNamespace(
+        external_command="python",
+        external_args=("default",),
+        external_command_env="TEST_ACP_COMMAND",
+        external_args_env="TEST_ACP_ARGS",
+        external_auth_args=(),
+    )
+    config = ProviderConfig(
+        id="test-acp-env",
+        name="Test ACP Env",
+        auth_type="external_process",
+        inference_base_url="acp://test-env",
+    )
+    monkeypatch.setitem(PROVIDER_REGISTRY, "test-acp-env", config)
+    monkeypatch.setattr("providers.get_provider_profile", lambda _: profile)
+    monkeypatch.setenv("TEST_ACP_COMMAND", "python")
+    monkeypatch.setenv("TEST_ACP_ARGS", "-m overridden")
+
+    credentials = resolve_external_process_provider_credentials("test-acp-env")
+
+    assert credentials["args"] == ["-m", "overridden"]

--- a/tests/providers/test_external_acp_provider.py
+++ b/tests/providers/test_external_acp_provider.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+from agent.copilot_acp_client import CopilotACPClient, ExternalACPClient
 from hermes_cli.auth import (
     PROVIDER_REGISTRY,
     ProviderConfig,
@@ -15,6 +16,7 @@ def test_external_acp_profile_controls_command_and_auth(monkeypatch):
         external_command_env="TEST_ACP_COMMAND",
         external_args_env="TEST_ACP_ARGS",
         external_auth_args=("-c", "raise SystemExit(0)"),
+        external_model_arg="--model",
     )
     config = ProviderConfig(
         id="test-acp",
@@ -34,6 +36,7 @@ def test_external_acp_profile_controls_command_and_auth(monkeypatch):
     assert credentials["api_key"] == "test-acp"
     assert credentials["base_url"] == "acp://test"
     assert credentials["args"] == ["-m", "example_acp"]
+    assert credentials["model_arg"] == "--model"
 
 
 def test_external_acp_environment_overrides_profile(monkeypatch):
@@ -43,6 +46,7 @@ def test_external_acp_environment_overrides_profile(monkeypatch):
         external_command_env="TEST_ACP_COMMAND",
         external_args_env="TEST_ACP_ARGS",
         external_auth_args=(),
+        external_model_arg="",
     )
     config = ProviderConfig(
         id="test-acp-env",
@@ -58,3 +62,22 @@ def test_external_acp_environment_overrides_profile(monkeypatch):
     credentials = resolve_external_process_provider_credentials("test-acp-env")
 
     assert credentials["args"] == ["-m", "overridden"]
+
+
+def test_external_acp_client_binds_selected_model_to_process():
+    client = ExternalACPClient(
+        api_key="devin-acp",
+        command="devin",
+        args=["acp"],
+        provider_name="devin-acp",
+        display_name="Devin Subscription",
+        model_arg="--model",
+    )
+
+    assert client._build_process_args("gpt-5-6-sol-none") == [
+        "devin",
+        "acp",
+        "--model",
+        "gpt-5-6-sol-none",
+    ]
+    assert CopilotACPClient is ExternalACPClient

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -7880,7 +7880,7 @@ def test_aiagent_uses_copilot_acp_client():
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI") as mock_openai,
-        patch("agent.copilot_acp_client.CopilotACPClient") as mock_acp_client,
+        patch("agent.copilot_acp_client.ExternalACPClient") as mock_acp_client,
     ):
         acp_client = MagicMock()
         mock_acp_client.return_value = acp_client


### PR DESCRIPTION
## Summary

- generalize external-process ACP provider discovery and authentication
- replace provider-specific runtime identity with `ExternalACPClient` while retaining `CopilotACPClient` as a compatibility alias
- let provider profiles declare an optional model CLI flag so Hermes can bind the selected model to each ACP process
- keep Copilot behavior backward compatible while enabling standalone providers such as Devin ACP

## Why

The existing ACP transport was reusable at the wire level but still surfaced Copilot-specific identity and only passed the selected model as a prompt hint. A standalone external provider could execute the correct binary while appearing as Copilot, and could not guarantee the selected model was actually used.

## Validation

- `scripts/run_tests.sh tests/providers/test_external_acp_provider.py tests/agent/test_copilot_acp_client.py tests/run_agent/test_streaming.py tests/run_agent/test_run_agent.py` — 540 passed
- Ruff and `git diff --check` passed
- Real temp-`HERMES_HOME` E2E against authenticated Devin CLI returned `DEVIN_MODEL_BOUND_OK`
- Observed child argv: `devin acp --model gpt-5-6-sol-none`

The concrete Devin integration remains in its standalone plugin repository; this PR only widens the generic provider contract and transport.