### PR TITLE
fix(auxiliary): route oauth_minimax through AnthropicAuxiliaryClient (fixes all aux tasks)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3293,16 +3293,19 @@ def _build_minimax_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional
     re-uses the cached one if it still has enough lifetime left).
 
     Returns ``(None, None)`` when the user has not authenticated with
-    MiniMax OAuth, or when the anthropic SDK is missing. The caller is
-    responsible for passing a model — pinning a default would silently rot
-    when MiniMax's accepted-model list drifts.
+    MiniMax OAuth, or when the anthropic SDK is missing. The model falls
+    back to the provider profile's ``default_aux_model`` (MiniMax-M2.7)
+    when the caller does not pass one explicitly.
     """
     if not model:
-        logger.warning(
-            "Auxiliary client: minimax-oauth requested without a model; "
-            "pass model explicitly (auxiliary.<task>.model in config.yaml)."
-        )
-        return None, None
+        model = _get_aux_model_for_provider("minimax-oauth")
+        if not model:
+            logger.warning(
+                "Auxiliary client: minimax-oauth requested but no model "
+                "resolved (auxiliary.<task>.model in config.yaml or the "
+                "minimax-oauth provider profile default_aux_model)."
+            )
+            return None, None
     try:
         from agent.anthropic_adapter import build_anthropic_client
         from hermes_cli.auth import (
@@ -3346,13 +3349,14 @@ def _build_minimax_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional
         "Auxiliary client: MiniMax OAuth (%s) at %s (per-request token provider)",
         model, base_url,
     )
-    # is_oauth=True is the safer default for MiniMax: even if the callable
-    # path is bypassed in some future change, the AnthropicAuxiliaryClient
-    # shim already strips the OAuth identity headers that would leak to
-    # MiniMax's third-party endpoint. See agent.anthropic_adapter for the
-    # third-party identity-injection guard.
+    # is_oauth must stay False: MiniMax is a third-party Anthropic-
+    # Messages-compatible endpoint, and the OAuth code paths (Claude Code
+    # identity system prefix, mcp__ tool renaming, OAuth-only betas) are
+    # for native Anthropic subscriptions only — agent_init.py's guard
+    # (#1739) is explicit that third-party providers must never trip them.
+    # The callable token provider handles auth; nothing else is needed.
     return AnthropicAuxiliaryClient(
-        real_client, model, "oauth-callable", base_url, is_oauth=True,
+        real_client, model, token_provider, base_url, is_oauth=False,
     ), model
 
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3278,6 +3278,84 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
     return _fallback_client, model
 
 
+def _build_minimax_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
+    """Build an AnthropicAuxiliaryClient for a MiniMax OAuth-authenticated session.
+
+    MiniMax exposes an Anthropic-Messages-compatible endpoint
+    (https://api.minimax.io/anthropic) via OAuth, so we use the native Anthropic
+    SDK wrapped in AnthropicAuxiliaryClient — same pattern as ``_try_anthropic``
+    but with the MiniMax OAuth token provider as the bearer source.
+
+    MiniMax issues short-lived access tokens (~15 min), so we pass a *callable*
+    token provider from ``build_minimax_oauth_token_provider()`` instead of a
+    static string. ``build_anthropic_client`` detects the callable and installs
+    the bearer-injecting httpx hook that mints a fresh token per request (or
+    re-uses the cached one if it still has enough lifetime left).
+
+    Returns ``(None, None)`` when the user has not authenticated with
+    MiniMax OAuth, or when the anthropic SDK is missing. The caller is
+    responsible for passing a model — pinning a default would silently rot
+    when MiniMax's accepted-model list drifts.
+    """
+    if not model:
+        logger.warning(
+            "Auxiliary client: minimax-oauth requested without a model; "
+            "pass model explicitly (auxiliary.<task>.model in config.yaml)."
+        )
+        return None, None
+    try:
+        from agent.anthropic_adapter import build_anthropic_client
+        from hermes_cli.auth import (
+            build_minimax_oauth_token_provider,
+            resolve_minimax_oauth_runtime_credentials,
+        )
+    except ImportError as exc:
+        logger.debug(
+            "Auxiliary client: minimax-oauth requested but anthropic adapter "
+            "or auth helpers not importable: %s", exc
+        )
+        return None, None
+
+    try:
+        creds = resolve_minimax_oauth_runtime_credentials(as_token_provider=True)
+    except Exception as exc:
+        logger.warning(
+            "Auxiliary client: minimax-oauth requested but no valid token "
+            "found (run: hermes model and select MiniMax OAuth): %s", exc
+        )
+        return None, None
+
+    token_provider = creds["api_key"]          # zero-arg callable
+    base_url = creds["base_url"].rstrip("/")
+    # The token provider IS already a callable from resolve_minimax_oauth_runtime_credentials
+    # when as_token_provider=True. Re-wrap defensively in case the helper's
+    # contract changes — build_minimax_oauth_token_provider always returns a
+    # fresh callable so the cost is one extra closure allocation.
+    if not callable(token_provider):
+        token_provider = build_minimax_oauth_token_provider()
+    try:
+        real_client = build_anthropic_client(token_provider, base_url)
+    except ImportError:
+        logger.warning(
+            "Auxiliary client: minimax-oauth requested but the anthropic "
+            "SDK is not installed — install with `pip install 'anthropic>=0.39.0'`"
+        )
+        return None, None
+
+    logger.debug(
+        "Auxiliary client: MiniMax OAuth (%s) at %s (per-request token provider)",
+        model, base_url,
+    )
+    # is_oauth=True is the safer default for MiniMax: even if the callable
+    # path is bypassed in some future change, the AnthropicAuxiliaryClient
+    # shim already strips the OAuth identity headers that would leak to
+    # MiniMax's third-party endpoint. See agent.anthropic_adapter for the
+    # third-party identity-injection guard.
+    return AnthropicAuxiliaryClient(
+        real_client, model, "oauth-callable", base_url, is_oauth=True,
+    ), model
+
+
 def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
     """Build a CodexAuxiliaryClient for an xAI Grok OAuth-authenticated session.
 
@@ -5940,6 +6018,31 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
+    # ── MiniMax (OAuth · minimax.io) ─────────────────────────────────
+    # Same rationale as xAI Grok OAuth above: without an explicit branch,
+    # the generic ``oauth_external`` arm below would return ``(None, None)``,
+    # silently re-routing every auxiliary task (compression, web extract,
+    # session search, curator, title generation, vision, ...) to whichever
+    # Step-2 fallback the user has configured. For users on MiniMax OAuth —
+    # a third-party Anthropic-Messages-compatible endpoint with OAuth
+    # credentials — that would mean surprise DeepSeek / OpenRouter bills for
+    # side tasks they thought were running on their MiniMax subscription.
+    # MiniMax uses the Anthropic Messages wire, so we route through the
+    # same AnthropicAuxiliaryClient as native Anthropic — the only thing
+    # that differs is the auth source (MiniMax OAuth token provider).
+    if provider == "minimax-oauth":
+        client, default = _build_minimax_oauth_aux_client(model)
+        if client is None:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth requested but no "
+                "valid MiniMax OAuth token found (run: hermes model and "
+                "select MiniMax (OAuth · minimax.io))"
+            )
+            return None, None
+        final_model = _normalize_resolved_model(model or default, provider)
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
+
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         custom_base = ""
@@ -6420,14 +6523,23 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
-    elif pconfig.auth_type in {"oauth_device_code", "oauth_external"}:
-        # OAuth providers — route through their specific try functions
+    elif pconfig.auth_type in {"oauth_device_code", "oauth_external", "oauth_minimax"}:
+        # OAuth providers — route through their specific try functions.
+        # ``oauth_minimax`` is a third-party OAuth (PKCE, portal-based) that
+        # uses the Anthropic Messages wire, so it lives in the same
+        # dispatch block as ``oauth_external``. The specific provider name
+        # check below (xai-oauth, minimax-oauth) handles routing to its
+        # own _build_*_aux_client — without that, the helper returns
+        # (None, None) and every auxiliary task silently leaks to the
+        # api-key fallback chain (DeepSeek, OpenRouter, ...).
         if provider == "nous":
             return resolve_provider_client("nous", model, async_mode)
         if provider == "openai-codex":
             return resolve_provider_client("openai-codex", model, async_mode)
         if provider == "xai-oauth":
             return resolve_provider_client("xai-oauth", model, async_mode)
+        if provider == "minimax-oauth":
+            return resolve_provider_client("minimax-oauth", model, async_mode)
         # Other OAuth providers not directly supported
         if provider not in _LOGGED_UNSUPPORTED_OAUTH_KEYS:
             _LOGGED_UNSUPPORTED_OAUTH_KEYS.add(provider)

--- a/contributors/emails/dr.basimu@gmail.com
+++ b/contributors/emails/dr.basimu@gmail.com
@@ -1,0 +1,2 @@
+Dr-Basim
+# PR #47703 salvage (auxiliary: route oauth_minimax through AnthropicAuxiliaryClient)

--- a/tests/agent/test_auxiliary_client_oauth_minimax.py
+++ b/tests/agent/test_auxiliary_client_oauth_minimax.py
@@ -1,0 +1,84 @@
+"""Regression tests: oauth_minimax auth_type must route to the MiniMax OAuth
+auxiliary client instead of falling through to the unhandled-auth_type
+(None, None) return (#45241, #45242, #58231).
+
+The minimax-oauth provider uses the Anthropic Messages wire with a
+callable MiniMax OAuth token provider. Before the fix, the dispatch block
+at resolve_provider_client only handled oauth_device_code / oauth_external,
+so oauth_minimax fell through to 'unhandled auth_type' and every auxiliary
+task (compression, vision, title_generation, session_search, ...) returned
+(None, None).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+def _import_resolve():
+    from agent.auxiliary_client import resolve_provider_client
+
+    return resolve_provider_client
+
+
+class TestOauthMinimaxAuthTypeDispatch:
+    """oauth_minimax auth_type routes to the minimax-oauth builder."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        self.resolve = _import_resolve()
+
+    def _make_pconfig(self, provider="minimax-oauth", auth_type="oauth_minimax"):
+        class _PConfig:
+            def __init__(self, provider, auth_type):
+                self.provider = provider
+                self.auth_type = auth_type
+                self.base_url = "https://api.minimax.io/anthropic"
+                self.api_key = None
+                self.model = "minimax/minimax-m2.7"
+                self.api_base = None
+                self.extra_headers = None
+                self.timeout = None
+                self.max_retries = None
+                self.aws_region = None
+                self.aws_access_key_id = None
+                self.aws_secret_access_key = None
+                self.aws_session_token = None
+                self.external_process = None
+
+        return _PConfig(provider, auth_type)
+
+    def test_oauth_minimax_dispatch_returns_client(self, monkeypatch):
+        """resolve_provider_client(minimax-oauth, ...) must build a client via
+        _build_minimax_oauth_aux_client, not return (None, None)."""
+        class _FakeClient:
+            def __init__(self, model):
+                self.model = model
+
+        with patch(
+            "agent.auxiliary_client._build_minimax_oauth_aux_client",
+            return_value=(_FakeClient("minimax-m2.7"), "minimax-m2.7"),
+        ) as mock_build:
+            client, model = self.resolve("minimax-oauth", "minimax/minimax-m2.7")
+        mock_build.assert_called_once()
+        assert client is not None
+        assert model == "minimax/minimax-m2.7"
+
+    def test_oauth_minimax_unauthenticated_returns_none_none(self, monkeypatch):
+        """No valid token -> (None, None), matching the other OAuth branches."""
+        with patch(
+            "agent.auxiliary_client._build_minimax_oauth_aux_client",
+            return_value=(None, None),
+        ):
+            client, model = self.resolve("minimax-oauth", "minimax/minimax-m2.7")
+        assert client is None
+        assert model is None
+
+    def test_auth_type_set_includes_oauth_minimax(self):
+        """The dispatch set must contain oauth_minimax (the #45241 symptom)."""
+        import agent.auxiliary_client as ac
+
+        src = open(ac.__file__, encoding="utf-8").read()
+        assert '"oauth_device_code", "oauth_external", "oauth_minimax"' in src or (
+            '"oauth_device_code", "oauth_external", "oauth_minimax"'
+        ) in src, "oauth_minimax must be in the auth_type dispatch set"

--- a/tests/agent/test_auxiliary_client_oauth_minimax.py
+++ b/tests/agent/test_auxiliary_client_oauth_minimax.py
@@ -1,6 +1,6 @@
 """Regression tests: oauth_minimax auth_type must route to the MiniMax OAuth
 auxiliary client instead of falling through to the unhandled-auth_type
-(None, None) return (#45241, #45242, #58231).
+(None, None) return (#21521, #45241, #45242, #58231, #36091, #29910, #38685).
 
 The minimax-oauth provider uses the Anthropic Messages wire with a
 callable MiniMax OAuth token provider. Before the fix, the dispatch block
@@ -28,26 +28,6 @@ class TestOauthMinimaxAuthTypeDispatch:
     def _import(self):
         self.resolve = _import_resolve()
 
-    def _make_pconfig(self, provider="minimax-oauth", auth_type="oauth_minimax"):
-        class _PConfig:
-            def __init__(self, provider, auth_type):
-                self.provider = provider
-                self.auth_type = auth_type
-                self.base_url = "https://api.minimax.io/anthropic"
-                self.api_key = None
-                self.model = "minimax/minimax-m2.7"
-                self.api_base = None
-                self.extra_headers = None
-                self.timeout = None
-                self.max_retries = None
-                self.aws_region = None
-                self.aws_access_key_id = None
-                self.aws_secret_access_key = None
-                self.aws_session_token = None
-                self.external_process = None
-
-        return _PConfig(provider, auth_type)
-
     def test_oauth_minimax_dispatch_returns_client(self, monkeypatch):
         """resolve_provider_client(minimax-oauth, ...) must build a client via
         _build_minimax_oauth_aux_client, not return (None, None)."""
@@ -74,11 +54,104 @@ class TestOauthMinimaxAuthTypeDispatch:
         assert client is None
         assert model is None
 
-    def test_auth_type_set_includes_oauth_minimax(self):
-        """The dispatch set must contain oauth_minimax (the #45241 symptom)."""
-        import agent.auxiliary_client as ac
 
-        src = open(ac.__file__, encoding="utf-8").read()
-        assert '"oauth_device_code", "oauth_external", "oauth_minimax"' in src or (
-            '"oauth_device_code", "oauth_external", "oauth_minimax"'
-        ) in src, "oauth_minimax must be in the auth_type dispatch set"
+class TestBuildMinimaxOauthAuxClient:
+    """The real builder path: AnthropicAuxiliaryClient, is_oauth=False,
+    profile model fallback — the semantics that make MiniMax work as a
+    third-party Anthropic-compatible endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from agent.auxiliary_client import _build_minimax_oauth_aux_client
+
+        self.build = _build_minimax_oauth_aux_client
+
+    def _patch_creds(self, monkeypatch, api_key="fake-token-callable"):
+        from hermes_cli.auth import AuthError
+
+        def _resolve_creds(*, min_token_ttl_seconds=None, as_token_provider=False):
+            return {
+                "provider": "minimax-oauth",
+                "api_key": (lambda: api_key) if as_token_provider else api_key,
+                "base_url": "https://api.minimax.io/anthropic/",
+                "source": "oauth",
+            }
+
+        def _raise_no_auth(*, min_token_ttl_seconds=None, as_token_provider=False):
+            raise AuthError(
+                "Not logged into MiniMax OAuth.", provider="minimax-oauth",
+                code="not_logged_in", relogin_required=True,
+            )
+
+        # The builder imports resolve_minimax_oauth_runtime_credentials fresh
+        # from hermes_cli.auth at call time — patch the source module.
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+            _resolve_creds,
+        )
+        return _raise_no_auth
+
+    def test_builds_anthropic_auxiliary_client_with_is_oauth_false(
+        self, monkeypatch,
+    ):
+        """The wrapper must carry is_oauth=False: MiniMax is a third-party
+        Anthropic-compatible endpoint and must never trip the Claude Code
+        identity OAuth code paths (agent_init.py guard, #1739)."""
+        class _FakeRealClient:
+            def close(self):
+                pass
+
+        def _fake_build_anthropic_client(api_key, base_url, **kwargs):
+            assert callable(api_key), "token provider must stay callable"
+            return _FakeRealClient()
+
+        self._patch_creds(monkeypatch)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.build_anthropic_client",
+            _fake_build_anthropic_client,
+        )
+
+        from agent.auxiliary_client import AnthropicAuxiliaryClient
+
+        client, model = self.build("minimax/minimax-m2.7")
+        assert isinstance(client, AnthropicAuxiliaryClient)
+        assert client.chat.completions._is_oauth is False
+        assert client.base_url == "https://api.minimax.io/anthropic"
+        assert model == "minimax/minimax-m2.7"
+
+    def test_unauthenticated_returns_none_none(self, monkeypatch):
+        """resolve_minimax_oauth_runtime_credentials raising AuthError
+        propagates as (None, None) — the same contract as xai-oauth."""
+        from hermes_cli.auth import AuthError
+
+        def _raise(*, min_token_ttl_seconds=None, as_token_provider=False):
+            raise AuthError(
+                "Not logged into MiniMax OAuth.", provider="minimax-oauth",
+                code="not_logged_in", relogin_required=True,
+            )
+
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+            _raise,
+        )
+        client, model = self.build("minimax/minimax-m2.7")
+        assert client is None
+        assert model is None
+
+    def test_model_falls_back_to_provider_profile_default(self, monkeypatch):
+        """No explicit model -> the provider profile's default_aux_model
+        (MiniMax-M2.7) is used, so the auto-detection chain (#29910) and
+        auxiliary.<task>.provider: minimax-oauth with empty model work."""
+        class _FakeRealClient:
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.build_anthropic_client",
+            lambda api_key, base_url, **kwargs: _FakeRealClient(),
+        )
+        self._patch_creds(monkeypatch)
+
+        client, model = self.build(None)
+        assert client is not None
+        assert model == "MiniMax-M2.7"

--- a/website/docs/guides/minimax-oauth.md
+++ b/website/docs/guides/minimax-oauth.md
@@ -170,7 +170,7 @@ hermes --provider minimax-oauth
 
 Both models support up to 200,000 tokens of context.
 
-`MiniMax-M2.7` is also used automatically as the auxiliary model for vision and delegation tasks when `minimax-oauth` is the primary provider.
+`MiniMax-M2.7` is also used automatically as the auxiliary model for vision and delegation tasks when `minimax-oauth` is the primary provider. All auxiliary tasks (compression, vision, title generation, session search, web extraction, approval, memory flush, kanban decomposition, MCP, profile description, skills hub, triage specification, curator) route through the same Anthropic-Messages-compatible endpoint with a callable OAuth token provider — tokens are minted per request and reused while still valid, so no static key is stored.
 
 ## Troubleshooting
 


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #1739 #21521 #29910 #36091 #38685 #45241 #45242 #47703 #58231
## What does this PR do?

Fixes the `oauth_minimax` auth_type breaking **every auxiliary task** for
MiniMax OAuth users — one bug class, one fix, closing the whole duplicate
cluster: #21521 (canonical), #45241, #45242, #58231, #36091, #29910, #38685.

### Root cause

`resolve_provider_client` in `agent/auxiliary_client.py` dispatched
`auth_type in {"oauth_device_code", "oauth_external"}` — but MiniMax OAuth
uses `auth_type == "oauth_minimax"`, which fell through to the
"unhandled auth_type" branch and returned `(None, None)`. Every auxiliary
task (compression, vision, title generation, session search, web
extraction, approval, memory flush, kanban decomposition, MCP, profile
description, skills hub, triage specification, curator) silently failed —
leaking down the api-key fallback chain or failing outright.

### The fix

- `oauth_minimax` added to the OAuth dispatch set.
- `provider == "minimax-oauth"` routes to `_build_minimax_oauth_aux_client()`,
  which builds an `AnthropicAuxiliaryClient` against MiniMax's
  Anthropic-Messages-compatible endpoint (`https://api.minimax.io/anthropic`)
  with a **callable** token provider — MiniMax tokens are short-lived
  (~15 min), so the bearer is minted per request and reused while valid.
- `is_oauth=False`: MiniMax is a third-party Anthropic-compatible endpoint,
  and the OAuth code paths (Claude Code identity system prefix, `mcp__`
  tool renaming, OAuth-only betas) are for native Anthropic subscriptions
  only — the `agent_init.py` guard (#1739) is explicit that third-party
  providers must never trip them. The callable token provider handles auth.
- Model falls back to the provider profile's `default_aux_model`
  (MiniMax-M2.7) when no explicit model is passed, so the auto-detection
  chain (#29910) and empty `auxiliary.<task>.model` configs resolve
  instead of returning `(None, None)`.
- Unauthenticated users get a clear warning pointing at `hermes model`,
  matching the other OAuth branches.

### Credit

The core dispatch is cherry-picked from **#47703 by @Dr-Basim**
(authorship preserved in git history) — it applied cleanly to current
main. The PR was closed before it could land; this ships the code with
regression tests and docs it never had, plus the third-party `is_oauth`
correction and profile-model fallback above.

## How to test

```bash
scripts/run_tests.sh tests/agent/test_auxiliary_client_oauth_minimax.py
# 5 passed — dispatch routes to the builder; builder returns
# AnthropicAuxiliaryClient with is_oauth=False; unauthenticated -> (None, None);
# model falls back to the profile default.

scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/plugins/model_providers/test_minimax_profile.py
# 168 passed, 1 failed (TestStaleBaseUrlWarning — pre-existing env-dependent
# failure, reproduces identically on pristine main)
```

RED proof: the same 5 tests fail/error on unpatched main (2 failed,
3 errors — the branch and builder don't exist there).

## What platforms were tested?

- Windows 10 native (git-bash): 173 passed across the auxiliary suites
  (+5 new), 1 pre-existing env-dependent failure stash-proven on pristine
  main, `git diff --check` clean, Windows-footgun lint clean on both
  changed files.

## Why this matters to users

Before: selecting MiniMax (OAuth) as your provider silently disabled
compression, vision, title generation, session search and a dozen other
auxiliary systems — every task returned `(None, None)` with only a debug
log, or fell back to an api-key provider and billed that instead of the
OAuth subscription. The docs even claimed `MiniMax-M2.7` was the automatic
auxiliary model; it never was.

After: all auxiliary tasks route through MiniMax's Anthropic-compatible
endpoint with per-request OAuth tokens — no surprise DeepSeek/OpenRouter
bills for side tasks, no `MINIMAX-OAUTH_API_KEY` env-var requirement for
an OAuth provider, no Claude Code identity leaked to a third-party
endpoint. The docs now accurately describe the routing.

Fixes #21521
Fixes #45241
Closes #58231
Closes #36091
Closes #29910
Closes #38685

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] Code follows repo style (reuses AnthropicAuxiliaryClient pattern)
- [x] Self-review complete
- [x] Tests added (5 regressions, incl. real builder path + RED proof)
- [x] Suite green: 173 passed (1 pre-existing env-dependent failure, stash-proven)
- [x] `git diff --check` clean
- [x] Documentation updated (minimax-oauth.md auxiliary routing)
- [x] Credit: core implementation from #47703 by @Dr-Basim, cherry-picked with authorship preserved


