### PR TITLE
fix(tools): honor docker cleanup settings in file and execute_code tools

### DIFF
--- a/tests/tools/test_file_tools_container_config.py
+++ b/tests/tools/test_file_tools_container_config.py
@@ -1,6 +1,8 @@
-"""Tests for docker container_config key propagation in file_tools."""
+"""Tests for docker container_config key propagation in file_tools and execute_code."""
 
+import threading
 from unittest.mock import patch, MagicMock
+import tools.code_execution_tool as code_execution_tool
 import tools.file_tools as file_tools
 
 
@@ -54,6 +56,18 @@ class TestFileToolsContainerConfig:
         cc = self._run(_make_env_config(docker_mount_cwd_to_workspace=True), "t1").get("container_config", {})
         assert cc.get("docker_mount_cwd_to_workspace") is True
 
+    def test_docker_cleanup_flags_are_forwarded(self):
+        """docker cleanup flags must reach file-tool environment creation (#75291)."""
+        cc = self._run(
+            _make_env_config(
+                docker_persist_across_processes=False,
+                docker_orphan_reaper=False,
+            ),
+            "t1",
+        ).get("container_config", {})
+        assert cc.get("docker_persist_across_processes") is False
+        assert cc.get("docker_orphan_reaper") is False
+
 
     def test_cwd_only_raw_task_override_reaches_file_environment(self):
         """CWD-only task overrides collapse to default but must keep their cwd."""
@@ -65,3 +79,39 @@ class TestFileToolsContainerConfig:
 
         assert captured["task_id"] == "default"
         assert captured["cwd"] == "/workspace/session"
+
+
+class TestCodeExecutionContainerConfig:
+    def _run(self, env_config, task_id):
+        captured = {}
+        mock_env = MagicMock()
+
+        def fake_create_env(**kwargs):
+            captured.update(kwargs)
+            return mock_env
+
+        with patch("tools.terminal_tool._get_env_config", return_value=env_config), \
+             patch("tools.terminal_tool._task_env_overrides", {}), \
+             patch("tools.terminal_tool._active_environments", {}), \
+             patch("tools.terminal_tool._env_lock", threading.Lock()), \
+             patch("tools.terminal_tool._last_activity", {}), \
+             patch("tools.terminal_tool._creation_locks", {}), \
+             patch("tools.terminal_tool._creation_locks_lock", threading.Lock()), \
+             patch("tools.terminal_tool._resolve_container_task_id", lambda tid: tid), \
+             patch("tools.terminal_tool._create_environment", side_effect=fake_create_env), \
+             patch("tools.terminal_tool._start_cleanup_thread"):
+            code_execution_tool._get_or_create_env(task_id)
+
+        return captured
+
+    def test_docker_cleanup_flags_are_forwarded(self):
+        """execute_code must honor docker cleanup settings on first creation (#75291)."""
+        cc = self._run(
+            _make_env_config(
+                docker_persist_across_processes=False,
+                docker_orphan_reaper=False,
+            ),
+            "exec-t1",
+        ).get("container_config", {})
+        assert cc.get("docker_persist_across_processes") is False
+        assert cc.get("docker_orphan_reaper") is False

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -847,6 +847,8 @@ def _get_or_create_env(task_id: str):
                 "docker_volumes": config.get("docker_volumes", []),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                 "docker_network": config.get("docker_network", True),
+                "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+                "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
             }
 
         ssh_config = None

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1208,6 +1208,8 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "docker_forward_env": config.get("docker_forward_env", []),
                     "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                     "docker_network": config.get("docker_network", True),
+                    "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+                    "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
                 }
 
             ssh_config = None


### PR DESCRIPTION
## Background

Closes #75291.

When Docker environments are first created through the file tools or `execute_code`, those two entry points were not forwarding `terminal.docker_persist_across_processes` or `terminal.docker_orphan_reaper` into `container_config`. That meant `terminal_tool._create_environment()` silently fell back to its default cleanup behavior instead of honoring the configured per-process cleanup settings.

## What changed

- added `docker_persist_across_processes` and `docker_orphan_reaper` to the Docker `container_config` built by [tools/file_tools.py](file:///Users/bytedance/Documents/trae_projects/ai-assistant/hermes-agent/tools/file_tools.py)
- added the same two keys to the Docker `container_config` built by [tools/code_execution_tool.py](file:///Users/bytedance/Documents/trae_projects/ai-assistant/hermes-agent/tools/code_execution_tool.py)
- extended [tests/tools/test_file_tools_container_config.py](file:///Users/bytedance/Documents/trae_projects/ai-assistant/hermes-agent/tests/tools/test_file_tools_container_config.py) with focused regressions that assert both public entry points forward both flags when disabled

## Why this approach

- keeps the fix minimal and localized to the two creation paths called out in the issue
- validates the actual `_create_environment(..., container_config=...)` kwargs instead of relying on indirect behavior

## Out of scope

- no changes to terminal config env bridging
- no changes to the cleanup semantics inside [tools/terminal_tool.py](file:///Users/bytedance/Documents/trae_projects/ai-assistant/hermes-agent/tools/terminal_tool.py)

## Verification

- `~/.pyenv/versions/3.12.12/bin/python -m pytest tests/tools/test_file_tools_container_config.py -q`
