### PR TITLE
fix(plugins): use gh pr view-compatible field list in github-pr-dashboard detail

### DIFF
--- a/plugins/github-pr-dashboard/CHANGELOG.md
+++ b/plugins/github-pr-dashboard/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to the GitHub Pull Requests dashboard plugin.
+
+## [1.0.1] - 2026-08-02
+
+### Fixed
+
+- PR detail loading (HTTP 502 → 200): `DETAIL_FIELDS` was built from the
+  `gh search prs` field list (`SUMMARY_FIELDS`), which contains `repository`
+  and `commentsCount` — fields `gh pr view --json` rejects. Every `/detail`
+  request failed with `RuntimeError` → HTTP 502, so the desktop UI showed
+  "Could not load PR details" for every PR. `DETAIL_FIELDS` is now an explicit
+  `gh pr view`-compatible field list. The repository is still passed via
+  `--repo`; `commentsCount` is not rendered in the detail view.
+
+## [1.0.0] - 2026-08-02
+
+### Added
+
+- Initial release: Created / Review requested / Closed pull request views
+  backed by the user's authenticated `gh` CLI. Read-only.

--- a/plugins/github-pr-dashboard/dashboard/manifest.json
+++ b/plugins/github-pr-dashboard/dashboard/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "github-pr-dashboard",
+  "label": "GitHub Pull Requests",
+  "description": "Account-wide pull requests dashboard — Created, Review requested, and Closed views backed by the gh CLI. Read-only.",
+  "icon": "git-pull-request",
+  "version": "1.0.1",
+  "api": "plugin_api.py"
+}

--- a/plugins/github-pr-dashboard/dashboard/plugin_api.py
+++ b/plugins/github-pr-dashboard/dashboard/plugin_api.py
@@ -1,0 +1,327 @@
+"""GitHub Pull Requests dashboard plugin — backend API routes.
+
+Mounted at /api/plugins/github-pr-dashboard/ by the Hermes plugin system
+(manifest.json declares api=plugin_api.py; import requires the plugin to be
+in plugins.enabled in config.yaml).
+
+This is a read-only port of the Hermes Desktop account-wide PR dashboard
+backing (hermes_cli/web_github.py): every operation shells out to the user's
+authenticated `gh` CLI with fixed argument arrays — no shell strings, no new
+dependencies, no writes. Validation and response shapes are identical to the
+core implementation so the plugin UI can be shared/shipped independently of
+the upstream PR.
+
+Routes:
+    GET /list?kind=created|review-requested&state=open|closed&limit=N
+    GET /detail?repository=owner/repo&number=N
+    GET /health
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import time
+from typing import Any, Callable
+
+from fastapi import APIRouter, HTTPException, Query
+
+router = APIRouter()
+
+SUMMARY_FIELDS = "number,title,url,state,isDraft,updatedAt,createdAt,repository,author,labels,commentsCount"
+# gh pr view --json rejects the gh search prs field list (repository, commentsCount
+# are search-only); the repository is passed separately via --repo, and the detail
+# view does not render commentsCount. Keep this list aligned with `gh pr view --json`
+# accepted fields only (see tests/plugins/test_github_pr_dashboard_plugin.py).
+DETAIL_FIELDS = "number,title,url,state,isDraft,updatedAt,createdAt,author,labels,body,headRefName,baseRefName,additions,deletions,changedFiles,reviewDecision,mergeStateStatus,mergedAt,statusCheckRollup"
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+MAX_OUTPUT = 8 * 1024 * 1024
+
+
+def validate_filter(kind: str, state: str, limit: int = 100) -> tuple[str, str, int]:
+    if kind not in {"created", "review-requested"}:
+        raise ValueError("Unsupported pull request filter")
+    if state not in {"open", "closed"} or (
+        kind == "review-requested" and state != "open"
+    ):
+        raise ValueError("Unsupported pull request state")
+    return kind, state, max(1, min(100, int(limit)))
+
+
+def validate_ref(repository: str, number: int) -> tuple[str, int]:
+    if not REPOSITORY_RE.fullmatch(repository or ""):
+        raise ValueError("Invalid GitHub repository")
+    if isinstance(number, bool) or not isinstance(number, int) or number <= 0:
+        raise ValueError("Invalid pull request number")
+    return repository, number
+
+
+def search_args(kind: str, state: str, limit: int = 100) -> list[str]:
+    kind, state, limit = validate_filter(kind, state, limit)
+    actor = ["--author", "@me"] if kind == "created" else ["--review-requested", "@me"]
+    return [
+        "search",
+        "prs",
+        *actor,
+        "--state",
+        state,
+        "--sort",
+        "updated",
+        "--order",
+        "desc",
+        "--limit",
+        str(limit),
+        "--json",
+        SUMMARY_FIELDS,
+    ]
+
+
+def _run(args: list[str], timeout: int = 30) -> dict[str, Any]:
+    gh = shutil.which("gh")
+    if not gh:
+        return {"ok": False, "kind": "missing", "stdout": ""}
+    try:
+        result = subprocess.run(
+            [gh, *args],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            shell=False,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "kind": "timeout", "stdout": ""}
+    stdout = result.stdout[:MAX_OUTPUT]
+    return {
+        "ok": result.returncode == 0 and len(result.stdout) <= MAX_OUTPUT,
+        "kind": "success" if result.returncode == 0 else "failure",
+        "stdout": stdout,
+    }
+
+
+def _repository(raw: Any) -> str | None:
+    value = (
+        raw
+        if isinstance(raw, str)
+        else raw.get("nameWithOwner")
+        if isinstance(raw, dict)
+        else None
+    )
+    return value if value and REPOSITORY_RE.fullmatch(value) else None
+
+
+def normalize_summary(raw: Any, repository: str | None = None) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    repo = repository or _repository(raw.get("repository"))
+    number = raw.get("number")
+    if (
+        not repo
+        or not isinstance(number, int)
+        or number <= 0
+        or not isinstance(raw.get("title"), str)
+        or not isinstance(raw.get("url"), str)
+    ):
+        return None
+    state = str(raw.get("state", "UNKNOWN")).upper()
+    if state not in {"OPEN", "CLOSED", "MERGED"}:
+        state = "UNKNOWN"
+    author = raw.get("author")
+    normalized_author = (
+        {"login": author["login"]}
+        if isinstance(author, dict) and isinstance(author.get("login"), str)
+        else None
+    )
+    if normalized_author is not None and isinstance(author.get("url"), str):
+        normalized_author["url"] = author["url"]
+    labels = (
+        [
+            {
+                "name": item["name"],
+                **(
+                    {"color": item["color"]}
+                    if isinstance(item.get("color"), str)
+                    else {}
+                ),
+            }
+            for item in raw.get("labels", [])
+            if isinstance(item, dict) and isinstance(item.get("name"), str)
+        ]
+        if isinstance(raw.get("labels"), list)
+        else []
+    )
+    return {
+        "id": f"{repo}#{number}",
+        "repository": repo,
+        "number": number,
+        "title": raw["title"],
+        "url": raw["url"],
+        "state": state,
+        "isDraft": bool(raw.get("isDraft")),
+        "author": normalized_author,
+        "labels": labels,
+        "commentsCount": max(0, int(raw.get("commentsCount") or 0)),
+        "createdAt": raw.get("createdAt")
+        if isinstance(raw.get("createdAt"), str)
+        else "",
+        "updatedAt": raw.get("updatedAt")
+        if isinstance(raw.get("updatedAt"), str)
+        else "",
+    }
+
+
+def normalize_checks(raw: Any) -> dict[str, int]:
+    out = {"total": 0, "pending": 0, "passed": 0, "failed": 0, "skipped": 0}
+    for check in raw if isinstance(raw, list) else []:
+        if not isinstance(check, dict):
+            continue
+        out["total"] += 1
+        status, conclusion = (
+            str(check.get("status", "")).upper(),
+            str(check.get("conclusion", check.get("state", ""))).upper(),
+        )
+        bucket = (
+            "pending"
+            if status and status != "COMPLETED"
+            else "passed"
+            if conclusion in {"SUCCESS", "NEUTRAL"}
+            else "skipped"
+            if conclusion in {"SKIPPED", "STALE"}
+            else "failed"
+            if conclusion
+            in {"FAILURE", "ERROR", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"}
+            else "pending"
+        )
+        out[bucket] += 1
+    return out
+
+
+def list_pull_requests(
+    kind: str, state: str, limit: int = 100, runner: Callable = _run
+) -> dict[str, Any]:
+    fetched_at = int(time.time() * 1000)
+    auth = runner(["auth", "status"])
+    if not auth["ok"]:
+        return {
+            "authState": "gh-missing"
+            if auth.get("kind") == "missing"
+            else "not-authenticated",
+            "items": [],
+            "fetchedAt": fetched_at,
+        }
+    result = runner(search_args(kind, state, limit))
+    if not result["ok"]:
+        return {
+            "authState": "error",
+            "items": [],
+            "fetchedAt": fetched_at,
+            "error": "GitHub CLI request timed out"
+            if result.get("kind") == "timeout"
+            else "Failed to load pull requests",
+        }
+    try:
+        raw = json.loads(result["stdout"])
+        if not isinstance(raw, list):
+            raise ValueError
+    except (ValueError, TypeError, json.JSONDecodeError):
+        return {
+            "authState": "error",
+            "items": [],
+            "fetchedAt": fetched_at,
+            "error": "GitHub CLI returned invalid data",
+        }
+    return {
+        "authState": "ready",
+        "items": [item for item in (normalize_summary(value) for value in raw) if item],
+        "fetchedAt": fetched_at,
+    }
+
+
+def pull_request_detail(
+    repository: str, number: int, runner: Callable = _run
+) -> dict[str, Any]:
+    repository, number = validate_ref(repository, number)
+    result = runner([
+        "pr",
+        "view",
+        str(number),
+        "--repo",
+        repository,
+        "--json",
+        DETAIL_FIELDS,
+    ])
+    if not result["ok"]:
+        raise RuntimeError(
+            "GitHub CLI request timed out"
+            if result.get("kind") == "timeout"
+            else "Failed to load pull request details"
+        )
+    try:
+        raw = json.loads(result["stdout"])
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("GitHub CLI returned invalid data") from exc
+    summary = normalize_summary(raw, repository)
+    if not summary:
+        raise RuntimeError("GitHub CLI returned invalid pull request data")
+    merged_at = raw.get("mergedAt") if isinstance(raw.get("mergedAt"), str) else None
+    return {
+        **summary,
+        "state": "MERGED" if merged_at else summary["state"],
+        "body": raw.get("body") if isinstance(raw.get("body"), str) else "",
+        "headRefName": raw.get("headRefName")
+        if isinstance(raw.get("headRefName"), str)
+        else "",
+        "baseRefName": raw.get("baseRefName")
+        if isinstance(raw.get("baseRefName"), str)
+        else "",
+        "additions": max(0, int(raw.get("additions") or 0)),
+        "deletions": max(0, int(raw.get("deletions") or 0)),
+        "changedFiles": max(0, int(raw.get("changedFiles") or 0)),
+        "reviewDecision": raw.get("reviewDecision") or None,
+        "mergeStateStatus": raw.get("mergeStateStatus") or None,
+        "mergedAt": merged_at,
+        "checks": normalize_checks(raw.get("statusCheckRollup")),
+    }
+
+
+@router.get("/health")
+async def health() -> dict[str, Any]:
+    gh = shutil.which("gh")
+    return {"ok": True, "gh": bool(gh)}
+
+
+@router.get("/list")
+async def list_route(
+    kind: str = Query(default="created"),
+    state: str = Query(default="open"),
+    limit: int = Query(default=100),
+) -> dict[str, Any]:
+    try:
+        kind, state, limit = validate_filter(kind, state, limit)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    try:
+        return list_pull_requests(kind, state, limit)
+    except Exception as exc:  # noqa: BLE001 — keep the plugin surface stable
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/detail")
+async def detail_route(
+    repository: str = Query(...),
+    number: int = Query(...),
+) -> dict[str, Any]:
+    try:
+        repository, number = validate_ref(repository, number)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    try:
+        return pull_request_detail(repository, number)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/tests/plugins/test_github_pr_dashboard_plugin.py
+++ b/tests/plugins/test_github_pr_dashboard_plugin.py
@@ -1,0 +1,438 @@
+"""Regression tests for the GitHub Pull Requests dashboard plugin backend.
+
+The plugin (``~/.hermes/plugins/github-pr-dashboard/dashboard/plugin_api.py``)
+mounts as ``/api/plugins/github-pr-dashboard/`` inside the dashboard's FastAPI
+app. Every operation shells out to the user's authenticated ``gh`` CLI; the
+``runner`` parameter on ``list_pull_requests`` / ``pull_request_detail`` is the
+documented injection point for testing.
+
+These tests pin the PR-loading contract:
+
+* ``GET /list`` — a mocked ``gh search prs`` response in the documented shape
+  is served as ``authState: ready`` with normalized items.
+* ``GET /detail`` — a mocked ``gh pr view`` response in the documented shape is
+  served without throwing or entering an error state.
+
+Regression (kanban t_0dfde5f0; diagnosis t_28acff12): ``DETAIL_FIELDS`` is
+built from ``SUMMARY_FIELDS + detail fields``, but ``SUMMARY_FIELDS`` is the
+field list for ``gh search prs`` — it contains ``repository`` and
+``commentsCount``, which ``gh pr view --json`` rejects (``Unknown JSON field:
+"repository"`` / ``"commentsCount"``). The ``gh`` subprocess exits non-zero,
+``_run`` returns ``ok=False``, ``pull_request_detail`` raises
+``RuntimeError("Failed to load pull request details")``, and the ``/detail``
+route converts that to HTTP 502. The desktop renderer sees ``isError`` and
+shows the "Could not load PR details" error state — every PR, every time.
+
+The fake runner below emulates the real ``gh`` CLI contract: it validates the
+requested ``--json`` fields against the field sets the real CLI accepts, so a
+field-list bug in the plugin fails exactly the way it fails in production.
+"""
+
+from __future__ import annotations
+
+import getpass
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# The field sets the real gh CLI accepts for each command (gh 2.96, 2026-07).
+# The detail test enforces these: requesting any field outside the set is
+# exactly what makes production `gh pr view` exit non-zero.
+# ---------------------------------------------------------------------------
+
+GH_SEARCH_JSON_FIELDS = frozenset({
+    "number",
+    "title",
+    "url",
+    "state",
+    "isDraft",
+    "updatedAt",
+    "createdAt",
+    "repository",
+    "author",
+    "labels",
+    "commentsCount",
+})
+
+GH_PR_VIEW_JSON_FIELDS = frozenset({
+    "additions",
+    "assignees",
+    "author",
+    "autoMergeRequest",
+    "baseRefName",
+    "baseRefOid",
+    "body",
+    "changedFiles",
+    "closed",
+    "closedAt",
+    "closingIssuesReferences",
+    "comments",
+    "commits",
+    "createdAt",
+    "deletions",
+    "files",
+    "fullDatabaseId",
+    "headRefName",
+    "headRefOid",
+    "headRepository",
+    "headRepositoryOwner",
+    "id",
+    "isCrossRepository",
+    "isDraft",
+    "labels",
+    "latestReviews",
+    "maintainerCanModify",
+    "mergeCommit",
+    "mergeStateStatus",
+    "mergeable",
+    "mergedAt",
+    "mergedBy",
+    "milestone",
+    "number",
+    "potentialMergeCommit",
+    "projectCards",
+    "projectItems",
+    "reactionGroups",
+    "reviewDecision",
+    "reviewRequests",
+    "reviews",
+    "state",
+    "statusCheckRollup",
+    "title",
+    "updatedAt",
+    "url",
+})
+
+#: A realistic ``gh search prs --json <SUMMARY_FIELDS>`` item (documented shape).
+SEARCH_ITEM: dict = {
+    "author": {
+        "id": "U_kgDODMy8WQ",
+        "is_bot": False,
+        "login": "asimons81",
+        "type": "User",
+        "url": "https://github.com/asimons81",
+    },
+    "commentsCount": 1,
+    "createdAt": "2026-07-29T04:47:45Z",
+    "isDraft": False,
+    "labels": [],
+    "number": 1,
+    "repository": {"name": "buzz", "nameWithOwner": "amanning3390/buzz"},
+    "state": "open",
+    "title": "feat: native Linux support — build, install, and companion runtime",
+    "updatedAt": "2026-08-01T23:38:49Z",
+    "url": "https://github.com/amanning3390/buzz/pull/1",
+}
+
+#: A realistic ``gh pr view --json`` object (documented shape for the fields
+#: ``gh pr view`` actually supports — no ``repository``, no ``commentsCount``).
+VIEW_ITEM: dict = {
+    "additions": 605,
+    "author": {
+        "id": "U_kgDODMy8WQ",
+        "is_bot": False,
+        "login": "asimons81",
+        "name": "Tony Simons",
+        "url": "https://github.com/asimons81",
+    },
+    "baseRefName": "release/buzz-for-hermes",
+    "body": "## What this adds\n\nFull Linux build, install, and companion runtime support.",
+    "changedFiles": 12,
+    "createdAt": "2026-07-29T04:47:45Z",
+    "deletions": 88,
+    "headRefName": "feat/linux-support",
+    "isDraft": False,
+    "labels": [],
+    "mergeStateStatus": "UNSTABLE",
+    "mergedAt": None,
+    "number": 1,
+    "reviewDecision": "REVIEW_REQUIRED",
+    "state": "OPEN",
+    "statusCheckRollup": [
+        {"status": "COMPLETED", "conclusion": "SUCCESS"},
+        {"status": "COMPLETED", "conclusion": "FAILURE"},
+    ],
+    "title": "feat: native Linux support — build, install, and companion runtime",
+    "updatedAt": "2026-08-01T23:38:49Z",
+    "url": "https://github.com/amanning3390/buzz/pull/1",
+}
+
+
+def _json_fields(args: list[str]) -> frozenset[str]:
+    """Extract the ``--json <csv>`` field list from a gh argv, if present."""
+    try:
+        idx = args.index("--json")
+    except ValueError:
+        return frozenset()
+    if idx + 1 >= len(args):
+        return frozenset()
+    return frozenset(f.strip() for f in args[idx + 1].split(",") if f.strip())
+
+
+class FakeGhRunner:
+    """Emulates the ``gh`` CLI contract for the three calls the plugin makes.
+
+    - ``auth status`` → success.
+    - ``search prs ... --json <fields>`` → validates fields against
+      :data:`GH_SEARCH_JSON_FIELDS`, returns the search items JSON.
+    - ``pr view <n> --repo <r> --json <fields>`` → validates fields against
+      :data:`GH_PR_VIEW_JSON_FIELDS`, returns the view item JSON.
+
+    Requesting a field the real CLI would reject returns ``ok=False`` — the
+    same failure the plugin sees in production, and the same reason the
+    detail flow throws today.
+    """
+
+    def __init__(self, search_items: list[dict], view_item: dict) -> None:
+        self.search_items = search_items
+        self.view_item = view_item
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args: list[str]) -> dict:
+        self.calls.append(list(args))
+        command = args[0]
+        if command == "auth":
+            return {"ok": True, "kind": "success", "stdout": ""}
+        fields = _json_fields(args)
+        if command == "search":
+            unsupported = fields - GH_SEARCH_JSON_FIELDS
+            if unsupported:
+                return {
+                    "ok": False,
+                    "kind": "failure",
+                    "stdout": f"Unknown JSON field: {sorted(unsupported)[0]!r}",
+                }
+            return {
+                "ok": True,
+                "kind": "success",
+                "stdout": json.dumps(self.search_items),
+            }
+        if command == "pr":
+            unsupported = fields - GH_PR_VIEW_JSON_FIELDS
+            if unsupported:
+                return {
+                    "ok": False,
+                    "kind": "failure",
+                    "stdout": f"Unknown JSON field: {sorted(unsupported)[0]!r}",
+                }
+            return {"ok": True, "kind": "success", "stdout": json.dumps(self.view_item)}
+        raise AssertionError(f"unexpected gh command: {command!r} ({args})")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _load_plugin_module():
+    """Dynamically load the installed github-pr-dashboard plugin_api.py.
+
+    The plugin is not bundled in-tree; it lives under the operator's plugin
+    install dir. ``Path.home()`` is NOT redirected by the test suite's
+    hermetic fixtures, but worker shells may redirect HOME to a profile dir,
+    so we also try the OS user's real home and HERMES_HOME. If a future fix
+    vendors the plugin into the repo, the repo copy wins.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    candidates = [
+        # Repo-vendored copy (preferred if the plugin ever lands in-tree).
+        repo_root / "plugins" / "github-pr-dashboard" / "dashboard" / "plugin_api.py",
+        # HERMES_HOME-relative install.
+        Path(os.environ.get("HERMES_HOME", ""))
+        / "plugins"
+        / "github-pr-dashboard"
+        / "dashboard"
+        / "plugin_api.py",
+        # OS user's real home (robust when HOME is redirected to a profile).
+        Path("/home")
+        / getpass.getuser()
+        / ".hermes"
+        / "plugins"
+        / "github-pr-dashboard"
+        / "dashboard"
+        / "plugin_api.py",
+        # Path.home() last — resolves to the real home in a normal shell.
+        Path.home()
+        / ".hermes"
+        / "plugins"
+        / "github-pr-dashboard"
+        / "dashboard"
+        / "plugin_api.py",
+        Path.home() / ".hermes" / "plugins" / "github-pr-dashboard" / "plugin_api.py",
+    ]
+    plugin_file = next((p for p in candidates if p.exists()), None)
+    assert plugin_file is not None, (
+        "github-pr-dashboard plugin_api.py not found; tried: "
+        + "; ".join(str(c) for c in candidates)
+    )
+
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_github_pr_test",
+        plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def plugin_mod():
+    return _load_plugin_module()
+
+
+@pytest.fixture
+def client(plugin_mod):
+    """Bare FastAPI app with the plugin router mounted (no full dashboard)."""
+    app = FastAPI()
+    app.include_router(plugin_mod.router, prefix="/api/plugins/github-pr-dashboard")
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Regression: the detail field list must only request fields gh pr view accepts
+# ---------------------------------------------------------------------------
+
+
+def test_detail_fields_are_valid_for_gh_pr_view(plugin_mod):
+    """DETAIL_FIELDS must be a subset of the fields ``gh pr view --json`` accepts.
+
+    The original bug: DETAIL_FIELDS = SUMMARY_FIELDS + detail fields, and
+    SUMMARY_FIELDS is the ``gh search prs`` field list. `repository` and
+    `commentsCount` are valid for `search` but rejected by `pr view`, so the
+    real CLI exits non-zero and every detail request 502s.
+    """
+    requested = frozenset(plugin_mod.DETAIL_FIELDS.split(","))
+    unsupported = requested - GH_PR_VIEW_JSON_FIELDS
+    assert not unsupported, (
+        f"pull_request_detail requests fields gh pr view rejects: {sorted(unsupported)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Function-level: list + detail serve mocked gh responses without throwing
+# ---------------------------------------------------------------------------
+
+
+def test_list_serves_documented_shape(plugin_mod):
+    """A mocked `gh search prs` response is served as ready + normalized items."""
+    runner = FakeGhRunner(search_items=[SEARCH_ITEM], view_item=VIEW_ITEM)
+
+    result = plugin_mod.list_pull_requests("created", "open", 100, runner=runner)
+
+    assert result["authState"] == "ready"
+    assert "error" not in result
+    assert len(result["items"]) == 1
+    item = result["items"][0]
+    assert item["id"] == "amanning3390/buzz#1"
+    assert item["repository"] == "amanning3390/buzz"
+    assert item["number"] == 1
+    assert item["state"] == "OPEN"
+    assert item["isDraft"] is False
+    assert item["author"] == {
+        "login": "asimons81",
+        "url": "https://github.com/asimons81",
+    }
+    assert item["labels"] == []
+    assert item["commentsCount"] == 1
+    # The search command requested the documented summary fields only.
+    search_call = next(c for c in runner.calls if c[0] == "search")
+    assert _json_fields(search_call) == GH_SEARCH_JSON_FIELDS
+
+
+def test_detail_serves_documented_shape(plugin_mod):
+    """A mocked `gh pr view` response is served without throwing.
+
+    Regression: this currently raises RuntimeError("Failed to load pull
+    request details") because DETAIL_FIELDS contains fields `gh pr view`
+    rejects (repository, commentsCount). The test asserts the plugin serves
+    the data instead of entering the error state.
+    """
+    runner = FakeGhRunner(search_items=[SEARCH_ITEM], view_item=VIEW_ITEM)
+
+    detail = plugin_mod.pull_request_detail("amanning3390/buzz", 1, runner=runner)
+
+    assert detail["repository"] == "amanning3390/buzz"
+    assert detail["number"] == 1
+    assert detail["state"] == "OPEN"
+    assert detail["title"] == SEARCH_ITEM["title"]
+    assert detail["body"].startswith("## What this adds")
+    assert detail["headRefName"] == "feat/linux-support"
+    assert detail["baseRefName"] == "release/buzz-for-hermes"
+    assert detail["additions"] == 605
+    assert detail["deletions"] == 88
+    assert detail["changedFiles"] == 12
+    assert detail["reviewDecision"] == "REVIEW_REQUIRED"
+    assert detail["mergeStateStatus"] == "UNSTABLE"
+    assert detail["mergedAt"] is None
+    assert detail["checks"] == {
+        "total": 2,
+        "pending": 0,
+        "passed": 1,
+        "failed": 1,
+        "skipped": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# HTTP surface: the routes the desktop renderer actually calls
+# ---------------------------------------------------------------------------
+
+
+def test_list_route_serves_mocked_response(client, plugin_mod, monkeypatch):
+    """GET /list returns 200 with authState ready + items for a mocked gh."""
+    runner = FakeGhRunner(search_items=[SEARCH_ITEM], view_item=VIEW_ITEM)
+    original = plugin_mod.list_pull_requests
+    monkeypatch.setattr(
+        plugin_mod,
+        "list_pull_requests",
+        lambda kind, state, limit: original(kind, state, limit, runner=runner),
+    )
+
+    r = client.get(
+        "/api/plugins/github-pr-dashboard/list?kind=created&state=open&limit=100"
+    )
+
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["authState"] == "ready"
+    assert len(data["items"]) == 1
+    assert data["items"][0]["id"] == "amanning3390/buzz#1"
+
+
+def test_detail_route_serves_mocked_response(client, plugin_mod, monkeypatch):
+    """GET /detail returns 200 with the PR detail for a mocked gh.
+
+    Regression: today this route returns HTTP 502 ("Failed to load pull
+    request details") for every PR because the backend requests fields
+    ``gh pr view`` rejects. The desktop renderer treats ≥400 as an error
+    state, so this is the exact user-visible failure.
+    """
+    runner = FakeGhRunner(search_items=[SEARCH_ITEM], view_item=VIEW_ITEM)
+    original = plugin_mod.pull_request_detail
+    monkeypatch.setattr(
+        plugin_mod,
+        "pull_request_detail",
+        lambda repository, number: original(repository, number, runner=runner),
+    )
+
+    r = client.get(
+        "/api/plugins/github-pr-dashboard/detail?repository=amanning3390/buzz&number=1"
+    )
+
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["repository"] == "amanning3390/buzz"
+    assert data["number"] == 1
+    assert data["state"] == "OPEN"
+    assert data["checks"]["total"] == 2
+    assert data["checks"]["passed"] == 1
+    assert data["checks"]["failed"] == 1


### PR DESCRIPTION
## Summary
The GitHub Pull Requests dashboard plugin returned HTTP 502 for **every** PR detail request — the desktop UI showed "Could not load PR details" + Retry for every PR.

**Root cause:** `DETAIL_FIELDS` was built by concatenating `SUMMARY_FIELDS` (the `gh search prs --json` field list) with detail fields. `gh search prs` accepts `repository` and `commentsCount`, but `gh pr view --json` rejects both (`Unknown JSON field: "repository"` / `"commentsCount"`). The `gh` subprocess exited non-zero → `RuntimeError("Failed to load pull request details")` → HTTP 502 on `/detail`.

**Fix:** define an explicit `gh pr view`-compatible `DETAIL_FIELDS` list (19 fields, no search-only fields). `repository` is still passed via `--repo` and re-injected in `normalize_summary`; `commentsCount` is not rendered in the detail view.

Also vendors the plugin into `plugins/github-pr-dashboard/` (following the in-tree `plugins/kanban/` convention) so the regression test loads the repo copy, bumps manifest to 1.0.1, and adds a CHANGELOG.

## Test Plan
- Regression tests added: `tests/plugins/test_github_pr_dashboard_plugin.py` — 5/5 green (was 3 failed RED before the fix).
  - `test_detail_fields_are_valid_for_gh_pr_view` asserts `DETAIL_FIELDS` is a subset of the `gh pr view` accepted field set.
  - Fake gh runner validates `--json` fields per-command and returns `ok=False` for unsupported fields (same failure mode as production).
- Full `tests/plugins/` suite: 1090 passed, 1 failed (pre-existing unrelated `test_hindsight_provider.py` missing optional dep).
- ruff check + format: clean.
- Live verification: `gh pr view 1 --repo amanning3390/buzz --json <DETAIL_FIELDS>` exits 0; `GET /detail` returns HTTP 200 on the desktop backend (was 502).