### PR TITLE
fix(fallback): use Messages API for Kimi coding fallback (#77256)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2059,13 +2059,18 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_provider == "anthropic"
             or fb_base_url.rstrip("/").lower().endswith("/anthropic")
             or base_url_hostname(fb_base_url) == "api.anthropic.com"
+            or (
+                base_url_hostname(fb_base_url) == "api.kimi.com"
+                and "/coding" in fb_base_url.lower()
+            )
         ):
             # Custom providers (e.g. cron-anthropic) point at the native
-            # api.anthropic.com host with no "/anthropic" path suffix, so the
-            # name/suffix checks above miss them and they default to
-            # chat_completions → POST /v1/chat/completions → 404. Match the
-            # host the same way determine_api_mode() and _detect_api_mode_for_url()
-            # do on the primary path. (#32243, #49247)
+            # api.anthropic.com host with no "/anthropic" path suffix, and
+            # Kimi Coding Plan uses an Anthropic Messages-only /coding route.
+            # Match the host/path the same way determine_api_mode() and
+            # _detect_api_mode_for_url() do on the primary path so fallback
+            # activation cannot drift onto chat_completions → 404. (#32243,
+            # #49247, #77256)
             fb_api_mode = "anthropic_messages"
         elif _fb_is_azure:
             # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -201,6 +201,66 @@ class TestFallbackChainAdvancement:
         assert rebuilt["base_url"] == portal
         assert agent._anthropic_client is not None
 
+    def test_kimi_coding_fallback_uses_the_messages_wire(self):
+        """Kimi Coding fallbacks must route over Anthropic Messages.
+
+        ``resolve_provider_client`` can normalize the user-supplied
+        ``.../coding/v1`` hint to the canonical ``.../coding`` base URL, but
+        fallback activation still has to re-derive ``api_mode`` from that
+        resolved endpoint or the retry POSTs ``/chat/completions`` and 404s.
+        """
+        fbs = [
+            {
+                "provider": "kimi-coding",
+                "model": "kimi-for-coding",
+                "base_url": "https://api.kimi.com/coding/v1",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        rebuilt = {"count": 0}
+
+        def _fake_build(api_key, base_url, timeout=None, **kwargs):
+            rebuilt["count"] += 1
+            rebuilt["api_key"] = api_key
+            rebuilt["base_url"] = base_url
+            return MagicMock(name="anthropic-client")
+
+        with (
+            patch(
+                "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+                return_value=None,
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(
+                        base_url="https://api.kimi.com/coding",
+                        api_key="sk-kimi-test",
+                    ),
+                    "kimi-for-coding",
+                ),
+            ) as mock_resolve,
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                side_effect=_fake_build,
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert mock_resolve.call_args.kwargs["explicit_base_url"] == "https://api.kimi.com/coding/v1"
+        assert agent.api_mode == "anthropic_messages"
+        assert agent.provider == "kimi-coding"
+        assert agent.model == "kimi-for-coding"
+        assert agent.client is None
+        assert rebuilt["count"] == 1
+        assert rebuilt["api_key"] == "sk-kimi-test"
+        assert rebuilt["base_url"] == "https://api.kimi.com/coding"
+        assert agent._anthropic_client is not None
+
     def test_nous_non_anthropic_fallback_stays_on_chat_completions(self):
         portal = "https://inference-api.nousresearch.com/v1"
         fbs = [{"provider": "nous", "model": "hermes-4-405b"}]


### PR DESCRIPTION
## What does this PR do?

This fixes a fallback transport mismatch for Kimi Coding endpoints.

When `try_activate_fallback()` switches to a fallback entry that resolves to `https://api.kimi.com/coding`, Hermes was still classifying the fallback as `chat_completions`. That sends the retry to `/chat/completions`, which returns 404 for Kimi Coding's Anthropic Messages-only route.

This patch keeps the fallback path aligned with the existing primary-path detection logic, so Kimi Coding fallbacks rebuild the Anthropic client and retry over the native Messages wire instead.

## Related Issue

Fixes #77256

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/chat_completion_helpers.py` so fallback activation treats `api.kimi.com/coding` endpoints as `anthropic_messages`
- Kept the fallback heuristic aligned with the existing primary/auxiliary transport detection for Kimi Coding
- Added a regression test in `tests/run_agent/test_provider_fallback.py` that covers a `fallback_providers` entry pointing at `https://api.kimi.com/coding/v1`

## How to Test

1. Configure a fallback entry for Kimi Coding (for example `provider: kimi-coding`, `model: kimi-for-coding`, `base_url: https://api.kimi.com/coding/v1`)
2. Trigger a primary-provider failure that activates the fallback chain
3. Confirm the fallback rebuilds the Anthropic client and routes over the Messages API instead of `/chat/completions`
4. Run:
   `~/.pyenv/versions/3.12.12/bin/python -m pytest tests/run_agent/test_provider_fallback.py`

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `~/.pyenv/versions/3.12.12/bin/python -m pytest tests/run_agent/test_provider_fallback.py`
- `15 passed in 16.97s`
