### PR TITLE
feat(memory): archive evicted entries to ARCHIVE.jsonl before rewrites

### DIFF
--- a/agent/learning_mutations.py
+++ b/agent/learning_mutations.py
@@ -18,7 +18,7 @@ file. Pure stdlib + existing skill/memory helpers.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 _MEMORY_FILES = {"memory": "MEMORY.md", "profile": "USER.md"}
 
@@ -141,6 +141,37 @@ def _delete_skill(name: str) -> dict[str, Any]:
     return {"ok": ok, "message": f"archived '{name}' — restore with: hermes curator restore {name}" if ok else message}
 
 
+def _archive_target_for_source(source: str) -> str:
+    """Journey source → memory-tool archive target.
+
+    ``profile`` nodes live in USER.md, so they must archive as ``user`` and
+    honor the same privacy gate (``memory.archive_user``) as direct USER.md
+    mutations — never as ``memory``, which would both mislabel the record and
+    bypass the opt-in default (#77154 review).
+    """
+    return "user" if source == "profile" else "memory"
+
+
+def _archive_evicted(archive_target: str, action: str, evicted: str) -> tuple[Optional[str], Optional[str]]:
+    """Archive an evicted chunk through the memory tool, gated per store.
+
+    Returns ``(record_id, None)`` when archived, ``(None, None)`` when the
+    store's privacy default skips archiving, ``(None, error)`` when the write
+    failed (mutation proceeds; the caller surfaces the degraded note).
+    """
+    try:
+        from tools.memory_tool import _should_archive_target, archive_entry
+
+        if not _should_archive_target(archive_target):
+            return None, None
+        archived_id, archived_error = archive_entry(archive_target, action, evicted)
+        if archived_error:
+            return None, archived_error
+        return archived_id, None
+    except Exception as exc:  # pragma: no cover - import/IO edge
+        return None, str(exc)
+
+
 def _delete_memory(node_id: str) -> dict[str, Any]:
     source, gidx = _parse_memory_id(node_id)
     path, chunks, local = _locate_memory(source, gidx)
@@ -148,18 +179,10 @@ def _delete_memory(node_id: str) -> dict[str, Any]:
     evicted = chunks[local]
 
     # Reversible deletion: archive the evicted chunk before the rewrite, same
-    # ARCHIVE.jsonl as the memory tool's remove/replace (store="memory",
-    # action="removed"). Failure degrades (mutation proceeds + note) rather
-    # than blocking a user-initiated delete.
-    archived_id = None
-    try:
-        from tools.memory_tool import archive_entry
-
-        archived_id, archived_error = archive_entry("memory", "removed", evicted)
-        if archived_error:
-            archived_id = None
-    except Exception as exc:  # pragma: no cover - import/IO edge
-        archived_error = str(exc)
+    # ARCHIVE.jsonl as the memory tool's remove/replace. Profile nodes archive
+    # as ``user`` and honor the ``archive_user`` gate. Failure degrades
+    # (mutation proceeds + note) rather than blocking a user-initiated delete.
+    archived_id, archived_error = _archive_evicted(_archive_target_for_source(source), "removed", evicted)
 
     del chunks[local]
     _write_memory(path, chunks)
@@ -201,10 +224,21 @@ def _edit_memory(node_id: str, content: str) -> dict[str, Any]:
         return {"ok": False, "message": "empty memory — use delete to remove it"}
     path, chunks, local = _locate_memory(source, gidx)
 
+    evicted = chunks[local]
+
+    # Reversible edit: the superseded chunk is archived before the rewrite,
+    # same gate as delete (profile → user store, honor archive_user).
+    archived_id, archived_error = _archive_evicted(_archive_target_for_source(source), "superseded", evicted)
+
     chunks[local] = body
     _write_memory(path, chunks)
 
-    return {"ok": True, "message": f"updated memory in {path.name}"}
+    message = f"updated memory in {path.name}"
+    if archived_id:
+        message += f" — superseded content archived to ARCHIVE.jsonl#{archived_id} (reversible)"
+    elif archived_error:
+        message += f" — note: archive write failed ({archived_error})"
+    return {"ok": True, "message": message}
 
 
 # ── Helpers ─────────────────────────────────────────────────────────────────

--- a/agent/learning_mutations.py
+++ b/agent/learning_mutations.py
@@ -145,10 +145,31 @@ def _delete_memory(node_id: str) -> dict[str, Any]:
     source, gidx = _parse_memory_id(node_id)
     path, chunks, local = _locate_memory(source, gidx)
 
+    evicted = chunks[local]
+
+    # Reversible deletion: archive the evicted chunk before the rewrite, same
+    # ARCHIVE.jsonl as the memory tool's remove/replace (store="memory",
+    # action="removed"). Failure degrades (mutation proceeds + note) rather
+    # than blocking a user-initiated delete.
+    archived_id = None
+    try:
+        from tools.memory_tool import archive_entry
+
+        archived_id, archived_error = archive_entry("memory", "removed", evicted)
+        if archived_error:
+            archived_id = None
+    except Exception as exc:  # pragma: no cover - import/IO edge
+        archived_error = str(exc)
+
     del chunks[local]
     _write_memory(path, chunks)
 
-    return {"ok": True, "message": f"deleted memory from {path.name}"}
+    message = f"deleted memory from {path.name}"
+    if archived_id:
+        message += f" — evicted content archived to ARCHIVE.jsonl#{archived_id} (reversible)"
+    elif archived_error:
+        message += f" — note: archive write failed ({archived_error}), content is gone"
+    return {"ok": True, "message": message}
 
 
 # ── Edit ────────────────────────────────────────────────────────────────────

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1657,6 +1657,20 @@ DEFAULT_CONFIG = {
         # "hindsight", "holographic", "retaindb", "byterover".
         # Only ONE external provider is allowed at a time.
         "provider": "",
+        # Reversible memory mutations: evicted entries (remove/replace and
+        # /journey delete on memory nodes) are appended to
+        # ~/.hermes/memories/ARCHIVE.jsonl before the main file rewrite, so
+        # consolidation can never destroy distilled content irreversibly.
+        #   archive_user: false (default) — USER.md evictions are NOT archived
+        #                 (data minimization for profile data). MEMORY.md is
+        #                 always archived. Set true to archive both stores.
+        #   archive_on_failure: "warn" (default) — archive write failed: the
+        #                 mutation still proceeds and the tool result carries
+        #                 "archive_status": "degraded". "abort" restores strict
+        #                 behavior (mutation refused) but can deadlock the
+        #                 memory-full consolidation path, hence the default.
+        "archive_user": False,
+        "archive_on_failure": "warn",
     },
 
     # Subagent delegation — override the provider:model used by delegate_task

--- a/tests/agent/test_learning_mutations.py
+++ b/tests/agent/test_learning_mutations.py
@@ -117,3 +117,67 @@ def test_delete_memory_archives_evicted_chunk(home):
 
     # The delete itself still happened.
     assert (home / "memories" / "MEMORY.md").read_text(encoding="utf-8") == "beta note"
+
+
+def test_delete_profile_memory_not_archived_by_default(home):
+    """Journey profile nodes map to USER.md — archiving must honor the
+    ``memory.archive_user: false`` privacy default (#77154 review)."""
+    res = lm.delete_node("memory:profile:2")
+    assert res["ok"]
+    assert "ARCHIVE.jsonl" not in res["message"]
+    assert not (home / "memories" / "ARCHIVE.jsonl").exists()
+    # The delete itself still happened.
+    assert (home / "memories" / "USER.md").read_text(encoding="utf-8").strip() == ""
+
+
+def test_delete_profile_memory_archived_when_configured(home):
+    """With ``memory.archive_user: true``, profile deletes archive as the
+    ``user`` store — never mislabeled as ``memory``."""
+    import json
+
+    (get_hermes_home() / "config.yaml").write_text(
+        "memory:\n  archive_user: true\n", encoding="utf-8"
+    )
+    res = lm.delete_node("memory:profile:2")
+    assert res["ok"]
+    assert "ARCHIVE.jsonl" in res["message"]
+    archive = home / "memories" / "ARCHIVE.jsonl"
+    records = [
+        json.loads(line)
+        for line in archive.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(records) == 1
+    assert records[0]["store"] == "user"
+    assert records[0]["action"] == "removed"
+    assert records[0]["entry"] == "user profile note"
+
+
+def test_edit_memory_archives_superseded(home):
+    """/journey edit archives the superseded chunk (reversible edits, same
+    ARCHIVE.jsonl) instead of destroying it (#77154 review)."""
+    import json
+
+    res = lm.edit_node("memory:memory:0", "alpha rewritten")
+    assert res["ok"]
+    assert "ARCHIVE.jsonl" in res["message"]
+    archive = home / "memories" / "ARCHIVE.jsonl"
+    records = [
+        json.loads(line)
+        for line in archive.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(records) == 1
+    assert records[0]["store"] == "memory"
+    assert records[0]["action"] == "superseded"
+    assert records[0]["entry"] == "alpha note\nline two"
+    # The edit itself landed.
+    assert (home / "memories" / "MEMORY.md").read_text(encoding="utf-8").startswith("alpha rewritten")
+
+
+def test_edit_profile_memory_not_archived_by_default(home):
+    """Profile edits honor the privacy gate too — nothing archived by default."""
+    res = lm.edit_node("memory:profile:2", "rewritten profile")
+    assert res["ok"]
+    assert "ARCHIVE.jsonl" not in res["message"]
+    assert not (home / "memories" / "ARCHIVE.jsonl").exists()

--- a/tests/agent/test_learning_mutations.py
+++ b/tests/agent/test_learning_mutations.py
@@ -91,3 +91,29 @@ def test_memory_writes_match_memory_tool_format(home):
 
     assert entries == ["alpha rewritten", "beta note"]
     assert path.read_text(encoding="utf-8") == ENTRY_DELIMITER.join(entries)
+
+
+def test_delete_memory_archives_evicted_chunk(home):
+    """/journey delete on a memory node archives the evicted chunk to
+    ARCHIVE.jsonl before the rewrite — the same reversible-delete semantics
+    as the memory tool's remove() (#76883)."""
+    import json
+
+    res = lm.delete_node("memory:memory:0")
+    assert res["ok"]
+    assert "ARCHIVE.jsonl" in res["message"]
+
+    archive = home / "memories" / "ARCHIVE.jsonl"
+    assert archive.exists()
+    records = [
+        json.loads(line)
+        for line in archive.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(records) == 1
+    assert records[0]["store"] == "memory"
+    assert records[0]["action"] == "removed"
+    assert records[0]["entry"] == "alpha note\nline two"
+
+    # The delete itself still happened.
+    assert (home / "memories" / "MEMORY.md").read_text(encoding="utf-8") == "beta note"

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -745,3 +745,55 @@ class TestMemoryArchive:
         assert result["success"] is False
         assert "abort" in result["error"]
         assert "Precious entry" in store.memory_entries
+
+    def test_batch_abort_never_leaves_partial_archive(
+        self, store, tmp_path, monkeypatch
+    ):
+        """Abort-mode archive failure must be caller-visible atomic: the batch
+        is refused AND the archive is untouched — no partial records from
+        earlier evictions can survive a later failure (#77154 review)."""
+        (get_hermes_home() / "config.yaml").write_text(
+            "memory:\n  archive_on_failure: abort\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(
+            "tools.memory_tool._archive_append_lines",
+            lambda lines: (_ for _ in ()).throw(OSError("disk full")),
+        )
+        store.add("memory", "Entry one")
+        store.add("memory", "Entry two")
+        result = store.apply_batch(
+            "memory",
+            [
+                {"action": "remove", "old_text": "Entry one"},
+                {"action": "replace", "old_text": "Entry two", "content": "Entry two v2"},
+            ],
+        )
+        assert result["success"] is False
+        assert "abort" in result["error"]
+        # No partial archive, memory untouched.
+        assert _read_archive(tmp_path) == []
+        assert "Entry one" in store.memory_entries
+        assert "Entry two" in store.memory_entries
+
+    def test_batch_archive_failure_degrades_atomically(
+        self, store, tmp_path, monkeypatch
+    ):
+        """Default warn mode: a failed archive write leaves NO records behind
+        (atomic), the mutation proceeds, and the result says degraded."""
+        monkeypatch.setattr(
+            "tools.memory_tool._archive_append_lines",
+            lambda lines: (_ for _ in ()).throw(OSError("disk full")),
+        )
+        store.add("memory", "Entry one")
+        store.add("memory", "Entry two")
+        result = store.apply_batch(
+            "memory",
+            [
+                {"action": "remove", "old_text": "Entry one"},
+                {"action": "remove", "old_text": "Entry two"},
+            ],
+        )
+        assert result["success"] is True
+        assert result["archive_status"] == "degraded"
+        assert _read_archive(tmp_path) == []
+        assert store.memory_entries == []

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -4,6 +4,8 @@ import json
 import pytest
 from pathlib import Path
 
+from hermes_constants import get_hermes_home
+
 from tools.memory_tool import (
     MemoryStore,
     memory_tool,
@@ -627,3 +629,119 @@ class TestLoadTimeSnapshotSanitization:
         # Block marker appears exactly once, not nested
         assert snapshot.count("[BLOCKED:") == 1
         assert "Clean fact" in snapshot
+
+
+# =========================================================================
+# Reversible mutations — eviction archive (ARCHIVE.jsonl)
+# =========================================================================
+
+
+def _read_archive(tmp_path):
+    path = tmp_path / "ARCHIVE.jsonl"
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+class TestMemoryArchive:
+    def test_remove_archives_evicted_entry(self, store, tmp_path):
+        store.add("memory", "Retired fact about the old stack")
+        result = store.remove("memory", "Retired fact")
+        assert result["success"] is True
+        records = _read_archive(tmp_path)
+        assert len(records) == 1
+        assert records[0]["store"] == "memory"
+        assert records[0]["action"] == "removed"
+        assert records[0]["entry"] == "Retired fact about the old stack"
+        assert "archived" in result
+        assert result["archived"]["id"] == records[0]["id"]
+        assert "ARCHIVE.jsonl" in result["message"]
+
+    def test_replace_archives_superseded_entry(self, store, tmp_path):
+        store.add("memory", "Python 3.11 project")
+        result = store.replace("memory", "3.11", "Python 3.12 project")
+        assert result["success"] is True
+        records = _read_archive(tmp_path)
+        assert len(records) == 1
+        assert records[0]["action"] == "superseded"
+        assert records[0]["entry"] == "Python 3.11 project"
+        assert result["archived"]["action"] == "superseded"
+
+    def test_user_target_not_archived_by_default(self, store, tmp_path):
+        store.add("user", "Name: Alice")
+        result = store.remove("user", "Name: Alice")
+        assert result["success"] is True
+        assert "archived" not in result
+        assert _read_archive(tmp_path) == []
+
+    def test_user_target_archived_when_configured(self, store, tmp_path, monkeypatch):
+        # Config is read through the sanctioned loader (hermes_cli.config),
+        # which resolves the sandboxed session HERMES_HOME — write there.
+        (get_hermes_home() / "config.yaml").write_text(
+            "memory:\n  archive_user: true\n", encoding="utf-8"
+        )
+        store.add("user", "Name: Alice")
+        result = store.remove("user", "Name: Alice")
+        assert result["success"] is True
+        records = _read_archive(tmp_path)
+        assert len(records) == 1
+        assert records[0]["store"] == "user"
+
+    def test_apply_batch_archives_evicted_entries_on_commit(self, store, tmp_path):
+        store.add("memory", "Entry one")
+        store.add("memory", "Entry two")
+        result = store.apply_batch(
+            "memory",
+            [
+                {"action": "replace", "old_text": "Entry one", "content": "Entry one v2"},
+                {"action": "remove", "old_text": "Entry two"},
+            ],
+        )
+        assert result["success"] is True
+        records = _read_archive(tmp_path)
+        assert [r["action"] for r in records] == ["superseded", "removed"]
+        assert len(result["archived"]) == 2
+
+    def test_failed_batch_never_archives(self, store, tmp_path):
+        store.add("memory", "Keep me")
+        result = store.apply_batch(
+            "memory",
+            [
+                {"action": "remove", "old_text": "Keep me"},
+                {"action": "replace", "old_text": "no such entry", "content": "x"},
+            ],
+        )
+        assert result["success"] is False
+        assert _read_archive(tmp_path) == []
+        assert "Keep me" in store.memory_entries
+
+    def test_archive_write_failure_degrades_by_default(self, store, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "tools.memory_tool.archive_entry", lambda *a, **k: (None, "disk full")
+        )
+        store.add("memory", "Doomed entry")
+        result = store.remove("memory", "Doomed entry")
+        assert result["success"] is True
+        assert result["archive_status"] == "degraded"
+        assert "Doomed entry" not in store.memory_entries
+
+    def test_archive_write_failure_aborts_when_configured(
+        self, store, tmp_path, monkeypatch
+    ):
+        # Config is read through the sanctioned loader (hermes_cli.config),
+        # which resolves the sandboxed session HERMES_HOME — write there.
+        (get_hermes_home() / "config.yaml").write_text(
+            "memory:\n  archive_on_failure: abort\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(
+            "tools.memory_tool.archive_entry", lambda *a, **k: (None, "disk full")
+        )
+        store.add("memory", "Precious entry")
+        result = store.remove("memory", "Precious entry")
+        assert result["success"] is False
+        assert "abort" in result["error"]
+        assert "Precious entry" in store.memory_entries

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -153,31 +153,68 @@ def _archive_abort_on_failure() -> bool:
     return _read_memory_archive_config().get("archive_on_failure") == "abort"
 
 
+def _archive_append_lines(lines: List[str]) -> None:
+    """Append prebuilt JSONL lines to ARCHIVE.jsonl in a single write.
+
+    Raises OSError on failure. The single write plus an ftruncate rollback
+    keeps the archive caller-visible atomic: either every line lands or none
+    does — no partial batch can survive an archive failure.
+    """
+    path = _archive_path()
+    get_memory_dir().mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        start = f.tell()
+        try:
+            f.write("".join(lines))
+            f.flush()
+        except OSError:
+            try:
+                f.truncate(start)
+            except OSError:
+                pass
+            raise
+
+
+def archive_entries(
+    target: str, actions_entries: List[Tuple[str, str]]
+) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    """Append evicted entries to ARCHIVE.jsonl as one atomic batch.
+
+    Returns ``(records, None)`` on success (records carry ``id``/``ts``/
+    ``store``/``action``/``entry``) or ``([], error)`` after one retry when the
+    write keeps failing — in which case nothing was appended. Never raises.
+    """
+    records = [
+        {
+            "id": uuid.uuid4().hex,
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "store": target,
+            "action": action,  # "removed" | "superseded"
+            "entry": entry,
+        }
+        for action, entry in actions_entries
+    ]
+    lines = [json.dumps(record, ensure_ascii=False) + "\n" for record in records]
+    last_error: Optional[str] = None
+    for _ in (1, 2):  # one retry, then degrade per config
+        try:
+            _archive_append_lines(lines)
+            return records, None
+        except OSError as exc:
+            last_error = str(exc)
+    return [], last_error
+
+
 def archive_entry(target: str, action: str, entry: str) -> Tuple[Optional[str], Optional[str]]:
     """Append one evicted entry to ARCHIVE.jsonl.
 
     Returns ``(record_id, None)`` on success, ``(None, error)`` after one
     retry when the write keeps failing. Never raises.
     """
-    record = {
-        "id": uuid.uuid4().hex,
-        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "store": target,
-        "action": action,  # "removed" | "superseded"
-        "entry": entry,
-    }
-    line = json.dumps(record, ensure_ascii=False) + "\n"
-    path = _archive_path()
-    last_error: Optional[str] = None
-    for _ in (1, 2):  # one retry, then degrade per config
-        try:
-            get_memory_dir().mkdir(parents=True, exist_ok=True)
-            with open(path, "a", encoding="utf-8") as f:
-                f.write(line)
-            return record["id"], None
-        except OSError as exc:
-            last_error = str(exc)
-    return None, last_error
+    records, error = archive_entries(target, [(action, entry)])
+    if error:
+        return None, error
+    return records[0]["id"], None
 
 
 def _drift_error(path: "Path", bak_path: str) -> Dict[str, Any]:
@@ -788,28 +825,36 @@ class MemoryStore:
                 })
 
             # Archive evicted entries at the commit point — a failed batch
-            # never touches the archive. MEMORY.md always archives; USER.md
-            # only when configured in.
+            # never touches the archive, and the write itself is atomic (one
+            # append for all records, rolled back on failure), so abort mode
+            # can never leave a partial archive behind. MEMORY.md always
+            # archives; USER.md only when configured in.
             archives: List[Dict[str, Any]] = []
             degraded = False
             if evicted and _should_archive_target(target):
-                for action, entry in evicted:
-                    archived_id, archived_error = archive_entry(target, action, entry)
-                    if archived_error:
-                        if _archive_abort_on_failure():
-                            return {
-                                "success": False,
-                                "error": (
-                                    f"Archive write failed ({archived_error}) and "
-                                    "memory.archive_on_failure=abort — batch not applied."
-                                ),
-                            }
-                        logger.warning("Memory archive write failed (degraded): %s", archived_error)
-                        degraded = True
-                    else:
-                        archives.append(
-                            {"file": ARCHIVE_FILENAME, "id": archived_id, "store": target, "action": action, "entry": entry}
-                        )
+                archived_records, archived_error = archive_entries(target, evicted)
+                if archived_error:
+                    if _archive_abort_on_failure():
+                        return {
+                            "success": False,
+                            "error": (
+                                f"Archive write failed ({archived_error}) and "
+                                "memory.archive_on_failure=abort — batch not applied."
+                            ),
+                        }
+                    logger.warning("Memory archive write failed (degraded): %s", archived_error)
+                    degraded = True
+                else:
+                    archives = [
+                        {
+                            "file": ARCHIVE_FILENAME,
+                            "id": record["id"],
+                            "store": record["store"],
+                            "action": record["action"],
+                            "entry": record["entry"],
+                        }
+                        for record in archived_records
+                    ]
 
             # Commit.
             self._set_entries(target, working)

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -26,6 +26,7 @@ Design:
 import json
 import logging
 import time
+import uuid
 from contextlib import contextmanager
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -86,6 +87,97 @@ from tools.threat_patterns import first_threat_message as _first_threat_message
 def _scan_memory_content(content: str) -> Optional[str]:
     """Scan memory content for injection/exfil patterns. Returns error string if blocked."""
     return _first_threat_message(content, scope="strict")
+
+
+# ---------------------------------------------------------------------------
+# Reversible mutations — local eviction archive (ARCHIVE.jsonl)
+#
+# remove/replace/apply_batch (and ``/journey delete`` on memory nodes) append
+# the evicted entry to ``~/.hermes/memories/ARCHIVE.jsonl`` before the main
+# file rewrite, so consolidation can never destroy distilled content
+# irreversibly. Zero-dependency, provider-independent, per-profile (the file
+# lives under get_memory_dir(), which is already profile-scoped).
+#
+# Semantics:
+#   - At-least-once: a crash between archive-append and main rewrite leaves a
+#     ghost record (reconcilable by ``id``) but never loses content.
+#   - Failure degradation: an archive write failure is retried once; if it
+#     still fails the mutation proceeds by default and the tool result carries
+#     ``"archive_status": "degraded"``. ``memory.archive_on_failure: "abort"``
+#     restores strict behavior (mutation refused) at the cost of being able to
+#     deadlock the memory-full consolidation path.
+#   - Privacy: MEMORY.md evictions are archived by default; USER.md is not
+#     (``memory.archive_user: false``) — data minimization for profile data.
+# ---------------------------------------------------------------------------
+
+ARCHIVE_FILENAME = "ARCHIVE.jsonl"
+
+
+def _archive_path() -> Path:
+    return get_memory_dir() / ARCHIVE_FILENAME
+
+
+def _read_memory_archive_config() -> Dict[str, Any]:
+    """Read the ``memory.archive_*`` keys through the sanctioned config loader.
+
+    Uses ``hermes_cli.config.load_config_readonly()`` — the canonical owner
+    of config.yaml reads (the config-read guard forbids raw ``yaml.safe_load``
+    here), so the managed-scope overlay, ``${ENV_VAR}`` expansion, and
+    profile-aware pathing all apply. Only consulted at mutation time (not at
+    import), so config edits apply immediately (the loader's cache is keyed on
+    the file's mtime/size). A missing/unreadable config degrades to defaults.
+    """
+    cfg: Dict[str, Any] = {"archive_user": False, "archive_on_failure": "warn"}
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        memory_cfg = load_config_readonly().get("memory") or {}
+        if isinstance(memory_cfg, dict):
+            if "archive_user" in memory_cfg:
+                cfg["archive_user"] = bool(memory_cfg["archive_user"])
+            if "archive_on_failure" in memory_cfg:
+                cfg["archive_on_failure"] = str(memory_cfg["archive_on_failure"])
+    except Exception:
+        logger.debug("Memory archive config unreadable — using defaults", exc_info=True)
+    return cfg
+
+
+def _should_archive_target(target: str) -> bool:
+    """MEMORY.md always archives; USER.md only when configured in."""
+    if target == "user":
+        return bool(_read_memory_archive_config()["archive_user"])
+    return True
+
+
+def _archive_abort_on_failure() -> bool:
+    return _read_memory_archive_config().get("archive_on_failure") == "abort"
+
+
+def archive_entry(target: str, action: str, entry: str) -> Tuple[Optional[str], Optional[str]]:
+    """Append one evicted entry to ARCHIVE.jsonl.
+
+    Returns ``(record_id, None)`` on success, ``(None, error)`` after one
+    retry when the write keeps failing. Never raises.
+    """
+    record = {
+        "id": uuid.uuid4().hex,
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "store": target,
+        "action": action,  # "removed" | "superseded"
+        "entry": entry,
+    }
+    line = json.dumps(record, ensure_ascii=False) + "\n"
+    path = _archive_path()
+    last_error: Optional[str] = None
+    for _ in (1, 2):  # one retry, then degrade per config
+        try:
+            get_memory_dir().mkdir(parents=True, exist_ok=True)
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(line)
+            return record["id"], None
+        except OSError as exc:
+            last_error = str(exc)
+    return None, last_error
 
 
 def _drift_error(path: "Path", bak_path: str) -> Dict[str, Any]:
@@ -511,11 +603,26 @@ class MemoryStore:
                     "usage": f"{current:,}/{limit:,}",
                 })
 
+            evicted = entries[idx]
+            archived_id = archived_error = None
+            if _should_archive_target(target):
+                archived_id, archived_error = archive_entry(target, "superseded", evicted)
+                if archived_error:
+                    if _archive_abort_on_failure():
+                        return {
+                            "success": False,
+                            "error": (
+                                f"Archive write failed ({archived_error}) and "
+                                "memory.archive_on_failure=abort — replacement not applied."
+                            ),
+                        }
+                    logger.warning("Memory archive write failed (degraded): %s", archived_error)
             entries[idx] = new_content
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
-        return self._success_response(target, "Entry replaced.")
+        result = self._success_response(target, "Entry replaced.")
+        return self._attach_archive(result, target, "superseded", evicted, archived_id, archived_error)
 
     def remove(self, target: str, old_text: str) -> Dict[str, Any]:
         """Remove the entry containing old_text substring."""
@@ -553,11 +660,26 @@ class MemoryStore:
                 # All identical -- safe to remove just the first
 
             idx = matches[0][0]
+            evicted = entries[idx]
+            archived_id = archived_error = None
+            if _should_archive_target(target):
+                archived_id, archived_error = archive_entry(target, "removed", evicted)
+                if archived_error:
+                    if _archive_abort_on_failure():
+                        return {
+                            "success": False,
+                            "error": (
+                                f"Archive write failed ({archived_error}) and "
+                                "memory.archive_on_failure=abort — removal not applied."
+                            ),
+                        }
+                    logger.warning("Memory archive write failed (degraded): %s", archived_error)
             entries.pop(idx)
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
-        return self._success_response(target, "Entry removed.")
+        result = self._success_response(target, "Entry removed.")
+        return self._attach_archive(result, target, "removed", evicted, archived_id, archived_error)
 
     def apply_batch(self, target: str, operations: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Apply a sequence of add/replace/remove ops to one target atomically.
@@ -595,6 +717,7 @@ class MemoryStore:
             # Work on a copy; only commit if the whole batch validates.
             working: List[str] = list(self._entries_for(target))
             limit = self._char_limit(target)
+            evicted: List[Tuple[str, str]] = []  # (action, entry) — archived at commit
 
             for i, op in enumerate(operations):
                 op = op or {}
@@ -626,6 +749,7 @@ class MemoryStore:
                             target,
                             f"{pos}: '{old_text}' matched multiple distinct entries -- be more specific.",
                         )
+                    evicted.append(("superseded", working[matches[0]]))
                     working[matches[0]] = content
 
                 elif act == "remove":
@@ -639,6 +763,7 @@ class MemoryStore:
                             target,
                             f"{pos}: '{old_text}' matched multiple distinct entries -- be more specific.",
                         )
+                    evicted.append(("removed", working[matches[0]]))
                     working.pop(matches[0])
 
                 else:
@@ -662,11 +787,44 @@ class MemoryStore:
                     "usage": f"{current:,}/{limit:,}",
                 })
 
+            # Archive evicted entries at the commit point — a failed batch
+            # never touches the archive. MEMORY.md always archives; USER.md
+            # only when configured in.
+            archives: List[Dict[str, Any]] = []
+            degraded = False
+            if evicted and _should_archive_target(target):
+                for action, entry in evicted:
+                    archived_id, archived_error = archive_entry(target, action, entry)
+                    if archived_error:
+                        if _archive_abort_on_failure():
+                            return {
+                                "success": False,
+                                "error": (
+                                    f"Archive write failed ({archived_error}) and "
+                                    "memory.archive_on_failure=abort — batch not applied."
+                                ),
+                            }
+                        logger.warning("Memory archive write failed (degraded): %s", archived_error)
+                        degraded = True
+                    else:
+                        archives.append(
+                            {"file": ARCHIVE_FILENAME, "id": archived_id, "store": target, "action": action, "entry": entry}
+                        )
+
             # Commit.
             self._set_entries(target, working)
             self.save_to_disk(target)
 
-        return self._success_response(target, f"Applied {len(operations)} operation(s).")
+        result = self._success_response(target, f"Applied {len(operations)} operation(s).")
+        if archives:
+            result["archived"] = archives
+            result["message"] = (result.get("message") or "") + (
+                f" {len(archives)} evicted entr{'y' if len(archives) == 1 else 'ies'}"
+                f" archived to {ARCHIVE_FILENAME} (reversible)."
+            )
+        if degraded:
+            result["archive_status"] = "degraded"
+        return result
 
     def _batch_error(self, target: str, message: str) -> Dict[str, Any]:
         """Build a batch-abort error that reports live (uncommitted) state."""
@@ -727,6 +885,37 @@ class MemoryStore:
             resp["message"] = message
         resp["note"] = "Write saved. This update is complete — do not repeat it."
         return resp
+
+    @staticmethod
+    def _attach_archive(
+        result: Dict[str, Any],
+        target: str,
+        action: str,
+        entry: str,
+        archived_id: Optional[str],
+        archived_error: Optional[str],
+    ) -> Dict[str, Any]:
+        """Attach archive bookkeeping to a mutation's success result.
+
+        Successful archive → ``archived`` block (id + evicted entry, so the
+        model sees exactly what was captured at the moment of the mutation —
+        zero standing prompt cost). Failed archive → ``archive_status:
+        "degraded"``; the mutation itself already proceeded.
+        """
+        if archived_id:
+            result["archived"] = {
+                "file": ARCHIVE_FILENAME,
+                "id": archived_id,
+                "store": target,
+                "action": action,
+                "entry": entry,
+            }
+            result["message"] = (result.get("message") or "") + (
+                f" Evicted content archived to {ARCHIVE_FILENAME}#{archived_id} (reversible)."
+            )
+        elif archived_error:
+            result["archive_status"] = "degraded"
+        return result
 
     def _render_block(self, target: str, entries: List[str]) -> str:
         """Render a system prompt block with header and usage indicator."""


### PR DESCRIPTION
## Summary

Makes built-in memory mutations reversible: `remove()` / `replace()` / `apply_batch()` (and `/journey delete` on memory nodes) append the evicted entry to `~/.hermes/memories/ARCHIVE.jsonl` **before** the main file rewrite, so consolidation can never destroy distilled content irreversibly. Implements the PR1 scope of #76883 (remove/replace return-value fix + archive write path + `learning_mutations._delete_memory` coverage).

Skills already enjoy archive-not-delete semantics via the curator; this closes the asymmetry for memory entries — equally distilled learning artifacts.

## Design

- **Zero-dependency, per-profile**: `ARCHIVE.jsonl` lives under `get_memory_dir()` (already profile-scoped). Append-only JSONL records: `{id, ts, store, action: "removed"|"superseded", entry}`.
- **At-least-once**: archive append happens before the main rewrite; a crash in between leaves a ghost record (reconcilable by `id`) but never loses content.
- **Recall at zero standing prompt cost**: the tool result carries the archive `id` + the evicted entry itself (`"archived"`), so the model sees exactly what was captured at the moment of mutation — no system-prompt addition, prompt cache untouched.
- **Privacy defaults** (per the issue's lean): `MEMORY.md` archives by default; `USER.md` does **not** (`memory.archive_user: false` default, opt-in).
- **Failure degradation**: an archive write failure is retried once; if it still fails the mutation proceeds and the result carries `"archive_status": "degraded"`. `memory.archive_on_failure: "abort"` restores strict behavior (mutation refused) — off by default so the memory-full consolidation path can never deadlock.
- **Batch semantics**: evicted entries are archived only at the commit point — a failed batch never touches the archive.
- **`/journey delete`**: `learning_mutations._delete_memory` archives the evicted chunk through the same `archive_entry()` helper (was bypassing the memory tool entirely).

## Config (new keys, `config_defaults.py`)

```yaml
memory:
  archive_user: false        # USER.md evictions archived only when true
  archive_on_failure: warn   # warn (default) | abort
```

## Verification

- New `TestMemoryArchive` suite (8 tests): remove/replace capture, user-store privacy default + opt-in, batch commit capture, failed-batch never archives, degraded default, abort when configured.
- New `test_delete_memory_archives_evicted_chunk` for `/journey delete`.
- `pytest tests/tools/test_memory_tool.py tests/agent/test_learning_mutations.py tests/hermes_cli/test_config.py` → 122 passed.

## Open questions from #76883 I resolved conservatively

- On-by-default for `MEMORY.md`, opt-in for `USER.md` (the issue's stated lean; maintainers can flip the default in review).
- No new tool schema fields; the `no_archive` escape valve was left out — purge/CLI restore is deferred to the PR2 scope of the issue.