### PR TITLE
fix(kanban): skip promotion bookkeeping when UPDATE affects zero rows

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4204,16 +4204,27 @@ def recompute_ready(
                     )
                     if failures >= effective_limit:
                         continue
-                    conn.execute(
+                    cur = conn.execute(
                         "UPDATE tasks SET status = 'ready' "
                         "WHERE id = ? AND status = 'blocked'",
                         (task_id,),
                     )
                 else:
-                    conn.execute(
+                    cur = conn.execute(
                         "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = 'todo'",
                         (task_id,),
                     )
+                if cur.rowcount != 1:
+                    # A concurrent writer or a suppressing trigger moved the
+                    # row between selection and UPDATE — do not fabricate a
+                    # promotion event or count it (audit log + dispatcher
+                    # 'promoted=N' must report only real transitions).
+                    _log.debug(
+                        "Skipped promotion bookkeeping for task %s "
+                        "(UPDATE affected %s rows)",
+                        task_id, cur.rowcount,
+                    )
+                    continue
                 _append_event(conn, task_id, "promoted", None)
                 promoted += 1
     return promoted

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -422,6 +422,42 @@ def test_recompute_ready_honours_dispatcher_failure_limit(kanban_home):
         assert kb.get_task(conn, t2).status == "blocked"
 
 
+def test_recompute_ready_skips_bookkeeping_when_update_suppressed(kanban_home):
+    """A promotion UPDATE that affects zero rows must not fabricate an event.
+
+    A suppressing trigger (or a concurrent writer) can make the UPDATE match
+    nothing between candidate selection and the write.  Before the fix,
+    recompute_ready appended a 'promoted' event and incremented its return
+    counter regardless, so the audit log and the dispatcher 'promoted=N'
+    line reported transitions that never happened (#77140).
+    """
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="a")
+        child = kb.create_task(conn, title="child", assignee="a")
+        kb.link_tasks(conn, parent_id=parent, child_id=child)
+        # Guard trigger mirrors the reporter's deployment: mirror-owned rows
+        # must not be mutated by other writers.  RAISE(IGNORE) silently skips
+        # the row, so the UPDATE affects zero rows.
+        conn.execute(
+            "CREATE TRIGGER suppress_promote BEFORE UPDATE OF status ON tasks "
+            "WHEN NEW.status = 'ready' AND OLD.status = 'todo' "
+            "BEGIN SELECT RAISE(IGNORE); END"
+        )
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (parent,))
+        conn.commit()
+
+        assert kb.recompute_ready(conn) == 0
+        # The child stays todo — the promotion never landed.
+        assert kb.get_task(conn, child).status == "todo"
+        # And no fabricated event was appended for it.
+        promoted_events = conn.execute(
+            "SELECT COUNT(*) FROM task_events "
+            "WHERE task_id = ? AND kind = 'promoted'",
+            (child,),
+        ).fetchone()[0]
+        assert promoted_events == 0
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`recompute_ready` appended a `promoted` event to `task_events` and incremented its return counter **even when the status UPDATE matched no row**, fabricating audit-log entries and dispatcher `promoted=N` counts for transitions that never happened. Fixes #77140.

The suppression is real in the wild: a `BEFORE UPDATE ... RAISE(IGNORE)` guard trigger (or a concurrent writer moving the task between candidate selection and the UPDATE) makes `cur.rowcount == 0` while the function still reports success. One deployment logged 623,418 fabricated events in ~12 hours from this path.

## Change

- Capture the `UPDATE` cursor in both promotion branches (`blocked` and `todo`).
- Only append the event and increment `promoted` when `cur.rowcount == 1`, matching the rowcount-as-source-of-truth convention already used by `archive_task`.
- Log the skipped promotion at `debug` so a suppressed write is observable instead of silent.

## Verification

- New regression test `test_recompute_ready_skips_bookkeeping_when_update_suppressed`: creates a task whose promotion is suppressed by a `RAISE(IGNORE)` trigger (the reporter's deployment shape), asserts `recompute_ready() == 0`, the task stays `todo`, and no `promoted` event exists.
- Confirmed the test **fails on the unfixed code** (fabricated event + `promoted == 1`) and passes with the fix.
- `pytest tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_blocked_sticky.py` → 60 passed.