### PR TITLE
fix(gateway): defer plugin discovery until startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2018,7 +2018,11 @@ if _config_path.exists():
             _aux_bridged_keys = {"vision", "web_extract", "approval"}
             try:
                 from hermes_cli.plugins import get_plugin_auxiliary_tasks
-                for _entry in get_plugin_auxiliary_tasks():
+                # ``gateway.run`` is still importing here. Starting global
+                # discovery can load a user plugin whose register() imports
+                # GatewayRunner, permanently caching that circular-import
+                # failure before the explicit startup discovery below.
+                for _entry in get_plugin_auxiliary_tasks(discover=False):
                     _aux_bridged_keys.add(_entry["key"])
             except Exception:
                 # Plugin discovery failure must not break gateway startup;

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2425,18 +2425,20 @@ def get_plugin_commands() -> Dict[str, dict]:
     return _ensure_plugins_discovered()._plugin_commands
 
 
-def get_plugin_auxiliary_tasks() -> List[Dict[str, Any]]:
+def get_plugin_auxiliary_tasks(*, discover: bool = True) -> List[Dict[str, Any]]:
     """Return all plugin-registered auxiliary tasks as a stable-ordered list.
 
     Each entry is the registration dict from
     :meth:`PluginContext.register_auxiliary_task`:
     ``{key, display_name, description, defaults, plugin}``.
 
-    Triggers idempotent plugin discovery so callers can read the registry
-    before any explicit ``discover_plugins()`` call. Sorted by ``key`` for
-    deterministic ordering in pickers and tests.
+    By default, triggers idempotent plugin discovery so callers can read the
+    registry before any explicit ``discover_plugins()`` call. Pass
+    ``discover=False`` while a module is still initializing to inspect only
+    tasks already registered without starting a global discovery sweep. Sorted
+    by ``key`` for deterministic ordering in pickers and tests.
     """
-    manager = _ensure_plugins_discovered()
+    manager = _ensure_plugins_discovered() if discover else get_plugin_manager()
     return [manager._aux_tasks[k] for k in sorted(manager._aux_tasks)]
 
 

--- a/tests/gateway/test_plugin_discovery_initialization.py
+++ b/tests/gateway/test_plugin_discovery_initialization.py
@@ -25,12 +25,10 @@ def test_gateway_import_defers_user_plugin_discovery_until_explicit_startup(tmp_
         encoding="utf-8",
     )
     (hermes_home / "config.yaml").write_text(
-        yaml.safe_dump(
-            {
-                "plugins": {"enabled": ["gateway_importer"]},
-                "auxiliary": {"title_generation": {"provider": "auto"}},
-            }
-        ),
+        yaml.safe_dump({
+            "plugins": {"enabled": ["gateway_importer"]},
+            "auxiliary": {"title_generation": {"provider": "auto"}},
+        }),
         encoding="utf-8",
     )
 

--- a/tests/gateway/test_plugin_discovery_initialization.py
+++ b/tests/gateway/test_plugin_discovery_initialization.py
@@ -1,0 +1,62 @@
+"""Plugin discovery must not run while ``gateway.run`` is partially imported."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def test_gateway_import_defers_user_plugin_discovery_until_explicit_startup(tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    plugin_dir = hermes_home / "plugins" / "gateway_importer"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": "gateway_importer", "version": "0.1.0"}),
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "def register(ctx):\n"
+        "    from gateway.run import GatewayRunner\n"
+        "    ctx.register_middleware('llm_request', lambda **kwargs: None)\n",
+        encoding="utf-8",
+    )
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "plugins": {"enabled": ["gateway_importer"]},
+                "auxiliary": {"title_generation": {"provider": "auto"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    script = """
+import gateway.run
+from hermes_cli.plugins import discover_plugins, get_plugin_manager
+
+manager = get_plugin_manager()
+assert manager._discovered is False, "gateway import triggered plugin discovery"
+discover_plugins()
+loaded = manager._plugins["gateway_importer"]
+assert loaded.enabled is True, loaded.error
+assert loaded.error is None
+assert manager.has_middleware("llm_request")
+"""
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, (
+        f"subprocess failed ({result.returncode})\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

- prevents the import-time `auxiliary` config bridge from starting global plugin discovery while `gateway.run` is only partially initialized
- preserves the default lazy-discovery behaviour for every other auxiliary-task registry caller
- verifies that a user plugin importing `GatewayRunner` registers successfully at the explicit gateway-startup discovery point

## RED-GREEN evidence

Before the production change, the isolated regression failed with:

```text
Failed to load plugin 'gateway_importer': cannot import name 'GatewayRunner' from partially initialized module 'gateway.run'
AssertionError: gateway import triggered plugin discovery
```

After the change, the same test passes and confirms the plugin's middleware is registered after explicit discovery.

## Test plan

- [x] `uv run pytest tests/gateway/test_plugin_discovery_initialization.py tests/gateway/test_runtime_config_env_expansion.py tests/hermes_cli/test_plugin_auxiliary_tasks.py tests/hermes_cli/test_plugins.py -o 'addopts=' -q` — 40 passed
- [x] neighbouring plugin suites — 216 passed, 2 skipped
- [x] isolated LINE dual-stack test — 1 passed (the combined plugin run exposes a pre-existing order-dependent mock leak in this test)
- [x] `uv run ruff check gateway/run.py hermes_cli/plugins.py tests/gateway/test_plugin_discovery_initialization.py`
- [x] `python -m py_compile` on all changed Python files

Closes #77200
