### PR TITLE
fix(update): re-check venv holders before dependency sync to catch respawned gateways

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4073,6 +4073,48 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # marker survives and the next ``hermes`` launch finishes the install
         # via ``_recover_from_interrupted_install``. Cleared after the core
         # ``.[all]`` install completes — lazy refresh uses a separate marker.
+
+        # Second venv-holder re-check: the guard at the top of this function
+        # runs BEFORE git operations (which can take 30+ seconds). A gateway
+        # supervisor (Scheduled Task, login watchdog) can respawn its gateway
+        # in that window, re-locking .pyd files and causing the dependency
+        # sync to fail with "os error 5" on rename. Re-check now and kill
+        # any respawned gateways before touching the venv. (#77394)
+        if (
+            _m()._is_windows()
+            and _windows_gateway_resume is not None
+            and not getattr(args, "force_venv", False)
+        ):
+            _venv_holders_recheck = _m()._detect_venv_python_processes()
+            if _venv_holders_recheck:
+                _gateway_holders_recheck = _m()._leftover_pausable_gateway_pids(
+                    _venv_holders_recheck
+                )
+                if _gateway_holders_recheck is not None:
+                    from gateway.status import terminate_pid
+
+                    print(
+                        f"  ⚠ {len(_gateway_holders_recheck)} gateway process(es)"
+                        " respawned during update; stopping them"
+                    )
+                    for _pid in _gateway_holders_recheck:
+                        try:
+                            terminate_pid(int(_pid), force=True)
+                        except Exception as exc:
+                            logger.debug(
+                                "Could not stop respawned gateway %s: %s",
+                                _pid,
+                                exc,
+                            )
+                    _time.sleep(2.0)
+                    _venv_holders_recheck = _m()._detect_venv_python_processes()
+                if _venv_holders_recheck:
+                    print(_format_venv_python_holders_message(_venv_holders_recheck))
+                    _m()._resume_windows_gateways_after_update(
+                        _windows_gateway_resume
+                    )
+                    sys.exit(2)
+
         _write_update_incomplete_marker()
         print("→ Updating Python dependencies...")
         from hermes_cli.managed_uv import ensure_uv, update_managed_uv


### PR DESCRIPTION
## Summary

The venv-holder guard in `hermes update` runs **before** git operations (which can take 30+ seconds on Windows). A gateway supervisor (Scheduled Task, login watchdog) can respawn its gateway in that window, re-locking `.pyd` files (e.g. `cryptography/_rust.pyd`) and causing the dependency sync to fail with "os error 5" on rename.

Fixes #77394

## Root cause

The existing guard (line 3629) checks for venv-holding processes and kills pausable gateways, but this check runs **before** the git checkout/pull (lines 3660-4066). A gateway respawned by its supervisor during that window locks `.pyd` files, and the install at line 4100 fails.

Timeline from the issue:
- Guard check: no holders found
- Git operations: 30+ seconds
- Gateway respawned by Scheduled Task during git ops
- `uv pip install` fails: `os error 5` on `_rust.pyd` rename

## Fix

Add a second venv-holder re-check right before the dependency install, using the same `_detect_venv_python_processes()` + `_leftover_pausable_gateway_pids()` + `terminate_pid(force=True)` pattern as the original guard. If non-pausable holders are detected (e.g. Desktop backend), abort as before.

## Changes

- `hermes_cli/update_cmd.py`: Add 42-line re-check block between git operations and dependency install

## Test Plan

- [x] Syntax check passes (`ast.parse`)
- [ ] On Windows: run `hermes update` with a gateway running via Scheduled Task
- [ ] Verify the re-check prints the "respawned during update" message and kills the gateway
- [ ] Verify the install completes successfully after the re-check
