### PR TITLE
fix(kanban): add dependency_wait respawn cooldown + fix recurrence counter

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -323,6 +323,29 @@ def _resolve_rate_limit_cooldown_seconds() -> int:
     return DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS
 
 
+def _resolve_dependency_wait_cooldown_seconds() -> int:
+    """Return the dependency-wait respawn cooldown in seconds.
+
+    Reads ``HERMES_KANBAN_DEPENDENCY_WAIT_COOLDOWN_SECONDS`` from the
+    environment; falls back to ``DEFAULT_DEPENDENCY_WAIT_COOLDOWN_SECONDS``
+    when absent, empty, non-integer, or negative. A value of 0 disables the
+    cooldown (re-spawn on the next tick) — useful for tests that want to
+    assert the task becomes spawnable again immediately. Mirrors
+    ``_resolve_rate_limit_cooldown_seconds()``.
+    """
+    raw = os.environ.get(
+        "HERMES_KANBAN_DEPENDENCY_WAIT_COOLDOWN_SECONDS", ""
+    ).strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = -1
+        if parsed >= 0:
+            return parsed
+    return DEFAULT_DEPENDENCY_WAIT_COOLDOWN_SECONDS
+
+
 # Worker-context caps so build_worker_context() stays bounded on
 # pathological boards (retry-heavy tasks, comment storms, giant
 # summaries). Values chosen to fit a typical 100k-char LLM prompt with
@@ -5673,8 +5696,16 @@ def block_task(
         # Dependency blocks never enter the human ``blocked`` bucket — they
         # wait in ``todo`` and let ``recompute_ready`` gate on parents. Routing
         # here (rather than ``blocked``) is what keeps a cron from ever seeing
-        # a dependency-wait as something to "unblock".
+        # a dependency-wait as something to "unblock". The unblock-loop
+        # counter (``block_recurrences``) is still tracked here — mirroring
+        # the truly-blocked path's ``same_cause`` logic below — so
+        # ``check_respawn_guard``'s dependency-wait escalation can hard-stop
+        # respawning once the SAME still-unsatisfied dependency has been
+        # reconfirmed ``BLOCK_RECURRENCE_LIMIT`` times in a row, instead of
+        # the dispatcher hammering a respawn every tick forever.
         if kind == "dependency":
+            same_cause = prev_kind == kind
+            dep_recurrences = prev_recurrences + 1 if same_cause else 1
             cur = conn.execute(
                 """
                 UPDATE tasks
@@ -5682,12 +5713,13 @@ def block_task(
                        claim_lock    = NULL,
                        claim_expires = NULL,
                        worker_pid    = NULL,
-                       block_kind    = ?
+                       block_kind    = ?,
+                       block_recurrences = ?
                  WHERE id = ?
                    AND status IN ('running', 'ready')
                 """ + ("" if expected_run_id is None else " AND current_run_id = ?"),
-                (kind, task_id) if expected_run_id is None
-                else (kind, task_id, int(expected_run_id)),
+                (kind, dep_recurrences, task_id) if expected_run_id is None
+                else (kind, dep_recurrences, task_id, int(expected_run_id)),
             )
             if cur.rowcount != 1:
                 return False
@@ -5702,7 +5734,8 @@ def block_task(
                 )
             _append_event(
                 conn, task_id, "dependency_wait",
-                {"reason": reason, "kind": kind}, run_id=run_id,
+                {"reason": reason, "kind": kind, "recurrences": dep_recurrences},
+                run_id=run_id,
             )
             _blocked_task = get_task(conn, task_id)
             _fire_kanban_lifecycle_hook(
@@ -6777,6 +6810,17 @@ _RESPAWN_GUARD_SUCCESS_WINDOW = 3600  # 1 hour
 # without thrashing. Overridable via ``HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS``
 # for operators who want a tighter/looser probe cadence.
 DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS = 300  # 5 minutes
+
+# Cooldown after a ``dependency_wait`` block (a ``kind='dependency'`` block
+# via ``block_task``) before the dispatcher re-spawns the worker to
+# re-verify the same still-unsatisfied parent state. Without this, a `todo`
+# card whose parent is still blocked/running respawns EVERY dispatch tick
+# with zero backoff, burning a worker slot to re-confirm the exact same
+# "still waiting" fact over and over. Overridable via
+# ``HERMES_KANBAN_DEPENDENCY_WAIT_COOLDOWN_SECONDS`` for operators who want a
+# tighter/looser probe cadence. See ``check_respawn_guard``'s
+# ``"dependency_wait_cooldown"`` guard.
+DEFAULT_DEPENDENCY_WAIT_COOLDOWN_SECONDS = 900  # 15 minutes
 
 # Within this window a GitHub PR URL in a comment blocks re-spawn.
 _RESPAWN_GUARD_PR_WINDOW = 86400  # 24 hours
@@ -8040,6 +8084,37 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         blocks via the normal path — but a transient 429 gets a few
         ticks of recovery first.
 
+    ``"dependency_wait_cooldown"``
+        The most recent ``dependency_wait`` event for this task (a
+        ``block_task(kind="dependency")`` call) has no genuine promotion
+        evidence after it, and we're still inside
+        ``_resolve_dependency_wait_cooldown_seconds()`` of that event.
+        A dependency-blocked task lands in ``todo``, not ``blocked``, so it
+        can be flipped back to ``ready`` by ``recompute_ready`` without any
+        real change in the underlying dependency (e.g. an empty parent set
+        vacuously satisfying ``all(...)``, tracked separately at
+        t_78db38db). Without this guard such a task respawns every single
+        dispatch tick to re-confirm the exact same still-unsatisfied
+        dependency, burning a worker slot with zero backoff.
+
+    ``"dependency_wait_escalated"``
+        Same trigger as above, but ``block_recurrences`` (incremented by
+        ``block_task``'s dependency branch on each same-cause re-block) has
+        reached :data:`BLOCK_RECURRENCE_LIMIT`. Past that point this guard
+        stops respawning entirely — not merely for the cooldown window —
+        until genuine promotion evidence arrives. This mirrors the
+        truly-blocked path's "loop detected -> triage" breaker, adapted for
+        dependency waits: a hard stop is the correct response to a
+        dependency that has been reconfirmed unsatisfied 3+ times in a row,
+        rather than a longer timed cooldown that would eventually respawn
+        anyway.
+
+        Bypass (both reasons above): a ``status`` / ``promoted`` /
+        ``unblocked`` / ``reclaimed`` event created AFTER the dependency_wait
+        event is treated as proof of a genuine state change — mirrors the
+        ``recent_success`` bypass below — and the respawn is honored
+        immediately rather than deferred or escalated.
+
     ``"recent_success"``
         A completed run exists within ``_RESPAWN_GUARD_SUCCESS_WINDOW``
         seconds.  Useful work already succeeded for this task; wait for
@@ -8106,6 +8181,54 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     err = row["last_failure_error"]
     if err and _RESPAWN_BLOCKER_RE.search(err):
         return "blocker_auth"
+
+    # 2.5. Dependency-wait cooldown. A ``dependency`` block routes to
+    #    ``todo`` (not ``blocked``) so ``recompute_ready`` can flip it back
+    #    to ``ready`` — but that promotion path can fire on a vacuous or
+    #    unchanged parent state, not just a genuine completion. Look at the
+    #    LATEST ``dependency_wait`` event only: if a newer status/promoted/
+    #    unblocked/reclaimed event supersedes it, treat that as real
+    #    promotion evidence and fall through immediately (mirrors the
+    #    recent_success bypass below). Otherwise defer for the cooldown
+    #    window, escalating to a hard stop past BLOCK_RECURRENCE_LIMIT.
+    latest_dep_wait = conn.execute(
+        "SELECT id, created_at, payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'dependency_wait' "
+        "ORDER BY created_at DESC, id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if latest_dep_wait is not None:
+        dep_wait_at = int(latest_dep_wait["created_at"] or 0)
+        dep_wait_id = latest_dep_wait["id"]
+        promoted_after = conn.execute(
+            "SELECT 1 FROM task_events "
+            "WHERE task_id = ? "
+            "AND (created_at > ? OR (created_at = ? AND id > ?)) "
+            "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed') "
+            "LIMIT 1",
+            (task_id, dep_wait_at, dep_wait_at, dep_wait_id),
+        ).fetchone()
+        if not promoted_after:
+            block_row = conn.execute(
+                "SELECT block_recurrences FROM tasks WHERE id = ?",
+                (task_id,),
+            ).fetchone()
+            dep_recurrences = (
+                int(block_row["block_recurrences"])
+                if block_row is not None and block_row["block_recurrences"] is not None
+                else 0
+            )
+            if dep_recurrences >= BLOCK_RECURRENCE_LIMIT:
+                # Loop detected: the same still-unsatisfied dependency has
+                # been reconfirmed BLOCK_RECURRENCE_LIMIT+ times in a row.
+                # Hard-stop respawning entirely until a genuine promotion
+                # event (parent completion, manual unblock/reclaim) arrives
+                # — no timed cooldown would be honest here since the
+                # dependency itself hasn't moved.
+                return "dependency_wait_escalated"
+            dep_cooldown = _resolve_dependency_wait_cooldown_seconds()
+            if dep_cooldown > 0 and (now - dep_wait_at) < dep_cooldown:
+                return "dependency_wait_cooldown"
 
     # 3. Completed run within guard window — proof of recent success.
     #    Exception: an explicit re-queue AFTER that success (an operator

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -101,6 +101,167 @@ def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Dependency-wait respawn cooldown (check_respawn_guard)
+# ---------------------------------------------------------------------------
+
+
+def test_dependency_wait_respawn_guard_defers_within_cooldown_across_ticks(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dependency-wait card with an UNCHANGED (still-blocked) parent must
+    not respawn more than once per cooldown window across N simulated
+    dispatcher ticks (brief A1/A4a)."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setenv("HERMES_KANBAN_DEPENDENCY_WAIT_COOLDOWN_SECONDS", "900")
+    now = 10_000_000
+
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='blocked' WHERE id=?", (parent,))
+        child = _running_task(conn, title="child")
+        kb.link_tasks(conn, parent_id=parent, child_id=child)
+
+        monkeypatch.setattr(_kb.time, "time", lambda: now)
+        kb.block_task(conn, child, reason="wait", kind="dependency")
+        assert kb.get_task(conn, child).status == "todo"
+        assert kb.get_task(conn, child).block_recurrences == 1
+
+        # Simulate N dispatcher ticks, all inside the cooldown window, with
+        # the parent's status never changing. The guard must defer every
+        # single tick — never allowing a respawn.
+        for tick in range(5):
+            monkeypatch.setattr(_kb.time, "time", lambda t=tick: now + 60 * t)
+            assert kb.check_respawn_guard(conn, child) == "dependency_wait_cooldown"
+
+
+def test_dependency_wait_respawn_guard_bypasses_on_parent_completion(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The SAME card must respawn IMMEDIATELY (next tick, guard returns
+    None) once the parent transitions to 'done' (brief A3 — safety
+    critical, must never wait out the cooldown)."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setenv("HERMES_KANBAN_DEPENDENCY_WAIT_COOLDOWN_SECONDS", "900")
+    now = 10_000_000
+
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='blocked' WHERE id=?", (parent,))
+        child = _running_task(conn, title="child")
+        kb.link_tasks(conn, parent_id=parent, child_id=child)
+
+        monkeypatch.setattr(_kb.time, "time", lambda: now)
+        kb.block_task(conn, child, reason="wait", kind="dependency")
+
+        # Still well inside the cooldown window — guard defers.
+        monkeypatch.setattr(_kb.time, "time", lambda: now + 30)
+        assert kb.check_respawn_guard(conn, child) == "dependency_wait_cooldown"
+
+        # Parent transitions blocked -> done, then recompute_ready promotes
+        # the child (emits a 'promoted' event AFTER the dependency_wait).
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (parent,))
+        kb.claim_task(conn, parent, claimer="worker")
+        monkeypatch.setattr(_kb.time, "time", lambda: now + 31)
+        kb.complete_task(conn, parent, result="done")
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "ready"
+
+        # Guard must return None on the VERY NEXT tick — not wait out the
+        # 900s cooldown — because a genuine promotion event now postdates
+        # the dependency_wait event.
+        monkeypatch.setattr(_kb.time, "time", lambda: now + 32)
+        assert kb.check_respawn_guard(conn, child) is None
+
+
+def test_dependency_wait_recurrence_escalates_past_limit(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-blocking the SAME dependency wait (same parent, unchanged state)
+    across BLOCK_RECURRENCE_LIMIT+ cycles must increment block_recurrences
+    (fixing block_task's dependency branch) and, once the limit is reached,
+    the guard escalates to a hard stop instead of a timed cooldown
+    (brief A2/A4c)."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setenv("HERMES_KANBAN_DEPENDENCY_WAIT_COOLDOWN_SECONDS", "900")
+    now = 10_000_000
+
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='blocked' WHERE id=?", (parent,))
+        child = _running_task(conn, title="child")
+        kb.link_tasks(conn, parent_id=parent, child_id=child)
+
+        # First dependency block: recurrences == 1.
+        monkeypatch.setattr(_kb.time, "time", lambda: now)
+        kb.block_task(conn, child, reason="wait", kind="dependency")
+        assert kb.get_task(conn, child).block_recurrences == 1
+
+        # Repeatedly: re-verify the SAME still-unsatisfied parent and
+        # re-block with the same 'dependency' kind. Each cycle increments
+        # the counter. (We force status='running' directly via SQL rather
+        # than through claim_task, since claim_task's parent-gating
+        # invariant is a separate, out-of-scope concern here — this test
+        # only exercises block_task's recurrence counting + the guard.)
+        for expected in range(2, kb.BLOCK_RECURRENCE_LIMIT + 2):
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET status='running' WHERE id=?", (child,),
+                )
+            monkeypatch.setattr(_kb.time, "time", lambda t=expected: now + t)
+            kb.block_task(conn, child, reason="wait", kind="dependency")
+            assert kb.get_task(conn, child).block_recurrences == expected
+
+        # Now past BLOCK_RECURRENCE_LIMIT — the guard must hard-stop
+        # (escalated), not merely apply the timed cooldown, even far outside
+        # the cooldown window.
+        monkeypatch.setattr(
+            _kb.time, "time", lambda: now + 100_000,
+        )
+        assert kb.check_respawn_guard(conn, child) == "dependency_wait_escalated"
+
+        # A genuine promotion event (parent done) still bypasses the
+        # escalated hard-stop.
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (parent,))
+        kb.claim_task(conn, parent, claimer="worker")
+        kb.complete_task(conn, parent, result="done")
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "ready"
+        assert kb.check_respawn_guard(conn, child) is None
+
+
+def test_dependency_wait_cooldown_disabled_via_zero(
+    kanban_home: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cooldown of 0 disables the guard (test-friendly escape hatch),
+    mirroring the rate-limit cooldown's documented 0-disables behaviour."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setenv("HERMES_KANBAN_DEPENDENCY_WAIT_COOLDOWN_SECONDS", "0")
+    now = 10_000_000
+
+    with kb.connect_closing() as conn:
+        parent = kb.create_task(conn, title="parent", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status='blocked' WHERE id=?", (parent,))
+        child = _running_task(conn, title="child")
+        kb.link_tasks(conn, parent_id=parent, child_id=child)
+
+        monkeypatch.setattr(_kb.time, "time", lambda: now)
+        kb.block_task(conn, child, reason="wait", kind="dependency")
+
+        monkeypatch.setattr(_kb.time, "time", lambda: now + 1)
+        assert kb.check_respawn_guard(conn, child) is None
+
+
+# ---------------------------------------------------------------------------
 # Completion resets loop memory
 # ---------------------------------------------------------------------------
 
@@ -108,5 +269,3 @@ def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
 # ---------------------------------------------------------------------------
 # Validation + back-compat
 # ---------------------------------------------------------------------------
-
-


### PR DESCRIPTION
## Summary

`check_respawn_guard` in `hermes_cli/kanban_db.py` had exactly four guards
(rate_limit_cooldown, blocker_auth, recent_success, active_pr) but **no
backoff for dependency-kind blocks**. A `todo` card whose most recent
lifecycle event is `dependency_wait` (via `block_task(kind="dependency")`)
respawned on **every** dispatch tick with zero cooldown, because
`recompute_ready` can flip a dependency-parked task back to `ready` without
a genuine parent-completion change.

Separately, `block_task`'s `kind == "dependency"` branch never set
`block_recurrences` on its UPDATE, unlike the truly-blocked path — so a
dependency block could never increment the existing unblock-loop counter.

## Changes

- New `_resolve_dependency_wait_cooldown_seconds()` config helper (mirrors
  `_resolve_rate_limit_cooldown_seconds`), default **900s** via
  `DEFAULT_DEPENDENCY_WAIT_COOLDOWN_SECONDS`, overridable via
  `HERMES_KANBAN_DEPENDENCY_WAIT_COOLDOWN_SECONDS`. `0` disables the guard
  (test escape hatch, same convention as the rate-limit cooldown).
- New `"dependency_wait_cooldown"` guard in `check_respawn_guard`, ordered
  **after** `blocker_auth` and **before** `recent_success` (per spec):
  looks at the latest `dependency_wait` event; if no
  `status`/`promoted`/`unblocked`/`reclaimed` event postdates it (i.e. no
  genuine promotion evidence), defers the respawn for the cooldown window.
- Bug fix: `block_task`'s `kind == "dependency"` branch now sets
  `block_recurrences`, mirroring the `same_cause` / `prev_recurrences` logic
  already used by the truly-blocked branch.
- **Escalation decision** (documented here per the brief, since this is a
  judgment call): once `block_recurrences` reaches `BLOCK_RECURRENCE_LIMIT`
  for the *same* still-unsatisfied dependency, the guard returns
  `"dependency_wait_escalated"` — a **hard stop**, not a longer timed
  cooldown — until a genuine promotion event arrives. Rationale: a longer
  cooldown would still eventually respawn and re-confirm the identical
  unsatisfied state; since the dependency itself hasn't moved, only a real
  promotion event (parent completion, manual unblock/reclaim) justifies a
  respawn past that point. There's no `triage` reroute here (unlike the
  truly-blocked breaker) because the task already correctly sits in `todo`,
  not `blocked` — it just stops being *respawned* until something changes.
- **Safety-critical bypass** (A3): a real promotion event
  (`status`/`promoted`/`unblocked`/`reclaimed`) created **after** the
  `dependency_wait` event bypasses both the cooldown and the escalated
  hard-stop immediately — a parent transitioning `blocked -> done` respawns
  the child on the very next tick, never waiting out the cooldown.

## Test plan

`tests/hermes_cli/test_kanban_block_kinds.py` — 4 new tests, all others in
the module and the wider kanban suite unaffected:

- `test_dependency_wait_respawn_guard_defers_within_cooldown_across_ticks`:
  unchanged parent → guard defers every tick across 5 simulated dispatcher
  ticks inside the cooldown window.
- `test_dependency_wait_respawn_guard_bypasses_on_parent_completion`: parent
  transitions to `done` → guard returns `None` on the very next tick
  (safety-critical, does not wait out the 900s cooldown).
- `test_dependency_wait_recurrence_escalates_past_limit`: `block_recurrences`
  increments correctly across `BLOCK_RECURRENCE_LIMIT + 1` repeated
  same-cause dependency re-blocks; guard escalates to
  `dependency_wait_escalated` past the limit even far outside the cooldown
  window; a genuine promotion event still bypasses the escalated stop.
- `test_dependency_wait_cooldown_disabled_via_zero`: cooldown of `0`
  disables the guard immediately.

Verified RED before the fix (checked out the pre-fix `kanban_db.py`,
confirmed 3/4 new tests fail: two `AssertionError` on the guard returning
`None` instead of deferring, one on `block_recurrences` staying `0`), then
GREEN after re-applying the fix. Ran the full `-k kanban` suite before/after:
identical 7 pre-existing failures both with and without this diff (unrelated
test-isolation issues in `test_kanban_write_guard.py` /
`test_kanban_decompose.py` / `test_kanban_lifecycle_hooks.py` /
`test_kanban_db.py::test_rate_limit_exit_requeues_without_counting_failure`
/ `test_connect_works_when_wal_is_silently_refused` when run in the full
module ordering) — not introduced by this change.

## Deployment impact

Kanban dispatcher logic only, no schema change, no migration. New env var
is additive with a safe default (900s) matching the brief's specified
default. No production deploy / DB apply implicated.

## Rollback

Revert this commit; `check_respawn_guard` and `block_task` return to their
current (no-cooldown, no-recurrence-tracking) behavior.

## Scope fence

Does **not** touch the `parents_terminal` vacuous-emptyset fix
(t_4f14b90d / PR #76160 / #76681, tracked separately, undeployed, at
t_78db38db). This PR is the independent dependency-kind respawn-backoff gap
only — sibling to t_4f14b90d.

Ref: Kanban t_360d58da (CTO-dispatched brief) / t_6f15ab11 (this work).

## Linear

No Linear issue was identified for this GitHub+Kanban-tracked defect fix;
GitHub PR + Kanban card evidence chain applies per
`engineering-definition-of-done`.
