### PR TITLE
fix(auxiliary): preserve custom provider headers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6077,6 +6077,18 @@ def resolve_provider_client(
                     raw_base_for_wrap = custom_base
                 _clean_base2, _dq2 = _extract_url_query_params(openai_base)
                 _extra2 = {"default_query": _dq2} if _dq2 else {}
+                # Named custom providers may carry credentials in
+                # ``extra_headers`` (for example Cloudflare Access service
+                # headers).  Preserve them on auxiliary clients just as the
+                # main client path does.  Values are intentionally never
+                # logged.
+                _provider_headers2 = custom_entry.get("extra_headers")
+                if isinstance(_provider_headers2, dict) and _provider_headers2:
+                    _extra2["default_headers"] = {
+                        str(key): str(value)
+                        for key, value in _provider_headers2.items()
+                        if value is not None
+                    }
                 _headers2 = _apply_user_default_headers(_extra2.get("default_headers"))
                 if _headers2:
                     _extra2["default_headers"] = _headers2

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -109,6 +109,50 @@ class TestResolveProviderClientNamedCustom:
         assert model == "my-model"
         assert "beans.local" in str(client.base_url)
 
+    def test_named_custom_provider_extra_headers_reach_auxiliary_client(self, tmp_path):
+        """Named-provider headers must be installed on auxiliary OpenAI clients."""
+        _write_config(tmp_path, {
+            "providers": {
+                "llama": {
+                    "name": "llama",
+                    "base_url": "https://llama.example/v1",
+                    "api_key": "no-key-required",
+                    "extra_headers": {
+                        "CF-Access-Client-Id": "client.access",
+                        "CF-Access-Client-Secret": "secret-value",
+                    },
+                },
+            },
+        })
+        from agent import auxiliary_client
+
+        with patch.object(auxiliary_client, "OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, model = auxiliary_client.resolve_provider_client(
+                "llama", "gemma-test"
+            )
+
+        assert client is not None
+        assert model == "gemma-test"
+        kwargs = mock_openai.call_args.kwargs
+        assert kwargs["default_headers"] == {
+            "CF-Access-Client-Id": "client.access",
+            "CF-Access-Client-Secret": "secret-value",
+        }
+
+    def test_named_custom_provider_default_model(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "main-model"},
+            "custom_providers": [
+                {"name": "beans", "base_url": "http://beans.local/v1", "api_key": "k"},
+            ],
+        })
+        from agent.auxiliary_client import resolve_provider_client
+        client, model = resolve_provider_client("beans")
+        assert client is not None
+        # Should use _read_main_model() fallback
+        assert model == "main-model"
+
 
     def test_named_custom_no_api_key_uses_fallback(self, tmp_path):
         _write_config(tmp_path, {


### PR DESCRIPTION
## Summary

- Preserve `providers.<name>.extra_headers` when Hermes constructs auxiliary OpenAI-compatible clients.
- Ensures named custom providers retain Cloudflare Access service-auth headers for automatic auxiliary tasks such as compression.
- Keeps the existing secure pair-header design and does not change provider selection or Ollama binding.

## Verification

- Upstream-main auxiliary/provider tests: 55 passed.
- Canonical per-file runner: 35/35 passed.
- Ruff: clean.
- Live temporary-config acceptance through Cloudflare Access → Pop!_OS → Ollama: `UPSTREAM_BASE_AUX_LIVE_OK`.

## Deployment note

After this upstream fix is included in the managed Hermes image, the existing `llama` provider can be assigned to auxiliary compression and verified end to end.
