### PR TITLE
chore: add contributor email mapping for danielblankhh

### DIFF
--- a/contributors/emails/daniel.blank@reportsolution.de
+++ b/contributors/emails/daniel.blank@reportsolution.de
@@ -1,0 +1,1 @@
+danielblankhh


### PR DESCRIPTION
Attribution mapping for @danielblankhh (daniel.blank@reportsolution.de), needed by the #69926 salvage.