### PR TITLE
fix(auxiliary): keep ZAI Coding Plan routing

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1010,15 +1010,23 @@ def _to_openai_base_url(base_url: str) -> str:
     Some providers (MiniMax, MiniMax-CN) expose an ``/anthropic`` endpoint for
     the Anthropic Messages API and a separate ``/v1`` endpoint for OpenAI chat
     completions.  The auxiliary client uses the OpenAI SDK, so it must hit the
-    ``/v1`` surface.  Passing the raw ``inference_base_url`` causes requests to
-    land on ``/anthropic/chat/completions`` — a 404.
+    provider's OpenAI-compatible surface.  Passing the raw
+    ``inference_base_url`` causes requests to land on
+    ``/anthropic/chat/completions`` — a 404.
+
+    ZAI exposes its general API and Coding Plan on separate endpoints.  Its
+    Anthropic-compatible Coding Plan endpoint maps to ``/api/coding/paas/v4``
+    on the OpenAI wire, not the general ``/api/paas/v4`` endpoint.  Rewriting
+    to the general endpoint changes the billing pool and can return a false
+    insufficient-balance error for a valid Coding Plan key.
     """
     url = str(base_url or "").strip().rstrip("/")
     if url.endswith("/anthropic"):
-        # ZAI (open.bigmodel.cn) uses /api/anthropic for Anthropic wire
-        # but /api/paas/v4 for OpenAI wire — the generic /v1 rewrite is wrong.
-        if "open.bigmodel.cn" in url or "bigmodel" in url:
-            rewritten = url[: -len("/anthropic")] + "/paas/v4"
+        # ZAI uses /api/anthropic for the Coding Plan's Anthropic wire.  The
+        # matching OpenAI-wire endpoint is /api/coding/paas/v4; /api/paas/v4
+        # is the independently billed general API.
+        if "open.bigmodel.cn" in url or "bigmodel" in url or "api.z.ai" in url:
+            rewritten = url[: -len("/anthropic")] + "/coding/paas/v4"
             logger.debug("Auxiliary client: rewrote ZAI base URL %s → %s", url, rewritten)
             return rewritten
         rewritten = url[: -len("/anthropic")] + "/v1"

--- a/tests/agent/test_minimax_auxiliary_url.py
+++ b/tests/agent/test_minimax_auxiliary_url.py
@@ -1,7 +1,9 @@
-"""Tests for MiniMax auxiliary client URL normalization.
+"""Tests for Anthropic-to-OpenAI auxiliary URL normalization.
 
 MiniMax and MiniMax-CN set inference_base_url to the /anthropic path.
-The auxiliary client uses the OpenAI SDK, which needs /v1 instead.
+The auxiliary client uses the OpenAI SDK, which needs /v1 instead. ZAI's
+Anthropic endpoint belongs to Coding Plan, whose OpenAI-compatible peer is the
+separately billed /api/coding/paas/v4 endpoint.
 """
 
 import sys
@@ -16,12 +18,17 @@ class TestToOpenaiBaseUrl:
     def test_minimax_global_anthropic_suffix_replaced(self):
         assert _to_openai_base_url("https://api.minimax.io/anthropic") == "https://api.minimax.io/v1"
 
+    def test_zai_anthropic_routes_to_coding_plan_openai_endpoint(self):
+        assert (
+            _to_openai_base_url("https://api.z.ai/api/anthropic")
+            == "https://api.z.ai/api/coding/paas/v4"
+        )
 
-
-
-
-
-
+    def test_bigmodel_anthropic_routes_to_coding_plan_openai_endpoint(self):
+        assert (
+            _to_openai_base_url("https://open.bigmodel.cn/api/anthropic")
+            == "https://open.bigmodel.cn/api/coding/paas/v4"
+        )
 
     def test_none(self):
         assert _to_openai_base_url(None) == ""


### PR DESCRIPTION
## What changed

- Route Z.AI Anthropic-compatible auxiliary URLs to the matching Coding Plan OpenAI endpoint, `/api/coding/paas/v4`.
- Cover both `api.z.ai` and `open.bigmodel.cn` hosts.
- Preserve the existing MiniMax `/anthropic` to `/v1` normalization.

## Why

The current rewrite sends Z.AI Coding Plan traffic to `/api/paas/v4`, which is the independently billed general API endpoint. A valid Coding Plan key can therefore receive a misleading insufficient-balance response even though the Coding Plan pool is available.

Z.AI documents the Coding Plan base URL separately from the general endpoint: https://docs.z.ai/guides/develop/http/introduction

## Validation

- `python -m pytest -q tests/agent/test_minimax_auxiliary_url.py` — 4 passed
- `python -m py_compile agent/auxiliary_client.py`
- `git diff origin/main...HEAD --check`