### PR TITLE
fix(security): scrub applied-secrets snapshot from child-process envs

### DIFF
--- a/tests/tools/test_build_subprocess_env.py
+++ b/tests/tools/test_build_subprocess_env.py
@@ -8,7 +8,8 @@ import sys
 
 import pytest
 
-from tools.environments.local import build_subprocess_env
+from tools.env_passthrough import clear_env_passthrough, register_env_passthrough
+from tools.environments.local import build_subprocess_env, hermes_subprocess_env
 
 
 # ---------------------------------------------------------------------------
@@ -97,3 +98,132 @@ def test_e2e_no_scrub_child_keeps_planted_secret(tmp_path, monkeypatch):
         env=env, capture_output=True, text=True, timeout=60, check=True,
     )
     assert out.stdout.strip() == "sk-FAKE-planted"
+
+
+# ---------------------------------------------------------------------------
+# Provenance-aware scrub: externally-applied secrets under ANY name shape
+# (issue #77164)
+#
+# The shape predicates (_is_hermes_internal_secret + the static blocklist)
+# only match credential-shaped names. Values applied from external secret
+# sources (Bitwarden / 1Password / secret-source command) under
+# non-credential-shaped names — DATABASE_URL, FOO, arbitrary 1Password item
+# keys — were inherited verbatim by every spawned child. These tests pin the
+# fix: the scrub consults hermes_cli.env_loader's per-home applied-secrets
+# snapshot (get_secret_source_values), which is authoritative about WHAT came
+# from an external source regardless of name shape.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def applied_secrets(tmp_path, monkeypatch):
+    """Simulate external secret-source application for a temp HERMES_HOME.
+
+    Mirrors exactly what load_hermes_dotenv()/_hydrate_profile_secret_sources()
+    record in ``hermes_cli.env_loader._SECRET_SOURCE_VALUES_BY_HOME`` for
+    externally-applied secrets — including under NON-credential-shaped names
+    that no shape predicate matches.
+    """
+    from hermes_cli import env_loader
+
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    home_key = str(home.resolve())
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    snapshot = {
+        "DATABASE_URL": "postgres://user:supersecret@db",
+        "FOO": "bar-value",
+        # A credential-shaped key supplied by an external source: provenance
+        # (not shape) must drive the strip.
+        "OPENAI_API_KEY": "sk-applied-via-bitwarden",
+    }
+    env_loader._SECRET_SOURCE_VALUES_BY_HOME[home_key] = dict(snapshot)
+    try:
+        yield home_key, snapshot
+    finally:
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME.pop(home_key, None)
+
+
+def test_scrub_strips_applied_secret_names(applied_secrets, monkeypatch):
+    """Non-credential-shaped applied secrets must be stripped from the
+    terminal factory's env even though no shape predicate matches them."""
+    monkeypatch.setenv("DATABASE_URL", "postgres://user:supersecret@db")
+    monkeypatch.setenv("FOO", "bar-value")
+    monkeypatch.setenv("MY_OWN_THING", "keep-me")  # .env/shell var, NOT applied
+    env = build_subprocess_env()
+    assert "DATABASE_URL" not in env
+    assert "FOO" not in env
+    # A user's own env (never applied from an external source) still flows.
+    assert env["MY_OWN_THING"] == "keep-me"
+
+
+def test_e2e_child_does_not_see_applied_secrets(applied_secrets, monkeypatch):
+    """A real child spawned with the terminal factory's env must not see
+    externally-applied secrets under non-credential-shaped names, while still
+    seeing the user's own non-applied env vars."""
+    monkeypatch.setenv("DATABASE_URL", "postgres://user:supersecret@db")
+    monkeypatch.setenv("FOO", "bar-value")
+    monkeypatch.setenv("MY_OWN_THING", "keep-me")
+
+    env = build_subprocess_env()
+
+    code = (
+        "import os, json; "
+        "print(json.dumps({'db': 'DATABASE_URL' in os.environ, "
+        "'foo': 'FOO' in os.environ, "
+        "'mine': os.environ.get('MY_OWN_THING')}))"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env, capture_output=True, text=True, timeout=60, check=True,
+    )
+    import json
+
+    result = json.loads(out.stdout)
+    assert result["db"] is False
+    assert result["foo"] is False
+    assert result["mine"] == "keep-me"
+
+
+def test_passthrough_applied_secret_survives_terminal_path(applied_secrets, monkeypatch):
+    """env_passthrough wins on the terminal path: an explicitly registered
+    applied name still reaches the child; a non-registered applied name is
+    still stripped."""
+    monkeypatch.setenv("DATABASE_URL", "postgres://user:supersecret@db")
+    monkeypatch.setenv("FOO", "bar-value")
+    try:
+        register_env_passthrough(["DATABASE_URL"])
+        env = build_subprocess_env()
+        assert env.get("DATABASE_URL") == "postgres://user:supersecret@db"
+        assert "FOO" not in env
+    finally:
+        clear_env_passthrough()
+
+
+def test_hermes_subprocess_env_strips_applied_secrets(applied_secrets, monkeypatch):
+    """Non-terminal surface: applied-secret names are stripped unconditionally
+    (no passthrough concept there), and non-applied user env still flows."""
+    monkeypatch.setenv("DATABASE_URL", "postgres://user:supersecret@db")
+    monkeypatch.setenv("FOO", "bar-value")
+    monkeypatch.setenv("MY_OWN_THING", "keep-me")
+    env = hermes_subprocess_env()
+    assert "DATABASE_URL" not in env
+    assert "FOO" not in env
+    assert env["MY_OWN_THING"] == "keep-me"
+
+
+def test_hermes_subprocess_env_strips_applied_secrets_when_inheriting(applied_secrets, monkeypatch):
+    """Applied-secret names are stripped even with inherit_credentials=True
+    (same unconditional class as the static Tier-1 blocklist), while
+    non-applied provider keys still flow on the inherit path."""
+    monkeypatch.setenv("DATABASE_URL", "postgres://user:supersecret@db")
+    monkeypatch.setenv("FOO", "bar-value")
+    # Credential-shaped AND in the applied snapshot: provenance wins.
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-applied-via-bitwarden")
+    # Credential-shaped but user's own .env/shell, never applied: still flows.
+    monkeypatch.setenv("GEMINI_API_KEY", "sk-own-env")
+    env = hermes_subprocess_env(inherit_credentials=True)
+    assert "DATABASE_URL" not in env
+    assert "FOO" not in env
+    assert "OPENAI_API_KEY" not in env
+    assert env["GEMINI_API_KEY"] == "sk-own-env"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -394,6 +394,56 @@ def _is_hermes_internal_secret(key: str) -> bool:
     return False
 
 
+# Per-home cache of applied-secret KEY NAMES (never values).  The snapshot in
+# ``hermes_cli.env_loader`` is immutable per home for the life of the process
+# (``reset_secret_source_cache`` clears it, e.g. in tests), so caching the
+# names avoids re-resolving the home path on every spawn.
+_applied_secret_names_cache: dict[str, frozenset[str]] = {}
+
+
+def _applied_secret_names() -> frozenset[str]:
+    """Return the KEY names of externally-applied secret values for the
+    effective Hermes home.
+
+    Provenance-aware complement to :func:`_is_hermes_internal_secret` and the
+    static blocklists.  External secret sources (Bitwarden / 1Password /
+    secret-source command) can apply values under ANY name —
+    ``DATABASE_URL``, ``FOO``, arbitrary 1Password item keys — that no shape
+    predicate matches, and those values were previously inherited verbatim by
+    every spawned child (issue #77164).  ``hermes_cli.env_loader`` records
+    exactly which keys an external source contributed per home; consulting
+    that snapshot decides by provenance instead of guessing by name shape.
+
+    Only the KEY names are returned — values are never read out of the
+    snapshot; the scrub only needs names to strip them from child envs.
+
+    Fail open: any failure to resolve the snapshot (missing ``env_loader``,
+    unresolvable home) yields an empty set so a secret-source problem can
+    never break child-process spawning.
+    """
+    try:
+        from hermes_cli.env_loader import get_secret_source_values
+        from hermes_constants import get_hermes_home
+    except Exception:
+        return frozenset()
+
+    try:
+        home_key = str(Path(get_hermes_home()).resolve())
+    except Exception:
+        return frozenset()
+
+    cached = _applied_secret_names_cache.get(home_key)
+    if cached is not None:
+        return cached
+
+    try:
+        names = frozenset(get_secret_source_values(home_key).keys())
+    except Exception:
+        names = frozenset()
+    _applied_secret_names_cache[home_key] = names
+    return names
+
+
 def _inject_context_hermes_home(env: dict) -> None:
     """Bridge the context-local Hermes home override into subprocess env."""
     try:
@@ -465,6 +515,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         _resolve_passthrough_value = lambda _name, fallback: fallback  # noqa: E731
 
     sanitized: dict[str, str] = {}
+    applied_secret_names = _applied_secret_names()
 
     for key, value in (base_env or {}).items():
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
@@ -473,6 +524,12 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
             continue
         passthrough = _is_passthrough(key)
         if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+            continue
+        # Provenance scrub: externally-applied secrets (Bitwarden / 1Password
+        # / secret-source command) are recorded per-home under any name shape
+        # (DATABASE_URL, FOO, ...).  An explicit env_passthrough registration
+        # still wins, exactly like the blocklist behavior above.
+        if key in applied_secret_names and not passthrough:
             continue
         resolved = _resolve_passthrough_value(key, value) if passthrough else value
         if resolved is not None:
@@ -489,6 +546,8 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         else:
             passthrough = _is_passthrough(key)
             if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+                continue
+            if key in applied_secret_names and not passthrough:
                 continue
             resolved = _resolve_passthrough_value(key, value) if passthrough else value
             if resolved is not None:
@@ -583,7 +642,7 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     skill-aware (``env_passthrough``); this helper is for spawns that have no
     skill-passthrough concept.
 
-    Two-tier stripping:
+    Two-tier stripping, plus a provenance pass:
 
     * **Tier 1 (always):** ``_ALWAYS_STRIP_KEYS`` — gateway bot tokens, GitHub
       auth, and remote-compute secrets are removed regardless of
@@ -591,6 +650,12 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     * **Tier 2 (conditional):** the rest of ``_HERMES_PROVIDER_ENV_BLOCKLIST``
       (LLM provider API keys, tool secrets) is removed unless the caller passes
       ``inherit_credentials=True``.
+    * **Provenance (always):** any key recorded in the current home's
+      applied-secrets snapshot (``hermes_cli.env_loader`` — values applied
+      from Bitwarden / 1Password / a secret-source command, under any name
+      shape) is removed, even with ``inherit_credentials=True``.  Vault-applied
+      secrets are exactly the ones a child must never read from its
+      environment (issue #77164).
 
     Pass ``inherit_credentials=True`` **only** when the child legitimately
     needs LLM provider credentials — a user-blessed ``claude`` / ``codex`` /
@@ -618,6 +683,17 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
             env.pop(key, None)
         elif _is_hermes_internal_secret(key):
             env.pop(key, None)
+
+    # Applied-secrets provenance scrub (issue #77164): keys contributed by
+    # external secret sources (Bitwarden / 1Password / secret-source command)
+    # are recorded per-home in ``hermes_cli.env_loader`` under ANY name —
+    # including non-credential-shaped names (``DATABASE_URL``, ``FOO``,
+    # arbitrary 1Password item keys) that no shape predicate matches.  Strip
+    # them unconditionally, same class as ``_ALWAYS_STRIP_KEYS``: no child
+    # Hermes spawns, even a model-driving CLI with ``inherit_credentials=True``,
+    # needs vault-applied secrets read from its environment.
+    for key in _applied_secret_names():
+        env.pop(key, None)
 
     if not inherit_credentials:
         # Tier 2 — strip provider/tool credentials unless explicitly inherited.


### PR DESCRIPTION
## What changed and why

The child-process environment scrub was a **name-shape heuristic**. When Hermes spawns a child process (a terminal command via `build_subprocess_env`, or a non-terminal surface — browser worker, ACP executor, computer-use driver — via `hermes_subprocess_env`), secrets were stripped by matching exact names plus credential-shaped suffixes (`_API_KEY` / `_SECRET` / `_KEY` / `_TOKEN`) against a static blocklist.

That left a hole: values applied from **external secret sources** (Bitwarden Secrets Manager, 1Password, a secret-source command) under **non-credential-shaped names** — `DATABASE_URL`, `FOO`, arbitrary 1Password item keys — matched no predicate and were inherited verbatim by every spawned child. The scrub guessed by name shape instead of consulting the authoritative record of what actually came from an external source.

This change makes the scrub **provenance-aware**: both env factories now also strip any key present in the current home's applied-secrets snapshot (`hermes_cli.env_loader.get_secret_source_values`, which records exactly which keys an external source contributed, regardless of name). `env_passthrough` semantics on the terminal path are preserved — an explicitly registered passthrough var still receives its value. Secrets from the user's own `.env` or shell are untouched: only externally-applied secret-source names are removed. The lookup is per-home cached and fails open (empty set) so a secret-source problem can never break child-process spawning.

## Why this matters to you as a user

Before: if you wire Bitwarden or 1Password into Hermes and a vault item happens to be named `DATABASE_URL` (or any non-credential-shaped name), that value silently leaked into **every** child process Hermes spawned — terminal commands the agent runs, the browser worker, the ACP executor, the computer-use driver. Any of those children could read a secret you only intended for the main Hermes process.

After: a child process — terminal command, browser worker, ACP executor, computer-use driver — can no longer read externally-applied secrets from its environment **at all**, unless you explicitly registered the variable for passthrough (terminal path only, e.g. via `terminal.env_passthrough` in config.yaml or a skill's `required_environment_variables`). Your own `.env` and shell variables behave exactly as before.

## How to test

```bash
cd <repo>
HERMES_PYTHON="<venv>/Scripts/python.exe" scripts/run_tests.sh tests/tools/test_build_subprocess_env.py tests/tools/test_env_passthrough.py -q
```

Result: `2 files, 34 tests passed, 0 failed`. New tests cover:

- E2E: a real child spawned via `sys.executable` does **not** see applied secrets under non-credential-shaped names (`DATABASE_URL`, `FOO`) from either factory, while the user's own env var (`MY_OWN_THING`) still reaches it.
- `env_passthrough` preservation: a registered applied name still reaches the terminal child; a non-registered applied name is still stripped.
- `hermes_subprocess_env` strips applied-secret names unconditionally — including with `inherit_credentials=True` — while non-applied provider keys still flow on the inherit path.

Also verified: `git diff --check` clean, `python scripts/check-windows-footguns.py` passes on changed files.

## Platforms tested

- Windows 11, git-bash, Python 3.12, canonical `scripts/run_tests.sh` runner (per-file subprocess isolation).

## Related

Closes #77164; part of the secrets-exfiltration disclosure-class series: #77008 #77012 #77020 #77027 #77031 #77039
