### PR TITLE
fix: archive, export SHA256, ACP, and kanban fixes

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -608,11 +608,29 @@ class SessionManager:
         model_cfg = config.get("model")
         default_model = ""
         config_provider = None
+        agent_cfg = config.get("agent")
+        if not isinstance(agent_cfg, dict):
+            agent_cfg = {}
         if isinstance(model_cfg, dict):
             default_model = str(model_cfg.get("default") or default_model)
             config_provider = model_cfg.get("provider")
         elif isinstance(model_cfg, str) and model_cfg.strip():
             default_model = model_cfg.strip()
+
+        try:
+            max_iterations = int(
+                agent_cfg.get("max_turns", config.get("max_turns", 90))
+            )
+            if max_iterations < 1:
+                raise ValueError("max_turns must be positive")
+        except (TypeError, ValueError):
+            max_iterations = 90
+
+        from hermes_constants import parse_reasoning_effort
+
+        reasoning_config = parse_reasoning_effort(
+            agent_cfg.get("reasoning_effort")
+        )
 
         configured_mcp_servers = [
             name
@@ -630,6 +648,8 @@ class SessionManager:
             "session_id": session_id,
             "session_db": self._get_db(),
             "model": model or default_model,
+            "max_iterations": max_iterations,
+            "reasoning_config": reasoning_config,
         }
 
         try:

--- a/cli.py
+++ b/cli.py
@@ -18162,6 +18162,15 @@ def main(
         # (and only) tool snapshot. See #51316.
         cli._single_query_mode = True
         if not cli._claim_active_session("cli", stderr=bool(quiet)):
+            # A dispatcher-spawned Kanban worker can lose the race for the
+            # global session cap after the task has already been claimed.
+            # Treat that as temporary backpressure, not a worker crash: the
+            # dispatcher already understands EX_TEMPFAIL and will requeue the
+            # task without incrementing its consecutive-failure counter.
+            if os.environ.get("HERMES_KANBAN_TASK"):
+                from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE
+
+                sys.exit(KANBAN_RATE_LIMIT_EXIT_CODE)
             sys.exit(1)
         try:
             query, single_query_images = _collect_query_images(query, image)

--- a/hermes_cli/session_export_md.py
+++ b/hermes_cli/session_export_md.py
@@ -161,7 +161,18 @@ def _export_body_without_hash(session: dict[str, Any], *, fmt: str, exported_at:
 
 
 def _body_for_digest(text: str) -> str:
-    return _SHA_LINE_RE.sub("- SHA256 of exported body: `pending`", text)
+    """Replace only the footer SHA line (last match) with ``pending``.
+
+    Session content (tool output quoting other exports) can contain SHA256
+    lines matching the same regex.  Using ``re.sub`` (all occurrences) would
+    also replace those embedded lines, producing a different digest than the
+    one computed at export time (which only replaced the placeholder).
+    """
+    matches = list(_SHA_LINE_RE.finditer(text))
+    if not matches:
+        return text
+    last = matches[-1]
+    return text[: last.start()] + "- SHA256 of exported body: `pending`" + text[last.end() :]
 
 
 def render_session_markdown(
@@ -172,10 +183,22 @@ def render_session_markdown(
         raise ValueError("fmt must be 'md' or 'qmd'")
     exported_at = time.time()
     body = _export_body_without_hash(session, fmt=fmt, exported_at=exported_at)
-    digest_body = body.replace("`__SHA256_PLACEHOLDER__`", "`pending`")
-    digest = hashlib.sha256(digest_body.encode("utf-8")).hexdigest()
+    # Replace only the footer placeholder (last occurrence) so embedded
+    # copies of the placeholder inside session content (e.g. tool output
+    # quoting this module's source) don't alter the digest.
+    placeholder = "`__SHA256_PLACEHOLDER__`"
+    footer_pos = body.rfind(placeholder)
+    if footer_pos == -1:
+        # No placeholder — shouldn't happen, but compute digest of full body.
+        digest_body = body
+        digest = hashlib.sha256(digest_body.encode("utf-8")).hexdigest()
+    else:
+        digest_body = body[:footer_pos] + "`pending`" + body[footer_pos + len(placeholder) :]
+        digest = hashlib.sha256(digest_body.encode("utf-8")).hexdigest()
     if include_verification:
-        return body.replace("__SHA256_PLACEHOLDER__", digest)
+        if footer_pos != -1:
+            return body[:footer_pos] + "`" + digest + "`" + body[footer_pos + len(placeholder) :]
+        return body
     before_verification = body.split("\n## Export verification\n", 1)[0].rstrip() + "\n"
     return before_verification
 
@@ -202,9 +225,10 @@ def verify_export_file(path: Path | str, session: dict[str, Any]) -> tuple[bool,
     if not p.exists():
         return False, "file missing"
     text = p.read_text(encoding="utf-8")
-    match = _SHA_LINE_RE.search(text)
-    if not match:
+    matches = list(_SHA_LINE_RE.finditer(text))
+    if not matches:
         return False, "sha256 marker missing"
+    match = matches[-1]  # footer is always the last SHA line
     actual = hashlib.sha256(_body_for_digest(text).encode("utf-8")).hexdigest()
     if actual != match.group(1):
         return False, "sha256 mismatch"

--- a/hermes_cli/session_export_md.py
+++ b/hermes_cli/session_export_md.py
@@ -284,7 +284,14 @@ def write_session_markdown(
     return path
 
 
-def append_manifest_entry(output_dir: Path | str, session: dict[str, Any], path: Path | str, *, fmt: str) -> Path:
+def append_manifest_entry(
+    output_dir: Path | str,
+    session: dict[str, Any],
+    path: Path | str,
+    *,
+    fmt: str,
+    source_fingerprint: str | None = None,
+) -> Path:
     out_dir = Path(output_dir).expanduser()
     out_dir.mkdir(parents=True, exist_ok=True)
     export_path = Path(path)
@@ -297,6 +304,8 @@ def append_manifest_entry(output_dir: Path | str, session: dict[str, Any], path:
         "sha256": file_sha256(export_path),
         "exported_at": time.time(),
     }
+    if source_fingerprint:
+        entry["source_fingerprint"] = source_fingerprint
     manifest = out_dir / "manifest.jsonl"
     with manifest.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(entry, ensure_ascii=False, sort_keys=True) + "\n")

--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -218,22 +218,57 @@ class SessionPortabilityMixin:
         decoded = self._decode_content(row["content"])
         return decoded if isinstance(decoded, str) else ""
 
-    def export_session(self, session_id: str) -> Optional[Dict[str, Any]]:
-        """Export a single session with all its messages as a dict."""
+    def export_session(
+        self,
+        session_id: str,
+        *,
+        include_compacted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Export a single session with its durable messages as a dict.
+
+        The default preserves the historical live-context export contract and
+        returns only active messages.  Destructive archive callers can opt in
+        to ``include_compacted`` so pre-compaction turns are preserved before
+        the source session is deleted.  Rewind/undo rows remain excluded:
+        those are inactive with ``compacted=0`` and are not durable transcript
+        history.
+        """
         session = self.get_session(session_id)
         if not session:
             return None
-        messages = self.get_messages(session_id)
+        messages = self.get_messages(
+            session_id,
+            include_inactive=include_compacted,
+        )
+        if include_compacted:
+            messages = [
+                message
+                for message in messages
+                if bool(message.get("active")) or bool(message.get("compacted"))
+            ]
         return {**session, "messages": messages}
 
-    def export_session_lineage(self, session_id: str) -> Optional[Dict[str, Any]]:
-        """Export a compression lineage as one logical session dict."""
+    def export_session_lineage(
+        self,
+        session_id: str,
+        *,
+        include_compacted: bool = False,
+    ) -> Optional[Dict[str, Any]]:
+        """Export a compression lineage as one logical session dict.
+
+        ``include_compacted=True`` is intended for verified archive-before-
+        delete workflows.  It retains compacted historical turns while still
+        excluding inactive rewind/undo rows.
+        """
         lineage_ids = self.get_compression_lineage(session_id)
         if not lineage_ids:
             return None
         segments = []
         for sid in lineage_ids:
-            segment = self.export_session(sid)
+            segment = self.export_session(
+                sid,
+                include_compacted=include_compacted,
+            )
             if segment:
                 segments.append(segment)
         if not segments:

--- a/scripts/archive_sessions.py
+++ b/scripts/archive_sessions.py
@@ -1,0 +1,746 @@
+#!/usr/bin/env python3
+"""Archive completed Jack-Hermes sessions before deleting local history."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import stat
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERMES_HOME = Path(
+    os.environ.get(
+        "HERMES_ARCHIVE_HOME",
+        "/opt/rent-oleg-runtime/data/hermes_jack_v2",
+    )
+)
+HERMES_SOURCE = Path(
+    os.environ.get("HERMES_ARCHIVE_SOURCE", str(HERMES_HOME / "hermes-agent"))
+)
+WEBUI_SOURCE = Path(
+    os.environ.get("HERMES_ARCHIVE_WEBUI_SOURCE", "/opt/hermes-jack-webui")
+)
+WEBUI_STATE = HERMES_HOME / "webui"
+WEBUI_SESSIONS = WEBUI_STATE / "sessions"
+WEBUI_URL = "http://127.0.0.1:8787"
+WEBUI_ARCHIVE_COOKIE = HERMES_HOME / ".webui-archive-session"
+STATE_DB = HERMES_HOME / "state.db"
+SESSIONS_DIR = HERMES_HOME / "sessions"
+VAULT = Path(
+    os.environ.get(
+        "HERMES_ARCHIVE_VAULT",
+        "/opt/rent-oleg-runtime/data/obsidian/jack_hermes_v2",
+    )
+)
+SESSION_ARCHIVE = VAULT / "10 Sessions"
+EVENT_LOG = VAULT / "90 System/Archive Logs/archive-events.jsonl"
+SYNCTHING_CONFIG = Path("/var/lib/hermes-jack/.config/syncthing/config.xml")
+SYNCTHING_API = "http://127.0.0.1:8384/rest"
+SYNCTHING_FOLDER = "jack-hermes-v2"
+MAC_DEVICE_ID = "VCRSNRS-ST5WDPR-J2AD5B6-LLFK7HE-MNNZKZV-6QAWWSG-WLXUVZX-UNTAHAK"
+
+sys.path.insert(0, str(HERMES_SOURCE))
+sys.path.insert(0, str(WEBUI_SOURCE))
+
+from hermes_cli.session_export_md import (  # noqa: E402
+    append_manifest_entry,
+    redact_session_data,
+    render_session_markdown,
+    safe_session_filename,
+    verify_export_file,
+    write_session_markdown,
+)
+from hermes_state import SessionDB  # noqa: E402
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def append_event(event: dict) -> None:
+    EVENT_LOG.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"at": utc_now(), **event}
+    with EVENT_LOG.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def syncthing_api_key() -> str:
+    root = ET.parse(SYNCTHING_CONFIG).getroot()
+    key = root.findtext("./gui/apikey")
+    if not key:
+        raise RuntimeError("Syncthing API key is missing")
+    return key
+
+
+def syncthing_json(
+    endpoint: str,
+    *,
+    params: dict[str, str] | None = None,
+    method: str = "GET",
+) -> dict:
+    query = "?" + urllib.parse.urlencode(params or {}) if params else ""
+    request = urllib.request.Request(
+        SYNCTHING_API + endpoint + query,
+        data=b"" if method == "POST" else None,
+        method=method,
+        headers={"X-API-Key": syncthing_api_key()},
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        return json.load(response) if response.length != 0 else {}
+
+
+def remote_connected() -> bool:
+    payload = syncthing_json("/system/connections")
+    return bool(
+        payload.get("connections", {})
+        .get(MAC_DEVICE_ID, {})
+        .get("connected")
+    )
+
+
+def trigger_scan(relative_path: str) -> None:
+    syncthing_json(
+        "/db/scan",
+        params={"folder": SYNCTHING_FOLDER, "sub": relative_path},
+        method="POST",
+    )
+
+
+def local_index_has_file(relative_path: str, expected_size: int) -> bool:
+    try:
+        payload = syncthing_json(
+            "/db/file",
+            params={"folder": SYNCTHING_FOLDER, "file": relative_path},
+        )
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return False
+        raise
+    local = payload.get("local") or {}
+    return (
+        local.get("name") == relative_path
+        and int(local.get("size") or -1) == expected_size
+        and not local.get("deleted", False)
+        and not local.get("invalid", False)
+    )
+
+
+def remote_complete() -> bool:
+    if not remote_connected():
+        return False
+    payload = syncthing_json(
+        "/db/completion",
+        params={"device": MAC_DEVICE_ID, "folder": SYNCTHING_FOLDER},
+    )
+    return (
+        payload.get("remoteState") == "valid"
+        and float(payload.get("completion") or 0) == 100.0
+        and int(payload.get("needItems") or 0) == 0
+        and int(payload.get("needBytes") or 0) == 0
+        and int(payload.get("needDeletes") or 0) == 0
+    )
+
+
+def wait_for_remote(relative_path: str, expected_size: int, timeout: int) -> bool:
+    """Wait for Syncthing to index the file and (if online) confirm remote delivery.
+
+    Returns True if remote confirmed, False if remote was offline and only
+    local indexing completed.  When the remote device is offline we do not
+    block the archive pipeline — the file is already in the local vault and
+    Syncthing (sendonly) will sync it when the remote reappears.
+    """
+    deadline = time.monotonic() + timeout
+    indexed = False
+    remote_was_online = remote_connected()
+    while time.monotonic() < deadline:
+        if not indexed:
+            indexed = local_index_has_file(relative_path, expected_size)
+        if indexed and remote_complete():
+            return True
+        if indexed and not remote_was_online:
+            # Remote device is offline — local index is sufficient.
+            # Syncthing will deliver when the remote reconnects.
+            return False
+        time.sleep(2)
+    raise TimeoutError(
+        f"Syncthing indexing timed out for {relative_path}"
+    )
+
+
+def webui_sidecar(session_id: str) -> Path:
+    candidate = (WEBUI_SESSIONS / f"{session_id}.json").resolve()
+    candidate.relative_to(WEBUI_SESSIONS.resolve())
+    return candidate
+
+
+def durable_message_count(data: dict) -> int:
+    segments = data.get("segments")
+    if isinstance(segments, list) and segments:
+        return sum(
+            len(segment.get("messages") or [])
+            for segment in segments
+            if isinstance(segment, dict)
+        )
+    return len(data.get("messages") or [])
+
+
+def export_snapshot_fingerprint(data: dict) -> str:
+    """Hash only durable transcript identity/content, excluding live counters."""
+    segments = data.get("segments")
+    if not isinstance(segments, list) or not segments:
+        segments = [data]
+    payload = {
+        "session_id": str(data.get("id") or data.get("session_id") or ""),
+        "lineage_session_ids": list(data.get("lineage_session_ids") or []),
+        "segments": [
+            {
+                "id": str(segment.get("id") or segment.get("session_id") or ""),
+                "messages": list(segment.get("messages") or []),
+            }
+            for segment in segments
+            if isinstance(segment, dict)
+        ],
+    }
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def manifest_source_fingerprint(output_dir: Path, export_path: Path) -> str | None:
+    manifest = output_dir / "manifest.jsonl"
+    if not manifest.exists():
+        return None
+    expected_path = str(export_path)
+    found = None
+    for raw_line in manifest.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip():
+            continue
+        try:
+            entry = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if str(entry.get("path") or "") == expected_path:
+            found = entry.get("source_fingerprint")
+    return str(found) if found else None
+
+
+def revision_export_path(base_path: Path, source_fingerprint: str) -> Path:
+    return base_path.with_name(
+        f"{base_path.stem}-rev-{source_fingerprint[:12]}{base_path.suffix}"
+    )
+
+
+def write_export_revision(
+    data: dict,
+    output_dir: Path,
+    export_path: Path,
+    source_fingerprint: str,
+) -> Path:
+    """Write one immutable export revision and record its source snapshot."""
+    if export_path.exists():
+        ok, reason = verify_export_file(export_path, data)
+        if not ok:
+            raise RuntimeError(f"existing export revision failed verification: {reason}")
+        recorded = manifest_source_fingerprint(output_dir, export_path)
+        if recorded and recorded != source_fingerprint:
+            raise RuntimeError("existing export revision fingerprint mismatch")
+        if not recorded:
+            append_manifest_entry(
+                output_dir,
+                data,
+                export_path,
+                fmt="md",
+                source_fingerprint=source_fingerprint,
+            )
+        return export_path
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with export_path.open("x", encoding="utf-8") as handle:
+        handle.write(render_session_markdown(data, fmt="md"))
+    append_manifest_entry(
+        output_dir,
+        data,
+        export_path,
+        fmt="md",
+        source_fingerprint=source_fingerprint,
+    )
+    return export_path
+
+
+def webui_session_is_active(session_id: str) -> bool:
+    sidecar = webui_sidecar(session_id)
+    if sidecar.exists():
+        data = json.loads(sidecar.read_text(encoding="utf-8"))
+        if (
+            data.get("active_stream_id")
+            or data.get("pending_started_at")
+            or data.get("pending_user_message")
+        ):
+            return True
+
+    request = urllib.request.Request(
+        WEBUI_URL + "/health",
+        headers={"Accept": "application/json"},
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        health = json.load(response)
+    for run in health.get("runs") or []:
+        if str((run or {}).get("session_id") or "") == session_id:
+            return True
+    return False
+
+
+def webui_archive_cookie() -> str:
+    info = WEBUI_ARCHIVE_COOKIE.stat()
+    if info.st_uid != os.getuid() or stat.S_IMODE(info.st_mode) != 0o600:
+        raise RuntimeError(
+            f"unsafe WebUI archive credential permissions: {WEBUI_ARCHIVE_COOKIE}"
+        )
+    value = WEBUI_ARCHIVE_COOKIE.read_text(encoding="utf-8").strip()
+    if not value:
+        raise RuntimeError("WebUI archive credential is empty")
+    return value
+
+
+def delete_webui_session(session_id: str) -> None:
+    if webui_session_is_active(session_id):
+        raise RuntimeError(f"refusing to delete active WebUI session: {session_id}")
+
+    cookie_value = webui_archive_cookie()
+    from api.auth import (  # noqa: PLC0415
+        _resolve_cookie_name,
+        csrf_token_for_session,
+        verify_session,
+    )
+
+    if not verify_session(cookie_value):
+        raise RuntimeError("WebUI archive credential is invalid or expired")
+    csrf_token = csrf_token_for_session(cookie_value)
+    if not csrf_token:
+        raise RuntimeError("could not derive WebUI archive CSRF token")
+
+    payload = json.dumps({"session_id": session_id}).encode("utf-8")
+    request = urllib.request.Request(
+        WEBUI_URL + "/api/session/delete",
+        data=payload,
+        method="POST",
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Cookie": f"{_resolve_cookie_name()}={cookie_value}",
+            "X-Hermes-CSRF-Token": csrf_token,
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            result = json.load(response)
+    except urllib.error.HTTPError as exc:
+        body = exc.read(512).decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"WebUI session delete returned HTTP {exc.code}: {body}"
+        ) from exc
+    if result.get("ok") is not True:
+        raise RuntimeError(f"WebUI session delete failed: {result}")
+    if webui_sidecar(session_id).exists():
+        raise RuntimeError(f"WebUI sidecar survived deletion: {session_id}")
+
+
+def ended_candidates(db: SessionDB, session_id: str | None, min_age: int) -> list[str]:
+    cutoff = time.time() - min_age
+    all_rows = db.list_sessions_rich(
+        limit=1000,
+        include_children=True,
+        include_archived=False,
+        project_compression_tips=False,
+        order_by_last_active=True,
+        min_message_count=0,
+        compact_rows=True,
+    )
+    if session_id:
+        resolved = db.resolve_session_id(session_id)
+        rows = (
+            [row for row in all_rows if row.get("id") == resolved]
+            if resolved
+            else []
+        )
+        if resolved and not rows:
+            rows = [{"id": resolved}]
+    else:
+        rows = all_rows
+
+    rows_by_id = {str(row.get("id") or ""): row for row in rows}
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        candidate_id = row.get("id")
+        if not candidate_id:
+            continue
+        lineage = db.get_compression_lineage(candidate_id)
+        if not lineage:
+            continue
+        tip = db.get_session(lineage[-1])
+        if not tip or tip.get("ended_at") is None:
+            continue
+        if float(tip["ended_at"]) > cutoff:
+            continue
+        tip_row = rows_by_id.get(str(tip.get("id") or ""), tip)
+        last_active = float(
+            tip_row.get("last_active")
+            or tip_row.get("started_at")
+            or tip.get("ended_at")
+            or 0
+        )
+        if last_active > cutoff:
+            # A WebUI session may resume under the same ID after an idle seal.
+            # Wait a full grace period from actual activity, not stale ended_at.
+            continue
+        logical_id = lineage[0]
+        if logical_id not in seen:
+            seen.add(logical_id)
+            candidates.append(logical_id)
+    return candidates
+
+
+def idle_webui_candidates(db: SessionDB, min_idle: int) -> list[str]:
+    """Return inactive WebUI sessions that can be safely sealed.
+
+    A row is eligible only when both persistence layers agree that it is idle:
+    the Hermes DB has seen no activity for ``min_idle`` seconds and WebUI has
+    neither a live run nor pending input for the session.
+    """
+    cutoff = time.time() - max(min_idle, 0)
+    rows = db.list_sessions_rich(
+        limit=1000,
+        include_children=False,
+        include_archived=True,
+        project_compression_tips=False,
+        order_by_last_active=True,
+        min_message_count=1,
+        compact_rows=True,
+    )
+    candidates: list[str] = []
+    for row in rows:
+        session_id = str(row.get("id") or "")
+        if not session_id or row.get("source") != "webui":
+            continue
+        if row.get("ended_at") is not None:
+            continue
+        last_active = float(row.get("last_active") or row.get("started_at") or 0)
+        if last_active <= 0 or last_active > cutoff:
+            continue
+        if webui_session_is_active(session_id):
+            continue
+        candidates.append(session_id)
+    return candidates
+
+
+def seal_idle_webui_sessions(db: SessionDB, min_idle: int) -> list[str]:
+    """Mark safely idle WebUI sessions complete so the archive gate can export them."""
+    sealed: list[str] = []
+    for session_id in idle_webui_candidates(db, min_idle):
+        # Re-check immediately before the mutation to close the check/use gap.
+        if webui_session_is_active(session_id):
+            continue
+        db.end_session(session_id, "webui_idle_archive")
+        row = db.get_session(session_id)
+        if not row or row.get("ended_at") is None:
+            raise RuntimeError(f"failed to seal idle WebUI session: {session_id}")
+        sealed.append(session_id)
+        append_event(
+            {
+                "event": "session_sealed",
+                "session_id": session_id,
+                "source": "webui",
+                "end_reason": "webui_idle_archive",
+            }
+        )
+    return sealed
+
+
+def seal_idle_non_webui_sessions(db: SessionDB, min_idle: int) -> list[str]:
+    """Mark idle CLI, Telegram, and ACP sessions complete so the archive gate can export them.
+
+    Unlike WebUI sessions, these sources have no live-stream probe — once they
+    have been inactive for ``min_idle`` seconds they are considered safely
+    sealable.  Subagent sessions are NOT handled here: they already receive
+    ``ended_at`` from the agent loop and are picked up by ``ended_candidates``
+    directly.
+    """
+    cutoff = time.time() - max(min_idle, 0)
+    rows = db.list_sessions_rich(
+        limit=1000,
+        include_children=False,
+        include_archived=False,
+        project_compression_tips=False,
+        order_by_last_active=True,
+        min_message_count=0,
+        compact_rows=True,
+    )
+    sealable_sources = {"cli", "telegram", "acp"}
+    sealed: list[str] = []
+    for row in rows:
+        session_id = str(row.get("id") or "")
+        source = row.get("source")
+        if not session_id or source not in sealable_sources:
+            continue
+        if row.get("ended_at") is not None:
+            continue
+        last_active = float(row.get("last_active") or row.get("started_at") or 0)
+        if last_active <= 0 or last_active > cutoff:
+            continue
+        db.end_session(session_id, "idle_archive_seal")
+        row2 = db.get_session(session_id)
+        if not row2 or row2.get("ended_at") is None:
+            raise RuntimeError(f"failed to seal idle {source} session: {session_id}")
+        sealed.append(session_id)
+        append_event(
+            {
+                "event": "session_sealed",
+                "session_id": session_id,
+                "source": source,
+                "end_reason": "idle_archive_seal",
+                "last_active": last_active,
+            }
+        )
+    return sealed
+
+
+def archive_one(
+    db: SessionDB,
+    session_id: str,
+    *,
+    delete_after_sync: bool,
+    timeout: int,
+) -> dict:
+    data = db.export_session_lineage(session_id, include_compacted=True)
+    if not data:
+        raise RuntimeError(f"session disappeared before export: {session_id}")
+    if data.get("source") == "webui" and webui_session_is_active(session_id):
+        raise RuntimeError(f"refusing to export active WebUI session: {session_id}")
+    data = redact_session_data(data)
+    source_fingerprint = export_snapshot_fingerprint(data)
+
+    ended_at = data.get("ended_at") or time.time()
+    month = datetime.fromtimestamp(float(ended_at), tz=timezone.utc)
+    output_dir = SESSION_ARCHIVE / f"{month:%Y}" / f"{month:%m}"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    base_export_path = output_dir / safe_session_filename(data, fmt="md")
+    export_path = base_export_path
+
+    if export_path.exists():
+        ok, reason = verify_export_file(export_path, data)
+        recorded_fingerprint = manifest_source_fingerprint(output_dir, export_path)
+        if ok and recorded_fingerprint == source_fingerprint:
+            pass
+        elif not ok and reason != "message count mismatch":
+            raise RuntimeError(f"existing export failed verification: {reason}")
+        else:
+            # Preserve the earlier internally-valid snapshot.  A resumed
+            # session or later compaction legitimately changes the source;
+            # publishing a content-addressed revision avoids overwriting it.
+            export_path = revision_export_path(
+                base_export_path,
+                source_fingerprint,
+            )
+            write_export_revision(
+                data,
+                output_dir,
+                export_path,
+                source_fingerprint,
+            )
+    else:
+        export_path = write_session_markdown(
+            data,
+            output_dir,
+            fmt="md",
+            force=False,
+        )
+        append_manifest_entry(
+            output_dir,
+            data,
+            export_path,
+            fmt="md",
+            source_fingerprint=source_fingerprint,
+        )
+
+    ok, reason = verify_export_file(export_path, data)
+    if not ok:
+        raise RuntimeError(f"export verification failed: {reason}")
+
+    relative_path = export_path.relative_to(VAULT).as_posix()
+    trigger_scan(relative_path)
+    remote_confirmed = wait_for_remote(relative_path, export_path.stat().st_size, timeout)
+
+    fresh_data = db.export_session_lineage(session_id, include_compacted=True)
+    if not fresh_data:
+        raise RuntimeError(f"session disappeared during archive: {session_id}")
+    fresh_data = redact_session_data(fresh_data)
+    if export_snapshot_fingerprint(fresh_data) != source_fingerprint:
+        raise RuntimeError(f"session changed during archive: {session_id}")
+    if data.get("source") == "webui" and webui_session_is_active(session_id):
+        raise RuntimeError(f"refusing to delete active WebUI session: {session_id}")
+
+    lineage = list(data.get("lineage_session_ids") or [data["id"]])
+    deleted: list[str] = []
+    webui_deleted: list[str] = []
+    if delete_after_sync:
+        for lineage_id in reversed(lineage):
+            if webui_sidecar(lineage_id).exists():
+                delete_webui_session(lineage_id)
+                webui_deleted.append(lineage_id)
+        for lineage_id in reversed(lineage):
+            if db.delete_session(lineage_id, sessions_dir=SESSIONS_DIR):
+                deleted.append(lineage_id)
+            elif not db.get_session(lineage_id):
+                deleted.append(lineage_id)
+
+    result = {
+        "event": "session_archived",
+        "session_id": session_id,
+        "lineage_session_ids": lineage,
+        "archive_path": relative_path,
+        "archive_sha256": hashlib.sha256(export_path.read_bytes()).hexdigest(),
+        "archive_message_count": durable_message_count(data),
+        "source_fingerprint": source_fingerprint,
+        "remote_device": MAC_DEVICE_ID,
+        "remote_confirmed": remote_confirmed,
+        "deleted_session_ids": deleted,
+        "deleted_webui_session_ids": webui_deleted,
+        "delete_after_sync": delete_after_sync,
+    }
+    append_event(result)
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--session-id")
+    parser.add_argument("--min-age-seconds", type=int, default=900)
+    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument("--max-sessions", type=int, default=20)
+    parser.add_argument("--delete-after-sync", action="store_true")
+    parser.add_argument(
+        "--seal-idle-webui-seconds",
+        type=int,
+        default=0,
+        help="mark inactive WebUI sessions complete before selecting archive candidates",
+    )
+    parser.add_argument(
+        "--list-idle-webui",
+        action="store_true",
+        help="print inactive WebUI candidates without changing state",
+    )
+    parser.add_argument(
+        "--seal-idle-non-webui-seconds",
+        type=int,
+        default=0,
+        help="mark inactive CLI/Telegram/ACP sessions complete before selecting archive candidates",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    HERMES_HOME.mkdir(parents=True, exist_ok=True)
+    lock_path = HERMES_HOME / "session-archive.lock"
+    with lock_path.open("w", encoding="utf-8") as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            print("archive run already in progress")
+            return 0
+
+        if not STATE_DB.exists():
+            print("no state.db; nothing to archive")
+            return 0
+
+        db = SessionDB(db_path=STATE_DB)
+        try:
+            if args.list_idle_webui:
+                candidates = idle_webui_candidates(
+                    db,
+                    max(args.seal_idle_webui_seconds, 0),
+                )
+                print(json.dumps({"idle_webui_sessions": candidates}, sort_keys=True))
+                return 0
+
+            if args.seal_idle_webui_seconds > 0:
+                sealed = seal_idle_webui_sessions(
+                    db,
+                    args.seal_idle_webui_seconds,
+                )
+                if sealed:
+                    print(
+                        json.dumps(
+                            {"sealed_idle_webui_sessions": sealed},
+                            ensure_ascii=False,
+                            sort_keys=True,
+                        )
+                    )
+
+            if args.seal_idle_non_webui_seconds > 0:
+                sealed_non_webui = seal_idle_non_webui_sessions(
+                    db,
+                    args.seal_idle_non_webui_seconds,
+                )
+                if sealed_non_webui:
+                    print(
+                        json.dumps(
+                            {"sealed_idle_non_webui_sessions": sealed_non_webui},
+                            ensure_ascii=False,
+                            sort_keys=True,
+                        )
+                    )
+
+            candidates = ended_candidates(
+                db,
+                args.session_id,
+                max(args.min_age_seconds, 0),
+            )[: max(args.max_sessions, 0)]
+            if not candidates:
+                print("no completed sessions eligible for archive")
+                return 0
+
+            failures = 0
+            for session_id in candidates:
+                try:
+                    result = archive_one(
+                        db,
+                        session_id,
+                        delete_after_sync=args.delete_after_sync,
+                        timeout=max(args.timeout, 1),
+                    )
+                    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+                except Exception as exc:
+                    failures += 1
+                    append_event(
+                        {
+                            "event": "session_archive_failed",
+                            "session_id": session_id,
+                            "error": str(exc),
+                            "delete_after_sync": args.delete_after_sync,
+                        }
+                    )
+                    print(f"archive failed for {session_id}: {exc}", file=sys.stderr)
+            return 1 if failures else 0
+        finally:
+            db.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/archive_sessions.py
+++ b/scripts/archive_sessions.py
@@ -47,7 +47,7 @@ EVENT_LOG = VAULT / "90 System/Archive Logs/archive-events.jsonl"
 SYNCTHING_CONFIG = Path("/var/lib/hermes-jack/.config/syncthing/config.xml")
 SYNCTHING_API = "http://127.0.0.1:8384/rest"
 SYNCTHING_FOLDER = "jack-hermes-v2"
-MAC_DEVICE_ID = "VCRSNRS-ST5WDPR-J2AD5B6-LLFK7HE-MNNZKZV-6QAWWSG-WLXUVZX-UNTAHAK"
+MAC_DEVICE_ID = os.environ.get("HERMES_ARCHIVE_SYNC_DEVICE_ID", "").strip()
 
 sys.path.insert(0, str(HERMES_SOURCE))
 sys.path.insert(0, str(WEBUI_SOURCE))
@@ -65,6 +65,12 @@ from hermes_state import SessionDB  # noqa: E402
 
 def utc_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def syncthing_remote_device_id() -> str:
+    if not MAC_DEVICE_ID:
+        raise RuntimeError("HERMES_ARCHIVE_SYNC_DEVICE_ID is not configured")
+    return MAC_DEVICE_ID
 
 
 def append_event(event: dict) -> None:
@@ -100,10 +106,11 @@ def syncthing_json(
 
 
 def remote_connected() -> bool:
+    device_id = syncthing_remote_device_id()
     payload = syncthing_json("/system/connections")
     return bool(
         payload.get("connections", {})
-        .get(MAC_DEVICE_ID, {})
+        .get(device_id, {})
         .get("connected")
     )
 
@@ -136,11 +143,12 @@ def local_index_has_file(relative_path: str, expected_size: int) -> bool:
 
 
 def remote_complete() -> bool:
+    device_id = syncthing_remote_device_id()
     if not remote_connected():
         return False
     payload = syncthing_json(
         "/db/completion",
-        params={"device": MAC_DEVICE_ID, "folder": SYNCTHING_FOLDER},
+        params={"device": device_id, "folder": SYNCTHING_FOLDER},
     )
     return (
         payload.get("remoteState") == "valid"
@@ -617,7 +625,7 @@ def archive_one(
         "archive_sha256": hashlib.sha256(export_path.read_bytes()).hexdigest(),
         "archive_message_count": durable_message_count(data),
         "source_fingerprint": source_fingerprint,
-        "remote_device": MAC_DEVICE_ID,
+        "remote_device": syncthing_remote_device_id(),
         "remote_confirmed": remote_confirmed,
         "deleted_session_ids": deleted,
         "deleted_webui_session_ids": webui_deleted,

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -81,6 +81,10 @@ class TestCreateSession:
                     "default": "fake-model",
                     "provider": "fake-provider",
                 },
+                "agent": {
+                    "max_turns": 100,
+                    "reasoning_effort": "high",
+                },
                 "mcp_servers": {},
             },
             raising=False,
@@ -91,6 +95,10 @@ class TestCreateSession:
                 "model": {
                     "default": "fake-model",
                     "provider": "fake-provider",
+                },
+                "agent": {
+                    "max_turns": 100,
+                    "reasoning_effort": "high",
                 },
                 "mcp_servers": {},
             },
@@ -109,6 +117,11 @@ class TestCreateSession:
         state = SessionManager(db=None).create_session(cwd="/tmp/project")
 
         assert state.agent.session_cwd == "/tmp/project"
+        assert state.agent.kwargs["max_iterations"] == 100
+        assert state.agent.kwargs["reasoning_config"] == {
+            "enabled": True,
+            "effort": "high",
+        }
 
 
 

--- a/tests/hermes_cli/test_cli_active_session_limit.py
+++ b/tests/hermes_cli/test_cli_active_session_limit.py
@@ -1,8 +1,14 @@
+import signal
+
+import pytest
+
+import cli as cli_mod
 from cli import HermesCLI
 from hermes_cli.active_sessions import (
     active_session_registry_snapshot,
     try_acquire_active_session,
 )
+from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE
 
 
 def test_cli_claim_active_session_respects_global_limit(tmp_path, monkeypatch):
@@ -39,3 +45,39 @@ def test_cli_claim_active_session_respects_global_limit(tmp_path, monkeypatch):
     finally:
         held.release()
         cli._release_active_session()
+
+
+def _install_rejecting_cli(monkeypatch):
+    class RejectingCLI:
+        def __init__(self, **_kwargs):
+            self.session_id = "rejected-session"
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            assert surface == "cli"
+            assert stderr is True
+            return False
+
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {})
+    monkeypatch.setattr(cli_mod, "HermesCLI", RejectingCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(signal, "signal", lambda *_args, **_kwargs: None)
+
+
+def test_kanban_worker_session_limit_is_temporary_backpressure(monkeypatch):
+    _install_rejecting_cli(monkeypatch)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_backpressure")
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_mod.main(query="work kanban task", quiet=True, toolsets="terminal")
+
+    assert exc_info.value.code == KANBAN_RATE_LIMIT_EXIT_CODE
+
+
+def test_human_cli_session_limit_remains_a_regular_failure(monkeypatch):
+    _install_rejecting_cli(monkeypatch)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli_mod.main(query="hello", quiet=True, toolsets="terminal")
+
+    assert exc_info.value.code == 1

--- a/tests/ops/test_archive_sessions.py
+++ b/tests/ops/test_archive_sessions.py
@@ -11,6 +11,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[2]
 os.environ.setdefault("HERMES_ARCHIVE_SOURCE", str(ROOT))
 os.environ.setdefault("HERMES_ARCHIVE_HOME", "/tmp/hermes-archive-regression-home")
+os.environ.setdefault("HERMES_ARCHIVE_SYNC_DEVICE_ID", "test-device")
 
 from hermes_cli.session_export_md import (  # noqa: E402
     append_manifest_entry,
@@ -238,3 +239,13 @@ def test_ended_candidate_becomes_eligible_after_latest_activity_grace():
     db = CandidateDB(last_active=time.time() - 120)
 
     assert archive.ended_candidates(db, None, min_age=60) == [SESSION_ID]
+
+
+def test_syncthing_device_id_must_be_configured(monkeypatch):
+    monkeypatch.setattr(archive, "MAC_DEVICE_ID", "")
+
+    with pytest.raises(
+        RuntimeError,
+        match="HERMES_ARCHIVE_SYNC_DEVICE_ID is not configured",
+    ):
+        archive.syncthing_remote_device_id()

--- a/tests/ops/test_archive_sessions.py
+++ b/tests/ops/test_archive_sessions.py
@@ -1,0 +1,240 @@
+import copy
+import importlib.util
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+os.environ.setdefault("HERMES_ARCHIVE_SOURCE", str(ROOT))
+os.environ.setdefault("HERMES_ARCHIVE_HOME", "/tmp/hermes-archive-regression-home")
+
+from hermes_cli.session_export_md import (  # noqa: E402
+    append_manifest_entry,
+    verify_export_file,
+    write_session_markdown,
+)
+
+ARCHIVE_SCRIPT = ROOT / "scripts" / "archive_sessions.py"
+_archive_spec = importlib.util.spec_from_file_location(
+    "hermes_runtime_archive_sessions",
+    ARCHIVE_SCRIPT,
+)
+assert _archive_spec is not None and _archive_spec.loader is not None
+archive = importlib.util.module_from_spec(_archive_spec)
+_archive_spec.loader.exec_module(archive)
+
+
+SESSION_ID = "519dcf294078"
+
+
+def _data(contents, *, source="webui"):
+    messages = [
+        {
+            "id": index,
+            "session_id": SESSION_ID,
+            "role": "user" if index % 2 else "assistant",
+            "content": content,
+            "timestamp": 1_800_000_000 + index,
+            "active": 1,
+            "compacted": 0,
+        }
+        for index, content in enumerate(contents, start=1)
+    ]
+    segment = {
+        "id": SESSION_ID,
+        "source": source,
+        "title": "session",
+        "started_at": 1_799_999_000.0,
+        "ended_at": 1_800_000_100.0,
+        "messages": messages,
+    }
+    return {
+        **segment,
+        "segments": [segment],
+        "lineage_session_ids": [SESSION_ID],
+        "message_count": len(messages),
+    }
+
+
+class FakeDB:
+    def __init__(self, snapshots):
+        self.snapshots = [copy.deepcopy(item) for item in snapshots]
+        self.export_calls = []
+        self.deleted = []
+
+    def export_session_lineage(self, session_id, *, include_compacted=False):
+        self.export_calls.append((session_id, include_compacted))
+        index = min(len(self.export_calls) - 1, len(self.snapshots) - 1)
+        return copy.deepcopy(self.snapshots[index])
+
+    def delete_session(self, session_id, sessions_dir=None):
+        self.deleted.append(session_id)
+        return True
+
+    def get_session(self, session_id):
+        return self.snapshots[-1]
+
+
+def _isolate_archive(monkeypatch, tmp_path, *, active=False):
+    vault = tmp_path / "vault"
+    monkeypatch.setattr(archive, "VAULT", vault)
+    monkeypatch.setattr(archive, "SESSION_ARCHIVE", vault / "10 Sessions")
+    monkeypatch.setattr(archive, "trigger_scan", lambda _path: None)
+    monkeypatch.setattr(archive, "wait_for_remote", lambda *_args: True)
+    monkeypatch.setattr(archive, "append_event", lambda _event: None)
+    monkeypatch.setattr(archive, "webui_session_is_active", lambda _sid: active)
+    return vault
+
+
+def test_active_webui_session_is_rejected_before_export(monkeypatch, tmp_path):
+    vault = _isolate_archive(monkeypatch, tmp_path, active=True)
+    db = FakeDB([_data(["still running"])])
+
+    with pytest.raises(RuntimeError, match="refusing to export active WebUI"):
+        archive.archive_one(
+            db,
+            SESSION_ID,
+            delete_after_sync=True,
+            timeout=1,
+        )
+
+    assert db.export_calls == [(SESSION_ID, True)]
+    assert db.deleted == []
+    assert not vault.exists()
+
+
+def test_stale_valid_export_is_preserved_and_new_revision_is_verified(
+    monkeypatch,
+    tmp_path,
+):
+    vault = _isolate_archive(monkeypatch, tmp_path)
+    old_data = _data(["old snapshot"])
+    current_data = _data(["old snapshot", "continued turn"])
+    output_dir = vault / "10 Sessions" / "2027" / "01"
+    base_path = write_session_markdown(old_data, output_dir)
+    append_manifest_entry(output_dir, old_data, base_path, fmt="md")
+    old_bytes = base_path.read_bytes()
+    db = FakeDB([current_data, current_data])
+
+    result = archive.archive_one(
+        db,
+        SESSION_ID,
+        delete_after_sync=False,
+        timeout=1,
+    )
+
+    revision_path = vault / result["archive_path"]
+    assert base_path.read_bytes() == old_bytes
+    assert revision_path != base_path
+    assert "-rev-" in revision_path.name
+    assert verify_export_file(revision_path, current_data) == (True, "ok")
+    assert result["archive_message_count"] == 2
+    assert db.export_calls == [(SESSION_ID, True), (SESSION_ID, True)]
+
+    entries = [
+        json.loads(line)
+        for line in (output_dir / "manifest.jsonl").read_text().splitlines()
+    ]
+    revision_entry = [entry for entry in entries if entry["path"] == str(revision_path)][-1]
+    assert revision_entry["source_fingerprint"] == result["source_fingerprint"]
+
+
+def test_corrupt_existing_export_is_not_bypassed_by_revision(monkeypatch, tmp_path):
+    vault = _isolate_archive(monkeypatch, tmp_path)
+    data = _data(["original snapshot"])
+    output_dir = vault / "10 Sessions" / "2027" / "01"
+    base_path = write_session_markdown(data, output_dir)
+    base_path.write_text(
+        base_path.read_text(encoding="utf-8") + "\ntampered\n",
+        encoding="utf-8",
+    )
+    db = FakeDB([data])
+
+    with pytest.raises(RuntimeError, match="sha256 mismatch"):
+        archive.archive_one(
+            db,
+            SESSION_ID,
+            delete_after_sync=False,
+            timeout=1,
+        )
+
+    assert list(output_dir.glob("*-rev-*.md")) == []
+    assert db.deleted == []
+
+
+def test_session_change_during_sync_prevents_delete(monkeypatch, tmp_path):
+    _isolate_archive(monkeypatch, tmp_path)
+    before = _data(["first snapshot"])
+    after = _data(["first snapshot", "late message"])
+    db = FakeDB([before, after])
+
+    with pytest.raises(RuntimeError, match="session changed during archive"):
+        archive.archive_one(
+            db,
+            SESSION_ID,
+            delete_after_sync=True,
+            timeout=1,
+        )
+
+    assert db.deleted == []
+
+
+def test_webui_reactivation_after_sync_prevents_delete(monkeypatch, tmp_path):
+    _isolate_archive(monkeypatch, tmp_path)
+    active_checks = iter([False, True])
+    monkeypatch.setattr(
+        archive,
+        "webui_session_is_active",
+        lambda _sid: next(active_checks),
+    )
+    data = _data(["stable snapshot"])
+    db = FakeDB([data, data])
+
+    with pytest.raises(RuntimeError, match="refusing to delete active WebUI"):
+        archive.archive_one(
+            db,
+            SESSION_ID,
+            delete_after_sync=True,
+            timeout=1,
+        )
+
+    assert db.deleted == []
+
+
+class CandidateDB:
+    def __init__(self, last_active):
+        self.last_active = last_active
+
+    def list_sessions_rich(self, **_kwargs):
+        return [
+            {
+                "id": SESSION_ID,
+                "last_active": self.last_active,
+                "started_at": self.last_active - 100,
+            }
+        ]
+
+    def get_compression_lineage(self, session_id):
+        return [session_id]
+
+    def get_session(self, session_id):
+        return {
+            "id": session_id,
+            "ended_at": self.last_active - 500,
+        }
+
+
+def test_ended_candidate_grace_uses_latest_activity_not_stale_ended_at():
+    db = CandidateDB(last_active=time.time() - 5)
+
+    assert archive.ended_candidates(db, None, min_age=60) == []
+
+
+def test_ended_candidate_becomes_eligible_after_latest_activity_grace():
+    db = CandidateDB(last_active=time.time() - 120)
+
+    assert archive.ended_candidates(db, None, min_age=60) == [SESSION_ID]

--- a/tests/test_session_export_compacted.py
+++ b/tests/test_session_export_compacted.py
@@ -1,0 +1,52 @@
+from hermes_state import SessionDB
+
+
+def test_export_lineage_can_include_compacted_but_not_rewound_rows(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        session_id = "archive-compacted"
+        db.create_session(session_id=session_id, source="webui")
+        db.append_message(session_id, role="user", content="original user")
+        db.append_message(session_id, role="assistant", content="original answer")
+
+        db.archive_and_compact(
+            session_id,
+            [
+                {"role": "user", "content": "compaction context"},
+                {"role": "assistant", "content": "compaction summary"},
+            ],
+        )
+        db.append_message(session_id, role="user", content="after compaction")
+        db.append_message(session_id, role="assistant", content="rewound answer")
+
+        def _rewind_last(conn):
+            conn.execute(
+                "UPDATE messages SET active = 0, compacted = 0 "
+                "WHERE session_id = ? AND content = ?",
+                (session_id, "rewound answer"),
+            )
+
+        db._execute_write(_rewind_last)
+
+        live = db.export_session_lineage(session_id)
+        durable = db.export_session_lineage(
+            session_id,
+            include_compacted=True,
+        )
+
+        assert [message["content"] for message in live["messages"]] == [
+            "compaction context",
+            "compaction summary",
+            "after compaction",
+        ]
+        assert [message["content"] for message in durable["messages"]] == [
+            "original user",
+            "original answer",
+            "compaction context",
+            "compaction summary",
+            "after compaction",
+        ]
+        assert durable["message_count"] == 5
+        assert durable["lineage_session_ids"] == [session_id]
+    finally:
+        db.close()


### PR DESCRIPTION
5 fixes for session archiving, export verification, ACP config propagation, and kanban backpressure handling.

## Commits

1. **fix(export): SHA256 verification** — session export SHA256 verification fails when session content embeds SHA lines or placeholder
2. **fix(acp): propagate turn and reasoning config** — ACP adapter wasn't propagating turn/reasoning config into sessions
3. **fix(archive): preserve durable session revisions** — full archive_sessions.py script for Obsidian session archiving
4. **fix(kanban): requeue workers on session backpressure** — kanban workers weren't requeued on backpressure
5. **fix(archive): configure sync device outside Git** — sync device configuration moved outside Git tracking