### PR TITLE
fix(kanban): accept line-wrapped and data-URI base64 in kanban_attach (#77215)

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1023,3 +1023,84 @@ def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkey
         assert Path(atts[0].stored_path).read_bytes() == payload
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# kanban_attach — permissive base64 (line-wrapped / data-URI prefixed)
+# ---------------------------------------------------------------------------
+
+
+def _b64_wrap_76(data: bytes) -> str:
+    """Encode ``data`` the way the coreutils `base64` CLI does: newline-
+    wrapped at 76 characters (RFC 2045)."""
+    import base64 as _b64
+
+    encoded = _b64.b64encode(data).decode()
+    return "\n".join(encoded[i:i + 76] for i in range(0, len(encoded), 76))
+
+
+def test_attach_accepts_line_wrapped_base64(worker_env):
+    """76-char-wrapped base64 (coreutils CLI output) decodes successfully."""
+    from pathlib import Path
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    payload = b"line-wrapped attachment payload " * 8
+    wrapped = _b64_wrap_76(payload)
+
+    out = kt._handle_attach({"filename": "wrapped.txt", "content_base64": wrapped})
+    d = json.loads(out)
+    assert d.get("ok") is True, out
+    assert d["size"] == len(payload)
+
+    conn = kb.connect()
+    try:
+        atts = kb.list_attachments(conn, worker_env)
+        assert [a.filename for a in atts] == ["wrapped.txt"]
+        assert Path(atts[0].stored_path).read_bytes() == payload
+    finally:
+        conn.close()
+
+
+def test_attach_accepts_data_uri_base64_prefix(worker_env):
+    """A data:<mime>;base64, URI prefix is stripped before decoding."""
+    import base64 as _b64
+    from pathlib import Path
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    payload = b"\x89PNG\r\n\x1a\n fake image bytes"
+    uri = f"data:image/png;base64,{_b64.b64encode(payload).decode()}"
+
+    out = kt._handle_attach(
+        {
+            "filename": "img.png",
+            "content_base64": uri,
+            "content_type": "image/png",
+        }
+    )
+    d = json.loads(out)
+    assert d.get("ok") is True, out
+
+    conn = kb.connect()
+    try:
+        atts = kb.list_attachments(conn, worker_env)
+        assert [a.filename for a in atts] == ["img.png"]
+        assert atts[0].content_type == "image/png"
+        assert Path(atts[0].stored_path).read_bytes() == payload
+    finally:
+        conn.close()
+
+
+def test_attach_rejects_genuinely_invalid_base64(worker_env):
+    """Non-whitespace garbage still fails cleanly after normalization."""
+    from tools import kanban_tools as kt
+
+    out = kt._handle_attach(
+        {"filename": "bad.txt", "content_base64": "%%%not-base64%%%"}
+    )
+    d = json.loads(out)
+    assert "error" in d, out
+    assert "not valid base64" in d["error"]

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -998,8 +998,19 @@ def _handle_attach(args: dict, **kw) -> str:
         return tool_error("content_base64 is required")
     import base64
     import binascii
+    import re as _re
+    # Normalize before strict validation: tolerate a `data:<mime>;base64,`
+    # URI prefix (common for anything touched by browser/vision tooling) and
+    # whitespace/newlines (the coreutils `base64` CLI line-wraps at 76 chars,
+    # RFC 2045). Both are valid base64 once the non-alphabet formatting is
+    # stripped; validate=True then still rejects genuinely bad characters.
+    raw = str(content_b64).strip()
+    raw = _re.sub(r"^data:[^;]*;base64,", "", raw)
+    raw = _re.sub(r"\s+", "", raw)
+    if not raw:
+        return tool_error("content_base64 is not valid base64: empty payload")
     try:
-        data = base64.b64decode(str(content_b64), validate=True)
+        data = base64.b64decode(raw, validate=True)
     except (binascii.Error, ValueError) as e:
         return tool_error(f"content_base64 is not valid base64: {e}")
     content_type = args.get("content_type")


### PR DESCRIPTION
## Summary

Fixes #77215 — `kanban_attach` now accepts base64 payloads that are line-wrapped or carry a `data:` URI prefix, instead of rejecting them with `content_base64 is not valid base64`.

## Root Cause

`_handle_attach` in `tools/kanban_tools.py` decoded with `base64.b64decode(str(content_b64), validate=True)` — Python's strict mode, which raises on any character outside the base64 alphabet. Two common, perfectly valid inputs were rejected:

1. **Line-wrapped base64** — the coreutils `base64` CLI wraps output at 76 chars (RFC 2045). Any agent that shells out to `base64 <file>` produces output `validate=True` refuses to decode.
2. **`data:<mime>;base64,` URI prefix** — the standard way to represent in-memory files from browser/vision tooling.

Observed in production: a Bridge kanban worker took a screenshot, base64-encoded it with the CLI, and had two consecutive `kanban_attach` calls rejected before giving up.

## Change

In `_handle_attach`, normalize the payload before strict validation:

- strip a leading `data:<mime>;base64,` prefix,
- strip all whitespace/newlines,

then decode with `validate=True` as before, so genuinely invalid characters still produce a clean error. An empty payload after normalization is rejected as invalid base64.

## Verification

New tests in `tests/tools/test_kanban_tools.py`:

- `test_attach_accepts_line_wrapped_base64` — 76-char-wrapped payload (coreutils CLI style) decodes and stores byte-for-byte.
- `test_attach_accepts_data_uri_base64_prefix` — `data:image/png;base64,...` payload decodes and stores byte-for-byte.
- `test_attach_rejects_genuinely_invalid_base64` — non-whitespace garbage still errors cleanly.

`python3 -m pytest tests/tools/test_kanban_tools.py -k attach -p no:xdist -q` → 6 passed. Full `tests/ -k kanban` run: 311 passed; the 7 failures are pre-existing on `main` (identical failure set, `tests/hermes_cli` decompose/write-guard tests, unrelated to this change).
