### PR TITLE
fix(agent): refund iteration budget when fallback activates after API failure (#77305)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2153,6 +2153,10 @@ def run_conversation(
                             retry_count = 0
                             compression_attempts = 0
                             _retry.primary_recovery_attempted = False
+                            try:
+                                agent.iteration_budget.refund()
+                            except Exception:
+                                pass
                             continue
                         # No fallback available — surface buffered context
                         # so user sees the rate-limit message that led here.
@@ -2595,6 +2599,10 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
+                        try:
+                            agent.iteration_budget.refund()
+                        except Exception:
+                            pass
                         continue
 
                     # Check for error field in response (some providers include this)
@@ -2668,6 +2676,10 @@ def run_conversation(
                             retry_count = 0
                             compression_attempts = 0
                             _retry.primary_recovery_attempted = False
+                            try:
+                                agent.iteration_budget.refund()
+                            except Exception:
+                                pass
                             continue
                         # Terminal — flush buffered retry trace so user sees what happened.
                         agent._flush_status_buffer()
@@ -2845,6 +2857,10 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
+                        try:
+                            agent.iteration_budget.refund()
+                        except Exception:
+                            pass
                         continue
 
                     agent._flush_status_buffer()
@@ -4452,6 +4468,10 @@ def run_conversation(
                             retry_count = 0
                             compression_attempts = 0
                             _retry.primary_recovery_attempted = False
+                            try:
+                                agent.iteration_budget.refund()
+                            except Exception:
+                                pass
                             continue
 
                 # ── Auth-failure provider failover ───────────────────────
@@ -4485,6 +4505,10 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
+                        try:
+                            agent.iteration_budget.refund()
+                        except Exception:
+                            pass
                         continue
 
                 # ── Nous Portal: record rate limit & skip retries ─────
@@ -5049,6 +5073,10 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
+                        try:
+                            agent.iteration_budget.refund()
+                        except Exception:
+                            pass
                         continue
                     if api_kwargs is not None:
                         agent._dump_api_request_debug(
@@ -5272,6 +5300,10 @@ def run_conversation(
                         retry_count = 0
                         compression_attempts = 0
                         _retry.primary_recovery_attempted = False
+                        try:
+                            agent.iteration_budget.refund()
+                        except Exception:
+                            pass
                         continue
                     # Terminal — flush buffered retry/fallback trace.
                     agent._flush_status_buffer()
@@ -6703,6 +6735,10 @@ def run_conversation(
                                 "now using %s on %s",
                                 agent.model, agent.provider,
                             )
+                            try:
+                                agent.iteration_budget.refund()
+                            except Exception:
+                                pass
                             continue
 
                     # Exhausted retries and fallback chain (or no


### PR DESCRIPTION
## What does this PR do?

Fixes #77305 — failed API calls consume the subagent iteration budget without refund, causing premature `exit_reason=max_iterations`.

## Root Cause

In `agent/conversation_loop.py`, the iteration budget is consumed **before** the API call (line 1433). When the call fails (429 rate limit, billing exhaustion, transport error) and `try_activate_fallback` successfully switches providers, the loop `continue`s without refunding the consumed budget.

Each retryable failure permanently burns one iteration. In subagent sessions with long code-read loops (50-90 iterations), a burst of rate limits exhausts the budget before the fallback chain gets a fair chance to recover.

## Fix

Add `iteration_budget.refund()` before `continue` in all 9 `try_activate_fallback` success paths. This matches the existing refund pattern already used for context-too-small (line 1905) and compression recovery (line 2060).

## Changes

- `agent/conversation_loop.py`: +36 lines (9 × 4-line try/except refund blocks)

## Testing

- `python3 -m py_compile agent/conversation_loop.py` — passes
- `pytest tests/tui_gateway/ -q` — 327/327 passed
