### PR TITLE
fix(env): config.yaml terminal.* keys win over stale .env on every reload (#29186)

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -512,7 +512,48 @@ def load_hermes_dotenv(
     _apply_external_secret_sources(home_path)
     _apply_managed_env()
 
+    # config.yaml is the documented source of truth for terminal.* settings,
+    # but the dotenv loads above run with override=True — so a stale
+    # TERMINAL_ENV=docker left in ~/.hermes/.env (e.g. written by an older
+    # `hermes setup` before the user switched terminal.backend in config.yaml)
+    # silently wins again on every reload. Startup launchers bridge
+    # config→env once, but long-lived processes (gateway per-turn reload,
+    # cron standalone runs) call load_hermes_dotenv() repeatedly and used to
+    # flip the effective backend back to the stale .env value mid-session
+    # (#29186, #67323). Re-apply config.yaml's explicit terminal keys last so
+    # the documented config path always wins. Runs after _apply_managed_env()
+    # so the merged config (which already carries the managed overlay) is
+    # what lands in the env.
+    _reapply_terminal_config_bridge(home_path)
+
     return loaded
+
+
+def _reapply_terminal_config_bridge(home_path: Path) -> None:
+    """Re-assert config.yaml's explicit ``terminal.*`` keys over reloaded .env.
+
+    Delegates to ``hermes_cli.config.apply_terminal_config_to_env`` — the
+    single shared bridge (same one terminal_tool's fallback and the TUI/
+    dashboard launchers use) — so key coverage, explicit-keys-only override
+    semantics, cwd placeholder handling, and the managed-scope overlay can't
+    drift from the other bridge sites. Only keys the user actually wrote in
+    config.yaml's ``terminal`` section override env values; a config.yaml
+    without a terminal section leaves .env/shell selections untouched.
+
+    Scoped to the process HERMES_HOME: the shared bridge reads the
+    process-global config, so re-applying it for a *different* profile's
+    ``load_hermes_dotenv(hermes_home=...)`` call would bridge the wrong
+    profile's config. Fail-open — a config problem must never break dotenv
+    loading (the historical env-driven behavior still applies).
+    """
+    try:
+        if Path(home_path).resolve() != _process_hermes_home().resolve():
+            return
+        from hermes_cli.config import apply_terminal_config_to_env
+
+        apply_terminal_config_to_env(env=None)
+    except Exception:  # noqa: BLE001 — early bootstrap / malformed config
+        pass
 
 
 def _apply_managed_env() -> None:

--- a/tests/gateway/test_runtime_env_reload_config_authority.py
+++ b/tests/gateway/test_runtime_env_reload_config_authority.py
@@ -37,3 +37,33 @@ def test_reload_runtime_env_preserves_config_max_turns(tmp_path: Path, monkeypat
     assert os.environ["HERMES_MAX_ITERATIONS"] == "9000"
 
 
+def test_reload_runtime_env_preserves_config_terminal_backend(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Regression for #29186: the per-turn .env reload must not restore a
+    stale TERMINAL_ENV=docker over config.yaml's terminal.backend=local.
+
+    This is the exact mid-session backend flip from the field report: the
+    gateway starts on the bridged local backend, works for hours, then a
+    later turn's reload re-loads .env with override=True and every terminal /
+    execute_code / read_file call starts trying Docker — while
+    ``hermes config get terminal.backend`` still says local.
+    """
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"terminal": {"backend": "local"}}),
+        encoding="utf-8",
+    )
+    (hermes_home / ".env").write_text("TERMINAL_ENV=docker\n", encoding="utf-8")
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    # Startup bridge already ran: the effective backend is local.
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    gateway_run._reload_runtime_env_preserving_config_authority()
+
+    assert os.environ["TERMINAL_ENV"] == "local"
+
+

--- a/tests/hermes_cli/test_dump_terminal_backend.py
+++ b/tests/hermes_cli/test_dump_terminal_backend.py
@@ -25,15 +25,25 @@ def _seed(home: Path, *, config_yaml: str, env_text: str) -> None:
 
 
 def test_dump_surfaces_terminal_env_override(monkeypatch, capsys, tmp_path):
+    """A TERMINAL_ENV override that survives dotenv loading is surfaced.
+
+    Since the #29186 fix, config.yaml's explicit terminal keys are re-applied
+    after every .env load, so a stale .env value can no longer produce this
+    mismatch. The dump's override line remains as defense-in-depth for env
+    values set AFTER load (in-process mutation, config-bridge failure), so
+    pin it with a config.yaml that has no explicit backend key.
+    """
     from hermes_cli import dump
     from hermes_cli.config import get_hermes_home
 
-    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
     # Keep run_dump's project-.env fallback from touching the real repo.
     monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
 
     home = get_hermes_home()
-    _seed(home, config_yaml="terminal:\n  backend: local\n", env_text="TERMINAL_ENV=docker\n")
+    # No explicit terminal.backend in config.yaml — merged default is 'local',
+    # the env override is what actually runs.
+    _seed(home, config_yaml="display:\n  streaming: true\n", env_text="")
 
     dump.run_dump(SimpleNamespace(show_keys=False))
 
@@ -43,6 +53,27 @@ def test_dump_surfaces_terminal_env_override(monkeypatch, capsys, tmp_path):
     assert "overrides config.yaml" in line
     # The shadowed config value is still shown so the mismatch is obvious.
     assert "terminal.backend=local" in line
+
+
+def test_dump_reports_config_backend_winning_over_stale_env(monkeypatch, capsys, tmp_path):
+    """Regression for #29186: a stale TERMINAL_ENV=docker in .env no longer
+    beats config.yaml terminal.backend=local — load_hermes_dotenv re-applies
+    the explicit config keys, so the dump reports local with no override
+    warning."""
+    from hermes_cli import dump
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+
+    home = get_hermes_home()
+    _seed(home, config_yaml="terminal:\n  backend: local\n", env_text="TERMINAL_ENV=docker\n")
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _terminal_line(capsys.readouterr().out)
+    assert "local" in line
+    assert "overrides" not in line
 
 
 def test_dump_reports_config_backend_when_no_override(monkeypatch, capsys, tmp_path):

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -325,3 +325,118 @@ def test_cleanup_scope_is_the_profile_managed_set():
             f"{key} looks credential-shaped; startup scrub must not "
             "cover credentials — read-time secret scoping owns those"
         )
+
+
+# ---------------------------------------------------------------------------
+# config.yaml terminal.* re-apply after dotenv loads (#29186 / #67323)
+#
+# load_hermes_dotenv loads .env with override=True, so a stale
+# TERMINAL_ENV=docker in .env used to silently beat config.yaml's
+# terminal.backend on every reload (gateway per-turn reload, cron standalone
+# runs). The bridge re-applies config.yaml's EXPLICIT terminal keys last via
+# the shared hermes_cli.config.apply_terminal_config_to_env helper.
+# ---------------------------------------------------------------------------
+
+
+def _seed_terminal_home(tmp_path, monkeypatch, *, config_yaml=None, env_text=None):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    if config_yaml is not None:
+        (home / "config.yaml").write_text(config_yaml, encoding="utf-8")
+    if env_text is not None:
+        (home / ".env").write_text(env_text, encoding="utf-8")
+    # The bridge is scoped to the process HERMES_HOME (a different profile's
+    # load must not bridge this process's config), so point the process at
+    # the seeded home like a real gateway/cron process would be.
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def test_config_yaml_terminal_backend_overrides_stale_env(tmp_path, monkeypatch):
+    """Regression for #29186: a leftover TERMINAL_ENV=docker in ~/.hermes/.env
+    must not silently override the user's choice in config.yaml. config.yaml
+    is the documented source of truth, so its value must win after load."""
+    home = _seed_terminal_home(
+        tmp_path, monkeypatch,
+        config_yaml="terminal:\n  backend: local\n",
+        env_text="TERMINAL_ENV=docker\n",
+    )
+
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TERMINAL_ENV") == "local"
+
+
+def test_config_yaml_terminal_backend_overrides_stale_shell(tmp_path, monkeypatch):
+    """config.yaml must also beat a stale TERMINAL_ENV exported in the shell
+    (e.g. set in ~/.zshrc when the user was experimenting with docker)."""
+    home = _seed_terminal_home(
+        tmp_path, monkeypatch,
+        config_yaml="terminal:\n  backend: local\n",
+    )
+
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TERMINAL_ENV") == "local"
+
+
+def test_no_terminal_section_leaves_env_value_alone(tmp_path, monkeypatch):
+    """When config.yaml has no terminal section, the .env value is still the
+    user's active setting — the bridge must NOT clobber it with merged
+    defaults."""
+    home = _seed_terminal_home(
+        tmp_path, monkeypatch,
+        config_yaml="display:\n  streaming: true\n",
+        env_text="TERMINAL_ENV=docker\n",
+    )
+
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TERMINAL_ENV") == "docker"
+
+
+def test_config_yaml_terminal_omitted_key_does_not_clear_env(tmp_path, monkeypatch):
+    """If config.yaml has a terminal block but no `backend`, the .env value
+    must survive (only explicit config keys override env)."""
+    home = _seed_terminal_home(
+        tmp_path, monkeypatch,
+        config_yaml="terminal:\n  timeout: 600\n",
+        env_text="TERMINAL_ENV=docker\n",
+    )
+
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TERMINAL_ENV") == "docker"
+    assert os.getenv("TERMINAL_TIMEOUT") == "600"
+
+
+def test_other_profile_home_does_not_bridge_process_config(tmp_path, monkeypatch):
+    """Loading a DIFFERENT profile's .env must not re-bridge this process's
+    config.yaml — the shared bridge reads the process-global config, so
+    applying it for another home would stamp the wrong profile's terminal
+    settings into the env."""
+    process_home = tmp_path / "process-home"
+    process_home.mkdir()
+    (process_home / "config.yaml").write_text(
+        "terminal:\n  backend: local\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+
+    other_home = tmp_path / "other-profile"
+    other_home.mkdir()
+    (other_home / ".env").write_text("TERMINAL_ENV=docker\n", encoding="utf-8")
+
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    load_hermes_dotenv(hermes_home=other_home)
+
+    # The other profile's .env value stands; the process config was not applied.
+    assert os.getenv("TERMINAL_ENV") == "docker"


### PR DESCRIPTION
## Summary
A stale `TERMINAL_ENV` in `~/.hermes/.env` can no longer flip the terminal backend away from `config.yaml`'s `terminal.backend` mid-session — `load_hermes_dotenv()` now re-applies config.yaml's explicit `terminal.*` keys after every .env (re)load.

Salvages #29239 by @Jiahui-Gu (earliest fix for #29186, May 20) onto current main, reworked to use the shared bridge instead of a duplicated key map.

Root cause: dotenv loads run with `override=True`, and only *startup* launchers bridge config→env (#76047's terminal_tool fallback is one-shot per process). Long-lived processes reload .env repeatedly — the gateway per-turn (`_reload_runtime_env_preserving_config_authority`) and cron standalone runs — so a stale `TERMINAL_ENV=docker` silently won again on the first reload after startup. This is the exact field failure from the Nous support thread (diagnostics 4238f956): gateway works on `local` for hours, then every `terminal`/`execute_code`/`read_file` call starts trying Docker while `hermes config get terminal.backend` still says `local`.

## Changes
- `hermes_cli/env_loader.py`: `load_hermes_dotenv()` ends with `_reapply_terminal_config_bridge()` — delegates to the shared `hermes_cli.config.apply_terminal_config_to_env()` (explicit-keys-only override, cwd placeholder handling, managed-scope overlay), runs after `_apply_managed_env()`, scoped to the process HERMES_HOME so multiplex/other-profile loads don't bridge the wrong config, fail-open.
- `tests/hermes_cli/test_env_loader.py`: 5 tests — stale .env beaten, stale shell export beaten, no-terminal-section preserved, omitted-key preserved, other-profile home not bridged.
- `tests/gateway/test_runtime_env_reload_config_authority.py`: regression driving the real gateway per-turn reload path.
- `tests/hermes_cli/test_dump_terminal_backend.py`: the test that pinned the old stale-env-wins symptom now pins the fixed contract; the dump's override warning is re-pinned via post-load env mutation (still reachable).

## Validation
| Scenario (live, real imports, temp HERMES_HOME: config `local` + .env `docker`) | Before | After |
|---|---|---|
| Effective backend after gateway startup bridge | local | local |
| Effective backend after per-turn `.env` reload | **docker** | **local** |

Targeted tests: 32/32 (`test_env_loader`, `test_runtime_env_reload_config_authority`, `test_terminal_env_bridge`, `test_dump_terminal_backend`, `test_cjk_fts_config_bridge`) + 96/96 adjacent (`test_set_config_value`, `test_terminal_requirements`).

Resolves #29186. Also fixes the cron-standalone variant (#67323) at the class level, since the cron scheduler reloads through the same `load_hermes_dotenv()`.

## Infographic

![config.yaml wins the terminal backend](https://v3b.fal.media/files/b/0aa4c973/Sx4ym6ZTbmR_KolbOEVNk_DGsdFcy6.png)
