### PR TITLE
fix(relay): handle event-loop conflict when managed execution wraps tools with persistent loops (#77244)

### DIFF
--- a/agent/relay_tools.py
+++ b/agent/relay_tools.py
@@ -63,6 +63,18 @@ def execute(
             and relay_runtime._is_relay_wrapped_callback_error(exc, callback_error)
         ):
             raise callback_error
+        # Tools with persistent internal event loops (e.g. vision_analyze)
+        # can trigger "Future attached to a different loop" when Relay's
+        # asyncio.run() creates a second loop.  Fall back to direct
+        # execution so the tool still works.  (#77244)
+        if isinstance(exc, RuntimeError) and "attached to a different loop" in str(exc):
+            logger.warning(
+                "NeMo Relay event-loop conflict for tool %s; "
+                "falling back to direct execution",
+                tool_name,
+                exc_info=True,
+            )
+            return callback(args), args
         if (
             isinstance(exc, Exception)
             and callback_error is None

--- a/hermes_cli/observability/relay_shared_metrics.py
+++ b/hermes_cli/observability/relay_shared_metrics.py
@@ -108,7 +108,10 @@ class _Runtime:
             runtime_id=self.host.runtime_id,
         )
         self.relay.subscribers.register(self._subscriber_name, self.subscriber)
-        self.host.retain_managed_execution(self._subscriber_name)
+        # Do NOT retain managed execution unconditionally — tools with
+        # persistent internal event loops (e.g. vision_analyze) conflict
+        # with Relay's asyncio.run().  The subscriber receives events
+        # through relay.subscribers independently.  (#77244)
         self._registered = True
         atexit.register(self.shutdown)
 


### PR DESCRIPTION
## Fixes #77244

### Root Cause

`relay_shared_metrics.py` unconditionally called `retain_managed_execution()` during initialization, which forced ALL tool calls through Relay's managed-execution pipeline. Tools with persistent internal event loops (e.g. `vision_analyze`) then failed with:

```
RuntimeError: Task ... got Future ... attached to a different loop
```

because Relay's `asyncio.run()` created a second event loop that conflicted with the tool's own persistent loop.

### Fix

**Two changes, both minimal:**

1. **`agent/relay_tools.py`**: Catch the `"attached to a different loop"` RuntimeError in `execute()` and fall back to direct callback execution. The tool still works — it just bypasses Relay's managed-execution wrapper for that call.

2. **`hermes_cli/observability/relay_shared_metrics.py`**: Remove the unconditional `retain_managed_execution()` call at init. The subscriber receives events through `relay.subscribers` independently of managed execution — it doesn't need to force all tool calls through the Relay pipeline.

### Testing

- `tests/agent/test_relay_tools.py` — passes (1 skipped, pre-existing)
- `tests/agent/test_relay_llm.py` — passes (1 skipped, pre-existing)
- `tests/agent/test_auxiliary_relay.py` — passes (1 skipped, pre-existing)
- Syntax check: `py_compile` passes on both modified files
