### PR TITLE
feat(terminal): hand off long foreground commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -659,6 +659,7 @@ def load_cli_config() -> Dict[str, Any]:
         "env_type": "TERMINAL_ENV",
         "cwd": "TERMINAL_CWD",
         "timeout": "TERMINAL_TIMEOUT",
+        "handoff_timeout": "TERMINAL_HANDOFF_TIMEOUT",
         "home_mode": "TERMINAL_HOME_MODE",
         "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
         "docker_image": "TERMINAL_DOCKER_IMAGE",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1932,6 +1932,7 @@ if _config_path.exists():
                 "backend": "TERMINAL_ENV",
                 "cwd": "TERMINAL_CWD",
                 "timeout": "TERMINAL_TIMEOUT",
+                "handoff_timeout": "TERMINAL_HANDOFF_TIMEOUT",
                 "home_mode": "TERMINAL_HOME_MODE",
                 "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
                 "docker_image": "TERMINAL_DOCKER_IMAGE",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3185,6 +3185,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "modal_mode": "TERMINAL_MODAL_MODE",
     "cwd": "TERMINAL_CWD",
     "timeout": "TERMINAL_TIMEOUT",
+    "handoff_timeout": "TERMINAL_HANDOFF_TIMEOUT",
     "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
     "docker_image": "TERMINAL_DOCKER_IMAGE",
     "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -248,6 +248,10 @@ DEFAULT_CONFIG = {
         # it here without patching the built desktop app.
         "font_family": "",
         "timeout": 180,
+        # Foreground commands are handed to the process registry after this
+        # short synchronous window instead of being killed.  The command keeps
+        # running under its execution timeout and returns a session_id.
+        "handoff_timeout": 10,
         # Bounded grace period (seconds) between SIGTERM and an escalated
         # SIGKILL when terminating a host process tree (browser daemons, etc.).
         # A daemon that stalls in its SIGTERM handler is force-killed after this

--- a/tests/tools/test_approved_command_clean_slate.py
+++ b/tests/tools/test_approved_command_clean_slate.py
@@ -180,6 +180,9 @@ def test_retry_backoff_does_not_clear_genuine_interrupt(monkeypatch):
         return {"output": "partial\n[Command interrupted]", "returncode": 130}
 
     monkeypatch.setattr(LocalEnvironment, "execute", fake_execute)
+    # This test targets the retry loop itself; disable the separate
+    # foreground-to-background lifecycle path so the fake executor is used.
+    monkeypatch.setattr(tt, "_auto_handoff_foreground", lambda **_: None)
     monkeypatch.setattr("tools.terminal_tool.time.sleep", lambda *a, **k: None)
     set_interrupt(False)
 

--- a/tests/tools/test_terminal_foreground_timeout_cap.py
+++ b/tests/tools/test_terminal_foreground_timeout_cap.py
@@ -15,6 +15,7 @@ def _make_env_config(**overrides):
     config = {
         "env_type": "local",
         "timeout": 180,
+        "handoff_timeout": 10,
         "cwd": "/tmp",
         "host_cwd": None,
         "modal_mode": "auto",

--- a/tests/tools/test_terminal_handoff.py
+++ b/tests/tools/test_terminal_handoff.py
@@ -1,0 +1,89 @@
+"""Tests for automatic foreground-to-background handoff."""
+
+import json
+
+from tools import terminal_tool as terminal_module
+from tools.process_registry import process_registry
+
+
+def test_long_foreground_command_is_handed_to_background(monkeypatch):
+    """A command past handoff_timeout keeps running and returns a process id."""
+    monkeypatch.setenv("TERMINAL_HANDOFF_TIMEOUT", "1")
+    monkeypatch.setenv("TERMINAL_TIMEOUT", "30")
+
+    result = json.loads(
+        terminal_module.terminal_tool(
+            "sleep 4",
+            timeout=30,
+            force=True,
+        )
+    )
+
+    assert result["status"] == "running"
+    assert result["auto_handoff"] is True
+    assert result["session_id"].startswith("proc_")
+
+    try:
+        assert process_registry.poll(result["session_id"])["status"] == "running"
+    finally:
+        process_registry.kill_process(result["session_id"])
+
+
+def test_handoff_persists_session_cwd_after_completion(monkeypatch, tmp_path):
+    """An adopted command updates the durable cwd after it exits."""
+    monkeypatch.setenv("TERMINAL_HANDOFF_TIMEOUT", "1")
+    monkeypatch.setenv("TERMINAL_TIMEOUT", "30")
+    task_id = "handoff-cwd-test"
+    from tools.terminal_tool import clear_session_cwd, get_session_cwd
+    clear_session_cwd(task_id)
+
+    result = json.loads(
+        terminal_module.terminal_tool(
+            f"cd {tmp_path}; sleep 2",
+            timeout=30,
+            task_id=task_id,
+            force=True,
+        )
+    )
+    assert result["status"] == "running", result
+
+    try:
+        waited = process_registry.wait(result["session_id"], timeout=5)
+        assert waited["status"] == "exited", waited
+        assert get_session_cwd(task_id) == str(tmp_path)
+    finally:
+        clear_session_cwd(task_id)
+
+
+def test_handoff_failure_after_start_is_not_retried(monkeypatch):
+    """A post-start handoff failure must not execute the command a second time."""
+    monkeypatch.setattr(
+        terminal_module,
+        "_auto_handoff_foreground",
+        lambda **_: {
+            "output": "",
+            "returncode": -1,
+            "error": "handoff failed after start",
+            "handoff_failed": True,
+        },
+    )
+    execute_calls = []
+    from tools.environments.local import LocalEnvironment
+    monkeypatch.setattr(
+        LocalEnvironment,
+        "execute",
+        lambda self, command, **kwargs: execute_calls.append(command),
+    )
+
+    result = json.loads(
+        terminal_module.terminal_tool(
+            "touch /tmp/should-not-run-twice",
+            timeout=30,
+            task_id="handoff-failure-test",
+            force=True,
+        )
+    )
+
+    assert execute_calls == []
+    assert result["exit_code"] == -1
+    assert result["error"] == "handoff failed after start"

--- a/tests/tools/test_terminal_timeout_output.py
+++ b/tests/tools/test_terminal_timeout_output.py
@@ -25,3 +25,14 @@ class TestTimeoutPreservesPartialOutput:
         assert result["returncode"] == 124
         assert "timed out" in result["output"].lower()
         assert not result["output"].startswith("\n")
+
+
+def test_environment_can_spawn_without_waiting():
+    """Long commands must be detachable before the normal wait deadline."""
+    env = LocalEnvironment()
+    proc, _cwd = env.spawn("sleep 30", timeout=60)
+
+    try:
+        assert proc.poll() is None
+    finally:
+        env._kill_process(proc)

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -1189,6 +1189,51 @@ class BaseEnvironment(ABC):
     # Unified execute()
     # ------------------------------------------------------------------
 
+    def spawn(
+        self,
+        command: str,
+        cwd: str = "",
+        *,
+        timeout: int | None = None,
+        stdin_data: str | None = None,
+        rewrite_compound_background: bool = True,
+    ):
+        """Prepare and start a command without waiting for it to finish.
+
+        This lifecycle seam lets the terminal tool hand a live command to the
+        process registry without losing the environment snapshot, cwd marker,
+        sudo stdin handling, or shell wrapper used by ``execute()``.
+        """
+        self._before_execute()
+
+        exec_command, sudo_stdin = self._prepare_command(command)
+        if rewrite_compound_background:
+            from tools.terminal_tool import _rewrite_compound_background
+            exec_command = _rewrite_compound_background(exec_command)
+        effective_timeout = timeout or self.timeout
+        effective_cwd = cwd or self.cwd
+
+        if sudo_stdin is not None and stdin_data is not None:
+            effective_stdin = sudo_stdin + stdin_data
+        elif sudo_stdin is not None:
+            effective_stdin = sudo_stdin
+        else:
+            effective_stdin = stdin_data
+
+        if effective_stdin and self._stdin_mode == "heredoc":
+            exec_command = self._embed_stdin_heredoc(exec_command, effective_stdin)
+            effective_stdin = None
+
+        wrapped = self._wrap_command(exec_command, effective_cwd)
+        login = not self._snapshot_ready and not self._prefer_nonlogin
+        proc = self._run_bash(
+            wrapped,
+            login=login,
+            timeout=effective_timeout,
+            stdin_data=effective_stdin,
+        )
+        return proc, effective_cwd
+
     def execute(
         self,
         command: str,
@@ -1210,40 +1255,14 @@ class BaseEnvironment(ABC):
         the patch engine, code-execution RPC reads, log reads — MUST leave
         it False: truncating those corrupts data, not just display.
         """
-        self._before_execute()
-
-        exec_command, sudo_stdin = self._prepare_command(command)
-        # Guard against the `A && B &` subshell-wait trap by default.
-        # Some callers (spawn_via_env) already produce shell-safe wrappers and
-        # pass rewrite_compound_background=False.
-        if rewrite_compound_background:
-            from tools.terminal_tool import _rewrite_compound_background
-            exec_command = _rewrite_compound_background(exec_command)
-        effective_timeout = timeout or self.timeout
-        effective_cwd = cwd or self.cwd
-
-        # Merge sudo stdin with caller stdin
-        if sudo_stdin is not None and stdin_data is not None:
-            effective_stdin = sudo_stdin + stdin_data
-        elif sudo_stdin is not None:
-            effective_stdin = sudo_stdin
-        else:
-            effective_stdin = stdin_data
-
-        # Embed stdin as heredoc for backends that need it
-        if effective_stdin and self._stdin_mode == "heredoc":
-            exec_command = self._embed_stdin_heredoc(exec_command, effective_stdin)
-            effective_stdin = None
-
-        wrapped = self._wrap_command(exec_command, effective_cwd)
-
-        # Use login shell if snapshot failed (so user's profile still loads),
-        # unless login itself is broken — then non-login is the only path.
-        login = not self._snapshot_ready and not self._prefer_nonlogin
-
-        proc = self._run_bash(
-            wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
+        proc, effective_cwd = self.spawn(
+            command,
+            cwd,
+            timeout=timeout,
+            stdin_data=stdin_data,
+            rewrite_compound_background=rewrite_compound_background,
         )
+        effective_timeout = timeout or self.timeout
         result = self._wait_for_process(
             proc, timeout=effective_timeout, bounded_capture=bounded_capture
         )

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -107,6 +107,14 @@ class ProcessSession:
     termination_source: str = ""                # process.kill|kill_all|backend_lost|failed_start
     output_buffer: str = ""                     # Rolling output (last MAX_OUTPUT_CHARS)
     max_output_chars: int = MAX_OUTPUT_CHARS
+    # Optional bounded head/tail capture used by foreground-to-background
+    # handoff. Ordinary background sessions keep the historical rolling tail;
+    # foreground handoffs must preserve the same head/tail contract as
+    # BaseEnvironment._wait_for_process.
+    bounded_capture_limit: Optional[int] = None
+    _bounded_capture_text: str = field(default="", repr=False)
+    _bounded_capture_total: int = field(default=0, repr=False)
+    persist_cwd: bool = False
     detached: bool = False                      # True if recovered from crash (no pipe)
     pid_scope: str = "host"                     # "host" for local/PTY PIDs, "sandbox" for env-local PIDs
     # Watcher/notification metadata (persisted for crash recovery)
@@ -221,6 +229,69 @@ class ProcessRegistry:
         while lines and any(noise in lines[0] for noise in ProcessRegistry._SHELL_NOISE_SUBSTRINGS):
             lines.pop(0)
         return "\n".join(lines)
+
+    def _visible_output(self, session: ProcessSession, output: str) -> str:
+        """Return output without private environment bookkeeping markers."""
+        from tools.ansi_strip import strip_ansi
+
+        visible = strip_ansi(output)
+        if session.env_ref is None:
+            return visible
+        cleaned = {"output": visible}
+        try:
+            # Environment-backed foreground handoffs include a private cwd
+            # marker. Keep cwd tracking while hiding that marker from poll,
+            # log, and wait consumers.
+            session.env_ref._update_cwd(cleaned)
+            self._persist_session_cwd(session)
+            return cleaned["output"]
+        except Exception:
+            return visible
+
+    @staticmethod
+    def _append_bounded_capture(session: ProcessSession, chunk: str) -> None:
+        """Maintain a bounded head/tail capture for foreground handoffs."""
+        limit = session.bounded_capture_limit
+        if not limit or limit <= 0 or not chunk:
+            return
+        session._bounded_capture_total += len(chunk)
+        candidate = session._bounded_capture_text + chunk
+        if len(candidate) <= limit:
+            session._bounded_capture_text = candidate
+            return
+        head_chars = int(limit * 0.4)
+        tail_chars = limit - head_chars
+        session._bounded_capture_text = (
+            candidate[:head_chars] + candidate[-tail_chars:]
+        )
+
+    @staticmethod
+    def _bounded_capture_output(session: ProcessSession) -> Optional[str]:
+        """Render the configured head/tail capture, including its notice."""
+        limit = session.bounded_capture_limit
+        if not limit or limit <= 0:
+            return None
+        output = session._bounded_capture_text
+        if session._bounded_capture_total <= limit:
+            return output
+        head_chars = int(limit * 0.4)
+        tail_chars = limit - head_chars
+        omitted = session._bounded_capture_total - head_chars - tail_chars
+        notice = (
+            f"\n\n... [OUTPUT TRUNCATED - {omitted} chars omitted "
+            f"out of {session._bounded_capture_total} total] ...\n\n"
+        )
+        return output[:head_chars] + notice + output[-tail_chars:]
+
+    def _persist_session_cwd(self, session: ProcessSession) -> None:
+        """Persist cwd learned from an adopted foreground command."""
+        if not session.persist_cwd or session.env_ref is None:
+            return
+        try:
+            from tools.terminal_tool import record_session_cwd
+            record_session_cwd(session.session_key, getattr(session.env_ref, "cwd", None))
+        except Exception:
+            logger.debug("Failed to persist adopted process cwd", exc_info=True)
 
     def _emit_output(self, session: ProcessSession, chunk: str) -> None:
         """Forward a freshly-read chunk to the live-output sink, if one is set.
@@ -835,6 +906,70 @@ class ProcessRegistry:
 
         return session
 
+    def adopt_local_process(
+        self,
+        process: subprocess.Popen,
+        *,
+        command: str,
+        cwd: str,
+        task_id: str = "",
+        session_key: str = "",
+        env_ref: Any = None,
+        max_runtime: Optional[float] = None,
+        bounded_capture_limit: Optional[int] = None,
+        persist_cwd: bool = False,
+    ) -> ProcessSession:
+        """Register an already-started local process.
+
+        ``BaseEnvironment.spawn()`` starts a command with the same environment
+        snapshot and shell wrapper as foreground ``execute()``.  This method
+        hands that live Popen to the normal registry reader instead of starting
+        a second shell during foreground-to-background handoff.
+        """
+        session = ProcessSession(
+            id=f"proc_{uuid.uuid4().hex[:12]}",
+            command=command,
+            task_id=task_id,
+            session_key=session_key,
+            pid=process.pid,
+            process=process,
+            env_ref=env_ref,
+            cwd=_resolve_safe_cwd(cwd or os.getcwd()),
+            started_at=time.time(),
+            bounded_capture_limit=bounded_capture_limit,
+            persist_cwd=persist_cwd,
+        )
+        session.host_start_time = self._safe_host_start_time(process.pid)
+        with self._lock:
+            self._prune_if_needed()
+            self._running[session.id] = session
+
+        session._reader_thread = threading.Thread(
+            target=self._reader_loop,
+            args=(session,),
+            name=f"process-reader-{session.id}",
+            daemon=True,
+        )
+        session._reader_thread.start()
+        if max_runtime and max_runtime > 0:
+            threading.Thread(
+                target=self._enforce_max_runtime,
+                args=(session, float(max_runtime)),
+                name=f"process-deadline-{session.id}",
+                daemon=True,
+            ).start()
+        self._write_checkpoint()
+        return session
+
+    def _enforce_max_runtime(self, session: ProcessSession, max_runtime: float) -> None:
+        """Kill an adopted process only at its true execution deadline."""
+        if session._completion_event.wait(timeout=max_runtime):
+            return
+        with session._lock:
+            if session.exited:
+                return
+        self.kill_process(session.id, source="execution_timeout")
+
     def spawn_via_env(
         self,
         env: Any,
@@ -977,6 +1112,7 @@ class ProcessRegistry:
                 first_chunk = False
             with session._lock:
                 session.output_buffer += chunk
+                self._append_bounded_capture(session, chunk)
                 if len(session.output_buffer) > session.max_output_chars:
                     session.output_buffer = session.output_buffer[-session.max_output_chars:]
             self._check_watch_patterns(session, chunk)
@@ -1068,6 +1204,7 @@ class ProcessRegistry:
                 session.exit_code = session.process.returncode
                 session.completion_reason = "exited"
             self._move_to_finished(session)
+            self._persist_session_cwd(session)
 
     def _env_poller_loop(
         self, session: ProcessSession, env: Any, log_path: str, pid_path: str, exit_path: str
@@ -1425,6 +1562,7 @@ class ProcessRegistry:
         with session._lock:
             if drained:
                 session.output_buffer += drained
+                self._append_bounded_capture(session, drained)
                 if len(session.output_buffer) > session.max_output_chars:
                     session.output_buffer = session.output_buffer[-session.max_output_chars:]
             session.exited = True
@@ -1437,10 +1575,10 @@ class ProcessRegistry:
             session.id, rc,
         )
         self._move_to_finished(session)
+        self._persist_session_cwd(session)
 
     def poll(self, session_id: str) -> dict:
         """Check status and get new output for a background process."""
-        from tools.ansi_strip import strip_ansi
 
         session = self.get(session_id)
         if session is None:
@@ -1451,7 +1589,8 @@ class ProcessRegistry:
         self._reconcile_local_exit(session)
 
         with session._lock:
-            output_preview = strip_ansi(session.output_buffer[-1000:]) if session.output_buffer else ""
+            raw_output = session.output_buffer[-1000:] if session.output_buffer else ""
+        output_preview = self._visible_output(session, raw_output)
 
         result = {
             "session_id": session.id,
@@ -1483,14 +1622,13 @@ class ProcessRegistry:
 
     def read_log(self, session_id: str, offset: int = 0, limit: int = 200) -> dict:
         """Read the full output log with optional pagination by lines."""
-        from tools.ansi_strip import strip_ansi
 
         session = self.get(session_id)
         if session is None:
             return {"status": "not_found", "error": f"No process with ID {session_id}"}
 
         with session._lock:
-            full_output = strip_ansi(session.output_buffer)
+            full_output = self._visible_output(session, session.output_buffer)
 
         lines = full_output.splitlines()
         total_lines = len(lines)
@@ -1566,23 +1704,40 @@ class ProcessRegistry:
             self._reconcile_local_exit(session)
             if session.exited:
                 self._completion_consumed.add(session_id)
+                visible_output = self._bounded_capture_output(session)
+                if visible_output is None:
+                    visible_output = strip_ansi(session.output_buffer[-2000:])
+                if session.env_ref is not None:
+                    # Environment-backed foreground handoffs include a private
+                    # cwd marker in shell output. Consume it here so process
+                    # wait exposes the same clean output as terminal.
+                    cleaned = {"output": visible_output}
+                    try:
+                        session.env_ref._update_cwd(cleaned)
+                        self._persist_session_cwd(session)
+                        visible_output = cleaned["output"]
+                    except Exception:
+                        pass
                 result = {
                     "status": "exited",
                     "command": session.command,
                     "exit_code": session.exit_code,
                     "completion_reason": session.completion_reason,
                     "termination_source": session.termination_source,
-                    "output": strip_ansi(session.output_buffer[-2000:]),
+                    "output": visible_output,
                 }
                 if timeout_note:
                     result["timeout_note"] = timeout_note
                 return result
 
             if _is_interrupted():
+                interrupted_output = self._bounded_capture_output(session)
+                if interrupted_output is None:
+                    interrupted_output = session.output_buffer[-1000:]
                 result = {
                     "status": "interrupted",
                     "command": session.command,
-                    "output": strip_ansi(session.output_buffer[-1000:]),
+                    "output": strip_ansi(interrupted_output),
                     "note": "User sent a new message -- wait interrupted",
                 }
                 if timeout_note:
@@ -1594,10 +1749,13 @@ class ProcessRegistry:
                 break
             session._completion_event.wait(timeout=min(1.0, remaining))
 
+        timed_out_output = self._bounded_capture_output(session)
+        if timed_out_output is None:
+            timed_out_output = session.output_buffer[-1000:]
         result = {
             "status": "timeout",
             "command": session.command,
-            "output": strip_ansi(session.output_buffer[-1000:]),
+            "output": strip_ansi(timed_out_output),
         }
         if timeout_note:
             result["timeout_note"] = timeout_note

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1033,7 +1033,7 @@ Do NOT use echo/cat heredoc to create files — use write_file instead.
 Reserve terminal for: builds, installs, git, processes, scripts, network, package managers, and anything that needs a shell.
 Because exported environment state persists, activate a virtualenv or export setup variables once per session; do not re-source the same environment before every command unless a command proves the shell state was reset.
 
-Foreground (default): Commands return INSTANTLY when done, even if the timeout is high. Set timeout=300 for long builds/scripts — you'll still get the result in seconds if it's fast. Prefer foreground for short commands.
+Foreground (default): Commands return INSTANTLY when done, even if the timeout is high. Set timeout=300 for long builds/scripts — you'll still get the result in seconds if it's fast. After the configured handoff window (default 10s), a still-running local command is adopted as a managed background process and returns a session_id; this handoff does NOT kill the command. Prefer foreground for short commands.
 Background: Set background=true to get a session_id. Almost always pair with notify_on_complete=true — bg without notify runs SILENTLY and you have no way to learn it finished short of calling process(action='poll') yourself. Two legitimate uses:
   (1) Long-lived processes that never exit (servers, watchers, daemons) — silent is correct, there's no exit to notify on.
   (2) Long-running bounded tasks (tests, builds, deploys, CI pollers, batch jobs) — MUST set notify_on_complete=true. Without it you'll either forget to poll or sit blocked waiting for the user to surface the result.
@@ -1514,6 +1514,7 @@ def _get_env_config() -> Dict[str, Any]:
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
         "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
+        "handoff_timeout": _parse_env_var("TERMINAL_HANDOFF_TIMEOUT", "10"),
         "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
         # SSH-specific config
         "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
@@ -2200,6 +2201,101 @@ def _resolve_command_cwd(
     return get_session_cwd(session_key) or default_cwd
 
 
+def _auto_handoff_foreground(
+    *,
+    env: Any,
+    env_type: str,
+    command: str,
+    command_cwd: str,
+    effective_timeout: int,
+    handoff_timeout: int,
+    effective_task_id: str,
+    session_key: str,
+    persist_cwd: bool = True,
+):
+    """Run a local foreground command with a non-destructive handoff window.
+
+    Returns a normal ``env.execute``-shaped result when the command exits
+    quickly, a terminal-tool response when it is handed off, or ``None`` when
+    the backend cannot support this lifecycle path.
+    """
+    if env_type != "local" or handoff_timeout <= 0:
+        return None
+    if effective_timeout <= handoff_timeout:
+        return None
+
+    from tools.process_registry import process_registry
+    from tools.tool_output_limits import get_max_bytes
+
+    proc = None
+    proc_session = None
+    try:
+        proc, spawned_cwd = env.spawn(
+            command,
+            cwd=command_cwd,
+            timeout=effective_timeout,
+        )
+        proc_session = process_registry.adopt_local_process(
+            proc,
+            command=command,
+            cwd=spawned_cwd,
+            task_id=effective_task_id,
+            session_key=session_key,
+            env_ref=env,
+            max_runtime=effective_timeout,
+            bounded_capture_limit=get_max_bytes(),
+            persist_cwd=persist_cwd,
+        )
+        waited = process_registry.wait(proc_session.id, timeout=handoff_timeout)
+        if waited.get("status") == "timeout":
+            return {
+                "output": waited.get("output", ""),
+                "session_id": proc_session.id,
+                "pid": proc_session.pid,
+                "exit_code": 0,
+                "error": None,
+                "status": "running",
+                "auto_handoff": True,
+                "handoff_timeout": handoff_timeout,
+                "execution_timeout": effective_timeout,
+            }
+        if waited.get("status") == "interrupted":
+            process_registry.kill_process(proc_session.id, source="interrupt")
+            return {
+                "output": waited.get("output", "") + "\n[Command interrupted]",
+                "returncode": 130,
+            }
+
+        output = waited.get("output", "")
+        if persist_cwd:
+            env._update_cwd({"output": output})
+            record_session_cwd(session_key, getattr(env, "cwd", None))
+        return {
+            "output": output,
+            "returncode": waited.get("exit_code", 0),
+        }
+    except Exception:
+        if proc_session is not None:
+            try:
+                process_registry.kill_process(proc_session.id, source="handoff_error")
+            except Exception:
+                pass
+        elif proc is not None:
+            try:
+                env._kill_process(proc)
+            except Exception:
+                pass
+        logger.debug("Automatic foreground handoff unavailable", exc_info=True)
+        if proc is not None:
+            return {
+                "output": "",
+                "returncode": -1,
+                "error": "Automatic foreground handoff failed after the command was started; the command was not retried.",
+                "handoff_failed": True,
+            }
+        return None
+
+
 def terminal_tool(
     command: str,
     background: bool = False,
@@ -2218,7 +2314,10 @@ def terminal_tool(
     Args:
         command: The command to execute
         background: Whether to run in background (default: False)
-        timeout: Command timeout in seconds (default: from config)
+        timeout: Maximum execution time in seconds (default: from config). The
+                 shorter terminal.handoff_timeout only controls how long a
+                 foreground call waits before handing a live local process to
+                 the process registry.
         task_id: Unique identifier for environment isolation (optional)
         session_id: Conversation/session identifier for durable observability
         force: If True, skip dangerous command check (use after user confirms)
@@ -2318,6 +2417,9 @@ def terminal_tool(
                 f"timeout must be a positive number of seconds (got {timeout})."
             )
         effective_timeout = timeout or default_timeout
+        # Keep compatibility with older/custom config-shaped mappings that do
+        # not yet carry the newly introduced handoff timeout.
+        handoff_timeout = config.get("handoff_timeout", 10)
 
         # Reject foreground commands where the model explicitly requests
         # a timeout above FOREGROUND_MAX_TIMEOUT — nudge it toward background.
@@ -2869,25 +2971,49 @@ def terminal_tool(
             max_retries = 3
             retry_count = 0
             result = None
-            command_cwd = None
+            command_cwd = _resolve_command_cwd(
+                workdir=workdir,
+                default_cwd=cwd,
+                session_key=session_key,
+            )
 
-            # Clean interrupt slate for an approved command, ONCE before the
-            # retry loop: drop a stale bit that landed on this thread during the
-            # approval-wait so it can't SIGINT the just-approved run.  Do NOT
-            # re-clear inside the loop -- a genuine interrupt arriving during the
-            # backoff sleep between retries must survive and abort the command
-            # (caught by the next attempt's _wait_for_process poll loop -> 130).
+            # Clean interrupt slate before starting any approved command,
+            # including the handoff path. A stale approval-time bit must not be
+            # mistaken for a new interrupt by ProcessRegistry.wait().
             if _approved_run:
                 from tools.interrupt import clear_current_thread_interrupt
                 clear_current_thread_interrupt()
 
+            handoff_running = False
+            # A short foreground window is a handoff, not a kill.  The
+            # environment process is adopted by ProcessRegistry so its shell
+            # snapshot and cwd semantics are preserved while the agent gets
+            # control back with a session_id.
+            if not effective_pty:
+                handoff_result = _auto_handoff_foreground(
+                    env=env,
+                    env_type=env_type,
+                    command=command,
+                    command_cwd=command_cwd,
+                    effective_timeout=effective_timeout,
+                    handoff_timeout=handoff_timeout,
+                    effective_task_id=effective_task_id,
+                    session_key=session_key,
+                    persist_cwd=not bool(workdir),
+                )
+                if handoff_result and handoff_result.get("status") == "running":
+                    handoff_running = True
+                if handoff_result is not None:
+                    result = handoff_result
+
+            # The interrupt slate is intentionally not cleared again inside
+            # the retry loop: a genuine interrupt arriving during backoff must
+            # survive and abort the command or its adopted ProcessRegistry
+            # session.
             while retry_count <= max_retries:
+                if result is not None:
+                    break
                 try:
-                    command_cwd = _resolve_command_cwd(
-                        workdir=workdir,
-                        default_cwd=cwd,
-                        session_key=session_key,
-                    )
                     execute_kwargs = {
                         "timeout": effective_timeout,
                         "cwd": command_cwd,
@@ -2939,12 +3065,13 @@ def terminal_tool(
             # (docstring: "Working directory for this command"). Recording it
             # would hijack the session's durable cwd for every later command
             # that doesn't pass ``workdir``. Skip the dual-write in that case.
-            if not workdir:
+            if not workdir and not handoff_running:
                 record_session_cwd(session_key, getattr(env, "cwd", None))
 
             # Extract output
-            output = result.get("output", "")
-            returncode = result.get("returncode", 0)
+            result_data = result or {}
+            output = result_data.get("output", "")
+            returncode = result_data.get("returncode", result_data.get("exit_code", 0))
 
             # Add helpful message for sudo failures in messaging context
             output = _handle_sudo_failure(output, env_type)
@@ -3021,27 +3148,37 @@ def terminal_tool(
             result_dict = {
                 "output": output,
                 "exit_code": returncode,
-                "error": None,
+                "error": result_data.get("error"),
             }
-            try:
-                from agent.verification_evidence import record_terminal_result
+            if handoff_running:
+                # Preserve the lifecycle metadata while still applying the
+                # foreground output pipeline to the initial handoff response.
+                for key in (
+                    "status", "session_id", "pid", "auto_handoff",
+                    "handoff_timeout", "execution_timeout",
+                ):
+                    if key in result_data:
+                        result_dict[key] = result_data[key]
+            if not handoff_running:
+                try:
+                    from agent.verification_evidence import record_terminal_result
 
-                evidence = record_terminal_result(
-                    command=command,
-                    cwd=command_cwd,
-                    session_id=session_id or task_id or effective_task_id or "default",
-                    exit_code=returncode,
-                    output=output,
-                )
-                if evidence:
-                    result_dict["verification_evidence"] = {
-                        "status": evidence.get("status"),
-                        "kind": evidence.get("kind"),
-                        "scope": evidence.get("scope"),
-                        "canonical_command": evidence.get("canonical_command"),
-                    }
-            except Exception:
-                logger.debug("verification evidence recording failed", exc_info=True)
+                    evidence = record_terminal_result(
+                        command=command,
+                        cwd=command_cwd,
+                        session_id=session_id or task_id or effective_task_id or "default",
+                        exit_code=returncode,
+                        output=output,
+                    )
+                    if evidence:
+                        result_dict["verification_evidence"] = {
+                            "status": evidence.get("status"),
+                            "kind": evidence.get("kind"),
+                            "scope": evidence.get("scope"),
+                            "canonical_command": evidence.get("canonical_command"),
+                        }
+                except Exception:
+                    logger.debug("verification evidence recording failed", exc_info=True)
             if approval_note:
                 # Treat rc=130 as an interrupt only when the executor's marker is
                 # present.  A command can legitimately exit 130 on its own


### PR DESCRIPTION
## Summary

- Automatically hand off long-running local foreground commands to ProcessRegistry after the configured handoff window.
- Preserve the existing foreground output pipeline, including bounded head/tail capture, ANSI cleanup, secret redaction, output transforms, sudo handling, and exit-code semantics.
- Persist cwd changes and prevent already-started commands from being executed a second time after adoption failures.
- Add configuration and regression coverage for handoff, timeout output, cwd persistence, stale interrupts, and retry behavior.

## Validation

- `scripts/run_tests.sh tests/tools/ --tb=short`: 390 files, 5212 tests passed.
- `uv run ruff check` on all changed Python files: passed.
- `git diff --check`: passed.

This is a Draft PR for review. The implementation is intentionally limited to foreground-to-background terminal lifecycle handling; Codex watchdog changes are not included.