### PR TITLE
test(memory): write the dedup fixture as UTF-8 with LF

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -260,9 +260,21 @@ class TestMemoryStorePersistence:
 
     def test_deduplication_on_load(self, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
-        # Write file with duplicates
+        # Write file with duplicates.
+        #
+        # UTF-8 and LF are both deliberate. Path.write_text defaults to the
+        # platform encoding and translates newlines, which on Windows wrote the
+        # delimiter as a lone cp1252 0xa7 byte — invalid UTF-8, so the store
+        # correctly refused the file as unreadable and returned no entries —
+        # and wrapped it in CRLF, which would not have matched ENTRY_DELIMITER
+        # ("\n§\n") even had it decoded. The store's own writer always emits
+        # UTF-8 with LF, so this now writes what the code under test reads.
         mem_file = tmp_path / "MEMORY.md"
-        mem_file.write_text("duplicate entry\n§\nduplicate entry\n§\nunique entry")
+        mem_file.write_text(
+            "duplicate entry\n§\nduplicate entry\n§\nunique entry",
+            encoding="utf-8",
+            newline="\n",
+        )
 
         store = MemoryStore()
         store.load_from_disk()


### PR DESCRIPTION
## Summary

`tests/tools/test_memory_tool.py::TestMemoryStorePersistence::test_deduplication_on_load` fails on Windows and passes on Linux/macOS. The failure is in the fixture, not in `MemoryStore`.

The test builds a `MEMORY.md` by hand with `Path.write_text`, which defaults to the platform encoding and translates newlines:

```python
mem_file.write_text("duplicate entry\n§\nduplicate entry\n§\nunique entry")
```

On Windows (`cp1252`) that writes the `§` delimiter as a lone `0xa7` byte. That is invalid UTF-8, so `_read_raw_checked` correctly reports the file as unreadable and `load_from_disk` returns no entries — the assertion sees `0` where it expects `2`.

Newline translation is a second, independent break: the delimiter lands as `\r\n§\r\n`, which would not match `ENTRY_DELIMITER` (`"\n§\n"`) even if the bytes had decoded.

Observed:

```
preferred encoding: cp1252
bytes around delimiter: b'\r\n\xa7\r\ndu'
'utf-8' codec can't decode byte 0xa7 in position 17: invalid start byte
```

## Change

Pin the fixture to UTF-8 with LF. `_write_file` always emits UTF-8 with LF, so the test was the only thing constructing a file the code under test would never encounter.

Test-only. No production code changes, and the reader's rejection of invalid UTF-8 is correct behaviour that this deliberately does not weaken.

## Verification

- `tests/tools/test_memory_tool.py` — 33 passed / 1 failed → **34 passed** on Windows
- Unaffected on Linux/macOS, where UTF-8 with LF is already what `write_text` produces
- `ruff check tests/tools/test_memory_tool.py` — passed
- `git diff --check` — passed

Sole occurrence: this is the only test in `tests/` that writes `§` through `write_text` without an explicit encoding.