### PR TITLE
fix(security): wire applied-secrets snapshot into provider-egress sanitizers

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1455,8 +1455,10 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # Respects HERMES_REDACT_SECRETS via redact_sensitive_text — no-op
     # when disabled. (#19798)
     if isinstance(_san_content, str) and _san_content:
-        from agent.redact import redact_sensitive_text
-        _san_content = redact_sensitive_text(_san_content)
+        from agent.redact import egress_applied_secret_values, redact_sensitive_text
+        _san_content = redact_sensitive_text(
+            _san_content, extra_secret_values=egress_applied_secret_values()
+        )
 
     # NOTE (empty-content class fix): textless assistant turns are NOT padded
     # here.  The single owner for "never send a turn strict wire validation

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -39,10 +39,16 @@ _MEMORY_CONTEXT_TRUNCATION_MARKER = "\n...[memory provider context truncated]...
 
 def sanitize_memory_context(memory_context: str) -> str:
     """Prepare provider context for a context-engine/LLM egress boundary."""
+    # Exact-value masking of THIS home's applied external secrets
+    # (Bitwarden/1Password/command) — best-effort; on any resolution
+    # failure the call falls back to shape-based redaction alone.
+    from agent.redact import egress_applied_secret_values
+
     sanitized = redact_sensitive_text(
         memory_context.strip(),
         force=True,
         redact_url_credentials=True,
+        extra_secret_values=egress_applied_secret_values(),
     )
     if len(sanitized) <= MEMORY_CONTEXT_MAX_CHARS:
         return sanitized

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -692,7 +692,7 @@ def _egress_known_secret_values() -> set[str]:
         if (
             value
             and len(value) >= _EGRESS_SECRET_VALUE_MIN_LEN
-            and name.endswith(_EGRESS_CREDENTIAL_VALUE_SUFFIXES)
+            and name.upper().endswith(_EGRESS_CREDENTIAL_VALUE_SUFFIXES)
         ):
             values.add(value)
     return values

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -656,6 +656,111 @@ def _mask_token_nonreusable(token: str) -> str:
     return f"«redacted:{label}…»" if label else "«redacted-secret»"
 
 
+# ── Exact-value masking of applied secrets (provider-egress) ─────────────
+#
+# Shape-based redaction (vendor prefixes, URL userinfo, auth headers)
+# cannot catch opaque secret values under arbitrary names (DATABASE_URL,
+# FOO, arbitrary 1Password item keys) applied from external secret sources
+# (Bitwarden / 1Password / command). These helpers mask the exact values
+# themselves. The names carry the ``egress`` prefix so they cannot collide
+# with other in-flight exact-value maskers in this file.
+
+# Environment variable name suffixes whose values are treated as
+# credentials for exact-value masking.
+_EGRESS_CREDENTIAL_VALUE_SUFFIXES = (
+    "_API_KEY",
+    "_TOKEN",
+    "_SECRET",
+    "_KEY",
+    "_PASSWORD",
+)
+
+# Values shorter than this are too likely to collide with ordinary prose
+# (e.g. "test", "local") to mask safely.
+_EGRESS_SECRET_VALUE_MIN_LEN = 6
+
+
+def _egress_known_secret_values() -> set[str]:
+    """Collect exact credential values from the process environment.
+
+    Scans ``os.environ`` for variable names ending in credential suffixes
+    (``_API_KEY`` / ``_TOKEN`` / ``_SECRET`` / ``_KEY`` / ``_PASSWORD``)
+    and returns their values, filtered to ``len >= 6``.
+    """
+    values = set()
+    for name, value in os.environ.items():
+        if (
+            value
+            and len(value) >= _EGRESS_SECRET_VALUE_MIN_LEN
+            and name.endswith(_EGRESS_CREDENTIAL_VALUE_SUFFIXES)
+        ):
+            values.add(value)
+    return values
+
+
+def mask_egress_secret_values(
+    text: str,
+    extra_values: set[str] | None = None,
+) -> str:
+    """Replace exact occurrences of known credential values with ``***``.
+
+    Combines the ``os.environ`` credential-suffixed values (see
+    :func:`_egress_known_secret_values`) with ``extra_values`` — the
+    per-home applied-secrets snapshot from external sources — and replaces
+    exact matches in ``text`` with ``***``. Longest values are replaced
+    first so a secret embedding a shorter one is fully masked.
+
+    Callers must only pass THIS home's applied values as ``extra_values``
+    (see :func:`egress_applied_secret_values`); the env scan is global but
+    restricted to credential-suffixed names.
+
+    Falsy ``text`` passes through unchanged. Never raises — unexpected
+    ``extra_values`` elements are skipped and any internal failure returns
+    ``text`` unmodified.
+    """
+    if not text:
+        return text
+    result = text
+    try:
+        values = _egress_known_secret_values()
+        if extra_values:
+            values.update(
+                v
+                for v in extra_values
+                if isinstance(v, str)
+                and v
+                and len(v) >= _EGRESS_SECRET_VALUE_MIN_LEN
+            )
+        for value in sorted(values, key=len, reverse=True):
+            if value in result:
+                result = result.replace(value, "***")
+    except Exception:
+        return text
+    return result
+
+
+def egress_applied_secret_values() -> set[str] | None:
+    """Return THIS home's applied external-secret values for egress masking.
+
+    Resolves the current hermes home and returns the raw values applied
+    from external secret sources (Bitwarden / 1Password / command) for that
+    home only — per-home scoping: another profile's applied secrets are
+    never masked into this egress.
+
+    Best-effort: any exception (home resolution, snapshot lookup) returns
+    ``None`` so callers fall back to shape-based redaction alone and never
+    break the tool call. Imports are lazy to keep this leaf module free of
+    heavy dependencies at import time.
+    """
+    try:
+        from hermes_cli.env_loader import get_secret_source_values
+        from hermes_constants import get_hermes_home
+
+        return set(get_secret_source_values(get_hermes_home()).values())
+    except Exception:
+        return None
+
+
 def redact_sensitive_text(
     text: str,
     *,
@@ -663,6 +768,7 @@ def redact_sensitive_text(
     code_file: bool = False,
     file_read: bool = False,
     redact_url_credentials: bool = False,
+    extra_secret_values: set[str] | None = None,
 ) -> str:
     """Apply all redaction patterns to a block of text.
 
@@ -691,6 +797,13 @@ def redact_sensitive_text(
     sentinel is syntactically invalid as a token, so it can't be mistaken for a
     usable key or written back as one. Implies code_file=True (config/data
     files shouldn't trigger the source-code ENV/JSON false-positive paths).
+
+    Set extra_secret_values to additionally replace exact occurrences of the
+    given credential values with ``***``. Shape-based passes cannot catch
+    opaque values applied under arbitrary names (DATABASE_URL, FOO, 1Password
+    item keys); egress callers pass the per-home applied-secrets snapshot here
+    (see :func:`egress_applied_secret_values`). Default None keeps current
+    behavior byte-identical — the exact-value pass is skipped entirely.
 
     Performance: each regex pattern is gated behind a cheap substring
     pre-check (e.g. ``"=" in text`` for ENV assignments, ``"://" in text``
@@ -876,6 +989,12 @@ def redact_sensitive_text(
             return phone[:4] + "****" + phone[-4:]
         text = _SIGNAL_PHONE_RE.sub(_redact_phone, text)
 
+    # Exact-value masking of applied secrets (per-home snapshot from
+    # external sources). Optional: default None keeps prior behavior
+    # byte-identical (prompt-cache safe — no change for existing callers).
+    if extra_secret_values:
+        text = mask_egress_secret_values(text, extra_values=extra_secret_values)
+
     return text
 
 
@@ -916,7 +1035,11 @@ def is_env_dump_command(command: str | None) -> bool:
 
 
 def redact_terminal_output(
-    output: str, command: str | None = None, *, force: bool = False
+    output: str,
+    command: str | None = None,
+    *,
+    force: bool = False,
+    extra_secret_values: set[str] | None = None,
 ) -> str:
     """Redact secrets from terminal/process stdout.
 
@@ -936,7 +1059,12 @@ def redact_terminal_output(
     if not output:
         return output
     code_file = not is_env_dump_command(command or "")
-    return redact_sensitive_text(output, force=force, code_file=code_file)
+    return redact_sensitive_text(
+        output,
+        force=force,
+        code_file=code_file,
+        extra_secret_values=extra_secret_values,
+    )
 
 
 # Substrings used to gate ``_PREFIX_RE`` execution. If none of these appear in

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -858,6 +858,15 @@ class TestEgressSecretValueMasking:
         assert self._OPAQUE not in result
         assert result == "token *** in output"
 
+    def test_masks_lowercase_env_name_value(self, monkeypatch):
+        """Suffix match is case-insensitive — a lowercase env var name
+        (e.g. from a .env carrying ``db_password=``) must still be caught,
+        matching the sibling exact-value masker's behavior."""
+        monkeypatch.setitem(os.environ, "egress_test_db_password", self._OPAQUE)
+        result = mask_egress_secret_values(f"the db password is {self._OPAQUE}")
+        assert self._OPAQUE not in result
+        assert "***" in result
+
     def test_masks_extra_values(self):
         result = mask_egress_secret_values(
             f"FOO={self._OPAQUE}", extra_values={self._OPAQUE}

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1,10 +1,17 @@
 """Tests for agent.redact -- secret masking in logs and output."""
 
 import logging
+import os
 
 import pytest
 
-from agent.redact import redact_cdp_url, redact_sensitive_text, RedactingFormatter
+from agent.redact import (
+    mask_egress_secret_values,
+    redact_cdp_url,
+    redact_sensitive_text,
+    redact_terminal_output,
+    RedactingFormatter,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -829,5 +836,81 @@ class TestKeywordWordBoundary:
         text = "secrets: hunter2hunter2hunter2hh"
         result = redact_sensitive_text(text)
         assert "hunter2hunter2hunter2hh" not in result
+
+
+class TestEgressSecretValueMasking:
+    """Exact-value masking of applied secrets on provider-egress surfaces.
+
+    Shape-based redaction (vendor prefixes, URL userinfo, auth headers)
+    cannot catch opaque secret values under arbitrary names (DATABASE_URL,
+    FOO, arbitrary 1Password item keys). These tests cover the exact-value
+    masker the egress sanitizers apply on top of the shape passes, plus the
+    ``extra_secret_values`` plumbing on ``redact_sensitive_text`` and
+    ``redact_terminal_output``.
+    """
+
+    # No vendor prefix, no recognisable shape -- invisible to regex redaction.
+    _OPAQUE = "abc123randomstring"
+
+    def test_masks_credential_suffixed_env_value(self, monkeypatch):
+        monkeypatch.setitem(os.environ, "EGRESS_TEST_API_KEY", self._OPAQUE)
+        result = mask_egress_secret_values(f"token {self._OPAQUE} in output")
+        assert self._OPAQUE not in result
+        assert result == "token *** in output"
+
+    def test_masks_extra_values(self):
+        result = mask_egress_secret_values(
+            f"FOO={self._OPAQUE}", extra_values={self._OPAQUE}
+        )
+        assert self._OPAQUE not in result
+        assert result == "FOO=***"
+
+    def test_skips_short_values(self, monkeypatch):
+        # len < 6 is too likely to collide with ordinary prose.
+        monkeypatch.setitem(os.environ, "EGRESS_TEST_API_KEY", "abc12")
+        assert mask_egress_secret_values("abc12") == "abc12"
+        assert mask_egress_secret_values("abc12", extra_values={"abc12"}) == "abc12"
+
+    def test_falsy_text_passthrough(self):
+        assert mask_egress_secret_values("") == ""
+        assert mask_egress_secret_values("", extra_values={self._OPAQUE}) == ""
+
+    def test_never_raises_on_bad_extra_values(self):
+        result = mask_egress_secret_values(
+            f"token {self._OPAQUE} here", extra_values={None, 123, self._OPAQUE}
+        )
+        assert result == "token *** here"
+
+    def test_longest_value_masked_first(self):
+        # A longer secret embedding a shorter one must be fully masked
+        # (longest-first replacement avoids partial-mask artifacts).
+        longer = "abcdefghij"
+        shorter = "abcdefgh"
+        result = mask_egress_secret_values(
+            f"v={longer}", extra_values={shorter, longer}
+        )
+        assert result == "v=***"
+
+    def test_redact_sensitive_text_opaque_value_unchanged_by_default(self):
+        # No extra_secret_values -> exact-value masking is off; the opaque
+        # value passes through exactly as today (byte-identical behavior).
+        text = f"FOO={self._OPAQUE}"
+        assert redact_sensitive_text(text) == text
+
+    def test_redact_sensitive_text_extra_secret_values_masks_opaque(self):
+        result = redact_sensitive_text(
+            f"FOO={self._OPAQUE}", extra_secret_values={self._OPAQUE}
+        )
+        assert self._OPAQUE not in result
+        assert result == "FOO=***"
+
+    def test_redact_terminal_output_extra_secret_values_masks_opaque(self):
+        text = f"the token {self._OPAQUE} is here"
+        # Default: shape-based only -- opaque values pass through.
+        assert redact_terminal_output(text, "cat x") == text
+        result = redact_terminal_output(
+            text, "cat x", extra_secret_values={self._OPAQUE}
+        )
+        assert self._OPAQUE not in result
 
 

--- a/tests/test_egress_secret_masking.py
+++ b/tests/test_egress_secret_masking.py
@@ -1,0 +1,120 @@
+"""E2E wiring tests: applied external secrets are masked at provider egress.
+
+External secret sources (Bitwarden / 1Password / command) apply values
+under arbitrary names (``DATABASE_URL``, ``FOO``, arbitrary 1Password item
+keys) via ``hermes_cli.env_loader.get_secret_source_values``. Shape-based
+redaction cannot catch those opaque values. These tests prove the per-home
+applied-secrets snapshot is wired into the memory-context sanitizer and the
+pre-send assistant-content sanitizer, and that failures are best-effort.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agent.chat_completion_helpers import build_assistant_message  # noqa: E402
+from agent.context_engine import sanitize_memory_context  # noqa: E402
+from tools.process_registry import _redact_process_result  # noqa: E402
+
+# No vendor prefix, no recognisable shape -- invisible to regex redaction,
+# exactly like an opaque value applied under an arbitrary secret name.
+OPAQUE = "abc123randomstring"
+
+
+def _fake_applied_snapshot(monkeypatch, tmp_path, snapshot):
+    """Point egress snapshot resolution at a fake per-home applied snapshot."""
+    monkeypatch.setattr(
+        "hermes_cli.env_loader.get_secret_source_values",
+        lambda home: snapshot,
+    )
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+
+def test_sanitize_memory_context_masks_applied_secret(monkeypatch, tmp_path):
+    _fake_applied_snapshot(monkeypatch, tmp_path, {"DATABASE_URL": OPAQUE})
+    out = sanitize_memory_context(f"connecting to {OPAQUE}")
+    assert OPAQUE not in out
+    assert "***" in out
+
+
+def test_sanitize_memory_context_does_not_mask_other_homes_secrets(monkeypatch, tmp_path):
+    # Per-home scoping: only THIS home's applied values are masked. A
+    # snapshot registered under a different home must not leak into egress.
+    other_home = tmp_path / "other"
+
+    def _snapshot(home):
+        return {"DATABASE_URL": OPAQUE} if str(home) == str(other_home) else {}
+
+    monkeypatch.setattr("hermes_cli.env_loader.get_secret_source_values", _snapshot)
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    out = sanitize_memory_context(f"connecting to {OPAQUE}")
+    assert OPAQUE in out
+
+
+def test_sanitize_memory_context_survives_resolution_failure(monkeypatch, tmp_path):
+    # Best-effort: any exception in snapshot resolution must never break
+    # the sanitizer call -- it falls back to shape-based redaction alone.
+    def _boom(_home):
+        raise RuntimeError("secrets backend unavailable")
+
+    monkeypatch.setattr("hermes_cli.env_loader.get_secret_source_values", _boom)
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    assert sanitize_memory_context("plain memory context") == "plain memory context"
+
+
+class _FakeAssistantMsg:
+    def __init__(self, content):
+        self.content = content
+        self.tool_calls = None
+        self.function_call = None
+        self.reasoning_content = None
+        self.model_extra = None
+        self.reasoning_details = None
+
+    def __getattr__(self, _name):
+        return None
+
+
+class _FakeAgent:
+    stream_delta_callback = None
+    _stream_callback = None
+    reasoning_callback = None
+    verbose_logging = False
+
+    def _extract_reasoning(self, _msg):
+        return None
+
+    def _strip_think_blocks(self, text):
+        return text
+
+    def _needs_thinking_reasoning_pad(self):
+        return False
+
+
+def test_build_assistant_message_masks_applied_secret(monkeypatch, tmp_path):
+    # The pre-send assistant-content sanitizer (the seam at
+    # chat_completion_helpers.py ~:1457) must mask this home's applied
+    # secret values before the message enters conversation history.
+    _fake_applied_snapshot(monkeypatch, tmp_path, {"DATABASE_URL": OPAQUE})
+    msg = build_assistant_message(
+        _FakeAgent(), _FakeAssistantMsg(f"the token {OPAQUE} leaked"), "stop"
+    )
+    assert OPAQUE not in msg["content"]
+    assert "***" in msg["content"]
+
+
+def test_redact_process_result_masks_applied_secret(monkeypatch, tmp_path):
+    # Background-process output (poll/log/wait) passes through
+    # redact_terminal_output; the applied snapshot must be wired there too.
+    _fake_applied_snapshot(monkeypatch, tmp_path, {"DATABASE_URL": OPAQUE})
+    result = _redact_process_result(
+        {"command": "cat x", "output": f"the token {OPAQUE} leaked"}
+    )
+    assert OPAQUE not in result["output"]

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2465,13 +2465,22 @@ def _redact_process_result(result: dict) -> dict:
     """
     if not isinstance(result, dict):
         return result
-    from agent.redact import redact_sensitive_text, redact_terminal_output
+    from agent.redact import (
+        egress_applied_secret_values,
+        redact_sensitive_text,
+        redact_terminal_output,
+    )
 
     command = result.get("command") or ""
+    # Best-effort applied-secrets snapshot (THIS home only); on any
+    # resolution failure the redactor is called without extra values.
+    extra_secret_values = egress_applied_secret_values()
     for field in ("output", "output_preview"):
         value = result.get(field)
         if isinstance(value, str) and value:
-            result[field] = redact_terminal_output(value, command)
+            result[field] = redact_terminal_output(
+                value, command, extra_secret_values=extra_secret_values
+            )
     if isinstance(result.get("command"), str) and result["command"]:
         result["command"] = redact_sensitive_text(result["command"], code_file=True)
     return result

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3037,8 +3037,16 @@ def terminal_tool(
             # (code_file=False) to mask opaque tokens with no vendor prefix.
             # Real prefixes, auth headers, JWTs, private keys are masked in
             # both modes. See issue #43025.
-            from agent.redact import redact_terminal_output
-            output = redact_terminal_output(output.strip(), command) if output else ""
+            from agent.redact import egress_applied_secret_values, redact_terminal_output
+            output = (
+                redact_terminal_output(
+                    output.strip(),
+                    command,
+                    extra_secret_values=egress_applied_secret_values(),
+                )
+                if output
+                else ""
+            )
 
             # Interpret non-zero exit codes that aren't real errors
             # (e.g. grep=1 means "no matches", diff=1 means "files differ")


### PR DESCRIPTION
## What changed and why

Secrets applied from external secret sources (Bitwarden / 1Password / command — `hermes_cli.env_loader.get_secret_source_values`) can arrive under **arbitrary names** (`DATABASE_URL`, `FOO`, any 1Password item key). Shape-based redaction (vendor prefixes, URL userinfo, auth headers) cannot catch those opaque values, so they were still leaking verbatim on several provider-egress surfaces.

This PR wires the per-home applied-secrets snapshot into the remaining unclosed egress sanitizers:

- **`agent/redact.py`** — new exact-value masking primitive, namespaced with an `egress` prefix to avoid colliding with other in-flight exact-value maskers:
  - `mask_egress_secret_values(text, extra_values=None)` — replaces exact occurrences of known credential values with `***`; scans `os.environ` for credential-suffixed names (`_API_KEY` / `_TOKEN` / `_SECRET` / `_KEY` / `_PASSWORD`, values len ≥ 6) and merges caller-supplied `extra_values` (also len ≥ 6). Falsy text passes through unchanged; never raises.
  - `egress_applied_secret_values()` — resolves **this** home's applied-secrets snapshot (per-home scoping; another profile's secrets are never masked into this egress). Best-effort: any resolution failure returns `None`.
  - `redact_sensitive_text(..., extra_secret_values=None)` and `redact_terminal_output(..., extra_secret_values=None)` — optional exact-value pass applied to the result. Default `None` keeps existing behavior byte-identical (no prompt-cache impact for existing callers).
- **Wired call sites** (each best-effort via the helper above — a snapshot resolution failure never breaks the tool call):
  - `agent/context_engine.py` — `sanitize_memory_context` (memory-context → LLM egress).
  - `agent/chat_completion_helpers.py` — pre-send assistant-content sanitizer before the message enters conversation history.
  - `tools/terminal_tool.py` — foreground `terminal` tool result output.
  - `tools/process_registry.py` — background-process `output` / `output_preview` fields.

## Why this matters to you as a user

If you use Bitwarden Secrets Manager, 1Password, or command-based secret sources, the raw values those sources apply can appear in model-visible surfaces — memory provider context, assistant messages persisted to `state.db`/session transcripts, and terminal output — whenever the value happens to sit under a name or in a shape the regex redactor doesn't recognize. After this PR, any value that was actually **applied from an external source for your home** is masked at those egress boundaries even if it has no recognizable prefix, URL shape, or header form. Values that were never applied as secrets are untouched, so ordinary prose, source code, and config dumps behave exactly as before.

## How to test

```
HERMES_PYTHON=... scripts/run_tests.sh tests/agent/test_redact.py tests/test_egress_secret_masking.py -q
```

- RED → GREEN verified: the new tests fail on `origin/main` (3 E2E failures + masker missing) and pass with this change.
- New unit tests (`tests/agent/test_redact.py`, `TestEgressSecretValueMasking`, 9 tests): env-suffixed value masking, `extra_values` masking, short-value (len < 6) skip, falsy passthrough, never-raises on malformed input, longest-first replacement, `redact_sensitive_text` / `redact_terminal_output` plumbing.
- New E2E tests (`tests/test_egress_secret_masking.py`, 5 tests): memory-context masking, per-home scoping (another home's snapshot is NOT masked), resolution-failure resilience, pre-send content masking, background-process output masking.
- Regression: `tests/agent/test_redact.py` (82 passed), `tests/test_egress_secret_masking.py` (5 passed), `tests/test_env_loader_secret_sources.py` (18 passed), plus adjacent suites `test_tool_call_arg_no_redaction.py`, `test_browser_secret_exfil.py`, `test_approval_prompt_redaction.py`, `test_context_engine.py`, `test_pre_compress_memory_context.py` — all green.
- `git diff --check` clean; `scripts/check-windows-footguns.py` clean on all changed files.

## Platforms tested

Windows 11, git-bash, Python 3.12, `scripts/run_tests.sh` (per-file isolated subprocesses, TZ=UTC, PYTHONHASHSEED=0).

## Related

Closes #77165. Part of the secrets-exfiltration disclosure-class series: #77008 #77012 #77020 #77027 #77031 #77039 #77162 #77164.
