### PR TITLE
fix(desktop): prevent code blocks with no tag, text, or yaml from bei…

### DIFF
--- a/apps/desktop/src/lib/markdown-code.test.ts
+++ b/apps/desktop/src/lib/markdown-code.test.ts
@@ -14,6 +14,17 @@ const SENTENCE_3 = [
 ].join('\n')
 const MARKDOWN_BLOCK = ['# Deployment notes', '', 'This block should stay fenced'].join('\n')
 const YAML_LIST = ['providers:', '  - name: deepseek', '  - name: openai'].join('\n')
+const BULLET_2 = ['- item one', '- item two'].join('\n')
+
+// Stone441 macOS repro (2026-08-14): long `text`/`prompt` fences with
+// numbered Chinese prose were downgraded to rendered prose. Numbered lines
+// ("1. 中文…") match proseLineCount's ASCII-leading regex, so they trip the
+// prose heuristic; the explicit-tag guard must keep them fenced.
+const CHINESE_NUMBERED = [
+  '1. 这是一个较长的中文提示词，包含编号和具体步骤说明。',
+  '2. 第二行继续描述用户希望保留的完整提示词内容。',
+  '3. 第三行用于验证换行、编号和空格在代码块内保持原样。'
+].join('\n')
 
 describe('isLikelyProseCodeBlock', () => {
   it('detects prose that Streamdown mislabels as an unknown language', () => {
@@ -70,6 +81,34 @@ describe('isLikelyProseCodeBlock', () => {
 
   it('keeps yaml bullet lists as code', () => {
     expect(isLikelyProseCodeBlock('yaml', YAML_LIST)).toBe(false)
+  })
+
+  // Whole-class regression (spfcraze triage, 2026-08-14): non-COMMON explicit
+  // tags with bullet-list bodies were prose-classified by the bullet heuristic
+  // before the explicit-tag guard was reached. gdscript/zsh are non-COMMON,
+  // text/plain/plaintext are NON_CODE (not COMMON) — all must stay code.
+  it('keeps gdscript bullet lists as code (spfcraze repro)', () => {
+    expect(isLikelyProseCodeBlock('gdscript', BULLET_2)).toBe(false)
+  })
+
+  it('keeps zsh bullet lists as code (spfcraze repro)', () => {
+    expect(isLikelyProseCodeBlock('zsh', BULLET_2)).toBe(false)
+  })
+
+  it('keeps NON_CODE-family bullet lists as code (text/plain/plaintext)', () => {
+    expect(isLikelyProseCodeBlock('text', BULLET_2)).toBe(false)
+    expect(isLikelyProseCodeBlock('plain', BULLET_2)).toBe(false)
+    expect(isLikelyProseCodeBlock('plaintext', BULLET_2)).toBe(false)
+  })
+
+  // Stone441 macOS repro: numbered Chinese prose inside text/prompt fences
+  // must stay code blocks (the numbered lines trip the prose heuristic).
+  it('keeps text fences with numbered Chinese prose as code (Stone441)', () => {
+    expect(isLikelyProseCodeBlock('text', CHINESE_NUMBERED)).toBe(false)
+  })
+
+  it('keeps prompt fences with numbered Chinese prose as code (Stone441)', () => {
+    expect(isLikelyProseCodeBlock('prompt', CHINESE_NUMBERED)).toBe(false)
   })
 })
 
@@ -150,5 +189,24 @@ describe('isLikelyProseFence', () => {
 
   it('keeps yaml bullet lists as code', () => {
     expect(isLikelyProseFence('yaml', YAML_LIST)).toBe(false)
+  })
+
+  // Whole-class regression (spfcraze triage, 2026-08-14): same bullet-list
+  // coverage on the fence layer — non-COMMON explicit tags must stay code.
+  it('keeps gdscript/zsh bullet-list fences as code', () => {
+    expect(isLikelyProseFence('gdscript', BULLET_2)).toBe(false)
+    expect(isLikelyProseFence('zsh', BULLET_2)).toBe(false)
+  })
+
+  it('keeps NON_CODE-family bullet-list fences as code', () => {
+    expect(isLikelyProseFence('text', BULLET_2)).toBe(false)
+    expect(isLikelyProseFence('plain', BULLET_2)).toBe(false)
+    expect(isLikelyProseFence('plaintext', BULLET_2)).toBe(false)
+  })
+
+  // Stone441 macOS repro: text/prompt fences with numbered Chinese prose.
+  it('keeps text/prompt fences with numbered Chinese prose as code (Stone441)', () => {
+    expect(isLikelyProseFence('text', CHINESE_NUMBERED)).toBe(false)
+    expect(isLikelyProseFence('prompt', CHINESE_NUMBERED)).toBe(false)
   })
 })

--- a/apps/desktop/src/lib/markdown-code.test.ts
+++ b/apps/desktop/src/lib/markdown-code.test.ts
@@ -2,6 +2,19 @@ import { describe, expect, it } from 'vitest'
 
 import { isLikelyProseCodeBlock, isLikelyProseFence, isLikelyStructuredText } from './markdown-code'
 
+// Explicit-tag regression matrix (XpycT's four-block repro on Windows 11,
+// Hermes v0.19.1): text/markdown/gdscript/yaml fences whose content looks
+// prose-like (>=3 lines, no code signals) must stay code blocks. Only bare
+// fences ('') still fall through to the prose heuristic.
+const LOREM_3 = ['lorem ipsum dolor sit amet', 'consectetur adipiscing elit', 'sed do eiusmod tempor'].join('\n')
+const SENTENCE_3 = [
+  'The quarterly report shows steady growth across all sectors.',
+  'Regional performance exceeded expectations by twelve percent.',
+  'Customer retention rates improved for the third consecutive month.'
+].join('\n')
+const MARKDOWN_BLOCK = ['# Deployment notes', '', 'This block should stay fenced'].join('\n')
+const YAML_LIST = ['providers:', '  - name: deepseek', '  - name: openai'].join('\n')
+
 describe('isLikelyProseCodeBlock', () => {
   it('detects prose that Streamdown mislabels as an unknown language', () => {
     expect(
@@ -34,6 +47,29 @@ describe('isLikelyProseCodeBlock', () => {
 
   it('keeps an .env-style dump fenced', () => {
     expect(isLikelyProseCodeBlock('', ['API_KEY=abc123', 'PORT=8080', 'DEBUG=true'].join('\n'))).toBe(false)
+  })
+
+  it('keeps text fences as code even with zero code signals', () => {
+    expect(isLikelyProseCodeBlock('text', LOREM_3)).toBe(false)
+    expect(isLikelyProseCodeBlock('text', SENTENCE_3)).toBe(false)
+  })
+
+  it('keeps plain/plaintext fences as code', () => {
+    expect(isLikelyProseCodeBlock('plain', LOREM_3)).toBe(false)
+    expect(isLikelyProseCodeBlock('plaintext', SENTENCE_3)).toBe(false)
+  })
+
+  it('keeps markdown/md fences as code instead of rich-rendering them', () => {
+    expect(isLikelyProseCodeBlock('markdown', MARKDOWN_BLOCK)).toBe(false)
+    expect(isLikelyProseCodeBlock('md', SENTENCE_3)).toBe(false)
+  })
+
+  it('keeps gdscript as code (non-COMMON explicit tag)', () => {
+    expect(isLikelyProseCodeBlock('gdscript', SENTENCE_3)).toBe(false)
+  })
+
+  it('keeps yaml bullet lists as code', () => {
+    expect(isLikelyProseCodeBlock('yaml', YAML_LIST)).toBe(false)
   })
 })
 
@@ -91,5 +127,28 @@ describe('isLikelyProseFence', () => {
         ].join('\n')
       )
     ).toBe(true)
+  })
+
+  it('keeps text fences as code', () => {
+    expect(isLikelyProseFence('text', LOREM_3)).toBe(false)
+    expect(isLikelyProseFence('text', SENTENCE_3)).toBe(false)
+  })
+
+  it('keeps plain/plaintext fences as code', () => {
+    expect(isLikelyProseFence('plain', LOREM_3)).toBe(false)
+    expect(isLikelyProseFence('plaintext', SENTENCE_3)).toBe(false)
+  })
+
+  it('keeps markdown/md fences as code instead of rich-rendering them', () => {
+    expect(isLikelyProseFence('markdown', MARKDOWN_BLOCK)).toBe(false)
+    expect(isLikelyProseFence('md', SENTENCE_3)).toBe(false)
+  })
+
+  it('keeps gdscript as code (non-COMMON explicit tag)', () => {
+    expect(isLikelyProseFence('gdscript', SENTENCE_3)).toBe(false)
+  })
+
+  it('keeps yaml bullet lists as code', () => {
+    expect(isLikelyProseFence('yaml', YAML_LIST)).toBe(false)
   })
 })

--- a/apps/desktop/src/lib/markdown-code.ts
+++ b/apps/desktop/src/lib/markdown-code.ts
@@ -361,6 +361,16 @@ export function isLikelyProseFence(info: string, body: string): boolean {
     return true
   }
 
+  // Any explicit, valid language tag is respected as code. sanitizeLanguageTag
+  // only returns non-empty for tags matching VALID_LANGUAGE_RE, so this covers
+  // text/plain/plaintext/md/markdown (in NON_CODE_FENCE_LANGUAGES) as well as
+  // gdscript/zsh and other non-COMMON tags the fallback below would otherwise
+  // prose-classify. Bare fences ('') skip this guard and fall through to the
+  // structured/prose heuristics so untagged paragraph fences still unwrap.
+  if (language !== '' && VALID_LANGUAGE_RE.test(language)) {
+    return false
+  }
+
   if (!NON_CODE_FENCE_LANGUAGES.has(language)) {
     return false
   }
@@ -388,14 +398,28 @@ export function isLikelyProseCodeBlock(language: string | undefined, code: strin
 
   // A bullet list with markdown emphasis is prose even when it happens to be
   // structured; the config veto below is only meant to protect config/kv
-  // listings, so let the bullet-prose case win first.
-  if (signals.bulletLines >= 1 && (signals.hasMarkdown || signals.proseLines >= 2)) {
+  // listings, so let the bullet-prose case win first. Known code languages
+  // (yaml/markdown) are exempt: their lists are data, not prose.
+  if (
+    signals.bulletLines >= 1 &&
+    (signals.hasMarkdown || signals.proseLines >= 2) &&
+    !COMMON_CODE_LANGUAGES.has(cleanLanguage)
+  ) {
     return true
   }
 
   // Config / key-value / indented listings are code, not prose — never
   // unwrap them (SSH config, .env, INI, key/value tables).
   if (isLikelyStructuredText(code || '')) {
+    return false
+  }
+
+  // Any explicit, valid language tag is respected and rendered as code
+  // (covers gdscript/zsh and other non-COMMON languages, plus text/plain/
+  // plaintext/md/markdown). sanitizeLanguageTag returning non-empty means
+  // VALID_LANGUAGE_RE matched; only bare fences ('') and unknown tags fall
+  // through to the prose heuristic below.
+  if (cleanLanguage !== '' && VALID_LANGUAGE_RE.test(cleanLanguage)) {
     return false
   }
 

--- a/apps/desktop/src/lib/markdown-code.ts
+++ b/apps/desktop/src/lib/markdown-code.ts
@@ -396,6 +396,19 @@ export function isLikelyProseCodeBlock(language: string | undefined, code: strin
     return false
   }
 
+  // Any explicit, valid language tag is respected as code — even when the
+  // body is a bullet list (gdscript/zsh lists were prose-classified by the
+  // bullet heuristic below, which only exempts COMMON languages). Exception:
+  // Streamdown-mislabeled unknown tags like "heads" (bullet + inline
+  // markdown emphasis) stay prose per the upstream test locked in below.
+  if (
+    cleanLanguage !== '' &&
+    VALID_LANGUAGE_RE.test(cleanLanguage) &&
+    !(signals.bulletLines >= 1 && signals.hasMarkdown)
+  ) {
+    return false
+  }
+
   // A bullet list with markdown emphasis is prose even when it happens to be
   // structured; the config veto below is only meant to protect config/kv
   // listings, so let the bullet-prose case win first. Known code languages


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where Hermes Desktop misclassifies fenced code blocks as prose — losing their CodeCard, stripping fence markers, and collapsing whitespace. Affected: `text`/`plain`/`plaintext`, `yaml` with bullet lists, `markdown`/`md` fences (rich-rendered as prose instead of code), and any **non-COMMON language tag** (gdscript, zsh, ...) whose content looks prose-like.

**Root cause:** Two functions in `markdown-code.ts`:

- `isLikelyProseFence` — `NON_CODE_FENCE_LANGUAGES` included `''`, `text`, `plain`, `plaintext`, `md`, `markdown`, so explicit text-like tags were never treated as code; `proseLines >= 3 && codeSignals === 0` then misclassified zero-code-signal content as prose.
- `isLikelyProseCodeBlock` — the `bulletLines >= 1` prose check caught YAML list items; the fallthrough caught text/plain/plaintext and any non-COMMON explicit tag (gdscript, zsh, ...).

**Fix (2 files):**

1. `isLikelyProseFence` — any explicit, valid language tag (`VALID_LANGUAGE_RE`) is respected and rendered as code. Covers text/plain/plaintext/md/markdown (previously in `NON_CODE_FENCE_LANGUAGES`) and gdscript/zsh and other non-COMMON tags.
2. `isLikelyProseCodeBlock` —
   - exempt known code languages (`COMMON_CODE_LANGUAGES`, e.g. yaml/markdown) from the bullet-prose heuristic so their lists render as code;
   - respect any explicit, valid language tag, same guard as `isLikelyProseFence`.

Bare fences (`''`) keep the existing behavior: untagged paragraph fences still unwrap to prose, and config/key-value listings (SSH config, .env, INI) stay fenced via the existing `isLikelyStructuredText` guard. Unknown tags (e.g. Streamdown's `heads`) still classify as prose.

## Related Issue

Fixes #77253

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `apps/desktop/src/lib/markdown-code.ts`: classification logic — explicit-tag respect in both prose-detection paths
- `apps/desktop/src/lib/markdown-code.test.ts`: extended repro matrix (22 assertions)

## How to Test

1. `text` fence with 3+ lines of keyword-free text — CodeCard
2. `yaml` fence with a bullet list — CodeCard
3. `gdscript` (or any non-COMMON tag) fence with prose-like lines — CodeCard
4. `markdown`/`md` fence — CodeCard with raw (highlighted) content
5. bare (no tag) fence with 3+ lines of plain prose — still unwraps (existing behavior)
6. `text` fence with SSH config / .env content — CodeCard (structured guard preserved)
7. `python``/`bash` control — still renders normally

## Verification

**Trigger precision (verified):** the misclassification fires at `proseLines >= 3 && codeSignals === 0`... content with zero code signals (no JS keywords like `for`/`while`, no operators `=>` `}{``,`}` `;`, no HTML tags). English sentences frequently contain `for`/`while` and are accidentally immune, which is why line-count alone looked unreliable. No sticky state: after a misclassified block, subsequent well-formed blocks render fine.

**Behaviour table (tested on Windows 11, packaged app, after rebase onto latest main @ 1f8fdc7bd8 desktop v0.17.0):**

| Fence type | Before | After |
|---------------|-----:|----:|
| `text` with keyword-free lines | Prose, collapsed | CodeCard |
| `yaml` with bullet list | Prose | CodeCard |
| `gdscript` with prose-like lines | Prose, no card | CodeCard |
| `markdown`/`md` fence | Rich-rendered as prose | CodeCard (raw, highlighted) |
| Bare fence (no tag), plain prose | Unwrapped (existing behavior) | Unwrapped (unchanged) |
| `text` with SSH config / .env | CodeCard (structured guard) | CodeCard (unchanged) |
| `python`` / `bash` | CodeCard | CodeCard |

**Tests:** 22/22 pass (`markdown-code.test.ts`): explicit-tag matrix (text/plain/plaintext/markdown/md/gdscript/yaml) across both functions + upstream regression cases (SSH config, .env, bullet-prose with unknown tags, structured-text veto, bare-prose unwrap).

## Notes

Lebased onto latest `main` (includes upstream `isLikelyStructuredText` guard, #84664). The fix was narrowed to explicit-tag respect — bare fences intentionally keep the upstream unwrap philosophy.