### PR TITLE
docs(skills): add risk classification to grounded-citations

### DIFF
--- a/skills/research/grounded-citations/SKILL.md
+++ b/skills/research/grounded-citations/SKILL.md
@@ -2,6 +2,7 @@
 name: grounded-citations
 description: "Ground answers and documents in cited, verifiable sources."
 version: 1.1.0
+risk: DRAFT
 author: Hermes Agent + Teknium
 license: MIT
 platforms: [linux, macos, windows]

--- a/skills/research/grounded-citations/SKILL.md
+++ b/skills/research/grounded-citations/SKILL.md
@@ -2,6 +2,7 @@
 name: grounded-citations
 description: "Ground answers and documents in cited, verifiable sources."
 version: 1.2.0
+risk: DRAFT
 author: Hermes Agent + Teknium
 license: MIT
 platforms: [linux, macos, windows]


### PR DESCRIPTION
## Summary

`skills/research/grounded-citations/SKILL.md` was added in #71698 (and extended in #77104) without a `risk` field in frontmatter. The nightly skill-frontmatter validator flags it.

## Change

- Add `risk: DRAFT` to the skill's frontmatter.

Classification: the skill produces written documents/reports (markdown, PDF, docx, slides) and fact-checking chains — write-side work, never sends or destroys. `DRAFT` matches the documented risk-class table. No behavior change.

## Validation

- `validate_skill_frontmatter.py` passes for this skill after the change (verified locally).
