### PR TITLE
fix(update): check Node.js deps health on already-current checkout (#77211)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3920,7 +3920,29 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
-                print("✓ Already up to date!")
+                # A current checkout does NOT imply healthy Node deps either:
+                # a previous npm install may have failed (EBADENGINE, network
+                # timeout, interrupted install), leaving node_modules in a
+                # mixed state.  The "Already up to date!" path previously only
+                # checked the Python venv — mirror the same "repair if broken"
+                # pattern for Node.js dependencies (#77211).
+                from hermes_constants import get_default_hermes_root
+
+                _shared_root = get_default_hermes_root()
+                if _m()._npm_lockfile_changed(_shared_root):
+                    print("⚠ Checkout is current, but Node.js dependencies may be stale.")
+                    print("→ Refreshing Node.js dependencies...")
+                    node_failures = _update_node_dependencies()
+                    if node_failures:
+                        print(
+                            f"  ⚠ Node.js refresh failed for: {', '.join(node_failures)}"
+                        )
+                        print("    Fix npm and re-run `hermes update`.")
+                    else:
+                        _m()._build_web_ui(_m().PROJECT_ROOT / "web")
+                        print("✓ Node.js dependencies refreshed!")
+                else:
+                    print("✓ Already up to date!")
             if runtime_repaired is not None and not _m()._is_windows():
                 print()
                 print(


### PR DESCRIPTION
## Summary

When `hermes update` finds no new commits, it previously only checked the Python venv health. A previous run that partially failed at the npm install step (EBADENGINE, network timeout, interrupted install) left `node_modules` in a mixed state, and the "Already up to date!" path never repaired it — despite the error message telling users to "re-run `hermes update`".

## Root Cause

The "no new commits" early-return path at `update_cmd.py:3922` only called `_venv_core_imports_healthy()` for Python deps. The Node.js dependency health check (`_npm_lockfile_changed()`) was only consulted on the new-commits path (line 2072), never on the already-current path.

## Fix

Mirror the existing "repair if broken" pattern for Node.js: consult `_npm_lockfile_changed()` on the no-new-commits path. When it reports stale (missing `node_modules`, lockfile hash mismatch, or incomplete web toolchain), run `_update_node_dependencies()` + `_build_web_ui()` to bring Node deps into a consistent state.

## Changes

- `hermes_cli/update_cmd.py`: Add Node.js health check to the "already up to date" path. When `_npm_lockfile_changed()` returns True, call `_update_node_dependencies()` and `_build_web_ui()` before reporting success.

## Test Plan

- [ ] `hermes update` on a current checkout with missing `node_modules` triggers Node dep refresh
- [ ] `hermes update` on a current checkout with healthy Node deps prints "Already up to date!" as before
- [ ] `hermes update` on a current checkout with failed npm install repairs the install
- [ ] Python syntax: `python3 -c "import ast; ast.parse(open('hermes_cli/update_cmd.py').read())"`

Fixes #77211