### PR TITLE
docs(skills): add risk classification to inspecting-hermes-desktop-dom

### DIFF
--- a/skills/software-development/inspecting-hermes-desktop-dom/SKILL.md
+++ b/skills/software-development/inspecting-hermes-desktop-dom/SKILL.md
@@ -2,6 +2,7 @@
 name: inspecting-hermes-desktop-dom
 description: "Read the live Hermes desktop DOM/CSS over CDP."
 version: 1.0.0
+risk: READ
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]


### PR DESCRIPTION
## Summary

`skills/software-development/inspecting-hermes-desktop-dom/SKILL.md` was added in #73121 without a `risk` field in frontmatter. The nightly skill-frontmatter validator flags it as the only bundled skill missing `risk` (38/39 bundled skills have it).

## Change

- Add `risk: READ` to the skill's frontmatter.

This is a read-only inspection skill (reads the live desktop DOM/CSS over CDP, never writes/mutates), so `READ` is the correct risk class. No behavior change.

## Validation

- `validate_skill_frontmatter.py` passes for this skill after the change.
