### PR TITLE
fix(gateway): prevent import-time plugin discovery from permanently disabling plugins (#77200)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1777,6 +1777,72 @@ def _bridge_max_turns_from_config(home: "Path") -> None:
             os.environ["HERMES_SEARCH_SLOW_MS"] = str(sessions_cfg["search_slow_ms"])
 
 
+def _bridge_auxiliary_env_from_config(home: "Path", discover: bool = False) -> None:
+    """Bridge ``auxiliary.<task>.*`` config into ``AUXILIARY_<TASK>_*`` env vars.
+
+    Each task has provider/model/base_url/api_key; non-default values are
+    exported so subprocesses (local/container tool environments) and other
+    entry points pick them up via ``os.getenv``. The legacy hard-coded list
+    (vision/web_extract/approval) is extended with plugin-registered tasks so
+    they benefit from the same config→env bridging without core knowing about
+    each one.
+
+    The import-time call passes ``discover=False``: merely importing
+    ``gateway.run`` must never trigger global plugin discovery, because a user
+    plugin whose ``register()`` imports ``GatewayRunner`` would fail with a
+    circular import while the module is only partially initialized, and the
+    manager would stay marked as discovered — permanently disabling the plugin
+    for the process lifetime without a visible gateway warning (#77200). The
+    gateway-startup call passes ``discover=True``, after explicit discovery
+    has run, so plugin-registered auxiliary tasks still get their env
+    bridging.
+    """
+    config_path = home / "config.yaml"
+    if not config_path.exists():
+        return
+    try:
+        from hermes_cli.config import _expand_env_vars, read_user_config_raw
+        cfg = read_user_config_raw(config_path)
+        cfg = _expand_env_vars(cfg)
+        if not isinstance(cfg, dict):
+            cfg = {}
+    except Exception:
+        return
+    _auxiliary_cfg = cfg.get("auxiliary", {})
+    if not _auxiliary_cfg or not isinstance(_auxiliary_cfg, dict):
+        return
+    # Built-in tasks that previously had explicit env-var bridging. Kept here
+    # as the canonical bridged set; plugin tasks are added below via the
+    # plugin auxiliary registry.
+    _aux_bridged_keys = {"vision", "web_extract", "approval"}
+    try:
+        from hermes_cli.plugins import get_plugin_auxiliary_tasks
+        for _entry in get_plugin_auxiliary_tasks(discover=discover):
+            _aux_bridged_keys.add(_entry["key"])
+    except Exception:
+        # Plugin discovery failure must not break gateway startup;
+        # built-in bridging stays intact.
+        pass
+
+    for _task_key in _aux_bridged_keys:
+        _task_cfg = _auxiliary_cfg.get(_task_key, {})
+        if not isinstance(_task_cfg, dict):
+            continue
+        _prov = str(_task_cfg.get("provider", "")).strip()
+        _model = str(_task_cfg.get("model", "")).strip()
+        _base_url = str(_task_cfg.get("base_url", "")).strip()
+        _api_key = str(_task_cfg.get("api_key", "")).strip()
+        _upper = _task_key.upper()
+        if _prov and _prov != "auto":
+            os.environ[f"AUXILIARY_{_upper}_PROVIDER"] = _prov
+        if _model:
+            os.environ[f"AUXILIARY_{_upper}_MODEL"] = _model
+        if _base_url:
+            os.environ[f"AUXILIARY_{_upper}_BASE_URL"] = _base_url
+        if _api_key:
+            os.environ[f"AUXILIARY_{_upper}_API_KEY"] = _api_key
+
+
 def _current_max_iterations() -> int:
     """Return the current per-turn iteration budget after runtime env refresh."""
     _reload_runtime_env_preserving_config_authority()
@@ -2004,44 +2070,14 @@ if _config_path.exists():
         # Compression config is read directly from config.yaml by run_agent.py
         # and auxiliary_client.py — no env var bridging needed.
         # Auxiliary model/direct-endpoint overrides (vision, web_extract,
-        # approval, plus any plugin-registered auxiliary tasks).
-        # Each task has provider/model/base_url/api_key; bridge non-default
-        # values to env vars named AUXILIARY_<KEY_UPPER>_*. The legacy
-        # hard-coded list (vision/web_extract/approval) is replaced by a
-        # dynamic loop so plugin-registered tasks benefit from the same
-        # config→env bridging without core knowing about each one.
-        _auxiliary_cfg = _cfg.get("auxiliary", {})
-        if _auxiliary_cfg and isinstance(_auxiliary_cfg, dict):
-            # Built-in tasks that previously had explicit env-var bridging.
-            # Kept here as the canonical bridged set; plugin tasks are added
-            # below via the plugin auxiliary registry.
-            _aux_bridged_keys = {"vision", "web_extract", "approval"}
-            try:
-                from hermes_cli.plugins import get_plugin_auxiliary_tasks
-                for _entry in get_plugin_auxiliary_tasks():
-                    _aux_bridged_keys.add(_entry["key"])
-            except Exception:
-                # Plugin discovery failure must not break gateway startup;
-                # built-in bridging stays intact.
-                pass
-
-            for _task_key in _aux_bridged_keys:
-                _task_cfg = _auxiliary_cfg.get(_task_key, {})
-                if not isinstance(_task_cfg, dict):
-                    continue
-                _prov = str(_task_cfg.get("provider", "")).strip()
-                _model = str(_task_cfg.get("model", "")).strip()
-                _base_url = str(_task_cfg.get("base_url", "")).strip()
-                _api_key = str(_task_cfg.get("api_key", "")).strip()
-                _upper = _task_key.upper()
-                if _prov and _prov != "auto":
-                    os.environ[f"AUXILIARY_{_upper}_PROVIDER"] = _prov
-                if _model:
-                    os.environ[f"AUXILIARY_{_upper}_MODEL"] = _model
-                if _base_url:
-                    os.environ[f"AUXILIARY_{_upper}_BASE_URL"] = _base_url
-                if _api_key:
-                    os.environ[f"AUXILIARY_{_upper}_API_KEY"] = _api_key
+        # approval, plus any plugin-registered auxiliary tasks).  See
+        # _bridge_auxiliary_env_from_config(): the import-time call must not
+        # trigger global plugin discovery while gateway.run is only partially
+        # initialized — a user plugin importing GatewayRunner would fail and
+        # stay disabled for the process lifetime (#77200).  Plugin-registered
+        # tasks are bridged again at gateway startup, after explicit
+        # discovery has run.
+        _bridge_auxiliary_env_from_config(_hermes_home)
         # config.yaml is the documented, authoritative source for these
         # settings — it unconditionally wins over .env values. Previously
         # the guards below read `if X not in os.environ` and let stale
@@ -10671,6 +10707,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             logger.warning(
                 "plugin discovery failed at gateway startup", exc_info=True,
+            )
+
+        # Plugin-registered auxiliary tasks only exist once discovery has
+        # run. Re-bridge their auxiliary.<key>.* config into
+        # AUXILIARY_<KEY>_* env vars now that plugins are loaded: the
+        # import-time bridge must skip plugin discovery (see
+        # _bridge_auxiliary_env_from_config), so without this re-run a
+        # plugin task's provider/model would never reach subprocess
+        # environments (#77200).
+        try:
+            _bridge_auxiliary_env_from_config(_hermes_home, discover=True)
+        except Exception:
+            logger.debug(
+                "auxiliary env re-bridge failed after plugin discovery",
+                exc_info=True,
             )
 
         # Register the generic relay adapter when a connector relay URL is

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2425,18 +2425,23 @@ def get_plugin_commands() -> Dict[str, dict]:
     return _ensure_plugins_discovered()._plugin_commands
 
 
-def get_plugin_auxiliary_tasks() -> List[Dict[str, Any]]:
+def get_plugin_auxiliary_tasks(discover: bool = True) -> List[Dict[str, Any]]:
     """Return all plugin-registered auxiliary tasks as a stable-ordered list.
 
     Each entry is the registration dict from
     :meth:`PluginContext.register_auxiliary_task`:
     ``{key, display_name, description, defaults, plugin}``.
 
-    Triggers idempotent plugin discovery so callers can read the registry
-    before any explicit ``discover_plugins()`` call. Sorted by ``key`` for
-    deterministic ordering in pickers and tests.
+    By default, triggers idempotent plugin discovery so callers can read the
+    registry before any explicit ``discover_plugins()`` call. Pass
+    ``discover=False`` for import-time callers that must only inspect plugins
+    already registered — this avoids making module initialization execute
+    arbitrary user-plugin code (a plugin importing a partially-initialized
+    module would fail and stay disabled for the process lifetime, see
+    #77200). Sorted by ``key`` for deterministic ordering in pickers and
+    tests.
     """
-    manager = _ensure_plugins_discovered()
+    manager = _ensure_plugins_discovered() if discover else get_plugin_manager()
     return [manager._aux_tasks[k] for k in sorted(manager._aux_tasks)]
 
 

--- a/tests/gateway/test_plugin_discovery_initialization.py
+++ b/tests/gateway/test_plugin_discovery_initialization.py
@@ -1,0 +1,60 @@
+"""Plugin discovery must not run while ``gateway.run`` is partially imported."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def test_gateway_import_defers_user_plugin_discovery_until_explicit_startup(tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    plugin_dir = hermes_home / "plugins" / "gateway_importer"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": "gateway_importer", "version": "0.1.0"}),
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "def register(ctx):\n"
+        "    from gateway.run import GatewayRunner\n"
+        "    ctx.register_middleware('llm_request', lambda **kwargs: None)\n",
+        encoding="utf-8",
+    )
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "plugins": {"enabled": ["gateway_importer"]},
+            "auxiliary": {"title_generation": {"provider": "auto"}},
+        }),
+        encoding="utf-8",
+    )
+
+    script = """
+import gateway.run
+from hermes_cli.plugins import discover_plugins, get_plugin_manager
+
+manager = get_plugin_manager()
+assert manager._discovered is False, "gateway import triggered plugin discovery"
+discover_plugins()
+loaded = manager._plugins["gateway_importer"]
+assert loaded.enabled is True, loaded.error
+assert loaded.error is None
+assert manager.has_middleware("llm_request")
+"""
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, (
+        f"subprocess failed ({result.returncode})\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )

--- a/tests/hermes_cli/test_plugin_auxiliary_tasks.py
+++ b/tests/hermes_cli/test_plugin_auxiliary_tasks.py
@@ -89,6 +89,43 @@ def test_register_auxiliary_task_basic():
 # ── Module-level helper ──────────────────────────────────────────────────────
 
 
+def test_get_plugin_auxiliary_tasks_can_skip_discovery(monkeypatch, patched_manager):
+    """discover=False must read the registry without triggering plugin discovery.
+
+    Import-time callers (e.g. ``gateway.run`` module init) must never execute
+    arbitrary user-plugin code — a plugin whose ``register()`` imports a
+    partially-initialized module would fail and stay disabled for the process
+    lifetime (#77200).
+    """
+    import hermes_cli.plugins as plugins_mod
+
+    calls = {"discovery": 0}
+
+    def _spy_discovery() -> plugins_mod.PluginManager:
+        calls["discovery"] += 1
+        return patched_manager
+
+    monkeypatch.setattr(plugins_mod, "_ensure_plugins_discovered", _spy_discovery)
+
+    ctx = PluginContext(PluginManifest(name="hindsight"), patched_manager)
+    ctx.register_auxiliary_task(
+        key="memory_retain_filter",
+        display_name="Memory retain filter",
+        description="hindsight pre-retain dedup/extract",
+    )
+
+    # discover=False → registry read, discovery NOT triggered.
+    tasks = get_plugin_auxiliary_tasks(discover=False)
+    keys = [t["key"] for t in tasks]
+    assert "memory_retain_filter" in keys
+    assert calls["discovery"] == 0, "discover=False must not trigger discovery"
+
+    # discover=True (default) still routes through discovery.
+    tasks_default = get_plugin_auxiliary_tasks()
+    assert [t["key"] for t in tasks_default] == keys
+    assert calls["discovery"] == 1
+
+
 
 
 # ── _all_aux_tasks merges built-in + plugin ──────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #77200 — importing `gateway.run` triggered global plugin discovery via the `auxiliary.title_generation` bridge (`get_plugin_auxiliary_tasks()`) before `GatewayRunner` was defined. A user plugin whose `register()` imports `GatewayRunner` failed with a circular import; the per-plugin failure was recorded, but the global plugin manager stayed marked as discovered, so the later `discover_plugins()` at startup returned immediately and the plugin remained disabled for the lifetime of the gateway process — without any visible warning.

## Root Cause

`gateway/run.py` had an inline module-level config→env bridge that called `get_plugin_auxiliary_tasks()`, which unconditionally triggered idempotent plugin discovery at import time. Discovery executes arbitrary user-plugin `register()` code while the module is only partially initialized.

## Change

- `gateway/run.py` — extracted the inline bridge into `_bridge_auxiliary_env_from_config(home, discover=False)`; the import-time call passes `discover=False` (no discovery at import), and a re-bridge with `discover=True` runs immediately after `discover_plugins()` at gateway startup so plugin-registered auxiliary tasks still get their `AUXILIARY_<KEY>_*` env bridging in fresh gateway processes.
- `hermes_cli/plugins.py` — `get_plugin_auxiliary_tasks(discover: bool = True)`: default preserves existing behavior; import-time callers pass `False`, reading the registry via `get_plugin_manager()` without discovery.
- Tests: E2E reproduction (subprocess imports `gateway.run` with a `GatewayRunner`-importing plugin; asserts no discovery at import, plugin loads after `discover_plugins()`) + unit test proving `discover=False` reads the registry without triggering discovery.

## Relationship to #77204

[#77204](https://github.com/NousResearch/hermes-agent/pull/77204) (Rashooodhi, still open) implements the same `get_plugin_auxiliary_tasks(discover=False)` idea and fixes the circular import. I verified its diff applies cleanly and fixes the bug, but it also removes the import-time env bridge entirely — which I proved breaks `AUXILIARY_<KEY>_*` env bridging for plugin auxiliary tasks in fresh gateway processes (`AUXILIARY_CUSTOM_TASK_PROVIDER` goes from `openai` → `None` vs main). This PR implements the same fix **and** restores the bridging after real startup discovery, closing that regression gap. If #77204 lands first, this diff reduces cleanly to the re-bridge addition.

## Verification

- `pytest tests/gateway/test_plugin_discovery_initialization.py tests/hermes_cli/test_plugin_auxiliary_tasks.py` → 5 passed
- `pytest tests/hermes_cli/ -k "plugin or aux"` → 234 passed
- `pytest tests/gateway/ -k "plugin"` → 207 passed, 3 skipped
