### PR TITLE
fix(usage): preserve Anthropic percentage points

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -782,7 +782,7 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
         util = window.get("utilization")
         if util is None:
             continue
-        used = float(util) * 100 if float(util) <= 1 else float(util)
+        used = float(util)
         windows.append(
             AccountUsageWindow(
                 label=label,

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -95,6 +95,35 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert "Credits balance: $12.50" in snapshot.details
 
 
+def test_fetch_account_usage_anthropic_treats_float_utilization_as_percentage_points(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_anthropic_token", lambda: "oauth-token"
+    )
+    monkeypatch.setattr("agent.account_usage._is_oauth_token", lambda token: True)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "five_hour": {
+                    "utilization": 1.0,
+                    "resets_at": "2030-03-17T15:00:00Z",
+                },
+                "seven_day": {
+                    "utilization": 8.0,
+                    "resets_at": "2030-03-21T12:00:00Z",
+                },
+            }
+        ),
+    )
+
+    snapshot = fetch_account_usage("anthropic")
+
+    assert snapshot is not None
+    assert tuple(window.used_percent for window in snapshot.windows) == (1.0, 8.0)
+
+
 def test_render_account_usage_lines_includes_reset_and_provider():
     snapshot = AccountUsageSnapshot(
         provider="openai-codex",


### PR DESCRIPTION
## Summary
- treat Anthropic OAuth `utilization` floats as percentage points
- remove the magnitude heuristic that turned `1.0%` used into `100%` used
- add a regression covering Session `1.0` and Week `8.0`

## Root cause
Anthropic’s OAuth usage endpoint reports percentage points as floats. The existing `value <= 1 ? value * 100 : value` heuristic corrupted the valid boundary value `1.0`.

## Verification
- `./scripts/run_tests.sh tests/test_account_usage.py -q` — 5 passed
- live sanitized provider probe: Session utilization `1.0`, Week utilization `8.0`
- published cache/backend proof: Session 99% remaining, Week 92% remaining, stale=false
