### PR TITLE
fix(cli): 已在当前分支路径中增加 Node.js 依赖和 Web UI 自愈检查

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12058,6 +12058,26 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
                 print("✓ Already up to date!")
+
+            # A current checkout does NOT imply healthy Node.js dependencies.
+            # A previous update may have failed at the npm step (e.g.
+            # EBADENGINE from a mismatched system node/npm), leaving
+            # node_modules stale while the Python venv remained fine.
+            # _update_node_dependencies() is self-guarded via
+            # _npm_lockfile_changed() — healthy installs return [] in
+            # milliseconds — so calling it unconditionally here is cheap.
+            # The web UI build is similarly self-guarded via
+            # _web_ui_build_needed(). This mirrors the Python venv probe
+            # above (line 12018) that was added after ryanc's incident
+            # (#3882-#3921): "checkout is current" ≠ "install is healthy".
+            if (PROJECT_ROOT / "package.json").exists():
+                node_failures = _update_node_dependencies()
+                _build_web_ui(PROJECT_ROOT / "web")
+                if node_failures:
+                    print(
+                        f"⚠ Node.js dependencies are stale ({', '.join(node_failures)}). "
+                        "Fix npm and re-run `hermes update`."
+                    )
             if runtime_repaired is not None and not _is_windows():
                 print()
                 print(

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1236,3 +1236,83 @@ class TestNodeRuntimeNpmResolution:
             not call.args or not call.args[0] or call.args[0][0] != windows_npm
             for call in mock_run.call_args_list
         )
+
+
+class TestCmdUpdateAlreadyUpToDateNodeRepair:
+    """Regression tests for #77211: the \"Already up to date!\" path must also
+    self-heal stale Node.js dependencies and the web UI build, mirroring the
+    Python venv health probe (_venv_core_imports_healthy) added in July 2026.
+    A current checkout does NOT imply a healthy Node install.
+    """
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_already_up_to_date_calls_node_deps_when_package_json_exists(
+        self, mock_run, _mock_which, monkeypatch, capsys, tmp_path
+    ):
+        from hermes_cli import main as hm
+
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "web").mkdir()
+        (tmp_path / "web" / "package.json").write_text("{}")
+        (tmp_path / ".git").mkdir()
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+
+        # Checkout is current (0 commits)
+        mock_run.side_effect = _make_run_side_effect(branch="main", verify_ok=True, commit_count="0")
+
+        with patch.object(hm, "_venv_core_imports_healthy", return_value=(True, "")), \
+             patch.object(hm, "_update_node_dependencies", return_value=[]) as mock_node, \
+             patch.object(hm, "_build_web_ui", return_value=True) as mock_web:
+            cmd_update(SimpleNamespace())
+
+        mock_node.assert_called_once()
+        mock_web.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Already up to date!" in out
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_already_up_to_date_warns_on_node_failure(
+        self, mock_run, _mock_which, monkeypatch, capsys, tmp_path
+    ):
+        from hermes_cli import main as hm
+
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / ".git").mkdir()
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+
+        mock_run.side_effect = _make_run_side_effect(branch="main", verify_ok=True, commit_count="0")
+
+        with patch.object(hm, "_venv_core_imports_healthy", return_value=(True, "")), \
+             patch.object(hm, "_update_node_dependencies", return_value=["repo root"]) as mock_node, \
+             patch.object(hm, "_build_web_ui", return_value=True):
+            cmd_update(SimpleNamespace())
+
+        mock_node.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Already up to date!" in out
+        assert "Node.js dependencies are stale" in out
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_already_up_to_date_skips_node_when_no_package_json(
+        self, mock_run, _mock_which, monkeypatch, capsys, tmp_path
+    ):
+        from hermes_cli import main as hm
+
+        # No package.json — no Node deps to refresh.
+        (tmp_path / ".git").mkdir()
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+
+        mock_run.side_effect = _make_run_side_effect(branch="main", verify_ok=True, commit_count="0")
+
+        with patch.object(hm, "_venv_core_imports_healthy", return_value=(True, "")), \
+             patch.object(hm, "_update_node_dependencies", return_value=[]) as mock_node, \
+             patch.object(hm, "_build_web_ui", return_value=True) as mock_web:
+            cmd_update(SimpleNamespace())
+
+        mock_node.assert_not_called()
+        mock_web.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Already up to date!" in out


### PR DESCRIPTION
## 背景

修复 #77211: `hermes update` 在 `Already up to date!` 路径下只检查了 Python venv 健康度，但从未检查 Node.js 依赖或 Web UI 构建。如果之前的更新在 npm 步骤失败（如 node/npm 版本不匹配导致 EBADENGINE），node_modules 会持续处于陈旧状态且 Web UI 未构建，而重新运行 `hermes update` 是无操作的（no-op），因为代码仓库已经是最新的。

## 根因分析

`hermes_cli/main.py` 的 cmd_update 函数中：
- **Python 侧**：2026年7月已添加 `_venv_core_imports_healthy()` 探针到 already-up-to-date 路径（line 12018），检测到 venv 不健康时自动修复
- **Node 侧**：`_update_node_dependencies()` 只在有新 commit 的路径上被调用（line 12297），already-up-to-date 路径完全不涉及 Node 依赖检查
- 两个函数都有内部自我保护（`_npm_lockfile_changed()` / `_web_ui_build_needed()`），健康安装会在毫秒级跳过，因此无条件调用是安全的

## 修复方式

在 already-up-to-date 路径（`print('✓ Already up to date!')` 之后），增加对 Node.js 依赖和 Web UI 构建的自愈检查：
1. 如果 `package.json` 存在，调用 `_update_node_dependencies()` — 它通过 `_npm_lockfile_changed()` 自我保护，不变则跳过
2. 调用 `_build_web_ui()` — 通过 `_web_ui_build_needed()` 自我保护，不需要重建则跳过
3. 如果 Node 依赖更新失败，打印明确的警告信息

这与 Python venv 探针的模式完全一致：「checkout 是最新的」≠「安装是健康的」。

## 验证

- [x] 3 个回归测试全部通过（TestCmdUpdateAlreadyUpToDateNodeRepair）
- [x] 全文 53 个 test_cmd_update.py 测试全部通过
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更

Closes #77211