### PR TITLE
fix(cron): reconcile operational control delivery boundaries

### DIFF
--- a/agent/delegation_context.py
+++ b/agent/delegation_context.py
@@ -50,6 +50,23 @@ def delegated_child_context(session_id: str | None = None) -> Iterator[None]:
         _DELEGATED_CHILD_CONTEXT.reset(token)
 
 
+@contextmanager
+def cron_parent_context() -> Iterator[None]:
+    """Run a scheduler-owned cron job outside a caller's child lineage.
+
+    ``cron.scheduler.tick`` copies ContextVars into its worker threads so
+    per-request state remains available.  A cron execution is nevertheless a
+    scheduler parent: it must not inherit a surrounding ``delegate_task``
+    child's no-Kanban-mutation authority.  This only resets the ContextVar;
+    an explicit process environment marker remains a hard child boundary.
+    """
+    token = _DELEGATED_CHILD_CONTEXT.set(False)
+    try:
+        yield
+    finally:
+        _DELEGATED_CHILD_CONTEXT.reset(token)
+
+
 def is_delegated_child_context() -> bool:
     """Return True while code is running for a delegate_task child."""
     return bool(_DELEGATED_CHILD_CONTEXT.get())

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1783,6 +1783,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     route_metadata["thread_id"] = route_thread_id
                 media_metadata = {"thread_id": thread_id} if thread_id else None
 
+            if platform == Platform.TELEGRAM and job.get("telegram_strip_cron_wrapper"):
+                route_metadata["strip_cron_wrapper"] = True
+
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content.
                 # Route through the gateway's DeliveryRouter so the live send
@@ -2031,7 +2034,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.extend(target_errors)
                 continue
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            standalone_metadata = {"job_id": job["id"]}
+            if platform == Platform.TELEGRAM and job.get("telegram_strip_cron_wrapper"):
+                standalone_metadata["strip_cron_wrapper"] = True
+            coro = _send_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                cleaned_delivery_content,
+                thread_id=thread_id,
+                media_files=media_files,
+                metadata=standalone_metadata,
+            )
             try:
                 result = asyncio.run(coro)
             except RuntimeError as run_err:
@@ -2060,7 +2074,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 try:
                     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                     try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                        future = pool.submit(
+                            asyncio.run,
+                            _send_to_platform(
+                                platform,
+                                pconfig,
+                                chat_id,
+                                cleaned_delivery_content,
+                                thread_id=thread_id,
+                                media_files=media_files,
+                                metadata=standalone_metadata,
+                            ),
+                        )
                         result = future.result(timeout=30)
                     finally:
                         pool.shutdown(wait=False)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4282,7 +4282,20 @@ def tick(
 
             def _run_and_release(j=dispatched_job, ctx=_ctx):
                 try:
-                    return ctx.run(_process_job, j)
+                    # A scheduled job is a scheduler parent, never a
+                    # ``delegate_task`` child.  ``copy_context`` preserves
+                    # useful per-tick state, but it also used to propagate a
+                    # caller's delegated-child marker into the cron agent and
+                    # its terminal subprocesses, denying its Kanban closure
+                    # authority.  Retain the copied context while explicitly
+                    # resetting only that child-local marker for this job.
+                    def _run_as_cron_parent():
+                        from agent.delegation_context import cron_parent_context
+
+                        with cron_parent_context():
+                            return _process_job(j)
+
+                    return ctx.run(_run_as_cron_parent)
                 finally:
                     with _running_lock:
                         _running_job_ids.discard(j["id"])

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3779,13 +3779,13 @@ def run_job(
             _cron_session_var.reset(_cron_session_token)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
+        _final_cron_session_id = _cron_session_id
         if _session_db:
             # Compression can rotate the live agent onto a continuation while
             # this run is in flight. Finalize that continuation, not the stale
             # cron id captured before AIAgent started. SessionDB is the source
             # of truth for the lineage; agent.session_id is only a fail-safe
             # when the lookup itself is unavailable.
-            _final_cron_session_id = _cron_session_id
             try:
                 _compression_tip = _session_db.get_compression_tip(
                     _cron_session_id
@@ -3849,6 +3849,11 @@ def run_job(
                 _session_db.close()
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to close SQLite session store: %s", job_id, e)
+        # The scheduler persists and delivers after run_job returns. Preserve
+        # only this ephemeral correlation key on the in-memory job so a
+        # terminal observer receives the session transform_llm_output audited,
+        # including a compression continuation when one was created.
+        job["_hermes_final_cron_session_id"] = _final_cron_session_id
         # Release subprocesses, terminal sandboxes, browser daemons, and the
         # main OpenAI/httpx client held by this ephemeral cron agent. Without
         # this, a gateway that ticks cron every N minutes leaks fds per job
@@ -3887,6 +3892,30 @@ def _teardown_cron_agent(agent, job_id: str) -> None:
         cleanup_stale_async_clients()
     except Exception as e:
         logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
+
+
+def _finalize_persisted_cron_output(job: dict, output: str, output_file: Path | str) -> None:
+    """Notify observer plugins after durable cron-output persistence.
+
+    This post-save, best-effort hook receives the exact artifact text and path
+    but cannot influence delivery, scheduler status, or provider behavior.
+    """
+    session_id = str(job.get("_hermes_final_cron_session_id") or "")
+    if not session_id:
+        return
+    try:
+        from hermes_cli.plugins import invoke_hook
+
+        invoke_hook(
+            "cron_output_finalized",
+            response_text=output,
+            session_id=session_id,
+            platform="cron",
+            artifact_path=str(output_file),
+            delivery_state="PERSISTED_ONLY",
+        )
+    except Exception as exc:
+        logger.warning("cron_output_finalized hook dispatch failed: %s", exc)
 
 
 def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -> bool:
@@ -3982,6 +4011,8 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             output_file = save_job_output(job["id"], output)
             if verbose:
                 logger.info("Output saved to: %s", output_file)
+
+            _finalize_persisted_cron_output(job, output, output_file)
 
             # If the gateway shutdown killed this job's tool subprocess
             # mid-flight (#60432), the agent may still have produced a

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -141,6 +141,10 @@ VALID_HOOKS: Set[str] = {
     # Plugins return a string to replace the response text, or None/empty to leave unchanged.
     # First non-None string wins. Useful for vocabulary/personality transformation.
     "transform_llm_output",
+    # Observer-only terminal cron-artifact hook. Fired after the scheduler
+    # atomically persists output and before any delivery attempt. Return values
+    # are ignored, so a plugin cannot suppress or alter delivery.
+    "cron_output_finalized",
     "pre_llm_call",
     "post_llm_call",
     # Verification-loop gate. Fired once per turn when the agent has edited code

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -25,6 +25,26 @@ from typing import Dict, List, Optional, Set, Any
 logger = logging.getLogger(__name__)
 
 
+def _strip_cron_wrapper_for_clean_delivery(
+    content: str, metadata: Optional[Dict[str, Any]] = None
+) -> str:
+    """Strip the scheduler wrapper only for an explicitly opted-in delivery."""
+    if not (metadata or {}).get("strip_cron_wrapper"):
+        return content
+    if not content.startswith("Cronjob Response: "):
+        return content
+
+    divider = "\n-------------\n\n"
+    footer_prefix = '\n\nTo stop or manage this job, send me a new message (e.g. "stop reminder '
+    divider_pos = content.find(divider)
+    footer_pos = content.rfind(footer_prefix)
+    if divider_pos < 0 or footer_pos < 0 or footer_pos <= divider_pos:
+        return content
+
+    body_start = divider_pos + len(divider)
+    return content[body_start:footer_pos].strip()
+
+
 def _redact_telegram_error_text(error: object) -> str:
     """Redact secrets from Telegram transport errors before logging or returning them."""
     text = "" if error is None else str(error)
@@ -4430,7 +4450,9 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
-        
+
+        content = _strip_cron_wrapper_for_clean_delivery(content, metadata)
+
         try:
             # Bot API 10.1 rich fast-path: send the raw agent markdown via
             # sendRichMessage so tables/task lists/etc. render natively. Falls

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -13,6 +13,12 @@ extracted helper directly.
 import cron.scheduler as s
 
 
+def test_cron_output_finalized_hook_is_supported():
+    from hermes_cli.plugins import VALID_HOOKS
+
+    assert "cron_output_finalized" in VALID_HOOKS
+
+
 def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final response",
                     error=None, silent_marker_in=None):
     """Patch the job pipeline primitives and record the call order."""
@@ -64,6 +70,49 @@ def test_run_one_job_success_sequence(monkeypatch):
     assert ok is True
     assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
     assert calls[-1] == ("mark", "j2", True)
+
+
+def test_run_one_job_finalizes_persisted_llm_output_before_delivery(monkeypatch):
+    """A post-persistence observer receives the exact saved artifact before delivery."""
+    order = []
+    observed = {}
+
+    def fake_run_job(job, *, defer_agent_teardown=None):
+        order.append("run_job")
+        job["_hermes_final_cron_session_id"] = "cron_j2_20260727_010000"
+        return True, "persisted report", "human report", None
+
+    def fake_save(job_id, output):
+        order.append("save")
+        assert (job_id, output) == ("j2", "persisted report")
+        return "/tmp/j2.md"
+
+    def fake_finalize(name, **kwargs):
+        order.append("finalize")
+        observed.update(name=name, **kwargs)
+        return "[SILENT]"
+
+    def fake_deliver(*_args, **_kwargs):
+        order.append("deliver")
+        return None
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", fake_save)
+    monkeypatch.setattr(s, "_deliver_result", fake_deliver)
+    monkeypatch.setattr(s, "mark_job_run", lambda *_args, **_kwargs: order.append("mark"))
+    import hermes_cli.plugins as plugins
+    monkeypatch.setattr(plugins, "invoke_hook", fake_finalize)
+
+    assert s.run_one_job({"id": "j2", "name": "t"}) is True
+    assert order == ["run_job", "save", "finalize", "deliver", "mark"]
+    assert observed == {
+        "name": "cron_output_finalized",
+        "response_text": "persisted report",
+        "session_id": "cron_j2_20260727_010000",
+        "platform": "cron",
+        "artifact_path": "/tmp/j2.md",
+        "delivery_state": "PERSISTED_ONLY",
+    }
 
 
 def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path):

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -60,6 +60,39 @@ def test_tick_process_job_sequence(monkeypatch):
     assert calls[-1] == ("mark", "j1", True)
 
 
+def test_tick_does_not_propagate_delegated_child_context_to_cron_parent(monkeypatch):
+    """A scheduler-owned cron run must retain Kanban authority.
+
+    ``tick`` uses ``copy_context`` to bridge request-local state into a worker
+    thread. A caller can itself be a delegated child, but a scheduled job is a
+    scheduler parent, not that child's descendant. Propagating the child marker
+    made every Kanban operation fail closed inside PM cron jobs.
+    """
+    from agent.delegation_context import (
+        delegated_child_context,
+        is_delegated_child_process_context,
+    )
+
+    # The test runner itself may be a delegated child. The regression is about
+    # copied *ContextVar* state, so remove any inherited process marker before
+    # establishing the test's child scope.
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+
+    seen = []
+    monkeypatch.setattr(s, "get_due_jobs", lambda: [{"id": "j-context", "name": "t"}])
+    monkeypatch.setattr(s, "advance_next_run", lambda _: True)
+    monkeypatch.setattr(
+        s,
+        "run_one_job",
+        lambda *args, **kwargs: seen.append(is_delegated_child_process_context()) or True,
+    )
+
+    with delegated_child_context():
+        s.tick(verbose=False, sync=True)
+
+    assert seen == [False]
+
+
 def test_run_one_job_success_sequence(monkeypatch):
     """The extracted helper runs the same execute→save→deliver→mark sequence
     for a successful job."""

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -80,7 +80,7 @@ def test_tick_does_not_propagate_delegated_child_context_to_cron_parent(monkeypa
 
     seen = []
     monkeypatch.setattr(s, "get_due_jobs", lambda: [{"id": "j-context", "name": "t"}])
-    monkeypatch.setattr(s, "advance_next_run", lambda _: True)
+    monkeypatch.setattr(s, "advance_next_runs", lambda _ids: 1)
     monkeypatch.setattr(
         s,
         "run_one_job",

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1858,6 +1858,17 @@ class TestMultiTargetDeliveryContinuesOnFailure:
         mock_cfg.platforms = {Platform.EMAIL: pconfig}
         return mock_cfg
 
+    @staticmethod
+    def _submit_futures_after_closing_coroutine(*futures):
+        """Model executor ownership when its mocked worker never runs a coro."""
+        pending_futures = iter(futures)
+
+        def submit(_runner, coroutine):
+            coroutine.close()
+            return next(pending_futures)
+
+        return submit
+
     def test_first_target_failure_does_not_crash_loop(self):
         """First email target fails in the fallback; the second is still attempted."""
         job = {
@@ -1876,7 +1887,9 @@ class TestMultiTargetDeliveryContinuesOnFailure:
             fail_future.result.side_effect = ConnectionError("SMTP connection refused")
             ok_future = MagicMock()
             ok_future.result.return_value = {"success": True}
-            mock_pool.submit.side_effect = [fail_future, ok_future]
+            mock_pool.submit.side_effect = self._submit_futures_after_closing_coroutine(
+                fail_future, ok_future
+            )
 
             result = _deliver_result(job, "Report content")
 
@@ -1905,7 +1918,9 @@ class TestMultiTargetDeliveryContinuesOnFailure:
 
             fail_future = MagicMock()
             fail_future.result.side_effect = ConnectionError("connection refused")
-            mock_pool.submit.return_value = fail_future
+            mock_pool.submit.side_effect = self._submit_futures_after_closing_coroutine(
+                fail_future, fail_future
+            )
 
             result = _deliver_result(job, "Report content")
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -284,7 +284,36 @@ class TestDeliverResultWrapping:
         assert "-------------" in sent_content
         assert "Here is today's summary." in sent_content
         assert "To stop or manage this job" in sent_content
+        assert send_mock.call_args.kwargs["metadata"] == {"job_id": "test-job"}
 
+
+    def test_delivery_marks_opted_in_telegram_job_for_wrapper_stripping(self):
+        """Only an opted-in Telegram job adds the boundary cleanup metadata."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "stock-job",
+                "name": "stock-alpha",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+                "telegram_strip_cron_wrapper": True,
+            }
+            _deliver_result(job, "Research header\nBody")
+
+        send_mock.assert_called_once()
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][3]
+        assert "Cronjob Response: stock-alpha" in sent_content
+        assert send_mock.call_args.kwargs["metadata"] == {
+            "job_id": "stock-job",
+            "strip_cron_wrapper": True,
+        }
 
     def test_relay_fronted_home_uses_relay_config_and_live_adapter(self, monkeypatch, tmp_path):
         """Persisted Slack home survives restart without native Slack config."""

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -137,6 +137,57 @@ def _make_adapter():
     return adapter
 
 
+@pytest.mark.asyncio
+async def test_send_strips_cron_wrapper_when_metadata_requests_clean_delivery():
+    adapter = _make_adapter()
+    mock_send_message = AsyncMock(return_value=SimpleNamespace(message_id=321))
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+    adapter.send_typing = AsyncMock()
+    adapter._should_attempt_rich = lambda content, metadata=None: False
+
+    result = await adapter.send(
+        chat_id="-100123",
+        content=(
+            "Cronjob Response: stock-alpha (job_id: stock-job)\n-------------\n\n"
+            "Stock Alpha — 2026-07-15\nTop picks\n\n"
+            "To stop or manage this job, send me a new message (e.g. \"stop reminder abc123\")"
+        ),
+        metadata={"strip_cron_wrapper": True},
+    )
+
+    assert result.success is True
+    mock_send_message.assert_awaited_once()
+    sent_text = mock_send_message.await_args.kwargs["text"]
+    assert "Stock Alpha" in sent_text
+    assert "Top picks" in sent_text
+    assert "Cronjob Response" not in sent_text
+    assert "To stop or manage this job" not in sent_text
+
+
+@pytest.mark.asyncio
+async def test_send_keeps_cron_wrapper_without_opt_in_metadata():
+    adapter = _make_adapter()
+    mock_send_message = AsyncMock(return_value=SimpleNamespace(message_id=322))
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+    adapter.send_typing = AsyncMock()
+    adapter._should_attempt_rich = lambda content, metadata=None: False
+
+    result = await adapter.send(
+        chat_id="-100124",
+        content=(
+            "Cronjob Response: other-job (job_id: other-job)\n-------------\n\n"
+            "Keep this wrapped\n\n"
+            "To stop or manage this job, send me a new message (e.g. \"stop reminder abc123\")"
+        ),
+        metadata={"job_id": "other-job"},
+    )
+
+    assert result.success is True
+    sent_text = mock_send_message.await_args.kwargs["text"]
+    assert "Cronjob Response" in sent_text
+    assert "To stop or manage this job" in sent_text
+
+
 def test_non_forum_group_reply_thread_id_does_not_fork_session_key():
     """Reply-derived thread ids in ordinary groups must not create topic lanes."""
     import plugins.platforms.telegram.adapter as telegram_mod

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -8,6 +8,7 @@ user message. If either anchor is unavailable or rejected, the adapter must
 avoid retrying with a partial topic route that can render outside the lane.
 """
 
+import importlib
 import sys
 import socket
 import types
@@ -32,7 +33,11 @@ from gateway.session import build_session_key
 #   BadRequest → NetworkError → TelegramError → Exception
 
 
-class FakeNetworkError(Exception):
+class FakeTelegramError(Exception):
+    pass
+
+
+class FakeNetworkError(FakeTelegramError):
     pass
 
 
@@ -44,7 +49,7 @@ class FakeTimedOut(FakeNetworkError):
     pass
 
 
-class FakeRetryAfter(Exception):
+class FakeRetryAfter(FakeTelegramError):
     def __init__(self, seconds):
         super().__init__(f"Retry after {seconds}")
         self.retry_after = seconds
@@ -74,10 +79,13 @@ _fake_telegram = types.ModuleType("telegram")
 _fake_telegram.Update = object
 _fake_telegram.Bot = object
 _fake_telegram.Message = object
+setattr(_fake_telegram, "MessageEntity", object)
 _fake_telegram.InlineKeyboardButton = _FakeInlineKeyboardButton
 _fake_telegram.InlineKeyboardMarkup = _FakeInlineKeyboardMarkup
 _fake_telegram.InputMediaPhoto = _FakeInputMediaPhoto
+setattr(_fake_telegram, "LinkPreviewOptions", object)
 _fake_telegram_error = types.ModuleType("telegram.error")
+setattr(_fake_telegram_error, "TelegramError", FakeTelegramError)
 _fake_telegram_error.NetworkError = FakeNetworkError
 _fake_telegram_error.BadRequest = FakeBadRequest
 _fake_telegram_error.TimedOut = FakeTimedOut
@@ -105,16 +113,44 @@ _fake_telegram_ext.ContextTypes = SimpleNamespace(DEFAULT_TYPE=object)
 _fake_telegram_ext.filters = object
 _fake_telegram_request = types.ModuleType("telegram.request")
 _fake_telegram_request.HTTPXRequest = object
+_ADAPTER_MODULE = "plugins.platforms.telegram.adapter"
+_ADAPTER_PARENT_MODULE = "plugins.platforms.telegram"
+_MISSING = object()
 
 
 @pytest.fixture(autouse=True)
 def _inject_fake_telegram(monkeypatch):
-    """Inject fake telegram modules so the adapter can import from them."""
+    """Load the adapter against complete fakes without leaking import state."""
+    parent = sys.modules.get(_ADAPTER_PARENT_MODULE)
+    previous_parent_adapter = getattr(parent, "adapter", _MISSING)
+    previous_adapter = sys.modules.pop(_ADAPTER_MODULE, None)
     monkeypatch.setitem(sys.modules, "telegram", _fake_telegram)
     monkeypatch.setitem(sys.modules, "telegram.error", _fake_telegram_error)
     monkeypatch.setitem(sys.modules, "telegram.constants", _fake_telegram_constants)
     monkeypatch.setitem(sys.modules, "telegram.ext", _fake_telegram_ext)
     monkeypatch.setitem(sys.modules, "telegram.request", _fake_telegram_request)
+    importlib.import_module(_ADAPTER_MODULE)
+    yield
+
+    sys.modules.pop(_ADAPTER_MODULE, None)
+    if previous_adapter is not None:
+        sys.modules[_ADAPTER_MODULE] = previous_adapter
+    if parent is not None:
+        if previous_parent_adapter is _MISSING:
+            delattr(parent, "adapter")
+        else:
+            setattr(parent, "adapter", previous_parent_adapter)
+
+
+def test_scheduler_then_proxy_import_order_uses_fake_chat_types():
+    """The thread fixture must override adapter state cached by other suites."""
+    from cron import scheduler
+    from tools import send_message_tool
+    import plugins.platforms.telegram.adapter as telegram_mod
+
+    assert scheduler is not None
+    assert send_message_tool is not None
+    assert telegram_mod.ChatType is _fake_telegram_constants.ChatType
 
 
 def _make_adapter():

--- a/tests/tools/test_send_message_telegram_proxy.py
+++ b/tests/tools/test_send_message_telegram_proxy.py
@@ -155,3 +155,54 @@ class TestSendTelegramStandaloneProxy:
         assert "get_updates_request" not in call_kwargs
         httpx_request_factory.assert_not_called()
         bot.send_message.assert_awaited_once()
+
+    def test_wrapper_strip_metadata_reaches_standalone_telegram_boundary(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The standalone platform router forwards opt-in metadata to Telegram."""
+        from gateway.config import Platform
+        from tools.send_message_tool import _send_to_platform
+
+        for var in (
+            "TELEGRAM_PROXY",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "HTTP_PROXY",
+            "http_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+        monkeypatch.setattr(sys, "platform", "linux")
+
+        bot = _make_bot()
+        bot_factory = MagicMock(return_value=bot)
+        httpx_request_factory = MagicMock(side_effect=lambda **kw: MagicMock(_kw=kw))
+        _install_telegram_mock_with_request(monkeypatch, bot_factory, httpx_request_factory)
+
+        wrapped = (
+            "Cronjob Response: stock-alpha (job_id: stock-job)\n-------------\n\n"
+            "Stock Alpha — 2026-07-15\nTop picks\n\n"
+            "To stop or manage this job, send me a new message (e.g. \"stop reminder abc123\")"
+        )
+        pconfig = SimpleNamespace(token="tok", extra={})
+        result: dict[str, Any] = asyncio.run(
+            _send_to_platform(
+                Platform.TELEGRAM,
+                pconfig,
+                "123",
+                wrapped,
+                metadata={"strip_cron_wrapper": True},
+            )
+        )
+
+        assert result["success"] is True
+        bot.send_message.assert_awaited_once()
+        sent_text = bot.send_message.await_args.kwargs["text"]
+        assert "Stock Alpha" in sent_text
+        assert "Top picks" in sent_text
+        assert "Cronjob Response" not in sent_text
+        assert "To stop or manage this job" not in sent_text

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -780,7 +780,16 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(
+    platform,
+    pconfig,
+    chat_id,
+    message,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+    metadata=None,
+):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -852,6 +861,9 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     # after all text chunks.
     if platform == Platform.TELEGRAM:
         disable_link_previews = bool(getattr(pconfig, "extra", {}) and pconfig.extra.get("disable_link_previews"))
+        telegram_metadata = dict(metadata or {})
+        if thread_id is not None and "thread_id" not in telegram_metadata:
+            telegram_metadata["thread_id"] = thread_id
         return await _send_telegram(
             pconfig.token,
             chat_id,
@@ -860,6 +872,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             thread_id=thread_id,
             disable_link_previews=disable_link_previews,
             force_document=force_document,
+            metadata=telegram_metadata or None,
         )
 
     # --- Discord: chunked delivery via the registry's standalone_sender_fn.
@@ -1173,7 +1186,16 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(
+    token,
+    chat_id,
+    message,
+    media_files=None,
+    thread_id=None,
+    disable_link_previews=False,
+    force_document=False,
+    metadata=None,
+):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -1184,6 +1206,10 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
     try:
         from telegram import Bot
         from telegram.constants import ParseMode
+
+        from plugins.platforms.telegram.adapter import _strip_cron_wrapper_for_clean_delivery
+
+        message = _strip_cron_wrapper_for_clean_delivery(message, metadata)
 
         # Auto-detect HTML tags — if present, skip MarkdownV2 and send as HTML.
         # Inspired by github.com/ashaney — PR #1568.


### PR DESCRIPTION
## Summary
- Reconciles the five reviewed operational-control commits onto current `main`.
- Restores scheduler-parent authority, finalized persisted-output observer evidence, and opt-in Telegram cron-wrapper removal.
- Preserves delivery metadata through gateway and standalone Telegram paths.
- Reconciles the authority regression test with current batch scheduler advancement (`advance_next_runs`).

## Focused verification
- `uv run --extra dev --extra messaging python -m pytest -q tests/cron/test_scheduler.py tests/cron/test_run_one_job.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_thread_fallback.py tests/tools/test_send_message_telegram_proxy.py tests/hermes_cli/test_plugins.py` (154 passed)
- `python -m compileall agent cron hermes_cli plugins tools -q`
- `ruff check` on the nine changed paths
- `git diff --check origin/main...HEAD`

Full repository suite and runtime activation are intentionally deferred to the PM-managed runner.
