### PR TITLE
fix(photon): mirror imported sidecar modules

### DIFF
--- a/plugins/platforms/photon/sidecar_paths.py
+++ b/plugins/platforms/photon/sidecar_paths.py
@@ -22,7 +22,14 @@ logger = logging.getLogger(__name__)
 SOURCE_SIDECAR_DIR = Path(__file__).parent / "sidecar"
 # Files that define the sidecar; node_modules is deliberately absent (baked on managed
 # images or installed by npm in the mirror).
-_MIRROR_FILES = ("index.mjs", "package.json", "package-lock.json", "patch-spectrum-mixed-attachments.mjs")
+_MIRROR_FILES = (
+    "index.mjs",
+    "package.json",
+    "package-lock.json",
+    "patch-spectrum-mixed-attachments.mjs",
+    "send-format.mjs",
+    "stream-staleness.mjs",
+)
 # Tests monkeypatch these module globals directly; the accessors honor a non-None value.
 _SIDECAR_DIR: Optional[Path] = None
 # Written by `hermes photon install-sidecar` on npm failure so check_requirements() can

--- a/plugins/platforms/photon/sidecar_paths.py
+++ b/plugins/platforms/photon/sidecar_paths.py
@@ -53,6 +53,8 @@ _MIRROR_FILES = (
     "package.json",
     "package-lock.json",
     "patch-spectrum-mixed-attachments.mjs",
+    "send-format.mjs",
+    "stream-staleness.mjs",
 )
 
 

--- a/tests/plugins/platforms/photon/test_sidecar_paths.py
+++ b/tests/plugins/platforms/photon/test_sidecar_paths.py
@@ -9,11 +9,22 @@ volume when a runtime install is unavoidable.
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 
 import pytest
 
 import plugins.platforms.photon.sidecar_paths as sidecar_paths
+
+
+def test_mirror_inventory_includes_local_index_imports() -> None:
+    """A mirrored index must retain every sibling module it imports."""
+    index = (sidecar_paths.SOURCE_SIDECAR_DIR / "index.mjs").read_text(
+        encoding="utf-8"
+    )
+    local_imports = set(re.findall(r'from ["\']\./([^"\']+\.mjs)["\']', index))
+
+    assert local_imports <= set(sidecar_paths._MIRROR_FILES)
 
 
 def _seed_source(source: Path, *, with_node_modules: bool = False) -> None:


### PR DESCRIPTION
## What changed

- mirror `send-format.mjs` and `stream-staleness.mjs` with the Photon sidecar on immutable installs
- add a regression test that requires every local module imported by `index.mjs` to appear in the mirror inventory

## Why

The writable fallback copied `index.mjs` without two sibling modules it imports. On read-only managed images the mirrored sidecar then exited with `ERR_MODULE_NOT_FOUND`, leaving Photon in a retry loop.

## Validation

- `uv run --extra dev pytest -q tests/plugins/platforms/photon/test_sidecar_paths.py`
- `uv run ruff check plugins/platforms/photon/sidecar_paths.py tests/plugins/platforms/photon/test_sidecar_paths.py`
- `git diff --check`
