### PR TITLE
fix(update): single-pass npm install keeps root deps (agent-browser no longer pruned)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1993,6 +1993,27 @@ def _npm_manifests_digest() -> str | None:
             h.update(b"<missing>")
     return h.hexdigest()
 
+def _root_declared_deps_present() -> bool:
+    """True when every dep declared in the root package.json is installed.
+
+    Only ``dependencies`` are checked: ``optionalDependencies`` may be
+    legitimately absent (platform-specific, install-failure-tolerant), and
+    ``devDependencies`` are not something ``hermes update`` guarantees at the
+    repo root. A missing or unparseable manifest returns True — no evidence the
+    deps are missing — so this guard only ever *adds* a reinstall for the
+    concrete pruned-tree case and never strips the cache's existing behaviour.
+    An empty ``dependencies`` (e.g. if root deps are dropped entirely) is
+    vacuously present, so the guard is a no-op there.
+    """
+    root_pkg = _m().PROJECT_ROOT / "package.json"
+    try:
+        deps = json.loads(root_pkg.read_text(encoding="utf-8")).get("dependencies", {})
+    except (OSError, ValueError):
+        return True
+    node_modules = _m().PROJECT_ROOT / "node_modules"
+    return all((node_modules / name).exists() for name in deps)
+
+
 def _npm_lockfile_changed(hermes_root: Path) -> bool:
     current = _npm_manifests_digest()
     if current is None:
@@ -2000,6 +2021,14 @@ def _npm_lockfile_changed(hermes_root: Path) -> bool:
     # Also check that node_modules exists; a matching hash with missing
     # node_modules means the cache was recorded by another checkout.
     if not (_m().PROJECT_ROOT / "node_modules").is_dir():
+        return True
+    # A tree pruned by the pre-fix two-pass update (agent-browser/@streamdown
+    # deleted, #64354) still has a node_modules/ and records a matching marker,
+    # so honouring the cache here would skip the repair on exactly the installs
+    # that hit the bug. Verify the root deps are present before trusting it;
+    # this also self-heals trees damaged by any other cause (manual rm, an
+    # older hermes) and is a no-op once root declares no deps.
+    if not _root_declared_deps_present():
         return True
     # A matching lockfile hash over a tree whose web build toolchain never
     # landed must NOT skip the reinstall — otherwise every later `hermes
@@ -2101,24 +2130,22 @@ def _update_node_dependencies() -> list[str]:
     # print download progress, and capturing it makes a long download look
     # hung. The chatty npm-deprecation noise during `hermes update` comes from
     # the *desktop* build, not this step; that one is captured to update.log.
-    root_args = [*extra_args, "--workspaces=false"]
-    root_result = _m()._run_npm_install_deterministic(
-        npm,
-        _m().PROJECT_ROOT,
-        extra_args=tuple(root_args),
-        capture_output=False,
-        env=nixos_env,
-    )
-    if root_result.returncode != 0:
-        print("  ⚠ npm install failed in repo root")
-        stderr = (root_result.stderr or "").strip() if root_result.stderr else ""
-        if stderr:
-            print(f"    {stderr.splitlines()[-1]}")
-        return _partial_update_failure("repo root")
-
-    # Step 2: install only the workspaces update needs (ui-tui, web).
-    # --workspace selects specific workspaces; the rest (desktop) are skipped.
-    ws_args = [*extra_args, "--workspace", "ui-tui", "--workspace", "web"]
+    #
+    # This must be a SINGLE npm invocation (--include-workspace-root rather
+    # than a root-only pass followed by a workspace-scoped pass): the helper
+    # prefers `npm ci`, which deletes node_modules before reifying the
+    # requested tree, so a second scoped pass silently wipes the root-only
+    # deps (agent-browser, @streamdown) installed by the first while still
+    # exiting 0. See #64354/#43564. Prior art: #64410 diagnosed the
+    # two-pass wipe and proposed --include-workspace-root.
+    ws_args = [
+        *extra_args,
+        "--workspace",
+        "ui-tui",
+        "--workspace",
+        "web",
+        "--include-workspace-root",
+    ]
     ws_result = _m()._run_npm_install_deterministic(
         npm,
         _m().PROJECT_ROOT,

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -708,7 +708,9 @@ class TestNodeRuntimeNpmResolution:
         )
 
         failed = hm._update_node_dependencies()
-        assert failed == ["repo root"]
+        # Single-pass contract (#64354): the one npm invocation covers root +
+        # ui-tui + web; a failure is reported under the workspace label.
+        assert failed == ["ui-tui, web workspaces"]
         out = capsys.readouterr().out
         assert "mixed state" in out
 

--- a/tests/hermes_cli/test_update_node_dependencies.py
+++ b/tests/hermes_cli/test_update_node_dependencies.py
@@ -1,0 +1,82 @@
+"""Tests for _update_node_dependencies — single-pass npm install (#64354/#43564).
+
+The updater used to run two passes (root-only, then workspace-scoped).
+Both went through _run_npm_install_deterministic, which prefers ``npm ci``;
+``npm ci`` deletes node_modules before reifying the requested tree, so the
+second pass wiped the root-only deps (agent-browser, @streamdown) installed
+by the first while still exiting 0. The fix collapses the install into one
+invocation using --include-workspace-root.
+
+Patches the hermes_cli.main surface (the historical test surface reachable
+via update_cmd._m()).
+"""
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.update_cmd import _root_declared_deps_present
+
+
+@pytest.fixture
+def project_root(tmp_path):
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "node_modules").mkdir()
+    return tmp_path
+
+
+def _run_with_mocked_install(project_root):
+    result = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+    with patch("hermes_cli.main.PROJECT_ROOT", project_root), \
+         patch("hermes_cli.update_cmd._record_npm_lockfile_hash", lambda *a, **k: None), \
+         patch("hermes_cli.update_cmd._npm_lockfile_changed", lambda *a, **k: True), \
+         patch("hermes_cli.main._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
+         patch("hermes_cli.main._nixos_build_env", return_value={}), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=result) as mock_install:
+        from hermes_cli.update_cmd import _update_node_dependencies
+
+        failed = _update_node_dependencies()
+    return failed, mock_install
+
+
+def test_installs_in_a_single_pass(project_root):
+    """One npm invocation — a second scoped pass would wipe root deps under npm ci."""
+    failed, mock_install = _run_with_mocked_install(project_root)
+    assert failed == []
+    assert mock_install.call_count == 1
+
+
+def test_single_pass_uses_include_workspace_root(project_root):
+    """The one pass must keep the root's own deps via --include-workspace-root."""
+    failed, mock_install = _run_with_mocked_install(project_root)
+    assert failed == []
+    _, kwargs = mock_install.call_args
+    extra = kwargs.get("extra_args") or ()
+    assert "--include-workspace-root" in extra
+    assert "--workspace" in extra
+
+
+def test_root_declared_deps_present_true_when_installed(project_root):
+    (project_root / "package.json").write_text(
+        json.dumps({"dependencies": {"agent-browser": "^1.0"}}), encoding="utf-8"
+    )
+    (project_root / "node_modules" / "agent-browser").mkdir()
+    with patch("hermes_cli.main.PROJECT_ROOT", project_root):
+        assert _root_declared_deps_present() is True
+
+
+def test_root_declared_deps_present_false_when_pruned(project_root):
+    """The pruned-tree case: dep declared but node_modules entry missing."""
+    (project_root / "package.json").write_text(
+        json.dumps({"dependencies": {"agent-browser": "^1.0"}}), encoding="utf-8"
+    )
+    with patch("hermes_cli.main.PROJECT_ROOT", project_root):
+        assert _root_declared_deps_present() is False
+
+
+def test_root_declared_deps_present_noop_without_manifest(project_root):
+    (project_root / "package.json").unlink()
+    with patch("hermes_cli.main.PROJECT_ROOT", project_root):
+        assert _root_declared_deps_present() is True


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #43564 #64354 #64394 #64397 #64410
## What does this PR do?

Fixes `hermes update` silently removing repo-root-only npm deps
(**agent-browser**, @streamdown) — browser tools stay broken after every
update even though update prints success (#64354, #43564).

### Root cause

`_update_node_dependencies` ran **two npm passes**:

1. root-only: `npm install --workspaces=false`
2. workspace-scoped: `npm install --workspace ui-tui --workspace web`

Both go through `_run_npm_install_deterministic`, which **prefers `npm ci`**.
`npm ci` deletes `node_modules` before reifying the requested tree — so the
second, workspace-scoped pass **wiped the root-only deps installed by the
first**, while still exiting 0. Update reported success; `agent-browser`
was gone; `hermes doctor` said "run: npm install".

### The fix (whole class)

- **Single npm invocation** with `--include-workspace-root` instead of the
  two-pass shape. The flag adds only the root package's own deps, not
  sibling workspaces — so `desktop/` (Electron, ~200MB postinstall)
  stays excluded exactly as before, but `agent-browser`/`@streamdown`
  survive.
- **`_root_declared_deps_present()` guard** in `_npm_lockfile_changed`:
  a tree already pruned by the old two-pass bug has a matching lockfile
  marker, so honoring the cache would skip the repair forever. The guard
  checks the root's declared deps are actually present before trusting
  the cache — self-healing damaged trees and being a no-op when the root
  declares no deps.

### Prior art

#64410 correctly **diagnosed** the two-pass `npm ci` wipe and proposed
`--include-workspace-root`; this PR ships that approach reimplemented
against current main (the updater code has since moved from
`hermes_cli/main.py` to `hermes_cli/update_cmd.py`, so the old branch no
longer applies). #64394 and #64397 also attempted this cluster and were
closed without landing.

## How to test

```bash
pytest tests/hermes_cli/test_update_node_dependencies.py -q
# 5 passed (single-pass, --include-workspace-root, guard ×3)

pytest tests/hermes_cli/test_cmd_update.py -q
# 20 passed (1 pre-existing failure, stash-proven on pristine main)
```

The new tests patch the `hermes_cli.main` surface (the historical test
surface reachable via `update_cmd._m()`) and assert: exactly one npm
invocation, `--include-workspace-root` present, and the guard's three
behaviors (present / pruned / no-manifest).

## What platforms were tested?

- Windows 11 native: 25 passed across the two suites, `git diff --check`
  clean, `check-windows-footguns.py` clean on both changed files.

## Why this matters to users

Before: every `hermes update` on a git install silently deleted
`agent-browser` from the repo root's `node_modules`; browser tools
(web scraping, screenshots) broke until the user manually ran
`npm install agent-browser` — and nothing in the update output hinted
anything was wrong, because both npm passes exited 0.

After: the single-pass install keeps root deps; trees already damaged by
the old bug self-heal on the next update (the guard forces a reinstall
instead of trusting a stale cache marker). No more silent breakage.

Fixes #64354
Closes #43564

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] Code follows repo style (reuses existing npm-install helper)
- [x] Self-review complete
- [x] Tests added (5 new, adapted to current main structure)
- [x] Suite green: 25 passed (1 pre-existing, stash-proven)
- [x] `git diff --check` clean
- [x] Windows footgun lint clean
- [x] Prior art cited (#64410 diagnosis) where it guided the fix

