### PR TITLE
fix(relay): finalize nested logical scopes in LIFO order

### DIFF
--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -821,37 +821,14 @@ def _complete_logical(
     if logical is None:
         return
     turn, handle, request_id = logical
-    lease = turn.lease
-    if not isinstance(lease.host, relay_runtime.RelayRuntime):
-        return
-    with turn.finalize_lock:
-        with turn.logical_llm_lock:
-            if turn.logical_llm_calls.get(request_id) is not handle:
-                return
-        if lease.session is None:
+    with turn.logical_llm_lock:
+        if turn.logical_llm_calls.get(request_id) is not handle:
             return
-        try:
-            lease.host.run_in_session(
-                lease.session,
-                lease.host.relay.scope.pop,
-                handle,
-                output={"outcome": outcome},
-                metadata={
-                    relay_runtime.RUNTIME_SCHEMA_KEY: relay_runtime.RUNTIME_SCHEMA_VERSION,
-                    relay_runtime.RUNTIME_INSTANCE_KEY: lease.host.runtime_id,
-                },
-            )
-        except Exception:
-            # The provider result is authoritative. Retain the handle so turn
-            # finalization can retry cleanup without changing that result.
-            logger.warning(
-                "Hermes Relay logical LLM finalization failed",
-                exc_info=True,
-            )
-            return
-        with turn.logical_llm_lock:
-            if turn.logical_llm_calls.get(request_id) is handle:
-                turn.logical_llm_calls.pop(request_id, None)
+    relay_runtime.SESSION_COORDINATOR.complete_logical_call(
+        turn,
+        request_id=request_id,
+        outcome=outcome,
+    )
 
 
 def _recover_successful_callback(

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -474,6 +474,7 @@ class RelayTurnContext:
     task_id: str
     handle: Any = None
     logical_llm_calls: dict[str, Any] = field(default_factory=dict, repr=False)
+    logical_llm_outcomes: dict[str, str] = field(default_factory=dict, repr=False)
     logical_llm_lock: threading.RLock = field(
         default_factory=threading.RLock,
         repr=False,
@@ -638,7 +639,7 @@ class RelaySessionCoordinator:
             lease = turn.lease
             try:
                 if isinstance(lease.host, RelayRuntime) and lease.session is not None:
-                    self._finish_logical_calls(turn, outcome=outcome)
+                    self._finish_logical_calls(turn, outcome=outcome, force=True)
                     if turn.handle is not None:
                         try:
                             lease.host.run_in_session(
@@ -708,50 +709,69 @@ class RelaySessionCoordinator:
         with turn.finalize_lock:
             if turn.closed:
                 return
-            self._finish_logical_calls(turn, outcome=outcome)
+            self._finish_logical_calls(turn, outcome=outcome, force=True)
+
+    def complete_logical_call(
+        self,
+        turn: RelayTurnContext,
+        *,
+        request_id: str,
+        outcome: str,
+    ) -> None:
+        """Record completion and drain only logical scopes that are stack-ready."""
+        with turn.finalize_lock:
+            if turn.closed:
+                return
+            with turn.logical_llm_lock:
+                if request_id not in turn.logical_llm_calls:
+                    return
+                turn.logical_llm_outcomes[request_id] = outcome
+            self._finish_logical_calls(turn, outcome=outcome, force=False)
 
     @staticmethod
     def _finish_logical_calls(
         turn: RelayTurnContext,
         *,
         outcome: str,
+        force: bool,
     ) -> None:
         lease = turn.lease
         if not isinstance(lease.host, RelayRuntime) or lease.session is None:
             return
-        with turn.logical_llm_lock:
-            logical_calls = list(turn.logical_llm_calls.items())
-            turn.logical_llm_calls.clear()
-        for index in range(len(logical_calls) - 1, -1, -1):
-            request_id, logical_handle = logical_calls[index]
+        while True:
+            with turn.logical_llm_lock:
+                if not turn.logical_llm_calls:
+                    return
+                request_id, logical_handle = next(
+                    reversed(turn.logical_llm_calls.items())
+                )
+                logical_outcome = turn.logical_llm_outcomes.get(request_id)
+                if logical_outcome is None:
+                    if not force:
+                        return
+                    logical_outcome = outcome
+                    turn.logical_llm_outcomes[request_id] = logical_outcome
             try:
                 lease.host.run_in_session(
                     lease.session,
                     lease.host.relay.scope.pop,
                     logical_handle,
-                    output={"outcome": outcome},
+                    output={"outcome": logical_outcome},
                     metadata={
                         RUNTIME_SCHEMA_KEY: RUNTIME_SCHEMA_VERSION,
                         RUNTIME_INSTANCE_KEY: lease.host.runtime_id,
                     },
                 )
             except Exception:
-                with turn.logical_llm_lock:
-                    # Relay scopes are stack-owned. If the newest remaining
-                    # handle cannot close, older handles cannot close safely
-                    # either, so retain the unclosed prefix for diagnostics.
-                    for pending_request_id, pending_handle in logical_calls[
-                        : index + 1
-                    ]:
-                        turn.logical_llm_calls.setdefault(
-                            pending_request_id,
-                            pending_handle,
-                        )
                 logger.warning(
                     "Hermes Relay logical LLM finalization failed",
                     exc_info=True,
                 )
-                break
+                return
+            with turn.logical_llm_lock:
+                if turn.logical_llm_calls.get(request_id) is logical_handle:
+                    turn.logical_llm_calls.pop(request_id, None)
+                    turn.logical_llm_outcomes.pop(request_id, None)
 
     @staticmethod
     def _reset_turn_context(turn: RelayTurnContext) -> None:

--- a/tests/agent/test_relay_llm.py
+++ b/tests/agent/test_relay_llm.py
@@ -12,7 +12,7 @@ import pytest
 
 pytest.importorskip("nemo_relay")
 
-from agent import relay_llm, relay_runtime
+from agent import relay_llm, relay_runtime, relay_tools
 
 
 @pytest.fixture()
@@ -398,6 +398,156 @@ def test_non_stream_defers_logical_success_and_reuses_scope_for_retry(relay_turn
     relay_llm.complete_logical_call("request-retry", outcome="success")
 
     assert turn.logical_llm_calls == {}
+
+
+def test_nested_logical_completion_drains_in_lifo_order(relay_turn, monkeypatch):
+    relay, turn = relay_turn
+    events = []
+    original_pop = relay.scope.pop
+    pop_handles = []
+
+    def record_pop(handle, **kwargs):
+        pop_handles.append(handle)
+        return original_pop(handle, **kwargs)
+
+    monkeypatch.setattr(relay.scope, "pop", record_pop)
+    relay.subscribers.register("test-nested-logical-completion", events.append)
+    try:
+        relay_llm.execute(
+            {"model": "test-model", "messages": []},
+            lambda _request: {"content": "first"},
+            session_id="session-1",
+            name="test-provider",
+            model_name="test-model",
+            metadata={"api_mode": "custom", "api_request_id": "request-first"},
+            defer_logical_completion=True,
+        )
+        first_handle = turn.logical_llm_calls["request-first"]
+        relay_llm.execute(
+            {"model": "test-model", "messages": []},
+            lambda _request: {"content": "second"},
+            session_id="session-1",
+            name="test-provider",
+            model_name="test-model",
+            metadata={"api_mode": "custom", "api_request_id": "request-second"},
+            defer_logical_completion=True,
+        )
+        second_handle = turn.logical_llm_calls["request-second"]
+
+        relay_llm.complete_logical_call("request-first", outcome="success")
+
+        assert pop_handles == []
+        assert set(turn.logical_llm_calls) == {"request-first", "request-second"}
+
+        relay_llm.complete_logical_call("request-second", outcome="success")
+
+        assert pop_handles == [second_handle, first_handle]
+        assert turn.logical_llm_calls == {}
+        result, _ = relay_tools.execute(
+            "write_file",
+            {"path": "audit"},
+            lambda args: {"persisted": args["path"]},
+            session_id="session-1",
+            metadata={"tool_call_id": "tool-after-nested-llm"},
+        )
+        assert result == {"persisted": "audit"}
+
+        relay_runtime.SESSION_COORDINATOR.end_turn(turn, outcome="success")
+        relay_runtime.SESSION_COORDINATOR.finalize_conversation(
+            profile_key=turn.lease.profile_key,
+            session_id="session-1",
+        )
+    finally:
+        relay.subscribers.deregister("test-nested-logical-completion")
+
+    scope_ends = [
+        (event.category, event.scope_category, event.name)
+        for event in events
+        if event.kind == "scope" and event.scope_category == "end"
+    ]
+    assert ("tool", "end", "write_file") in scope_ends
+    assert scope_ends[-2:] == [
+        ("function", "end", relay_runtime.TURN_SCOPE),
+        ("agent", "end", relay_runtime.SESSION_SCOPE),
+    ]
+
+
+def test_nested_logical_finalization_recovers_after_top_pop_failure(
+    relay_turn, monkeypatch
+):
+    relay, turn = relay_turn
+    original_pop = relay.scope.pop
+    pop_handles = []
+    fail_second_once = True
+
+    relay_llm.execute(
+        {"model": "test-model", "messages": []},
+        lambda _request: {"content": "first"},
+        session_id="session-1",
+        name="test-provider",
+        model_name="test-model",
+        metadata={"api_mode": "custom", "api_request_id": "request-first"},
+        defer_logical_completion=True,
+    )
+    first_handle = turn.logical_llm_calls["request-first"]
+    relay_llm.execute(
+        {"model": "test-model", "messages": []},
+        lambda _request: {"content": "second"},
+        session_id="session-1",
+        name="test-provider",
+        model_name="test-model",
+        metadata={"api_mode": "custom", "api_request_id": "request-second"},
+        defer_logical_completion=True,
+    )
+    second_handle = turn.logical_llm_calls["request-second"]
+
+    def fail_second_pop_once(handle, **kwargs):
+        nonlocal fail_second_once
+        pop_handles.append(handle)
+        if handle is second_handle and fail_second_once:
+            fail_second_once = False
+            raise RuntimeError("simulated top logical scope close failure")
+        return original_pop(handle, **kwargs)
+
+    monkeypatch.setattr(relay.scope, "pop", fail_second_pop_once)
+    relay_llm.complete_logical_call("request-first", outcome="success")
+    relay_llm.complete_logical_call("request-second", outcome="success")
+
+    assert set(turn.logical_llm_calls) == {"request-first", "request-second"}
+
+    relay_runtime.SESSION_COORDINATOR.finish_logical_calls(turn, outcome="success")
+
+    assert pop_handles == [second_handle, second_handle, first_handle]
+    assert turn.logical_llm_calls == {}
+    events = []
+    relay.subscribers.register("test-nested-logical-recovery", events.append)
+    try:
+        result, _ = relay_tools.execute(
+            "write_file",
+            {"path": "audit-after-retry"},
+            lambda args: {"persisted": args["path"]},
+            session_id="session-1",
+            metadata={"tool_call_id": "tool-after-retry"},
+        )
+        assert result == {"persisted": "audit-after-retry"}
+        relay_runtime.SESSION_COORDINATOR.end_turn(turn, outcome="success")
+        relay_runtime.SESSION_COORDINATOR.finalize_conversation(
+            profile_key=turn.lease.profile_key,
+            session_id="session-1",
+        )
+    finally:
+        relay.subscribers.deregister("test-nested-logical-recovery")
+
+    scope_ends = [
+        (event.category, event.scope_category, event.name)
+        for event in events
+        if event.kind == "scope" and event.scope_category == "end"
+    ]
+    assert ("tool", "end", "write_file") in scope_ends
+    assert scope_ends[-2:] == [
+        ("function", "end", relay_runtime.TURN_SCOPE),
+        ("agent", "end", relay_runtime.SESSION_SCOPE),
+    ]
 
 
 def test_non_stream_result_survives_logical_scope_close_failure(


### PR DESCRIPTION
## Summary
- Finalize deferred nested logical LLM scopes only when the newest scope is ready, preserving LIFO stack ownership.
- Retain the unclosed logical scope stack after a pop failure so a later finalization can retry safely.
- Cover ordered nested completion and recovery after top-scope close failure.

## Verification
- `python -m pytest tests/agent/test_relay_llm.py -q` — 20 passed
- `python -m compileall agent -q`
- `git diff --check origin/main...HEAD`

No runtime activation, gateway, cron, or configuration changes.