### PR TITLE
chore: AUTHOR_MAP for ckaznocha

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -79,6 +79,7 @@ LEGACY_AUTHOR_MAP = {
     "75556242+webtecnica@users.noreply.github.com": "webtecnica",  # PR #63360 salvage (nous: restore inference-api base_url)
     "contato@webtecnica.com.br": "webtecnica",  # PR #70888 salvage
     "webtecnica@gmail.com": "webtecnica",  # PR #75838 salvage (aux: free-only fallback guard; #75803)
+    "ckaznocha@gmail.com": "ckaznocha",  # PR #71543 salvage (matrix: crypto store reset + pickle migration)
     "skosarevivan@yandex.ru": "Epoxidex",  # PR #29820 salvage (ollama: top-level reasoning_effort=none; #25758)
     "jdjiayou@163.com": "JiaDe-Wu",  # PR #34742 salvage (bedrock: bearer routing + streaming fallback + image decode; #28156)
     "changhyun.min@gmail.com": "minchang",  # PR #42231 salvage (providers: add Upstage Solar)


### PR DESCRIPTION
## Summary
Adds ckaznocha@gmail.com → ckaznocha to AUTHOR_MAP for upcoming Matrix crypto salvage PRs (#71543, #71547).

## Validation
- `python3 -m py_compile scripts/release.py` passes
- GitHub ID 1851985 verified via API