### PR TITLE
fix(gateway): skip cross-loop live adapter in _send_via_adapter

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -829,7 +829,7 @@ class TestSendTelegramThreadIdMapping:
 
         # Create a test file
         test_file = tmp_path / "doc.txt"
-        test_file.write_text("test content")
+        test_file.write_text("test content", encoding="utf-8")
 
         asyncio.run(
             _send_telegram(
@@ -1699,6 +1699,134 @@ class TestSendViaAdapterStandaloneFallback:
             platform_registry.unregister("fakeplatform")
 
         assert result == {"error": "Plugin standalone send failed: boom!"}
+
+
+class TestSendViaAdapterCrossLoopSession:
+    """Cron delivery runs _send_via_adapter on a worker-thread loop (asyncio.run
+    inside a ThreadPoolExecutor) while the live adapter's aiohttp session was
+    created on the gateway's main loop.  Reusing that session raises "Timeout
+    context manager should be used inside a task" (#39836, #76799, #37005).
+    The live adapter must be skipped when its session belongs to a different
+    event loop, falling through to the plugin's standalone sender — mirroring
+    the Weixin fix in commit a22465e07a.
+    """
+
+    @staticmethod
+    def _make_ntfy_entry(send_fn):
+        from gateway.platform_registry import PlatformEntry
+
+        return PlatformEntry(
+            name="ntfy",
+            label="Ntfy",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: True,
+            standalone_sender_fn=send_fn,
+        )
+
+    @pytest.mark.asyncio
+    async def test_foreign_loop_session_falls_back_to_standalone_sender(self, monkeypatch):
+        from tools.send_message_tool import _send_via_adapter
+        from gateway.platform_registry import platform_registry
+
+        gateway_loop = asyncio.new_event_loop()
+        try:
+            live_calls = []
+
+            class LiveAdapter:
+                _session = SimpleNamespace(closed=False, _loop=gateway_loop)
+
+                async def send(self, *, chat_id, content, metadata=None):
+                    live_calls.append(chat_id)
+                    return SimpleNamespace(success=True, message_id="live-id")
+
+            platform = Platform("ntfy")
+            runner = SimpleNamespace(adapters={platform: LiveAdapter()})
+            monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+
+            async def standalone(pconfig, chat_id, message, **kwargs):
+                return {"success": True, "message_id": "standalone-id", "via": "standalone"}
+
+            platform_registry.register(self._make_ntfy_entry(standalone))
+            try:
+                result = await _send_via_adapter(
+                    platform,
+                    SimpleNamespace(extra={}),
+                    "alerts-channel",
+                    "done",
+                )
+            finally:
+                platform_registry.unregister("ntfy")
+
+            assert result == {"success": True, "message_id": "standalone-id", "via": "standalone"}
+            assert live_calls == [], (
+                "live adapter must be skipped when its session is bound to "
+                "a different event loop (cron worker-thread path)"
+            )
+        finally:
+            gateway_loop.close()
+
+    @pytest.mark.asyncio
+    async def test_closed_session_falls_back_to_standalone_sender(self, monkeypatch):
+        from tools.send_message_tool import _send_via_adapter
+        from gateway.platform_registry import platform_registry
+
+        live_calls = []
+
+        class LiveAdapter:
+            _session = SimpleNamespace(closed=True, _loop=asyncio.get_running_loop())
+
+            async def send(self, *, chat_id, content, metadata=None):
+                live_calls.append(chat_id)
+                return SimpleNamespace(success=True, message_id="live-id")
+
+        platform = Platform("ntfy")
+        runner = SimpleNamespace(adapters={platform: LiveAdapter()})
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+
+        async def standalone(pconfig, chat_id, message, **kwargs):
+            return {"success": True, "message_id": "standalone-id"}
+
+        platform_registry.register(self._make_ntfy_entry(standalone))
+        try:
+            result = await _send_via_adapter(
+                platform,
+                SimpleNamespace(extra={}),
+                "alerts-channel",
+                "done",
+            )
+        finally:
+            platform_registry.unregister("ntfy")
+
+        assert result == {"success": True, "message_id": "standalone-id"}
+        assert live_calls == [], "closed sessions must not be reused"
+
+    @pytest.mark.asyncio
+    async def test_current_loop_session_uses_live_adapter(self, monkeypatch):
+        from tools.send_message_tool import _send_via_adapter
+
+        platform = Platform("ntfy")
+        live_calls = []
+
+        class LiveAdapter:
+            async def send(self, *, chat_id, content, metadata=None):
+                live_calls.append(chat_id)
+                return SimpleNamespace(success=True, message_id="live-id")
+
+        live = LiveAdapter()
+        live._session = SimpleNamespace(closed=False, _loop=asyncio.get_running_loop())
+
+        runner = SimpleNamespace(adapters={platform: live})
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+
+        result = await _send_via_adapter(
+            platform,
+            SimpleNamespace(extra={}),
+            "alerts-channel",
+            "done",
+        )
+
+        assert result == {"success": True, "message_id": "live-id"}
+        assert live_calls == ["alerts-channel"]
 
 # ---------------------------------------------------------------------------
 # _check_send_message — availability gating

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -685,6 +685,36 @@ def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id:
     }
 
 
+def _adapter_session_is_usable(adapter) -> bool:
+    """True when the adapter's aiohttp session can be driven from this loop.
+
+    Adapters create their aiohttp session on the gateway's main event loop.
+    When ``_send_via_adapter`` runs on a worker-thread loop — cron delivery
+    executes ``asyncio.run(coro)`` in a ``ThreadPoolExecutor``, and the
+    send_message tool's ``_run_async`` bridge also spawns a worker thread with
+    a separate loop — reusing that session makes aiohttp's ``TimerContext``
+    call ``asyncio.current_task(loop=session._loop)``, see ``None``, and raise
+    "Timeout context manager should be used inside a task".  Skip the live
+    adapter in that case and fall through to the plugin's
+    ``standalone_sender_fn``, which creates a fresh session on the current
+    loop (mirrors the Weixin fix in commit ``a22465e07a``).
+    """
+    try:
+        current = asyncio.get_running_loop()
+    except RuntimeError:
+        return True  # no running loop → nothing to compare against
+    for attr in ("_session", "_send_session", "session"):
+        session = getattr(adapter, attr, None)
+        if session is None:
+            continue
+        if getattr(session, "closed", False):
+            return False
+        bound_loop = getattr(session, "_loop", None)
+        if bound_loop is not None:
+            return bound_loop is current
+    return True
+
+
 async def _send_via_adapter(
     platform,
     pconfig,
@@ -700,10 +730,14 @@ async def _send_via_adapter(
 
     Order of attempts:
       1. Live in-process adapter via ``_gateway_runner_ref()`` (the path that
-         existed before this change).
+         existed before this change) — only when the adapter's aiohttp
+         session is bound to the current event loop; a session created on the
+         gateway's main loop cannot be reused from a cron worker-thread loop
+         ("Timeout context manager should be used inside a task").
       2. The plugin's ``standalone_sender_fn`` registered on its
          ``PlatformEntry`` (used when the gateway is not in this process, so
-         the runner weakref is ``None``).
+         the runner weakref is ``None``, or when the live adapter's session
+         belongs to a different event loop).
       3. A descriptive error explaining both options.
     """
     platform_name = platform.value if hasattr(platform, "value") else str(platform)
@@ -719,7 +753,7 @@ async def _send_via_adapter(
             adapter = runner.adapters.get(platform)
         except Exception:
             adapter = None
-        if adapter is not None:
+        if adapter is not None and _adapter_session_is_usable(adapter):
             try:
                 metadata = {}
                 if thread_id:


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #37005 #39836 #39877 #76799 #78791
## What / Why

Cron delivery of plugin-platform messages runs `_send_to_platform` via `asyncio.run()` on a scheduler worker thread (`cron/scheduler.py`, `_sequential_pool`/`_parallel_pool`). When the gateway runs in the same process, `_send_via_adapter` (`tools/send_message_tool.py:688`) prefers the live in-process adapter — whose `aiohttp.ClientSession` was created on the gateway's **main event loop**. Reusing that session from the worker-thread loop makes aiohttp's `TimerContext` call `asyncio.current_task(loop=session._loop)`, see `None`, and raise:

```
RuntimeError: Timeout context manager should be used inside a task
```

which surfaces as `delivery error: Plugin platform send failed: Timeout context manager should be used inside a task` on cron jobs whose execution itself succeeds (`last_status: ok`). The same path is hit by the `send_message` tool when invoked from a running loop: `_run_async` (`model_tools.py:103`) spins up a worker thread with a fresh `asyncio.new_event_loop()` and runs the coroutine there.

The bug is loop-bound session reuse, not the timeout mechanism itself — a *fresh* `ClientSession` inside `asyncio.run()` works fine (the author of #39877 verified this before closing it), which is why the failure is specific to the in-process live-adapter shortcut and affects **every plugin platform** with a `standalone_sender_fn` (Mattermost, etc.), not just one adapter.

**Fix:** gate the live-adapter shortcut on `_adapter_session_is_usable()` — the adapter's session must be open and bound to the *current* event loop. When the session belongs to a different loop (or is closed), delivery falls through to the plugin's `standalone_sender_fn`, which creates a fresh session on the current loop. This mirrors the Weixin fix in commit `a22465e07a` (`send_weixin_direct` cross-loop session check), applied to the generic path all plugin platforms share.

## How to test

1. Run the gateway with a Mattermost (or any plugin) platform connected and cron running in-process.
2. Create a cron job with `deliver: "mattermost"` targeting a channel.
3. Before the fix: the job executes with `last_status: ok`, but `last_delivery_error` is `Timeout context manager should be used inside a task` and the message never arrives.
4. After the fix: delivery falls back to the plugin's standalone sender and the message arrives.

## Tests

- New `TestSendViaAdapterCrossLoopSession` (3 tests, `tests/tools/test_send_message_tool.py`):
  - foreign-loop session → falls back to standalone sender, live adapter not called;
  - closed session → falls back to standalone sender;
  - same-loop session → live adapter still used (control).
- RED on unpatched `main` (6858e0d9): 2 failed, 1 passed (control). GREEN with fix: 3 passed.
- Full file: `50 passed` on the branch.
- `git diff --check` clean; `scripts/check-windows-footguns.py` clean (2 files scanned).

## Platforms tested

Windows native (git-bash). The change is event-loop identity logic — platform-agnostic; the identical code path executes on macOS/Linux.

## Related issues

Fixes #39836, #76799, #37005 — same root cause (cross-loop aiohttp session reuse in cron / send_message-tool delivery).

## Why this matters to users

Before: a Hermes user running cron jobs that deliver to Mattermost or another plugin platform *inside the same process as the gateway* saw every job succeed but every delivery fail with "Timeout context manager should be used inside a task" — the message never arrived and there was no workaround. The same failure hit the `send_message` tool when the agent used it from inside a running gateway. After: delivery detects the loop mismatch and uses the platform's standalone sender, which builds a fresh session on the current loop, so messages arrive. Users no longer need to keep the gateway and cron in separate processes to get plugin-platform deliveries.

Part of #37005
Part of #39836
Part of #76799

Part of #55009
