### PR TITLE
fix(ui-tui): pause status-chrome timers while a blocking overlay is open (#71934 salvage)

### DIFF
--- a/ui-tui/src/__tests__/appChromeBlockedTimers.test.tsx
+++ b/ui-tui/src/__tests__/appChromeBlockedTimers.test.tsx
@@ -1,0 +1,241 @@
+import { PassThrough } from 'stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { OverlayState } from '../app/interfaces.js'
+import { patchOverlayState, resetOverlayState } from '../app/overlayStore.js'
+import { StatusRule } from '../components/appChrome.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+type StatusRuleProps = React.ComponentProps<typeof StatusRule>
+type IntervalSpy = ReturnType<typeof vi.spyOn<typeof globalThis, 'setInterval'>>
+
+// Fixed wall clock so the rendered elapsed read-outs are exact strings rather
+// than whatever the machine's clock happens to produce mid-test.
+const T0 = 1_800_000_000_000
+
+const mounted: Array<() => void> = []
+
+/**
+ * Mount a real StatusRule through Ink so the leaf components' effects — and
+ * therefore their `setInterval` calls — actually run.  The existing
+ * appChromeStatusRule tests invoke `StatusRule(...)` as a plain function,
+ * which only builds the element tree and never mounts FaceTicker /
+ * SessionDuration / IdleSince, so it cannot observe timer behaviour.
+ *
+ * Teardown is registered up front so a failing assertion still unmounts the
+ * tree — a leaked instance would keep re-arming timers into the next test.
+ */
+const mount = (props: StatusRuleProps) => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+
+  let output = ''
+
+  Object.assign(stdout, { columns: 120, isTTY: false, rows: 20 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(<StatusRule {...props} />, {
+    patchConsole: false,
+    stderr: stderr as NodeJS.WriteStream,
+    stdin: stdin as NodeJS.ReadStream,
+    stdout: stdout as NodeJS.WriteStream
+  })
+
+  mounted.push(() => {
+    instance.unmount()
+    instance.cleanup()
+  })
+
+  return {
+    /** Drop frames rendered so far so `output()` reads only what comes next. */
+    clear: () => {
+      output = ''
+    },
+    output: () => stripAnsi(output)
+  }
+}
+
+const idleProps: StatusRuleProps = {
+  bgCount: 0,
+  busy: false,
+  cols: 120,
+  cwdLabel: '~/repo',
+  lastTurnEndedAt: T0 - 5_000,
+  liveSessionCount: 0,
+  model: 'opus-4.8',
+  sessionStartedAt: T0 - 60_000,
+  status: 'ready',
+  statusColor: DEFAULT_THEME.color.ok,
+  t: DEFAULT_THEME,
+  turnStartedAt: null,
+  usage: { context_max: 200_000, context_percent: 25, context_used: 50_000, total: 50_000 },
+  voiceLabel: ''
+}
+
+// Busy swaps the idle read-out for the FaceTicker, which owns the glyph +
+// verb + elapsed-clock trio.
+const busyProps: StatusRuleProps = {
+  ...idleProps,
+  busy: true,
+  indicatorStyle: 'kaomoji',
+  lastTurnEndedAt: null,
+  turnStartedAt: T0 - 30_000
+}
+
+/** Delays of every interval armed while the spy was installed. */
+const armedDelays = (spy: IntervalSpy) => spy.mock.calls.map(call => call[1])
+
+const oneSecondTimers = (spy: IntervalSpy) => armedDelays(spy).filter(delay => delay === 1000).length
+
+// Give React's scheduler a turn so a store-driven re-render (and the effect
+// re-arm that follows it) lands before we assert.
+const flush = () => new Promise(resolve => setTimeout(resolve, 20))
+
+let intervalSpy: IntervalSpy
+let nowSpy: ReturnType<typeof vi.spyOn<typeof Date, 'now'>>
+
+beforeEach(() => {
+  resetOverlayState()
+  nowSpy = vi.spyOn(Date, 'now').mockReturnValue(T0)
+  intervalSpy = vi.spyOn(globalThis, 'setInterval')
+})
+
+afterEach(() => {
+  while (mounted.length > 0) {
+    mounted.pop()!()
+  }
+
+  intervalSpy.mockRestore()
+  nowSpy.mockRestore()
+  resetOverlayState()
+})
+
+describe('status-chrome timers under a blocking overlay', () => {
+  it('arms the one-second SessionDuration + IdleSince clocks when nothing is blocking', () => {
+    mount(idleProps)
+
+    expect(oneSecondTimers(intervalSpy)).toBe(2)
+  })
+
+  it('arms no timer at all when a blocking overlay is already open', () => {
+    patchOverlayState({ modelPicker: true })
+
+    mount(idleProps)
+
+    expect(oneSecondTimers(intervalSpy)).toBe(0)
+  })
+
+  it('arms the FaceTicker glyph/verb/clock trio mid-turn when nothing is blocking', () => {
+    mount(busyProps)
+
+    // kaomoji cadence for the glyph + verb rotation, plus the elapsed clock.
+    expect(armedDelays(intervalSpy)).toContain(2500)
+    expect(oneSecondTimers(intervalSpy)).toBeGreaterThan(0)
+  })
+
+  it('arms no FaceTicker timer mid-turn while a blocking overlay is open', () => {
+    patchOverlayState({ sudo: { requestId: 'sudo-1' } })
+
+    mount(busyProps)
+
+    expect(armedDelays(intervalSpy)).not.toContain(2500)
+    expect(oneSecondTimers(intervalSpy)).toBe(0)
+  })
+
+  it('re-syncs the elapsed read-outs from the wall clock on unblock instead of resuming stale', async () => {
+    // Regression guard for the naive fix: an early `return` that pauses the
+    // interval but never re-seeds `now` leaves SessionDuration and IdleSince
+    // frozen at the instant the overlay opened.
+    patchOverlayState({ sessions: true })
+
+    const rule = mount(idleProps)
+
+    expect(rule.output()).toContain('1m 0s')
+    expect(rule.output()).toContain('✓ 5s')
+
+    // Five minutes of wall clock elapse while the overlay covers the rule.
+    nowSpy.mockReturnValue(T0 + 300_000)
+    rule.clear()
+    resetOverlayState()
+    await flush()
+
+    const resumed = rule.output()
+
+    // Caught up to real elapsed time, not stuck on the pre-overlay values.
+    expect(resumed).toContain('6m 0s')
+    expect(resumed).toContain('✓ 5m 5s')
+    expect(resumed).not.toContain('1m 0s')
+
+    // …and the clocks are running again.
+    expect(oneSecondTimers(intervalSpy)).toBe(2)
+  })
+
+  it('tears the clocks down when an overlay opens over an already-running status rule', async () => {
+    mount(idleProps)
+
+    // Handles of the two live 1-second clocks (SessionDuration + IdleSince).
+    const clocks = intervalSpy.mock.results
+      .filter((_result, i) => intervalSpy.mock.calls[i]?.[1] === 1000)
+      .map(result => result.value as ReturnType<typeof setInterval>)
+
+    expect(clocks).toHaveLength(2)
+
+    const clearSpy = vi.spyOn(globalThis, 'clearInterval')
+
+    patchOverlayState({ pluginsHub: true })
+    await flush()
+
+    // Each running clock is cleared as the overlay goes up …
+    for (const handle of clocks) {
+      expect(clearSpy).toHaveBeenCalledWith(handle)
+    }
+
+    // … and the blocked re-run arms no replacement (still just the original two).
+    expect(oneSecondTimers(intervalSpy)).toBe(2)
+
+    clearSpy.mockRestore()
+  })
+})
+
+// teknium1's review of #12463 called out that its test asserted on a `picker`
+// overlay state that no longer exists.  Pin the gate to fields the current
+// OverlayState actually carries so a rename breaks this file loudly.
+describe('status-chrome timers track the current overlay model', () => {
+  const blocking: Array<[string, Partial<OverlayState>]> = [
+    ['agents', { agents: true }],
+    ['journey', { journey: true }],
+    ['modelPicker', { modelPicker: true }],
+    ['pager', { pager: { lines: ['a'], offset: 0 } }],
+    ['petPicker', { petPicker: true }],
+    ['pluginsHub', { pluginsHub: true }],
+    ['sessions', { sessions: true }],
+    ['skillsHub', { skillsHub: true }]
+  ]
+
+  it.each(blocking)('pauses the status clocks while %s is open', (_name, patch) => {
+    patchOverlayState(patch)
+
+    mount(idleProps)
+
+    expect(oneSecondTimers(intervalSpy)).toBe(0)
+  })
+
+  it('keeps the clocks running for the non-blocking ambient dock', () => {
+    // `ambient` is deliberately excluded from $isBlocked — a glanceable dock
+    // doesn't cover the status rule, so pausing there would be a regression.
+    patchOverlayState({ ambient: [{ appId: 'clock', state: null }] })
+
+    mount(idleProps)
+
+    expect(oneSecondTimers(intervalSpy)).toBe(2)
+  })
+})

--- a/ui-tui/src/__tests__/appChromeBlockedTimers.test.tsx
+++ b/ui-tui/src/__tests__/appChromeBlockedTimers.test.tsx
@@ -4,9 +4,14 @@ import { renderSync } from '@hermes/ink'
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { OverlayState } from '../app/interfaces.js'
+import { GatewayProvider } from '../app/gatewayContext.js'
+import type { AppLayoutProps, OverlayState, UiState } from '../app/interfaces.js'
 import { patchOverlayState, resetOverlayState } from '../app/overlayStore.js'
+import { patchUiState, resetUiState } from '../app/uiStore.js'
 import { StatusRule } from '../components/appChrome.js'
+import { AppLayout } from '../components/appLayout.js'
+import type { GatewayClient } from '../gatewayClient.js'
+import { DEFAULT_VOICE_RECORD_KEY } from '../lib/platform.js'
 import { stripAnsi } from '../lib/text.js'
 import { DEFAULT_THEME } from '../theme.js'
 
@@ -29,7 +34,7 @@ const mounted: Array<() => void> = []
  * Teardown is registered up front so a failing assertion still unmounts the
  * tree — a leaked instance would keep re-arming timers into the next test.
  */
-const mount = (props: StatusRuleProps) => {
+const mountTree = (tree: React.ReactElement, { interactive = false } = {}) => {
   const stdout = new PassThrough()
   const stdin = new PassThrough()
   const stderr = new PassThrough()
@@ -37,13 +42,18 @@ const mount = (props: StatusRuleProps) => {
   let output = ''
 
   Object.assign(stdout, { columns: 120, isTTY: false, rows: 20 })
-  Object.assign(stdin, { isTTY: false })
+  // PromptZone's prompts call `useInput`, which needs raw mode; without it Ink
+  // swaps the whole tree for an error panel and stops updating.
+  Object.assign(
+    stdin,
+    interactive ? { isTTY: true, ref: () => {}, setRawMode: () => {}, unref: () => {} } : { isTTY: false }
+  )
   Object.assign(stderr, { isTTY: false })
   stdout.on('data', chunk => {
     output += chunk.toString()
   })
 
-  const instance = renderSync(<StatusRule {...props} />, {
+  const instance = renderSync(tree, {
     patchConsole: false,
     stderr: stderr as NodeJS.WriteStream,
     stdin: stdin as NodeJS.ReadStream,
@@ -63,6 +73,8 @@ const mount = (props: StatusRuleProps) => {
     output: () => stripAnsi(output)
   }
 }
+
+const mount = (props: StatusRuleProps) => mountTree(<StatusRule {...props} />)
 
 const idleProps: StatusRuleProps = {
   bgCount: 0,
@@ -96,6 +108,97 @@ const armedDelays = (spy: IntervalSpy) => spy.mock.calls.map(call => call[1])
 
 const oneSecondTimers = (spy: IntervalSpy) => armedDelays(spy).filter(delay => delay === 1000).length
 
+/** The handlers of every 1s clock armed so far — `() => setNow(Date.now())`. */
+const oneSecondTicks = (spy: IntervalSpy) =>
+  spy.mock.calls.filter(call => call[1] === 1000).map(call => call[0] as () => void)
+
+// ── AppLayout harness ────────────────────────────────────────────────
+//
+// teknium1's review of this file was right that mounting StatusRule alone
+// proves the store pauses timers but NOT that the overlay in question covers
+// the status rule.  These props render the real AppLayout so the rule sits in
+// its true position relative to PromptZone / FloatingOverlays / the widget
+// slot, and the assertions can read what is actually on screen.
+
+const gatewayStub = {
+  gw: {
+    request: () => new Promise<never>(() => {}),
+    send: () => {}
+  } as unknown as GatewayClient,
+  rpc: (() => new Promise<never>(() => {})) as never
+}
+
+const layoutProps: AppLayoutProps = {
+  actions: {
+    activateLiveSession: () => {},
+    answerApproval: () => {},
+    answerClarify: () => {},
+    answerSecret: () => {},
+    answerSudo: () => {},
+    clearSelection: () => {},
+    closeLiveSession: () => Promise.resolve(null),
+    newLiveSession: () => {},
+    newPromptSession: () => {},
+    onModelSelect: () => {},
+    resumeById: () => {},
+    setStickyPrompt: () => {}
+  },
+  composer: {
+    cols: 120,
+    compIdx: 0,
+    completions: [],
+    empty: true,
+    handleTextPaste: () => null,
+    input: '',
+    inputBuf: [],
+    pagerPageSize: 10,
+    queueEditIdx: null,
+    queuedDisplay: [],
+    submit: () => {},
+    updateInput: () => {},
+    voiceRecordKey: DEFAULT_VOICE_RECORD_KEY
+  },
+  mouseTracking: 'off',
+  progress: { showProgressArea: false },
+  status: {
+    cwdLabel: '~/repo',
+    goodVibesTick: 0,
+    lastTurnEndedAt: T0 - 5_000,
+    sessionStartedAt: T0 - 60_000,
+    showStickyPrompt: false,
+    statusColor: DEFAULT_THEME.color.ok,
+    stickyPrompt: '',
+    turnStartedAt: null,
+    voiceLabel: ''
+  },
+  transcript: {
+    historyItems: [],
+    scrollRef: { current: null },
+    virtualHistory: {
+      bottomSpacer: 0,
+      end: 0,
+      measureRef: () => () => {},
+      offsets: [],
+      start: 0,
+      topSpacer: 0
+    },
+    virtualRows: []
+  }
+}
+
+/** Mount the real AppLayout with the given overlay + ui state applied first. */
+const mountLayout = (overlay: Partial<OverlayState> = {}, ui: Partial<UiState> = {}) => {
+  patchUiState({ sessionTitle: 'test', sid: 'sid-1', status: 'ready', ...ui })
+  patchOverlayState(overlay)
+
+  return mountTree(
+    <GatewayProvider value={gatewayStub}>
+      <AppLayout {...layoutProps} />
+    </GatewayProvider>,
+    { interactive: true }
+  )
+}
+
 // Give React's scheduler a turn so a store-driven re-render (and the effect
 // re-arm that follows it) lands before we assert.
 const flush = () => new Promise(resolve => setTimeout(resolve, 20))
@@ -105,6 +208,7 @@ let nowSpy: ReturnType<typeof vi.spyOn<typeof Date, 'now'>>
 
 beforeEach(() => {
   resetOverlayState()
+  resetUiState()
   nowSpy = vi.spyOn(Date, 'now').mockReturnValue(T0)
   intervalSpy = vi.spyOn(globalThis, 'setInterval')
 })
@@ -117,16 +221,17 @@ afterEach(() => {
   intervalSpy.mockRestore()
   nowSpy.mockRestore()
   resetOverlayState()
+  resetUiState()
 })
 
-describe('status-chrome timers under a blocking overlay', () => {
-  it('arms the one-second SessionDuration + IdleSince clocks when nothing is blocking', () => {
+describe('status-chrome timers under an occluding overlay', () => {
+  it('arms the one-second SessionDuration + IdleSince clocks when nothing covers the rule', () => {
     mount(idleProps)
 
     expect(oneSecondTimers(intervalSpy)).toBe(2)
   })
 
-  it('arms no timer at all when a blocking overlay is already open', () => {
+  it('arms no timer at all when an occluding overlay is already open', () => {
     patchOverlayState({ modelPicker: true })
 
     mount(idleProps)
@@ -134,7 +239,7 @@ describe('status-chrome timers under a blocking overlay', () => {
     expect(oneSecondTimers(intervalSpy)).toBe(0)
   })
 
-  it('arms the FaceTicker glyph/verb/clock trio mid-turn when nothing is blocking', () => {
+  it('arms the FaceTicker glyph/verb/clock trio mid-turn when nothing covers the rule', () => {
     mount(busyProps)
 
     // kaomoji cadence for the glyph + verb rotation, plus the elapsed clock.
@@ -142,8 +247,8 @@ describe('status-chrome timers under a blocking overlay', () => {
     expect(oneSecondTimers(intervalSpy)).toBeGreaterThan(0)
   })
 
-  it('arms no FaceTicker timer mid-turn while a blocking overlay is open', () => {
-    patchOverlayState({ sudo: { requestId: 'sudo-1' } })
+  it('arms no FaceTicker timer mid-turn while the modal widget slot is open', () => {
+    patchOverlayState({ widget: { appId: 'demo', state: null } })
 
     mount(busyProps)
 
@@ -151,7 +256,30 @@ describe('status-chrome timers under a blocking overlay', () => {
     expect(oneSecondTimers(intervalSpy)).toBe(0)
   })
 
-  it('re-syncs the elapsed read-outs from the wall clock on unblock instead of resuming stale', async () => {
+  it('keeps the FaceTicker running mid-turn under a flow-layout sudo prompt', () => {
+    // `sudo` is in `$isBlocked` but renders in PromptZone's normal flow, so it
+    // pushes the rule down rather than covering it — the trio must keep going.
+    patchOverlayState({ sudo: { requestId: 'sudo-1' } })
+
+    mount(busyProps)
+
+    expect(armedDelays(intervalSpy)).toContain(2500)
+    expect(oneSecondTimers(intervalSpy)).toBeGreaterThan(0)
+  })
+
+  it('keeps the clocks running when a floating overlay cannot reach a bottom status rule', () => {
+    // FloatingOverlays is `position="absolute" bottom="100%"` inside
+    // ComposerPane's relative Box, so it grows UPWARD: it covers the `at="top"`
+    // rule and never the `at="bottom"` one.
+    patchUiState({ statusBar: 'bottom' })
+    patchOverlayState({ modelPicker: true })
+
+    mount(idleProps)
+
+    expect(oneSecondTimers(intervalSpy)).toBe(2)
+  })
+
+  it('re-syncs the elapsed read-outs from the wall clock on reveal instead of resuming stale', async () => {
     // Regression guard for the naive fix: an early `return` that pauses the
     // interval but never re-seeds `now` leaves SessionDuration and IdleSince
     // frozen at the instant the overlay opened.
@@ -199,7 +327,7 @@ describe('status-chrome timers under a blocking overlay', () => {
       expect(clearSpy).toHaveBeenCalledWith(handle)
     }
 
-    // … and the blocked re-run arms no replacement (still just the original two).
+    // … and the occluded re-run arms no replacement (still just the original two).
     expect(oneSecondTimers(intervalSpy)).toBe(2)
 
     clearSpy.mockRestore()
@@ -210,18 +338,35 @@ describe('status-chrome timers under a blocking overlay', () => {
 // overlay state that no longer exists.  Pin the gate to fields the current
 // OverlayState actually carries so a rename breaks this file loudly.
 describe('status-chrome timers track the current overlay model', () => {
-  const blocking: Array<[string, Partial<OverlayState>]> = [
-    ['agents', { agents: true }],
-    ['journey', { journey: true }],
+  // Everything that genuinely paints over the rule: the modal widget slot,
+  // plus the FloatingOverlays set (with the rule at its default `top`).
+  const occluding: Array<[string, Partial<OverlayState>]> = [
     ['modelPicker', { modelPicker: true }],
     ['pager', { pager: { lines: ['a'], offset: 0 } }],
     ['petPicker', { petPicker: true }],
     ['pluginsHub', { pluginsHub: true }],
     ['sessions', { sessions: true }],
-    ['skillsHub', { skillsHub: true }]
+    ['skillsHub', { skillsHub: true }],
+    ['widget', { widget: { appId: 'demo', state: null } }]
   ]
 
-  it.each(blocking)('pauses the status clocks while %s is open', (_name, patch) => {
+  // In `$isBlocked` but NOT occluding.  `agents` / `journey` unmount the whole
+  // ComposerPane subtree, so React's effect cleanup already stops the clocks
+  // and gating on them would be dead code; the rest are PromptZone states that
+  // render in normal flow and push the rule down without covering it.
+  const nonOccluding: Array<[string, Partial<OverlayState>]> = [
+    ['agents', { agents: true }],
+    ['approval', { approval: { command: 'ls', requestId: 'a-1' } as OverlayState['approval'] }],
+    ['billing', { billing: { kind: 'credits' } as OverlayState['billing'] }],
+    ['clarify', { clarify: { question: 'which?', requestId: 'c-1' } as OverlayState['clarify'] }],
+    ['confirm', { confirm: { onConfirm: () => {}, prompt: 'sure?' } as OverlayState['confirm'] }],
+    ['journey', { journey: true }],
+    ['secret', { secret: { envVar: 'TOKEN', prompt: 'token?' } as OverlayState['secret'] }],
+    ['subscription', { subscription: { kind: 'expired' } as OverlayState['subscription'] }],
+    ['sudo', { sudo: { requestId: 'sudo-1' } as OverlayState['sudo'] }]
+  ]
+
+  it.each(occluding)('pauses the status clocks while %s covers the rule', (_name, patch) => {
     patchOverlayState(patch)
 
     mount(idleProps)
@@ -229,12 +374,75 @@ describe('status-chrome timers track the current overlay model', () => {
     expect(oneSecondTimers(intervalSpy)).toBe(0)
   })
 
-  it('keeps the clocks running for the non-blocking ambient dock', () => {
-    // `ambient` is deliberately excluded from $isBlocked — a glanceable dock
+  it.each(nonOccluding)('keeps the status clocks running while %s is open', (_name, patch) => {
+    patchOverlayState(patch)
+
+    mount(idleProps)
+
+    expect(oneSecondTimers(intervalSpy)).toBe(2)
+  })
+
+  it('keeps the clocks running for the non-occluding ambient dock', () => {
+    // `ambient` is a glanceable in-flow dock that reserves its own rows and
     // doesn't cover the status rule, so pausing there would be a regression.
     patchOverlayState({ ambient: [{ appId: 'clock', state: null }] })
 
     mount(idleProps)
+
+    expect(oneSecondTimers(intervalSpy)).toBe(2)
+  })
+})
+
+// The visibility gate teknium1 asked for: mount the REAL AppLayout so the
+// status rule sits in its true position relative to PromptZone (normal flow,
+// above ComposerPane) and FloatingOverlays (absolute, growing upward), then
+// assert on what is actually on screen rather than on the store alone.
+describe('AppLayout status-rule visibility', () => {
+  it('keeps the status rule on screen AND its clock advancing under a flow-layout approval prompt', async () => {
+    const layout = mountLayout({ approval: { command: 'rm -rf /', requestId: 'a-1' } as OverlayState['approval'] })
+
+    await flush()
+
+    // The rule is genuinely rendered — the approval prompt pushed it, it did
+    // not cover it — so freezing its clock would freeze something visible.
+    expect(layout.output()).toContain('~/repo')
+    expect(layout.output()).toContain('1m 0s')
+    expect(oneSecondTimers(intervalSpy)).toBe(2)
+
+    // …and it really advances: drive the armed 1s handlers forward.
+    nowSpy.mockReturnValue(T0 + 30_000)
+
+    for (const tick of oneSecondTicks(intervalSpy)) {
+      tick()
+    }
+
+    await flush()
+    await flush()
+
+    expect(layout.output()).toContain('1m 30s')
+  })
+
+  it('keeps the status rule on screen AND its clock advancing under a flow-layout sudo prompt', async () => {
+    const layout = mountLayout({ sudo: { requestId: 'sudo-1' } as OverlayState['sudo'] })
+
+    await flush()
+
+    expect(layout.output()).toContain('1m 0s')
+    expect(oneSecondTimers(intervalSpy)).toBe(2)
+  })
+
+  it('arms no clock under a floating model picker while the rule is at the top', async () => {
+    mountLayout({ modelPicker: true }, { statusBar: 'top' })
+
+    await flush()
+
+    expect(oneSecondTimers(intervalSpy)).toBe(0)
+  })
+
+  it('keeps the clocks armed under a floating model picker while the rule is at the bottom', async () => {
+    mountLayout({ modelPicker: true }, { statusBar: 'bottom' })
+
+    await flush()
 
     expect(oneSecondTimers(intervalSpy)).toBe(2)
   })

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -107,17 +107,28 @@ export const $isBlocked = computed(
  * `statusBar: 'off'` needs no branch: `StatusRulePane` returns null for both
  * slots, so the timers are never mounted in the first place.
  */
-export const $isStatusRuleOccluded = computed([$overlayState, $uiState], (overlay, ui) =>
+/**
+ * True when any floating overlay PANEL is open (widget overlays and inline
+ * completions are separate concerns — see $isStatusRuleOccluded for why
+ * completions never occlude the status rule).
+ *
+ * SINGLE SOURCE for the floating-panel kind set: consumed by both
+ * FloatingOverlays' render gate (plus completions, which it adds locally)
+ * and $isStatusRuleOccluded's top-statusbar occlusion arm. Add new floating
+ * panels HERE so the timer gate can't silently miss them.
+ */
+export const hasFloatingPanel = (overlay: OverlayState): boolean =>
   Boolean(
-    overlay.widget ||
-      (ui.statusBar === 'top' &&
-        (overlay.modelPicker ||
-          overlay.pager ||
-          overlay.petPicker ||
-          overlay.pluginsHub ||
-          overlay.sessions ||
-          overlay.skillsHub))
+    overlay.modelPicker ||
+      overlay.pager ||
+      overlay.petPicker ||
+      overlay.pluginsHub ||
+      overlay.sessions ||
+      overlay.skillsHub
   )
+
+export const $isStatusRuleOccluded = computed([$overlayState, $uiState], (overlay, ui) =>
+  Boolean(overlay.widget || (ui.statusBar === 'top' && hasFloatingPanel(overlay)))
 )
 
 export const getOverlayState = () => $overlayState.get()

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -1,6 +1,7 @@
 import { atom, computed } from 'nanostores'
 
 import type { OverlayState } from './interfaces.js'
+import { $uiState } from './uiStore.js'
 
 const buildOverlayState = (): OverlayState => ({
   agents: false,
@@ -63,6 +64,60 @@ export const $isBlocked = computed(
       sudo ||
       widget
     )
+)
+
+/**
+ * Does an open overlay actually PAINT OVER the status rule?
+ *
+ * Deliberately NOT `$isBlocked`.  That aggregate answers a different
+ * question — "is text input suspended" — and `appLayout` uses it only to hide
+ * the input rows (`appLayout.tsx:384`).  `StatusRulePane` is rendered OUTSIDE
+ * that guard (`appLayout.tsx:365` for `at="top"`, `:449` for `at="bottom"`),
+ * so most `$isBlocked` fields leave the rule fully visible.
+ *
+ * Occluding (included here):
+ *
+ * - `widget` — the modal widget slot renders at viewport level
+ *   (`ActiveWidgetSlot`, `sdk/host.tsx:209`, outside the ComposerPane
+ *   subtree) so it can anchor the full-screen absolute `Overlay`
+ *   (`components/overlay.tsx`) against the whole terminal.
+ * - The FloatingOverlays set — `modelPicker`, `pager`, `petPicker`,
+ *   `sessions`, `skillsHub`, `pluginsHub` — but ONLY when the rule sits at
+ *   the top.  That panel is `position="absolute" bottom="100%"` inside
+ *   ComposerPane's relative Box (`appOverlays.tsx:387`), so it grows UPWARD
+ *   over the `at="top"` rule and never reaches the `at="bottom"` one.
+ *
+ * NOT occluding (deliberately excluded):
+ *
+ * - The PromptZone flow states — `approval`, `billing`, `subscription`,
+ *   `confirm`, `clarify`, `sudo`, `secret` (`appOverlays.tsx:58-162`).  They
+ *   render in NORMAL FLOW above ComposerPane (`appLayout.tsx:553-568`): they
+ *   push content down, they do not cover it.  The rule stays on screen and
+ *   its clock must keep running.
+ * - `agents` and `journey`.  They unmount the entire ComposerPane subtree
+ *   (`appLayout.tsx:553`), so `StatusRule` unmounts with it and React's own
+ *   effect cleanup clears the intervals.  Gating on them would be dead code.
+ * - `ambient` — a glanceable in-flow dock that reserves its own rows.
+ * - Composer completions.  They share the FloatingOverlays grid and do
+ *   occlude, but they are a render prop rather than store state and they
+ *   change on every keystroke; re-arming a 1s interval per character would
+ *   restart the countdown each time and starve the tick outright — strictly
+ *   worse than the churn this gate removes.
+ *
+ * `statusBar: 'off'` needs no branch: `StatusRulePane` returns null for both
+ * slots, so the timers are never mounted in the first place.
+ */
+export const $isStatusRuleOccluded = computed([$overlayState, $uiState], (overlay, ui) =>
+  Boolean(
+    overlay.widget ||
+      (ui.statusBar === 'top' &&
+        (overlay.modelPicker ||
+          overlay.pager ||
+          overlay.petPicker ||
+          overlay.pluginsHub ||
+          overlay.sessions ||
+          overlay.skillsHub))
+  )
 )
 
 export const getOverlayState = () => $overlayState.get()

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -5,6 +5,7 @@ import unicodeSpinners from 'unicode-animations'
 
 import { $delegationState } from '../app/delegationStore.js'
 import type { BatteryInfo, IndicatorStyle, Notice } from '../app/interfaces.js'
+import { $isBlocked } from '../app/overlayStore.js'
 import { useTurnSelector } from '../app/turnStore.js'
 import { DEV_CREDITS_MODE } from '../config/env.js'
 import { FACES } from '../content/faces.js'
@@ -122,6 +123,7 @@ function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: nu
   const [tick, setTick] = useState(() => Math.floor(Math.random() * 1000))
   const [verbTick, setVerbTick] = useState(() => Math.floor(Math.random() * VERBS.length))
   const [now, setNow] = useState(() => Date.now())
+  const isBlocked = useStore($isBlocked)
 
   // Pre-compute cadence + verb-visibility for the active style so an
   // `/indicator` switch re-arms the interval (and skips the verb timer
@@ -130,6 +132,18 @@ function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: nu
   const { intervalMs, showVerb } = renderIndicator(style, 0)
 
   useEffect(() => {
+    // A blocking overlay (approval, model picker, pager, …) is painted over
+    // the status rule, so every tick below is a re-render nobody can see —
+    // in an Ink TUI that churn reads as the dialog tearing.  Arm nothing
+    // while blocked.  The effect re-runs on unblock and re-seeds `now` from
+    // the wall clock, so the elapsed read-out resumes live rather than
+    // frozen at the moment the overlay opened.
+    if (isBlocked) {
+      return
+    }
+
+    setNow(Date.now())
+
     const glyph = setInterval(() => setTick(n => n + 1), intervalMs)
     const clock = setInterval(() => setNow(Date.now()), 1000)
     // Verb timer is gated on `showVerb` — `unicode` style hides the verb
@@ -144,7 +158,7 @@ function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: nu
         clearInterval(verb)
       }
     }
-  }, [intervalMs, showVerb])
+  }, [intervalMs, isBlocked, showVerb])
 
   const { frame } = renderIndicator(style, tick)
   const verb = VERBS[verbTick % VERBS.length] ?? ''
@@ -360,13 +374,21 @@ function SpawnHud({ t }: { t: Theme }) {
 
 function SessionDuration({ startedAt }: { startedAt: number }) {
   const [now, setNow] = useState(() => Date.now())
+  const isBlocked = useStore($isBlocked)
 
   useEffect(() => {
+    // Paused while a blocking overlay covers the status rule — see
+    // FaceTicker.  The `setNow` below already re-seeds from the wall clock
+    // on every re-arm, so it doubles as the unblock catch-up.
+    if (isBlocked) {
+      return
+    }
+
     setNow(Date.now())
     const id = setInterval(() => setNow(Date.now()), 1000)
 
     return () => clearInterval(id)
-  }, [startedAt])
+  }, [isBlocked, startedAt])
 
   return fmtDuration(now - startedAt)
 }
@@ -375,13 +397,21 @@ function IdleSince({ endedAt }: { endedAt: number }) {
   // Time since the last final agent response. Re-ticks every second like
   // SessionDuration so the read-out stays live while the session idles.
   const [now, setNow] = useState(() => Date.now())
+  const isBlocked = useStore($isBlocked)
 
   useEffect(() => {
+    // Paused while a blocking overlay covers the status rule — see
+    // FaceTicker.  The `setNow` below re-seeds from the wall clock on
+    // unblock so the idle read-out is not frozen when the overlay closes.
+    if (isBlocked) {
+      return
+    }
+
     setNow(Date.now())
     const id = setInterval(() => setNow(Date.now()), 1000)
 
     return () => clearInterval(id)
-  }, [endedAt])
+  }, [endedAt, isBlocked])
 
   return `✓ ${fmtDuration(now - endedAt)}`
 }

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -5,7 +5,7 @@ import unicodeSpinners from 'unicode-animations'
 
 import { $delegationState } from '../app/delegationStore.js'
 import type { BatteryInfo, IndicatorStyle, Notice } from '../app/interfaces.js'
-import { $isBlocked } from '../app/overlayStore.js'
+import { $isStatusRuleOccluded } from '../app/overlayStore.js'
 import { useTurnSelector } from '../app/turnStore.js'
 import { DEV_CREDITS_MODE } from '../config/env.js'
 import { FACES } from '../content/faces.js'
@@ -123,7 +123,7 @@ function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: nu
   const [tick, setTick] = useState(() => Math.floor(Math.random() * 1000))
   const [verbTick, setVerbTick] = useState(() => Math.floor(Math.random() * VERBS.length))
   const [now, setNow] = useState(() => Date.now())
-  const isBlocked = useStore($isBlocked)
+  const isOccluded = useStore($isStatusRuleOccluded)
 
   // Pre-compute cadence + verb-visibility for the active style so an
   // `/indicator` switch re-arms the interval (and skips the verb timer
@@ -132,13 +132,14 @@ function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: nu
   const { intervalMs, showVerb } = renderIndicator(style, 0)
 
   useEffect(() => {
-    // A blocking overlay (approval, model picker, pager, …) is painted over
-    // the status rule, so every tick below is a re-render nobody can see —
-    // in an Ink TUI that churn reads as the dialog tearing.  Arm nothing
-    // while blocked.  The effect re-runs on unblock and re-seeds `now` from
-    // the wall clock, so the elapsed read-out resumes live rather than
-    // frozen at the moment the overlay opened.
-    if (isBlocked) {
+    // An overlay is painted OVER the status rule (the modal widget slot, or a
+    // floating panel growing up over the top rule), so every tick below is a
+    // re-render nobody can see — in an Ink TUI that churn reads as the dialog
+    // tearing.  Arm nothing while occluded.  The effect re-runs when the rule
+    // is revealed again and re-seeds `now` from the wall clock, so the elapsed
+    // read-out resumes live rather than frozen at the moment it was covered.
+    // See `$isStatusRuleOccluded` for why this is NOT `$isBlocked`.
+    if (isOccluded) {
       return
     }
 
@@ -158,7 +159,7 @@ function FaceTicker({ color, startedAt, style }: { color: string; startedAt?: nu
         clearInterval(verb)
       }
     }
-  }, [intervalMs, isBlocked, showVerb])
+  }, [intervalMs, isOccluded, showVerb])
 
   const { frame } = renderIndicator(style, tick)
   const verb = VERBS[verbTick % VERBS.length] ?? ''
@@ -374,13 +375,13 @@ function SpawnHud({ t }: { t: Theme }) {
 
 function SessionDuration({ startedAt }: { startedAt: number }) {
   const [now, setNow] = useState(() => Date.now())
-  const isBlocked = useStore($isBlocked)
+  const isOccluded = useStore($isStatusRuleOccluded)
 
   useEffect(() => {
-    // Paused while a blocking overlay covers the status rule — see
+    // Paused only while an overlay actually covers the status rule — see
     // FaceTicker.  The `setNow` below already re-seeds from the wall clock
-    // on every re-arm, so it doubles as the unblock catch-up.
-    if (isBlocked) {
+    // on every re-arm, so it doubles as the reveal catch-up.
+    if (isOccluded) {
       return
     }
 
@@ -388,7 +389,7 @@ function SessionDuration({ startedAt }: { startedAt: number }) {
     const id = setInterval(() => setNow(Date.now()), 1000)
 
     return () => clearInterval(id)
-  }, [isBlocked, startedAt])
+  }, [isOccluded, startedAt])
 
   return fmtDuration(now - startedAt)
 }
@@ -397,13 +398,13 @@ function IdleSince({ endedAt }: { endedAt: number }) {
   // Time since the last final agent response. Re-ticks every second like
   // SessionDuration so the read-out stays live while the session idles.
   const [now, setNow] = useState(() => Date.now())
-  const isBlocked = useStore($isBlocked)
+  const isOccluded = useStore($isStatusRuleOccluded)
 
   useEffect(() => {
-    // Paused while a blocking overlay covers the status rule — see
-    // FaceTicker.  The `setNow` below re-seeds from the wall clock on
-    // unblock so the idle read-out is not frozen when the overlay closes.
-    if (isBlocked) {
+    // Paused only while an overlay actually covers the status rule — see
+    // FaceTicker.  The `setNow` below re-seeds from the wall clock on reveal
+    // so the idle read-out is not frozen when the overlay closes.
+    if (isOccluded) {
       return
     }
 
@@ -411,7 +412,7 @@ function IdleSince({ endedAt }: { endedAt: number }) {
     const id = setInterval(() => setNow(Date.now()), 1000)
 
     return () => clearInterval(id)
-  }, [endedAt, isBlocked])
+  }, [endedAt, isOccluded])
 
   return `✓ ${fmtDuration(now - endedAt)}`
 }

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react'
 
 import { useGateway } from '../app/gatewayContext.js'
 import type { AppOverlaysProps } from '../app/interfaces.js'
-import { $overlayState, patchOverlayState } from '../app/overlayStore.js'
+import { $overlayState, hasFloatingPanel, patchOverlayState } from '../app/overlayStore.js'
 import { $uiSessionId, $uiTheme } from '../app/uiStore.js'
 
 import { ActiveSessionSwitcher } from './activeSessionSwitcher.js'
@@ -191,14 +191,7 @@ export function FloatingOverlays({
   const sid = useStore($uiSessionId)
   const theme = useStore($uiTheme)
 
-  const hasAny =
-    overlay.modelPicker ||
-    overlay.pager ||
-    overlay.petPicker ||
-    overlay.sessions ||
-    overlay.skillsHub ||
-    overlay.pluginsHub ||
-    completions.length
+  const hasAny = hasFloatingPanel(overlay) || completions.length
 
   if (!hasAny) {
     return null


### PR DESCRIPTION
Salvage of #71934 by @briandevans — both commits cherry-picked to preserve authorship (rebased clean), plus one review follow-up commit.

## Context — what this changes for users

The TUI's status-chrome timers (session clock, spinners) kept ticking and re-rendering behind blocking overlays — wasted wakeups and paint churn while a modal has the screen. This PR pauses them, with the distinction that made it the right fix (and why it superseded #12463): OCCLUDED vs merely open. A widget overlay always occludes; floating panels (model picker, pager, sessions, skills hub...) occlude only when the status bar is at the TOP (they grow upward from the bottom); flow-layout prompts like sudo/approval — where the clock stays visible — correctly never freeze it. On reveal, the clock re-seeds with setNow(Date.now()) so it jumps to true time instead of resuming stale.

## Review & verification

- Full ui-tui suite: 136 files, 1487 tests green; tsc clean; the PR's own 29-test suite pins behavior (frozen under blocking, running under non-blocking, re-seed on reveal), not internals.
- Predicate verified against real layout mechanics (the top/bottom asymmetry docstring has file:line receipts); commit 2's refinement left zero dead code from the earlier $isBlocked approach ($isBlocked retains its 3 legitimate pre-existing consumers).
- Efficiency: occlusion computes per store change, never per timer tick (verified empirically with nanostores — notify only on boolean flip); paused intervals are cleared, not skipped; unmount-while-paused is leak-free.

## Follow-up commit (simplify finding folded)

$isStatusRuleOccluded and FloatingOverlays each enumerated the same six overlay kinds — a 7th floating panel would require updating both or the timer gate silently misses it. Extracted hasFloatingPanel as the single source (completions stays local to FloatingOverlays; it deliberately never occludes). Suite re-green post-fold.

Closes #71934.
