### PR TITLE
fix(gateway): use merged ps -Aeww form in gateway PID scan

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -480,7 +480,10 @@ def _scan_gateway_pids(
                     current_cmd = ""
         else:
             # Try /proc first (works in Docker without procps installed),
-            # fall back to ps -A eww.
+            # fall back to ps -A eww.  Use the merged -Aeww form: macOS 26's
+            # ps rejects the separated `ps -A eww` spelling (exit 1), which
+            # silently emptied every gateway scan on that platform (#77276
+            # follow-up — the reaper could never see its orphans there).
             _found_via_proc = False
             if os.path.isdir("/proc"):
                 try:
@@ -507,7 +510,7 @@ def _scan_gateway_pids(
 
             if not _found_via_proc:
                 result = subprocess.run(
-                    ["ps", "-A", "eww", "-o", "pid=,command="],
+                    ["ps", "-Aeww", "-o", "pid=,command="],
                     capture_output=True,
                     text=True, encoding='utf-8', errors='replace',
                     timeout=10,

--- a/tests/hermes_cli/test_gateway_proc_fallback.py
+++ b/tests/hermes_cli/test_gateway_proc_fallback.py
@@ -105,3 +105,82 @@ class TestProcFallback:
         # PermissionError swallowed — empty result, no crash
         assert 12345 not in pids
         mock_ps.assert_not_called()  # /proc dir existed, so ps not called
+
+
+# ---------------------------------------------------------------------------
+# ps fallback branch (/proc absent) — pins the merged `-Aeww` spelling that
+# macOS 26 requires (`ps -A eww` exits 1 there), plus the parser's pid/command
+# extraction, exit-code handling, and BSD `ps aux` column fallback.
+# ---------------------------------------------------------------------------
+
+_PS_AEWW_OUTPUT = """\
+  PID COMMAND
+    1 /sbin/launchd
+12345 python -m hermes_cli.main gateway run
+23456 python -m hermes_cli.main gateway status
+34567 python -m some_other_thing
+45678 grep gateway
+"""
+
+
+def _ps_path_mocks(ps_returncode=0, ps_stdout=_PS_AEWW_OUTPUT):
+    """Patches that force _scan_gateway_pids down the ps fallback branch:
+    POSIX (not Windows), no /proc, and a canned ps subprocess result."""
+    result = MagicMock()
+    result.returncode = ps_returncode
+    result.stdout = ps_stdout
+    return result
+
+
+class TestPsFallback:
+    """_scan_gateway_pids uses `ps -Aeww` when /proc is absent."""
+
+    def _run_scan(self, ps_result):
+        with (
+            patch("hermes_cli.gateway.is_windows", return_value=False),
+            patch("os.path.isdir", return_value=False),  # no /proc
+            patch("hermes_cli.gateway._get_ancestor_pids", return_value=set()),
+            patch("subprocess.run", return_value=ps_result) as mock_ps,
+        ):
+            pids = gateway_mod._scan_gateway_pids(set(), all_profiles=True)
+        return pids, mock_ps
+
+    def test_invokes_ps_with_merged_aeww_spelling(self):
+        """Pin the exact argv: `ps -Aeww`, never the separated `ps -A eww`
+        that macOS 26 rejects with exit 1 (the bug this fixes)."""
+        _, mock_ps = self._run_scan(_ps_path_mocks())
+        argv = mock_ps.call_args[0][0]
+        assert argv[:2] == ["ps", "-Aeww"], (
+            f"ps must use the merged -Aeww form (macOS 26 rejects '-A eww'); got {argv}"
+        )
+
+    def test_extracts_gateway_pid_from_ps_output(self):
+        """A realistic `ps -Aeww -o pid=,command=` listing yields only the
+        gateway `run` process — status/management, unrelated, and grep lines
+        are all excluded."""
+        pids, _ = self._run_scan(_ps_path_mocks())
+        assert 12345 in pids
+        assert 23456 not in pids  # `gateway status` is not a runtime process
+        assert 34567 not in pids  # unrelated process
+        assert 45678 not in pids  # grep line
+
+    def test_nonzero_ps_exit_returns_empty(self):
+        """macOS 26's `ps -A eww` failure mode: a non-zero exit means no
+        scan results (and no crash), not a partial parse."""
+        pids, _ = self._run_scan(_ps_path_mocks(ps_returncode=1, ps_stdout=""))
+        assert pids == []
+
+    def test_bsd_ps_aux_column_fallback(self):
+        """When the `pid= command=` header parse misses, the parser falls back
+        to BSD `ps aux` column positions (USER PID ... COMMAND)."""
+        aux_output = (
+            "USER              PID  %CPU %MEM      VSZ    RSS   TT  STAT STARTED      TIME COMMAND\n"
+            "wmbt7052        12345   0.0  0.2 435534576 136768   ??  S     8:01AM   0:00.94 "
+            "python -m hermes_cli.main gateway run\n"
+            "wmbt7052        23456   0.0  0.1 435534576  55056   ??  S     8:01AM   0:00.12 "
+            "python -m some_other_thing\n"
+        )
+        pids, _ = self._run_scan(_ps_path_mocks(ps_stdout=aux_output))
+        assert 12345 in pids
+        assert 23456 not in pids
+


### PR DESCRIPTION
## What does this PR do?

Fixes the gateway PID scan on macOS 26, where `_scan_gateway_pids()` invokes `ps -A eww` (separated flags). macOS 26's `ps` rejects that spelling with exit 1, so the scan silently returns `[]` and `find_gateway_pids()` never sees a single gateway process on that platform. Downstream, the orphan reaper adopted in #75936 (`_reap_unsupervised_gateway_orphans`) — and any caller that relies on the scan to spot gateway processes — can never actually reap anything on macOS.

The merged `-Aeww` form is POSIX-portable: Linux accepts both spellings, macOS 26 accepts only the merged one.

Discovered while E2E-testing a fix for #77276: a masqueraded `python -m hermes_cli.main gateway run --replace` process was invisible to `find_gateway_pids` until this change; after it, the scan finds the process and the reaper terminates it (SIGTERM → 5s grace → SIGKILL).

## Related Issue

Refs #75936 (the reaper this scan feeds), #77276 (the Desktop-managed orphan path where the broken scan was reproduced). No dedicated issue filed for the ps spelling itself — happy to open one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: `_scan_gateway_pids()` — `["ps", "-A", "eww", ...]` → `["ps", "-Aeww", ...]`, with a comment recording the platform constraint so the separated form doesn't get "cleaned up" back.

## How to Test

1. On macOS 26: `ps -A eww -o pid=,command=` exits 1; `ps -Aeww -o pid=,command=` exits 0. (macOS 26.5.1, build 25F80.)
2. Spawn a decoy gateway: `/bin/bash -c 'exec -a "python -m hermes_cli.main gateway run --replace" sleep 600'`
3. Before this change: `find_gateway_pids()` → `[]`. After: `find_gateway_pids()` → `[<pid>]`, and `_reap_unsupervised_gateway_orphans()` terminates the decoy.
4. `scripts/run_tests.sh tests/hermes_cli/test_gateway.py -q` — 15/15 pass.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A: existing `test_gateway.py` suite covers the scan path; the fix is a one-flag spelling change verified E2E on the affected platform
- [x] I've tested on my platform: macOS 26.5.1 (ARM64)

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment added at the changed call site)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — merged `-Aeww` is POSIX-portable; Linux accepts both forms, Windows path (wmic/PowerShell) untouched
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ ps -A eww -o pid=,command= ; echo "exit=$?"   # macOS 26.5.1
exit=1
$ ps -Aeww -o pid=,command= | grep "gateway run --replace" ; echo "exit=$?"
26163 python -m hermes_cli.main gateway run --replace 300
exit=0
```
