### PR TITLE
feat(discord): support per-category mention and ignore rules

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -386,6 +386,9 @@ _GATE_ENV_KEYS = (
     "DISCORD_IGNORED_CHANNELS",
     "DISCORD_NO_THREAD_CHANNELS",
     "DISCORD_FREE_RESPONSE_CHANNELS",
+    "DISCORD_FREE_RESPONSE_CATEGORIES",
+    "DISCORD_IGNORED_CATEGORIES",
+    "DISCORD_REQUIRE_MENTION_CATEGORIES",
     "DISCORD_MISSED_MESSAGE_BACKFILL_CHANNELS",
     "DISCORD_ALLOW_ALL_USERS",
     "DISCORD_ALLOW_BOTS",
@@ -1260,6 +1263,10 @@ class DiscordAdapter(BasePlatformAdapter):
             # first-writer-wins process-global env bridge.
             self._snapshot_gate_env()
 
+            # Surface ambiguous per-category rule pairings (a category in both
+            # free_response_categories and ignored_categories) once at startup.
+            self._warn_category_rule_conflicts()
+
             # Parse allowed user entries (may contain usernames or IDs)
             self._allowed_user_ids = self._get_allowed_users()
 
@@ -1485,8 +1492,15 @@ class DiscordAdapter(BasePlatformAdapter):
                 if hasattr(message.channel, "parent_id") and message.channel.parent_id:
                     parent_id = str(message.channel.parent_id)
                 free_channels = self._discord_free_response_channels()
+                free_categories = self._discord_free_response_categories()
                 channel_keys = self._discord_channel_keys(message, parent_id)
-                if "*" not in free_channels and not (channel_keys & free_channels):
+                category_keys = self._discord_category_keys(message.channel)
+                if (
+                    "*" not in free_channels
+                    and not (channel_keys & free_channels)
+                    and "*" not in free_categories
+                    and not (category_keys & free_categories)
+                ):
                     return False, False
 
         return True, role_authorized
@@ -2293,6 +2307,8 @@ class DiscordAdapter(BasePlatformAdapter):
             parent_id = self._get_parent_channel_id(message.channel)
             channel_keys = self._discord_channel_keys(message, parent_id)
             free_channels = self._discord_free_response_channels()
+            free_categories = self._discord_free_response_categories()
+            category_keys = self._discord_category_keys(message.channel)
             in_bot_thread = (
                 isinstance(message.channel, discord.Thread)
                 and str(message.channel.id) in self._threads
@@ -2302,6 +2318,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 self._discord_require_mention()
                 and "*" not in free_channels
                 and not (channel_keys & free_channels)
+                and "*" not in free_categories
+                and not (category_keys & free_categories)
                 and not in_bot_thread
                 and not self._self_is_explicitly_mentioned(message)
             ):
@@ -6279,6 +6297,110 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
 
+    def _discord_category_keys(self, channel: Any) -> set[str]:
+        """Return the Discord category ID a channel/thread belongs to.
+
+        Resolves ``channel.category`` — discord.py exposes the category on
+        both text channels and threads (threads resolve through their
+        parent channel), so a single lookup covers both. Returns an empty
+        set for DMs, uncategorised channels, and channel objects without a
+        category.
+
+        ``discord.Thread.category`` raises ``ClientException`` when the
+        parent channel is not cached (e.g. a thread seen right after a
+        partial gateway fetch), so the property access is guarded: a
+        missing parent is treated the same as no category — the message
+        falls through to the channel-ID rules.
+
+        Category rules match on category IDs only: names are not stable
+        and a category can be renamed without breaking the bot.
+        """
+        try:
+            category = getattr(channel, "category", None)
+        except Exception:
+            category = None
+        category_id = getattr(category, "id", None)
+        if category_id is None:
+            return set()
+        return {str(category_id)}
+
+    def _discord_free_response_categories(self) -> set:
+        """Return Discord category IDs where no bot mention is required.
+
+        A category listed here makes every channel and thread inside it a
+        free-response scope, mirroring ``free_response_channels`` at the
+        category level. A single ``"*"`` entry (list or comma-separated
+        string) is preserved in the returned set so callers can
+        short-circuit on wildcard membership, consistent with the channel
+        list.
+        """
+        raw = self.config.extra.get("free_response_categories")
+        if raw is None:
+            raw = self._gate_env("DISCORD_FREE_RESPONSE_CATEGORIES")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
+        return set()
+
+    def _discord_ignored_categories(self) -> set:
+        """Return Discord category IDs where the bot never responds.
+
+        A category listed here silences every channel and thread inside
+        it — even when the bot is explicitly @mentioned — mirroring
+        ``ignored_channels`` at the category level.
+        """
+        raw = self.config.extra.get("ignored_categories")
+        if raw is None:
+            raw = self._gate_env("DISCORD_IGNORED_CATEGORIES")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
+        return set()
+
+    def _discord_require_mention_categories(self) -> set:
+        """Return Discord category IDs where @mention is always required.
+
+        A category listed here flips the message to gated (mention
+        required) even when the global ``require_mention`` default is
+        false, and overrides any free-response exemption for that
+        category. This is the per-category counterpart of
+        ``require_mention`` — it lets a bot be free everywhere except a
+        single category without enumerating every other channel.
+        """
+        raw = self.config.extra.get("require_mention_categories")
+        if raw is None:
+            raw = self._gate_env("DISCORD_REQUIRE_MENTION_CATEGORIES")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
+        return set()
+
+    def _warn_category_rule_conflicts(self) -> None:
+        """Log once per conflicted category at startup.
+
+        A category listed in both ``free_response_categories`` and
+        ``ignored_categories`` is ambiguous: the ignore rule wins at
+        message time, but the pairing is almost always a config mistake
+        (the category can never be free AND silent). Surface it once so
+        the operator can remove it from one of the lists.
+        """
+        free = self._discord_free_response_categories()
+        ignored = self._discord_ignored_categories()
+        for category_id in sorted((free & ignored) - {"*"}):
+            logger.warning(
+                "[%s] Category %s is listed in both free_response_categories "
+                "and ignored_categories; ignored_categories wins. Remove it "
+                "from one of the lists.",
+                self.name,
+                category_id,
+            )
+
     def _raw_mentioned_user_ids(self, message: Any) -> set:
         """Extract Discord user-mention IDs directly from raw message content.
 
@@ -7634,6 +7756,9 @@ class DiscordAdapter(BasePlatformAdapter):
         #   discord.allowed_channels: If set, bot ONLY responds in these channels (whitelist)
         #   discord.no_thread_channels: Channel IDs where bot responds directly without creating thread
         #   discord.auto_thread: Auto-create thread on @mention in channels (default: true)
+        #   discord.free_response_categories: Category IDs (channels + threads inside) where bot responds without mention
+        #   discord.ignored_categories: Category IDs (channels + threads inside) where bot NEVER responds (even when mentioned)
+        #   discord.require_mention_categories: Category IDs where @mention is required even when globally free
 
         thread_id = None
         parent_channel_id = None
@@ -7685,7 +7810,28 @@ class DiscordAdapter(BasePlatformAdapter):
                 logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_keys)
                 return False
 
+            # Category-level ignore rules (per-category mention/ignore rules):
+            # a category listed in ignored_categories silences every channel
+            # and thread inside it, even when the bot is @mentioned.
+            category_keys = self._discord_category_keys(message.channel)
+            ignored_categories = self._discord_ignored_categories()
+            if "*" in ignored_categories or (category_keys & ignored_categories):
+                logger.debug("[%s] Ignoring message in ignored category: %s", self.name, category_keys)
+                return False
+
             free_channels = self._discord_free_response_channels()
+            free_categories = self._discord_free_response_categories()
+            require_mention_categories = self._discord_require_mention_categories()
+            # A category in require_mention_categories flips the message to
+            # gated (@mention required) even when the global require_mention
+            # default is false — and overrides a free-response exemption for
+            # that category. Precedence: allowed_channels → ignored_channels
+            # → ignored_categories → free_response_channels/
+            # free_response_categories → require_mention_categories →
+            # require_mention global default.
+            category_requires_mention = "*" in require_mention_categories or bool(
+                category_keys & require_mention_categories
+            )
 
             require_mention = self._discord_require_mention()
             # Voice-linked text channels act as free-response while voice is active.
@@ -7696,6 +7842,8 @@ class DiscordAdapter(BasePlatformAdapter):
             is_free_channel = (
                 "*" in free_channels
                 or bool(channel_keys & free_channels)
+                or "*" in free_categories
+                or bool(category_keys & free_categories)
                 or is_voice_linked_channel
             )
 
@@ -7710,9 +7858,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 and not self._discord_thread_require_mention()
             )
 
-            if require_mention and not is_free_channel and not in_bot_thread:
-                if not self._self_is_explicitly_mentioned(message) and not mention_prefix:
-                    return False
+            if (require_mention or category_requires_mention) and not in_bot_thread:
+                if not is_free_channel or category_requires_mention:
+                    if not self._self_is_explicitly_mentioned(message) and not mention_prefix:
+                        return False
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
         # Messages already inside threads or DMs are unaffected.
@@ -9966,6 +10115,30 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         seeded_extra["ignored_channels"] = str(ic)
         if not _skip_env_bridge and not os.getenv("DISCORD_IGNORED_CHANNELS"):
             os.environ["DISCORD_IGNORED_CHANNELS"] = str(ic)
+    # Per-category mention/ignore rules: mirror the channel-ID keys at the
+    # category level. A listed category applies to every channel and thread
+    # inside it.
+    frc_cat = discord_cfg.get("free_response_categories")
+    if frc_cat is not None:
+        if isinstance(frc_cat, list):
+            frc_cat = ",".join(str(v) for v in frc_cat)
+        seeded_extra["free_response_categories"] = str(frc_cat)
+        if not _skip_env_bridge and not os.getenv("DISCORD_FREE_RESPONSE_CATEGORIES"):
+            os.environ["DISCORD_FREE_RESPONSE_CATEGORIES"] = str(frc_cat)
+    ic_cat = discord_cfg.get("ignored_categories")
+    if ic_cat is not None:
+        if isinstance(ic_cat, list):
+            ic_cat = ",".join(str(v) for v in ic_cat)
+        seeded_extra["ignored_categories"] = str(ic_cat)
+        if not _skip_env_bridge and not os.getenv("DISCORD_IGNORED_CATEGORIES"):
+            os.environ["DISCORD_IGNORED_CATEGORIES"] = str(ic_cat)
+    rmc_cat = discord_cfg.get("require_mention_categories")
+    if rmc_cat is not None:
+        if isinstance(rmc_cat, list):
+            rmc_cat = ",".join(str(v) for v in rmc_cat)
+        seeded_extra["require_mention_categories"] = str(rmc_cat)
+        if not _skip_env_bridge and not os.getenv("DISCORD_REQUIRE_MENTION_CATEGORIES"):
+            os.environ["DISCORD_REQUIRE_MENTION_CATEGORIES"] = str(rmc_cat)
     # allowed_channels: if set, bot ONLY responds in these channels (whitelist)
     ac = discord_cfg.get("allowed_channels")
     if ac is not None:

--- a/tests/gateway/test_discord_category_rules.py
+++ b/tests/gateway/test_discord_category_rules.py
@@ -1,0 +1,462 @@
+"""Tests for Discord per-category mention and ignore rules.
+
+Covers the three category-level config keys added alongside the existing
+channel-ID controls:
+
+- ``free_response_categories``: bot responds without @mention in every
+  channel/thread inside the listed categories
+- ``ignored_categories``: bot never responds inside the listed categories,
+  even when @mentioned
+- ``require_mention_categories``: bot requires @mention inside the listed
+  categories even when the global ``require_mention`` default is false
+
+Also covers thread inheritance (a thread whose parent channel sits in a
+listed category picks up the category rule), precedence (ignore beats
+free; require-mention beats free), the startup mutual-exclusion warning,
+CSV/YAML parsing parity, the ingress admission gate, and the config.yaml
+→ env bridge.
+"""
+
+from types import SimpleNamespace
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+discord = discord_platform.discord
+
+
+class FakeDMChannel:
+    def __init__(self, channel_id: int = 1, name: str = "dm"):
+        self.id = channel_id
+        self.name = name
+
+
+class FakeCategory:
+    def __init__(self, category_id: int = 1, name: str = "Category"):
+        self.id = category_id
+        self.name = name
+
+
+class FakeTextChannel:
+    def __init__(
+        self,
+        channel_id: int = 1,
+        name: str = "general",
+        category: FakeCategory = None,
+        guild_name: str = "Hermes Server",
+    ):
+        self.id = channel_id
+        self.name = name
+        self.category = category
+        self.guild = SimpleNamespace(name=guild_name)
+        self.topic = None
+
+
+class FakeThread:
+    def __init__(
+        self,
+        channel_id: int = 1,
+        name: str = "thread",
+        parent: FakeTextChannel = None,
+        guild_name: str = "Hermes Server",
+    ):
+        self.id = channel_id
+        self.name = name
+        self.parent = parent
+        self.parent_id = getattr(parent, "id", None)
+        # Mirror discord.py: Thread.category resolves through the parent
+        # channel, so a thread in a channel inside a category inherits it.
+        self.category = getattr(parent, "category", None)
+        self.guild = getattr(parent, "guild", None) or SimpleNamespace(name=guild_name)
+        self.topic = None
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    monkeypatch.setattr(discord_platform.discord, "DMChannel", FakeDMChannel, raising=False)
+    monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
+
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = DiscordAdapter(config)
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+    adapter._text_batch_delay_seconds = 0  # disable batching for tests
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+def make_message(*, channel, content: str, mentions=None, bot_author: bool = False):
+    author = SimpleNamespace(
+        id=42, display_name="TestUser", name="TestUser", bot=bot_author
+    )
+    return SimpleNamespace(
+        id=123,
+        content=content,
+        mentions=list(mentions or []),
+        attachments=[],
+        reference=None,
+        created_at=datetime.now(timezone.utc),
+        channel=channel,
+        author=author,
+    )
+
+
+def _message_type_default():
+    """MessageType.default against either the real discord.py or the mock."""
+    message_type = getattr(discord, "MessageType", None)
+    if message_type is None:
+        return 0
+    return message_type.default
+
+
+# ── free_response_categories ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_free_response_category_waives_mention_in_category_channels(adapter, monkeypatch):
+    """Channels inside a free-response category respond without @mention."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CATEGORIES", "1")
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=500, category=FakeCategory(category_id=1)),
+        content="hello",
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_free_response_category_still_gates_other_channels(adapter, monkeypatch):
+    """Channels outside a free-response category still require @mention."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CATEGORIES", "1")
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=500, name="uncategorised"),
+        content="hello",
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_free_response_category_applies_to_threads_in_category(adapter, monkeypatch):
+    """A thread whose parent channel is in a free category inherits the rule."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CATEGORIES", "1")
+    # Thread messages always trigger history backfill; the fake channel has no
+    # history API, so disable it to keep this test scoped to the category rule.
+    monkeypatch.setenv("DISCORD_HISTORY_BACKFILL", "false")
+
+    parent = FakeTextChannel(
+        channel_id=500, name="support", category=FakeCategory(category_id=1)
+    )
+    thread = FakeThread(channel_id=900, name="ticket-1", parent=parent)
+    message = make_message(channel=thread, content="hello")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_free_response_category_wildcard_waives_mention_everywhere(adapter, monkeypatch):
+    """A ``*`` free-response category entry is a global free-response scope."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CATEGORIES", "*")
+
+    message = make_message(channel=FakeTextChannel(channel_id=500), content="hello")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+
+
+# ── ignored_categories ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ignored_category_silences_even_when_mentioned(adapter, monkeypatch):
+    """Ignored categories take priority — even @mentions are dropped."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_IGNORED_CATEGORIES", "1")
+
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=500, category=FakeCategory(category_id=1)),
+        content=f"<@{bot_user.id}> hello",
+        mentions=[bot_user],
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ignored_category_applies_to_threads(adapter, monkeypatch):
+    """Threads inside an ignored category are silent even when mentioned."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_IGNORED_CATEGORIES", "1")
+
+    bot_user = adapter._client.user
+    parent = FakeTextChannel(
+        channel_id=500, name="support", category=FakeCategory(category_id=1)
+    )
+    thread = FakeThread(channel_id=900, name="ticket-1", parent=parent)
+    message = make_message(
+        channel=thread, content=f"<@{bot_user.id}> hello", mentions=[bot_user]
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ignored_category_overrides_free_response_category(adapter, monkeypatch):
+    """A category in both lists is ignored: ignore wins over free (precedence)."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CATEGORIES", "1")
+    monkeypatch.setenv("DISCORD_IGNORED_CATEGORIES", "1")
+
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=500, category=FakeCategory(category_id=1)),
+        content=f"<@{bot_user.id}> hello",
+        mentions=[bot_user],
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ignored_category_wildcard_silences_everywhere(adapter, monkeypatch):
+    """A ``*`` ignored-category entry silences every channel, even when mentioned."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_IGNORED_CATEGORIES", "*")
+
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=500),
+        content=f"<@{bot_user.id}> hello",
+        mentions=[bot_user],
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+# ── require_mention_categories ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_require_mention_category_gates_category_when_globally_free(adapter, monkeypatch):
+    """A listed category flips to gated even when require_mention is false."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION_CATEGORIES", "1")
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=500, category=FakeCategory(category_id=1)),
+        content="hello",
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_require_mention_category_mentions_still_work(adapter, monkeypatch):
+    """@mention still triggers the bot inside a require-mention category."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION_CATEGORIES", "1")
+
+    adapter._auto_create_thread = AsyncMock(return_value=FakeThread(channel_id=999))
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=500, category=FakeCategory(category_id=1)),
+        content=f"<@{bot_user.id}> hello",
+        mentions=[bot_user],
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_require_mention_category_leaves_other_channels_free(adapter, monkeypatch):
+    """Channels outside the listed category stay free under require_mention=false."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION_CATEGORIES", "1")
+
+    adapter._auto_create_thread = AsyncMock(return_value=FakeThread(channel_id=999))
+    message = make_message(channel=FakeTextChannel(channel_id=500), content="hello")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_require_mention_category_overrides_free_response_channel(adapter, monkeypatch):
+    """A require-mention category beats a channel-level free-response exemption."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "500")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION_CATEGORIES", "1")
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=500, category=FakeCategory(category_id=1)),
+        content="hello",
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+# ── accessor parsing parity ──────────────────────────────────────────
+
+_CATEGORY_ACCESSORS = [
+    ("free_response_categories", "DISCORD_FREE_RESPONSE_CATEGORIES", "_discord_free_response_categories"),
+    ("ignored_categories", "DISCORD_IGNORED_CATEGORIES", "_discord_ignored_categories"),
+    ("require_mention_categories", "DISCORD_REQUIRE_MENTION_CATEGORIES", "_discord_require_mention_categories"),
+]
+
+
+@pytest.mark.parametrize("extra_key,env_key,attr", _CATEGORY_ACCESSORS)
+def test_category_accessors_parse_yaml_list(monkeypatch, extra_key, env_key, attr):
+    """A YAML list in PlatformConfig.extra parses to the ID set."""
+    config = PlatformConfig(enabled=True, token="fake-token", extra={extra_key: ["11", "22"]})
+    adapter = DiscordAdapter(config)
+    monkeypatch.delenv(env_key, raising=False)
+    assert getattr(adapter, attr)() == {"11", "22"}
+
+
+@pytest.mark.parametrize("extra_key,env_key,attr", _CATEGORY_ACCESSORS)
+def test_category_accessors_parse_env_csv(monkeypatch, extra_key, env_key, attr):
+    """A CSV env var parses to the same ID set as the YAML list."""
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = DiscordAdapter(config)
+    monkeypatch.setenv(env_key, "33, 44")
+    assert getattr(adapter, attr)() == {"33", "44"}
+
+
+@pytest.mark.parametrize("extra_key,env_key,attr", _CATEGORY_ACCESSORS)
+def test_category_accessors_coerce_numeric_scalar(monkeypatch, extra_key, env_key, attr):
+    """A bare numeric scalar in YAML is coerced to str, matching the channel keys."""
+    config = PlatformConfig(
+        enabled=True, token="fake-token", extra={extra_key: 1491973769726791812}
+    )
+    adapter = DiscordAdapter(config)
+    monkeypatch.delenv(env_key, raising=False)
+    assert getattr(adapter, attr)() == {"1491973769726791812"}
+
+
+# ── mutual-exclusion startup warning ─────────────────────────────────
+
+
+def test_mutual_exclusion_warning_logged(adapter, monkeypatch, caplog):
+    """A category in both free_response_categories and ignored_categories warns once."""
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CATEGORIES", "1,2")
+    monkeypatch.setenv("DISCORD_IGNORED_CATEGORIES", "2")
+
+    with caplog.at_level("WARNING", logger="plugins.platforms.discord.adapter"):
+        adapter._warn_category_rule_conflicts()
+
+    messages = [record.message for record in caplog.records]
+    assert any("2" in m and "free_response_categories" in m and "ignored_categories" in m for m in messages)
+    # Category 1 is only in the free list — must not be flagged.
+    assert not any("1" in m and "free_response_categories" in m and "ignored_categories" in m for m in messages)
+
+
+def test_mutual_exclusion_no_warning_when_disjoint(adapter, monkeypatch, caplog):
+    """Disjoint category lists produce no startup warning."""
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CATEGORIES", "1")
+    monkeypatch.setenv("DISCORD_IGNORED_CATEGORIES", "2")
+
+    with caplog.at_level("WARNING", logger="plugins.platforms.discord.adapter"):
+        adapter._warn_category_rule_conflicts()
+
+    assert not caplog.records
+
+
+# ── ingress admission gate ───────────────────────────────────────────
+
+
+def test_admission_gate_honors_free_response_categories(adapter, monkeypatch):
+    """The pre-dispatch admission gate admits unmentioned messages in free categories."""
+    monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+    monkeypatch.setenv("DISCORD_IGNORE_NO_MENTION", "true")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CATEGORIES", "1")
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    channel = FakeTextChannel(channel_id=500, category=FakeCategory(category_id=1))
+    message = make_message(
+        channel=channel, content="hello", mentions=[SimpleNamespace(id=7, bot=False)]
+    )
+    message.type = _message_type_default()
+    message.guild = channel.guild
+
+    admitted, _ = adapter._discord_message_admission(message, claim=False)
+    assert admitted is True
+
+
+def test_admission_gate_blocks_unmentioned_outside_free_categories(adapter, monkeypatch):
+    """The admission gate still drops unmentioned messages outside free categories."""
+    monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+    monkeypatch.setenv("DISCORD_IGNORE_NO_MENTION", "true")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CATEGORIES", "1")
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    channel = FakeTextChannel(channel_id=500, name="uncategorised")
+    message = make_message(
+        channel=channel, content="hello", mentions=[SimpleNamespace(id=7, bot=False)]
+    )
+    message.type = _message_type_default()
+    message.guild = channel.guild
+
+    admitted, _ = adapter._discord_message_admission(message, claim=False)
+    assert admitted is False
+
+
+# ── config.yaml bridging ─────────────────────────────────────────────
+
+
+def test_config_bridges_category_rules(monkeypatch, tmp_path):
+    """gateway/config.py bridges the three discord.*_categories keys to env vars."""
+    import yaml
+    import os
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        yaml.dump(
+            {
+                "discord": {
+                    "free_response_categories": ["111", "222"],
+                    "ignored_categories": ["333"],
+                    "require_mention_categories": ["444"],
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Use setenv (not delenv) so monkeypatch registers cleanup even when
+    # the var doesn't exist yet — load_gateway_config will overwrite it.
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CATEGORIES", "")
+    monkeypatch.setenv("DISCORD_IGNORED_CATEGORIES", "")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION_CATEGORIES", "")
+
+    from gateway.config import load_gateway_config
+
+    load_gateway_config()
+
+    assert os.getenv("DISCORD_FREE_RESPONSE_CATEGORIES") == "111,222"
+    assert os.getenv("DISCORD_IGNORED_CATEGORIES") == "333"
+    assert os.getenv("DISCORD_REQUIRE_MENTION_CATEGORIES") == "444"


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #38539 #38540 #54338 #61593
## What & Why

Adds per-category Discord mention/ignore rules so a bot's gating can target a **Discord category and everything inside it** (channels + threads) instead of enumerating every child channel ID.

Three new config keys mirror the existing channel-ID helpers (`_discord_free_response_channels()` et al.):

```yaml
discord:
  free_response_categories:   ["<category_id>"]   # additive: free in this category + its channels/threads
  ignored_categories:         ["<category_id>"]   # subtractive: silent here, even when @mentioned
  require_mention_categories: ["<category_id>"]   # flip free→gated for this category
```

The headline use case from #38539: running two bots with inverse regional coverage. Bot 1 wants "free everywhere **except** category C" — previously inexpressible without enumerating every non-C channel ID (brittle, breaks when a channel is added). Now:

```yaml
# Bot 1: free globally, gated inside category C
discord:
  require_mention: false
  require_mention_categories: ["<category_id>"]

# Bot 2: gated globally, free inside category C
discord:
  require_mention: true
  free_response_categories: ["<category_id>"]
```

Implementation:

- `_discord_free_response_categories()`, `_discord_ignored_categories()`, `_discord_require_mention_categories()` — same parsing contract as the channel keys: list in YAML, CSV in env (`DISCORD_FREE_RESPONSE_CATEGORIES`, `DISCORD_IGNORED_CATEGORIES`, `DISCORD_REQUIRE_MENTION_CATEGORIES`), `"*"` wildcard sentinel preserved.
- `_discord_category_keys(channel)` — resolves the category ID on text channels and threads (discord.py exposes `Thread.category` through the parent; a missing/uncached parent is treated as "no category" so the message falls through to the channel-ID rules).
- Gating block (`_handle_message` + ingress admission + missed-message backfill dispatch): `ignored_categories` silences even when @mentioned; category-derived free/require-mention scopes **augment** (union) the channel-derived sets; `require_mention_categories` overrides a free-response exemption for that category.
- Precedence: `allowed_channels` → `ignored_channels` → `ignored_categories` → `free_response_channels` / `free_response_categories` → `require_mention_categories` → `require_mention` global default.
- Startup warning when a category is listed in both `free_response_categories` and `ignored_categories` (mutual exclusion, per the issue spec).
- YAML→env bridge in `_apply_yaml_config` writes the three env vars following the existing channel-ID pattern.

Thread inheritance: a thread whose parent channel sits in a listed category picks up the category rule through `Thread.category` — no new inheritance code.

## How to test

```bash
scripts/run_tests.sh tests/gateway/test_discord_category_rules.py
```

26 new tests cover: free-response category waives mention (channels + threads + wildcard), ignored category silences even when @mentioned (channels + threads + wildcard + beats free-response), require-mention category gates when globally free (and mentions still work, and other channels stay free, and it overrides a channel-level free-response exemption), CSV/YAML/numeric-scalar parsing parity for all three accessors, the mutual-exclusion warning, the ingress admission gate, and the config.yaml → env bridge.

Existing gating suites re-run clean (see Platforms).

## What platforms tested on

- Windows 10 native (git-bash), Python 3.12, discord.py 2.7.1.
- `tests/gateway/test_discord_category_rules.py`: 26 passed.
- `tests/gateway/test_discord_channel_controls.py` + `test_discord_free_response.py` + `test_discord_allowed_channels.py` + `test_discord_allowed_mentions.py` + `test_discord_approval_mentions.py` + `test_discord_bot_filter.py` + `test_discord_roles_dm_scope.py`: 46 passed.
- Full `tests/gateway/ -k discord` (minus `test_discord_voice_mixer.py`, which fails collection on this machine from a pre-existing numpy binary mismatch): 294 passed; the only 4 failures (video/attachment send tests) reproduce identically on clean `main` and are unrelated to this diff.
- `python scripts/check-windows-footguns.py` on both files: clean. `git diff --check`: clean.

## Why this matters to users

**Before:** a Discord bot operator who wanted "respond freely everywhere except inside one category" (e.g. a second bot covering the rest of the server) had to maintain a hand-curated list of every channel ID *outside* that category — a list that silently drifts every time anyone adds a channel. Silencing or whitelisting a whole category likewise required enumerating its children.

**After:** the rule is one line — `require_mention_categories: ["<category_id>"]` or `free_response_categories` / `ignored_categories`. New channels inside the category inherit the rule automatically, and the config survives category renames (IDs only, per the issue's conventions). Multi-bot servers can express complementary per-region gating without drift or enumeration.

## References

- Fixes #38539 (canonical: per-category mention and ignore rules)
- Closes #38540 (duplicate of #38539, byte-identical body)
- Supersedes the partial implementations in #54338 (category scoping for allowed/ignored/free-response only) and #61593 (allowed + free-response categories only) for the `require_mention_categories` gap — this PR delivers all three keys from the issue spec, including the third key that makes "free everywhere except category C" expressible.
