### PR TITLE
fix(secrets): exact-value applied-secret redaction on the provider-egress path

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import shlex
+from pathlib import Path
 from urllib.parse import unquote_plus
 
 logger = logging.getLogger(__name__)
@@ -656,6 +657,148 @@ def _mask_token_nonreusable(token: str) -> str:
     return f"«redacted:{label}…»" if label else "«redacted-secret»"
 
 
+# ── Exact-value applied-secret masking (#77162, #77165) ─────────────────────
+#
+# Values applied from external secret sources (Bitwarden / 1Password /
+# command) under ANY env name — including non-credential-shaped names like
+# ``DATABASE_URL``, ``FOO``, or arbitrary 1Password item keys — pass every
+# shape-based regex above when a tool echoes the raw value (config/env
+# artifact read, ``printenv``, a backend error quoting a key). This pass
+# masks the exact VALUES from the per-home applied-secrets snapshot plus
+# values of credential-suffixed env vars, closing the provider-egress gap.
+
+# Env-var name suffixes whose values are treated as credentials for the
+# exact-value pass even when NOT applied from an external source (plain
+# .env / shell export). Upper-cased key matching.
+_CREDENTIAL_ENV_SUFFIXES = (
+    "_API_KEY",
+    "_TOKEN",
+    "_SECRET",
+    "_KEY",
+    "_PASSWORD",
+)
+
+# Minimum length for a value to participate in exact-value masking. A
+# 1-char secret would otherwise match inside every word of ordinary text
+# and destroy unrelated content; real credentials are far longer. Mirrors
+# the module's conservative short-token treatment (mask_secret's floor).
+_EXACT_SECRET_MIN_LEN = 8
+
+
+def _resolve_secret_home(home: str | os.PathLike | None):
+    """Resolve the Hermes home whose applied secrets should mask ``text``.
+
+    Defaults to the ACTIVE home exactly as ``hermes_cli.env_loader`` keys
+    its per-home snapshot: ``hermes_constants.get_hermes_home()``
+    (context-local per-profile override → ``HERMES_HOME`` env → platform
+    default), so a multiplexed gateway masks each profile with its OWN
+    applied secrets. Falls back to ``$HERMES_HOME``/``~/.hermes`` if the
+    constants module is unavailable (early bootstrap / import isolation).
+    """
+    if home is not None:
+        return Path(home)
+    try:
+        from hermes_constants import get_hermes_home  # lazy: avoid cycles
+        return get_hermes_home()
+    except Exception:
+        return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+
+
+def _collect_exact_secret_values(home: Path) -> tuple[str, ...]:
+    """Collect values eligible for exact-value masking for ``home``.
+
+    Sources, in order:
+
+    1. the per-home applied-secrets snapshot
+       (``hermes_cli.env_loader.get_secret_source_values``) — values
+       injected from Bitwarden/1Password/command sources under ANY env
+       name, including non-credential-shaped names like ``DATABASE_URL``;
+    2. values of credential-suffixed env vars (``*_API_KEY``/``_TOKEN``/
+       ``_SECRET``/``_KEY``/``_PASSWORD``) in the current process env.
+
+    Values shorter than ``_EXACT_SECRET_MIN_LEN`` are excluded. Returns a
+    deterministic tuple (longest first, ties by codepoint) so the compiled
+    alternation always prefers the longest match at a position.
+    """
+    values: set[str] = set()
+    try:
+        from hermes_cli.env_loader import get_secret_source_values  # lazy: avoid cycles
+        snapshot = get_secret_source_values(home)
+    except Exception:
+        logger.debug(
+            "exact-value secret snapshot unavailable for %s", home, exc_info=True
+        )
+        snapshot = {}
+    for value in snapshot.values():
+        if isinstance(value, str):
+            values.add(value)
+    for name, value in os.environ.items():
+        if name.upper().endswith(_CREDENTIAL_ENV_SUFFIXES) and isinstance(value, str):
+            values.add(value)
+    return tuple(
+        sorted(
+            (v for v in values if len(v) >= _EXACT_SECRET_MIN_LEN),
+            key=lambda v: (-len(v), v),
+        )
+    )
+
+
+def redact_known_secret_values(
+    text: str,
+    home: str | os.PathLike | None = None,
+    *,
+    force: bool = False,
+) -> str:
+    """Mask exact values of applied external secrets in ``text``.
+
+    Closes the provider-egress gap (#77162, #77165): secrets applied from
+    external sources (Bitwarden / 1Password / command) under ANY env name —
+    including non-credential-shaped names like ``DATABASE_URL`` or arbitrary
+    1Password item keys — pass every shape-based redaction pass when a tool
+    echoes the raw value. This pass masks the exact VALUES from the current
+    home's applied-secrets snapshot, plus values of credential-suffixed env
+    vars (``*_API_KEY``/``_TOKEN``/``_SECRET``/``_KEY``/``_PASSWORD``),
+    replacing each with the module-standard ``***`` placeholder.
+
+    Design invariants:
+
+    * **Deterministic & side-effect-free** — returns a masked copy, never
+      mutates ``text``; the replacement is a fixed ``***`` placeholder, so
+      output depends only on the input and the current snapshot. Safe for
+      prompt-cache / message-alternation invariants.
+    * **Regex-safe** — values are ``re.escape``d before alternation, so
+      metacharacter values (``p@ss:word{1}``, connection strings) match
+      literally.
+    * **Min-length guarded** — values shorter than ``_EXACT_SECRET_MIN_LEN``
+      are skipped, so a 1-char secret can't nuke surrounding text.
+    * **Per-home isolated** — ``home`` defaults to the ACTIVE Hermes home
+      (``hermes_constants.get_hermes_home()``, profile-aware); values come
+      from that home's snapshot only — a multiplexed gateway never masks
+      with another profile's values.
+    * **Config-gated** — respects ``security.redact_secrets``
+      (``_REDACT_ENABLED``) unless ``force=True``; degrades gracefully to a
+      no-op when the snapshot is empty or the env_loader import fails.
+    """
+    if text is None:
+        return None
+    if not isinstance(text, str):
+        text = str(text)
+    if not text:
+        return text
+    if not (force or _REDACT_ENABLED):
+        return text
+
+    values = _collect_exact_secret_values(_resolve_secret_home(home))
+    if not values:
+        return text
+    # Cheap pre-screen mirroring the module's substring gates: if no value
+    # appears in the text, the compiled alternation cannot match.
+    if not any(value in text for value in values):
+        return text
+    pattern = re.compile("|".join(re.escape(value) for value in values))
+    return pattern.sub("***", text)
+
+
 def redact_sensitive_text(
     text: str,
     *,
@@ -876,6 +1019,15 @@ def redact_sensitive_text(
             return phone[:4] + "****" + phone[-4:]
         text = _SIGNAL_PHONE_RE.sub(_redact_phone, text)
 
+    # Exact-value pass (#77162, #77165): applied external secrets
+    # (Bitwarden/1Password/command) under ANY env name — including
+    # non-credential-shaped names like DATABASE_URL — pass the shape-based
+    # passes above when a tool echoes the raw value. Mask the exact values
+    # from the per-home applied-secrets snapshot plus credential-suffixed
+    # env values. Runs LAST so no later pass can re-expose a value; force
+    # propagates the safety-boundary contract.
+    text = redact_known_secret_values(text, force=force)
+
     return text
 
 
@@ -929,6 +1081,11 @@ def redact_terminal_output(
       → ``code_file=False`` so the ENV-assignment pass masks opaque tokens.
     - anything else (or unknown command) → ``code_file=True`` to avoid
       false positives on source/config dumps.
+
+    Inherits the exact-value applied-secret pass from
+    :func:`redact_sensitive_text` (#77162, #77165), so a ``printenv`` echo
+    of an externally applied secret under an arbitrary name (e.g.
+    ``DATABASE_URL``) is masked regardless of the command class.
 
     ``force=True`` bypasses the global ``security.redact_secrets`` preference
     for safety boundaries that must never emit raw credentials.

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -556,6 +556,13 @@ def make_tool_result_message(
     callers should compare by value, not by ``is``.
     """
     wrapped = _maybe_wrap_untrusted(name, content)
+    # Exact-value applied-secret masking (#77162, #77165) — AFTER the
+    # untrusted-result wrapping so the delimiter framing survives, and so
+    # opaque applied secrets under arbitrary names (DATABASE_URL, FOO,
+    # arbitrary 1Password item keys) that the shape-based passes miss never
+    # reach the provider verbatim. Deterministic: returns masked copies,
+    # never mutates ``content``.
+    wrapped = _mask_applied_secret_values(wrapped)
     message = {
         "role": "tool",
         "name": name,
@@ -705,6 +712,53 @@ def _maybe_wrap_untrusted(name: str, content: Any) -> Any:
     return content
 
 
+def _mask_applied_secret_values(content: Any) -> Any:
+    """Mask exact applied-secret values in tool-result content (egress).
+
+    Provider-egress exact-value pass for #77162/#77165: secrets applied
+    from external sources (Bitwarden/1Password/command) under ANY env name
+    — including non-credential-shaped names like ``DATABASE_URL`` — that a
+    tool echoes into its result pass the shape-based redaction passes and
+    would otherwise be transmitted VERBATIM to the model provider. This
+    masks the exact values (via ``agent.redact.redact_known_secret_values``)
+    on the primary wire.
+
+    Handles plain string content, multimodal content lists
+    (``[{"type": "text", "text": ...}, ...]`` — each text-type part is
+    masked individually, non-text parts preserved by identity), and dict
+    content (multimodal envelopes like computer_use's
+    ``{"error": ..., "text_summary": ...}`` and raw error dicts — every
+    string value is masked in a shallow copy). Any other content shape
+    passes through unchanged. Returns a masked copy — never mutates the
+    input. No-op when redaction is disabled or no applied secrets exist.
+    """
+    from agent.redact import redact_known_secret_values  # lazy: avoid cycles
+
+    if isinstance(content, str):
+        return redact_known_secret_values(content)
+    if isinstance(content, list):
+        return [
+            redact_known_secret_values(item)
+            if isinstance(item, str)
+            else (
+                {**item, "text": redact_known_secret_values(item["text"])}
+                if isinstance(item, dict)
+                and item.get("type") == "text"
+                and isinstance(item.get("text"), str)
+                else item
+            )
+            for item in content
+        ]
+    if isinstance(content, dict):
+        return {
+            key: _mask_applied_secret_values(value)
+            if isinstance(value, (str, list, dict))
+            else value
+            for key, value in content.items()
+        }
+    return content
+
+
 __all__ = [
     "_NEVER_PARALLEL_TOOLS",
     "_PARALLEL_SAFE_TOOLS",
@@ -727,5 +781,6 @@ __all__ = [
     "_extract_landed_file_mutation_paths",
     "_extract_error_preview",
     "_trajectory_normalize_msg",
+    "_mask_applied_secret_values",
     "make_tool_result_message",
 ]

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -831,3 +831,216 @@ class TestKeywordWordBoundary:
         assert "hunter2hunter2hunter2hh" not in result
 
 
+class TestExactValueAppliedSecrets:
+    """#77162/#77165 — exact-value masking of externally applied secrets.
+
+    Values applied from external secret sources (Bitwarden/1Password/
+    command) under ANY name — including non-credential-shaped names like
+    ``DATABASE_URL``, ``FOO``, or arbitrary 1Password item keys — pass the
+    shape-based passes when a tool echoes them verbatim. The exact-value
+    pass masks the raw values from the per-home applied-secrets snapshot
+    (``hermes_cli.env_loader._SECRET_SOURCE_VALUES_BY_HOME``) plus values
+    of credential-suffixed env vars.
+    """
+
+    SECRET_A = "opaque-applied-value-x9q2"
+    SECRET_B = "another-applied-value-77k3m"
+    META_VALUE = "p@ss:word{1}?x=9&y=[z]"
+
+    @pytest.fixture(autouse=True)
+    def _seed_active_home_snapshot(self, tmp_path, monkeypatch):
+        """Point HERMES_HOME at a tmp home and seed its applied snapshot."""
+        from hermes_cli import env_loader
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setitem(
+            env_loader._SECRET_SOURCE_VALUES_BY_HOME,
+            str(tmp_path.resolve()),
+            {
+                "DATABASE_URL": self.SECRET_B,
+                "FOO": self.SECRET_A,
+                "BITWARDEN_ITEM_KEY": self.META_VALUE,
+                "SHORT1": "a",        # 1 char — must never nuke text
+                "SHORT7": "7chrs!x",  # 7 chars — below the floor
+            },
+        )
+        return str(tmp_path.resolve())
+
+    def test_masks_applied_value_in_plain_text(self):
+        result = redact_sensitive_text(f"leaked credential: {self.SECRET_A}")
+        assert self.SECRET_A not in result
+        assert "***" in result
+
+    def test_masks_applied_value_under_database_url_name(self):
+        result = redact_sensitive_text(f"cat .env -> DATABASE_URL={self.SECRET_B}")
+        assert self.SECRET_B not in result
+        assert "DATABASE_URL=" in result
+        assert "***" in result
+
+    def test_masks_applied_value_in_tool_result_message(self):
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        msg = make_tool_result_message(
+            "terminal",
+            f"$ cat .env\nDATABASE_URL={self.SECRET_B}\nFOO={self.SECRET_A}\nOTHER=1",
+            "call_abc123",
+        )
+        content = msg["content"]
+        assert self.SECRET_B not in content
+        assert self.SECRET_A not in content
+        assert "***" in content
+        assert "DATABASE_URL=" in content  # key survives; value masked
+
+    def test_multimodal_text_parts_masked(self):
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        text_part = {"type": "text", "text": f"snapshot shows {self.SECRET_A} here"}
+        image_part = {"type": "image_url", "image_url": {"url": "data:..."}}
+        msg = make_tool_result_message("browser_snapshot", [text_part, image_part], "call_2")
+        parts = msg["content"]
+        assert self.SECRET_A not in parts[0]["text"]
+        assert "***" in parts[0]["text"]
+        assert parts[1] is image_part  # non-text parts preserved by identity
+
+    def test_plain_string_list_items_masked(self):
+        """Plain str items in a content list must be masked too (QA residual:
+        only dict text-parts were covered originally)."""
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        msg = make_tool_result_message(
+            "some_tool", [f"first {self.SECRET_A}", "clean", self.SECRET_B], "call_5"
+        )
+        parts = msg["content"]
+        assert isinstance(parts, list)
+        assert self.SECRET_A not in parts[0]
+        assert "***" in parts[0]
+        assert parts[1] == "clean"
+        assert self.SECRET_B not in parts[2]
+        assert "***" in parts[2]
+
+    def test_dict_content_string_values_masked(self):
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        envelope = {
+            "error": "vision unavailable",
+            "text_summary": f"screen shows {self.SECRET_A}",
+        }
+        msg = make_tool_result_message("computer_use", envelope, "call_4")
+        content = msg["content"]
+        assert self.SECRET_A not in content["text_summary"]
+        assert "***" in content["text_summary"]
+        assert content["error"] == "vision unavailable"  # non-secret preserved
+
+    def test_tool_result_message_does_not_mutate_input(self):
+        from agent.tool_dispatch_helpers import make_tool_result_message
+
+        original = f"$ printenv\nFOO={self.SECRET_A}"
+        msg = make_tool_result_message("terminal", original, "call_3")
+        assert self.SECRET_A not in msg["content"]
+        assert original == f"$ printenv\nFOO={self.SECRET_A}"  # input untouched
+
+    def test_masks_applied_value_in_terminal_output(self):
+        from agent.redact import redact_terminal_output
+
+        out = redact_terminal_output(
+            f"$ printenv\nFOO={self.SECRET_A}\nDATABASE_URL={self.SECRET_B}", "printenv"
+        )
+        assert self.SECRET_A not in out
+        assert self.SECRET_B not in out
+        assert "FOO=" in out
+
+    def test_regex_metachar_values_masked_literally(self):
+        result = redact_sensitive_text(f"meta {self.META_VALUE} here")
+        assert self.META_VALUE not in result
+        assert "***" in result
+
+    def test_short_values_never_nuke_surrounding_text(self):
+        # 1-char and sub-floor values in the snapshot must not destroy text.
+        result = redact_sensitive_text(f"a a a a and {self.SECRET_A}")
+        assert result.startswith("a a a a")
+        assert self.SECRET_A not in result
+
+    def test_min_length_boundary(self):
+        from agent.redact import redact_known_secret_values, _EXACT_SECRET_MIN_LEN
+        from hermes_cli import env_loader
+
+        # 7-char value below the floor is untouched…
+        assert "7chrs!x" in redact_sensitive_text("7chrs!x")
+        # …an 8-char value at the floor is masked.
+        eight = "8chrsval"
+        assert len(eight) == _EXACT_SECRET_MIN_LEN
+        # seed under a fresh home to keep the shared fixture snapshot intact
+        import tempfile
+        from pathlib import Path
+
+        fresh = Path(tempfile.mkdtemp())
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME[str(fresh.resolve())] = {"X": eight}
+        assert "8chrsval" not in redact_known_secret_values(f"v {eight}", home=fresh)
+
+    def test_per_home_isolation(self, tmp_path, monkeypatch):
+        from hermes_cli import env_loader
+        from agent.redact import redact_known_secret_values
+
+        home_a = tmp_path / "home_a"
+        home_b = tmp_path / "home_b"
+        home_a.mkdir()
+        home_b.mkdir()
+        value_a = "value-a-only-123456"
+        value_b = "value-b-only-789012"
+        monkeypatch.setitem(
+            env_loader._SECRET_SOURCE_VALUES_BY_HOME, str(home_a.resolve()), {"FOO": value_a}
+        )
+        monkeypatch.setitem(
+            env_loader._SECRET_SOURCE_VALUES_BY_HOME, str(home_b.resolve()), {"FOO": value_b}
+        )
+        text = f"{value_a} and {value_b}"
+
+        masked_a = redact_known_secret_values(text, home=home_a)
+        assert value_a not in masked_a
+        assert value_b in masked_a  # other home's value must survive
+
+        masked_b = redact_known_secret_values(text, home=home_b)
+        assert value_b not in masked_b
+        assert value_a in masked_b  # other home's value must survive
+
+    def test_empty_snapshot_is_noop(self, tmp_path, monkeypatch):
+        from hermes_cli import env_loader
+        from agent.redact import redact_known_secret_values
+
+        monkeypatch.setattr(env_loader, "_SECRET_SOURCE_VALUES_BY_HOME", {})
+        text = f"nothing to hide {self.SECRET_A}"
+        assert redact_known_secret_values(text, home=tmp_path) == text
+
+    def test_credential_suffixed_env_value_masked(self, monkeypatch):
+        from agent.redact import redact_known_secret_values
+
+        monkeypatch.setenv("MYAPP_API_KEY", "env-key-value-12345678")
+        result = redact_known_secret_values("token is env-key-value-12345678")
+        assert "env-key-value-12345678" not in result
+        assert "***" in result
+
+    def test_credential_suffixed_env_value_not_masked_when_short(self, monkeypatch):
+        from agent.redact import redact_known_secret_values
+
+        monkeypatch.setenv("MYAPP_API_KEY", "short")
+        text = "short is fine to show"
+        assert redact_known_secret_values(text) == text
+
+    def test_disabled_respects_redact_secrets_flag(self, monkeypatch):
+        from agent.redact import redact_known_secret_values
+
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        text = f"value {self.SECRET_A} here"
+        # Config off → exact-value pass is a no-op…
+        assert redact_sensitive_text(text) == text
+        assert redact_known_secret_values(text) == text
+        # …but force=True (safety boundary) still masks.
+        assert self.SECRET_A not in redact_known_secret_values(text, force=True)
+
+    def test_deterministic_output(self):
+        from agent.redact import redact_known_secret_values
+
+        text = f"x {self.SECRET_A} y {self.SECRET_B} z"
+        assert redact_known_secret_values(text) == redact_known_secret_values(text)
+
+

--- a/tests/test_secrets_exfiltration.py
+++ b/tests/test_secrets_exfiltration.py
@@ -1,0 +1,111 @@
+"""Provider-egress secret exfiltration gate (#77162, #77165).
+
+A secret applied from an external source (Bitwarden/1Password/command)
+under ANY name — including non-credential-shaped names like
+``DATABASE_URL`` or ``FOO`` — that a tool echoes into its result passes
+all shape-based redaction passes (no vendor prefix, no secret keyword in
+the key name) and would previously be transmitted VERBATIM to the model
+provider in the next API call. The exact-value pass
+(``agent.redact.redact_known_secret_values``) masks the raw values from
+the per-home applied-secrets snapshot before they reach the provider-bound
+message list.
+
+Seeding mirrors ``tests/agent/test_secret_scope.py``: the per-home applied
+snapshot (``hermes_cli.env_loader._SECRET_SOURCE_VALUES_BY_HOME``) is
+populated directly and restored by monkeypatch.
+"""
+
+import pytest
+
+from agent.redact import redact_sensitive_text, redact_terminal_output
+from agent.tool_dispatch_helpers import make_tool_result_message
+
+
+@pytest.fixture(autouse=True)
+def _ensure_redaction_enabled(monkeypatch):
+    """Ensure redaction is active regardless of host HERMES_REDACT_SECRETS."""
+    monkeypatch.delenv("HERMES_REDACT_SECRETS", raising=False)
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+
+
+@pytest.fixture()
+def applied_secret_home(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a tmp home seeded with one arbitrary-named secret.
+
+    Returns ``(home, name, value)``. The value is deliberately opaque —
+    no vendor prefix, no secret keyword in the name — so only the
+    exact-value pass can mask it.
+    """
+    from hermes_cli import env_loader
+
+    name = "DATABASE_URL"
+    value = "opaque-applied-db-value-9f2a"
+    home_key = str(tmp_path.resolve())
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setitem(
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME, home_key, {name: value}
+    )
+    return tmp_path, name, value
+
+
+class TestProviderEgressWire:
+    """The primary wire: tool results appended to provider-bound messages."""
+
+    def test_tool_result_message_masks_applied_secret(self, applied_secret_home):
+        """A tool echoing the secret must not reach the provider verbatim."""
+        _home, name, value = applied_secret_home
+        echoed = f"$ printenv\n{name}={value}\nPATH=/usr/bin"
+        msg = make_tool_result_message("terminal", echoed, "call_abc123")
+
+        content = msg["content"]
+        assert value not in content
+        assert "***" in content
+        assert f"{name}=" in content  # key survives; value masked
+
+        # The provider-bound message list receives the masked content.
+        provider_bound = [
+            {"role": "assistant", "content": "run printenv", "tool_calls": []},
+            msg,
+        ]
+        assert value not in str(provider_bound)
+
+    def test_tool_result_message_multimodal_masks_applied_secret(
+        self, applied_secret_home
+    ):
+        """Text-type parts of multimodal content are masked on the wire."""
+        _home, name, value = applied_secret_home
+        msg = make_tool_result_message(
+            "browser_snapshot",
+            [
+                {"type": "text", "text": f"config read: {name}={value}"},
+                {"type": "image_url", "image_url": {"url": "data:..."}},
+            ],
+            "call_xyz",
+        )
+        parts = msg["content"]
+        assert value not in parts[0]["text"]
+        assert "***" in parts[0]["text"]
+
+    def test_printenv_echo_masked_in_terminal_output(self, applied_secret_home):
+        """terminal_tool / process_registry redact_terminal_output path."""
+        _home, name, value = applied_secret_home
+        out = redact_terminal_output(f"{name}={value}\nPATH=/usr/bin", "printenv")
+        assert value not in out
+        assert "PATH=/usr/bin" in out
+
+    def test_file_read_echo_masked(self, applied_secret_home):
+        """read_file/search_files/cat (file_read=True) mask applied secrets."""
+        _home, name, value = applied_secret_home
+        out = redact_sensitive_text(
+            f"# .env\n{name}={value}", file_read=True, force=True
+        )
+        assert value not in out
+        assert f"{name}=" in out
+
+    def test_unrelated_text_unchanged_when_secret_not_echoed(
+        self, applied_secret_home
+    ):
+        """Output that does not echo the secret passes through untouched."""
+        _home, _name, value = applied_secret_home
+        text = "ordinary build output, nothing sensitive here"
+        assert make_tool_result_message("terminal", text, "call_1")["content"] == text


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #77012 #77020 #77039 #77162 #77165
## What changed and why

Closes **#77162** and **#77165**. Values applied from external secret sources (Bitwarden/1Password/command) under **any** env name — including non-credential-shaped names like `DATABASE_URL`, `FOO`, arbitrary 1Password item keys — that a tool echoes into its result (config/env artifact read, `printenv`, backend error quoting a key) passed all shape-based redaction passes and were transmitted **verbatim to the model provider** in the next API call. Emission-side channels (status lines #77012, logs #77020) already masked exact values; the **egress path** did not.

### The fix: one exact-value pass, wired into all three egress surfaces

New `agent.redact.redact_known_secret_values` masks every value in the per-home **applied-secrets snapshot** (`hermes_cli.env_loader.get_secret_source_values` / `_SECRET_SOURCE_VALUES_BY_HOME`) plus credential-suffixed env values. It is:

- **Min-length guarded** (8 chars) — a 1-char value never nukes ordinary text
- **Regex-escaped** — metacharacters in secret values masked literally
- **Longest-first** — the alternation prefers the longest match
- **Per-home isolated** — home resolution matches the snapshot keying exactly (context-local override → `HERMES_HOME` env → platform default), so multiplexed gateways never mask with another profile's values
- **Config-gated** — respects `security.redact_secrets: false` (with `force=True` bypass)
- **Deterministic & side-effect-free** — masked copies, never in-place mutation

Wired into:

| Surface | Where | Inherited by |
|---|---|---|
| Tool-result wire | `make_tool_result_message` (`agent/tool_dispatch_helpers.py`) — string, multimodal list (text parts **and** plain-string items), dict content; masked **after** untrusted-tool-result wrapping | all 7 `tool_executor` append sites + `agent_runtime_helpers` + `replay_cleanup` |
| Pre-send sanitizers | `redact_sensitive_text` (`agent/redact.py`) | `context_engine.sanitize_memory_context`, `chat_completion_helpers` pre-send, plus the other inheritors (compressor, moa_loop, monitoring, trace_upload) |
| Terminal output | `redact_terminal_output` (`agent/redact.py`) | `tools/terminal_tool`, `tools/process_registry` |

## Tests

- **16 exact-value cases** in `tests/agent/test_redact.py`: applied value under `DATABASE_URL`/`FOO`/arbitrary key masked in plain text, tool-result-shaped strings, multimodal text parts, plain-string list items, dict content; per-home isolation; min-length boundary (7 vs 8); metachar literals; config gate; no input mutation.
- **5 wire-path cases** in `tests/test_secrets_exfiltration.py` (the #77039 no-exfiltration gate): a `printenv`-style echo of an applied secret runs through the **real** `make_tool_result_message` and the provider-bound message asserts the value is absent and `***` is present — nothing mocked.

## Verification

- `tests/agent/test_redact.py` + `tests/test_secrets_exfiltration.py`: **95 passed, 0 failed**
- Egress regression files: **102 passed**; broad `tests/agent/` sweep: 431 passed / 6 failed — the full 14-failure set (context_refs, relay_llm, process_registry, browser_secret_exfil) proven **identical on pristine `origin/main`** via `git stash` — all pre-existing Windows-box failures
- Ruff clean on all four touched files
- Independent QA critique (separate agent): **SAFE TO SHIP** — value-based on the real snapshot, all three surfaces wired, no post-append re-exposure, wrapping order preserved, per-home isolation proven on the wire; the plain-string list-item hardening gap it raised is fixed in this commit with a regression test

Part of #77165

Part of #77465

<!-- security-campaign-marker: SECURITY-AUDIT-42-CLASSES-F51AA6A9 -->
<!-- security-campaign-class: SECURITY-CLASS-0763b8ccb601a767 -->
Closes #77165
Part of #82591
