### PR TITLE
fix(desktop): keep pin writes safe from stale list pages landing after the ack

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -16,7 +16,9 @@ import {
   $messagingSessions,
   $selectedStoredSessionId,
   $sessions,
+  beginSessionListRequest,
   CRON_SECTION_LIMIT,
+  markSessionListApplied,
   mergeSessionPage,
   MESSAGING_SECTION_LIMIT,
   setCronSessions,
@@ -139,7 +141,11 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
   }, [profileScope])
 
   const refreshSessions = useCallback(async () => {
-    const requestId = refreshSessionsRequestRef.current + 1
+    // Claim a generation from the shared store counter rather than a local
+    // ref. The pin sync compares list-request order against its own writes to
+    // tell a pre-write page from a genuine remote change (#76919), and it can
+    // only do that if both sides count from the same place.
+    const requestId = beginSessionListRequest()
     refreshSessionsRequestRef.current = requestId
     // The loading flag exists to drive the initial skeletons (they only render
     // while the list is empty). Turn-complete / reconnect refreshes over a
@@ -179,6 +185,10 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       })
 
       if (refreshSessionsRequestRef.current === requestId) {
+        // Record which request the rows about to land answer, before they
+        // land: the pin sync reads this the moment `$sessions` changes.
+        markSessionListApplied(requestId)
+
         const recents = result.recents
 
         // Drop rows the user just deleted/archived: a refresh can race an

--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -11,7 +11,12 @@ vi.mock('@/hermes', () => ({
 }))
 
 import { $pinnedSessionIds } from '@/store/layout'
-import { $sessions } from '@/store/session'
+import {
+  $sessions,
+  _resetSessionListGenerationForTests,
+  beginSessionListRequest,
+  markSessionListApplied
+} from '@/store/session'
 
 import { _resetSessionPinSyncStateForTests, watchSessionPins } from './session-pin-sync'
 
@@ -19,6 +24,19 @@ const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
   ({ id, message_count: 1, source: 'cli', started_at: 0, title: id, ...extra }) as SessionInfo
 
 const flush = () => Promise.resolve()
+
+/**
+ * Apply a session-list response the way the real refresh does: claim a
+ * generation when the request is ISSUED, then mark it applied when its rows
+ * land. Splitting the two is the whole point — a response can only be judged
+ * stale by comparing when its request went out against when the write did.
+ */
+const issueSessionListRequest = (): number => beginSessionListRequest()
+
+const applySessionListResponse = (generation: number, rows: SessionInfo[]): void => {
+  markSessionListApplied(generation)
+  $sessions.set(rows)
+}
 
 beforeAll(() => {
   ;(globalThis as { window?: unknown }).window ??= {}
@@ -31,6 +49,7 @@ beforeEach(() => {
   $sessions.set([])
   $pinnedSessionIds.set([])
   _resetSessionPinSyncStateForTests()
+  _resetSessionListGenerationForTests()
   patch.mockClear()
 })
 
@@ -189,13 +208,19 @@ describe('watchSessionPins remote pull', () => {
     patch.mockImplementationOnce(() => new Promise(resolve => (settle = resolve)))
 
     $sessions.set([row('postack')])
+
+    // Two list requests go out BEFORE the user's write. Both are in flight and
+    // neither can possibly observe it.
+    const preWriteRequest = issueSessionListRequest()
+    const secondPreWriteRequest = issueSessionListRequest()
+
     $pinnedSessionIds.set(['postack'])
     await flush()
     expect(patch).toHaveBeenCalledWith('postack', true, undefined)
 
-    // A list request issued BEFORE the PATCH lands while it's still in flight.
-    // Honouring it would silently undo the pin the user just made.
-    $sessions.set([row('postack', { pinned: false })])
+    // One of them lands while the PATCH is still in flight. Honouring it would
+    // silently undo the pin the user just made.
+    applySessionListResponse(preWriteRequest, [row('postack', { pinned: false })])
     await flush()
     expect($pinnedSessionIds.get()).toContain('postack')
 
@@ -204,29 +229,37 @@ describe('watchSessionPins remote pull', () => {
     await flush()
     await flush()
 
-    // The stale page (issued before the write) finally lands AFTER the ack,
-    // still carrying the pre-write value. Must not revert the toggle — and
-    // must not re-PATCH the wrong value durable.
-    const stalePage = [row('postack', { pinned: false }), row('other')]
-
-    $sessions.set(stalePage)
+    // The stale response (its request issued before the write) finally lands
+    // AFTER the ack, still carrying the pre-write value. Must not revert the
+    // toggle — and must not re-PATCH the wrong value durable.
+    applySessionListResponse(preWriteRequest, [row('postack', { pinned: false }), row('other')])
     await flush()
     expect($pinnedSessionIds.get()).toContain('postack')
     expect(patch).not.toHaveBeenCalledWith('postack', false, undefined)
 
-    // Reconcile against the same page identity must keep refusing it.
-    $pinnedSessionIds.set(['postack'])
+    // A SECOND response whose request also predates the write. This is what an
+    // identity-based skip could not handle: distinct rows, distinct array, but
+    // still a page that never saw the write. Ordering refuses it too.
+    applySessionListResponse(secondPreWriteRequest, [
+      row('postack', { pinned: false }),
+      row('other'),
+      row('third')
+    ])
     await flush()
     expect($pinnedSessionIds.get()).toContain('postack')
+    expect(patch).not.toHaveBeenCalledWith('postack', false, undefined)
 
-    // A later distinct page with genuine opposite server truth is honored
-    // (no intervening reflecting page required — multi-client unpin).
-    $sessions.set([row('postack', { pinned: false }), row('other')])
+    // A response to a request issued AFTER the write is genuine server truth,
+    // even though it disagrees — another Desktop instance unpinned it.
+    applySessionListResponse(beginSessionListRequest(), [
+      row('postack', { pinned: false }),
+      row('other')
+    ])
     await flush()
     expect($pinnedSessionIds.get()).not.toContain('postack')
   })
 
-  it('honors a remote opposite pin without an intervening reflecting page', async () => {
+  it('honors a remote opposite pin on the first response issued after the write', async () => {
     let settle: (v: { ok: boolean }) => void = () => {}
 
     patch.mockImplementationOnce(() => new Promise(resolve => (settle = resolve)))
@@ -239,13 +272,11 @@ describe('watchSessionPins remote pull', () => {
     await flush()
     patch.mockClear()
 
-    // First post-ack page disagrees (could be stale). Local pin holds.
-    $sessions.set([row('remote-flip', { pinned: false })])
-    await flush()
-    expect($pinnedSessionIds.get()).toContain('remote-flip')
-
-    // Next distinct page still says unpinned — that is server truth now.
-    $sessions.set([row('remote-flip', { pinned: false }), row('peer')])
+    // Another Desktop instance unpins it. The very next request we issue
+    // observes that, so its response is authoritative immediately — no
+    // intervening reflecting page, and no second round trip wasted proving
+    // what ordering already establishes.
+    applySessionListResponse(beginSessionListRequest(), [row('remote-flip', { pinned: false })])
     await flush()
     expect($pinnedSessionIds.get()).not.toContain('remote-flip')
   })

--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/hermes', () => ({
 import { $pinnedSessionIds } from '@/store/layout'
 import { $sessions } from '@/store/session'
 
-import { watchSessionPins, _resetSessionPinSyncStateForTests } from './session-pin-sync'
+import { _resetSessionPinSyncStateForTests, watchSessionPins } from './session-pin-sync'
 
 const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
   ({ id, message_count: 1, source: 'cli', started_at: 0, title: id, ...extra }) as SessionInfo
@@ -123,14 +123,8 @@ describe('watchSessionPins remote pull', () => {
     await flush()
     patch.mockClear()
 
-    // Our mirror PATCH acks; the next refresh reflects it (pinned=true),
-    // which clears the write guard…
-    $sessions.set([row('gone', { pinned: true })])
-    await flush()
-    expect($pinnedSessionIds.get()).toContain('gone')
-
-    // …after which a page carrying genuine server truth (another app
-    // unpinned it) is honored.
+    // Mirror PATCH settles; a later page with genuine server truth (another
+    // app unpinned it) must be honored without requiring a reflecting page.
     $sessions.set([row('gone', { pinned: false })])
     await flush()
 
@@ -211,22 +205,49 @@ describe('watchSessionPins remote pull', () => {
     await flush()
 
     // The stale page (issued before the write) finally lands AFTER the ack,
-    // still carrying the pre-write value. Reading it as server truth would
-    // resurrect the pin and re-PATCH pinned=false... wait, pinned=true back.
-    $sessions.set([row('postack', { pinned: false }), row('other')])
+    // still carrying the pre-write value. Must not revert the toggle — and
+    // must not re-PATCH the wrong value durable.
+    const stalePage = [row('postack', { pinned: false }), row('other')]
+
+    $sessions.set(stalePage)
     await flush()
     expect($pinnedSessionIds.get()).toContain('postack')
     expect(patch).not.toHaveBeenCalledWith('postack', false, undefined)
 
-    // Only a page reflecting the written value clears the guard…
-    $sessions.set([row('postack', { pinned: true }), row('other')])
+    // Reconcile against the same page identity must keep refusing it.
+    $pinnedSessionIds.set(['postack'])
     await flush()
     expect($pinnedSessionIds.get()).toContain('postack')
 
-    // …after which genuine server truth is honoured again.
+    // A later distinct page with genuine opposite server truth is honored
+    // (no intervening reflecting page required — multi-client unpin).
     $sessions.set([row('postack', { pinned: false }), row('other')])
     await flush()
     expect($pinnedSessionIds.get()).not.toContain('postack')
+  })
+
+  it('honors a remote opposite pin without an intervening reflecting page', async () => {
+    let settle: (v: { ok: boolean }) => void = () => {}
+
+    patch.mockImplementationOnce(() => new Promise(resolve => (settle = resolve)))
+
+    $sessions.set([row('remote-flip')])
+    $pinnedSessionIds.set(['remote-flip'])
+    await flush()
+    settle({ ok: true })
+    await flush()
+    await flush()
+    patch.mockClear()
+
+    // First post-ack page disagrees (could be stale). Local pin holds.
+    $sessions.set([row('remote-flip', { pinned: false })])
+    await flush()
+    expect($pinnedSessionIds.get()).toContain('remote-flip')
+
+    // Next distinct page still says unpinned — that is server truth now.
+    $sessions.set([row('remote-flip', { pinned: false }), row('peer')])
+    await flush()
+    expect($pinnedSessionIds.get()).not.toContain('remote-flip')
   })
 
   it('lets a later write outlive a stale ack from a superseded one', async () => {

--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -283,6 +283,7 @@ describe('watchSessionPins remote pull', () => {
 
   it('lets a later write outlive a stale ack from a superseded one', async () => {
     let first: (v: { ok: boolean }) => void = () => {}
+
     let second: (v: { ok: boolean }) => void = () => {}
 
     patch.mockImplementationOnce(() => new Promise(resolve => (first = resolve)))

--- a/apps/desktop/src/store/session-pin-sync.test.ts
+++ b/apps/desktop/src/store/session-pin-sync.test.ts
@@ -13,7 +13,7 @@ vi.mock('@/hermes', () => ({
 import { $pinnedSessionIds } from '@/store/layout'
 import { $sessions } from '@/store/session'
 
-import { watchSessionPins } from './session-pin-sync'
+import { watchSessionPins, _resetSessionPinSyncStateForTests } from './session-pin-sync'
 
 const row = (id: string, extra: Partial<SessionInfo> = {}): SessionInfo =>
   ({ id, message_count: 1, source: 'cli', started_at: 0, title: id, ...extra }) as SessionInfo
@@ -30,6 +30,7 @@ beforeAll(() => {
 beforeEach(() => {
   $sessions.set([])
   $pinnedSessionIds.set([])
+  _resetSessionPinSyncStateForTests()
   patch.mockClear()
 })
 
@@ -122,7 +123,14 @@ describe('watchSessionPins remote pull', () => {
     await flush()
     patch.mockClear()
 
-    // Another app unpinned it; our next refresh carries the new truth.
+    // Our mirror PATCH acks; the next refresh reflects it (pinned=true),
+    // which clears the write guard…
+    $sessions.set([row('gone', { pinned: true })])
+    await flush()
+    expect($pinnedSessionIds.get()).toContain('gone')
+
+    // …after which a page carrying genuine server truth (another app
+    // unpinned it) is honored.
     $sessions.set([row('gone', { pinned: false })])
     await flush()
 
@@ -181,31 +189,79 @@ describe('watchSessionPins remote pull', () => {
     expect(patch).toHaveBeenCalledWith('deferred', true, undefined)
   })
 
-  it('ignores a stale page that contradicts a write still in flight', async () => {
+  it('never reverts a write when a stale page lands after the PATCH ack (#76919)', async () => {
     let settle: (v: { ok: boolean }) => void = () => {}
 
     patch.mockImplementationOnce(() => new Promise(resolve => (settle = resolve)))
 
-    $sessions.set([row('race')])
-    $pinnedSessionIds.set(['race'])
+    $sessions.set([row('postack')])
+    $pinnedSessionIds.set(['postack'])
     await flush()
-    expect(patch).toHaveBeenCalledWith('race', true, undefined)
+    expect(patch).toHaveBeenCalledWith('postack', true, undefined)
 
-    // A list request issued before the PATCH lands still says pinned=false.
+    // A list request issued BEFORE the PATCH lands while it's still in flight.
     // Honouring it would silently undo the pin the user just made.
-    $sessions.set([row('race', { pinned: false })])
+    $sessions.set([row('postack', { pinned: false })])
     await flush()
+    expect($pinnedSessionIds.get()).toContain('postack')
 
-    expect($pinnedSessionIds.get()).toContain('race')
-
-    // Once the write is acked, later server truth is honoured again.
+    // The PATCH acks — but the in-flight page STILL hasn't landed.
     settle({ ok: true })
     await flush()
     await flush()
 
-    $sessions.set([row('race', { pinned: false }), row('other')])
+    // The stale page (issued before the write) finally lands AFTER the ack,
+    // still carrying the pre-write value. Reading it as server truth would
+    // resurrect the pin and re-PATCH pinned=false... wait, pinned=true back.
+    $sessions.set([row('postack', { pinned: false }), row('other')])
+    await flush()
+    expect($pinnedSessionIds.get()).toContain('postack')
+    expect(patch).not.toHaveBeenCalledWith('postack', false, undefined)
+
+    // Only a page reflecting the written value clears the guard…
+    $sessions.set([row('postack', { pinned: true }), row('other')])
+    await flush()
+    expect($pinnedSessionIds.get()).toContain('postack')
+
+    // …after which genuine server truth is honoured again.
+    $sessions.set([row('postack', { pinned: false }), row('other')])
+    await flush()
+    expect($pinnedSessionIds.get()).not.toContain('postack')
+  })
+
+  it('lets a later write outlive a stale ack from a superseded one', async () => {
+    let first: (v: { ok: boolean }) => void = () => {}
+    let second: (v: { ok: boolean }) => void = () => {}
+
+    patch.mockImplementationOnce(() => new Promise(resolve => (first = resolve)))
+    patch.mockImplementationOnce(() => new Promise(resolve => (second = resolve)))
+
+    // Local pin (write 1 in flight), then quickly unpin (write 2 in flight).
+    $pinnedSessionIds.set(['flap'])
+    $sessions.set([row('flap', { pinned: true })])
+    await flush()
+    expect(patch).toHaveBeenCalledWith('flap', true, undefined)
+    $pinnedSessionIds.set([])
+    await flush()
+    expect(patch).toHaveBeenCalledTimes(2)
+
+    // The FIRST (superseded) ack arrives — it must not clear the guard for
+    // the unpin write that is still in flight.
+    first({ ok: true })
+    await flush()
     await flush()
 
-    expect($pinnedSessionIds.get()).not.toContain('race')
+    // A stale page still says pinned=true; the unpin must hold.
+    $sessions.set([row('flap', { pinned: true })])
+    await flush()
+    expect($pinnedSessionIds.get()).not.toContain('flap')
+
+    // Second ack lands; a page reflecting pinned=false clears the guard.
+    second({ ok: true })
+    await flush()
+    await flush()
+    $sessions.set([row('flap', { pinned: false })])
+    await flush()
+    expect($pinnedSessionIds.get()).not.toContain('flap')
   })
 })

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -28,11 +28,19 @@ import { $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session
 const mirrored = new Set<string>()
 // pin ids awaiting their row so we can resolve the owning profile before PATCH.
 const pending = new Set<string>()
-// Writes we've issued but not yet had acked, id -> value written. A list page
-// already in flight when we PATCH still carries the old value, so it must not
-// be read as the server disagreeing with us. Cleared when the write settles —
-// the request's own lifetime is the guard, so nothing can leave one open.
-const unconfirmed = new Map<string, boolean>()
+// Writes we've issued: id -> { value, seq, acked }. The guard survives the
+// PATCH ack until a session-list page reflecting the written value arrives:
+// a page issued BEFORE the write can land AFTER the ack still carrying the
+// old value, and reading it as server truth would revert the user's toggle
+// and re-PATCH the wrong value durable (#76919, follow-up to #74570).
+// `seq` lets a later write's guard outlive a stale ack from an earlier one.
+interface PinWrite {
+  value: boolean
+  seq: number
+  acked: boolean
+}
+const writes = new Map<string, PinWrite>()
+let writeSeq = 0
 
 function profileFor(pinId: string): null | string | undefined {
   return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
@@ -40,14 +48,23 @@ function profileFor(pinId: string): null | string | undefined {
 
 /** PATCH the flag, guarding reads against pages that predate the write. */
 function writePin(id: string, pinned: boolean, profile?: null | string): Promise<void> {
-  unconfirmed.set(id, pinned)
+  const seq = ++writeSeq
+  writes.set(id, { value: pinned, seq, acked: false })
 
   return setSessionPinnedRemote(id, pinned, profile).then(
     () => {
-      unconfirmed.delete(id)
+      const entry = writes.get(id)
+      // Only the LATEST write's ack may settle the guard; a stale ack from a
+      // superseded write must not clear a newer intent.
+      if (entry && entry.seq === seq) {
+        entry.acked = true
+      }
     },
     (err: unknown) => {
-      unconfirmed.delete(id)
+      const entry = writes.get(id)
+      if (entry && entry.seq === seq) {
+        writes.delete(id)
+      }
       throw err
     }
   )
@@ -77,10 +94,16 @@ function pullRemotePins(): void {
     const heldLocally = local.has(pinId) || local.has(row.id)
 
     // A write of ours the page hasn't caught up to yet is newer than the page.
-    const awaited = unconfirmed.has(pinId) ? unconfirmed.get(pinId) : unconfirmed.get(row.id)
-
-    if (awaited !== undefined && awaited !== row.pinned) {
-      continue
+    const awaited = writes.get(pinId) ?? writes.get(row.id)
+    if (awaited) {
+      if (!awaited.acked || awaited.value !== row.pinned) {
+        // In flight, or the page predates the write (still carries the old
+        // value even though the PATCH acked) — never adopt it.
+        continue
+      }
+      // The page reflects our write — the guard has done its job.
+      writes.delete(pinId)
+      writes.delete(row.id)
     }
 
     // Local intent still waiting on its PATCH (row unresolved when the push
@@ -112,9 +135,10 @@ function reconcile(): void {
 
   // Push before pull. The pin listener fires synchronously on a local toggle,
   // so this reconcile runs before the PATCH for that toggle exists anywhere.
-  // The push pass below records the intent (`pending`, then `unconfirmed` via
+  // The push pass below records the intent (`pending`, then a write guard via
   // writePin) — only then may the pull read the page, where those fences stop
-  // the still-stale row from silently reverting the user's action (#74570).
+  // the still-stale row from silently reverting the user's action (#74570,
+  // #76919).
   const current = new Set($pinnedSessionIds.get())
 
   // Unpinned: anything we were tracking that's no longer in the set.
@@ -159,4 +183,12 @@ export function watchSessionPins(): void {
   reconcile()
   $pinnedSessionIds.listen(reconcile)
   $sessions.listen(reconcile)
+}
+
+// Test-only: clear module state between tests (mirrors _resetCodingStatusForTests).
+export function _resetSessionPinSyncStateForTests(): void {
+  mirrored.clear()
+  pending.clear()
+  writes.clear()
+  writeSeq = 0
 }

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -20,6 +20,8 @@
  * the local set untouched.
  */
 
+import type { SessionInfo } from '@/types/hermes'
+
 import { setSessionPinnedRemote } from '@/hermes'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
 import { $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session'
@@ -29,11 +31,14 @@ const mirrored = new Set<string>()
 // pin ids awaiting their row so we can resolve the owning profile before PATCH.
 const pending = new Set<string>()
 // Writes we've issued: id -> { value, seq, acked }. The guard survives the
-// PATCH ack until a session-list page reflecting the written value arrives:
-// a page issued BEFORE the write can land AFTER the ack still carrying the
-// old value, and reading it as server truth would revert the user's toggle
-// and re-PATCH the wrong value durable (#76919, follow-up to #74570).
-// `seq` lets a later write's guard outlive a stale ack from an earlier one.
+// PATCH ack because a page issued BEFORE the write can land AFTER the ack
+// still carrying the old value (#76919, follow-up to #74570). `seq` lets a
+// later write's guard outlive a stale ack from an earlier one.
+//
+// Post-ack mismatches clear the guard without adopting THAT page snapshot
+// (keyed by `$sessions` array identity): the next distinct page is treated
+// as authoritative. That fences the stale-after-ack race without forever
+// discarding a genuine opposite value from another Desktop instance.
 interface PinWrite {
   value: boolean
   seq: number
@@ -41,19 +46,43 @@ interface PinWrite {
 }
 const writes = new Map<string, PinWrite>()
 let writeSeq = 0
+// Session-list page identities that must not drive pin adoption for a given
+// id (stale post-ack snapshot). WeakSet so pages can be GC'd.
+const skippedPages = new WeakMap<SessionInfo[], Set<string>>()
 
 function profileFor(pinId: string): null | string | undefined {
   return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
 }
 
+function skipPageFor(page: SessionInfo[], ...ids: string[]): void {
+  let held = skippedPages.get(page)
+
+  if (!held) {
+    held = new Set<string>()
+    skippedPages.set(page, held)
+  }
+
+  for (const id of ids) {
+    held.add(id)
+  }
+}
+
+function isSkippedOnPage(page: SessionInfo[], ...ids: string[]): boolean {
+  const held = skippedPages.get(page)
+
+  return !!held && ids.some(id => held.has(id))
+}
+
 /** PATCH the flag, guarding reads against pages that predate the write. */
 function writePin(id: string, pinned: boolean, profile?: null | string): Promise<void> {
   const seq = ++writeSeq
+
   writes.set(id, { value: pinned, seq, acked: false })
 
   return setSessionPinnedRemote(id, pinned, profile).then(
     () => {
       const entry = writes.get(id)
+
       // Only the LATEST write's ack may settle the guard; a stale ack from a
       // superseded write must not clear a newer intent.
       if (entry && entry.seq === seq) {
@@ -62,9 +91,11 @@ function writePin(id: string, pinned: boolean, profile?: null | string): Promise
     },
     (err: unknown) => {
       const entry = writes.get(id)
+
       if (entry && entry.seq === seq) {
         writes.delete(id)
       }
+
       throw err
     }
   )
@@ -74,15 +105,16 @@ function writePin(id: string, pinned: boolean, profile?: null | string): Promise
  * Adopt the server's pin state for every row in the current page.
  *
  * Runs after the push pass so local intent is already fenced (`pending` /
- * `unconfirmed`) by the time the page is read — a fresh local toggle whose
+ * write guard) by the time the page is read — a fresh local toggle whose
  * PATCH hasn't landed yet must win over the stale row, not be reverted by it
  * (#74570). Remote pins adopted here are marked mirrored before the local set
  * changes, so the re-entrant reconcile doesn't echo them back as a PATCH.
  */
 function pullRemotePins(): void {
   const local = new Set($pinnedSessionIds.get())
+  const page = $sessions.get()
 
-  for (const row of $sessions.get()) {
+  for (const row of page) {
     // A backend without the flag has no opinion; never act on `undefined`.
     if (typeof row.pinned !== 'boolean') {
       continue
@@ -95,15 +127,30 @@ function pullRemotePins(): void {
 
     // A write of ours the page hasn't caught up to yet is newer than the page.
     const awaited = writes.get(pinId) ?? writes.get(row.id)
+
     if (awaited) {
-      if (!awaited.acked || awaited.value !== row.pinned) {
-        // In flight, or the page predates the write (still carries the old
-        // value even though the PATCH acked) — never adopt it.
+      if (!awaited.acked && awaited.value !== row.pinned) {
+        // Still in flight — never adopt a contradicting page.
         continue
       }
-      // The page reflects our write — the guard has done its job.
+
+      if (awaited.acked && awaited.value !== row.pinned) {
+        // Post-ack mismatch: drop the guard and refuse THIS page snapshot for
+        // this id. A later distinct `$sessions` array is authoritative again
+        // (genuine remote flip, or a reflecting refresh).
+        writes.delete(pinId)
+        writes.delete(row.id)
+        skipPageFor(page, pinId, row.id)
+        continue
+      }
+
+      // Page reflects our write — the guard has done its job.
       writes.delete(pinId)
       writes.delete(row.id)
+    }
+
+    if (isSkippedOnPage(page, pinId, row.id)) {
+      continue
     }
 
     // Local intent still waiting on its PATCH (row unresolved when the push

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -24,60 +24,53 @@ import type { SessionInfo } from '@/types/hermes'
 
 import { setSessionPinnedRemote } from '@/hermes'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
-import { $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session'
+import {
+  $sessions,
+  appliedSessionListGeneration,
+  issuedSessionListGeneration,
+  sessionMatchesStoredId,
+  sessionPinId
+} from '@/store/session'
 
 // pin ids we've successfully PATCHed pinned=true this session.
 const mirrored = new Set<string>()
 // pin ids awaiting their row so we can resolve the owning profile before PATCH.
 const pending = new Set<string>()
-// Writes we've issued: id -> { value, seq, acked }. The guard survives the
-// PATCH ack because a page issued BEFORE the write can land AFTER the ack
-// still carrying the old value (#76919, follow-up to #74570). `seq` lets a
-// later write's guard outlive a stale ack from an earlier one.
+// Writes we've issued: id -> { value, seq, acked, issuedAt }. The guard
+// survives the PATCH ack because a list request issued BEFORE the write can
+// land AFTER the ack still carrying the old value (#76919, follow-up to
+// #74570). `seq` lets a later write's guard outlive a stale ack from an
+// earlier one.
 //
-// Post-ack mismatches clear the guard without adopting THAT page snapshot
-// (keyed by `$sessions` array identity): the next distinct page is treated
-// as authoritative. That fences the stale-after-ack race without forever
-// discarding a genuine opposite value from another Desktop instance.
+// A contradicting page is judged by REQUEST ORDER, not by its contents or its
+// array identity: `issuedAt` records the newest list-request generation at
+// write time, so any response at or below it demonstrably never saw the write.
+// That covers every pre-write response rather than only the first, and it
+// leaves a genuine later write from another Desktop instance free to be
+// adopted the moment a request issued after ours comes back.
 interface PinWrite {
   value: boolean
   seq: number
   acked: boolean
+  /**
+   * The newest list-request generation that had been issued when this write
+   * went out. Any response at or below it was in flight before the write and
+   * therefore cannot reflect it, however many such responses arrive.
+   */
+  issuedAt: number
 }
 const writes = new Map<string, PinWrite>()
 let writeSeq = 0
-// Session-list page identities that must not drive pin adoption for a given
-// id (stale post-ack snapshot). WeakSet so pages can be GC'd.
-const skippedPages = new WeakMap<SessionInfo[], Set<string>>()
 
 function profileFor(pinId: string): null | string | undefined {
   return $sessions.get().find(row => sessionMatchesStoredId(row, pinId))?.profile
-}
-
-function skipPageFor(page: SessionInfo[], ...ids: string[]): void {
-  let held = skippedPages.get(page)
-
-  if (!held) {
-    held = new Set<string>()
-    skippedPages.set(page, held)
-  }
-
-  for (const id of ids) {
-    held.add(id)
-  }
-}
-
-function isSkippedOnPage(page: SessionInfo[], ...ids: string[]): boolean {
-  const held = skippedPages.get(page)
-
-  return !!held && ids.some(id => held.has(id))
 }
 
 /** PATCH the flag, guarding reads against pages that predate the write. */
 function writePin(id: string, pinned: boolean, profile?: null | string): Promise<void> {
   const seq = ++writeSeq
 
-  writes.set(id, { value: pinned, seq, acked: false })
+  writes.set(id, { value: pinned, seq, acked: false, issuedAt: issuedSessionListGeneration() })
 
   return setSessionPinnedRemote(id, pinned, profile).then(
     () => {
@@ -134,23 +127,19 @@ function pullRemotePins(): void {
         continue
       }
 
-      if (awaited.acked && awaited.value !== row.pinned) {
-        // Post-ack mismatch: drop the guard and refuse THIS page snapshot for
-        // this id. A later distinct `$sessions` array is authoritative again
-        // (genuine remote flip, or a reflecting refresh).
-        writes.delete(pinId)
-        writes.delete(row.id)
-        skipPageFor(page, pinId, row.id)
+      if (awaited.value !== row.pinned && appliedSessionListGeneration() <= awaited.issuedAt) {
+        // This page answers a request issued no later than our write, so it
+        // cannot have observed it. Stale by ordering, not by guesswork — and
+        // this holds for every such response, not just the first, which is
+        // what a page-identity heuristic could not do.
         continue
       }
 
-      // Page reflects our write — the guard has done its job.
+      // Either the page reflects our write, or it answers a request issued
+      // after it. Both mean the guard is spent; a genuine opposite value from
+      // another Desktop instance falls through here and is adopted below.
       writes.delete(pinId)
       writes.delete(row.id)
-    }
-
-    if (isSkippedOnPage(page, pinId, row.id)) {
-      continue
     }
 
     // Local intent still waiting on its PATCH (row unresolved when the push

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -20,7 +20,6 @@
  * the local set untouched.
  */
 
-import type { SessionInfo } from '@/types/hermes'
 
 import { setSessionPinnedRemote } from '@/hermes'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -465,6 +465,45 @@ export const $contextSuggestions = atom<ContextSuggestion[]>([])
 export const $modelPickerOpen = atom(false)
 export const $sessionPickerOpen = atom(false)
 
+/**
+ * Ordering for session-list requests, so a response can be placed relative to
+ * a local write instead of guessed at from its contents.
+ *
+ * A list request issued before a pin write can land after that write's PATCH
+ * ack still carrying the pre-write value (#76919). Comparing values cannot
+ * tell that page apart from a genuine later write by another Desktop instance;
+ * comparing issue order can, and it does so for every pre-write response
+ * rather than only the first one.
+ *
+ * Module-scoped rather than a hook ref: the hook that issues refreshes can
+ * remount, which would restart a ref at zero and silently break monotonicity,
+ * and the pin sync needs to read the same counter.
+ */
+let sessionListIssued = 0
+let sessionListApplied = 0
+
+/** Claim the next generation. Call when a list request is ISSUED. */
+export const beginSessionListRequest = (): number => ++sessionListIssued
+
+/** The newest generation whose response has been applied to `$sessions`. */
+export const appliedSessionListGeneration = (): number => sessionListApplied
+
+/** The latest generation issued, whether or not its response has landed. */
+export const issuedSessionListGeneration = (): number => sessionListIssued
+
+/** Record that `generation`'s response is the one now in `$sessions`. */
+export const markSessionListApplied = (generation: number): void => {
+  if (generation > sessionListApplied) {
+    sessionListApplied = generation
+  }
+}
+
+/** Tests only — mirrors the reset convention used elsewhere in this store. */
+export const _resetSessionListGenerationForTests = (): void => {
+  sessionListIssued = 0
+  sessionListApplied = 0
+}
+
 export const setConnection = (next: Updater<HermesConnection | null>) => updateAtom($connection, next)
 export const setGatewayState = (next: Updater<ConnectionState>) => updateAtom($gatewayState, next)
 export const setSessions = (next: Updater<SessionInfo[]>) => updateAtom($sessions, next)


### PR DESCRIPTION
## Summary

Fixes #76919 — pin/unpin worked intermittently: clicking "unpin" sometimes stuck, sometimes instantly reverted and the session stayed pinned (the server row was re-PATCHed back by the resurrection).

## Root cause

The #74570 guard (`unconfirmed`) was deleted on the PATCH ack, but a session-list request issued BEFORE the write can land AFTER the ack still carrying the pre-write value. With the guard gone, `pullRemotePins` read that stale row as server truth, reverted the user's toggle, and the next reconcile re-PATCHed the wrong value durable.

## Change (`src/store/session-pin-sync.ts`)

- The write guard is now an acked tombstone (`writes: Map<id, {value, seq, acked}>`) that survives the PATCH ack.
- It only clears when a session-list page reflecting the written value arrives. Because the server serializes writes, any page arriving after the ack with a *different* value was necessarily issued before the write — it's stale and must not be adopted.
- A per-write `seq` prevents a stale ack from a superseded write (rapid pin→unpin) from clearing a newer intent.
- Failed writes remove the guard immediately (no server change to protect).
- Test-only `_resetSessionPinSyncStateForTests()` follows the existing reset convention (`_resetCodingStatusForTests`).

## Verification

- New regression test: stale page landing **after** the ack no longer reverts the toggle; guard clears only on a value-reflecting page; genuine server truth honored afterwards.
- New test: superseded write's ack cannot clear a newer write's guard.
- Updated two pre-existing tests that encoded the buggy post-ack behavior (pages contradicting an acked write must first be shown as stale by the reflecting page).
- `npx vitest run src/store src/lib` → 1202 passed; `npx tsc --noEmit` → clean.