### PR TITLE
docs(tui): correct Ctrl+L keybinding description

### DIFF
--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -135,7 +135,7 @@ Current input behavior is split across `app.tsx`, `components/textInput.tsx`, an
 | `Ctrl+C`                        | Interrupt active run, or clear the current draft, or exit if nothing is pending                                                                         |
 | `Ctrl+D`                        | Exit                                                                                                                                                    |
 | `Cmd/Ctrl+G` / `Alt+G`          | Open `$EDITOR` with the current draft (use `Alt+G` in VSCode/Cursor — they bind the primary keystroke to Find Next)                                     |
-| `Ctrl+L`                        | New session (same as `/clear`)                                                                                                                          |
+| `Ctrl+L`                        | Redraw / repaint the current screen                                                                                                                     |
 | `Ctrl+V` / `Alt+V`              | Paste text first, then fall back to image/path attachment when applicable                                                                               |
 | `Tab`                           | Apply the active completion                                                                                                                             |
 | `Up/Down`                       | Cycle completions if the completion list is open; otherwise edit queued messages first, then walk input history                                         |


### PR DESCRIPTION
## Summary

- update the TUI README to describe `Ctrl+L` as redraw/repaint rather than starting a new session
- match the runtime behavior and in-app hotkey text introduced by #16657

## Verification

- `git diff --check`
- confirmed `useInputHandlers.ts` calls `forceRedraw()` for `Ctrl+L`
- confirmed the in-app hotkey catalog describes it as `redraw / repaint`

Docs-only change; no runtime tests were needed.