### PR TITLE
Fix stale OpenRouter image model defaults

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -3780,7 +3780,7 @@ def _configure_imagegen_model_for_plugin(plugin_name: str, config: dict) -> None
         config["image_gen"] = cur_cfg
     current_model = cur_cfg.get("model") or default_model
     if current_model not in catalog:
-        current_model = default_model
+        current_model = default_model if default_model in catalog else next(iter(catalog))
 
     model_ids = list(catalog.keys())
     ordered = [current_model] + [m for m in model_ids if m != current_model]

--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -243,7 +243,9 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
         ]
 
     def default_model(self) -> Optional[str]:
-        return self._resolve_model()
+        # This is the catalog default, not the effective runtime model.
+        # Runtime overrides are resolved separately by _resolve_model_chain().
+        return DEFAULT_MODEL
 
     def get_setup_schema(self) -> Dict[str, Any]:
         return dict(self._setup_schema)

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -423,6 +423,26 @@ class TestImagegenModelPicker:
         assert isinstance(config["image_gen"], dict)
         assert config["image_gen"]["model"] == "fal-ai/flux-2/klein/9b"
 
+    def test_plugin_picker_falls_back_when_default_is_missing_from_catalog(self):
+        """A stale cross-provider model must not become an unindexable row."""
+        from hermes_cli.tools_config import _configure_imagegen_model_for_plugin
+
+        catalog = {
+            "openai/gpt-5.4-image-2": {"strengths": "quality"},
+            "google/gemini-3-pro-image": {"strengths": "fallback"},
+        }
+        config = {"image_gen": {"model": "gpt-image-2-medium"}}
+        with (
+            patch(
+                "hermes_cli.tools_config._plugin_image_gen_catalog",
+                return_value=(catalog, "also-missing"),
+            ),
+            patch("hermes_cli.tools_config._prompt_choice", return_value=0),
+        ):
+            _configure_imagegen_model_for_plugin("openrouter", config)
+
+        assert config["image_gen"]["model"] == "openai/gpt-5.4-image-2"
+
 
 
 

--- a/tests/plugins/image_gen/test_openrouter_compat_provider.py
+++ b/tests/plugins/image_gen/test_openrouter_compat_provider.py
@@ -95,6 +95,17 @@ class TestProviderClass:
             # Default must be an image-output model id (provider/model form).
             assert "/" in DEFAULT_MODEL and "image" in DEFAULT_MODEL
 
+    def test_default_model_ignores_runtime_overrides(self, monkeypatch):
+        """Catalog defaults must not inherit another provider's saved model."""
+        from plugins.image_gen.openrouter import DEFAULT_MODEL
+
+        monkeypatch.setenv("OPENROUTER_IMAGE_MODEL", "custom/provider-image-model")
+        stale = {"model": "gpt-image-2-medium"}
+        with patch("plugins.image_gen.openrouter._load_image_gen_config", return_value=stale):
+            provider = _openrouter()
+            assert provider.default_model() == DEFAULT_MODEL
+            assert provider._resolve_model() == "custom/provider-image-model"
+
 
     def test_model_env_override(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_IMAGE_MODEL", "black-forest-labs/flux.2-pro")


### PR DESCRIPTION
## Summary
- keep the OpenRouter provider catalog default independent from runtime config overrides
- fall back to the first catalog entry when both the saved and provider-default model IDs are stale
- add regression coverage for cross-provider model settings and missing catalog defaults

## Problem
Selecting OpenRouter after another image provider could leave `image_gen.model` set to a model such as `gpt-image-2-medium`. OpenRouter returned that configured value from `default_model()`, even though it was absent from `list_models()`, causing the setup picker to raise `KeyError`.

## Testing
- `python3 -m pytest -q tests/plugins/image_gen/test_openrouter_compat_provider.py tests/hermes_cli/test_tools_config.py` (51 passed)
- `git diff --check`