### PR TITLE
fix(config): serve last-known-good raw config on YAML parse failure

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2960,6 +2960,17 @@ def read_raw_config() -> Dict[str, Any]:
                 data = fast_safe_load(f) or {}
         except Exception as e:
             _warn_config_parse_failure(config_path, e)
+            # Serve the last-known-good cached raw config when the file
+            # has become unreadable (broken YAML, permission error,
+            # transient I/O failure).  Returning {} here would let a
+            # read_raw_config() → mutate → save_config() round-trip
+            # silently overwrite the corrupted file with only the
+            # caller's single-section mutation, losing every other
+            # config section.  The same guard _load_config_impl uses
+            # for the expanded/merged config path.
+            cached = _RAW_CONFIG_CACHE.get(path_key)
+            if cached is not None:
+                return copy.deepcopy(cached[2])
             return {}
 
         if not isinstance(data, dict):

--- a/tests/hermes_cli/test_read_raw_config_lkg.py
+++ b/tests/hermes_cli/test_read_raw_config_lkg.py
@@ -1,0 +1,69 @@
+"""Tests for read_raw_config() LKG fallback on YAML parse errors.
+
+Similar to _load_config_impl's last-known-good guard, read_raw_config()
+must serve the previously-cached raw config when the file becomes
+unparseable, rather than silently returning {} and letting a
+read→mutate→save_config() caller overwrite the corrupted file.
+"""
+
+import os
+
+import pytest
+import yaml
+
+
+@pytest.fixture()
+def isolated_hermes_home():
+    """Per-test HERMES_HOME dir with the raw-config cache cleared."""
+    from pathlib import Path
+
+    import hermes_cli.config as config_mod
+
+    home = Path(os.environ["HERMES_HOME"])
+    home.mkdir(parents=True, exist_ok=True)
+    config_mod._RAW_CONFIG_CACHE.clear()
+    yield home
+    config_mod._RAW_CONFIG_CACHE.clear()
+
+
+def _write_config(home, data):
+    cfg = home / "config.yaml"
+    cfg.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return cfg
+
+
+def test_lkg_on_broken_yaml(isolated_hermes_home):
+    """read_raw_config returns last-known-good when YAML becomes broken."""
+    from hermes_cli.config import read_raw_config
+
+    # Populate cache with valid config
+    _write_config(
+        isolated_hermes_home,
+        {"model": {"default": "claude-opus-4-8"}, "agent": {"max_turns": 90}},
+    )
+    first = read_raw_config()
+    assert first == {"model": {"default": "claude-opus-4-8"}, "agent": {"max_turns": 90}}
+
+    # Corrupt the file
+    cfg = isolated_hermes_home / "config.yaml"
+    cfg.write_text("model:\n  default: claude\n  provider: [broken YAML")
+    # Bump mtime to invalidate the signature-based cache hit
+    st = cfg.stat()
+    os.utime(cfg, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+
+    # Should return LKG, not {}
+    second = read_raw_config()
+    assert second == {"model": {"default": "claude-opus-4-8"}, "agent": {"max_turns": 90}}, (
+        f"Expected LKG config, got {second}"
+    )
+
+
+def test_cold_start_broken_yaml_still_returns_empty(isolated_hermes_home):
+    """Cold start with no cache: broken YAML still returns {} (existing behavior)."""
+    from hermes_cli.config import read_raw_config
+
+    cfg = isolated_hermes_home / "config.yaml"
+    cfg.write_text("model:\n  default: claude\n  provider: [broken YAML")
+
+    result = read_raw_config()
+    assert result == {}, f"Cold start with broken YAML should return {{}}, got {result}"


### PR DESCRIPTION
## Bug

`read_raw_config()` silently returns `{}` when `config.yaml` has broken YAML syntax (the broad `except Exception` at `hermes_cli/config.py:2961`). Callers that do `read_raw_config()` → mutate → `save_config()` (e.g. `write_platform_config_field` with `raw=True`) would then **overwrite the corrupted file with only the caller's single mutation, losing every other config section**.

This is the same **parse-error → silent-return-empty → write-back → data-loss** pattern as #75431/#75885, in the sibling raw-config read path.

## Root Cause

`read_raw_config()` catches `Exception` (including `YAMLError`) and returns `{}`. `require_readable_config_before_write` only checks file I/O readability, not YAML validity — so the guard passes and the write proceeds.

## Fix

Mirrors `_load_config_impl`'s last-known-good pattern: when `fast_safe_load` raises, check `_RAW_CONFIG_CACHE` for the previously cached value and serve that instead of `{}`. Cold-start (no cache) still returns `{}` as before — there is no previous state to preserve.

## Test

2 new tests in `tests/hermes_cli/test_read_raw_config_lkg.py`:
- `test_lkg_on_broken_yaml` — verify LKG served on parse failure
- `test_cold_start_broken_yaml_still_returns_empty` — verify cold-start behavior unchanged

Closes #75431 (sibling fix)