### PR TITLE
fix(config): strip inline comments from unquoted .env values (#76544)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3638,6 +3638,12 @@ def _parse_env_value(raw_value: str) -> str:
         return "".join(parsed)
     if len(value) >= 2 and value[0] == value[-1] == "'":
         return value[1:-1]
+    # Strip inline comments from unquoted values.  The dotenv convention
+    # is that ``#`` preceded by whitespace starts a comment.  A ``#`` that
+    # is NOT preceded by a space is part of the value (e.g. a hex color).
+    comment_idx = value.find(" #")
+    if comment_idx != -1:
+        value = value[:comment_idx].rstrip()
     return value
 
 


### PR DESCRIPTION
## Summary

`_parse_env_value()` did not strip inline comments from unquoted `.env` values. A line like:

```
MINIMAX_BASE_URL=https://api.minimax.io/anthropic  # official endpoint
```

was parsed as the literal value `https://api.minimax.io/anthropic  # official endpoint` (trailing comment included). The spaces got URL-encoded (`%20%20`), producing requests against a non-existent path and a confusing `HTTP 404` at inference time.

## Fix

Strip everything after ` #` (space + hash) from unquoted values, following the standard dotenv convention. A `#` not preceded by a space is kept as part of the value (e.g. hex color codes like `#FF0000`).

## Testing

Verified with:
- `VALUE = https://example.com  # comment` -> `https://example.com`
- `COLOR = #FF0000` -> `#FF0000` (no space before #)
- `QUOTED = "value # with hash"` -> `value # with hash` (quoted values unaffected)

Fixes #76544