### PR TITLE
fix(matrix): E2EE crypto state recovery across device ID changes and restarts

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1329,6 +1329,37 @@ class MatrixAdapter(BasePlatformAdapter):
             return False
         return True
 
+    async def _reset_crypto_store_if_device_changed(
+        self, crypto_store: Any, device_id: str
+    ) -> bool:
+        """Reset the local Olm account when the access token's device changed.
+
+        The crypto store is keyed by user ID, so a new access token (= new
+        device ID) would otherwise inherit the previous device's Olm account.
+        Its identity keys can never be published under the new device ID
+        (and the pickle key embeds the old device ID anyway), which leads to
+        stale-key mismatches and cross-signing signatures that the
+        homeserver refuses to replace. Returns True if the store was reset.
+        """
+        if not device_id:
+            return False
+        try:
+            stored_device_id = await crypto_store.get_device_id()
+        except Exception as exc:
+            logger.warning("Matrix: could not read stored device ID: %s", exc)
+            return False
+        if not stored_device_id or stored_device_id == device_id:
+            return False
+        logger.warning(
+            "Matrix: access token belongs to a new device (%s -> %s) — "
+            "resetting local Olm account so fresh identity keys are "
+            "generated for this device",
+            stored_device_id,
+            device_id,
+        )
+        await crypto_store.delete()
+        return True
+
     async def _verify_device_keys_on_server(self, client: Any, olm: Any) -> bool:
         """Verify our device keys are on the homeserver after loading crypto state.
 
@@ -1608,6 +1639,9 @@ class MatrixAdapter(BasePlatformAdapter):
                     await crypto_store.open()
 
                     if client.device_id:
+                        await self._reset_crypto_store_if_device_changed(
+                            crypto_store, client.device_id
+                        )
                         await crypto_store.put_device_id(client.device_id)
 
                     crypto_state = _CryptoStateStore(state_store, self._joined_rooms, client)

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1394,10 +1394,24 @@ class MatrixAdapter(BasePlatformAdapter):
                 continue
             if account is None:
                 continue
+            # Sessions first, account last. The account is the migration's
+            # commit marker: once it reads under the current key, the fast
+            # path above short-circuits every later startup. Writing it
+            # before the sweep means an interrupted sweep is never retried
+            # and the remaining legacy-key sessions are stranded for good.
+            try:
+                await self._repickle_crypto_sessions(
+                    crypto_db, acct_id, legacy_key, pickle_key
+                )
+            except Exception as exc:
+                logger.error(
+                    "Matrix: pickle key migration failed while re-pickling "
+                    "sessions (%s) — leaving the account under the legacy "
+                    "key so the migration is retried on the next start.",
+                    exc,
+                )
+                return False
             await crypto_store.put_account(account)
-            await self._repickle_crypto_sessions(
-                crypto_db, acct_id, legacy_key, pickle_key
-            )
             logger.info(
                 "Matrix: re-pickled crypto store account and sessions under "
                 "the current pickle key (device ID was configured after the "
@@ -1446,9 +1460,14 @@ class MatrixAdapter(BasePlatformAdapter):
                 try:
                     session = session_cls.from_pickle(pickled, legacy_key)
                 except Exception as exc:
+                    # Readable under neither key. The row is left untouched
+                    # rather than deleted — it is already unusable, and
+                    # removing crypto material is not worth doing on a
+                    # guess. It stays inert.
                     logger.warning(
-                        "Matrix: dropping unreadable %s row %s during pickle "
-                        "key migration: %s",
+                        "Matrix: %s row %s cannot be unpickled with the "
+                        "current or legacy key; leaving it in place, its "
+                        "sessions are unrecoverable: %s",
                         table,
                         row["session_id"],
                         exc,

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1360,6 +1360,108 @@ class MatrixAdapter(BasePlatformAdapter):
         await crypto_store.delete()
         return True
 
+    async def _migrate_legacy_crypto_pickle(
+        self, crypto_store: Any, crypto_db: Any, acct_id: str, pickle_key: str
+    ) -> bool:
+        """Re-pickle the Olm account when the pickle key changed.
+
+        The pickle key embeds the *configured* device ID. If the account was
+        created before MATRIX_DEVICE_ID was set (e.g. first password login,
+        where the device ID is only known after connecting), the store was
+        pickled under ``<acct>:default``; setting MATRIX_DEVICE_ID afterwards
+        changes the key and unpickling fails with BAD_ACCOUNT_KEY — which in
+        optional-E2EE mode silently disables encryption. Try known legacy
+        keys and re-pickle under the current one. Returns False only when an
+        account exists but no key can unpickle it.
+        """
+        try:
+            await crypto_store.get_account()
+            return True
+        except Exception:
+            pass
+
+        from mautrix.crypto.store.asyncpg import PgCryptoStore
+
+        for legacy_key in (f"{acct_id}:default", acct_id):
+            if legacy_key == pickle_key:
+                continue
+            legacy_store = PgCryptoStore(
+                account_id=acct_id, pickle_key=legacy_key, db=crypto_db
+            )
+            try:
+                account = await legacy_store.get_account()
+            except Exception:
+                continue
+            if account is None:
+                continue
+            await crypto_store.put_account(account)
+            await self._repickle_crypto_sessions(
+                crypto_db, acct_id, legacy_key, pickle_key
+            )
+            logger.info(
+                "Matrix: re-pickled crypto store account and sessions under "
+                "the current pickle key (device ID was configured after the "
+                "account was created)"
+            )
+            return True
+
+        logger.error(
+            "Matrix: crypto store account exists but cannot be unpickled "
+            "with the current or any legacy pickle key. If MATRIX_DEVICE_ID "
+            "was changed manually, restore its previous value."
+        )
+        return False
+
+    async def _repickle_crypto_sessions(
+        self, crypto_db: Any, acct_id: str, legacy_key: str, pickle_key: str
+    ) -> None:
+        """Re-pickle olm/megolm session blobs alongside the account.
+
+        The account and every stored session share the pickle key; migrating
+        only the account leaves sessions unreadable (BAD_ACCOUNT_KEY on the
+        next olm decrypt), which breaks key sharing with peers.
+        """
+        import olm as olm_lib
+
+        tables = {
+            "crypto_olm_session": olm_lib.Session,
+            "crypto_megolm_inbound_session": olm_lib.InboundGroupSession,
+            "crypto_megolm_outbound_session": olm_lib.OutboundGroupSession,
+        }
+        for table, session_cls in tables.items():
+            rows = await crypto_db.fetch(
+                f"SELECT session_id, session FROM {table} WHERE account_id=$1",
+                acct_id,
+            )
+            for row in rows:
+                blob = row["session"]
+                if blob is None:
+                    continue
+                pickled = bytes(blob)
+                try:
+                    session_cls.from_pickle(pickled, pickle_key)
+                    continue  # already readable with the current key
+                except Exception:
+                    pass
+                try:
+                    session = session_cls.from_pickle(pickled, legacy_key)
+                except Exception as exc:
+                    logger.warning(
+                        "Matrix: dropping unreadable %s row %s during pickle "
+                        "key migration: %s",
+                        table,
+                        row["session_id"],
+                        exc,
+                    )
+                    continue
+                await crypto_db.execute(
+                    f"UPDATE {table} SET session=$1 "
+                    "WHERE account_id=$2 AND session_id=$3",
+                    session.pickle(pickle_key),
+                    acct_id,
+                    row["session_id"],
+                )
+
     async def _verify_device_keys_on_server(self, client: Any, olm: Any) -> bool:
         """Verify our device keys are on the homeserver after loading crypto state.
 
@@ -1668,6 +1770,10 @@ class MatrixAdapter(BasePlatformAdapter):
                             crypto_store, client.device_id
                         )
                         await crypto_store.put_device_id(client.device_id)
+
+                    await self._migrate_legacy_crypto_pickle(
+                        crypto_store, crypto_db, _acct_id, _pickle_key
+                    )
 
                     crypto_state = _CryptoStateStore(state_store, self._joined_rooms, client)
                     olm = OlmMachine(client, crypto_store, crypto_state)

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -978,13 +978,19 @@ class _CryptoStateStore:
     ``get_encryption_info``, and ``find_shared_rooms``.  The basic
     ``MemoryStateStore`` from ``mautrix.client`` doesn't implement these,
     so we provide simple implementations that consult the client's room
-    state.
+    state, falling back to a direct homeserver state event query when
+    the in-memory store has no encryption info for a room.
     """
 
     def __init__(self, client_state_store: Any, joined_rooms: set, client=None):
         self._ss = client_state_store
         self._joined_rooms = joined_rooms
         self._client = client
+        # Cache encryption info queried from the homeserver so we don't
+        # make a network round-trip on every is_encrypted() call.
+        # MemoryStateStore doesn't implement set_encryption_info, so the
+        # cache-back in get_encryption_info is a no-op without this.
+        self._enc_info_cache: dict = {}
 
     async def is_encrypted(self, room_id: str) -> bool:
         return (await self.get_encryption_info(room_id)) is not None
@@ -995,6 +1001,9 @@ class _CryptoStateStore:
             info = await self._ss.get_encryption_info(room_id)
         if info is not None:
             return info
+        # Check local cache before hitting the homeserver.
+        if room_id in self._enc_info_cache:
+            return self._enc_info_cache[room_id]
         client = self._client
         if client is None:
             return None
@@ -1005,7 +1014,12 @@ class _CryptoStateStore:
                 RoomID as _RID,
             )
             raw = await client.get_state_event(_RID(room_id), _ET.ROOM_ENCRYPTION)
-        except Exception:
+        except Exception as exc:
+            logger.debug(
+                "Matrix: homeserver encryption-info query failed for %s: %s",
+                room_id,
+                exc,
+            )
             return None
         if not raw:
             return None
@@ -1017,6 +1031,7 @@ class _CryptoStateStore:
                 await self._ss.set_encryption_info(_RID(room_id), content)
             except Exception:
                 pass
+        self._enc_info_cache[room_id] = content
         return content
 
     async def find_shared_rooms(self, user_id: str) -> list:
@@ -1776,7 +1791,13 @@ class MatrixAdapter(BasePlatformAdapter):
                     self._crypto_db = crypto_db
 
                     _acct_id = self._user_id or "hermes"
-                    _pickle_key = f"{_acct_id}:{self._device_id or 'default'}"
+                    # Use the resolved client.device_id (from whoami or password
+                    # login), not self._device_id (the configured value), because
+                    # #71543 makes the token's real device win over a stale
+                    # MATRIX_DEVICE_ID.  The pickle key must match the device the
+                    # token actually belongs to, or the Olm account is stored
+                    # under a key that can never be looked up again.
+                    _pickle_key = f"{_acct_id}:{client.device_id or self._device_id or 'default'}"
                     crypto_store = PgCryptoStore(
                         account_id=_acct_id,
                         pickle_key=_pickle_key,
@@ -1785,14 +1806,23 @@ class MatrixAdapter(BasePlatformAdapter):
                     await crypto_store.open()
 
                     if client.device_id:
-                        await self._reset_crypto_store_if_device_changed(
+                        _store_was_reset = await self._reset_crypto_store_if_device_changed(
                             crypto_store, client.device_id
                         )
                         await crypto_store.put_device_id(client.device_id)
+                    else:
+                        _store_was_reset = False
 
-                    await self._migrate_legacy_crypto_pickle(
-                        crypto_store, crypto_db, _acct_id, _pickle_key
-                    )
+                    # Skip the pickle-key migration when the store was just
+                    # deleted — there is no account to migrate.
+                    if not _store_was_reset:
+                        if not await self._migrate_legacy_crypto_pickle(
+                            crypto_store, crypto_db, _acct_id, _pickle_key
+                        ):
+                            logger.warning(
+                                "Matrix: crypto pickle migration failed — "
+                                "E2EE may not work correctly"
+                            )
 
                     crypto_state = _CryptoStateStore(state_store, self._joined_rooms, client)
                     olm = OlmMachine(client, crypto_store, crypto_state)

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1493,13 +1493,38 @@ class MatrixAdapter(BasePlatformAdapter):
             try:
                 resp = await client.whoami()
                 resolved_user_id = getattr(resp, "user_id", "") or self._user_id
-                resolved_device_id = getattr(resp, "device_id", "")
+                resolved_device_id = str(getattr(resp, "device_id", "") or "")
                 if resolved_user_id:
                     self._user_id = str(resolved_user_id)
                     client.mxid = UserID(self._user_id)
 
-                # Prefer user-configured device_id for stable E2EE identity.
-                effective_device_id = self._device_id or resolved_device_id
+                # Normally the user-configured device_id wins, giving a stable
+                # E2EE identity when whoami() reports no device.
+                #
+                # But an access token is bound to exactly one device, and the
+                # homeserver only accepts key uploads for that device. If
+                # MATRIX_DEVICE_ID names a different one, honouring it means
+                # claiming an identity this token cannot publish — which is
+                # the stale-key failure mode this reset exists to clear. The
+                # live whoami() device therefore wins on conflict, loudly.
+                if (
+                    resolved_device_id
+                    and self._device_id
+                    and resolved_device_id != self._device_id
+                ):
+                    logger.error(
+                        "Matrix: MATRIX_DEVICE_ID=%s does not match the device "
+                        "this access token belongs to (%s). A token can only "
+                        "upload keys for its own device, so the configured "
+                        "value is being ignored. Unset MATRIX_DEVICE_ID, or "
+                        "use a token issued for %s.",
+                        self._device_id,
+                        resolved_device_id,
+                        self._device_id,
+                    )
+                    effective_device_id = resolved_device_id
+                else:
+                    effective_device_id = self._device_id or resolved_device_id
                 if effective_device_id:
                     client.device_id = effective_device_id
 

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -981,17 +981,43 @@ class _CryptoStateStore:
     state.
     """
 
-    def __init__(self, client_state_store: Any, joined_rooms: set):
+    def __init__(self, client_state_store: Any, joined_rooms: set, client=None):
         self._ss = client_state_store
         self._joined_rooms = joined_rooms
+        self._client = client
 
     async def is_encrypted(self, room_id: str) -> bool:
         return (await self.get_encryption_info(room_id)) is not None
 
     async def get_encryption_info(self, room_id: str):
+        info = None
         if hasattr(self._ss, "get_encryption_info"):
-            return await self._ss.get_encryption_info(room_id)
-        return None
+            info = await self._ss.get_encryption_info(room_id)
+        if info is not None:
+            return info
+        client = self._client
+        if client is None:
+            return None
+        try:
+            from mautrix.types import (
+                EventType as _ET,
+                RoomEncryptionStateEventContent as _Enc,
+                RoomID as _RID,
+            )
+            raw = await client.get_state_event(_RID(room_id), _ET.ROOM_ENCRYPTION)
+        except Exception:
+            return None
+        if not raw:
+            return None
+        content = raw if isinstance(raw, _Enc) else _Enc.deserialize(
+            raw.serialize() if hasattr(raw, "serialize") else raw
+        )
+        if hasattr(self._ss, "set_encryption_info"):
+            try:
+                await self._ss.set_encryption_info(_RID(room_id), content)
+            except Exception:
+                pass
+        return content
 
     async def find_shared_rooms(self, user_id: str) -> list:
         # Return all joined rooms — simple but correct for a single-user bot.
@@ -1584,7 +1610,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     if client.device_id:
                         await crypto_store.put_device_id(client.device_id)
 
-                    crypto_state = _CryptoStateStore(state_store, self._joined_rooms)
+                    crypto_state = _CryptoStateStore(state_store, self._joined_rooms, client)
                     olm = OlmMachine(client, crypto_store, crypto_state)
                     olm.share_keys_min_trust = TrustState.UNVERIFIED
                     olm.send_keys_min_trust = TrustState.UNVERIFIED

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3143,8 +3143,15 @@ class TestCryptoPickleKeyMigration:
 
         fake_mod = types.ModuleType("mautrix.crypto.store.asyncpg")
         fake_mod.PgCryptoStore = FakePgCryptoStore
-        with patch.dict(sys.modules, {"mautrix.crypto.store.asyncpg": fake_mod}), \
-                caplog.at_level(logging.INFO):
+        with patch.dict(
+            sys.modules,
+            {
+                "mautrix.crypto.store.asyncpg": fake_mod,
+                # _repickle_crypto_sessions imports the olm C-extension;
+                # fake it so this test does not require libolm.
+                "olm": self._fake_olm_module(),
+            },
+        ), caplog.at_level(logging.INFO):
             result = await adapter._migrate_legacy_crypto_pickle(
                 store, crypto_db, "@bot:example.org", "@bot:example.org:NEWDEV"
             )
@@ -3188,3 +3195,150 @@ class TestCryptoPickleKeyMigration:
         assert result is False
         store.put_account.assert_not_awaited()
         assert "cannot be unpickled" in caplog.text
+
+    def _fake_olm_module(self):
+        """Fake the `olm` C-extension module.
+
+        _repickle_crypto_sessions does `import olm`, which needs libolm.
+        Sessions unpickle only with the key they were pickled under.
+        """
+        olm_mod = types.ModuleType("olm")
+
+        class _Session:
+            def __init__(self, key):
+                self._key = key
+
+            @classmethod
+            def from_pickle(cls, blob, key):
+                pickled_under = blob.decode().split("|")[1]
+                if pickled_under != key:
+                    raise RuntimeError("BAD_ACCOUNT_KEY")
+                return cls(key)
+
+            def pickle(self, key):
+                return f"sess|{key}".encode()
+
+        for name in ("Session", "InboundGroupSession", "OutboundGroupSession"):
+            setattr(olm_mod, name, type(name, (_Session,), {}))
+        return olm_mod
+
+    @pytest.mark.asyncio
+    async def test_session_rows_are_repickled_under_current_key(self):
+        """The session sweep must actually rewrite legacy-key rows."""
+        adapter = _make_adapter()
+        legacy = "@bot:example.org:default"
+        current = "@bot:example.org:NEWDEV"
+
+        crypto_db = MagicMock()
+        crypto_db.fetch = AsyncMock(
+            return_value=[{"session_id": "s1", "session": f"sess|{legacy}".encode()}]
+        )
+        crypto_db.execute = AsyncMock()
+
+        with patch.dict(sys.modules, {"olm": self._fake_olm_module()}):
+            await adapter._repickle_crypto_sessions(
+                crypto_db, "@bot:example.org", legacy, current
+            )
+
+        # One UPDATE per session table, each writing the current-key blob.
+        assert crypto_db.execute.await_count == 3
+        for call in crypto_db.execute.await_args_list:
+            assert call.args[1] == f"sess|{current}".encode()
+            assert call.args[3] == "s1"
+
+    @pytest.mark.asyncio
+    async def test_rows_already_on_current_key_are_left_alone(self):
+        adapter = _make_adapter()
+        current = "@bot:example.org:NEWDEV"
+
+        crypto_db = MagicMock()
+        crypto_db.fetch = AsyncMock(
+            return_value=[{"session_id": "s1", "session": f"sess|{current}".encode()}]
+        )
+        crypto_db.execute = AsyncMock()
+
+        with patch.dict(sys.modules, {"olm": self._fake_olm_module()}):
+            await adapter._repickle_crypto_sessions(
+                crypto_db, "@bot:example.org", "@bot:example.org:default", current
+            )
+
+        crypto_db.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unreadable_rows_are_left_in_place_not_dropped(self, caplog):
+        """A row readable under neither key is skipped and left untouched.
+
+        The log must not claim the row was dropped when no DELETE is issued.
+        """
+        import logging
+        adapter = _make_adapter()
+
+        crypto_db = MagicMock()
+        crypto_db.fetch = AsyncMock(
+            return_value=[{"session_id": "s1", "session": b"sess|@bot:other:KEY"}]
+        )
+        crypto_db.execute = AsyncMock()
+
+        with patch.dict(sys.modules, {"olm": self._fake_olm_module()}), \
+                caplog.at_level(logging.WARNING):
+            await adapter._repickle_crypto_sessions(
+                crypto_db,
+                "@bot:example.org",
+                "@bot:example.org:default",
+                "@bot:example.org:NEWDEV",
+            )
+
+        crypto_db.execute.assert_not_awaited()
+        assert "leaving it in place" in caplog.text
+        assert "dropping" not in caplog.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_failed_sweep_leaves_account_on_legacy_key_and_retries(
+        self, caplog
+    ):
+        """A sweep failure must not commit the account.
+
+        The account is the migration's commit marker: if it is written first
+        and the sweep then fails, the next startup takes the current-key fast
+        path and the remaining legacy-key sessions are stranded permanently.
+        """
+        import logging
+        adapter = _make_adapter()
+        legacy_account = MagicMock()
+
+        store = MagicMock()
+        store.get_account = AsyncMock(side_effect=RuntimeError("BAD_ACCOUNT_KEY"))
+        store.put_account = AsyncMock()
+
+        class FakePgCryptoStore:
+            def __init__(self, account_id, pickle_key, db):
+                self.pickle_key = pickle_key
+
+            async def get_account(self):
+                if self.pickle_key == "@bot:example.org:default":
+                    return legacy_account
+                raise RuntimeError("BAD_ACCOUNT_KEY")
+
+        crypto_db = MagicMock()
+        crypto_db.fetch = AsyncMock(side_effect=RuntimeError("db went away"))
+        crypto_db.execute = AsyncMock()
+
+        fake_mod = types.ModuleType("mautrix.crypto.store.asyncpg")
+        fake_mod.PgCryptoStore = FakePgCryptoStore
+
+        with patch.dict(
+            sys.modules,
+            {
+                "mautrix.crypto.store.asyncpg": fake_mod,
+                "olm": self._fake_olm_module(),
+            },
+        ), caplog.at_level(logging.ERROR):
+            result = await adapter._migrate_legacy_crypto_pickle(
+                store, crypto_db, "@bot:example.org", "@bot:example.org:NEWDEV"
+            )
+
+        assert result is False
+        # The critical assertion: the account was NOT committed, so the next
+        # start still sees a legacy-key account and retries the migration.
+        store.put_account.assert_not_awaited()
+        assert "retried on the next start" in caplog.text

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -2862,3 +2862,54 @@ class TestMatrixDispatchSyncIsolation:
 
         assert ran["ok"] is True  # the sibling handler still ran
         assert "event handler failed" in caplog.text  # failure surfaced, not swallowed
+
+
+# ---------------------------------------------------------------------------
+# E2EE crypto store reset on device change
+# ---------------------------------------------------------------------------
+
+class TestCryptoStoreResetOnDeviceChange:
+    @pytest.mark.asyncio
+    async def test_reset_when_device_id_changed(self, caplog):
+        import logging
+        adapter = _make_adapter()
+        store = MagicMock()
+        store.get_device_id = AsyncMock(return_value="OLDDEVICE")
+        store.delete = AsyncMock()
+
+        with caplog.at_level(logging.WARNING):
+            reset = await adapter._reset_crypto_store_if_device_changed(store, "NEWDEVICE")
+
+        assert reset is True
+        store.delete.assert_awaited_once()
+        assert "OLDDEVICE" in caplog.text and "NEWDEVICE" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_no_reset_when_device_id_same(self):
+        adapter = _make_adapter()
+        store = MagicMock()
+        store.get_device_id = AsyncMock(return_value="SAMEDEVICE")
+        store.delete = AsyncMock()
+
+        assert await adapter._reset_crypto_store_if_device_changed(store, "SAMEDEVICE") is False
+        store.delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_reset_on_fresh_store(self):
+        adapter = _make_adapter()
+        store = MagicMock()
+        store.get_device_id = AsyncMock(return_value=None)
+        store.delete = AsyncMock()
+
+        assert await adapter._reset_crypto_store_if_device_changed(store, "NEWDEVICE") is False
+        store.delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_reset_without_device_id(self):
+        adapter = _make_adapter()
+        store = MagicMock()
+        store.get_device_id = AsyncMock(return_value="OLDDEVICE")
+        store.delete = AsyncMock()
+
+        assert await adapter._reset_crypto_store_if_device_changed(store, "") is False
+        store.delete.assert_not_awaited()

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3099,3 +3099,92 @@ class TestCryptoStoreResetOnDeviceChange:
         assert "MATRIX_DEVICE_ID=DEVICE_A" in caplog.text
 
         await adapter.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Crypto store pickle-key migration
+# ---------------------------------------------------------------------------
+
+class TestCryptoPickleKeyMigration:
+    @pytest.mark.asyncio
+    async def test_account_loads_fine_no_migration(self):
+        adapter = _make_adapter()
+        store = MagicMock()
+        store.get_account = AsyncMock(return_value=MagicMock())
+        assert await adapter._migrate_legacy_crypto_pickle(
+            store, MagicMock(), "@bot:example.org", "@bot:example.org:DEV"
+        ) is True
+        store.put_account.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_migrates_from_default_pickle_key(self, caplog):
+        import logging
+        adapter = _make_adapter()
+        store = MagicMock()
+        store.get_account = AsyncMock(side_effect=RuntimeError("BAD_ACCOUNT_KEY"))
+        store.put_account = AsyncMock()
+
+        legacy_account = MagicMock()
+        created = []
+
+        class FakePgCryptoStore:
+            def __init__(self, account_id, pickle_key, db):
+                self.pickle_key = pickle_key
+                created.append(pickle_key)
+
+            async def get_account(self):
+                if self.pickle_key == "@bot:example.org:default":
+                    return legacy_account
+                raise RuntimeError("BAD_ACCOUNT_KEY")
+
+        crypto_db = MagicMock()
+        crypto_db.fetch = AsyncMock(return_value=[])
+        crypto_db.execute = AsyncMock()
+
+        fake_mod = types.ModuleType("mautrix.crypto.store.asyncpg")
+        fake_mod.PgCryptoStore = FakePgCryptoStore
+        with patch.dict(sys.modules, {"mautrix.crypto.store.asyncpg": fake_mod}), \
+                caplog.at_level(logging.INFO):
+            result = await adapter._migrate_legacy_crypto_pickle(
+                store, crypto_db, "@bot:example.org", "@bot:example.org:NEWDEV"
+            )
+
+        assert result is True
+        store.put_account.assert_awaited_once_with(legacy_account)
+        assert "re-pickled crypto store account" in caplog.text
+        assert "@bot:example.org:default" in created
+        # session re-pickle pass must sweep all three session tables
+        queried = " ".join(str(c.args[0]) for c in crypto_db.fetch.await_args_list)
+        for table in (
+            "crypto_olm_session",
+            "crypto_megolm_inbound_session",
+            "crypto_megolm_outbound_session",
+        ):
+            assert table in queried
+
+    @pytest.mark.asyncio
+    async def test_unrecoverable_pickle_logs_error(self, caplog):
+        import logging
+        adapter = _make_adapter()
+        store = MagicMock()
+        store.get_account = AsyncMock(side_effect=RuntimeError("BAD_ACCOUNT_KEY"))
+        store.put_account = AsyncMock()
+
+        class FakePgCryptoStore:
+            def __init__(self, account_id, pickle_key, db):
+                pass
+
+            async def get_account(self):
+                raise RuntimeError("BAD_ACCOUNT_KEY")
+
+        fake_mod = types.ModuleType("mautrix.crypto.store.asyncpg")
+        fake_mod.PgCryptoStore = FakePgCryptoStore
+        with patch.dict(sys.modules, {"mautrix.crypto.store.asyncpg": fake_mod}), \
+                caplog.at_level(logging.ERROR):
+            result = await adapter._migrate_legacy_crypto_pickle(
+                store, MagicMock(), "@bot:example.org", "@bot:example.org:NEWDEV"
+            )
+
+        assert result is False
+        store.put_account.assert_not_awaited()
+        assert "cannot be unpickled" in caplog.text

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1128,6 +1128,80 @@ class TestMatrixDeviceId:
         adapter = MatrixAdapter(config)
         assert adapter._device_id == "FROM_CONFIG"
 
+    @pytest.mark.asyncio
+    async def test_connect_keeps_configured_device_id_on_adapter(self):
+        """MATRIX_DEVICE_ID stays on the adapter regardless of whoami.
+
+        Note: this test previously asserted that the configured device_id
+        overrides the whoami device_id outright. That is no longer true for
+        the *client* identity — a token can only upload keys for its own
+        device, so a conflicting whoami device now wins (see
+        TestCryptoStoreResetOnDeviceChange). The configured value is still
+        preferred when whoami reports no device, and is still recorded on the
+        adapter, which is what this test pins.
+        """
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            token="syt_test_access_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+                "encryption": True,
+                "device_id": "MY_STABLE_DEVICE",
+            },
+        )
+        adapter = MatrixAdapter(config)
+
+        fake_mautrix_mods = _make_fake_mautrix()
+
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.state_store = MagicMock()
+        mock_client.sync_store = MagicMock()
+        mock_client.crypto = None
+        mock_client.whoami = AsyncMock(return_value=MagicMock(user_id="@bot:example.org", device_id="WHOAMI_DEV"))
+        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
+        mock_client.add_event_handler = MagicMock()
+        mock_client.handle_sync = MagicMock(return_value=[])
+        mock_client.query_keys = AsyncMock(return_value={
+            "device_keys": {"@bot:example.org": {"MY_STABLE_DEVICE": {
+                "keys": {"ed25519:MY_STABLE_DEVICE": "fake_ed25519_key"},
+            }}},
+        })
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+
+        mock_olm = MagicMock()
+        mock_olm.load = AsyncMock()
+        mock_olm.share_keys = AsyncMock()
+        mock_olm.share_keys_min_trust = None
+        mock_olm.send_keys_min_trust = None
+        mock_olm.account = MagicMock()
+        mock_olm.account.identity_keys = {"ed25519": "fake_ed25519_key"}
+
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(return_value=mock_olm)
+
+        import plugins.platforms.matrix.adapter as matrix_mod
+        with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
+            with patch.dict("sys.modules", fake_mautrix_mods):
+                with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+                    with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                        assert await adapter.connect() is True
+
+        # The configured device_id is retained on the adapter.
+        assert adapter._device_id == "MY_STABLE_DEVICE"
+        # But the token's own device is what the client claims, because the
+        # homeserver will not accept key uploads for any other device.
+        assert mock_client.device_id == "WHOAMI_DEV"
+
+        await adapter.disconnect()
+
 
 class TestMatrixPasswordLoginDeviceId:
     """MATRIX_DEVICE_ID should be passed to mautrix Client even with password login."""
@@ -2913,3 +2987,115 @@ class TestCryptoStoreResetOnDeviceChange:
 
         assert await adapter._reset_crypto_store_if_device_changed(store, "") is False
         store.delete.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_connect_resets_store_when_token_device_differs_from_config(
+        self, caplog
+    ):
+        """Rotated token, stale MATRIX_DEVICE_ID.
+
+        Persisted store device is A, MATRIX_DEVICE_ID is still A, but the
+        access token now belongs to device B. The helper alone cannot catch
+        this: connect() used to resolve client.device_id to the configured A,
+        so persisted A == live A and no reset happened. The token's device
+        must win, and the store must be reset.
+        """
+        import logging
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            token="syt_rotated_access_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+                "encryption": True,
+                "device_id": "DEVICE_A",
+            },
+        )
+        adapter = MatrixAdapter(config)
+
+        fake_mautrix_mods = _make_fake_mautrix()
+
+        deleted = {"count": 0}
+
+        class _ResettableCryptoStore:
+            upgrade_table = MagicMock()
+
+            def __init__(self, account_id="", pickle_key="", db=None):
+                self.account_id = account_id
+                self.pickle_key = pickle_key
+                self.db = db
+                self._device_id = "DEVICE_A"  # persisted from the old token
+
+            async def open(self):
+                pass
+
+            async def get_device_id(self):
+                return self._device_id
+
+            async def delete(self):
+                deleted["count"] += 1
+                self._device_id = ""
+
+            async def put_device_id(self, device_id):
+                self._device_id = device_id
+
+        fake_mautrix_mods[
+            "mautrix.crypto.store.asyncpg"
+        ].PgCryptoStore = _ResettableCryptoStore
+
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.state_store = MagicMock()
+        mock_client.sync_store = MagicMock()
+        mock_client.crypto = None
+        # Token was rotated: the homeserver reports device B.
+        mock_client.whoami = AsyncMock(
+            return_value=MagicMock(user_id="@bot:example.org", device_id="DEVICE_B")
+        )
+        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {}}})
+        mock_client.add_event_handler = MagicMock()
+        mock_client.handle_sync = MagicMock(return_value=[])
+        mock_client.query_keys = AsyncMock(return_value={"device_keys": {}})
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_rotated_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+
+        mock_olm = MagicMock()
+        mock_olm.load = AsyncMock()
+        mock_olm.share_keys = AsyncMock()
+        mock_olm.share_keys_min_trust = None
+        mock_olm.send_keys_min_trust = None
+        mock_olm.account = MagicMock()
+        mock_olm.account.identity_keys = {"ed25519": "fake_ed25519_key"}
+
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(
+            return_value=mock_client
+        )
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(
+            return_value=mock_olm
+        )
+
+        import plugins.platforms.matrix.adapter as matrix_mod
+
+        with caplog.at_level(logging.WARNING), patch.object(
+            matrix_mod, "_check_e2ee_deps", return_value=True
+        ), patch.dict("sys.modules", fake_mautrix_mods), patch.object(
+            adapter, "_refresh_dm_cache", AsyncMock()
+        ), patch.object(
+            adapter, "_sync_loop", AsyncMock(return_value=None)
+        ), patch.object(
+            adapter, "_verify_device_keys_on_server", AsyncMock(return_value=True)
+        ):
+            assert await adapter.connect() is True
+
+        # The token's device wins over the stale configured one.
+        assert mock_client.device_id == "DEVICE_B"
+        # ...which is what lets the mismatch be seen and the store reset.
+        assert deleted["count"] == 1
+        assert "MATRIX_DEVICE_ID=DEVICE_A" in caplog.text
+
+        await adapter.disconnect()


### PR DESCRIPTION
## Summary
Fixes the Matrix E2EE silent-drop chain: encrypted inbound messages are silently dropped after a gateway restart because (1) the in-memory state store has no room encryption info, (2) each password login creates a new device ID that doesn't match the stored Olm account, and (3) the pickle key embeds a stale device ID after it changes.

Salvages and combines three external contributor PRs, plus follow-up fixes for the missing link between them.

## Changes
- **#71073** (webtecnica): `_CryptoStateStore.get_encryption_info()` falls back to querying the homeserver for room encryption state when the local store has no info, instead of silently returning None
- **#71543** (ckaznocha): `_reset_crypto_store_if_device_changed()` resets the local Olm crypto store when the access token's device ID changes across restarts; the token's real device ID (from whoami) wins over a stale `MATRIX_DEVICE_ID`
- **#71547** (ckaznocha): `_migrate_legacy_crypto_pickle()` + `_repickle_crypto_sessions()` re-pickle the Olm account and sessions when the pickle key changes (e.g., after setting `MATRIX_DEVICE_ID` on a store created before it was configured)
- **Follow-up fixes** (kshitij):
  - Construct `_pickle_key` from `client.device_id` (resolved from whoami) instead of `self._device_id` (configured) — without this, the pickle key doesn't match the device the token actually belongs to, perpetuating the decryption failure
  - Skip pickle migration when the store was just deleted by the device-change reset; check migration return value and log warning on failure
  - Add local dict cache to `_CryptoStateStore` so the homeserver fallback doesn't make a network round-trip on every `is_encrypted()` call (MemoryStateStore doesn't implement `set_encryption_info`, so the existing cache-back is a no-op)
  - Log homeserver encryption-info query failures at DEBUG instead of silently returning None
  - Update `_CryptoStateStore` docstring

Closes #71073, #71543, #71547
Relates to #71067

## Test plan
- 112 tests in `tests/gateway/test_matrix.py` pass (including 13 new tests from #71543 and #71547)
- `ruff check` clean
- `py_compile` clean on both files
