### PR TITLE
fix(tui_gateway): normalize git probe paths so main checkout isn't misclassified as a worktree

### DIFF
--- a/tui_gateway/git_probe.py
+++ b/tui_gateway/git_probe.py
@@ -166,7 +166,19 @@ def resolve(cwd: str) -> dict | None:
     worktree_root = repo_root(cwd)
     if not worktree_root:
         return None
-    return {"repo_root": common_repo_root(cwd) or worktree_root, "worktree_root": worktree_root}
+    # Normalize both roots to the same path spelling. `git rev-parse
+    # --show-toplevel` returns forward slashes while `os.path.realpath`
+    # (in common_repo_root) returns backslashes on Windows; on a main
+    # checkout the two describe the SAME directory, and `build_tree` decides
+    # "main vs linked worktree" by string equality
+    # (`worktree_root == repo_root`). Without normalization a main checkout
+    # is misclassified as a linked worktree, and the sidebar renders two
+    # identically-labeled lanes (the repo's own lane relabeled to the live
+    # branch + the synthetic home lane).
+    return {
+        "repo_root": os.path.normpath(common_repo_root(cwd) or worktree_root),
+        "worktree_root": os.path.normpath(worktree_root),
+    }
 
 
 def warm_roots(cwds: Iterable[str], max_workers: int = _WARM_WORKERS) -> None:


### PR DESCRIPTION
## Problem

On Windows, the desktop sidebar rendered **two identical "main" lanes** under a repo in the "All Projects" view (same 9 sessions shown twice).

## Root cause

`git_probe.resolve()` returned:
- `repo_root` from `os.path.realpath` → backslash separators (`D:\Programs\Hermes-agent`)
- `worktree_root` from `git rev-parse --show-toplevel` → forward slashes (`D:/Programs/Hermes-agent`)

`project_tree._place` decides "main checkout vs linked worktree" by string equality (`worktree_root == repo_root`, project_tree.py:233). On a main checkout the two describe the same directory but never compare equal, so the checkout was misclassified as a linked worktree (`isMain=False`).

The frontend (`mergeRepoWorktreeGroups`) then:
1. relabeled the repo's own lane to the live branch ("main") via the git worktree probe, AND
2. created the synthetic home lane (also "main")

→ two identically-labeled lanes with the same sessions.

## Fix

Normalize both roots with `os.path.normpath()` in `git_probe.resolve()` so a main checkout compares equal and is classified correctly. The backend then emits a single `::branch::<branch>` lane.

## Verification

- `git_probe.resolve('D:/Programs/Hermes-agent')` now returns equal `repo_root`/`worktree_root` and `is_main=True`
- Full `_build_project_tree` produces 1 lane (`main`, isMain=True, 9 sessions) instead of the duplicated lanes
- `tests/tui_gateway/test_project_tree.py` + `tests/agent/test_probe_cache_followups.py`: 34 passed
- `tests/tui_gateway/test_projects_rpc.py`: 19 passed