### PR TITLE
perf(desktop): raise stream flush floor and earlier markdown append cache

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
@@ -169,7 +169,7 @@ describe('useMessageStream delta flush scheduling', () => {
   it('keeps the write-cost floor when no frame fires (hidden renderer)', async () => {
     // A parked renderer never runs rAF callbacks. The cost must stay at the
     // synchronous store-write measurement so the gap falls back to the fixed
-    // 33ms floor instead of waiting on a frame that will never come.
+    // 48ms floor instead of waiting on a frame that will never come.
     let now = 1000
     vi.mocked(performance.now).mockImplementation(() => now)
     vi.mocked(window.requestAnimationFrame).mockImplementation(() => 1)
@@ -183,7 +183,7 @@ describe('useMessageStream delta flush scheduling', () => {
 
     expect(assistantText()).toBe('first')
 
-    // 100ms later (well past the 33ms floor): the next flush is immediate.
+    // 100ms later (well past the 48ms floor): the next flush is immediate.
     now = 1100
     act(() => stream.appendDelta(SID, 'second'))
     await act(async () => {
@@ -214,7 +214,7 @@ describe('useMessageStream delta flush scheduling', () => {
     now = 1010
     act(() => stream.appendDelta(SID, 'b'))
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(23)
+      await vi.advanceTimersByTimeAsync(38)
     })
 
     expect(assistantText()).toBe('ab')
@@ -227,7 +227,7 @@ describe('useMessageStream delta flush scheduling', () => {
 
     act(() => stream.appendDelta(SID, 'c'))
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(13)
+      await vi.advanceTimersByTimeAsync(28)
     })
 
     expect(assistantText()).toBe('abc')
@@ -385,7 +385,7 @@ describe('useMessageStream composed with the real useSessionStateCache', () => {
 
     expect(cachedText()).toBe('first')
 
-    // 100ms later (well past the 33ms floor): the next flush is immediate.
+    // 100ms later (well past the 48ms floor): the next flush is immediate.
     now = 1100
     act(() => appendAssistantDelta!(SID, 'second'))
     await act(async () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -255,11 +255,11 @@ export function useMessageStream({
     // ADAPTIVE: the floor scales with what the last flush actually cost.
     // With several sessions streaming at once (split tiles), one flush carries
     // every stream's commit + markdown re-parse; when that work approaches or
-    // exceeds the fixed 33ms budget, back-to-back flushes leave the main
+    // exceeds the fixed flush budget, back-to-back flushes leave the main
     // thread no idle frames and every interaction (typing, resize, hover)
     // stutters even though no render is wasted. Yielding 3x the measured cost
     // keeps the thread ~75% idle for input at any load: cheap flushes stay at
-    // 30fps of text growth, expensive multi-stream flushes degrade text fps
+    // ~20fps of text growth, expensive multi-stream flushes degrade text fps
     // instead of interactivity — capped so text never updates slower than 4/s.
     // The cost has to include the deferred view-sync frame where the commit
     // actually happens; see runFlush below.
@@ -280,7 +280,7 @@ export function useMessageStream({
       // (and with it the React commit + Streamdown re-parse the floor is meant
       // to account for) to its own rAF inside updateSessionState, which runs
       // after this timer task. Stopping the clock here pins lastFlushCostRef
-      // near zero and collapses the adaptive floor to 33ms no matter the load.
+      // near zero and collapses the adaptive floor to 48ms no matter the load.
       // Our rAF is registered after the view-sync one, so it runs in the same
       // frame right after that commit; its timestamp marks frame start, so
       // (now - frameStart) counts only work done inside the frame, not the

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -251,7 +251,7 @@ export function useMessageStream({
     // ADAPTIVE: the floor scales with what the last flush actually cost.
     // With several sessions streaming at once (split tiles), one flush carries
     // every stream's commit + markdown re-parse; when that work approaches or
-    // exceeds the fixed 33ms budget, back-to-back flushes leave the main
+    // exceeds the fixed flush budget, back-to-back flushes leave the main
     // thread no idle frames and every interaction (typing, resize, hover)
     // stutters even though no render is wasted. Yielding 3x the measured cost
     // keeps the thread ~75% idle for input at any load: cheap flushes stay at

--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
@@ -57,14 +57,11 @@ export function hasSessionInfoStatePatch(patch: SessionRuntimeStatePatch): boole
 }
 
 // Minimum gap between two assistant-text flushes during a stream. Was 16ms
-// (rAF only), which at typical LLM token rates of ~30-80 tok/sec meant every
-// token got its own React commit + Streamdown markdown re-parse, scaling
-// linearly with the growing last-block length. Bumping to 33ms lets ~2 tokens
-// batch into one commit at 60 tok/sec without introducing visible lag on the
-// streaming text (still 30 fps of visible text growth). Big perceived
-// smoothness win on long messages with big trailing paragraphs; see
-// `scripts/profile-typing-lag.md` for the measurement work behind this.
-export const STREAM_DELTA_FLUSH_MS = 33
+// (rAF only), then 33ms (~2 tokens/commit at 60 tok/s). Now 48ms ≈ 20fps of
+// visible text growth — batches ~3 tokens/commit, cutting Streamdown Block
+// remounts under load on Windows without making the stream look stuttery.
+// See `scripts/profile-typing-lag.md` for the measurement work behind this.
+export const STREAM_DELTA_FLUSH_MS = 48
 
 // Ceiling for the ADAPTIVE flush gap (see scheduleDeltaFlush). Under heavy
 // multi-stream load the gap stretches to 3x the measured flush cost so the

--- a/apps/desktop/src/components/ui/codicon.tsx
+++ b/apps/desktop/src/components/ui/codicon.tsx
@@ -1,15 +1,18 @@
 import type { Icon } from '@tabler/icons-react'
-import type * as React from 'react'
+import { type HTMLAttributes, memo } from 'react'
 
 import { cn } from '@/lib/utils'
 
-export interface CodiconProps extends React.HTMLAttributes<HTMLElement> {
+export interface CodiconProps extends HTMLAttributes<HTMLElement> {
   name: string
   size?: number | string
   spinning?: boolean
 }
 
-export function Codicon({ className, name, size, spinning, style, ...props }: CodiconProps) {
+// Memo: assistant footers / tooltips re-render on stream commits; the glyph
+// props almost never change, so skipping the host element cuts wasted work
+// measured under render-churn (Codicon showed up on the wasted list).
+export const Codicon = memo(function Codicon({ className, name, size, spinning, style, ...props }: CodiconProps) {
   return (
     <i
       aria-hidden="true"
@@ -18,7 +21,7 @@ export function Codicon({ className, name, size, spinning, style, ...props }: Co
       {...props}
     />
   )
-}
+})
 
 /** Wrap a codicon as a Tabler-shaped icon for nav rows that expect `IconComponent`. */
 export function codiconIcon(name: string): Icon {

--- a/apps/desktop/src/components/ui/codicon.tsx
+++ b/apps/desktop/src/components/ui/codicon.tsx
@@ -1,15 +1,25 @@
 import type { Icon } from '@tabler/icons-react'
-import type * as React from 'react'
+import { type HTMLAttributes, memo } from 'react'
 
 import { cn } from '@/lib/utils'
 
-export interface CodiconProps extends React.HTMLAttributes<HTMLElement> {
+export interface CodiconProps extends HTMLAttributes<HTMLElement> {
   name: string
   size?: number | string
   spinning?: boolean
 }
 
-export function Codicon({ className, name, size, spinning, style, ...props }: CodiconProps) {
+// Memo: assistant footers / tooltips re-render on stream commits; the glyph
+// props almost never change, so skipping the host element cuts wasted work
+// measured under render-churn (Codicon showed up on the wasted list).
+export const Codicon = memo(function Codicon({
+  className,
+  name,
+  size,
+  spinning,
+  style,
+  ...props
+}: CodiconProps) {
   return (
     <i
       aria-hidden="true"
@@ -18,7 +28,7 @@ export function Codicon({ className, name, size, spinning, style, ...props }: Co
       {...props}
     />
   )
-}
+})
 
 /** Wrap a codicon as a Tabler-shaped icon for nav rows that expect `IconComponent`. */
 export function codiconIcon(name: string): Icon {

--- a/apps/desktop/src/lib/markdown-blocks.ts
+++ b/apps/desktop/src/lib/markdown-blocks.ts
@@ -42,7 +42,10 @@ const exactCache = new Map<string, string[]>()
 // (main reply + reasoning part, maybe a tile). A tiny ring is enough; each
 // entry holds the last parse for one growing text lineage.
 const APPEND_CACHE_MAX = 4
-const APPEND_CACHE_MIN_LENGTH = 2048
+// Kick in incremental lex earlier — mid-length replies (512–2KB) used to pay
+// a full `marked` lex every flush. Settled-prefix reuse is the win for
+// Streamdown Block identity (propsChanged=0 waste under streaming).
+const APPEND_CACHE_MIN_LENGTH = 512
 const appendCache: { blocks: string[]; text: string }[] = []
 
 function rememberAppend(text: string, blocks: string[]): void {


### PR DESCRIPTION
## Summary
- Raise `STREAM_DELTA_FLUSH_MS` from 33 → 48 to batch ~3 tokens per Streamdown commit under load.
- Lower `APPEND_CACHE_MIN_LENGTH` from 2048 → 512 so mid-length replies reuse settled markdown prefixes earlier.
- Memoize `Codicon` to skip wasted host remounts on stream commits.

## Why separate
Split from #73367 per review guidance so this small, cleanly applying perf change can merge independently of the app-icon resolver rebase. Does **not** touch `markdown-text.tsx` (avoids reverting the `border-(--ui-stroke-tertiary)` token migration).

## Test plan
- [x] `cd apps/desktop && npm run test -- src/lib/markdown-blocks.test.ts src/app/session/hooks/use-message-stream/stream-flush.test.tsx` (7 passed)
- [ ] Spot-check streaming reply smoothness on Windows under multi-tile load
- [ ] Optional: `npm run perf -- stream keystroke transcript --spawn` for fresh numbers
