### PR TITLE
feat(models): let BYOK users opt into the full OpenRouter catalog

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -195,6 +195,21 @@ model:
 #   response_cache_ttl: 300      # Cache TTL in seconds, 1-86400 (default: 300)
 
 # =============================================================================
+# OpenRouter Full Catalog (BYOK)
+# =============================================================================
+# The model picker shows a curated OpenRouter list — the agentic models Hermes
+# recommends, not the raw /models dump. If you bring your own OpenRouter key and
+# run models the curated list has no opinion about, this shows every
+# tool-calling model OpenRouter serves instead.
+#
+# Curated entries still come first, in their curated order; the rest follow.
+# Models that don't advertise tool calling (TTS, image, rerankers) stay hidden
+# either way — Hermes can't drive them.
+#
+# openrouter:
+#   show_all_models: true        # Default: false (curated list only)
+
+# =============================================================================
 # Git Worktree Isolation
 # =============================================================================
 # When enabled, each CLI session creates an isolated git worktree so multiple

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -778,6 +778,13 @@ DEFAULT_CONFIG = {
         "response_cache": True,
         "response_cache_ttl": 300,
         "min_coding_score": 0.65,
+        # Show every tool-calling model OpenRouter serves in the picker instead
+        # of the curated list. Off by default: the curated list is a deliberate
+        # recommendation, and BYOK users who want the rest should have to ask.
+        # The tool-calling filter still applies either way, so this never
+        # surfaces the TTS, image and reranker models the curation exists to
+        # keep out.
+        "show_all_models": False,
     },
 
     # AWS Bedrock provider configuration.

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -101,6 +101,10 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
 ]
 
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None
+# Which mode built the cache above. The curated and show-all lists are
+# different answers to the same call, so the cache has to remember which one it
+# holds or a config change is invisible until the process restarts.
+_openrouter_catalog_cache_show_all: bool | None = None
 
 
 # Fallback Vercel AI Gateway snapshot used when the live catalog is unavailable.
@@ -1494,15 +1498,45 @@ def _openrouter_model_supports_tools(item: Any) -> bool:
     return "tools" in params
 
 
+def openrouter_show_all_models() -> bool:
+    """Should the picker list every tool-calling model OpenRouter serves?
+
+    ``openrouter.show_all_models`` exists for BYOK users, who pay OpenRouter
+    directly and may have models configured that the curated list has no
+    opinion about (#76732). Off by default, so the curated recommendation stays
+    the default experience and this stays an explicit opt-in.
+    """
+    try:
+        from hermes_cli.config import load_config
+        openrouter_cfg = load_config().get("openrouter", {})
+        if isinstance(openrouter_cfg, dict):
+            return bool(openrouter_cfg.get("show_all_models", False))
+    except Exception:
+        # An unreadable config must not change which models a user sees.
+        pass
+    return False
+
+
 def fetch_openrouter_models(
     timeout: float = 8.0,
     *,
     force_refresh: bool = False,
 ) -> list[tuple[str, str]]:
-    """Return the curated OpenRouter picker list, refreshed from the live catalog when possible."""
-    global _openrouter_catalog_cache
+    """Return the OpenRouter picker list, refreshed from the live catalog when possible.
 
-    if _openrouter_catalog_cache is not None and not force_refresh:
+    Curated by default. With ``openrouter.show_all_models`` the curated entries
+    still come first, in their curated order, and every other tool-calling model
+    follows — the recommendation is preserved, the ceiling is removed.
+    """
+    global _openrouter_catalog_cache, _openrouter_catalog_cache_show_all
+
+    show_all = openrouter_show_all_models()
+
+    if (
+        _openrouter_catalog_cache is not None
+        and _openrouter_catalog_cache_show_all == show_all
+        and not force_refresh
+    ):
         return list(_openrouter_catalog_cache)
 
     # Prefer the remotely-hosted catalog manifest; fall back to the in-repo
@@ -1540,9 +1574,17 @@ def fetch_openrouter_models(
             continue
         live_by_id[mid] = item
 
+    selected_ids = preferred_ids
+    if show_all:
+        # Curated first, in curated order, then everything else alphabetically.
+        # Appending rather than replacing keeps the recommendation intact: the
+        # models Hermes actually endorses still lead the picker.
+        already = set(preferred_ids)
+        selected_ids = preferred_ids + sorted(mid for mid in live_by_id if mid not in already)
+
     curated: list[tuple[str, str]] = []
     silent_default = get_preferred_silent_default_model("openrouter")
-    for preferred_id in preferred_ids:
+    for preferred_id in selected_ids:
         live_item = live_by_id.get(preferred_id)
         if live_item is None:
             continue
@@ -1566,6 +1608,7 @@ def fetch_openrouter_models(
     if not first_desc:
         curated[0] = (first_id, "recommended")
     _openrouter_catalog_cache = curated
+    _openrouter_catalog_cache_show_all = show_all
     return list(curated)
 
 

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -483,3 +483,99 @@ class TestFormatPricePerMtok:
     def test_one_cent_boundary_stays_two_decimals(self):
         from hermes_cli.models import _format_price_per_mtok
         assert _format_price_per_mtok("0.00000001") == "$0.01"
+
+
+class TestOpenRouterShowAllModels:
+    """`openrouter.show_all_models` lifts the curated ceiling for BYOK users (#76732).
+
+    The curated list exists so the picker recommends rather than dumps, and the
+    docs say so explicitly. A BYOK user pays OpenRouter directly and may run
+    models the list has no opinion about, so this is an opt-in that appends —
+    curation still leads the picker, and the tool-calling filter still keeps out
+    the TTS/image/reranker models curation exists to exclude.
+    """
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return (
+                b'{"data":['
+                b'{"id":"anthropic/claude-opus-4.6","pricing":{"prompt":"0.000015","completion":"0.000075"},'
+                b'"supported_parameters":["tools"]},'
+                b'{"id":"zzz/uncurated-tools","pricing":{"prompt":"0.000001","completion":"0.000002"},'
+                b'"supported_parameters":["tools"]},'
+                b'{"id":"aaa/uncurated-no-tools","pricing":{"prompt":"0.000001","completion":"0.000002"},'
+                b'"supported_parameters":["temperature"]}'
+                b']}'
+            )
+
+    def _fetch(self, monkeypatch, show_all: bool):
+        monkeypatch.setattr(_models_mod, "OPENROUTER_MODELS", [("anthropic/claude-opus-4.6", "")])
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache_show_all", None)
+        with (
+            patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=[]),
+            patch("hermes_cli.models._urlopen_model_catalog_request", return_value=self._Resp()),
+            patch("hermes_cli.models.openrouter_show_all_models", return_value=show_all),
+        ):
+            return [mid for mid, _ in fetch_openrouter_models(force_refresh=True)]
+
+    def test_curated_only_by_default(self, monkeypatch):
+        ids = self._fetch(monkeypatch, show_all=False)
+
+        assert ids == ["anthropic/claude-opus-4.6"]
+
+    def test_show_all_appends_uncurated_tool_models(self, monkeypatch):
+        ids = self._fetch(monkeypatch, show_all=True)
+
+        # Curated entry still leads: enabling this must not demote the
+        # recommendation, only extend past it.
+        assert ids[0] == "anthropic/claude-opus-4.6"
+        assert "zzz/uncurated-tools" in ids
+
+    def test_show_all_still_hides_models_without_tool_calling(self, monkeypatch):
+        ids = self._fetch(monkeypatch, show_all=True)
+
+        # The reason the curated list exists is to keep TTS/image/reranker
+        # models out of an agent picker. Opting into the full catalog must not
+        # opt out of that.
+        assert "aaa/uncurated-no-tools" not in ids
+
+    def test_cache_does_not_leak_between_modes(self, monkeypatch):
+        """A cached curated list must not be served to a show-all caller.
+
+        Both modes answer the same function, so a cache that only remembers
+        "we fetched once" would make the setting look inert until restart.
+        """
+        curated = self._fetch(monkeypatch, show_all=False)
+        # Deliberately no cache reset here: only the mode changes.
+        monkeypatch.setattr(_models_mod, "OPENROUTER_MODELS", [("anthropic/claude-opus-4.6", "")])
+        with (
+            patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=[]),
+            patch("hermes_cli.models._urlopen_model_catalog_request", return_value=self._Resp()),
+            patch("hermes_cli.models.openrouter_show_all_models", return_value=True),
+        ):
+            expanded = [mid for mid, _ in fetch_openrouter_models()]
+
+        assert "zzz/uncurated-tools" not in curated
+        assert "zzz/uncurated-tools" in expanded
+
+
+class TestOpenRouterShowAllModelsSetting:
+    def test_defaults_to_false_when_unset(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert _models_mod.openrouter_show_all_models() is False
+
+    def test_reads_the_flag(self):
+        with patch("hermes_cli.config.load_config", return_value={"openrouter": {"show_all_models": True}}):
+            assert _models_mod.openrouter_show_all_models() is True
+
+    def test_unreadable_config_keeps_the_curated_list(self):
+        """An unreadable config must never silently change which models a user sees."""
+        with patch("hermes_cli.config.load_config", side_effect=OSError("boom")):
+            assert _models_mod.openrouter_show_all_models() is False


### PR DESCRIPTION
Implements the long-term half of #76732.

## Why not just add more models

The curated list is deliberate, and the docs say so: it is "not the raw `/models` dump (which on OpenRouter includes 400+ models including TTS, image generators, and rerankers)" (`configuring-models.md`).

I opened #77159 to add four Gemini models and closed it, because @teknium1 was right that model availability plus tool support is not a curation argument. Expanding the list one request at a time makes every BYOK user's gap a separate judgement call for a maintainer.

This solves the reporter's actual problem without touching that judgement. A BYOK user pays OpenRouter directly and may run models the curated list has no opinion about; today their only option is typing `/model openrouter/<id>` every time.

```yaml
openrouter:
  show_all_models: true    # default: false
```

## Why this extends curation rather than repudiating it

**Curated entries still come first**, in their curated order; the rest follow alphabetically. Enabling this widens the picker, it never demotes what Hermes actually recommends.

**The tool-calling filter still applies.** The reason the curated list exists is to keep models the agent cannot drive out of an agent picker, and opting into the full catalog must not opt out of that. On the live catalogue today that is **271 tool-calling models rather than all 337** — the TTS, image and reranker models stay hidden in both modes.

So the flag removes the allowlist, not the capability floor.

## Implementation notes

The cache now remembers which mode produced it. Both modes answer the same function, so a cache that only remembered "we fetched once" would make the setting look inert until restart. There is a regression test for exactly that.

Placed under the existing `openrouter:` block rather than the `model:` block the issue proposed, next to `response_cache` and `min_coding_score`, so OpenRouter settings stay in one place and the key does not say "openrouter" twice. Happy to move it if you prefer the issue's shape.

## Verification

- `pytest tests/hermes_cli/test_models.py test_model_catalog.py test_config_validation.py` → **64 passed**
- New coverage: default stays curated; opt-in appends; non-tool models stay hidden in **both** modes; the cache does not leak across modes; an unreadable config never silently changes which models a user sees
- `ruff check` → passed
- `cli-config.yaml.example` still parses, and documents the flag

Closes #76732.