### PR TITLE
fix(cli): back up config.yaml before --reset overwrites it

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2934,6 +2934,13 @@ def _run_portal_one_shot(config: dict) -> None:
     print_info("  Run `hermes` to start chatting.")
 
 
+def _print_config_backup_notice(backup_path: Path, config_path: Path) -> None:
+    """Tell the user where the pre-setup copy of config.yaml lives."""
+    print_info(f"Previous config backed up to: {backup_path}")
+    print_info("If setup changed a value you customized, restore it with:")
+    print_info(f"  cp {backup_path} {config_path}")
+
+
 def run_setup_wizard(args):
     """Run the interactive setup wizard.
 
@@ -2953,18 +2960,13 @@ def run_setup_wizard(args):
         return
     ensure_hermes_home()
 
-    reset_requested = bool(getattr(args, "reset", False))
-    if reset_requested:
-        save_config(copy.deepcopy(DEFAULT_CONFIG))
-        print_success("Configuration reset to defaults.")
-
-    reconfigure_requested = bool(getattr(args, "reconfigure", False))
-    quick_requested = bool(getattr(args, "quick", False))
-
-    config = load_config()
-    hermes_home = get_hermes_home()
-
-    # Back up existing config before setup modifies it (#3522)
+    # Back up existing config before setup modifies it (#3522).
+    #
+    # This MUST stay ahead of the --reset branch below: --reset overwrites
+    # config.yaml with DEFAULT_CONFIG, and get_config_path() is the very file
+    # save_config() writes, so a backup taken afterwards copies the defaults we
+    # just wrote. The user's real config would be unrecoverable on precisely
+    # the invocation where the backup matters most.
     config_path = get_config_path()
     if config_path.exists():
         from datetime import datetime as _dt
@@ -2978,6 +2980,24 @@ def run_setup_wizard(args):
             _backup_path = None
     else:
         _backup_path = None
+    _backup_notice_shown = False
+
+    reset_requested = bool(getattr(args, "reset", False))
+    if reset_requested:
+        save_config(copy.deepcopy(DEFAULT_CONFIG))
+        print_success("Configuration reset to defaults.")
+        # --reset is destructive and can leave the wizard early (e.g. the
+        # non-interactive return below), never reaching the end-of-setup
+        # notice. Tell the user where the copy is while it still helps.
+        if _backup_path and _backup_path.exists():
+            _print_config_backup_notice(_backup_path, config_path)
+            _backup_notice_shown = True
+
+    reconfigure_requested = bool(getattr(args, "reconfigure", False))
+    quick_requested = bool(getattr(args, "quick", False))
+
+    config = load_config()
+    hermes_home = get_hermes_home()
 
     # Detect non-interactive environments (headless SSH, Docker, CI/CD)
     non_interactive = getattr(args, 'non_interactive', False)
@@ -3163,10 +3183,8 @@ def run_setup_wizard(args):
 
     # Save and show summary
     save_config(config)
-    if _backup_path and _backup_path.exists():
-        print_info(f"Previous config backed up to: {_backup_path}")
-        print_info("If setup changed a value you customized, restore it with:")
-        print_info(f"  cp {_backup_path} {config_path}")
+    if _backup_path and _backup_path.exists() and not _backup_notice_shown:
+        _print_config_backup_notice(_backup_path, config_path)
     _print_setup_summary(config, hermes_home)
 
 

--- a/tests/hermes_cli/test_setup_reset_backup.py
+++ b/tests/hermes_cli/test_setup_reset_backup.py
@@ -1,0 +1,130 @@
+"""Ordering guarantees for the setup wizard's config.yaml backup (#3522).
+
+The wizard copies ``config.yaml`` to ``config.yaml.bak.<timestamp>`` so a user
+can recover values setup overwrote. ``hermes setup --reset`` replaces that same
+file with ``DEFAULT_CONFIG``, so the copy is only useful if it is taken *before*
+the reset runs — and the user has to be told where it landed even when --reset
+exits the wizard early.
+"""
+
+from argparse import Namespace
+
+from hermes_cli.config import (
+    DEFAULT_CONFIG,
+    get_config_path,
+    load_config,
+    save_config,
+)
+
+SENTINEL_MODEL = "hand-tuned-local-model-xyz"
+
+
+def _make_setup_args(**overrides):
+    return Namespace(
+        non_interactive=overrides.get("non_interactive", True),
+        section=overrides.get("section", None),
+        reset=overrides.get("reset", False),
+    )
+
+
+def _write_user_config(tmp_path):
+    """Persist a config.yaml holding a distinctive, non-default user value."""
+    config_path = get_config_path()
+    cfg = load_config()
+    cfg["model"] = {
+        "provider": "custom",
+        "base_url": "http://localhost:8080/v1",
+        "default": SENTINEL_MODEL,
+    }
+    cfg["agent"]["max_turns"] = 47
+    save_config(cfg)
+
+    assert config_path.parent == tmp_path
+    text = config_path.read_text(encoding="utf-8")
+    assert SENTINEL_MODEL in text, "fixture failed to persist the user value"
+    return config_path
+
+
+def _backups(tmp_path):
+    return sorted(tmp_path.glob("config.yaml.bak.*"))
+
+
+class TestResetBackupOrdering:
+    def test_reset_backs_up_user_config_not_the_reset_defaults(
+        self, tmp_path, monkeypatch
+    ):
+        """The --reset backup must hold the user's config, not DEFAULT_CONFIG.
+
+        Regression for the ordering bug: the backup block used to run after the
+        --reset branch had already overwritten config.yaml, so the ``.bak`` file
+        advertised as the recovery path captured the defaults that had just been
+        written and the user's real config was unrecoverable.
+        """
+        from hermes_cli.setup import run_setup_wizard
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config_path = _write_user_config(tmp_path)
+
+        run_setup_wizard(_make_setup_args(non_interactive=True, reset=True))
+
+        backups = _backups(tmp_path)
+        assert len(backups) == 1, f"expected exactly one backup, got {backups}"
+        backup_text = backups[0].read_text(encoding="utf-8")
+        assert SENTINEL_MODEL in backup_text, (
+            "backup captured the post-reset defaults instead of the user's config"
+        )
+        assert "47" in backup_text
+
+        # The reset itself must still take effect on config.yaml.
+        assert SENTINEL_MODEL not in config_path.read_text(encoding="utf-8")
+        assert load_config()["model"] == DEFAULT_CONFIG["model"]
+
+    def test_reset_reports_where_the_backup_landed(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """--reset can exit early, so it must surface the backup path itself."""
+        from hermes_cli.setup import run_setup_wizard
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_user_config(tmp_path)
+
+        run_setup_wizard(_make_setup_args(non_interactive=True, reset=True))
+
+        out = capsys.readouterr().out
+        backups = _backups(tmp_path)
+        assert len(backups) == 1
+        assert "Configuration reset to defaults." in out
+        assert "Previous config backed up to:" in out
+        assert backups[0].name in out
+
+    def test_run_without_reset_still_backs_up_the_pre_setup_config(
+        self, tmp_path, monkeypatch
+    ):
+        """Non---reset runs keep backing up the pre-setup file exactly as before."""
+        from hermes_cli.setup import run_setup_wizard
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config_path = _write_user_config(tmp_path)
+        original_text = config_path.read_text(encoding="utf-8")
+
+        run_setup_wizard(_make_setup_args(non_interactive=True, reset=False))
+
+        backups = _backups(tmp_path)
+        assert len(backups) == 1, f"expected exactly one backup, got {backups}"
+        assert backups[0].read_text(encoding="utf-8") == original_text
+        # Nothing was reset, so config.yaml is untouched.
+        assert config_path.read_text(encoding="utf-8") == original_text
+
+    def test_no_backup_and_no_notice_when_config_does_not_exist(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A first install has nothing to copy — --reset must not claim otherwise."""
+        from hermes_cli.setup import run_setup_wizard
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert not get_config_path().exists()
+
+        run_setup_wizard(_make_setup_args(non_interactive=True, reset=True))
+
+        assert _backups(tmp_path) == []
+        assert "Previous config backed up to:" not in capsys.readouterr().out

--- a/tests/hermes_cli/test_setup_reset_backup.py
+++ b/tests/hermes_cli/test_setup_reset_backup.py
@@ -100,7 +100,7 @@ class TestResetBackupOrdering:
     def test_run_without_reset_still_backs_up_the_pre_setup_config(
         self, tmp_path, monkeypatch
     ):
-        """Non---reset runs keep backing up the pre-setup file exactly as before."""
+        """Runs without --reset back up the pre-setup file exactly as before."""
         from hermes_cli.setup import run_setup_wizard
 
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## What does this PR do?

`hermes setup --reset` destroys the user's `config.yaml`, and the safety net that
is supposed to protect it captures the wrong file.

In `run_setup_wizard()` the `--reset` branch runs first:

```python
reset_requested = bool(getattr(args, "reset", False))
if reset_requested:
    save_config(copy.deepcopy(DEFAULT_CONFIG))   # config.yaml overwritten here
    print_success("Configuration reset to defaults.")
```

and the backup block runs ~12 lines *later*:

```python
# Back up existing config before setup modifies it (#3522)
config_path = get_config_path()
if config_path.exists():
    ...
    shutil.copy2(config_path, _backup_path)      # copies the ALREADY-RESET file
```

`save_config()` writes `get_hermes_home()/config.yaml`, and `get_config_path()`
returns `get_hermes_home() / "config.yaml"` (`hermes_cli/config.py:694-696`) —
the same file. So on `--reset` the `config.yaml.bak.<timestamp>` we create and
advertise as the recovery path contains `DEFAULT_CONFIG`, not the user's data.
The original is unrecoverable. The block's own comment claims it runs "before
setup modifies it"; on the `--reset` path that is false.

**User-visible failure:** `hermes setup --reset` wipes a hand-tuned
`config.yaml` (provider settings, `agent.max_turns`, compression thresholds).
The user follows the advertised `cp config.yaml.bak.<ts> config.yaml` recovery
and restores the defaults they were trying to escape. The one invocation where a
backup matters most is exactly the one where it is worthless.

There is a second, quieter symptom of the same ordering: on a **first install**
(no `config.yaml` yet), `--reset` writes the file and the backup block then sees
it exist, so the wizard emits a spurious `config.yaml.bak.<ts>` full of defaults
for a config that never existed.

**The fix is the ordering, nothing else.** The backup feature itself is correct
and works on normal runs; it just has to be taken before the `--reset` branch.

Additionally, `--reset` is destructive and can leave the wizard early — the
non-interactive return exits well before the end-of-setup notice — so a user who
just lost their config was never told where the copy is. The notice is now also
printed on the `--reset` path, reusing the existing wording. It is suppressed at
the end of setup when it has already been shown, so no run prints it twice.

Deliberately out of scope (follow-ups, not implemented here): pruning
accumulated `.bak.*` files, and printing the notice on the other early-return
paths (`--portal`, section runs).

## Related Issue

Context only — no issue is closed by this PR.

`#3522` is the report that motivated the backup, and the backup itself landed in
`aede94e75`. This PR does **not** re-implement that feature and does not
supersede the still-open `#4150`; it fixes an ordering defect in the landed code.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/setup.py` — move the `#3522` backup block from after `load_config()`
  to immediately after `ensure_hermes_home()`, ahead of the `--reset` branch, so
  it captures the true pre-setup `config.yaml` on **every** path.
- `hermes_cli/setup.py` — print the backup location on the `--reset` path, since
  `--reset` can return before the end-of-setup notice is reached.
- `hermes_cli/setup.py` — extract the 3-line notice into
  `_print_config_backup_notice()` so the two call sites cannot drift, and guard
  the end-of-setup call with `_backup_notice_shown` so a `--reset` run that
  continues into full setup does not print it twice.
- `tests/hermes_cli/test_setup_reset_backup.py` — new file, 4 tests.

Behaviour preserved: `shutil.copy2` (config.yaml holds secrets, so file mode must
be preserved), the `try/except` → `_backup_path = None` fallback, and the
end-of-setup notice on the normal full-setup path.

### Root-cause coverage

`--reset` is the only reset-before-backup site. Sweep over the repo (excluding
tests):

- `grep -rn "deepcopy(DEFAULT_CONFIG)"` → 2 hits: `hermes_cli/setup.py:2958`
  (this bug) and `hermes_cli/config.py:3333`, which is inside `load_config()` and
  is a pure read — it never writes `config.yaml`.
- `grep -rn "reset_requested"` and `grep -rn "Configuration reset to defaults"` →
  the single `run_setup_wizard` site fixed here.
- `grep -rn "yaml.bak"` → the single backup site fixed here.

No sibling site was left out.

## How to Test

Reproduce on `main`:

```bash
export HERMES_HOME=$(mktemp -d)
hermes config set model.default my-hand-tuned-model
hermes setup --reset --non-interactive
grep -l my-hand-tuned-model "$HERMES_HOME"/config.yaml.bak.*   # no match on main
```

The backup holds `DEFAULT_CONFIG`, and nothing printed where it went.

Automated, from the new file:

```
uv run --with pytest --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_setup_reset_backup.py -v
```

**Before the production change (`hermes_cli/setup.py` reverted to `main`,
tests kept): 3 failed, 1 passed.**

| Test | Failure on main |
| --- | --- |
| `test_reset_backs_up_user_config_not_the_reset_defaults` | `AssertionError: backup captured the post-reset defaults instead of the user's config` — the `.bak` file contains `agent:\n  max_turns: 500`, i.e. `DEFAULT_CONFIG`, and not `hand-tuned-local-model-xyz` |
| `test_reset_reports_where_the_backup_landed` | `assert 'Previous config backed up to:' in "✓ Configuration reset to defaults.\n\n⚕ Hermes Setup — Non-interactive mode…"` — the wizard returns before the notice |
| `test_no_backup_and_no_notice_when_config_does_not_exist` | `assert [PosixPath('…/config.yaml.bak.20260803_033404')] == []` — a spurious backup of defaults on a first install |
| `test_run_without_reset_still_backs_up_the_pre_setup_config` | passes on main (by design — it pins the behaviour this PR must not change) |

**After the change: 4 passed.**

Adjacent suites, all green with the change applied (27 passed):

```
tests/hermes_cli/test_setup_reset_backup.py
tests/hermes_cli/test_setup_noninteractive.py
tests/hermes_cli/test_setup_reconfigure.py
tests/hermes_cli/test_setup.py
tests/hermes_cli/test_setup_openclaw_migration.py
tests/hermes_cli/test_setup_model_provider.py
```

`tests/hermes_cli/test_setup_noninteractive.py::test_reset_flag_rewrites_config_before_noninteractive_exit`
is the existing pin on `--reset` semantics and still passes — the reset itself is
unchanged, only the backup that precedes it is new.

`ruff check hermes_cli/setup.py tests/hermes_cli/test_setup_reset_backup.py` — all
checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the focused + adjacent suites listed above (27 passed), not the full suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no user-facing docs describe the backup ordering; the misleading in-code comment is corrected)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code is touched (pure statement reordering plus `pathlib`/`shutil.copy2`, both already in use here), but I only executed the tests on macOS
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Related / Positioning

Checked against the open queue before opening:

- Four open PRs touch `hermes_cli/setup.py` — #76694, #76425, #76424 (all a single
  hunk at `@@ -2587` in `_load_openclaw_migration_module`) and #75689 (`@@ -953`,
  `@@ -981`, `@@ -1460`, `@@ -1501`). All are hunk-disjoint from this change's
  region (~2950–3190).
- #4150 (`fix: back up config.yaml before hermes setup modifies it`) is the
  original backup PR and is still open. Its diff inserts the block *after*
  `config = load_config()` — the same position that produces this bug. This PR
  neither duplicates nor supersedes it.
