### PR TITLE
fix: harden remote backend updates

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -7,6 +7,7 @@ import {
   AUDIO_TRANSCRIBE_MIN_REQUEST_TIMEOUT_MS,
   audioSpeakRequestTimeoutMs,
   audioTranscribeRequestTimeoutMs,
+  getActionStatus,
   getCronJobs,
   getGlobalModelInfo,
   getGlobalModelOptions,
@@ -48,6 +49,17 @@ describe('Hermes REST helpers', () => {
     setApiRequestProfile(null)
     vi.restoreAllMocks()
     Reflect.deleteProperty(window, 'hermesDesktop')
+  })
+
+  it('forwards the remaining action deadline to the API request', async () => {
+    await getActionStatus('update', 200, 12_345)
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/actions/update/status?lines=200',
+        timeoutMs: 12_345
+      })
+    )
   })
 
   it('uses a longer timeout for the single-profile session list', async () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1550,10 +1550,11 @@ export function checkHermesUpdate(force = false): Promise<BackendUpdateCheckResp
   })
 }
 
-export function getActionStatus(name: string, lines = 200): Promise<ActionStatusResponse> {
+export function getActionStatus(name: string, lines = 200, timeoutMs?: number): Promise<ActionStatusResponse> {
   return window.hermesDesktop.api<ActionStatusResponse>({
     ...profileScoped(),
-    path: `/api/actions/${encodeURIComponent(name)}/status?lines=${Math.max(1, lines)}`
+    path: `/api/actions/${encodeURIComponent(name)}/status?lines=${Math.max(1, lines)}`,
+    ...(timeoutMs === undefined ? {} : { timeoutMs })
   })
 }
 

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -537,6 +537,89 @@ describe('applyBackendUpdate recovery', () => {
     await promise
   })
 
+  it('keeps polling when the backend update runs past the old 45-second window', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
+    let polls = 0
+    getActionStatusSpy.mockImplementation(async () => {
+      polls += 1
+
+      if (polls <= 31) {
+        return {
+          exit_code: null,
+          lines: ['Installing dependencies...'],
+          name: 'update',
+          pid: 1,
+          running: true
+        }
+      }
+
+      return {
+        exit_code: 0,
+        lines: ['Update complete.'],
+        name: 'update',
+        pid: 1,
+        running: false
+      }
+    })
+    checkHermesUpdateSpy.mockResolvedValue({
+      install_method: 'git',
+      current_version: '0.19.1',
+      behind: 0,
+      update_available: false,
+      can_apply: true,
+      update_command: 'hermes update',
+      message: null
+    })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(60000)
+    const result = await promise
+
+    expect(result.ok).toBe(true)
+    expect(polls).toBeGreaterThan(30)
+    expect($backendUpdateApply.get().stage).toBe('idle')
+  })
+
+  it('bounds slow status requests by a ten-minute wall-clock deadline', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
+    getActionStatusSpy.mockImplementation(
+      (_name: string, _lines: number, timeoutMs?: number) =>
+        new Promise((resolve, reject) => {
+          const requestBudgetMs = timeoutMs ?? 15_000
+          globalThis.setTimeout(() => {
+            if (requestBudgetMs < 15_000) {
+              reject(new Error('request timed out'))
+
+              return
+            }
+
+            resolve({
+              exit_code: null,
+              lines: ['Still running...'],
+              name: 'update',
+              pid: 1,
+              running: true
+            })
+          }, Math.min(15_000, requestBudgetMs))
+        })
+    )
+
+    let settled = false
+
+    const promise = applyBackendUpdate().then(result => {
+      settled = true
+
+      return result
+    })
+
+    await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 1)
+
+    expect(settled).toBe(true)
+    expect((await promise).ok).toBe(false)
+    expect($backendUpdateApply.get().stage).toBe('error')
+    expect(getActionStatusSpy.mock.calls.every(call => Number(call[2]) > 0)).toBe(true)
+  })
+
   it('surfaces an error when the backend never comes back after the restart', async () => {
     updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
     getActionStatusSpy.mockRejectedValue(new Error('ECONNREFUSED'))

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -489,6 +489,11 @@ export async function applyUpdates(opts: DesktopUpdateApplyOptions = {}): Promis
 
 const BACKEND_RETURN_POLL_MS = 1500
 const BACKEND_RETURN_MAX_ATTEMPTS = 40
+const BACKEND_ACTION_POLL_MS = 1500
+// Dependency refreshes and native Desktop rebuilds can legitimately take
+// several minutes. The old 45-second budget produced a false failure while
+// the original action kept running, then invited a lock-rejected retry.
+const BACKEND_ACTION_TIMEOUT_MS = 10 * 60 * 1000
 
 async function waitForBackendReturn(): Promise<boolean> {
   for (let attempt = 0; attempt < BACKEND_RETURN_MAX_ATTEMPTS; attempt += 1) {
@@ -575,14 +580,26 @@ export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
     })
 
     let last: Awaited<ReturnType<typeof getActionStatus>> | null = null
+    const actionDeadline = Date.now() + BACKEND_ACTION_TIMEOUT_MS
 
-    for (let attempt = 0; attempt < 30; attempt += 1) {
-      await new Promise(resolve => globalThis.setTimeout(resolve, 1500))
+    while (Date.now() < actionDeadline) {
+      const sleepMs = Math.min(BACKEND_ACTION_POLL_MS, actionDeadline - Date.now())
+      await new Promise(resolve => globalThis.setTimeout(resolve, sleepMs))
+
+      const requestTimeoutMs = actionDeadline - Date.now()
+
+      if (requestTimeoutMs <= 0) {
+        break
+      }
 
       try {
-        last = await getActionStatus(started.name, 200)
+        last = await getActionStatus(started.name, 200, requestTimeoutMs)
         ingestBackendActionStatus(last)
       } catch {
+        if (Date.now() >= actionDeadline) {
+          break
+        }
+
         // The dashboard restarts mid-update, dropping this connection — expected, not a failure.
         $backendUpdateApply.set({
           ...$backendUpdateApply.get(),

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -37,10 +37,9 @@ def _scan_dashboard_processes(
     disk is updated, causing a silent frontend/backend mismatch (e.g. new
     auth headers the old backend doesn't recognise → every API call 401s).
 
-    The dashboard may be manually started or managed by the optional
-    ``hermes-dashboard.service`` systemd unit.  Managed units are restarted
-    through their owning systemd scope; only manually-started processes use
-    the kill path because we can't know their original launch args.
+    The dashboard may be manually started or managed by systemd/launchd.
+    Managed units are restarted through their owning service manager; only
+    manually-started processes use the raw argv respawn path.
 
     *exclude_pids* is an optional set of PIDs that must never be returned.
     This is used by the Hermes Desktop Electron app to protect its own
@@ -202,23 +201,27 @@ def _kill_stale_dashboard_processes(
     print()
     print(f"⟲ Stopping {len(pids)} dashboard process(es) ({reason})")
 
-    # Before killing, snapshot systemd cgroup info for each PID so we can
-    # restart supervised services after the kill (the cgroup disappears
-    # along with the process).  Only meaningful on Linux, and only when the
-    # caller asked for restarts (the `hermes update` path) — `--stop` must
-    # stay a stop, not a restart.
+    # Before killing, snapshot service-manager ownership and argv for each PID
+    # so supervised services can be restarted without also raw-respawning an
+    # identical command. Only the update path requests restarts; `--stop` must
+    # stay a stop.
     pid_cgroup: dict[int, str | None] = {}
     pid_service: dict[int, str | None] = {}
+    pid_launchd_service: dict[int, str | None] = {}
+    pid_all_cmdline: dict[int, list[str]] = {}
     pid_cmdline: dict[int, list[str]] = {}
     if restart_managed and sys.platform != "win32":
         for pid in pids:
             cg_path = _m()._get_pid_cgroup_path(pid)
             pid_cgroup[pid] = cg_path
             pid_service[pid] = _m()._get_systemd_service_for_pid(pid)
-            if not pid_service[pid]:
+            pid_launchd_service[pid] = _m()._get_launchd_service_for_pid(pid)
+            cmdline = _m()._dashboard_cmdline_for_pid(pid)
+            if cmdline:
+                pid_all_cmdline[pid] = cmdline
+            if not pid_service[pid] and not pid_launchd_service[pid]:
                 # Manually-started process: preserve its exact argv so we
                 # can respawn it after the update (#40449, #68934).
-                cmdline = _m()._dashboard_cmdline_for_pid(pid)
                 if cmdline:
                     pid_cmdline[pid] = cmdline
 
@@ -299,9 +302,22 @@ def _kill_stale_dashboard_processes(
     if killed and restart_managed:
         failed_restarts: list[tuple[str, str]] = []
         seen_services: set[str] = set()
+        seen_launchd_services: set[str] = set()
+        seen_respawn_cmds: set[tuple[str, ...]] = set()
+
+        def _respawn_command_key(command: list[str]) -> tuple[str, ...]:
+            """Normalise argv differences introduced by our own respawner."""
+            return tuple(arg for arg in command if arg != "--no-open")
+
+        managed_cmds = {
+            _respawn_command_key(command)
+            for pid, command in pid_all_cmdline.items()
+            if pid_service.get(pid) or pid_launchd_service.get(pid)
+        }
         respawn_cmds: list[list[str]] = []
         for pid in killed:
             svc_name = pid_service.get(pid)
+            launchd_target = pid_launchd_service.get(pid)
             if svc_name:
                 if svc_name in seen_services:
                     continue
@@ -311,13 +327,31 @@ def _kill_stale_dashboard_processes(
                 else:
                     failed_restarts.append((svc_name, "systemctl restart returned non-zero"))
                     unrecovered.append(pid)
+            elif launchd_target:
+                if launchd_target in seen_launchd_services:
+                    continue
+                seen_launchd_services.add(launchd_target)
+                if _m()._try_restart_launchd_service(launchd_target):
+                    restarted_services.append(launchd_target)
+                else:
+                    failed_restarts.append((launchd_target, "launchctl kickstart returned non-zero"))
+                    unrecovered.append(pid)
             elif pid in pid_cmdline:
-                respawn_cmds.append(pid_cmdline[pid])
+                command = pid_cmdline[pid]
+                command_key = _respawn_command_key(command)
+                # A stale raw duplicate may have been created by an older
+                # update beside an equivalent managed service. Restarting both
+                # recreates the port collision, so the managed copy wins.
+                if command_key in managed_cmds or command_key in seen_respawn_cmds:
+                    continue
+                seen_respawn_cmds.add(command_key)
+                respawn_cmds.append(command)
             else:
                 unrecovered.append(pid)
 
         for svc in restarted_services:
-            print(f"    ✓ restarted systemd service {svc}")
+            manager = "launchd" if svc.startswith(("gui/", "user/")) else "systemd"
+            print(f"    ✓ restarted {manager} service {svc}")
         for svc, err in failed_restarts:
             print(f"    ⚠ {svc}: {err}")
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7424,6 +7424,83 @@ def _get_systemd_service_for_pid(pid: int) -> str | None:
     return None
 
 
+def _get_launchd_service_for_pid(pid: int) -> str | None:
+    """Return the verified launchd service target that owns *pid* on macOS.
+
+    ``launchctl print pid/<pid>`` exposes the process's resource-coalition
+    name without requiring root. Coalition names alone are only hints, so the
+    candidate is accepted only when ``launchctl print <domain>/<label>``
+    reports the same live PID. The fully-qualified target can be passed
+    directly to ``launchctl kickstart``.
+    """
+    if sys.platform != "darwin" or not hasattr(os, "getuid"):
+        return None
+
+    try:
+        process = subprocess.run(
+            ["launchctl", "print", f"pid/{pid}"],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if process.returncode != 0:
+        return None
+
+    label: str | None = None
+    in_resource_coalition = False
+    for raw_line in (process.stdout or "").splitlines():
+        line = raw_line.strip()
+        if line == "resource coalition = {":
+            in_resource_coalition = True
+            continue
+        if in_resource_coalition and line.startswith("name = "):
+            label = line.removeprefix("name = ").strip()
+            break
+        if in_resource_coalition and line == "}":
+            break
+    if not label:
+        return None
+
+    uid = os.getuid()
+    for domain in (f"gui/{uid}", f"user/{uid}"):
+        target = f"{domain}/{label}"
+        try:
+            service = subprocess.run(
+                ["launchctl", "print", target],
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                timeout=10,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            continue
+        if service.returncode != 0:
+            continue
+        if any(
+            raw_line.strip() == f"pid = {pid}"
+            for raw_line in (service.stdout or "").splitlines()
+        ):
+            return target
+    return None
+
+
+def _try_restart_launchd_service(target: str) -> bool:
+    """Restart a verified launchd *target* and return whether it succeeded."""
+    if sys.platform != "darwin":
+        return False
+    try:
+        result = subprocess.run(
+            ["launchctl", "kickstart", "-k", target],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=15,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+
+
 def _extract_scope_from_cgroup(cgroup_entry: str) -> str | None:
     """Extract the systemd scope (``user`` or ``system``) from a cgroup path.
 

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -323,6 +323,91 @@ class TestManualBackendRespawn:
     def _live(self):
         return sys.modules["hermes_cli.main"]
 
+    def test_launchd_pid_resolution_verifies_the_owning_job(self, monkeypatch):
+        live = self._live()
+        calls: list[list[str]] = []
+
+        def fake_run(args, *a, **kw):
+            calls.append(list(args))
+            if args == ["launchctl", "print", "pid/4321"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout="""pid/4321 = {
+\tresource coalition = {
+\t\tname = com.hermes.dashboard
+\t}
+}\n""",
+                    stderr="",
+                )
+            if args == ["launchctl", "print", "gui/501/com.hermes.dashboard"]:
+                return MagicMock(returncode=0, stdout="\tpid = 4321\n", stderr="")
+            return MagicMock(returncode=1, stdout="", stderr="not found")
+
+        monkeypatch.setattr(live.sys, "platform", "darwin")
+        monkeypatch.setattr(live.os, "getuid", lambda: 501)
+        with patch.object(live.subprocess, "run", side_effect=fake_run):
+            target = live._get_launchd_service_for_pid(4321)
+
+        assert target == "gui/501/com.hermes.dashboard"
+        assert calls[:2] == [
+            ["launchctl", "print", "pid/4321"],
+            ["launchctl", "print", "gui/501/com.hermes.dashboard"],
+        ]
+
+    def test_launchd_owned_backend_restarts_service_without_raw_respawn(self, capsys):
+        """A launchd-owned PID is restarted through launchctl, not Popen."""
+        live = self._live()
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                raise ProcessLookupError
+
+        command = ["hermes", "dashboard", "--host", "100.83.89.64", "--port", "9119"]
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4321]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_get_launchd_service_for_pid",
+                          return_value="gui/501/com.hermes.dashboard"), \
+             patch.object(live, "_dashboard_cmdline_for_pid", return_value=command), \
+             patch.object(live, "_try_restart_launchd_service", return_value=True) as restart, \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        restart.assert_called_once_with("gui/501/com.hermes.dashboard")
+        respawn.assert_not_called()
+        assert result["unrecovered"] == []
+        assert "restarted launchd service gui/501/com.hermes.dashboard" in capsys.readouterr().out
+
+    def test_duplicate_manual_command_is_not_respawned_beside_launchd(self):
+        """A stale raw duplicate must not race the equivalent managed job."""
+        live = self._live()
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                raise ProcessLookupError
+
+        managed_command = ["hermes", "dashboard", "--host", "100.83.89.64", "--port", "9119"]
+        stale_command = [*managed_command, "--no-open"]
+        with patch.object(live, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[4321, 4322]), \
+             patch.object(live, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(live, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(live, "_get_launchd_service_for_pid",
+                          side_effect=lambda pid: "gui/501/com.hermes.dashboard" if pid == 4321 else None), \
+             patch.object(live, "_dashboard_cmdline_for_pid",
+                          side_effect=lambda pid: managed_command if pid == 4321 else stale_command), \
+             patch.object(live, "_try_restart_launchd_service", return_value=True), \
+             patch.object(live, "_respawn_dashboard_processes") as respawn, \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        respawn.assert_not_called()
+        assert result["unrecovered"] == []
+
 
     def test_argv_capture_failure_falls_back_to_hint(self, capsys):
         live = self._live()


### PR DESCRIPTION
## Summary

- replace Desktop's old 45-second backend-action polling window with a true 10-minute wall-clock deadline
- cap each action-status API request to the remaining deadline so slow requests cannot inflate the total budget
- identify macOS launchd ownership by verifying the PID against the matching `gui/<uid>/<label>` or `user/<uid>/<label>` job
- restart launchd-owned dashboards through `launchctl kickstart -k` instead of raw-spawning their captured command
- suppress duplicate manual respawns when they differ from a managed command only by the respawner-added `--no-open` flag
- add regressions for updates that remain active past 45 seconds, full deadline exhaustion, timeout forwarding, launchd ownership, launchd restart routing and duplicate-command suppression

## Root cause

A real remote update took about 94 seconds. Desktop stopped polling after `30 × 1.5s = 45s`, reported failure while the action was still running, and offered a retry that the backend correctly rejected with `Another Hermes update is already running`.

On macOS, update cleanup captured and raw-respawned dashboard argv even when the process belonged to a KeepAlive LaunchAgent. launchd also restarted its child, so the two processes raced for the same port and the launchd child repeatedly exited with `Errno 48: address already in use`.

## Verification

- `npm run typecheck`
- targeted ESLint on changed Desktop files
- focused Desktop helpers/update tests: 52 passed
- full Desktop UI suite: 3,298 passed
- focused Python regression: 18 passed
- update-related Python suites: 142 passed
- Ruff, `py_compile` and `git diff --check`
- live read-only macOS resolver probe mapped the running dashboard PID to `gui/501/com.hermes.dashboard`
- `npm run pack`
- packaged arm64 app strictly verified with `codesign --verify --deep --strict`; install stamp is clean at `20a6037b0`

Supersedes #77314, which GitHub closed when its temporary fork repository disappeared and cannot reopen after the fork was recreated.