### PR TITLE
chore: add ATran28 to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1347,6 +1347,7 @@ LEGACY_AUTHOR_MAP = {
     "iamagenius00@users.noreply.github.com": "iamagenius00",
     "9219265+cresslank@users.noreply.github.com": "cresslank",
     "trevmanthony@gmail.com": "trevthefoolish",
+    "at828@proton.me": "ATran28",  # PR #77270 whatsapp bridge reconnect wedge fix
     "ziliangpeng@users.noreply.github.com": "ziliangpeng",
     "ziliangdotme@gmail.com": "ziliangpeng",
     "centripetal-star@users.noreply.github.com": "centripetal-star",


### PR DESCRIPTION
## Summary
Add `at828@proton.me` -> `ATran28` (GH id=1445620) to AUTHOR_MAP in scripts/release.py.

Needed for attribution check on PR #77270 (whatsapp bridge reconnect wedge fix).