### PR TITLE
fix(agent): preserve custom fallback transport

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1785,7 +1785,10 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     # raw_codex=True because the main agent needs direct responses.stream()
     # access for Codex providers.
     try:
-        from agent.auxiliary_client import resolve_provider_client
+        from agent.auxiliary_client import (
+            AnthropicAuxiliaryClient,
+            resolve_provider_client,
+        )
         # Pass base_url and api_key from fallback config so custom
         # endpoints (e.g. Ollama Cloud) resolve correctly instead of
         # falling through to OpenRouter defaults.
@@ -1820,11 +1823,22 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_model, fb_provider, _norm_err,
             )
 
-        # Determine api_mode from provider / base URL / model
+        # Honor the transport selected by the centralized resolver before
+        # falling back to provider/URL heuristics. Named custom providers can
+        # declare anthropic_messages on arbitrary relay hostnames; the resolver
+        # represents that decision with AnthropicAuxiliaryClient.
         fb_api_mode = "chat_completions"
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
+        _fb_is_bedrock = fb_provider == "bedrock" or (
+            base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
+            and base_url_host_matches(fb_base_url, "amazonaws.com")
+        )
+        if _fb_is_bedrock:
+            fb_api_mode = "bedrock_converse"
+        elif isinstance(fb_client, AnthropicAuxiliaryClient):
+            fb_api_mode = "anthropic_messages"
+        elif fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
         elif fb_provider in {"nous", "nous-portal", "nousresearch"}:
             # Portal is dual-wire: anthropic/* must land on /v1/messages.
@@ -1860,11 +1874,6 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             # provider-specific exceptions like Copilot gpt-5-mini on
             # chat completions.
             fb_api_mode = "codex_responses"
-        elif fb_provider == "bedrock" or (
-            base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
-            and base_url_host_matches(fb_base_url, "amazonaws.com")
-        ):
-            fb_api_mode = "bedrock_converse"
 
         old_model = agent.model
         old_provider = agent.provider

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -231,6 +231,102 @@ class TestFallbackChainAdvancement:
         assert agent.api_mode == "chat_completions"
         assert agent.client is not None
 
+    def test_named_custom_anthropic_fallback_uses_declared_transport(
+        self, tmp_path, monkeypatch
+    ):
+        """Request-level failover must preserve a named provider's API mode.
+
+        The fallback chain intentionally stores only provider + model.  The
+        named provider declaration remains the source of truth for transport;
+        an arbitrary relay hostname must not downgrade Messages to Chat.
+        """
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "custom_providers:\n"
+            "  - name: castor-fallback\n"
+            "    base_url: https://relay.example.test/v1\n"
+            "    key_env: CASTOR_TEST_KEY\n"
+            "    api_mode: anthropic_messages\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("CASTOR_TEST_KEY", "test-key")
+
+        agent = _make_agent(fallback_model=[{
+            "provider": "custom:castor-fallback",
+            "model": "claude-opus-5",
+        }])
+        built_clients = []
+
+        def _fake_build(api_key, base_url, timeout=None, **kwargs):
+            client = MagicMock(name="anthropic-client")
+            built_clients.append((api_key, base_url, client))
+            return client
+
+        with (
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                side_effect=_fake_build,
+            ),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                return_value=200_000,
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.provider == "custom:castor-fallback"
+        assert agent.model == "claude-opus-5"
+        assert agent.api_mode == "anthropic_messages"
+        assert agent.client is None
+        assert agent._anthropic_client is built_clients[-1][2]
+        assert built_clients[-1][:2] == (
+            "test-key",
+            "https://relay.example.test/v1",
+        )
+
+    def test_bedrock_transport_precedes_generic_anthropic_adapter(self):
+        """Resolved Anthropic wrappers must not override Bedrock Converse."""
+        from agent.auxiliary_client import AnthropicAuxiliaryClient
+
+        model = "anthropic.claude-haiku-4-5-20251001-v1:0"
+        endpoint = "https://bedrock-runtime.us-west-2.amazonaws.com"
+        resolved = AnthropicAuxiliaryClient(
+            MagicMock(name="bedrock-native-client"),
+            model,
+            "aws-sdk",
+            endpoint,
+        )
+        agent = _make_agent(fallback_model=[{
+            "provider": "bedrock",
+            "model": model,
+        }])
+
+        with (
+            patch(
+                "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+                return_value=None,
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(resolved, model),
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                side_effect=AssertionError(
+                    "Bedrock fallback must not build a plain Anthropic client"
+                ),
+            ),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                return_value=200_000,
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.api_mode == "bedrock_converse"
+        assert agent.client is resolved
+
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

Request-level fallback activation now preserves the Anthropic Messages transport selected by the centralized provider resolver.

A named custom provider can declare `api_mode: anthropic_messages` on an arbitrary relay hostname. `resolve_provider_client()` correctly returned an `AnthropicAuxiliaryClient`, but `try_activate_fallback()` discarded that decision and derived `fb_api_mode` again from only the provider name and URL. The fallback then defaulted to `chat_completions` and sent an OpenAI Chat request to a model available only through the Anthropic Messages API.

The fix treats the resolved adapter as the first source of truth. Existing provider and URL heuristics remain unchanged for every other client.

## Related Issue

No existing issue or open PR matched this failure mode.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/chat_completion_helpers.py`
  - recognize `AnthropicAuxiliaryClient` before applying generic fallback provider and URL heuristics
  - keep Bedrock provider/host routing authoritative over the generic Anthropic adapter signal
  - retain `anthropic_messages` during the in-place fallback runtime swap
- `tests/run_agent/test_provider_fallback.py`
  - add a temporary `HERMES_HOME` regression test that exercises the real named custom-provider resolver
  - verify the fallback chain contains only provider and model while transport still propagates from `custom_providers`

## How to Test

1. Configure a named custom provider with an arbitrary relay hostname and `api_mode: anthropic_messages`.
2. Configure `fallback_providers` with only `provider: custom:<name>` and a Claude model.
3. Exhaust the primary provider retries and confirm fallback activates with `api_mode == anthropic_messages` and uses the native Anthropic client.

Commands run:

```bash
scripts/run_tests.sh tests/run_agent/ -q
scripts/run_tests.sh tests/agent/test_auxiliary_named_custom_providers.py tests/agent/test_auxiliary_client_anthropic_custom.py tests/agent/test_set_runtime_main_custom_provider.py -q
```

Results: 1,357 unique relevant tests passed, including all 1,330 tests under `tests/run_agent/`. A manual activated-fallback smoke test against an Anthropic-compatible custom relay returned `OK` through the Messages transport.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete `pytest tests/ -q` suite. Relevant canonical tests passed; the full suite is left to CI.
- [x] I've added tests for my changes
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] Documentation update is N/A
- [x] `cli-config.yaml.example` update is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] Cross-platform impact considered. The change is provider-routing logic with no OS-specific behavior.
- [x] Tool description/schema update is N/A

## Screenshots / Logs

Before the fix, the new regression test failed with:

```text
assert 'chat_completions' == 'anthropic_messages'
```

After the fix:

```text
1,357 relevant tests passed
fallback activation: anthropic_messages
manual inference response: OK
```
