### PR TITLE
fix(opencode-go): route gpt-* models to /v1/responses (codex_responses)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4108,6 +4108,7 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
     OpenCode routes different models behind different API surfaces:
 
     - GPT-5 / Codex models on Zen use ``/v1/responses``
+    - GPT models on Go (gpt-5.6-luna) use ``/v1/responses``
     - Claude models on Zen use ``/v1/messages``
     - MiniMax and Qwen models on Go use ``/v1/messages``
     - GLM / Kimi / DeepSeek / MiMo on Go use ``/v1/chat/completions``
@@ -4124,6 +4125,11 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
         return "chat_completions"
 
     if provider == "opencode-go":
+        if normalized.startswith("gpt-"):
+            # GPT models on Go (gpt-5.6-luna) are served via /v1/responses
+            # per the published Go endpoint table, same as GPT on Zen:
+            # https://opencode.ai/docs/go/#endpoints
+            return "codex_responses"
         if normalized.startswith("minimax-"):
             return "anthropic_messages"
         if normalized.startswith("qwen"):

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -269,6 +269,9 @@ class TestCopilotNormalization:
         assert opencode_model_api_mode("opencode-go", "kimi-k2.7-code") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "glm-5.2") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "minimax-m3") == "anthropic_messages"
+        # GPT models on Go are Responses-only (Go endpoint table).
+        assert opencode_model_api_mode("opencode-go", "gpt-5.6-luna") == "codex_responses"
+        assert opencode_model_api_mode("opencode-go", "opencode-go/gpt-5.6-luna") == "codex_responses"
 
 
 class TestNormalizeOpencodeBaseUrl:


### PR DESCRIPTION
## Summary

OpenCode Go added **GPT 5.6 Luna** to its catalog, served exclusively via the Responses API. `opencode_model_api_mode()` has no `gpt-` case in its `opencode-go` branch (only `minimax-`/`qwen` map to `anthropic_messages`), so Luna falls through to `chat_completions` and is POSTed to `https://opencode.ai/zen/go/v1/chat/completions`.

The relay answers anyway: it streams the complete response text but never emits a `finish_reason` chunk. Hermes' stream classifier then treats every fully delivered answer as a mid-stream drop:

```
WARNING agent.chat_completion_helpers: Stream ended with no finish_reason
after delivering text with no tool calls; treating as a mid-stream drop.
```

The loop injects the network-error continuation nudge, the model correctly replies that nothing was pending, that reply also ends without a `finish_reason`, and after 4 rounds the turn fails with `Response remained truncated after 4 continuation attempts`. **Every turn on this model/provider pair fails this way**, including a plain "testing" message.

## Root cause

OpenCode's published Go endpoint table (https://opencode.ai/docs/go/#endpoints):

| Model | Endpoint |
| --- | --- |
| gpt-5.6-luna | `https://opencode.ai/zen/go/v1/responses` |
| minimax-*, qwen* | `https://opencode.ai/zen/go/v1/messages` |
| grok, glm, kimi, deepseek, mimo, hy3 | `https://opencode.ai/zen/go/v1/chat/completions` |

The Zen branch already routes `gpt-` to `codex_responses`; the Go branch predates GPT models on Go and never got the case.

## Change

- `hermes_cli/models.py`: add `gpt-` -> `codex_responses` to the `opencode-go` branch of `opencode_model_api_mode()`, mirroring the Zen branch, plus the matching docstring bullet.
- `tests/hermes_cli/test_model_validation.py`: extend `test_opencode_go_api_modes_match_docs` with the two Luna assertions (bare and `opencode-go/`-prefixed IDs).

No base-URL change needed: `normalize_opencode_base_url()` already keeps the `/v1` suffix for `codex_responses` on opencode.ai hosts, yielding exactly the documented `https://opencode.ai/zen/go/v1/responses`, and Zen's `gpt-` models prove `codex_responses` works over api_key auth on these relays.

## Verification

- `test_opencode_go_api_modes_match_docs` passes with the new assertions; minimax/qwen/kimi/glm/deepseek/mimo routing on Go and gpt/claude on Zen unchanged.
- Verified live before/after on a Go subscription: before the fix, every `gpt-5.6-luna` turn burned 4 continuation nudges and failed with the truncation error; after the fix, turns complete cleanly with zero nudges and no further `no finish_reason` warnings.

## Related

The relay-side half (Go's chat-completions shim streaming text for a Responses-only model without ever sending `finish_reason`, rather than rejecting the request) is being reported to OpenCode separately. Hermes should carry this routing fix regardless: `/v1/responses` is the documented surface for this model.

Credit to Discord user Mirrowel for pointing at the endpoint mismatch.
