### PR TITLE
fix(feishu): serialize card.data to JSON string in approval/update-prompt callbacks

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2806,7 +2806,10 @@ class FeishuAdapter(BasePlatformAdapter):
         if CallBackCard is not None:
             card = CallBackCard()
             card.type = "raw"
-            card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name)
+            card.data = json.dumps(
+                self._build_resolved_approval_card(choice=choice, user_name=user_name),
+                ensure_ascii=False,
+            )
             response.card = card
         return response
 
@@ -2863,7 +2866,10 @@ class FeishuAdapter(BasePlatformAdapter):
         if CallBackCard is not None:
             card = CallBackCard()
             card.type = "raw"
-            card.data = self._build_resolved_update_prompt_card(answer=answer, user_name=user_name)
+            card.data = json.dumps(
+                self._build_resolved_update_prompt_card(answer=answer, user_name=user_name),
+                ensure_ascii=False,
+            )
             response.card = card
         return response
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -327,7 +327,8 @@ class TestCardActionCallbackResponse:
         assert response is not None
         assert response.card is not None
         assert response.card.type == "raw"
-        card = response.card.data
+        assert isinstance(response.card.data, str)
+        card = json.loads(response.card.data)
         assert card["header"]["template"] == "green"
         assert "Approved once" in card["header"]["title"]["content"]
         assert "Bob" in card["elements"][0]["content"]
@@ -352,7 +353,8 @@ class TestCardActionCallbackResponse:
         with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
             response = adapter._on_card_action_trigger(data)
 
-        card = response.card.data
+        assert isinstance(response.card.data, str)
+        card = json.loads(response.card.data)
         assert "Old Name" not in card["elements"][0]["content"]
         assert "ou_expired" in card["elements"][0]["content"]
 
@@ -425,6 +427,34 @@ class TestCardActionCallbackResponse:
         assert response.card is None
         assert 8 in adapter._update_prompt_state
         mock_submit.assert_not_called()
+
+
+    def test_update_prompt_returns_serialized_card(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_bob"}
+        adapter._update_prompt_state[9] = {
+            "session_key": "sess-up-9",
+            "message_id": "msg_up_009",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_update_prompt_action": "y", "update_prompt_id": 9},
+            open_id="ou_bob",
+        )
+        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.type == "raw"
+        assert isinstance(response.card.data, str)
+        card = json.loads(response.card.data)
+        assert card["header"]["template"] == "green"
+        assert "Answered by **Bob**" in card["elements"][0]["content"]
 
 
 class TestResolveUpdatePrompt:


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #6893 #7675 #8246 #8764 #10073 #10154 #10251 #10256 #10628 #10801 #13924 #25886 #38305 #42465
## What & Why

Fixes #10251 (and its duplicate reports: #10073, #13924, #38305, #25886, #10154, #8246, #10628, #6893, #8764, #7675).

The Feishu (Lark) adapter builds the synchronous card-action callback response by assigning a **Python dict** to `CallBackCard.data` in `_handle_approval_card_action` and the structurally identical `_handle_update_prompt_card_action`. Feishu's card-action callback contract requires `data` to be a **JSON string** of the raw card object; when a dict is passed, the callback response is malformed and Feishu rejects the click with error 200340 (or 200343 / 220340 on some clients), leaving the approval thread blocked forever.

The fix serializes the resolved-card dict with `json.dumps(..., ensure_ascii=False)` at both sites — the same serialization already used everywhere else in this adapter for outgoing cards (e.g. `send_exec_approval`). It fixes the whole bug class: the approval handler *and* the update-prompt handler.

## How to test

1. `scripts/run_tests.sh tests/gateway/test_feishu_approval_buttons.py` — 14 tests pass. The two callback-response tests now assert `isinstance(response.card.data, str)` and parse the JSON before inspecting card contents; a new `test_update_prompt_returns_serialized_card` covers the second fixed handler (previously only negative paths were tested).
2. Manual (requires a Feishu bot): trigger a dangerous command, click an approval-card button, and confirm the card updates to the resolved state instead of returning `code: 200340`.

## Platforms

- Tested: native Windows (git-bash), Python 3.11/3.12 via `scripts/run_tests.sh` (TZ=UTC, LANG=C.UTF-8, per-file subprocess isolation).
- Change is pure serialization at two call sites; no file I/O, process, signal, or network-path changes. `scripts/check-windows-footguns.py` passes on both changed files.
- Note: 22 failures in `tests/gateway/test_feishu.py` are pre-existing on this host (`ssl.SSLError: [SSL] unknown error` in aiohttp's SSL context creation on Windows) and reproduce identically with the change stashed; they are unrelated to this diff.

## Related PRs

Prior attempts #10256, #42465, and #10801 all address this issue but are now stale/conflicting with `main` (the Feishu adapter moved from `gateway/platforms/feishu.py` to `plugins/platforms/feishu/adapter.py` in a later refactor). This PR applies the same root-cause fix to the adapter's current location, scoped to the serialization bug only.

## Why this matters to users

Before: every Feishu/Lark user who clicked **Allow Once / Session / Always / Deny** on a command-approval card saw "Something went wrong. Please try again later (code 200340)" — the approval never landed, so the dangerous command was neither run nor denied, and the agent thread stayed blocked waiting for a decision that could never arrive. Group chats with multiple admins and mobile Feishu users hit this on every approval.

After: clicking a button instantly updates the card to the resolved state ("✅ Approved once by …" / "❌ Denied") and the approval reaches the agent exactly once. Users no longer have to fall back to re-approving in a second channel or waiting out the timeout; the approval flow works on desktop and mobile alike.
