### PR TITLE
fix(desktop): make the window translucency slider usable across its range

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -209,6 +209,7 @@ import {
 import { formatBlockerMessage, formatProbeFailedMessage, scanVenvBlockers } from './venv-blocker-scan'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
+import { clampIntensity, windowOpacity } from './window-opacity'
 import {
   computeWindowOptions,
   debounce,
@@ -735,14 +736,8 @@ nativeTheme.themeSource = readPersistedThemeSource()
 // default). Mapped to the native window opacity so the desktop shows through
 // the whole window. Persisted so a cold launch applies it at window creation,
 // before the renderer reports its value. macOS + Windows only; `setOpacity` is
-// a no-op on Linux. See store/translucency.
+// a no-op on Linux. See store/translucency, and window-opacity for the ramp.
 const TRANSLUCENCY_CONFIG_PATH = path.join(app.getPath('userData'), 'translucency.json')
-
-function clampIntensity(value) {
-  const n = Math.round(Number(value))
-
-  return Number.isFinite(n) ? Math.min(100, Math.max(0, n)) : 0
-}
 
 function readPersistedTranslucency() {
   try {
@@ -763,12 +758,6 @@ function writePersistedTranslucency(intensity) {
 
 let translucencyIntensity = readPersistedTranslucency()
 
-// Map the 0–100 lever to a window opacity. Floor at 0.3 so the most see-through
-// setting is still usable rather than nearly invisible. 0 → fully opaque.
-function windowOpacity() {
-  return 1 - (translucencyIntensity / 100) * 0.7
-}
-
 // Re-apply translucency to a live window (runtime toggle, no recreation).
 // `setOpacity` is a no-op on Linux, which is fine — it just stays opaque there.
 function applyWindowTranslucency(win) {
@@ -777,7 +766,7 @@ function applyWindowTranslucency(win) {
   }
 
   try {
-    win.setOpacity(windowOpacity())
+    win.setOpacity(windowOpacity(translucencyIntensity))
   } catch (error) {
     rememberLog(`[translucency] apply failed: ${error.message}`)
   }
@@ -8751,7 +8740,7 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
     titleBarOverlay: getTitleBarOverlayOptions(),
     trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
     vibrancy: IS_MAC ? 'sidebar' : undefined,
-    opacity: windowOpacity(),
+    opacity: windowOpacity(translucencyIntensity),
     icon,
     // Don't show until the renderer's first themed paint is ready. macOS
     // `vibrancy` ignores `backgroundColor` and paints a translucent OS
@@ -8837,7 +8826,7 @@ function createInstanceWindow() {
     titleBarOverlay: getTitleBarOverlayOptions(),
     trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
     vibrancy: IS_MAC ? 'sidebar' : undefined,
-    opacity: windowOpacity(),
+    opacity: windowOpacity(translucencyIntensity),
     icon,
     show: false,
     backgroundColor: getWindowBackgroundColor(),
@@ -9248,7 +9237,7 @@ function createWindow() {
     titleBarOverlay: getTitleBarOverlayOptions(),
     trafficLightPosition: IS_MAC ? WINDOW_BUTTON_POSITION : undefined,
     vibrancy: IS_MAC ? 'sidebar' : undefined,
-    opacity: windowOpacity(),
+    opacity: windowOpacity(translucencyIntensity),
     icon,
     // Hidden until the first themed paint so macOS `vibrancy` (which ignores
     // `backgroundColor` and follows the OS appearance) can't flash a light

--- a/apps/desktop/electron/window-opacity.test.ts
+++ b/apps/desktop/electron/window-opacity.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for the pure translucency helpers: the intensity -> opacity ramp
+ * the window options and the runtime IPC toggle share, its endpoints, and the
+ * clamping that keeps a corrupt translucency.json from reaching setOpacity.
+ */
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  clampIntensity,
+  TRANSLUCENCY_CURVE,
+  TRANSLUCENCY_MAX,
+  TRANSLUCENCY_MIN,
+  TRANSLUCENCY_OPACITY_FLOOR,
+  windowOpacity
+} from './window-opacity'
+
+/** The linear ramp this curve replaced. Endpoints must still agree with it. */
+const legacyOpacity = (intensity: number) => 1 - (intensity / 100) * 0.7
+
+test('lever bounds and floor stay stable so persisted settings survive upgrades', () => {
+  assert.equal(TRANSLUCENCY_MIN, 0)
+  assert.equal(TRANSLUCENCY_MAX, 100)
+  assert.equal(TRANSLUCENCY_OPACITY_FLOOR, 0.3)
+})
+
+test('endpoints are unchanged from the linear ramp', () => {
+  assert.equal(windowOpacity(TRANSLUCENCY_MIN), legacyOpacity(0))
+  assert.equal(windowOpacity(TRANSLUCENCY_MAX), legacyOpacity(100))
+})
+
+test('off is fully opaque and max is exactly the floor', () => {
+  assert.equal(windowOpacity(0), 1)
+  assert.equal(windowOpacity(100), 1 - (1 - TRANSLUCENCY_OPACITY_FLOOR))
+})
+
+test('opacity decreases monotonically and never sinks below the floor', () => {
+  let previous = windowOpacity(TRANSLUCENCY_MIN)
+
+  for (let intensity = TRANSLUCENCY_MIN + 1; intensity <= TRANSLUCENCY_MAX; intensity += 1) {
+    const opacity = windowOpacity(intensity)
+
+    assert.ok(opacity < previous, `expected ${intensity} to be more see-through than ${intensity - 1}`)
+    assert.ok(opacity >= TRANSLUCENCY_OPACITY_FLOOR, `expected ${intensity} to stay at or above the floor`)
+
+    previous = opacity
+  }
+})
+
+// The bug this module fixes: setOpacity fades text too, so anything under ~0.95
+// is where reading gets hard. A linear ramp put that boundary at intensity 7,
+// leaving almost the whole lever unusable.
+test('the readable band covers a useful stretch of the lever, not just its first few percent', () => {
+  const readable = []
+
+  for (let intensity = TRANSLUCENCY_MIN; intensity <= TRANSLUCENCY_MAX; intensity += 1) {
+    if (windowOpacity(intensity) >= 0.95) {
+      readable.push(intensity)
+    }
+  }
+
+  assert.ok(
+    readable.length > 20,
+    `expected more than 20 readable settings, got ${readable.length} (max ${readable[readable.length - 1]})`
+  )
+})
+
+test('a curved ramp keeps fine control near the opaque end', () => {
+  // Linear gave 0.965 here — a visible jump off "off" on the very first step.
+  assert.ok(windowOpacity(5) > 0.99, `expected 5% to stay near-opaque, got ${windowOpacity(5)}`)
+  assert.ok(windowOpacity(1) > legacyOpacity(1))
+  assert.ok(TRANSLUCENCY_CURVE > 1)
+})
+
+test('clampIntensity rejects garbage and enforces bounds', () => {
+  assert.equal(clampIntensity(NaN), TRANSLUCENCY_MIN)
+  assert.equal(clampIntensity(Infinity), TRANSLUCENCY_MIN)
+  assert.equal(clampIntensity(undefined), TRANSLUCENCY_MIN)
+  assert.equal(clampIntensity(null), TRANSLUCENCY_MIN)
+  assert.equal(clampIntensity('nope'), TRANSLUCENCY_MIN)
+  assert.equal(clampIntensity(-40), TRANSLUCENCY_MIN)
+  assert.equal(clampIntensity(240), TRANSLUCENCY_MAX)
+  assert.equal(clampIntensity('35'), 35)
+  assert.equal(clampIntensity(35.6), 36)
+})
+
+test('windowOpacity clamps before mapping so corrupt state cannot escape the range', () => {
+  assert.equal(windowOpacity(-40), 1)
+  assert.equal(windowOpacity(240), windowOpacity(TRANSLUCENCY_MAX))
+  assert.equal(windowOpacity('nope'), 1)
+})

--- a/apps/desktop/electron/window-opacity.ts
+++ b/apps/desktop/electron/window-opacity.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure helpers for window translucency. The main process owns
+ * BrowserWindow#setOpacity, so both window creation and the runtime IPC toggle
+ * funnel through this one mapping. Intensity is the user-facing unit
+ * (0 = opaque, 100 = most see-through); Electron's unit is window opacity.
+ *
+ * `setOpacity` fades the whole window, text included, so the band a user can
+ * actually read in sits just under opacity 1. A linear ramp spends that band in
+ * its first few percent and the rest of the lever on settings nobody can use.
+ * Curving the ramp keeps both endpoints exactly where they have always been and
+ * gives the readable band most of the travel instead.
+ */
+
+export const TRANSLUCENCY_MIN = 0
+export const TRANSLUCENCY_MAX = 100
+
+/** Most see-through setting — floored so it stays usable, not near-invisible. */
+export const TRANSLUCENCY_OPACITY_FLOOR = 0.3
+
+/**
+ * Exponent for the intensity -> opacity ramp. 1 is the linear ramp this
+ * replaces. 2 holds the readable settings across roughly the first third of the
+ * lever while leaving windowOpacity(0) and windowOpacity(100) bit-identical.
+ */
+export const TRANSLUCENCY_CURVE = 2
+
+export function clampIntensity(value) {
+  const n = Math.round(Number(value))
+
+  return Number.isFinite(n) ? Math.min(TRANSLUCENCY_MAX, Math.max(TRANSLUCENCY_MIN, n)) : TRANSLUCENCY_MIN
+}
+
+export function windowOpacity(intensity) {
+  const ratio = clampIntensity(intensity) / TRANSLUCENCY_MAX
+
+  return 1 - (1 - TRANSLUCENCY_OPACITY_FLOOR) * Math.pow(ratio, TRANSLUCENCY_CURVE)
+}

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -17,7 +17,13 @@ import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedM
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
-import { $translucency, setTranslucency } from '@/store/translucency'
+import {
+  $translucency,
+  setTranslucency,
+  TRANSLUCENCY_MAX,
+  TRANSLUCENCY_MIN,
+  TRANSLUCENCY_STEP
+} from '@/store/translucency'
 import { $zoomPercent, setZoomPercent } from '@/store/zoom'
 import { getBaseColors, useTheme } from '@/themes/context'
 import { installVscodeThemeFromMarketplace } from '@/themes/install'
@@ -439,13 +445,13 @@ export function AppearanceSettings() {
                 <input
                   aria-label={a.translucencyTitle}
                   className="h-1 w-40 cursor-pointer appearance-none rounded-full bg-(--ui-stroke-tertiary)"
-                  max={100}
-                  min={0}
+                  max={TRANSLUCENCY_MAX}
+                  min={TRANSLUCENCY_MIN}
                   onChange={event => {
                     triggerHaptic('selection')
                     setTranslucency(Number(event.target.value))
                   }}
-                  step={5}
+                  step={TRANSLUCENCY_STEP}
                   style={{ accentColor: 'var(--dt-primary)' }}
                   type="range"
                   value={translucency}

--- a/apps/desktop/src/store/translucency.test.ts
+++ b/apps/desktop/src/store/translucency.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { onPersistenceEvent, type PersistenceEvent } from '@/lib/storage'
+
+import { $translucency, setTranslucency, TRANSLUCENCY_MAX, TRANSLUCENCY_MIN, TRANSLUCENCY_STEP } from './translucency'
+
+const KEY = 'hermes.desktop.translucency.v1'
+
+describe('window translucency lever', () => {
+  beforeEach(() => setTranslucency(TRANSLUCENCY_MIN))
+
+  it('steps in single percent so the readable low end is reachable', () => {
+    expect(TRANSLUCENCY_STEP).toBe(1)
+    expect(TRANSLUCENCY_MIN).toBe(0)
+    expect(TRANSLUCENCY_MAX).toBe(100)
+  })
+
+  it('defaults to off', () => {
+    expect($translucency.get()).toBe(TRANSLUCENCY_MIN)
+  })
+
+  it('accepts every step the slider can emit', () => {
+    for (let intensity = TRANSLUCENCY_MIN; intensity <= TRANSLUCENCY_MAX; intensity += TRANSLUCENCY_STEP) {
+      setTranslucency(intensity)
+      expect($translucency.get()).toBe(intensity)
+    }
+  })
+
+  it('clamps out-of-range input to the lever bounds', () => {
+    setTranslucency(-40)
+    expect($translucency.get()).toBe(TRANSLUCENCY_MIN)
+
+    setTranslucency(240)
+    expect($translucency.get()).toBe(TRANSLUCENCY_MAX)
+  })
+
+  it('rounds fractional input to a whole percent', () => {
+    setTranslucency(35.6)
+    expect($translucency.get()).toBe(36)
+  })
+
+  it('persists under a stable key so a saved setting survives upgrades', () => {
+    const writes: PersistenceEvent[] = []
+
+    const stop = onPersistenceEvent(event => {
+      if (event.op === 'write') {
+        writes.push(event)
+      }
+    })
+
+    try {
+      setTranslucency(23)
+    } finally {
+      stop()
+    }
+
+    expect(writes).toContainEqual({ key: KEY, op: 'write', value: '23' })
+  })
+})

--- a/apps/desktop/src/store/translucency.ts
+++ b/apps/desktop/src/store/translucency.ts
@@ -16,7 +16,14 @@ import { persistString, storedString } from '@/lib/storage'
 
 const KEY = 'hermes.desktop.translucency.v1'
 
-const clamp = (n: number): number => Math.min(100, Math.max(0, Math.round(n)))
+// Slider bounds — mirror `electron/window-opacity.ts` (TRANSLUCENCY_MIN / MAX)
+// so the control and the main-process clamp agree on the same range. The step
+// is renderer-only: the main process takes any integer in range.
+export const TRANSLUCENCY_MIN = 0
+export const TRANSLUCENCY_MAX = 100
+export const TRANSLUCENCY_STEP = 1
+
+const clamp = (n: number): number => Math.min(TRANSLUCENCY_MAX, Math.max(TRANSLUCENCY_MIN, Math.round(n)))
 
 const read = (): number => {
   const n = Number(storedString(KEY))

--- a/contributors/emails/nicolasdmolina76@gmail.com
+++ b/contributors/emails/nicolasdmolina76@gmail.com
@@ -1,0 +1,1 @@
+nicolasdmolina


### PR DESCRIPTION
## What does this PR do?

Makes **Settings → Appearance → Window Translucency** adjustable across its whole range instead of only at its first step or two.

Two independent causes, both fixed here:

1. The slider was hardcoded to `step={5}` — 21 stops in a 160px track, and arrow keys jumping 5 at a time.
2. `setOpacity` fades the whole window *including text*, so readability sets the usable ceiling. The linear ramp put everything still comfortable to read (opacity ≳ 0.95) inside `intensity ≤ 7`, spending ~90% of the travel on settings nobody can work in.

**Both endpoints are bit-identical to before.** `windowOpacity(0) === 1` and `windowOpacity(100) === 0.30000000000000004` evaluate exactly the same as the old expression — asserted directly in a test against the old formula. The 0.3 floor and the "0% is byte-for-byte the opaque window" property from #45086 are deliberate design and are preserved; only the shape *between* the endpoints changes.

```
opacity = 1 - (1 - 0.3) * (intensity / 100) ** 2
```

| intensity | before | after |
|---:|---:|---:|
| 0 | 1.000 | **1.000** ← unchanged |
| 5 | 0.965 | 0.998 |
| 10 | 0.930 | 0.993 |
| 20 | 0.860 | 0.972 |
| 40 | 0.720 | 0.888 |
| 100 | 0.300 | **0.300** ← unchanged |

Readable band moves from `intensity ∈ [0, 7]` to roughly `[0, 27]`.

**The two commits are independent on purpose** — if only the step change is wanted, `7180911` stands alone as a complete fix and the curve commit can be dropped.

## Related Issue

Fixes #77312

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/settings/appearance-settings.tsx` — `step={5}` → `step={TRANSLUCENCY_STEP}` (1); `min`/`max` from the same constants.
- `apps/desktop/src/store/translucency.ts` — export `TRANSLUCENCY_MIN` / `MAX` / `STEP` and reuse them in the existing clamp, mirroring `PET_SCALE_MIN`/`PET_SCALE_MAX` in `store/pet-gallery.ts` so the control and the clamp read from one source.
- `apps/desktop/electron/window-opacity.ts` **(new)** — the ramp, its clamp, and named constants (`TRANSLUCENCY_OPACITY_FLOOR`, `TRANSLUCENCY_CURVE`). Extracted from `main.ts` following the existing `electron/zoom.ts` split, because the mapping was previously unreachable from tests inside a ~12k-line file. `TRANSLUCENCY_CURVE` is a single tunable if you want it gentler.
- `apps/desktop/electron/window-opacity.test.ts` **(new)** — 8 tests.
- `apps/desktop/electron/main.ts` — drops the local `clampIntensity`/`windowOpacity` and imports them; `main.ts` keeps ownership of the persisted intensity and passes it in. Net −22 lines there.
- `apps/desktop/src/store/translucency.test.ts` **(new)** — 6 tests.
- `contributors/emails/…` — required by `contributor-check`.

No i18n changes: the existing copy stays accurate, so `en`/`ja`/`zh`/`zh-hant`/`ar` and `types.ts` are untouched.

**Considered and rejected:** remapping stored values (`t_new = 100·√(t_old/100)`, bumping the store key to `v2`) so existing users see a pixel-identical window. It's speculative migration complexity for a setting that defaults to off, and users sitting at a mid-range value are exactly the ones this fixes. Raise it if you'd rather have it.

## How to Test

1. `cd apps/desktop && npm run dev`
2. Settings → Appearance → Window Translucency. Drag it: it now moves in 1% steps, and arrow keys nudge by 1.
3. Set it to ~40%. The window is visibly translucent but the UI text stays crisp; on `main` the same 40% is washed out.
4. Set it to 100% and compare against `main` — identical, the max see-through is unchanged.
5. Set 0% and confirm it is indistinguishable from an opaque window.
6. Quit and relaunch: the saved value is re-applied at window creation from `translucency.json`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — `gh search prs/issues "translucency"` turns up #45086 (the original feature) and #54413 (backdrop opacity, self-closed by its author); nothing touching step size or the ramp.
- [x] My PR contains **only** changes related to this fix
- [ ] ~~I've run `pytest tests/ -q`~~ — N/A, this is a JS/TS-only desktop change with no Python touched. The JS equivalents were run instead, see below.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Apple Silicon). Local Node was 25.9, outside the repo's supported range — see the note on the `ui` suite below.

**Verification actually run**, from `apps/desktop/`:

```
npm run check:lint              # tsc ×3 + eslint src/ electron/ → 0 errors
npm run test:desktop:platforms  # vitest --project electron → 943 passed, 2 skipped
npx vitest run --project ui src/store/translucency.test.ts → 6 passed
```

**Proof the tests bite:** setting `TRANSLUCENCY_CURVE = 1` reproduces the old linear ramp exactly; the two low-end assertions then fail (`expected 5% to stay near-opaque, got 0.965`) while the other six — endpoints, monotonicity, the floor, and clamping — still pass, confirming the extraction is faithful to current behaviour before the curve is applied.

**Full `--project ui` run:** 227 pre-existing failures on my machine, identical on unmodified `main` @ `aac74be2f` (35 files / 227 tests both ways); this branch adds 6 passing tests and changes nothing else. Those failures look environmental (Node 25.9 locally vs the repo's pinned `>=22.22.0` toolchain), so I could not get a fully green `ui` run locally to compare against — CI is the better signal there.

**Not verified by me:** Windows and Linux. Windows takes the same `setOpacity` path with no platform branch, and Linux is a documented no-op — but I only exercised macOS.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (no user-facing copy or config keys change)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — see "Not verified by me" above
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Same window, same bounds (`488,165,1220,800`), same wallpaper behind it, every other app hidden — the only variable is the build. macOS.

**At 40% — the bug and the fix.** Before, the skyline behind dominates and the body text and `No sessions yet` go muddy; after, the window is still clearly translucent but the UI stays legible.

| Before (`main`) — opacity 0.720 | After — opacity 0.888 |
|---|---|
| <img src="https://raw.githubusercontent.com/nicolasdmolina/hermes-agent/pr-assets-translucency/pr-assets/shot-OLD-40.png" width="420"> | <img src="https://raw.githubusercontent.com/nicolasdmolina/hermes-agent/pr-assets-translucency/pr-assets/shot-NEW-40.png" width="420"> |

**At 100% — unchanged, on purpose.** The maximum see-through setting is byte-identical to `main`; nothing was taken away to buy the readability above.

| Before (`main`) — opacity 0.300 | After — opacity 0.300 |
|---|---|
| <img src="https://raw.githubusercontent.com/nicolasdmolina/hermes-agent/pr-assets-translucency/pr-assets/shot-OLD-100.png" width="420"> | <img src="https://raw.githubusercontent.com/nicolasdmolina/hermes-agent/pr-assets-translucency/pr-assets/shot-NEW-100.png" width="420"> |

**At 0% — also unchanged**, the opaque window: [before](https://raw.githubusercontent.com/nicolasdmolina/hermes-agent/pr-assets-translucency/pr-assets/shot-OLD-0.png) · [after](https://raw.githubusercontent.com/nicolasdmolina/hermes-agent/pr-assets-translucency/pr-assets/shot-NEW-0.png).

Images are hosted on a branch of my fork rather than committed here, since `ee66ff279` ("chore(desktop): drop PR screenshot assets from tree") makes clear these don't belong in the tree.
