### PR TITLE
feat(agent): skill learning loop — lessons overlay, skill_view inject, review fact_store

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -120,6 +120,192 @@ def _msg_text(m: Dict) -> str:
     return ""
 
 
+_CORRECTION_HINTS = (
+    "stop doing",
+    "don't do",
+    "do not",
+    "don't format",
+    "too verbose",
+    "remember this",
+    "always do",
+    "never do",
+    "i hate when",
+    "why are you",
+    "that's not what",
+    "that is not what",
+    "i told you",
+    "i asked you",
+)
+
+
+def _tool_result_has_error(content: Any) -> tuple[bool, str]:
+    """Return whether a tool-result payload represents an error."""
+    if not isinstance(content, str) or not content.strip():
+        return False, ""
+    try:
+        data = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        lower = content.lower()
+        if "error" in lower[:200] and ("traceback" in lower or "failed" in lower):
+            return True, content[:160].replace("\n", " ")
+        return False, ""
+    if not isinstance(data, dict):
+        return False, ""
+    if data.get("error"):
+        return True, str(data["error"])[:160].replace("\n", " ")
+    if data.get("success") is False:
+        return True, str(data.get("message") or "success=false")[:160].replace("\n", " ")
+    return False, ""
+
+
+def build_review_evidence_digest(
+    messages: List[Dict],
+    *,
+    max_skills: int = 12,
+    max_failures: int = 10,
+    max_corrections: int = 6,
+) -> str:
+    """Extract high-signal skill, failure, and correction evidence."""
+    skills: list[str] = []
+    seen_skills: set[str] = set()
+    failures: list[str] = []
+    corrections: list[str] = []
+    successes_after: list[str] = []
+    pending_names: dict[str, str] = {}
+    failed_tools: set[str] = set()
+
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                if not isinstance(tc, dict):
+                    continue
+                fn = tc.get("function") or {}
+                name = fn.get("name") or "?"
+                tcid = tc.get("id") or ""
+                if tcid:
+                    pending_names[tcid] = name
+                args_raw = fn.get("arguments") or "{}"
+                try:
+                    args = json.loads(args_raw) if isinstance(args_raw, str) else (args_raw or {})
+                except (json.JSONDecodeError, TypeError):
+                    args = {}
+                if name == "skill_view":
+                    skill_name = str(args.get("name") or "").strip()
+                    if skill_name and skill_name not in seen_skills:
+                        seen_skills.add(skill_name)
+                        skills.append(skill_name)
+                elif name == "skill_manage":
+                    skill_name = str(args.get("name") or "").strip()
+                    if skill_name and skill_name not in seen_skills:
+                        seen_skills.add(skill_name)
+                        skills.append(f"{skill_name} (managed)")
+        elif role == "tool":
+            tool_name = pending_names.get(msg.get("tool_call_id") or "", msg.get("name") or "tool")
+            is_error, error_message = _tool_result_has_error(msg.get("content"))
+            if is_error:
+                failed_tools.add(tool_name)
+                if len(failures) < max_failures:
+                    failures.append(f"{tool_name}: {error_message or 'error'}")
+            elif tool_name in failed_tools and len(successes_after) < max_failures:
+                successes_after.append(f"{tool_name}: later call succeeded")
+        elif role == "user":
+            text = _msg_text(msg)
+            if not text:
+                continue
+            stripped = text.lstrip()
+            if stripped.startswith("/") and not stripped.startswith("//"):
+                token = stripped[1:].split()[0].split("@")[0].strip()
+                if token and token not in {"new", "stop", "help", "reset", "model", "tools"}:
+                    if token not in seen_skills and len(skills) < max_skills:
+                        seen_skills.add(token)
+                        skills.append(f"{token} (slash)")
+            if any(hint in text.lower() for hint in _CORRECTION_HINTS):
+                if len(corrections) < max_corrections:
+                    corrections.append(text[:200].replace("\n", " "))
+
+    if not (skills or failures or corrections or successes_after):
+        return (
+            "## Evidence (machine-extracted)\n"
+            "No skill loads, tool failures, or explicit user corrections detected "
+            "in this transcript. Still review for durable preferences/techniques; "
+            "if nothing stands out, say 'Nothing to save.'"
+        )
+
+    lines = ["## Evidence (machine-extracted)"]
+    if skills:
+        lines.append("Skills loaded/consulted: " + ", ".join(skills[:max_skills]))
+    if failures:
+        lines.append("Tool failures:")
+        lines.extend(f"  - {failure}" for failure in failures)
+    if successes_after:
+        lines.append("Successful retries after failure:")
+        lines.extend(f"  - {success}" for success in successes_after)
+    if corrections:
+        lines.append("User correction signals:")
+        lines.extend(f"  - {correction}" for correction in corrections)
+    lines.append(
+        "When evidence shows a failure + fix (or an explicit correction), you MUST "
+        "persist the lesson via the decision ladder — do not no-op."
+    )
+    return "\n".join(lines)
+
+
+class _ReviewMemoryToolsProxy:
+    """Expose parent memory-provider tools without review lifecycle ingestion."""
+
+    def __init__(self, parent_mm: Any):
+        self._parent = parent_mm
+
+    @property
+    def providers(self) -> Any:
+        return getattr(self._parent, "providers", [])
+
+    def has_tool(self, tool_name: str) -> bool:
+        return bool(self._parent.has_tool(tool_name))
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs: Any) -> str:
+        return self._parent.handle_tool_call(tool_name, args, **kwargs)
+
+    def get_all_tool_names(self) -> set:
+        return set(self._parent.get_all_tool_names())
+
+    def get_all_tool_schemas(self) -> List[Dict[str, Any]]:
+        getter = getattr(self._parent, "get_all_tool_schemas", None)
+        return list(getter() or []) if callable(getter) else []
+
+    def build_system_prompt(self) -> str:
+        return ""
+
+    def prefetch_all(self, *args: Any, **kwargs: Any) -> str:
+        return ""
+
+    def queue_prefetch_all(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def sync_all(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def on_turn_start(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def on_session_end(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def notify_memory_tool_write(self, *args: Any, **kwargs: Any) -> None:
+        notify = getattr(self._parent, "notify_memory_tool_write", None)
+        if callable(notify):
+            notify(*args, **kwargs)
+
+    def shutdown_all(self) -> None:
+        return None
+
+    def shutdown_drain_state(self) -> Dict[str, Any]:
+        return {}
+
+
 def _digest_history(messages_snapshot: List[Dict], tail: int = 24) -> List[Dict]:
     """Compact replay for the routed (different-model) path only.
 
@@ -243,6 +429,23 @@ _SKILL_REVIEW_PROMPT = (
     "codename, library-alone name, or 'fix-X / debug-Y / audit-Z-today' "
     "session artifact. If the proposed name only makes sense for "
     "today's task, it's wrong — fall back to (1), (2), or (3).\n\n"
+    "Learning-loop decision ladder — use this order when a signal fired:\n"
+    "  1. UPDATE A CURRENTLY-LOADED AGENT-CREATED SKILL. If an "
+    "agent-created skill covers the lesson, patch its SKILL.md first.\n"
+    "  2. LESSONS OVERLAY for manual, hub, bundled, or pinned local "
+    "skills. Write the durable correction to `references/lessons.md` "
+    "via skill_manage(action='write_file', "
+    "file_path='references/lessons.md'). skill_view auto-loads this "
+    "file next session; this is the correct escape hatch, not "
+    "'Nothing to save.'\n"
+    "  3. UPDATE AN EXISTING UMBRELLA or add a support file under it.\n"
+    "  4. fact_store lesson (when available): for cross-cutting tool "
+    "quirks or when no skill applies, use "
+    "fact_store(action='add', category='tool', "
+    "tags='lesson,skill:<name>,validated', content=...). Do not store "
+    "message IDs, one-offs, or negative claims that a tool is broken.\n"
+    "  5. CREATE A NEW CLASS-LEVEL UMBRELLA only when no existing "
+    "skill covers the class.\n\n"
     "User-preference embedding (important): when the user expressed a "
     "style/format/workflow preference, the update belongs in the "
     "SKILL.md body, not just in memory. Memory captures 'who the user "
@@ -252,23 +455,20 @@ _SKILL_REVIEW_PROMPT = (
     "skill that governs that task needs to carry the lesson.\n\n"
     "If you notice two existing skills that overlap, note it in your "
     "reply — the background curator handles consolidation at scale.\n\n"
-    "Protected skills (DO NOT edit these):\n"
+    "Protected skills — do NOT edit SKILL.md body for:\n"
     "  • Bundled skills (shipped with Hermes, e.g. 'hermes-agent').\n"
     "  • Hub-installed skills (installed via 'hermes skills install').\n"
     "  • Skills in skills.external_dirs (externally owned).\n"
-    "  • PINNED skills (marked via 'hermes curator pin'). You are an "
-    "autonomous no-user-present actor, so pin blocks your writes too — "
-    "content updates included. Only the user, in a foreground session, "
-    "can change a pinned skill.\n"
+    "  • PINNED skills (marked via 'hermes curator pin').\n"
     "  • USER-OWNED skills — anything not curator-managed. A skill the "
     "user hand-wrote, installed by URL, or asked a foreground agent to "
     "create is theirs, not yours; your writes to it WILL be refused. "
     "This includes skills that were loaded or consulted this session: "
     "being in play does not make one yours to edit. If such a skill is "
-    "wrong or outdated, say so in your reply and recommend "
-    "'hermes curator adopt <name>' — do not try to patch it.\n"
-    "If the only skills that need updating are protected, say\n"
-    "'Nothing to save.' and stop.\n\n"
+    "wrong or outdated, write `references/lessons.md` instead.\n"
+    "For any protected local skill, the lessons overlay is allowed; "
+    "SKILL.md body edits remain restricted by ownership. Only say "
+    "'Nothing to save.' when there is truly no durable lesson.\n\n"
     "Do NOT capture (these become persistent self-imposed constraints "
     "that bite you later when the environment changes):\n"
     "  • Environment-dependent failures: missing binaries, fresh-install "
@@ -349,6 +549,18 @@ _COMBINED_REVIEW_PROMPT = (
     "codename, library-alone name, or 'fix-X / debug-Y' session "
     "artifact. If the name only fits today's task, fall back to (1), "
     "(2), or (3).\n\n"
+    "Learning-loop decision ladder — use this order when a signal fired:\n"
+    "  1. UPDATE A CURRENTLY-LOADED AGENT-CREATED SKILL.\n"
+    "  2. LESSONS OVERLAY: for manual, hub, bundled, or pinned local "
+    "skills, use skill_manage(action='write_file', "
+    "file_path='references/lessons.md') with the durable correction. "
+    "Do not say 'Nothing to save.' just because SKILL.md is protected.\n"
+    "  3. UPDATE AN EXISTING UMBRELLA or add a support file.\n"
+    "  4. fact_store lesson (when available): use "
+    "fact_store(action='add', category='tool', "
+    "tags='lesson,skill:<name>,validated', content=...) for "
+    "cross-cutting quirks or when no skill applies.\n"
+    "  5. CREATE A NEW CLASS-LEVEL UMBRELLA only when nothing exists.\n\n"
     "User-preference embedding: when the user complains about how "
     "you handled a task, update the skill that governs that task — "
     "memory alone isn't enough. Memory says 'who the user is and "
@@ -357,20 +569,19 @@ _COMBINED_REVIEW_PROMPT = (
     "should carry user-preference lessons when relevant.\n\n"
     "If you notice overlapping existing skills, mention it — the "
     "background curator handles consolidation.\n\n"
-    "Protected skills (DO NOT edit these):\n"
+    "Protected skills — do NOT edit SKILL.md body for:\n"
     "  • Bundled skills (shipped with Hermes, e.g. 'hermes-agent').\n"
     "  • Hub-installed skills (installed via 'hermes skills install').\n"
     "  • Skills in skills.external_dirs (externally owned).\n"
-    "  • PINNED skills (marked via 'hermes curator pin'). Pin blocks "
-    "autonomous writes entirely — content updates included — because no "
-    "user is present to consent. Only a foreground session can change one.\n"
+    "  • PINNED skills (marked via 'hermes curator pin').\n"
     "  • USER-OWNED skills — anything not curator-managed (hand-written, "
     "URL-installed, or created by a foreground agent at the user's "
-    "request). Your writes to these WILL be refused, including to skills "
-    "loaded or consulted this session. If one is wrong, say so in your "
-    "reply and recommend 'hermes curator adopt <name>' instead.\n"
-    "If the only skills that need updating are protected, say\n"
-    "'Nothing to save.' and stop.\n\n"
+    "request). SKILL.md body writes to these will be refused, including "
+    "to skills loaded or consulted this session. Write "
+    "`references/lessons.md` instead.\n"
+    "For any protected local skill, the lessons overlay is allowed; "
+    "SKILL.md body edits remain restricted by ownership. Only say "
+    "'Nothing to save.' when there is truly no durable lesson.\n\n"
     "Do NOT capture as skills (these become persistent self-imposed "
     "constraints that bite you later when the environment changes):\n"
     "  • Environment-dependent failures: missing binaries, fresh-install "
@@ -446,7 +657,7 @@ def summarize_background_review_actions(
     # result JSON only says "Entry added"; the call arguments contain action,
     # target, and content previews.  Restricting to notify_tools also prevents
     # helper tools from surfacing as memory work just because they succeeded.
-    notify_tools = {"memory", "skill_manage"}
+    notify_tools = {"memory", "skill_manage", "fact_store"}
     all_tool_call_ids: set = set()
     call_details: dict = {}
     for msg in review_messages or []:
@@ -505,12 +716,27 @@ def summarize_background_review_actions(
         # Defensively normalize everything through a dict-typed alias so
         # the rest of the function can stay terse without per-call
         # ``isinstance`` guards (#59437).
-        if not isinstance(data, dict) or not data.get("success"):
+        if not isinstance(data, dict):
             continue
         message = data.get("message", "")
         detail = call_details.get(tcid) or {}
         if not isinstance(detail, dict):
             detail = {}
+        is_fact = detail.get("tool") == "fact_store"
+        if is_fact:
+            status = str(data.get("status") or "").lower()
+            if status not in {"added", "updated", "ok", "success"} and "fact_id" not in data:
+                continue
+            action = detail.get("action", "add")
+            content = detail.get("content", "") or data.get("content", "")
+            preview = str(content)[:100].replace("\n", " ")
+            if verbose and preview:
+                actions.append(f"🧠 Fact store {action}: {preview}{'…' if len(str(content)) > 100 else ''}")
+            else:
+                actions.append(f"🧠 Fact store {action}")
+            continue
+        if not data.get("success"):
+            continue
         target = data.get("target", "") or detail.get("target", "")
         is_skill = detail.get("tool") == "skill_manage"
 
@@ -812,6 +1038,11 @@ def _run_review_in_thread(
             review_agent._memory_store = agent._memory_store
             review_agent._memory_enabled = agent._memory_enabled
             review_agent._user_profile_enabled = agent._user_profile_enabled
+            # Share provider tool dispatch only: fact_store writes must use the
+            # parent provider, while the review harness must not ingest itself.
+            parent_mm = getattr(agent, "_memory_manager", None)
+            if parent_mm is not None:
+                review_agent._memory_manager = _ReviewMemoryToolsProxy(parent_mm)
             review_agent._memory_nudge_interval = 0
             review_agent._skill_nudge_interval = 0
             # PERSISTENCE ISOLATION (the curator-takeover root cause): the fork
@@ -900,11 +1131,21 @@ def _run_review_in_thread(
                     quiet_mode=True,
                 )
             }
+            if parent_mm is not None:
+                for tool_name in ("fact_store", "fact_feedback"):
+                    try:
+                        if parent_mm.has_tool(tool_name):
+                            review_whitelist.add(tool_name)
+                    except Exception:
+                        pass
+            allowed_kinds = "memory/skill"
+            if "fact_store" in review_whitelist:
+                allowed_kinds = "memory/skill/fact_store"
             set_thread_tool_whitelist(
                 review_whitelist,
                 deny_msg_fmt=(
                     "Background review denied non-whitelisted tool: "
-                    "{tool_name}. Only memory/skill tools are allowed."
+                    f"{{tool_name}}. Only {allowed_kinds} tools are allowed."
                 ),
             )
             try:
@@ -922,12 +1163,19 @@ def _run_review_in_thread(
                     _digest_history(messages_snapshot) if _routed
                     else messages_snapshot
                 )
+                evidence = build_review_evidence_digest(messages_snapshot)
+                tool_hint = (
+                    "memory and skill management tools"
+                    if "fact_store" not in review_whitelist
+                    else "memory, skill management, and fact_store tools"
+                )
                 review_agent.run_conversation(
                     user_message=(
                         prompt
-                        + "\n\nYou can only call memory and skill "
-                        "management tools. Other tools will be denied "
-                        "at runtime — do not attempt them."
+                        + "\n\n"
+                        + evidence
+                        + f"\n\nYou can only call {tool_hint}. "
+                        "Other tools will be denied at runtime — do not attempt them."
                     ),
                     conversation_history=_review_history,
                 )
@@ -1059,6 +1307,7 @@ __all__ = [
     "_MEMORY_REVIEW_PROMPT",
     "_SKILL_REVIEW_PROMPT",
     "_COMBINED_REVIEW_PROMPT",
+    "build_review_evidence_digest",
     "spawn_background_review_thread",
     "summarize_background_review_actions",
     "build_memory_write_metadata",

--- a/tests/agent/test_learning_loop.py
+++ b/tests/agent/test_learning_loop.py
@@ -1,0 +1,376 @@
+"""Tests for the skill/memory learning-loop pieces.
+
+Covers:
+- machine-extracted evidence digest for background review
+- references/lessons.md overlay guard for non-agent skills
+- skill_view auto-injection of lessons.md
+- fact_store notification summarization
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from agent.background_review import (
+    build_review_evidence_digest,
+    summarize_background_review_actions,
+)
+
+
+# ---------------------------------------------------------------------------
+# Evidence digest
+# ---------------------------------------------------------------------------
+
+
+def test_evidence_digest_extracts_skill_view_failures_and_corrections():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "function": {
+                        "name": "skill_view",
+                        "arguments": json.dumps({"name": "amazon-shopping"}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "c1",
+            "content": json.dumps({"success": True, "name": "amazon-shopping"}),
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "c2",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": json.dumps({"command": "curl ..."}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "c2",
+            "content": json.dumps({"error": "401 Unauthorized"}),
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "c3",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": json.dumps({"command": "curl -H Bearer ..."}),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "c3",
+            "content": json.dumps({"success": True, "output": "ok"}),
+        },
+        {
+            "role": "user",
+            "content": "Stop doing that — remember this: always send the API token.",
+        },
+    ]
+    digest = build_review_evidence_digest(messages)
+    assert "amazon-shopping" in digest
+    assert "401" in digest or "Unauthorized" in digest
+    assert "succeeded" in digest.lower()
+    assert "remember this" in digest.lower() or "Stop doing" in digest
+    assert "MUST persist" in digest or "decision ladder" in digest
+
+
+def test_evidence_digest_empty_transcript_has_noop_guidance():
+    digest = build_review_evidence_digest([{"role": "user", "content": "hi"}])
+    assert "Nothing to save" in digest
+    assert "No skill loads" in digest or "no skill" in digest.lower()
+
+
+# ---------------------------------------------------------------------------
+# Lessons overlay guard
+# ---------------------------------------------------------------------------
+
+
+def test_background_review_allows_lessons_overlay_for_manual_skill(tmp_path, monkeypatch):
+    from tools.skill_manager_tool import (
+        _background_review_write_guard,
+        skill_manage,
+    )
+    from tools.skill_provenance import (
+        BACKGROUND_REVIEW,
+        reset_current_write_origin,
+        set_current_write_origin,
+    )
+
+    hermes_home = tmp_path / ".hermes"
+    skills_root = hermes_home / "skills"
+    skill_dir = skills_root / "manual-skill"
+    skill_dir.mkdir(parents=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: manual-skill\ndescription: Manual test skill.\n---\n\n# Manual\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with patch("tools.skill_manager_tool.SKILLS_DIR", skills_root), patch(
+        "tools.skills_tool.SKILLS_DIR", skills_root
+    ), patch(
+        "agent.skill_utils.get_all_skills_dirs", return_value=[skills_root]
+    ), patch(
+        "tools.skill_usage.load_usage",
+        return_value={"manual-skill": {"created_by": None, "use_count": 10}},
+    ), patch(
+        "tools.skill_usage.get_record",
+        side_effect=lambda n: (
+            {"created_by": None, "use_count": 10, "pinned": False}
+            if n == "manual-skill"
+            else {}
+        ),
+    ), patch(
+        "tools.skill_provenance.is_background_review", return_value=True
+    ):
+        # Body patch still refused
+        body_guard = _background_review_write_guard(
+            "manual-skill", skill_dir, "patch", file_path=None
+        )
+        assert body_guard is not None
+        assert "manually authored" in body_guard["error"].lower()
+
+        # Lessons overlay allowed at guard level
+        overlay_guard = _background_review_write_guard(
+            "manual-skill",
+            skill_dir,
+            "write_file",
+            file_path="references/lessons.md",
+        )
+        assert overlay_guard is None
+
+        token = set_current_write_origin(BACKGROUND_REVIEW)
+        try:
+            # New file: no prior read required
+            raw = skill_manage(
+                action="write_file",
+                name="manual-skill",
+                file_path="references/lessons.md",
+                file_content="- Always pass CRAWL4AI_API_TOKEN (401 without it).\n",
+            )
+        finally:
+            reset_current_write_origin(token)
+
+    result = json.loads(raw)
+    assert result["success"] is True, result
+    lessons = skill_dir / "references" / "lessons.md"
+    assert lessons.exists()
+    assert "CRAWL4AI_API_TOKEN" in lessons.read_text(encoding="utf-8")
+
+
+def test_background_review_still_blocks_manual_skill_body_edit(tmp_path, monkeypatch):
+    from tools.skill_manager_tool import skill_manage, mark_background_review_skill_read
+    from tools.skill_provenance import (
+        BACKGROUND_REVIEW,
+        reset_current_write_origin,
+        set_current_write_origin,
+    )
+
+    hermes_home = tmp_path / ".hermes"
+    skills_root = hermes_home / "skills"
+    skill_dir = skills_root / "manual-skill"
+    skill_dir.mkdir(parents=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: manual-skill\ndescription: Manual test skill.\n---\n\n# Manual\nStep 1.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with patch("tools.skill_manager_tool.SKILLS_DIR", skills_root), patch(
+        "tools.skills_tool.SKILLS_DIR", skills_root
+    ), patch(
+        "agent.skill_utils.get_all_skills_dirs", return_value=[skills_root]
+    ), patch(
+        "tools.skill_usage.load_usage",
+        return_value={"manual-skill": {"created_by": None}},
+    ), patch(
+        "tools.skill_usage.get_record",
+        return_value={"created_by": None, "pinned": False},
+    ):
+        token = set_current_write_origin(BACKGROUND_REVIEW)
+        try:
+            mark_background_review_skill_read(skill_md)
+            raw = skill_manage(
+                action="patch",
+                name="manual-skill",
+                old_string="Step 1.",
+                new_string="Step 1 (fixed).",
+            )
+        finally:
+            reset_current_write_origin(token)
+
+    result = json.loads(raw)
+    assert result["success"] is False
+    assert "manually authored" in result["error"].lower()
+    assert "lessons.md" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# skill_view injection
+# ---------------------------------------------------------------------------
+
+
+def test_skill_view_injects_lessons_overlay(tmp_path, monkeypatch):
+    from tools.skills_tool import skill_view, _append_lessons_overlay
+
+    hermes_home = tmp_path / ".hermes"
+    skills_root = hermes_home / "skills"
+    skill_dir = skills_root / "demo-skill"
+    (skill_dir / "references").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo-skill\ndescription: Demo.\n---\n\n# Demo\nDo the thing.\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "references" / "lessons.md").write_text(
+        "- Prefer brightness_pct over raw brightness.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # Unit the helper directly
+    out = _append_lessons_overlay("# Demo\n", skill_dir)
+    assert "Learned corrections (auto-loaded)" in out
+    assert "brightness_pct" in out
+
+    with patch("tools.skills_tool.SKILLS_DIR", skills_root), patch(
+        "tools.skills_tool._skills_dir", return_value=skills_root
+    ), patch(
+        "agent.skill_utils.get_external_skills_dirs", return_value=[]
+    ), patch(
+        "agent.skill_utils.get_all_skills_dirs", return_value=[skills_root]
+    ):
+        raw = skill_view("demo-skill", preprocess=False)
+    data = json.loads(raw)
+    assert data["success"] is True, data
+    assert "Learned corrections (auto-loaded)" in data["content"]
+    assert "brightness_pct" in data["content"]
+
+
+def test_append_lessons_overlay_truncates_long_file(tmp_path):
+    from tools.skills_tool import _append_lessons_overlay, _LESSONS_OVERLAY_MAX_CHARS
+
+    skill_dir = tmp_path / "s"
+    (skill_dir / "references").mkdir(parents=True)
+    big = "A" * (_LESSONS_OVERLAY_MAX_CHARS + 500)
+    (skill_dir / "references" / "lessons.md").write_text(big, encoding="utf-8")
+    out = _append_lessons_overlay("# Title\n", skill_dir)
+    assert "truncated" in out
+    assert len(out) < len(big) + 200
+
+
+# ---------------------------------------------------------------------------
+# fact_store review notifications
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_includes_fact_store_adds():
+    review_messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "f1",
+                    "function": {
+                        "name": "fact_store",
+                        "arguments": json.dumps(
+                            {
+                                "action": "add",
+                                "content": "HA brightness_pct tip",
+                                "category": "tool",
+                                "tags": "lesson,skill:home-assistant,validated",
+                            }
+                        ),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "f1",
+            "content": json.dumps({"fact_id": 51, "status": "added"}),
+        },
+    ]
+    actions = summarize_background_review_actions(review_messages, prior_snapshot=[])
+    assert any("Fact store" in a for a in actions)
+
+
+def test_background_review_whitelist_includes_fact_store_when_parent_has_it():
+    """Review whitelist must allow fact_store when the parent memory manager has it."""
+    import run_agent
+    from hermes_cli import plugins as _plugins
+
+    class _MM:
+        def has_tool(self, name):
+            return name in {"fact_store", "fact_feedback"}
+
+    captured = {}
+
+    def _capture_whitelist(whitelist, deny_msg_fmt=None):
+        captured["whitelist"] = set(whitelist)
+        raise RuntimeError("stop after capturing whitelist")
+
+    agent = object.__new__(run_agent.AIAgent)
+    agent.model = "test-model"
+    agent.platform = "test"
+    agent.provider = "openai"
+    agent.session_id = "sess-123"
+    agent.quiet_mode = True
+    agent._memory_store = None
+    agent._memory_enabled = True
+    agent._user_profile_enabled = False
+    agent._memory_manager = _MM()
+    agent._memory_nudge_interval = 5
+    agent._skill_nudge_interval = 5
+    agent.background_review_callback = None
+    agent.status_callback = None
+    agent._cached_system_prompt = None
+    import datetime as _dt
+    agent.session_start = _dt.datetime(2026, 1, 1, 12, 0, 0)
+    agent._MEMORY_REVIEW_PROMPT = "review memory"
+    agent._SKILL_REVIEW_PROMPT = "review skills"
+    agent._COMBINED_REVIEW_PROMPT = "review both"
+    agent.enabled_toolsets = ["memory", "skills"]
+    agent.disabled_toolsets = None
+
+    class _SyncThread:
+        def __init__(self, *, target=None, daemon=None, name=None):
+            self._target = target
+
+        def start(self):
+            if self._target:
+                self._target()
+
+    def _no_init(self, *args, **kwargs):
+        return None
+
+    with patch.object(run_agent.AIAgent, "__init__", _no_init), patch.object(
+        _plugins, "set_thread_tool_whitelist", _capture_whitelist
+    ), patch("threading.Thread", _SyncThread):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=True,
+        )
+
+    assert "fact_store" in captured["whitelist"]
+    assert "fact_feedback" in captured["whitelist"]

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -298,10 +298,24 @@ def _pinned_guard(name: str) -> Optional[str]:
     return None
 
 
+LESSONS_OVERLAY_RELPATH = "references/lessons.md"
+
+
+def _normalize_skill_relpath(file_path: str | None) -> str:
+    return str(file_path or "").replace("\\", "/").lstrip("./")
+
+
+def _is_lessons_overlay_path(file_path: str | None) -> bool:
+    """Return whether a path targets the learning-loop lessons overlay."""
+    return _normalize_skill_relpath(file_path) == LESSONS_OVERLAY_RELPATH
+
+
 def _background_review_write_guard(
     name: str,
     skill_dir: Path,
     action: str,
+    *,
+    file_path: str | None = None,
 ) -> Optional[Dict[str, Any]]:
     """Refuse autonomous curator writes to externally owned skills.
 
@@ -317,26 +331,32 @@ def _background_review_write_guard(
     except Exception:
         return None
 
+    lessons_overlay = (
+        action in {"write_file", "patch"}
+        and _is_lessons_overlay_path(file_path)
+    )
+
     # Pin must be respected by autonomous maintenance. The curator already
     # skips pinned skills from every auto-transition; the background review
     # fork is the same kind of autonomous, no-user-present actor, so it must
     # not write to a pinned skill either (issue #25839). This is stricter than
     # the foreground ``_pinned_guard`` (which only blocks deletion) precisely
     # because there is no user in the loop to consent to an edit here.
-    try:
-        from tools import skill_usage
-        if skill_usage.get_record(name).get("pinned"):
-            return {
-                "success": False,
-                "error": (
-                    f"Refusing background curator {action} for pinned skill "
-                    f"'{name}': pinned skills are off-limits to autonomous "
-                    "maintenance. Ask the user to run "
-                    f"`hermes curator unpin {name}` if they want it changed."
-                ),
-            }
-    except Exception:
-        logger.debug("pinned skill guard lookup failed for %s", name, exc_info=True)
+    if not lessons_overlay:
+        try:
+            from tools import skill_usage
+            if skill_usage.get_record(name).get("pinned"):
+                return {
+                    "success": False,
+                    "error": (
+                        f"Refusing background curator {action} for pinned skill "
+                        f"'{name}': pinned skills are off-limits to autonomous "
+                        "maintenance. Ask the user to run "
+                        f"`hermes curator unpin {name}` if they want it changed."
+                    ),
+                }
+        except Exception:
+            logger.debug("pinned skill guard lookup failed for %s", name, exc_info=True)
 
     try:
         from agent.skill_utils import is_external_skill_path
@@ -351,6 +371,11 @@ def _background_review_write_guard(
             }
     except Exception:
         logger.debug("external skill guard lookup failed for %s", name, exc_info=True)
+
+    # A local lessons overlay is additive learning that is safe on protected
+    # skills. External directories remain blocked above.
+    if lessons_overlay:
+        return None
 
     try:
         from tools import skill_usage
@@ -403,9 +428,11 @@ def _background_review_write_guard(
                 "success": False,
                 "error": (
                     f"Refusing background curator {action} for skill "
-                    f"'{name}': the skill is not curator-managed ({_detail}). "
-                    "User-owned skills are off-limits to autonomous curation. "
-                    f"Run `hermes curator adopt {name}` to opt it in."
+                    f"'{name}': the skill is manually authored or not "
+                    f"curator-managed ({_detail}). Manually authored skills "
+                    "are off-limits to autonomous curation. "
+                    f"Write durable corrections to '{LESSONS_OVERLAY_RELPATH}' "
+                    f"instead, or run `hermes curator adopt {name}` to opt it in."
                 ),
             }
     except Exception:
@@ -451,13 +478,20 @@ def _background_review_read_before_write_guard(
     }
 
 
-def _background_review_preflight(action: str, name: str) -> Optional[Dict[str, Any]]:
+def _background_review_preflight(
+    action: str,
+    name: str,
+    *,
+    file_path: str | None = None,
+) -> Optional[Dict[str, Any]]:
     if action not in {"edit", "patch", "delete", "write_file", "remove_file"}:
         return None
     existing = _find_skill(name)
     if not existing:
         return None
-    return _background_review_write_guard(name, existing["path"], action)
+    return _background_review_write_guard(
+        name, existing["path"], action, file_path=file_path
+    )
 
 
 def _curator_consolidation_delete_guard(
@@ -1061,7 +1095,9 @@ def _patch_skill(
     org_guard = _org_mirror_write_guard(name, skill_dir, "patch")
     if org_guard:
         return org_guard
-    guard = _background_review_write_guard(name, skill_dir, "patch")
+    guard = _background_review_write_guard(
+        name, skill_dir, "patch", file_path=file_path
+    )
     if guard:
         return guard
 
@@ -1294,7 +1330,9 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     org_guard = _org_mirror_write_guard(name, existing["path"], "write_file")
     if org_guard:
         return org_guard
-    guard = _background_review_write_guard(name, existing["path"], "write_file")
+    guard = _background_review_write_guard(
+        name, existing["path"], "write_file", file_path=file_path
+    )
     if guard:
         return guard
 
@@ -1527,7 +1565,9 @@ def skill_manage(
 
     Returns JSON string with results.
     """
-    preflight = _background_review_preflight(action, name)
+    preflight = _background_review_preflight(
+        action, name, file_path=file_path
+    )
     if preflight is not None:
         return json.dumps(preflight, ensure_ascii=False)
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -88,6 +88,41 @@ from agent.skill_utils import (
 
 logger = logging.getLogger(__name__)
 
+_LESSONS_OVERLAY_MAX_CHARS = 4000
+_LESSONS_OVERLAY_RELPATH = "references/lessons.md"
+
+
+def _append_lessons_overlay(content: str, skill_dir: Path) -> str:
+    """Append bounded learning-loop corrections to a main skill view."""
+    lessons_path = skill_dir / _LESSONS_OVERLAY_RELPATH
+    if not lessons_path.is_file():
+        return content
+    try:
+        lessons = lessons_path.read_text(encoding="utf-8").strip()
+    except Exception:
+        logger.debug("Could not read lessons overlay at %s", lessons_path, exc_info=True)
+        return content
+    if not lessons:
+        return content
+    if len(lessons) > _LESSONS_OVERLAY_MAX_CHARS:
+        lessons = "…(earlier lessons truncated)…\n" + lessons[-_LESSONS_OVERLAY_MAX_CHARS:]
+    try:
+        from tools.skill_manager_tool import mark_background_review_skill_read
+
+        mark_background_review_skill_read(lessons_path)
+    except Exception:
+        logger.debug(
+            "Could not record background-review read for lessons overlay %s",
+            lessons_path,
+            exc_info=True,
+        )
+    return (
+        f"{content.rstrip()}\n\n"
+        "## Learned corrections (auto-loaded)\n\n"
+        f"{lessons}\n"
+    )
+
+
 # Per-session skill discovery cache.  _find_all_skills() re-reads every
 # SKILL.md on every call; with hundreds of skills this is wasteful.
 # Cache validation (mirrors hermes_cli/profiles.py::_count_skills, d5eee133e):
@@ -1564,6 +1599,11 @@ def skill_view(
                 logger.debug(
                     "Could not preprocess skill content for %s", skill_name, exc_info=True
                 )
+
+        # Runtime corrections for protected skills are always part of the main
+        # view, so a later session cannot miss the lessons overlay.
+        if skill_dir is not None:
+            rendered_content = _append_lessons_overlay(rendered_content, skill_dir)
 
         # ── M2 org provenance header (load-time) ──────────────────────────
         # An org-shared skill announces its provenance IN the returned content


### PR DESCRIPTION
## Summary
- Allow background review to append `references/lessons.md` on local hub/manual skills without rewriting protected `SKILL.md` bodies.
- Auto-inject lessons overlay when viewing a skill so the agent sees prior failure notes.
- Give the review fork a compact evidence digest plus a fact_store whitelist so durable lessons can land in holographic memory without full memory tool surface.
- Add focused tests for the learning-loop contracts.

## Why
Background review previously refused patches on skills with `created_by: null` (typical for hub/manual installs), and `skip_memory=True` blocked fact_store writes. Mistakes never became durable lessons.

## Test plan
- [x] `scripts/run_tests.sh tests/agent/test_learning_loop.py tests/agent/test_review_prompt_class_first.py -q`
- [ ] Manual: trigger background review after a skill failure; confirm `references/lessons.md` append + optional fact_store entry