### PR TITLE
fix(kanban): add local-path option to kanban_attach (#77216)

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1023,3 +1023,101 @@ def test_attach_url_happy_path_public_host(worker_env, default_url_guard, monkey
         assert Path(atts[0].stored_path).read_bytes() == payload
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# kanban_attach — local-path option (read file server-side)
+# ---------------------------------------------------------------------------
+
+
+def test_attach_from_local_path_happy_path(worker_env, tmp_path):
+    """path reads the file server-side; filename defaults to the basename."""
+    from pathlib import Path
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    src = tmp_path / "report.pdf"
+    payload = b"%PDF-1.7 fake report bytes"
+    src.write_bytes(payload)
+
+    out = kt._handle_attach({"path": str(src)})
+    d = json.loads(out)
+    assert d.get("ok") is True, out
+    assert d["size"] == len(payload)
+
+    conn = kb.connect()
+    try:
+        atts = kb.list_attachments(conn, worker_env)
+        assert [a.filename for a in atts] == ["report.pdf"]
+        assert Path(atts[0].stored_path).read_bytes() == payload
+    finally:
+        conn.close()
+
+
+def test_attach_from_local_path_explicit_filename(worker_env, tmp_path):
+    """filename overrides the basename when provided alongside path."""
+    from pathlib import Path
+
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    src = tmp_path / "source.bin"
+    src.write_bytes(b"bytes")
+
+    out = kt._handle_attach({"path": str(src), "filename": "stored.bin"})
+    d = json.loads(out)
+    assert d.get("ok") is True, out
+
+    conn = kb.connect()
+    try:
+        atts = kb.list_attachments(conn, worker_env)
+        assert [a.filename for a in atts] == ["stored.bin"]
+    finally:
+        conn.close()
+
+
+def test_attach_path_and_content_base64_mutually_exclusive(worker_env, tmp_path):
+    from tools import kanban_tools as kt
+
+    src = tmp_path / "a.txt"
+    src.write_bytes(b"x")
+
+    out = kt._handle_attach(
+        {"filename": "a.txt", "content_base64": "eA==", "path": str(src)}
+    )
+    d = json.loads(out)
+    assert "error" in d, out
+    assert "not both" in d["error"]
+
+
+def test_attach_requires_content_base64_or_path(worker_env):
+    from tools import kanban_tools as kt
+
+    out = kt._handle_attach({"filename": "a.txt"})
+    d = json.loads(out)
+    assert "error" in d, out
+    assert "required" in d["error"]
+
+
+def test_attach_path_missing_file(worker_env, tmp_path):
+    from tools import kanban_tools as kt
+
+    out = kt._handle_attach({"path": str(tmp_path / "does-not-exist.txt")})
+    d = json.loads(out)
+    assert "error" in d, out
+    assert "does not exist" in d["error"]
+
+
+def test_attach_path_over_size_cap(worker_env, tmp_path, monkeypatch):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.setattr(kb, "KANBAN_ATTACHMENT_MAX_BYTES", 64)
+    src = tmp_path / "big.bin"
+    src.write_bytes(b"z" * 128)
+
+    out = kt._handle_attach({"path": str(src)})
+    d = json.loads(out)
+    assert "error" in d, out
+    assert "exceeds" in d["error"]

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -970,12 +970,14 @@ def _handle_comment(args: dict, **kw) -> str:
 
 
 def _handle_attach(args: dict, **kw) -> str:
-    """Attach an inline (base64) file to a task.
+    """Attach a file to a task — either inline (base64) or from a local path.
 
-    Mirrors the dashboard's upload endpoint for the agent surface: decode
-    the payload, enforce the shared size cap, write it under the per-task
+    Mirrors the dashboard's upload endpoint for the agent surface: read the
+    bytes (decoded from ``content_base64``, or straight off disk via
+    ``path``), enforce the shared size cap, write it under the per-task
     attachments dir, and record the metadata row — all via
-    ``kanban_db.store_attachment_bytes`` so the three surfaces stay in lockstep.
+    ``kanban_db.store_attachment_bytes`` so the three surfaces stay in
+    lockstep. Exactly one of ``content_base64`` / ``path`` is required.
     """
     from hermes_cli import kanban_db as kb
 
@@ -991,17 +993,45 @@ def _handle_attach(args: dict, **kw) -> str:
     if ownership_err:
         return ownership_err
     filename = args.get("filename")
-    if not filename or not str(filename).strip():
-        return tool_error("filename is required")
     content_b64 = args.get("content_base64")
-    if not content_b64 or not str(content_b64).strip():
-        return tool_error("content_base64 is required")
-    import base64
-    import binascii
-    try:
-        data = base64.b64decode(str(content_b64), validate=True)
-    except (binascii.Error, ValueError) as e:
-        return tool_error(f"content_base64 is not valid base64: {e}")
+    path_arg = args.get("path")
+    if content_b64 and path_arg:
+        return tool_error("pass exactly one of content_base64 or path, not both")
+    if not content_b64 and not path_arg:
+        return tool_error("one of content_base64 or path is required")
+
+    if path_arg:
+        # Local-path branch: read the file directly off disk, server-side —
+        # the analog of kanban_attach_url for files that already exist
+        # locally. Large files never round-trip through the model's output,
+        # so there is no silent-truncation risk.
+        import os as _os
+
+        src_path = _os.path.expanduser(str(path_arg).strip())
+        if not filename or not str(filename).strip():
+            filename = _os.path.basename(src_path) or "attachment"
+        if not _os.path.isfile(src_path):
+            return tool_error(f"path does not exist or is not a regular file: {src_path}")
+        size = _os.path.getsize(src_path)
+        if size > kb.KANBAN_ATTACHMENT_MAX_BYTES:
+            return tool_error(
+                f"file at {src_path} is {size} bytes, exceeds the "
+                f"{kb.KANBAN_ATTACHMENT_MAX_BYTES}-byte attachment limit"
+            )
+        with open(src_path, "rb") as f:
+            data = f.read()
+    else:
+        # Inline branch: decode the base64 payload.
+        if not filename or not str(filename).strip():
+            return tool_error("filename is required")
+        if not content_b64 or not str(content_b64).strip():
+            return tool_error("content_base64 is required")
+        import base64
+        import binascii
+        try:
+            data = base64.b64decode(str(content_b64), validate=True)
+        except (binascii.Error, ValueError) as e:
+            return tool_error(f"content_base64 is not valid base64: {e}")
     content_type = args.get("content_type")
     board = args.get("board")
     try:
@@ -1809,12 +1839,14 @@ KANBAN_COMMENT_SCHEMA = {
 KANBAN_ATTACH_SCHEMA = {
     "name": "kanban_attach",
     "description": (
-        "Attach a file to a task by passing its bytes inline (base64). "
-        "Use for genuine file artifacts the next worker or a human should "
-        "be able to download — generated reports, images, exports. The "
-        "file is stored as a real attachment (not a comment link) under "
-        "the task's attachments dir, capped at 25 MB. Prefer "
-        "kanban_attach_url when you only have a URL."
+        "Attach a file to a task, either inline as base64 bytes "
+        "(content_base64) or by pointing at a file already on disk (path). "
+        "Prefer path whenever the file exists locally — it is read "
+        "server-side, so large files are never round-tripped through the "
+        "model's output (no truncation risk); prefer kanban_attach_url when "
+        "you only have a URL. Exactly one of content_base64 or path is "
+        "required. The file is stored as a real attachment (not a comment "
+        "link) under the task's attachments dir, capped at 25 MB."
     ),
     "parameters": {
         "type": "object",
@@ -1827,12 +1859,26 @@ KANBAN_ATTACH_SCHEMA = {
                 "type": "string",
                 "description": (
                     "File name to store it under (e.g. 'report.pdf'). "
-                    "Directory components are stripped; only the leaf is kept."
+                    "Directory components are stripped; only the leaf is kept. "
+                    "Required with content_base64; defaults to the path's "
+                    "basename when using path."
                 ),
             },
             "content_base64": {
                 "type": "string",
-                "description": "The file contents, base64-encoded. Max 25 MB decoded.",
+                "description": (
+                    "The file contents, base64-encoded. Max 25 MB decoded. "
+                    "Mutually exclusive with path."
+                ),
+            },
+            "path": {
+                "type": "string",
+                "description": (
+                    "Path to a file already on disk to attach — read "
+                    "server-side, so the bytes never pass through the model's "
+                    "output. '~' is expanded. Mutually exclusive with "
+                    "content_base64."
+                ),
             },
             "content_type": {
                 "type": "string",
@@ -1840,7 +1886,7 @@ KANBAN_ATTACH_SCHEMA = {
             },
             "board": _board_schema_prop(),
         },
-        "required": ["filename", "content_base64"],
+        "required": [],
     },
 }
 


### PR DESCRIPTION
## Summary

Fixes #77216 — `kanban_attach` gains a `path` option that reads a file directly off disk server-side, so attaching a local file never requires the model to reproduce the entire file as one inline base64 string (and never risks silent mid-generation truncation).

## Root Cause

`kanban_attach` only accepted `content_base64`, forcing the model to emit the whole file as a single continuous base64 string inside one tool-call argument. Under output-length pressure the string gets cut off: the truncated base64 looks superficially plausible but decodes to corrupt/incomplete data, with no clean signal to the calling agent. `kanban_attach_url` already solves the equivalent problem for remote files (server-side download); `kanban_attach` had no analogous "read it directly" path for a local file — the far more common case (an agent that just wrote a report or took a screenshot has the file on disk).

Observed in production: a Bridge kanban worker tried to attach a real 140,341-byte screenshot; the emitted `content_base64` was cut to 16,489 chars and failed with `number of data characters (16489) cannot be 1 more than a multiple of 4` — while the file sat intact on disk the whole time.

## Change

In `tools/kanban_tools.py`:

- `_handle_attach` accepts a new `path` argument, mutually exclusive with `content_base64` (exactly one required — handler-enforced with clear errors for "both" and "neither").
- The `path` branch: `~`-expands the path, rejects missing/non-regular files, enforces the shared `kb.KANBAN_ATTACHMENT_MAX_BYTES` cap before reading, then reads the bytes server-side and stores them via the same `store_attachment_bytes` write path.
- `filename` becomes optional when `path` is used (defaults to the path's basename), and stays required for the `content_base64` branch.
- `KANBAN_ATTACH_SCHEMA` documents `path`, and its description steers models toward `path` whenever the file already exists on disk — mirroring the existing "prefer `kanban_attach_url` when you only have a URL" guidance.

## Verification

New tests in `tests/tools/test_kanban_tools.py`:

- `test_attach_from_local_path_happy_path` — attaches via `path`, filename defaults to basename, stored bytes identical to source.
- `test_attach_from_local_path_explicit_filename` — `filename` overrides the basename.
- `test_attach_path_and_content_base64_mutually_exclusive` — both args → clean error.
- `test_attach_requires_content_base64_or_path` — neither arg → clean error.
- `test_attach_path_missing_file` — nonexistent path → clean error.
- `test_attach_path_over_size_cap` — file over the size cap → clean error.

`python3 -m pytest tests/tools/test_kanban_tools.py -k attach -p no:xdist -q` → 9 passed. Full `tests/ -k kanban` run: 314 passed; the 7 failures are pre-existing on `main` (identical failure set, `tests/hermes_cli` decompose/write-guard tests, unrelated to this change).
