### PR TITLE
fix(guard): handle binary executables in lifecycle script scan

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -267,7 +267,14 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         os.close(descriptor)
     if len(data) > _MAX_REFERENCED_SCRIPT_BYTES:
         return None, True
-    return data.decode("utf-8", errors="replace"), False
+    text = data.decode("utf-8", errors="replace")
+    # Strip NUL bytes so binary content (e.g. a venv interpreter passed as
+    # an executable) can still be scanned without crashing downstream path
+    # resolution, which raises ValueError("embedded null byte") on paths
+    # containing "\\x00". The scan must still run: removing NULs keeps the
+    # fail-closed guarantee that a crafted binary cannot hide a lifecycle
+    # command behind non-UTF-8 bytes.
+    return text.replace("\x00", ""), False
 
 
 def _contains_unsafe_gateway_action(
@@ -298,7 +305,7 @@ def _contains_unsafe_gateway_action(
     for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
         try:
             resolved = script_path.resolve(strict=False)
-        except OSError:
+        except (OSError, ValueError):
             resolved = script_path
         if resolved in visited:
             continue

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -560,6 +560,55 @@ class TestTerminalToolGatewayLifecycleGuard:
         assert result["exit_code"] == 0
         assert calls == ["systemctl status nginx"]
 
+    def test_binary_executable_referenced_in_command_does_not_crash(
+        self, monkeypatch, tmp_path
+    ):
+        """A command whose executable is a NUL-byte-laden binary (e.g. a venv
+        interpreter) must not crash the guard with ValueError('embedded null
+        byte') while resolving the referenced path, and must pass through when
+        the binary contains no lifecycle command."""
+        import tools.terminal_tool as tt
+
+        calls = []
+        binary = tmp_path / "venv-python"
+        # Realistic binary signature: NUL bytes + non-UTF-8 junk. No
+        # lifecycle command inside, so the scan must come back clean.
+        binary.write_bytes(b"\x7fELF\x00\x00\x00\x00\xfe\xff\x00\x00MZ\x00")
+        binary.chmod(0o755)
+
+        class _FakeEnv:
+            env = {}
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "", "returncode": 0}
+
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True}
+        )
+
+        # Referenced as an absolute executable path (the crash shape).
+        result = json.loads(tt.terminal_tool(command=f"{binary} --version"))
+        assert result["exit_code"] == 0
+        assert calls == [f"{binary} --version"]
+
+    def test_binary_executable_hiding_lifecycle_command_still_blocked(
+        self, monkeypatch, tmp_path
+    ):
+        """Fail-closed guarantee: a NUL-byte binary that embeds a gateway
+        lifecycle command must still be blocked — stripping NULs cannot let
+        a crafted binary bypass the guard."""
+        import tools.terminal_tool as tt
+
+        binary = tmp_path / "sneaky-bin"
+        binary.write_bytes(b"\x00\x00hermes gateway restart\x00\x00")
+        binary.chmod(0o755)
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
+
+        result = json.loads(tt.terminal_tool(command=f"{binary}"))
+        assert result["exit_code"] == 1
+        assert "Blocked" in result["error"]
+
 
 # ---------------------------------------------------------------------------
 # cron.lifecycle_guard module — the shared checker create_job/CLI/terminal use


### PR DESCRIPTION
## Summary

The gateway lifecycle guard (`cron/lifecycle_guard.py`) crashes with `ValueError: embedded null byte` whenever a terminal command references a **binary executable by path** — e.g. `.venv/bin/python -m src.main` or `/usr/local/opt/python@3.14/bin/python3.14 --version`. The guard reads the referenced file, decodes it, tokenizes the content as shell text, and `Path.resolve()` blows up on NUL bytes found in the binary. The result: legitimate commands get hard-blocked with a confusing error, and any workflow that shells out to a venv interpreter breaks.

I hit this immediately after upgrading to the version that introduced the referenced-script scanning — the very first command referencing the events-scraper's venv python crashed the guard.

## Root Cause

- `_iter_referenced_shell_scripts` treats any executable containing `/` (or ending in `.sh`/`.bash`/`.zsh`) as a script to scan.
- A Python interpreter qualifies (path contains `/`), so the guard opens and reads the binary.
- `data.decode("utf-8", errors="replace")` keeps NUL bytes intact (they're valid UTF-8 code points).
- The decoded binary text is then scanned as shell content; `_iter_referenced_shell_scripts` yields tokenized "paths" containing `\x00`, and `Path.resolve()` raises `ValueError("embedded null byte")`.
- Only `OSError` was caught, so the `ValueError` propagated up and killed the terminal call.

## Fix

Two changes, both in `cron/lifecycle_guard.py`:

1. **`_read_referenced_script`** — strip NUL bytes from the decoded text before returning it. Binary content can then still be scanned as text (preserving the **fail-closed** guarantee that a crafted binary can't hide a lifecycle command behind non-UTF-8 bytes) without poisoning downstream path resolution.

2. **`_contains_unsafe_gateway_action`** — also catch `ValueError` from `Path.resolve()` alongside `OSError`, as defense-in-depth for any other path that could smuggle a NUL byte in.

## Test Plan

Added regression tests to `tests/hermes_cli/test_gateway_restart_loop.py`:

- `test_binary_executable_referenced_in_command_does_not_crash` — a NUL-byte-laden binary executable (ELF-ish signature) passes through the terminal tool cleanly (exit 0, command executed).
- `test_binary_executable_hiding_lifecycle_command_still_blocked` — a binary embedding `hermes gateway restart` is **still blocked** (fail-closed preserved).

Manually verified all four behavior classes against the patched module:
- ✅ Binary executable, no lifecycle command → passes (was: crash)
- ✅ Binary hiding a lifecycle command → still blocked
- ✅ Plain lifecycle command → still blocked
- ✅ Benign shell script → still passes

## Repro (before fix)

```
$ cd ~/.hermes/events-scraper && ./.venv/bin/python --version
Failed to execute command: embedded null byte
ValueError: embedded null byte  (traceback through cron/lifecycle_guard.py)
```
