### PR TITLE
fix(api): auto-load session history on /v1/runs when only session_id given

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6338,13 +6338,16 @@ class APIServerAdapter(BasePlatformAdapter):
 
         session_id = body.get("session_id") or stored_session_id
 
-        # Auto-load persisted session history when the client supplied only a
-        # session_id (mirrors /chat, which always loads history from the
-        # session store). Explicit conversation_history, previous_response_id
-        # chaining, and multi-message input all take precedence; this only
-        # fires when none of those produced history. repair_alternation=True
-        # because this feed is LIVE REPLAY: a durable user;user wedge would
-        # otherwise re-trigger the pre-request repair on every request (see
+        # Auto-load persisted session history only when the client supplied NO
+        # history mechanism at all (mirrors /chat, which always loads history
+        # from the session store). A supplied-but-empty source must win: an
+        # explicit conversation_history: [] means "fresh run", an unknown
+        # previous_response_id stays authoritative, and a multi-message input
+        # array is itself the history. Tracking source presence (not resolved
+        # list truthiness) keeps the documented precedence exact at its
+        # boundary cases. repair_alternation=True because this feed is LIVE
+        # REPLAY: a durable user;user wedge would otherwise re-trigger the
+        # pre-request repair on every request (see
         # SessionDB.get_messages_as_conversation docstring). A missing session
         # degrades to empty history, never an error — the run still starts.
         # Callers that use session_id purely as a tracking/telemetry token
@@ -6352,7 +6355,14 @@ class APIServerAdapter(BasePlatformAdapter):
         # load_session_history=false. Loaded history is tail-windowed to
         # RUNS_SESSION_HISTORY_LIMIT so an arbitrarily long transcript cannot
         # blow the model context (compaction summaries are preserved).
-        if not conversation_history and session_id and body.get("load_session_history", True):
+        history_source_supplied = ("conversation_history" in body) or bool(
+            previous_response_id
+        ) or (isinstance(raw_input, list) and len(raw_input) > 1)
+        if (
+            not history_source_supplied
+            and session_id
+            and body.get("load_session_history", True)
+        ):
             conversation_history = await self._conversation_history_for_session(
                 session_id, repair_alternation=True
             )

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -155,6 +155,12 @@ CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
+
+# Cap on messages auto-loaded from the session store by /v1/runs when the
+# client supplies only a session_id. Prevents an arbitrarily long transcript
+# from blowing the model context on replay; compaction summaries survive the
+# window (see _auto_truncate_response_history).
+RUNS_SESSION_HISTORY_LIMIT = 100
 _COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
 
 
@@ -6341,10 +6347,25 @@ class APIServerAdapter(BasePlatformAdapter):
         # otherwise re-trigger the pre-request repair on every request (see
         # SessionDB.get_messages_as_conversation docstring). A missing session
         # degrades to empty history, never an error — the run still starts.
-        if not conversation_history and session_id:
+        # Callers that use session_id purely as a tracking/telemetry token
+        # (and want each run stateless) can opt out with
+        # load_session_history=false. Loaded history is tail-windowed to
+        # RUNS_SESSION_HISTORY_LIMIT so an arbitrarily long transcript cannot
+        # blow the model context (compaction summaries are preserved).
+        if not conversation_history and session_id and body.get("load_session_history", True):
             conversation_history = await self._conversation_history_for_session(
                 session_id, repair_alternation=True
             )
+            if len(conversation_history) > RUNS_SESSION_HISTORY_LIMIT:
+                logger.info(
+                    "runs_history_load session_id=%s rows=%d windowed_to=%d",
+                    session_id,
+                    len(conversation_history),
+                    RUNS_SESSION_HISTORY_LIMIT,
+                )
+                conversation_history = _auto_truncate_response_history(
+                    conversation_history, limit=RUNS_SESSION_HISTORY_LIMIT
+                )
 
         route = self._resolve_route(body.get("model"))
         agent_overrides = _request_agent_overrides(body, virtual_model=self._model_name)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3195,12 +3195,18 @@ class APIServerAdapter(BasePlatformAdapter):
             return None, web.json_response(_openai_error(f"Session not found: {session_id}", code="session_not_found"), status=404)
         return session, None
 
-    async def _conversation_history_for_session(self, session_id: str) -> List[Dict[str, Any]]:
+    async def _conversation_history_for_session(
+        self, session_id: str, repair_alternation: bool = False
+    ) -> List[Dict[str, Any]]:
         db = await self._ensure_session_db_async()
         if db is None:
             return []
         try:
-            return await asyncio.to_thread(db.get_messages_as_conversation, session_id)
+            return await asyncio.to_thread(
+                db.get_messages_as_conversation,
+                session_id,
+                repair_alternation=repair_alternation,
+            )
         except Exception as exc:
             logger.warning("Failed to load session history for %s: %s", session_id, exc)
             return []
@@ -6325,6 +6331,21 @@ class APIServerAdapter(BasePlatformAdapter):
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
         session_id = body.get("session_id") or stored_session_id
+
+        # Auto-load persisted session history when the client supplied only a
+        # session_id (mirrors /chat, which always loads history from the
+        # session store). Explicit conversation_history, previous_response_id
+        # chaining, and multi-message input all take precedence; this only
+        # fires when none of those produced history. repair_alternation=True
+        # because this feed is LIVE REPLAY: a durable user;user wedge would
+        # otherwise re-trigger the pre-request repair on every request (see
+        # SessionDB.get_messages_as_conversation docstring). A missing session
+        # degrades to empty history, never an error — the run still starts.
+        if not conversation_history and session_id:
+            conversation_history = await self._conversation_history_for_session(
+                session_id, repair_alternation=True
+            )
+
         route = self._resolve_route(body.get("model"))
         agent_overrides = _request_agent_overrides(body, virtual_model=self._model_name)
         selection_error = self._request_route_conflict_error(

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -353,6 +353,147 @@ class TestStartRun:
         mock_db.get_messages_as_conversation.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_start_explicit_empty_history_wins_over_session_store(self, adapter):
+        """conversation_history: [] is an explicit history source meaning
+        'fresh run' — it must win over the session store (source presence,
+        not list truthiness, gates the fallback)."""
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "should-not-be-used"},
+        ]
+        adapter._session_db = mock_db
+
+        captured = {}
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    captured["history"] = conversation_history
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "hello",
+                        "session_id": "persisted-session",
+                        "conversation_history": [],
+                    },
+                )
+                assert resp.status == 202
+                for _ in range(40):
+                    if captured.get("history") is not None:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert captured.get("history") == []
+        mock_db.get_messages_as_conversation.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_unknown_previous_response_id_stays_authoritative(self, adapter):
+        """An unknown previous_response_id is a supplied history source: even
+        though the response store yields nothing, the session store must NOT
+        be consulted as a fallback."""
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "should-not-be-used"},
+        ]
+        adapter._session_db = mock_db
+        mock_store = MagicMock()
+        mock_store.get.return_value = None
+        adapter._response_store = mock_store
+
+        captured = {}
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    captured["history"] = conversation_history
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "hello",
+                        "session_id": "persisted-session",
+                        "previous_response_id": "resp_unknown",
+                    },
+                )
+                assert resp.status == 202
+                for _ in range(40):
+                    if captured.get("history") is not None:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert captured.get("history") == []
+        mock_db.get_messages_as_conversation.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_multi_message_input_uses_input_not_session_store(self, adapter):
+        """A multi-message input array is itself the history source; the
+        session store must not be consulted even when the client also passed
+        a session_id."""
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "should-not-be-used"},
+        ]
+        adapter._session_db = mock_db
+
+        captured = {}
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    captured["history"] = conversation_history
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": [
+                            {"role": "user", "content": "prior turn"},
+                            {"role": "assistant", "content": "prior reply"},
+                            {"role": "user", "content": "new question"},
+                        ],
+                        "session_id": "persisted-session",
+                    },
+                )
+                assert resp.status == 202
+                for _ in range(40):
+                    if captured.get("history") is not None:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert captured.get("history") == [
+            {"role": "user", "content": "prior turn"},
+            {"role": "assistant", "content": "prior reply"},
+        ]
+        mock_db.get_messages_as_conversation.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_start_missing_session_degrades_to_empty_history(self, adapter):
         """A session_id with no persisted rows (or an unavailable store) must
         not fail the run — history stays empty and the run still starts."""

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -11,7 +11,7 @@ Covers:
 import asyncio
 import threading
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
@@ -257,6 +257,175 @@ class TestStartRun:
         assert kwargs["requested_model"] == "MiniMax-M3"
         assert kwargs["requested_provider"] == "minimax"
         assert kwargs["model_options"] == model_options
+
+    @pytest.mark.asyncio
+    async def test_start_loads_session_history_when_only_session_id_provided(self, adapter):
+        """When /v1/runs receives only a session_id (no explicit history,
+        no previous_response_id, no multi-message input), history must be
+        auto-loaded from the session store so the run is not amnesiac —
+        mirroring /chat. repair_alternation must be True (live replay)."""
+        db_history = [
+            {"role": "user", "content": "stored message 1"},
+            {"role": "assistant", "content": "stored reply 1"},
+        ]
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = db_history
+        adapter._session_db = mock_db
+
+        captured = {}
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    captured["history"] = conversation_history
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "persisted-session"},
+                )
+                assert resp.status == 202
+                for _ in range(40):
+                    if captured.get("history") is not None:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert captured.get("history") == db_history, (
+            "session_id-only run must load persisted session history"
+        )
+        mock_db.get_messages_as_conversation.assert_called_once_with(
+            "persisted-session", repair_alternation=True
+        )
+
+    @pytest.mark.asyncio
+    async def test_start_explicit_conversation_history_wins_over_session_store(self, adapter):
+        """Explicit conversation_history in the body must take precedence and
+        the session store must not be consulted for history."""
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "should-not-be-used"},
+        ]
+        adapter._session_db = mock_db
+
+        explicit_history = [
+            {"role": "user", "content": "client msg 1"},
+            {"role": "assistant", "content": "client reply 1"},
+        ]
+        captured = {}
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    captured["history"] = conversation_history
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "hello",
+                        "session_id": "persisted-session",
+                        "conversation_history": explicit_history,
+                    },
+                )
+                assert resp.status == 202
+                for _ in range(40):
+                    if captured.get("history") is not None:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert captured.get("history") == explicit_history
+        mock_db.get_messages_as_conversation.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_missing_session_degrades_to_empty_history(self, adapter):
+        """A session_id with no persisted rows (or an unavailable store) must
+        not fail the run — history stays empty and the run still starts."""
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = []
+        adapter._session_db = mock_db
+
+        captured = {}
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    captured["history"] = conversation_history
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "no-rows-session"},
+                )
+                assert resp.status == 202
+                data = await resp.json()
+                assert data["status"] == "started"
+                for _ in range(40):
+                    if captured.get("history") is not None:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert captured.get("history") == []
+
+    @pytest.mark.asyncio
+    async def test_start_session_store_unavailable_degrades_to_empty_history(self, adapter):
+        """When the session store is unavailable (db is None), a session_id
+        run must still start with empty history instead of 500ing."""
+        adapter._session_db = None
+        with patch.object(
+            adapter, "_ensure_session_db_async", new_callable=AsyncMock
+        ) as mock_ensure:
+            mock_ensure.return_value = None
+            captured = {}
+            app = _create_runs_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                with patch.object(adapter, "_create_agent") as mock_create:
+                    mock_agent = MagicMock()
+
+                    def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                        captured["history"] = conversation_history
+                        return {"final_response": "done"}
+
+                    mock_agent.run_conversation.side_effect = _capture_run
+                    mock_agent.session_prompt_tokens = 0
+                    mock_agent.session_completion_tokens = 0
+                    mock_agent.session_total_tokens = 0
+                    mock_create.return_value = mock_agent
+
+                    resp = await cli.post(
+                        "/v1/runs",
+                        json={"input": "hello", "session_id": "store-down-session"},
+                    )
+                    assert resp.status == 202
+                    for _ in range(40):
+                        if captured.get("history") is not None:
+                            break
+                        await asyncio.sleep(0.05)
+
+            assert captured.get("history") == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -391,6 +391,142 @@ class TestStartRun:
         assert captured.get("history") == []
 
     @pytest.mark.asyncio
+    async def test_start_load_session_history_opt_out_keeps_run_stateless(self, adapter):
+        """load_session_history=false must skip the session store entirely so
+        clients using session_id as a tracking token keep stateless runs."""
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "should-not-be-loaded"},
+        ]
+        adapter._session_db = mock_db
+
+        captured = {}
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    captured["history"] = conversation_history
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "hello",
+                        "session_id": "tracking-only-session",
+                        "load_session_history": False,
+                    },
+                )
+                assert resp.status == 202
+                for _ in range(40):
+                    if captured.get("history") is not None:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert captured.get("history") == []
+        mock_db.get_messages_as_conversation.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_loads_session_history_capped_at_limit(self, adapter, monkeypatch):
+        """Auto-loaded history must be tail-windowed to RUNS_SESSION_HISTORY_LIMIT
+        so a long transcript cannot blow the model context."""
+        from gateway.platforms import api_server as api_server_mod
+
+        monkeypatch.setattr(api_server_mod, "RUNS_SESSION_HISTORY_LIMIT", 5)
+        big_history = [
+            {"role": "user", "content": f"msg {i}"} if i % 2 == 0
+            else {"role": "assistant", "content": f"reply {i}"}
+            for i in range(20)
+        ]
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = big_history
+        adapter._session_db = mock_db
+
+        captured = {}
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    captured["history"] = conversation_history
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "long-session"},
+                )
+                assert resp.status == 202
+                for _ in range(40):
+                    if captured.get("history") is not None:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert captured.get("history") == big_history[-5:], (
+            "history must be tail-windowed to the limit"
+        )
+
+    @pytest.mark.asyncio
+    async def test_start_session_history_with_tool_rows_replays_safely(self, adapter):
+        """Session transcripts containing tool-call/tool-response rows must
+        replay without error and preserve the message roles (repair_alternation
+        must not corrupt tool pairs)."""
+        db_history = [
+            {"role": "user", "content": "query"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "search", "arguments": "{}"}}]},
+            {"role": "tool", "content": "results", "tool_call_id": "call_1"},
+            {"role": "assistant", "content": "final answer"},
+        ]
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = db_history
+        adapter._session_db = mock_db
+
+        captured = {}
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _capture_run(user_message=None, conversation_history=None, task_id=None):
+                    captured["history"] = conversation_history
+                    return {"final_response": "done"}
+
+                mock_agent.run_conversation.side_effect = _capture_run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "tool-session"},
+                )
+                assert resp.status == 202
+                for _ in range(40):
+                    if captured.get("history") is not None:
+                        break
+                    await asyncio.sleep(0.05)
+
+        assert captured.get("history") == db_history
+        roles = [m["role"] for m in captured["history"]]
+        assert roles == ["user", "assistant", "tool", "assistant"], (
+            "tool-call/tool-response pairs must survive replay"
+        )
+
+    @pytest.mark.asyncio
     async def test_start_session_store_unavailable_degrades_to_empty_history(self, adapter):
         """When the session store is unavailable (db is None), a session_id
         run must still start with empty history instead of 500ing."""

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -353,6 +353,8 @@ Create a new agent run. Returns a `run_id` that can be used to subscribe to prog
 
 Runs accept a simple `input` string and optional `session_id`, `instructions`, `conversation_history`, or `previous_response_id`. When `session_id` is provided, Hermes surfaces it in the run status so external UIs can correlate runs with their own conversation IDs.
 
+**Session history replay:** if a run provides `session_id` but *none* of the explicit history mechanisms (`conversation_history`, `previous_response_id`, or a multi-message `input` array), Hermes automatically loads the persisted transcript for that session so the run continues the conversation instead of starting amnesiac — mirroring the `/api/sessions/{session_id}/chat` endpoints. Explicit history always wins; `conversation_history: []` means "fresh run" and suppresses replay. Auto-loaded history is tail-windowed to the last 100 messages (compaction summaries preserved) so a long transcript cannot exceed the model context. Clients that use `session_id` purely as a tracking/telemetry token and want each run stateless can opt out with `"load_session_history": false`.
+
 ### GET /v1/runs/\{run_id\}
 
 Poll the current run state. This is useful for dashboards that need status without holding an SSE connection open, or for UIs that reconnect after navigation.


### PR DESCRIPTION
## Problem

`POST /v1/runs` builds the transcript only from the request body. When a client sends `session_id` alone (no `conversation_history`, no `previous_response_id`, single-string `input`), the run starts with **empty history** — the agent is amnesiac even though the conversation is persisted under that session. Sibling endpoints (`/chat`, `/chat/completions`, `/chat/stream`) all load history from the session store via `_conversation_history_for_session`; `/v1/runs` was the exception.

Observed in production: a web agent forgot "I don't have any context for what 'that' is" on turn 2, because each `/v1/runs` call started from `messages = []`. The client had to add an extra round-trip (`GET /api/sessions/{id}/messages`) to hydrate history itself.

## Fix

In `_handle_runs`, after the existing precedence chain (explicit `conversation_history` > `previous_response_id` chaining > multi-message input array), fall back to loading the persisted transcript from the session store when `session_id` is present and no history was produced — mirroring `/chat`.

- `_conversation_history_for_session` gains an optional `repair_alternation` parameter (default `False`, so `/chat` etc. behavior is byte-identical).
- The runs path passes `repair_alternation=True` because this feed is **live replay**: a durable `user;user` wedge would otherwise re-trigger the pre-request defensive repair on every request forever (see `SessionDB.get_messages_as_conversation` docstring).
- A missing session or unavailable store degrades to empty history — the run still starts; never an error.

## Tests

4 new tests in `tests/gateway/test_api_server_runs.py`:
1. `session_id`-only run loads persisted history and calls the store with `repair_alternation=True`
2. Explicit `conversation_history` in the body wins; store not consulted
3. Missing session rows → empty history, run still starts
4. Store unavailable → empty history, run still starts

Full surface: `tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py tests/gateway/test_api_server_active_work_drain.py` → **124 passed**.
