### PR TITLE
fix(desktop): add media privilege to hermes-media protocol

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1014,6 +1014,10 @@ protocol.registerSchemesAsPrivileged([
       secure: true,
       standard: true,
       stream: true,
+      // Required for HTML5 audio/video from a custom scheme: without the
+      // `media` privilege Chromium can render the video track but blocks
+      // audio output from the scheme (#76834).
+      media: true,
       supportFetchAPI: true
     }
   }


### PR DESCRIPTION
## Summary

Fixes #76834 — Desktop inline MEDIA playback (local mode) rendered video but was completely silent for MP4/WAV/MP3. Files were verified valid (ffprobe/ffmpeg audio present, play fine in other players, YouTube in the same app has sound).

## Root cause

`apps/desktop/electron/main.ts` registers the `hermes-media` custom scheme via `protocol.registerSchemesAsPrivileged` with `{ secure, standard, stream, supportFetchAPI }` but **without the `media` privilege**. Chromium uses that privilege to decide whether a custom scheme can drive HTML5 media features — without it the video track renders while audio output from the scheme is blocked.

## Change

Add `media: true` to the `hermes-media` scheme privileges (single declarative flag; the protocol handler itself already delegates to Electron's net stack with proper Content-Type and Range handling).

## Verification

- `npx vitest run src/lib src/store` → 116 files / 1201 tests passed
- `npx tsc --noEmit` → clean