### PR TITLE
fix(fuzzy_match): guard against model indentation typos in non-exact matches

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -138,6 +138,93 @@ class TestIndentationPreservation:
         assert lines[2] == "    b = 99"
 
 
+class TestRogueIndentGuard:
+    """CRLF files (Windows checkouts) + LF old_string make exact matching
+    fail, so the chain falls through to line_trimmed / indentation_flexible.
+    In that path _reindent_replacement only re-indents when old_indent !=
+    file_indent; when they are equal (the common case) it returns new_string
+    verbatim — so a model indentation typo (a line indented deeper than the
+    surrounding block with no nesting opener) is silently written into the
+    file. _detect_rogue_indent refuses such patches instead.
+    """
+
+    def test_crlf_file_lf_old_typo_rejected(self):
+        # Reproduction: CRLF file + LF old_string + model indentation typo.
+        # The new_string's inner lines are indented 16 spaces while the
+        # surrounding block (and old_string) is 8 — no nesting opener
+        # anywhere, so this is a typo, not a real nested block.
+        content = (
+            "if (cd >= bestD) continue;\r\n"
+            "        if (data.cells[cand[0] + ',' + cand[1]] === 'OBSTACLE') continue;\r\n"
+            "        bestD = cd; best = cand;\r\n"
+        )
+        old = (
+            "if (cd >= bestD) continue;\n"
+            "        if (data.cells[cand[0] + ',' + cand[1]] === 'OBSTACLE') continue;\n"
+            "        bestD = cd; best = cand;"
+        )
+        # Typo: 16-space indent on the inserted lines (file/old use 8).
+        new_err = (
+            "if (cd >= bestD) continue;\n"
+            "                const ck = cand[0] + ',' + cand[1];\n"
+            "                const ckind = data.cells[ck];\n"
+            "                if (ckind === 'OBSTACLE' || !ckind) continue;\n"
+            "        bestD = cd; best = cand;"
+        )
+        out, count, strategy, err = fuzzy_find_and_replace(content, old, new_err)
+        assert count == 0
+        assert err is not None and "Suspicious indentation" in err
+        # File untouched.
+        assert out == content
+
+    def test_crlf_file_lf_old_correct_indent_passes(self):
+        # Same reproduction but the correct 8-space indent -> must succeed.
+        content = (
+            "if (cd >= bestD) continue;\r\n"
+            "        if (data.cells[cand[0] + ',' + cand[1]] === 'OBSTACLE') continue;\r\n"
+            "        bestD = cd; best = cand;\r\n"
+        )
+        old = (
+            "if (cd >= bestD) continue;\n"
+            "        if (data.cells[cand[0] + ',' + cand[1]] === 'OBSTACLE') continue;\n"
+            "        bestD = cd; best = cand;"
+        )
+        new_ok = (
+            "if (cd >= bestD) continue;\n"
+            "        const ck = cand[0] + ',' + cand[1];\n"
+            "        const ckind = data.cells[ck];\n"
+            "        if (ckind === 'OBSTACLE' || !ckind) continue;\n"
+            "        bestD = cd; best = cand;"
+        )
+        out, count, strategy, err = fuzzy_find_and_replace(content, old, new_ok)
+        assert err is None and count == 1
+        assert strategy != "exact"  # CRLF file -> non-exact path
+        for line in out.split("\n"):
+            if "const ck" in line:
+                indent = len(line) - len(line.lstrip())
+                assert indent == 8, f"Expected 8-space indent, got {indent}: {line!r}"
+
+    def test_intentional_nesting_not_flagged(self):
+        # new_string legitimately adds a nested block (if x: followed by a
+        # deeper-indented body) -> the guard must not refuse it.
+        content = "def f():\r\n    a = 1\r\n    b = 2\r\n"
+        old = "a = 1\nb = 2"
+        new = "a = 1\nif a > 0:\n    b = 2"
+        out, count, strategy, err = fuzzy_find_and_replace(content, old, new)
+        assert err is None and count == 1
+        assert "if a > 0:" in out and "    b = 2" in out
+
+    def test_lf_exact_match_unaffected(self):
+        # Pure-LF file + exact old_string -> exact strategy, no guard run.
+        content = "def f():\n    return 1\n"
+        old = "    return 1"
+        new = "    return 2"
+        out, count, strategy, err = fuzzy_find_and_replace(content, old, new)
+        assert err is None and count == 1
+        assert strategy == "exact"
+        assert "    return 2" in out
+
+
 class TestReplaceAll:
     def test_multiple_matches_without_flag_errors(self):
         content = "aaa bbb aaa"

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -204,6 +204,13 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
                 drift_err = _detect_escape_drift(content, matches, old_string, new_string)
                 if drift_err:
                     return content, 0, None, drift_err
+                # Indentation-typo guard: non-exact strategies (CRLF file +
+                # LF old_string) bypass _reindent_replacement when
+                # old_indent == file_indent, so a model indent typo would be
+                # written verbatim. Detect and refuse instead.
+                indent_err = _detect_rogue_indent(old_string, new_string)
+                if indent_err:
+                    return content, 0, None, indent_err
 
             # Perform replacement. When the matched strategy is NOT `exact`,
             # the file's indentation may differ from what the LLM sent in
@@ -479,6 +486,43 @@ def _preserve_unicode_in_replacement(
             result_parts.append(new_string[j1:j2])
 
     return "".join(result_parts)
+
+
+def _detect_rogue_indent(old_string: str, new_string: str) -> Optional[str]:
+    """Detect new_string indentation typos after a non-exact fuzzy match.
+
+    CRLF files (e.g. Windows checkouts) + LF old_string make exact matching
+    fail, so the chain falls through to line_trimmed / indentation_flexible.
+    ``_reindent_replacement`` only re-indents when old_indent != file_indent;
+    when they are equal (the common case) it returns new_string verbatim, so
+    a model indentation typo (a line indented deeper than the surrounding
+    block with no nesting opener) is silently written into the file.
+
+    This guard: when neither old_string nor new_string opens a nesting block
+    (':', '{', '('), but new_string has lines indented deeper than
+    old_string's max indent, the new lines are almost certainly a typo —
+    report an error so the caller re-reads and re-patches instead of
+    silently corrupting indentation.
+    """
+    old_lines = [l for l in old_string.split("\n") if l.strip()]
+    new_lines = [l for l in new_string.split("\n") if l.strip()]
+    if not old_lines or not new_lines:
+        return None
+    max_old = max(len(_leading_whitespace(l)) for l in old_lines)
+    if any(l.rstrip().endswith((":", "{", "(")) for l in old_lines):
+        return None  # old_string nests; deeper indent may be legitimate
+    if any(l.rstrip().endswith((":", "{", "(")) for l in new_lines):
+        return None  # new_string intentionally adds a block (e.g. if x:)
+    deeper = [l for l in new_lines if len(_leading_whitespace(l)) > max_old]
+    if not deeper:
+        return None
+    sample = deeper[0].strip()[:60]
+    return (
+        f"Suspicious indentation in new_string: {len(deeper)} line(s) indented "
+        f"deeper than old_string's max indent ({max_old} spaces), but neither "
+        f"old_string nor new_string opens a nesting block (':', '{{', '('). "
+        f"Likely a model indent typo — check the indentation of: {sample!r}"
+    )
 
 
 def _apply_replacements(content: str, matches: List[Tuple[int, int]],


### PR DESCRIPTION
## Problem

CRLF files (Windows checkouts) + LF `old_string` make exact matching fail, so the fuzzy chain falls through to `line_trimmed` / `indentation_flexible`. In that path `_reindent_replacement` only re-indents when `old_indent != file_indent`; when they are equal (the common case) it returns `new_string` verbatim — so a model indentation typo (a line indented deeper than the surrounding block with no nesting opener) is silently written into the file, corrupting indentation.

## Fix

Add `_detect_rogue_indent`: when neither `old_string` nor `new_string` opens a nesting block (`:`, `{`, `(`), but `new_string` has lines indented deeper than `old_string`'s max indent, refuse the patch with an actionable error instead of silently corrupting indentation.

## Verification

- Repro test: CRLF content + LF old_string + 16-space typo in new_string → previously written verbatim (bug), now refused with `Suspicious indentation...` error
- Regression: correct indentation passes, intentional nesting (`if x:` blocks) not flagged, LF+exact path unaffected
- Existing suite: `tests/tools/test_fuzzy_match.py` — 45 passed