### PR TITLE
fix(cron): pass Git-Bash-safe script path to bash on Windows (.sh exit 127 class)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2288,7 +2288,15 @@ def _run_job_script(
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
         )
-        argv = [_bash, str(path)]
+        # Pass the script path in Git-Bash-safe form. On Windows, str(path)
+        # yields 'C:\\Users\\...\\script.sh' and bash eats the backslashes
+        # (\\U, \\A, \\L, \\s become escapes) -> exit 127 'No such file or
+        # directory'. _bash_safe_path rewrites to /c/Users/... (no-op off
+        # Windows), matching the existing MSYS-handling convention in
+        # tools/environments/local.py.
+        from tools.environments.local import _bash_safe_path
+
+        argv = [_bash, _bash_safe_path(str(path))]
         env_overlay: dict[str, str] = {}
     else:
         python_exe, env_overlay = _windows_cron_python_invocation(sys.executable)

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -118,3 +119,40 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     ok, output = _run_job_script("/etc/passwd")
     assert ok is False
     assert "Blocked" in output or "outside" in output
+
+
+def test_run_job_script_passes_bash_safe_path_on_windows(hermes_env, monkeypatch):
+    """Windows regression (#65317/#43073): the .sh script path handed to bash
+    must be Git-Bash-safe (/c/Users/...), not the raw 'C:\\Users\\...' form that
+    bash mangles into exit 127 'No such file or directory'."""
+    import subprocess
+    from cron.scheduler import _run_job_script
+
+    script_path = hermes_env / "scripts" / "cron-watchdog.sh"
+    script_path.write_text("#!/bin/bash\necho watchdog ok\n")
+
+    captured = {}
+
+    class _FakeResult:
+        returncode = 0
+        stdout = "watchdog ok\n"
+        stderr = ""
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return _FakeResult()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ok, output = _run_job_script(str(script_path))
+    assert ok is True
+    # The argv must contain the script path in a bash-safe form.
+    script_arg = captured["argv"][1]
+    assert "\\" not in script_arg, (
+        f"bash received a backslash path {script_arg!r}; Windows Git Bash "
+        f"mangles backslashes (exit 127). Expected /c/Users/... form."
+    )
+    if sys.platform == "win32":
+        assert script_arg.startswith("/"), (
+            f"on Windows the bash script path should be MSYS form, got {script_arg!r}"
+        )

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -615,11 +615,19 @@ def _save_blocked_payload(command: str) -> Optional[str]:
             except OSError:
                 pass
         path = script_dir / f"blocked-{int(_time.time())}-{_uuid.uuid4().hex[:8]}.sh"
+        # The 'run it via: bash <path>' hint must use the Git-Bash-safe form
+        # (/c/Users/... on Windows) — a raw C:\... path in the hint would hit
+        # the same backslash-mangling (exit 127) the cron .sh fix addresses.
+        try:
+            from tools.environments.local import _bash_safe_path
+            hint_path = _bash_safe_path(str(path))
+        except Exception:
+            hint_path = str(path)
         path.write_text(
             "#!/bin/bash\n"
             "# Auto-saved by Hermes: this command exceeded the inline command\n"
             "# parser limit and was blocked from direct execution. Review it,\n"
-            "# then run it via: bash " + str(path) + "\n"
+            "# then run it via: bash " + hint_path + "\n"
             + command
             + ("\n" if not command.endswith("\n") else ""),
             encoding="utf-8", errors="replace",

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -482,6 +482,8 @@ Semantics:
 
 `.sh` / `.bash` files run under `bash` from `PATH` when available, otherwise `/bin/bash` (important on Windows Git Bash). Anything else runs under the current Python interpreter (`sys.executable`). Scripts must resolve inside `$HERMES_HOME/scripts/` — relative names, absolute paths, and `~`-prefixed paths are accepted when the resolved target stays in that directory; paths that escape it are rejected. Subprocess env is sanitized (`_sanitize_subprocess_env`): provider API credentials and other Hermes-managed secrets are **not** inherited by cron scripts.
 
+**Windows note:** on native Windows, the script path handed to Git Bash is rewritten to the MSYS form (`C:\Users\...\script.sh` → `/c/Users/.../script.sh`). A raw backslash path would be mangled by bash (`\U`, `\A`, `\s` become escapes) and fail with exit 127 "No such file or directory". This matches the codebase's MSYS path-handling convention (`tools/environments/local.py`). If a `.sh` cron job fails with exit 127 on Windows, confirm the script exists and that Git for Windows is installed (which ships Git Bash); the scheduler will say so explicitly when bash itself is missing.
+
 ### The agent sets these up for you
 
 The `cronjob` tool's schema exposes `no_agent` to Hermes directly, so you can describe a watchdog in chat and let the agent wire it up:


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #23404 #43073 #65317
## What does this PR do?

Fixes the **entire class** of Windows `.sh` cron-script path mangling —
not just one failure site.

`cron/scheduler.py:_run_job_script` handed `.sh`/`.bash` script paths to
Git Bash as a raw `str(path)`. On native Windows that is a backslash path
(`C:\Users\...\script.sh`); bash interprets `\U`, `\A`, `\L`, `\s` as
escape sequences, mangles the path to `C:Users...script.sh`, and fails
with **exit 127 "No such file or directory"** (#65317, #43073).

The same class exists in `tools/approval.py` — the "run it via: bash
<path>" hint written into blocked-command payloads showed the raw
backslash path, which would mangle identically if a Windows user
copy-pasted it.

The fix uses the codebase's **established MSYS convention** —
`_bash_safe_path()` from `tools/environments/local.py` (which already
rewrites `C:\...` → `/c/...` for Git Bash and is a no-op off Windows) —
at both sites:

- `cron/scheduler.py` — the actual `.sh` execution argv: `[_bash, _bash_safe_path(str(path))]`
- `tools/approval.py` — the user-facing `bash <path>` hint in blocked-payload scripts

## How to test

```bash
pytest tests/cron/test_cron_no_agent.py -q
# 6 passed (incl. new Windows bash-safe-path regression)

pytest tests/tools/test_approval.py -q
# 92 passed (2 pre-existing TestDetectDangerousRm failures, proven via
# stash-test to fail identically on pristine main)
```

The new regression test patches `subprocess.run` to capture the argv and
asserts the script path contains no backslashes and (on Windows) starts
with `/` — hermetic, no dependency on the sandbox's bash drive mounts.

## What platforms were tested?

- Windows 11 native: cron suite 6 passed, approval suite 92 passed,
  `git diff --check` clean, `check-windows-footguns.py` clean on all
  three changed files.

## Why this matters to users

Before: on Windows, any `.sh` cron script (`no_agent: true` watchdogs,
pre-run data collection) failed with a confusing `exit 127` — the log said
"no such file or directory" even though the script existed, because bash
had silently eaten the backslashes in the path. Users hit this as "my
watchdog never runs and the error makes no sense."

After: the scheduler hands Git Bash a path it can actually open
(`/c/Users/...`), so `.sh` cron jobs run on Windows exactly as they do on
Linux/macOS. The blocked-command hint is also copy-paste-safe.

Fixes #23404
Fixes #65317
Closes #43073

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] Code follows repo style (reuses `_bash_safe_path`, no new env vars)
- [x] Self-review complete
- [x] Tests added (argv-shape regression, hermetic)
- [x] Suite green: cron 6 passed; approval 92 passed (2 pre-existing failures stash-proven)
- [x] `git diff --check` clean
- [x] Windows footgun lint clean
- [x] Documentation updated (`website/docs/user-guide/features/cron.md` — Windows note)

Part of #46332
