### PR TITLE
fix(desktop): put Close last and drop Archive/Delete from session tab menu

### DIFF
--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -456,11 +456,13 @@ function useTileMenuRow(storedSessionId: string): { pinId: string; profile?: str
   })
 }
 
-/** A session TAB's context menu: the full session verb set (pin, copy id, new
- *  window, branch, rename, archive, delete) — the SAME menu a sidebar row
- *  gets, targeted through the tile delegate (whose verbs are generic over
- *  stored ids, primary included). The wrapper stops the contextmenu from also
- *  opening the zone strip's menu. Shared by tile tabs AND the main tab. */
+/** A session TAB's context menu: the session verb set (pin, copy id, new
+ *  window, branch, rename) MINUS the destructive Archive/Delete pair — those
+ *  stay on the sidebar row menu, because a tab's bottom slot is where users
+ *  expect Close and destructive verbs there invite mis-clicks. Verbs target
+ *  through the tile delegate (generic over stored ids, primary included). The
+ *  wrapper stops the contextmenu from also opening the zone strip's menu.
+ *  Shared by tile tabs AND the main tab. */
 export function SessionTabMenu({
   children,
   onClose,

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -100,4 +100,39 @@ describe('SessionActionsMenu', () => {
     expect(screen.getByRole('menuitem', { name: /rename/i })).toBeTruthy()
     expect(screen.getByRole('menuitem', { name: /archive/i })).toBeTruthy()
   })
+
+  // Tab surfaces (right-clicking a session tab in the strip): the destructive
+  // Archive/Delete pair stays on the sidebar row menu — a tab's bottom slot is
+  // where users expect Close, so destructive verbs there invite mis-clicks.
+  // Plain Close is the LAST item for the same reason.
+  it('tab surface omits Archive/Delete and puts Close last', async () => {
+    render(
+      <SessionActionsMenu
+        onArchive={() => undefined}
+        onClose={() => undefined}
+        onDelete={() => undefined}
+        sessionId="s1"
+        surface="tab"
+        tabPaneId="session-tile:s1"
+        title="My session"
+      >
+        <button aria-label="Session actions" type="button">
+          ⋮
+        </button>
+      </SessionActionsMenu>
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Session actions' })
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(trigger)
+
+    expect(await screen.findByRole('menu')).toBeTruthy()
+    expect(screen.queryByRole('menuitem', { name: /archive/i })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: /delete/i })).toBeNull()
+
+    const items = screen.getAllByRole('menuitem')
+    const last = items[items.length - 1]
+    expect(last.textContent?.trim()).toBe('Close')
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -258,19 +258,6 @@ function useSessionActions({
                 })
               ]
             : []),
-          ...(onClose
-            ? [
-                spec({
-                  disabled: false,
-                  icon: 'close',
-                  label: t.common.close,
-                  onSelect: () => {
-                    triggerHaptic('selection')
-                    onClose()
-                  }
-                })
-              ]
-            : []),
           ...(tabPaneId
             ? [
                 spec({
@@ -301,33 +288,55 @@ function useSessionActions({
                   }
                 })
               ]
+            : []),
+          // Plain Close goes LAST: users reach for the bottom item expecting
+          // it, so the wider-blast-radius verbs (close-all) must not sit there.
+          ...(onClose
+            ? [
+                spec({
+                  disabled: false,
+                  icon: 'close',
+                  label: t.common.close,
+                  onSelect: () => {
+                    triggerHaptic('selection')
+                    onClose()
+                  }
+                })
+              ]
             : [])
         ]
       : []
 
   // DANGER — put it away / destroy it (delete stays last, destructive-red).
-  const dangerItems: ActionItemSpec[] = [
-    spec({
-      disabled: !onArchive,
-      icon: 'archive',
-      label: r.archive,
-      onSelect: () => {
-        triggerHaptic('selection')
-        onArchive?.()
-      }
-    }),
-    {
-      className: 'text-destructive focus:text-destructive',
-      disabled: !onDelete,
-      icon: 'trash',
-      label: t.common.delete,
-      onSelect: () => {
-        triggerHaptic('warning')
-        onDelete?.()
-      },
-      variant: 'destructive'
-    }
-  ]
+  // Sidebar rows only: tab surfaces omit Archive/Delete entirely. A tab's
+  // bottom slot is where users expect Close, so destructive verbs there are
+  // one mis-click away from losing a session; session lifecycle stays on the
+  // sidebar row menu.
+  const dangerItems: ActionItemSpec[] =
+    surface === 'tab'
+      ? []
+      : [
+          spec({
+            disabled: !onArchive,
+            icon: 'archive',
+            label: r.archive,
+            onSelect: () => {
+              triggerHaptic('selection')
+              onArchive?.()
+            }
+          }),
+          {
+            className: 'text-destructive focus:text-destructive',
+            disabled: !onDelete,
+            icon: 'trash',
+            label: t.common.delete,
+            onSelect: () => {
+              triggerHaptic('warning')
+              onDelete?.()
+            },
+            variant: 'destructive'
+          }
+        ]
 
   const renderItems = (kit: MenuKit) => (
     <>
@@ -361,8 +370,12 @@ function useSessionActions({
           {tabItems.map(item => renderActionItem(kit, item))}
         </>
       )}
-      <kit.Separator />
-      {dangerItems.map(item => renderActionItem(kit, item))}
+      {dangerItems.length > 0 && (
+        <>
+          <kit.Separator />
+          {dangerItems.map(item => renderActionItem(kit, item))}
+        </>
+      )}
       {onHideTabBar && (
         <>
           <kit.Separator />


### PR DESCRIPTION
## What does this PR do?

Right-clicking a session **tab** (tabs opened via "Open in new tab", and the main tab) shows a context menu whose bottom entries are **Close All → Archive → Delete**. People reach for the last item of a tab menu expecting plain **Close** — that muscle memory comes from every browser and editor. Having destructive verbs (Archive/Delete) and a wide-blast verb (Close All) at the bottom of a *tab* menu makes a mis-click costly: I have accidentally deleted a session this way.

This PR makes tab surfaces safer without removing any capability:

- **Archive/Delete no longer appear on tab surfaces** (`surface === 'tab'`). They remain fully available on sidebar rows, where session lifecycle actions belong.
- **Plain Close moves to the very bottom** of the tab menu, below Close others / Close to the right / Close all — the last item is now the least destructive, most expected one.

Before (tab context menu):

```
Reload
Close            <- easy to miss
Close others
Close to the right
Close all        <- bottom-ish, wide blast radius
Archive          <- destructive, one mis-click away
Delete           <- destructive, at the very bottom
```

After (tab context menu):

```
Reload
Close others
Close to the right
Close all
Close            <- bottom = the safe, expected default
```

Sidebar row menus are unchanged (still end with Archive → Delete).

## Related Issue

No tracking issue — small UX safety improvement, happy to open one if maintainers prefer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx`
  - `dangerItems` (Archive/Delete) render only when `surface !== 'tab'`; their separator is hidden with them.
  - Tab verb order changed to Reload → Close others → Close to the right → Close all → **Close** (Close moved last, with a comment explaining why).
- `apps/desktop/src/app/chat/session-tile.tsx` — updated the `SessionTabMenu` doc comment: the tab menu is no longer "the SAME menu a sidebar row gets".
- `apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx` — new test: tab surface omits Archive/Delete and renders Close as the last menu item.

## How to Test

1. Open the desktop app, open any session, then right-click another session in the sidebar and choose "Open in new tab" so the tab strip shows multiple tabs.
2. Right-click a tab title: the menu ends with **Close**; **Archive** and **Delete** do not appear.
3. Right-click the same session's sidebar row: **Archive** and **Delete** still appear and still work.
4. Automated: `npx vitest run src/app/chat/sidebar/session-actions-menu.test.tsx` in `apps/desktop` — 2 tests pass (the existing row-menu test asserts Archive still renders on rows).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (3 files, +92/-42)
- [x] I've run the desktop vitest suites for the touched files — 7/7 pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10 (desktop app rebuilt from source, change verified in the running app)

### Documentation & Housekeeping

- [x] Documentation updated — N/A (behavior change is self-documenting in menus; component doc comments updated)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — menu structure only, no platform-specific code
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Test run on the PR branch (based on `main` @ d1afa1605):

```
 ✓  ui  src/app/chat/sidebar/session-actions-menu.test.ts (5 tests)
 ✓  ui  src/app/chat/sidebar/session-actions-menu.test.tsx (2 tests)
     ✓ opens the dropdown on click without a tooltip on the kebab
     ✓ tab surface omits Archive/Delete and puts Close last

 Test Files  2 passed (2)
      Tests  7 passed (7)
```

`eslint` and `tsc --build` are both clean on the touched files.
