### PR TITLE
fix(agent): detect api.kimi.com/coding anthropic_messages in try_activate_fallback (#77256)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1846,6 +1846,14 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             # host the same way determine_api_mode() and _detect_api_mode_for_url()
             # do on the primary path. (#32243, #49247)
             fb_api_mode = "anthropic_messages"
+        elif (
+            base_url_hostname(fb_base_url) == "api.kimi.com"
+            and "/coding" in fb_base_url.lower()
+        ):
+            # Kimi Code's api.kimi.com/coding endpoint speaks Anthropic
+            # Messages only — same detection as _detect_api_mode_for_url()
+            # on the primary path. (#77256)
+            fb_api_mode = "anthropic_messages"
         elif _fb_is_azure:
             # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
             # support the Responses API. Stay on chat_completions.


### PR DESCRIPTION
## What does this PR do?

Fixes #77256 — fallback to Kimi Code (`api.kimi.com/coding`) fails with HTTP 404 because `try_activate_fallback` routes over OpenAI `chat_completions` instead of Anthropic Messages.

## Root Cause

`agent/chat_completion_helpers.py` `try_activate_fallback` derives `fb_api_mode` with a heuristic chain that checks for Anthropic hosts (`api.anthropic.com`, `/anthropic` suffix) but misses `api.kimi.com/coding`, which only speaks Anthropic Messages.

The primary path (`hermes_cli/runtime_provider._detect_api_mode_for_url`, line 143) already detects this:
```python
if hostname == "api.kimi.com" and "/coding" in normalized:
    return "anthropic_messages"
```

The fallback path was missing this detection.

## Fix

Added `api.kimi.com/coding` check after the existing Anthropic host check in `try_activate_fallback`'s `api_mode` derivation chain. 8 lines added.

## Testing

- `python3 -m py_compile agent/chat_completion_helpers.py` passes
- No existing fallback tests to run (pre-existing)
