### PR TITLE
fix(state): stop branch replay at fork snapshot

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10093,8 +10093,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         verbatim.
         """
         session_ids = [session_id]
-        if include_ancestors and not self._is_explicit_branch_session(session_id):
-            session_ids = self._session_lineage_root_to_tip(session_id)
+        if include_ancestors:
+            session_ids = self._session_replay_lineage_root_to_tip(session_id)
 
         active_clause = "" if include_inactive else " AND active = 1"
         with self._read_ctx() as conn:
@@ -10286,11 +10286,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         halves the resume's DB work versus two separate calls, with byte-identical
         output (see test_get_resume_conversations_matches_separate_reads).
         """
-        session_ids = (
-            [session_id]
-            if self._is_explicit_branch_session(session_id)
-            else self._session_lineage_root_to_tip(session_id)
-        )
+        session_ids = self._session_replay_lineage_root_to_tip(session_id)
         with self._read_ctx() as conn:
             placeholders = ",".join("?" for _ in session_ids)
             rows = conn.execute(
@@ -10426,10 +10422,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         returns ONLY the genuine ancestor messages, identified by
         ``session_id != tip_session_id``. (#65919)
         """
-        if self._is_explicit_branch_session(session_id):
-            return []
-
-        session_ids = self._session_lineage_root_to_tip(session_id)
+        session_ids = self._session_replay_lineage_root_to_tip(session_id)
         if len(session_ids) <= 1:
             return []
         with self._read_ctx() as conn:
@@ -10450,32 +10443,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             repair_alternation=False,
         )
 
-    def _is_explicit_branch_session(self, session_id: str) -> bool:
-        """Return whether *session_id* is a copied user-facing branch.
-
-        Branches and compression continuations both use ``parent_session_id``,
-        but they have different history semantics: a branch owns a copied
-        transcript, while a compression continuation needs its ended parent's
-        archived rows for display. The durable ``_branched_from`` marker is the
-        existing discriminator written by all branch creation paths.
-        """
-        if not session_id:
-            return False
-        with self._read_ctx() as conn:
-            row = conn.execute(
-                "SELECT model_config FROM sessions WHERE id = ?",
-                (session_id,),
-            ).fetchone()
-        if row is None:
-            return False
-        raw_config = row["model_config"] if hasattr(row, "keys") else row[0]
-        if not raw_config:
-            return False
-        try:
-            config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
-        except (json.JSONDecodeError, TypeError):
-            return False
-        return isinstance(config, dict) and bool(config.get("_branched_from"))
 
     def get_conversation_root(self, session_id: str) -> str:
         """Return the ROOT id of *session_id*'s lineage chain.
@@ -10511,6 +10478,52 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if row is None:
                     break
                 current = row["parent_session_id"] if hasattr(row, "keys") else row[0]
+        return list(reversed(chain)) or [session_id]
+
+    def _session_replay_lineage_root_to_tip(self, session_id: str) -> List[str]:
+        """Return ancestors that belong to the tip's persisted transcript.
+
+        Compression continuations store only their new segment, so replay must
+        walk through their parents. Explicit branches are different: the child
+        already persists the fork-time transcript snapshot and carries
+        ``model_config._branched_from`` only to preserve presentation lineage.
+        Stop before crossing that edge so later parent turns cannot enter the
+        branch on a cold resume.
+        """
+        if not session_id:
+            return [session_id]
+
+        chain = []
+        current = session_id
+        seen = set()
+        with self._read_ctx() as conn:
+            for _ in range(100):
+                if not current or current in seen:
+                    break
+                seen.add(current)
+                chain.append(current)
+                row = conn.execute(
+                    "SELECT parent_session_id, model_config FROM sessions WHERE id = ?",
+                    (current,),
+                ).fetchone()
+                if row is None:
+                    break
+                session = (
+                    dict(row)
+                    if hasattr(row, "keys")
+                    else {"parent_session_id": row[0], "model_config": row[1]}
+                )
+                raw_config = session["model_config"]
+                try:
+                    config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
+                except (json.JSONDecodeError, TypeError):
+                    config = None
+                branch_parent = config.get("_branched_from") if isinstance(config, dict) else None
+                # Compression continuations can inherit branch provenance. It
+                # marks this edge as a fork only when it names this row's parent.
+                if branch_parent == session["parent_session_id"]:
+                    break
+                current = session["parent_session_id"]
         return list(reversed(chain)) or [session_id]
 
     @staticmethod

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10319,7 +10319,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
     def get_resume_message_count(self, session_id: str) -> int:
         """Count active rows that a full resume would materialize."""
-        session_ids = self._session_lineage_root_to_tip(session_id)
+        session_ids = self._session_replay_lineage_root_to_tip(session_id)
         placeholders = ",".join("?" for _ in session_ids)
         with self._read_ctx() as conn:
             row = conn.execute(
@@ -10350,7 +10350,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # return value, and an unbounded lineage COUNT here would do the
             # exact pathological work the disable exists to avoid.
             return 0
-        session_ids = self._session_lineage_root_to_tip(session_id)
+        session_ids = self._session_replay_lineage_root_to_tip(session_id)
         placeholders = ",".join("?" for _ in session_ids)
         with self._read_ctx() as conn:
             row = conn.execute(
@@ -10518,11 +10518,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 except (json.JSONDecodeError, TypeError):
                     config = None
                 branch_parent = config.get("_branched_from") if isinstance(config, dict) else None
+                parent_id = session["parent_session_id"]
                 # Compression continuations can inherit branch provenance. It
                 # marks this edge as a fork only when it names this row's parent.
-                if branch_parent == session["parent_session_id"]:
+                if branch_parent and branch_parent == parent_id:
                     break
-                current = session["parent_session_id"]
+                current = parent_id
         return list(reversed(chain)) or [session_id]
 
     @staticmethod

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10275,11 +10275,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         - ``model_history`` — the tip session's active rows, alternation-repaired
           (the live-replay working conversation). Equivalent to
           ``get_messages_as_conversation(session_id, repair_alternation=True)``.
-        - ``display_history`` — the full compression lineage (ancestors → tip),
-          verbatim, with replayed-user dedup. Explicit ``/branch`` sessions are
-          excluded from this lineage because their own rows already contain the
-          copied transcript; including the live parent's rows would let messages
-          written to the original after the fork leak into the branch.
+        - ``display_history`` — the replay lineage (compression ancestors since
+          the nearest explicit branch boundary → tip), verbatim, with replayed-user
+          dedup. Equivalent to ``get_messages_as_conversation(session_id,
+          include_ancestors=True)``.
 
         The display fetch already reads a superset of the model fetch (the tip
         rows are part of the lineage), so serving both from one lineage SELECT

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7195,7 +7195,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         session_ids = [session_id]
         if include_ancestors:
-            session_ids = self._session_lineage_root_to_tip(session_id)
+            session_ids = self._session_replay_lineage_root_to_tip(session_id)
 
         active_clause = "" if include_inactive else " AND active = 1"
         with self._read_ctx() as conn:
@@ -7385,7 +7385,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         halves the resume's DB work versus two separate calls, with byte-identical
         output (see test_get_resume_conversations_matches_separate_reads).
         """
-        session_ids = self._session_lineage_root_to_tip(session_id)
+        session_ids = self._session_replay_lineage_root_to_tip(session_id)
         with self._read_ctx() as conn:
             placeholders = ",".join("?" for _ in session_ids)
             rows = conn.execute(
@@ -7437,7 +7437,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         returns ONLY the genuine ancestor messages, identified by
         ``session_id != tip_session_id``. (#65919)
         """
-        session_ids = self._session_lineage_root_to_tip(session_id)
+        session_ids = self._session_replay_lineage_root_to_tip(session_id)
         if len(session_ids) <= 1:
             return []
         with self._read_ctx() as conn:
@@ -7492,6 +7492,44 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 if row is None:
                     break
                 current = row["parent_session_id"] if hasattr(row, "keys") else row[0]
+        return list(reversed(chain)) or [session_id]
+
+    def _session_replay_lineage_root_to_tip(self, session_id: str) -> List[str]:
+        """Return ancestors that belong to the tip's persisted transcript.
+
+        Compression continuations store only their new segment, so replay must
+        walk through their parents. Explicit branches are different: the child
+        already persists the fork-time transcript snapshot and carries
+        ``model_config._branched_from`` only to preserve presentation lineage.
+        Stop before crossing that edge so later parent turns cannot enter the
+        branch on a cold resume.
+        """
+        if not session_id:
+            return [session_id]
+
+        chain = []
+        current = session_id
+        seen = set()
+        with self._read_ctx() as conn:
+            for _ in range(100):
+                if not current or current in seen:
+                    break
+                seen.add(current)
+                chain.append(current)
+                row = conn.execute(
+                    "SELECT parent_session_id, model_config FROM sessions WHERE id = ?",
+                    (current,),
+                ).fetchone()
+                if row is None:
+                    break
+                session = (
+                    dict(row)
+                    if hasattr(row, "keys")
+                    else {"parent_session_id": row[0], "model_config": row[1]}
+                )
+                if self._is_branch_child_row(session):
+                    break
+                current = session["parent_session_id"]
         return list(reversed(chain)) or [session_id]
 
     @staticmethod

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7376,9 +7376,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         - ``model_history`` — the tip session's active rows, alternation-repaired
           (the live-replay working conversation). Equivalent to
           ``get_messages_as_conversation(session_id, repair_alternation=True)``.
-        - ``display_history`` — the full lineage (ancestors → tip), verbatim, with
-          replayed-user dedup. Equivalent to
-          ``get_messages_as_conversation(session_id, include_ancestors=True)``.
+        - ``display_history`` — the replay lineage (compression ancestors since
+          the nearest explicit branch boundary → tip), verbatim, with replayed-user
+          dedup. Equivalent to ``get_messages_as_conversation(session_id,
+          include_ancestors=True)``.
 
         The display fetch already reads a superset of the model fetch (the tip
         rows are part of the lineage), so serving both from one lineage SELECT

--- a/tests/hermes_state/test_branch_replay_lineage.py
+++ b/tests/hermes_state/test_branch_replay_lineage.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from hermes_state import SessionDB
+from hermes_state import SessionDB, SessionResumeTooLargeError
 
 
 @pytest.fixture
@@ -152,3 +152,32 @@ def test_compression_after_branch_replays_from_branch_boundary(db):
         "branch before compression prompt",
         "branch before compression answer",
     ]
+
+
+def test_resume_safety_counts_only_the_branch_aware_replay_lineage(db):
+    db.create_session("root", source="desktop")
+    _append_turn(db, "root", "fork snapshot")
+
+    db.create_session(
+        "branch",
+        source="desktop",
+        parent_session_id="root",
+        model_config={"_branched_from": "root"},
+    )
+    _append_turn(db, "branch", "fork snapshot")
+    _append_turn(db, "branch", "branch before compression")
+    db.end_session("branch", "compression")
+
+    db.create_session(
+        "continuation",
+        source="desktop",
+        parent_session_id="branch",
+        model_config={"_branched_from": "root"},
+    )
+    _append_turn(db, "continuation", "branch after compression")
+
+    assert db.get_resume_message_count("continuation") == 6
+    assert db.assert_resume_safe("continuation", max_messages=6) == 6
+    with pytest.raises(SessionResumeTooLargeError) as exc_info:
+        db.assert_resume_safe("continuation", max_messages=5)
+    assert exc_info.value.message_count == 6

--- a/tests/hermes_state/test_branch_replay_lineage.py
+++ b/tests/hermes_state/test_branch_replay_lineage.py
@@ -126,7 +126,14 @@ def test_compression_after_branch_replays_from_branch_boundary(db):
     _append_turn(db, "branch", "branch before compression")
     db.end_session("branch", "compression")
 
-    db.create_session("continuation", source="desktop", parent_session_id="branch")
+    db.create_session(
+        "continuation",
+        source="desktop",
+        parent_session_id="branch",
+        # Compression continuations inherit model_config. The branch marker
+        # still names the original fork edge, not this continuation edge.
+        model_config={"_branched_from": "root"},
+    )
     _append_turn(db, "continuation", "branch after compression")
 
     _, display_history = db.get_resume_conversations("continuation")

--- a/tests/hermes_state/test_branch_replay_lineage.py
+++ b/tests/hermes_state/test_branch_replay_lineage.py
@@ -1,0 +1,147 @@
+"""Regression coverage for explicit branch replay boundaries (#77375)."""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = SessionDB(tmp_path / "state.db")
+    yield database
+    database.close()
+
+
+def _append_turn(db: SessionDB, session_id: str, label: str) -> None:
+    db.append_message(session_id, role="user", content=f"{label} prompt")
+    db.append_message(session_id, role="assistant", content=f"{label} answer")
+
+
+def _contents(messages):
+    return [message["content"] for message in messages]
+
+
+def test_explicit_branch_resume_uses_its_fork_snapshot_not_live_parent(db):
+    db.create_session("parent", source="desktop")
+    _append_turn(db, "parent", "before fork")
+
+    db.create_session(
+        "branch",
+        source="desktop",
+        parent_session_id="parent",
+        model_config={"_branched_from": "parent"},
+    )
+    _append_turn(db, "branch", "before fork")
+    _append_turn(db, "parent", "after fork")
+    _append_turn(db, "branch", "branch")
+
+    model_history, display_history = db.get_resume_conversations("branch")
+
+    expected = [
+        "before fork prompt",
+        "before fork answer",
+        "branch prompt",
+        "branch answer",
+    ]
+    assert _contents(model_history) == expected
+    assert _contents(display_history) == expected
+    assert db.get_ancestor_display_prefix("branch") == []
+
+
+def test_nested_branch_resume_excludes_parent_turns_written_after_nested_fork(db):
+    db.create_session("root", source="desktop")
+    _append_turn(db, "root", "root before branch")
+
+    db.create_session(
+        "branch",
+        source="desktop",
+        parent_session_id="root",
+        model_config={"_branched_from": "root"},
+    )
+    _append_turn(db, "branch", "root before branch")
+    _append_turn(db, "branch", "branch before nested fork")
+
+    db.create_session(
+        "nested",
+        source="desktop",
+        parent_session_id="branch",
+        model_config={"_branched_from": "branch"},
+    )
+    _append_turn(db, "nested", "root before branch")
+    _append_turn(db, "nested", "branch before nested fork")
+    _append_turn(db, "branch", "branch after nested fork")
+    _append_turn(db, "nested", "nested")
+
+    _, display_history = db.get_resume_conversations("nested")
+
+    assert _contents(display_history) == [
+        "root before branch prompt",
+        "root before branch answer",
+        "branch before nested fork prompt",
+        "branch before nested fork answer",
+        "nested prompt",
+        "nested answer",
+    ]
+    assert db.get_ancestor_display_prefix("nested") == []
+
+
+def test_compression_continuation_still_replays_ancestors(db):
+    db.create_session("root", source="desktop")
+    _append_turn(db, "root", "before compression")
+    db.end_session("root", "compression")
+
+    db.create_session("continuation", source="desktop", parent_session_id="root")
+    _append_turn(db, "continuation", "after compression")
+
+    model_history, display_history = db.get_resume_conversations("continuation")
+
+    assert _contents(model_history) == [
+        "after compression prompt",
+        "after compression answer",
+    ]
+    assert _contents(display_history) == [
+        "before compression prompt",
+        "before compression answer",
+        "after compression prompt",
+        "after compression answer",
+    ]
+    assert _contents(db.get_ancestor_display_prefix("continuation")) == [
+        "before compression prompt",
+        "before compression answer",
+    ]
+
+
+def test_compression_after_branch_replays_from_branch_boundary(db):
+    db.create_session("root", source="desktop")
+    _append_turn(db, "root", "fork snapshot")
+
+    db.create_session(
+        "branch",
+        source="desktop",
+        parent_session_id="root",
+        model_config={"_branched_from": "root"},
+    )
+    _append_turn(db, "branch", "fork snapshot")
+    _append_turn(db, "root", "root after fork")
+    _append_turn(db, "branch", "branch before compression")
+    db.end_session("branch", "compression")
+
+    db.create_session("continuation", source="desktop", parent_session_id="branch")
+    _append_turn(db, "continuation", "branch after compression")
+
+    _, display_history = db.get_resume_conversations("continuation")
+
+    assert _contents(display_history) == [
+        "fork snapshot prompt",
+        "fork snapshot answer",
+        "branch before compression prompt",
+        "branch before compression answer",
+        "branch after compression prompt",
+        "branch after compression answer",
+    ]
+    assert _contents(db.get_ancestor_display_prefix("continuation")) == [
+        "fork snapshot prompt",
+        "fork snapshot answer",
+        "branch before compression prompt",
+        "branch before compression answer",
+    ]


### PR DESCRIPTION
## Summary
- walk transcript replay through compression continuations, but stop at the nearest explicit branch edge
- keep presentation lineage unchanged for branch trees and conversation-root resolution
- make resume counting and safety guards use the same branch-aware lineage as the actual resume read

## Why this remains needed after #86775
#86775 fixed direct branch resumes on `main`, but its tip-only branch check still walks through the original parent after a branch is compressed. The result is a duplicated fork snapshot plus post-fork parent turns in the resumed continuation.

This PR detects a branch boundary on each traversed edge. Inherited `_branched_from` provenance on compression continuations is not treated as a new fork unless it names that row’s immediate parent.

## Regression coverage
Real `SessionDB` tests cover:
- direct branch resume excludes parent turns written after the fork
- nested branch resume excludes parent turns written after the nested fork
- ordinary compression continuation still replays ancestors
- compression after a branch replays from the branch boundary, including inherited branch provenance
- resume counts and size guards match the branch-aware transcript actually materialized

## TDD evidence
- current `main` + the regression file: 3 passed / 1 failed at `test_compression_after_branch_replays_from_branch_boundary`
- inherited-marker variant before the edge comparison: 3 passed / 1 failed
- resume-count regression before guard alignment: 4 passed / 1 failed (`8 != 6`)
- final focused file: 5 passed

## Validation
- `scripts/run_tests.sh tests/hermes_state tests/test_hermes_state.py -q` → 375 passed, 0 failed, 2 skipped
- `uv run ruff check hermes_state.py tests/hermes_state/test_branch_replay_lineage.py` → clean
- `python -m py_compile`, `git diff --check`, and ancestry check against current `origin/main` → clean

Closes #77375