### PR TITLE
fix(desktop): show script field in Cron detail when prompt is empty

### DIFF
--- a/apps/desktop/src/app/cron/cron-job-model.test.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { cronEditorUpdates, jobIsScriptOnly, validateCronEditor } from './cron-job-model'
+import { cronEditorUpdates, jobDescription, jobIsScriptOnly, validateCronEditor } from './cron-job-model'
 
 describe('jobIsScriptOnly', () => {
   it('is true when no_agent is set and a script is present', () => {
@@ -11,6 +11,21 @@ describe('jobIsScriptOnly', () => {
     expect(jobIsScriptOnly({ no_agent: false, script: 'echo hi' })).toBe(false)
     expect(jobIsScriptOnly({ no_agent: true, script: '' })).toBe(false)
     expect(jobIsScriptOnly({ no_agent: true, script: null })).toBe(false)
+  })
+})
+
+describe('jobDescription', () => {
+  it('returns the prompt when present', () => {
+    expect(jobDescription({ prompt: 'Summarize mail', script: 'sync.sh' })).toBe('Summarize mail')
+  })
+
+  it('falls back to the script when the prompt is empty (script-only jobs)', () => {
+    expect(jobDescription({ prompt: '', script: 'sync_quillreach_cron.sh' })).toBe('sync_quillreach_cron.sh')
+  })
+
+  it('returns an empty string when neither prompt nor script is set', () => {
+    expect(jobDescription({ prompt: '', script: '' })).toBe('')
+    expect(jobDescription({ prompt: null, script: null })).toBe('')
   })
 })
 

--- a/apps/desktop/src/app/cron/cron-job-model.ts
+++ b/apps/desktop/src/app/cron/cron-job-model.ts
@@ -7,6 +7,11 @@ export function jobIsScriptOnly(job: Pick<CronJob, 'no_agent' | 'script'>): bool
   return Boolean(job.no_agent) && Boolean(asText(job.script).trim())
 }
 
+/** Description shown for a cron job: the prompt, or the script when script-only. */
+export function jobDescription(job: Pick<CronJob, 'prompt' | 'script'>): string {
+  return asText(job.prompt) || asText(job.script)
+}
+
 export type CronEditorValidationError = 'prompt' | 'prompt_and_schedule' | 'schedule'
 
 export interface CronEditorValidationInput {

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -73,7 +73,7 @@ import {
 import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
 
 import { BlueprintSlotControl, blueprintSlotHelp, cleanBlueprintFieldError, initialBlueprintValues } from './blueprints'
-import { cronEditorUpdates, jobIsScriptOnly, validateCronEditor } from './cron-job-model'
+import { cronEditorUpdates, jobDescription, jobIsScriptOnly, validateCronEditor } from './cron-job-model'
 import { jobState, jobTitle, STATE_DOT } from './job-state'
 
 const DEFAULT_DELIVER = 'local'
@@ -613,6 +613,8 @@ function CronJobDetail({
   const isPaused = state === 'paused'
   const deliver = jobDeliver(job)
   const prompt = jobPrompt(job)
+  const scriptOnly = jobIsScriptOnly(job)
+  const description = jobDescription(job)
   const modelOverride = jobModel(job)
 
   return (
@@ -621,6 +623,7 @@ function CronJobDetail({
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="flex min-w-0 flex-wrap items-center gap-2">
             <h3 className="text-[0.95rem] font-semibold tracking-tight text-foreground">{jobTitle(job)}</h3>
+            {scriptOnly && <PanelPill tone="muted">{c.scriptBadge}</PanelPill>}
             <PanelPill tone={STATE_TONE[state] ?? 'muted'}>{c.states[state] ?? state}</PanelPill>
           </div>
           <div className="flex shrink-0 items-center gap-0.5">
@@ -651,10 +654,10 @@ function CronJobDetail({
         ) : null}
       </header>
 
-      {prompt ? (
+      {description ? (
         <section className="space-y-1.5">
-          <PanelSectionLabel>{c.promptLabel}</PanelSectionLabel>
-          <PanelBlock>{prompt}</PanelBlock>
+          <PanelSectionLabel>{scriptOnly && !prompt ? c.scriptLabel : c.promptLabel}</PanelSectionLabel>
+          <PanelBlock>{description}</PanelBlock>
         </section>
       ) : null}
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1459,6 +1459,8 @@ export const ar = defineLocale({
     namePlaceholder: 'مثال: الملخص الصباحي',
     promptLabel: 'الرسالة',
     promptPlaceholder: 'ماذا تريد من Hermes أن يفعل؟',
+    scriptLabel: 'البرنامج النصي',
+    scriptBadge: 'برنامج نصي',
     frequencyLabel: 'التكرار',
     deliverLabel: 'التسليم',
     customScheduleLabel: 'جدول مخصص',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1729,6 +1729,8 @@ export const en: Translations = {
     namePlaceholder: 'Morning briefing',
     promptLabel: 'Prompt',
     promptPlaceholder: 'Summarize my unread Slack threads and email me the top 5...',
+    scriptLabel: 'Script',
+    scriptBadge: 'script',
     frequencyLabel: 'Frequency',
     deliverLabel: 'Deliver to',
     deliverNeedsHomeChannel: 'set a home channel first',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1570,6 +1570,8 @@ export const ja = defineLocale({
     namePlaceholder: '例: 日次サマリー',
     promptLabel: 'プロンプト',
     promptPlaceholder: '実行ごとにエージェントが行う内容は？',
+    scriptLabel: 'スクリプト',
+    scriptBadge: 'スクリプト',
     frequencyLabel: '頻度',
     deliverLabel: '配信先',
     deliverNeedsHomeChannel: '先にホームチャンネルを設定してください',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1435,6 +1435,8 @@ export interface Translations {
     namePlaceholder: string
     promptLabel: string
     promptPlaceholder: string
+    scriptLabel: string
+    scriptBadge: string
     frequencyLabel: string
     deliverLabel: string
     deliverNeedsHomeChannel: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1515,6 +1515,8 @@ export const zhHant = defineLocale({
     namePlaceholder: '例如：每日摘要',
     promptLabel: '提示詞',
     promptPlaceholder: '代理每次執行時應做什麼？',
+    scriptLabel: '指令碼',
+    scriptBadge: '指令碼',
     frequencyLabel: '頻率',
     deliverLabel: '傳遞至',
     deliverNeedsHomeChannel: '請先設定主頻道',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1923,6 +1923,8 @@ export const zh: Translations = {
     namePlaceholder: '晨间简报',
     promptLabel: '提示词',
     promptPlaceholder: '总结我未读的 Slack 话题，并把前 5 条邮件发给我…',
+    scriptLabel: '脚本',
+    scriptBadge: '脚本',
     frequencyLabel: '频率',
     deliverLabel: '投递至',
     deliverNeedsHomeChannel: '请先设置主频道',


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #42433 #61403 #62341
## What does this PR do?

Fixes the blank-detail half of #42433: script-only (`no_agent`) cron jobs rendered with an empty description in the Desktop Cron view because the detail panel rendered only the job's `prompt`, and script jobs have `prompt: ""`.

Changes:
- New `jobDescription()` in `cron-job-model.ts`: returns `prompt || script`, so a script-only job shows its script instead of a blank block.
- Muted **script** badge next to the state pill for script-only jobs (`jobIsScriptOnly`), so users can tell script jobs from prompt jobs at a glance.
- The detail section label switches to "Script" when the description comes from the script.
- i18n keys `scriptLabel` / `scriptBadge` added to all five locales (ar, en, ja, zh, zh-hant).

## Related Issue

Addresses #42433 (blank prompt / script never shown). Run-history fallback for script jobs is a separate facet tracked in #62341 / PR #61403.

## How to Test

1. Create a cron job via CLI/config with a `script` and no `prompt` (`no_agent: true`).
2. Open the Desktop Cron view → select the job.
3. Previously: blank description, no way to tell it's a script job. Now: the script path is shown in the description area with a "script" badge.

Unit tests: `jobDescription()` covered in `cron-job-model.test.ts` (prompt wins when present, script fallback, empty when neither).

## What platforms tested

Windows 10 native (git-bash). `vitest run --project ui` on `cron-job-model.test.ts` (13/13) + `languages.test.ts` (4/4); `tsc -p tsconfig.json --noEmit` clean; `git diff --check` clean. Change touches renderer display only.

## Why this matters to users

Before: script-based cron jobs — a fully supported, first-class job type — looked broken in the Desktop Cron view: blank body, "No runs" history, nothing telling you what the job does. After: the job's script is visible in its detail view with a clear "script" badge, so you can see at a glance what's scheduled. (Run history for script jobs is addressed separately in #61403.)

Part of #42433
Part of #62341

Part of #44080
