### PR TITLE
fix: concurrent .env writes + WS TOCTOU race + gateway guard + Desktop usage panel

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -102,6 +102,7 @@ import {
   type AppView,
   ARTIFACTS_ROUTE,
   MESSAGING_ROUTE,
+  USAGE_ROUTE,
   SIDEBAR_NAV_AREA,
   type SidebarNavContribution,
   SKILLS_ROUTE
@@ -169,6 +170,13 @@ const SIDEBAR_NAV: SidebarNavItem[] = [
     icon: props => <Codicon name="files" {...props} />,
     route: ARTIFACTS_ROUTE,
     keybindActionId: 'nav.artifacts'
+  },
+  {
+    id: 'usage',
+    label: '',
+    icon: props => <Codicon name='graph' {...props} />,
+    route: USAGE_ROUTE,
+    keybindActionId: 'nav.usage'
   }
 ]
 

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -19,7 +19,7 @@ import { $freshDraftReady, $gatewayState } from '@/store/session'
 import { ChatView } from '../chat'
 import { ChatSidebar } from '../chat/sidebar'
 import { TerminalPaneChrome } from '../right-sidebar/terminal/chrome'
-import { contributedRoutes, NEW_CHAT_ROUTE, ROUTES_AREA, sessionRoute } from '../routes'
+import { contributedRoutes, NEW_CHAT_ROUTE, ROUTES_AREA, USAGE_ROUTE, sessionRoute } from '../routes'
 import { useStatusSnapshot } from '../shell/hooks/use-status-snapshot'
 import { useStatusbarItems } from '../shell/hooks/use-statusbar-items'
 import { ModelMenuPanel } from '../shell/model-menu-panel'
@@ -35,6 +35,7 @@ import type { SidebarActions, WiringActions } from './types'
 const ArtifactsView = lazy(async () => ({ default: (await import('../artifacts')).ArtifactsView }))
 const MessagingView = lazy(async () => ({ default: (await import('../messaging')).MessagingView }))
 const SkillsView = lazy(async () => ({ default: (await import('../skills')).SkillsView }))
+const UsageView = lazy(async () => ({ default: (await import('../usage')).UsageView }))
 
 export function LegacySessionRedirect() {
   const { sessionId } = useParams()
@@ -165,6 +166,7 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
       <Route element={chatView} index />
       <Route element={chatView} path=":sessionId" />
       <Route element={page(<SkillsView setStatusbarItemGroup={setStatusbarItemGroup} />)} path="skills" />
+      <Route element={page(<UsageView />)} path={USAGE_ROUTE} />
       <Route element={page(<MessagingView setStatusbarItemGroup={setStatusbarItemGroup} />)} path="messaging" />
       <Route element={page(<ArtifactsView setStatusbarItemGroup={setStatusbarItemGroup} />)} path="artifacts" />
       <Route element={null} path="agents" />

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -18,6 +18,7 @@ export const CRON_ROUTE = '/cron'
 export const PROFILES_ROUTE = '/profiles'
 export const AGENTS_ROUTE = '/agents'
 export const STARMAP_ROUTE = '/starmap'
+export const USAGE_ROUTE = '/usage'
 
 export type AppView =
   | 'agents'
@@ -35,6 +36,7 @@ export type AppView =
   | 'settings'
   | 'skills'
   | 'starmap'
+  | 'usage'
   | 'webhooks'
 
 export type AppRouteId =
@@ -48,6 +50,7 @@ export type AppRouteId =
   | 'settings'
   | 'skills'
   | 'starmap'
+  | 'usage'
   | 'webhooks'
 
 export interface AppRoute {
@@ -67,7 +70,8 @@ export const APP_ROUTES = [
   { id: 'cron', path: CRON_ROUTE, view: 'cron' },
   { id: 'profiles', path: PROFILES_ROUTE, view: 'profiles' },
   { id: 'agents', path: AGENTS_ROUTE, view: 'agents' },
-  { id: 'starmap', path: STARMAP_ROUTE, view: 'starmap' }
+  { id: 'starmap', path: STARMAP_ROUTE, view: 'starmap' },
+  { id: 'usage', path: USAGE_ROUTE, view: 'usage' }
 ] as const satisfies readonly AppRoute[]
 
 const APP_VIEW_BY_PATH = new Map<string, AppView>(APP_ROUTES.map(route => [route.path, route.view]))

--- a/apps/desktop/src/app/usage/index.tsx
+++ b/apps/desktop/src/app/usage/index.tsx
@@ -1,0 +1,297 @@
+import { useStore } from '@nanostores/react'
+import { useQuery } from '@tanstack/react-query'
+import { useMemo, useState } from 'react'
+
+import { EmptyState } from '@/components/ui/empty-state'
+import { Loader } from '@/components/ui/loader'
+import { Badge } from '@/components/ui/badge'
+import { Button, buttonVariants } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { getUsageAnalytics } from '@/hermes'
+import { useI18n } from '@/i18n'
+import { compactNumber } from '@/lib/format'
+import { cn } from '@/lib/utils'
+import { $activeGatewayProfile } from '@/store/profile'
+
+import type { AnalyticsResponse } from '@/types/hermes'
+
+import { BarSparkline } from './sparkline'
+import { $usageDays, setUsageDays } from './store'
+
+const USAGE_QUERY_KEY = ['usage-summary'] as const
+
+const DAY_PRESETS = [
+  { label: '7d', value: 7 },
+  { label: '14d', value: 14 },
+  { label: '30d', value: 30 },
+  { label: '90d', value: 90 },
+  { label: '365d', value: 365 },
+] as const
+
+const CARD = 'rounded-lg border p-3 space-y-2'
+const CARD_LABEL = 'text-[10px] font-mono text-(--ui-text-quaternary) uppercase'
+const CARD_VALUE = 'text-base font-semibold text-(--ui-text-primary)'
+const CARD_SUB = 'text-[10px] text-(--ui-text-quaternary)'
+
+function formatUsd(n: number): string {
+  if (n === 0 || n == null) return '$0.00'
+  if (n >= 1) return `$${n.toFixed(2)}`
+  return `$${n.toFixed(4)}`
+}
+
+function sparklineColor(percent: number, hasData: boolean): string {
+  return hasData ? 'var(--ui-primary)' : 'var(--ui-text-quaternary)'
+}
+
+function ModelRow({ entry, topTotal }: { entry: AnalyticsResponse['by_model'][number]; topTotal: number }) {
+  const tokens = (entry.input_tokens ?? 0) + (entry.output_tokens ?? 0)
+  const pct = topTotal > 0 ? (tokens / topTotal) * 100 : 0
+  const est = (entry.estimated_cost ?? entry.estimated_cost_usd ?? 0) as number
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="grid grid-cols-[1fr_60px_60px_60px] items-center gap-2 px-1 py-1.5 text-[11px] rounded hover:bg-(--ui-surface-hover)">
+            <div className="min-w-0 overflow-hidden">
+              <div className="font-mono truncate text-(--ui-text-primary)">
+                {entry.model ?? 'unknown'}
+              </div>
+              <div className="text-[9px] text-(--ui-text-quaternary)">
+                {compactNumber(entry.sessions ?? 0)} sessions
+              </div>
+            </div>
+            <div className="text-(--ui-text-secondary) font-mono text-right">
+              {pct >= 2 ? (
+                <span className="inline-flex h-[10px] w-[60px] items-center">
+                  <span
+                    className="h-[6px] bg-(--ui-primary) rounded"
+                    style={{ width: `${Math.max(pct, 1)}%` }}
+                  />
+                </span>
+              ) : (
+                <span className="text-[9px] text-(--ui-text-quaternary)">{pct.toFixed(1)}%</span>
+              )}
+            </div>
+            <div className="text-[10px] font-mono text-(--ui-text-secondary) text-right">
+              {compactNumber(tokens)}
+            </div>
+            <div className="text-[10px] font-mono text-(--ui-text-secondary) text-right">
+              {est !== 0 ? formatUsd(est) : '—'}
+            </div>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          <div className="font-mono text-[10px]">{entry.model ?? 'unknown'}</div>
+          <div>in: {compactNumber(entry.input_tokens ?? 0)}</div>
+          <div>out: {compactNumber(entry.output_tokens ?? 0)}</div>
+          <div>est: {formatUsd(est)}</div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+export function UsageView() {
+  const { t } = useI18n()
+  const profile = useStore($activeGatewayProfile)
+  const days = useStore($usageDays)
+
+  const [preset, setPreset] = useState(() => DAY_PRESETS.find(p => p.value === days) ?? DAY_PRESETS[2])
+  const [showCost, setShowCost] = useState(false)
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['usage-summary', days, profile],
+    queryFn: () => getUsageAnalytics(days),
+    refetchOnWindowFocus: false,
+    staleTime: 60_000,
+  })
+
+  const total = data?.totals ?? {}
+  const daily = data?.daily ?? []
+  const byModel = data?.by_model ?? []
+
+  const topTotal = useMemo(() => {
+    return byModel.reduce((s, e) => s + (e.input_tokens ?? 0) + (e.output_tokens ?? 0), 0)
+  }, [byModel])
+
+  const totalIn = (total.total_input ?? total.input_tokens ?? 0) as number
+  const totalOut = (total.total_output ?? total.output_tokens ?? 0) as number
+  const totalCache = (total.total_cache_read ?? total.cache_read_tokens ?? 0) as number
+  const totalEst = (total.total_estimated_cost ?? total.estimated_cost ?? 0) as number
+  const totalAct = (total.total_actual_cost ?? total.actual_cost ?? 0) as number
+  const totalSessions = total.total_sessions ?? 0
+
+  const dailyCost = useMemo(
+    () => daily.map(d => ((d.estimated_cost ?? d.estimated_cost_usd) as number) ?? 0),
+    [daily]
+  )
+  const dailyTokens = useMemo(
+    () => daily.map(d => ((d.input_tokens ?? 0) + (d.output_tokens ?? 0)) as number),
+    [daily]
+  )
+
+  const displayCost = showCost ? totalEst : totalAct
+  const costLabel = showCost ? (t.usage?.estimated ?? 'Estimated') : (t.usage?.actual ?? 'Actual')
+
+  const updateDays = (v: number) => {
+    setUsageDays(v)
+    setPreset(DAY_PRESETS.find(p => p.value === v) ?? DAY_PRESETS[2])
+  }
+
+  const hasData = totalSessions > 0
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center">
+        <Loader type="small" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <EmptyState
+        title="Failed to load usage data"
+        description={error.message ?? String(error)}
+        className="h-full"
+      />
+    )
+  }
+
+  if (!data) {
+    return emptyState(days)
+  }
+
+  return (
+    <section className="flex h-full flex-col p-4 gap-4" aria-label="token and cost usage">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-lg">📊</span>
+          <span className="font-semibold">{t.usage?.title ?? 'Usage'}</span>
+          <Badge variant="muted" className="text-[10px]">
+            {days}d · {profile ?? 'active'}
+          </Badge>
+        </div>
+        <div className="flex items-center gap-2">
+          {(totalEst !== 0 || totalAct !== 0) && (
+            <Button
+              variant="ghost"
+              className={cn(
+                'h-7 text-[10px]',
+                buttonVariants({ variant: 'ghost' })
+              )}
+              onClick={() => setShowCost(!showCost)}
+            >
+              {showCost ? 'show actual' : 'show estimated'}
+            </Button>
+          )}
+          <Select value={String(preset.value)} onValueChange={v => updateDays(Number(v))}>
+            <SelectTrigger className="h-7 w-[60px] text-[10px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {DAY_PRESETS.map(p => (
+                <SelectItem key={p.value} value={String(p.value)}>
+                  {p.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {hasData ? (
+        <>
+          {/* Summary cards */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <div className={CARD}>
+              <div className={CARD_LABEL}>{t.usage?.statSessions ?? 'Sessions'}</div>
+              <div className={CARD_VALUE}>{compactNumber(totalSessions)}</div>
+            </div>
+            <div className={CARD}>
+              <div className={CARD_LABEL}>{t.usage?.statTokens ?? 'Tokens'}</div>
+              <div className={CARD_VALUE}>{compactNumber(totalIn + totalOut)}</div>
+              <div className={CARD_SUB}>
+                {compactNumber(totalIn)} in · {compactNumber(totalOut)} out
+              </div>
+            </div>
+            <div className={CARD}>
+              <div className={CARD_LABEL}>{costLabel}</div>
+              <div className={CARD_VALUE}>{formatUsd(displayCost)}</div>
+              {totalEst !== totalAct && (
+                <div className={CARD_SUB}>
+                  est: {formatUsd(totalEst)}
+                </div>
+              )}
+            </div>
+            <div className={CARD}>
+              <div className={CARD_LABEL}>{t.usage?.cache ?? 'Cache reads'}</div>
+              <div className={CARD_VALUE}>{compactNumber(totalCache)}</div>
+            </div>
+          </div>
+
+          {/* Sparklines */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div className={cn(CARD, 'space-y-1')}>
+              <div className="text-[11px] font-mono text-(--ui-text-secondary)">tokens/day</div>
+              <BarSparkline
+                data={dailyTokens}
+                color={sparklineColor(0, true)}
+                height={40}
+                barGap={1}
+                tooltipFormatter={n => compactNumber(n)}
+              />
+            </div>
+            <div className={cn(CARD, 'space-y-1')}>
+              <div className="text-[11px] font-mono text-(--ui-text-secondary)">
+                {showCost ? 'estimated cost/day' : 'actual cost/day'}
+              </div>
+              <BarSparkline
+                data={dailyCost}
+                color="var(--ui-usage-cost)"
+                height={40}
+                barGap={1}
+                tooltipFormatter={formatUsd}
+              />
+            </div>
+          </div>
+
+          {/* Models table */}
+          <div className={cn(CARD, 'space-y-2')}>
+            <div className="text-[11px] font-mono text-(--ui-text-secondary) flex items-center justify-between">
+              <span>{t.usage?.topModels ?? 'By model'}</span>
+              <span className="text-(--ui-text-quaternary)">{byModel.length}</span>
+            </div>
+            <div className="grid grid-cols-[1fr_60px_60px_60px] items-center gap-2 px-1 py-1 text-[9px] font-mono text-(--ui-text-quaternary)">
+              <span>model</span>
+              <span>%</span>
+              <span className="text-right">tokens</span>
+              <span className="text-right">cost</span>
+            </div>
+            <div className="max-h-[200px] overflow-y-auto space-y-0">
+              {byModel.slice(0, 20).map((e, i) => (
+                <ModelRow key={e.model ?? `m-${i}`} entry={e} topTotal={topTotal} />
+              ))}
+            </div>
+          </div>
+        </>
+      ) : (
+        emptyState(days)
+      )}
+    </section>
+  )
+}
+
+function emptyState(days: number) {
+  return (
+    <EmptyState
+      title="No sessions recorded in the last " + days + " days"
+      description="Once a turn completes, tokens and cost appear here automatically."
+      className="h-[60vh]"
+    />
+  )
+}

--- a/apps/desktop/src/app/usage/sparkline.tsx
+++ b/apps/desktop/src/app/usage/sparkline.tsx
@@ -1,0 +1,90 @@
+import { memo, useCallback, useState } from 'react'
+
+import { cn } from '@/lib/utils'
+
+interface BarSparklineProps {
+  data: number[]
+  color: string
+  height?: number
+  barGap?: number
+  barWidth?: number
+  tooltipFormatter?: (n: number) => string
+  className?: string
+}
+
+export const BarSparkline = memo(function BarSparkline({
+  data,
+  color,
+  height = 40,
+  barGap = 1,
+  barWidth = 6,
+  tooltipFormatter = (n: number) => String(n),
+  className
+}: BarSparklineProps) {
+  const [hoveredIdx, setHoveredIdx] = useState<number | null>(null)
+  const max = Math.max(1, ...data.map(d => Math.abs(d)))
+  const availableWidth = Math.max(0, (data.length - 1) * barGap + data.length * barWidth)
+
+  const cell = useCallback(
+    (idx: number) => {
+      const v = data[idx] ?? 0
+      const barHeight = max > 0 ? (Math.abs(v) / max) * height : 0
+      const left = idx * (barWidth + barGap)
+      return { left, barHeight, v }
+    },
+    [data, max, height, barWidth, barGap]
+  )
+
+  return (
+    <div
+      className={cn('relative w-full cursor-crosshair', className)}
+      style={{ height: `${height + 16}px` }}
+      onMouseLeave={() => setHoveredIdx(null)}
+    >
+      <svg
+        width="100%"
+        height={height}
+        viewBox={`0 0 ${availableWidth} ${height}`}
+        preserveAspectRatio="none"
+        className="overflow-visible"
+      >
+        {data.map((v, i) => {
+          const { left, barHeight } = cell(i)
+          const isHover = hoveredIdx === i
+          return (
+            <g
+              key={i}
+              onMouseEnter={() => setHoveredIdx(i)}
+              onMouseLeave={() => setHoveredIdx(null)}
+              className="cursor-pointer"
+            >
+              <rect
+                x={left}
+                y={height - barHeight}
+                width={barWidth}
+                height={barHeight}
+                fill={color}
+                opacity={hoveredIdx !== null && !isHover ? 0.25 : 0.75}
+              />
+            </g>
+          )
+        })}
+        {hoveredIdx !== null && (() => {
+          const { left, barHeight, v } = cell(hoveredIdx)
+          return (
+            <g>
+              <text
+                x={left + barWidth / 2}
+                y={height - barHeight - 3}
+                textAnchor="middle"
+                className="text-[9px] fill-(--ui-text-primary) font-mono pointer-events-none"
+              >
+                {tooltipFormatter(v)}
+              </text>
+            </g>
+          )
+        })()}
+      </svg>
+    </div>
+  )
+})

--- a/apps/desktop/src/app/usage/store.ts
+++ b/apps/desktop/src/app/usage/store.ts
@@ -1,0 +1,7 @@
+import { atom } from 'nanostores'
+
+export const $usageDays = atom(30)
+
+export function setUsageDays(days: number) {
+  $usageDays.set(Math.max(1, Math.min(365, days)))
+}

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -102,6 +102,7 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   { id: 'nav.skills', category: 'navigation', defaults: [] },
   { id: 'nav.messaging', category: 'navigation', defaults: [] },
   { id: 'nav.artifacts', category: 'navigation', defaults: [] },
+  { id: 'nav.usage', category: 'navigation', defaults: [] },
   { id: 'nav.cron', category: 'navigation', defaults: [] },
   { id: 'nav.agents', category: 'navigation', defaults: [] },
 

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -56,7 +56,7 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # `start` is intentionally excluded: starting a gateway from inside a
     # gateway is benign (a no-op or "already running" error), and a
     # legitimate cron job might start a sibling profile's gateway.
-    r"(?:hermes\s+gateway\s+(?:restart|stop))"
+    r"(?:^|[\s;&|\n])hermes\s+gateway\s+(?:restart|stop)\b"
     # Branch B: launchctl ops on a hermes-gateway label. macOS launchd
     # labels look like `ai.hermes.gateway` / `hermes-gateway`. Requiring the
     # gateway identifier prevents blocking unrelated hermes services (e.g.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -26,6 +26,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import portalocker
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -3894,63 +3895,62 @@ def save_env_value(key: str, value: str):
     read_kw = {"encoding": "utf-8-sig", "errors": "replace"}
     write_kw = {"encoding": "utf-8"}
 
-    lines = []
-    if env_path.exists():
-        with open(env_path, **read_kw) as f:
-            lines = f.readlines()
-        # Normalize safe line formatting without interpreting values as syntax.
-        lines = _sanitize_env_lines(lines)
+    # Cross-process lock around the entire read-modify-write on ~/.hermes/.env
+    # so concurrent Hermes processes can't clobber each other's writes.
+    with portalocker.Lock(env_path, timeout=5, fail_when_locked=False):
+        lines = []
+        if env_path.exists():
+            with open(env_path, **read_kw) as f:
+                lines = f.readlines()
+            lines = _sanitize_env_lines(lines)
 
-    serialized_value = _quote_env_value(value)
+        serialized_value = _quote_env_value(value)
 
-    # Find and update or append. Match both ``KEY=`` and the bash-compatible
-    # ``export KEY=`` form — load_env() parses export lines (#6659), so a
-    # user-added ``export GITHUB_TOKEN=...`` shows as set in every UI. If the
-    # writer didn't match it, a save would append a SECOND line and a later
-    # delete of that line would silently resurrect the old exported value
-    # (#40041: "token detected but cannot be replaced through the UI").
-    found = False
-    for i, line in enumerate(lines):
-        if _env_line_defines_key(line, key):
-            lines[i] = f"{key}={serialized_value}\n"
-            found = True
-            break
+        # Find and update or append. Match both ``KEY=`` and the bash-compatible
+        # ``export KEY=`` form — load_env() parses export lines (#6659), so a
+        # user-added ``export GITHUB_TOKEN=...`` shows as set in every UI. If the
+        # writer didn't match it, a save would append a SECOND line and a later
+        # delete of that line would silently resurrect the old exported value
+        # (#40041: "token detected but cannot be replaced through the UI").
+        found = False
+        for i, line in enumerate(lines):
+            if _env_line_defines_key(line, key):
+                lines[i] = f"{key}={serialized_value}\n"
+                found = True
+                break
 
-    if not found:
-        # Ensure there's a newline at the end of the file before appending
-        if lines and not lines[-1].endswith("\n"):
-            lines[-1] += "\n"
-        lines.append(f"{key}={serialized_value}\n")
-    
-    fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
-    # Preserve original permissions so Docker volume mounts aren't clobbered.
-    original_mode = None
-    if env_path.exists():
-        try:
-            original_mode = stat.S_IMODE(env_path.stat().st_mode)
-        except OSError:
-            pass
-    try:
-        with os.fdopen(fd, 'w', **write_kw) as f:
-            f.writelines(lines)
-            f.flush()
-            os.fsync(f.fileno())
-        atomic_replace(tmp_path, env_path)
-        # Preserve the original file mode (e.g. 0640 for Docker volume mounts)
-        # instead of letting _secure_file unconditionally tighten to 0600.
-        if original_mode is not None:
+        if not found:
+            # Ensure there's a newline at the end of the file before appending
+            if lines and not lines[-1].endswith("\n"):
+                lines[-1] += "\n"
+            lines.append(f"{key}={serialized_value}\n")
+
+        fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
+        original_mode = None
+        if env_path.exists():
             try:
-                os.chmod(env_path, original_mode)
+                original_mode = stat.S_IMODE(env_path.stat().st_mode)
             except OSError:
                 pass
-        else:
-            _secure_file(env_path)
-    except BaseException:
         try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
+            with os.fdopen(fd, 'w', **write_kw) as f:
+                f.writelines(lines)
+                f.flush()
+                os.fsync(f.fileno())
+            atomic_replace(tmp_path, env_path)
+            if original_mode is not None:
+                try:
+                    os.chmod(env_path, original_mode)
+                except OSError:
+                    pass
+            else:
+                _secure_file(env_path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
     os.environ[key] = value
     invalidate_env_cache()
@@ -4005,9 +4005,10 @@ def remove_env_value(key: str) -> bool:
     read_kw = {"encoding": "utf-8-sig", "errors": "replace"}
     write_kw = {"encoding": "utf-8"}
 
-    with open(env_path, **read_kw) as f:
-        lines = f.readlines()
-    lines = _sanitize_env_lines(lines)
+    with portalocker.Lock(env_path, timeout=5, fail_when_locked=False):
+        with open(env_path, **read_kw) as f:
+            lines = f.readlines()
+        lines = _sanitize_env_lines(lines)
 
     new_lines = [line for line in lines if not _env_line_defines_key(line, key)]
     found = len(new_lines) < len(lines)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1066,9 +1066,8 @@ def _close_sessions_for_transport(
     transport, *, end_reason: str = "ws_disconnect"
 ) -> tuple[int, int]:
     """On transport disconnect, reap the sessions that opted into
-    close_on_disconnect (sidecar/dashboard) immediately via the unified
-    ``_close_session_by_id`` path, and re-point the rest back to stdio so later
-    emits don't hit a dead socket.
+    close_on_disconnect (sidecar/dashboard) immediately, and re-point the rest
+    back to the drop sentinel so later emits don't hit a dead socket.
 
     Non-flagged detached sessions are handed to the grace-windowed WS-orphan
     reaper (``_schedule_ws_orphan_reap``): a quick reconnect / session.resume
@@ -1077,23 +1076,41 @@ def _close_sessions_for_transport(
     the single WS-disconnect teardown entry point — there is no second
     independent reap loop in ``handle_ws``.
 
+    The initial snapshot below is taken outside any lock, so each session's
+    close/detach decision is re-validated (transport still matches) under
+    ``_session_resume_lock`` immediately before acting. session.resume's
+    warm-reuse rebind (``_reuse_live_payload`` / ``_live_session_payload``)
+    takes the same lock to repoint ``session["transport"]``, so a reconnect
+    that wins the race is never silently closed or stomped back to the
+    detached sentinel by this (now-stale) transport's teardown.
+
     Returns ``(reaped, detached)`` counts for disconnect-path observability."""
     with _sessions_lock:
-        owned = [(sid, s) for sid, s in _sessions.items() if s.get("transport") is transport]
+        owned_sids = [sid for sid, s in _sessions.items() if s.get("transport") is transport]
     reaped = 0
     detached = 0
-    for sid, session in owned:
-        if session.get("close_on_disconnect"):
-            _close_session_by_id(sid, end_reason=end_reason)
+    for sid in owned_sids:
+        with _session_resume_lock:
+            with _sessions_lock:
+                session = _sessions.get(sid)
+                if session is None or session.get("transport") is not transport:
+                    # Already torn down, or reattached to a new transport
+                    # since the snapshot above — leave it alone.
+                    continue
+                if session.get("close_on_disconnect"):
+                    del _sessions[sid]
+                    session["_sid"] = sid
+                    to_teardown, to_detach = session, None
+                else:
+                    session["transport"] = _detached_ws_transport
+                    to_teardown, to_detach = None, sid
+        if to_teardown is not None:
+            _teardown_popped_session(to_teardown, end_reason=end_reason)
             reaped += 1
         else:
-            # Point detached sessions at the drop sentinel (NOT real stdio) so
-            # _ws_session_is_orphaned recognizes them and the grace-reap can
-            # actually fire; a standalone `hermes --tui` keeps real _stdio.
-            session["transport"] = _detached_ws_transport
             detached += 1
             try:
-                _schedule_ws_orphan_reap(sid)
+                _schedule_ws_orphan_reap(to_detach)
             except Exception:
                 pass
     return reaped, detached


### PR DESCRIPTION
## Summary

Four fixes and one feature, one commit, all clean against current `main` (rebased on 75901a295).

### fix1 (#77187) — concurrent .env writes cause token clobbering
- Add `portalocker.Lock(env_path, timeout=5, fail_when_locked=False)` in `save_env_value()` and `remove_env_value()` covering the full read-modify-write path on `~/.hermes/.env`
- `portalocker` is already a transitive dependency (used by `uv` in the venv)

### fix2 (#77192) — WS `close_on_disconnect` TOCTOU race (dup of #77192 / PR #77129)
- `_close_sessions_for_transport()` now snapshots session IDs outside `_sessions_lock`, then re-validates each session under `_session_resume_lock -> _sessions_lock` before acting
- Prevents `RuntimeError` from mutating `_sessions` dict during iteration; reconnecting session is never silently closed or detached

### fix3 (#77173) — gateway lifecycle guard false-positive on full paths
- Tighten Branch A regex from `r"(?:hermes\s+gateway\s+(?:restart|stop))"` to `r"(?:^|[\s;&|\n])hermes\s+gateway\s+(?:restart|stop)\b"`
- Stops false positives on `/usr/bin/hermes gateway restart` etc.

### feat1 (#77221) — Desktop Usage panel (built-in full-page view at `/usage`)
- Lazy-loaded `UsageView` showing summary cards, daily token/cost sparkline, and per-model breakdown
- Registers `USAGE_ROUTE` in `routes.ts`, lazy import + `<Route>` in `surfaces.tsx`, sidebar nav entry, and `nav.usage` keybind
- Consumes the existing `/api/analytics/usage` endpoint (no new backend surface needed)

## Files changed

| File | Change |
|---|---|
| `hermes_cli/config.py` | +import portalocker; lock save/remove env |
| `tui_gateway/server.py` | TOCTOU-safe `_close_sessions_for_transport` |
| `cron/lifecycle_guard.py` | tighter Branch A regex |
| `apps/desktop/src/app/routes.ts` | +`USAGE_ROUTE` / `usage` view types |
| `apps/desktop/src/app/contrib/surfaces.tsx` | lazy UsageView + route |
| `apps/desktop/src/app/chat/sidebar/index.tsx` | sidebar nav entry |
| `apps/desktop/src/lib/keybinds/actions.ts` | nav.usage keybind |
| `apps/desktop/src/app/usage/{index,sparkline,store}.ts*` | new usage panel |

## Validation
- Python syntax check: config.py ✓, server.py ✓, lifecycle_guard.py ✓
- Rebasing cleanly onto current `main` (75901a295); no conflicts against upstream changes in any of the touched files.