### PR TITLE
fix(models): drop curated OpenRouter ids that are retired or no longer tool-capable

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -89,15 +89,9 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
     # Sakana
     ("sakana/fugu-ultra",                      ""),
-    # OpenRouter routers
-    ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
     # Free tier
-    ("openrouter/elephant-alpha",              "free"),
-    ("poolside/laguna-m.1:free",               "free"),
-    ("tencent/hy3:free",                       "free"),
     ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
     ("nvidia/nemotron-3-ultra-550b-a55b:free", "free"),
-    ("inclusionai/ring-2.6-1t:free",           "free"),
 ]
 
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None

--- a/tests/hermes_cli/test_openrouter_catalog_drift_live.py
+++ b/tests/hermes_cli/test_openrouter_catalog_drift_live.py
@@ -1,0 +1,84 @@
+"""Live check that every curated OpenRouter model is still real and tool-capable.
+
+Opt-in only::
+
+    HERMES_LIVE_TESTS=1 OPENROUTER_API_KEY=sk-or-... \\
+        pytest tests/hermes_cli/test_openrouter_catalog_drift_live.py -q
+
+``OPENROUTER_MODELS`` is hand-maintained, and providers retire ids, rename
+generations and withdraw ``:free`` tiers without telling us. Nothing in the
+suite noticed, because every other model test asserts against the list itself
+rather than against what OpenRouter actually serves. That makes the list
+self-consistent and quietly wrong.
+
+Two distinct failures matter, and the second is the worse one:
+
+* A retired id fails loudly the moment a user picks it.
+* An id that is still served but has dropped ``tools`` from
+  ``supported_parameters`` keeps working — right up until the agent needs to
+  call a tool. In an agent framework that is a silent trap, not an error.
+
+Live and opt-in on purpose. This asserts against a third-party catalogue that
+changes without us, so it must never be able to redden CI on someone else's
+deploy; it is a maintenance check a maintainer runs deliberately, in the same
+shape as the other ``*_live.py`` tests here.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from hermes_cli.models import OPENROUTER_MODELS
+
+LIVE = os.environ.get("HERMES_LIVE_TESTS") == "1"
+OPENROUTER_KEY = os.environ.get("OPENROUTER_API_KEY", "")
+
+pytestmark = [
+    pytest.mark.skipif(not LIVE, reason="set HERMES_LIVE_TESTS=1 to run live catalogue checks"),
+    pytest.mark.skipif(not OPENROUTER_KEY, reason="OPENROUTER_API_KEY not set"),
+]
+
+MODELS_URL = "https://openrouter.ai/api/v1/models"
+
+
+@pytest.fixture(scope="module")
+def live_catalog() -> dict[str, dict]:
+    """Every model OpenRouter currently serves, keyed by id."""
+    import json
+    import urllib.request
+
+    request = urllib.request.Request(
+        MODELS_URL,
+        headers={
+            "Authorization": f"Bearer {OPENROUTER_KEY}",
+            "User-Agent": "hermes-cli-catalog-drift-check",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        payload = json.load(response)
+    catalog = {entry["id"]: entry for entry in payload.get("data", [])}
+    assert catalog, "OpenRouter returned an empty catalogue; refusing to judge drift from it"
+    return catalog
+
+
+def test_every_curated_model_is_still_served(live_catalog: dict[str, dict]) -> None:
+    retired = [model_id for model_id, _ in OPENROUTER_MODELS if model_id not in live_catalog]
+    assert not retired, (
+        "OPENROUTER_MODELS lists ids OpenRouter no longer serves; a user picking one gets a "
+        f"failure: {retired}"
+    )
+
+
+def test_every_curated_model_still_advertises_tools(live_catalog: dict[str, dict]) -> None:
+    toolless = [
+        model_id
+        for model_id, _ in OPENROUTER_MODELS
+        if model_id in live_catalog
+        and "tools" not in (live_catalog[model_id].get("supported_parameters") or [])
+    ]
+    assert not toolless, (
+        "OPENROUTER_MODELS lists ids that no longer advertise tool calling. These do not fail on "
+        f"selection — they fail on the first tool call: {toolless}"
+    )

--- a/tests/hermes_cli/test_tencent_tokenhub_provider.py
+++ b/tests/hermes_cli/test_tencent_tokenhub_provider.py
@@ -294,7 +294,11 @@ class TestTencentTokenhubAgentInit:
 
 
 class TestTencentTokenhubModelCatalogJSON:
-    """Verify tencent/hy3:free and tencent/hy3 are present in the website model-catalog.json."""
+    """Verify paid tencent/hy3 remains in the website model-catalog.json.
+
+    The OpenRouter free tier id ``tencent/hy3:free`` was withdrawn and dropped
+    from curation (see fix/openrouter-catalog-drift); the paid id stays.
+    """
 
     def test_in_model_catalog_json(self):
         catalog_path = os.path.join(
@@ -318,8 +322,8 @@ class TestTencentTokenhubModelCatalogJSON:
             for provider_entry in providers:
                 for model in provider_entry.get("models", []):
                     all_ids.add(model.get("id", ""))
-        assert "tencent/hy3:free" in all_ids
         assert "tencent/hy3" in all_ids
+        assert "tencent/hy3:free" not in all_ids
 
 
 # =============================================================================

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-07-31T15:41:39Z",
+  "updated_at": "2026-08-03T01:00:39Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -142,31 +142,11 @@
           "description": ""
         },
         {
-          "id": "openrouter/pareto-code",
-          "description": "auto-routes to cheapest coder meeting openrouter.min_coding_score"
-        },
-        {
-          "id": "openrouter/elephant-alpha",
-          "description": "free"
-        },
-        {
-          "id": "poolside/laguna-m.1:free",
-          "description": "free"
-        },
-        {
-          "id": "tencent/hy3:free",
-          "description": "free"
-        },
-        {
           "id": "nvidia/nemotron-3-super-120b-a12b:free",
           "description": "free"
         },
         {
           "id": "nvidia/nemotron-3-ultra-550b-a55b:free",
-          "description": "free"
-        },
-        {
-          "id": "inclusionai/ring-2.6-1t:free",
           "description": "free"
         }
       ]


### PR DESCRIPTION
## Summary

Five of the 39 entries in `OPENROUTER_MODELS` no longer work. Checked against OpenRouter's live `/api/v1/models` (337 models):

| Curated id | State |
|---|---|
| `openrouter/elephant-alpha` | retired, no successor |
| `poolside/laguna-m.1:free` | retired; family moved to `laguna-s-2.1` |
| `tencent/hy3:free` | free tier withdrawn |
| `inclusionai/ring-2.6-1t:free` | free tier withdrawn |
| `openrouter/pareto-code` | served, but `supported_parameters` is `[]` |

The first four fail the moment a user picks them.

**The fifth is the worse one.** `openrouter/pareto-code` is still served, so it selects and runs fine, and only fails when the agent tries to call a tool. In an agent framework that is a silent trap rather than an error.

Nothing caught this because every existing model test asserts against the curated list itself. That makes the list self-consistent, and says nothing about whether OpenRouter still serves what is in it.

## The two `:free` removals

`tencent/hy3` and `inclusionai/ring-2.6-1t` still exist as paid ids. I removed the `:free` entries rather than re-pointing them, because moving a user's free selection onto a paid id is a curation decision for you, not something a drift fix should do quietly. `tencent/hy3` is already curated separately and is untouched.

Same reasoning for `poolside/laguna-m.1:free`: `laguna-s-2.1` and `laguna-xs-2.1` are live, but adding them is a new curation call rather than a repair.

## Preventing recurrence

Adds `tests/hermes_cli/test_openrouter_catalog_drift_live.py`, opt-in and live in the same shape as the other `*_live.py` tests here:

```
HERMES_LIVE_TESTS=1 OPENROUTER_API_KEY=sk-or-... \
    pytest tests/hermes_cli/test_openrouter_catalog_drift_live.py -q
```

Live and opt-in on purpose: it asserts against a third-party catalogue that changes without us, so it must never be able to redden CI on someone else's deploy. It is a maintenance check run deliberately.

It checks the two failure modes separately, because they are not the same problem — one fails on selection, the other on first tool call.

## Verification

- Skips clean with no opt-in — **2 skipped**
- Passes live after this change — **2 passed**
- **Non-vacuous**: run against the unfixed list it fails and names all five:
  ```
  AssertionError: OPENROUTER_MODELS lists ids OpenRouter no longer serves; a user picking one
  gets a failure: ['openrouter/elephant-alpha', 'poolside/laguna-m.1:free', 'tencent/hy3:free',
  'inclusionai/ring-2.6-1t:free']
  assert not ['openrouter/pareto-code']
  ```
- `scripts/build_model_catalog.py` regenerated — openrouter 39 → 34 models
- `pytest tests/hermes_cli/test_model_catalog.py test_model_search.py test_ai_gateway_models.py` → **30 passed**
- `ruff check` → passed