### PR TITLE
fix(memory/holographic): extract entities from CJK facts

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -108,16 +108,24 @@ _RE_CJK = re.compile(
 _RE_CJK_QUOTE = re.compile(r'[「『《〈【“‘]'
                            r'([^」』》〉】”’]{1,40})'
                            r'[」』》〉】”’]')
-# A Latin run inside CJK prose is usually a proper noun or identifier:
+# A Latin run in a CJK fact is usually a proper noun or identifier:
 # "Notion에 정리한다" -> Notion, "飞书白兔 App 已接入" -> App. The run stops at the
 # first Hangul/Han character, so particles fall off for free, and trailing
 # capitalized words are absorbed so "John Doe가" stays one entity like rule 1
-# gives in English. All-lowercase runs are prose ("download", "use"), and an
-# entity per prose word is how the table fills with junk that links unrelated
-# facts (#57900) — the cost is missing lowercase tool names such as "pytest".
+# gives in English. The second branch keeps internal capitals whole (iPhone,
+# macOS, eBay); the lookbehind stops either branch from starting mid-word.
 _RE_LATIN_RUN = re.compile(
-    r'[A-Za-z][A-Za-z0-9]*(?:[.+-][A-Za-z0-9]+)*(?:\s+[A-Z][a-z]+)*'
+    r'(?<![A-Za-z0-9])'
+    r'(?:[A-Z][A-Za-z0-9]*(?:[.+-][A-Za-z0-9]+)*(?:\s+[A-Z][a-z]+)*'
+    r'|[a-z][A-Za-z0-9]*[A-Z][A-Za-z0-9]*(?:[.+-][A-Za-z0-9]+)*)'
 )
+# A fact only has to contain one CJK character for this rule to see the whole
+# sentence, so an English clause inside it would otherwise become entities
+# (#57900). A name is followed by CJK, by another name, or by nothing:
+# "Slack 대신", "Notion, Slack 그리고 Jira", "회의록 Jira". English prose keeps
+# going in lowercase, which is what "Today we discussed" and "Follow up
+# needed" do, so a lowercase word after the run rules it out.
+_RE_RUN_TRAILER = re.compile(r'[\s,;:.!?/()\[\]{}"\'\u201c\u201d\u2018\u2019]*(.?)')
 _LATIN_RUN_STOPWORDS = frozenset(
     'a an the and or of in on at to for with is are was were be it this that'.split()
 )
@@ -520,9 +528,10 @@ class MemoryStore:
 
             for m in _RE_LATIN_RUN.finditer(text):
                 run = m.group(0)
+                trailer = _RE_RUN_TRAILER.match(text, m.end()).group(1)
                 if (
                     len(run) > 1
-                    and not run.islower()
+                    and not (trailer.isascii() and trailer.islower())
                     and run.lower() not in _LATIN_RUN_STOPWORDS
                 ):
                     _add(run)

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -90,6 +90,38 @@ _RE_AKA          = re.compile(
     re.IGNORECASE,
 )
 
+# CJK-aware patterns. Every rule above keys off ASCII capitalization, which
+# Hangul, Han and Kana do not have, so a fact written in Korean, Chinese or
+# Japanese produced no entities at all: fact_entities stayed empty, the HRR
+# vector was encoded with entities=[], and probe/related/reason silently
+# degraded to FTS5 keyword matching. Both rules below only fire when the text
+# actually contains CJK, so extraction from English text is unchanged.
+# Segmenting bare CJK noun phrases ("김철수는", "白兔控股") needs a morphological
+# analyzer and stays out of scope. CJK punctuation is part of the range set, so
+# a bracket-quoted name gates rule 5 on its own.
+_RE_CJK = re.compile(
+    '[\u1100-\u11ff\u3000-\u303f\u3040-\u30ff\u3130-\u318f'
+    '\u3400-\u4dbf\u4e00-\u9fff\uac00-\ud7a3\uf900-\ufaff]'
+)
+# Bracket quotes are the CJK "this is a name" marker, the role ASCII quotes
+# already play for English.
+_RE_CJK_QUOTE = re.compile(r'[「『《〈【“‘]'
+                           r'([^」』》〉】”’]{1,40})'
+                           r'[」』》〉】”’]')
+# A Latin run inside CJK prose is usually a proper noun or identifier:
+# "Notion에 정리한다" -> Notion, "飞书白兔 App 已接入" -> App. The run stops at the
+# first Hangul/Han character, so particles fall off for free, and trailing
+# capitalized words are absorbed so "John Doe가" stays one entity like rule 1
+# gives in English. All-lowercase runs are prose ("download", "use"), and an
+# entity per prose word is how the table fills with junk that links unrelated
+# facts (#57900) — the cost is missing lowercase tool names such as "pytest".
+_RE_LATIN_RUN = re.compile(
+    r'[A-Za-z][A-Za-z0-9]*(?:[.+-][A-Za-z0-9]+)*(?:\s+[A-Z][a-z]+)*'
+)
+_LATIN_RUN_STOPWORDS = frozenset(
+    'a an the and or of in on at to for with is are was were be it this that'.split()
+)
+
 
 def _clamp_trust(value: float) -> float:
     return max(_TRUST_MIN, min(_TRUST_MAX, value))
@@ -453,6 +485,11 @@ class MemoryStore:
         3. Single-quoted terms             e.g. 'pytest'
         4. AKA patterns                    e.g. "Guido aka BDFL" -> two entities
 
+        Rules 5-6 apply only when the text contains CJK, where rules 1-4 find
+        nothing because Hangul/Han/Kana have no capitalization:
+        5. CJK bracket-quoted terms        e.g. 「白兔控股」 -> 白兔控股
+        6. Latin runs in CJK prose         e.g. "Notion에 정리" -> Notion
+
         Returns a deduplicated list preserving first-seen order.
         """
         seen: set[str] = set()
@@ -476,6 +513,19 @@ class MemoryStore:
         for m in _RE_AKA.finditer(text):
             _add(m.group(1))
             _add(m.group(2))
+
+        if _RE_CJK.search(text):
+            for m in _RE_CJK_QUOTE.finditer(text):
+                _add(m.group(1))
+
+            for m in _RE_LATIN_RUN.finditer(text):
+                run = m.group(0)
+                if (
+                    len(run) > 1
+                    and not run.islower()
+                    and run.lower() not in _LATIN_RUN_STOPWORDS
+                ):
+                    _add(run)
 
         return candidates
 

--- a/tests/plugins/memory/test_holographic_cjk_entities.py
+++ b/tests/plugins/memory/test_holographic_cjk_entities.py
@@ -1,0 +1,94 @@
+"""Entity extraction must work for CJK facts, and stay unchanged for English.
+
+`_extract_entities` used to rely entirely on ASCII capitalization, so a store
+holding Korean/Chinese/Japanese facts kept `entities` and `fact_entities`
+empty: `probe`/`related`/`reason` lost their structural signal and quietly
+fell back to FTS5 keyword matching (issue #24416).
+
+The CJK rules are gated on the text containing CJK, so the English behaviour
+these tests pin down must not move, and un-bracketed candidates have to look
+like names — an entities table full of ordinary prose words is its own bug
+(issue #57900).
+"""
+
+import pytest
+
+from plugins.memory.holographic.store import MemoryStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = MemoryStore(tmp_path / "memory.db")
+    yield s
+    s.close()
+
+
+def test_korean_fact_links_entities_end_to_end(store):
+    fact_id = store.add_fact("팀은 회의록을 Notion에 정리한다")
+
+    rows = store._conn.execute(
+        "SELECT e.name FROM entities e "
+        "JOIN fact_entities fe ON fe.entity_id = e.entity_id "
+        "WHERE fe.fact_id = ?",
+        (fact_id,),
+    ).fetchall()
+
+    assert [r["name"] for r in rows] == ["Notion"]
+
+
+def test_particles_fall_off_latin_runs(store):
+    # 는/에/를 attach with no space; the run stops at the first Hangul char.
+    assert store._extract_entities("Hermes는 Notion에 GPT-5를 쓴다") == [
+        "Hermes",
+        "Notion",
+        "GPT-5",
+    ]
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        # Reproduction from issue #24416.
+        (
+            "用户公司日常用「白兔」/「白兔控股」，不要用工商执照名「成都抖咖」",
+            ["白兔", "白兔控股", "成都抖咖"],
+        ),
+        ("『月報』は Slack で共有する", ["月報", "Slack"]),
+        # The brackets are CJK punctuation, so rule 5 does not need other CJK.
+        ("「Slack」", ["Slack"]),
+    ],
+)
+def test_cjk_bracket_quotes(store, text, expected):
+    assert store._extract_entities(text) == expected
+
+
+def test_multiword_name_stays_one_entity_across_scripts(store):
+    assert store._extract_entities("The Q3 report은 John Doe가 작성") == [
+        "Q3",
+        "John Doe",
+    ]
+
+
+def test_lowercase_prose_is_not_an_entity(store):
+    assert store._extract_entities("그 파일을 download 했다") == []
+    assert store._extract_entities("코드는 don't use it 이다") == []
+    assert store._extract_entities("이건 the best 방법 a b") == []
+
+
+def test_urls_and_emails_are_not_split_into_entities(store):
+    assert store._extract_entities("문서는 https://www.notion.so/team/abc-123 에 있다") == []
+    assert store._extract_entities("이메일은 foo.bar@example.com 이다") == []
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("John Doe joined the team", ["John Doe"]),
+        ('The tool is "Python" here', ["Python"]),
+        ("Guido aka BDFL", ["Guido", "BDFL"]),
+        ("Active users grew and the report is fine", []),
+        ("download the file from https://example.com/a_b", []),
+    ],
+)
+def test_english_extraction_is_unchanged(store, text, expected):
+    assert store._extract_entities(text) == expected

--- a/tests/plugins/memory/test_holographic_cjk_entities.py
+++ b/tests/plugins/memory/test_holographic_cjk_entities.py
@@ -63,10 +63,53 @@ def test_cjk_bracket_quotes(store, text, expected):
 
 
 def test_multiword_name_stays_one_entity_across_scripts(store):
-    assert store._extract_entities("The Q3 report은 John Doe가 작성") == [
-        "Q3",
-        "John Doe",
+    # John and Doe stay together; Q3 sits inside English prose, away from any
+    # CJK character, so the run rule leaves it alone.
+    assert store._extract_entities("The Q3 report은 John Doe가 작성") == ["John Doe"]
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        # One CJK character is enough to open the rule on the whole sentence,
+        # so an English clause must not turn into entities (#57900). The clause
+        # can sit on either side of the CJK.
+        ("Today we discussed 中文", []),
+        ("결론: 中文 We should ship tomorrow", []),
+        ("팀 회의 Today was long", []),
+        ("Meeting notes 会議 Follow up needed", []),
+        ("이건 The 방법 이다", []),
+        # A lowercase word must not swallow the name behind it: the run has to
+        # match at Notion, not at "in".
+        ("Please save this in Notion 中文", ["Notion"]),
+        ("회의는 Zoom 에서 한다", ["Zoom"]),
+    ],
+)
+def test_english_prose_in_cjk_facts_is_not_an_entity(store, text, expected):
+    assert store._extract_entities(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        # An internal capital is part of the name, not the start of one.
+        ("iPhone은 비싸다", ["iPhone"]),
+        ("macOS에서 실행", ["macOS"]),
+        ("팀은 eBay를 쓴다", ["eBay"]),
+    ],
+)
+def test_internal_capitals_stay_whole(store, text, expected):
+    assert store._extract_entities(text) == expected
+
+
+def test_names_in_a_list_all_survive(store):
+    # A name is followed by CJK, by another name, or by nothing.
+    assert store._extract_entities("Notion, Slack 그리고 Jira") == [
+        "Notion",
+        "Slack",
+        "Jira",
     ]
+    assert store._extract_entities("Slack\n\n중요") == ["Slack"]
 
 
 def test_lowercase_prose_is_not_an_entity(store):


### PR DESCRIPTION
## What does this PR do?

Every rule in `_extract_entities` keys off ASCII capitalization: a capitalized multi-word phrase, a quoted term, an `aka` pattern.
Hangul, Han and Kana have no capitalization, so a fact written in Korean, Chinese or Japanese produced no entities at all.
`fact_entities` stayed empty, `encode_fact` ran with `entities=[]`, and `probe` / `related` / `reason` fell back to FTS5 keyword matching without logging anything.
`add`, `search` and `list` all keep working, so nothing looks broken while the entity tables sit empty.

This adds two rules that only run when the text contains CJK, so extraction from English text is unchanged:

1. Bracket quotes `「」『』《》〈〉【】“”‘’`.
   They mark a name in CJK the way the ASCII quote rules already treat one in English, so the rule reuses a convention the file already has.
2. Latin runs inside CJK prose, usually a tool or product name.
   `"Notion에 정리한다"` gives `Notion`.
   The run stops at the first Hangul or Han character, so the attached Korean particle drops off and no particle list is needed.
   A trailing capitalized word gets absorbed, so `"John Doe가 작성"` stays one entity instead of two, the same result rule 1 gives for `"John Doe joined the team"`.
   Rule 1 cannot reach the Korean sentence, because `\b` does not fire between `Doe` and `가`.

The second rule rejects all-lowercase runs.
Minting an entity for every prose word is how the table filled with junk in #57900, and `download`, `notes` and `use` are not names.
The cost is lowercase tool names such as `pytest`, which FTS5 still finds.

Bare CJK noun phrases (`김철수는`, `白兔控股`) need a morphological analyzer or a segmenter, so they stay out of scope here.
#73868 tracks the related tokenization question for FTS5.

## Related Issue

Fixes #24416

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`plugins/memory/holographic/store.py`

- `_RE_CJK`: the presence gate.
  Covers Hangul jamo (so NFD-decomposed text matches too), kana, compatibility jamo, CJK ideographs plus ext A and compat, precomposed Hangul syllables, and CJK punctuation so a bracketed name gates on its own.
- `_RE_CJK_QUOTE`: bracket-quoted terms, capped at 40 characters.
- `_RE_LATIN_RUN` and `_LATIN_RUN_STOPWORDS`: Latin runs, with an all-lowercase reject and a stoplist for capitalized function words such as `The`.
- `_extract_entities`: the new rules run inside `if _RE_CJK.search(text)`.
  Rules 1 to 4 are untouched, and the docstring gains rules 5 and 6.

`tests/plugins/memory/test_holographic_cjk_entities.py` (new, 94 lines)

- A Korean fact end to end: `add_fact` links an entity row, which is the DB-level symptom from the issue.
- A Korean particle falls off a Latin run.
- Bracket quotes, parametrized over the Chinese repro from the issue, a Japanese sentence, and a bare `「Slack」`.
- A multi-word name stays one entity across scripts.
- Lowercase prose, URLs and emails produce nothing.
- English extraction pinned, including the sentence-initial capitalized case that #57900 is about.

## How to Test

**1. Save the reproduction script.**
The first three facts are the reproduction from #24416.
The Korean ones cover particle attachment, which a bracket-only rule would miss.

<details>
<summary><code>repro24416.py</code></summary>

```python
import sys, tempfile, pathlib
sys.path.insert(0, '.')
from plugins.memory.holographic.store import MemoryStore

FACTS = [
    "飞书白兔 App 已于 2026-5-10 接入完成",
    "Coco 香港插班项目计划",
    "用户公司日常用「白兔」/「白兔控股」，不要用工商执照名「成都抖咖」",
    "팀은 회의록을 Notion에 정리한다",
    "배포 알림은 Slack 대신 Notion 댓글로 받는다",
    "이 프로젝트는 pytest로 테스트한다",
]
db = pathlib.Path(tempfile.mkdtemp()) / "m.db"
s = MemoryStore(db)
for f in FACTS:
    s.add_fact(f)
c = s._conn
print("facts        ", c.execute("SELECT COUNT(*) FROM facts").fetchone()[0])
print("entities     ", c.execute("SELECT COUNT(*) FROM entities").fetchone()[0])
print("fact_entities", c.execute("SELECT COUNT(*) FROM fact_entities").fetchone()[0])
print("names        ", [r[0] for r in c.execute("SELECT name FROM entities")])
s.close()
```

</details>

**2. Run it on `main`, then on this branch, from the repo root.**

```console
$ git checkout main && python repro24416.py
facts         6
entities      0
fact_entities 0
names         []

$ git checkout fix/holographic-cjk-entity-extraction && python repro24416.py
facts         6
entities      7
fact_entities 8
names         ['App', 'Coco', 'Notion', 'Slack', '成都抖咖', '白兔', '白兔控股']
```

Six facts go in either way.
On `main` the entity tables stay at zero, which is what the issue reports.

**3. Run the plugin tests.**

```console
$ pytest tests/plugins/memory -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (Apple silicon), Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings in `_extract_entities`)
- [x] N/A `cli-config.yaml.example`, no config keys
- [x] N/A `CONTRIBUTING.md` / `AGENTS.md`, no architecture or workflow change
- [x] I've considered cross-platform impact: pure stdlib `re`, no filesystem or encoding assumptions
- [x] N/A tool descriptions and schemas, no tool behavior change
