### PR TITLE
fix(telegram): honor HERMES_TELEGRAM_HTTP_* timeouts in standalone send path

### DIFF
--- a/tests/tools/test_send_message_telegram_proxy.py
+++ b/tests/tools/test_send_message_telegram_proxy.py
@@ -113,8 +113,9 @@ class TestSendTelegramStandaloneProxy:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Without TELEGRAM_PROXY (and no inherited HTTPS_PROXY/etc), Bot()
-        is constructed plainly — no ``request``/``get_updates_request``
-        kwargs, and HTTPXRequest is not invoked at all.
+        is constructed without a proxy: ``request=`` carries only the
+        timeout-tuned HTTPXRequest (no ``proxy=`` kwarg), and no
+        ``get_updates_request`` is passed (the standalone path never polls).
         """
         from tools.send_message_tool import _send_telegram
 
@@ -151,7 +152,8 @@ class TestSendTelegramStandaloneProxy:
         call_args = bot_factory.call_args.args
         # token may be passed positionally or as a kwarg; either is fine.
         assert call_kwargs.get("token", call_args[0] if call_args else None) == "tok"
-        assert "request" not in call_kwargs
         assert "get_updates_request" not in call_kwargs
-        httpx_request_factory.assert_not_called()
+        # The direct branch still tunes timeouts, but must not attach a proxy.
+        assert httpx_request_factory.call_count == 1
+        assert "proxy" not in httpx_request_factory.call_args.kwargs
         bot.send_message.assert_awaited_once()

--- a/tests/tools/test_send_message_telegram_timeouts.py
+++ b/tests/tools/test_send_message_telegram_timeouts.py
@@ -1,0 +1,157 @@
+"""Regression tests for the standalone Telegram send path's HTTP timeouts.
+
+The ``send_message`` tool, when invoked from a process *other than* the
+gateway (agent / TUI / cron / ``hermes send``), runs ``_send_telegram``
+directly with a ``telegram.Bot`` it constructs itself. Before the fix that
+accompanies these tests, that Bot used PTB's default ``HTTPXRequest``
+timeouts (5s across the board). Telegram can hold sendDocument/sendPhoto
+responses for 30s+ when a bot is under flood control, so every standalone
+media send failed with ``Timed out`` even though the upload itself
+succeeded server-side.
+
+These tests verify that the standalone path now honours the same
+``HERMES_TELEGRAM_HTTP_*`` env knobs as the gateway adapter
+(``plugins/platforms/telegram/adapter.py``) and matches its defaults.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.tools.test_send_message_telegram_proxy import (
+    _install_telegram_mock_with_request,
+    _make_bot,
+)
+
+_TIMEOUT_ENV = {
+    "HERMES_TELEGRAM_HTTP_POOL_TIMEOUT": "pool_timeout",
+    "HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT": "connect_timeout",
+    "HERMES_TELEGRAM_HTTP_READ_TIMEOUT": "read_timeout",
+    "HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT": "write_timeout",
+}
+
+_ADAPTER_DEFAULTS = {
+    "pool_timeout": 8.0,
+    "connect_timeout": 10.0,
+    "read_timeout": 20.0,
+    "write_timeout": 20.0,
+}
+
+
+def _clear_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wipe every env var resolve_proxy_url() inspects, and disable macOS
+    system-proxy auto-detection, so ambient host settings can't change
+    which Bot() branch runs.
+    """
+    for var in (
+        "TELEGRAM_PROXY",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(sys, "platform", "linux")
+
+
+class TestSendTelegramStandaloneTimeouts:
+    """The standalone ``_send_telegram`` path must construct its Bot with
+    adapter-parity HTTP timeouts instead of PTB's 5s defaults.
+    """
+
+    def _run_send(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> tuple[MagicMock, MagicMock]:
+        from tools.send_message_tool import _send_telegram
+
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+        bot = _make_bot()
+        bot_factory = MagicMock(return_value=bot)
+        httpx_request_factory = MagicMock(side_effect=lambda **kw: MagicMock(_kw=kw))
+        _install_telegram_mock_with_request(monkeypatch, bot_factory, httpx_request_factory)
+
+        result: dict[str, Any] = asyncio.run(_send_telegram("tok", "123", "hello"))
+        assert result["success"] is True
+        return bot_factory, httpx_request_factory
+
+    def test_direct_branch_uses_adapter_default_timeouts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without any env overrides, HTTPXRequest gets the gateway
+        adapter's defaults (pool 8 / connect 10 / read 20 / write 20).
+        """
+        _clear_proxy_env(monkeypatch)
+        for var in _TIMEOUT_ENV:
+            monkeypatch.delenv(var, raising=False)
+
+        bot_factory, httpx_request_factory = self._run_send(monkeypatch)
+
+        assert "request" in bot_factory.call_args.kwargs
+        assert httpx_request_factory.call_count == 1
+        kw = httpx_request_factory.call_args.kwargs
+        for name, expected in _ADAPTER_DEFAULTS.items():
+            assert kw.get(name) == expected, (
+                f"{name}: expected adapter default {expected}, got {kw.get(name)!r}"
+            )
+
+    def test_direct_branch_honours_env_overrides(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """HERMES_TELEGRAM_HTTP_* env vars override each timeout, exactly
+        as they do for the in-gateway adapter.
+        """
+        _clear_proxy_env(monkeypatch)
+        for i, var in enumerate(_TIMEOUT_ENV):
+            monkeypatch.setenv(var, str(100.0 + i))
+
+        _bot_factory, httpx_request_factory = self._run_send(monkeypatch)
+
+        kw = httpx_request_factory.call_args.kwargs
+        for i, (var, kwarg) in enumerate(_TIMEOUT_ENV.items()):
+            assert kw.get(kwarg) == 100.0 + i, (
+                f"{var} not honoured: expected {100.0 + i}, got {kw.get(kwarg)!r}"
+            )
+
+    def test_direct_branch_ignores_malformed_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-numeric env value falls back to the default instead of
+        crashing the send.
+        """
+        _clear_proxy_env(monkeypatch)
+        for var in _TIMEOUT_ENV:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", "not-a-number")
+
+        _bot_factory, httpx_request_factory = self._run_send(monkeypatch)
+
+        kw = httpx_request_factory.call_args.kwargs
+        assert kw.get("read_timeout") == _ADAPTER_DEFAULTS["read_timeout"]
+
+    def test_proxy_branch_carries_timeouts_too(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With TELEGRAM_PROXY set, both HTTPXRequest instances carry the
+        proxy *and* the tuned timeouts.
+        """
+        proxy_url = "socks5://127.0.0.1:1080"
+        _clear_proxy_env(monkeypatch)
+        monkeypatch.setenv("TELEGRAM_PROXY", proxy_url)
+        monkeypatch.setenv("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", "120")
+
+        _bot_factory, httpx_request_factory = self._run_send(monkeypatch)
+
+        assert httpx_request_factory.call_count == 2
+        for call in httpx_request_factory.call_args_list:
+            assert call.kwargs.get("proxy") == proxy_url
+            assert call.kwargs.get("read_timeout") == 120.0
+            assert call.kwargs.get("connect_timeout") == _ADAPTER_DEFAULTS["connect_timeout"]

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1213,20 +1213,43 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             _tg_proxy = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
         except Exception:
             _tg_proxy = None
+        # Honour the gateway adapter's HTTP timeout knobs here too
+        # (HERMES_TELEGRAM_HTTP_*, see plugins/platforms/telegram/adapter.py).
+        # PTB's HTTPXRequest defaults every timeout to 5s, but Telegram can
+        # hold sendDocument/sendPhoto responses for 30s+ when a bot is under
+        # flood control, so standalone media sends time out even though the
+        # upload itself succeeds. Matching the adapter defaults (and letting
+        # the same env vars raise them) keeps the two send paths consistent.
+        def _tg_env_float(name: str, default: float) -> float:
+            try:
+                return float(os.environ.get(name, str(default)))
+            except (TypeError, ValueError):
+                return default
+
+        _tg_request_kwargs = {
+            "pool_timeout": _tg_env_float("HERMES_TELEGRAM_HTTP_POOL_TIMEOUT", 8.0),
+            "connect_timeout": _tg_env_float("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", 10.0),
+            "read_timeout": _tg_env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
+            "write_timeout": _tg_env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
+        }
         if _tg_proxy:
             try:
                 from telegram.request import HTTPXRequest
                 logger.info("send_message: standalone Telegram send routed through proxy %s", _tg_proxy)
                 bot = Bot(
                     token=token,
-                    request=HTTPXRequest(proxy=_tg_proxy),
-                    get_updates_request=HTTPXRequest(proxy=_tg_proxy),
+                    request=HTTPXRequest(proxy=_tg_proxy, **_tg_request_kwargs),
+                    get_updates_request=HTTPXRequest(proxy=_tg_proxy, **_tg_request_kwargs),
                 )
             except Exception as _proxy_err:
                 logger.warning("send_message: failed to attach Telegram proxy (%s), falling back to direct connection", _proxy_err)
                 bot = Bot(token=token)
         else:
-            bot = Bot(token=token)
+            try:
+                from telegram.request import HTTPXRequest
+                bot = Bot(token=token, request=HTTPXRequest(**_tg_request_kwargs))
+            except Exception:
+                bot = Bot(token=token)
         from plugins.platforms.telegram.telegram_ids import (
             normalize_telegram_chat_id,
         )


### PR DESCRIPTION
## What does this PR do?

Makes the **standalone** Telegram send path (`tools/send_message_tool.py::_send_telegram`, used by agent / TUI / cron / `hermes send`) honor the same `HERMES_TELEGRAM_HTTP_*` timeout env knobs as the in-gateway adapter, with the same defaults (pool 8s / connect 10s / read 20s / write 20s).

Today that path constructs `telegram.Bot(token=...)` with PTB's default `HTTPXRequest`, which times every request out at **5s**. Telegram can hold `sendDocument`/`sendPhoto` responses for **30s+** when a bot is under flood control, so every standalone media send fails with `Timed out` — surfaced to the caller as the misleading `No deliverable text or media remained after processing MEDIA tags` — even though the upload itself succeeds server-side (risking silent duplicates on retry).

Real-world incident: a production deployment lost two days of scheduled document deliveries (all `hermes send` MEDIA pushes timing out every 5-minute retry sweep) while `curl` uploads of the same files completed in <2s. Raising the read timeout via the (previously gateway-only) env knob fixed it — this PR makes that knob work for the standalone path too, and aligns the defaults so the two send paths behave consistently.

## Related Issue

No existing issue found (searched `telegram timeout`, `send_message_tool timeout`, `telegram media timed out`; closed PRs #47238/#47923 addressed *retry* for text sends, not the media/`HTTPXRequest` timeout configuration).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/send_message_tool.py` — standalone `Bot()` construction now builds `HTTPXRequest` with `HERMES_TELEGRAM_HTTP_POOL/CONNECT/READ/WRITE_TIMEOUT` (defaults matching `plugins/platforms/telegram/adapter.py`: 8/10/20/20s), on both the proxy and direct branches. Malformed env values fall back to defaults. If `telegram.request` is unavailable, falls back to a plain `Bot(token=...)` as before.
- `tests/tools/test_send_message_telegram_timeouts.py` — new: default values, env overrides, malformed-env fallback, proxy branch carrying timeouts.
- `tests/tools/test_send_message_telegram_proxy.py` — updated `test_no_proxy_env_uses_plain_bot` to the new contract (direct branch passes a timeout-tuned `request=`, still no `proxy=`, still no `get_updates_request=`).

## How to Test

1. `pytest tests/tools/test_send_message_telegram_timeouts.py tests/tools/test_send_message_telegram_proxy.py -q` → 6 passed.
2. Reproduce the incident: from a machine whose bot is flood-limited (or with `HERMES_TELEGRAM_HTTP_READ_TIMEOUT=1` to simulate), run `hermes send --to telegram:<chat> "hi
MEDIA:/path/to/file.docx"` → fails with `Timed out` before this fix at default settings when Telegram responds slowly.
3. With this fix, set `HERMES_TELEGRAM_HTTP_READ_TIMEOUT=120` in `~/.hermes/.env` → same command delivers.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(telegram): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the relevant tests: `pytest tests/tools/ -q` — the tests touching this area all pass; the 60 pre-existing failures on my machine (voice/wake-word/web-tools env-dependent) fail identically on a pristine `origin/main` checkout
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.4)

### Documentation & Housekeeping

- [x] Docs: N/A — the env vars already exist for the gateway adapter and were undocumented; this PR extends where they apply (happy to add a docs entry if you'd like them documented)
- [x] `cli-config.yaml.example`: N/A — no config keys added
- [x] `CONTRIBUTING.md`/`AGENTS.md`: N/A
- [x] Cross-platform: env parsing only; no platform-specific code
- [x] Tool descriptions/schemas: N/A — no schema change
