### PR TITLE
fix(tui-gateway): stop forcing authenticated=True on model.save_key (RAH-04)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11675,6 +11675,11 @@ def test_model_save_key_uses_credential_lifecycle_and_picker_context(monkeypatch
         "name": "Test Provider",
         "models": ["test-model"],
         "total_models": 1,
+        # A real build_models_payload(picker_hints=True) call always sets
+        # this via _apply_picker_hints; the mock below bypasses that, so it
+        # must supply the field itself (RAH-04: model.save_key no longer
+        # force-overwrites whatever the real inventory computed).
+        "authenticated": True,
     }
     server._sessions["save-key-session"] = _session(agent=agent)
     monkeypatch.setattr(
@@ -11721,6 +11726,55 @@ def test_model_save_key_uses_credential_lifecycle_and_picker_context(monkeypatch
         picker_hints=True,
         max_models=50,
     )
+
+
+def test_model_save_key_does_not_force_authenticated_when_inventory_says_false(
+    monkeypatch,
+):
+    """RAH-04: a saved key that the rebuilt inventory still treats as an
+    unauthenticated skeleton row (e.g. the model-list probe failed) must be
+    reported that way, not silently upgraded to authenticated=True."""
+    env_var = "TEST_PROVIDER_API_KEY"
+    agent = object()
+    provider = {
+        "slug": "test-provider",
+        "name": "Test Provider",
+        "models": [],
+        "total_models": 0,
+        "authenticated": False,
+    }
+    server._sessions["save-key-session-2"] = _session(agent=agent)
+    monkeypatch.setattr(
+        "hermes_cli.auth.PROVIDER_REGISTRY",
+        {
+            "test-provider": types.SimpleNamespace(
+                name="Test Provider",
+                auth_type="api_key",
+                api_key_env_vars=(env_var,),
+            )
+        },
+    )
+    monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+    monkeypatch.setattr(
+        "hermes_cli.credential_lifecycle.save_provider_env_credential", Mock()
+    )
+    monkeypatch.setattr(server, "_model_picker_context", Mock(return_value=object()))
+    monkeypatch.setattr(
+        "hermes_cli.inventory.build_models_payload",
+        Mock(return_value={"providers": [provider]}),
+    )
+
+    resp = server._methods["model.save_key"](
+        104,
+        {
+            "slug": "test-provider",
+            "api_key": "some-key",
+            "session_id": "save-key-session-2",
+        },
+    )
+
+    assert "result" in resp, resp
+    assert resp["result"]["provider"]["authenticated"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -410,7 +410,12 @@ def _(rid, params: dict) -> dict:
             (p for p in payload["providers"] if p["slug"] == slug), None
         )
         if provider_data is None:
-            # Key was saved but provider didn't appear — still return success.
+            # Key was saved but provider didn't appear in the rebuilt
+            # inventory — still return success. picker_hints sets
+            # `authenticated` from the row state for every row that DID
+            # come back from build_models_payload; this synthetic fallback
+            # is the only case that never goes through that path, so it's
+            # the only case that needs the field set explicitly here.
             provider_data = {
                 "slug": slug,
                 "name": pconfig.name,
@@ -419,9 +424,6 @@ def _(rid, params: dict) -> dict:
                 "total_models": 0,
                 "authenticated": True,
             }
-        # picker_hints sets `authenticated` from the row state, but the
-        # synthetic fallback above doesn't go through that path.
-        provider_data["authenticated"] = True
         return _ok(rid, {"provider": provider_data})
     except Exception as e:
         return _err(rid, 5034, str(e))


### PR DESCRIPTION
## Summary

Closes #77190.

`model.save_key` (`tui_gateway/methods_complete.py`) rebuilds the provider inventory via `build_models_payload(picker_hints=True)`, which already computes a real `authenticated` value per row via `_apply_picker_hints()`. The handler then unconditionally ran `provider_data["authenticated"] = True` afterward — even for the row it had just found in that payload. The comment directly above the line said the override was only meant to cover the synthetic fallback (provider not found in the rebuilt payload at all); it ran regardless, silently discarding the real computed value whenever it happened to be `False`.

## Fix

Scoped the forced `True` to the fallback branch only. The row returned from the real inventory now keeps whatever `build_models_payload` actually computed.

Note: this does not change the broader, codebase-wide meaning of `authenticated` in `hermes_cli/inventory.py`, which has always meant "a credential is configured", not "verified live against the provider" — redefining that contract touches every RPC/dashboard endpoint reading the field and is out of scope here.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[🔑 model.save_key] -->|rebuild inventory| B[⚡ build_models_payload picker_hints]
    B --> C{Provider row found?}
    C -->|yes| D[🚀 Keep real authenticated value]
    C -->|no: fallback| E[🚀 Force authenticated=True]
```
## Infographic :
<img width="1024" height="1024" alt="infographic" src="https://github.com/user-attachments/assets/afd05842-7f0d-44a6-95e8-fce0a693ebca" />


## Test plan

- [x] New test `test_model_save_key_does_not_force_authenticated_when_inventory_says_false`
- [x] Confirmed to **fail** against the pre-fix code (`assert True is False`)
- [x] Existing test `test_model_save_key_uses_credential_lifecycle_and_picker_context` updated (mock now supplies `authenticated` itself, matching what a real `_apply_picker_hints` call would set — previously relied on the override bug to paper over an incomplete mock)
- [x] `tests/test_tui_gateway_server.py -k model_save_key` — 2 passed
- [x] `python -m py_compile tui_gateway/methods_complete.py`

 
