### PR TITLE
fix(state): increase compression busy-wait to 300s and fix misleading disk-full messages (#77386)

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -670,7 +670,8 @@ def finalize_turn(
     # (and desktop can toast disk-full) instead of a quiet complete frame.
     if failed and str(_turn_exit_reason) == "session_persistence_failed":
         result["error"] = final_response or (
-            "session storage could not be written — free disk space and try again"
+            "session storage could not be written — a long context compression "
+            "may be in progress; wait a moment and try again"
         )
     # Surface any post-loop cleanup failures so the caller can distinguish a
     # clean turn from one whose trajectory/session/resource teardown raised

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1819,7 +1819,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # a writer that is still locked out after this budget must still be
     # refused rather than allowed to land a stale turn in a session whose
     # compression is genuinely long-running or wedged.
-    _COMPRESSION_BUSY_WAIT_S = 5.0
+    _COMPRESSION_BUSY_WAIT_S = 300.0
     _WRITE_RETRY_MIN_S = 0.020   # 20ms
     _WRITE_RETRY_MAX_S = 0.150   # 150ms
     _WRITE_RETRY_SLOW_AFTER_S = 2.0
@@ -2474,15 +2474,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     self._try_incremental_merge_fts()
                 return result
             except SessionCompressionInProgressError:
-                # A live foreign compression lock is transient: the compressor
-                # publishes in a couple of seconds. Without any wait, a steer
-                # that lands mid-compression aborts the user's turn as
-                # session_persistence_failed and sends the operator hunting
-                # disk space that was never the problem (#75083).
+                # A live foreign compression lock is transient but can last
+                # minutes: LLM-streamed context compression routinely takes
+                # 2-10 minutes (observed 129s-148s with ceiling 600s).
+                # Without any wait, a steer that lands mid-compression aborts
+                # the user's turn as session_persistence_failed and sends the
+                # operator hunting disk space that was never the problem
+                # (#75083, #77386).
                 #
                 # The budget is _COMPRESSION_BUSY_WAIT_S, not the write-lock
                 # patience: the lease is a correctness boundary, so a writer
-                # still locked out after a short wait must be refused rather
+                # still locked out after the wait must be refused rather
                 # than left to land a stale turn once a long-running or wedged
                 # compression finally lets go.
                 if compression_deadline is None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3623,8 +3623,9 @@ class AIAgent:
                 prefix
                 + "the turn was stopped because session storage could not be "
                 "written (the transcript would have been lost on restart). "
-                "This is often a full disk — free some space (or fix state.db "
-                "permissions), then send your message again."
+                "This can happen when a long context compression is in "
+                "progress — wait a moment and try again. If it persists, "
+                "check disk space or state.db permissions."
             )
         # Unknown/diagnostic-only reasons (e.g. "unknown", guardrail_halt
         # which already surfaces its own message) — don't second-guess.


### PR DESCRIPTION
## Fixes #77386

### Problem

`_COMPRESSION_BUSY_WAIT_S = 5.0` but LLM-streamed context compression routinely takes **2-10 minutes** (observed 129s-148s, ceiling 600s). Every turn that writes during a compression window still dies as `session_persistence_failed` after the 5s wait, and the user sees a misleading "Disk full — free some space" dialog even though disk space is fine.

### Changes

| File | Change |
|------|--------|
| `hermes_state.py` | `_COMPRESSION_BUSY_WAIT_S` 5.0 → 300.0; update comment to reflect real compression times |
| `run_agent.py` | Update `session_persistence_failed` message to mention compression lock instead of "often a full disk" |
| `agent/turn_finalizer.py` | Update error message to distinguish compression lock from disk full |

### Why 300s?

The compression path itself logs "still streaming after 120s — extending wait (ceiling 600s)". 300s (5 min) covers the typical 2-3 minute compression while still being well below the 600s ceiling. Writers locked out beyond 300s are refused (correctness boundary preserved).

### Testing

- `tests/test_hermes_state_compression_busy_retry.py` — all 6 tests pass
- `py_compile` passes on all 3 modified files
