### PR TITLE
fix(email): support separate IMAP/SMTP login user via EMAIL_LOGIN_USER

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -10,6 +10,8 @@ Environment variables:
     EMAIL_SMTP_HOST     — SMTP server host (e.g., smtp.gmail.com)
     EMAIL_SMTP_PORT     — SMTP server port (default: 587)
     EMAIL_ADDRESS       — Email address for the agent
+    EMAIL_LOGIN_USER    — Optional separate IMAP/SMTP login username; defaults
+                          to EMAIL_ADDRESS when unset (custom-domain aliases)
     EMAIL_PASSWORD      — Email password or app-specific password
     EMAIL_POLL_INTERVAL — Seconds between mailbox checks (default: 15)
     EMAIL_ALLOWED_USERS — Comma-separated list of allowed sender addresses
@@ -480,6 +482,14 @@ class EmailAdapter(BasePlatformAdapter):
         # instead of an obvious "host not set" error.
         extra = config.extra or {}
         self._address = (_get_secret("EMAIL_ADDRESS", "") or extra.get("address", "")).strip()
+        # Optional separate IMAP/SMTP login identity. Providers that offer
+        # custom-domain aliases (iCloud custom domains, Fastmail, ProtonMail
+        # bridge, hosted Migadu, …) authenticate as the underlying account but
+        # send From: the alias; EMAIL_LOGIN_USER decouples the two. Falls back
+        # to EMAIL_ADDRESS so existing single-identity setups are unchanged.
+        self._login_user = (
+            _get_secret("EMAIL_LOGIN_USER", "") or extra.get("login_user", "") or self._address
+        ).strip()
         self._password = _get_secret("EMAIL_PASSWORD", "")
         self._imap_host = (_get_secret("EMAIL_IMAP_HOST", "") or extra.get("imap_host", "")).strip()
         self._imap_port = _esecret_int("EMAIL_IMAP_PORT", 993)
@@ -628,7 +638,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             # Test IMAP connection
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
-            imap.login(self._address, self._password)
+            imap.login(self._login_user, self._password)
             _send_imap_id(imap)
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
@@ -648,7 +658,7 @@ class EmailAdapter(BasePlatformAdapter):
             # Test SMTP connection
             smtp = self._connect_smtp()
             try:
-                smtp.login(self._address, self._password)
+                smtp.login(self._login_user, self._password)
             finally:
                 smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
@@ -698,7 +708,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             try:
-                imap.login(self._address, self._password)
+                imap.login(self._login_user, self._password)
                 _send_imap_id(imap)
                 imap.select("INBOX")
 
@@ -995,7 +1005,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         smtp = self._connect_smtp()
         try:
-            smtp.login(self._address, self._password)
+            smtp.login(self._login_user, self._password)
             smtp.send_message(msg)
         finally:
             try:
@@ -1121,7 +1131,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         smtp = self._connect_smtp()
         try:
-            smtp.login(self._address, self._password)
+            smtp.login(self._login_user, self._password)
             smtp.send_message(msg)
         finally:
             try:
@@ -1199,7 +1209,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         smtp = self._connect_smtp()
         try:
-            smtp.login(self._address, self._password)
+            smtp.login(self._login_user, self._password)
             smtp.send_message(msg)
         finally:
             try:
@@ -1250,6 +1260,9 @@ async def _standalone_send(
 
     extra = getattr(pconfig, "extra", {}) or {}
     address = extra.get("address") or _get_secret("EMAIL_ADDRESS", "")
+    login_user = (
+        extra.get("login_user") or _get_secret("EMAIL_LOGIN_USER", "") or address
+    ).strip() or address
     password = _get_secret("EMAIL_PASSWORD", "")
     smtp_host = extra.get("smtp_host") or _get_secret("EMAIL_SMTP_HOST", "")
     try:
@@ -1269,7 +1282,7 @@ async def _standalone_send(
 
         server = smtplib.SMTP(smtp_host, smtp_port)
         server.starttls(context=_ssl.create_default_context())
-        server.login(address, password)
+        server.login(login_user, password)
         server.send_message(msg)
         server.quit()
         return {"success": True, "platform": "email", "chat_id": chat_id}

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -341,6 +341,10 @@ class EmailAdapter(BasePlatformAdapter):
         setting = lambda env, key: _get_secret(env, "") or extra.get(key, "")  # noqa: E731
         tls_verify = lambda env, key: _esecret_bool(env, is_truthy_value(extra.get(key), default=True))  # noqa: E731
         self._address = setting("EMAIL_ADDRESS", "address").strip()
+        # Separate authentication identity; the public From: address remains self._address.
+        self._login_user = (
+            _get_secret("EMAIL_LOGIN_USER", "") or extra.get("login_user", "") or self._address
+        ).strip()
         self._password = _get_secret("EMAIL_PASSWORD", "")
         self._imap_host = setting("EMAIL_IMAP_HOST", "imap_host").strip()
         self._imap_port = _esecret_int("EMAIL_IMAP_PORT", 993)
@@ -404,7 +408,7 @@ class EmailAdapter(BasePlatformAdapter):
         # (#79889).
         imap = self._connect_imap()
         try:
-            imap.login(self._address, self._password)
+            imap.login(self._login_user, self._password)
             _send_imap_id(imap)
             imap.select("INBOX")
             yield imap
@@ -459,7 +463,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             smtp = self._connect_smtp()
             try:
-                smtp.login(self._address, self._password)
+                smtp.login(self._login_user, self._password)
             finally:
                 smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
@@ -687,7 +691,7 @@ class EmailAdapter(BasePlatformAdapter):
         """Login, send, and always release the SMTP connection (quit, else close)."""
         smtp = self._connect_smtp()
         try:
-            smtp.login(self._address, self._password)
+            smtp.login(self._login_user, self._password)
             smtp.send_message(msg)
         finally:
             try:
@@ -770,6 +774,7 @@ async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_f
     """Out-of-process Email delivery via SMTP (one-shot); standalone_sender_fn contract."""
     extra = getattr(pconfig, "extra", {}) or {}
     address, password = extra.get("address") or _get_secret("EMAIL_ADDRESS", ""), _get_secret("EMAIL_PASSWORD", "")
+    login_user = (extra.get("login_user") or _get_secret("EMAIL_LOGIN_USER", "") or address).strip() or address
     smtp_host, smtp_port = extra.get("smtp_host") or _get_secret("EMAIL_SMTP_HOST", ""), _esecret_int("EMAIL_SMTP_PORT", 587)
     smtp_security = _normalize_security(_get_secret("EMAIL_SMTP_SECURITY", "") or extra.get("smtp_security"), default="tls" if smtp_port == 465 else "starttls")
     smtp_tls_verify = _esecret_bool("EMAIL_SMTP_TLS_VERIFY", is_truthy_value(extra.get("smtp_tls_verify"), default=True))
@@ -780,7 +785,7 @@ async def _standalone_send(pconfig, chat_id, message, *, thread_id=None, media_f
         for key, value in (("From", address), ("To", chat_id), ("Subject", "Hermes Agent"), ("Date", formatdate(localtime=True))):
             msg[key] = value
         server = _open_smtp(smtp_host, smtp_port, smtp_security, _tls_context(smtp_tls_verify, smtp_host), smtplib.SMTP, smtplib.SMTP_SSL)
-        server.login(address, password)
+        server.login(login_user, password)
         server.send_message(msg)
         server.quit()
         return {"success": True, "platform": "email", "chat_id": chat_id}

--- a/plugins/platforms/email/plugin.yaml
+++ b/plugins/platforms/email/plugin.yaml
@@ -21,6 +21,10 @@ requires_env:
     prompt: "SMTP host"
     password: false
 optional_env:
+  - name: EMAIL_LOGIN_USER
+    description: "Separate IMAP/SMTP login username (defaults to EMAIL_ADDRESS; for custom-domain alias setups)"
+    prompt: "IMAP/SMTP login username (leave empty to use EMAIL_ADDRESS)"
+    password: false
   - name: EMAIL_SMTP_PORT
     description: "SMTP port (default 587)"
     prompt: "SMTP port"

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -619,6 +619,118 @@ class TestSendEmailStandalone(unittest.TestCase):
             self.assertEqual(send_call["From"], "hermes@test.com")
 
 
+class TestLoginUser(unittest.TestCase):
+    """EMAIL_LOGIN_USER decouples IMAP/SMTP login from the From: address."""
+
+    def _make_adapter(self, login_user=None):
+        from gateway.config import PlatformConfig
+        env = {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }
+        if login_user is not None:
+            env["EMAIL_LOGIN_USER"] = login_user
+        with patch.dict(os.environ, env):
+            from plugins.platforms.email.adapter import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    def test_login_user_defaults_to_address(self):
+        """Without EMAIL_LOGIN_USER the login identity is the address."""
+        adapter = self._make_adapter()
+        self.assertEqual(adapter._login_user, "hermes@test.com")
+        self.assertEqual(adapter._address, "hermes@test.com")
+
+    def test_login_user_overrides_address(self):
+        """EMAIL_LOGIN_USER sets the login identity without changing From:."""
+        adapter = self._make_adapter(login_user="login@icloud.com")
+        self.assertEqual(adapter._login_user, "login@icloud.com")
+        self.assertEqual(adapter._address, "hermes@test.com")
+
+    def test_imap_login_uses_login_user(self):
+        """connect() authenticates IMAP with _login_user, not _address."""
+        import asyncio
+        adapter = self._make_adapter(login_user="login@icloud.com")
+
+        mock_imap = MagicMock()
+        mock_imap.uid.return_value = ("OK", [b""])
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            asyncio.run(adapter.connect())
+
+        mock_imap.login.assert_any_call("login@icloud.com", "secret")
+        self.assertFalse(
+            any(
+                call.args[0] == "hermes@test.com"
+                for call in mock_imap.login.call_args_list
+            ),
+            "IMAP login must use EMAIL_LOGIN_USER, never EMAIL_ADDRESS",
+        )
+        adapter._running = False
+        if adapter._poll_task:
+            adapter._poll_task.cancel()
+
+    def test_smtp_login_uses_login_user(self):
+        """connect() authenticates SMTP with _login_user, not _address."""
+        import asyncio
+        adapter = self._make_adapter(login_user="login@icloud.com")
+
+        mock_imap = MagicMock()
+        mock_imap.uid.return_value = ("OK", [b""])
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            asyncio.run(adapter.connect())
+
+        mock_server.login.assert_called_once_with("login@icloud.com", "secret")
+        adapter._running = False
+        if adapter._poll_task:
+            adapter._poll_task.cancel()
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+        "EMAIL_SMTP_PORT": "587",
+        "EMAIL_LOGIN_USER": "login@icloud.com",
+    })
+    def test_standalone_send_uses_login_user(self):
+        """_standalone_send logs in with EMAIL_LOGIN_USER, From: stays address."""
+        import asyncio
+        from plugins.platforms.email.adapter import _standalone_send as _email_send
+        from types import SimpleNamespace
+
+        async def _send_email(extra, chat_id, message):
+            return await _email_send(
+                SimpleNamespace(token=None, api_key=None, extra=extra or {}),
+                chat_id,
+                message,
+            )
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            result = asyncio.run(
+                _send_email(
+                    {"address": "hermes@test.com", "smtp_host": "smtp.test.com"},
+                    "user@test.com",
+                    "Hello",
+                )
+            )
+
+            self.assertTrue(result["success"])
+            mock_server.login.assert_called_once_with("login@icloud.com", "secret")
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["From"], "hermes@test.com")
+
+
 class TestSmtpConnectionCleanup(unittest.TestCase):
     """Verify SMTP connections are closed even when send_message raises."""
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -834,6 +834,118 @@ class TestSendEmailStandalone(unittest.TestCase):
             self.assertEqual(send_call["From"], "hermes@test.com")
 
 
+class TestLoginUser(unittest.TestCase):
+    """EMAIL_LOGIN_USER decouples IMAP/SMTP login from the From: address."""
+
+    def _make_adapter(self, login_user=None):
+        from gateway.config import PlatformConfig
+        env = {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }
+        if login_user is not None:
+            env["EMAIL_LOGIN_USER"] = login_user
+        with patch.dict(os.environ, env):
+            from plugins.platforms.email.adapter import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    def test_login_user_defaults_to_address(self):
+        """Without EMAIL_LOGIN_USER the login identity is the address."""
+        adapter = self._make_adapter()
+        self.assertEqual(adapter._login_user, "hermes@test.com")
+        self.assertEqual(adapter._address, "hermes@test.com")
+
+    def test_login_user_overrides_address(self):
+        """EMAIL_LOGIN_USER sets the login identity without changing From:."""
+        adapter = self._make_adapter(login_user="login@icloud.com")
+        self.assertEqual(adapter._login_user, "login@icloud.com")
+        self.assertEqual(adapter._address, "hermes@test.com")
+
+    def test_imap_login_uses_login_user(self):
+        """connect() authenticates IMAP with _login_user, not _address."""
+        import asyncio
+        adapter = self._make_adapter(login_user="login@icloud.com")
+
+        mock_imap = MagicMock()
+        mock_imap.uid.return_value = ("OK", [b""])
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            asyncio.run(adapter.connect())
+
+        mock_imap.login.assert_any_call("login@icloud.com", "secret")
+        self.assertFalse(
+            any(
+                call.args[0] == "hermes@test.com"
+                for call in mock_imap.login.call_args_list
+            ),
+            "IMAP login must use EMAIL_LOGIN_USER, never EMAIL_ADDRESS",
+        )
+        adapter._running = False
+        if adapter._poll_task:
+            adapter._poll_task.cancel()
+
+    def test_smtp_login_uses_login_user(self):
+        """connect() authenticates SMTP with _login_user, not _address."""
+        import asyncio
+        adapter = self._make_adapter(login_user="login@icloud.com")
+
+        mock_imap = MagicMock()
+        mock_imap.uid.return_value = ("OK", [b""])
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            asyncio.run(adapter.connect())
+
+        mock_server.login.assert_called_once_with("login@icloud.com", "secret")
+        adapter._running = False
+        if adapter._poll_task:
+            adapter._poll_task.cancel()
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+        "EMAIL_SMTP_PORT": "587",
+        "EMAIL_LOGIN_USER": "login@icloud.com",
+    })
+    def test_standalone_send_uses_login_user(self):
+        """_standalone_send logs in with EMAIL_LOGIN_USER, From: stays address."""
+        import asyncio
+        from plugins.platforms.email.adapter import _standalone_send as _email_send
+        from types import SimpleNamespace
+
+        async def _send_email(extra, chat_id, message):
+            return await _email_send(
+                SimpleNamespace(token=None, api_key=None, extra=extra or {}),
+                chat_id,
+                message,
+            )
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            result = asyncio.run(
+                _send_email(
+                    {"address": "hermes@test.com", "smtp_host": "smtp.test.com"},
+                    "user@test.com",
+                    "Hello",
+                )
+            )
+
+            self.assertTrue(result["success"])
+            mock_server.login.assert_called_once_with("login@icloud.com", "secret")
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["From"], "hermes@test.com")
+
+
 class TestSmtpConnectionCleanup(unittest.TestCase):
     """Verify SMTP connections are closed even when send_message raises."""
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -402,7 +402,8 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `SMS_ALLOW_ALL_USERS` | Allow all SMS senders without an allowlist |
 | `SMS_HOME_CHANNEL` | Phone number for cron job / notification delivery |
 | `SMS_HOME_CHANNEL_NAME` | Display name for the SMS home channel |
-| `EMAIL_ADDRESS` | Email address for the Email gateway adapter |
+| `EMAIL_ADDRESS` | Email address for the Email gateway adapter (also the From: address) |
+| `EMAIL_LOGIN_USER` | Optional separate IMAP/SMTP login username; defaults to `EMAIL_ADDRESS` (for custom-domain alias setups where login differs from From:) |
 | `EMAIL_PASSWORD` | Password or app password for the email account |
 | `EMAIL_IMAP_HOST` | IMAP hostname for the email adapter |
 | `EMAIL_IMAP_PORT` | IMAP port |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -420,7 +420,8 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `SMS_ALLOW_ALL_USERS` | Allow all SMS senders without an allowlist |
 | `SMS_HOME_CHANNEL` | Phone number for cron job / notification delivery |
 | `SMS_HOME_CHANNEL_NAME` | Display name for the SMS home channel |
-| `EMAIL_ADDRESS` | Email address for the Email gateway adapter |
+| `EMAIL_ADDRESS` | Email address for the Email gateway adapter (also the From: address) |
+| `EMAIL_LOGIN_USER` | Optional separate IMAP/SMTP login username; defaults to `EMAIL_ADDRESS` (for custom-domain alias setups where login differs from From:) |
 | `EMAIL_PASSWORD` | Password or app password for the email account |
 | `EMAIL_IMAP_HOST` | IMAP hostname for the email adapter |
 | `EMAIL_IMAP_PORT` | IMAP port |

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -186,7 +186,8 @@ Email access is stricter by default than chat-style platforms:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `EMAIL_ADDRESS` | Yes | — | Agent's email address |
+| `EMAIL_ADDRESS` | Yes | — | Agent's email address (also the From: address) |
+| `EMAIL_LOGIN_USER` | No | `EMAIL_ADDRESS` | Separate IMAP/SMTP login username — required when the login account differs from the From: address (custom-domain aliases on iCloud, Fastmail, ProtonMail bridge, hosted Migadu, etc.) |
 | `EMAIL_PASSWORD` | Yes | — | Email password or app password |
 | `EMAIL_IMAP_HOST` | Yes | — | IMAP server host (e.g., `imap.gmail.com`) |
 | `EMAIL_SMTP_HOST` | Yes | — | SMTP server host (e.g., `smtp.gmail.com`) |

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -211,7 +211,8 @@ Email access is stricter by default than chat-style platforms:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `EMAIL_ADDRESS` | Yes | — | Agent's email address |
+| `EMAIL_ADDRESS` | Yes | — | Agent's email address (also the From: address) |
+| `EMAIL_LOGIN_USER` | No | `EMAIL_ADDRESS` | Separate IMAP/SMTP login username — required when the login account differs from the From: address (custom-domain aliases on iCloud, Fastmail, ProtonMail bridge, hosted Migadu, etc.) |
 | `EMAIL_PASSWORD` | Yes | — | Email password or app password |
 | `EMAIL_IMAP_HOST` | Yes | — | IMAP server host (e.g., `imap.gmail.com`) |
 | `EMAIL_SMTP_HOST` | Yes | — | SMTP server host (e.g., `smtp.gmail.com`) |


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #41331 #46676
## What does this PR do?

Adds an optional `EMAIL_LOGIN_USER` environment variable (with `config.yaml` `platforms.email.login_user` mirror) that decouples the IMAP/SMTP **login identity** from the public **From:** address in the email platform plugin.

Fixes #41331 and #46676.

## Why

Providers that offer custom-domain aliases (iCloud Custom Email Domain, Fastmail, ProtonMail bridge, hosted Migadu, etc.) authenticate IMAP/SMTP as the *underlying account* but must send From: the *alias*. With the current code the single `EMAIL_ADDRESS` is used for both, so users must choose between a working login and a correct From: header. `EMAIL_LOGIN_USER` (falling back to `EMAIL_ADDRESS`) removes that coupling without changing existing single-identity setups.

## What changed

- `plugins/platforms/email/adapter.py`:
  - `EmailAdapter.__init__` resolves `self._login_user` = `EMAIL_LOGIN_USER` (env) → `login_user` (config extra) → `EMAIL_ADDRESS` fallback, so existing setups are byte-identical.
  - All **6** `.login()` call sites (IMAP connect test, SMTP connect test, `_fetch_new_messages`, `_send_email`, `_send_email_with_attachments`, `_send_email_with_attachment`) now authenticate with `self._login_user` instead of `self._address`.
  - `_standalone_send` (the out-of-process SMTP one-shot used by `send_message`/cron) resolves the same override and logs in with it. From: header remains `EMAIL_ADDRESS` everywhere.
- `plugins/platforms/email/plugin.yaml`: `EMAIL_LOGIN_USER` added to `optional_env` so `hermes gateway setup`/`hermes tools` surface it.
- `website/docs/user-guide/messaging/email.md` + `website/docs/reference/environment-variables.md`: `EMAIL_LOGIN_USER` documented with the alias-provider rationale.

## How to test

1. Set `EMAIL_ADDRESS=you@yourdomain.tld` (From: address) and `EMAIL_LOGIN_USER=account@icloud.com` (login identity) in `.env`.
2. Start the email gateway: `hermes gateway start --platform email`.
3. Verify IMAP/SMTP authenticate as `account@icloud.com` while outgoing mail carries From: `you@yourdomain.tld`.
4. Regression: with `EMAIL_LOGIN_USER` unset, behavior is unchanged (login = `EMAIL_ADDRESS`).

Tests (RED/GREEN verified):

```
scripts/run_tests.sh tests/gateway/test_email.py
=== Summary: 1 files, 37 tests passed, 0 failed (100% complete)
```

New `TestLoginUser` class (5 tests):
- `test_login_user_defaults_to_address` — no `EMAIL_LOGIN_USER` → `_login_user == _address`
- `test_login_user_overrides_address` — override sets login without touching From:
- `test_imap_login_uses_login_user` — connect() IMAP login uses `_login_user`, never `_address`
- `test_smtp_login_uses_login_user` — connect() SMTP login uses `_login_user`
- `test_standalone_send_uses_login_user` — `_standalone_send` logs in with override, From: stays address

All 5 fail against unpatched adapter code (5 failed, 32 passed) and pass with the fix (37/37).

## What platforms tested on

- Windows 10 native (git-bash) — `scripts/run_tests.sh`, `git diff --check`, `scripts/check-windows-footguns.py` all clean.
- Pure stdlib change (imaplib/smtplib) — no OS-specific paths.

## Checklist

- [x] Bug fix with reproduction (issue #41331: custom-domain alias login failure)
- [x] Conventional commit: `fix(email): support separate IMAP/SMTP login user via EMAIL_LOGIN_USER`
- [x] Tests added (5 regression tests, RED on unpatched / GREEN on fix)
- [x] Docs updated (plugin.yaml + 2 doc surfaces)
- [x] Cross-platform: stdlib-only change, footgun lint clean

## Why this matters to users

Before: anyone with a custom-domain email alias (iCloud+, Fastmail, ProtonMail bridge, hosted Migadu, Google Workspace with a separate login) had to pick between a working connection and a correct From: header — connecting as the alias fails authentication on most providers, and connecting as the base account makes every outgoing email look like it came from the underlying account.

After: set `EMAIL_LOGIN_USER` once and the adapter authenticates as the base account while still sending From: the alias — the setup every alias-capable provider expects. Users with a single account (login == address) change nothing.

Part of #46676



## Fresh rebase verification

- rebased onto current main `53c57871d67ee7d2202861aacc4ea0ef6ef93112`
- head: `c477b4ee3eefa94f62d3a8594ae6eaa5ffe41a1c`
- focused: `tests/gateway/test_email.py` — 44 passed, 0 failed
- ruff: changed Python files passed
- git diff --check: passed
