### PR TITLE
fix: add usedforsecurity=False to hashlib.sha1 calls for FIPS compliance

### DIFF
--- a/optional-skills/security/unbroker/scripts/dossier.py
+++ b/optional-skills/security/unbroker/scripts/dossier.py
@@ -22,7 +22,7 @@ def now() -> str:
 def new_subject_id(full_name: str = "") -> str:
     # Opaque id: derives NOTHING from the name, so PII never leaks into directory names,
     # case ids, drafts, or the audit log. full_name kept only for call compatibility.
-    return "sub_" + hashlib.sha1(os.urandom(8)).hexdigest()[:10]
+    return "sub_" + hashlib.sha1(os.urandom(8), usedforsecurity=False).hexdigest()[:10]
 
 
 def create(identity: dict, consent: dict, residency: str = "US", prefs: dict | None = None) -> dict:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11668,7 +11668,7 @@ def _compute_mcp_rev() -> str:
             sort_keys=True,
             default=str,
         )
-        return hashlib.sha1(rev_src.encode()).hexdigest()[:12]
+        return hashlib.sha1(rev_src.encode(), usedforsecurity=False).hexdigest()[:12]
     except Exception:
         return ""
 


### PR DESCRIPTION
## Summary

`hashlib.sha1()` without `usedforsecurity=False` crashes on FIPS-enabled systems (RHEL 8/9 with FIPS mode) with `ValueError: EVP_DigestInit_ex disabled for FIPS`.

Two uncovered sites fixed:
- `tui_gateway/server.py:11671` — config revision hash for MCP reload detection
- `optional-skills/security/unbroker/scripts/dossier.py:25` — opaque subject ID generation

Both are non-security uses (cache keys / dedup) where SHA-1 is used purely for content hashing, not for cryptographic security.

## Context

This pattern has been fixed across the codebase in prior PRs:
- #56715 (context_compressor.py md5)
- #56716 (codex_responses_adapter.py sha1)
- #56719 (gateway/platforms + skills_hub.py)
- #62654 (skills_sync, skills_hub, web_server)
- #64062 (qqbot, wecom, yuanbao_media)
- #66857 (weixin.py)

These two sites were missed in the earlier sweeps.

## Test Plan
- [ ] `python3 -c "import ast; ast.parse(open('tui_gateway/server.py').read())"`
- [ ] `python3 -c "import ast; ast.parse(open('optional-skills/security/unbroker/scripts/dossier.py').read())"`