### PR TITLE
fix: handle display.message_reactions in config.set (#77241)

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11050,6 +11050,12 @@ def _(rid, params: dict) -> dict:
             {"key": "terminal.cwd", "value": cwd, "cwd": cwd, "branch": _git_branch_for_cwd(cwd)},
         )
 
+    if key in {"message_reactions", "display.message_reactions"}:
+        raw = str(value or "").strip().lower()
+        enabled = raw in {"1", "on", "true", "yes"}
+        _write_config_key("display.message_reactions", enabled)
+        return _ok(rid, {"key": key, "value": "on" if enabled else "off"})
+
     if key in {"prompt", "personality", "skin"}:
         try:
             cfg = _load_cfg_raw()  # write-back round-trip ("prompt" saves cfg)


### PR DESCRIPTION
## Summary

The Desktop renderer sends `config.set` with key `display.message_reactions` when the user toggles **Message reactions** in Settings → Appearance, but the gateway's `config.set` handler had no branch for this key. It fell through to `return _err(rid, 4002, "unknown config key")`, and the renderer's `.catch(() => {})` silently swallowed the error.

This left `display.message_reactions` unset in `config.yaml`, which caused two backend gates to read the value as disabled (False):
- `tools/react_to_message_tool.py:107` — gates the `react_to_message` tool
- `tui_gateway/methods_prompt.py:33` — gates the model-context annotation

## Changes

Added a handler in `tui_gateway/server.py`'s `config.set` method that:
- Accepts both `message_reactions` and `display.message_reactions` as keys
- Normalizes the boolean value from string input (`true`/`on`/`1`/`yes` → enabled)
- Writes to `display.message_reactions` in config via `_write_config_key`

## Test Plan

- [ ] Enable "Message reactions" in Desktop Settings → Appearance
- [ ] Verify `config.set` returns success (not 4002)
- [ ] Verify `display.message_reactions` is persisted in `config.yaml`
- [ ] Verify agent can react to messages after enabling the toggle

Fixes #77241