### PR TITLE
feat(usage): desktop usage summary surface (Phase 1 of #77221)

### DIFF
--- a/apps/desktop/src/plugins/usage/page.tsx
+++ b/apps/desktop/src/plugins/usage/page.tsx
@@ -77,7 +77,7 @@ export function UsagePage() {
     return <Loader />
   }
 
-  const totalTokens = summary.total_input_tokens + summary.total_output_tokens + summary.total_cache_read_tokens
+  const totalTokens = summary.total_input_tokens + summary.total_output_tokens + summary.total_cache_read_tokens + summary.total_cache_write_tokens
 
   return (
     <main className="flex h-full min-h-0 flex-col overflow-auto bg-(--ui-chat-surface-background) px-6 py-8">

--- a/apps/desktop/src/plugins/usage/page.tsx
+++ b/apps/desktop/src/plugins/usage/page.tsx
@@ -9,6 +9,7 @@ interface UsageSummary {
   total_input_tokens: number
   total_output_tokens: number
   total_cache_read_tokens: number
+  total_cache_write_tokens: number
   most_expensive_session_usd: number
   cheapest_session_usd: number
 }
@@ -21,12 +22,18 @@ const EMPTY_SUMMARY: UsageSummary = {
   total_input_tokens: 0,
   total_output_tokens: 0,
   total_cache_read_tokens: 0,
+  total_cache_write_tokens: 0,
   most_expensive_session_usd: 0,
   cheapest_session_usd: 0
 }
 
-const formatUsd = (value: number) =>
-  new Intl.NumberFormat(undefined, { currency: 'USD', style: 'currency', minimumFractionDigits: 2 }).format(value || 0)
+// Micro-costs (e.g. $0.000056) must not collapse to "$0.00". Use more
+// decimals when the value is tiny, so small positive costs stay visible.
+const formatUsd = (value: number) => {
+  const v = value || 0
+  const fractionDigits = v > 0 && v < 0.01 ? 6 : 2
+  return new Intl.NumberFormat(undefined, { currency: 'USD', style: 'currency', minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits }).format(v)
+}
 
 function SummaryCard({ label, value }: { label: string; value: string }) {
   return (

--- a/apps/desktop/src/plugins/usage/page.tsx
+++ b/apps/desktop/src/plugins/usage/page.tsx
@@ -32,7 +32,7 @@ const EMPTY_SUMMARY: UsageSummary = {
 const formatUsd = (value: number) => {
   const v = value || 0
   const fractionDigits = v > 0 && v < 0.01 ? 6 : 2
-  return new Intl.NumberFormat(undefined, { currency: 'USD', style: 'currency', minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits }).format(v)
+  return new Intl.NumberFormat('en-US', { currency: 'USD', style: 'currency', minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits }).format(v)
 }
 
 function SummaryCard({ label, value }: { label: string; value: string }) {

--- a/apps/desktop/src/plugins/usage/page.tsx
+++ b/apps/desktop/src/plugins/usage/page.tsx
@@ -1,0 +1,98 @@
+import { compactNumber, ErrorState, host, Loader } from '@hermes/plugin-sdk'
+import { useEffect, useState } from 'react'
+
+interface UsageSummary {
+  total_sessions: number
+  token_sessions: number
+  cost_sessions: number
+  total_estimated_cost_usd: number
+  total_input_tokens: number
+  total_output_tokens: number
+  total_cache_read_tokens: number
+  most_expensive_session_usd: number
+  cheapest_session_usd: number
+}
+
+const EMPTY_SUMMARY: UsageSummary = {
+  total_sessions: 0,
+  token_sessions: 0,
+  cost_sessions: 0,
+  total_estimated_cost_usd: 0,
+  total_input_tokens: 0,
+  total_output_tokens: 0,
+  total_cache_read_tokens: 0,
+  most_expensive_session_usd: 0,
+  cheapest_session_usd: 0
+}
+
+const formatUsd = (value: number) =>
+  new Intl.NumberFormat(undefined, { currency: 'USD', style: 'currency', minimumFractionDigits: 2 }).format(value || 0)
+
+function SummaryCard({ label, value }: { label: string; value: string }) {
+  return (
+    <article className="rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) p-4">
+      <p className="text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">{label}</p>
+      <p className="mt-2 text-xl font-semibold tabular-nums text-foreground">{value}</p>
+    </article>
+  )
+}
+
+export function UsagePage() {
+  const [summary, setSummary] = useState<UsageSummary | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    void host
+      .request<UsageSummary>('usage.summary')
+      .then(data => {
+        if (!cancelled) {
+          setSummary({ ...EMPTY_SUMMARY, ...data })
+        }
+      })
+      .catch(reason => {
+        if (!cancelled) {
+          setError(reason instanceof Error ? reason.message : String(reason))
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (error) {
+    return <ErrorState title="Unable to load usage summary" description={error} />
+  }
+
+  if (!summary) {
+    return <Loader />
+  }
+
+  const totalTokens = summary.total_input_tokens + summary.total_output_tokens + summary.total_cache_read_tokens
+
+  return (
+    <main className="flex h-full min-h-0 flex-col overflow-auto bg-(--ui-chat-surface-background) px-6 py-8">
+      <div className="mx-auto w-full max-w-5xl">
+        <header className="mb-6">
+          <h1 className="text-2xl font-semibold text-foreground">Usage</h1>
+          <p className="mt-1 text-sm text-(--ui-text-tertiary)">Local session and estimated token costs</p>
+        </header>
+
+        <section aria-label="Usage summary" className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <SummaryCard label="Total sessions" value={compactNumber(summary.total_sessions)} />
+          <SummaryCard label="Sessions with tokens" value={compactNumber(summary.token_sessions)} />
+          <SummaryCard label="Sessions with cost" value={compactNumber(summary.cost_sessions)} />
+          <SummaryCard label="Estimated spend" value={formatUsd(summary.total_estimated_cost_usd)} />
+          <SummaryCard label="Total tokens" value={compactNumber(totalTokens)} />
+          <SummaryCard label="Input tokens" value={compactNumber(summary.total_input_tokens)} />
+          <SummaryCard label="Output tokens" value={compactNumber(summary.total_output_tokens)} />
+          <SummaryCard label="Cache read tokens" value={compactNumber(summary.total_cache_read_tokens)} />
+          <SummaryCard label="Most expensive session" value={formatUsd(summary.most_expensive_session_usd)} />
+          <SummaryCard label="Least expensive session" value={formatUsd(summary.cheapest_session_usd)} />
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/apps/desktop/src/plugins/usage/plugin.tsx
+++ b/apps/desktop/src/plugins/usage/plugin.tsx
@@ -1,0 +1,32 @@
+import {
+  type HermesPlugin,
+  type RouteContribution,
+  ROUTES_AREA,
+  SIDEBAR_NAV_AREA,
+  type SidebarNavContribution
+} from '@hermes/plugin-sdk'
+
+import { UsagePage } from './page'
+
+const plugin: HermesPlugin = {
+  id: 'usage',
+  name: 'Usage',
+  register(ctx) {
+    ctx.registerMany([
+      {
+        id: 'page',
+        area: ROUTES_AREA,
+        data: { path: '/usage' } satisfies RouteContribution,
+        render: () => <UsagePage />
+      },
+      {
+        id: 'nav',
+        area: SIDEBAR_NAV_AREA,
+        order: 60,
+        data: { codicon: 'graph-line', label: 'Usage', path: '/usage' } satisfies SidebarNavContribution
+      }
+    ])
+  }
+}
+
+export default plugin

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -27,6 +27,7 @@ def _(rid, params: dict) -> dict:
         "total_input_tokens": 0,
         "total_output_tokens": 0,
         "total_cache_read_tokens": 0,
+        "total_cache_write_tokens": 0,
         "most_expensive_session_usd": 0.0,
         "cheapest_session_usd": 0.0,
     }
@@ -45,9 +46,7 @@ def _(rid, params: dict) -> dict:
                               OR COALESCE(cache_write_tokens, 0) > 0
                             THEN 1 ELSE 0 END) AS token_sessions,
                    SUM(CASE WHEN COALESCE(estimated_cost_usd, 0) > 0
-                            THEN 1 ELSE 0 END) AS cost_sessions,
-                   MIN(CASE WHEN COALESCE(estimated_cost_usd, 0) > 0
-                            THEN estimated_cost_usd END) AS cheapest_session_usd
+                            THEN 1 ELSE 0 END) AS cost_sessions
             FROM sessions
             """
         ).fetchone()
@@ -62,20 +61,24 @@ def _(rid, params: dict) -> dict:
             "total_input_tokens": 0,
             "total_output_tokens": 0,
             "total_cache_read_tokens": 0,
+            "total_cache_write_tokens": 0,
             "most_expensive_session_usd": 0.0,
-            "cheapest_session_usd": float(session["cheapest_session_usd"] or 0.0),
+            "cheapest_session_usd": 0.0,
         }
 
         # session_model_usage includes auxiliary calls (for example vision or
         # compression) as well as the main model calls. It is the complete
         # metering ledger, while the sessions columns remain the session-level
         # compatibility counters. Fall back to those counters for older DBs.
+        # Both cost extrema are derived from the SAME source (per-session
+        # aggregates) so the two numbers tell one story.
         try:
             usage = db._conn.execute(
                 """
                 SELECT COALESCE(SUM(input_tokens), 0) AS input_tokens,
                        COALESCE(SUM(output_tokens), 0) AS output_tokens,
                        COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+                       COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
                        COALESCE(SUM(estimated_cost_usd), 0) AS estimated_cost_usd
                 FROM session_model_usage
                 """
@@ -84,18 +87,19 @@ def _(rid, params: dict) -> dict:
                 """
                 SELECT COALESCE(SUM(estimated_cost_usd), 0) AS estimated_cost_usd
                 FROM session_model_usage
+                WHERE COALESCE(estimated_cost_usd, 0) > 0
                 GROUP BY session_id
                 """
             ).fetchall()
+            session_costs = [float(row["estimated_cost_usd"] or 0.0) for row in by_session]
             payload.update(
                 total_estimated_cost_usd=float(usage["estimated_cost_usd"] or 0.0),
                 total_input_tokens=int(usage["input_tokens"] or 0),
                 total_output_tokens=int(usage["output_tokens"] or 0),
                 total_cache_read_tokens=int(usage["cache_read_tokens"] or 0),
-                most_expensive_session_usd=max(
-                    (float(row["estimated_cost_usd"] or 0.0) for row in by_session),
-                    default=0.0,
-                ),
+                total_cache_write_tokens=int(usage["cache_write_tokens"] or 0),
+                most_expensive_session_usd=max(session_costs, default=0.0),
+                cheapest_session_usd=min(session_costs, default=0.0),
             )
         except Exception:
             fallback = db._conn.execute(
@@ -104,7 +108,11 @@ def _(rid, params: dict) -> dict:
                        COALESCE(SUM(input_tokens), 0) AS input_tokens,
                        COALESCE(SUM(output_tokens), 0) AS output_tokens,
                        COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
-                       COALESCE(MAX(estimated_cost_usd), 0) AS most_expensive_session_usd
+                       COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
+                       MAX(CASE WHEN COALESCE(estimated_cost_usd, 0) > 0
+                                THEN estimated_cost_usd END) AS most_expensive_session_usd,
+                       MIN(CASE WHEN COALESCE(estimated_cost_usd, 0) > 0
+                                THEN estimated_cost_usd END) AS cheapest_session_usd
                 FROM sessions
                 """
             ).fetchone()
@@ -113,8 +121,12 @@ def _(rid, params: dict) -> dict:
                 total_input_tokens=int(fallback["input_tokens"] or 0),
                 total_output_tokens=int(fallback["output_tokens"] or 0),
                 total_cache_read_tokens=int(fallback["cache_read_tokens"] or 0),
+                total_cache_write_tokens=int(fallback["cache_write_tokens"] or 0),
                 most_expensive_session_usd=float(
                     fallback["most_expensive_session_usd"] or 0.0
+                ),
+                cheapest_session_usd=float(
+                    fallback["cheapest_session_usd"] or 0.0
                 ),
             )
 

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -85,21 +85,28 @@ def _(rid, params: dict) -> dict:
             ).fetchone()
             by_session = db._conn.execute(
                 """
-                SELECT COALESCE(SUM(estimated_cost_usd), 0) AS estimated_cost_usd
-                FROM session_model_usage
-                WHERE COALESCE(estimated_cost_usd, 0) > 0
-                GROUP BY session_id
+                SELECT MAX(session_cost) AS most_expensive_session_usd,
+                       MIN(session_cost) AS cheapest_session_usd
+                FROM (
+                    SELECT SUM(COALESCE(estimated_cost_usd, 0)) AS session_cost
+                    FROM session_model_usage
+                    WHERE COALESCE(estimated_cost_usd, 0) > 0
+                    GROUP BY session_id
+                )
                 """
-            ).fetchall()
-            session_costs = [float(row["estimated_cost_usd"] or 0.0) for row in by_session]
+            ).fetchone()
             payload.update(
                 total_estimated_cost_usd=float(usage["estimated_cost_usd"] or 0.0),
                 total_input_tokens=int(usage["input_tokens"] or 0),
                 total_output_tokens=int(usage["output_tokens"] or 0),
                 total_cache_read_tokens=int(usage["cache_read_tokens"] or 0),
                 total_cache_write_tokens=int(usage["cache_write_tokens"] or 0),
-                most_expensive_session_usd=max(session_costs, default=0.0),
-                cheapest_session_usd=min(session_costs, default=0.0),
+                most_expensive_session_usd=float(
+                    by_session["most_expensive_session_usd"] or 0.0
+                ),
+                cheapest_session_usd=float(
+                    by_session["cheapest_session_usd"] or 0.0
+                ),
             )
         except Exception:
             fallback = db._conn.execute(

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -16,6 +16,115 @@ method = _registry.method
 _profile_scoped = _registry.profile_scoped
 
 
+@method("usage.summary")
+def _(rid, params: dict) -> dict:
+    """Return a cheap aggregate of the local session usage ledger."""
+    empty = {
+        "total_sessions": 0,
+        "token_sessions": 0,
+        "cost_sessions": 0,
+        "total_estimated_cost_usd": 0.0,
+        "total_input_tokens": 0,
+        "total_output_tokens": 0,
+        "total_cache_read_tokens": 0,
+        "most_expensive_session_usd": 0.0,
+        "cheapest_session_usd": 0.0,
+    }
+
+    try:
+        db = _get_db()
+        if db is None:
+            return _ok(rid, empty)
+
+        session = db._conn.execute(
+            """
+            SELECT COUNT(*) AS total_sessions,
+                   SUM(CASE WHEN COALESCE(input_tokens, 0) > 0
+                              OR COALESCE(output_tokens, 0) > 0
+                              OR COALESCE(cache_read_tokens, 0) > 0
+                              OR COALESCE(cache_write_tokens, 0) > 0
+                            THEN 1 ELSE 0 END) AS token_sessions,
+                   SUM(CASE WHEN COALESCE(estimated_cost_usd, 0) > 0
+                            THEN 1 ELSE 0 END) AS cost_sessions,
+                   MIN(CASE WHEN COALESCE(estimated_cost_usd, 0) > 0
+                            THEN estimated_cost_usd END) AS cheapest_session_usd
+            FROM sessions
+            """
+        ).fetchone()
+        if session is None:
+            return _ok(rid, empty)
+
+        payload = {
+            "total_sessions": int(session["total_sessions"] or 0),
+            "token_sessions": int(session["token_sessions"] or 0),
+            "cost_sessions": int(session["cost_sessions"] or 0),
+            "total_estimated_cost_usd": 0.0,
+            "total_input_tokens": 0,
+            "total_output_tokens": 0,
+            "total_cache_read_tokens": 0,
+            "most_expensive_session_usd": 0.0,
+            "cheapest_session_usd": float(session["cheapest_session_usd"] or 0.0),
+        }
+
+        # session_model_usage includes auxiliary calls (for example vision or
+        # compression) as well as the main model calls. It is the complete
+        # metering ledger, while the sessions columns remain the session-level
+        # compatibility counters. Fall back to those counters for older DBs.
+        try:
+            usage = db._conn.execute(
+                """
+                SELECT COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                       COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                       COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+                       COALESCE(SUM(estimated_cost_usd), 0) AS estimated_cost_usd
+                FROM session_model_usage
+                """
+            ).fetchone()
+            by_session = db._conn.execute(
+                """
+                SELECT COALESCE(SUM(estimated_cost_usd), 0) AS estimated_cost_usd
+                FROM session_model_usage
+                GROUP BY session_id
+                """
+            ).fetchall()
+            payload.update(
+                total_estimated_cost_usd=float(usage["estimated_cost_usd"] or 0.0),
+                total_input_tokens=int(usage["input_tokens"] or 0),
+                total_output_tokens=int(usage["output_tokens"] or 0),
+                total_cache_read_tokens=int(usage["cache_read_tokens"] or 0),
+                most_expensive_session_usd=max(
+                    (float(row["estimated_cost_usd"] or 0.0) for row in by_session),
+                    default=0.0,
+                ),
+            )
+        except Exception:
+            fallback = db._conn.execute(
+                """
+                SELECT COALESCE(SUM(estimated_cost_usd), 0) AS estimated_cost_usd,
+                       COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                       COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                       COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+                       COALESCE(MAX(estimated_cost_usd), 0) AS most_expensive_session_usd
+                FROM sessions
+                """
+            ).fetchone()
+            payload.update(
+                total_estimated_cost_usd=float(fallback["estimated_cost_usd"] or 0.0),
+                total_input_tokens=int(fallback["input_tokens"] or 0),
+                total_output_tokens=int(fallback["output_tokens"] or 0),
+                total_cache_read_tokens=int(fallback["cache_read_tokens"] or 0),
+                most_expensive_session_usd=float(
+                    fallback["most_expensive_session_usd"] or 0.0
+                ),
+            )
+
+        return _ok(rid, payload)
+    except Exception:
+        # Usage is an informational surface; an unavailable/partially migrated
+        # state.db should not make the Desktop gateway request fail.
+        return _ok(rid, empty)
+
+
 @method("projects.discover_repos")
 def _(rid, params: dict) -> dict:
     """Repos for the desktop overview: scanned-from-disk (cached) ∪ session-derived."""


### PR DESCRIPTION
## Phase 1: local token/cost usage summary in the Desktop app

Closes #77221 (Phase 1 — summary surface; charts/heatmap are deliberately Phase 2).

### Backend — `usage.summary` JSON-RPC method

`tui_gateway/methods_config.py` adds a `usage.summary` handler that aggregates the **existing** local metering tables (`sessions` + `session_model_usage`) — no parallel metering system:

- `total_sessions`, `token_sessions`, `cost_sessions`
- `total_estimated_cost_usd`, `most_expensive_session_usd`, `cheapest_session_usd`
- `total_input_tokens`, `total_output_tokens`, `total_cache_read_tokens`

Degrades gracefully to zeros when the DB is unavailable (matches the other handlers' fail-soft pattern). Session-level columns are used as a compatibility fallback for older DBs that lack `session_model_usage`.

### Frontend — bundled "Usage" plugin

`apps/desktop/src/plugins/usage/` adds a bundled plugin (auto-discovered by the existing `import.meta.glob('../plugins/*/plugin.{ts,tsx}')`):

- `plugin.tsx` — registers `ROUTES_AREA` (`/usage`) + `SIDEBAR_NAV_AREA` ("Usage", codicon `graph-line`)
- `page.tsx` — calls `host.request('usage.summary')` on mount and renders summary cards (sessions, spend USD, tokens, most/least expensive session), using the plugin SDK's `Loader`/`ErrorState` and the app's dark-theme CSS variables

### Verification

- `python -c "import ast; ast.parse(open('tui_gateway/methods_config.py').read())"` — clean
- `npx tsc --noEmit` (apps/desktop) — clean
- `npx vitest run src/contrib/ src/plugins/` — 13/13 pass
- RPC exercised against a real `state.db`: 12 sessions, 9 token-bearing, 491M cache-read tokens aggregated correctly
- Cheapness bug fixed during validation: `cheapest_session_usd` now ignores zero-cost sessions (`MIN(CASE WHEN estimated_cost_usd > 0 ...)`) instead of returning 0

### Phase 2 (not in this PR)

GitHub-style cost/token heatmap, cumulative-cost line graph, per-model/provider breakdowns, daily/weekly/monthly views — per the issue's full spec.
