### PR TITLE
chore: add contributor email mapping for LFDMcore

### DIFF
--- a/contributors/emails/core@lfdm.co
+++ b/contributors/emails/core@lfdm.co
@@ -1,0 +1,1 @@
+LFDMcore


### PR DESCRIPTION
## Summary
Adds contributor email mapping for `core@lfdm.co` → `LFDMcore` (GitHub user ID 117396079).

## Why
PR #77169 cherry-picks commits authored by `core@lfdm.co`. The CI contributor-check gate requires either a `contributors/emails/` mapping file or a legacy AUTHOR_MAP entry for any non-noreply email.

## Changes
- `contributors/emails/core@lfdm.co` → `LFDMcore`
