### PR TITLE
feat(voice): make concise response guidance configurable

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -435,7 +435,8 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
   voice: {
     recordKey: 'Voice Shortcut',
     maxRecordingSeconds: 'Max Recording Length',
-    autoTts: 'Read Responses Aloud'
+    autoTts: 'Read Responses Aloud',
+    conciseResponses: 'Concise CLI Voice Responses'
   },
   stt: {
     enabled: 'Speech To Text',
@@ -592,7 +593,8 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
     enabled: 'Summarize older context when conversations get large.'
   },
   voice: {
-    autoTts: 'Automatically speak assistant responses.'
+    autoTts: 'Automatically speak assistant responses.',
+    conciseResponses: 'Apply brief conversational response guidance to CLI microphone requests.'
   },
   tts: {
     xai: {
@@ -699,6 +701,7 @@ export const SECTIONS: DesktopConfigSection[] = [
       'stt.echo_transcripts',
       'stt.provider',
       'voice.auto_tts',
+      'voice.concise_responses',
       'tts.edge.voice',
       'tts.openai.model',
       'tts.openai.voice',

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -448,7 +448,8 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
   voice: {
     recordKey: 'Voice Shortcut',
     maxRecordingSeconds: 'Max Recording Length',
-    autoTts: 'Read Responses Aloud'
+    autoTts: 'Read Responses Aloud',
+    conciseResponses: 'Concise CLI Voice Responses'
   },
   stt: {
     enabled: 'Speech To Text',
@@ -605,7 +606,8 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
     enabled: 'Summarize older context when conversations get large.'
   },
   voice: {
-    autoTts: 'Automatically speak assistant responses.'
+    autoTts: 'Automatically speak assistant responses.',
+    conciseResponses: 'Apply brief conversational response guidance to CLI microphone requests.'
   },
   tts: {
     xai: {
@@ -712,6 +714,7 @@ export const SECTIONS: DesktopConfigSection[] = [
       'stt.echo_transcripts',
       'stt.provider',
       'voice.auto_tts',
+      'voice.concise_responses',
       'tts.edge.voice',
       'tts.openai.model',
       'tts.openai.voice',

--- a/apps/desktop/src/app/settings/voice-field-visible.test.ts
+++ b/apps/desktop/src/app/settings/voice-field-visible.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { HermesConfigRecord } from '@/types/hermes'
 
+import { SECTIONS } from './constants'
 import { voiceFieldVisible } from './helpers'
 
 const cfg = (over: Record<string, unknown> = {}): HermesConfigRecord =>
@@ -12,10 +13,23 @@ const cfg = (over: Record<string, unknown> = {}): HermesConfigRecord =>
   }) as unknown as HermesConfigRecord
 
 describe('voiceFieldVisible', () => {
+  it('includes concise response guidance in the curated Voice settings', () => {
+    const voice = SECTIONS.find(section => section.id === 'voice')
+
+    expect(voice?.keys).toContain('voice.concise_responses')
+  })
+
   it('always shows top-level + non-provider keys', () => {
     const config = cfg()
 
-    for (const key of ['tts.provider', 'stt.enabled', 'stt.provider', 'voice.auto_tts', 'voice.record_key']) {
+    for (const key of [
+      'tts.provider',
+      'stt.enabled',
+      'stt.provider',
+      'voice.auto_tts',
+      'voice.concise_responses',
+      'voice.record_key'
+    ]) {
       expect(voiceFieldVisible(key, config)).toBe(true)
     }
   })

--- a/apps/desktop/src/app/settings/voice-field-visible.test.ts
+++ b/apps/desktop/src/app/settings/voice-field-visible.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { HermesConfigRecord } from '@/types/hermes'
 
 import { voiceFieldVisible } from './config-settings'
+import { SECTIONS } from './constants'
 
 const cfg = (over: Record<string, unknown> = {}): HermesConfigRecord =>
   ({
@@ -12,10 +13,23 @@ const cfg = (over: Record<string, unknown> = {}): HermesConfigRecord =>
   }) as unknown as HermesConfigRecord
 
 describe('voiceFieldVisible', () => {
+  it('includes concise response guidance in the curated Voice settings', () => {
+    const voice = SECTIONS.find(section => section.id === 'voice')
+
+    expect(voice?.keys).toContain('voice.concise_responses')
+  })
+
   it('always shows top-level + non-provider keys', () => {
     const config = cfg()
 
-    for (const key of ['tts.provider', 'stt.enabled', 'stt.provider', 'voice.auto_tts', 'voice.record_key']) {
+    for (const key of [
+      'tts.provider',
+      'stt.enabled',
+      'stt.provider',
+      'voice.auto_tts',
+      'voice.concise_responses',
+      'voice.record_key'
+    ]) {
       expect(voiceFieldVisible(key, config)).toBe(true)
     }
   })

--- a/apps/desktop/src/i18n/runtime.test.ts
+++ b/apps/desktop/src/i18n/runtime.test.ts
@@ -54,9 +54,14 @@ describe('desktop i18n runtime translator', () => {
 
   it('keeps translated settings field copy addressable from schema keys', () => {
     const field = ['display', 'show_reasoning'].join('.')
+    const voiceField = ['voice', 'concise_responses'].join('.')
 
     expect(fieldCopyForSchemaKey(zh.settings.fieldLabels, field)).toBe('推理过程块')
     expect(fieldCopyForSchemaKey(zh.settings.fieldDescriptions, field)).toBe('当后端提供推理内容时予以显示。')
+    expect(fieldCopyForSchemaKey(zh.settings.fieldLabels, voiceField)).toBe('简洁的 CLI 语音回复')
+    expect(fieldCopyForSchemaKey(zh.settings.fieldDescriptions, voiceField)).toBe(
+      '为 CLI 麦克风请求应用简短、对话式的回复指引。'
+    )
   })
 
   it('falls back to English when the active locale cannot resolve a key', () => {

--- a/apps/desktop/src/i18n/runtime.test.ts
+++ b/apps/desktop/src/i18n/runtime.test.ts
@@ -48,9 +48,14 @@ describe('desktop i18n runtime translator', () => {
 
   it('keeps translated settings field copy addressable from schema keys', () => {
     const field = ['display', 'show_reasoning'].join('.')
+    const voiceField = ['voice', 'concise_responses'].join('.')
 
     expect(fieldCopyForSchemaKey(zh.settings.fieldLabels, field)).toBe('推理过程块')
     expect(fieldCopyForSchemaKey(zh.settings.fieldDescriptions, field)).toBe('当后端提供推理内容时予以显示。')
+    expect(fieldCopyForSchemaKey(zh.settings.fieldLabels, voiceField)).toBe('简洁的 CLI 语音回复')
+    expect(fieldCopyForSchemaKey(zh.settings.fieldDescriptions, voiceField)).toBe(
+      '为 CLI 麦克风请求应用简短、对话式的回复指引。'
+    )
   })
 
   it('falls back to English when the active locale cannot resolve a key', () => {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -655,7 +655,8 @@ export const zh: Translations = {
       voice: {
         recordKey: '语音快捷键',
         maxRecordingSeconds: '最长录音时长',
-        autoTts: '朗读回复'
+        autoTts: '朗读回复',
+        conciseResponses: '简洁的 CLI 语音回复'
       },
       stt: {
         enabled: '语音转文字',
@@ -802,7 +803,8 @@ export const zh: Translations = {
         enabled: '当对话变大时对较早的上下文进行摘要。'
       },
       voice: {
-        autoTts: '自动朗读助手回复。'
+        autoTts: '自动朗读助手回复。',
+        conciseResponses: '为 CLI 麦克风请求应用简短、对话式的回复指引。'
       },
       stt: {
         enabled: '启用本地或提供方支持的语音转写。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -568,7 +568,8 @@ export const zh: Translations = {
       voice: {
         recordKey: '语音快捷键',
         maxRecordingSeconds: '最长录音时长',
-        autoTts: '朗读回复'
+        autoTts: '朗读回复',
+        conciseResponses: '简洁的 CLI 语音回复'
       },
       stt: {
         enabled: '语音转文字',
@@ -715,7 +716,8 @@ export const zh: Translations = {
         enabled: '当对话变大时对较早的上下文进行摘要。'
       },
       voice: {
-        autoTts: '自动朗读助手回复。'
+        autoTts: '自动朗读助手回复。',
+        conciseResponses: '为 CLI 麦克风请求应用简短、对话式的回复指引。'
       },
       stt: {
         enabled: '启用本地或提供方支持的语音转写。',

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1415,6 +1415,11 @@ stt:
 #                      # client: always desktop-streamed PCM (detection stays
 #                      #         on the backend).
 
+# CLI microphone input. Keep concise_responses enabled for short,
+# conversational voice replies; disable it to treat dictation like typed input.
+# voice:
+#   concise_responses: true
+
 # Image generation. Each provider plugin reads its own ``image_gen.<name>``
 # block; deepinfra discovers models live from
 # api.deepinfra.com/v1/openai/models filtered by the ``image-gen`` tag —

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1206,6 +1206,11 @@ stt:
 #     model: ""
 #     voice: "default"
 
+# CLI microphone input. Keep concise_responses enabled for short,
+# conversational voice replies; disable it to treat dictation like typed input.
+# voice:
+#   concise_responses: true
+
 # Image generation. Each provider plugin reads its own ``image_gen.<name>``
 # block; deepinfra discovers models live from
 # api.deepinfra.com/v1/openai/models filtered by the ``image-gen`` tag —

--- a/cli.py
+++ b/cli.py
@@ -14443,6 +14443,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             pass
         return True
 
+    def _voice_concise_responses_enabled(self) -> bool:
+        try:
+            from hermes_cli.config import load_config_readonly
+            from utils import is_truthy_value
+
+            voice_cfg = load_config_readonly().get("voice", {})
+            return not isinstance(voice_cfg, dict) or is_truthy_value(
+                voice_cfg.get("concise_responses", True), default=True
+            )
+        except Exception:
+            return True
+
     def _enable_voice_mode(self):
         """Enable voice mode after checking requirements."""
         if self._voice_mode:
@@ -15858,7 +15870,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # model responds concisely. The prefix is API-call-local only —
             # run_conversation persists the original clean user message.
             _voice_prefix = ""
-            if voice_input and isinstance(message, str):
+            if (
+                voice_input
+                and isinstance(message, str)
+                and self._voice_concise_responses_enabled()
+            ):
                 _voice_prefix = (
                     "[Voice input — respond concisely and conversationally, "
                     "2-3 sentences max. No code blocks or markdown.] "

--- a/cli.py
+++ b/cli.py
@@ -12690,6 +12690,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             pass
         return True
 
+    def _voice_concise_responses_enabled(self) -> bool:
+        try:
+            from hermes_cli.config import load_config_readonly
+            from utils import is_truthy_value
+
+            voice_cfg = load_config_readonly().get("voice", {})
+            return not isinstance(voice_cfg, dict) or is_truthy_value(
+                voice_cfg.get("concise_responses", True), default=True
+            )
+        except Exception:
+            return True
+
     def _enable_voice_mode(self):
         """Enable voice mode after checking requirements."""
         if self._voice_mode:
@@ -13894,7 +13906,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # model responds concisely. The prefix is API-call-local only —
             # run_conversation persists the original clean user message.
             _voice_prefix = ""
-            if voice_input and isinstance(message, str):
+            if (
+                voice_input
+                and isinstance(message, str)
+                and self._voice_concise_responses_enabled()
+            ):
                 _voice_prefix = (
                     "[Voice input — respond concisely and conversationally, "
                     "2-3 sentences max. No code blocks or markdown.] "

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1712,6 +1712,7 @@ DEFAULT_CONFIG = {
         "submit_mode": "direct",       # TUI: direct submits immediately; draft leaves an editable transcript
         "max_recording_seconds": 120,
         "auto_tts": False,
+        "concise_responses": True,      # Add concise/conversational guidance to classic CLI microphone requests
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
         "beep_volume": 0.3,           # Beep amplitude multiplier (0.0-1.0, default keeps prior hardcoded value)
         "thinking_sound": True,       # Calm ambient bubble sound while the agent works in voice chat (volume follows beep_volume)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1556,6 +1556,7 @@ DEFAULT_CONFIG = {
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,
         "auto_tts": False,
+        "concise_responses": True,      # Add concise/conversational guidance to classic CLI microphone requests
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
         "beep_volume": 0.3,           # Beep amplitude multiplier (0.0-1.0, default keeps prior hardcoded value)
         "thinking_sound": True,       # Calm ambient bubble sound while the agent works in voice chat (volume follows beep_volume)

--- a/tests/cli/test_cli_interrupt_ack_race.py
+++ b/tests/cli/test_cli_interrupt_ack_race.py
@@ -89,8 +89,10 @@ class _StubAgent:
         self.max_iterations = 90
         self.model = "test/model"
         self.platform = "cli"
+        self.captured = None
 
     def run_conversation(self, **kwargs):
+        self.captured = kwargs
         # Simulate a turn that finishes normally — it never observed the
         # interrupt flag (raced past its last check).
         time.sleep(self.turn_seconds)
@@ -193,6 +195,76 @@ def test_chat_persists_clean_input_when_a_queued_note_changes_api_message():
     assert agent.captured is not None
     assert agent.captured["user_message"] == "[MODEL SWITCH NOTE]\n\nclean prompt"
     assert agent.captured["persist_user_message"] == "clean prompt"
+
+
+def test_voice_chat_persists_clean_input_when_concise_guidance_is_enabled():
+    """Voice guidance is model-facing only; history keeps the transcription."""
+    cli = _make_cli()
+    agent = _StubAgent(cli.session_id, turn_seconds=0)
+    cli.agent = agent
+    cli._interrupt_queue = queue.Queue()
+    cli._pending_input = queue.Queue()
+
+    with patch("hermes_cli.config.load_config_readonly", return_value={"voice": {}}), \
+         patch.object(cli, "_ensure_runtime_credentials", return_value=True), \
+         patch.object(cli, "_resolve_turn_agent_config", return_value={
+             "signature": cli._active_agent_route_signature,
+             "model": None, "runtime": None, "request_overrides": None,
+         }), \
+         patch.object(cli, "_init_agent", return_value=True):
+        cli.chat("clean transcription", voice_input=True)
+
+    assert agent.captured is not None
+    assert agent.captured["user_message"].startswith("[Voice input —")
+    assert agent.captured["user_message"].endswith("clean transcription")
+    assert agent.captured["persist_user_message"] == "clean transcription"
+
+
+def test_voice_chat_matches_typed_input_when_concise_guidance_is_disabled():
+    """The accessibility toggle removes only the model-facing style prefix."""
+    cli = _make_cli()
+    agent = _StubAgent(cli.session_id, turn_seconds=0)
+    cli.agent = agent
+    cli._interrupt_queue = queue.Queue()
+    cli._pending_input = queue.Queue()
+
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value={"voice": {"concise_responses": False}},
+    ), patch.object(cli, "_ensure_runtime_credentials", return_value=True), \
+         patch.object(cli, "_resolve_turn_agent_config", return_value={
+             "signature": cli._active_agent_route_signature,
+             "model": None, "runtime": None, "request_overrides": None,
+         }), \
+         patch.object(cli, "_init_agent", return_value=True):
+        cli.chat("run a multi-step task", voice_input=True)
+
+    assert agent.captured is not None
+    assert agent.captured["user_message"] == "run a multi-step task"
+    assert agent.captured["persist_user_message"] is None
+
+
+def test_typed_chat_never_gets_voice_guidance_when_setting_is_enabled():
+    """The voice setting never changes ordinary typed input."""
+    cli = _make_cli()
+    agent = _StubAgent(cli.session_id, turn_seconds=0)
+    cli.agent = agent
+    cli._interrupt_queue = queue.Queue()
+    cli._pending_input = queue.Queue()
+
+    with patch(
+        "hermes_cli.config.load_config_readonly",
+        return_value={"voice": {"concise_responses": True}},
+    ), patch.object(cli, "_ensure_runtime_credentials", return_value=True), \
+         patch.object(cli, "_resolve_turn_agent_config", return_value={
+             "signature": cli._active_agent_route_signature,
+             "model": None, "runtime": None, "request_overrides": None,
+         }), \
+         patch.object(cli, "_init_agent", return_value=True):
+        cli.chat("typed request")
+
+    assert agent.captured is not None
+    assert agent.captured["user_message"] == "typed request"
 
 
 def test_chat_preserves_clean_multimodal_input_when_note_changes_api_message():

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2366,6 +2366,30 @@ class TestConfigRoundTrip:
         reloaded = self.client.get("/api/config").json()
         assert reloaded["terminal"]["font_family"] == "MesloLGS NF"
 
+    def test_voice_concise_responses_schema_and_round_trip(self):
+        """Dashboard/desktop config API exposes and persists the voice toggle."""
+        from hermes_cli.config import load_config, read_raw_config
+
+        schema = self.client.get("/api/config/schema").json()["fields"]
+        field = schema["voice.concise_responses"]
+        assert field["type"] == "boolean"
+        assert field["category"] == "voice"
+
+        web_config = self.client.get("/api/config").json()
+        assert web_config["voice"]["concise_responses"] is True
+        auto_tts_before = web_config["voice"]["auto_tts"]
+        web_config["voice"]["concise_responses"] = False
+
+        response = self.client.put("/api/config", json={"config": web_config})
+
+        assert response.status_code == 200
+        assert read_raw_config()["voice"]["concise_responses"] is False
+        persisted_voice = load_config()["voice"]
+        assert persisted_voice["concise_responses"] is False
+        assert persisted_voice["auto_tts"] is auto_tts_before
+        reloaded = self.client.get("/api/config").json()
+        assert reloaded["voice"]["concise_responses"] is False
+
 
 # ---------------------------------------------------------------------------
 # New feature endpoint tests

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1782,6 +1782,30 @@ class TestConfigRoundTrip:
         reloaded = self.client.get("/api/config").json()
         assert reloaded["terminal"]["font_family"] == "MesloLGS NF"
 
+    def test_voice_concise_responses_schema_and_round_trip(self):
+        """Dashboard/desktop config API exposes and persists the voice toggle."""
+        from hermes_cli.config import load_config, read_raw_config
+
+        schema = self.client.get("/api/config/schema").json()["fields"]
+        field = schema["voice.concise_responses"]
+        assert field["type"] == "boolean"
+        assert field["category"] == "voice"
+
+        web_config = self.client.get("/api/config").json()
+        assert web_config["voice"]["concise_responses"] is True
+        auto_tts_before = web_config["voice"]["auto_tts"]
+        web_config["voice"]["concise_responses"] = False
+
+        response = self.client.put("/api/config", json={"config": web_config})
+
+        assert response.status_code == 200
+        assert read_raw_config()["voice"]["concise_responses"] is False
+        persisted_voice = load_config()["voice"]
+        assert persisted_voice["concise_responses"] is False
+        assert persisted_voice["auto_tts"] is auto_tts_before
+        reloaded = self.client.get("/api/config").json()
+        assert reloaded["voice"]["concise_responses"] is False
+
 
 # ---------------------------------------------------------------------------
 # New feature endpoint tests

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -184,6 +184,42 @@ class TestVoiceBeepConfigReal:
         mock_beep.assert_not_called()
 
 
+class TestVoiceConciseResponsesConfigReal:
+    """Test the model-facing concise-response guidance toggle from config.yaml."""
+
+    @pytest.mark.parametrize(
+        ("config_text", "expected"),
+        [
+            ("{}\n", True),
+            ("voice:\n  concise_responses: true\n", True),
+            ("voice:\n  concise_responses: false\n", False),
+            ("voice:\n  concise_responses: \"false\"\n", False),
+            # A non-mapping section must preserve the backward-compatible
+            # default rather than fail a turn.
+            ("voice: invalid\n", True),
+            # A YAML parse failure falls back to DEFAULT_CONFIG in load_config().
+            ("voice: [broken\n", True),
+        ],
+    )
+    def test_config_yaml_values(self, config_text, expected):
+        from hermes_cli import config as config_module
+
+        config_path = config_module.get_config_path()
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(config_text, encoding="utf-8")
+        config_module._LOAD_CONFIG_CACHE.clear()
+        config_module._RAW_CONFIG_CACHE.clear()
+
+        assert _make_voice_cli()._voice_concise_responses_enabled() is expected
+
+    def test_config_load_failure_preserves_the_compatible_default(self):
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            side_effect=RuntimeError("unreadable config"),
+        ):
+            assert _make_voice_cli()._voice_concise_responses_enabled() is True
+
+
 class TestMaxRecordingSecondsConfigReal:
     """voice.max_recording_seconds must reach the recorder from config.
 

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -181,6 +181,42 @@ class TestVoiceBeepConfigReal:
         mock_beep.assert_not_called()
 
 
+class TestVoiceConciseResponsesConfigReal:
+    """Test the model-facing concise-response guidance toggle from config.yaml."""
+
+    @pytest.mark.parametrize(
+        ("config_text", "expected"),
+        [
+            ("{}\n", True),
+            ("voice:\n  concise_responses: true\n", True),
+            ("voice:\n  concise_responses: false\n", False),
+            ("voice:\n  concise_responses: \"false\"\n", False),
+            # A non-mapping section must preserve the backward-compatible
+            # default rather than fail a turn.
+            ("voice: invalid\n", True),
+            # A YAML parse failure falls back to DEFAULT_CONFIG in load_config().
+            ("voice: [broken\n", True),
+        ],
+    )
+    def test_config_yaml_values(self, config_text, expected):
+        from hermes_cli import config as config_module
+
+        config_path = config_module.get_config_path()
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(config_text, encoding="utf-8")
+        config_module._LOAD_CONFIG_CACHE.clear()
+        config_module._RAW_CONFIG_CACHE.clear()
+
+        assert _make_voice_cli()._voice_concise_responses_enabled() is expected
+
+    def test_config_load_failure_preserves_the_compatible_default(self):
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            side_effect=RuntimeError("unreadable config"),
+        ):
+            assert _make_voice_cli()._voice_concise_responses_enabled() is True
+
+
 class TestMaxRecordingSecondsConfigReal:
     """voice.max_recording_seconds must reach the recorder from config.
 

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -169,6 +169,7 @@ voice:
   submit_mode: "direct"  # TUI: direct | draft
   max_recording_seconds: 120
   auto_tts: false
+  concise_responses: true
   beep_enabled: true
   silence_threshold: 200
   silence_duration: 3.0

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -168,6 +168,7 @@ voice:
   record_key: "ctrl+b"
   max_recording_seconds: 120
   auto_tts: false
+  concise_responses: true
   beep_enabled: true
   silence_threshold: 200
   silence_duration: 3.0

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2022,13 +2022,14 @@ voice:
   record_key: "ctrl+b"         # Push-to-talk key inside the CLI
   max_recording_seconds: 120    # Hard stop for long recordings
   auto_tts: false               # Enable spoken replies automatically when /voice on
+  concise_responses: true       # Add concise/conversational response guidance to classic CLI microphone input
   beep_enabled: true            # Play record start/stop beeps in CLI voice mode
   beep_volume: 0.3              # Beep amplitude (0.0-1.0); raise it on quiet systems / headphones
   silence_threshold: 200        # RMS threshold for speech detection
   silence_duration: 3.0         # Seconds of silence before auto-stop
 ```
 
-Use `/voice on` in the CLI to enable microphone mode, `record_key` to start/stop recording, and `/voice tts` to toggle spoken replies. See [Voice Mode](/user-guide/features/voice-mode) for end-to-end setup and platform-specific behavior.
+Use `/voice on` in the CLI to enable microphone mode, `record_key` to start/stop recording, and `/voice tts` to toggle spoken replies. Set `concise_responses: false` when classic-CLI dictation should behave like typed input without the voice-only 2–3 sentence and formatting guidance. This does not change transcription language, TTS, tools, or persisted conversation history. See [Voice Mode](/user-guide/features/voice-mode) for end-to-end setup and platform-specific behavior.
 
 ## Streaming
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1853,13 +1853,14 @@ voice:
   record_key: "ctrl+b"         # Push-to-talk key inside the CLI
   max_recording_seconds: 120    # Hard stop for long recordings
   auto_tts: false               # Enable spoken replies automatically when /voice on
+  concise_responses: true       # Add concise/conversational response guidance to classic CLI microphone input
   beep_enabled: true            # Play record start/stop beeps in CLI voice mode
   beep_volume: 0.3              # Beep amplitude (0.0-1.0); raise it on quiet systems / headphones
   silence_threshold: 200        # RMS threshold for speech detection
   silence_duration: 3.0         # Seconds of silence before auto-stop
 ```
 
-Use `/voice on` in the CLI to enable microphone mode, `record_key` to start/stop recording, and `/voice tts` to toggle spoken replies. See [Voice Mode](/user-guide/features/voice-mode) for end-to-end setup and platform-specific behavior.
+Use `/voice on` in the CLI to enable microphone mode, `record_key` to start/stop recording, and `/voice tts` to toggle spoken replies. Set `concise_responses: false` when classic-CLI dictation should behave like typed input without the voice-only 2–3 sentence and formatting guidance. This does not change transcription language, TTS, tools, or persisted conversation history. See [Voice Mode](/user-guide/features/voice-mode) for end-to-end setup and platform-specific behavior.
 
 ## Streaming
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -148,6 +148,17 @@ This loop continues until you press **Ctrl+B** during recording (exits continuou
 The record key is configurable via `voice.record_key` in `~/.hermes/config.yaml` (default: `ctrl+b`).
 :::
 
+### Response guidance
+
+By default, classic-CLI microphone requests include brief, conversational response guidance. To make classic-CLI dictation behave like typed input, disable only that guidance:
+
+```yaml
+voice:
+  concise_responses: false
+```
+
+This does not change speech recognition, language hints, editable transcription, TTS, tool use, or conversation history. The setting only removes the API-call-local instruction limiting voice replies to 2–3 sentences without Markdown or code blocks.
+
 ### Silence Detection
 
 Two-stage algorithm detects when you've finished speaking:
@@ -412,6 +423,7 @@ voice:
   record_key: "ctrl+b"            # Key to start/stop recording
   max_recording_seconds: 120       # Maximum recording length
   auto_tts: false                  # Auto-enable TTS when voice mode starts
+  concise_responses: true          # Keep classic-CLI microphone replies concise and conversational
   beep_enabled: true               # Play record start/stop beeps
   silence_threshold: 200           # RMS level (0-32767) below which counts as silence
   silence_duration: 3.0            # Seconds of silence before auto-stop

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/use-voice-mode-with-hermes.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/use-voice-mode-with-hermes.md
@@ -165,6 +165,7 @@ voice:
   submit_mode: "direct"  # TUI：direct | draft
   max_recording_seconds: 120
   auto_tts: false
+  concise_responses: true
   beep_enabled: true
   silence_threshold: 200
   silence_duration: 3.0

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/use-voice-mode-with-hermes.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/use-voice-mode-with-hermes.md
@@ -164,6 +164,7 @@ voice:
   record_key: "ctrl+b"
   max_recording_seconds: 120
   auto_tts: false
+  concise_responses: true
   beep_enabled: true
   silence_threshold: 200
   silence_duration: 3.0

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1369,12 +1369,13 @@ voice:
   record_key: "ctrl+b"         # CLI 内的按键通话键
   max_recording_seconds: 120    # 长录音的硬停止
   auto_tts: false               # /voice on 时自动启用口语回复
+  concise_responses: true       # 为经典 CLI 麦克风输入添加简洁、对话式回复指引
   beep_enabled: true            # 在 CLI 语音模式中播放录音开始/停止提示音
   silence_threshold: 200        # 语音检测的 RMS 阈值
   silence_duration: 3.0         # 自动停止前的静默秒数
 ```
 
-在 CLI 中使用 `/voice on` 启用麦克风模式，使用 `record_key` 开始/停止录音，使用 `/voice tts` 切换口语回复。端到端设置和平台特定行为请参阅[语音模式](/user-guide/features/voice-mode)。
+在 CLI 中使用 `/voice on` 启用麦克风模式，使用 `record_key` 开始/停止录音，使用 `/voice tts` 切换口语回复。将 `concise_responses` 设为 `false` 可让经典 CLI 中的口述请求像键入请求一样处理，不再添加仅适用于语音输入的 2–3 句和格式指引。这不会改变转录语言、TTS、工具或持久会话历史。端到端设置和平台特定行为请参阅[语音模式](/user-guide/features/voice-mode)。
 
 ## 流式传输
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1368,12 +1368,13 @@ voice:
   record_key: "ctrl+b"         # CLI 内的按键通话键
   max_recording_seconds: 120    # 长录音的硬停止
   auto_tts: false               # /voice on 时自动启用口语回复
+  concise_responses: true       # 为经典 CLI 麦克风输入添加简洁、对话式回复指引
   beep_enabled: true            # 在 CLI 语音模式中播放录音开始/停止提示音
   silence_threshold: 200        # 语音检测的 RMS 阈值
   silence_duration: 3.0         # 自动停止前的静默秒数
 ```
 
-在 CLI 中使用 `/voice on` 启用麦克风模式，使用 `record_key` 开始/停止录音，使用 `/voice tts` 切换口语回复。端到端设置和平台特定行为请参阅[语音模式](/user-guide/features/voice-mode)。
+在 CLI 中使用 `/voice on` 启用麦克风模式，使用 `record_key` 开始/停止录音，使用 `/voice tts` 切换口语回复。将 `concise_responses` 设为 `false` 可让经典 CLI 中的口述请求像键入请求一样处理，不再添加仅适用于语音输入的 2–3 句和格式指引。这不会改变转录语言、TTS、工具或持久会话历史。端到端设置和平台特定行为请参阅[语音模式](/user-guide/features/voice-mode)。
 
 ## 流式传输
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/voice-mode.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/voice-mode.md
@@ -146,6 +146,17 @@ hermes                # 启动交互式 CLI
 录音键可通过 `~/.hermes/config.yaml` 中的 `voice.record_key` 配置（默认：`ctrl+b`）。
 :::
 
+### 回复指引
+
+默认情况下，经典 CLI 的麦克风请求会包含简短、对话式的回复指引。要让经典 CLI 中的口述请求像键入请求一样处理，只需禁用这项指引：
+
+```yaml
+voice:
+  concise_responses: false
+```
+
+这不会改变语音识别、语言提示、可编辑的转录文本、TTS、工具使用或会话历史。该设置只会移除 API 调用本地的指令；该指令要求语音回复限制在 2–3 句且不使用 Markdown 或代码块。
+
 ### 静音检测
 
 两阶段算法检测您是否已停止说话：
@@ -389,6 +400,7 @@ voice:
   record_key: "ctrl+b"            # 开始/停止录音的按键
   max_recording_seconds: 120       # 最大录音时长
   auto_tts: false                  # 启用语音模式时自动开启 TTS
+  concise_responses: true          # 让经典 CLI 麦克风请求保持简洁、对话式回复
   beep_enabled: true               # 播放录音开始/结束提示音
   silence_threshold: 200           # 静音判定的 RMS 电平（0-32767）
   silence_duration: 3.0            # 自动停止前的静音秒数


### PR DESCRIPTION
What does this PR do?

Adds a backward-compatible voice.concise_responses boolean for classic CLI microphone input. It defaults to true, preserving the existing request-local instruction that asks for concise conversational replies. Setting it to false removes only that instruction, allowing dictated tasks to reach the agent with the same task semantics as typed input.

This reuses the existing _VoiceInputMessage and chat(..., voice_input=True) path. It does not change STT, TTS, language hints, tools, prompt caching, persisted history, Desktop microphone submission, TUI input, or messaging gateway audio paths.

Related Issue

Related to #74094.

Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

Changes Made

- Add voice.concise_responses: true to hermes_cli/config_defaults.py.
- Gate the existing classic CLI voice-response prefix in cli.py while preserving clean persisted transcription.
- Expose the setting through the generated config schema/API and the curated Desktop Voice settings list.
- Add Desktop English and Simplified Chinese labels scoped explicitly to CLI microphone requests.
- Cover enabled, disabled, quoted-false, absent, malformed-config, typed-input, persistence, API disk-round-trip, and Desktop visibility behavior.
- Document the setting in cli-config.yaml.example and the maintained English and Simplified Chinese voice/configuration pages.

How to Test

1. Run scripts/run_tests.sh tests/tools/test_voice_cli_integration.py tests/cli/test_cli_interrupt_ack_race.py tests/hermes_cli/test_web_server.py tests/tools/test_transcription_tools.py -q.
2. Run npx --yes npm@11.17.0 run test:ui --workspace apps/desktop -- --run src/app/settings/voice-field-visible.test.ts src/i18n/runtime.test.ts, then run the Desktop typecheck, lint, and build scripts.
3. In a temporary HERMES_HOME, run hermes config set voice.concise_responses false and verify both the effective config and physical config.yaml contain false.

Checklist

Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux 44 (kernel 7.1.5-201.fc44.x86_64)

The repository-wide canonical runner is not green on the audited base commit: the current branch and a clean baseline both fail in unrelated optional-dependency, environment, plugin, and timing-sensitive files. All changed and directly related voice/config/Desktop tests pass, including isolated reruns of the fluctuating transcription and TUI/web-handshake files.

Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

CONTRIBUTING.md/AGENTS.md and tool descriptions/schemas are N/A: this adds no architecture, workflow, or model-tool change.

Screenshots / Logs

The Desktop Voice settings surface exposes the new CLI-scoped control and reflects the persisted false value:

<img width="1386" height="775" alt="clip_20260803_000618_2" src="https://github.com/user-attachments/assets/a38eddd1-34b5-481b-a2db-ec852de500ee" />


The screenshot shows Concise CLI Voice Responses disabled after setting voice.concise_responses to false.

Verification completed:

- Targeted Python voice/config/API/transcription tests: 217 passed.
- Desktop Voice/i18n tests: 13 passed; Desktop typecheck, lint, and build passed.
- Docusaurus production build passed.
- Ruff, Python compilation, Windows-footgun scan (911 files), and git diff --check passed.
- hermes config set voice.concise_responses false persisted and reloaded false in a temporary HERMES_HOME.
- The packaged Fedora Desktop application displays the setting and its persisted disabled state.