### PR TITLE
fix(gateway): defer plugin discovery during module import

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2018,7 +2018,11 @@ if _config_path.exists():
             _aux_bridged_keys = {"vision", "web_extract", "approval"}
             try:
                 from hermes_cli.plugins import get_plugin_auxiliary_tasks
-                for _entry in get_plugin_auxiliary_tasks():
+                # This bridge runs while gateway.run is being imported. Do
+                # not trigger arbitrary user-plugin imports before
+                # GatewayRunner has finished initializing; the explicit
+                # gateway-startup discovery below handles that lifecycle.
+                for _entry in get_plugin_auxiliary_tasks(discover=False):
                     _aux_bridged_keys.add(_entry["key"])
             except Exception:
                 # Plugin discovery failure must not break gateway startup;

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10672,6 +10672,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             from hermes_cli.plugins import discover_plugins
             discover_plugins()
+            # The import-time config bridge intentionally skips plugin discovery.
+            # Re-bridge plugin auxiliary tasks now that startup discovery has made
+            # their keys available, otherwise plugin-specific AUXILIARY_* settings
+            # are never propagated to the gateway process.
+            _startup_auxiliary_cfg = self.config.get("auxiliary", {})
+            if isinstance(_startup_auxiliary_cfg, dict):
+                from hermes_cli.plugins import get_plugin_auxiliary_tasks
+
+                for _entry in get_plugin_auxiliary_tasks(discover=False):
+                    _task_key = _entry["key"]
+                    _task_cfg = _startup_auxiliary_cfg.get(_task_key, {})
+                    if not isinstance(_task_cfg, dict):
+                        continue
+                    _upper = _task_key.upper()
+                    for _cfg_key, _suffix in (
+                        ("provider", "PROVIDER"),
+                        ("model", "MODEL"),
+                        ("base_url", "BASE_URL"),
+                        ("api_key", "API_KEY"),
+                    ):
+                        _value = str(_task_cfg.get(_cfg_key, "")).strip()
+                        if _value and not (_cfg_key == "provider" and _value == "auto"):
+                            os.environ[f"AUXILIARY_{_upper}_{_suffix}"] = _value
         except Exception:
             logger.warning(
                 "plugin discovery failed at gateway startup", exc_info=True,

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2425,18 +2425,21 @@ def get_plugin_commands() -> Dict[str, dict]:
     return _ensure_plugins_discovered()._plugin_commands
 
 
-def get_plugin_auxiliary_tasks() -> List[Dict[str, Any]]:
+def get_plugin_auxiliary_tasks(discover: bool = True) -> List[Dict[str, Any]]:
     """Return all plugin-registered auxiliary tasks as a stable-ordered list.
 
     Each entry is the registration dict from
     :meth:`PluginContext.register_auxiliary_task`:
     ``{key, display_name, description, defaults, plugin}``.
 
-    Triggers idempotent plugin discovery so callers can read the registry
-    before any explicit ``discover_plugins()`` call. Sorted by ``key`` for
-    deterministic ordering in pickers and tests.
+    By default, triggers idempotent plugin discovery so callers can read the
+    registry before any explicit ``discover_plugins()`` call. Pass
+    ``discover=False`` for import-time callers that must only inspect plugins
+    already registered; this avoids making module initialization execute
+    arbitrary user-plugin code. Sorted by ``key`` for deterministic ordering
+    in pickers and tests.
     """
-    manager = _ensure_plugins_discovered()
+    manager = _ensure_plugins_discovered() if discover else get_plugin_manager()
     return [manager._aux_tasks[k] for k in sorted(manager._aux_tasks)]
 
 

--- a/tests/hermes_cli/test_plugin_auxiliary_tasks.py
+++ b/tests/hermes_cli/test_plugin_auxiliary_tasks.py
@@ -79,6 +79,29 @@ def test_register_auxiliary_task_basic():
     assert entry["defaults"]["timeout"] == 60
 
 
+def test_get_plugin_auxiliary_tasks_can_skip_discovery(monkeypatch):
+    """Import-time config bridges must not execute user-plugin registration."""
+    from hermes_cli import plugins as plugins_mod
+
+    manager = PluginManager()
+    manager._discovered = True
+    manifest = PluginManifest(name="already_loaded")
+    PluginContext(manifest, manager).register_auxiliary_task(
+        key="loaded_task",
+        display_name="Loaded task",
+        description="already registered",
+    )
+    monkeypatch.setattr(plugins_mod, "get_plugin_manager", lambda: manager)
+
+    def fail_discovery(*args, **kwargs):
+        raise AssertionError("plugin discovery must not run")
+
+    monkeypatch.setattr(plugins_mod, "_ensure_plugins_discovered", fail_discovery)
+    entries = get_plugin_auxiliary_tasks(discover=False)
+
+    assert [entry["key"] for entry in entries] == ["loaded_task"]
+
+
 
 
 # ── PluginManager state lifecycle ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- avoid discovering user plugins while gateway.run is importing
- retain normal plugin discovery at explicit gateway startup
- add a regression test for import-safe auxiliary-task lookup

## Test plan
- python3 -m py_compile passed
- direct auxiliary no-discovery regression check passed
- focused pytest blocked: pytest is not installed in the checkout environment