### PR TITLE
fix(feishu): serialize card.data to JSON string in approval/update-prompt callback responses

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2806,7 +2806,10 @@ class FeishuAdapter(BasePlatformAdapter):
         if CallBackCard is not None:
             card = CallBackCard()
             card.type = "raw"
-            card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name)
+            card.data = json.dumps(
+                self._build_resolved_approval_card(choice=choice, user_name=user_name),
+                ensure_ascii=False,
+            )
             response.card = card
         return response
 
@@ -2863,7 +2866,10 @@ class FeishuAdapter(BasePlatformAdapter):
         if CallBackCard is not None:
             card = CallBackCard()
             card.type = "raw"
-            card.data = self._build_resolved_update_prompt_card(answer=answer, user_name=user_name)
+            card.data = json.dumps(
+                self._build_resolved_update_prompt_card(answer=answer, user_name=user_name),
+                ensure_ascii=False,
+            )
             response.card = card
         return response
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -429,6 +429,34 @@ class TestCardActionCallbackResponse:
         mock_submit.assert_not_called()
 
 
+    def test_update_prompt_returns_serialized_card(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_bob"}
+        adapter._update_prompt_state[9] = {
+            "session_key": "sess-up-9",
+            "message_id": "msg_up_009",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_update_prompt_action": "y", "update_prompt_id": 9},
+            open_id="ou_bob",
+        )
+        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.type == "raw"
+        assert isinstance(response.card.data, str)
+        card = json.loads(response.card.data)
+        assert card["header"]["template"] == "green"
+        assert "Answered by **Bob**" in card["elements"][0]["content"]
+
+
 class TestResolveUpdatePrompt:
     """Test update prompt resolution persists the response file."""
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -327,7 +327,8 @@ class TestCardActionCallbackResponse:
         assert response is not None
         assert response.card is not None
         assert response.card.type == "raw"
-        card = response.card.data
+        assert isinstance(response.card.data, str)
+        card = json.loads(response.card.data)
         assert card["header"]["template"] == "green"
         assert "Approved once" in card["header"]["title"]["content"]
         assert "Bob" in card["elements"][0]["content"]
@@ -352,7 +353,8 @@ class TestCardActionCallbackResponse:
         with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
             response = adapter._on_card_action_trigger(data)
 
-        card = response.card.data
+        assert isinstance(response.card.data, str)
+        card = json.loads(response.card.data)
         assert "Old Name" not in card["elements"][0]["content"]
         assert "ou_expired" in card["elements"][0]["content"]
 


### PR DESCRIPTION
## What & why

Feishu (Lark) returns error 200340 when clicking command-approval card buttons: the callback response assigns a Python `dict` to `card.data`, but the Feishu card-action callback API requires the raw card payload as a JSON string.

The two callback handlers build the resolved card via builders that return `Dict[str, Any]`:

- `_handle_approval_card_action` -> `_build_resolved_approval_card` (plugins/platforms/feishu/adapter.py:2809)
- `_handle_update_prompt_card_action` -> `_build_resolved_update_prompt_card` (plugins/platforms/feishu/adapter.py:2866)

This change serializes both assignments with `json.dumps(..., ensure_ascii=False)` so the callback returns a JSON string, matching what the Feishu API expects.

This is the direct port of #42465's fix to the relocated adapter path, exactly as requested by the hermes-sweeper review on #42465 (`keep_open salvageability=high`): the adapter moved from `gateway/platforms/feishu.py` to `plugins/platforms/feishu/adapter.py` in `5600105478ffde29d7566b45421b100eaa29c4ef`, which left #42465, #10256, and #10801 conflicting/stale at the production-file path. Original fix authored by @liuhao1024 in #42465.

## How to test

1. `bash scripts/run_tests.sh tests/gateway/test_feishu_approval_buttons.py` — 14 tests, all pass.
2. Tests now assert `isinstance(response.card.data, str)` and parse it back with `json.loads()` before inspecting card contents, so a regression back to a raw dict fails the suite. `test_update_prompt_returns_serialized_card` covers the second fixed handler (update-prompt callbacks), which previously had no positive-path test.

## Platforms tested

- Native Windows (git-bash), Python 3.11/3.12 via `scripts/run_tests.sh` canonical runner (TZ=UTC LANG=C.UTF-8, per-file subprocess isolation).
- `git diff --check` clean; `scripts/check-windows-footguns.py` passes.
- Change is pure serialization at two call sites; no file I/O, process, signal, or network-path changes.

## Why this matters to users

Before: anyone running Hermes on Feishu/Lark who triggers a tool permission approval sees the button clicks fail with Feishu error 200340 (or 200343 / 220340 on some clients); the agent stays paused blocked on an approval that can never arrive, and the user must fall back to typing the approval command by hand. Group chats with multiple admins and mobile Feishu users hit this on every approval.

After: the Allow Once / Session / Always / Deny buttons on the interactive card work directly, the card updates with the resolved decision ("✅ Approved once by …" / "❌ Denied"), and the approval reaches the agent exactly once — on desktop and mobile alike.

Fixes #10251 (canonical cluster member)
Closes #10073, #13924, #38305, #25886, #7675 (open duplicates in the cluster)
Closes #10154, #8246, #10628, #6893, #8764 (already closed; listed for cluster reconciliation)

Cluster: Feishu command-approval card buttons fail with error 200340/200343/220340 (#10251 + 10 duplicate reports).
Lineage: #42465 (superseded — stale pre-migration path), #10256 (same fix + unrelated pairing.py change), #10801 (symptom workaround only).
