### PR TITLE
fix(mcp): treat mtime=0 as first observation, not external refresh (#77369)

### DIFF
--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -664,6 +664,16 @@ class MCPOAuthManager:
             if mtime_ns != entry.last_mtime_ns:
                 old = entry.last_mtime_ns
                 entry.last_mtime_ns = mtime_ns
+                if old == 0:
+                    # First observation — the provider was just created and
+                    # already loaded its state from disk.  Record the mtime
+                    # so future checks can detect genuine external refreshes
+                    # without spuriously invalidating.  (#77369)
+                    logger.debug(
+                        "MCP OAuth '%s': recording initial mtime %d",
+                        server_name, mtime_ns,
+                    )
+                    return False
                 # Force the SDK's OAuthClientProvider to reload from storage
                 # on its next auth flow. `_initialized` is private API but
                 # stable across the MCP SDK versions we pin (>=1.26.0).


### PR DESCRIPTION
## Fixes #77369

### Problem

`MCPOAuthManager.invalidate_if_disk_changed()` compared tokens file mtime against `entry.last_mtime_ns`, whose default is `0` ("never read"). A freshly created `_ProviderEntry` always took the "changed" branch on its first check, even when the tokens file hadn't moved.

Each false invalidation set `provider._initialized = False`, forcing a full OAuth re-initialization. On hosted OAuth MCP servers, this re-init regularly exceeded `connect_timeout`, producing `TimeoutError` → retry ladder → parking. Server availability dropped to **32%**.

### Fix

When `old == 0` (first observation), record the mtime and return `False` without invalidating. The provider was just created and already loaded its state from disk — no reload needed. Genuine external refreshes (`mtime X -> Y`) continue to be detected.

```python
if old == 0:
    # First observation — record mtime, don't invalidate
    entry.last_mtime_ns = mtime_ns
    return False
```

### Testing

- `tests/tools/test_mcp_oauth_metadata.py` — 12/12 pass
- `tests/tools/test_mcp_oauth_cold_load_expiry.py` — passes
- `py_compile` passes
