### PR TITLE
feat(insights): add per-day token/cost time-series aggregation (#77222)

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -20,7 +20,7 @@ import json
 import sqlite3
 import time
 from collections import Counter, defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from agent.usage_pricing import (
@@ -145,6 +145,7 @@ class InsightsEngine:
                     "top_skills": [],
                 },
                 "activity": {},
+                "daily_series": self._compute_daily_series(sessions, days),
                 "top_sessions": [],
             }
 
@@ -155,6 +156,7 @@ class InsightsEngine:
         tools = self._compute_tool_breakdown(tool_usage)
         skills = self._compute_skill_breakdown(skill_usage)
         activity = self._compute_activity_patterns(sessions)
+        daily_series = self._compute_daily_series(sessions, days)
         top_sessions = self._compute_top_sessions(sessions)
 
         return {
@@ -168,6 +170,7 @@ class InsightsEngine:
             "tools": tools,
             "skills": skills,
             "activity": activity,
+            "daily_series": daily_series,
             "top_sessions": top_sessions,
         }
 
@@ -829,6 +832,59 @@ class InsightsEngine:
             "active_days": active_days,
             "max_streak": max_streak,
         }
+
+    def _compute_daily_series(
+        self, sessions: List[Dict], days: int
+    ) -> Dict[str, Dict[str, Any]]:
+        """Aggregate token usage and estimated cost per calendar day.
+
+        Builds a per-day time series of token/cost buckets over the last
+        ``days`` calendar days, zero-filling days without sessions so
+        consumers (e.g. a cost/token intensity heatmap) get a continuous
+        axis without re-implementing ``_get_sessions`` + ``_estimate_cost``.
+
+        Returns a dict keyed by ``%Y-%m-%d`` in chronological order::
+
+            {
+                "2026-07-04": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_tokens": 0,
+                    "estimated_cost_usd": 0.0,
+                },
+                ...
+            }
+        """
+        # Zero-fill the whole window first so the axis is continuous,
+        # then accumulate sessions into it (keeps chronological order).
+        today = datetime.now()
+        series: Dict[str, Dict[str, Any]] = {}
+        for offset in range(days - 1, -1, -1):
+            day = (today - timedelta(days=offset)).strftime("%Y-%m-%d")
+            series[day] = {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "estimated_cost_usd": 0.0,
+            }
+
+        for s in sessions:
+            ts = s.get("started_at")
+            if not ts:
+                continue
+            day = datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+            bucket = series.get(day)
+            if bucket is None:
+                # Outside the requested window — matches the cutoff used by
+                # generate() when fetching sessions.
+                continue
+            bucket["input_tokens"] += s.get("input_tokens") or 0
+            bucket["output_tokens"] += s.get("output_tokens") or 0
+            bucket["cache_read_tokens"] += s.get("cache_read_tokens") or 0
+            estimated, _ = _estimate_cost(s)
+            bucket["estimated_cost_usd"] += estimated
+
+        return series
 
     def _compute_top_sessions(self, sessions: List[Dict]) -> List[Dict]:
         """Find notable sessions (longest, most messages, most tokens)."""

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -2,6 +2,7 @@
 
 import time
 import pytest
+from datetime import datetime
 
 from hermes_state import SessionDB
 from agent.insights import (
@@ -361,6 +362,116 @@ class TestInsightsPopulated:
         assert activity["active_days"] >= 1
         assert activity["busiest_day"] is not None
         assert activity["busiest_hour"] is not None
+
+
+class TestDailySeries:
+    def test_daily_series_shape_and_contiguity(self, populated_db):
+        engine = InsightsEngine(populated_db)
+        report = engine.generate(days=30)
+        series = report["daily_series"]
+
+        assert len(series) == 30
+        dates = list(series)
+        # Chronological and contiguous — a continuous axis for the heatmap.
+        for prev, cur in zip(dates, dates[1:]):
+            prev_dt = datetime.strptime(prev, "%Y-%m-%d")
+            cur_dt = datetime.strptime(cur, "%Y-%m-%d")
+            assert (cur_dt - prev_dt).days == 1
+        for bucket in series.values():
+            assert set(bucket) == {
+                "input_tokens",
+                "output_tokens",
+                "cache_read_tokens",
+                "estimated_cost_usd",
+            }
+
+    def test_daily_series_aggregates_tokens_and_cost(self, populated_db):
+        engine = InsightsEngine(populated_db)
+        report = engine.generate(days=30)
+        series = report["daily_series"]
+
+        # All 4 in-window sessions sum to the session-level totals.
+        assert sum(b["input_tokens"] for b in series.values()) == (
+            50000 + 20000 + 100000 + 10000
+        )
+        assert sum(b["output_tokens"] for b in series.values()) == (
+            15000 + 8000 + 40000 + 5000
+        )
+
+        # Session s4 (1 day ago, claude-sonnet) lands in a single day bucket.
+        s4_bucket = next(
+            b for b in series.values()
+            if b["input_tokens"] == 10000 and b["output_tokens"] == 5000
+        )
+        assert s4_bucket["estimated_cost_usd"] > 0
+
+        # The 45-day-old session is outside the 30-day window: no bucket
+        # carries its 5000/2000 tokens.
+        assert not any(
+            b["input_tokens"] == 5000 and b["output_tokens"] == 2000
+            for b in series.values()
+        )
+
+    def test_daily_series_zero_fills_empty_db(self, db):
+        engine = InsightsEngine(db)
+        report = engine.generate(days=7)
+        series = report["daily_series"]
+
+        assert len(series) == 7
+        assert all(
+            b["input_tokens"] == 0
+            and b["output_tokens"] == 0
+            and b["cache_read_tokens"] == 0
+            and b["estimated_cost_usd"] == 0.0
+            for b in series.values()
+        )
+
+    def test_daily_series_direct_buckets_and_window(self, db):
+        """Direct call: same-day sessions share a bucket; out-of-window and
+        timestamp-less sessions are ignored."""
+        now = time.time()
+        day = 86400
+        sessions = [
+            {
+                "id": "a",
+                "model": "gpt-4o",
+                "billing_provider": "openai",
+                "started_at": now - 2 * day,
+                "input_tokens": 1000,
+                "output_tokens": 200,
+                "cache_read_tokens": 300,
+            },
+            {
+                "id": "b",
+                "model": "gpt-4o",
+                "billing_provider": "openai",
+                "started_at": now - 2 * day,
+                "input_tokens": 500,
+                "output_tokens": 50,
+                "cache_read_tokens": 0,
+            },
+            {"id": "c", "model": "gpt-4o", "started_at": None, "input_tokens": 999},
+            {
+                "id": "d",
+                "model": "gpt-4o",
+                "billing_provider": "openai",
+                "started_at": now - 5 * day,
+                "input_tokens": 888,
+            },
+        ]
+        engine = InsightsEngine(db)
+        series = engine._compute_daily_series(sessions, days=3)
+
+        assert len(series) == 3
+        # The two same-day sessions share one bucket; out-of-window and
+        # timestamp-less sessions contributed nothing.
+        filled = [b for b in series.values() if b["input_tokens"]]
+        assert len(filled) == 1
+        assert filled[0]["input_tokens"] == 1500
+        assert filled[0]["output_tokens"] == 250
+        assert filled[0]["cache_read_tokens"] == 300
+        # Known-priced model -> non-zero estimated cost.
+        assert filled[0]["estimated_cost_usd"] > 0
 
 
 


### PR DESCRIPTION
## Summary

Adds a per-day token/cost time-series aggregation to `InsightsEngine` so consumers (e.g. a cost/token intensity heatmap on the desktop `usage.*` RPC) get `{date: {input_tokens, output_tokens, cache_read_tokens, estimated_cost_usd}}` buckets over an arbitrary range without re-implementing the engine's own session-querying and cost-estimation logic.

## Root Cause

`InsightsEngine._compute_activity_patterns` (`agent/insights.py`) aggregates sessions per day by **count only** (`daily_counts = Counter()` keyed on `%Y-%m-%d`, incremented once per session). There is no per-day aggregation of tokens or cost anywhere in the engine, so a day-granular token/cost series would have to be rebuilt in every consuming surface — duplicating `_get_sessions` + `_estimate_cost` and risking drift between the two implementations (a drift class already documented in #23270 / #58592).

## Change

- **`agent/insights.py`**: new `InsightsEngine._compute_daily_series(sessions, days)` that:
  - zero-fills the last `days` calendar days first, so the returned series always has a continuous axis (chronological, contiguous `%Y-%m-%d` keys);
  - accumulates per-day `input_tokens`, `output_tokens`, `cache_read_tokens`, and `estimated_cost_usd` (via the existing `_estimate_cost`) from the already-fetched sessions;
  - ignores sessions outside the window (matching the `generate()` cutoff) and sessions without a `started_at`.
  - Wired into `generate()` as the new `daily_series` report key (present in both the populated and empty-report paths). No changes to `format_terminal`/`format_gateway` output. `_compute_overview` is untouched (no overlap with the overview buckets work).
- **`tests/agent/test_insights.py`**: new `TestDailySeries` class covering series shape/contiguity, per-day token/cost aggregation, zero-fill on an empty DB, same-day bucket merging, and out-of-window/timestamp-less session exclusion.

## Verification

- `python3 -m pytest tests/agent/test_insights.py -p no:xdist -q` → **31 passed** (27 existing + 4 new)
- `python3 -m pytest tests/ -k insights -p no:xdist -q` → **45 passed, 3 skipped**

Closes #77222