### PR TITLE
fix(web): run toolsets/skills/platforms endpoints in threadpool; cache agent-browser probe

### DIFF
--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -156,7 +156,23 @@ def _toolset_enabled(config: Dict[str, object], toolset_key: str) -> bool:
     return False
 
 
+# Short-TTL cache for _has_agent_browser: [monotonic timestamp, verdict].
+# The agent-browser exec probe costs ~1s per call on Windows; the binary only
+# changes on `hermes update`, so 30s of staleness is harmless while it keeps
+# per-toolset /api/tools/toolsets checks from re-spawning a subprocess each time.
+_HAS_AGENT_BROWSER_CACHE: list = [None, False]
+
+
 def _has_agent_browser() -> bool:
+    # agent-browser resolution + exec probe is expensive (~1s subprocess on
+    # Windows). The binary only changes on `hermes update`, so cache the
+    # verdict briefly to keep /api/tools/toolsets (which calls this per
+    # toolset) from re-probing on every request.
+    import time as _time
+    now = _time.monotonic()
+    if _HAS_AGENT_BROWSER_CACHE[0] is not None and now - _HAS_AGENT_BROWSER_CACHE[0] < 30.0:
+        return _HAS_AGENT_BROWSER_CACHE[1]
+
     import shutil
 
     from hermes_constants import agent_browser_runnable, with_hermes_node_path
@@ -165,6 +181,8 @@ def _has_agent_browser() -> bool:
     # (issue #48521) is reported by ``which`` but fails at exec. Fall through to
     # the local node_modules copy, which the validator also checks.
     if agent_browser_runnable(shutil.which("agent-browser")):
+        _HAS_AGENT_BROWSER_CACHE[0] = now
+        _HAS_AGENT_BROWSER_CACHE[1] = True
         return True
 
     # Hermes-managed Node dirs (Windows installer / POSIX $HERMES_HOME/node)
@@ -175,6 +193,8 @@ def _has_agent_browser() -> bool:
     if managed_path:
         managed_hit = shutil.which("agent-browser", path=managed_path)
         if managed_hit and agent_browser_runnable(managed_hit):
+            _HAS_AGENT_BROWSER_CACHE[0] = now
+            _HAS_AGENT_BROWSER_CACHE[1] = True
             return True
 
     # Local node_modules/.bin: resolve via PATHEXT-aware ``shutil.which`` so
@@ -186,7 +206,11 @@ def _has_agent_browser() -> bool:
     if local_bin_dir.is_dir():
         local_which = shutil.which("agent-browser", path=str(local_bin_dir))
         if local_which and agent_browser_runnable(local_which):
+            _HAS_AGENT_BROWSER_CACHE[0] = now
+            _HAS_AGENT_BROWSER_CACHE[1] = True
             return True
+    _HAS_AGENT_BROWSER_CACHE[0] = now
+    _HAS_AGENT_BROWSER_CACHE[1] = False
     return False
 
 

--- a/hermes_cli/web_routers/skills.py
+++ b/hermes_cli/web_routers/skills.py
@@ -392,7 +392,7 @@ async def scan_skill_hub(identifier: str = "", profile: Optional[str] = None):
 
 
 @router.get("/api/skills")
-async def get_skills(profile: Optional[str] = None):
+def get_skills(profile: Optional[str] = None):
     from tools.skills_tool import _find_all_skills
     from hermes_cli.skills_config import get_disabled_skills
     from tools.skill_usage import (
@@ -401,6 +401,9 @@ async def get_skills(profile: Optional[str] = None):
         activity_count,
         load_usage,
     )
+    # Sync file-system scan (skill discovery + usage load) — a plain def
+    # route runs in FastAPI's threadpool, so a large skills dir never
+    # freezes the desktop event loop / WS.
     with _profile_scope(profile):
         config = load_config()
         disabled = get_disabled_skills(config)

--- a/hermes_cli/web_routers/tools.py
+++ b/hermes_cli/web_routers/tools.py
@@ -51,7 +51,7 @@ _TERMINAL_BACKEND_NAMES = LateState("_TERMINAL_BACKEND_NAMES")
 
 
 @router.get("/api/tools/toolsets")
-async def get_toolsets(profile: Optional[str] = None):
+def get_toolsets(profile: Optional[str] = None):
     from hermes_cli.tools_config import (
         _CONFIG_ONLY_TOOLSETS,
         _get_effective_configurable_toolsets,
@@ -173,7 +173,7 @@ async def toggle_toolset(name: str, body: ToolsetToggle, profile: Optional[str] 
 
 
 @router.get("/api/tools/toolsets/{name}/config")
-async def get_toolset_config(name: str, profile: Optional[str] = None):
+def get_toolset_config(name: str, profile: Optional[str] = None):
     """Return the provider matrix + key status for a toolset's config panel.
 
     Surfaces the same provider rows the CLI ``hermes tools`` picker shows
@@ -390,7 +390,7 @@ async def select_toolset_model(
 
 
 @router.put("/api/tools/toolsets/{name}/provider")
-async def select_toolset_provider(
+def select_toolset_provider(
     name: str, body: ToolsetProviderSelect, profile: Optional[str] = None
 ):
     """Persist a provider selection for a toolset (no key prompting).

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9190,7 +9190,7 @@ async def cancel_telegram_onboarding(pairing_id: str):
 
 
 @app.get("/api/messaging/platforms")
-async def get_messaging_platforms(profile: Optional[str] = None):
+def get_messaging_platforms(profile: Optional[str] = None):
     # Profile-scoped so the dashboard's global profile switcher shows the
     # TARGET profile's channel credentials/state, not the root install's.
     # load_env() honors the HERMES_HOME contextvar override; the gateway


### PR DESCRIPTION
## Problem

On Windows, the desktop sidebar's Skills & Tools / Messaging Platforms lists fail to load, and `gui.log` shows repeated `event loop stalled 20-25s (GIL pressure suspected)` + `ws write slow ... frame left in flight`.

## Root cause

`GET /api/tools/toolsets` is declared `async def`, so FastAPI runs it **directly on the event loop thread**. The body is fully synchronous (zero `await`s) yet, for **every** toolset, it synchronously calls:

```
_toolset_has_keys × ~27 toolsets
  → get_nous_subscription_features
    → _has_agent_browser → subprocess.run(agent-browser --version)  (~1s, uncached)
    → get_nous_portal_account_info → network call (waits on timeout when not logged into Nous)
```

A single request serially blocks the event loop for **~30s**, freezing all WebSocket frames — so the sidebar lists never arrive. Confirmed with `py-spy` stack dumps during the stall window: `MainThread` parked in `subprocess.run` inside the `get_toolsets` chain.

## Fix

1. **Move the sync bodies off the event loop** — convert the await-free endpoints to plain `def` so FastAPI dispatches them to its threadpool:
   - `get_toolsets` (`/api/tools/toolsets`)
   - `get_toolset_config` (`/api/tools/toolsets/{name}/config`)
   - `select_toolset_provider` (`/api/tools/toolsets/{name}/provider`)
   - `get_skills` (`/api/skills`) — does file-system skill discovery + usage load
   - `get_messaging_platforms` (`/api/messaging/platforms`) — reads env + gateway state

2. **Cache the expensive agent-browser exec probe** — `_has_agent_browser()` spawns `agent-browser --version` (~1s subprocess, no cache) and is invoked per toolset. Added a 30s TTL verdict cache.

## Measured impact (Windows, not logged into Nous)

| | before | after |
|---|---|---|
| `get_toolsets` cold | ~31s | ~7.5s |
| `get_toolsets` warm | ~30s (uncached) | **~0.7s** |
| event loop stall | 20-25s per request | **none** |

## Verification

- `pytest tests/hermes_cli/test_nous_subscription.py tests/hermes_cli/test_nous_account.py tests/hermes_cli/test_tools_config.py -q` → 37 passed
- `pytest tests/hermes_cli/test_web_server.py tests/test_toolsets.py -q -k "tools or toolset or skills or messaging or nous"` → 29 passed, 1 skipped
- `inspect.iscoroutinefunction()` confirms all five endpoints are now sync (threadpool-dispatched)
- The single pre-existing failure (`test_shared_store_write_and_read_roundtrip`, Windows chmod 0o600 vs 0o666) fails identically without this change

## Notes

- No new env vars, no config changes, no API surface changes — endpoints/routes unchanged, only the dispatch mode.
- The 30s-TTL cache only shortens staleness of an already-cached-in-practice binary probe; correctness semantics are unchanged (fresh probe still happens on expiry).