### PR TITLE
fix(tools): preflight V4A write candidates before batch apply

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -299,6 +299,74 @@ class TestAdditionOnlyHunks:
         assert file_ops.written.endswith("def new_func():\n    return True\n")
         assert "existing = True" in file_ops.written
 
+    def test_addition_only_hunk_then_dependent_hunk_applies(self):
+        """A later hunk that targets text inserted by an earlier addition-only
+        hunk must apply: validation has to simulate the insertion, otherwise the
+        dependent hunk is validated against pre-insert content and wrongly
+        rejected (no files modified)."""
+        patch = """\
+*** Begin Patch
+*** Update File: src/app.py
++y = 2
+@@ y = 2 @@
+-y = 2
++y = 3
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        assert len(ops) == 1
+        assert len(ops[0].hunks) == 2
+
+        class FakeFileOps:
+            written = None
+            def read_file_raw(self, path):
+                return SimpleNamespace(content="x = 1\n", error=None)
+            def write_file(self, path, content):
+                self.written = content
+                return SimpleNamespace(error=None)
+
+        file_ops = FakeFileOps()
+        result = apply_v4a_operations(ops, file_ops)
+        assert result.success is True, result.error
+        assert "y = 3" in file_ops.written
+        assert "x = 1" in file_ops.written
+
+    def test_addition_only_hunk_creating_ambiguity_rejected_at_validation(self):
+        """If an addition-only hunk duplicates text a later hunk searches for,
+        the ambiguity must be caught during validation (before any write), not
+        surface as an 'inconsistent state' apply failure."""
+        patch = """\
+*** Begin Patch
+*** Update File: src/app.py
+@@ def main @@
++    return val
+@@ def main @@
+-    return val
++    return other
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        assert len(ops[0].hunks) == 2
+
+        class FakeFileOps:
+            written = None
+            def read_file_raw(self, path):
+                return SimpleNamespace(
+                    content="def main():\n    return val\n",
+                    error=None,
+                )
+            def write_file(self, path, content):
+                self.written = content
+                return SimpleNamespace(error=None)
+
+        file_ops = FakeFileOps()
+        result = apply_v4a_operations(ops, file_ops)
+        assert result.success is False
+        # Caught up front: no write attempted, no "inconsistent state" warning.
+        assert file_ops.written is None
+        assert "validation failed" in result.error
+        assert "no files were modified" in result.error
+
 
 class TestReadFileRaw:
     """Bug 1 regression tests — files > 2000 lines and lines > 2000 chars."""

--- a/tests/tools/test_v4a_candidate_preflight.py
+++ b/tests/tools/test_v4a_candidate_preflight.py
@@ -1,0 +1,73 @@
+"""Real-path regressions for V4A candidate preflight."""
+
+from pathlib import Path
+
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import ShellFileOperations
+from tools.patch_parser import apply_v4a_operations, parse_v4a_patch
+
+
+def _apply(patch: str, root: Path):
+    operations, error = parse_v4a_patch(patch)
+    assert error is None
+    file_ops = ShellFileOperations(LocalEnvironment(cwd=str(root)), cwd=str(root))
+    return apply_v4a_operations(operations, file_ops)
+
+
+def test_invalid_structured_candidate_blocks_entire_batch(tmp_path: Path):
+    good = tmp_path / "good.txt"
+    structured = tmp_path / "config.json"
+    good.write_text("old\n")
+    structured.write_text('{"ok": true}\n')
+
+    result = _apply(
+        f"""*** Begin Patch
+*** Update File: {good}
+@@
+-old
++new
+*** Update File: {structured}
+@@
+-{{"ok": true}}
++{{"ok":
+*** End Patch
+""",
+        tmp_path,
+    )
+
+    assert result.success is False
+    assert "no files were modified" in (result.error or "")
+    assert good.read_text() == "old\n"
+    assert structured.read_text() == '{"ok": true}\n'
+
+
+def test_write_policy_denial_blocks_entire_batch(
+    tmp_path: Path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    protected = hermes_home / ".env"
+    protected.write_text("SECRET=unchanged\n")
+    good = tmp_path / "good.txt"
+    good.write_text("old\n")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    result = _apply(
+        f"""*** Begin Patch
+*** Update File: {good}
+@@
+-old
++new
+*** Add File: {protected}
++SECRET=overwritten
+*** End Patch
+""",
+        tmp_path,
+    )
+
+    assert result.success is False
+    assert "no files were modified" in (result.error or "")
+    assert "Write denied" in (result.error or "")
+    assert good.read_text() == "old\n"
+    assert protected.read_text() == "SECRET=unchanged\n"

--- a/tests/tools/test_v4a_candidate_preflight.py
+++ b/tests/tools/test_v4a_candidate_preflight.py
@@ -1,6 +1,7 @@
 """Real-path regressions for V4A candidate preflight."""
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from tools.environments.local import LocalEnvironment
 from tools.file_operations import ShellFileOperations
@@ -71,3 +72,50 @@ def test_write_policy_denial_blocks_entire_batch(
     assert "Write denied" in (result.error or "")
     assert good.read_text() == "old\n"
     assert protected.read_text() == "SECRET=unchanged\n"
+
+
+def test_non_string_backend_preflight_result_is_not_a_rejection(tmp_path: Path):
+    target = tmp_path / "plain.txt"
+    target.write_text("old\n")
+    file_ops = MagicMock()
+    file_ops.read_file_raw.return_value.content = "old\n"
+    file_ops.read_file_raw.return_value.error = None
+    file_ops.validate_write_candidate.return_value = True
+    file_ops.write_file.return_value.error = None
+    file_ops.write_file.return_value.lsp_diagnostics = None
+
+    operations, error = parse_v4a_patch(
+        f"""*** Begin Patch
+*** Update File: {target}
+@@
+-old
++new
+*** End Patch
+"""
+    )
+    assert error is None
+
+    result = apply_v4a_operations(operations, file_ops)
+
+    assert result.success is True
+    file_ops.write_file.assert_called_once_with(str(target), "new\n")
+
+
+def test_missing_addition_only_hint_rejects_without_appending(tmp_path: Path):
+    target = tmp_path / "plain.py"
+    target.write_text("x = 1\n")
+
+    result = _apply(
+        f"""*** Begin Patch
+*** Update File: {target}
+@@ missing_anchor @@
++y = 2
+*** End Patch
+""",
+        tmp_path,
+    )
+
+    assert result.success is False
+    assert "missing_anchor" in (result.error or "")
+    assert "not found" in (result.error or "")
+    assert target.read_text() == "x = 1\n"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -464,6 +464,14 @@ class FileOperations(ABC):
         """
         ...
 
+    def validate_write_candidate(self, path: str, content: str) -> Optional[str]:
+        """Return an error when a candidate cannot safely be written.
+
+        Backends may override this non-mutating preflight. The default keeps
+        third-party backends compatible with V4A's validation phase.
+        """
+        return None
+
     @abstractmethod
     def write_file(self, path: str, content: str) -> WriteResult:
         """Write content to a file, creating directories as needed."""
@@ -1400,6 +1408,26 @@ class ShellFileOperations(FileOperations):
     # WRITE Implementation
     # =========================================================================
 
+    def validate_write_candidate(self, path: str, content: str) -> Optional[str]:
+        """Preflight write policy and fail-closed structured syntax gates."""
+        path = self._expand_path(path)
+        denied = get_write_denied_error(path)
+        if denied:
+            return denied
+
+        ext = os.path.splitext(path)[1].lower()
+        inproc_linter = LINTERS_INPROC.get(ext) if ext in _FAIL_CLOSED_INPROC_EXTS else None
+        if inproc_linter is None:
+            return None
+        ok, lint_error = inproc_linter(content)
+        if ok or lint_error == "__SKIP__":
+            return None
+        return (
+            f"Refusing to write '{path}': candidate content fails "
+            f"{ext} syntax validation ({lint_error}). The file was "
+            "NOT created or modified. Fix the content and retry."
+        )
+
     def write_file(self, path: str, content: str) -> WriteResult:
         """
         Write content to a file, creating parent directories as needed.
@@ -1431,51 +1459,13 @@ class ShellFileOperations(FileOperations):
         Returns:
             WriteResult with bytes written, lint summary, or error.
         """
-        # Expand ~ and other shell paths
+        # Expand paths and run the same non-mutating gate used by V4A batch
+        # validation, keeping preflight and apply policy in lockstep.
         path = self._expand_path(path)
-
-        # Block writes to sensitive paths
-        denied = get_write_denied_error(path)
-        if denied:
-            return WriteResult(error=denied)
-
-        # ── Fail-closed pre-write syntax gate ───────────────────────────
-        # Validate the CANDIDATE content BEFORE any bytes touch disk —
-        # previously this only ran as a post-write lint *report* that the
-        # caller could ignore (or that ``files_modified`` gating wouldn't
-        # catch, since a lint failure never set the top-level ``error``
-        # key). A structured-format write that doesn't even parse (mashed
-        # quotes, truncated generation, wrong indentation dialect) is a
-        # corrupt write, not a style nit — refuse it outright instead of
-        # writing first and reporting the damage afterward.
-        #
-        # Scope: only extensions in ``_FAIL_CLOSED_INPROC_EXTS`` (JSON/
-        # YAML/TOML). ``.py`` deliberately keeps its pre-existing,
-        # non-blocking lint-delta *report* instead of a hard refusal — see
-        # ``_FAIL_CLOSED_INPROC_EXTS``'s docstring above for why. Extensions
-        # with no in-process linter at all (including ones only covered by
-        # a shell linter) are completely unaffected — this gate never runs
-        # for them, so behavior there is unchanged.
-        #
-        # Checked against the raw ``content`` argument, before the
-        # BOM/CRLF preservation shims below run. Those shims exist purely
-        # to match the on-disk file's existing conventions; linting
-        # post-shim would false-positive a JSONDecodeError on a
-        # legitimately BOM-marked JSON file purely because this method
-        # re-adds the marker the read layer strips — see
-        # ``_file_has_bom``/``_UTF8_BOM`` below.
+        candidate_error = self.validate_write_candidate(path, content)
+        if candidate_error:
+            return WriteResult(error=candidate_error)
         ext = os.path.splitext(path)[1].lower()
-        inproc_linter = LINTERS_INPROC.get(ext) if ext in _FAIL_CLOSED_INPROC_EXTS else None
-        if inproc_linter is not None:
-            _ok, _lint_err = inproc_linter(content)
-            if not _ok and _lint_err != "__SKIP__":
-                return WriteResult(
-                    error=(
-                        f"Refusing to write '{path}': candidate content fails "
-                        f"{ext} syntax validation ({_lint_err}). The file was "
-                        "NOT created or modified. Fix the content and retry."
-                    )
-                )
 
         # Capture pre-write content.  Two consumers want it:
         #

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -263,8 +263,10 @@ def _apply_addition_only_hunk(content: str, hunk: Hunk) -> Tuple[str, Optional[s
     if hunk.context_hint:
         occurrences = _count_occurrences(content, hunk.context_hint)
         if occurrences == 0:
-            # Hint not found — append at end as a safe fallback
-            return content.rstrip('\n') + '\n' + insert_text + '\n', None
+            return content, (
+                f"addition-only hunk: context hint '{hunk.context_hint}' "
+                "not found"
+            )
         if occurrences > 1:
             return content, (
                 f"addition-only hunk: context hint '{hunk.context_hint}' is ambiguous "
@@ -289,7 +291,10 @@ def _candidate_validation_error(
         return None
     try:
         result = candidate_validator(path, content)
-        return str(result) if result else None
+        # The interface contract is Optional[str]. Ignore other truthy values
+        # so duck-typed backends and unspecced mocks do not become accidental
+        # hard rejections merely because they expose a callable attribute.
+        return result if isinstance(result, str) and result else None
     except Exception as exc:
         return f"candidate preflight raised {type(exc).__name__}: {exc}"
 

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -246,6 +246,39 @@ def _count_occurrences(text: str, pattern: str) -> int:
     return count
 
 
+def _apply_addition_only_hunk(content: str, hunk: Hunk) -> Tuple[str, Optional[str]]:
+    """Insert an addition-only hunk (only ``+`` lines) into *content*.
+
+    Shared by the validate and apply phases so both operate on byte-identical
+    intermediate content for every hunk type. Returns ``(new_content, error)``;
+    on error ``content`` is returned unchanged.
+
+    Insertion rules (mirrored exactly by both phases):
+    - context hint present and unique → insert after the line holding the hint;
+    - context hint present but missing → append at end of file (safe fallback);
+    - context hint present but ambiguous → error (caller rejects the patch);
+    - no context hint → append at end of file.
+    """
+    insert_text = '\n'.join(l.content for l in hunk.lines if l.prefix == '+')
+    if hunk.context_hint:
+        occurrences = _count_occurrences(content, hunk.context_hint)
+        if occurrences == 0:
+            # Hint not found — append at end as a safe fallback
+            return content.rstrip('\n') + '\n' + insert_text + '\n', None
+        if occurrences > 1:
+            return content, (
+                f"addition-only hunk: context hint '{hunk.context_hint}' is ambiguous "
+                f"({occurrences} occurrences) — provide a more unique hint"
+            )
+        hint_pos = content.find(hunk.context_hint)
+        # Insert after the line containing the context hint
+        eol = content.find('\n', hint_pos)
+        if eol != -1:
+            return content[:eol + 1] + insert_text + '\n' + content[eol + 1:], None
+        return content + '\n' + insert_text, None
+    return content.rstrip('\n') + '\n' + insert_text + '\n', None
+
+
 def _validate_operations(
     operations: List[PatchOperation],
     file_ops: Any,
@@ -302,20 +335,14 @@ def _validate_operations(
                     continue
                 real_change_count += 1
                 if not search_lines:
-                    # Addition-only hunk: validate context hint uniqueness
-                    if hunk.context_hint:
-                        occurrences = _count_occurrences(simulated, hunk.context_hint)
-                        if occurrences == 0:
-                            errors.append(
-                                f"{op.file_path}: addition-only hunk context hint "
-                                f"'{hunk.context_hint}' not found"
-                            )
-                        elif occurrences > 1:
-                            errors.append(
-                                f"{op.file_path}: addition-only hunk context hint "
-                                f"'{hunk.context_hint}' is ambiguous "
-                                f"({occurrences} occurrences)"
-                            )
+                    # Addition-only hunk: simulate the insertion exactly as the
+                    # apply phase does, so later hunks validate against the same
+                    # post-insertion content apply will see.
+                    new_simulated, add_error = _apply_addition_only_hunk(simulated, hunk)
+                    if add_error:
+                        errors.append(f"{op.file_path}: {add_error}")
+                    else:
+                        simulated = new_simulated
                     continue
 
                 search_pattern = '\n'.join(search_lines)
@@ -653,28 +680,10 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str, Optiona
                     return False, err_msg, None
         else:
             # Addition-only hunk (no context or removed lines).
-            # Insert at the location indicated by the context hint, or at end of file.
-            insert_text = '\n'.join(replace_lines)
-            if hunk.context_hint:
-                occurrences = _count_occurrences(new_content, hunk.context_hint)
-                if occurrences == 0:
-                    # Hint not found — append at end as a safe fallback
-                    new_content = new_content.rstrip('\n') + '\n' + insert_text + '\n'
-                elif occurrences > 1:
-                    return False, (
-                        f"Addition-only hunk: context hint '{hunk.context_hint}' is ambiguous "
-                        f"({occurrences} occurrences) — provide a more unique hint"
-                    ), None
-                else:
-                    hint_pos = new_content.find(hunk.context_hint)
-                    # Insert after the line containing the context hint
-                    eol = new_content.find('\n', hint_pos)
-                    if eol != -1:
-                        new_content = new_content[:eol + 1] + insert_text + '\n' + new_content[eol + 1:]
-                    else:
-                        new_content = new_content + '\n' + insert_text
-            else:
-                new_content = new_content.rstrip('\n') + '\n' + insert_text + '\n'
+            # Use the shared helper so apply and validation stay byte-identical.
+            new_content, add_error = _apply_addition_only_hunk(new_content, hunk)
+            if add_error:
+                return False, add_error, None
     
     # Write new content
     write_result = file_ops.write_file(op.file_path, new_content)

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -279,6 +279,21 @@ def _apply_addition_only_hunk(content: str, hunk: Hunk) -> Tuple[str, Optional[s
     return content.rstrip('\n') + '\n' + insert_text + '\n', None
 
 
+def _candidate_validation_error(
+    candidate_validator: Any,
+    path: str,
+    content: str,
+) -> Optional[str]:
+    """Keep backend preflight exceptions inside the structured patch result."""
+    if not callable(candidate_validator):
+        return None
+    try:
+        result = candidate_validator(path, content)
+        return str(result) if result else None
+    except Exception as exc:
+        return f"candidate preflight raised {type(exc).__name__}: {exc}"
+
+
 def _validate_operations(
     operations: List[PatchOperation],
     file_ops: Any,
@@ -296,6 +311,7 @@ def _validate_operations(
 
     errors: List[str] = []
     real_change_count = 0
+    candidate_validator = getattr(file_ops, "validate_write_candidate", None)
 
     # Virtual filesystem overlay so inter-op state (notably a MOVE creating the
     # destination a later UPDATE targets) validates correctly. Maps a path to
@@ -316,6 +332,7 @@ def _validate_operations(
         return r.content, None
 
     for op in operations:
+        operation_error_count = len(errors)
         if op.operation != OperationType.UPDATE:
             real_change_count += 1
         if op.operation == OperationType.UPDATE:
@@ -380,6 +397,26 @@ def _validate_operations(
             # Record the post-update content so a later op (e.g. a MOVE of this
             # file) sees the edited version in the overlay.
             pending_content[op.file_path] = simulated
+
+            if len(errors) == operation_error_count and simulated is not None:
+                candidate_error = _candidate_validation_error(
+                    candidate_validator, op.file_path, simulated
+                )
+                if candidate_error:
+                    errors.append(f"{op.file_path}: {candidate_error}")
+
+        elif op.operation == OperationType.ADD:
+            content = '\n'.join(
+                line.content
+                for hunk in op.hunks
+                for line in hunk.lines
+                if line.prefix == '+'
+            )
+            candidate_error = _candidate_validation_error(
+                candidate_validator, op.file_path, content
+            )
+            if candidate_error:
+                errors.append(f"{op.file_path}: {candidate_error}")
 
         elif op.operation == OperationType.DELETE:
             _content, read_err = _read(op.file_path)

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -255,7 +255,7 @@ def _apply_addition_only_hunk(content: str, hunk: Hunk) -> Tuple[str, Optional[s
 
     Insertion rules (mirrored exactly by both phases):
     - context hint present and unique → insert after the line holding the hint;
-    - context hint present but missing → append at end of file (safe fallback);
+    - context hint present but missing → error (caller rejects the patch);
     - context hint present but ambiguous → error (caller rejects the patch);
     - no context hint → append at end of file.
     """
@@ -451,7 +451,8 @@ def _validate_operations(
                 pending_content.pop(op.file_path, None)
                 removed_paths.add(op.file_path)
 
-        # ADD: parent directory creation handled by write_file; no pre-check needed.
+        # ADD parent creation and mutation remain apply-phase responsibilities;
+        # candidate policy/syntax was preflighted above.
 
     if not errors and real_change_count == 0:
         errors.append("Patch contains no changes (only context lines were provided)")


### PR DESCRIPTION
## What does this PR do?

V4A validates that patch hunks can be transformed before it starts applying a batch, but ADD/UPDATE candidates were not checked with the same write-policy and fail-closed JSON/YAML/TOML validation used by the write path. A later malformed or denied candidate could therefore reject only after an earlier file had already been written.

This PR adds a side-effect-free `validate_write_candidate()` seam and invokes it for every simulated ADD/UPDATE result before V4A begins applying the batch. It also carries the addition-only validate/apply synchronization from #41272, preserving kernel-t1's authorship, so validation and application transform intermediate content identically.

Explicitly supplied addition-only context hints that are absent or ambiguous now reject instead of silently appending at EOF.

## Related Issue

Related: #41272, #41515, #76840, #41393

#41515 adds pre-mutation repository checkpoints for rollback; this PR instead prevents policy/syntax-invalid ADD/UPDATE candidates from reaching the first write.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/file_operations.py`: add non-mutating write-policy and structured-syntax candidate validation.
- `tools/patch_parser.py`: preflight simulated ADD/UPDATE candidates and share addition-only transformation between validation and apply.
- `tests/tools/test_patch_parser.py`: cover dependent and ambiguous addition-only hunks.
- `tests/tools/test_v4a_candidate_preflight.py`: cover zero-write policy/syntax rejection, compatibility, and missing-hint behavior.

Scope is intentionally limited to ADD/UPDATE candidate validation. DELETE/MOVE filesystem failures remain apply-time behavior.

## How to Test

1. Run `HERMES_PYTHON=/path/to/venv/bin/python scripts/run_tests.sh tests/tools/test_patch_parser.py tests/tools/test_v4a_candidate_preflight.py`.
2. Confirm `35 passed`.
3. Run the full suite. On the sealed Linux candidate: `25,111 passed, 2 failed`; both failures reproduce on exact current `upstream/main` (`credential_pool_routing` and the environment-sensitive leading-dash `sort` fixture).
4. Run Ruff on the four touched Python files and `git diff --check upstream/main..HEAD`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — two exact-base failures remain; see test evidence above
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu/Linux x86_64

### Documentation & Housekeeping

- [x] Documentation update — N/A; no public configuration or schema changed
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered; implementation uses existing pathlib/policy/write seams
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Sealed against `upstream/main` `d1afa16053a3777849c2b5465d59a0147b2172f9` at candidate `35bb60096b83d8bebfaab44dfdc62d8f8946e522`.

Focused: 35 passed. Full: 25,111 passed, 2 exact-base failures. Ruff and `git diff --check`: pass.
