### PR TITLE
fix(config): stop false-warning on 20 roots the module already calls known

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4707,6 +4707,11 @@ def _known_top_level_keys() -> set[str]:
     keys.update(_OPEN_DICT_TOP_LEVEL_KEYS)
     keys.update(_DYNAMIC_TOP_LEVEL_KEYS)
     keys.update(_SCHEMA_DEFINED_DICT_KEYS)
+    # _KNOWN_ROOT_KEYS is built as DEFAULT_CONFIG | _EXTRA_KNOWN_ROOT_KEYS, so
+    # omitting the extras here gave the module two different notions of "known
+    # root" and left this one narrower. Roots the setup wizard writes and the
+    # gateway reads were reported to the user as unrecognized.
+    keys.update(_EXTRA_KNOWN_ROOT_KEYS)
     return keys
 
 

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -5,6 +5,7 @@ from hermes_cli.config import (
     DEFAULT_CONFIG,
     _EXTRA_KNOWN_ROOT_KEYS,
     _KNOWN_ROOT_KEYS,
+    _known_top_level_keys,
     validate_config_structure,
     ConfigIssue,
 )
@@ -106,6 +107,23 @@ class TestUnknownTopLevelKeys:
         assert set(DEFAULT_CONFIG.keys()).issubset(_KNOWN_ROOT_KEYS)
         assert _EXTRA_KNOWN_ROOT_KEYS.issubset(_KNOWN_ROOT_KEYS)
         assert _KNOWN_ROOT_KEYS == frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
+
+    def test_validator_knows_every_extra_root_key(self):
+        """`hermes config set` must accept every root the module calls known.
+
+        The test above asserts _EXTRA_KNOWN_ROOT_KEYS is part of
+        _KNOWN_ROOT_KEYS. _known_top_level_keys() feeds _validate_config_key and
+        was built from a different union that omitted them, so the CLI warned
+        "not a recognized config key" on 20 roots this file already declares
+        known — including ones the setup wizard writes and the gateway reads.
+        Two registries, one of them narrower, and only the narrow one visible to
+        the user.
+        """
+        missing = _EXTRA_KNOWN_ROOT_KEYS - _known_top_level_keys()
+        assert not missing, (
+            "_known_top_level_keys() omits roots that _KNOWN_ROOT_KEYS declares known, so "
+            f"`hermes config set` will false-warn on them: {sorted(missing)}"
+        )
 
     def test_provider_like_unknown_root_keeps_misplaced_message(self):
         """Preserve existing base_url/api_key root-level guidance."""


### PR DESCRIPTION
## Summary

`hermes config set` reports **"not a recognized config key"** for 20 top-level roots that this module's own `_KNOWN_ROOT_KEYS` declares known, and that real code reads.

The module carries two notions of a known root, and they disagree:

```python
_KNOWN_ROOT_KEYS      = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS   # line 1881
_known_top_level_keys = DEFAULT_CONFIG.keys() | _OPEN_DICT | _DYNAMIC | _SCHEMA_DEFINED
```

`_validate_config_key` uses the second, which never picked up `_EXTRA_KNOWN_ROOT_KEYS`. Only the narrower set is visible to the user.

```
always_log_local          image_gen                 profile_routes
fallback_model            known_builtin_toolsets    require_mention
filter_silence_narration  known_plugin_toolsets     reset_triggers
group_sessions_per_user   multiplex_profiles        session_reset
platform_toolsets         platforms                 smart_model_routing
plugins                   stt_echo_transcripts      thread_sessions_per_user
unauthorized_dm_behavior  video_gen
```

These are not dead names. `image_gen` has 61 references outside the registry, `session_reset` 25, `platform_toolsets` 9, `profile_routes` 6, across `gateway/` and `hermes_cli/`.

**One case is worse than a false warning.** `fallback_model` is answered with a suggestion of `fallback_providers` — a different, real key:

```
fallback_model.some_setting     valid=False  suggests='fallback_providers.some_setting'
```

That contradicts `_suggest_closest_key`'s own docstring, which says we would rather say nothing than point a user at a wrong-but-similar key.

`tests/hermes_cli/test_config_validation.py:107` has asserted `_EXTRA_KNOWN_ROOT_KEYS.issubset(_KNOWN_ROOT_KEYS)` since before this change. The suite already treats these as known while the CLI tells users they are not.

## Change

One line in `_known_top_level_keys()` so both registries share a source of truth, plus an invariant test so they cannot drift apart again.

**This narrows nothing.** Top-level scalars still bridge to `os.environ` and arbitrary unknown roots are still accepted, per the policy at `config.py:2036` and its test. Deep paths under these roots do become unconditionally valid (`session_reset.a.b.c` → True), matching the `_SCHEMA_DEFINED_DICT_KEYS` precedent already in this function — flagging that explicitly since it is the one behaviour change.

## Verification

- New invariant test **fails on unfixed code** and names all 20:
  ```
  AssertionError: _known_top_level_keys() omits roots that _KNOWN_ROOT_KEYS declares known,
  so `hermes config set` will false-warn on them: ['always_log_local', 'fallback_model', ...]
  ```
- Gap closes to **0** after the change
- Typo detection unaffected: `sessionz.mode` → suggests `sessions.mode`; `bogus_root_xyz.thing` → `(False, None)`
- `pytest tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_set_config_value.py` → **91 passed**
- `ruff check` → passed

Note: `tests/hermes_cli/test_config.py::TestGetHermesHome::test_default_path` fails identically on unmodified `main` in my environment and is unrelated to this change.

Possible textual conflict with #75192, which edits the same function at the display sub-key layer.