### PR TITLE
fix(desktop): persist message reactions config

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1174,6 +1174,51 @@ def test_config_set_battery_explicit_off(monkeypatch):
     assert writes == {"display.battery": False}
 
 
+@pytest.mark.parametrize(("value", "enabled"), [("true", True), ("false", False)])
+def test_config_set_message_reactions_persists_renderer_value(
+    monkeypatch, value, enabled
+):
+    writes: dict[str, object] = {}
+    monkeypatch.setattr(
+        server, "_write_config_key", lambda k, v: writes.__setitem__(k, v)
+    )
+
+    resp = server.dispatch(
+        {
+            "id": "reactions",
+            "method": "config.set",
+            "params": {"key": "display.message_reactions", "value": value},
+        }
+    )
+
+    assert resp["result"] == {
+        "key": "display.message_reactions",
+        "value": "on" if enabled else "off",
+    }
+    assert writes == {"display.message_reactions": enabled}
+
+
+def test_config_set_message_reactions_rejects_unknown_value(monkeypatch):
+    writes: dict[str, object] = {}
+    monkeypatch.setattr(
+        server, "_write_config_key", lambda k, v: writes.__setitem__(k, v)
+    )
+
+    resp = server.dispatch(
+        {
+            "id": "reactions",
+            "method": "config.set",
+            "params": {"key": "display.message_reactions", "value": "sometimes"},
+        }
+    )
+
+    assert resp["error"] == {
+        "code": 4002,
+        "message": "unknown message reactions value: sometimes",
+    }
+    assert writes == {}
+
+
 def test_voice_toggle_returns_configured_record_key(monkeypatch):
     monkeypatch.setattr(
         server,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10974,6 +10974,17 @@ def _(rid, params: dict) -> dict:
         _write_config_key("display.battery", nv_b)
         return _ok(rid, {"key": key, "value": "on" if nv_b else "off"})
 
+    if key == "display.message_reactions":
+        raw = ("" if value is None else str(value)).strip().lower()
+        if raw in {"1", "on", "true", "yes"}:
+            enabled = True
+        elif raw in {"0", "off", "false", "no"}:
+            enabled = False
+        else:
+            return _err(rid, 4002, f"unknown message reactions value: {value}")
+        _write_config_key("display.message_reactions", enabled)
+        return _ok(rid, {"key": key, "value": "on" if enabled else "off"})
+
     if key == "theme":
         # TUI light/dark mode pin: 'light'/'dark' beat background
         # auto-detection (xterm.js hosts misreport OSC 11); 'auto' trusts it.


### PR DESCRIPTION
## Summary

Fix the Desktop message-reactions toggle so its `config.set` request persists `display.message_reactions` instead of falling through to error 4002. The handler accepts the renderer's canonical key, normalizes explicit boolean values, and rejects unsupported values without changing configuration.

This is an alternative to #77260. This version also adds regression coverage and avoids silently interpreting malformed values as `false`.

## Related Issue

Fixes #77241

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`: handle `display.message_reactions`, persist its normalized boolean value, and reject invalid values.
- `tests/test_tui_gateway_server.py`: cover renderer-provided `true` and `false` values, canonical-key persistence, and invalid-value rejection.

## How to Test

1. Run `uv run --extra dev pytest tests/test_tui_gateway_server.py -k 'config_set' -q`.
2. Send `config.set` with `{"key":"display.message_reactions","value":"true"}` and verify the response is successful and `display.message_reactions` is written as `true`.
3. Send the same request with an unsupported value and verify error 4002 is returned without writing configuration.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls); #77260 overlaps, and the differences are described above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the local full suite exceeded 10 minutes; targeted tests and lint pass, and CI is expected to run the full suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 under WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; the existing key is now persisted
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — string normalization and config persistence are platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before the fix, the renderer request returned `4002: unknown config key`. After the fix, direct JSON-RPC verification persisted both enabled and disabled values, while an unsupported value returned 4002 without writing configuration.

```text
42 passed, 474 deselected
All checks passed!
```
