### PR TITLE
fix(cron): fail closed on invalid skill packages

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -158,6 +158,109 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
+_CRON_SKILL_VALIDATOR_RELATIVE_PATH = Path(
+    "skills/tools/cron-skill-control/cron_skill_control.py"
+)
+_CRON_SKILL_VALIDATOR_TIMEOUT_SECONDS = 30
+
+
+def _validate_cron_skill_dependencies() -> list[dict[str, str]]:
+    """Run the installed canonical format-2 skill validator for an agent cron run.
+
+    The validator owns the manifest, job-binding, top-level hash, package-tree,
+    and package-worktree rules.  This scheduler seam deliberately treats an
+    unavailable or malformed validator result as a dependency-integrity finding:
+    an agent cron must not construct a prompt from an unverified skill package.
+    """
+    hermes_home = _get_hermes_home()
+    validator = hermes_home / _CRON_SKILL_VALIDATOR_RELATIVE_PATH
+    if not validator.is_file():
+        return [{
+            "code": "validator_unavailable",
+            "detail": f"canonical validator is missing: {validator}",
+        }]
+
+    popen_kwargs: dict[str, Any] = {}
+    if sys.platform == "win32":
+        popen_kwargs["creationflags"] = windows_hide_flags()
+        popen_kwargs["encoding"] = "utf-8"
+        popen_kwargs["errors"] = "replace"
+    try:
+        result = subprocess.run(
+            [sys.executable, str(validator), "validate", "--home", str(hermes_home)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_CRON_SKILL_VALIDATOR_TIMEOUT_SECONDS,
+            **popen_kwargs,
+        )
+    except subprocess.TimeoutExpired:
+        return [{
+            "code": "validator_timeout",
+            "detail": "canonical validator did not finish before the scheduler timeout",
+        }]
+    except OSError as exc:
+        return [{
+            "code": "validator_unavailable",
+            "detail": f"canonical validator could not start: {exc}",
+        }]
+
+    try:
+        payload = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        return [{
+            "code": "validator_invalid_output",
+            "detail": f"canonical validator returned exit={result.returncode} without valid JSON",
+        }]
+    findings = payload.get("findings") if isinstance(payload, dict) else None
+    if not isinstance(findings, list) or not all(
+        isinstance(item, dict)
+        and isinstance(item.get("code"), str)
+        and isinstance(item.get("detail"), str)
+        for item in findings
+    ):
+        return [{
+            "code": "validator_invalid_output",
+            "detail": "canonical validator findings were not a list of code/detail objects",
+        }]
+    if result.returncode == 0 and payload.get("command") == "validate" and payload.get("status") == "ok" and not findings:
+        return []
+    if (
+        result.returncode == 3
+        and payload.get("command") == "validate"
+        and payload.get("status") == "dependency_integrity_failure"
+        and findings
+    ):
+        return findings
+    return [{
+        "code": "validator_invalid_result",
+        "detail": (
+            "canonical validator returned an unexpected result "
+            f"(exit={result.returncode}, command={payload.get('command')!r}, "
+            f"status={payload.get('status')!r})"
+        ),
+    }]
+
+
+def _dependency_integrity_failure_artifact(
+    job_id: str, job_name: str, findings: list[dict[str, str]]
+) -> tuple[str, str]:
+    """Build the persisted failure artifact used when canonical skill validation fails."""
+    finding_codes = sorted({item["code"] for item in findings})
+    error = f"dependency_integrity_failure: {', '.join(finding_codes)}"
+    document = (
+        f"# Cron Job: {job_name}\n\n"
+        f"**Job ID:** {job_id}\n"
+        f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+        "**Status:** Dependency integrity failure\n\n"
+        "The canonical skill validator failed before prompt or agent construction. "
+        "No degraded report was produced.\n\n"
+        "**Findings:**\n"
+        f"```json\n{json.dumps(findings, sort_keys=True)}\n```\n"
+    )
+    return document, error
+
+
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
@@ -2886,6 +2989,17 @@ def run_job(
             f"{output}\n"
         )
         return True, doc, output, None
+
+    # Agent-backed cron runs must validate their canonical skill packages before
+    # importing agent machinery or assembling a prompt.  A failed package is a
+    # dependency-integrity failure, not a degraded successful report.
+    dependency_findings = _validate_cron_skill_dependencies()
+    if dependency_findings:
+        document, error = _dependency_integrity_failure_artifact(
+            job_id, job_name, dependency_findings
+        )
+        logger.error("Job '%s': %s", job_id, error)
+        return False, document, "", error
 
     # ---------------------------------------------------------------
     # Default (LLM) path — import and construct the agent machinery now

--- a/tests/cron/conftest.py
+++ b/tests/cron/conftest.py
@@ -39,3 +39,15 @@ def _reset_session_context_vars():
     _reset_all()
     yield
     _reset_all()
+
+
+@pytest.fixture(autouse=True)
+def _default_cron_skill_integrity_pass(monkeypatch):
+    """Keep unrelated scheduler tests focused on their own execution seam.
+
+    Dependency-integrity behavior is covered explicitly in
+    ``TestRunJobDependencyIntegrity``; ordinary cron tests should not require a
+    live canonical skills checkout in their temporary HERMES_HOME.
+    """
+    monkeypatch.setattr("cron.scheduler._validate_cron_skill_dependencies", lambda: [])
+    yield

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -105,6 +105,26 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert "RAM 92% on host" in doc
 
 
+def test_run_job_no_agent_does_not_invoke_skill_integrity_validator(hermes_env):
+    """Script-only jobs retain their no-agent fast path and need no skill package preflight."""
+    from cron.jobs import create_job
+    from cron.scheduler import run_job
+
+    script_path = hermes_env / "scripts" / "alert.sh"
+    script_path.write_text("#!/bin/bash\necho 'still script only'\n")
+    job = create_job(
+        prompt=None, schedule="every 5m", script="alert.sh", no_agent=True, deliver="local"
+    )
+
+    with patch("cron.scheduler._validate_cron_skill_dependencies") as validate:
+        success, _, final_response, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    assert final_response == "still script only"
+    validate.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # _run_job_script: shell-script support
 # ---------------------------------------------------------------------------

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -898,6 +898,47 @@ class TestRunJobSkillBacked:
         assert final_response == "ok"
 
 
+class TestRunJobDependencyIntegrity:
+    """Agent-backed jobs must stop before prompt or agent construction on a bad skill package."""
+
+    @pytest.mark.parametrize(
+        "finding_code",
+        [
+            "skill_missing",
+            "skill_hash_mismatch",
+            "binding_mismatch",
+            "package_tree_mismatch",
+            "package_worktree_dirty",
+        ],
+    )
+    def test_skill_integrity_finding_returns_explicit_failure_before_prompt_build(
+        self, finding_code
+    ):
+        job = {
+            "id": "integrity-job",
+            "name": "integrity check",
+            "prompt": "produce a report",
+            "skills": ["alpha"],
+        }
+        findings = [{"code": finding_code, "detail": "skill=alpha"}]
+
+        with patch(
+            "cron.scheduler._validate_cron_skill_dependencies", return_value=findings
+        ) as validate, patch("cron.scheduler._build_job_prompt") as build_prompt, patch(
+            "run_agent.AIAgent"
+        ) as agent_cls:
+            success, document, final_response, error = run_job(job)
+
+        assert success is False
+        assert final_response == ""
+        assert error == f"dependency_integrity_failure: {finding_code}"
+        assert "Dependency integrity failure" in document
+        assert finding_code in document
+        validate.assert_called_once_with()
+        build_prompt.assert_not_called()
+        agent_cls.assert_not_called()
+
+
 class TestSilentDelivery:
     """Verify that [SILENT] responses suppress delivery while still saving output."""
 


### PR DESCRIPTION
Applies the reviewed skill-package preflight to current origin/main. Agent-backed jobs stop before prompt or agent construction when canonical validation is unavailable, malformed, or reports integrity findings; no-agent jobs retain their fast path. Focused scheduler/no-agent and canonical-validator tests pass. Runtime activation and the existing natural evidence gate remain out of scope.