### PR TITLE
fix(gateway): surface iLink ret<0 API failures in Weixin adapter logs

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -416,7 +416,25 @@ async def _api_post(
             raw = await response.text()
             if not response.ok:
                 raise RuntimeError(f"iLink POST {endpoint} HTTP {response.status}: {raw[:200]}")
-            return json.loads(raw)
+            data = json.loads(raw)
+            # iLink returns HTTP 200 even for API-level failures (ret < 0).
+            # Without this, endpoints whose response is discarded (sendTyping,
+            # the final media sendmessage) fail silently. Log a warning; do not
+            # raise, because callers legitimately inspect ret < 0 responses
+            # (rate limit, session expiry) and handle them with backoff/retry.
+            ret = data.get("ret")
+            errcode = data.get("errcode")
+            if (isinstance(ret, (int, float)) and ret < 0) or (
+                isinstance(errcode, (int, float)) and errcode < 0
+            ):
+                logger.warning(
+                    "iLink POST %s returned ret=%s errcode=%s errmsg=%s",
+                    endpoint,
+                    ret,
+                    errcode,
+                    data.get("errmsg") or data.get("msg") or "",
+                )
+            return data
     return await asyncio.wait_for(_do(), timeout=timeout_ms / 1000)
 
 

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import json
+import logging
 import os
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -628,6 +629,49 @@ class TestWeixinApiTimeout:
         # gone and `timeout` is no longer forwarded to session.post().
         [(_url, kwargs)] = session.post_calls
         assert "timeout" not in kwargs
+
+    def test_api_post_logs_warning_for_negative_ret(self, caplog):
+        """iLink returns HTTP 200 even for API-level failures (ret < 0).
+
+        Regression test for #64704 / #70776 / #70792: a getUploadUrl rejection
+        like ``{'ret': -2}`` must be surfaced in the logs instead of being
+        silently swallowed (some endpoints, e.g. the final media sendmessage,
+        discard the response entirely). The response dict must still be
+        returned so callers can inspect ret < 0 for rate-limit / session-expiry
+        handling.
+        """
+        session = _StubSession(_StubResponse(body='{"ret": -2, "errcode": -2, "errmsg": "rate limited"}'))
+        with caplog.at_level(logging.WARNING, logger="gateway.platforms.weixin"):
+            result = asyncio.run(
+                weixin._api_post(
+                    session,
+                    base_url="https://weixin.example.com",
+                    endpoint=weixin.EP_GET_UPLOAD_URL,
+                    payload={"filekey": "k"},
+                    token="tok",
+                    timeout_ms=5000,
+                )
+            )
+        assert result == {"ret": -2, "errcode": -2, "errmsg": "rate limited"}
+        assert any(
+            "ilink/bot/getuploadurl" in rec.message and "ret=-2" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_api_post_no_warning_for_success_ret(self, caplog):
+        session = _StubSession(_StubResponse(body='{"ret": 0}'))
+        with caplog.at_level(logging.WARNING, logger="gateway.platforms.weixin"):
+            asyncio.run(
+                weixin._api_post(
+                    session,
+                    base_url="https://weixin.example.com",
+                    endpoint="ep",
+                    payload={"k": "v"},
+                    token="tok",
+                    timeout_ms=5000,
+                )
+            )
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
 
     def test_get_updates_returns_empty_sentinel_on_timeout(self):


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #64704 #64740 #70776 #70792 #78791
## What & why

`gateway/platforms/weixin.py::_api_post` raised only on HTTP-level failures. The iLink Bot API returns **HTTP 200 even for API-level errors** (`ret: -2`, `errcode: -2`, ...), so those responses were parsed and returned to the caller without any log. For endpoints whose response is discarded — `sendTyping`, and crucially the **final media `sendmessage`** after a CDN upload (`_send_file`, line 2222) — a rejection was completely invisible in the logs.

This surfaced in the Weixin image-send failure reports (#64704, #70776, #70792): `getUploadUrl` returns `{'ret': -2}` and the only user-visible trace was the confusing downstream error `getUploadUrl returned neither upload_param nor upload_full_url: {'ret': -2}`, with no record at the API boundary of what iLink actually said.

This change adds a `logger.warning(...)` in `_api_post` when an HTTP-200 response carries `ret < 0` or `errcode < 0`, including endpoint, ret, errcode, and errmsg. It deliberately does **not** raise: callers legitimately inspect `ret < 0` responses (rate-limit backoff, session-expiry retry without token, `_is_stale_session_ret` discrimination) and raising would break those flows.

Scope note (important): the underlying `ret: -2` from `getUploadUrl` is an **iLink server-side account-tier restriction** on personal bot accounts — confirmed by QR re-login tests, fresh `context_token` tests, the closed #64740 attempt (field-tested, still `ret=-2`), and ecosystem-wide reports (Tencent/openclaw-weixin#213, HCF-STUDIOS/openhermit#193, cc-connect#369). No Hermes code change can make that endpoint succeed. This PR is the diagnostics half of the issue: the failure is now logged with iLink's own error codes so users can identify the restriction instead of hunting for a code bug that isn't there.

## How to test

```bash
python -m pytest tests/gateway/test_weixin.py -k api_post
```

New tests:
- `test_api_post_logs_warning_for_negative_ret` — `_api_post` with an HTTP-200 body `{"ret": -2, "errcode": -2, "errmsg": "rate limited"}` returns the dict unchanged (callers can still inspect it) **and** emits a WARNING containing the endpoint and `ret=-2`.
- `test_api_post_no_warning_for_success_ret` — `{"ret": 0}` produces no WARNING.

Full file: `32 passed` (`tests/gateway/test_weixin.py`).

## What platforms

- Windows 11 (native) — full test file green
- Change is log-only; no POSIX-only APIs, no signals, no file I/O changes. `scripts/check-windows-footguns.py` passes.

## Related issues

- Closes / references: #64704 (canonical), #70776, #70792
- Prior failed fix attempt, kept closed: #64740

## Why this matters to users

Before: if you send an image or file over Weixin and iLink rejects the upload-URL request (ret=-2 — an account-permission restriction on personal bots), your gateway log shows a confusing `getUploadUrl returned neither upload_param nor upload_full_url` line and nothing else. If the failure happens on a path whose response is discarded, you get **no log at all** — messages appear to vanish.

After: every iLink API rejection at HTTP-200 level is logged with the actual error code (`iLink POST ilink/bot/getuploadurl returned ret=-2 errcode=-2 errmsg=...`). You immediately see that iLink itself rejected the request and why, instead of assuming Hermes is broken. Affected: anyone running the Weixin/iLink gateway — you no longer have to guess whether a failed send was a code bug (it wasn't) or a platform-side restriction.

Part of #70776
Part of #70792
