### PR TITLE
fix(web): stop /api/messaging/platforms blocking the event loop (#77048)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -88,6 +88,7 @@ from plugins.memory.config_schema import (
     get_provider_config_schema,
 )
 from gateway.status import (
+    GatewayLiveness,
     derive_gateway_busy,
     derive_gateway_drainable,
     get_running_pid_cached,
@@ -8095,6 +8096,7 @@ def _messaging_platform_payload(
     runtime: dict | None,
     scoped: bool = False,
     profile_home: Optional[Path] = None,
+    liveness: Optional[GatewayLiveness] = None,
 ) -> dict[str, Any]:
     platform_id = entry["id"]
     runtime_platforms = runtime.get("platforms") if runtime else {}
@@ -8115,16 +8117,23 @@ def _messaging_platform_payload(
     # HERMES_HOME contextvar override (#56986 / #69143), so the profile's
     # directory has to be handed over explicitly or messaging silently reports
     # another profile's gateway (#71211).
-    liveness = resolve_gateway_liveness(
-        profile_dir=profile_home,
-        runtime=runtime,
-        health_probe=(
-            _probe_gateway_health if _GATEWAY_HEALTH_URL else None
-        ),
-        pid_probe=get_running_pid_cached,
-        runtime_reader=read_runtime_status,
-        runtime_pid_probe=get_runtime_status_running_pid,
-    )
+    #
+    # ``liveness`` is optional: the catalog endpoint resolves it ONCE per
+    # request and shares it across every platform entry (it reads the same
+    # gateway state for all of them — resolving 32x per poll is what stalled
+    # the event loop 6-12s in #77048). Callers with a single platform (the
+    # /test endpoint) leave it None and get the same per-call resolution.
+    if liveness is None:
+        liveness = resolve_gateway_liveness(
+            profile_dir=profile_home,
+            runtime=runtime,
+            health_probe=(
+                _probe_gateway_health if _GATEWAY_HEALTH_URL else None
+            ),
+            pid_probe=get_running_pid_cached,
+            runtime_reader=read_runtime_status,
+            runtime_pid_probe=get_runtime_status_running_pid,
+        )
     gateway_running = liveness.running
     env_vars = []
 
@@ -9130,27 +9139,54 @@ async def get_messaging_platforms(profile: Optional[str] = None):
     # load_env() honors the HERMES_HOME contextvar override; the gateway
     # status readers do NOT (they resolve process-level paths), so the
     # profile directory is passed explicitly for those (#71211).
-    with _profile_scope(profile) as scoped_dir:
-        env_on_disk = load_env()
-        runtime = (
-            read_runtime_status(path=scoped_dir / "gateway_state.json")
-            if scoped_dir is not None
-            else read_runtime_status()
-        )
-        return {
-            "env_path": str(get_env_path()),
-            "gateway_start_command": _gateway_display_command(profile, "start"),
-            "platforms": [
-                _messaging_platform_payload(
-                    entry,
-                    env_on_disk,
-                    runtime,
-                    scoped=scoped_dir is not None,
-                    profile_home=scoped_dir,
-                )
-                for entry in _messaging_platform_catalog()
-            ]
-        }
+    #
+    # The catalog build is fully synchronous and slow: _messaging_platform_payload
+    # resolves gateway liveness per platform, and resolve_gateway_liveness does
+    # PID/process-table probing + file I/O. On a stock install the catalog has
+    # ~32 entries, so running the whole build inline stalled the event loop for
+    # 6-12s per poll (#77048) and tripped the Desktop's readiness timeout.
+    # Run it off the loop via run_in_threadpool, the same pattern /api/status's
+    # topology scan and /api/model/options already use, and resolve liveness
+    # ONCE for the request instead of once per platform — it reads the same
+    # gateway state for every catalog entry.
+    def _build_payload_scoped() -> dict:
+        # Keep the profile override inside the worker thread so the full
+        # sync catalog build (config load, env read, liveness probes) runs
+        # off the event loop under the requested profile.
+        with _profile_scope(profile) as scoped_dir:
+            env_on_disk = load_env()
+            runtime = (
+                read_runtime_status(path=scoped_dir / "gateway_state.json")
+                if scoped_dir is not None
+                else read_runtime_status()
+            )
+            liveness = resolve_gateway_liveness(
+                profile_dir=scoped_dir,
+                runtime=runtime,
+                health_probe=(
+                    _probe_gateway_health if _GATEWAY_HEALTH_URL else None
+                ),
+                pid_probe=get_running_pid_cached,
+                runtime_reader=read_runtime_status,
+                runtime_pid_probe=get_runtime_status_running_pid,
+            )
+            return {
+                "env_path": str(get_env_path()),
+                "gateway_start_command": _gateway_display_command(profile, "start"),
+                "platforms": [
+                    _messaging_platform_payload(
+                        entry,
+                        env_on_disk,
+                        runtime,
+                        scoped=scoped_dir is not None,
+                        profile_home=scoped_dir,
+                        liveness=liveness,
+                    )
+                    for entry in _messaging_platform_catalog()
+                ],
+            }
+
+    return await run_in_threadpool(_build_payload_scoped)
 
 
 def _multiplex_port_binding_conflict(

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -306,6 +306,42 @@ class TestWebServerEndpoints:
 
 
 
+    def test_messaging_platforms_resolves_liveness_once(self, monkeypatch):
+        """#77048: the catalog must resolve gateway liveness ONCE per request.
+
+        Every catalog entry shares the same gateway state, so the old code's
+        per-platform resolve_gateway_liveness() — each doing PID/process-table
+        probing + file I/O — ran ~32 sync probes on the event-loop thread and
+        stalled it 6-12s, tripping the Desktop's 15s readiness timeout. The
+        endpoint now resolves liveness a single time and reuses it across all
+        entries, off the loop via run_in_threadpool.
+        """
+        import hermes_cli.web_server as web_server
+
+        _real_resolve = web_server.resolve_gateway_liveness
+        resolve_calls = []
+
+        def _counting_resolve(*args, **kwargs):
+            resolve_calls.append(kwargs)
+            return _real_resolve(*args, **kwargs)
+
+        monkeypatch.setattr(web_server, "resolve_gateway_liveness", _counting_resolve)
+        monkeypatch.setattr(web_server, "_GATEWAY_HEALTH_URL", None)
+
+        resp = self.client.get("/api/messaging/platforms")
+
+        assert resp.status_code == 200
+        platforms = resp.json()["platforms"]
+        assert len(platforms) > 1
+        # One shared liveness resolution for the whole catalog, not one per
+        # platform entry (previously ~32 per poll, #77048).
+        assert len(resolve_calls) == 1
+        # Every payload reflects the same shared liveness result.
+        assert all(p["gateway_running"] is False for p in platforms)
+
+
+
+
     def test_gateway_drain_bad_action_400(self):
         resp = self.client.post("/api/gateway/drain", json={"action": "explode"})
         assert resp.status_code == 400


### PR DESCRIPTION
## What

`GET /api/messaging/platforms` ran **fully synchronously on the FastAPI event-loop thread**. For every entry in the ~32-platform catalog, `_messaging_platform_payload` called `resolve_gateway_liveness`, which does PID/process-table probing and file I/O. 32 sequential probes stalled the loop for **6–12s per poll**, producing `event loop stalled Ns (GIL pressure suspected)` warnings in `errors.log` and intermittently tripping the Desktop's 15s readiness timeout ("Messaging platforms failed to load").

## Root cause

`get_messaging_platforms()` is declared `async def` but its body runs entirely synchronously — no `await`, no threadpool offload. Same bug class already fixed for `/api/status`'s topology scan and `/api/model/options`; this endpoint was missed.

## Fix

1. **Run the catalog build off the loop** — body extracted into `_build_payload_scoped()` and executed via `run_in_threadpool` (same pattern as `/api/status` topology scan and `/api/model/options`). `_profile_scope` stays inside the worker thread so profile-scoping is preserved.
2. **Resolve gateway liveness ONCE per request** — new optional `liveness: Optional[GatewayLiveness]` param on `_messaging_platform_payload`; the catalog resolves it a single time and shares it across all entries (they all read the same gateway state). Single-platform callers (the `/test` endpoint) leave it `None` and keep per-call resolution — fully backward compatible.

## How to test

- `pytest tests/hermes_cli/test_web_server.py -k messaging_platforms` — new test `test_messaging_platforms_resolves_liveness_once` asserts `resolve_gateway_liveness` is called **exactly once** for a full catalog request (previously ~32).
- Existing profile-scoping test (`test_messaging_platforms_profile_scopes_gateway_reads`) still passes unchanged.
- Direct repro from the issue: `GET /api/messaging/platforms` now returns sub-second and no longer blocks concurrent requests.

## Platforms tested

- macOS (local), full `tests/hermes_cli/test_web_server.py` + `test_web_server_messaging_profiles.py` suite: 129 passed (1 pre-existing unrelated failure in `TestThemeBootstrapCSS::test_serve_index_injects_bootstrap_for_user_theme`, reproduces on `main` without this change).

## Issue

Closes #77048