### PR TITLE
feat(cli): add --reasoning flag for per-invocation reasoning effort

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4114,6 +4114,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         checkpoints: bool = False,
         pass_session_id: bool = False,
         ignore_rules: bool = False,
+        reasoning_effort: Optional[str] = None,
     ):
         """
         Initialize the Hermes CLI.
@@ -4379,8 +4380,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Reasoning config (OpenRouter reasoning effort level)
         # Per-model override > global reasoning_effort — resolved through the
         # shared chokepoint in hermes_constants (Closes #21256).
+        # --reasoning / HERMES_REASONING (per-invocation override) wins over
+        # everything: it is ephemeral, never written to config.yaml.
         from hermes_constants import resolve_reasoning_config
-        self.reasoning_config = resolve_reasoning_config(CLI_CONFIG, self.model)
+        from hermes_constants import parse_reasoning_effort
+
+        _cli_reasoning_effort = (
+            (reasoning_effort or "").strip()
+            or os.environ.get("HERMES_REASONING", "").strip()
+        )
+        _cli_reasoning_config = parse_reasoning_effort(_cli_reasoning_effort)
+        self.reasoning_config = (
+            _cli_reasoning_config
+            if _cli_reasoning_config is not None
+            else resolve_reasoning_config(CLI_CONFIG, self.model or "")
+        )
         self.service_tier = _parse_service_tier_config(
             CLI_CONFIG["agent"].get("service_tier", "")
         )
@@ -16873,6 +16887,7 @@ def main(
     pass_session_id: bool = False,
     ignore_user_config: bool = False,
     ignore_rules: bool = False,
+    reasoning_effort: Optional[str] = None,
 ):
     """
     Hermes Agent CLI - Interactive AI Assistant
@@ -17008,6 +17023,7 @@ def main(
         checkpoints=checkpoints,
         pass_session_id=pass_session_id,
         ignore_rules=ignore_rules,
+        reasoning_effort=reasoning_effort,
     )
 
     if parsed_skills:

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -147,6 +147,18 @@ def build_top_level_parser():
             "under model.provider — use `hermes setup` or edit the file to change it."
         ),
     )
+    _inherited_flag(
+        parser,
+        "--reasoning",
+        choices=("none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"),
+        default=None,
+        help=(
+            "Reasoning effort override for this invocation "
+            "(none|minimal|low|medium|high|xhigh|max|ultra). Applies to -z/--oneshot "
+            "and --tui. Overrides agent.reasoning_effort in config.yaml for this "
+            "launch only — nothing is written to config."
+        ),
+    )
     parser.add_argument(
         "-t",
         "--toolsets",
@@ -316,6 +328,17 @@ def build_top_level_parser():
         # `--provider` flag.
         default=argparse.SUPPRESS,
         help="Inference provider (default: auto). Built-in or a user-defined name from `providers:` in config.yaml.",
+    )
+    _inherited_flag(
+        chat_parser,
+        "--reasoning",
+        choices=("none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"),
+        default=argparse.SUPPRESS,
+        help=(
+            "Reasoning effort override for this session "
+            "(none|minimal|low|medium|high|xhigh|max|ultra). Overrides "
+            "agent.reasoning_effort in config.yaml for this launch only."
+        ),
     )
     chat_parser.add_argument(
         "-v",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -171,6 +171,7 @@ def _run_and_exit_oneshot(
     provider: object = None,
     toolsets: object = None,
     usage_file: object = None,
+    reasoning_effort: object = None,
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
@@ -181,6 +182,7 @@ def _run_and_exit_oneshot(
             provider=provider,
             toolsets=toolsets,
             usage_file=usage_file,
+            reasoning_effort=reasoning_effort,
         )
     except KeyboardInterrupt:
         rc = 130
@@ -2248,6 +2250,7 @@ def _launch_tui(
     pass_session_id: bool = False,
     max_turns: Optional[int] = None,
     accept_hooks: bool = False,
+    reasoning_effort: Optional[str] = None,
 ):
     """Replace current process with the TUI."""
     tui_dir = PROJECT_ROOT / "ui-tui"
@@ -2297,6 +2300,8 @@ def _launch_tui(
     if provider:
         env["HERMES_TUI_PROVIDER"] = provider
         env["HERMES_INFERENCE_PROVIDER"] = provider
+    if reasoning_effort:
+        env["HERMES_TUI_REASONING"] = str(reasoning_effort).strip().lower()
     tui_toolsets = _normalize_tui_toolsets(toolsets)
     if tui_toolsets:
         env["HERMES_TUI_TOOLSETS"] = ",".join(tui_toolsets)
@@ -2637,6 +2642,14 @@ def cmd_chat(args):
     if getattr(args, "source", None):
         os.environ["HERMES_SESSION_SOURCE"] = args.source
 
+    # --reasoning: per-invocation reasoning-effort override. The classic CLI
+    # reads it back from the env (see cli.py HermesCLI.__init__), the TUI
+    # wrapper forwards it via HERMES_TUI_REASONING below, and the oneshot
+    # path passes it as an explicit kwarg. Nothing is written to config.yaml.
+    _reasoning_effort = getattr(args, "reasoning", None)
+    if _reasoning_effort:
+        os.environ["HERMES_REASONING"] = str(_reasoning_effort).strip().lower()
+
     _pin_kanban_board_env()
 
     if use_tui:
@@ -2656,6 +2669,7 @@ def cmd_chat(args):
             pass_session_id=getattr(args, "pass_session_id", False),
             max_turns=getattr(args, "max_turns", None),
             accept_hooks=getattr(args, "accept_hooks", False),
+            reasoning_effort=getattr(args, "reasoning", None),
         )
 
     # Import and run the CLI
@@ -2679,6 +2693,7 @@ def cmd_chat(args):
         "ignore_rules": getattr(args, "ignore_rules", False) or getattr(args, "safe_mode", False),
         "ignore_user_config": getattr(args, "ignore_user_config", False) or getattr(args, "safe_mode", False),
         "compact": getattr(args, "compact", False),
+        "reasoning_effort": getattr(args, "reasoning", None),
     }
     # Filter out None values
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
@@ -15666,6 +15681,7 @@ def _set_chat_arg_defaults(args) -> None:
         ("resume", None),
         ("continue_last", None),
         ("worktree", False),
+        ("reasoning", None),
     ]:
         if not hasattr(args, attr):
             setattr(args, attr, default)
@@ -15717,6 +15733,7 @@ def _try_termux_fast_cli_launch() -> bool:
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            reasoning_effort=getattr(args, "reasoning", None),
         )
 
     if (args.resume or args.continue_last) and args.command is None:
@@ -18368,6 +18385,7 @@ def main():
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
             usage_file=getattr(args, "usage_file", None),
+            reasoning_effort=getattr(args, "reasoning", None),
         )
 
     # Handle top-level --resume / --continue as shortcut to chat

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -173,6 +173,7 @@ def run_oneshot(
     provider: Optional[str] = None,
     toolsets: object = None,
     usage_file: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -187,6 +188,9 @@ def run_oneshot(
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
             spend per invocation.
+        reasoning_effort: Optional per-invocation reasoning-effort level
+            (none|minimal|low|medium|high|xhigh|max|ultra). Overrides
+            agent.reasoning_effort in config.yaml for this run only.
 
     Returns the exit code.  The caller owns process termination.
     """
@@ -248,6 +252,7 @@ def run_oneshot(
                     provider=provider,
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
+                    reasoning_effort=reasoning_effort,
                 )
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
@@ -316,6 +321,7 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    reasoning_effort: Optional[str] = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
     run a single conversation.  Returns ``(final_response, run_result)``."""
@@ -338,6 +344,21 @@ def _run_agent(
 
     env_model = os.getenv("HERMES_INFERENCE_MODEL", "").strip()
     effective_model = (model or "").strip() or env_model or cfg_model
+
+    # Per-invocation reasoning-effort override (--reasoning / HERMES_REASONING).
+    # Resolved through the shared chokepoint so per-model overrides and the
+    # YAML boolean-False semantics still apply when no explicit flag is given.
+    from hermes_constants import parse_reasoning_effort, resolve_reasoning_config
+
+    _effort = (reasoning_effort or "").strip() or os.environ.get(
+        "HERMES_REASONING", ""
+    ).strip()
+    _effort_config = parse_reasoning_effort(_effort)
+    effective_reasoning_config = (
+        _effort_config
+        if _effort_config is not None
+        else resolve_reasoning_config(cfg, effective_model)
+    )
 
     # Resolve effective provider: explicit arg → (auto-detect from model if
     # model was explicit) → env / config (handled inside resolve_runtime_provider).
@@ -420,6 +441,7 @@ def _run_agent(
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,
+            reasoning_config=effective_reasoning_config,
             # Interactive callbacks are intentionally NOT wired beyond this
             # one.  In oneshot mode there's no user sitting at a terminal:
             #   - clarify  → returns a synthetic "pick a default" instruction

--- a/tests/hermes_cli/test_cli_reasoning_flag.py
+++ b/tests/hermes_cli/test_cli_reasoning_flag.py
@@ -1,0 +1,301 @@
+"""Tests for the per-invocation ``--reasoning`` CLI flag.
+
+Covers:
+- argparse: ``--reasoning`` accepted on top-level and ``chat`` subparser with
+  the documented choices; absent flag leaves ``args.reasoning`` unset.
+- ``cmd_chat``: ``HERMES_REASONING`` env var set from ``--reasoning``.
+- ``_launch_tui``: ``HERMES_TUI_REASONING`` env forwarded to the TUI process.
+- ``HermesCLI.__init__``: ``reasoning_effort`` / ``HERMES_REASONING`` override
+  the resolved ``reasoning_config``.
+- ``run_oneshot`` → ``_run_agent``: ``reasoning_config`` plumbed into AIAgent.
+- ``tui_gateway.server._load_reasoning_config``: ``HERMES_TUI_REASONING`` wins
+  over config.yaml.
+"""
+
+import os
+
+import pytest
+
+
+def _build_parser():
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+    return parser
+
+
+class TestArgparseReasoningFlag:
+    def test_top_level_accepts_reasoning(self):
+        parser = _build_parser()
+        args = parser.parse_args(["--reasoning", "high", "chat", "-q", "hi"])
+        assert args.reasoning == "high"
+
+    def test_chat_subparser_accepts_reasoning(self):
+        parser = _build_parser()
+        args = parser.parse_args(["chat", "--reasoning", "low", "-q", "hi"])
+        assert args.reasoning == "low"
+
+    def test_absent_reasoning_defaults_none(self):
+        parser = _build_parser()
+        args = parser.parse_args(["chat", "-q", "hi"])
+        assert getattr(args, "reasoning", None) is None
+
+    def test_invalid_reasoning_rejected(self):
+        parser = _build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["chat", "--reasoning", "bogus", "-q", "hi"])
+
+    def test_reasoning_none_is_valid(self):
+        parser = _build_parser()
+        args = parser.parse_args(["chat", "--reasoning", "none", "-q", "hi"])
+        assert args.reasoning == "none"
+
+    def test_oneshot_accepts_reasoning(self):
+        parser = _build_parser()
+        args = parser.parse_args(["-z", "hello", "--reasoning", "max"])
+        assert args.reasoning == "max"
+
+
+class TestCmdChatReasoningEnv:
+    def test_cmd_chat_sets_hermes_reasoning_env(self, monkeypatch):
+        from hermes_cli.main import cmd_chat
+
+        class Args:
+            reasoning = "high"
+            source = None
+            yolo = False
+            ignore_user_config = False
+            ignore_rules = False
+            safe_mode = False
+            resume = None
+            continue_last = None
+            no_restore_cwd = False
+            worktree = False
+            model = None
+            provider = None
+            toolsets = None
+            skills = None
+            verbose = None
+            quiet = False
+            query = None
+            image = None
+            checkpoints = False
+            pass_session_id = False
+            max_turns = None
+            accept_hooks = False
+            tui_dev = False
+            compact = False
+
+        monkeypatch.delenv("HERMES_REASONING", raising=False)
+        # Avoid actually launching anything.
+        monkeypatch.setattr(
+            "hermes_cli.main._resolve_use_tui", lambda args: False
+        )
+        monkeypatch.setattr(
+            "hermes_cli.main._apply_safe_mode", lambda args: None
+        )
+        monkeypatch.setattr(
+            "hermes_cli.main._has_any_provider_configured", lambda: True
+        )
+        monkeypatch.setattr(
+            "hermes_cli.main._sync_bundled_skills_for_startup",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.main._pin_kanban_board_env", lambda: None
+        )
+        monkeypatch.setattr(
+            "hermes_cli.main._termux_should_prefetch_update_check",
+            lambda: False,
+        )
+        # cmd_chat imports cli.main at the end; monkeypatch the module-level
+        # name so the real REPL never starts.
+        import cli as cli_mod
+
+        monkeypatch.setattr(cli_mod, "main", lambda **kw: None)
+
+        cmd_chat(Args())
+        assert os.environ.get("HERMES_REASONING") == "high"
+
+
+class TestLaunchTuiReasoningEnv:
+    def test_launch_tui_forwards_reasoning_env(self, monkeypatch, tmp_path):
+        import hermes_cli.main as main_mod
+        from hermes_cli.main import _launch_tui
+
+        captured = {}
+
+        def fake_make_tui_argv(tui_dir, tui_dev):
+            return ["node", "entry.js"], str(tmp_path)
+
+        monkeypatch.setattr(
+            "hermes_cli.main._make_tui_argv", fake_make_tui_argv
+        )
+        monkeypatch.setattr(
+            "hermes_cli.main._apply_tui_python_env", lambda env: None
+        )
+        monkeypatch.setattr(
+            "hermes_cli.main._resolve_tui_heap_mb", lambda: 4096
+        )
+        monkeypatch.setattr(
+            "hermes_cli.main._normalize_tui_toolsets", lambda t: None
+        )
+        monkeypatch.setattr(
+            "hermes_cli.main._termux_should_prefetch_update_check",
+            lambda: False,
+        )
+        # The wrapper calls subprocess.call at the end; capture instead of
+        # actually spawning node.
+        def fake_call(argv, cwd=None, env=None):
+            captured["env"] = env
+            return 0
+
+        monkeypatch.setattr("hermes_cli.main.subprocess.call", fake_call)
+
+        try:
+            _launch_tui(
+                resume_session_id=None,
+                model=None,
+                provider=None,
+                toolsets=None,
+                skills=None,
+                verbose=None,
+                quiet=False,
+                query=None,
+                image=None,
+                worktree=False,
+                checkpoints=False,
+                pass_session_id=False,
+                max_turns=None,
+                accept_hooks=False,
+                reasoning_effort="medium",
+            )
+        except SystemExit:
+            # _launch_tui ends with sys.exit(code); code=0 here.
+            pass
+
+        env = captured.get("env")
+        assert env is not None
+        assert env.get("HERMES_TUI_REASONING") == "medium"
+
+
+class TestHermesCLIReasoningEffort:
+    def test_init_accepts_reasoning_effort_kwarg(self, monkeypatch):
+        import cli as cli_mod
+
+        orig = cli_mod.CLI_CONFIG
+        cli_mod.CLI_CONFIG = {
+            "agent": {},
+            "display": {},
+            "model": {},
+            "compression": {},
+            "terminal": {},
+        }
+        try:
+            from cli import HermesCLI
+
+            h = HermesCLI(reasoning_effort="low")
+            assert h.reasoning_config == {"enabled": True, "effort": "low"}
+        finally:
+            cli_mod.CLI_CONFIG = orig
+
+    def test_env_var_override(self, monkeypatch):
+        import cli as cli_mod
+
+        monkeypatch.setenv("HERMES_REASONING", "high")
+        orig = cli_mod.CLI_CONFIG
+        cli_mod.CLI_CONFIG = {
+            "agent": {},
+            "display": {},
+            "model": {},
+            "compression": {},
+            "terminal": {},
+        }
+        try:
+            from cli import HermesCLI
+
+            h = HermesCLI()
+            assert h.reasoning_config == {"enabled": True, "effort": "high"}
+        finally:
+            cli_mod.CLI_CONFIG = orig
+
+
+class TestOneshotReasoningEffort:
+    def test_run_agent_plumbs_reasoning_config(self, monkeypatch):
+        import hermes_cli.oneshot as oneshot_mod
+        from hermes_cli.oneshot import _run_agent
+
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured["reasoning_config"] = kwargs.get("reasoning_config")
+
+            def run_conversation(self, prompt):
+                return {"final_response": "ok", "failed": False}
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"default": "test-model"}},
+        )
+        monkeypatch.setattr(
+            oneshot_mod, "_normalize_toolsets", lambda t: None
+        )
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools", lambda cfg, p: []
+        )
+        monkeypatch.setattr(
+            oneshot_mod, "_create_session_db_for_oneshot", lambda: None
+        )
+        monkeypatch.setattr(
+            oneshot_mod, "get_fallback_chain", lambda cfg: {}
+        )
+        monkeypatch.setattr(
+            oneshot_mod, "declare_stateless_channel", lambda: None
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda **kw: {
+                "api_key": "k",
+                "base_url": "b",
+                "provider": "p",
+                "requested_provider": "p",
+                "api_mode": "chat",
+                "credential_pool": None,
+            },
+        )
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+
+        resp, result = _run_agent(
+            "hello", model="test-model", reasoning_effort="high"
+        )
+        assert resp == "ok"
+        assert captured["reasoning_config"] == {
+            "enabled": True,
+            "effort": "high",
+        }
+
+
+class TestTuiGatewayReasoningEnv:
+    def test_load_reasoning_config_env_override(self, monkeypatch):
+        from tui_gateway.server import _load_reasoning_config
+
+        monkeypatch.setenv("HERMES_TUI_REASONING", "xhigh")
+        monkeypatch.setattr(
+            "tui_gateway.server._load_cfg",
+            lambda: {"agent": {"reasoning_effort": "low"}},
+        )
+        assert _load_reasoning_config() == {"enabled": True, "effort": "xhigh"}
+
+    def test_load_reasoning_config_falls_back_to_cfg(self, monkeypatch):
+        from tui_gateway.server import _load_reasoning_config
+
+        monkeypatch.delenv("HERMES_TUI_REASONING", raising=False)
+        monkeypatch.setattr(
+            "tui_gateway.server._load_cfg",
+            lambda: {"agent": {"reasoning_effort": "low"}},
+        )
+        assert _load_reasoning_config("") == {
+            "enabled": True,
+            "effort": "low",
+        }

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3597,9 +3597,19 @@ def _load_reasoning_config(model: str = "") -> dict | None:
     :func:`hermes_constants.resolve_reasoning_config` (per-model override >
     global ``agent.reasoning_effort``; YAML boolean False = disabled).
     Closes #21256.
-    """
-    from hermes_constants import resolve_reasoning_config
 
+    ``HERMES_TUI_REASONING`` (set by ``hermes chat --reasoning <level>`` /
+    ``hermes --reasoning <level> --tui`` in hermes_cli/main.py) is a
+    per-invocation override and wins over everything — it is ephemeral and
+    never written to config.yaml.
+    """
+    from hermes_constants import parse_reasoning_effort, resolve_reasoning_config
+
+    _env_effort = os.environ.get("HERMES_TUI_REASONING", "").strip()
+    if _env_effort:
+        _env_config = parse_reasoning_effort(_env_effort)
+        if _env_config is not None:
+            return _env_config
     return resolve_reasoning_config(_load_cfg(), model)
 
 


### PR DESCRIPTION
## Summary

Adds `--reasoning <level>` to the `hermes` CLI so users can set the reasoning-effort level **per invocation** without editing `config.yaml`.

```bash
hermes chat -q "..." --reasoning high
hermes -z "summarize this" --reasoning low
hermes --tui --reasoning max
```

Levels: `none | minimal | low | medium | high | xhigh | max | ultra` (same set as `agent.reasoning_effort`).

## Motivation

`hermes chat -q` (and `-z`/`--tui`) had no way to override reasoning effort from the command line — the only controls were the config file (`agent.reasoning_effort` / `agent.reasoning_overrides`) or the interactive `/reasoning` slash command. Scripts and one-shot automations that want a cheaper/faster run (or a deeper one) had to mutate config, which is fragile in CI.

## Implementation

- `hermes_cli/_parser.py`: `--reasoning` flag on the top-level parser and the `chat` subparser (with `choices=`, `default=argparse.SUPPRESS` on the subparser to preserve parent→subparser propagation semantics).
- `hermes_cli/main.py`:
  - `cmd_chat` sets `HERMES_REASONING` when `--reasoning` is passed (classic CLI reads it back).
  - `_launch_tui` forwards it as `HERMES_TUI_REASONING` to the TUI process.
  - `_run_and_exit_oneshot` passes it through to `run_oneshot`.
- `cli.py`: `HermesCLI.__init__` and `main()` accept `reasoning_effort`; the resolved `reasoning_config` prefers the per-invocation value over config (via the shared `parse_reasoning_effort` / `resolve_reasoning_config` chokepoint in `hermes_constants`).
- `hermes_cli/oneshot.py`: `run_oneshot` / `_run_agent` accept `reasoning_effort` and plumb it into `AIAgent(reasoning_config=...)`.
- `tui_gateway/server.py`: `_load_reasoning_config` honors `HERMES_TUI_REASONING` before falling back to config.yaml.

The override is **ephemeral** — nothing is written to `config.yaml`, and the per-model `agent.reasoning_overrides` still apply when the flag is absent.

## Tests

- New `tests/hermes_cli/test_cli_reasoning_flag.py` (13 tests): argparse parsing (top-level, chat subparser, invalid value rejection, `none`, oneshot), `HERMES_REASONING` env propagation from `cmd_chat`, `HERMES_TUI_REASONING` env forwarding from `_launch_tui`, `HermesCLI` reasoning-config resolution, oneshot `_run_agent` → `AIAgent` plumbing, and TUI gateway env override.
- Existing suites pass: `test_argparse_flag_propagation.py` (23), `test_tui_gateway_server.py` (479), plus the new file. The 2 pre-existing `test_reasoning_full_command.py` / `test_tui_gateway_server.py` failures are caused by a missing `ruamel` dependency in this environment and reproduce on `main` without these changes.