### PR TITLE
kanban: steer a running worker over REST

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
+import os
 import re
 import threading
 import time
@@ -3829,6 +3830,39 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
 
 
 
+def _pull_board_steer(agent) -> None:
+    """Fold any kanban-queued steer into the agent's pending-steer slot.
+
+    No-op unless this process is a dispatcher-spawned worker
+    (``HERMES_KANBAN_TASK`` set). For those, the board's ``task_steers``
+    mailbox is the only inbound control channel an operator has — the
+    worker is a detached subprocess, so nothing outside it can call
+    ``agent.steer()`` the way ``session.steer`` does for in-process
+    sessions.
+
+    Routing the text through ``agent.steer()`` rather than appending it to
+    the tool result directly is deliberate: it inherits the existing
+    concatenation, empty-text rejection, and interrupt-supersedes-steer
+    semantics for free, so a board steer and a ``/steer`` behave
+    identically from here on.
+    """
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        return
+    try:
+        from tools.kanban_tools import fetch_pending_steer_from_env
+        text = fetch_pending_steer_from_env()
+    except Exception:
+        # Import-time failures on deployment surfaces without kanban_tools.
+        # The bridge already swallows its own runtime errors.
+        return
+    if not text:
+        return
+    try:
+        agent.steer(text)
+    except Exception:
+        _ra().logger.debug("board steer: agent.steer() failed", exc_info=True)
+
+
 def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: int) -> None:
     """Append any pending /steer text to the last tool result in this turn.
 
@@ -3845,6 +3879,7 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
     """
     if num_tool_msgs <= 0 or not messages:
         return
+    _pull_board_steer(agent)
     steer_text = agent._drain_pending_steer()
     if not steer_text:
         return

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1291,6 +1291,36 @@ CREATE TABLE IF NOT EXISTS task_comments (
     created_at INTEGER NOT NULL
 );
 
+-- Mid-run steer mailbox for dispatcher-spawned workers.
+--
+-- A worker is a detached ``hermes ... chat -q`` subprocess (see
+-- ``_default_spawn``): nothing in the dispatcher's or dashboard's process
+-- holds a reference to its ``AIAgent``, so ``AIAgent.steer()`` cannot be
+-- called across the boundary the way ``session.steer`` does for in-process
+-- TUI/dashboard sessions. This table is the cross-process channel: an
+-- operator (CLI, dashboard, REST) queues a row, and the worker drains it
+-- at its next tool-batch boundary and feeds it through the SAME
+-- ``AIAgent.steer()`` path an interactive ``/steer`` uses.
+--
+-- Rows are pinned to ``run_id`` so a steer queued for a run that gets
+-- reclaimed is never delivered to the respawned attempt — the operator's
+-- instruction was written about work that no longer exists. Delivery is
+-- one-shot: ``delivered_at`` is stamped inside the claiming transaction.
+CREATE TABLE IF NOT EXISTS task_steers (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id      TEXT NOT NULL,
+    run_id       INTEGER NOT NULL,
+    author       TEXT NOT NULL,
+    text         TEXT NOT NULL,
+    created_at   INTEGER NOT NULL,
+    delivered_at INTEGER
+);
+
+-- The worker polls this on every tool batch; keep the undelivered lookup
+-- an index hit rather than a scan of the board's whole steer history.
+CREATE INDEX IF NOT EXISTS idx_task_steers_pending
+    ON task_steers(task_id, run_id, delivered_at);
+
 CREATE TABLE IF NOT EXISTS task_events (
     id         INTEGER PRIMARY KEY AUTOINCREMENT,
     task_id    TEXT NOT NULL,
@@ -3699,6 +3729,147 @@ def list_comments_after(
         )
         for r in rows
     ]
+
+
+# ---------------------------------------------------------------------------
+# Mid-run steer mailbox
+#
+# ``add_comment`` above is the *next-spawn* channel: comments are rendered
+# into the worker's prompt by ``build_worker_context``, which only runs when
+# a worker starts. These two functions are the *mid-run* channel — the
+# cross-process equivalent of typing ``/steer`` at an interactive session.
+# ---------------------------------------------------------------------------
+
+# A steer rides on a tool result, not on its own turn. Keep it small enough
+# that it reads as an interjection rather than a second prompt competing with
+# the card body (which is itself capped at 8 KB in build_worker_context).
+_STEER_MAX_CHARS = 4096
+
+# Undelivered steers are drained in one batch, so an operator hammering the
+# endpoint against a worker stuck in a long tool call would otherwise dump an
+# unbounded wall of text into a single tool result.
+_STEER_MAX_PENDING = 10
+
+
+def queue_steer(
+    conn: sqlite3.Connection,
+    task_id: str,
+    text: str,
+    *,
+    author: str = "dashboard",
+    expected_run_id: Optional[int] = None,
+) -> int:
+    """Queue a mid-run steer for the worker currently running ``task_id``.
+
+    Returns the run id the steer was pinned to.
+
+    Raises :class:`ValueError` when the task is unknown, is not ``running``
+    (there is no live worker to steer — comment on it instead, which lands
+    at the next spawn), has no open run, when ``expected_run_id`` does not
+    match the live run, when the text is empty or over
+    ``_STEER_MAX_CHARS``, or when ``_STEER_MAX_PENDING`` steers are already
+    waiting undelivered.
+
+    Delivery is best-effort *by design*: the worker drains at its next
+    tool-batch boundary, so a steer queued while it is composing its final
+    answer may never be picked up. Callers must treat a successful queue as
+    "accepted", never as "the model has seen it" — the same contract
+    ``AIAgent.steer()`` already has for interactive sessions.
+    """
+    if not text or not text.strip():
+        raise ValueError("steer text is required")
+    cleaned = text.strip()
+    if len(cleaned) > _STEER_MAX_CHARS:
+        raise ValueError(
+            f"steer text is {len(cleaned)} chars; limit is {_STEER_MAX_CHARS}"
+        )
+    if not author or not author.strip():
+        raise ValueError("steer author is required")
+    now = int(time.time())
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, current_run_id FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"unknown task {task_id}")
+        if row["status"] != "running":
+            raise ValueError(
+                f"task {task_id} is {row['status']!r}, not running — "
+                "no live worker to steer"
+            )
+        run_id = row["current_run_id"]
+        if run_id is None:
+            raise ValueError(f"task {task_id} is running but has no open run")
+        run_id = int(run_id)
+        if expected_run_id is not None and int(expected_run_id) != run_id:
+            raise ValueError(
+                f"run {expected_run_id} is no longer the live run for task "
+                f"{task_id} (now {run_id})"
+            )
+        pending = conn.execute(
+            "SELECT COUNT(*) AS n FROM task_steers "
+            "WHERE task_id = ? AND run_id = ? AND delivered_at IS NULL",
+            (task_id, run_id),
+        ).fetchone()["n"]
+        if pending >= _STEER_MAX_PENDING:
+            raise ValueError(
+                f"{pending} steers already queued undelivered for run {run_id}; "
+                "wait for the worker to reach a tool boundary, or reclaim it"
+            )
+        conn.execute(
+            "INSERT INTO task_steers (task_id, run_id, author, text, created_at, delivered_at) "
+            "VALUES (?, ?, ?, ?, ?, NULL)",
+            (task_id, run_id, author.strip(), cleaned, now),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "steer_queued",
+            {"author": author.strip(), "len": len(cleaned)},
+            run_id=run_id,
+        )
+    return run_id
+
+
+def pop_pending_steer(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    run_id: int,
+) -> Optional[str]:
+    """Atomically claim every undelivered steer for ``run_id``.
+
+    Returns the queued texts joined by newlines (matching how
+    ``AIAgent.steer()`` concatenates repeat calls), or ``None`` when the
+    mailbox is empty.
+
+    Called from the worker process on the agent's tool-batch boundary. The
+    SELECT and the ``delivered_at`` stamp share one IMMEDIATE transaction,
+    so a second poller — a goal-loop respawn racing the same run, say —
+    cannot re-deliver text the model has already been shown.
+    """
+    with write_txn(conn):
+        rows = conn.execute(
+            "SELECT id, text FROM task_steers "
+            "WHERE task_id = ? AND run_id = ? AND delivered_at IS NULL "
+            "ORDER BY id ASC",
+            (task_id, int(run_id)),
+        ).fetchall()
+        if not rows:
+            return None
+        now = int(time.time())
+        conn.executemany(
+            "UPDATE task_steers SET delivered_at = ? WHERE id = ?",
+            [(now, r["id"]) for r in rows],
+        )
+        _append_event(
+            conn,
+            task_id,
+            "steer_delivered",
+            {"count": len(rows)},
+            run_id=int(run_id),
+        )
+    return "\n".join(r["text"] for r in rows)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1168,6 +1168,126 @@ def add_comment(task_id: str, payload: CommentBody, board: Optional[str] = Query
 
 
 # ---------------------------------------------------------------------------
+# Steer — mid-run course correction
+#
+# The comment endpoint above lands at the NEXT spawn (comments are rendered
+# into the prompt by ``build_worker_context``). This one lands during the
+# CURRENT run: the worker drains the board's steer mailbox at its next
+# tool-batch boundary and injects the text through the same
+# ``AIAgent.steer()`` path an interactive ``/steer`` uses.
+#
+# Until now the only mid-run control an operator had over a dispatched
+# worker was ``/terminate`` — kill it and re-dispatch, losing the run's
+# context. This is the "you can see it going the wrong way, nudge it"
+# surface that ``session.steer`` already gives in-process sessions.
+# ---------------------------------------------------------------------------
+
+class SteerBody(BaseModel):
+    text: str = Field(..., description="Text to inject into the worker's next tool result")
+    author: Optional[str] = "dashboard"
+    run_id: Optional[int] = Field(
+        None,
+        description=(
+            "Optional guard: reject the steer unless this is still the task's "
+            "live run. Use it when steering from a stale board view so a "
+            "correction written about one attempt cannot land on its "
+            "reclaimed-and-respawned successor."
+        ),
+    )
+
+
+def _steer_task(
+    task_id: str,
+    payload: SteerBody,
+    board: Optional[str],
+    *,
+    expected_run_id: Optional[int] = None,
+) -> dict:
+    """Shared body for the task- and run-scoped steer endpoints."""
+    if not payload.text.strip():
+        raise HTTPException(status_code=400, detail="text is required")
+    board = _resolve_board(board)
+    conn = _conn(board=board)
+    try:
+        if kanban_db.get_task(conn, task_id) is None:
+            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+        try:
+            run_id = kanban_db.queue_steer(
+                conn,
+                task_id,
+                payload.text,
+                author=payload.author or "dashboard",
+                expected_run_id=(
+                    expected_run_id if expected_run_id is not None else payload.run_id
+                ),
+            )
+        except ValueError as exc:
+            # Every rejection from queue_steer is a state/precondition
+            # problem the caller can act on (task not running, run moved on,
+            # mailbox full, text too long), not a server fault.
+            raise HTTPException(status_code=409, detail=str(exc))
+        return {"ok": True, "task_id": task_id, "run_id": run_id, "status": "queued"}
+    finally:
+        conn.close()
+
+
+@router.post("/tasks/{task_id}/steer")
+def steer_task_endpoint(
+    task_id: str,
+    payload: SteerBody,
+    board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
+):
+    """Queue a mid-run steer for the worker currently running ``task_id``.
+
+    Responses:
+      * 200 ``{"ok": true, "task_id": ..., "run_id": ..., "status": "queued"}``
+      * 404 when the task is unknown.
+      * 409 when the task is not ``running`` (no live worker — POST a
+        comment instead, which the next spawn will read), when ``run_id``
+        no longer matches the live run, when the text exceeds the size
+        limit, or when too many steers are already waiting undelivered.
+
+    ``"queued"`` means accepted for delivery, NOT that the model has read
+    it. The worker drains at its next tool-call boundary, so a steer sent
+    while it is composing a final answer may never be picked up, and a
+    steer is dropped outright if the run is interrupted first — the same
+    contract ``AIAgent.steer()`` has for interactive sessions. Poll the
+    task's events for ``steer_delivered`` to confirm pickup.
+    """
+    return _steer_task(task_id, payload, board)
+
+
+@router.post("/runs/{run_id}/steer")
+def steer_run_endpoint(
+    run_id: int,
+    payload: SteerBody,
+    board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
+):
+    """Run-scoped sibling of ``POST /tasks/{task_id}/steer``.
+
+    Mirrors ``POST /runs/{run_id}/terminate``: a client watching
+    ``/workers/active`` holds run ids, not task ids, and resolving one to
+    the other client-side reintroduces exactly the race the ``run_id``
+    guard exists to close.
+
+    Responses match the task-scoped endpoint, plus 404 when ``run_id`` is
+    unknown and 409 when that run has already ended.
+    """
+    board_slug = _resolve_board(board)
+    conn = _conn(board=board_slug)
+    try:
+        r = kanban_db.get_run(conn, run_id)
+        if r is None:
+            raise HTTPException(status_code=404, detail=f"run {run_id} not found")
+        if r.ended_at is not None:
+            raise HTTPException(status_code=409, detail=f"run {run_id} already ended")
+        task_id = r.task_id
+    finally:
+        conn.close()
+    return _steer_task(task_id, payload, board, expected_run_id=run_id)
+
+
+# ---------------------------------------------------------------------------
 # Links
 # ---------------------------------------------------------------------------
 

--- a/tests/plugins/test_kanban_steer.py
+++ b/tests/plugins/test_kanban_steer.py
@@ -1,0 +1,371 @@
+"""Tests for the kanban mid-run steer channel.
+
+Covers the three layers the feature spans:
+
+  * ``kanban_db.queue_steer`` / ``pop_pending_steer`` — the mailbox, its
+    preconditions, and one-shot delivery.
+  * ``tools.kanban_tools.fetch_pending_steer_from_env`` — the worker-side
+    bridge, which must be inert outside a dispatcher-spawned worker.
+  * ``POST /tasks/{task_id}/steer`` and ``POST /runs/{run_id}/steer`` — the
+    REST surface.
+
+The end-to-end path (queued steer reaching the model's tool result) is
+covered by ``tests/run_agent/test_steer.py``, which already exercises
+``_apply_pending_steer_to_tool_results``; this file stops at the seam where
+the board hands text to ``AIAgent.steer()``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import secrets
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban_db as kb
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _load_plugin_router():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
+
+    mod_name = "hermes_dashboard_plugin_kanban_steer_test"
+    if mod_name in sys.modules:
+        return sys.modules[mod_name].router
+
+    spec = importlib.util.spec_from_file_location(mod_name, plugin_file)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod.router
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def conn(kanban_home):
+    c = kb.connect()
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+@pytest.fixture
+def client(kanban_home):
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
+    return TestClient(app)
+
+
+def _running_task(conn, *, title="steer me", assignee="worker"):
+    """Create a task in ``running`` with an open run, as the dispatcher does.
+
+    Unlike the helper in ``test_kanban_worker_runs.py`` this also stamps
+    ``tasks.current_run_id`` — ``queue_steer`` pins to it, because a steer
+    that cannot name a run cannot be kept off a respawned attempt.
+    """
+    task_id = kb.create_task(conn, title=title, assignee=assignee)
+    lock = secrets.token_hex(8)
+    future = int(time.time()) + 3600
+    cur = conn.execute(
+        "INSERT INTO task_runs "
+        "(task_id, status, claim_lock, claim_expires, worker_pid, started_at) "
+        "VALUES (?, 'running', ?, ?, ?, ?)",
+        (task_id, lock, future, 4242, int(time.time())),
+    )
+    run_id = cur.lastrowid
+    conn.execute(
+        "UPDATE tasks SET status='running', claim_lock=?, claim_expires=?, "
+        "worker_pid=?, current_run_id=? WHERE id=?",
+        (lock, future, 4242, run_id, task_id),
+    )
+    conn.commit()
+    return task_id, run_id
+
+
+# ---------------------------------------------------------------------------
+# kanban_db.queue_steer
+# ---------------------------------------------------------------------------
+
+def test_queue_steer_returns_live_run_id(conn):
+    task_id, run_id = _running_task(conn)
+    assert kb.queue_steer(conn, task_id, "check the migrations too") == run_id
+
+
+def test_queue_steer_rejects_non_running_task(conn):
+    task_id = kb.create_task(conn, title="not started", assignee="worker")
+    with pytest.raises(ValueError, match="not running"):
+        kb.queue_steer(conn, task_id, "too early")
+
+
+def test_queue_steer_rejects_unknown_task(conn):
+    with pytest.raises(ValueError, match="unknown task"):
+        kb.queue_steer(conn, "t_nope", "hello")
+
+
+def test_queue_steer_rejects_empty_text(conn):
+    task_id, _ = _running_task(conn)
+    with pytest.raises(ValueError, match="required"):
+        kb.queue_steer(conn, task_id, "   ")
+
+
+def test_queue_steer_rejects_oversized_text(conn):
+    task_id, _ = _running_task(conn)
+    with pytest.raises(ValueError, match="limit"):
+        kb.queue_steer(conn, task_id, "x" * (kb._STEER_MAX_CHARS + 1))
+
+
+def test_queue_steer_rejects_stale_run_id(conn):
+    """A steer written against a reclaimed attempt must not land on its successor."""
+    task_id, run_id = _running_task(conn)
+    with pytest.raises(ValueError, match="no longer the live run"):
+        kb.queue_steer(conn, task_id, "stale", expected_run_id=run_id - 1)
+
+
+def test_queue_steer_caps_undelivered_backlog(conn):
+    task_id, _ = _running_task(conn)
+    for i in range(kb._STEER_MAX_PENDING):
+        kb.queue_steer(conn, task_id, f"note {i}")
+    with pytest.raises(ValueError, match="already queued undelivered"):
+        kb.queue_steer(conn, task_id, "one too many")
+
+
+# ---------------------------------------------------------------------------
+# kanban_db.pop_pending_steer
+# ---------------------------------------------------------------------------
+
+def test_pop_returns_none_when_empty(conn):
+    task_id, run_id = _running_task(conn)
+    assert kb.pop_pending_steer(conn, task_id, run_id=run_id) is None
+
+
+def test_pop_joins_multiple_steers_in_order(conn):
+    task_id, run_id = _running_task(conn)
+    kb.queue_steer(conn, task_id, "first")
+    kb.queue_steer(conn, task_id, "second")
+    assert kb.pop_pending_steer(conn, task_id, run_id=run_id) == "first\nsecond"
+
+
+def test_pop_is_one_shot(conn):
+    """Delivery must not repeat — the model has already been shown the text."""
+    task_id, run_id = _running_task(conn)
+    kb.queue_steer(conn, task_id, "only once")
+    assert kb.pop_pending_steer(conn, task_id, run_id=run_id) == "only once"
+    assert kb.pop_pending_steer(conn, task_id, run_id=run_id) is None
+
+
+def test_pop_ignores_other_runs(conn):
+    task_id, run_id = _running_task(conn)
+    kb.queue_steer(conn, task_id, "for the first attempt")
+    assert kb.pop_pending_steer(conn, task_id, run_id=run_id + 1) is None
+
+
+def test_steer_lifecycle_is_visible_in_events(conn):
+    task_id, run_id = _running_task(conn)
+    kb.queue_steer(conn, task_id, "look at auth.log")
+    kb.pop_pending_steer(conn, task_id, run_id=run_id)
+    kinds = [e.kind for e in kb.list_events(conn, task_id)]
+    assert "steer_queued" in kinds
+    assert "steer_delivered" in kinds
+
+
+# ---------------------------------------------------------------------------
+# tools.kanban_tools.fetch_pending_steer_from_env
+# ---------------------------------------------------------------------------
+
+def _reset_steer_poll_rate_limit():
+    import tools.kanban_tools as kt
+    kt._steer_poll_last_attempt = 0.0
+
+
+def test_bridge_is_inert_outside_worker(conn, monkeypatch):
+    """A normal chat session must never touch the board's steer mailbox."""
+    from tools.kanban_tools import fetch_pending_steer_from_env
+
+    task_id, _ = _running_task(conn)
+    kb.queue_steer(conn, task_id, "not for you")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    _reset_steer_poll_rate_limit()
+    assert fetch_pending_steer_from_env() is None
+
+
+def test_bridge_requires_a_run_id(conn, monkeypatch):
+    """Without a run id we cannot tell this attempt's steers from a stale one's."""
+    from tools.kanban_tools import fetch_pending_steer_from_env
+
+    task_id, _ = _running_task(conn)
+    kb.queue_steer(conn, task_id, "ambiguous")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    _reset_steer_poll_rate_limit()
+    assert fetch_pending_steer_from_env() is None
+
+
+def test_bridge_delivers_for_the_live_run(conn, monkeypatch):
+    from tools.kanban_tools import fetch_pending_steer_from_env
+
+    task_id, run_id = _running_task(conn)
+    kb.queue_steer(conn, task_id, "prefer the smaller diff")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    _reset_steer_poll_rate_limit()
+    assert fetch_pending_steer_from_env() == "prefer the smaller diff"
+
+
+def test_bridge_is_rate_limited(conn, monkeypatch):
+    """Back-to-back tool batches must not each pay a DB round trip."""
+    from tools.kanban_tools import fetch_pending_steer_from_env
+
+    task_id, run_id = _running_task(conn)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    _reset_steer_poll_rate_limit()
+    assert fetch_pending_steer_from_env() is None  # consumes the budget
+    kb.queue_steer(conn, task_id, "arrives on the next poll")
+    assert fetch_pending_steer_from_env() is None
+
+
+# ---------------------------------------------------------------------------
+# agent bridge — the seam into AIAgent.steer()
+# ---------------------------------------------------------------------------
+
+class _StubAgent:
+    def __init__(self):
+        self.steered = []
+
+    def steer(self, text):
+        self.steered.append(text)
+        return True
+
+
+def test_agent_bridge_routes_board_steer_through_agent_steer(conn, monkeypatch):
+    from agent.agent_runtime_helpers import _pull_board_steer
+
+    task_id, run_id = _running_task(conn)
+    kb.queue_steer(conn, task_id, "stop after the next step")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    _reset_steer_poll_rate_limit()
+
+    agent = _StubAgent()
+    _pull_board_steer(agent)
+    assert agent.steered == ["stop after the next step"]
+
+
+def test_agent_bridge_swallows_bridge_failures(monkeypatch):
+    """The agent loop must survive a broken board — never raise into it."""
+    import tools.kanban_tools as kt
+    from agent.agent_runtime_helpers import _pull_board_steer
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_gone")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "1")
+    monkeypatch.setattr(
+        kt, "fetch_pending_steer_from_env", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    _pull_board_steer(_StubAgent())  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# REST — POST /tasks/{task_id}/steer
+# ---------------------------------------------------------------------------
+
+def test_post_task_steer_queues(client, conn):
+    task_id, run_id = _running_task(conn)
+    r = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/steer",
+        json={"text": "use the existing helper"},
+    )
+    assert r.status_code == 200
+    assert r.json() == {
+        "ok": True,
+        "task_id": task_id,
+        "run_id": run_id,
+        "status": "queued",
+    }
+
+
+def test_post_task_steer_404_unknown_task(client):
+    r = client.post(
+        "/api/plugins/kanban/tasks/t_missing/steer", json={"text": "hello"}
+    )
+    assert r.status_code == 404
+
+
+def test_post_task_steer_409_not_running(client, conn):
+    """The fallback for a non-running task is a comment, not a steer."""
+    task_id = kb.create_task(conn, title="queued", assignee="worker")
+    r = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/steer", json={"text": "hello"}
+    )
+    assert r.status_code == 409
+    assert "not running" in r.json()["detail"]
+
+
+def test_post_task_steer_400_empty_text(client, conn):
+    task_id, _ = _running_task(conn)
+    r = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/steer", json={"text": "  "}
+    )
+    assert r.status_code == 400
+
+
+def test_post_task_steer_409_stale_run_guard(client, conn):
+    task_id, run_id = _running_task(conn)
+    r = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/steer",
+        json={"text": "stale", "run_id": run_id - 1},
+    )
+    assert r.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# REST — POST /runs/{run_id}/steer
+# ---------------------------------------------------------------------------
+
+def test_post_run_steer_queues(client, conn):
+    task_id, run_id = _running_task(conn)
+    r = client.post(
+        f"/api/plugins/kanban/runs/{run_id}/steer",
+        json={"text": "narrow the scope"},
+    )
+    assert r.status_code == 200
+    assert r.json()["task_id"] == task_id
+
+
+def test_post_run_steer_404_unknown_run(client):
+    r = client.post("/api/plugins/kanban/runs/999999/steer", json={"text": "x"})
+    assert r.status_code == 404
+
+
+def test_post_run_steer_409_ended_run(client, conn):
+    task_id, run_id = _running_task(conn)
+    conn.execute(
+        "UPDATE task_runs SET ended_at = ? WHERE id = ?", (int(time.time()), run_id)
+    )
+    conn.commit()
+    r = client.post(
+        f"/api/plugins/kanban/runs/{run_id}/steer", json={"text": "too late"}
+    )
+    assert r.status_code == 409
+    assert "already ended" in r.json()["detail"]

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -399,6 +399,71 @@ def inject_new_comments_from_env(agent: Any) -> bool:
         return False
 
 
+# ---------------------------------------------------------------------------
+# Board steer mailbox → agent steer bridge
+# ---------------------------------------------------------------------------
+# A dispatcher-spawned worker is a detached subprocess with stdin on
+# /dev/null and no RPC listener, so the in-process route every other surface
+# uses (``agent.steer(text)`` from the CLI key handler, the gateway, or the
+# ``session.steer`` JSON-RPC method) is unreachable from outside. The board
+# DB is the one piece of state the worker and the operator both hold open, so
+# it carries the steer instead.
+#
+# Constraints, mirroring the heartbeat bridge above:
+#   - Best-effort: never raise into the agent loop.
+#   - No-op outside dispatcher-spawned worker context.
+#   - Rate-limited, but far tighter than the heartbeat's 60s — this one sets
+#     how stale an operator's redirect can be, and a tool batch is the only
+#     place it can land. A read against an indexed, usually-empty table is
+#     cheap enough to run most batches.
+
+_STEER_POLL_MIN_INTERVAL_SECONDS = 3.0
+_steer_poll_last_attempt: float = 0.0
+
+
+def fetch_pending_steer_from_env() -> Optional[str]:
+    """Claim any operator-queued steer for the current worker's live run.
+
+    Returns the steer text, or ``None`` when this process is not a
+    dispatcher-spawned worker, the poll is rate-limited, the mailbox is
+    empty, or anything at all went wrong.
+
+    Identity comes from ``HERMES_KANBAN_TASK`` and ``HERMES_KANBAN_RUN_ID``.
+    The run id is REQUIRED — without it we cannot tell a steer written for
+    this attempt from one written for an attempt that was reclaimed, and
+    delivering the latter would inject an instruction about work that no
+    longer exists.
+    """
+    global _steer_poll_last_attempt
+    tid = os.environ.get("HERMES_KANBAN_TASK")
+    if not tid:
+        return None
+    run_id_raw = os.environ.get("HERMES_KANBAN_RUN_ID")
+    try:
+        run_id = int(run_id_raw) if run_id_raw else None
+    except (TypeError, ValueError):
+        run_id = None
+    if run_id is None:
+        return None
+    import time as _time
+    now = _time.monotonic()
+    if (now - _steer_poll_last_attempt) < _STEER_POLL_MIN_INTERVAL_SECONDS:
+        return None
+    _steer_poll_last_attempt = now
+    try:
+        kb, conn = _connect()
+        try:
+            return kb.pop_pending_steer(conn, tid, run_id=run_id)
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+    except Exception:
+        logger.debug("steer bridge: poll failed", exc_info=True)
+        return None
+
+
 def _ok(**fields: Any) -> str:
     return json.dumps({"ok": True, **fields})
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -626,6 +626,7 @@ All routes are mounted under `/api/plugins/kanban/` and protected by the dashboa
 | `PATCH` | `/tasks/:id` | Status / assignee / priority / title / body / result |
 | `POST` | `/tasks/bulk` | Apply the same patch (status / archive / assignee / priority) to every id in `ids`. Per-id failures reported without aborting siblings |
 | `POST` | `/tasks/:id/comments` | Append a comment |
+| `POST` | `/tasks/:id/steer` | Steer the **currently running** worker — see [Steering a running worker](#steering-a-running-worker). `409` when the task isn't `running` |
 | `POST` | `/tasks/:id/specify` | Run the triage specifier — auxiliary LLM fleshes out the task body and promotes it from `triage` to `todo`. Returns `{ok, task_id, reason, new_title}`; `ok=false` with a human-readable reason on "not in triage" / no aux client / LLM error is a 200, not a 4xx |
 | `POST` | `/tasks/:id/decompose` | Run the kanban decomposer — auxiliary LLM produces a task graph and the helper atomically creates the children + links the root + flips `triage → todo`. Returns `{ok, task_id, reason, fanout, child_ids, new_title}`. Same 200-on-LLM-error convention as `/specify`. |
 | `GET` | `/profiles` | List installed profiles with their descriptions (consumed by the dashboard's profile-description editor and the orchestrator picker). |
@@ -789,9 +790,50 @@ The dashboard plugin API now exposes these read-only endpoints (plus a run-contr
 | `GET /api/plugins/kanban/workers/active` | Currently spawned workers with PID, profile, task id, started-at, last heartbeat |
 | `GET /api/plugins/kanban/runs/{id}` | Single-run detail — task id, status, started/ended, exit code, log path |
 | `POST /api/plugins/kanban/runs/{run_id}/terminate` | Terminate a reclaimable run — stops the worker and frees the task for re-dispatch |
+| `POST /api/plugins/kanban/runs/{run_id}/steer` | Steer that run without stopping it — see below |
 | `GET /api/plugins/kanban/inspect` | Combined dispatcher snapshot — backlog, in-progress count vs. `max_in_progress`, recent events |
 
 All of these are gated by the same dashboard plugin auth as the rest of the kanban plugin API.
+
+### Steering a running worker
+
+Terminate is a blunt instrument: you lose the run's context and pay for a
+respawn. When a worker is *working, just heading the wrong way*, steer it
+instead — the same nudge `/steer` gives an interactive session.
+
+```bash
+curl -X POST "$HERMES/api/plugins/kanban/tasks/$TASK/steer?board=$BOARD" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"text": "Skip the migration — just fix the query."}'
+```
+
+The text lands on the worker's **next tool result**, so the model reads it
+as an interjection on its following iteration. No interrupt, no new turn.
+
+Two channels, two moments — pick by whether a worker is running right now:
+
+| | `POST /tasks/:id/comments` | `POST /tasks/:id/steer` |
+|---|---|---|
+| Arrives | At the **next spawn**, via `build_worker_context` | **Mid-run**, on the next tool result |
+| Requires | Any status | `status = running` (else `409`) |
+| Durable | Yes — part of the card's thread | No — delivered once, then spent |
+
+Mechanics and caveats worth knowing before you build on it:
+
+- A worker is a detached subprocess, so the steer travels through the
+  board's `task_steers` table rather than a direct call. Delivery is
+  therefore **at the next tool-call boundary**, not instant.
+- `{"status": "queued"}` means *accepted*, never *read*. A steer sent while
+  the worker is composing its final answer may never be picked up, and one
+  pending when the run is interrupted is dropped — the same contract
+  `AIAgent.steer()` has everywhere else. Watch the task's events for
+  `steer_delivered` to confirm pickup.
+- Steers are pinned to the run that was live when you sent them. If that run
+  is reclaimed, the steer dies with it rather than surprising its
+  replacement. Pass `run_id` to make that guard explicit when you're acting
+  on a board view that may be stale.
+- Text is capped at 4 KB, and at most 10 undelivered steers may be queued
+  per run.
 
 ### Kanban Swarm topology helper
 
@@ -1015,6 +1057,8 @@ Every transition appends a row to `task_events`. Each row carries an optional `r
 |---|---|---|
 | `spawned` | `{pid}` | Dispatcher successfully started a worker process. |
 | `heartbeat` | `{note?}` | Worker called `hermes kanban heartbeat $TASK` to signal liveness during long operations. |
+| `steer_queued` | `{author, len}` | An operator queued a mid-run steer via `POST /tasks/:id/steer`. Pinned to the `run_id` that was live at the time. |
+| `steer_delivered` | `{count}` | The worker drained `count` queued steers at a tool-call boundary and injected them into its next tool result. Absence of this event after a `steer_queued` means the model never saw the text. |
 | `reclaimed` | `{stale_lock}` | Claim TTL expired without a completion; task goes back to `ready`. |
 | `crashed` | `{pid, claimer}` | Worker PID no longer alive but TTL hadn't expired yet. |
 | `timed_out` | `{pid, elapsed_seconds, limit_seconds, sigkill}` | `max_runtime_seconds` exceeded; dispatcher SIGTERM'd (then SIGKILL'd after 5 s grace) and re-queued. |


### PR DESCRIPTION
## Problem

`steer` exists for interactive sessions, but a dispatched kanban worker is a detached subprocess (`Popen(..., start_new_session=True, stdin=DEVNULL)`), so `agent.steer()` is unreachable across the process boundary.

An operator watching a worker head the wrong way can only terminate it — losing the run's accumulated context and paying for a respawn. `steer` is the right tool and it simply isn't reachable from a kanban run.

## Approach

A steer mailbox in the board database. The operator queues a row; the worker drains it at its next tool-call boundary, and the text lands on its **next tool result** — so the model reads it as an interjection on its following iteration rather than an interrupt or a new turn.

This deliberately reuses the path `run_agent` already uses for worker heartbeats, which demonstrates that a detached worker can reach the board mid-loop. No new IPC mechanism, no signal handling.

## API

```
POST /api/plugins/kanban/tasks/{task_id}/steer
POST /api/plugins/kanban/runs/{run_id}/steer
```

```bash
curl -X POST "$HERMES/api/plugins/kanban/tasks/$TASK/steer?board=$BOARD" \
  -H "Authorization: Bearer $TOKEN" \
  -d '{"text": "Skip the migration — just fix the query."}'
```

Returns `409` when the task is not `running`. Auth is inherited from the existing dashboard API — no new surface.

**Delivery is best-effort by design.** A steer sent during a long tool call arrives once that call completes. Undelivered steers are drained in one batch, so an operator sending several in quick succession does not queue up a backlog of interjections.

## Testing

- **26 new tests** in `tests/plugins/test_kanban_steer.py`
- **88 pass across the full kanban suite** (`tests/plugins/test_kanban_*`) — nothing regressed
- Verified applying cleanly against current `main`

## Docs

`website/docs/user-guide/features/kanban.md` gains a *Steering a running worker* section and two API-table rows.

---

Happy to split this, rework the API shape, or take it to an issue first if you'd prefer discussion before a change of this size.
