### PR TITLE
fix(desktop): stop app-managed gateway on backend shutdown

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -281,6 +281,8 @@ async def _lifespan(app: "FastAPI"):
         await PTY_REGISTRY.close_all()
         if cron_stop is not None:
             cron_stop.set()
+        if os.getenv("HERMES_DESKTOP") == "1":
+            _terminate_desktop_managed_gateway()
 
 
 def _get_event_state(app: "FastAPI"):
@@ -3808,6 +3810,19 @@ _ACTION_IDS: Dict[str, str] = {}
 # ``name`` → completed synthetic action result for actions the server handled
 # without spawning a subprocess (for example, unsupported Docker updates).
 _ACTION_RESULTS: Dict[str, Dict[str, Any]] = {}
+
+
+def _terminate_desktop_managed_gateway() -> None:
+    """Stop a live gateway restart child when its Desktop backend shuts down."""
+    proc = _ACTION_PROCS.get("gateway-restart")
+    if proc is None:
+        return
+    try:
+        if proc.poll() is None:
+            proc.terminate()
+    except OSError:
+        # The child may have exited between poll() and terminate().
+        pass
 
 
 def _record_completed_action(name: str, message: str, exit_code: int = 1) -> None:

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -997,6 +997,7 @@ def test_desktop_lifespan_reaps_orphan_gateways_on_startup(
     # real cron scheduler thread.
     monkeypatch.setattr(ws, "_warm_gateway_module", lambda: None)
     monkeypatch.setattr(ws, "_start_desktop_cron_ticker", lambda *_args: None)
+    monkeypatch.delitem(ws._ACTION_PROCS, "gateway-restart", raising=False)
     # web_server imports the reaper lazily from hermes_cli.gateway, so patch it
     # on that module.
     import hermes_cli.gateway as g
@@ -1010,8 +1011,11 @@ def test_desktop_lifespan_reaps_orphan_gateways_on_startup(
     assert called == [True]
 
 
-def test_desktop_lifespan_terminates_managed_gateway_restart(monkeypatch):
+def test_desktop_lifespan_terminates_managed_gateway_restart(
+    monkeypatch, _isolate_hermes_home
+):
     """A Desktop-owned gateway child must not survive its serve backend."""
+    import hermes_cli.gateway as g
     import hermes_cli.web_server as ws
 
     calls = []
@@ -1026,6 +1030,7 @@ def test_desktop_lifespan_terminates_managed_gateway_restart(monkeypatch):
     monkeypatch.setenv("HERMES_DESKTOP", "1")
     monkeypatch.setattr(ws, "_warm_gateway_module", lambda: None)
     monkeypatch.setattr(ws, "_start_desktop_cron_ticker", lambda *_args: None)
+    monkeypatch.setattr(g, "_reap_unsupervised_gateway_orphans", lambda: False)
     monkeypatch.setitem(ws._ACTION_PROCS, "gateway-restart", _FakeRunningProc())
 
     client, _header = _client()

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -970,7 +970,7 @@ def test_spawn_hermes_action_scrubs_gateway_loop_guard_env(monkeypatch, tmp_path
 
 
 # ---------------------------------------------------------------------------
-# Desktop lifespan reaps orphan gateways at serve startup (#77276)
+# Desktop lifespan gateway cleanup (#77276)
 # ---------------------------------------------------------------------------
 
 def test_desktop_lifespan_reaps_orphan_gateways_on_startup(
@@ -1009,3 +1009,27 @@ def test_desktop_lifespan_reaps_orphan_gateways_on_startup(
 
     assert called == [True]
 
+
+def test_desktop_lifespan_terminates_managed_gateway_restart(monkeypatch):
+    """A Desktop-owned gateway child must not survive its serve backend."""
+    import hermes_cli.web_server as ws
+
+    calls = []
+
+    class _FakeRunningProc:
+        def poll(self):
+            return None
+
+        def terminate(self):
+            calls.append("terminate")
+
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setattr(ws, "_warm_gateway_module", lambda: None)
+    monkeypatch.setattr(ws, "_start_desktop_cron_ticker", lambda *_args: None)
+    monkeypatch.setitem(ws._ACTION_PROCS, "gateway-restart", _FakeRunningProc())
+
+    client, _header = _client()
+    with client:
+        pass
+
+    assert calls == ["terminate"]


### PR DESCRIPTION
## Summary
- complement the startup orphan sweep now on `main` by covering graceful Desktop backend shutdown
- terminate the live app-managed `gateway-restart` child when the Desktop `serve` lifespan exits
- keep the shutdown regression isolated from the startup reaper and shared action-process state

## TDD evidence
- RED: `uv run pytest tests/hermes_cli/test_dashboard_admin_endpoints.py::test_desktop_lifespan_terminates_managed_gateway_restart -q` failed because the gateway child was not terminated
- GREEN: the same regression passes after the fix
- Relevant suites: `327 passed, 1 skipped`
- Blocking lint: `uv run ruff check .` passed
- Windows footgun scan: `944 file(s) scanned`, no findings
- Real subprocess shutdown probe: managed child exited on SIGTERM with code `-15`

Fixes #77276