### PR TITLE
feat(desktop): add 'hermes desktop install' subcommand and auto-shortcut creation

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7216,6 +7216,189 @@ def cmd_gui(args: argparse.Namespace):
     launch_result = subprocess.run(launch_command, cwd=desktop_dir, env=env, check=False)
     sys.exit(launch_result.returncode)
 
+def cmd_gui_install(args: argparse.Namespace):
+    """Create desktop shortcut/menu entry for the Hermes desktop app."""
+    import os
+    import sys
+    from pathlib import Path
+    
+    # First, ensure the desktop app is built
+    desktop_dir = PROJECT_ROOT / "apps" / "desktop"
+    if not (desktop_dir / "package.json").exists():
+        print(f"Desktop GUI source not found at: {desktop_dir}")
+        sys.exit(1)
+    
+    # Check if packaged app exists
+    from hermes_cli.main import _desktop_packaged_executable
+    packaged_executable = _desktop_packaged_executable(desktop_dir)
+    
+    if packaged_executable is None:
+        print("ERROR: No packaged desktop app found. Build it first with: hermes desktop --build-only")
+        sys.exit(1)
+    
+    print(f"Found desktop app at: {packaged_executable}")
+    
+    # Platform-specific shortcut creation
+    if sys.platform == "win32":
+        _create_windows_shortcut(packaged_executable, args.user, args.force)
+    elif sys.platform == "darwin":
+        _create_macos_alias(packaged_executable, args.user, args.force)
+    else:
+        _create_linux_desktop_entry(packaged_executable, args.user, args.force)
+    
+    print("SUCCESS: Desktop shortcut created successfully")
+
+def _create_windows_shortcut(exe_path: Path, user_only: bool, force: bool):
+    """Create Windows Start Menu and Desktop shortcuts."""
+    try:
+        import win32com.client
+    except ImportError:
+        print("ERROR: pywin32 required for Windows shortcut creation. Install with: pip install pywin32")
+        sys.exit(1)
+    
+    shell = win32com.client.Dispatch("WScript.Shell")
+    work_dir = exe_path.parent
+    
+    # Icon location
+    icon_ico = work_dir / "resources" / "icon.ico"
+    if icon_ico.exists():
+        icon_location = f"{icon_ico},0"
+    else:
+        icon_location = f"{exe_path},0"
+    
+    # Determine target directories
+    if user_only:
+        programs_dir = Path(os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming")) / "Microsoft" / "Windows" / "Start Menu" / "Programs"
+        desktop_dir = Path.home() / "Desktop"
+    else:
+        programs_dir = Path(os.environ.get("ALLUSERSPROFILE", r"C:\ProgramData")) / "Microsoft" / "Windows" / "Start Menu" / "Programs"
+        desktop_dir = Path(os.environ.get("PUBLIC", r"C:\Users\Public")) / "Desktop"
+    
+    programs_dir.mkdir(parents=True, exist_ok=True)
+    desktop_dir.mkdir(parents=True, exist_ok=True)
+    
+    shortcuts = [
+        (programs_dir / "Hermes.lnk", "Start Menu"),
+        (desktop_dir / "Hermes.lnk", "Desktop"),
+    ]
+    
+    for shortcut_path, location in shortcuts:
+        if shortcut_path.exists() and not force:
+            print(f"  Skipping {location} shortcut (already exists, use --force to overwrite)")
+            continue
+        try:
+            sc = shell.CreateShortcut(str(shortcut_path))
+            sc.TargetPath = str(exe_path)
+            sc.WorkingDirectory = str(work_dir)
+            sc.IconLocation = icon_location
+            sc.Description = "Hermes Agent"
+            sc.Save()
+            print(f"  Created {location} shortcut: {shortcut_path}")
+        except Exception as e:
+            print(f"  Failed to create {location} shortcut: {e}")
+    
+    # Bust icon cache
+    try:
+        import subprocess
+        subprocess.run(["ie4uinit.exe", "-show"], capture_output=True)
+    except Exception:
+        pass
+
+def _create_macos_alias(exe_path: Path, user_only: bool, force: bool):
+    """Create macOS Application folder alias."""
+    import subprocess
+    
+    if user_only:
+        apps_dir = Path.home() / "Applications"
+    else:
+        apps_dir = Path("/Applications")
+    
+    apps_dir.mkdir(parents=True, exist_ok=True)
+    alias_path = apps_dir / "Hermes.app"
+    
+    if alias_path.exists() and not force:
+        print(f"  Skipping Applications alias (already exists, use --force to overwrite)")
+        return
+    
+    # On macOS, the packaged app is a .app bundle
+    # The exe_path points to the executable inside, we need the .app bundle
+    app_bundle = exe_path
+    while app_bundle.suffix != ".app" and app_bundle != app_bundle.parent:
+        app_bundle = app_bundle.parent
+    
+    if app_bundle.suffix != ".app":
+        print(f"  Could not find .app bundle from {exe_path}")
+        return
+    
+    try:
+        # Create alias using osascript
+        script = 'tell application "Finder"\nmake alias file to POSIX file "' + str(app_bundle) + '" at POSIX file "' + str(apps_dir) + '"\nend tell'
+        subprocess.run(["osascript", "-e", script], check=True, capture_output=True)
+        print(f"  Created Applications alias: {alias_path}")
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.decode() if e.stderr else str(e)
+        print(f"  Failed to create Applications alias: {stderr}")
+
+def _create_linux_desktop_entry(exe_path: Path, user_only: bool, force: bool):
+    """Create Linux .desktop file."""
+    import os
+    import subprocess
+    
+    if user_only:
+        applications_dir = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share")) / "applications"
+    else:
+        applications_dir = Path("/usr/share/applications")
+    
+    applications_dir.mkdir(parents=True, exist_ok=True)
+    desktop_file = applications_dir / "hermes.desktop"
+    
+    if desktop_file.exists() and not force:
+        print(f"  Skipping .desktop entry (already exists, use --force to overwrite)")
+        return
+    
+    # Find icon
+    icon_path = exe_path.parent / "resources" / "icon.png"
+    if not icon_path.exists():
+        icon_path = exe_path.parent / "icon.png"
+    if not icon_path.exists():
+        icon_path = exe_path.parent / "icon.ico"
+    # Check assets/ in source tree (for dev builds)
+    if not icon_path.exists():
+        # PROJECT_ROOT might not be in scope here, so try relative to cwd
+        import os
+        assets_icon = Path(os.getcwd()) / "apps" / "desktop" / "assets" / "icon.png"
+        if assets_icon.exists():
+            icon_path = assets_icon
+    
+    icon_str = str(icon_path) if icon_path.exists() else "hermes"
+    
+    desktop_content = f"""[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Hermes
+GenericName=AI Agent
+Comment=Hermes Agent Desktop App
+Exec={exe_path}
+Icon={icon_str}
+Terminal=false
+Categories=Development;Utility;
+StartupWMClass=Hermes
+"""
+    
+    try:
+        desktop_file.write_text(desktop_content)
+        desktop_file.chmod(0o644)
+        print(f"  Created .desktop entry: {desktop_file}")
+        
+        # Update desktop database
+        try:
+            subprocess.run(["update-desktop-database", str(applications_dir)], capture_output=True)
+        except Exception:
+            pass
+    except Exception as e:
+        print(f"  Failed to create .desktop entry: {e}")
+
+
 
 # Dashboard process-hygiene helpers extracted to hermes_cli/dashboard_procs.py
 # (main.py decomposition, mechanical move). Re-exported so callers and test
@@ -12383,7 +12566,7 @@ def main():
     # =========================================================================
     # gui command  (parser built in hermes_cli/subcommands/gui.py)
     # =========================================================================
-    build_gui_parser(subparsers, cmd_gui=cmd_gui)
+    build_gui_parser(subparsers, cmd_gui=cmd_gui, cmd_gui_install=cmd_gui_install)
 
     # =========================================================================
     # logs command  (parser built in hermes_cli/subcommands/logs.py)

--- a/hermes_cli/subcommands/gui.py
+++ b/hermes_cli/subcommands/gui.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Callable
 
 
-def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
+def build_gui_parser(subparsers, *, cmd_gui: Callable, cmd_gui_install: Callable) -> None:
     """Attach the ``gui`` subcommand to ``subparsers``."""
     # =========================================================================
     gui_parser = subparsers.add_parser(
@@ -22,42 +22,76 @@ def build_gui_parser(subparsers, *, cmd_gui: Callable) -> None:
             "Electron app, then launches that packaged artifact."
         ),
     )
-    gui_parser.add_argument(
+    # Default behavior: launch the desktop app
+    gui_parser.set_defaults(func=cmd_gui)
+    
+    gui_subparsers = gui_parser.add_subparsers(dest="gui_subcommand")
+
+    # Launch subcommand (explicit)
+    launch_parser = gui_subparsers.add_parser(
+        "launch",
+        help="Launch the desktop app (default)",
+        description="Build and launch the Hermes Electron desktop app",
+        add_help=False,
+    )
+    launch_parser.add_argument(
         "--source",
         action="store_true",
         help="Launch via `electron .` against apps/desktop/dist instead of the packaged app",
     )
-    gui_parser.add_argument(
+    launch_parser.add_argument(
         "--build-only",
         action="store_true",
         help="Build the desktop app but do not launch it (used by the installer's --update flow)",
     )
-    gui_parser.add_argument(
+    launch_parser.add_argument(
         "--fake-boot",
         action="store_true",
         help="Enable deterministic desktop boot delays for validating startup UI",
     )
-    gui_parser.add_argument(
+    launch_parser.add_argument(
         "--ignore-existing",
         action="store_true",
         help="Force Desktop to ignore any hermes CLI already on PATH during backend resolution",
     )
-    gui_parser.add_argument(
+    launch_parser.add_argument(
         "--hermes-root",
         help="Override the Hermes source root used by Desktop (sets HERMES_DESKTOP_HERMES_ROOT)",
     )
-    gui_parser.add_argument(
+    launch_parser.add_argument(
         "--cwd",
         help="Initial project directory for Desktop chat sessions (sets HERMES_DESKTOP_CWD)",
     )
-    gui_parser.add_argument(
+    launch_parser.add_argument(
         "--skip-build",
         action="store_true",
         help="Skip npm install/package and launch the existing unpacked app from apps/desktop/release",
     )
-    gui_parser.add_argument(
+    launch_parser.add_argument(
         "--force-build",
         action="store_true",
         help="Force a full rebuild even if the content stamp matches",
     )
-    gui_parser.set_defaults(func=cmd_gui)
+    launch_parser.set_defaults(func=cmd_gui)
+
+    # Install subcommand - creates desktop shortcuts/entries
+    install_parser = gui_subparsers.add_parser(
+        "install",
+        help="Create desktop shortcut/menu entry for the Hermes desktop app",
+        description=(
+            "Create a desktop shortcut (Windows), .desktop file (Linux), or "
+            "Application folder entry (macOS) to launch Hermes Desktop from your "
+            "system's application menu."
+        ),
+    )
+    install_parser.add_argument(
+        "--user",
+        action="store_true",
+        help="Install for current user only (default: system-wide if possible)",
+    )
+    install_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing shortcut/entry",
+    )
+    install_parser.set_defaults(func=cmd_gui_install)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2397,7 +2397,107 @@ install_node_deps() {
     fi
 
     # Keep the checkout clean so `hermes update` doesn't autostash every run.
-    restore_dirty_lockfiles "$INSTALL_DIR"
+    
+# Create desktop shortcuts/launchers for the built app (Linux/macOS)
+# Mirrors the Windows New-DesktopShortcuts function
+create_desktop_shortcuts() {
+    local desktop_exe="$1"
+    local user_only="${2:-true}"
+    
+    if [ "$OS" = "linux" ]; then
+        create_linux_desktop_entry "$desktop_exe" "$user_only"
+    elif [ "$OS" = "macos" ]; then
+        create_macos_alias "$desktop_exe" "$user_only"
+    fi
+}
+
+create_linux_desktop_entry() {
+    local exe_path="$1"
+    local user_only="$2"
+    
+    if [ "$user_only" = "true" ]; then
+        local applications_dir="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+    else
+        local applications_dir="/usr/share/applications"
+    fi
+    
+    mkdir -p "$applications_dir"
+    local desktop_file="$applications_dir/hermes.desktop"
+    
+    # Find icon
+    local icon_path=""
+    if [ -f "$(dirname "$exe_path")/resources/icon.png" ]; then
+        icon_path="$(dirname "$exe_path")/resources/icon.png"
+    elif [ -f "$(dirname "$exe_path")/icon.png" ]; then
+        icon_path="$(dirname "$exe_path")/icon.png"
+    elif [ -f "$INSTALL_DIR/apps/desktop/assets/icon.png" ]; then
+        icon_path="$INSTALL_DIR/apps/desktop/assets/icon.png"
+    fi
+    
+    local icon_str="${icon_path:-hermes}"
+    
+    cat > "$desktop_file" <<EOF
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Hermes
+GenericName=AI Agent
+Comment=Hermes Agent Desktop App
+Exec=$exe_path
+Icon=$icon_str
+Terminal=false
+Categories=Development;Utility;
+StartupWMClass=Hermes
+EOF
+    
+    chmod 644 "$desktop_file"
+    log_success "Created .desktop entry: $desktop_file"
+    
+    # Update desktop database
+    if command -v update-desktop-database >/dev/null 2>&1; then
+        update-desktop-database "$applications_dir" 2>/dev/null || true
+    fi
+}
+
+create_macos_alias() {
+    local exe_path="$1"
+    local user_only="$2"
+    
+    if [ "$user_only" = "true" ]; then
+        local apps_dir="$HOME/Applications"
+    else
+        local apps_dir="/Applications"
+    fi
+    
+    mkdir -p "$apps_dir"
+    
+    # Find the .app bundle from the executable path
+    local app_bundle="$exe_path"
+    while [ "${app_bundle##*.}" != "app" ] && [ "$app_bundle" != "$(dirname "$app_bundle")" ]; do
+        app_bundle="$(dirname "$app_bundle")"
+    done
+    
+    if [ "${app_bundle##*.}" != "app" ]; then
+        log_warn "Could not find .app bundle from $exe_path"
+        return 0
+    fi
+    
+    local alias_path="$apps_dir/Hermes.app"
+    
+    # Create alias using osascript
+    osascript -e "
+        tell application "Finder"
+            make alias file to POSIX file "$app_bundle" at POSIX file "$apps_dir"
+        end tell
+    " 2>/dev/null || {
+        log_warn "Failed to create Applications alias (osascript failed)"
+        return 0
+    }
+    
+    log_success "Created Applications alias: $alias_path"
+}
+
+restore_dirty_lockfiles "$INSTALL_DIR"
 }
 
 run_setup_wizard() {
@@ -3097,6 +3197,9 @@ install_desktop() {
         return 1
     fi
     log_success "Desktop app built: $app"
+
+    # Create desktop shortcuts/launchers
+    create_desktop_shortcuts "$app" "true"
 
     # Linux: Electron's chrome-sandbox helper needs root:root 4755 or the
     # sandboxed renderer will abort on startup.  Check the file is a regular


### PR DESCRIPTION
## Summary
- Adds the new **** CLI subcommand to create desktop shortcuts/menu entries for Hermes Desktop.
- Implements cross-platform shortcut creation for:
  - **Linux**: `.desktop` file in `~/.local/share/applications/` (or `/usr/share/applications/`)
  - **macOS**: Applications alias via `osascript`
  - **Windows**: `.lnk` shortcuts in Start Menu & Desktop via `win32com.client`
- Integrates shortcut creation into `scripts/install.sh` so fresh Linux and macOS installations automatically provision app launchers (matching Windows behavior).

## Related Issues
- Addresses missing standalone desktop launcher setup for Linux/macOS (cf. #42106, #50643).

## Test Plan
- Ran `hermes desktop install --user --force` successfully on Linux, verifying correct generation of `hermes.desktop`.
- Verified script syntax with `bash -n scripts/install.sh` and Python syntax compilation.