### PR TITLE
test(hermes-cli): isolate Qwen OAuth fallthrough test from real credential pool

### DIFF
--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -87,20 +87,35 @@ def test_resolve_runtime_provider_uses_credential_pool(monkeypatch):
 
 
 def test_qwen_oauth_auto_fallthrough_on_auth_failure(monkeypatch):
-    """When requested_provider is 'auto' and Qwen creds fail, fall through."""
+    """When requested_provider is 'auto' and Qwen creds fail, fall through.
+
+    Must mock ``load_pool`` too: resolve_runtime_provider() checks the
+    credential pool before it ever reaches the qwen-oauth singleton block, so
+    on a machine with a real qwen-oauth pool entry the unmocked pool path
+    would return early with the *real* credentials and this test would pass
+    or fail based on the local auth profile instead of exercising the
+    fallthrough logic under test. See #HPA-03.
+    """
     from hermes_cli.auth import AuthError
 
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "qwen-oauth")
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: SimpleNamespace(has_credentials=lambda: False))
+    fallback_creds_calls = []
     monkeypatch.setattr(
         rp,
         "resolve_qwen_runtime_credentials",
-        lambda **kw: (_ for _ in ()).throw(AuthError("stale", provider="qwen-oauth", code="qwen_auth_missing")),
+        lambda **kw: fallback_creds_calls.append(kw) or (_ for _ in ()).throw(
+            AuthError("stale", provider="qwen-oauth", code="qwen_auth_missing")
+        ),
     )
     monkeypatch.setattr(rp, "_get_model_config", lambda: {})
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-or-key")
 
     # Should NOT raise — falls through to OpenRouter
     resolved = rp.resolve_runtime_provider(requested="auto")
+    # The mock actually ran — proves the fallthrough branch under test
+    # executed, not just that the final provider happens to differ.
+    assert len(fallback_creds_calls) == 1
     # The fallthrough means it won't be qwen-oauth
     assert resolved["provider"] != "qwen-oauth"
 


### PR DESCRIPTION
## Summary

- Fixes #77148: `test_qwen_oauth_auto_fallthrough_on_auth_failure` mocked `resolve_provider` and `resolve_qwen_runtime_credentials` but not `load_pool`. `resolve_runtime_provider()` checks the credential pool (`runtime_provider.py:1852`) and can return early via a pool entry (`runtime_provider.py:1910`) *before* it ever reaches the `qwen-oauth` singleton block (`runtime_provider.py:1981`) — so on a machine with a real Qwen OAuth pool entry, the mocked `AuthError` never fires and the test's outcome depends on the local auth profile instead of the fallthrough logic it's meant to cover.
- Mocks `load_pool` to report no credentials, matching the pattern two sibling tests in the same file already use.
- Adds an assertion that the mocked `resolve_qwen_runtime_credentials` was actually invoked, proving the fallthrough branch under test executed rather than just checking the final provider differs.

## Root cause diagram

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
flowchart TD
    A["resolve_runtime_provider(requested='auto')"] --> B["load_pool('qwen-oauth')"]
    B --> C{"Real pool entry present on this machine?"}
    C -- "Yes (before fix: unmocked)" --> D["Early return via _resolve_runtime_from_pool_entry"]
    D --> E["Mocked resolve_qwen_runtime_credentials NEVER called"]
    E --> F["Test outcome depends on local auth profile"]
    C -- "No (after fix: load_pool mocked)" --> G["Falls through to qwen-oauth singleton block"]
    G --> H["resolve_qwen_runtime_credentials() raises mocked AuthError"]
    H --> I["requested == 'auto' -> falls through to OpenRouter"]
    I --> J["Test verifies the actual fallthrough logic"]
```

## Test plan

- [x] `pytest tests/hermes_cli/test_runtime_provider_resolution.py -q` — 55 passed.
- [x] Traced `resolve_runtime_provider()` end-to-end to confirm the pool-check-and-early-return block executes unconditionally before the `qwen-oauth` block, and that the fix's added assertion (`fallback_creds_calls`) would fail if the pool short-circuited the fallthrough path.
