### PR TITLE
fix(desktop): play local MEDIA over HTTP instead of hermes-media

### DIFF
--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -164,9 +164,18 @@ describe('resolveMediaPlaybackSrc', () => {
     )
   })
 
-  it('uses the Electron streaming protocol for local desktop video', async () => {
+  it('routes local desktop video through the local backend download endpoint', async () => {
     vi.stubGlobal('window', { hermesDesktop: { api: vi.fn() } })
-    $connection.set({ mode: 'local' } as never)
+    $connection.set({ mode: 'local', baseUrl: 'http://127.0.0.1:8642', token: 'local-secret' } as never)
+
+    await expect(resolveMediaPlaybackSrc('C:\\renders\\demo.mp4')).resolves.toBe(
+      'http://127.0.0.1:8642/api/files/download?path=C%3A%5Crenders%5Cdemo.mp4&token=local-secret'
+    )
+  })
+
+  it('falls back to hermes-media when local connection has no token yet', async () => {
+    vi.stubGlobal('window', { hermesDesktop: { api: vi.fn() } })
+    $connection.set({ mode: 'local', baseUrl: 'http://127.0.0.1:8642' } as never)
 
     await expect(resolveMediaPlaybackSrc('C:\\renders\\demo.mp4')).resolves.toBe(
       'hermes-media://stream/C%3A%5Crenders%5Cdemo.mp4'

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -82,10 +82,10 @@ export async function resolveMediaDisplaySrc(path: string): Promise<string> {
   return window.hermesDesktop.readFileDataUrl(filePathFromMediaPath(path))
 }
 
-// Audio/video need a seekable source instead of a whole-file data URL. Keep
-// remote URLs untouched, route gateway-local files through the authenticated
-// download endpoint, and reserve the Electron protocol for files on this
-// desktop machine.
+// Audio/video need a seekable source instead of a whole-file data URL. Prefer
+// the authenticated /api/files/download HTTP path (remote already proves audio
+// works there). hermes-media:// is a known broken class for HTML5 media audio
+// on Electron 36–41 (electron#51442) — keep it only as a no-connection fallback.
 export async function resolveMediaPlaybackSrc(path: string): Promise<string> {
   if (isInlineMediaSrc(path)) {
     return path
@@ -98,6 +98,20 @@ export async function resolveMediaPlaybackSrc(path: string): Promise<string> {
   return resolveMediaDisplaySrc(path)
 }
 
+// Build the same authenticated download URL remote mode already uses for
+// playback. Local desktop backends also expose baseUrl + token on 127.0.0.1.
+function authenticatedFileDownloadUrl(path: string): string | null {
+  const conn = $connection.get()
+
+  if (!conn?.baseUrl || !conn.token) {
+    return null
+  }
+
+  const file = encodeURIComponent(filePathFromMediaPath(path))
+
+  return `${conn.baseUrl.replace(/\/+$/, '')}/api/files/download?path=${file}&token=${encodeURIComponent(conn.token)}`
+}
+
 // Resolve a media path to a URL the shell can open. Remote mode rewrites
 // gateway-local paths to an authenticated /api/files/download URL (the file
 // lives on the gateway, not this disk); local mode keeps the file:// form.
@@ -107,23 +121,21 @@ export function mediaExternalUrl(path: string): string {
   }
 
   if (isRemoteGateway()) {
-    const conn = $connection.get()
-
-    if (conn?.baseUrl && conn.token) {
-      const file = encodeURIComponent(filePathFromMediaPath(path))
-
-      return `${conn.baseUrl}/api/files/download?path=${file}&token=${encodeURIComponent(conn.token)}`
-    }
+    return authenticatedFileDownloadUrl(path) ?? (/^file:/i.test(path) ? path : `file://${path}`)
   }
 
   return /^file:/i.test(path) ? path : `file://${path}`
 }
 
-// Custom Electron scheme (registered in electron/main.ts) that streams a local
-// file with Range support. Used for audio/video so playback bypasses the data
-// URL size cap and supports seeking. `path` may be a plain path or `file://…`.
+// Local audio/video playback source. Prefer HTTP through the local hermes
+// backend (same download endpoint remote mode uses — audio works there). Fall
+// back to the Electron hermes-media protocol only when connection creds are
+// missing. `path` may be a plain path or `file://…`.
 export function mediaStreamUrl(path: string): string {
-  return `hermes-media://stream/${encodeURIComponent(filePathFromMediaPath(path))}`
+  return (
+    authenticatedFileDownloadUrl(path) ??
+    `hermes-media://stream/${encodeURIComponent(filePathFromMediaPath(path))}`
+  )
 }
 
 export function mediaPathFromMarkdownHref(href?: string): string | null {


### PR DESCRIPTION
## Summary
- Fixes #76834 — Desktop local-mode inline MEDIA cards played video (or appeared to play audio) with **no sound**.
- Root cause is the known Electron/Chromium custom-protocol media class (`electron/electron#51442`): `hermes-media://` via `protocol.handle` + `net.fetch(file://)` can decode video while audio never arrives. Privileges were already correct; adding a non-existent `media` flag was a dead end (closed #77166).
- App-side fix: for local desktop audio/video, prefer the same authenticated `/api/files/download?path=&token=` HTTP URL remote mode already uses (where audio works). Keep `hermes-media://` only as a fallback when local connection creds are missing.

## Test plan
- [x] `npx vitest run src/lib/media.remote.test.ts` — 20/20 passed
- [ ] Manual Windows Desktop local mode: TTS → inline MEDIA card → confirm audible playback
- [ ] Manual: local MP4 with audio track → picture + sound
- [ ] Regression: remote-gateway MEDIA still plays with audio