### PR TITLE
fix(ui-tui): correctly detect WSL for Ctrl+J/Ctrl+Enter newline preservation

### DIFF
--- a/ui-tui/src/__tests__/textInputPassThrough.test.ts
+++ b/ui-tui/src/__tests__/textInputPassThrough.test.ts
@@ -19,6 +19,25 @@ describe('shouldPreserveCtrlJNewline', () => {
   it('keeps bare local POSIX LF-compatible prompts submitting on Ctrl+J', () => {
     expect(shouldPreserveCtrlJNewline({ TERM: 'xterm-256color' })).toBe(false)
   })
+
+  it('preserves Ctrl+J as newline on WSL via WSL_DISTRO_NAME alone (issue #77283)', () => {
+    // WSL_DISTRO_NAME is the distro REGISTRATION name (e.g. "Ubuntu",
+    // "Debian", "kali-linux") -- it never contains "microsoft". Its mere
+    // presence (not a substring match against it) is the reliable signal.
+    expect(
+      shouldPreserveCtrlJNewline({ WSL_DISTRO_NAME: 'Ubuntu', TERM: 'xterm-256color' })
+    ).toBe(true)
+  })
+
+  it('falls back to the /proc-based WSL2 kernel probe when env vars are scrubbed', () => {
+    // e.g. under sudo, where WSL_DISTRO_NAME and friends may not survive.
+    expect(
+      shouldPreserveCtrlJNewline({ TERM: 'xterm-256color' }, () => true)
+    ).toBe(true)
+    expect(
+      shouldPreserveCtrlJNewline({ TERM: 'xterm-256color' }, () => false)
+    ).toBe(false)
+  })
 })
 
 describe('shouldPassThroughToGlobalHandler', () => {

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1,5 +1,6 @@
 import type { InputEvent, Key } from '@hermes/ink'
 import * as Ink from '@hermes/ink'
+import { readFileSync } from 'node:fs'
 import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'react'
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
@@ -157,7 +158,40 @@ export function applyPrintableInsert(
 
 export const shouldRouteMultiCharInputAsPaste = (text: string): boolean => text.includes('\n')
 
-export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boolean {
+// Memoized WSL2 kernel probe, mirroring cli.py's own
+// _preserve_ctrl_enter_newline() (issue #22379): WSL_DISTRO_NAME (the
+// distro registration name, e.g. "Ubuntu") never contains "microsoft",
+// so relying on it alone leaves WSL undetected on every normal install.
+// The WSL2 kernel's own version string does contain "microsoft" (e.g.
+// "...microsoft-standard-WSL2"), so fall back to reading it directly.
+// Computed once and cached: this check backs a function that runs on
+// every Enter keystroke, and synchronous file reads on every call would
+// be wasteful.
+let _wsl2KernelCache: boolean | null = null
+
+function isWsl2Kernel(): boolean {
+  if (_wsl2KernelCache !== null) {
+    return _wsl2KernelCache
+  }
+  _wsl2KernelCache = false
+  for (const path of ['/proc/version', '/proc/sys/kernel/osrelease']) {
+    try {
+      if (readFileSync(path, 'utf8').toLowerCase().includes('microsoft')) {
+        _wsl2KernelCache = true
+        break
+      }
+    } catch {
+      // File doesn't exist (non-Linux) or isn't readable -- try the next
+      // path, or fall through to false if none matched.
+    }
+  }
+  return _wsl2KernelCache
+}
+
+export function shouldPreserveCtrlJNewline(
+  env: MinimalEnv = process.env,
+  wsl2KernelCheck: () => boolean = isWsl2Kernel
+): boolean {
   if (env.WT_SESSION) {
     return true
   }
@@ -178,7 +212,16 @@ export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boole
     return true
   }
 
-  return (env.WSL_DISTRO_NAME ?? '').toLowerCase().includes('microsoft')
+  // WSL_DISTRO_NAME is the distro registration name (e.g. "Ubuntu",
+  // "Debian", "kali-linux") -- it never contains "microsoft". Its mere
+  // presence is the reliable signal: it's only injected inside WSL.
+  if (env.WSL_DISTRO_NAME) {
+    return true
+  }
+
+  // Env vars can be scrubbed (e.g. under sudo) -- fall back to reading
+  // the kernel version string directly.
+  return wsl2KernelCheck()
 }
 
 function prevPos(s: string, p: number) {


### PR DESCRIPTION
Fixes #77283.

## Problem

`shouldPreserveCtrlJNewline()` checked whether `WSL_DISTRO_NAME` contained the substring `"microsoft"`, but `WSL_DISTRO_NAME` is the distro registration name (e.g. `"Ubuntu"`, `"Debian"`, `"kali-linux"`) -- it never contains that substring. The WSL branch was effectively dead code, so Ctrl+J/Ctrl+Enter submitted instead of inserting a newline on every normal WSL install not already covered by the Windows Terminal / SSH / Ghostty checks.

## Fix

Fixed the `WSL_DISTRO_NAME` check to use its mere presence rather than a substring match. Also added a memoized `/proc`-based fallback (checking `/proc/version` and `/proc/sys/kernel/osrelease` for the WSL2 kernel's own "microsoft" signature), mirroring `cli.py`'s existing `_preserve_ctrl_enter_newline()` (issue #22379) for cases where env vars are scrubbed (e.g. under sudo). Memoized since this backs a function that runs on every Enter keystroke.

Made the kernel probe an injectable second parameter (matching the existing injectable `env` parameter) for testability.

## Verification

Added the requested `WSL_DISTRO_NAME` test case plus a case for the `/proc`-based fallback.

`npm run typecheck`: 0 errors. 1462/1463 tests pass across the full `ui-tui` vitest suite (1 pre-existing unrelated skip; no regression).