### PR TITLE
feat(models): add four Gemini models to the OpenRouter curated list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -64,6 +64,10 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # Google
     ("google/gemini-3.1-pro-preview",          ""),
     ("google/gemini-3.6-flash",                ""),
+    ("google/gemini-3.5-flash",                ""),
+    ("google/gemini-3.5-flash-lite",           ""),
+    ("google/gemini-3.1-flash-lite",           ""),
+    ("google/gemini-2.5-flash",                ""),
     # xAI
     ("x-ai/grok-4.5",                          ""),
     # DeepSeek

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-31T15:41:39Z",
+  "updated_at": "2026-08-02T23:53:39Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -82,6 +82,22 @@
         },
         {
           "id": "google/gemini-3.6-flash",
+          "description": ""
+        },
+        {
+          "id": "google/gemini-3.5-flash",
+          "description": ""
+        },
+        {
+          "id": "google/gemini-3.5-flash-lite",
+          "description": ""
+        },
+        {
+          "id": "google/gemini-3.1-flash-lite",
+          "description": ""
+        },
+        {
+          "id": "google/gemini-2.5-flash",
           "description": ""
         },
         {


### PR DESCRIPTION
## Summary

Adds the four confirmed tool-calling Gemini models to the OpenRouter curated picker so BYOK users can select them without typing the model id by hand:

| Model ID | Name |
|---|---|
| `google/gemini-3.5-flash` | Gemini 3.5 Flash |
| `google/gemini-3.5-flash-lite` | Gemini 3.5 Flash Lite |
| `google/gemini-3.1-flash-lite` | Gemini 3.1 Flash Lite |
| `google/gemini-2.5-flash` | Gemini 2.5 Flash |

Fixes #76732.

## Verification

- All four ids confirmed present in OpenRouter's live `/v1/models` catalog, each advertising `tools` + `tool_choice` in `supported_parameters` (tool-calling capable).
- Image-only models (e.g. `google/gemini-3.1-flash-image`) intentionally excluded — no tool calling.
- Catalog regenerated with `scripts/build_model_catalog.py` (the JSON manifest is generated from `OPENROUTER_MODELS`).
- `pytest tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_model_search.py tests/hermes_cli/test_ai_gateway_models.py` → 30 passed.