### PR TITLE
docs: overnight documentation sweep

### DIFF
--- a/website/docs/guides/cron-script-only.md
+++ b/website/docs/guides/cron-script-only.md
@@ -151,7 +151,12 @@ The "silent when empty" behavior is the key to the classic watchdog pattern: the
 
 ## Script Rules
 
-Scripts must live in `~/.hermes/scripts/`. This is enforced at both job-creation time and run time — absolute paths, `~/` expansion, and path-traversal patterns (`../`) are rejected. The same directory is shared with the pre-check script gate used by LLM jobs.
+Scripts must resolve inside `~/.hermes/scripts/`. At run time, relative paths,
+absolute paths, and `~`-prefixed paths are accepted only when their resolved
+target stays in that directory; path traversal and symlink escapes are rejected.
+The `cronjob` tool accepts only relative paths at its agent-facing creation
+boundary, so use a filename such as `memory-watchdog.sh` in chat-created jobs.
+The same directory is shared with the pre-check script gate used by LLM jobs.
 
 Interpreter choice is by file extension:
 


### PR DESCRIPTION
## Summary
- Reviewed the codebase for documentation drift using the 7-day implementation window and Hermes high-signal probes.
- Corrected the script-path security/behavior contract in the script-only cron guide.
- Saved run progress in `/tmp/overnight-docs-sweep.md`.

## Sweep window
- From: `2026-07-27T00:00:00+01:00`
- To: `2026-08-03T00:00:00+01:00`

## Recent changes reviewed
- `80631c4ae` feat(terminal): recoverable truncation — spill full output + report pre-truncation size
- `837003b1e` feat(a2a): consolidated Agent-to-Agent protocol plugin
- `7483745da` feat(gateway): simplex channel enumeration + configured platforms in `hermes send --list`
- `fb6446fc9` fix(cron): scope cron approval context per session
- Plus recent search, file, patch, gateway, memory-provider, curator, and cron changes.

## Documentation checked
- `website/docs/reference/slash-commands.md`
- `website/docs/developer-guide/gateway-internals.md` and matching zh-Hans key table
- `website/docs/user-guide/features/curator.md`
- `website/docs/user-guide/features/memory-providers.md`
- `website/docs/reference/environment-variables.md`
- `website/docs/user-guide/configuration.md`
- Cron user, script-only, developer, dashboard, and desktop documentation

## Documentation updated
- `website/docs/guides/cron-script-only.md` — distinguish runtime path validation (relative, absolute, and `~` paths are accepted only when resolving inside `$HERMES_HOME/scripts`) from the agent-facing `cronjob` creation boundary (relative paths only).

## Verification
- `git diff --check` — passed
- `npx --no-install markdownlint-cli2 docs/guides/cron-script-only.md` — baseline has 45 pre-existing violations; edited file has 44, so the change adds none
- `npm run typecheck` — failed before source checking: installed TypeScript rejects the repository's deprecated `baseUrl` setting
- `npm run lint:diagrams` — failed: installed `website/node_modules` lacks `ascii-guard`
- `npm run build` — failed at a deliberate 1 GiB V8 memory cap during Docusaurus webpack compilation; not retried on the low-RAM cron host
- Independent docs autoreview — passed; no blocking findings

## Open questions / risks
- Website verification has pre-existing/dependency-host blockers listed above. The documentation diff is source-grounded and `git diff --check` passes.
