### PR TITLE
test(voice): pin container + PowerShell fallback detection in WSL test

### DIFF
--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -207,6 +207,15 @@ class TestDetectAudioEnvironment:
         monkeypatch.setattr("tools.voice_mode._pulse_socket_reachable", lambda: False)
         monkeypatch.setattr("tools.voice_mode._import_audio",
                             lambda: (MagicMock(), MagicMock()))
+        # Pin the two host-dependent detection paths so this test is
+        # deterministic on every machine: (1) is_container() returns True on
+        # container-like hosts (WSL/CI) and diverts the warning to the
+        # "container" branch (no "WSL" string); (2) the WSL2 PowerShell TTS
+        # fallback, present on hosts with powershell.exe + ffmpeg, downgrades
+        # the WSL-without-forwarding case to a notice instead of a warning.
+        # Same host-dependence class as test_voice_wsl_pipewire.py (#76999).
+        monkeypatch.setattr("hermes_constants.is_container", lambda: False)
+        monkeypatch.setattr("tools.voice_mode._wsl_powershell_tts_available", lambda: False)
 
         proc_version = tmp_path / "proc_version"
         proc_version.write_text("Linux 5.15.0-microsoft-standard-WSL2")


### PR DESCRIPTION
## What does this PR do?

Pin hermes_constants.is_container and tools.voice_mode._wsl_powershell_tts_available to False in test_wsl_without_pulse_blocks_voice. On container-like hosts is_container()=True diverts the warning to the 'container' branch (no 'WSL' string); on hosts with powershell.exe+ffmpeg the PowerShell-TTS fallback downgrades the no-forwarding case to a notice. Both made the test host-dependent. Same class as #76999.

## Related Issue

No GitHub issue — discovered via code review and reproduced live (see below). Happy to file one first if preferred.

## Changes Made

- `fix/voice-mode-wsl-test-isolation` — 1 file(s) changed vs base:
  - `tests/tools/test_voice_mode.py`

## How to Test

Validation completed (recorded by prp):
1. Sabotage check: not applicable to this change class (non-pytest) — manual verification recorded: host-dependent test-isolation bug: prp's clean worktree has is_container()=False so the base leg cannot reproduce. Verified on this WSL host (is_container()=True + powershell.exe present): without the two pins the test fails (warning says 'container' not 'WSL'; WSL text lands in notices via the PowerShell-TTS fallback); with both pins (is_container False + _wsl_powershell_tts_available False) it passes. Proven via direct module-level patch (RAN) and the monkeypatch fix in the test.
2. Suite `tests/tools/test_voice_mode.py`: branch 62 passed / 0 failed vs baseline 61 passed / 1 failed — zero branch-only failures.
3. The full repo-wide suite was not run for this change; GitHub CI owns full-suite validation.

## Logs

Sabotage verification:

```
# not applicable to this change class (non-pytest).
# Manual verification performed: host-dependent test-isolation bug: prp's clean worktree has is_container()=False so the base leg cannot reproduce. Verified on this WSL host (is_container()=True + powershell.exe present): without the two pins the test fails (warning says 'container' not 'WSL'; WSL text lands in notices via the PowerShell-TTS fallback); with both pins (is_container False + _wsl_powershell_tts_available False) it passes. Proven via direct module-level patch (RAN) and the monkeypatch fix in the test.
```
