### PR TITLE
fix(search): drop unused m.content from search result rows (#77033)

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1242,7 +1242,6 @@ class SessionSearchMixin:
                 m.session_id,
                 m.role,
                 snippet({table}, -1, '>>>', '<<<', '...', 40) AS snippet,
-                m.content,
                 m.timestamp,
                 m.tool_name,
                 s.source,
@@ -1435,7 +1434,6 @@ class SessionSearchMixin:
                 m.session_id,
                 m.role,
                 snippet(messages_fts, -1, '>>>', '<<<', '...', 40) AS snippet,
-                m.content,
                 m.timestamp,
                 m.tool_name,
                 s.source,
@@ -1524,7 +1522,6 @@ class SessionSearchMixin:
                         m.session_id,
                         m.role,
                         snippet(messages_fts_cjk, -1, '>>>', '<<<', '...', 40) AS snippet,
-                        m.content,
                         m.timestamp,
                         m.tool_name,
                         s.source,
@@ -1613,7 +1610,6 @@ class SessionSearchMixin:
                         m.session_id,
                         m.role,
                         snippet(messages_fts_trigram, -1, '>>>', '<<<', '...', 40) AS snippet,
-                        m.content,
                         m.timestamp,
                         m.tool_name,
                         s.source,
@@ -1706,7 +1702,7 @@ class SessionSearchMixin:
                            substr(m.content,
                                   max(1, instr(m.content, ?) - 40),
                                   120) AS snippet,
-                           m.content, m.timestamp, m.tool_name,
+                           m.timestamp, m.tool_name,
                            s.source, s.model, s.started_at AS session_started
                     FROM messages m
                     JOIN sessions s ON s.id = m.session_id


### PR DESCRIPTION
## Summary

Every search route in `_search_messages_impl` selects the full `m.content` column for every match, then discards it with `match.pop("content", None)`. The snippet is computed in SQL (`snippet()` on FTS routes, `substr()` on LIKE routes) and the surrounding context is re-fetched by message id in a separate query. Removing `m.content` from the SELECT clauses eliminates unnecessary I/O on every search query.

## Changes

- Removed `m.content` from 5 SELECT clauses:
  - Main FTS5 path (`messages_fts`)
  - CJK bigram path (`messages_fts_cjk`)
  - Inline trigram path (`messages_fts_trigram`)
  - LIKE fallback path
  - `_run_trigram_search` helper
- Removed the now-unnecessary `match.pop("content", None)` loop

## Impact

For large state DBs with many sessions, `m.content` can be kilobytes per row. Fetching it only to discard it wastes disk I/O and memory proportional to the number of search matches. The snippet (short text preview) is already computed in SQL and stays in the result.

Fixes #77033