### PR TITLE
fix(desktop): expand @terminal selections on busy-turn steer and queue

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -2,6 +2,10 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  clearComposerTerminalSelections,
+  setComposerTerminalSelection
+} from '@/store/composer'
+import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
   enqueueQueuedPrompt,
@@ -23,10 +27,13 @@ import { useComposerQueue } from './use-composer-queue'
 
 const SESSION_KEY = 'stored-session-queue-hook'
 
-function renderQueueHook(overrides: { busy?: boolean; onCancel?: () => void } = {}) {
+function renderQueueHook(
+  overrides: { busy?: boolean; onCancel?: () => void; draft?: string } = {}
+) {
   const onSubmit = vi.fn<ChatBarProps['onSubmit']>(async () => true)
   const onCancel = overrides.onCancel ?? vi.fn()
   const queueEditRef: { current: QueueEditState | null } = { current: null }
+  const draftRef = { current: overrides.draft ?? '' }
 
   const hook = renderHook(
     ({ busy }: { busy: boolean }) =>
@@ -34,10 +41,14 @@ function renderQueueHook(overrides: { busy?: boolean; onCancel?: () => void } = 
         activeQueueSessionKey: SESSION_KEY,
         attachments: [],
         busy,
-        clearDraft: () => undefined,
-        draftRef: { current: '' },
+        clearDraft: () => {
+          draftRef.current = ''
+        },
+        draftRef,
         focusInput: () => undefined,
-        loadIntoComposer: () => undefined,
+        loadIntoComposer: (text: string) => {
+          draftRef.current = text
+        },
         onCancel,
         onSubmit,
         queueEditRef,
@@ -47,7 +58,7 @@ function renderQueueHook(overrides: { busy?: boolean; onCancel?: () => void } = 
     { initialProps: { busy: overrides.busy ?? false } }
   )
 
-  return { hook, onCancel, onSubmit }
+  return { draftRef, hook, onCancel, onSubmit }
 }
 
 describe('useComposerQueue park integration', () => {
@@ -55,6 +66,7 @@ describe('useComposerQueue park integration', () => {
     window.localStorage.clear()
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
+    clearComposerTerminalSelections()
   })
 
   afterEach(() => {
@@ -62,6 +74,7 @@ describe('useComposerQueue park integration', () => {
     vi.restoreAllMocks()
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
+    clearComposerTerminalSelections()
   })
 
   it('auto-drains an unparked queue once idle', async () => {
@@ -126,5 +139,38 @@ describe('useComposerQueue park integration', () => {
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
     expect(onSubmit.mock.calls[0]?.[0]).toBe('send me now')
+  })
+
+  it('freezes @terminal selection at enqueue so a later label collision cannot inject unrelated output', async () => {
+    setComposerTerminalSelection('zsh:23-58', 'selection A')
+
+    const { draftRef, hook, onSubmit } = renderQueueHook({
+      busy: true,
+      draft: 'look at @terminal:`zsh:23-58`'
+    })
+
+    act(() => {
+      expect(hook.result.current.queueCurrentDraft()).toBe(true)
+    })
+
+    const queued = getQueuedPrompts(SESSION_KEY)
+
+    expect(queued).toHaveLength(1)
+    expect(queued[0]?.text).toContain('selection A')
+    expect(queued[0]?.text).not.toContain('@terminal:')
+    expect(queued[0]?.displayText).toBe('look at @terminal:`zsh:23-58`')
+    expect(draftRef.current).toBe('')
+
+    // Another tab reuses the same shell:row label before drain.
+    setComposerTerminalSelection('zsh:23-58', 'selection B from another tab')
+
+    await act(async () => {
+      await hook.result.current.drainNextQueued()
+    })
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit.mock.calls[0]?.[0]).toContain('selection A')
+    expect(onSubmit.mock.calls[0]?.[0]).not.toContain('selection B')
+    expect(onSubmit.mock.calls[0]?.[1]).toMatchObject({ fromQueue: true })
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -9,10 +9,14 @@ import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
   enqueueQueuedPrompt,
+  getFrozenQueuedTransport,
   getQueuedPrompts,
   isQueueParked,
-  parkQueuedPrompts
+  parkQueuedPrompts,
+  resetFrozenQueuedTransportsForTests,
+  simulateComposerQueueReloadForTests
 } from '@/store/composer-queue'
+import { $notifications, clearNotifications } from '@/store/notifications'
 
 import type { QueueEditState } from '../composer-utils'
 import type { ChatBarProps } from '../types'
@@ -68,6 +72,8 @@ describe('useComposerQueue park integration', () => {
     window.localStorage.clear()
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
+    resetFrozenQueuedTransportsForTests()
+    clearNotifications()
     clearComposerTerminalSelections()
   })
 
@@ -76,6 +82,8 @@ describe('useComposerQueue park integration', () => {
     vi.restoreAllMocks()
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
+    resetFrozenQueuedTransportsForTests()
+    clearNotifications()
     clearComposerTerminalSelections()
   })
 
@@ -224,9 +232,10 @@ describe('useComposerQueue park integration', () => {
     const queued = getQueuedPrompts(SESSION_KEY)
 
     expect(queued).toHaveLength(1)
-    expect(queued[0]?.text).toContain('selection A')
-    expect(queued[0]?.text).not.toContain('@terminal:')
+    expect(queued[0]?.text).toBe('look at @terminal:`zsh:23-58`')
     expect(queued[0]?.displayText).toBe('look at @terminal:`zsh:23-58`')
+    expect(queued[0]?.text).not.toContain('selection A')
+    expect(getFrozenQueuedTransport(queued[0]!.id)).toContain('selection A')
     expect(draftRef.current).toBe('')
 
     setComposerTerminalSelection('zsh:23-58', 'selection B from another tab')
@@ -238,6 +247,32 @@ describe('useComposerQueue park integration', () => {
     expect(onSubmit).toHaveBeenCalledTimes(1)
     expect(onSubmit.mock.calls[0]?.[0]).toContain('selection A')
     expect(onSubmit.mock.calls[0]?.[0]).not.toContain('selection B')
-    expect(onSubmit.mock.calls[0]?.[1]).toMatchObject({ fromQueue: true })
+    expect(onSubmit.mock.calls[0]?.[1]).toMatchObject({
+      displayText: 'look at @terminal:`zsh:23-58`',
+      fromQueue: true
+    })
+  })
+
+  it('blocks drain after a simulated reload when the runtime terminal payload is gone', async () => {
+    setComposerTerminalSelection('zsh:23-58', 'selection A')
+
+    const { hook, onSubmit } = renderQueueHook({
+      busy: true,
+      draft: 'look at @terminal:`zsh:23-58`'
+    })
+
+    act(() => {
+      expect(hook.result.current.queueCurrentDraft()).toBe(true)
+    })
+
+    simulateComposerQueueReloadForTests()
+
+    await act(async () => {
+      expect(await hook.result.current.drainNextQueued()).toBe(false)
+    })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(1)
+    expect($notifications.get().some(n => n.message.includes('Re-select the lines'))).toBe(true)
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -2,6 +2,10 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  clearComposerTerminalSelections,
+  setComposerTerminalSelection
+} from '@/store/composer'
+import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
   enqueueQueuedPrompt,
@@ -23,11 +27,14 @@ import { useComposerQueue } from './use-composer-queue'
 
 const SESSION_KEY = 'stored-session-queue-hook'
 
-function renderQueueHook(overrides: { busy?: boolean; onCancel?: () => void; onSteer?: ChatBarProps['onSteer'] } = {}) {
+function renderQueueHook(
+  overrides: { busy?: boolean; draft?: string; onCancel?: () => void; onSteer?: ChatBarProps['onSteer'] } = {}
+) {
   const onSubmit = vi.fn<ChatBarProps['onSubmit']>(async () => true)
   const onCancel = overrides.onCancel ?? vi.fn()
   const onSteer = overrides.onSteer
   const queueEditRef: { current: QueueEditState | null } = { current: null }
+  const draftRef = { current: overrides.draft ?? '' }
 
   const hook = renderHook(
     ({ busy }: { busy: boolean }) =>
@@ -35,10 +42,14 @@ function renderQueueHook(overrides: { busy?: boolean; onCancel?: () => void; onS
         activeQueueSessionKey: SESSION_KEY,
         attachments: [],
         busy,
-        clearDraft: () => undefined,
-        draftRef: { current: '' },
+        clearDraft: () => {
+          draftRef.current = ''
+        },
+        draftRef,
         focusInput: () => undefined,
-        loadIntoComposer: () => undefined,
+        loadIntoComposer: (text: string) => {
+          draftRef.current = text
+        },
         onCancel,
         onSteer,
         onSubmit,
@@ -49,7 +60,7 @@ function renderQueueHook(overrides: { busy?: boolean; onCancel?: () => void; onS
     { initialProps: { busy: overrides.busy ?? false } }
   )
 
-  return { hook, onCancel, onSubmit }
+  return { draftRef, hook, onCancel, onSubmit }
 }
 
 describe('useComposerQueue park integration', () => {
@@ -57,6 +68,7 @@ describe('useComposerQueue park integration', () => {
     window.localStorage.clear()
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
+    clearComposerTerminalSelections()
   })
 
   afterEach(() => {
@@ -64,6 +76,7 @@ describe('useComposerQueue park integration', () => {
     vi.restoreAllMocks()
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
+    clearComposerTerminalSelections()
   })
 
   it('auto-drains an unparked queue once idle', async () => {
@@ -194,5 +207,37 @@ describe('useComposerQueue park integration', () => {
 
     expect(isQueueParked(SESSION_KEY)).toBe(false)
     expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(1)
+  })
+
+  it('freezes @terminal selection at enqueue so a later label collision cannot inject unrelated output', async () => {
+    setComposerTerminalSelection('zsh:23-58', 'selection A')
+
+    const { draftRef, hook, onSubmit } = renderQueueHook({
+      busy: true,
+      draft: 'look at @terminal:`zsh:23-58`'
+    })
+
+    act(() => {
+      expect(hook.result.current.queueCurrentDraft()).toBe(true)
+    })
+
+    const queued = getQueuedPrompts(SESSION_KEY)
+
+    expect(queued).toHaveLength(1)
+    expect(queued[0]?.text).toContain('selection A')
+    expect(queued[0]?.text).not.toContain('@terminal:')
+    expect(queued[0]?.displayText).toBe('look at @terminal:`zsh:23-58`')
+    expect(draftRef.current).toBe('')
+
+    setComposerTerminalSelection('zsh:23-58', 'selection B from another tab')
+
+    await act(async () => {
+      await hook.result.current.drainNextQueued()
+    })
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit.mock.calls[0]?.[0]).toContain('selection A')
+    expect(onSubmit.mock.calls[0]?.[0]).not.toContain('selection B')
+    expect(onSubmit.mock.calls[0]?.[1]).toMatchObject({ fromQueue: true })
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -4,7 +4,7 @@ import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { useSessionSlice } from '@/lib/use-session-slice'
-import { type ComposerAttachment } from '@/store/composer'
+import { type ComposerAttachment, expandComposerDraftWithTerminalContext } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $parkedQueueSessions,
@@ -182,7 +182,12 @@ export function useComposerQueue({
       return false
     }
 
-    if (!enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments })) {
+    // Expand `@terminal:` chips before enqueue so the queued entry is
+    // self-contained. Drain goes through submit (which also expands), but the
+    // side-channel map can be empty by then after remount/reload (#77078).
+    const expanded = text.trim() ? expandComposerDraftWithTerminalContext(text) : text
+
+    if (!enqueueQueuedPrompt(activeQueueSessionKey, { text: expanded, attachments })) {
       return false
     }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -4,7 +4,7 @@ import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { useSessionSlice } from '@/lib/use-session-slice'
-import { type ComposerAttachment, expandComposerDraftWithTerminalContext } from '@/store/composer'
+import { type ComposerAttachment, freezeComposerDraftWithTerminalContext } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $parkedQueueSessions,
@@ -25,6 +25,36 @@ import { notify } from '@/store/notifications'
 import { cloneAttachments, type QueueEditState } from '../composer-utils'
 import { useComposerScope } from '../scope'
 import type { ChatBarProps } from '../types'
+
+/** Freeze terminal chips for queue persistence. Returns null when a chip has
+ *  no selection payload (caller should abort without mutating the queue). */
+function freezeQueuedDraftText(
+  text: string,
+  copy: { terminalSelectionMissingTitle: string; terminalSelectionMissingBody: string }
+): null | { text: string; displayText?: string } {
+  const trimmed = text.trim()
+
+  if (!trimmed) {
+    return { text }
+  }
+
+  const frozen = freezeComposerDraftWithTerminalContext(trimmed)
+
+  if (frozen.missingLabels.length > 0) {
+    notify({
+      kind: 'warning',
+      title: copy.terminalSelectionMissingTitle,
+      message: copy.terminalSelectionMissingBody
+    })
+
+    return null
+  }
+
+  return {
+    text: frozen.transportText,
+    ...(frozen.displayText !== frozen.transportText ? { displayText: frozen.displayText } : {})
+  }
+}
 
 interface UseComposerQueueArgs {
   activeQueueSessionKey: string | null
@@ -128,11 +158,18 @@ export function useComposerQueue({
       return index >= 0 // at the oldest: swallow; missing entry: let it fall through
     }
 
+    const frozen = draftRef.current.trim()
+      ? freezeQueuedDraftText(draftRef.current, t.composer)
+      : { text: draftRef.current }
+
+    if (!frozen) {
+      return true
+    }
+
     const saved = updateQueuedPrompt(queueEdit.sessionKey, queueEdit.entryId, {
       attachments: cloneAttachments(attachments),
-      text: draftRef.current.trim()
-        ? expandComposerDraftWithTerminalContext(draftRef.current)
-        : draftRef.current
+      text: frozen.text,
+      displayText: frozen.displayText ?? null
     })
 
     const next = queuedPrompts[target]
@@ -164,10 +201,16 @@ export function useComposerQueue({
         return false
       }
 
-      const expanded = text.trim() ? expandComposerDraftWithTerminalContext(text) : text
+      const frozen = text.trim() ? freezeQueuedDraftText(text, t.composer) : { text }
+
+      if (!frozen) {
+        return false
+      }
+
       const saved = updateQueuedPrompt(queueEdit.sessionKey, queueEdit.entryId, {
         attachments: next,
-        text: expanded
+        text: frozen.text,
+        displayText: frozen.displayText ?? null
       })
       triggerHaptic(saved ? 'success' : 'selection')
     } else {
@@ -188,13 +231,22 @@ export function useComposerQueue({
       return false
     }
 
-    // Expand `@terminal:` chips before enqueue so the queued entry stays
-    // self-contained across remount/reload (the selection map is memory-only
-    // while the queue is persisted). Drain submit skips fences already present
-    // so this does not double-expand on the live path (#77078).
-    const expanded = text.trim() ? expandComposerDraftWithTerminalContext(text) : text
+    // Freeze `@terminal:` chips into transport text + chip displayText before
+    // enqueue. The selection map is memory-only and label-colliding; drain
+    // must never re-resolve against it (#77078).
+    const frozen = text.trim() ? freezeQueuedDraftText(text, t.composer) : { text }
 
-    if (!enqueueQueuedPrompt(activeQueueSessionKey, { text: expanded, attachments })) {
+    if (!frozen) {
+      return false
+    }
+
+    if (
+      !enqueueQueuedPrompt(activeQueueSessionKey, {
+        text: frozen.text,
+        attachments,
+        ...(frozen.displayText ? { displayText: frozen.displayText } : {})
+      })
+    ) {
       return false
     }
 
@@ -203,7 +255,7 @@ export function useComposerQueue({
     triggerHaptic('selection')
 
     return true
-  }, [activeQueueSessionKey, attachments, clearDraft, draftRef, scope.attachments])
+  }, [activeQueueSessionKey, attachments, clearDraft, draftRef, scope.attachments, t.composer])
 
   // All queue drain paths share one lock + send-then-remove sequence.
   // `pickEntry` lets each caller choose head, by-id, or skip-edited.

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -130,7 +130,9 @@ export function useComposerQueue({
 
     const saved = updateQueuedPrompt(queueEdit.sessionKey, queueEdit.entryId, {
       attachments: cloneAttachments(attachments),
-      text: draftRef.current
+      text: draftRef.current.trim()
+        ? expandComposerDraftWithTerminalContext(draftRef.current)
+        : draftRef.current
     })
 
     const next = queuedPrompts[target]
@@ -162,7 +164,11 @@ export function useComposerQueue({
         return false
       }
 
-      const saved = updateQueuedPrompt(queueEdit.sessionKey, queueEdit.entryId, { attachments: next, text })
+      const expanded = text.trim() ? expandComposerDraftWithTerminalContext(text) : text
+      const saved = updateQueuedPrompt(queueEdit.sessionKey, queueEdit.entryId, {
+        attachments: next,
+        text: expanded
+      })
       triggerHaptic(saved ? 'success' : 'selection')
     } else {
       triggerHaptic('cancel')

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -4,7 +4,7 @@ import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { useSessionSlice } from '@/lib/use-session-slice'
-import { type ComposerAttachment, expandComposerDraftWithTerminalContext } from '@/store/composer'
+import { type ComposerAttachment } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $parkedQueueSessions,
@@ -182,12 +182,11 @@ export function useComposerQueue({
       return false
     }
 
-    // Expand `@terminal:` chips before enqueue so the queued entry is
-    // self-contained. Drain goes through submit (which also expands), but the
-    // side-channel map can be empty by then after remount/reload (#77078).
-    const expanded = text.trim() ? expandComposerDraftWithTerminalContext(text) : text
-
-    if (!enqueueQueuedPrompt(activeQueueSessionKey, { text: expanded, attachments })) {
+    // Keep the raw draft (including `@terminal:` chips). Drain goes through
+    // submit, which expands from `$composerTerminalSelections`. Pre-expanding
+    // here would duplicate fences on the no-remount path because clearDraft
+    // does not clear that map (#77078).
+    if (!enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments })) {
       return false
     }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -4,7 +4,7 @@ import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { useSessionSlice } from '@/lib/use-session-slice'
-import { type ComposerAttachment } from '@/store/composer'
+import { type ComposerAttachment, expandComposerDraftWithTerminalContext } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $parkedQueueSessions,
@@ -182,11 +182,13 @@ export function useComposerQueue({
       return false
     }
 
-    // Keep the raw draft (including `@terminal:` chips). Drain goes through
-    // submit, which expands from `$composerTerminalSelections`. Pre-expanding
-    // here would duplicate fences on the no-remount path because clearDraft
-    // does not clear that map (#77078).
-    if (!enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments })) {
+    // Expand `@terminal:` chips before enqueue so the queued entry stays
+    // self-contained across remount/reload (the selection map is memory-only
+    // while the queue is persisted). Drain submit skips fences already present
+    // so this does not double-expand on the live path (#77078).
+    const expanded = text.trim() ? expandComposerDraftWithTerminalContext(text) : text
+
+    if (!enqueueQueuedPrompt(activeQueueSessionKey, { text: expanded, attachments })) {
       return false
     }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -4,7 +4,7 @@ import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { useSessionSlice } from '@/lib/use-session-slice'
-import { type ComposerAttachment } from '@/store/composer'
+import { type ComposerAttachment, freezeComposerTransportPayload } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $parkedQueueSessions,
@@ -26,6 +26,36 @@ import { notify } from '@/store/notifications'
 import { cloneAttachments, type QueueEditState } from '../composer-utils'
 import { useComposerScope } from '../scope'
 import type { ChatBarProps } from '../types'
+
+/** Freeze terminal chips for queue persistence. Returns null when a chip has
+ *  no selection payload (caller should abort without mutating the queue). */
+function freezeQueuedDraftText(
+  text: string,
+  copy: { terminalSelectionMissingTitle: string; terminalSelectionMissingBody: string }
+): null | { text: string; displayText?: string } {
+  const trimmed = text.trim()
+
+  if (!trimmed) {
+    return { text }
+  }
+
+  const frozen = freezeComposerTransportPayload(trimmed)
+
+  if (frozen.missingLabels.length > 0) {
+    notify({
+      kind: 'warning',
+      title: copy.terminalSelectionMissingTitle,
+      message: copy.terminalSelectionMissingBody
+    })
+
+    return null
+  }
+
+  return {
+    text: frozen.transportText,
+    ...(frozen.displayText !== frozen.transportText ? { displayText: frozen.displayText } : {})
+  }
+}
 
 interface UseComposerQueueArgs {
   activeQueueSessionKey: string | null
@@ -131,9 +161,18 @@ export function useComposerQueue({
       return index >= 0 // at the oldest: swallow; missing entry: let it fall through
     }
 
+    const frozen = draftRef.current.trim()
+      ? freezeQueuedDraftText(draftRef.current, t.composer)
+      : { text: draftRef.current }
+
+    if (!frozen) {
+      return true
+    }
+
     const saved = updateQueuedPrompt(queueEdit.sessionKey, queueEdit.entryId, {
       attachments: cloneAttachments(attachments),
-      text: draftRef.current
+      text: frozen.text,
+      displayText: frozen.displayText ?? null
     })
 
     const next = queuedPrompts[target]
@@ -165,7 +204,17 @@ export function useComposerQueue({
         return false
       }
 
-      const saved = updateQueuedPrompt(queueEdit.sessionKey, queueEdit.entryId, { attachments: next, text })
+      const frozen = text.trim() ? freezeQueuedDraftText(text, t.composer) : { text }
+
+      if (!frozen) {
+        return false
+      }
+
+      const saved = updateQueuedPrompt(queueEdit.sessionKey, queueEdit.entryId, {
+        attachments: next,
+        text: frozen.text,
+        displayText: frozen.displayText ?? null
+      })
       triggerHaptic(saved ? 'success' : 'selection')
     } else {
       triggerHaptic('cancel')
@@ -185,7 +234,22 @@ export function useComposerQueue({
       return false
     }
 
-    if (!enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments })) {
+    // Freeze `@terminal:` chips into transport text + chip displayText before
+    // enqueue. The selection map is memory-only and label-colliding; drain
+    // must never re-resolve against it (#77078).
+    const frozen = text.trim() ? freezeQueuedDraftText(text, t.composer) : { text }
+
+    if (!frozen) {
+      return false
+    }
+
+    if (
+      !enqueueQueuedPrompt(activeQueueSessionKey, {
+        text: frozen.text,
+        attachments,
+        ...(frozen.displayText ? { displayText: frozen.displayText } : {})
+      })
+    ) {
       return false
     }
 
@@ -194,7 +258,7 @@ export function useComposerQueue({
     triggerHaptic('selection')
 
     return true
-  }, [activeQueueSessionKey, attachments, clearDraft, draftRef, scope.attachments])
+  }, [activeQueueSessionKey, attachments, clearDraft, draftRef, scope.attachments, t.composer])
 
   // All queue drain paths share one lock + send-then-remove sequence.
   // `pickEntry` lets each caller choose head, by-id, or skip-edited.

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -17,6 +17,7 @@ import {
   promoteQueuedPrompt,
   type QueuedPromptEntry,
   removeQueuedPrompt,
+  resolveQueuedPromptTransport,
   shouldAutoDrain,
   unparkQueuedPrompts,
   updateQueuedPrompt
@@ -27,12 +28,16 @@ import { cloneAttachments, type QueueEditState } from '../composer-utils'
 import { useComposerScope } from '../scope'
 import type { ChatBarProps } from '../types'
 
-/** Freeze terminal chips for queue persistence. Returns null when a chip has
- *  no selection payload (caller should abort without mutating the queue). */
+/** Freeze terminal chips for queue persistence. Persists the chip/display
+ *  form; fenced selection CONTENTS stay in the runtime map. Returns null when
+ *  a chip has no selection payload (caller should abort without mutating the queue). */
 function freezeQueuedDraftText(
   text: string,
-  copy: { terminalSelectionMissingTitle: string; terminalSelectionMissingBody: string }
-): null | { text: string; displayText?: string } {
+  copy: {
+    terminalSelectionMissingTitle: string
+    terminalSelectionMissingBody: string
+  }
+): null | { text: string; displayText?: string; frozenTransport?: string } {
   const trimmed = text.trim()
 
   if (!trimmed) {
@@ -51,9 +56,14 @@ function freezeQueuedDraftText(
     return null
   }
 
+  const hasTerminalTransport = frozen.displayText !== frozen.transportText
+
   return {
-    text: frozen.transportText,
-    ...(frozen.displayText !== frozen.transportText ? { displayText: frozen.displayText } : {})
+    // Persist chips (or ordinary text). Never persist fenced selection contents.
+    text: frozen.displayText,
+    ...(hasTerminalTransport
+      ? { displayText: frozen.displayText, frozenTransport: frozen.transportText }
+      : {})
   }
 }
 
@@ -172,7 +182,8 @@ export function useComposerQueue({
     const saved = updateQueuedPrompt(queueEdit.sessionKey, queueEdit.entryId, {
       attachments: cloneAttachments(attachments),
       text: frozen.text,
-      displayText: frozen.displayText ?? null
+      displayText: frozen.displayText ?? null,
+      frozenTransport: frozen.frozenTransport ?? null
     })
 
     const next = queuedPrompts[target]
@@ -213,7 +224,8 @@ export function useComposerQueue({
       const saved = updateQueuedPrompt(queueEdit.sessionKey, queueEdit.entryId, {
         attachments: next,
         text: frozen.text,
-        displayText: frozen.displayText ?? null
+        displayText: frozen.displayText ?? null,
+        frozenTransport: frozen.frozenTransport ?? null
       })
       triggerHaptic(saved ? 'success' : 'selection')
     } else {
@@ -234,9 +246,9 @@ export function useComposerQueue({
       return false
     }
 
-    // Freeze `@terminal:` chips into transport text + chip displayText before
-    // enqueue. The selection map is memory-only and label-colliding; drain
-    // must never re-resolve against it (#77078).
+    // Freeze `@terminal:` chips at enqueue. Persist the chip form; keep the
+    // fenced selection in the runtime map so drain never re-resolves the live
+    // label map and localStorage never stores terminal CONTENTS (#77078).
     const frozen = text.trim() ? freezeQueuedDraftText(text, t.composer) : { text }
 
     if (!frozen) {
@@ -247,7 +259,8 @@ export function useComposerQueue({
       !enqueueQueuedPrompt(activeQueueSessionKey, {
         text: frozen.text,
         attachments,
-        ...(frozen.displayText ? { displayText: frozen.displayText } : {})
+        ...(frozen.displayText ? { displayText: frozen.displayText } : {}),
+        ...(frozen.frozenTransport ? { frozenTransport: frozen.frozenTransport } : {})
       })
     ) {
       return false
@@ -279,10 +292,23 @@ export function useComposerQueue({
       drainingQueueRef.current = true
 
       try {
+        const resolved = resolveQueuedPromptTransport(entry)
+
+        if (!resolved.ok) {
+          notify({
+            kind: 'warning',
+            title: t.composer.terminalSelectionMissingTitle,
+            message: t.composer.queuedTerminalSelectionExpiredBody
+          })
+          drainFailuresRef.current.set(entry.id, MAX_AUTO_DRAIN_ATTEMPTS)
+
+          return false
+        }
+
         const accepted = await Promise.resolve(
-          onSubmit(entry.text, {
+          onSubmit(resolved.transportText, {
             attachments: entry.attachments,
-            ...(entry.displayText ? { displayText: entry.displayText } : {}),
+            ...(resolved.displayText ? { displayText: resolved.displayText } : {}),
             fromQueue: true,
             sessionId: drainRuntimeSessionId,
             storedSessionId: drainQueueSessionKey
@@ -307,7 +333,7 @@ export function useComposerQueue({
         drainingQueueRef.current = false
       }
     },
-    [activeQueueSessionKey, onSubmit, sessionId]
+    [activeQueueSessionKey, onSubmit, sessionId, t.composer]
   )
 
   const pickDrainHead = useCallback(
@@ -368,9 +394,21 @@ export function useComposerQueue({
         return false
       }
 
+      const resolved = resolveQueuedPromptTransport(entry)
+
+      if (!resolved.ok) {
+        notify({
+          kind: 'warning',
+          title: t.composer.terminalSelectionMissingTitle,
+          message: t.composer.queuedTerminalSelectionExpiredBody
+        })
+
+        return false
+      }
+
       triggerHaptic('submit')
 
-      const accepted = await Promise.resolve(onSteer(entry.text))
+      const accepted = await Promise.resolve(onSteer(resolved.transportText))
 
       // Rejected (turn already settling, gateway said no): leave the entry
       // queued exactly where it was — the settle drain picks it up, so the
@@ -387,7 +425,7 @@ export function useComposerQueue({
 
       return true
     },
-    [activeQueueSessionKey, busy, onSteer, queueEditRef]
+    [activeQueueSessionKey, busy, onSteer, queueEditRef, t.composer]
   )
 
   // Edge-independent auto-drain: send the head whenever the session is idle and
@@ -406,7 +444,13 @@ export function useComposerQueue({
     }
 
     const onFail = () => {
-      const fails = (drainFailuresRef.current.get(entry.id) ?? 0) + 1
+      const already = drainFailuresRef.current.get(entry.id) ?? 0
+
+      if (already >= MAX_AUTO_DRAIN_ATTEMPTS) {
+        return
+      }
+
+      const fails = already + 1
       drainFailuresRef.current.set(entry.id, fails)
 
       if (fails >= MAX_AUTO_DRAIN_ATTEMPTS) {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -106,10 +106,24 @@ describe('useComposerSubmit busy-turn routing', () => {
     })
 
     await waitFor(() =>
-      expect(onSteer).toHaveBeenCalledWith(
-        '```terminal\nselected terminal lines\n```\n\nlook at @terminal:`zsh:23-58`'
-      )
+      expect(onSteer).toHaveBeenCalledWith('```terminal\nselected terminal lines\n```\n\nlook at')
     )
+    expect(queueCurrentDraft).not.toHaveBeenCalled()
+  })
+
+  it('refuses to steer when a restored @terminal chip has no selection payload', () => {
+    clearComposerTerminalSelections()
+
+    const { hook, onSteer, queueCurrentDraft } = renderSubmitHook({
+      busy: true,
+      text: 'look at @terminal:`zsh:23-58`'
+    })
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    expect(onSteer).not.toHaveBeenCalled()
     expect(queueCurrentDraft).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -2,7 +2,11 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $clarifyRequests } from '@/store/clarify'
-import type { ComposerAttachment } from '@/store/composer'
+import {
+  clearComposerTerminalSelections,
+  type ComposerAttachment,
+  setComposerTerminalSelection
+} from '@/store/composer'
 import { $gateway } from '@/store/gateway'
 
 import { useComposerSubmit } from './use-composer-submit'
@@ -70,6 +74,7 @@ describe('useComposerSubmit busy-turn routing', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    clearComposerTerminalSelections()
   })
 
   it('steers a plain-text follow-up instead of queueing or stopping', async () => {
@@ -86,6 +91,26 @@ describe('useComposerSubmit busy-turn routing', () => {
     expect(queueCurrentDraft).not.toHaveBeenCalled()
     expect(onCancel).not.toHaveBeenCalled()
     expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('expands @terminal selection chips before steering a busy turn (#77078)', async () => {
+    setComposerTerminalSelection('zsh:23-58', 'selected terminal lines')
+
+    const { hook, onSteer, queueCurrentDraft } = renderSubmitHook({
+      busy: true,
+      text: 'look at @terminal:`zsh:23-58`'
+    })
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    await waitFor(() =>
+      expect(onSteer).toHaveBeenCalledWith(
+        '```terminal\nselected terminal lines\n```\n\nlook at @terminal:`zsh:23-58`'
+      )
+    )
+    expect(queueCurrentDraft).not.toHaveBeenCalled()
   })
 
   it('queues a plain-text follow-up while the active turn is compacting', () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -186,6 +186,27 @@ describe('useComposerSubmit busy-turn routing', () => {
     expect(onCancel).not.toHaveBeenCalled()
   })
 
+  it('leaves idle @terminal chips for the submit transport freeze (does not expand here)', async () => {
+    setComposerTerminalSelection('zsh:23-58', 'selected terminal lines')
+
+    const { hook, onSteer, onSubmit, queueCurrentDraft } = renderSubmitHook({
+      text: 'look at @terminal:`zsh:23-58`'
+    })
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith('look at @terminal:`zsh:23-58`', {
+        attachments: [],
+        composerScope: 'stored-session'
+      })
+    )
+    expect(onSteer).not.toHaveBeenCalled()
+    expect(queueCurrentDraft).not.toHaveBeenCalled()
+  })
+
   it('expands @terminal selection chips before steering a busy turn', async () => {
     setComposerTerminalSelection('zsh:23-58', 'selected terminal lines')
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -2,7 +2,11 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $clarifyRequests } from '@/store/clarify'
-import type { ComposerAttachment } from '@/store/composer'
+import {
+  clearComposerTerminalSelections,
+  type ComposerAttachment,
+  setComposerTerminalSelection
+} from '@/store/composer'
 import { $gateway } from '@/store/gateway'
 import {
   clearAllPrompts,
@@ -77,6 +81,7 @@ describe('useComposerSubmit busy-turn routing', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    clearComposerTerminalSelections()
   })
 
   it('treats a payload mid-turn as send (steer), not stop', async () => {
@@ -179,6 +184,40 @@ describe('useComposerSubmit busy-turn routing', () => {
     expect(onSteer).not.toHaveBeenCalled()
     expect(queueCurrentDraft).not.toHaveBeenCalled()
     expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it('expands @terminal selection chips before steering a busy turn', async () => {
+    setComposerTerminalSelection('zsh:23-58', 'selected terminal lines')
+
+    const { hook, onSteer, queueCurrentDraft } = renderSubmitHook({
+      busy: true,
+      text: 'look at @terminal:`zsh:23-58`'
+    })
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    await waitFor(() =>
+      expect(onSteer).toHaveBeenCalledWith('```terminal\nselected terminal lines\n```\n\nlook at')
+    )
+    expect(queueCurrentDraft).not.toHaveBeenCalled()
+  })
+
+  it('refuses to steer when a restored @terminal chip has no selection payload', () => {
+    clearComposerTerminalSelections()
+
+    const { hook, onSteer, queueCurrentDraft } = renderSubmitHook({
+      busy: true,
+      text: 'look at @terminal:`zsh:23-58`'
+    })
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    expect(onSteer).not.toHaveBeenCalled()
+    expect(queueCurrentDraft).not.toHaveBeenCalled()
   })
 
   it('threads the loaded composer scope through onSubmit for the #59305 submit-time guard', async () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -1,15 +1,17 @@
 import { type RefObject, useEffect, useRef } from 'react'
 
+import { translateNow } from '@/i18n'
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { hasClarifyRequest, skipClarifyRequest } from '@/store/clarify'
 import {
   clearSessionDraft,
   type ComposerAttachment,
-  expandComposerDraftWithTerminalContext
+  freezeComposerDraftWithTerminalContext
 } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
 import { enqueueQueuedPrompt, type QueuedPromptEntry } from '@/store/composer-queue'
+import { notify } from '@/store/notifications'
 
 import { cloneAttachments, type QueueEditState } from '../composer-utils'
 import { onComposerSubmitRequest } from '../focus'
@@ -220,17 +222,30 @@ export function useComposerSubmit({
       return
     }
 
-    // Expand `@terminal:` chips the same way idle submit does. Steer used to
-    // forward the bare token only (#77078), so a busy-turn Add-to-Chat send
-    // arrived without the selected lines.
-    const expanded = expandComposerDraftWithTerminalContext(text)
+    // Freeze `@terminal:` chips the same way idle submit / queue enqueue do.
+    // Steer used to forward the bare token only (#77078).
+    const frozen = freezeComposerDraftWithTerminalContext(text)
+
+    if (frozen.missingLabels.length > 0) {
+      notify({
+        kind: 'warning',
+        title: translateNow('composer.terminalSelectionMissingTitle'),
+        message: translateNow('composer.terminalSelectionMissingBody')
+      })
+
+      return
+    }
 
     triggerHaptic('submit')
     clearDraft()
 
-    void Promise.resolve(onSteer(expanded)).then(accepted => {
+    void Promise.resolve(onSteer(frozen.transportText)).then(accepted => {
       if (!accepted && activeQueueSessionKey) {
-        enqueueQueuedPrompt(activeQueueSessionKey, { text: expanded, attachments: [] })
+        enqueueQueuedPrompt(activeQueueSessionKey, {
+          text: frozen.transportText,
+          attachments: [],
+          ...(frozen.displayText !== frozen.transportText ? { displayText: frozen.displayText } : {})
+        })
       }
     })
   }

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -3,7 +3,11 @@ import { type RefObject, useEffect, useRef } from 'react'
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { hasClarifyRequest, skipClarifyRequest } from '@/store/clarify'
-import { clearSessionDraft, type ComposerAttachment } from '@/store/composer'
+import {
+  clearSessionDraft,
+  type ComposerAttachment,
+  expandComposerDraftWithTerminalContext
+} from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
 import { enqueueQueuedPrompt, type QueuedPromptEntry } from '@/store/composer-queue'
 
@@ -216,12 +220,17 @@ export function useComposerSubmit({
       return
     }
 
+    // Expand `@terminal:` chips the same way idle submit does. Steer used to
+    // forward the bare token only (#77078), so a busy-turn Add-to-Chat send
+    // arrived without the selected lines.
+    const expanded = expandComposerDraftWithTerminalContext(text)
+
     triggerHaptic('submit')
     clearDraft()
 
-    void Promise.resolve(onSteer(text)).then(accepted => {
+    void Promise.resolve(onSteer(expanded)).then(accepted => {
       if (!accepted && activeQueueSessionKey) {
-        enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments: [] })
+        enqueueQueuedPrompt(activeQueueSessionKey, { text: expanded, attachments: [] })
       }
     })
   }

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -256,10 +256,14 @@ export function useComposerSubmit({
 
     void Promise.resolve(onSteer(frozen.transportText)).then(accepted => {
       if (!accepted && activeQueueSessionKey) {
+        const hasTerminalTransport = frozen.displayText !== frozen.transportText
+
         enqueueQueuedPrompt(activeQueueSessionKey, {
-          text: frozen.transportText,
+          text: frozen.displayText,
           attachments: [],
-          ...(frozen.displayText !== frozen.transportText ? { displayText: frozen.displayText } : {})
+          ...(hasTerminalTransport
+            ? { displayText: frozen.displayText, frozenTransport: frozen.transportText }
+            : {})
         })
       }
     })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -1,12 +1,14 @@
 import { type RefObject, useEffect, useRef } from 'react'
 
+import { translateNow } from '@/i18n'
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { hasClarifyRequest, skipClarifyRequest } from '@/store/clarify'
-import { clearSessionDraft, type ComposerAttachment } from '@/store/composer'
+import { clearSessionDraft, type ComposerAttachment, freezeComposerTransportPayload } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
 import { enqueueQueuedPrompt, type QueuedPromptEntry } from '@/store/composer-queue'
 import { hasMcpSetupRequest, skipMcpSetupRequest } from '@/store/mcp-setup'
+import { notify } from '@/store/notifications'
 import { hasBlockingPromptRequest } from '@/store/prompts'
 
 import { cloneAttachments, type QueueEditState } from '../composer-utils'
@@ -235,12 +237,30 @@ export function useComposerSubmit({
       return
     }
 
+    // Freeze `@terminal:` chips the same way idle submit / queue enqueue do.
+    // Steer used to forward the bare token only (#77078).
+    const frozen = freezeComposerTransportPayload(text)
+
+    if (frozen.missingLabels.length > 0) {
+      notify({
+        kind: 'warning',
+        title: translateNow('composer.terminalSelectionMissingTitle'),
+        message: translateNow('composer.terminalSelectionMissingBody')
+      })
+
+      return
+    }
+
     triggerHaptic('submit')
     clearDraft()
 
-    void Promise.resolve(onSteer(text)).then(accepted => {
+    void Promise.resolve(onSteer(frozen.transportText)).then(accepted => {
       if (!accepted && activeQueueSessionKey) {
-        enqueueQueuedPrompt(activeQueueSessionKey, { text, attachments: [] })
+        enqueueQueuedPrompt(activeQueueSessionKey, {
+          text: frozen.transportText,
+          attachments: [],
+          ...(frozen.displayText !== frozen.transportText ? { displayText: frozen.displayText } : {})
+        })
       }
     })
   }

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
@@ -95,6 +95,30 @@ describe('useBackgroundQueueDrain', () => {
     await waitFor(() => expect(getQueuedPrompts('stored-session-a')).toHaveLength(0))
   })
 
+  it('forwards queued displayText so frozen @terminal chips render in the bubble', async () => {
+    const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
+    const submitText = vi.fn(async () => true)
+
+    enqueueQueuedPrompt('stored-session-a', {
+      text: '```terminal\nselection A\n```\n\nlook at',
+      displayText: 'look at @terminal:`zsh:23-58`',
+      attachments: []
+    })
+    clearAllSessionStates()
+
+    render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
+
+    await waitFor(() => {
+      expect(submitText).toHaveBeenCalledWith('```terminal\nselection A\n```\n\nlook at', {
+        attachments: [],
+        displayText: 'look at @terminal:`zsh:23-58`',
+        fromQueue: true,
+        sessionId: 'rt-session-a',
+        storedSessionId: 'stored-session-a'
+      })
+    })
+  })
+
   it('leaves the selected session queue to the mounted ChatBar drainer', async () => {
     const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
     const submitText = vi.fn(async () => true)

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
@@ -8,7 +8,8 @@ import {
   $queuedPromptsBySession,
   enqueueQueuedPrompt,
   getQueuedPrompts,
-  parkQueuedPrompts
+  parkQueuedPrompts,
+  resetFrozenQueuedTransportsForTests
 } from '@/store/composer-queue'
 import { $sessions, setSessions } from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
@@ -62,6 +63,7 @@ describe('useBackgroundQueueDrain', () => {
   beforeEach(() => {
     vi.useRealTimers()
     clearAllSessionStates()
+    resetFrozenQueuedTransportsForTests()
   })
 
   afterEach(() => {
@@ -70,6 +72,7 @@ describe('useBackgroundQueueDrain', () => {
     vi.useRealTimers()
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
+    resetFrozenQueuedTransportsForTests()
     $sessions.set([])
     clearAllSessionStates()
   })
@@ -100,9 +103,10 @@ describe('useBackgroundQueueDrain', () => {
     const submitText = vi.fn(async () => true)
 
     enqueueQueuedPrompt('stored-session-a', {
-      text: '```terminal\nselection A\n```\n\nlook at',
+      text: 'look at @terminal:`zsh:23-58`',
       displayText: 'look at @terminal:`zsh:23-58`',
-      attachments: []
+      attachments: [],
+      frozenTransport: '```terminal\nselection A\n```\n\nlook at'
     })
     clearAllSessionStates()
 

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -121,6 +121,7 @@ export function useBackgroundQueueDrain({
           const accepted = await Promise.resolve(
             submitTextRef.current(liveEntry.text, {
               attachments: liveEntry.attachments,
+              ...(liveEntry.displayText ? { displayText: liveEntry.displayText } : {}),
               fromQueue: true,
               sessionId: runtimeSessionId,
               storedSessionId: sessionKey

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -10,6 +10,7 @@ import {
   MAX_AUTO_DRAIN_ATTEMPTS,
   type QueuedPromptEntry,
   removeQueuedPrompt,
+  resolveQueuedPromptTransport,
   shouldAutoDrain
 } from '@/store/composer-queue'
 import { notify } from '@/store/notifications'
@@ -116,12 +117,25 @@ export function useBackgroundQueueDrain({
             return true
           }
 
+          const resolved = resolveQueuedPromptTransport(liveEntry)
+
+          if (!resolved.ok) {
+            notify({
+              kind: 'warning',
+              title: t.composer.terminalSelectionMissingTitle,
+              message: t.composer.queuedTerminalSelectionExpiredBody
+            })
+            drainFailuresRef.current.set(liveEntry.id, MAX_AUTO_DRAIN_ATTEMPTS)
+
+            return true
+          }
+
           const runtimeSessionId = runtimeIdByStoredSessionIdRef.current.get(sessionKey) ?? null
 
           const accepted = await Promise.resolve(
-            submitTextRef.current(liveEntry.text, {
+            submitTextRef.current(resolved.transportText, {
               attachments: liveEntry.attachments,
-              ...(liveEntry.displayText ? { displayText: liveEntry.displayText } : {}),
+              ...(resolved.displayText ? { displayText: resolved.displayText } : {}),
               fromQueue: true,
               sessionId: runtimeSessionId,
               storedSessionId: sessionKey

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -123,7 +123,11 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         Boolean(a)
       )
 
-      const terminalContextBlocks = terminalContextBlocksFromDraft(rawText).join('\n\n')
+      const terminalContextBlocks = terminalContextBlocksFromDraft(rawText)
+        // Skip blocks already present (failed-steer re-queue of an expanded
+        // draft) so drain/submit cannot duplicate fences (#77078).
+        .filter(block => !rawText.includes(block))
+        .join('\n\n')
       const hasImage = attachments.some(a => a.kind === 'image')
 
       // Refs are recomputed after sync (file.attach rewrites @file: refs to

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -2,6 +2,7 @@ import { type MutableRefObject, useCallback } from 'react'
 
 import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
 import type { Translations } from '@/i18n'
+import { translateNow } from '@/i18n'
 import { type ChatMessage, textPart } from '@/lib/chat-messages'
 import { optimisticAttachmentRef } from '@/lib/chat-runtime'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
@@ -16,7 +17,7 @@ import {
   $composerAttachments,
   clearComposerAttachments,
   type ComposerAttachment,
-  terminalContextBlocksFromDraft
+  freezeComposerDraftWithTerminalContext
 } from '@/store/composer'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
@@ -111,7 +112,6 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
   return useCallback(
     async (rawText: string, options?: SubmitTextOptions) => {
-      const visibleText = sanitizeComposerInput(rawText).trim()
       const usingComposerAttachments = !options?.attachments
 
       // Drop undefined/null holes a session switch or draft restore can leave in
@@ -123,11 +123,34 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         Boolean(a)
       )
 
-      const terminalContextBlocks = terminalContextBlocksFromDraft(rawText)
-        // Skip blocks already present (failed-steer re-queue of an expanded
-        // draft) so drain/submit cannot duplicate fences (#77078).
-        .filter(block => !rawText.includes(block))
-        .join('\n\n')
+      // Freeze `@terminal:` chips into transport text before send. Queue drains
+      // already carry frozen transport (tokens stripped at enqueue) — never
+      // re-resolve against the live selection map, or a later Cmd+L that reused
+      // the same shell:row label silently injects unrelated output (#77078).
+      let transportRaw = rawText
+      let bubbleOverride = options?.displayText
+
+      if (!options?.fromQueue) {
+        const frozen = freezeComposerDraftWithTerminalContext(rawText)
+
+        if (frozen.missingLabels.length > 0) {
+          notify({
+            kind: 'warning',
+            title: translateNow('composer.terminalSelectionMissingTitle'),
+            message: translateNow('composer.terminalSelectionMissingBody')
+          })
+
+          return false
+        }
+
+        transportRaw = frozen.transportText
+
+        if (!bubbleOverride && frozen.displayText !== frozen.transportText) {
+          bubbleOverride = frozen.displayText
+        }
+      }
+
+      const visibleText = sanitizeComposerInput(transportRaw).trim()
       const hasImage = attachments.some(a => a.kind === 'image')
 
       // Refs are recomputed after sync (file.attach rewrites @file: refs to
@@ -147,8 +170,9 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           .filter(Boolean)
           .join('\n')
 
+        // Terminal fences live inside visibleText (frozen above / at enqueue).
         return (
-          [contextRefs, terminalContextBlocks, visibleText].filter(Boolean).join('\n\n') ||
+          [contextRefs, visibleText].filter(Boolean).join('\n\n') ||
           (present.some(a => a.kind === 'image') ? 'What do you see in this image?' : '')
         )
       }
@@ -162,7 +186,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // not the foreground flag: an explicit target (tile, queue drain) is
       // frequently not the session on screen, so the foreground flag would gate
       // one session's send on another session's turn.
-      const hasSendable = Boolean(visibleText || terminalContextBlocks || attachments.length || hasImage)
+      const hasSendable = Boolean(visibleText || attachments.length || hasImage)
 
       const guardSessionId = options?.sessionId ?? activeSessionIdRef.current
 
@@ -316,9 +340,9 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
       // What the bubble shows. A `/skill` send carries the whole expanded
       // skill body as its text — model-facing scaffolding — so the dispatcher
-      // hands us the invocation to render instead. Everything else shows what
-      // was typed.
-      const bubbleText = options?.displayText ?? visibleText
+      // hands us the invocation to render instead. Frozen `@terminal:` sends
+      // keep the chip form here while the agent receives fenced transport.
+      const bubbleText = bubbleOverride ?? visibleText
 
       const buildUserMessage = (): ChatMessage => ({
         id: optimisticId,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -1,7 +1,7 @@
 import { type MutableRefObject, useCallback } from 'react'
 
 import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS } from '@/hermes'
-import type { Translations } from '@/i18n'
+import { translateNow, type Translations } from '@/i18n'
 import { type ChatMessage, textPart } from '@/lib/chat-messages'
 import { optimisticAttachmentRef } from '@/lib/chat-runtime'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
@@ -15,8 +15,8 @@ import {
 import {
   $composerAttachments,
   type ComposerAttachment,
-  mainComposerScope,
-  terminalContextBlocksFromDraft
+  freezeComposerTransportPayload,
+  mainComposerScope
 } from '@/store/composer'
 import { $hudMode } from '@/store/hud'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
@@ -116,7 +116,6 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
   return useCallback(
     async (rawText: string, options?: SubmitTextOptions) => {
-      const visibleText = sanitizeComposerInput(rawText).trim()
       const usingComposerAttachments = !options?.attachments
 
       // Drop undefined/null holes a session switch or draft restore can leave in
@@ -128,7 +127,34 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         Boolean(a)
       )
 
-      const terminalContextBlocks = terminalContextBlocksFromDraft(rawText).join('\n\n')
+      // Freeze `@terminal:` chips into transport text before send. Queue drains
+      // already carry frozen transport (tokens stripped at enqueue) — never
+      // re-resolve against the live selection map, or a later Cmd+L that reused
+      // the same shell:row label silently injects unrelated output (#77078).
+      let transportRaw = rawText
+      let bubbleOverride = options?.displayText
+
+      if (!options?.fromQueue) {
+        const frozen = freezeComposerTransportPayload(rawText)
+
+        if (frozen.missingLabels.length > 0) {
+          notify({
+            kind: 'warning',
+            title: translateNow('composer.terminalSelectionMissingTitle'),
+            message: translateNow('composer.terminalSelectionMissingBody')
+          })
+
+          return false
+        }
+
+        transportRaw = frozen.transportText
+
+        if (!bubbleOverride && frozen.displayText !== frozen.transportText) {
+          bubbleOverride = frozen.displayText
+        }
+      }
+
+      const visibleText = sanitizeComposerInput(transportRaw).trim()
       const hasImage = attachments.some(a => a.kind === 'image')
 
       // Refs are recomputed after sync (file.attach rewrites @file: refs to
@@ -148,8 +174,9 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           .filter(Boolean)
           .join('\n')
 
+        // Terminal fences live inside visibleText (frozen above / at enqueue).
         return (
-          [contextRefs, terminalContextBlocks, visibleText].filter(Boolean).join('\n\n') ||
+          [contextRefs, visibleText].filter(Boolean).join('\n\n') ||
           (present.some(a => a.kind === 'image') ? 'What do you see in this image?' : '')
         )
       }
@@ -163,7 +190,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // not the foreground flag: an explicit target (tile, queue drain) is
       // frequently not the session on screen, so the foreground flag would gate
       // one session's send on another session's turn.
-      const hasSendable = Boolean(visibleText || terminalContextBlocks || attachments.length || hasImage)
+      const hasSendable = Boolean(visibleText || attachments.length || hasImage)
 
       const guardSessionId = options?.sessionId ?? activeSessionIdRef.current
 
@@ -335,7 +362,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       // skill body as its text — model-facing scaffolding — so the dispatcher
       // hands us the invocation to render instead. Everything else shows what
       // was typed.
-      const bubbleText = options?.displayText ?? visibleText
+      const bubbleText = bubbleOverride ?? visibleText
       // Keep the user-send boundary stable when later ref resolution rewrites
       // the optimistic bubble in place.
       const submittedAt = Date.now() / 1000

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1721,6 +1721,9 @@ export const ar = defineLocale({
     queueDelete: 'حذف من الطابور',
     queueStuckTitle: 'لم تُرسل الرسالة في قائمة الانتظار',
     queueStuckBody: 'ظل دور في قائمة الانتظار يفشل في الإرسال. ما زال في قائمة الانتظار — حاول إرساله مرة أخرى.',
+    terminalSelectionMissingTitle: 'تحديد الطرفية غير متاح',
+    terminalSelectionMissingBody:
+      'أعد تحديد أسطر الطرفية (Ctrl/Cmd+L) قبل الإرسال — لم يعد للرمز النص الأصلي.',
     previewUnavailable: 'المعاينة غير متاحة',
     previewLabel: label => `معاينة ${label}`,
     couldNotPreview: label => `تعذرت معاينة ${label}`,

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1800,6 +1800,9 @@ export const ar = defineLocale({
     queueDelete: 'حذف من الطابور',
     queueStuckTitle: 'لم تُرسل الرسالة في قائمة الانتظار',
     queueStuckBody: 'ظل دور في قائمة الانتظار يفشل في الإرسال. ما زال في قائمة الانتظار — حاول إرساله مرة أخرى.',
+    terminalSelectionMissingTitle: 'تحديد الطرفية غير متاح',
+    terminalSelectionMissingBody:
+      'أعد تحديد أسطر الطرفية (Ctrl/Cmd+L) قبل الإرسال — لا يحتوي هذا الوسم على النص الأصلي.',
     previewUnavailable: 'المعاينة غير متاحة',
     previewLabel: label => `معاينة ${label}`,
     couldNotPreview: label => `تعذرت معاينة ${label}`,

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1803,6 +1803,8 @@ export const ar = defineLocale({
     terminalSelectionMissingTitle: 'تحديد الطرفية غير متاح',
     terminalSelectionMissingBody:
       'أعد تحديد أسطر الطرفية (Ctrl/Cmd+L) قبل الإرسال — لا يحتوي هذا الوسم على النص الأصلي.',
+    queuedTerminalSelectionExpiredBody:
+      'تحديد الطرفية في قائمة الانتظار لم يعد متاحا. أعد تحديد الأسطر (Ctrl/Cmd+L) وضع الرسالة في القائمة مجددا.',
     previewUnavailable: 'المعاينة غير متاحة',
     previewLabel: label => `معاينة ${label}`,
     couldNotPreview: label => `تعذرت معاينة ${label}`,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2049,6 +2049,9 @@ export const en: Translations = {
     queueResumeTip: 'Paused by Stop — resume sending the queued turns',
     queueStuckTitle: 'Queued message not sent',
     queueStuckBody: 'A queued turn kept failing to send. It is still in the queue — try sending it again.',
+    terminalSelectionMissingTitle: 'Terminal selection unavailable',
+    terminalSelectionMissingBody:
+      'Re-select the terminal lines (Ctrl/Cmd+L) before sending — the chip no longer has the original text.',
     previewUnavailable: 'Preview unavailable',
     previewLabel: label => `Preview ${label}`,
     couldNotPreview: label => `Could not preview ${label}`,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2293,6 +2293,9 @@ export const en: Translations = {
     queueResumeTip: 'Paused by Stop — resume sending the queued turns',
     queueStuckTitle: 'Queued message not sent',
     queueStuckBody: 'A queued turn kept failing to send. It is still in the queue — try sending it again.',
+    terminalSelectionMissingTitle: 'Terminal selection unavailable',
+    terminalSelectionMissingBody:
+      'Re-select the terminal lines (Ctrl/Cmd+L) before sending — this chip has no original text.',
     previewUnavailable: 'Preview unavailable',
     previewLabel: label => `Preview ${label}`,
     couldNotPreview: label => `Could not preview ${label}`,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2296,6 +2296,8 @@ export const en: Translations = {
     terminalSelectionMissingTitle: 'Terminal selection unavailable',
     terminalSelectionMissingBody:
       'Re-select the terminal lines (Ctrl/Cmd+L) before sending — this chip has no original text.',
+    queuedTerminalSelectionExpiredBody:
+      'This queued terminal selection is no longer available. Re-select the lines (Ctrl/Cmd+L) and queue the message again.',
     previewUnavailable: 'Preview unavailable',
     previewLabel: label => `Preview ${label}`,
     couldNotPreview: label => `Could not preview ${label}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1886,6 +1886,9 @@ export const ja = defineLocale({
     queueStuckTitle: 'キュー内のメッセージを送信できません',
     queueStuckBody:
       'キューに入れたターンの送信が繰り返し失敗しました。まだキューに残っています。もう一度送信してください。',
+    terminalSelectionMissingTitle: 'ターミナル選択を利用できません',
+    terminalSelectionMissingBody:
+      '送信前にターミナル行を再選択（Ctrl/Cmd+L）してください — チップに元のテキストがありません。',
     previewUnavailable: 'プレビューは利用できません',
     previewLabel: label => `${label} のプレビュー`,
     couldNotPreview: label => `${label} をプレビューできませんでした`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1998,6 +1998,9 @@ export const ja = defineLocale({
     queueStuckTitle: 'キュー内のメッセージを送信できません',
     queueStuckBody:
       'キューに入れたターンの送信が繰り返し失敗しました。まだキューに残っています。もう一度送信してください。',
+    terminalSelectionMissingTitle: 'ターミナル選択を利用できません',
+    terminalSelectionMissingBody:
+      '送信前にターミナル行を再選択（Ctrl/Cmd+L）してください — チップに元のテキストがありません。',
     previewUnavailable: 'プレビューは利用できません',
     previewLabel: label => `${label} のプレビュー`,
     couldNotPreview: label => `${label} をプレビューできませんでした`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2001,6 +2001,8 @@ export const ja = defineLocale({
     terminalSelectionMissingTitle: 'ターミナル選択を利用できません',
     terminalSelectionMissingBody:
       '送信前にターミナル行を再選択（Ctrl/Cmd+L）してください — チップに元のテキストがありません。',
+    queuedTerminalSelectionExpiredBody:
+      'キュー内のターミナル選択はもう利用できません。行を再選択（Ctrl/Cmd+L）して、もう一度キューに入れてください。',
     previewUnavailable: 'プレビューは利用できません',
     previewLabel: label => `${label} のプレビュー`,
     couldNotPreview: label => `${label} をプレビューできませんでした`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1715,6 +1715,8 @@ export interface Translations {
     queueResumeTip: string
     queueStuckTitle: string
     queueStuckBody: string
+    terminalSelectionMissingTitle: string
+    terminalSelectionMissingBody: string
     previewUnavailable: string
     previewLabel: (label: string) => string
     couldNotPreview: (label: string) => string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1937,6 +1937,7 @@ export interface Translations {
     queueStuckBody: string
     terminalSelectionMissingTitle: string
     terminalSelectionMissingBody: string
+    queuedTerminalSelectionExpiredBody: string
     previewUnavailable: string
     previewLabel: (label: string) => string
     couldNotPreview: (label: string) => string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1935,6 +1935,8 @@ export interface Translations {
     queueResumeTip: string
     queueStuckTitle: string
     queueStuckBody: string
+    terminalSelectionMissingTitle: string
+    terminalSelectionMissingBody: string
     previewUnavailable: string
     previewLabel: (label: string) => string
     couldNotPreview: (label: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1827,6 +1827,8 @@ export const zhHant = defineLocale({
     queueResumeTip: '已被停止操作暫停 — 繼續傳送排隊的回合',
     queueStuckTitle: '佇列訊息未送出',
     queueStuckBody: '佇列中的對話多次傳送失敗。它仍在佇列中，請重試傳送。',
+    terminalSelectionMissingTitle: '終端選取內容不可用',
+    terminalSelectionMissingBody: '請重新選取終端列（Ctrl/Cmd+L）後再傳送 — 此標記已沒有原始文字。',
     previewUnavailable: '預覽不可用',
     previewLabel: label => `預覽 ${label}`,
     couldNotPreview: label => `無法預覽 ${label}`,

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1935,6 +1935,8 @@ export const zhHant = defineLocale({
     queueResumeTip: '已被停止操作暫停 — 繼續傳送排隊的回合',
     queueStuckTitle: '佇列訊息未送出',
     queueStuckBody: '佇列中的對話多次傳送失敗。它仍在佇列中，請重試傳送。',
+    terminalSelectionMissingTitle: '無法使用終端選區',
+    terminalSelectionMissingBody: '傳送前請重新選擇終端行（Ctrl/Cmd+L）— 此標籤沒有原始文字。',
     previewUnavailable: '預覽不可用',
     previewLabel: label => `預覽 ${label}`,
     couldNotPreview: label => `無法預覽 ${label}`,

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1937,6 +1937,7 @@ export const zhHant = defineLocale({
     queueStuckBody: '佇列中的對話多次傳送失敗。它仍在佇列中，請重試傳送。',
     terminalSelectionMissingTitle: '無法使用終端選區',
     terminalSelectionMissingBody: '傳送前請重新選擇終端行（Ctrl/Cmd+L）— 此標籤沒有原始文字。',
+    queuedTerminalSelectionExpiredBody: '佇列中的終端選區已無法使用。請重新選取行（Ctrl/Cmd+L）並再次加入佇列。',
     previewUnavailable: '預覽不可用',
     previewLabel: label => `預覽 ${label}`,
     couldNotPreview: label => `無法預覽 ${label}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2242,6 +2242,8 @@ export const zh: Translations = {
     queueResumeTip: '已被停止操作暂停 — 继续发送排队的回合',
     queueStuckTitle: '排队消息未发送',
     queueStuckBody: '排队的对话多次发送失败。它仍在队列中，请重试发送。',
+    terminalSelectionMissingTitle: '终端选区不可用',
+    terminalSelectionMissingBody: '请重新选择终端行（Ctrl/Cmd+L）后再发送 — 该引用已没有原始文本。',
     previewUnavailable: '预览不可用',
     previewLabel: label => `预览 ${label}`,
     couldNotPreview: label => `无法预览 ${label}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2476,6 +2476,8 @@ export const zh: Translations = {
     queueResumeTip: '已被停止操作暂停 — 继续发送排队的回合',
     queueStuckTitle: '排队消息未发送',
     queueStuckBody: '排队的对话多次发送失败。它仍在队列中，请重试发送。',
+    terminalSelectionMissingTitle: '无法使用终端选区',
+    terminalSelectionMissingBody: '发送前请重新选择终端行（Ctrl/Cmd+L）— 此标签没有原始文本。',
     previewUnavailable: '预览不可用',
     previewLabel: label => `预览 ${label}`,
     couldNotPreview: label => `无法预览 ${label}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2478,6 +2478,7 @@ export const zh: Translations = {
     queueStuckBody: '排队的对话多次发送失败。它仍在队列中，请重试发送。',
     terminalSelectionMissingTitle: '无法使用终端选区',
     terminalSelectionMissingBody: '发送前请重新选择终端行（Ctrl/Cmd+L）— 此标签没有原始文本。',
+    queuedTerminalSelectionExpiredBody: '队列中的终端选区已不可用。请重新选择行（Ctrl/Cmd+L）并再次加入队列。',
     previewUnavailable: '预览不可用',
     previewLabel: label => `预览 ${label}`,
     couldNotPreview: label => `无法预览 ${label}`,

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -7,13 +7,17 @@ import {
   clearQueuedPrompts,
   dequeueQueuedPrompt,
   enqueueQueuedPrompt,
+  getFrozenQueuedTransport,
   getQueuedPrompts,
   isQueueParked,
   migrateQueuedPrompts,
   parkQueuedPrompts,
   promoteQueuedPrompt,
   removeQueuedPrompt,
+  resetFrozenQueuedTransportsForTests,
+  resolveQueuedPromptTransport,
   shouldAutoDrain,
+  simulateComposerQueueReloadForTests,
   unparkQueuedPrompts,
   updateQueuedPrompt,
   updateQueuedPromptText
@@ -35,6 +39,7 @@ describe('composer queue store', () => {
   beforeEach(() => {
     window.localStorage.removeItem(QUEUE_STORAGE_KEY)
     $queuedPromptsBySession.set({})
+    resetFrozenQueuedTransportsForTests()
   })
 
   it('queues prompts in FIFO order', () => {
@@ -126,6 +131,7 @@ describe('migrateQueuedPrompts', () => {
   beforeEach(() => {
     window.localStorage.removeItem(QUEUE_STORAGE_KEY)
     $queuedPromptsBySession.set({})
+    resetFrozenQueuedTransportsForTests()
   })
 
   it('moves entries from a dead runtime key onto the live one', () => {
@@ -201,6 +207,7 @@ describe('parked queue sessions', () => {
     window.localStorage.removeItem(QUEUE_STORAGE_KEY)
     $queuedPromptsBySession.set({})
     $parkedQueueSessions.set({})
+    resetFrozenQueuedTransportsForTests()
   })
 
   it('parks only sessions with queued entries', () => {
@@ -260,3 +267,149 @@ describe('parked queue sessions', () => {
     expect(isQueueParked('rt-new')).toBe(false)
   })
 })
+
+const TERMINAL_CHIP_DRAFT = 'look at @terminal:`zsh:23-58`'
+const SELECTION_A = 'selection A from pane one'
+const SELECTION_A_TRANSPORT = '```terminal\nselection A from pane one\n```\n\nlook at'
+
+describe('composer queue terminal payload persistence', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
+    $queuedPromptsBySession.set({})
+    resetFrozenQueuedTransportsForTests()
+  })
+
+  it('does not persist frozen terminal CONTENTS into hermes.desktop.composerQueue.v1', () => {
+    const entry = enqueueQueuedPrompt(SESSION_KEY, {
+      attachments: [],
+      text: TERMINAL_CHIP_DRAFT,
+      displayText: TERMINAL_CHIP_DRAFT,
+      frozenTransport: SELECTION_A_TRANSPORT
+    })
+
+    expect(entry).not.toBeNull()
+    expect(getFrozenQueuedTransport(entry!.id)).toBe(SELECTION_A_TRANSPORT)
+
+    const raw = String(window.localStorage.getItem(QUEUE_STORAGE_KEY))
+
+    expect(raw).toContain(TERMINAL_CHIP_DRAFT)
+    expect(raw).not.toContain(SELECTION_A)
+    expect(raw).not.toContain('```terminal')
+    expect(JSON.parse(raw)[SESSION_KEY][0].text).toBe(TERMINAL_CHIP_DRAFT)
+  })
+
+  it('fails closed after reload when chips remain but the runtime payload is gone', () => {
+    const entry = enqueueQueuedPrompt(SESSION_KEY, {
+      attachments: [],
+      text: TERMINAL_CHIP_DRAFT,
+      displayText: TERMINAL_CHIP_DRAFT,
+      frozenTransport: SELECTION_A_TRANSPORT
+    })
+
+    expect(resolveQueuedPromptTransport(entry!).ok).toBe(true)
+
+    simulateComposerQueueReloadForTests()
+
+    const restored = getQueuedPrompts(SESSION_KEY)[0]
+
+    expect(restored).toBeDefined()
+    expect(restored!.id).toBe(entry!.id)
+    expect(restored!.text).toBe(TERMINAL_CHIP_DRAFT)
+    expect(getFrozenQueuedTransport(restored!.id)).toBeUndefined()
+
+    const resolved = resolveQueuedPromptTransport(restored!)
+
+    expect(resolved).toEqual({ ok: false, reason: 'missing-terminal-payload' })
+  })
+
+  it('lets an ordinary text queue survive reload and send normally', () => {
+    const entry = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'plain follow-up' })
+
+    simulateComposerQueueReloadForTests()
+
+    const restored = getQueuedPrompts(SESSION_KEY)[0]
+
+    expect(restored!.id).toBe(entry!.id)
+    expect(resolveQueuedPromptTransport(restored!)).toEqual({
+      ok: true,
+      transportText: 'plain follow-up'
+    })
+  })
+
+  it('cleans the ephemeral payload on remove and clear', () => {
+    const first = enqueueQueuedPrompt(SESSION_KEY, {
+      attachments: [],
+      text: TERMINAL_CHIP_DRAFT,
+      displayText: TERMINAL_CHIP_DRAFT,
+      frozenTransport: SELECTION_A_TRANSPORT
+    })
+    const second = enqueueQueuedPrompt(SESSION_KEY, {
+      attachments: [],
+      text: 'second @terminal:`bash:1-2`',
+      displayText: 'second @terminal:`bash:1-2`',
+      frozenTransport: '```terminal\nother\n```\n\nsecond'
+    })
+
+    expect(getFrozenQueuedTransport(first!.id)).toBeDefined()
+    expect(removeQueuedPrompt(SESSION_KEY, first!.id)).toBe(true)
+    expect(getFrozenQueuedTransport(first!.id)).toBeUndefined()
+    expect(getFrozenQueuedTransport(second!.id)).toBeDefined()
+
+    const dequeued = dequeueQueuedPrompt(SESSION_KEY)
+
+    expect(dequeued?.id).toBe(second!.id)
+    expect(getFrozenQueuedTransport(second!.id)).toBeUndefined()
+
+    const third = enqueueQueuedPrompt(SESSION_KEY, {
+      attachments: [],
+      text: TERMINAL_CHIP_DRAFT,
+      displayText: TERMINAL_CHIP_DRAFT,
+      frozenTransport: SELECTION_A_TRANSPORT
+    })
+
+    clearQueuedPrompts(SESSION_KEY)
+
+    expect(getFrozenQueuedTransport(third!.id)).toBeUndefined()
+    expect(getQueuedPrompts(SESSION_KEY)).toEqual([])
+  })
+
+  it('preserves the ephemeral payload by id across migrate, promote, and replacement edit', () => {
+    const entry = enqueueQueuedPrompt('rt-old', {
+      attachments: [],
+      text: TERMINAL_CHIP_DRAFT,
+      displayText: TERMINAL_CHIP_DRAFT,
+      frozenTransport: SELECTION_A_TRANSPORT
+    })
+    enqueueQueuedPrompt('rt-old', { attachments: [], text: 'later' })
+
+    expect(migrateQueuedPrompts('rt-old', 'rt-new')).toBe(true)
+    expect(entry!.id).toBe(getQueuedPrompts('rt-new')[0]?.id)
+    expect(getFrozenQueuedTransport(entry!.id)).toBe(SELECTION_A_TRANSPORT)
+
+    const later = getQueuedPrompts('rt-new')[1]!
+
+    expect(promoteQueuedPrompt('rt-new', later.id)).toBe(true)
+    expect(getFrozenQueuedTransport(entry!.id)).toBe(SELECTION_A_TRANSPORT)
+
+    const replacement = '```terminal\nselection B after edit\n```\n\nlook at'
+
+    expect(
+      updateQueuedPrompt('rt-new', entry!.id, {
+        text: TERMINAL_CHIP_DRAFT,
+        displayText: TERMINAL_CHIP_DRAFT,
+        frozenTransport: replacement
+      })
+    ).toBe(true)
+    expect(getFrozenQueuedTransport(entry!.id)).toBe(replacement)
+    expect(String(window.localStorage.getItem(QUEUE_STORAGE_KEY))).not.toContain('selection B after edit')
+
+    expect(
+      updateQueuedPrompt('rt-new', entry!.id, {
+        text: 'no longer a terminal chip',
+        frozenTransport: null
+      })
+    ).toBe(true)
+    expect(getFrozenQueuedTransport(entry!.id)).toBeUndefined()
+  })
+})
+

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -199,7 +199,13 @@ export const promoteQueuedPrompt = (key: string | null | undefined, id: string):
 export const updateQueuedPrompt = (
   key: string | null | undefined,
   id: string,
-  update: { text: string; attachments?: ComposerAttachment[] }
+  update: {
+    text: string
+    attachments?: ComposerAttachment[]
+    /** Pass a string to set, `null` to clear, omit to keep (unless text changes
+     *  without an explicit displayText — then the old projection is dropped). */
+    displayText?: string | null
+  }
 ): boolean => {
   const sid = sidOf(key)
 
@@ -216,8 +222,18 @@ export const updateQueuedPrompt = (
     }
 
     const attachments = update.attachments ? cloneAttachments(update.attachments) : entry.attachments
+    const displayTextExplicit = 'displayText' in update
+    const nextDisplayText = displayTextExplicit
+      ? update.displayText || undefined
+      : update.text !== entry.text
+        ? undefined
+        : entry.displayText
 
-    if (entry.text === update.text && !update.attachments) {
+    if (
+      entry.text === update.text &&
+      !update.attachments &&
+      (!displayTextExplicit || entry.displayText === nextDisplayText)
+    ) {
       return entry
     }
 
@@ -225,10 +241,16 @@ export const updateQueuedPrompt = (
 
     // The user rewrote the text, so any display projection it carried (a
     // `/skill` invocation standing in for the expanded body) no longer
-    // describes it — what they typed is now what sends.
+    // describes it — what they typed is now what sends — unless the caller
+    // explicitly passes a fresh displayText (frozen `@terminal:` chips).
     const { displayText: _dropped, ...rest } = entry
 
-    return { ...rest, text: update.text, attachments }
+    return {
+      ...rest,
+      text: update.text,
+      attachments,
+      ...(nextDisplayText ? { displayText: nextDisplayText } : {})
+    }
   })
 
   if (!changed) {

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -2,17 +2,122 @@ import { atom } from 'nanostores'
 
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 
-import type { ComposerAttachment } from './composer'
+import { type ComposerAttachment, draftHasTerminalChips } from './composer'
 
 export interface QueuedPromptEntry {
   id: string
   text: string
   /** What the queue panel and the sent bubble show, when it differs from the
    *  text the agent receives. A queued `/skill` invocation carries the whole
-   *  expanded skill body as `text` — the UI shows the invocation instead. */
+   *  expanded skill body as `text` — the UI shows the invocation instead.
+   *  A queued `@terminal:` chip keeps the chip form here (and in `text`); the
+   *  fenced selection payload lives only in the runtime map. */
   displayText?: string
   attachments: ComposerAttachment[]
   queuedAt: number
+}
+
+export interface EnqueueQueuedPromptPayload {
+  text: string
+  attachments: ComposerAttachment[]
+  displayText?: string
+  /** Fenced `@terminal` transport. Runtime-only; never written to localStorage. */
+  frozenTransport?: string
+}
+
+export type ResolvedQueuedPromptTransport =
+  | { ok: true; transportText: string; displayText?: string }
+  | { ok: false; reason: 'missing-terminal-payload' }
+
+/**
+ * Frozen terminal transport for queued entries, keyed by stable `queuedPromptId`.
+ * Memory-only on purpose: persisting selection CONTENTS in
+ * `hermes.desktop.composerQueue.v1` would survive renderer restart as stale
+ * secrets-adjacent terminal output, and label reuse after reload cannot
+ * reconstruct the original pane (#77078).
+ */
+const frozenQueuedTransportById = new Map<string, string>()
+
+export const getFrozenQueuedTransport = (id: string): string | undefined => frozenQueuedTransportById.get(id)
+
+export const setFrozenQueuedTransport = (id: string, transportText: string): void => {
+  const trimmed = transportText.trim()
+
+  if (!trimmed) {
+    frozenQueuedTransportById.delete(id)
+
+    return
+  }
+
+  frozenQueuedTransportById.set(id, trimmed)
+}
+
+export const clearFrozenQueuedTransport = (id: string): void => {
+  frozenQueuedTransportById.delete(id)
+}
+
+export const resetFrozenQueuedTransportsForTests = (): void => {
+  frozenQueuedTransportById.clear()
+}
+
+export const queuedEntryHasTerminalChips = (entry: Pick<QueuedPromptEntry, 'displayText' | 'text'>): boolean =>
+  draftHasTerminalChips(entry.displayText ?? '') || draftHasTerminalChips(entry.text)
+
+export const resolveQueuedPromptTransport = (entry: QueuedPromptEntry): ResolvedQueuedPromptTransport => {
+  if (!queuedEntryHasTerminalChips(entry)) {
+    return {
+      ok: true,
+      transportText: entry.text,
+      ...(entry.displayText ? { displayText: entry.displayText } : {})
+    }
+  }
+
+  const frozen = frozenQueuedTransportById.get(entry.id)?.trim()
+
+  if (!frozen) {
+    return { ok: false, reason: 'missing-terminal-payload' }
+  }
+
+  const chipText = entry.displayText ?? entry.text
+
+  return { ok: true, transportText: frozen, displayText: chipText }
+}
+
+const dropFrozenTransportsRemovedFrom = (previous: QueuedPromptEntry[], next: QueuedPromptEntry[]) => {
+  const nextIds = new Set(next.map(entry => entry.id))
+
+  for (const entry of previous) {
+    if (!nextIds.has(entry.id)) {
+      frozenQueuedTransportById.delete(entry.id)
+    }
+  }
+}
+
+const toPersistedEntry = (entry: QueuedPromptEntry): QueuedPromptEntry => {
+  const frozen = frozenQueuedTransportById.get(entry.id)?.trim()
+  const persisted: QueuedPromptEntry = {
+    id: entry.id,
+    text: entry.text,
+    attachments: entry.attachments,
+    queuedAt: entry.queuedAt,
+    ...(entry.displayText ? { displayText: entry.displayText } : {})
+  }
+
+  if (!frozen) {
+    return persisted
+  }
+
+  // Never write fenced selection CONTENTS into localStorage. Prefer the chip
+  // form already on the entry; if `text` accidentally holds transport, swap it.
+  if (persisted.text === frozen) {
+    persisted.text = persisted.displayText ?? ''
+  }
+
+  if (persisted.displayText === frozen) {
+    delete persisted.displayText
+  }
+
+  return persisted
 }
 
 /** Whether a queued entry can ride a mid-turn redirect: text-only, non-empty,
@@ -43,6 +148,16 @@ const load = (): QueueState => {
   }
 }
 
+const persistableState = (state: QueueState): QueueState => {
+  const out: QueueState = {}
+
+  for (const [sid, queue] of Object.entries(state)) {
+    out[sid] = queue.map(toPersistedEntry)
+  }
+
+  return out
+}
+
 const save = (state: QueueState) => {
   if (typeof window === 'undefined') {
     return
@@ -52,7 +167,7 @@ const save = (state: QueueState) => {
     if (Object.keys(state).length === 0) {
       window.localStorage.removeItem(STORAGE_KEY)
     } else {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(persistableState(state)))
     }
   } catch {
     // best-effort: storage may be unavailable, queue still works in-memory
@@ -60,6 +175,12 @@ const save = (state: QueueState) => {
 }
 
 export const $queuedPromptsBySession = atom<QueueState>(load())
+
+/** Drop runtime payloads and rehydrate the atom from localStorage (renderer restart). */
+export const simulateComposerQueueReloadForTests = (): void => {
+  frozenQueuedTransportById.clear()
+  $queuedPromptsBySession.set(load())
+}
 
 /**
  * Sessions whose queue the user explicitly halted (Stop button / Esc). A parked
@@ -90,6 +211,7 @@ const setParked = (sid: string, parked: boolean) => {
 
 const writeSession = (sid: string, queue: QueuedPromptEntry[]) => {
   const current = $queuedPromptsBySession.get()
+  dropFrozenTransportsRemovedFrom(queueFor(sid), queue)
   const next = { ...current }
 
   if (queue.length === 0) {
@@ -125,7 +247,7 @@ export const getQueuedPrompts = (key: string | null | undefined): QueuedPromptEn
 
 export const enqueueQueuedPrompt = (
   key: string | null | undefined,
-  payload: { text: string; attachments: ComposerAttachment[]; displayText?: string }
+  payload: EnqueueQueuedPromptPayload
 ): null | QueuedPromptEntry => {
   const sid = sidOf(key)
 
@@ -139,6 +261,10 @@ export const enqueueQueuedPrompt = (
     ...(payload.displayText ? { displayText: payload.displayText } : {}),
     attachments: cloneAttachments(payload.attachments),
     queuedAt: Date.now()
+  }
+
+  if (payload.frozenTransport?.trim()) {
+    setFrozenQueuedTransport(entry.id, payload.frozenTransport)
   }
 
   writeSession(sid, [...queueFor(sid), entry])
@@ -210,7 +336,13 @@ export const promoteQueuedPrompt = (key: string | null | undefined, id: string):
 export const updateQueuedPrompt = (
   key: string | null | undefined,
   id: string,
-  update: { text: string; attachments?: ComposerAttachment[]; displayText?: string | null }
+  update: {
+    text: string
+    attachments?: ComposerAttachment[]
+    displayText?: string | null
+    /** Replace (`string`), clear (`null`/empty), or leave (`undefined`) runtime transport. */
+    frozenTransport?: string | null
+  }
 ): boolean => {
   const sid = sidOf(key)
 
@@ -234,12 +366,25 @@ export const updateQueuedPrompt = (
     if (
       entry.text === update.text &&
       !update.attachments &&
-      (update.displayText === undefined || nextDisplay === entry.displayText)
+      (update.displayText === undefined || nextDisplay === entry.displayText) &&
+      update.frozenTransport === undefined
     ) {
       return entry
     }
 
     changed = true
+
+    if (update.frozenTransport !== undefined) {
+      const nextFrozen = update.frozenTransport?.trim() ?? ''
+
+      if (nextFrozen) {
+        setFrozenQueuedTransport(entry.id, nextFrozen)
+      } else {
+        clearFrozenQueuedTransport(entry.id)
+      }
+    } else if (!queuedEntryHasTerminalChips({ text: update.text, displayText: nextDisplay })) {
+      clearFrozenQueuedTransport(entry.id)
+    }
 
     // The user rewrote the text, so any display projection it carried (a
     // `/skill` invocation standing in for the expanded body) no longer

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -210,7 +210,7 @@ export const promoteQueuedPrompt = (key: string | null | undefined, id: string):
 export const updateQueuedPrompt = (
   key: string | null | undefined,
   id: string,
-  update: { text: string; attachments?: ComposerAttachment[] }
+  update: { text: string; attachments?: ComposerAttachment[]; displayText?: string | null }
 ): boolean => {
   const sid = sidOf(key)
 
@@ -228,7 +228,14 @@ export const updateQueuedPrompt = (
 
     const attachments = update.attachments ? cloneAttachments(update.attachments) : entry.attachments
 
-    if (entry.text === update.text && !update.attachments) {
+    const nextDisplay =
+      update.displayText === undefined ? undefined : update.displayText === null ? undefined : update.displayText
+
+    if (
+      entry.text === update.text &&
+      !update.attachments &&
+      (update.displayText === undefined || nextDisplay === entry.displayText)
+    ) {
       return entry
     }
 
@@ -236,10 +243,15 @@ export const updateQueuedPrompt = (
 
     // The user rewrote the text, so any display projection it carried (a
     // `/skill` invocation standing in for the expanded body) no longer
-    // describes it — what they typed is now what sends.
+    // describes it — unless the caller froze a new chip/display pair.
     const { displayText: _dropped, ...rest } = entry
 
-    return { ...rest, text: update.text, attachments }
+    return {
+      ...rest,
+      text: update.text,
+      attachments,
+      ...(nextDisplay ? { displayText: nextDisplay } : {})
+    }
   })
 
   if (!changed) {

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -59,6 +59,18 @@ describe('terminal selection expansion', () => {
     expect(twice).toBe(once)
   })
 
+  it('only prepends missing fences when one chip is already expanded', () => {
+    setComposerTerminalSelection('zsh:1-2', 'first block')
+    setComposerTerminalSelection('zsh:3-4', 'second block')
+
+    const partial =
+      '```terminal\nfirst block\n```\n\nsee @terminal:`zsh:1-2` and @terminal:`zsh:3-4`'
+
+    expect(expandComposerDraftWithTerminalContext(partial)).toBe(
+      '```terminal\nsecond block\n```\n\n```terminal\nfirst block\n```\n\nsee @terminal:`zsh:1-2` and @terminal:`zsh:3-4`'
+    )
+  })
+
   it('drops chips whose selection text is missing from the map', () => {
     expect(expandComposerDraftWithTerminalContext('@terminal:`zsh:1-2`')).toBe('@terminal:`zsh:1-2`')
     expect(missingComposerTerminalSelectionLabels('@terminal:`zsh:1-2`')).toEqual(['zsh:1-2'])

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -8,6 +8,7 @@ import {
   clearSessionDraft,
   type ComposerAttachment,
   expandComposerDraftWithTerminalContext,
+  freezeComposerDraftWithTerminalContext,
   missingComposerTerminalSelectionLabels,
   migrateSessionDraft,
   removeComposerAttachment,
@@ -39,18 +40,36 @@ describe('terminal selection expansion', () => {
     clearComposerTerminalSelections()
   })
 
-  it('expands @terminal chips into fenced blocks from the side-channel map', () => {
+  it('freezes @terminal chips into fenced transport without tokens', () => {
     setComposerTerminalSelection('zsh:23-58', 'line one\nline two')
 
-    const expanded = expandComposerDraftWithTerminalContext('see @terminal:`zsh:23-58` please')
+    const frozen = freezeComposerDraftWithTerminalContext('see @terminal:`zsh:23-58` please')
 
-    expect(expanded).toBe('```terminal\nline one\nline two\n```\n\nsee @terminal:`zsh:23-58` please')
+    expect(frozen.transportText).toBe('```terminal\nline one\nline two\n```\n\nsee please')
+    expect(frozen.displayText).toBe('see @terminal:`zsh:23-58` please')
+    expect(frozen.missingLabels).toEqual([])
+    expect(expandComposerDraftWithTerminalContext('see @terminal:`zsh:23-58` please')).toBe(frozen.transportText)
     expect(terminalContextBlocksFromDraft('see @terminal:`zsh:23-58` please')).toEqual([
       '```terminal\nline one\nline two\n```'
     ])
   })
 
-  it('leaves already-expanded drafts alone (idempotent for steer re-queue)', () => {
+  it('does not re-resolve a frozen queue entry after the label is overwritten', () => {
+    setComposerTerminalSelection('zsh:23-58', 'selection A')
+
+    const frozen = freezeComposerDraftWithTerminalContext('look at @terminal:`zsh:23-58`')
+
+    setComposerTerminalSelection('zsh:23-58', 'selection B from another tab')
+
+    // Drain / submit must not call terminalContextBlocksFromDraft on frozen
+    // transport — no tokens remain, so a mutated map cannot inject B.
+    expect(frozen.transportText).toContain('selection A')
+    expect(frozen.transportText).not.toContain('selection B')
+    expect(terminalContextBlocksFromDraft(frozen.transportText)).toEqual([])
+    expect(freezeComposerDraftWithTerminalContext(frozen.transportText).transportText).toBe(frozen.transportText)
+  })
+
+  it('leaves already-frozen transport alone (idempotent for steer re-queue)', () => {
     setComposerTerminalSelection('zsh:23-58', 'line one\nline two')
 
     const once = expandComposerDraftWithTerminalContext('see @terminal:`zsh:23-58` please')
@@ -67,12 +86,15 @@ describe('terminal selection expansion', () => {
       '```terminal\nfirst block\n```\n\nsee @terminal:`zsh:1-2` and @terminal:`zsh:3-4`'
 
     expect(expandComposerDraftWithTerminalContext(partial)).toBe(
-      '```terminal\nsecond block\n```\n\n```terminal\nfirst block\n```\n\nsee @terminal:`zsh:1-2` and @terminal:`zsh:3-4`'
+      '```terminal\nsecond block\n```\n\n```terminal\nfirst block\n```\n\nsee and'
     )
   })
 
-  it('drops chips whose selection text is missing from the map', () => {
-    expect(expandComposerDraftWithTerminalContext('@terminal:`zsh:1-2`')).toBe('@terminal:`zsh:1-2`')
+  it('reports chips whose selection text is missing from the map', () => {
+    const frozen = freezeComposerDraftWithTerminalContext('@terminal:`zsh:1-2`')
+
+    expect(frozen.transportText).toBe('@terminal:`zsh:1-2`')
+    expect(frozen.missingLabels).toEqual(['zsh:1-2'])
     expect(missingComposerTerminalSelectionLabels('@terminal:`zsh:1-2`')).toEqual(['zsh:1-2'])
     expect(terminalContextBlocksFromDraft('@terminal:`zsh:1-2`')).toEqual([])
   })

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -4,15 +4,20 @@ import {
   $composerAttachments,
   $voiceConversationStartRequest,
   addComposerAttachment,
+  clearComposerTerminalSelections,
   clearSessionDraft,
   type ComposerAttachment,
+  expandComposerDraftWithTerminalContext,
+  missingComposerTerminalSelectionLabels,
   migrateSessionDraft,
   removeComposerAttachment,
   requestVoiceConversationStart,
   SESSION_DRAFTS_STORAGE_KEY,
+  setComposerTerminalSelection,
   stashSessionDraft,
   takeSessionDraft,
   takeVoiceConversationStart,
+  terminalContextBlocksFromDraft,
   updateComposerAttachment
 } from './composer'
 
@@ -26,6 +31,36 @@ describe('voice conversation start requests', () => {
 
     requestVoiceConversationStart()
     expect(takeVoiceConversationStart($voiceConversationStartRequest.get())).toBe(true)
+  })
+})
+
+describe('terminal selection expansion', () => {
+  afterEach(() => {
+    clearComposerTerminalSelections()
+  })
+
+  it('expands @terminal chips into fenced blocks from the side-channel map', () => {
+    setComposerTerminalSelection('zsh:23-58', 'line one\nline two')
+
+    const expanded = expandComposerDraftWithTerminalContext('see @terminal:`zsh:23-58` please')
+
+    expect(expanded).toBe('```terminal\nline one\nline two\n```\n\nsee @terminal:`zsh:23-58` please')
+    expect(terminalContextBlocksFromDraft('see @terminal:`zsh:23-58` please')).toEqual([
+      '```terminal\nline one\nline two\n```'
+    ])
+  })
+
+  it('drops chips whose selection text is missing from the map', () => {
+    expect(expandComposerDraftWithTerminalContext('@terminal:`zsh:1-2`')).toBe('@terminal:`zsh:1-2`')
+    expect(missingComposerTerminalSelectionLabels('@terminal:`zsh:1-2`')).toEqual(['zsh:1-2'])
+    expect(terminalContextBlocksFromDraft('@terminal:`zsh:1-2`')).toEqual([])
+  })
+
+  it('leaves drafts without terminal chips unchanged', () => {
+    setComposerTerminalSelection('zsh:1-2', 'unused')
+
+    expect(expandComposerDraftWithTerminalContext('just a question')).toBe('just a question')
+    expect(missingComposerTerminalSelectionLabels('just a question')).toEqual([])
   })
 })
 

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -50,6 +50,15 @@ describe('terminal selection expansion', () => {
     ])
   })
 
+  it('leaves already-expanded drafts alone (idempotent for steer re-queue)', () => {
+    setComposerTerminalSelection('zsh:23-58', 'line one\nline two')
+
+    const once = expandComposerDraftWithTerminalContext('see @terminal:`zsh:23-58` please')
+    const twice = expandComposerDraftWithTerminalContext(once)
+
+    expect(twice).toBe(once)
+  })
+
   it('drops chips whose selection text is missing from the map', () => {
     expect(expandComposerDraftWithTerminalContext('@terminal:`zsh:1-2`')).toBe('@terminal:`zsh:1-2`')
     expect(missingComposerTerminalSelectionLabels('@terminal:`zsh:1-2`')).toEqual(['zsh:1-2'])

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -4,14 +4,17 @@ import {
   $composerAttachments,
   $voiceConversationStartRequest,
   addComposerAttachment,
+  clearComposerTerminalSelections,
   clearSessionDraft,
   type ComposerAttachment,
   createComposerAttachmentOccurrenceId,
   createComposerAttachmentScope,
+  freezeComposerTransportPayload,
   migrateSessionDraft,
   removeComposerAttachment,
   requestVoiceConversationStart,
   SESSION_DRAFTS_STORAGE_KEY,
+  setComposerTerminalSelection,
   stashSessionDraft,
   takeSessionDraft,
   takeVoiceConversationStart,
@@ -290,5 +293,63 @@ describe('session drafts', () => {
 
     clearSessionDraft('from')
     clearSessionDraft('to')
+  })
+})
+
+describe('freezeComposerTransportPayload', () => {
+  afterEach(() => {
+    clearComposerTerminalSelections()
+  })
+
+  it('leaves ordinary text unchanged', () => {
+    const frozen = freezeComposerTransportPayload('just a question')
+
+    expect(frozen.transportText).toBe('just a question')
+    expect(frozen.displayText).toBe('just a question')
+    expect(frozen.missingLabels).toEqual([])
+  })
+
+  it('freezes @terminal chips into fenced transport and keeps chips for display', () => {
+    setComposerTerminalSelection('zsh:23-58', 'selected terminal lines')
+
+    const frozen = freezeComposerTransportPayload('look at @terminal:`zsh:23-58`')
+
+    expect(frozen.transportText).toBe('```terminal\nselected terminal lines\n```\n\nlook at')
+    expect(frozen.displayText).toBe('look at @terminal:`zsh:23-58`')
+    expect(frozen.missingLabels).toEqual([])
+  })
+
+  it('does not expand a second time when transport is already frozen', () => {
+    setComposerTerminalSelection('zsh:23-58', 'selected terminal lines')
+
+    const once = freezeComposerTransportPayload('look at @terminal:`zsh:23-58`')
+    const twice = freezeComposerTransportPayload(once.transportText)
+
+    expect(twice.transportText).toBe(once.transportText)
+    expect(twice.displayText).toBe(once.transportText)
+    expect((once.transportText.match(/```terminal/g) ?? []).length).toBe(1)
+  })
+
+  it('reports unresolved chips instead of sending a bare token', () => {
+    const frozen = freezeComposerTransportPayload('look at @terminal:`zsh:23-58`')
+
+    expect(frozen.missingLabels).toEqual(['zsh:23-58'])
+    expect(frozen.transportText).toBe('look at @terminal:`zsh:23-58`')
+    expect(frozen.displayText).toBe('look at @terminal:`zsh:23-58`')
+  })
+
+  it('freezes multiple selections in document order', () => {
+    setComposerTerminalSelection('zsh:10-12', 'first block')
+    setComposerTerminalSelection('bash:3-9', 'second block')
+
+    const frozen = freezeComposerTransportPayload(
+      'compare @terminal:`bash:3-9` with @terminal:`zsh:10-12`'
+    )
+
+    expect(frozen.transportText).toBe(
+      '```terminal\nsecond block\n```\n\n```terminal\nfirst block\n```\n\ncompare with'
+    )
+    expect(frozen.displayText).toBe('compare @terminal:`bash:3-9` with @terminal:`zsh:10-12`')
+    expect(frozen.missingLabels).toEqual([])
   })
 })

--- a/apps/desktop/src/store/composer.test.ts
+++ b/apps/desktop/src/store/composer.test.ts
@@ -352,4 +352,14 @@ describe('freezeComposerTransportPayload', () => {
     expect(frozen.displayText).toBe('compare @terminal:`bash:3-9` with @terminal:`zsh:10-12`')
     expect(frozen.missingLabels).toEqual([])
   })
+
+  it('idle submit and steer still freeze at the transport boundary', () => {
+    setComposerTerminalSelection('zsh:23-58', 'selected terminal lines')
+
+    const frozen = freezeComposerTransportPayload('look at @terminal:`zsh:23-58`')
+
+    expect(frozen.transportText).toContain('selected terminal lines')
+    expect(frozen.displayText).toBe('look at @terminal:`zsh:23-58`')
+    expect(freezeComposerTransportPayload(frozen.transportText).transportText).toBe(frozen.transportText)
+  })
 })

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -364,6 +364,37 @@ export function terminalContextBlocksFromDraft(draft: string) {
   })
 }
 
+/**
+ * Labels present as `@terminal:` chips in the draft whose selection text is
+ * missing from the side-channel map (so expansion would silently drop them).
+ */
+export function missingComposerTerminalSelectionLabels(draft: string) {
+  const selections = $composerTerminalSelections.get()
+
+  return terminalLabelsFromDraft(draft).filter(label => !selections[label]?.trim())
+}
+
+/**
+ * Expand `@terminal:` chips into fenced selection blocks, matching the idle
+ * submit path in `submit.ts`. Busy-turn steer/redirect and queue enqueue must
+ * use this so the agent receives the selected lines, not just the bare token
+ * (#77078).
+ */
+export function expandComposerDraftWithTerminalContext(draft: string) {
+  const visible = draft.trim()
+  const blocks = terminalContextBlocksFromDraft(draft).join('\n\n')
+
+  if (!blocks) {
+    return visible
+  }
+
+  if (!visible) {
+    return blocks
+  }
+
+  return `${blocks}\n\n${visible}`
+}
+
 export function clearComposerTerminalSelections() {
   if (Object.keys($composerTerminalSelections.get()).length === 0) {
     return

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -374,28 +374,66 @@ export function missingComposerTerminalSelectionLabels(draft: string) {
   return terminalLabelsFromDraft(draft).filter(label => !selections[label]?.trim())
 }
 
+/** Remove `@terminal:` chips from transport text after their fences are frozen. */
+function stripTerminalRefTokens(text: string) {
+  return text
+    .replace(TERMINAL_REF_RE, ' ')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/ *\n */g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+export interface FrozenTerminalDraft {
+  /** Composer / bubble text — keeps `@terminal:` chips when present. */
+  displayText: string
+  /**
+   * Agent-facing text: fenced selection blocks plus prose, with resolved
+   * `@terminal:` tokens stripped so a later submit cannot re-resolve them
+   * against a mutated `$composerTerminalSelections` map (#77078).
+   */
+  transportText: string
+  /** Chips whose selection payload is missing from the live map. */
+  missingLabels: string[]
+}
+
 /**
- * Expand `@terminal:` chips into fenced selection blocks, matching the idle
- * submit path in `submit.ts`. Busy-turn steer/redirect and queue enqueue must
- * use this so the agent receives the selected lines, not just the bare token
- * (#77078).
+ * Freeze `@terminal:` chips into immutable fenced blocks for transport.
  *
- * Per-block idempotent: only prepends fences not already present in the draft
- * (failed-steer re-queue, or a draft that already expanded one of several chips).
+ * Busy-turn steer, queue enqueue/edit, and idle submit all use this so the
+ * agent receives selected lines (not bare tokens). Tokens are stripped from
+ * `transportText` so a queued drain cannot pick up a later selection that
+ * reused the same shell:row label.
+ */
+export function freezeComposerDraftWithTerminalContext(draft: string): FrozenTerminalDraft {
+  const displayText = draft.trim()
+  const missingLabels = missingComposerTerminalSelectionLabels(displayText)
+
+  if (missingLabels.length > 0) {
+    return { displayText, transportText: displayText, missingLabels }
+  }
+
+  const labels = terminalLabelsFromDraft(displayText)
+
+  if (labels.length === 0) {
+    return { displayText, transportText: displayText, missingLabels: [] }
+  }
+
+  const blocks = terminalContextBlocksFromDraft(displayText)
+  const missingBlocks = blocks.filter(block => !displayText.includes(block))
+  const prose = stripTerminalRefTokens(displayText)
+  const transportText = [missingBlocks.join('\n\n'), prose].filter(Boolean).join('\n\n').trim()
+
+  return { displayText, transportText, missingLabels: [] }
+}
+
+/**
+ * Expand `@terminal:` chips into fenced selection blocks for agent transport.
+ * Prefer {@link freezeComposerDraftWithTerminalContext} when the caller also
+ * needs `displayText` / `missingLabels` (queue + submit guards).
  */
 export function expandComposerDraftWithTerminalContext(draft: string) {
-  const visible = draft.trim()
-  const missingBlocks = terminalContextBlocksFromDraft(draft).filter(block => !draft.includes(block))
-
-  if (missingBlocks.length === 0) {
-    return visible
-  }
-
-  if (!visible) {
-    return missingBlocks.join('\n\n')
-  }
-
-  return `${missingBlocks.join('\n\n')}\n\n${visible}`
+  return freezeComposerDraftWithTerminalContext(draft).transportText
 }
 
 export function clearComposerTerminalSelections() {

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -376,23 +376,26 @@ export function missingComposerTerminalSelectionLabels(draft: string) {
 
 /**
  * Expand `@terminal:` chips into fenced selection blocks, matching the idle
- * submit path in `submit.ts`. Busy-turn steer/redirect and queue enqueue must
- * use this so the agent receives the selected lines, not just the bare token
- * (#77078).
+ * submit path in `submit.ts`. Busy-turn steer/redirect must use this so the
+ * agent receives the selected lines, not just the bare token (#77078).
+ *
+ * Idempotent: if the draft already contains the fenced blocks (e.g. a failed
+ * steer that was re-queued), returns the draft unchanged so a later submit
+ * expand cannot duplicate them.
  */
 export function expandComposerDraftWithTerminalContext(draft: string) {
   const visible = draft.trim()
-  const blocks = terminalContextBlocksFromDraft(draft).join('\n\n')
+  const blocks = terminalContextBlocksFromDraft(draft)
 
-  if (!blocks) {
+  if (blocks.length === 0) {
     return visible
   }
 
-  if (!visible) {
-    return blocks
+  if (blocks.every(block => draft.includes(block))) {
+    return visible
   }
 
-  return `${blocks}\n\n${visible}`
+  return `${blocks.join('\n\n')}\n\n${visible}`
 }
 
 export function clearComposerTerminalSelections() {

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -376,26 +376,26 @@ export function missingComposerTerminalSelectionLabels(draft: string) {
 
 /**
  * Expand `@terminal:` chips into fenced selection blocks, matching the idle
- * submit path in `submit.ts`. Busy-turn steer/redirect must use this so the
- * agent receives the selected lines, not just the bare token (#77078).
+ * submit path in `submit.ts`. Busy-turn steer/redirect and queue enqueue must
+ * use this so the agent receives the selected lines, not just the bare token
+ * (#77078).
  *
- * Idempotent: if the draft already contains the fenced blocks (e.g. a failed
- * steer that was re-queued), returns the draft unchanged so a later submit
- * expand cannot duplicate them.
+ * Per-block idempotent: only prepends fences not already present in the draft
+ * (failed-steer re-queue, or a draft that already expanded one of several chips).
  */
 export function expandComposerDraftWithTerminalContext(draft: string) {
   const visible = draft.trim()
-  const blocks = terminalContextBlocksFromDraft(draft)
+  const missingBlocks = terminalContextBlocksFromDraft(draft).filter(block => !draft.includes(block))
 
-  if (blocks.length === 0) {
+  if (missingBlocks.length === 0) {
     return visible
   }
 
-  if (blocks.every(block => draft.includes(block))) {
-    return visible
+  if (!visible) {
+    return missingBlocks.join('\n\n')
   }
 
-  return `${blocks.join('\n\n')}\n\n${visible}`
+  return `${missingBlocks.join('\n\n')}\n\n${visible}`
 }
 
 export function clearComposerTerminalSelections() {

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -515,6 +515,11 @@ function terminalLabelsFromDraft(draft: string) {
   return labels
 }
 
+/** True when the draft still carries `@terminal:` chips (not already-frozen transport). */
+export function draftHasTerminalChips(draft: string): boolean {
+  return terminalLabelsFromDraft(draft).length > 0
+}
+
 export function setComposerTerminalSelection(label: string, text: string) {
   const nextLabel = label.trim()
   const nextText = text.trim()

--- a/apps/desktop/src/store/composer.ts
+++ b/apps/desktop/src/store/composer.ts
@@ -556,6 +556,76 @@ export function reconcileComposerTerminalSelections(draft: string) {
   }
 }
 
+function terminalFence(text: string) {
+  return `\`\`\`terminal\n${text}\n\`\`\``
+}
+
+function stripTerminalRefTokens(draft: string) {
+  return draft
+    .replace(new RegExp(TERMINAL_REF_RE.source, 'g'), '')
+    .replace(/[ \t]{2,}/g, ' ')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n[ \t]+/g, '\n')
+    .trim()
+}
+
+export interface ComposerTransportPayload {
+  /** Model-facing text: fenced selection blocks with `@terminal:` chips stripped. */
+  transportText: string
+  /** UI-facing text: original chip form, when it differs from transport. */
+  displayText: string
+  /** Chip labels whose selection text is missing from the in-memory map. */
+  missingLabels: string[]
+}
+
+/**
+ * Freeze `@terminal:` chips into transport text at the moment a message
+ * crosses a send/steer/enqueue boundary. The selection map is memory-only and
+ * label-colliding — later resolve against it can inject a different pane's
+ * output (#77078). Callers that cannot resolve every chip must fail closed.
+ *
+ * Idempotent: already-frozen transport (no chips) is returned unchanged.
+ */
+export function freezeComposerTransportPayload(
+  draft: string,
+  selections: Record<string, string> = $composerTerminalSelections.get()
+): ComposerTransportPayload {
+  const labels = terminalLabelsFromDraft(draft)
+
+  if (labels.length === 0) {
+    return { transportText: draft, displayText: draft, missingLabels: [] }
+  }
+
+  const missingLabels = labels.filter(label => !selections[label]?.trim())
+
+  if (missingLabels.length > 0) {
+    return { transportText: draft, displayText: draft, missingLabels }
+  }
+
+  const existingFences = new Set(draft.match(/```terminal\n[\s\S]*?\n```/g) ?? [])
+  const fences: string[] = []
+
+  for (const label of labels) {
+    const text = selections[label]?.trim()
+
+    if (!text) {
+      continue
+    }
+
+    const fence = terminalFence(text)
+
+    if (!existingFences.has(fence)) {
+      fences.push(fence)
+      existingFences.add(fence)
+    }
+  }
+
+  const remainder = stripTerminalRefTokens(draft)
+  const transportText = [...fences, remainder].filter(Boolean).join('\n\n')
+
+  return { transportText, displayText: draft, missingLabels: [] }
+}
+
 export function terminalContextBlocksFromDraft(draft: string) {
   const labels = terminalLabelsFromDraft(draft)
 
@@ -572,7 +642,7 @@ export function terminalContextBlocksFromDraft(draft: string) {
       return []
     }
 
-    return `\`\`\`terminal\n${text}\n\`\`\``
+    return terminalFence(text)
   })
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes [#77078](https://github.com/NousResearch/hermes-agent/issues/77078):
busy-turn steer and queued prompts were sending bare `@terminal:N` chips
because only idle submit expanded `$composerTerminalSelections`.

**Privacy / lifecycle:** raw terminal selection **content is runtime-only**.
It is never written to `localStorage`. The persisted queue stores the
chip/display representation (plus attachments metadata, stable id, `queuedAt`).
The frozen transport payload lives in an in-memory map keyed by queued entry
id. A renderer restart drops that map; send **fails closed** with a recovery
message (`queuedTerminalSelectionExpiredBody`) rather than leaking terminal
contents. Ordinary text queue entries remain durable across reload.

Terminal context is still frozen when queued so later Cmd+L label reuse cannot
change it. Queue drain (`fromQueue`) never re-resolves against the live
selection map.

- Persistent queue: chip / display text only (no fenced terminal payload)
- Runtime map: `queuedPromptId -> frozenTerminalTransport`
- Restart: missing runtime payload blocks send (fail closed)
- Ordinary text: survives reload normally
- Idle submit and busy steer still freeze at transport; `displayText` stays
  as chips for the bubble / queue UI

Distinct from #76120 (duplicate Cmd+L chips) and #76204 (file preview).

Fixes #77078

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Tests

```bash
cd apps/desktop && npx vitest run \
  src/store/composer.test.ts \
  src/store/composer-queue.test.ts \
  src/app/chat/composer/hooks/use-composer-submit.test.tsx \
  src/app/chat/composer/hooks/use-composer-queue.test.tsx \
  src/app/session/hooks/use-background-queue-drain.test.tsx
```

**91 passed** on the privacy-safe implementation.

## How to Test (manual)

- Busy steer: long turn, Cmd+L a terminal selection, send while busy — steered
  message includes fenced selection text, not a bare `@terminal:0` chip
- Idle submit with an `@terminal` chip still expands once
- Enqueue with selection A, mutate the live label to B, drain — A is sent;
  persisted queue text stays chips
- Reload with a queued chip and no runtime payload — send blocked with recovery
  message; terminal contents are not in `localStorage`

Tip: `b71f77717c66cfaad420ef1b6de102b91ee7dddd` on `upstream/main` `74f99af470ae8ce47f0903cf431d106cecbd37f2`.
