### PR TITLE
feat(agent): enforce declared language standard via stable prompt directive

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1785,6 +1785,14 @@ def init_agent(
     # single turn; the runtime already executes such batches concurrently.
     agent._parallel_tool_call_guidance = bool(_agent_section.get("parallel_tool_call_guidance", True))
 
+    # Declared working-language standard (BCP-47 tag, e.g. "pt-BR", "es-MX").
+    # When non-empty, the stable system prompt carries a directive holding the
+    # model to that language/variant instead of drifting to a different
+    # variant of the same language or to its dominant training language.
+    # Resolved once here so the directive is byte-stable for the life of the
+    # conversation (prompt-cache safe); empty default costs zero tokens.
+    agent._language_standard = str(_agent_section.get("language_standard", "") or "").strip()
+
     # Local Python toolchain probe toggle.  Default True.  When False,
     # the probe is skipped entirely (no subprocess calls, no system-prompt
     # line).  Useful for users on exotic setups where the probe heuristics

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -397,6 +397,35 @@ PARALLEL_TOOL_CALL_GUIDANCE = (
     "in doubt and the calls are independent, batch them."
 )
 
+# Declared working-language standard.  Rendered once at agent init from the
+# `agent.language_standard` config value (BCP-47 tag) so the directive is
+# byte-stable for the life of the conversation — it joins the stable system
+# prompt tier and never changes mid-session, keeping upstream prompt caches
+# warm.  Empty tag → empty string (zero token cost for users who don't opt
+# in).  This is a prompt-side steer only; a post-generation grammar/spell
+# check (the rest of issue #31514) belongs to a plugin, not the core.
+def language_standard_guidance(language_standard: str) -> str:
+    """Return a stable-tier directive holding the model to a declared language.
+
+    ``language_standard`` is a BCP-47 tag (e.g. "pt-BR", "es-MX", "de-DE").
+    The directive tells the model to mirror the user's working language and
+    variant instead of silently drifting to a different variant of the same
+    language or to its own dominant training language.
+    """
+    tag = (language_standard or "").strip()
+    if not tag:
+        return ""
+    return (
+        "# Language standard\n"
+        f"The user's declared working language standard is {tag}. "
+        "Mirror the user's language and linguistic variant in every response: "
+        f"when the user writes in {tag}, respond in {tag} — keep its grammar, "
+        "spelling, and accentuation consistent, and never silently switch to a "
+        "different variant of the same language or to your dominant training "
+        "language. If the user writes in another language, respond in that "
+        "language unless they ask otherwise."
+    )
+
 # OpenAI GPT/Codex-specific execution guidance.  Addresses known failure modes
 # where GPT models abandon work on partial results, skip prerequisite lookups,
 # hallucinate instead of using tools, and declare "done" without verification.

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -47,6 +47,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     drain_truncation_warnings,
+    language_standard_guidance,
 )
 from agent.runtime_cwd import resolve_context_cwd
 from hermes_constants import get_hermes_home
@@ -202,6 +203,17 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
 
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
     stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
+
+    # Declared working-language standard — when the user sets
+    # agent.language_standard (BCP-47 tag), hold the model to that language
+    # and variant instead of drifting to a different variant of the same
+    # language or its dominant training language.  Resolved once at agent
+    # init (agent._language_standard), so it is byte-stable for the life of
+    # the conversation and never threatens prompt caching.  Empty by default
+    # → zero tokens.
+    _lang_standard = getattr(agent, "_language_standard", "")
+    if _lang_standard:
+        stable_parts.append(language_standard_guidance(_lang_standard))
 
     # Universal task-completion / no-fabrication guidance.  Applied to ALL
     # models regardless of tool_use_enforcement gating — the failure modes

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -116,6 +116,15 @@ DEFAULT_CONFIG = {
         # identity slot (SOUL.md). Empty by default. The HERMES_ENVIRONMENT_HINT
         # env var overrides this (build-time/container mechanism).
         "environment_hint": "",
+        # Declared working-language standard (BCP-47 tag, e.g. "pt-BR",
+        # "es-MX", "de-DE").  When set, the system prompt steers the model to
+        # hold that language and linguistic variant in its responses instead
+        # of silently drifting to a different variant (pt-BR ↔ pt-PT) or to
+        # the model's dominant training language.  Prompt-side steer only —
+        # it does NOT run a post-generation grammar/spell pass; that layer
+        # belongs to a plugin (see issue #31514).  Empty by default (no
+        # directive, zero extra tokens).
+        "language_standard": "",
         # Coding posture — on interactive coding surfaces (CLI, TUI, desktop
         # app, ACP) in a code workspace, Hermes adds a coding operating brief
         # + a live git/workspace snapshot to the system prompt. See

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -226,3 +226,66 @@ class TestTelegramRichMessagesHint:
             stable = _stable_prompt(agent)
         assert "Standard Markdown is automatically converted" in stable
         assert "lean into it" not in stable
+
+
+class TestLanguageStandardGuidance:
+    """agent.language_standard — stable-tier directive holding the model to a
+    declared BCP-47 language/variant (issue #31514)."""
+
+    def test_empty_tag_renders_nothing(self):
+        from agent.prompt_builder import language_standard_guidance
+
+        assert language_standard_guidance("") == ""
+        assert language_standard_guidance("   ") == ""
+        assert language_standard_guidance(None) == ""
+
+    def test_tag_renders_directive(self):
+        from agent.prompt_builder import language_standard_guidance
+
+        out = language_standard_guidance("pt-BR")
+        assert "pt-BR" in out
+        assert "Language standard" in out
+        assert "never silently switch" in out
+
+    def test_injected_when_configured(self):
+        agent = _make_agent(_language_standard="pt-BR")
+        stable = _stable_prompt(agent)
+        assert "The user's declared working language standard is pt-BR" in stable
+
+    def test_absent_when_unset(self):
+        agent = _make_agent(_language_standard="")
+        stable = _stable_prompt(agent)
+        assert "Language standard" not in stable
+        assert "declared working language" not in stable
+
+    def test_absent_when_attribute_missing(self):
+        # Agents built before the config resolution existed (or tests that
+        # construct minimal fakes) must not crash — getattr default is "".
+        agent = SimpleNamespace(
+            load_soul_identity=False,
+            skip_context_files=False,
+            valid_tool_names=[],
+            _task_completion_guidance=False,
+            _tool_use_enforcement=False,
+            _environment_probe=False,
+            _kanban_worker_guidance="",
+            _memory_store=None,
+            _memory_manager=None,
+            model="",
+            provider="",
+            platform="",
+            pass_session_id=False,
+            session_id="",
+        )
+        stable = _stable_prompt(agent)
+        assert "Language standard" not in stable
+
+    def test_injection_is_byte_stable(self):
+        # The directive is resolved once from the agent attr; rebuilding the
+        # prompt with the same agent must yield an identical stable tier
+        # (prompt-caching invariant — never re-render mid-session).
+        agent = _make_agent(_language_standard="es-MX")
+        first = _stable_prompt(agent)
+        second = _stable_prompt(agent)
+        assert first == second
+        assert "es-MX" in first


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #31514 #31515
## What & why

Feature request #31514 asks for a way to tell Hermes "my working language is pt-BR — maintain it faithfully and never silently switch to pt-PT or English." Today there is no such mechanism: the model drifts toward whatever variant its training data dominates, which is exactly the reported pain (pt-BR users getting pt-PT spelling, missing accents, non-native "corrections").

This PR implements the prompt-side enforcement half of that request:

- New config key `agent.language_standard` (BCP-47 tag, e.g. `pt-BR`, `es-MX`, `de-DE`), stored in the profile config, resolved once at agent init (`agent._language_standard`).
- When set, a short "Language standard" directive joins the **stable** tier of the system prompt (via `language_standard_guidance()` in `agent/prompt_builder.py`), holding the model to the declared language and variant: keep its grammar/spelling/accentuation, never silently switch to a different variant of the same language or to the model's dominant training language. If the user writes in another language, respond in that language unless asked otherwise.
- When unset (default), the directive is empty — zero extra tokens, no behavior change.

Design choices, per the contribution rubric:

- **Prompt-cache safe.** The directive is resolved once at init and rendered into the stable prompt tier; it is byte-stable for the life of the conversation and never re-rendered mid-session (regression test asserts this invariant).
- **Smallest core footprint.** The request's second half — a post-generation grammar/spell-check pass with a `strict_orthography` toggle — is deliberately **not** added to the core. That is plugin territory (`plugins/` or a standalone plugin repo); a new core tool for grammar checking would ship on every API call and fail the footprint ladder. The prompt directive is the core-appropriate slice; the issue stays open to track the plugin leg.
- **Config, not env.** No new `HERMES_*` env var; the setting lives in `config.yaml` under `agent:`.

## How to test

1. `hermes chat` with `agent.language_standard: pt-BR` in `config.yaml`, write in Brazilian Portuguese, observe responses stay pt-BR (no pt-PT spellings, accents preserved).
2. Without the key set (default), confirm no "Language standard" text appears in the system prompt and token behavior is unchanged.
3. Unit tests:
   - `scripts/run_tests.sh tests/agent/test_system_prompt.py` — 15 passed, 1 pre-existing Windows-only failure (`test_coding_prompt_preserves_legacy_workspace_order`, path-separator assertion, reproduces on clean main).
   - Sibling suites: `tests/agent/test_prompt_builder.py`, `test_prompt_caching.py`, `test_system_prompt_restore.py`, `test_learn_prompt.py`, `test_moa_reference_system_prompt.py`, `test_arcee_trinity_overrides.py`, `test_auxiliary_config_bridge.py`, `test_compression_max_attempts_config.py`, `test_proactive_prune_config.py`, `test_context_engine.py`, `tests/cli/test_cli_provider_resolution.py` — all pass (136+ tests).
   - `git diff --check` clean; `ruff check` clean; `scripts/check-windows-footguns.py --diff origin/main` clean.

New tests cover: empty/whitespace/None tag renders nothing; tag renders directive; directive injected when configured; absent when unset; absent when attribute missing (minimal agents don't crash); byte-stable re-render (prompt-caching invariant).

## Platforms tested

- Windows 10 native (git-bash), Python 3.11, via `scripts/run_tests.sh` with the dev venv.

## Related issues

- Implements the prompt-side half of #31514 (canonical feature request, stays open for the plugin grammar-check leg).
- #31515 is an exact duplicate of #31514 (same author, filed 4s later, already labeled `duplicate`) — recommend closing it in favor of #31514.

## Why this matters to users

Before: a Brazilian Portuguese user tells Hermes "write a relatório" and gets back European Portuguese spellings, dropped accents, or outright English — there is no way to pin Hermes to a language standard, and the model "corrects" their writing in ways that don't match how they actually write. After: one line in `config.yaml` (`language_standard: pt-BR`) makes every response hold the declared language and variant consistently — same grammar, spelling, and accentuation, no silent drift. This helps every non-primary-language user of Hermes (pt-BR, pt-PT, es-MX, de-DE, ...), not just Portuguese speakers, and costs nothing for users who don't set it.

Part of #31514
Part of #31515
