### PR TITLE
fix(skills): validate staged skill writes before pending creation

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1,6 +1,9 @@
 """Tests for tools/skill_manager_tool.py — skill creation, editing, and deletion."""
 
 import json
+import os
+import shutil
+import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
@@ -874,3 +877,331 @@ class TestCuratorConsolidationDeleteGuard:
             assert allowed["success"] is True, allowed
 
         _reset_background_review_read_marks()
+
+
+# ---------------------------------------------------------------------------
+# Staging preflight — validate create/edit payloads before they become pending
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _approval_home(monkeypatch, enabled):
+    """HERMES_HOME on a temp dir with skills.write_approval set to ``enabled``.
+
+    Always writes the flag explicitly: reading the operator's real config would
+    make gate-on/gate-off assertions depend on the machine.
+    """
+    d = tempfile.mkdtemp(prefix="hermes_skill_gate_test_")
+    home = os.path.join(d, ".hermes")
+    os.makedirs(home)
+    monkeypatch.setenv("HERMES_HOME", home)
+    import hermes_cli.config as cfg
+    config = cfg.load_config()
+    config.setdefault("skills", {})["write_approval"] = enabled
+    cfg.save_config(config)
+    try:
+        yield home
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def _desc_of_length(n):
+    """A one-sentence description padded to exactly ``n`` characters."""
+    head = "Use when staging a skill "
+    return head + "a" * (n - len(head) - 1) + "."
+
+
+def _desc_with_quoted_tail(budgeted_len):
+    """A plain-YAML description ending in a quote character.
+
+    YAML leaves the quote in the parsed value, but the budget check measures
+    ``desc.strip().strip("'\\"")`` — so the parsed value is one char longer
+    than the length the limit is actually applied to. Used to pin the reported
+    count to the measured one.
+    """
+    head = "Use when the user says "
+    return head + '"' + "a" * (budgeted_len - len(head) - 1) + '"'
+
+
+def _skill_md(desc, name="budget-skill"):
+    return f"---\nname: {name}\ndescription: {desc}\n---\n\n# Budget Skill\n\nStep 1.\n"
+
+
+def _skill_on_disk(tmp_path, name="budget-skill"):
+    """Materialize a valid skill so disk-state checks pass and payload
+    validation is what decides the outcome."""
+    skill = tmp_path / name
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "SKILL.md").write_text(
+        _skill_md(_desc_of_length(SKILL_PROMPT_DESC_LIMIT), name=name), encoding="utf-8"
+    )
+    return skill
+
+
+class TestStagedWritePreflight:
+    """An invalid write payload must be rejected before it is staged.
+
+    Staging defers the real write — and the validation inside the action
+    handlers — to approval replay, so validation that only runs there surfaces
+    the failure after the user already reviewed and approved the pending
+    record.
+    """
+
+    def test_over_budget_description_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        over = _desc_of_length(SKILL_PROMPT_DESC_LIMIT + 1)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="create", name="budget-skill", content=_skill_md(over),
+            ))
+            assert result.get("success") is False, result
+            assert result.get("staged") is not True
+            assert wa.pending_count(wa.SKILLS) == 0
+            # The rejection must name the real count, the limit, and the fix.
+            error = result["error"]
+            assert f"Description is {SKILL_PROMPT_DESC_LIMIT + 1} chars" in error
+            assert f"{SKILL_PROMPT_DESC_LIMIT}-char system-prompt budget" in error
+            assert "Move detail into the skill body." in error
+
+    def test_at_budget_description_stages_normally(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        at_limit = _desc_of_length(SKILL_PROMPT_DESC_LIMIT)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="create", name="budget-skill", content=_skill_md(at_limit),
+            ))
+            assert result["staged"] is True, result
+            assert result["pending_id"]
+            assert wa.pending_count(wa.SKILLS) == 1
+
+    def test_edit_over_budget_still_stages(self, tmp_path, monkeypatch):
+        """The 60-char rule is create-only, so edit must keep staging —
+        otherwise existing over-limit skills become uneditable."""
+        from tools import write_approval as wa
+        over = _desc_of_length(SKILL_PROMPT_DESC_LIMIT + 40)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="edit", name="budget-skill", content=_skill_md(over),
+            ))
+            assert result["staged"] is True, result
+            assert wa.pending_count(wa.SKILLS) == 1
+
+    def test_patch_merged_result_is_not_preflighted(self, tmp_path, monkeypatch):
+        """A patch's merged result does not exist until replay, so approval-time
+        validation stays its only checkpoint — even for a patch that will break
+        the frontmatter once applied."""
+        from tools import write_approval as wa
+        _skill_on_disk(tmp_path)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="patch", name="budget-skill",
+                old_string="name: budget-skill", new_string="",
+            ))
+            assert result["staged"] is True, result
+            assert wa.pending_count(wa.SKILLS) == 1
+
+    def test_patch_on_missing_skill_still_stages(self, tmp_path, monkeypatch):
+        """Whether the skill exists is disk state, which can change between
+        staging and approval — so it stays a replay-time check."""
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="patch", name="budget-skill",
+                old_string="Step 1.", new_string="Step 2.",
+            ))
+            assert result["staged"] is True, result
+            assert wa.pending_count(wa.SKILLS) == 1
+
+    def test_missing_content_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(action="create", name="budget-skill"))
+            assert result.get("success") is False, result
+            assert "content is required for 'create'" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_invalid_category_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        ok = _desc_of_length(SKILL_PROMPT_DESC_LIMIT)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="create", name="budget-skill", content=_skill_md(ok),
+                category="../escape",
+            ))
+            assert result.get("success") is False, result
+            assert "Invalid category '../escape'" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_malformed_frontmatter_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="create", name="budget-skill", content="# No frontmatter\n",
+            ))
+            assert result.get("success") is False, result
+            assert "must start with YAML frontmatter" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_gate_off_writes_through_unchanged(self, tmp_path, monkeypatch):
+        """With the gate off nothing stages and the create still lands."""
+        from tools import write_approval as wa
+        ok = _desc_of_length(SKILL_PROMPT_DESC_LIMIT)
+        with _approval_home(monkeypatch, False), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="create", name="budget-skill", content=_skill_md(ok),
+            ))
+            assert result["success"] is True, result
+            assert result.get("staged") is not True
+            assert wa.pending_count(wa.SKILLS) == 0
+        assert (tmp_path / "budget-skill" / "SKILL.md").exists()
+
+    def test_reported_count_is_the_measured_count(self, tmp_path, monkeypatch):
+        """The budget is applied to the quote-stripped description, so the
+        rejection must report that length — not the raw parsed one."""
+        over = _desc_with_quoted_tail(SKILL_PROMPT_DESC_LIMIT + 1)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="create", name="budget-skill", content=_skill_md(over),
+            ))
+            assert result.get("success") is False, result
+            error = result["error"]
+            assert f"Description is {SKILL_PROMPT_DESC_LIMIT + 1} chars" in error
+            assert f"Description is {SKILL_PROMPT_DESC_LIMIT + 2} chars" not in error
+
+    def test_patch_params_are_preflighted(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        _skill_on_disk(tmp_path)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="patch", name="budget-skill", new_string="Step 2.",
+            ))
+            assert result.get("success") is False, result
+            assert "old_string is required for 'patch'" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_patch_file_path_traversal_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        _skill_on_disk(tmp_path)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="patch", name="budget-skill", file_path="../escape.md",
+                old_string="Step 1.", new_string="Step 2.",
+            ))
+            assert result.get("success") is False, result
+            assert "Path traversal" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_write_file_traversal_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="write_file", name="budget-skill",
+                file_path="../escape.md", file_content="pwned\n",
+            ))
+            assert result.get("success") is False, result
+            assert "Path traversal" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_write_file_over_byte_limit_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        from tools.skill_manager_tool import MAX_SKILL_FILE_BYTES
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="write_file", name="budget-skill",
+                file_path="references/big.md", file_content="a" * (MAX_SKILL_FILE_BYTES + 1),
+            ))
+            assert result.get("success") is False, result
+            assert "1 MiB" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_write_file_missing_content_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="write_file", name="budget-skill", file_path="references/a.md",
+            ))
+            assert result.get("success") is False, result
+            assert "file_content is required for 'write_file'" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_write_file_empty_content_still_stages(self, tmp_path, monkeypatch):
+        """An empty supporting file is a legal write, so the preflight must not
+        be stricter than the handler it stands in for."""
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="write_file", name="budget-skill",
+                file_path="references/a.md", file_content="",
+            ))
+            assert result["staged"] is True, result
+            assert wa.pending_count(wa.SKILLS) == 1
+
+    def test_remove_file_traversal_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="remove_file", name="budget-skill", file_path="../escape.md",
+            ))
+            assert result.get("success") is False, result
+            assert "Path traversal" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_delete_stages_without_preflight(self, tmp_path, monkeypatch):
+        """Delete carries no payload beyond the name, whose existence is disk
+        state — nothing to preflight."""
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(action="delete", name="budget-skill"))
+            assert result["staged"] is True, result
+            assert wa.pending_count(wa.SKILLS) == 1
+
+    @pytest.mark.parametrize("kwargs", [
+        pytest.param(
+            {"action": "create", "content": _skill_md(_desc_of_length(SKILL_PROMPT_DESC_LIMIT + 1))},
+            id="create-over-budget",
+        ),
+        pytest.param({"action": "create"}, id="create-missing-content"),
+        pytest.param(
+            {"action": "create", "content": _skill_md(_desc_of_length(SKILL_PROMPT_DESC_LIMIT)),
+             "category": "../escape"},
+            id="create-bad-category",
+        ),
+        pytest.param(
+            {"action": "patch", "new_string": "Step 2."}, id="patch-missing-old-string",
+        ),
+        pytest.param(
+            {"action": "patch", "file_path": "../escape.md",
+             "old_string": "Step 1.", "new_string": "Step 2."},
+            id="patch-traversal",
+        ),
+        pytest.param(
+            {"action": "write_file", "file_path": "../escape.md", "file_content": "x"},
+            id="write-file-traversal",
+        ),
+        pytest.param(
+            {"action": "write_file", "file_path": "notes/a.md", "file_content": "x"},
+            id="write-file-bad-subdir",
+        ),
+        pytest.param({"action": "write_file", "file_path": "references/a.md"},
+                     id="write-file-missing-content"),
+        pytest.param({"action": "remove_file", "file_path": "../escape.md"},
+                     id="remove-file-traversal"),
+    ])
+    def test_gated_and_ungated_rejections_are_identical(self, tmp_path, monkeypatch, kwargs):
+        """The preflight must be the gate-off path's validation, not a parallel
+        copy of it: the same payload has to produce the same error either way.
+
+        Divergence is the real hazard here — a preflight that is stricter than
+        replay rejects writes approval would have accepted, and one that is
+        laxer re-introduces the round trip this exists to remove.
+        """
+        _skill_on_disk(tmp_path)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            gated = json.loads(skill_manage(name="budget-skill", **kwargs))
+        with _approval_home(monkeypatch, False), _skill_dir(tmp_path):
+            ungated = json.loads(skill_manage(name="budget-skill", **kwargs))
+
+        assert gated.get("success") is False, gated
+        assert gated.get("staged") is not True, gated
+        assert ungated.get("success") is False, ungated
+        assert gated["error"] == ungated["error"]

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -604,9 +604,10 @@ def _validate_frontmatter(content: str, *, new_skill: bool = False) -> Optional[
     desc = str(parsed["description"])
     if len(desc) > MAX_DESCRIPTION_LENGTH:
         return f"Description exceeds {MAX_DESCRIPTION_LENGTH} characters."
-    if new_skill and len(desc.strip().strip("'\"")) > SKILL_PROMPT_DESC_LIMIT:
+    budgeted_desc = desc.strip().strip("'\"")
+    if new_skill and len(budgeted_desc) > SKILL_PROMPT_DESC_LIMIT:
         return (
-            f"Description is {len(desc.strip())} chars — new skills must fit the "
+            f"Description is {len(budgeted_desc)} chars — new skills must fit the "
             f"{SKILL_PROMPT_DESC_LIMIT}-char system-prompt budget (one sentence, "
             f"trigger first, ends with a period). The skill index truncates "
             f"longer descriptions to {SKILL_PROMPT_DESC_LIMIT - 3} chars + '...', "
@@ -631,6 +632,21 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
             f"(limit: {MAX_SKILL_CONTENT_CHARS:,}). "
             f"Consider splitting into a smaller SKILL.md with supporting files "
             f"in references/ or templates/."
+        )
+    return None
+
+
+def _validate_file_bytes(file_content: str) -> Optional[str]:
+    """Check a supporting file's encoded size against the per-file byte limit.
+
+    Returns an error message or None if within bounds.
+    """
+    content_bytes = len(file_content.encode("utf-8"))
+    if content_bytes > MAX_SKILL_FILE_BYTES:
+        return (
+            f"File content is {content_bytes:,} bytes "
+            f"(limit: {MAX_SKILL_FILE_BYTES:,} bytes / 1 MiB). "
+            f"Consider splitting into smaller files."
         )
     return None
 
@@ -1273,17 +1289,9 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     if not file_content and file_content != "":
         return {"success": False, "error": "file_content is required."}
 
-    # Check size limits
-    content_bytes = len(file_content.encode("utf-8"))
-    if content_bytes > MAX_SKILL_FILE_BYTES:
-        return {
-            "success": False,
-            "error": (
-                f"File content is {content_bytes:,} bytes "
-                f"(limit: {MAX_SKILL_FILE_BYTES:,} bytes / 1 MiB). "
-                f"Consider splitting into smaller files."
-            ),
-        }
+    err = _validate_file_bytes(file_content)
+    if err:
+        return {"success": False, "error": err}
     err = _validate_content_size(file_content, label=file_path)
     if err:
         return {"success": False, "error": err}
@@ -1399,6 +1407,92 @@ _skill_gate_bypass: "_ctxvars.ContextVar[bool]" = _ctxvars.ContextVar(
 )
 
 
+# Missing-parameter messages, shared by skill_manage() and the staging preflight
+# so a gated write and an ungated one reject an incomplete payload identically.
+_REQUIRED_PARAM_ERRORS = {
+    "create": {
+        "content": "content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).",
+    },
+    "edit": {
+        "content": "content is required for 'edit'. Provide the full updated SKILL.md text.",
+    },
+    "patch": {
+        "old_string": "old_string is required for 'patch'. Provide the text to find.",
+        "new_string": "new_string is required for 'patch'. Use empty string to delete matched text.",
+    },
+    "write_file": {
+        "file_path": "file_path is required for 'write_file'. Example: 'references/api-guide.md'",
+        "file_content": "file_content is required for 'write_file'.",
+    },
+    "remove_file": {
+        "file_path": "file_path is required for 'remove_file'.",
+    },
+}
+
+
+def _preflight_staged_skill_write(action: str, name: str, payload: Dict[str, Any]) -> Optional[str]:
+    """Validate what is checkable about a write payload before it becomes pending.
+
+    Staging defers the real write — and with it every validation inside the
+    action handlers — until approval replay, so without this an invalid payload
+    sits in the pending queue and fails only after the user has reviewed and
+    approved it. Call the same validators the handlers call, not copies, so the
+    staged and replayed paths can never disagree, and run them in the handlers'
+    order so both paths report the same error for the same payload.
+
+    Only payload-intrinsic checks belong here. Anything that depends on the
+    state of the skill on disk — name collisions, the skill existing, the org
+    mirror and background-review guards, the security scan, and a patch's
+    merged result — stays a replay-time check: the disk can change between
+    staging and approval, so replay is the only correct place to evaluate it.
+    """
+    required = _REQUIRED_PARAM_ERRORS.get(action, {})
+    content = payload.get("content")
+    file_path = payload.get("file_path")
+    file_content = payload.get("file_content")
+
+    if action in ("create", "edit"):
+        if not content:
+            return required["content"]
+        if action == "create":
+            err = _validate_name(name) or _validate_category(payload.get("category"))
+            if err:
+                return err
+        return (
+            _validate_frontmatter(content, new_skill=(action == "create"))
+            or _validate_content_size(content)
+        )
+
+    if action == "patch":
+        if not payload.get("old_string"):
+            return required["old_string"]
+        if payload.get("new_string") is None:
+            return required["new_string"]
+        # Only the addressing is checkable: the merged result does not exist
+        # until replay, so _patch_skill stays the sole checkpoint for it.
+        return _validate_file_path(file_path) if file_path else None
+
+    if action == "write_file":
+        if not file_path:
+            return required["file_path"]
+        if file_content is None:
+            return required["file_content"]
+        return (
+            _validate_file_path(file_path)
+            or _validate_file_bytes(file_content)
+            or _validate_content_size(file_content, label=file_path)
+        )
+
+    if action == "remove_file":
+        if not file_path:
+            return required["file_path"]
+        return _validate_file_path(file_path)
+
+    # 'delete' carries no payload beyond the skill name, whose existence is a
+    # disk check.
+    return None
+
+
 def _apply_skill_write_gate(action, name, **payload_kwargs):
     """Evaluate the skill write gate. Returns a JSON tool-result string when the
     write should NOT proceed (blocked or staged), or None to perform the real
@@ -1419,6 +1513,10 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
         return None
     if decision.blocked:
         return tool_error(decision.message, success=False)
+
+    err = _preflight_staged_skill_write(action, name, payload_kwargs)
+    if err:
+        return tool_error(err, success=False)
 
     # stage — record the full skill_manage kwargs so approval can replay it.
     payload = {"action": action, "name": name}
@@ -1546,19 +1644,19 @@ def skill_manage(
 
     if action == "create":
         if not content:
-            return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
+            return tool_error(_REQUIRED_PARAM_ERRORS["create"]["content"], success=False)
         result = _create_skill(name, content, category)
 
     elif action == "edit":
         if not content:
-            return tool_error("content is required for 'edit'. Provide the full updated SKILL.md text.", success=False)
+            return tool_error(_REQUIRED_PARAM_ERRORS["edit"]["content"], success=False)
         result = _edit_skill(name, content)
 
     elif action == "patch":
         if not old_string:
-            return tool_error("old_string is required for 'patch'. Provide the text to find.", success=False)
+            return tool_error(_REQUIRED_PARAM_ERRORS["patch"]["old_string"], success=False)
         if new_string is None:
-            return tool_error("new_string is required for 'patch'. Use empty string to delete matched text.", success=False)
+            return tool_error(_REQUIRED_PARAM_ERRORS["patch"]["new_string"], success=False)
         result = _patch_skill(name, old_string, new_string, file_path, replace_all)
 
     elif action == "delete":
@@ -1566,14 +1664,14 @@ def skill_manage(
 
     elif action == "write_file":
         if not file_path:
-            return tool_error("file_path is required for 'write_file'. Example: 'references/api-guide.md'", success=False)
+            return tool_error(_REQUIRED_PARAM_ERRORS["write_file"]["file_path"], success=False)
         if file_content is None:
-            return tool_error("file_content is required for 'write_file'.", success=False)
+            return tool_error(_REQUIRED_PARAM_ERRORS["write_file"]["file_content"], success=False)
         result = _write_file(name, file_path, file_content)
 
     elif action == "remove_file":
         if not file_path:
-            return tool_error("file_path is required for 'remove_file'.", success=False)
+            return tool_error(_REQUIRED_PARAM_ERRORS["remove_file"]["file_path"], success=False)
         result = _remove_file(name, file_path)
 
     else:


### PR DESCRIPTION
## What does this PR do?

When `skills.write_approval` is on, `_apply_skill_write_gate()` stages every skill write payload **without validating it**. The validation that lives inside the action handlers therefore does not run until approval replay, so an invalid payload is accepted into the pending queue and fails only *after* the user has reviewed and approved it.

The most visible case is the 60-char system-prompt budget for new skills. An agent authors a skill with a 111-char description, the write stages cleanly, the user reviews the pending record and runs `/skills approve <id>`, and only then does it fail:

```
Approved 0 skills write(s).
Failed:
2712f89b: Description is 111 chars — new skills must fit the 60-char system-prompt budget ...
```

That costs a full review/approve round trip per invalid write, and the agent gets no signal at authoring time that anything was wrong. The same holds for a `write_file` carrying a `..` traversal path or a file over the 1 MiB limit, and for a `patch` missing `old_string` — all of them stage, wait for a human, and then fail.

This PR runs the same validators before staging, so the write is rejected at the point the agent authored it.

The memory subsystem already works this way — `test_memory_invalid_params_rejected_before_staging` asserts exactly this property, with the comment *"Param validation must run BEFORE the gate so a broken write is rejected immediately instead of staged and failing at approve time."* Skills were the remaining gap.

## What is and isn't preflighted

The split is **payload-intrinsic vs. disk state**, not action-by-action:

| Preflighted before staging | Stays a replay-time check |
|---|---|
| Missing required params (`content`, `old_string`/`new_string`, `file_path`, `file_content`) | Name collisions, the skill existing |
| Skill name / category | Org-mirror and background-review guards |
| Frontmatter (60-char budget on `create` only) | `_security_scan_skill` (scans a directory, which doesn't exist until the write lands) |
| Content size, per-file 1 MiB byte limit | A `patch`'s **merged result** — it doesn't exist until replay |
| `file_path` (traversal + allowed-subdir), including a `patch`'s target file | |

The right-hand column all depends on state that can change between staging and approval, so replay is the only correct place to evaluate it. `delete` carries no payload beyond the name, so there is nothing to preflight.

The batch path gets the same treatment: `tools/skill_manager_batch.py` preflights **every op** before the batch becomes one pending record, and prefixes the rejection with `operations[i]: ` — the same format `_validate_batch_ops` already uses, so one bad op in a multi-op batch stays attributable. Without it a single invalid op surfaced only after the whole batch was approved.

**Approach notes:**

- The preflight calls the **existing** validators (`_validate_name`, `_validate_category`, `_validate_frontmatter`, `_validate_content_size`, `_validate_file_path`, `_validate_file_bytes`) and the existing `_REQUIRED_ARGS` table rather than copies, and runs them in the handlers' order, so the staged path and the ungated path cannot drift apart.
- The dispatcher and handler checks are **kept** as a backstop — the skill on disk can change between staging and replay, so double validation is deliberate.
- Divergence in either direction is the real hazard: a preflight stricter than replay would reject writes approval would have accepted, and a laxer one re-introduces the round trip this exists to remove. `test_gated_and_ungated_rejections_are_identical` parametrizes 9 invalid payloads and asserts the gate-on and gate-off error strings are byte-identical.

## Related Issue

Fixes #94372

Addresses #78519 (open, **P2**) — Bug #2 in full; Bug #1's staging half (a `write_file` whose body arrived under `content` is now rejected before staging, with the misplaced-text hint, instead of after approval).

#94372 is the same symptom reported on its own and is already linked to #78519 as a duplicate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skill_manager_tool.py`
  - Added `_preflight_staged_skill_write(action, name, payload)` — validates the payload-intrinsic properties of `create` / `edit` / `patch` / `write_file` / `remove_file` by calling the existing validators, and returns the `_REQUIRED_ARGS` message plus `_misplaced_text_hint(...)` for a missing required argument so a gated rejection is byte-identical to the ungated one. `delete` and a `patch`'s merged result return `None` (not preflighted).
  - `_run_write_gate(build_staging, preflight=None)` — the shared gate now takes an optional preflight that runs after the blocked check and immediately before `wa.stage_write(...)`, returning `tool_error(err, success=False)` instead of staging. `_apply_skill_write_gate()` passes the flat-path preflight.
  - Extracted the per-file 1 MiB check out of `_write_file()` into `_validate_file_bytes()` so the gate and the handler share the logic, not a copied message.
  - Extracted the patch-shape strings into shared constants `_PATCH_OLD_STRING_ERROR`, `_PATCH_NEW_STRING_ERROR`, `_PATCH_INPUT_SHAPE_ERROR`, used by `_patch_skill` / `_act_patch` and the preflight alike.
  - Fixed a reporting inconsistency in `_validate_frontmatter()`: the 60-char comparison uses `desc.strip().strip("'\"")` but the error message reported `len(desc.strip())`, overstating a quote-terminated description by up to two characters. Both now use the same value.
- `tools/skill_manager_batch.py`
  - `_skill_manage_batch()` passes a preflight to `_run_write_gate` that walks every op through `_preflight_staged_skill_write` and returns `operations[i]: <error>`.
- `tests/tools/test_skill_manager_tool.py`
  - Added `TestStagedWritePreflight` — two invariant tests, 12 parametrized items.

## Tests

Two invariant tests, per AGENTS.md's *"Tests per fix: 1–2 INVARIANT tests (behaviour contract, proven red on base)"*. An earlier revision of this branch carried 27 tests; they were cut to the two contracts below (12 items) — the deleted ones were pass-through assertions and per-validator restatements, not additional contracts.

1. `test_over_budget_description_is_not_staged` (3 items: `flat-plain`, `flat-quoted-tail`, `batch-plain`) — a create whose description overruns the budget never enters the pending queue, and the rejection reports the length the budget check actually measured, on the flat path and the batch path alike.
2. `test_gated_and_ungated_rejections_are_identical` (9 items) — for the same invalid payload, the gate-on and gate-off error strings are byte-identical.

**Red on base** — source files reverted to `main`, tests kept:

```
$ git checkout upstream/main -- tools/skill_manager_tool.py tools/skill_manager_batch.py
$ scripts/run_tests.sh tests/tools/test_skill_manager_tool.py -k TestStagedWritePreflight -v

=== Summary: 1 files, 0 tests passed, 12 failed (100% complete) in 2.1s (22 workers) ===
```

All 12 items fail, none pass:

```
TestStagedWritePreflight::test_over_budget_description_is_not_staged[flat-plain]
TestStagedWritePreflight::test_over_budget_description_is_not_staged[flat-quoted-tail]
TestStagedWritePreflight::test_over_budget_description_is_not_staged[batch-plain]
TestStagedWritePreflight::test_gated_and_ungated_rejections_are_identical[create-over-budget]
TestStagedWritePreflight::test_gated_and_ungated_rejections_are_identical[create-missing-content]
TestStagedWritePreflight::test_gated_and_ungated_rejections_are_identical[create-bad-category]
TestStagedWritePreflight::test_gated_and_ungated_rejections_are_identical[patch-missing-old-string]
TestStagedWritePreflight::test_gated_and_ungated_rejections_are_identical[patch-traversal]
TestStagedWritePreflight::test_gated_and_ungated_rejections_are_identical[write-file-traversal]
TestStagedWritePreflight::test_gated_and_ungated_rejections_are_identical[write-file-bad-subdir]
TestStagedWritePreflight::test_gated_and_ungated_rejections_are_identical[write-file-body-under-content]
TestStagedWritePreflight::test_gated_and_ungated_rejections_are_identical[remove-file-traversal]
```

On base each one stages instead of rejecting, e.g.:

```
E  AssertionError: {'success': True, 'staged': True, 'pending_id': '744b5f3f',
   'gist': 'batch(1 ops: create) on budget-skill', ...}
E  assert True is False
```

**Green on this branch:**

```
$ scripts/run_tests.sh tests/tools/test_skill_manager_tool.py tests/tools/test_skill_manage_batch.py tests/tools/test_write_approval.py -v

✓ tests/tools/test_write_approval.py (15✓, 0.9s)
✓ tests/tools/test_skill_manage_batch.py (9✓, 1.8s)
✓ tests/tools/test_skill_manager_tool.py (85✓, 3.1s)

=== Summary: 3 files, 109 tests passed, 0 failed (100% complete) in 3.1s (22 workers) ===
```

`tests/tools/test_skill_manage_batch.py` is byte-identical to `main` — the batch path is covered by the `batch-plain` item above rather than by a second test file.

## How to Test

1. Enable the gate and try to create a skill whose description exceeds the budget:
   ```python
   # with skills.write_approval: true
   skill_manage(action="create", name="demo", content=OVER_BUDGET_SKILL_MD)
   ```
   Before: `{"success": true, "staged": true, "pending_id": "..."}` — and `/skills approve <id>` fails afterwards.
   After: `{"error": "Description is 61 chars — ...", "success": false}` and `wa.pending_count("skills") == 0`.

2. Same for a traversal path, which previously sat in the pending queue until a human approved it:
   ```python
   skill_manage(action="write_file", name="demo", file_path="../escape.md", file_content="x")
   # After: {"error": "Path traversal ('..') is not allowed.", "success": false}, pending_count == 0
   ```

3. Same payload through the batch path, which previously staged the whole batch:
   ```python
   skill_manage(action="", name="", operations=[
       {"action": "create", "name": "demo", "content": OVER_BUDGET_SKILL_MD}])
   # After: {"error": "operations[0]: Description is 61 chars — ...", "success": false}
   ```

4. Run the tests:
   ```bash
   scripts/run_tests.sh tests/tools/test_skill_manager_tool.py -k TestStagedWritePreflight -v
   # === Summary: 1 files, 12 tests passed, 0 failed (100% complete) in 1.0s (22 workers) ===
   ```

5. Confirm they carry the contract — revert the two source files to `main` and re-run: 12 failed, 0 passed (output above).

**Suite results** (macOS, Darwin 25.5.0, Python 3.12.13):

```
$ scripts/run_tests.sh tests/tools/
=== Summary: 660 files, 9587 tests passed, 204 failed, 157 skipped (100% complete) in 432.6s (22 workers) ===
```

The 204 failures are pre-existing and environment-dependent on this machine (Daytona/Modal/MCP-OAuth/connector suites needing optional deps or network — `test_daytona_environment`, `test_mcp_oauth*`, `test_connector_*`, `test_image_generation`, and similar). To confirm they are not mine, the 36 failing files were re-run against a pristine `main` working tree (both source files and both test files reverted):

```
$ scripts/run_tests.sh <the 36 failing files>   # on pristine main
=== Summary: 36 files, 870 tests passed, 204 failed, 35 skipped (100% complete) in 235.3s (22 workers) ===
```

Same 204. No failing file touches `skill_manager_tool` or `skill_manager_batch`; every `tests/tools/test_skill*` file passes on this branch.

```
$ python scripts/check-windows-footguns.py --all
✓ No Windows footguns found (1593 file(s) scanned).
```

## Salvage / credit

Rebased from @dacheah's port of this PR onto current `main` (`544eed96dd`), which re-derived the change against today's layout (`_ACTION_HANDLERS`, `_REQUIRED_ARGS`, `_misplaced_text_hint`, `tools/skill_manager_batch.py`). Batch-op coverage originates in #102021 (@djagya), closed as a duplicate of this PR. Both are credited via `Co-authored-by:` on the commit.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — one commit, three changed files
- [x] I've run `scripts/run_tests.sh tests/tools/` and compared against pristine `main` — see above. I did not run the entire `tests/` tree.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new functions and the changed behavior are documented in docstrings; no user-facing docs describe staging-time validation, so nothing else needed
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — the change is pure Python string/dict logic with no filesystem, path, or platform-specific behavior; the new tests use `tmp_path`/`monkeypatch` only, and `scripts/check-windows-footguns.py --all` is clean
