### PR TITLE
fix(tui): preserve Ctrl+J newline on WSL (#77283)

### DIFF
--- a/ui-tui/src/__tests__/textInputPassThrough.test.ts
+++ b/ui-tui/src/__tests__/textInputPassThrough.test.ts
@@ -16,6 +16,10 @@ describe('shouldPreserveCtrlJNewline', () => {
     ).toBe(true)
   })
 
+  it('preserves Ctrl+J as newline on WSL when WSL_DISTRO_NAME is set', () => {
+    expect(shouldPreserveCtrlJNewline({ TERM: 'xterm-256color', WSL_DISTRO_NAME: 'Ubuntu' })).toBe(true)
+  })
+
   it('keeps bare local POSIX LF-compatible prompts submitting on Ctrl+J', () => {
     expect(shouldPreserveCtrlJNewline({ TERM: 'xterm-256color' })).toBe(false)
   })

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -178,7 +178,7 @@ export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boole
     return true
   }
 
-  return (env.WSL_DISTRO_NAME ?? '').toLowerCase().includes('microsoft')
+  return Boolean(env.WSL_INTEROP || env.WSL_DISTRO_NAME)
 }
 
 function prevPos(s: string, p: number) {


### PR DESCRIPTION
## What does this PR do?

This fixes WSL newline preservation in the Ink TUI.

`shouldPreserveCtrlJNewline()` was checking whether `WSL_DISTRO_NAME` contains the string `microsoft`, but that variable holds the distro registration name (`Ubuntu`, `Debian`, etc.), so the condition can never match a normal WSL install. As a result, Ctrl+J / Ctrl+Enter was treated like a plain submit in `hermes --tui`.

This patch switches the WSL detection to the actual WSL environment signals already used elsewhere in the TUI (`WSL_INTEROP` / `WSL_DISTRO_NAME`) and adds a regression test for a normal WSL distro name.

## Related Issue

Fixes #77283

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `ui-tui/src/components/textInput.tsx` so WSL newline preservation uses real WSL env markers instead of a dead `includes('microsoft')` check
- Added a regression case in `ui-tui/src/__tests__/textInputPassThrough.test.ts` for `WSL_DISTRO_NAME: 'Ubuntu'`
- Kept the existing Ghostty and bare local POSIX behaviors unchanged

## How to Test

1. Build the local Ink package used by the TUI test harness:
   `/opt/homebrew/bin/npm --prefix ui-tui run build:ink`
2. Run the focused regression test:
   `/opt/homebrew/bin/npm --prefix ui-tui run test -- src/__tests__/textInputPassThrough.test.ts`
3. Confirm the WSL case passes and the existing Ghostty / local POSIX cases still pass

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `/opt/homebrew/bin/npm --prefix ui-tui run build:ink`
- `/opt/homebrew/bin/npm --prefix ui-tui run test -- src/__tests__/textInputPassThrough.test.ts`
- `7 passed`
