### PR TITLE
fix(computer-use): expose CUA app lifecycle

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3191,7 +3191,11 @@ TERMINAL_CONFIG_ENV_MAP = {
     "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
     "modal_image": "TERMINAL_MODAL_IMAGE",
     "daytona_image": "TERMINAL_DAYTONA_IMAGE",
+<<<<<<< HEAD
     "vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
+=======
+    "desktop_image": "TERMINAL_DESKTOP_IMAGE",
+>>>>>>> df75c0559 (feat: add compute provider capability poc)
     "ssh_host": "TERMINAL_SSH_HOST",
     "ssh_user": "TERMINAL_SSH_USER",
     "ssh_port": "TERMINAL_SSH_PORT",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3191,11 +3191,8 @@ TERMINAL_CONFIG_ENV_MAP = {
     "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
     "modal_image": "TERMINAL_MODAL_IMAGE",
     "daytona_image": "TERMINAL_DAYTONA_IMAGE",
-<<<<<<< HEAD
     "vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
-=======
     "desktop_image": "TERMINAL_DESKTOP_IMAGE",
->>>>>>> df75c0559 (feat: add compute provider capability poc)
     "ssh_host": "TERMINAL_SSH_HOST",
     "ssh_user": "TERMINAL_SSH_USER",
     "ssh_port": "TERMINAL_SSH_PORT",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -10,6 +10,7 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+<<<<<<< HEAD
     # SQLite journal mode used by every Hermes database opener. WAL is the
     # normal default; set DELETE for weak-fsync/shared filesystems where WAL is
     # not crash-safe (for example macOS virtiofs, NFS, or SMB).
@@ -19,6 +20,24 @@ DEFAULT_CONFIG = {
         # None = SQLite defaults (autocheckpoint 1000 pages, no size limit).
         "wal_autocheckpoint": None,
         "journal_size_limit": None,
+=======
+    "compute": {
+        "provider": "modal",
+        "image": "trycua/cua:latest",
+        "capabilities": ["terminal", "files", "process", "computer_use"],
+        "modal": {
+            "cpu": 2,
+            "memory": 8192,
+            "persistent_filesystem": True,
+        },
+        "cua_fleet": {
+            "base_url": "https://run.cua.ai",
+            "token_url": "https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token",
+            "pool": "hermes-desktop",
+            "image_pull_secret": "ecr-credentials",
+            "ready_timeout": 600,
+        },
+>>>>>>> df75c0559 (feat: add compute provider capability poc)
     },
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -33,6 +33,7 @@ DEFAULT_CONFIG = {
             "base_url": "https://run.cua.ai",
             "token_url": "https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token",
             "pool": "hermes-desktop",
+            "replicas": 1,
             "image_pull_secret": "ecr-credentials",
             "ready_timeout": 600,
         },

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -10,7 +10,6 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
-<<<<<<< HEAD
     # SQLite journal mode used by every Hermes database opener. WAL is the
     # normal default; set DELETE for weak-fsync/shared filesystems where WAL is
     # not crash-safe (for example macOS virtiofs, NFS, or SMB).
@@ -20,7 +19,7 @@ DEFAULT_CONFIG = {
         # None = SQLite defaults (autocheckpoint 1000 pages, no size limit).
         "wal_autocheckpoint": None,
         "journal_size_limit": None,
-=======
+    },
     "compute": {
         "provider": "modal",
         "image": "trycua/cua:latest",
@@ -37,7 +36,6 @@ DEFAULT_CONFIG = {
             "image_pull_secret": "ecr-credentials",
             "ready_timeout": 600,
         },
->>>>>>> df75c0559 (feat: add compute provider capability poc)
     },
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -7,6 +7,7 @@
   pyproject-nix,
   pyproject-build-systems,
   stdenv,
+  linuxHeaders,
   # Filtered Python source (see lib.nix pythonSrc) — keeps JS/docs/skills
   # edits from invalidating the venv derivation.
   pythonSrc,
@@ -58,9 +59,15 @@ let
           "alibabacloud-gateway-dingtalk"
           "alibabacloud-gateway-spi"
           "alibabacloud-tea"
-          "evdev"
         ] (_: null)
-      );
+      )
+      // {
+        evdev = prev.evdev.overrideAttrs (old: {
+          nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
+            final.setuptools
+          ] ++ lib.optionals stdenv.isLinux [ linuxHeaders ];
+        });
+      };
 
   pythonPackageOverrides =
     final: _prev:

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -58,6 +58,7 @@ let
           "alibabacloud-gateway-dingtalk"
           "alibabacloud-gateway-spi"
           "alibabacloud-tea"
+          "evdev"
         ] (_: null)
       );
 

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -66,6 +66,9 @@ let
           nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
             final.setuptools
           ] ++ lib.optionals stdenv.isLinux [ linuxHeaders ];
+          preBuild = (old.preBuild or "") + ''
+            export CPATH=${linuxHeaders}/include''${CPATH:+:$CPATH}
+          '';
         });
       };
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ fal = ["fal-client==0.13.1"]
 # ElevenLabs / OpenAI / MiniMax instead).
 edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
-cua-fleet = ["cua-fleet==0.0.5"]
+cua-fleet = ["cua-fleet==0.0.6"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
 hindsight = ["hindsight-client==0.6.1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ fal = ["fal-client==0.13.1"]
 # ElevenLabs / OpenAI / MiniMax instead).
 edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
+cua-fleet = ["cua-fleet==0.0.5"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
 hindsight = ["hindsight-client==0.6.1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ fal = ["fal-client==0.13.1"]
 # ElevenLabs / OpenAI / MiniMax instead).
 edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
-cua-fleet = ["cua-sandbox==0.1.20"]
+cua-fleet = ["cua-sandbox==0.1.21"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
 hindsight = ["hindsight-client==0.6.1"]
@@ -360,7 +360,7 @@ override-dependencies = [
   "pynacl>=1.6,<1.7",
 ]
 exclude-newer = "14 days"
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false }
+exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, cua-sandbox = false, cua-fleet = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ fal = ["fal-client==0.13.1"]
 # ElevenLabs / OpenAI / MiniMax instead).
 edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
-cua-fleet = ["cua-fleet==0.0.6"]
+cua-fleet = ["cua-sandbox==0.1.20"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
 hindsight = ["hindsight-client==0.6.1"]

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import Mock, patch
+
+from tools.computer_use.transports.http_mcp import HttpMcpTransport
+from tools.computer_use.transports.stdio import StdioMcpTransport
+from tools.environments.capability_adapter import resolve_tools
+from tools.environments.capability_manifest import CapabilityManifest, desktop_manifest
+from tools.environments.compute_provider import ComputeLease, EnvironmentCapabilities
+from tools.environments.cua_fleet import CuaFleetConfig
+from tools.environments.desktop_lease import DesktopSandboxManager
+from tools.environments.modal_desktop import ModalDesktopConfig
+
+
+def test_compute_lease_fields() -> None:
+    capabilities = EnvironmentCapabilities(computer_use=True)
+    lease = ComputeLease("task-1", "lease-1", "modal", "desktop:latest", capabilities)
+
+    assert lease.task_id == "task-1"
+    assert lease.lease_id == "lease-1"
+    assert lease.provider == "modal"
+    assert lease.capabilities.computer_use
+
+
+def test_environment_capabilities_to_capabilities() -> None:
+    capabilities = EnvironmentCapabilities(computer_use=True, extras=frozenset({"browser"}))
+
+    assert capabilities.to_capabilities() == {"terminal", "files", "process", "computer_use", "browser"}
+
+
+def test_manifest_parses_dict_and_json() -> None:
+    manifest = CapabilityManifest.from_dict({
+        "image": "desktop:latest",
+        "capabilities": {"terminal": True, "computer_use": {"service": "cua-driver"}},
+    })
+    json_manifest = CapabilityManifest.from_json(json.dumps({"capabilities": ["files"]}))
+
+    assert manifest.image == "desktop:latest"
+    assert manifest.capabilities["computer_use"].service == "cua-driver"
+    assert json_manifest.enabled_capabilities() == {"files"}
+
+
+def test_desktop_manifest_defaults() -> None:
+    manifest = desktop_manifest("desktop:latest")
+
+    assert manifest.image == "desktop:latest"
+    assert {"terminal", "files", "process", "computer_use"} <= manifest.enabled_capabilities()
+
+
+def test_capability_adapter_resolves_authorized_intersection() -> None:
+    tools = resolve_tools(
+        {"terminal", "files", "computer_use"},
+        {"terminal", "computer_use"},
+    )
+
+    assert tools == {"terminal", "computer_use"}
+
+
+def test_desktop_sandbox_manager_acquire_release() -> None:
+    provider = Mock()
+    lease = ComputeLease("task-1", "lease-1", "fake", "desktop", EnvironmentCapabilities(computer_use=True))
+    environment = Mock()
+    provider.acquire.return_value = lease
+    provider.create_environment.return_value = environment
+    manager = DesktopSandboxManager(provider)
+
+    first = manager.acquire("task-1")
+    second = manager.acquire("task-1")
+    manager.release("task-1")
+    manager.release("task-1")
+
+    assert first is second
+    assert first.references == 0
+    provider.acquire.assert_called_once()
+    environment.cleanup.assert_called_once()
+    provider.release.assert_called_once_with(lease)
+
+
+def test_stdio_transport_start_stop() -> None:
+    process = Mock()
+    process.poll.return_value = None
+    with patch("tools.computer_use.transports.stdio.subprocess.Popen", return_value=process) as popen:
+        transport = StdioMcpTransport(("cua-driver", "mcp"))
+        transport.start()
+        assert transport.is_alive()
+        transport.stop()
+
+    popen.assert_called_once()
+    process.terminate.assert_called_once()
+    process.wait.assert_called_once_with(timeout=5)
+    assert not transport.is_alive()
+
+
+def test_http_transport_start_stop_and_alive() -> None:
+    response = Mock()
+    response.read.return_value = b'{"result": {}}'
+    response.__enter__ = Mock(return_value=response)
+    response.__exit__ = Mock(return_value=False)
+    transport = HttpMcpTransport("https://cua.example/mcp")
+
+    assert not transport.is_alive()
+    transport.start()
+    with patch("tools.computer_use.transports.http_mcp.urlopen", return_value=response):
+        assert transport.is_alive()
+    transport.stop()
+    assert not transport.is_alive()
+
+
+def test_modal_desktop_config_defaults() -> None:
+    config = ModalDesktopConfig()
+
+    assert config.image == "trycua/cua:latest"
+    assert config.cua_driver_command == ("cua-driver", "mcp")
+    assert config.persistent_filesystem
+
+
+def test_cua_fleet_config_defaults() -> None:
+    config = CuaFleetConfig()
+
+    assert config.pool == "default"
+    assert config.endpoint == ""

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -20,7 +20,11 @@ from tools.environments.cua_fleet import (
     _provider_from_config,
 )
 from tools.environments.desktop_lease import DesktopSandboxManager
-from tools.environments.modal_desktop import ModalDesktopConfig, ModalDesktopEnvironment
+from tools.environments.modal_desktop import (
+    ModalDesktopConfig,
+    ModalDesktopEnvironment,
+    _TransportComputerBackend,
+)
 
 
 def test_compute_lease_fields() -> None:
@@ -213,6 +217,39 @@ def test_modal_desktop_backend_uses_the_lease_bound_transport() -> None:
         backend = environment.get_computer_backend()
 
     assert isinstance(backend.transport, ModalSandboxMcpTransport)
+
+
+def test_modal_transport_backend_forwards_app_lifecycle_actions() -> None:
+    transport = Mock()
+    transport.call_tool.side_effect = [
+        {"structuredContent": {"pid": 42, "name": "Chromium", "windows": []}},
+        {"structuredContent": {"ok": True, "message": "focused"}},
+        {"structuredContent": {"ok": True, "message": "terminated"}},
+    ]
+    backend = _TransportComputerBackend(transport)
+
+    launched = backend.launch_app(
+        name="Chromium",
+        urls=["https://example.com"],
+        additional_arguments=["--incognito"],
+        creates_new_application_instance=True,
+    )
+    focused = backend.bring_to_front(pid=42, window_id=7)
+    terminated = backend.kill_app(pid=42)
+
+    assert launched == {"pid": 42, "name": "Chromium", "windows": []}
+    assert focused.ok is True
+    assert terminated.ok is True
+    assert transport.call_tool.call_args_list[0].args == ("launch_app", {
+        "name": "Chromium",
+        "urls": ["https://example.com"],
+        "additional_arguments": ["--incognito"],
+        "creates_new_application_instance": True,
+    })
+    assert transport.call_tool.call_args_list[1].args == (
+        "bring_to_front", {"pid": 42, "window_id": 7},
+    )
+    assert transport.call_tool.call_args_list[2].args == ("kill_app", {"pid": 42})
 
 def test_modal_desktop_config_defaults() -> None:
     config = ModalDesktopConfig()

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -417,4 +417,13 @@ def test_cua_fleet_nix_build_declares_evdev_build_system() -> None:
     from pathlib import Path
 
     python_nix = Path(__file__).parents[2] / "nix" / "python.nix"
-    assert '"evdev"' in python_nix.read_text()
+    assert "evdev = prev.evdev.overrideAttrs" in python_nix.read_text()
+
+
+def test_cua_fleet_nix_build_provides_evdev_kernel_headers() -> None:
+    from pathlib import Path
+
+    python_nix = Path(__file__).parents[2] / "nix" / "python.nix"
+    source = python_nix.read_text()
+    assert "linuxHeaders" in source
+    assert "evdev = prev.evdev.overrideAttrs" in source

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -569,3 +569,25 @@ def test_cua_fleet_environment_cleanup_retries_claim_release() -> None:
     environment.cleanup()
     assert attempts == 2
     assert lease.lease_id not in provider._states
+
+
+def test_desktop_terminal_reuses_existing_task_lease_without_incrementing(monkeypatch):
+    from tools import terminal_tool
+    from tools.environments import desktop_lease
+
+    environment = Mock()
+    manager = Mock()
+    manager.get.return_value = SimpleNamespace(environment=environment)
+    monkeypatch.setattr(desktop_lease, "get_desktop_sandbox_manager", lambda: manager)
+
+    result = terminal_tool._create_environment(
+        "desktop",
+        "desktop:latest",
+        "/root",
+        60,
+        task_id="task-existing",
+    )
+
+    assert result is environment
+    manager.get.assert_called_once_with("task-existing")
+    manager.acquire.assert_not_called()

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -427,3 +427,10 @@ def test_cua_fleet_nix_build_provides_evdev_kernel_headers() -> None:
     source = python_nix.read_text()
     assert "linuxHeaders" in source
     assert "evdev = prev.evdev.overrideAttrs" in source
+
+
+def test_cua_fleet_nix_build_sets_evdev_header_search_path() -> None:
+    from pathlib import Path
+
+    python_nix = Path(__file__).parents[2] / "nix" / "python.nix"
+    assert "export CPATH=${linuxHeaders}/include" in python_nix.read_text()

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -382,7 +382,7 @@ def test_cua_fleet_terminal_parses_sse_command_response() -> None:
 def test_cua_fleet_sandbox_package_is_lazy_installable() -> None:
     from tools.lazy_deps import LAZY_DEPS
 
-    assert LAZY_DEPS["terminal.cua_fleet"] == ("cua-sandbox==0.1.20",)
+    assert LAZY_DEPS["terminal.cua_fleet"] == ("cua-sandbox==0.1.21",)
 
 
 def test_desktop_terminal_reuses_existing_task_lease_without_incrementing(monkeypatch):
@@ -410,7 +410,7 @@ def test_desktop_terminal_reuses_existing_task_lease_without_incrementing(monkey
 def test_cua_fleet_provider_uses_public_sandbox_facade() -> None:
     from tools.lazy_deps import LAZY_DEPS
 
-    assert LAZY_DEPS["terminal.cua_fleet"] == ("cua-sandbox==0.1.20",)
+    assert LAZY_DEPS["terminal.cua_fleet"] == ("cua-sandbox==0.1.21",)
 
 
 def test_cua_fleet_nix_build_declares_evdev_build_system() -> None:

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -183,10 +183,6 @@ class _FakeFleetClient:
             namespace="hermes-task", name="sandbox-1", services=["server", "mcp"]
         )
 
-    async def list_pools(self, namespace):
-        self.calls.append(("list_pools", namespace))
-        return self.pools
-
     async def create_pool(self, request):
         self.calls.append(("create_pool", request))
         self.pool.spec = request.spec
@@ -199,8 +195,10 @@ class _FakeFleetClient:
         self.pools = [pool]
         return pool
 
-    async def get_pool(self, pool):
-        self.calls.append(("get_pool", pool))
+    async def get_pool(self, name):
+        self.calls.append(("get_pool", name))
+        if not self.pools:
+            raise _FakeFleetSdk.SdkError.Status("get pool", 404, name)
         return self.pool
 
     async def create_claim(self, request):
@@ -232,6 +230,13 @@ class _FakeRecord:
 
 
 class _FakeFleetSdk:
+    class SdkError:
+        class Status(Exception):
+            def __init__(self, operation, status, body):
+                self.operation = operation
+                self.status = status
+                self.body = body
+
     class HttpClient:
         pass
 
@@ -315,7 +320,7 @@ def test_cua_fleet_reconciles_missing_pool_and_releases_only_claim() -> None:
     provider.release(lease)
     calls = [call[0] for call in _FakeFleetSdk.CyclopsClient.client.calls]
     assert calls[:5] == [
-        "list_pools",
+        "get_pool",
         "create_pool",
         "get_pool",
         "create_claim",
@@ -480,7 +485,7 @@ def test_cua_fleet_reconcile_recovers_pool_after_ambiguous_create_failure() -> N
     provider.release(lease)
     calls = [call[0] for call in client.calls]
     assert calls.count("create_pool") == 1
-    assert calls.count("list_pools") == 2
+    assert calls.count("get_pool") == 3
     assert "delete_pool" not in calls
 
 

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -436,7 +436,7 @@ def test_cua_fleet_release_reports_claim_delete_failure_without_deleting_pool() 
 def test_cua_fleet_sdk_package_is_lazy_installable() -> None:
     from tools.lazy_deps import LAZY_DEPS
 
-    assert LAZY_DEPS["terminal.cua_fleet"] == ("cua-fleet==0.0.5",)
+    assert LAZY_DEPS["terminal.cua_fleet"] == ("cua-fleet==0.0.6",)
 
 
 def test_cua_fleet_environment_cleanup_releases_sdk_resources() -> None:

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -7,6 +8,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from tools.computer_use.transports.http_mcp import HttpMcpTransport
+from tools.computer_use.transports.modal_sandbox import ModalSandboxMcpTransport
 from tools.computer_use.transports.stdio import StdioMcpTransport
 from tools.environments import CuaFleetConfig, CuaFleetDesktopProvider
 from tools.environments.capability_adapter import resolve_tools
@@ -18,7 +20,7 @@ from tools.environments.cua_fleet import (
     _provider_from_config,
 )
 from tools.environments.desktop_lease import DesktopSandboxManager
-from tools.environments.modal_desktop import ModalDesktopConfig
+from tools.environments.modal_desktop import ModalDesktopConfig, ModalDesktopEnvironment
 
 
 def test_compute_lease_fields() -> None:
@@ -138,11 +140,70 @@ def test_http_transport_start_stop_and_alive() -> None:
     assert not transport.is_alive()
 
 
+
+class _ModalWorker:
+    def run_coroutine(self, coroutine, timeout: int = 60):
+        return asyncio.run(coroutine)
+
+
+class _ModalSandbox:
+    async def _tunnels(self, timeout: int):
+        assert timeout == 50
+        return {8080: SimpleNamespace(url="https://lease-1.modal.host")}
+
+    def __init__(self):
+        self.tunnels = SimpleNamespace(aio=self._tunnels)
+
+
+def _modal_mcp_response():
+    response = Mock()
+    response.headers = {"mcp-session-id": "session-1"}
+    response.read.side_effect = [b'{"jsonrpc":"2.0","id":1,"result":{}}', b""]
+    response.__enter__ = Mock(return_value=response)
+    response.__exit__ = Mock(return_value=False)
+    return response
+
+
+def test_modal_sandbox_transport_uses_the_lease_tunnel() -> None:
+    transport = ModalSandboxMcpTransport(_ModalSandbox(), _ModalWorker(), port=8080, path="/mcp")
+
+    with patch("tools.computer_use.transports.modal_sandbox.urlopen", return_value=_modal_mcp_response()):
+        transport.start()
+
+    assert transport.endpoint == "https://lease-1.modal.host/mcp"
+    assert transport.headers["mcp-session-id"] == "session-1"
+
+
+def test_modal_desktop_starts_the_image_mcp_runtime_on_an_encrypted_port() -> None:
+    lease = ComputeLease("task-1", "lease-1", "modal", "registry.example/cua-driver-mcp@sha256:test", EnvironmentCapabilities(computer_use=True))
+
+    with patch("tools.environments.modal_desktop.ModalEnvironment.__init__") as init:
+        ModalDesktopEnvironment(compute_lease=lease, config=ModalDesktopConfig())
+
+    kwargs = init.call_args.kwargs
+    assert kwargs["sandbox_command"] == ("/bin/cua-driver-mcp-runtime",)
+    assert kwargs["modal_sandbox_kwargs"]["encrypted_ports"] == [8080]
+
+
+def test_modal_desktop_backend_uses_the_lease_bound_transport() -> None:
+    environment = object.__new__(ModalDesktopEnvironment)
+    environment._computer_backend = None
+    environment._desktop_config = ModalDesktopConfig()
+    environment._sandbox = _ModalSandbox()
+    environment._worker = _ModalWorker()
+
+    with patch("tools.computer_use.transports.modal_sandbox.urlopen", return_value=_modal_mcp_response()):
+        backend = environment.get_computer_backend()
+
+    assert isinstance(backend.transport, ModalSandboxMcpTransport)
+
 def test_modal_desktop_config_defaults() -> None:
     config = ModalDesktopConfig()
 
     assert config.image == "trycua/cua:latest"
-    assert config.cua_driver_command == ("cua-driver", "mcp")
+    assert config.cua_driver_runtime_command == ("/bin/cua-driver-mcp-runtime",)
+    assert config.cua_driver_port == 8080
+    assert config.cua_driver_path == "/mcp"
     assert config.persistent_filesystem
 
 

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-import urllib.error
-import urllib.request
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -169,224 +167,158 @@ def test_environments_package_reexports_cua_fleet_sdk() -> None:
     assert CuaFleetDesktopProvider is CuaFleetDesktopProviderImplementation
 
 
-class _FakeFleetClient:
+class _FakeResponse:
+    def __init__(self, status_code: int = 200, content: bytes | None = None):
+        self.status_code = status_code
+        self.content = content or b'{"result":{"stdout":"ok\\n","stderr":"","returncode":0}}'
+
+
+class _FakeServices:
     def __init__(self):
-        self.calls = []
-        self.pool = SimpleNamespace(
-            metadata=SimpleNamespace(namespace="hermes-desktop", name="hermes-desktop"),
-            status=SimpleNamespace(available_count=1),
-            spec=None,
-        )
-        self.pools = []
-        self.claim = SimpleNamespace(metadata=SimpleNamespace(name="hermes-task-claim"))
-        self.sandbox = SimpleNamespace(
-            namespace="hermes-task", name="sandbox-1", services=["server", "mcp"]
-        )
+        self.calls: list[tuple[str, str, str, object]] = []
 
-    async def create_pool(self, request):
-        self.calls.append(("create_pool", request))
-        self.pool.spec = request.spec
-        self.pools = [self.pool]
-        return self.pool
+    async def request(self, name, *, method, path, json=None):
+        self.calls.append((name, method, path, json))
+        return _FakeResponse()
 
-    async def update_pool(self, pool):
-        self.calls.append(("update_pool", pool))
-        self.pool = pool
-        self.pools = [pool]
-        return pool
 
-    async def get_pool(self, name):
-        self.calls.append(("get_pool", name))
-        if not self.pools:
-            raise _FakeFleetSdk.SdkError.Status("get pool", 404, name)
-        return self.pool
+class _FakeSandbox:
+    def __init__(self):
+        self.name = "sandbox-1"
+        self.services = _FakeServices()
 
-    async def create_claim(self, request):
-        self.calls.append(("create_claim", request))
-        return self.claim
 
-    async def wait_claim(self, claim):
-        self.calls.append(("wait_claim", claim))
+class _FakeClaimContext:
+    def __init__(self, sandbox: _FakeSandbox):
+        self.sandbox = sandbox
+        self.entered = 0
+        self.exited = 0
+        self.fail_exit_once = False
+
+    async def __aenter__(self):
+        self.entered += 1
         return self.sandbox
 
-    async def delete_claim(self, claim):
-        self.calls.append(("delete_claim", claim))
-
-    async def delete_pool(self, pool):
-        self.calls.append(("delete_pool", pool))
-
-    async def service_request(self, sandbox, service, path, request):
-        self.calls.append(("service_request", sandbox, service, path, request))
-        return SimpleNamespace(
-            status=200,
-            headers=[],
-            body=b'{"result":{"stdout":"ok\\n","stderr":"","returncode":0}}',
-        )
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        self.exited += 1
+        if self.fail_exit_once and self.exited == 1:
+            raise RuntimeError("claim release failed")
 
 
-class _FakeRecord:
-    def __eq__(self, other):
-        return type(self) is type(other) and self.__dict__ == other.__dict__
+class _FakePool:
+    def __init__(self):
+        self.name = "hermes-desktop"
+        self.claim_contexts: list[_FakeClaimContext] = []
+
+    def claim(self):
+        context = _FakeClaimContext(_FakeSandbox())
+        self.claim_contexts.append(context)
+        return context
 
 
-class _FakeFleetSdk:
-    class SdkError:
-        class Status(Exception):
-            def __init__(self, operation, status, body):
-                self.operation = operation
-                self.status = status
-                self.body = body
+class _FakeSandboxApi:
+    configure_calls: list[dict[str, str]] = []
+    reconcile_configs: list[dict[str, object]] = []
+    pool = _FakePool()
 
-    class HttpClient:
-        pass
+    @classmethod
+    def reset(cls) -> None:
+        cls.configure_calls = []
+        cls.reconcile_configs = []
+        cls.pool = _FakePool()
 
-    class CyclopsCredentials:
-        def __init__(self, client_id, client_secret):
-            self.client_id = client_id
-            self.client_secret = client_secret
+    @staticmethod
+    def configure(**kwargs) -> None:
+        _FakeSandboxApi.configure_calls.append(kwargs)
 
-    class CyclopsConfiguration(_FakeRecord):
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
+    class Image:
+        @staticmethod
+        def from_registry(ref: str):
+            return SimpleNamespace(ref=ref)
 
-    class CyclopsClient:
-        client = _FakeFleetClient()
-        connect_calls = 0
-
+    class Pool:
         @classmethod
-        def connect(cls, configuration, http_client):
-            cls.connect_calls += 1
-            cls.configuration = configuration
-            cls.http_client = http_client
-            return cls.client
-
-    class CreatePoolRequest(_FakeRecord):
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-
-    class CreateClaimRequest(_FakeRecord):
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-
-    class PoolSpec(_FakeRecord):
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-
-    class PoolTemplate(_FakeRecord):
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-
-    class SandboxService(_FakeRecord):
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-
-    class HttpHeader(_FakeRecord):
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-
-    class HttpRequest(_FakeRecord):
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-
-    class HttpResponse(_FakeRecord):
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
+        async def reconcile(cls, config):
+            _FakeSandboxApi.reconcile_configs.append(dict(config))
+            return _FakeSandboxApi.pool
 
 
-def _fleet_provider(
-    replicas: int = 2, available_count: int | None = None, ready_timeout: float = 600
-) -> CuaFleetDesktopProvider:
-    _FakeFleetSdk.CyclopsClient.client = _FakeFleetClient()
-    _FakeFleetSdk.CyclopsClient.client.pool.status.available_count = (
-        replicas if available_count is None else available_count
-    )
-    _FakeFleetSdk.CyclopsClient.connect_calls = 0
+def _fleet_provider(replicas: int = 2) -> CuaFleetDesktopProvider:
+    _FakeSandboxApi.reset()
     return CuaFleetDesktopProvider(
         CuaFleetConfig(
             client_id="ukey-test",
             client_secret="secret",
+            image="registry.example/desktop:latest",
+            pool="hermes-desktop",
             replicas=replicas,
-            ready_poll_interval=0,
-            ready_timeout=ready_timeout,
         ),
-        sdk_module=_FakeFleetSdk,
+        sandbox_module=_FakeSandboxApi,
     )
 
 
-def test_cua_fleet_reconciles_missing_pool_and_releases_only_claim() -> None:
+def test_cua_fleet_reconciles_named_pool_with_public_sandbox_api() -> None:
     provider = _fleet_provider()
-    lease = provider.acquire("task-1", image="registry.example/desktop:latest")
-    environment = provider.create_environment(lease)
+
+    lease = provider.acquire("task-1")
+
+    assert _FakeSandboxApi.configure_calls == [{
+        "fleet_base_url": "https://run.cua.ai",
+        "token_url": (
+            "https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token"
+        ),
+        "client_id": "ukey-test",
+        "client_secret": "secret",
+    }]
+    assert len(_FakeSandboxApi.reconcile_configs) == 1
+    config = _FakeSandboxApi.reconcile_configs[0]
+    assert config["name"] == "hermes-desktop"
+    assert config["image"].ref == "registry.example/desktop:latest"
+    assert config["replicas"] == 2
+    assert config["services"] == {"server": 8000, "mcp": 3000}
+    assert lease.metadata == {"pool": "hermes-desktop", "sandbox": "sandbox-1"}
+    assert _FakeSandboxApi.pool.claim_contexts[0].entered == 1
+
     provider.release(lease)
-    calls = [call[0] for call in _FakeFleetSdk.CyclopsClient.client.calls]
-    assert calls[:5] == [
-        "get_pool",
-        "create_pool",
-        "get_pool",
-        "create_claim",
-        "wait_claim",
-    ]
-    assert calls[-1] == "delete_claim"
-    assert "delete_pool" not in calls
-    assert environment.compute_lease is lease
-    assert lease.metadata["namespace"] == "hermes-desktop"
-    assert lease.metadata["pool"] == "hermes-desktop"
-    assert _FakeFleetSdk.CyclopsClient.client.pool.spec.replicas == 2
+    assert _FakeSandboxApi.pool.claim_contexts[0].exited == 1
 
 
-def test_cua_fleet_reconcile_is_noop_when_pool_spec_matches() -> None:
-    provider = _fleet_provider()
-    client = _FakeFleetSdk.CyclopsClient.client
-    desired = provider._pool_request(
-        _FakeFleetSdk, "hermes-desktop", provider.config.image
-    )
-    client.pool.spec = desired.spec
-    client.pools = [client.pool]
-    lease = provider.acquire("task-existing")
-    provider.release(lease)
-    calls = [call[0] for call in client.calls]
-    assert "create_pool" not in calls
-    assert "update_pool" not in calls
-    assert calls.count("delete_claim") == 1
-    assert "delete_pool" not in calls
-
-
-def test_cua_fleet_reconcile_updates_drifted_pool() -> None:
-    provider = _fleet_provider()
-    client = _FakeFleetSdk.CyclopsClient.client
-    client.pool.spec = SimpleNamespace(replicas=99)
-    client.pools = [client.pool]
-    lease = provider.acquire("task-drifted")
-    provider.release(lease)
-    calls = [call[0] for call in client.calls]
-    assert "create_pool" not in calls
-    assert calls.count("update_pool") == 1
-    assert client.pool.spec.replicas == 2
-    assert "delete_pool" not in calls
-
-
-def test_cua_fleet_environment_routes_terminal_through_bound_sandbox() -> None:
+def test_cua_fleet_environment_routes_terminal_through_named_server_service() -> None:
     provider = _fleet_provider()
     lease = provider.acquire("task-2")
     environment = provider.create_environment(lease)
 
-    handle = environment._run_bash("printf ok", timeout=10)
-    assert handle.wait(timeout=2) == 0
+    handle = environment._run_bash("printf ok")
+
     assert handle.stdout.read() == "ok\n"
-    service_call = next(
-        call
-        for call in _FakeFleetSdk.CyclopsClient.client.calls
-        if call[0] == "service_request"
-    )
-    assert service_call[1] is provider._states[lease.lease_id].sandbox
-    assert service_call[2:4] == ("server", "/cmd")
+    service_call = _FakeSandboxApi.pool.claim_contexts[0].sandbox.services.calls[0]
+    assert service_call[:3] == ("server", "POST", "/cmd")
+    provider.release(lease)
+
+
+def test_cua_fleet_mcp_transport_routes_through_named_mcp_service() -> None:
+    from tools.environments.cua_fleet import _FleetMcpTransport
+
+    provider = _fleet_provider()
+    lease = provider.acquire("task-mcp")
+    state = provider._states[lease.lease_id]
+    worker = provider._workers[lease.lease_id]
+    transport = _FleetMcpTransport(state, worker, provider.config.request_timeout)
+
+    transport.start()
+
+    service_call = state.sandbox.services.calls[0]
+    assert service_call[:3] == ("mcp", "POST", "/mcp")
+    assert service_call[3]["method"] == "initialize"
     provider.release(lease)
 
 
 def test_cua_fleet_requires_client_credentials(monkeypatch) -> None:
     monkeypatch.delenv("CUA_CLIENT_ID", raising=False)
     monkeypatch.delenv("CUA_CLIENT_SECRET", raising=False)
-    provider = CuaFleetDesktopProvider(CuaFleetConfig(), sdk_module=_FakeFleetSdk)
+    provider = CuaFleetDesktopProvider(
+        CuaFleetConfig(), sandbox_module=_FakeSandboxApi
+    )
 
     with pytest.raises(RuntimeError, match="CUA_CLIENT_ID"):
         provider.acquire("task-3")
@@ -410,56 +342,32 @@ def test_compute_config_selects_cua_fleet_provider(monkeypatch) -> None:
     assert provider.config.replicas == 2
 
 
-def test_cua_fleet_waits_for_configured_replicas() -> None:
-    provider = _fleet_provider(available_count=1, ready_timeout=0)
-
-    with pytest.raises(TimeoutError, match="Timed out waiting for Fleet pool"):
-        provider.acquire("task-insufficient-capacity")
-
-
-def test_cua_fleet_release_reports_claim_delete_failure_without_deleting_pool() -> None:
+def test_cua_fleet_environment_cleanup_exits_claim_once() -> None:
     provider = _fleet_provider()
     lease = provider.acquire("task-4")
-    client = _FakeFleetSdk.CyclopsClient.client
-
-    async def fail_delete_claim(claim):
-        client.calls.append(("delete_claim", claim))
-        raise RuntimeError("claim delete failed")
-
-    client.delete_claim = fail_delete_claim
-    with pytest.raises(RuntimeError, match="claim delete failed"):
-        provider.release(lease)
-    assert [call[0] for call in client.calls][-1] == "delete_claim"
-    assert "delete_pool" not in [call[0] for call in client.calls]
-
-
-def test_cua_fleet_sdk_package_is_lazy_installable() -> None:
-    from tools.lazy_deps import LAZY_DEPS
-
-    assert LAZY_DEPS["terminal.cua_fleet"] == ("cua-fleet==0.0.6",)
-
-
-def test_cua_fleet_environment_cleanup_releases_sdk_resources() -> None:
-    provider = _fleet_provider()
-    lease = provider.acquire("task-5")
     environment = provider.create_environment(lease)
 
     environment.cleanup()
     environment.cleanup()
 
-    calls = [call[0] for call in _FakeFleetSdk.CyclopsClient.client.calls]
-    assert calls.count("delete_claim") == 1
-    assert "delete_pool" not in calls
+    context = _FakeSandboxApi.pool.claim_contexts[0]
+    assert context.exited == 1
     assert lease.lease_id not in provider._states
 
 
-def test_cua_fleet_http_client_uses_concrete_execute_first() -> None:
-    class AbstractHttpClient:
-        async def execute(self, request):
-            raise NotImplementedError
+def test_cua_fleet_claim_release_can_retry_after_transient_failure() -> None:
+    provider = _fleet_provider()
+    lease = provider.acquire("task-retry-release")
+    context = _FakeSandboxApi.pool.claim_contexts[0]
+    context.fail_exit_once = True
 
-    client_type = CuaFleetDesktopProvider._http_client_type(AbstractHttpClient)
-    assert client_type.execute is not AbstractHttpClient.execute
+    with pytest.raises(RuntimeError, match="claim release failed"):
+        provider.release(lease)
+    assert lease.lease_id in provider._states
+
+    provider.release(lease)
+    assert lease.lease_id not in provider._states
+    assert context.exited == 2
 
 
 def test_cua_fleet_terminal_parses_sse_command_response() -> None:
@@ -471,109 +379,10 @@ def test_cua_fleet_terminal_parses_sse_command_response() -> None:
     assert parsed["result"] == {"stdout": "ok\n", "stderr": "", "returncode": 0}
 
 
-def test_cua_fleet_reconcile_recovers_pool_after_ambiguous_create_failure() -> None:
-    provider = _fleet_provider()
-    client = _FakeFleetSdk.CyclopsClient.client
-    original_create = client.create_pool
+def test_cua_fleet_sandbox_package_is_lazy_installable() -> None:
+    from tools.lazy_deps import LAZY_DEPS
 
-    async def create_then_fail(request):
-        await original_create(request)
-        raise TimeoutError("ambiguous create timeout")
-
-    client.create_pool = create_then_fail
-    lease = provider.acquire("task-timeout")
-    provider.release(lease)
-    calls = [call[0] for call in client.calls]
-    assert calls.count("create_pool") == 1
-    assert calls.count("get_pool") == 3
-    assert "delete_pool" not in calls
-
-
-def test_cua_fleet_claim_release_can_retry_after_transient_failure() -> None:
-    provider = _fleet_provider()
-    lease = provider.acquire("task-retry-release")
-    client = _FakeFleetSdk.CyclopsClient.client
-    original = client.delete_claim
-    attempts = 0
-
-    async def fail_once(claim):
-        nonlocal attempts
-        attempts += 1
-        if attempts == 1:
-            raise RuntimeError("transient delete failure")
-        await original(claim)
-
-    client.delete_claim = fail_once
-    with pytest.raises(RuntimeError, match="transient delete failure"):
-        provider.release(lease)
-    assert lease.lease_id in provider._states
-
-    provider.release(lease)
-    assert lease.lease_id not in provider._states
-    assert attempts == 2
-
-
-def test_cua_fleet_provider_reuses_sdk_client_across_claims() -> None:
-    provider = _fleet_provider()
-    first = provider.acquire("task-client-one")
-    first_client = provider._states[first.lease_id].client
-    second = provider.acquire("task-client-two")
-    second_client = provider._states[second.lease_id].client
-    assert first_client is second_client
-    assert _FakeFleetSdk.CyclopsClient.connect_calls == 1
-    provider.release(first)
-    provider.release(second)
-
-
-def test_cua_fleet_http_client_rejects_redirects(monkeypatch) -> None:
-    from tools.environments.cua_fleet import _UrlLibHttpClient
-
-    class Sdk:
-        class HttpHeader:
-            def __init__(self, **kwargs):
-                self.__dict__.update(kwargs)
-
-        class HttpResponse:
-            def __init__(self, **kwargs):
-                self.__dict__.update(kwargs)
-
-    client = _UrlLibHttpClient(Sdk, 1, ("run.cua.ai",))
-    request = SimpleNamespace(
-        url="https://run.cua.ai/api", body=None, method="GET", headers=[]
-    )
-    redirected = urllib.error.HTTPError(
-        request.url, 302, "Found", {"Location": "https://evil.example/steal"}, None
-    )
-    monkeypatch.setattr(
-        urllib.request,
-        "build_opener",
-        Mock(return_value=Mock(open=Mock(side_effect=redirected))),
-    )
-    response = client._execute(request)
-    assert response.status == 302
-
-
-def test_cua_fleet_environment_cleanup_retries_claim_release() -> None:
-    provider = _fleet_provider()
-    lease = provider.acquire("task-env-retry")
-    environment = provider.create_environment(lease)
-    client = _FakeFleetSdk.CyclopsClient.client
-    original = client.delete_claim
-    attempts = 0
-
-    async def fail_once(claim):
-        nonlocal attempts
-        attempts += 1
-        if attempts == 1:
-            raise RuntimeError("transient cleanup failure")
-        await original(claim)
-
-    client.delete_claim = fail_once
-    with pytest.raises(RuntimeError, match="transient cleanup failure"):
-        environment.cleanup()
-    environment.cleanup()
-    assert attempts == 2
-    assert lease.lease_id not in provider._states
+    assert LAZY_DEPS["terminal.cua_fleet"] == ("cua-sandbox==0.1.20",)
 
 
 def test_desktop_terminal_reuses_existing_task_lease_without_incrementing(monkeypatch):
@@ -596,3 +405,9 @@ def test_desktop_terminal_reuses_existing_task_lease_without_incrementing(monkey
     assert result is environment
     manager.get.assert_called_once_with("task-existing")
     manager.acquire.assert_not_called()
+
+
+def test_cua_fleet_provider_uses_public_sandbox_facade() -> None:
+    from tools.lazy_deps import LAZY_DEPS
+
+    assert LAZY_DEPS["terminal.cua_fleet"] == ("cua-sandbox==0.1.20",)

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
-import subprocess
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
+
+import pytest
 
 from tools.computer_use.transports.http_mcp import HttpMcpTransport
 from tools.computer_use.transports.stdio import StdioMcpTransport
@@ -13,6 +15,7 @@ from tools.environments.compute_provider import ComputeLease, EnvironmentCapabil
 from tools.environments.cua_fleet import (
     CuaFleetConfig as CuaFleetConfigImplementation,
     CuaFleetDesktopProvider as CuaFleetDesktopProviderImplementation,
+    _provider_from_config,
 )
 from tools.environments.desktop_lease import DesktopSandboxManager
 from tools.environments.modal_desktop import ModalDesktopConfig
@@ -29,9 +32,17 @@ def test_compute_lease_fields() -> None:
 
 
 def test_environment_capabilities_to_capabilities() -> None:
-    capabilities = EnvironmentCapabilities(computer_use=True, extras=frozenset({"browser"}))
+    capabilities = EnvironmentCapabilities(
+        computer_use=True, extras=frozenset({"browser"})
+    )
 
-    assert capabilities.to_capabilities() == {"terminal", "files", "process", "computer_use", "browser"}
+    assert capabilities.to_capabilities() == {
+        "terminal",
+        "files",
+        "process",
+        "computer_use",
+        "browser",
+    }
 
 
 def test_manifest_parses_dict_and_json() -> None:
@@ -39,7 +50,9 @@ def test_manifest_parses_dict_and_json() -> None:
         "image": "desktop:latest",
         "capabilities": {"terminal": True, "computer_use": {"service": "cua-driver"}},
     })
-    json_manifest = CapabilityManifest.from_json(json.dumps({"capabilities": ["files"]}))
+    json_manifest = CapabilityManifest.from_json(
+        json.dumps({"capabilities": ["files"]})
+    )
 
     assert manifest.image == "desktop:latest"
     assert manifest.capabilities["computer_use"].service == "cua-driver"
@@ -50,7 +63,12 @@ def test_desktop_manifest_defaults() -> None:
     manifest = desktop_manifest("desktop:latest")
 
     assert manifest.image == "desktop:latest"
-    assert {"terminal", "files", "process", "computer_use"} <= manifest.enabled_capabilities()
+    assert {
+        "terminal",
+        "files",
+        "process",
+        "computer_use",
+    } <= manifest.enabled_capabilities()
 
 
 def test_capability_adapter_resolves_authorized_intersection() -> None:
@@ -64,7 +82,13 @@ def test_capability_adapter_resolves_authorized_intersection() -> None:
 
 def test_desktop_sandbox_manager_acquire_release() -> None:
     provider = Mock()
-    lease = ComputeLease("task-1", "lease-1", "fake", "desktop", EnvironmentCapabilities(computer_use=True))
+    lease = ComputeLease(
+        "task-1",
+        "lease-1",
+        "fake",
+        "desktop",
+        EnvironmentCapabilities(computer_use=True),
+    )
     environment = Mock()
     provider.acquire.return_value = lease
     provider.create_environment.return_value = environment
@@ -85,7 +109,9 @@ def test_desktop_sandbox_manager_acquire_release() -> None:
 def test_stdio_transport_start_stop() -> None:
     process = Mock()
     process.poll.return_value = None
-    with patch("tools.computer_use.transports.stdio.subprocess.Popen", return_value=process) as popen:
+    with patch(
+        "tools.computer_use.transports.stdio.subprocess.Popen", return_value=process
+    ) as popen:
         transport = StdioMcpTransport(("cua-driver", "mcp"))
         transport.start()
         assert transport.is_alive()
@@ -123,10 +149,213 @@ def test_modal_desktop_config_defaults() -> None:
 def test_cua_fleet_config_defaults() -> None:
     config = CuaFleetConfig()
 
-    assert config.pool == "default"
-    assert config.endpoint == ""
+    assert config.base_url == "https://run.cua.ai"
+    assert config.token_url.startswith("https://auth.cua.ai/")
+    assert config.client_id == ""
+    assert config.client_secret == ""
 
 
 def test_environments_package_reexports_cua_fleet_sdk() -> None:
     assert CuaFleetConfig is CuaFleetConfigImplementation
     assert CuaFleetDesktopProvider is CuaFleetDesktopProviderImplementation
+
+
+class _FakeFleetClient:
+    def __init__(self):
+        self.calls = []
+        self.pool = SimpleNamespace(
+            metadata=SimpleNamespace(namespace="hermes-task", name="hermes-task"),
+            status=SimpleNamespace(available_count=1),
+        )
+        self.claim = SimpleNamespace(metadata=SimpleNamespace(name="hermes-task-claim"))
+        self.sandbox = SimpleNamespace(
+            namespace="hermes-task", name="sandbox-1", services=["server", "mcp"]
+        )
+
+    async def create_pool(self, request):
+        self.calls.append(("create_pool", request))
+        return self.pool
+
+    async def get_pool(self, pool):
+        self.calls.append(("get_pool", pool))
+        return self.pool
+
+    async def create_claim(self, request):
+        self.calls.append(("create_claim", request))
+        return self.claim
+
+    async def wait_claim(self, claim):
+        self.calls.append(("wait_claim", claim))
+        return self.sandbox
+
+    async def delete_claim(self, claim):
+        self.calls.append(("delete_claim", claim))
+
+    async def delete_pool(self, pool):
+        self.calls.append(("delete_pool", pool))
+
+    async def service_request(self, sandbox, service, path, request):
+        self.calls.append(("service_request", sandbox, service, path, request))
+        return SimpleNamespace(
+            status=200,
+            headers=[],
+            body=b'{"result":{"stdout":"ok\\n","stderr":"","returncode":0}}',
+        )
+
+
+class _FakeFleetSdk:
+    class HttpClient:
+        pass
+
+    class CyclopsCredentials:
+        def __init__(self, client_id, client_secret):
+            self.client_id = client_id
+            self.client_secret = client_secret
+
+    class CyclopsConfiguration:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class CyclopsClient:
+        client = _FakeFleetClient()
+
+        @classmethod
+        def connect(cls, configuration, http_client):
+            cls.configuration = configuration
+            cls.http_client = http_client
+            return cls.client
+
+    class CreatePoolRequest:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class CreateClaimRequest:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class PoolSpec:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class PoolTemplate:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class SandboxService:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class HttpHeader:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class HttpRequest:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class HttpResponse:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+
+def _fleet_provider() -> CuaFleetDesktopProvider:
+    _FakeFleetSdk.CyclopsClient.client = _FakeFleetClient()
+    return CuaFleetDesktopProvider(
+        CuaFleetConfig(
+            client_id="ukey-test", client_secret="secret", ready_poll_interval=0
+        ),
+        sdk_module=_FakeFleetSdk,
+    )
+
+
+def test_cua_fleet_sdk_owns_pool_claim_and_namespace_lifecycle() -> None:
+    provider = _fleet_provider()
+
+    lease = provider.acquire("task-1", image="registry.example/desktop:latest")
+    environment = provider.create_environment(lease)
+    provider.release(lease)
+
+    calls = [call[0] for call in _FakeFleetSdk.CyclopsClient.client.calls]
+    assert calls[:4] == ["create_pool", "get_pool", "create_claim", "wait_claim"]
+    assert calls[-2:] == ["delete_claim", "delete_pool"]
+    assert environment.compute_lease is lease
+    assert lease.metadata["namespace"] == lease.metadata["pool"]
+    request = _FakeFleetSdk.CyclopsClient.client.calls[0][1]
+    assert {service.name for service in request.spec.services} == {"server", "mcp"}
+
+
+def test_cua_fleet_environment_routes_terminal_through_bound_sandbox() -> None:
+    provider = _fleet_provider()
+    lease = provider.acquire("task-2")
+    environment = provider.create_environment(lease)
+
+    handle = environment._run_bash("printf ok", timeout=10)
+    assert handle.wait(timeout=2) == 0
+    assert handle.stdout.read() == "ok\n"
+    service_call = next(
+        call
+        for call in _FakeFleetSdk.CyclopsClient.client.calls
+        if call[0] == "service_request"
+    )
+    assert service_call[1] is provider._states[lease.lease_id].sandbox
+    assert service_call[2:4] == ("server", "/cmd")
+    provider.release(lease)
+
+
+def test_cua_fleet_requires_client_credentials(monkeypatch) -> None:
+    monkeypatch.delenv("CUA_CLIENT_ID", raising=False)
+    monkeypatch.delenv("CUA_CLIENT_SECRET", raising=False)
+    provider = CuaFleetDesktopProvider(CuaFleetConfig(), sdk_module=_FakeFleetSdk)
+
+    with pytest.raises(RuntimeError, match="CUA_CLIENT_ID"):
+        provider.acquire("task-3")
+
+
+def test_compute_config_selects_cua_fleet_provider(monkeypatch) -> None:
+    monkeypatch.setenv("CUA_CLIENT_ID", "ukey-test")
+    monkeypatch.setenv("CUA_CLIENT_SECRET", "secret")
+    provider = _provider_from_config({
+        "provider": "cua_fleet",
+        "image": "registry.example/desktop:latest",
+        "cua_fleet": {"base_url": "https://run.cua.ai", "pool_prefix": "hermes"},
+    })
+
+    assert isinstance(provider, CuaFleetDesktopProvider)
+    assert provider.config.image == "registry.example/desktop:latest"
+
+
+def test_cua_fleet_release_still_deletes_pool_when_claim_delete_fails() -> None:
+    provider = _fleet_provider()
+    lease = provider.acquire("task-4")
+    client = _FakeFleetSdk.CyclopsClient.client
+
+    async def fail_delete_claim(claim):
+        client.calls.append(("delete_claim", claim))
+        raise RuntimeError("claim delete failed")
+
+    client.delete_claim = fail_delete_claim
+
+    with pytest.raises(RuntimeError, match="claim delete failed"):
+        provider.release(lease)
+
+    assert [call[0] for call in client.calls][-2:] == ["delete_claim", "delete_pool"]
+
+
+def test_cua_fleet_sdk_package_is_lazy_installable() -> None:
+    from tools.lazy_deps import LAZY_DEPS
+
+    assert LAZY_DEPS["terminal.cua_fleet"] == ("cua-fleet==0.0.5",)
+
+
+def test_cua_fleet_environment_cleanup_releases_sdk_resources() -> None:
+    provider = _fleet_provider()
+    lease = provider.acquire("task-5")
+    environment = provider.create_environment(lease)
+
+    environment.cleanup()
+    environment.cleanup()
+
+    calls = [call[0] for call in _FakeFleetSdk.CyclopsClient.client.calls]
+    assert calls.count("delete_claim") == 1
+    assert calls.count("delete_pool") == 1
+    assert lease.lease_id not in provider._states

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -6,10 +6,14 @@ from unittest.mock import Mock, patch
 
 from tools.computer_use.transports.http_mcp import HttpMcpTransport
 from tools.computer_use.transports.stdio import StdioMcpTransport
+from tools.environments import CuaFleetConfig, CuaFleetDesktopProvider
 from tools.environments.capability_adapter import resolve_tools
 from tools.environments.capability_manifest import CapabilityManifest, desktop_manifest
 from tools.environments.compute_provider import ComputeLease, EnvironmentCapabilities
-from tools.environments.cua_fleet import CuaFleetConfig
+from tools.environments.cua_fleet import (
+    CuaFleetConfig as CuaFleetConfigImplementation,
+    CuaFleetDesktopProvider as CuaFleetDesktopProviderImplementation,
+)
 from tools.environments.desktop_lease import DesktopSandboxManager
 from tools.environments.modal_desktop import ModalDesktopConfig
 
@@ -121,3 +125,8 @@ def test_cua_fleet_config_defaults() -> None:
 
     assert config.pool == "default"
     assert config.endpoint == ""
+
+
+def test_environments_package_reexports_cua_fleet_sdk() -> None:
+    assert CuaFleetConfig is CuaFleetConfigImplementation
+    assert CuaFleetDesktopProvider is CuaFleetDesktopProviderImplementation

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -174,6 +174,23 @@ def test_modal_sandbox_transport_uses_the_lease_tunnel() -> None:
     assert transport.headers["mcp-session-id"] == "session-1"
 
 
+def test_modal_sandbox_transport_decodes_streamable_http_sse() -> None:
+    response = Mock()
+    response.headers = {"mcp-session-id": "session-1", "content-type": "text/event-stream"}
+    response.read.side_effect = [
+        b'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n',
+        b"",
+    ]
+    response.__enter__ = Mock(return_value=response)
+    response.__exit__ = Mock(return_value=False)
+    transport = ModalSandboxMcpTransport(_ModalSandbox(), _ModalWorker(), port=8080, path="/mcp")
+
+    with patch("tools.computer_use.transports.modal_sandbox.urlopen", return_value=response):
+        transport.start()
+
+    assert transport.headers["mcp-session-id"] == "session-1"
+
+
 def test_modal_desktop_starts_the_image_mcp_runtime_on_an_encrypted_port() -> None:
     lease = ComputeLease("task-1", "lease-1", "modal", "registry.example/cua-driver-mcp@sha256:test", EnvironmentCapabilities(computer_use=True))
 

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -411,3 +411,10 @@ def test_cua_fleet_provider_uses_public_sandbox_facade() -> None:
     from tools.lazy_deps import LAZY_DEPS
 
     assert LAZY_DEPS["terminal.cua_fleet"] == ("cua-sandbox==0.1.20",)
+
+
+def test_cua_fleet_nix_build_declares_evdev_build_system() -> None:
+    from pathlib import Path
+
+    python_nix = Path(__file__).parents[2] / "nix" / "python.nix"
+    assert '"evdev"' in python_nix.read_text()

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import urllib.error
+import urllib.request
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -153,6 +155,7 @@ def test_cua_fleet_config_defaults() -> None:
     assert config.token_url.startswith("https://auth.cua.ai/")
     assert config.client_id == ""
     assert config.client_secret == ""
+    assert config.pool == "hermes-desktop"
 
 
 def test_environments_package_reexports_cua_fleet_sdk() -> None:
@@ -164,17 +167,31 @@ class _FakeFleetClient:
     def __init__(self):
         self.calls = []
         self.pool = SimpleNamespace(
-            metadata=SimpleNamespace(namespace="hermes-task", name="hermes-task"),
+            metadata=SimpleNamespace(namespace="hermes-desktop", name="hermes-desktop"),
             status=SimpleNamespace(available_count=1),
+            spec=None,
         )
+        self.pools = []
         self.claim = SimpleNamespace(metadata=SimpleNamespace(name="hermes-task-claim"))
         self.sandbox = SimpleNamespace(
             namespace="hermes-task", name="sandbox-1", services=["server", "mcp"]
         )
 
+    async def list_pools(self, namespace):
+        self.calls.append(("list_pools", namespace))
+        return self.pools
+
     async def create_pool(self, request):
         self.calls.append(("create_pool", request))
+        self.pool.spec = request.spec
+        self.pools = [self.pool]
         return self.pool
+
+    async def update_pool(self, pool):
+        self.calls.append(("update_pool", pool))
+        self.pool = pool
+        self.pools = [pool]
+        return pool
 
     async def get_pool(self, pool):
         self.calls.append(("get_pool", pool))
@@ -203,6 +220,11 @@ class _FakeFleetClient:
         )
 
 
+class _FakeRecord:
+    def __eq__(self, other):
+        return type(self) is type(other) and self.__dict__ == other.__dict__
+
+
 class _FakeFleetSdk:
     class HttpClient:
         pass
@@ -212,54 +234,57 @@ class _FakeFleetSdk:
             self.client_id = client_id
             self.client_secret = client_secret
 
-    class CyclopsConfiguration:
+    class CyclopsConfiguration(_FakeRecord):
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
 
     class CyclopsClient:
         client = _FakeFleetClient()
+        connect_calls = 0
 
         @classmethod
         def connect(cls, configuration, http_client):
+            cls.connect_calls += 1
             cls.configuration = configuration
             cls.http_client = http_client
             return cls.client
 
-    class CreatePoolRequest:
+    class CreatePoolRequest(_FakeRecord):
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
 
-    class CreateClaimRequest:
+    class CreateClaimRequest(_FakeRecord):
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
 
-    class PoolSpec:
+    class PoolSpec(_FakeRecord):
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
 
-    class PoolTemplate:
+    class PoolTemplate(_FakeRecord):
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
 
-    class SandboxService:
+    class SandboxService(_FakeRecord):
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
 
-    class HttpHeader:
+    class HttpHeader(_FakeRecord):
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
 
-    class HttpRequest:
+    class HttpRequest(_FakeRecord):
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
 
-    class HttpResponse:
+    class HttpResponse(_FakeRecord):
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
 
 
 def _fleet_provider() -> CuaFleetDesktopProvider:
     _FakeFleetSdk.CyclopsClient.client = _FakeFleetClient()
+    _FakeFleetSdk.CyclopsClient.connect_calls = 0
     return CuaFleetDesktopProvider(
         CuaFleetConfig(
             client_id="ukey-test", client_secret="secret", ready_poll_interval=0
@@ -268,20 +293,55 @@ def _fleet_provider() -> CuaFleetDesktopProvider:
     )
 
 
-def test_cua_fleet_sdk_owns_pool_claim_and_namespace_lifecycle() -> None:
+def test_cua_fleet_reconciles_missing_pool_and_releases_only_claim() -> None:
     provider = _fleet_provider()
-
     lease = provider.acquire("task-1", image="registry.example/desktop:latest")
     environment = provider.create_environment(lease)
     provider.release(lease)
-
     calls = [call[0] for call in _FakeFleetSdk.CyclopsClient.client.calls]
-    assert calls[:4] == ["create_pool", "get_pool", "create_claim", "wait_claim"]
-    assert calls[-2:] == ["delete_claim", "delete_pool"]
+    assert calls[:5] == [
+        "list_pools",
+        "create_pool",
+        "get_pool",
+        "create_claim",
+        "wait_claim",
+    ]
+    assert calls[-1] == "delete_claim"
+    assert "delete_pool" not in calls
     assert environment.compute_lease is lease
-    assert lease.metadata["namespace"] == lease.metadata["pool"]
-    request = _FakeFleetSdk.CyclopsClient.client.calls[0][1]
-    assert {service.name for service in request.spec.services} == {"server", "mcp"}
+    assert lease.metadata["namespace"] == "hermes-desktop"
+    assert lease.metadata["pool"] == "hermes-desktop"
+
+
+def test_cua_fleet_reconcile_is_noop_when_pool_spec_matches() -> None:
+    provider = _fleet_provider()
+    client = _FakeFleetSdk.CyclopsClient.client
+    desired = provider._pool_request(
+        _FakeFleetSdk, "hermes-desktop", provider.config.image
+    )
+    client.pool.spec = desired.spec
+    client.pools = [client.pool]
+    lease = provider.acquire("task-existing")
+    provider.release(lease)
+    calls = [call[0] for call in client.calls]
+    assert "create_pool" not in calls
+    assert "update_pool" not in calls
+    assert calls.count("delete_claim") == 1
+    assert "delete_pool" not in calls
+
+
+def test_cua_fleet_reconcile_updates_drifted_pool() -> None:
+    provider = _fleet_provider()
+    client = _FakeFleetSdk.CyclopsClient.client
+    client.pool.spec = SimpleNamespace(replicas=99)
+    client.pools = [client.pool]
+    lease = provider.acquire("task-drifted")
+    provider.release(lease)
+    calls = [call[0] for call in client.calls]
+    assert "create_pool" not in calls
+    assert calls.count("update_pool") == 1
+    assert client.pool.spec.replicas == 1
+    assert "delete_pool" not in calls
 
 
 def test_cua_fleet_environment_routes_terminal_through_bound_sandbox() -> None:
@@ -317,14 +377,14 @@ def test_compute_config_selects_cua_fleet_provider(monkeypatch) -> None:
     provider = _provider_from_config({
         "provider": "cua_fleet",
         "image": "registry.example/desktop:latest",
-        "cua_fleet": {"base_url": "https://run.cua.ai", "pool_prefix": "hermes"},
+        "cua_fleet": {"base_url": "https://run.cua.ai", "pool": "hermes-desktop"},
     })
 
     assert isinstance(provider, CuaFleetDesktopProvider)
     assert provider.config.image == "registry.example/desktop:latest"
 
 
-def test_cua_fleet_release_still_deletes_pool_when_claim_delete_fails() -> None:
+def test_cua_fleet_release_reports_claim_delete_failure_without_deleting_pool() -> None:
     provider = _fleet_provider()
     lease = provider.acquire("task-4")
     client = _FakeFleetSdk.CyclopsClient.client
@@ -334,11 +394,10 @@ def test_cua_fleet_release_still_deletes_pool_when_claim_delete_fails() -> None:
         raise RuntimeError("claim delete failed")
 
     client.delete_claim = fail_delete_claim
-
     with pytest.raises(RuntimeError, match="claim delete failed"):
         provider.release(lease)
-
-    assert [call[0] for call in client.calls][-2:] == ["delete_claim", "delete_pool"]
+    assert [call[0] for call in client.calls][-1] == "delete_claim"
+    assert "delete_pool" not in [call[0] for call in client.calls]
 
 
 def test_cua_fleet_sdk_package_is_lazy_installable() -> None:
@@ -357,5 +416,128 @@ def test_cua_fleet_environment_cleanup_releases_sdk_resources() -> None:
 
     calls = [call[0] for call in _FakeFleetSdk.CyclopsClient.client.calls]
     assert calls.count("delete_claim") == 1
-    assert calls.count("delete_pool") == 1
+    assert "delete_pool" not in calls
+    assert lease.lease_id not in provider._states
+
+
+def test_cua_fleet_http_client_uses_concrete_execute_first() -> None:
+    class AbstractHttpClient:
+        async def execute(self, request):
+            raise NotImplementedError
+
+    client_type = CuaFleetDesktopProvider._http_client_type(AbstractHttpClient)
+    assert client_type.execute is not AbstractHttpClient.execute
+
+
+def test_cua_fleet_terminal_parses_sse_command_response() -> None:
+    from tools.environments.cua_fleet import _parse_service_response
+
+    parsed = _parse_service_response(
+        b'data: {"success":true,"result":{"stdout":"ok\\n","stderr":"","returncode":0}}\n\n'
+    )
+    assert parsed["result"] == {"stdout": "ok\n", "stderr": "", "returncode": 0}
+
+
+def test_cua_fleet_reconcile_recovers_pool_after_ambiguous_create_failure() -> None:
+    provider = _fleet_provider()
+    client = _FakeFleetSdk.CyclopsClient.client
+    original_create = client.create_pool
+
+    async def create_then_fail(request):
+        await original_create(request)
+        raise TimeoutError("ambiguous create timeout")
+
+    client.create_pool = create_then_fail
+    lease = provider.acquire("task-timeout")
+    provider.release(lease)
+    calls = [call[0] for call in client.calls]
+    assert calls.count("create_pool") == 1
+    assert calls.count("list_pools") == 2
+    assert "delete_pool" not in calls
+
+
+def test_cua_fleet_claim_release_can_retry_after_transient_failure() -> None:
+    provider = _fleet_provider()
+    lease = provider.acquire("task-retry-release")
+    client = _FakeFleetSdk.CyclopsClient.client
+    original = client.delete_claim
+    attempts = 0
+
+    async def fail_once(claim):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("transient delete failure")
+        await original(claim)
+
+    client.delete_claim = fail_once
+    with pytest.raises(RuntimeError, match="transient delete failure"):
+        provider.release(lease)
+    assert lease.lease_id in provider._states
+
+    provider.release(lease)
+    assert lease.lease_id not in provider._states
+    assert attempts == 2
+
+
+def test_cua_fleet_provider_reuses_sdk_client_across_claims() -> None:
+    provider = _fleet_provider()
+    first = provider.acquire("task-client-one")
+    first_client = provider._states[first.lease_id].client
+    second = provider.acquire("task-client-two")
+    second_client = provider._states[second.lease_id].client
+    assert first_client is second_client
+    assert _FakeFleetSdk.CyclopsClient.connect_calls == 1
+    provider.release(first)
+    provider.release(second)
+
+
+def test_cua_fleet_http_client_rejects_redirects(monkeypatch) -> None:
+    from tools.environments.cua_fleet import _UrlLibHttpClient
+
+    class Sdk:
+        class HttpHeader:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+        class HttpResponse:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+    client = _UrlLibHttpClient(Sdk, 1, ("run.cua.ai",))
+    request = SimpleNamespace(
+        url="https://run.cua.ai/api", body=None, method="GET", headers=[]
+    )
+    redirected = urllib.error.HTTPError(
+        request.url, 302, "Found", {"Location": "https://evil.example/steal"}, None
+    )
+    monkeypatch.setattr(
+        urllib.request,
+        "build_opener",
+        Mock(return_value=Mock(open=Mock(side_effect=redirected))),
+    )
+    response = client._execute(request)
+    assert response.status == 302
+
+
+def test_cua_fleet_environment_cleanup_retries_claim_release() -> None:
+    provider = _fleet_provider()
+    lease = provider.acquire("task-env-retry")
+    environment = provider.create_environment(lease)
+    client = _FakeFleetSdk.CyclopsClient.client
+    original = client.delete_claim
+    attempts = 0
+
+    async def fail_once(claim):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("transient cleanup failure")
+        await original(claim)
+
+    client.delete_claim = fail_once
+    with pytest.raises(RuntimeError, match="transient cleanup failure"):
+        environment.cleanup()
+    environment.cleanup()
+    assert attempts == 2
     assert lease.lease_id not in provider._states

--- a/tests/environments/test_compute_provider.py
+++ b/tests/environments/test_compute_provider.py
@@ -156,6 +156,12 @@ def test_cua_fleet_config_defaults() -> None:
     assert config.client_id == ""
     assert config.client_secret == ""
     assert config.pool == "hermes-desktop"
+    assert config.replicas == 1
+
+
+def test_cua_fleet_config_rejects_non_positive_replicas() -> None:
+    with pytest.raises(ValueError, match="replicas"):
+        CuaFleetConfig(replicas=0)
 
 
 def test_environments_package_reexports_cua_fleet_sdk() -> None:
@@ -282,12 +288,21 @@ class _FakeFleetSdk:
             self.__dict__.update(kwargs)
 
 
-def _fleet_provider() -> CuaFleetDesktopProvider:
+def _fleet_provider(
+    replicas: int = 2, available_count: int | None = None, ready_timeout: float = 600
+) -> CuaFleetDesktopProvider:
     _FakeFleetSdk.CyclopsClient.client = _FakeFleetClient()
+    _FakeFleetSdk.CyclopsClient.client.pool.status.available_count = (
+        replicas if available_count is None else available_count
+    )
     _FakeFleetSdk.CyclopsClient.connect_calls = 0
     return CuaFleetDesktopProvider(
         CuaFleetConfig(
-            client_id="ukey-test", client_secret="secret", ready_poll_interval=0
+            client_id="ukey-test",
+            client_secret="secret",
+            replicas=replicas,
+            ready_poll_interval=0,
+            ready_timeout=ready_timeout,
         ),
         sdk_module=_FakeFleetSdk,
     )
@@ -311,6 +326,7 @@ def test_cua_fleet_reconciles_missing_pool_and_releases_only_claim() -> None:
     assert environment.compute_lease is lease
     assert lease.metadata["namespace"] == "hermes-desktop"
     assert lease.metadata["pool"] == "hermes-desktop"
+    assert _FakeFleetSdk.CyclopsClient.client.pool.spec.replicas == 2
 
 
 def test_cua_fleet_reconcile_is_noop_when_pool_spec_matches() -> None:
@@ -340,7 +356,7 @@ def test_cua_fleet_reconcile_updates_drifted_pool() -> None:
     calls = [call[0] for call in client.calls]
     assert "create_pool" not in calls
     assert calls.count("update_pool") == 1
-    assert client.pool.spec.replicas == 1
+    assert client.pool.spec.replicas == 2
     assert "delete_pool" not in calls
 
 
@@ -377,11 +393,23 @@ def test_compute_config_selects_cua_fleet_provider(monkeypatch) -> None:
     provider = _provider_from_config({
         "provider": "cua_fleet",
         "image": "registry.example/desktop:latest",
-        "cua_fleet": {"base_url": "https://run.cua.ai", "pool": "hermes-desktop"},
+        "cua_fleet": {
+            "base_url": "https://run.cua.ai",
+            "pool": "hermes-desktop",
+            "replicas": 2,
+        },
     })
 
     assert isinstance(provider, CuaFleetDesktopProvider)
     assert provider.config.image == "registry.example/desktop:latest"
+    assert provider.config.replicas == 2
+
+
+def test_cua_fleet_waits_for_configured_replicas() -> None:
+    provider = _fleet_provider(available_count=1, ready_timeout=0)
+
+    with pytest.raises(TimeoutError, match="Timed out waiting for Fleet pool"):
+        provider.acquire("task-insufficient-capacity")
 
 
 def test_cua_fleet_release_reports_claim_delete_failure_without_deleting_pool() -> None:

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -46,7 +46,7 @@ class TestSchema:
         assert actions >= {
             "capture", "click", "double_click", "right_click", "middle_click",
             "drag", "scroll", "type", "key", "wait", "list_apps", "list_windows",
-            "focus_app",
+            "focus_app", "launch_app", "kill_app", "bring_to_front",
         }
 
     def test_schema_max_elements_documents_default_and_upper_bound(self):
@@ -112,6 +112,33 @@ class TestDispatch:
         assert "type" in call_names
         type_kw = next(c[1] for c in noop_backend.calls if c[0] == "type")
         assert type_kw["text"] == "hello"
+
+    def test_launch_app_routes_lifecycle_arguments(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+
+        out = handle_computer_use({
+            "action": "launch_app",
+            "name": "Chromium",
+            "urls": ["https://example.com"],
+            "additional_arguments": ["--incognito"],
+            "creates_new_application_instance": True,
+        })
+
+        assert json.loads(out)["pid"] == 1
+        assert noop_backend.calls[-1] == ("launch_app", {
+            "bundle_id": None,
+            "name": "Chromium",
+            "urls": ["https://example.com"],
+            "additional_arguments": ["--incognito"],
+            "creates_new_application_instance": True,
+        })
+
+    def test_launch_app_requires_an_app_identifier(self):
+        from tools.computer_use.tool import handle_computer_use
+
+        out = handle_computer_use({"action": "launch_app"})
+
+        assert json.loads(out)["error"] == "launch_app requires `name` or `bundle_id`"
 
     def test_drag_action_routes_to_backend_by_element(self, noop_backend):
         """drag action must dispatch to backend.drag with element indices (issue #24170, bug 4)."""

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2129,3 +2129,90 @@ class TestStartupTimeoutPhaseDetail:
                 msg = str(e)
                 assert "stuck in phase: mcp-initialize" in msg
                 assert "computer-use doctor" in msg
+
+    def test_timeout_error_defaults_to_unknown_phase(self):
+        import threading
+        from typing import Any, cast
+        from unittest.mock import MagicMock, patch as _patch
+        import asyncio
+        from tools.computer_use.cua_backend import _CuaDriverSession
+
+        session = cast(Any, _CuaDriverSession.__new__(_CuaDriverSession))
+        session._lock = threading.Lock()
+        session._ready_event = threading.Event()
+        session._setup_error = None
+        session._shutdown_event = None
+        # no _startup_phase attribute at all
+        session._signal_shutdown_locked = lambda: None
+        fake_bridge = MagicMock()
+        fake_bridge._loop = MagicMock()
+        session._bridge = fake_bridge
+
+        class _FakeEvent:
+            def set(self): pass
+            def is_set(self): return False
+            def clear(self): pass
+            def wait(self, timeout=None): return False
+
+        with _patch.object(threading, "Event", _FakeEvent), \
+             _patch.object(asyncio, "run_coroutine_threadsafe", return_value=MagicMock()), \
+             _patch.object(_CuaDriverSession, "_lifecycle_coro", lambda self: None):
+            try:
+                session._start_lifecycle_locked()
+                assert False, "expected RuntimeError"
+            except RuntimeError as e:
+                assert "stuck in phase: unknown" in str(e)
+
+
+def test_task_desktop_backend_reuses_terminal_lease(monkeypatch):
+    from tools.computer_use import tool
+
+    backend = MagicMock()
+    managed_lease = MagicMock()
+    managed_lease.environment.get_computer_backend.return_value = backend
+    manager = MagicMock()
+    manager.get.return_value = managed_lease
+
+    monkeypatch.setattr(tool, "_desktop_sandbox_enabled", lambda: True, raising=False)
+    monkeypatch.setattr(
+        tool,
+        "get_desktop_sandbox_manager",
+        lambda: manager,
+        raising=False,
+    )
+
+    assert tool._get_task_desktop_backend("task-1") is backend
+    manager.get.assert_called_once_with("task-1")
+    manager.acquire.assert_not_called()
+
+
+def test_task_desktop_backend_acquires_for_computer_first_flow(monkeypatch):
+    from tools.computer_use import tool
+
+    backend = MagicMock()
+    managed_lease = MagicMock()
+    managed_lease.environment.get_computer_backend.return_value = backend
+    manager = MagicMock()
+    manager.get.return_value = None
+    manager.acquire.return_value = managed_lease
+
+    monkeypatch.setattr(tool, "_desktop_sandbox_enabled", lambda: True, raising=False)
+    monkeypatch.setattr(
+        tool,
+        "get_desktop_sandbox_manager",
+        lambda: manager,
+        raising=False,
+    )
+
+    assert tool._get_task_desktop_backend("task-2") is backend
+    manager.get.assert_called_once_with("task-2")
+    manager.acquire.assert_called_once_with("task-2")
+
+
+def test_desktop_sandbox_tool_registers_through_builtin_discovery():
+    import tools.desktop_sandbox_tool  # noqa: F401
+    from tools.registry import registry
+
+    entry = registry._tools.get("desktop_sandbox")
+    assert entry is not None
+    assert entry.toolset == "desktop_sandbox"

--- a/tests/tools/test_terminal_requirements.py
+++ b/tests/tools/test_terminal_requirements.py
@@ -67,6 +67,13 @@ def test_unknown_terminal_env_logs_error_and_returns_false(monkeypatch, caplog):
     )
 
 
+def test_desktop_terminal_requirements_defer_to_configured_provider(monkeypatch):
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "desktop")
+
+    assert terminal_tool_module.check_terminal_requirements() is True
+
+
 def test_modal_backend_managed_mode_without_feature_flag_logs_clear_error(monkeypatch, caplog, tmp_path):
     _clear_terminal_env(monkeypatch)
     monkeypatch.setenv("TERMINAL_ENV", "modal")

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -204,6 +204,42 @@ class ComputerUseBackend(ABC):
     def focus_app(self, app: str, raise_window: bool = False) -> ActionResult:
         """Route input to `app` (by name or bundle ID). Default: focus without raise."""
 
+    # ── App lifecycle ────────────────────────────────────────────────
+    def launch_app(
+        self,
+        *,
+        bundle_id: Optional[str] = None,
+        name: Optional[str] = None,
+        urls: Optional[List[str]] = None,
+        additional_arguments: Optional[List[str]] = None,
+        creates_new_application_instance: bool = False,
+    ) -> Dict[str, Any]:
+        """Start an app when the backend exposes CUA's lifecycle tools."""
+        return {
+            "ok": False,
+            "status": "refused",
+            "code": "app_lifecycle_unavailable",
+            "message": "This computer-use backend cannot launch native applications.",
+        }
+
+    def kill_app(self, *, pid: int) -> ActionResult:
+        """Terminate an app when the backend exposes CUA's lifecycle tools."""
+        return ActionResult(
+            ok=False,
+            action="kill_app",
+            code="app_lifecycle_unavailable",
+            message="This computer-use backend cannot terminate native applications.",
+        )
+
+    def bring_to_front(self, *, pid: int, window_id: Optional[int] = None) -> ActionResult:
+        """Raise an app window when the backend exposes CUA's lifecycle tools."""
+        return ActionResult(
+            ok=False,
+            action="bring_to_front",
+            code="app_lifecycle_unavailable",
+            message="This computer-use backend cannot raise native application windows.",
+        )
+
     # ── Native-value mutation ────────────────────────────────────────
     @abstractmethod
     def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -46,6 +46,9 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                     "list_apps",
                     "list_windows",
                     "focus_app",
+                    "launch_app",
+                    "kill_app",
+                    "bring_to_front",
                     "cua_browser_state",
                     "cua_browser_prepare",
                     "cua_browser_navigate",
@@ -226,6 +229,28 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                     "— input is routed to the app without raising, "
                     "matching the background co-work model."
                 ),
+            },
+            "bundle_id": {
+                "type": "string",
+                "description": "For action='launch_app': native bundle or application ID.",
+            },
+            "name": {
+                "type": "string",
+                "description": "For action='launch_app': application name, e.g. 'Chromium'.",
+            },
+            "urls": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "For action='launch_app': optional URLs to open after launch.",
+            },
+            "additional_arguments": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "For action='launch_app': optional native command-line arguments.",
+            },
+            "creates_new_application_instance": {
+                "type": "boolean",
+                "description": "For action='launch_app': force a separate application instance.",
             },
             # ── delivery (verify → escalate ladder) ────────────────
             "delivery_mode": {

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -86,6 +86,7 @@ _SAFE_ACTIONS = frozenset({
 _DESTRUCTIVE_ACTIONS = frozenset({
     "click", "double_click", "right_click", "middle_click",
     "drag", "scroll", "type", "key", "set_value", "focus_app",
+    "launch_app", "kill_app", "bring_to_front",
     "cua_browser_prepare", "cua_browser_navigate", "cua_browser_click",
     "cua_browser_type", "cua_browser_pointer", "cua_browser_dialog",
     "cua_browser_set_input_files", "cua_browser_download",
@@ -432,6 +433,17 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
         self.calls.append(("set_value", {"value": value, "element": element}))
         return ActionResult(ok=True, action="set_value")
 
+    def launch_app(self, *, bundle_id=None, name=None, urls=None, additional_arguments=None,
+                   creates_new_application_instance=False) -> Dict[str, Any]:
+        self.calls.append(("launch_app", {
+            "bundle_id": bundle_id,
+            "name": name,
+            "urls": urls,
+            "additional_arguments": additional_arguments,
+            "creates_new_application_instance": creates_new_application_instance,
+        }))
+        return {"pid": 1, "name": name, "bundle_id": bundle_id, "windows": []}
+
 
 def get_desktop_sandbox_manager():
     """Load the shared desktop lease manager only when desktop mode is active."""
@@ -608,6 +620,12 @@ def _summarize_action(action: str, args: Dict[str, Any]) -> str:
         return f"key {args.get('keys', '')!r}{fg}"
     if action == "focus_app":
         return f"focus {args.get('app', '')!r}" + (" (raise)" if args.get("raise_window") else "")
+    if action == "launch_app":
+        return f"launch {(args.get('name') or args.get('bundle_id') or '')!r}"
+    if action == "kill_app":
+        return f"terminate pid {args.get('pid', '?')}"
+    if action == "bring_to_front":
+        return f"raise pid {args.get('pid', '?')}"
     return action + fg
 
 
@@ -645,6 +663,33 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         if not app:
             return json.dumps({"error": "focus_app requires `app`"})
         res = backend.focus_app(app, raise_window=bool(args.get("raise_window")))
+        return _maybe_follow_capture(backend, res, capture_after)
+
+    if action == "launch_app":
+        bundle_id = args.get("bundle_id")
+        name = args.get("name")
+        if not bundle_id and not name:
+            return json.dumps({"error": "launch_app requires `name` or `bundle_id`"})
+        return json.dumps(backend.launch_app(
+            bundle_id=bundle_id,
+            name=name,
+            urls=args.get("urls"),
+            additional_arguments=args.get("additional_arguments"),
+            creates_new_application_instance=bool(args.get("creates_new_application_instance")),
+        ))
+
+    if action == "kill_app":
+        if args.get("pid") is None:
+            return json.dumps({"error": "kill_app requires `pid`"})
+        return _text_response(backend.kill_app(pid=int(args["pid"])))
+
+    if action == "bring_to_front":
+        if args.get("pid") is None:
+            return json.dumps({"error": "bring_to_front requires `pid`"})
+        res = backend.bring_to_front(
+            pid=int(args["pid"]),
+            window_id=args.get("window_id"),
+        )
         return _maybe_follow_capture(backend, res, capture_after)
 
     # cua-driver's typed browser surface is namespaced inside the existing

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -493,7 +493,9 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
 
     # Dispatch to backend.
     try:
-        backend = _get_backend(session_id=session_id)
+        backend = _get_task_desktop_backend(kwargs.get("task_id")) or _get_backend(
+            session_id=session_id
+        )
     except Exception as e:
         return json.dumps({
             "error": f"computer_use backend unavailable: {e}",

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -433,6 +433,36 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
         return ActionResult(ok=True, action="set_value")
 
 
+def get_desktop_sandbox_manager():
+    """Load the shared desktop lease manager only when desktop mode is active."""
+    from tools.environments.desktop_lease import get_desktop_sandbox_manager as get_manager
+
+    return get_manager()
+
+
+def _desktop_sandbox_enabled() -> bool:
+    """Return whether computer use should share the desktop terminal lease."""
+    try:
+        from tools.terminal_tool import _get_env_config
+
+        return _get_env_config().get("env_type") == "desktop"
+    except Exception:
+        logger.debug("desktop sandbox configuration is unavailable", exc_info=True)
+        return False
+
+
+def _get_task_desktop_backend(task_id: str | None) -> ComputerUseBackend | None:
+    """Resolve the configured task desktop without creating a local backend."""
+    if not _desktop_sandbox_enabled():
+        return None
+
+    normalized_task_id = str(task_id or "default")
+    manager = get_desktop_sandbox_manager()
+    managed = manager.get(normalized_task_id)
+    if managed is None:
+        managed = manager.acquire(normalized_task_id)
+    return managed.environment.get_computer_backend()
+
 # ---------------------------------------------------------------------------
 # Dispatch
 # ---------------------------------------------------------------------------
@@ -1324,6 +1354,8 @@ def check_computer_use_requirements() -> bool:
     `hermes computer-use doctor` if their session is incomplete (e.g. no
     DISPLAY set).
     """
+    if _desktop_sandbox_enabled():
+        return True
     if sys.platform not in ("darwin", "win32", "linux"):
         return False
     from tools.computer_use.cua_backend import cua_driver_binary_available

--- a/tools/computer_use/transports/__init__.py
+++ b/tools/computer_use/transports/__init__.py
@@ -1,0 +1,7 @@
+"""Transports for connecting computer-use backends to cua-driver."""
+
+from tools.computer_use.transports.base import CuaToolTransport
+from tools.computer_use.transports.http_mcp import HttpMcpTransport
+from tools.computer_use.transports.stdio import StdioMcpTransport
+
+__all__ = ["CuaToolTransport", "HttpMcpTransport", "StdioMcpTransport"]

--- a/tools/computer_use/transports/__init__.py
+++ b/tools/computer_use/transports/__init__.py
@@ -2,6 +2,7 @@
 
 from tools.computer_use.transports.base import CuaToolTransport
 from tools.computer_use.transports.http_mcp import HttpMcpTransport
+from tools.computer_use.transports.modal_sandbox import ModalSandboxMcpTransport
 from tools.computer_use.transports.stdio import StdioMcpTransport
 
-__all__ = ["CuaToolTransport", "HttpMcpTransport", "StdioMcpTransport"]
+__all__ = ["CuaToolTransport", "HttpMcpTransport", "ModalSandboxMcpTransport", "StdioMcpTransport"]

--- a/tools/computer_use/transports/base.py
+++ b/tools/computer_use/transports/base.py
@@ -1,0 +1,30 @@
+"""Transport contract for CUA MCP services."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Mapping
+
+
+class CuaToolTransport(ABC):
+    """Lifecycle and RPC interface for a cua-driver MCP endpoint."""
+
+    @abstractmethod
+    def start(self) -> None:
+        """Connect to or start the CUA service."""
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Release local transport resources."""
+
+    @abstractmethod
+    def list_tools(self) -> list[Mapping[str, Any]]:
+        """Return MCP tool descriptions."""
+
+    @abstractmethod
+    def call_tool(self, name: str, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Call a CUA MCP tool."""
+
+    @abstractmethod
+    def is_alive(self) -> bool:
+        """Return whether the service can accept requests."""

--- a/tools/computer_use/transports/http_mcp.py
+++ b/tools/computer_use/transports/http_mcp.py
@@ -1,0 +1,65 @@
+"""HTTP transport for a remotely hosted cua-driver MCP endpoint."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from tools.computer_use.transports.base import CuaToolTransport
+
+
+class HttpMcpTransport(CuaToolTransport):
+    """Small JSON-RPC-over-HTTP transport suitable for fleet-backed CUA."""
+
+    def __init__(self, endpoint: str, *, headers: Mapping[str, str] | None = None, timeout: float = 30):
+        self.endpoint = endpoint.rstrip("/")
+        self.headers = dict(headers or {})
+        self.timeout = timeout
+        self._started = False
+        self._request_id = 0
+
+    def start(self) -> None:
+        self._started = True
+
+    def stop(self) -> None:
+        self._started = False
+
+    def is_alive(self) -> bool:
+        if not self._started:
+            return False
+        try:
+            self._post({"jsonrpc": "2.0", "id": 0, "method": "ping", "params": {}})
+        except (OSError, URLError, ValueError):
+            return False
+        return True
+
+    def list_tools(self) -> list[Mapping[str, Any]]:
+        result = self._request("tools/list", {})
+        tools = result.get("tools", [])
+        return tools if isinstance(tools, list) else []
+
+    def call_tool(self, name: str, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        return self._request("tools/call", {"name": name, "arguments": dict(arguments)})
+
+    def _request(self, method: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
+        if not self._started:
+            self.start()
+        self._request_id += 1
+        response = self._post({"jsonrpc": "2.0", "id": self._request_id, "method": method, "params": params})
+        if "error" in response:
+            error = response["error"]
+            raise RuntimeError(error.get("message", str(error)) if isinstance(error, Mapping) else str(error))
+        result = response.get("result", {})
+        return result if isinstance(result, Mapping) else {"result": result}
+
+    def _post(self, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        data = json.dumps(payload).encode("utf-8")
+        headers = {"Content-Type": "application/json", **self.headers}
+        request = Request(self.endpoint, data=data, headers=headers, method="POST")
+        with urlopen(request, timeout=self.timeout) as response:
+            parsed = json.loads(response.read().decode("utf-8"))
+        if not isinstance(parsed, Mapping):
+            raise ValueError("MCP endpoint returned a non-object response")
+        return parsed

--- a/tools/computer_use/transports/modal_sandbox.py
+++ b/tools/computer_use/transports/modal_sandbox.py
@@ -72,9 +72,16 @@ class ModalSandboxMcpTransport(HttpMcpTransport):
             session_id = response.headers.get("mcp-session-id")
             if session_id:
                 self.headers["mcp-session-id"] = session_id
+            content_type = response.headers.get("Content-Type", response.headers.get("content-type", ""))
             body = response.read().decode("utf-8")
         if not body:
             return {}
+        if "text/event-stream" in content_type.lower():
+            body = "\n".join(
+                line[5:].lstrip() for line in body.splitlines() if line.startswith("data:")
+            )
+            if not body:
+                return {}
         parsed = json.loads(body)
         if not isinstance(parsed, Mapping):
             raise ValueError("MCP endpoint returned a non-object response")

--- a/tools/computer_use/transports/modal_sandbox.py
+++ b/tools/computer_use/transports/modal_sandbox.py
@@ -1,0 +1,81 @@
+"""Stateful HTTP transport for a CUA Driver running in a Modal sandbox."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+from urllib.request import Request, urlopen
+
+from tools.computer_use.transports.http_mcp import HttpMcpTransport
+
+
+class ModalSandboxMcpTransport(HttpMcpTransport):
+    """Connect a desktop lease to its CUA Driver MCP tunnel."""
+
+    def __init__(
+        self,
+        sandbox: Any,
+        worker: Any,
+        *,
+        port: int,
+        path: str = "/mcp",
+        timeout: float = 30,
+        tunnel_timeout: int = 50,
+    ):
+        super().__init__("", timeout=timeout)
+        self._sandbox = sandbox
+        self._worker = worker
+        self._port = port
+        self._path = "/" + path.lstrip("/")
+        self._tunnel_timeout = tunnel_timeout
+
+    def start(self) -> None:
+        if self._started:
+            return
+        self.endpoint = self._resolve_endpoint()
+        self._started = True
+        self._request(
+            "initialize",
+            {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "hermes-agent", "version": "0.1"},
+            },
+        )
+        self._post({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+            "params": {},
+        })
+
+    def _resolve_endpoint(self) -> str:
+        async def resolve() -> str:
+            tunnels = await self._sandbox.tunnels.aio(timeout=self._tunnel_timeout)
+            tunnel = tunnels.get(self._port)
+            if tunnel is None:
+                raise RuntimeError(
+                    f"Modal sandbox did not expose CUA Driver port {self._port}"
+                )
+            return tunnel.url.rstrip("/") + self._path
+
+        return self._worker.run_coroutine(resolve(), timeout=self._tunnel_timeout + 5)
+
+    def _post(self, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        data = json.dumps(payload).encode("utf-8")
+        headers = {
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            **self.headers,
+        }
+        request = Request(self.endpoint, data=data, headers=headers, method="POST")
+        with urlopen(request, timeout=self.timeout) as response:
+            session_id = response.headers.get("mcp-session-id")
+            if session_id:
+                self.headers["mcp-session-id"] = session_id
+            body = response.read().decode("utf-8")
+        if not body:
+            return {}
+        parsed = json.loads(body)
+        if not isinstance(parsed, Mapping):
+            raise ValueError("MCP endpoint returned a non-object response")
+        return parsed

--- a/tools/computer_use/transports/stdio.py
+++ b/tools/computer_use/transports/stdio.py
@@ -1,0 +1,79 @@
+"""Stdio transport for the existing ``cua-driver mcp`` process."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import threading
+from typing import Any, Mapping, Sequence
+
+from tools.computer_use.transports.base import CuaToolTransport
+
+
+class StdioMcpTransport(CuaToolTransport):
+    """Spawn cua-driver and exchange simple JSON-RPC messages over stdio."""
+
+    def __init__(self, command: Sequence[str] | None = None, *, env: Mapping[str, str] | None = None):
+        self.command = list(command or ("cua-driver", "mcp"))
+        self.env = dict(env) if env is not None else None
+        self.process: subprocess.Popen[str] | None = None
+        self._lock = threading.Lock()
+        self._request_id = 0
+
+    def start(self) -> None:
+        if self.is_alive():
+            return
+        self.process = subprocess.Popen(
+            self.command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            env=self.env,
+        )
+
+    def stop(self) -> None:
+        process = self.process
+        self.process = None
+        if process is None:
+            return
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+
+    def is_alive(self) -> bool:
+        return self.process is not None and self.process.poll() is None
+
+    def list_tools(self) -> list[Mapping[str, Any]]:
+        result = self._request("tools/list", {})
+        tools = result.get("tools", [])
+        return tools if isinstance(tools, list) else []
+
+    def call_tool(self, name: str, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        return self._request("tools/call", {"name": name, "arguments": dict(arguments)})
+
+    def _request(self, method: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
+        if not self.is_alive():
+            self.start()
+        process = self.process
+        if process is None or process.stdin is None or process.stdout is None:
+            raise RuntimeError("cua-driver stdio transport is unavailable")
+        with self._lock:
+            self._request_id += 1
+            request_id = self._request_id
+            process.stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
+            process.stdin.flush()
+            line = process.stdout.readline()
+        if not line:
+            raise RuntimeError("cua-driver closed its MCP stdio stream")
+        response = json.loads(line)
+        if "error" in response:
+            error = response["error"]
+            raise RuntimeError(error.get("message", str(error)) if isinstance(error, Mapping) else str(error))
+        result = response.get("result", {})
+        return result if isinstance(result, Mapping) else {"result": result}

--- a/tools/desktop_sandbox_tool.py
+++ b/tools/desktop_sandbox_tool.py
@@ -1,0 +1,8 @@
+"""Register the task-scoped desktop sandbox tool during builtin discovery."""
+
+from tools.environments.desktop_sandbox_tool import (
+    DESKTOP_SANDBOX_SCHEMA,
+    handle_desktop_sandbox,
+)
+
+__all__ = ["DESKTOP_SANDBOX_SCHEMA", "handle_desktop_sandbox"]

--- a/tools/environments/__init__.py
+++ b/tools/environments/__init__.py
@@ -10,5 +10,6 @@ based on the TERMINAL_ENV configuration.
 """
 
 from tools.environments.base import BaseEnvironment
+from tools.environments.cua_fleet import CuaFleetConfig, CuaFleetDesktopProvider
 
-__all__ = ["BaseEnvironment"]
+__all__ = ["BaseEnvironment", "CuaFleetConfig", "CuaFleetDesktopProvider"]

--- a/tools/environments/capability_adapter.py
+++ b/tools/environments/capability_adapter.py
@@ -1,0 +1,45 @@
+"""Map verified image capabilities to Hermes model-tool names."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+
+@dataclass(frozen=True)
+class CapabilityDefinition:
+    """Tool names exposed only when all required capabilities are available."""
+
+    name: str
+    tools: frozenset[str]
+    requires: frozenset[str]
+
+
+CAPABILITIES: dict[str, CapabilityDefinition] = {
+    "terminal": CapabilityDefinition("terminal", frozenset({"terminal"}), frozenset({"terminal"})),
+    "files": CapabilityDefinition(
+        "files",
+        frozenset({"read_file", "write_file", "patch", "search_files"}),
+        frozenset({"files"}),
+    ),
+    "computer_use": CapabilityDefinition(
+        "computer_use", frozenset({"computer_use"}), frozenset({"computer_use"})
+    ),
+}
+
+
+def resolve_tools(
+    available_capabilities: Iterable[str],
+    authorized_capabilities: Iterable[str] | None = None,
+    registry: Mapping[str, CapabilityDefinition] | None = None,
+) -> frozenset[str]:
+    """Return tools whose capability is both image-verified and authorized."""
+    available = frozenset(available_capabilities)
+    authorized = available if authorized_capabilities is None else frozenset(authorized_capabilities)
+    permitted = available & authorized
+    definitions = CAPABILITIES if registry is None else registry
+    tools: set[str] = set()
+    for definition in definitions.values():
+        if definition.requires <= permitted:
+            tools.update(definition.tools)
+    return frozenset(tools)

--- a/tools/environments/capability_manifest.py
+++ b/tools/environments/capability_manifest.py
@@ -1,0 +1,99 @@
+"""Capability manifests declared by sandbox images."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from tools.environments.compute_provider import EnvironmentCapabilities
+
+
+@dataclass(frozen=True)
+class CapabilitySpec:
+    """A single image capability and optional service endpoint."""
+
+    name: str
+    enabled: bool = True
+    service: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, name: str, value: Any) -> "CapabilitySpec":
+        if isinstance(value, bool):
+            return cls(name=name, enabled=value)
+        if value is None:
+            return cls(name=name)
+        if not isinstance(value, Mapping):
+            raise ValueError(f"capability {name!r} must be a bool or object")
+        return cls(
+            name=name,
+            enabled=bool(value.get("enabled", True)),
+            service=value.get("service"),
+            metadata=dict(value.get("metadata", {})),
+        )
+
+
+@dataclass(frozen=True)
+class CapabilityManifest:
+    """Describes the services installed in a compute image."""
+
+    image: str = ""
+    capabilities: Mapping[str, CapabilitySpec] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "CapabilityManifest":
+        raw = value.get("capabilities", {})
+        if isinstance(raw, list):
+            raw = {name: True for name in raw}
+        if not isinstance(raw, Mapping):
+            raise ValueError("manifest capabilities must be an object or list")
+        capabilities = {
+            str(name): CapabilitySpec.from_dict(str(name), spec)
+            for name, spec in raw.items()
+        }
+        return cls(
+            image=str(value.get("image", "")),
+            capabilities=capabilities,
+            metadata=dict(value.get("metadata", {})),
+        )
+
+    @classmethod
+    def from_json(cls, value: str) -> "CapabilityManifest":
+        parsed = json.loads(value)
+        if not isinstance(parsed, Mapping):
+            raise ValueError("manifest JSON must contain an object")
+        return cls.from_dict(parsed)
+
+    def to_environment_capabilities(self) -> EnvironmentCapabilities:
+        enabled = {name for name, spec in self.capabilities.items() if spec.enabled}
+        return EnvironmentCapabilities(
+            terminal="terminal" in enabled,
+            files="files" in enabled,
+            computer_use="computer_use" in enabled,
+            process="process" in enabled or "terminal" in enabled,
+            extras=frozenset(enabled - {"terminal", "files", "computer_use", "process"}),
+        )
+
+    def enabled_capabilities(self) -> frozenset[str]:
+        return self.to_environment_capabilities().to_capabilities()
+
+
+def default_manifest(image: str = "") -> CapabilityManifest:
+    return CapabilityManifest.from_dict({
+        "image": image,
+        "capabilities": {"terminal": True, "files": True, "process": True},
+    })
+
+
+def desktop_manifest(image: str = "") -> CapabilityManifest:
+    return CapabilityManifest.from_dict({
+        "image": image,
+        "capabilities": {
+            "terminal": True,
+            "files": True,
+            "process": True,
+            "computer_use": {"service": "cua-driver"},
+        },
+    })

--- a/tools/environments/compute_provider.py
+++ b/tools/environments/compute_provider.py
@@ -1,0 +1,110 @@
+"""Compute-provider contracts for task-scoped, capability-aware sandboxes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Mapping, Protocol, Sequence, runtime_checkable
+
+
+@runtime_checkable
+class ProcessHandle(Protocol):
+    """Minimal process contract shared by local and remote executions."""
+
+    def poll(self) -> int | None: ...
+    def wait(self, timeout: float | None = None) -> int: ...
+    def terminate(self) -> None: ...
+    def kill(self) -> None: ...
+
+
+@runtime_checkable
+class DuplexProcess(ProcessHandle, Protocol):
+    """A process with readable stdout/stderr and writable stdin."""
+
+    stdin: Any
+    stdout: Any
+    stderr: Any
+
+
+@dataclass(frozen=True)
+class ServiceRequest:
+    """A request routed to a named service in a leased sandbox."""
+
+    service: str
+    method: str
+    params: Mapping[str, Any] = field(default_factory=dict)
+    timeout: float | None = None
+
+
+@dataclass(frozen=True)
+class ServiceResponse:
+    """Response returned by a sandbox service."""
+
+    ok: bool
+    result: Any = None
+    error: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class EnvironmentCapabilities:
+    """Verified capabilities supplied by an environment image."""
+
+    terminal: bool = True
+    files: bool = True
+    computer_use: bool = False
+    process: bool = True
+    extras: frozenset[str] = field(default_factory=frozenset)
+
+    def to_capabilities(self) -> frozenset[str]:
+        capabilities = set(self.extras)
+        for name, enabled in (
+            ("terminal", self.terminal),
+            ("files", self.files),
+            ("computer_use", self.computer_use),
+            ("process", self.process),
+        ):
+            if enabled:
+                capabilities.add(name)
+        return frozenset(capabilities)
+
+
+@dataclass(frozen=True)
+class ComputeLease:
+    """A task-scoped reservation; all task tools must use this lease."""
+
+    task_id: str
+    lease_id: str
+    provider: str
+    image: str
+    capabilities: EnvironmentCapabilities
+    endpoint: str | None = None
+    expires_at: datetime | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class ComputeProvider(Protocol):
+    """Owns placement, leasing, execution routing, and release."""
+
+    name: str
+
+    def acquire(
+        self,
+        task_id: str,
+        *,
+        image: str | None = None,
+        capabilities: Sequence[str] | None = None,
+    ) -> ComputeLease: ...
+
+    def release(self, lease: ComputeLease) -> None: ...
+
+
+@runtime_checkable
+class ComputerCapableEnvironment(Protocol):
+    """Environment extension used by computer_use to share a task lease."""
+
+    def get_computer_backend(self) -> Any: ...
+
+    @property
+    def compute_lease(self) -> ComputeLease: ...

--- a/tools/environments/cua_fleet.py
+++ b/tools/environments/cua_fleet.py
@@ -1,0 +1,46 @@
+"""Placeholder provider for a remotely managed CUA desktop fleet."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Sequence
+
+from tools.environments.compute_provider import ComputeLease, EnvironmentCapabilities
+
+
+@dataclass(frozen=True)
+class CuaFleetConfig:
+    endpoint: str = ""
+    image: str = "trycua/cua:latest"
+    pool: str = "default"
+    token: str = ""
+
+
+class CuaFleetDesktopProvider:
+    """PoC lifecycle surface for fleet pool/claim/release integration."""
+
+    name = "cua_fleet"
+
+    def __init__(self, config: CuaFleetConfig | None = None):
+        self.config = config or CuaFleetConfig()
+
+    def acquire(self, task_id: str, *, image: str | None = None,
+                capabilities: Sequence[str] | None = None) -> ComputeLease:
+        if not self.config.endpoint:
+            raise RuntimeError("cua_fleet.endpoint must be configured before acquiring a desktop")
+        enabled = EnvironmentCapabilities(computer_use=True)
+        requested = frozenset(capabilities or enabled.to_capabilities())
+        if not requested <= enabled.to_capabilities():
+            raise ValueError("Cua fleet desktop does not support all requested capabilities")
+        return ComputeLease(
+            task_id=task_id, lease_id=uuid.uuid4().hex, provider=self.name,
+            image=image or self.config.image, capabilities=enabled,
+            endpoint=self.config.endpoint, metadata={"pool": self.config.pool},
+        )
+
+    def create_environment(self, lease: ComputeLease):
+        raise NotImplementedError("CuaFleetDesktopProvider environment attachment is not implemented in this PoC")
+
+    def release(self, lease: ComputeLease) -> None:
+        return None

--- a/tools/environments/cua_fleet.py
+++ b/tools/environments/cua_fleet.py
@@ -1,4 +1,4 @@
-"""Cua Fleet compute provider backed by the public ``cua-fleet`` SDK."""
+"""CUA Fleet compute provider backed by the public ``cua-sandbox`` API."""
 
 from __future__ import annotations
 
@@ -8,10 +8,6 @@ import json
 import logging
 import os
 import threading
-import time
-import urllib.error
-import urllib.request
-import urllib.parse
 import uuid
 from dataclasses import dataclass, field
 from typing import Any, Mapping, Sequence
@@ -60,10 +56,8 @@ class CuaFleetConfig:
 
 @dataclass
 class _FleetState:
-    client: Any
-    http_client: Any
     pool: Any
-    claim: Any
+    claim_context: Any
     sandbox: Any
 
 
@@ -91,59 +85,9 @@ class _AsyncWorker:
         self._loop.close()
 
 
-class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
-    def redirect_request(self, request, file_pointer, code, message, headers, new_url):
-        return None
-
-
-class _UrlLibHttpClient:
-    """Build the SDK's HttpClient callback without depending on cua-sandbox."""
-
-    def __init__(self, sdk: Any, timeout: float, allowed_hosts: Sequence[str]):
-        self._sdk = sdk
-        self._timeout = timeout
-        self._allowed_hosts = frozenset(allowed_hosts)
-
-    async def execute(self, request: Any) -> Any:
-        return await asyncio.to_thread(self._execute, request)
-
-    def _execute(self, request: Any) -> Any:
-        parsed = urllib.parse.urlparse(request.url)
-        if parsed.scheme != "https" or parsed.hostname not in self._allowed_hosts:
-            raise ValueError(
-                f"Cua Fleet SDK attempted a request to an unexpected URL: {request.url!r}"
-            )
-        native = urllib.request.Request(
-            request.url,
-            data=request.body,
-            method=request.method,
-            headers={header.name: header.value for header in request.headers},
-        )
-        opener = urllib.request.build_opener(_NoRedirectHandler())
-        try:
-            with opener.open(native, timeout=self._timeout) as response:
-                return self._response(
-                    response.status, response.headers.items(), response.read()
-                )
-        except urllib.error.HTTPError as error:
-            return self._response(error.code, error.headers.items(), error.read())
-
-    def _response(self, status: int, headers: Any, body: bytes) -> Any:
-        return self._sdk.HttpResponse(
-            status=status,
-            headers=[
-                self._sdk.HttpHeader(name=name, value=value) for name, value in headers
-            ],
-            body=body,
-        )
-
-
 class _FleetMcpTransport(CuaToolTransport):
-    def __init__(
-        self, state: _FleetState, sdk: Any, worker: _AsyncWorker, timeout: float
-    ):
+    def __init__(self, state: _FleetState, worker: _AsyncWorker, timeout: float):
         self._state = state
-        self._sdk = sdk
         self._worker = worker
         self._timeout = timeout
         self._started = False
@@ -184,39 +128,23 @@ class _FleetMcpTransport(CuaToolTransport):
 
     def _request(self, method: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
         self._request_id += 1
-        payload = json.dumps(
-            {
-                "jsonrpc": "2.0",
-                "id": self._request_id,
-                "method": method,
-                "params": params,
-            },
-            separators=(",", ":"),
-        ).encode()
+        payload = {
+            "jsonrpc": "2.0",
+            "id": self._request_id,
+            "method": method,
+            "params": params,
+        }
         response = self._worker.run(
-            self._state.client.service_request(
-                self._state.sandbox,
-                "mcp",
-                "/mcp",
-                self._sdk.HttpRequest(
-                    method="POST",
-                    url="https://service.invalid/mcp",
-                    headers=[
-                        self._sdk.HttpHeader(
-                            name="accept", value="application/json, text/event-stream"
-                        ),
-                        self._sdk.HttpHeader(
-                            name="content-type", value="application/json"
-                        ),
-                    ],
-                    body=payload,
-                ),
+            self._state.sandbox.services.request(
+                "mcp", method="POST", path="/mcp", json=payload
             ),
             self._timeout,
         )
-        if not 200 <= response.status < 300:
-            raise RuntimeError(f"Fleet MCP request failed with HTTP {response.status}")
-        parsed = _parse_mcp_response(response.body)
+        if not 200 <= response.status_code < 300:
+            raise RuntimeError(
+                f"Fleet MCP request failed with HTTP {response.status_code}"
+            )
+        parsed = _parse_mcp_response(response.content)
         if "error" in parsed:
             error = parsed["error"]
             raise RuntimeError(
@@ -266,14 +194,12 @@ class CuaFleetEnvironment(BaseEnvironment):
         *,
         compute_lease: ComputeLease,
         state: _FleetState,
-        sdk: Any,
         config: CuaFleetConfig,
         worker: _AsyncWorker,
         release_callback: Any,
     ):
         self._compute_lease = compute_lease
         self._state = state
-        self._sdk = sdk
         self._fleet_config = config
         self._worker = worker
         self._release_callback = release_callback
@@ -290,7 +216,7 @@ class CuaFleetEnvironment(BaseEnvironment):
             from tools.environments.modal_desktop import _TransportComputerBackend
 
             transport = _FleetMcpTransport(
-                self._state, self._sdk, self._worker, self._fleet_config.request_timeout
+                self._state, self._worker, self._fleet_config.request_timeout
             )
             self._computer_backend = _TransportComputerBackend(transport)
             self._computer_backend.start()
@@ -342,24 +268,14 @@ class CuaFleetEnvironment(BaseEnvironment):
     async def _service_json(
         self, service: str, path: str, payload: Mapping[str, Any]
     ) -> Mapping[str, Any]:
-        response = await self._state.client.service_request(
-            self._state.sandbox,
-            service,
-            path,
-            self._sdk.HttpRequest(
-                method="POST",
-                url=f"https://service.invalid{path}",
-                headers=[
-                    self._sdk.HttpHeader(name="content-type", value="application/json")
-                ],
-                body=json.dumps(payload, separators=(",", ":")).encode(),
-            ),
+        response = await self._state.sandbox.services.request(
+            service, method="POST", path=path, json=dict(payload)
         )
-        if not 200 <= response.status < 300:
+        if not 200 <= response.status_code < 300:
             raise RuntimeError(
-                f"Fleet service {service!r} failed with HTTP {response.status}"
+                f"Fleet service {service!r} failed with HTTP {response.status_code}"
             )
-        return _parse_service_response(response.body)
+        return _parse_service_response(response.content)
 
     def cleanup(self) -> None:
         if self._computer_backend is not None:
@@ -379,21 +295,15 @@ def _shell_quote(value: str) -> str:
 class CuaFleetDesktopProvider:
     name = "cua_fleet"
 
-    def __init__(self, config: CuaFleetConfig | None = None, *, sdk_module: Any = None):
+    def __init__(
+        self, config: CuaFleetConfig | None = None, *, sandbox_module: Any = None
+    ):
         self.config = config or CuaFleetConfig()
-        self._sdk = sdk_module
+        self._sandbox_module = sandbox_module
         self._states: dict[str, _FleetState] = {}
         self._workers: dict[str, _AsyncWorker] = {}
         self._lock = threading.RLock()
         self._reconcile_lock = threading.Lock()
-        self._shared_worker: _AsyncWorker | None = None
-        self._shared_client: Any = None
-        self._shared_http_client: Any = None
-
-    @staticmethod
-    def _http_client_type(http_client_base: type) -> type:
-        # Concrete callback first: generated HttpClient.execute is abstract.
-        return type("FleetHttpClient", (_UrlLibHttpClient, http_client_base), {})
 
     def acquire(
         self,
@@ -419,33 +329,46 @@ class CuaFleetDesktopProvider:
                 "Cua Fleet requires CUA_CLIENT_ID and CUA_CLIENT_SECRET (a ukey credential)"
             )
 
-        sdk = self._load_sdk()
-        worker, client, http_client = self._shared_connection(
-            sdk, client_id, client_secret
+        sandbox_api = self._load_sandbox_api()
+        sandbox_api.configure(
+            fleet_base_url=self.config.base_url,
+            token_url=self.config.token_url,
+            client_id=client_id,
+            client_secret=client_secret,
         )
+        worker = _AsyncWorker()
         lease_id = uuid.uuid4().hex
-        namespace = self.config.pool
-        pool = claim = None
+        pool = claim_context = None
+        entered_claim = False
         try:
             with self._reconcile_lock:
-                pool = self._reconcile_pool(
-                    worker, client, sdk, namespace, image or self.config.image
+                pool = worker.run(
+                    sandbox_api.Pool.reconcile({
+                        "name": self.config.pool,
+                        "image": sandbox_api.Image.from_registry(
+                            image or self.config.image
+                        ),
+                        "replicas": self.config.replicas,
+                        "services": dict(self.config.services),
+                    }),
+                    self.config.request_timeout,
                 )
-            pool = self._wait_pool(worker, client, pool)
-            claim = worker.run(
-                client.create_claim(sdk.CreateClaimRequest(pool=pool, spec=None)),
-                self.config.request_timeout,
-            )
-            sandbox = worker.run(client.wait_claim(claim), self.config.ready_timeout)
+            claim_context = pool.claim()
+            sandbox = worker.run(claim_context.__aenter__(), self.config.ready_timeout)
+            entered_claim = True
         except BaseException:
-            if claim is not None:
+            if entered_claim:
                 try:
-                    worker.run(client.delete_claim(claim), self.config.request_timeout)
+                    worker.run(
+                        claim_context.__aexit__(None, None, None),
+                        self.config.request_timeout,
+                    )
                 except Exception:
                     logger.warning("Failed to roll back Fleet claim", exc_info=True)
+            worker.stop()
             raise
 
-        state = _FleetState(client, http_client, pool, claim, sandbox)
+        state = _FleetState(pool, claim_context, sandbox)
         with self._lock:
             self._states[lease_id] = state
             self._workers[lease_id] = worker
@@ -456,12 +379,7 @@ class CuaFleetDesktopProvider:
             image=image or self.config.image,
             capabilities=enabled,
             endpoint=self.config.base_url,
-            metadata={
-                "namespace": pool.metadata.namespace,
-                "pool": pool.metadata.name,
-                "claim": claim.metadata.name,
-                "sandbox": sandbox.name,
-            },
+            metadata={"pool": pool.name, "sandbox": sandbox.name},
         )
 
     def create_environment(self, lease: ComputeLease) -> CuaFleetEnvironment:
@@ -481,7 +399,6 @@ class CuaFleetDesktopProvider:
         return CuaFleetEnvironment(
             compute_lease=lease,
             state=state,
-            sdk=self._load_sdk(),
             config=config,
             worker=worker,
             release_callback=lambda: self.release(lease),
@@ -493,165 +410,27 @@ class CuaFleetDesktopProvider:
             worker = self._workers.get(lease.lease_id)
         if state is None or worker is None:
             return
-        worker.run(state.client.delete_claim(state.claim), self.config.request_timeout)
+        worker.run(
+            state.claim_context.__aexit__(None, None, None),
+            self.config.request_timeout,
+        )
         with self._lock:
             self._states.pop(lease.lease_id, None)
             self._workers.pop(lease.lease_id, None)
+        worker.stop()
 
-    def _shared_connection(
-        self, sdk: Any, client_id: str, client_secret: str
-    ) -> tuple[_AsyncWorker, Any, Any]:
-        with self._lock:
-            if self._shared_worker is not None:
-                return (
-                    self._shared_worker,
-                    self._shared_client,
-                    self._shared_http_client,
-                )
-            worker = _AsyncWorker()
-            http_client_type = self._http_client_type(sdk.HttpClient)
-            allowed_hosts = {
-                urllib.parse.urlparse(self.config.base_url).hostname,
-                urllib.parse.urlparse(self.config.token_url).hostname,
-            }
-            http_client = http_client_type(
-                sdk,
-                self.config.request_timeout,
-                tuple(host for host in allowed_hosts if host),
-            )
-            client = sdk.CyclopsClient.connect(
-                sdk.CyclopsConfiguration(
-                    base_url=self.config.base_url,
-                    token_url=self.config.token_url,
-                    credentials=sdk.CyclopsCredentials(client_id, client_secret),
-                    pool_poll_interval_ms=max(
-                        1, int(self.config.ready_poll_interval * 1000)
-                    ),
-                    pool_poll_limit=max(
-                        1,
-                        int(
-                            self.config.ready_timeout
-                            / max(self.config.ready_poll_interval, 0.001)
-                        ),
-                    ),
-                    claim_poll_interval_ms=max(
-                        1, int(self.config.ready_poll_interval * 1000)
-                    ),
-                    claim_poll_limit=max(
-                        1,
-                        int(
-                            self.config.ready_timeout
-                            / max(self.config.ready_poll_interval, 0.001)
-                        ),
-                    ),
-                ),
-                http_client,
-            )
-            self._shared_worker = worker
-            self._shared_client = client
-            self._shared_http_client = http_client
-            return worker, client, http_client
-
-    def _load_sdk(self) -> Any:
-        if self._sdk is not None:
-            return self._sdk
+    def _load_sandbox_api(self) -> Any:
+        if self._sandbox_module is not None:
+            return self._sandbox_module
         try:
             from tools.lazy_deps import ensure
 
             ensure("terminal.cua_fleet", prompt=False)
-            import cyclops_sdk
+            import cua_sandbox
         except Exception as exc:
-            raise ImportError(f"Cua Fleet SDK unavailable: {exc}") from exc
-        self._sdk = cyclops_sdk
-        return self._sdk
-
-    def _pool_request(self, sdk: Any, namespace: str, image: str) -> Any:
-        services = [
-            sdk.SandboxService(name=name, target_port=port, protocol=None)
-            for name, port in self.config.services.items()
-        ]
-        probes = None
-        if hasattr(sdk, "PreservedJson") and "server" in self.config.services:
-            probes = sdk.PreservedJson.from_json(
-                json.dumps({
-                    "readinessProbe": {
-                        "tcpSocket": {"port": self.config.services["server"]}
-                    }
-                })
-            )
-        return sdk.CreatePoolRequest(
-            namespace=namespace,
-            spec=sdk.PoolSpec(
-                replicas=self.config.replicas,
-                services=services,
-                template=sdk.PoolTemplate(
-                    runtime=None,
-                    runtime_class_name=None,
-                    node_selector=None,
-                    tolerations=None,
-                    command=None,
-                    container_disk_image=image,
-                    image_pull_secret=self.config.image_pull_secret or None,
-                    cpu_cores=self.config.cpu,
-                    memory=self.config.memory,
-                    firmware=None,
-                    probes=probes,
-                    oidc=None,
-                ),
-                autoscaling=None,
-            ),
-        )
-
-    def _reconcile_pool(
-        self,
-        worker: _AsyncWorker,
-        client: Any,
-        sdk: Any,
-        namespace: str,
-        image: str,
-    ) -> Any:
-        desired = self._pool_request(sdk, namespace, image)
-        try:
-            current = worker.run(
-                client.get_pool(namespace), self.config.request_timeout
-            )
-        except BaseException as error:
-            if not self._is_missing_pool_error(sdk, error):
-                raise
-            try:
-                return worker.run(
-                    client.create_pool(desired), self.config.request_timeout
-                )
-            except BaseException:
-                # Creation may have committed remotely before a local timeout.
-                return worker.run(
-                    client.get_pool(namespace), self.config.request_timeout
-                )
-        if current.spec != desired.spec:
-            current.spec = desired.spec
-            return worker.run(client.update_pool(current), self.config.request_timeout)
-        return current
-
-    @staticmethod
-    def _is_missing_pool_error(sdk: Any, error: BaseException) -> bool:
-        status_error = getattr(getattr(sdk, "SdkError", None), "Status", None)
-        return status_error is not None and isinstance(error, status_error) and error.status == 404
-
-    def _wait_pool(self, worker: _AsyncWorker, client: Any, pool: Any) -> Any:
-        deadline = time.monotonic() + self.config.ready_timeout
-        while True:
-            current = worker.run(client.get_pool(pool.metadata.name), self.config.request_timeout)
-            status = getattr(current, "status", None)
-            if (
-                status is not None
-                and (getattr(status, "available_count", 0) or 0) >= self.config.replicas
-            ):
-                return current
-            if time.monotonic() >= deadline:
-                raise TimeoutError(
-                    f"Timed out waiting for Fleet pool {pool.metadata.name!r}"
-                )
-            time.sleep(self.config.ready_poll_interval)
+            raise ImportError(f"CUA Sandbox API unavailable: {exc}") from exc
+        self._sandbox_module = cua_sandbox
+        return self._sandbox_module
 
 
 def _provider_from_config(compute_config: Mapping[str, Any] | None = None) -> Any:

--- a/tools/environments/cua_fleet.py
+++ b/tools/environments/cua_fleet.py
@@ -611,35 +611,36 @@ class CuaFleetDesktopProvider:
         image: str,
     ) -> Any:
         desired = self._pool_request(sdk, namespace, image)
-        pools = worker.run(client.list_pools(namespace), self.config.request_timeout)
-        current = next(
-            (pool for pool in pools if pool.metadata.name == namespace), None
-        )
-        if current is None:
+        try:
+            current = worker.run(
+                client.get_pool(namespace), self.config.request_timeout
+            )
+        except BaseException as error:
+            if not self._is_missing_pool_error(sdk, error):
+                raise
             try:
                 return worker.run(
                     client.create_pool(desired), self.config.request_timeout
                 )
             except BaseException:
                 # Creation may have committed remotely before a local timeout.
-                pools = worker.run(
-                    client.list_pools(namespace), self.config.request_timeout
+                return worker.run(
+                    client.get_pool(namespace), self.config.request_timeout
                 )
-                current = next(
-                    (pool for pool in pools if pool.metadata.name == namespace), None
-                )
-                if current is None:
-                    raise
-                return current
         if current.spec != desired.spec:
             current.spec = desired.spec
             return worker.run(client.update_pool(current), self.config.request_timeout)
         return current
 
+    @staticmethod
+    def _is_missing_pool_error(sdk: Any, error: BaseException) -> bool:
+        status_error = getattr(getattr(sdk, "SdkError", None), "Status", None)
+        return status_error is not None and isinstance(error, status_error) and error.status == 404
+
     def _wait_pool(self, worker: _AsyncWorker, client: Any, pool: Any) -> Any:
         deadline = time.monotonic() + self.config.ready_timeout
         while True:
-            current = worker.run(client.get_pool(pool), self.config.request_timeout)
+            current = worker.run(client.get_pool(pool.metadata.name), self.config.request_timeout)
             status = getattr(current, "status", None)
             if (
                 status is not None

--- a/tools/environments/cua_fleet.py
+++ b/tools/environments/cua_fleet.py
@@ -31,15 +31,11 @@ class CuaFleetConfig:
     client_id: str = ""
     client_secret: str = ""
     image: str = "trycua/cua:latest"
-    image_pull_secret: str = "ecr-credentials"
     pool: str = "hermes-desktop"
     replicas: int = 1
     cwd: str = "/root"
     timeout: int = 60
-    cpu: int | None = 2
-    memory: str | None = "8192Mi"
     ready_timeout: float = 600
-    ready_poll_interval: float = 5
     request_timeout: float = 30
     services: Mapping[str, int] = field(
         default_factory=lambda: {"server": 8000, "mcp": 3000}

--- a/tools/environments/cua_fleet.py
+++ b/tools/environments/cua_fleet.py
@@ -1,46 +1,630 @@
-"""Placeholder provider for a remotely managed CUA desktop fleet."""
+"""Cua Fleet compute provider backed by the public ``cua-fleet`` SDK."""
 
 from __future__ import annotations
 
+import asyncio
+import base64
+import json
+import logging
+import os
+import re
+import threading
+import time
+import urllib.error
+import urllib.request
+import urllib.parse
 import uuid
-from dataclasses import dataclass
-from typing import Sequence
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
 
+from tools.computer_use.transports.base import CuaToolTransport
+from tools.environments.base import BaseEnvironment, _ThreadedProcessHandle
 from tools.environments.compute_provider import ComputeLease, EnvironmentCapabilities
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://run.cua.ai"
+_DEFAULT_TOKEN_URL = (
+    "https://auth.cua.ai/realms/cyclops-cs/protocol/openid-connect/token"
+)
 
 
 @dataclass(frozen=True)
 class CuaFleetConfig:
-    endpoint: str = ""
+    base_url: str = _DEFAULT_BASE_URL
+    token_url: str = _DEFAULT_TOKEN_URL
+    client_id: str = ""
+    client_secret: str = ""
     image: str = "trycua/cua:latest"
-    pool: str = "default"
-    token: str = ""
+    image_pull_secret: str = "ecr-credentials"
+    pool_prefix: str = "hermes"
+    cwd: str = "/root"
+    timeout: int = 60
+    cpu: int | None = 2
+    memory: str | None = "8192Mi"
+    ready_timeout: float = 600
+    ready_poll_interval: float = 5
+    request_timeout: float = 30
+    services: Mapping[str, int] = field(
+        default_factory=lambda: {"server": 8000, "mcp": 3000}
+    )
+
+
+@dataclass
+class _FleetState:
+    client: Any
+    http_client: Any
+    pool: Any
+    claim: Any
+    sandbox: Any
+
+
+class _AsyncWorker:
+    def __init__(self):
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def run(self, coroutine: Any, timeout: float) -> Any:
+        future = asyncio.run_coroutine_threadsafe(coroutine, self._loop)
+        try:
+            return future.result(timeout=timeout)
+        except BaseException:
+            future.cancel()
+            raise
+
+    def stop(self) -> None:
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=10)
+        self._loop.close()
+
+
+class _UrlLibHttpClient:
+    """Build the SDK's HttpClient callback without depending on cua-sandbox."""
+
+    def __init__(self, sdk: Any, timeout: float, allowed_hosts: Sequence[str]):
+        self._sdk = sdk
+        self._timeout = timeout
+        self._allowed_hosts = frozenset(allowed_hosts)
+
+    async def execute(self, request: Any) -> Any:
+        return await asyncio.to_thread(self._execute, request)
+
+    def _execute(self, request: Any) -> Any:
+        parsed = urllib.parse.urlparse(request.url)
+        if parsed.scheme != "https" or parsed.hostname not in self._allowed_hosts:
+            raise ValueError(
+                f"Cua Fleet SDK attempted a request to an unexpected URL: {request.url!r}"
+            )
+        native = urllib.request.Request(
+            request.url,
+            data=request.body,
+            method=request.method,
+            headers={header.name: header.value for header in request.headers},
+        )
+        try:
+            with urllib.request.urlopen(native, timeout=self._timeout) as response:
+                return self._response(
+                    response.status, response.headers.items(), response.read()
+                )
+        except urllib.error.HTTPError as error:
+            return self._response(error.code, error.headers.items(), error.read())
+
+    def _response(self, status: int, headers: Any, body: bytes) -> Any:
+        return self._sdk.HttpResponse(
+            status=status,
+            headers=[
+                self._sdk.HttpHeader(name=name, value=value) for name, value in headers
+            ],
+            body=body,
+        )
+
+
+class _FleetMcpTransport(CuaToolTransport):
+    def __init__(
+        self, state: _FleetState, sdk: Any, worker: _AsyncWorker, timeout: float
+    ):
+        self._state = state
+        self._sdk = sdk
+        self._worker = worker
+        self._timeout = timeout
+        self._started = False
+        self._request_id = 0
+
+    def start(self) -> None:
+        if self._started:
+            return
+        self._started = True
+        self._request(
+            "initialize",
+            {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "hermes-agent", "version": "0.1"},
+            },
+        )
+
+    def stop(self) -> None:
+        self._started = False
+
+    def is_alive(self) -> bool:
+        if not self._started:
+            return False
+        try:
+            self.list_tools()
+            return True
+        except Exception:
+            return False
+
+    def list_tools(self) -> list[Mapping[str, Any]]:
+        result = self._request("tools/list", {})
+        tools = result.get("tools", [])
+        return tools if isinstance(tools, list) else []
+
+    def call_tool(self, name: str, arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+        return self._request("tools/call", {"name": name, "arguments": dict(arguments)})
+
+    def _request(self, method: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
+        self._request_id += 1
+        payload = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": self._request_id,
+                "method": method,
+                "params": params,
+            },
+            separators=(",", ":"),
+        ).encode()
+        response = self._worker.run(
+            self._state.client.service_request(
+                self._state.sandbox,
+                "mcp",
+                "/mcp",
+                self._sdk.HttpRequest(
+                    method="POST",
+                    url="https://service.invalid/mcp",
+                    headers=[
+                        self._sdk.HttpHeader(
+                            name="accept", value="application/json, text/event-stream"
+                        ),
+                        self._sdk.HttpHeader(
+                            name="content-type", value="application/json"
+                        ),
+                    ],
+                    body=payload,
+                ),
+            ),
+            self._timeout,
+        )
+        if not 200 <= response.status < 300:
+            raise RuntimeError(f"Fleet MCP request failed with HTTP {response.status}")
+        parsed = _parse_mcp_response(response.body)
+        if "error" in parsed:
+            error = parsed["error"]
+            raise RuntimeError(
+                error.get("message", str(error))
+                if isinstance(error, Mapping)
+                else str(error)
+            )
+        result = parsed.get("result", {})
+        return result if isinstance(result, Mapping) else {"result": result}
+
+
+def _parse_mcp_response(body: bytes) -> Mapping[str, Any]:
+    text = body.decode("utf-8", errors="replace").strip()
+    if text.startswith("data:") or "\ndata:" in text:
+        events = [
+            line[5:].strip() for line in text.splitlines() if line.startswith("data:")
+        ]
+        text = events[-1] if events else "{}"
+    parsed = json.loads(text or "{}")
+    if not isinstance(parsed, Mapping):
+        raise ValueError("Fleet MCP endpoint returned a non-object response")
+    return parsed
+
+
+class CuaFleetEnvironment(BaseEnvironment):
+    """One bound Fleet sandbox shared by terminal and computer-use tools."""
+
+    _stdin_mode = "heredoc"
+    _snapshot_timeout = 60
+
+    def __init__(
+        self,
+        *,
+        compute_lease: ComputeLease,
+        state: _FleetState,
+        sdk: Any,
+        config: CuaFleetConfig,
+        worker: _AsyncWorker,
+        release_callback: Any,
+    ):
+        self._compute_lease = compute_lease
+        self._state = state
+        self._sdk = sdk
+        self._fleet_config = config
+        self._worker = worker
+        self._release_callback = release_callback
+        self._released = False
+        self._computer_backend = None
+        super().__init__(cwd=config.cwd, timeout=config.timeout)
+
+    @property
+    def compute_lease(self) -> ComputeLease:
+        return self._compute_lease
+
+    def get_computer_backend(self):
+        if self._computer_backend is None:
+            from tools.environments.modal_desktop import _TransportComputerBackend
+
+            transport = _FleetMcpTransport(
+                self._state, self._sdk, self._worker, self._fleet_config.request_timeout
+            )
+            self._computer_backend = _TransportComputerBackend(transport)
+            self._computer_backend.start()
+        return self._computer_backend
+
+    def _run_bash(
+        self,
+        cmd_string: str,
+        *,
+        login: bool = False,
+        timeout: int = 120,
+        stdin_data: str | None = None,
+    ):
+        command = ["bash"]
+        if login:
+            command.append("-l")
+        command.extend(["-c", cmd_string])
+        shell_command = " ".join(_shell_quote(part) for part in command)
+        if stdin_data is not None:
+            encoded = base64.b64encode(stdin_data.encode()).decode("ascii")
+            shell_command = (
+                f"printf %s {_shell_quote(encoded)} | base64 -d | {shell_command}"
+            )
+
+        def execute() -> tuple[str, int]:
+            response = self._worker.run(
+                self._service_json(
+                    "server",
+                    "/cmd",
+                    {
+                        "command": "run_command",
+                        "params": {"command": shell_command, "timeout": timeout},
+                    },
+                ),
+                timeout + self._fleet_config.request_timeout,
+            )
+            result = response.get("result", response)
+            stdout = str(result.get("stdout", ""))
+            stderr = str(result.get("stderr", ""))
+            output = stdout + (
+                ("\n" if stdout and not stdout.endswith("\n") else "") + stderr
+                if stderr
+                else ""
+            )
+            return output, int(result.get("returncode", result.get("return_code", 0)))
+
+        return _ThreadedProcessHandle(execute)
+
+    async def _service_json(
+        self, service: str, path: str, payload: Mapping[str, Any]
+    ) -> Mapping[str, Any]:
+        response = await self._state.client.service_request(
+            self._state.sandbox,
+            service,
+            path,
+            self._sdk.HttpRequest(
+                method="POST",
+                url=f"https://service.invalid{path}",
+                headers=[
+                    self._sdk.HttpHeader(name="content-type", value="application/json")
+                ],
+                body=json.dumps(payload, separators=(",", ":")).encode(),
+            ),
+        )
+        if not 200 <= response.status < 300:
+            raise RuntimeError(
+                f"Fleet service {service!r} failed with HTTP {response.status}"
+            )
+        parsed = json.loads(response.body.decode("utf-8", errors="replace") or "{}")
+        if not isinstance(parsed, Mapping):
+            raise ValueError(
+                f"Fleet service {service!r} returned a non-object response"
+            )
+        return parsed
+
+    def cleanup(self) -> None:
+        if self._computer_backend is not None:
+            self._computer_backend.stop()
+            self._computer_backend = None
+        if not self._released:
+            self._released = True
+            self._release_callback()
+
+
+def _shell_quote(value: str) -> str:
+    import shlex
+
+    return shlex.quote(value)
 
 
 class CuaFleetDesktopProvider:
-    """PoC lifecycle surface for fleet pool/claim/release integration."""
-
     name = "cua_fleet"
 
-    def __init__(self, config: CuaFleetConfig | None = None):
+    def __init__(self, config: CuaFleetConfig | None = None, *, sdk_module: Any = None):
         self.config = config or CuaFleetConfig()
+        self._sdk = sdk_module
+        self._states: dict[str, _FleetState] = {}
+        self._workers: dict[str, _AsyncWorker] = {}
+        self._lock = threading.RLock()
 
-    def acquire(self, task_id: str, *, image: str | None = None,
-                capabilities: Sequence[str] | None = None) -> ComputeLease:
-        if not self.config.endpoint:
-            raise RuntimeError("cua_fleet.endpoint must be configured before acquiring a desktop")
+    def acquire(
+        self,
+        task_id: str,
+        *,
+        image: str | None = None,
+        capabilities: Sequence[str] | None = None,
+    ) -> ComputeLease:
         enabled = EnvironmentCapabilities(computer_use=True)
         requested = frozenset(capabilities or enabled.to_capabilities())
-        if not requested <= enabled.to_capabilities():
-            raise ValueError("Cua fleet desktop does not support all requested capabilities")
+        missing = requested - enabled.to_capabilities()
+        if missing:
+            raise ValueError(
+                f"Cua Fleet image lacks requested capabilities: {sorted(missing)}"
+            )
+
+        client_id = self.config.client_id or os.environ.get("CUA_CLIENT_ID", "")
+        client_secret = self.config.client_secret or os.environ.get(
+            "CUA_CLIENT_SECRET", ""
+        )
+        if not client_id or not client_secret:
+            raise RuntimeError(
+                "Cua Fleet requires CUA_CLIENT_ID and CUA_CLIENT_SECRET (a ukey credential)"
+            )
+
+        sdk = self._load_sdk()
+        worker = _AsyncWorker()
+        lease_id = uuid.uuid4().hex
+        namespace = _resource_name(self.config.pool_prefix, task_id, lease_id)
+        http_client_type = type(
+            "FleetHttpClient", (sdk.HttpClient, _UrlLibHttpClient), {}
+        )
+        allowed_hosts = {
+            urllib.parse.urlparse(self.config.base_url).hostname,
+            urllib.parse.urlparse(self.config.token_url).hostname,
+        }
+        http_client = http_client_type(
+            sdk,
+            self.config.request_timeout,
+            tuple(host for host in allowed_hosts if host),
+        )
+        client = sdk.CyclopsClient.connect(
+            sdk.CyclopsConfiguration(
+                base_url=self.config.base_url,
+                token_url=self.config.token_url,
+                credentials=sdk.CyclopsCredentials(client_id, client_secret),
+                pool_poll_interval_ms=max(
+                    1, int(self.config.ready_poll_interval * 1000)
+                ),
+                pool_poll_limit=max(
+                    1,
+                    int(
+                        self.config.ready_timeout
+                        / max(self.config.ready_poll_interval, 0.001)
+                    ),
+                ),
+                claim_poll_interval_ms=max(
+                    1, int(self.config.ready_poll_interval * 1000)
+                ),
+                claim_poll_limit=max(
+                    1,
+                    int(
+                        self.config.ready_timeout
+                        / max(self.config.ready_poll_interval, 0.001)
+                    ),
+                ),
+            ),
+            http_client,
+        )
+        pool = claim = None
+        try:
+            pool = worker.run(
+                client.create_pool(
+                    self._pool_request(sdk, namespace, image or self.config.image)
+                ),
+                self.config.request_timeout,
+            )
+            pool = self._wait_pool(worker, client, pool)
+            claim = worker.run(
+                client.create_claim(sdk.CreateClaimRequest(pool=pool, spec=None)),
+                self.config.request_timeout,
+            )
+            sandbox = worker.run(client.wait_claim(claim), self.config.ready_timeout)
+        except BaseException:
+            if claim is not None:
+                try:
+                    worker.run(client.delete_claim(claim), self.config.request_timeout)
+                except Exception:
+                    logger.warning("Failed to roll back Fleet claim", exc_info=True)
+            if pool is not None:
+                try:
+                    worker.run(client.delete_pool(pool), self.config.request_timeout)
+                except Exception:
+                    logger.warning("Failed to roll back Fleet pool", exc_info=True)
+            worker.stop()
+            raise
+
+        state = _FleetState(client, http_client, pool, claim, sandbox)
+        with self._lock:
+            self._states[lease_id] = state
+            self._workers[lease_id] = worker
         return ComputeLease(
-            task_id=task_id, lease_id=uuid.uuid4().hex, provider=self.name,
-            image=image or self.config.image, capabilities=enabled,
-            endpoint=self.config.endpoint, metadata={"pool": self.config.pool},
+            task_id=task_id,
+            lease_id=lease_id,
+            provider=self.name,
+            image=image or self.config.image,
+            capabilities=enabled,
+            endpoint=self.config.base_url,
+            metadata={
+                "namespace": pool.metadata.namespace,
+                "pool": pool.metadata.name,
+                "claim": claim.metadata.name,
+                "sandbox": sandbox.name,
+            },
         )
 
-    def create_environment(self, lease: ComputeLease):
-        raise NotImplementedError("CuaFleetDesktopProvider environment attachment is not implemented in this PoC")
+    def create_environment(self, lease: ComputeLease) -> CuaFleetEnvironment:
+        with self._lock:
+            state = self._states.get(lease.lease_id)
+            worker = self._workers.get(lease.lease_id)
+        if state is None or worker is None:
+            raise RuntimeError(f"Unknown Cua Fleet lease {lease.lease_id}")
+        config = self.config
+        if lease.image != config.image:
+            config = CuaFleetConfig(**{
+                field_name: lease.image
+                if field_name == "image"
+                else getattr(config, field_name)
+                for field_name in CuaFleetConfig.__dataclass_fields__
+            })
+        return CuaFleetEnvironment(
+            compute_lease=lease,
+            state=state,
+            sdk=self._load_sdk(),
+            config=config,
+            worker=worker,
+            release_callback=lambda: self.release(lease),
+        )
 
     def release(self, lease: ComputeLease) -> None:
-        return None
+        with self._lock:
+            state = self._states.pop(lease.lease_id, None)
+            worker = self._workers.pop(lease.lease_id, None)
+        if state is None or worker is None:
+            return
+        error = None
+        try:
+            worker.run(
+                state.client.delete_claim(state.claim), self.config.request_timeout
+            )
+        except Exception as exc:
+            error = exc
+        try:
+            # cua-fleet owns the coupled pool + namespace teardown here.
+            worker.run(
+                state.client.delete_pool(state.pool), self.config.request_timeout
+            )
+        except Exception as exc:
+            error = error or exc
+        finally:
+            worker.stop()
+        if error is not None:
+            raise error
+
+    def _load_sdk(self) -> Any:
+        if self._sdk is not None:
+            return self._sdk
+        try:
+            from tools.lazy_deps import ensure
+
+            ensure("terminal.cua_fleet", prompt=False)
+            import cyclops_sdk
+        except Exception as exc:
+            raise ImportError(f"Cua Fleet SDK unavailable: {exc}") from exc
+        self._sdk = cyclops_sdk
+        return self._sdk
+
+    def _pool_request(self, sdk: Any, namespace: str, image: str) -> Any:
+        services = [
+            sdk.SandboxService(name=name, target_port=port, protocol=None)
+            for name, port in self.config.services.items()
+        ]
+        probes = None
+        if hasattr(sdk, "PreservedJson") and "server" in self.config.services:
+            probes = sdk.PreservedJson.from_json(
+                json.dumps({
+                    "readinessProbe": {
+                        "tcpSocket": {"port": self.config.services["server"]}
+                    }
+                })
+            )
+        return sdk.CreatePoolRequest(
+            namespace=namespace,
+            spec=sdk.PoolSpec(
+                replicas=1,
+                services=services,
+                template=sdk.PoolTemplate(
+                    runtime=None,
+                    runtime_class_name=None,
+                    node_selector=None,
+                    tolerations=None,
+                    command=None,
+                    container_disk_image=image,
+                    image_pull_secret=self.config.image_pull_secret or None,
+                    cpu_cores=self.config.cpu,
+                    memory=self.config.memory,
+                    firmware=None,
+                    probes=probes,
+                    oidc=None,
+                ),
+                autoscaling=None,
+            ),
+        )
+
+    def _wait_pool(self, worker: _AsyncWorker, client: Any, pool: Any) -> Any:
+        deadline = time.monotonic() + self.config.ready_timeout
+        while True:
+            current = worker.run(client.get_pool(pool), self.config.request_timeout)
+            status = getattr(current, "status", None)
+            if status is not None and (getattr(status, "available_count", 0) or 0) >= 1:
+                return current
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Timed out waiting for Fleet pool {pool.metadata.name!r}"
+                )
+            time.sleep(self.config.ready_poll_interval)
+
+
+def _resource_name(prefix: str, task_id: str, lease_id: str) -> str:
+    value = re.sub(
+        r"[^a-z0-9-]+", "-", f"{prefix}-{task_id}-{lease_id[:8]}".lower()
+    ).strip("-")
+    return value[:63].rstrip("-") or f"hermes-{lease_id[:8]}"
+
+
+def _provider_from_config(compute_config: Mapping[str, Any] | None = None) -> Any:
+    config = dict(compute_config or {})
+    provider_name = str(config.get("provider") or "modal").lower()
+    if provider_name == "cua_fleet":
+        fleet = dict(config.get("cua_fleet") or {})
+        fleet["image"] = str(
+            config.get("image") or fleet.get("image") or CuaFleetConfig.image
+        )
+        allowed = CuaFleetConfig.__dataclass_fields__
+        return CuaFleetDesktopProvider(
+            CuaFleetConfig(**{
+                key: value for key, value in fleet.items() if key in allowed
+            })
+        )
+    if provider_name == "modal":
+        from tools.environments.modal_desktop import (
+            ModalDesktopConfig,
+            ModalDesktopProvider,
+        )
+
+        modal = dict(config.get("modal") or {})
+        modal["image"] = str(
+            config.get("image") or modal.get("image") or ModalDesktopConfig.image
+        )
+        allowed = ModalDesktopConfig.__dataclass_fields__
+        return ModalDesktopProvider(
+            ModalDesktopConfig(**{
+                key: value for key, value in modal.items() if key in allowed
+            })
+        )
+    raise ValueError(f"Unsupported compute provider: {provider_name}")

--- a/tools/environments/cua_fleet.py
+++ b/tools/environments/cua_fleet.py
@@ -37,6 +37,7 @@ class CuaFleetConfig:
     image: str = "trycua/cua:latest"
     image_pull_secret: str = "ecr-credentials"
     pool: str = "hermes-desktop"
+    replicas: int = 1
     cwd: str = "/root"
     timeout: int = 60
     cpu: int | None = 2
@@ -47,6 +48,14 @@ class CuaFleetConfig:
     services: Mapping[str, int] = field(
         default_factory=lambda: {"server": 8000, "mcp": 3000}
     )
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.replicas, bool)
+            or not isinstance(self.replicas, int)
+            or self.replicas < 1
+        ):
+            raise ValueError("replicas must be a positive integer")
 
 
 @dataclass
@@ -573,7 +582,7 @@ class CuaFleetDesktopProvider:
         return sdk.CreatePoolRequest(
             namespace=namespace,
             spec=sdk.PoolSpec(
-                replicas=1,
+                replicas=self.config.replicas,
                 services=services,
                 template=sdk.PoolTemplate(
                     runtime=None,
@@ -632,7 +641,10 @@ class CuaFleetDesktopProvider:
         while True:
             current = worker.run(client.get_pool(pool), self.config.request_timeout)
             status = getattr(current, "status", None)
-            if status is not None and (getattr(status, "available_count", 0) or 0) >= 1:
+            if (
+                status is not None
+                and (getattr(status, "available_count", 0) or 0) >= self.config.replicas
+            ):
                 return current
             if time.monotonic() >= deadline:
                 raise TimeoutError(

--- a/tools/environments/cua_fleet.py
+++ b/tools/environments/cua_fleet.py
@@ -7,7 +7,6 @@ import base64
 import json
 import logging
 import os
-import re
 import threading
 import time
 import urllib.error
@@ -37,7 +36,7 @@ class CuaFleetConfig:
     client_secret: str = ""
     image: str = "trycua/cua:latest"
     image_pull_secret: str = "ecr-credentials"
-    pool_prefix: str = "hermes"
+    pool: str = "hermes-desktop"
     cwd: str = "/root"
     timeout: int = 60
     cpu: int | None = 2
@@ -83,6 +82,11 @@ class _AsyncWorker:
         self._loop.close()
 
 
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, file_pointer, code, message, headers, new_url):
+        return None
+
+
 class _UrlLibHttpClient:
     """Build the SDK's HttpClient callback without depending on cua-sandbox."""
 
@@ -106,8 +110,9 @@ class _UrlLibHttpClient:
             method=request.method,
             headers={header.name: header.value for header in request.headers},
         )
+        opener = urllib.request.build_opener(_NoRedirectHandler())
         try:
-            with urllib.request.urlopen(native, timeout=self._timeout) as response:
+            with opener.open(native, timeout=self._timeout) as response:
                 return self._response(
                     response.status, response.headers.items(), response.read()
                 )
@@ -227,6 +232,20 @@ def _parse_mcp_response(body: bytes) -> Mapping[str, Any]:
     return parsed
 
 
+def _parse_service_response(body: bytes) -> Mapping[str, Any]:
+    """Parse computer-server JSON or its SSE ``data:`` envelope."""
+    text = body.decode("utf-8", errors="replace").strip()
+    data_frames = [
+        line[5:].strip() for line in text.splitlines() if line.startswith("data:")
+    ]
+    if data_frames:
+        text = data_frames[0]
+    parsed = json.loads(text or "{}")
+    if not isinstance(parsed, Mapping):
+        raise ValueError("Fleet service returned a non-object response")
+    return parsed
+
+
 class CuaFleetEnvironment(BaseEnvironment):
     """One bound Fleet sandbox shared by terminal and computer-use tools."""
 
@@ -331,20 +350,15 @@ class CuaFleetEnvironment(BaseEnvironment):
             raise RuntimeError(
                 f"Fleet service {service!r} failed with HTTP {response.status}"
             )
-        parsed = json.loads(response.body.decode("utf-8", errors="replace") or "{}")
-        if not isinstance(parsed, Mapping):
-            raise ValueError(
-                f"Fleet service {service!r} returned a non-object response"
-            )
-        return parsed
+        return _parse_service_response(response.body)
 
     def cleanup(self) -> None:
         if self._computer_backend is not None:
             self._computer_backend.stop()
             self._computer_backend = None
         if not self._released:
-            self._released = True
             self._release_callback()
+            self._released = True
 
 
 def _shell_quote(value: str) -> str:
@@ -362,6 +376,15 @@ class CuaFleetDesktopProvider:
         self._states: dict[str, _FleetState] = {}
         self._workers: dict[str, _AsyncWorker] = {}
         self._lock = threading.RLock()
+        self._reconcile_lock = threading.Lock()
+        self._shared_worker: _AsyncWorker | None = None
+        self._shared_client: Any = None
+        self._shared_http_client: Any = None
+
+    @staticmethod
+    def _http_client_type(http_client_base: type) -> type:
+        # Concrete callback first: generated HttpClient.execute is abstract.
+        return type("FleetHttpClient", (_UrlLibHttpClient, http_client_base), {})
 
     def acquire(
         self,
@@ -388,57 +411,17 @@ class CuaFleetDesktopProvider:
             )
 
         sdk = self._load_sdk()
-        worker = _AsyncWorker()
+        worker, client, http_client = self._shared_connection(
+            sdk, client_id, client_secret
+        )
         lease_id = uuid.uuid4().hex
-        namespace = _resource_name(self.config.pool_prefix, task_id, lease_id)
-        http_client_type = type(
-            "FleetHttpClient", (sdk.HttpClient, _UrlLibHttpClient), {}
-        )
-        allowed_hosts = {
-            urllib.parse.urlparse(self.config.base_url).hostname,
-            urllib.parse.urlparse(self.config.token_url).hostname,
-        }
-        http_client = http_client_type(
-            sdk,
-            self.config.request_timeout,
-            tuple(host for host in allowed_hosts if host),
-        )
-        client = sdk.CyclopsClient.connect(
-            sdk.CyclopsConfiguration(
-                base_url=self.config.base_url,
-                token_url=self.config.token_url,
-                credentials=sdk.CyclopsCredentials(client_id, client_secret),
-                pool_poll_interval_ms=max(
-                    1, int(self.config.ready_poll_interval * 1000)
-                ),
-                pool_poll_limit=max(
-                    1,
-                    int(
-                        self.config.ready_timeout
-                        / max(self.config.ready_poll_interval, 0.001)
-                    ),
-                ),
-                claim_poll_interval_ms=max(
-                    1, int(self.config.ready_poll_interval * 1000)
-                ),
-                claim_poll_limit=max(
-                    1,
-                    int(
-                        self.config.ready_timeout
-                        / max(self.config.ready_poll_interval, 0.001)
-                    ),
-                ),
-            ),
-            http_client,
-        )
+        namespace = self.config.pool
         pool = claim = None
         try:
-            pool = worker.run(
-                client.create_pool(
-                    self._pool_request(sdk, namespace, image or self.config.image)
-                ),
-                self.config.request_timeout,
-            )
+            with self._reconcile_lock:
+                pool = self._reconcile_pool(
+                    worker, client, sdk, namespace, image or self.config.image
+                )
             pool = self._wait_pool(worker, client, pool)
             claim = worker.run(
                 client.create_claim(sdk.CreateClaimRequest(pool=pool, spec=None)),
@@ -451,12 +434,6 @@ class CuaFleetDesktopProvider:
                     worker.run(client.delete_claim(claim), self.config.request_timeout)
                 except Exception:
                     logger.warning("Failed to roll back Fleet claim", exc_info=True)
-            if pool is not None:
-                try:
-                    worker.run(client.delete_pool(pool), self.config.request_timeout)
-                except Exception:
-                    logger.warning("Failed to roll back Fleet pool", exc_info=True)
-            worker.stop()
             raise
 
         state = _FleetState(client, http_client, pool, claim, sandbox)
@@ -503,28 +480,68 @@ class CuaFleetDesktopProvider:
 
     def release(self, lease: ComputeLease) -> None:
         with self._lock:
-            state = self._states.pop(lease.lease_id, None)
-            worker = self._workers.pop(lease.lease_id, None)
+            state = self._states.get(lease.lease_id)
+            worker = self._workers.get(lease.lease_id)
         if state is None or worker is None:
             return
-        error = None
-        try:
-            worker.run(
-                state.client.delete_claim(state.claim), self.config.request_timeout
+        worker.run(state.client.delete_claim(state.claim), self.config.request_timeout)
+        with self._lock:
+            self._states.pop(lease.lease_id, None)
+            self._workers.pop(lease.lease_id, None)
+
+    def _shared_connection(
+        self, sdk: Any, client_id: str, client_secret: str
+    ) -> tuple[_AsyncWorker, Any, Any]:
+        with self._lock:
+            if self._shared_worker is not None:
+                return (
+                    self._shared_worker,
+                    self._shared_client,
+                    self._shared_http_client,
+                )
+            worker = _AsyncWorker()
+            http_client_type = self._http_client_type(sdk.HttpClient)
+            allowed_hosts = {
+                urllib.parse.urlparse(self.config.base_url).hostname,
+                urllib.parse.urlparse(self.config.token_url).hostname,
+            }
+            http_client = http_client_type(
+                sdk,
+                self.config.request_timeout,
+                tuple(host for host in allowed_hosts if host),
             )
-        except Exception as exc:
-            error = exc
-        try:
-            # cua-fleet owns the coupled pool + namespace teardown here.
-            worker.run(
-                state.client.delete_pool(state.pool), self.config.request_timeout
+            client = sdk.CyclopsClient.connect(
+                sdk.CyclopsConfiguration(
+                    base_url=self.config.base_url,
+                    token_url=self.config.token_url,
+                    credentials=sdk.CyclopsCredentials(client_id, client_secret),
+                    pool_poll_interval_ms=max(
+                        1, int(self.config.ready_poll_interval * 1000)
+                    ),
+                    pool_poll_limit=max(
+                        1,
+                        int(
+                            self.config.ready_timeout
+                            / max(self.config.ready_poll_interval, 0.001)
+                        ),
+                    ),
+                    claim_poll_interval_ms=max(
+                        1, int(self.config.ready_poll_interval * 1000)
+                    ),
+                    claim_poll_limit=max(
+                        1,
+                        int(
+                            self.config.ready_timeout
+                            / max(self.config.ready_poll_interval, 0.001)
+                        ),
+                    ),
+                ),
+                http_client,
             )
-        except Exception as exc:
-            error = error or exc
-        finally:
-            worker.stop()
-        if error is not None:
-            raise error
+            self._shared_worker = worker
+            self._shared_client = client
+            self._shared_http_client = http_client
+            return worker, client, http_client
 
     def _load_sdk(self) -> Any:
         if self._sdk is not None:
@@ -576,6 +593,40 @@ class CuaFleetDesktopProvider:
             ),
         )
 
+    def _reconcile_pool(
+        self,
+        worker: _AsyncWorker,
+        client: Any,
+        sdk: Any,
+        namespace: str,
+        image: str,
+    ) -> Any:
+        desired = self._pool_request(sdk, namespace, image)
+        pools = worker.run(client.list_pools(namespace), self.config.request_timeout)
+        current = next(
+            (pool for pool in pools if pool.metadata.name == namespace), None
+        )
+        if current is None:
+            try:
+                return worker.run(
+                    client.create_pool(desired), self.config.request_timeout
+                )
+            except BaseException:
+                # Creation may have committed remotely before a local timeout.
+                pools = worker.run(
+                    client.list_pools(namespace), self.config.request_timeout
+                )
+                current = next(
+                    (pool for pool in pools if pool.metadata.name == namespace), None
+                )
+                if current is None:
+                    raise
+                return current
+        if current.spec != desired.spec:
+            current.spec = desired.spec
+            return worker.run(client.update_pool(current), self.config.request_timeout)
+        return current
+
     def _wait_pool(self, worker: _AsyncWorker, client: Any, pool: Any) -> Any:
         deadline = time.monotonic() + self.config.ready_timeout
         while True:
@@ -588,13 +639,6 @@ class CuaFleetDesktopProvider:
                     f"Timed out waiting for Fleet pool {pool.metadata.name!r}"
                 )
             time.sleep(self.config.ready_poll_interval)
-
-
-def _resource_name(prefix: str, task_id: str, lease_id: str) -> str:
-    value = re.sub(
-        r"[^a-z0-9-]+", "-", f"{prefix}-{task_id}-{lease_id[:8]}".lower()
-    ).strip("-")
-    return value[:63].rstrip("-") or f"hermes-{lease_id[:8]}"
 
 
 def _provider_from_config(compute_config: Mapping[str, Any] | None = None) -> Any:

--- a/tools/environments/desktop_lease.py
+++ b/tools/environments/desktop_lease.py
@@ -1,0 +1,95 @@
+"""Process-wide task-to-desktop lease manager."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from tools.environments.compute_provider import ComputeLease
+
+
+@dataclass
+class DesktopSandboxLease:
+    """One task's environment and the provider reservation backing it."""
+
+    task_id: str
+    lease: ComputeLease
+    environment: Any
+    references: int = 1
+
+
+class DesktopSandboxManager:
+    """Ensures terminal and computer-use resolve the same task lease."""
+
+    def __init__(self, provider: Any):
+        self.provider = provider
+        self._leases: dict[str, DesktopSandboxLease] = {}
+        self._lock = threading.RLock()
+
+    def acquire(self, task_id: str, *, image: str | None = None,
+                capabilities: Sequence[str] | None = None) -> DesktopSandboxLease:
+        with self._lock:
+            existing = self._leases.get(task_id)
+            if existing is not None:
+                existing.references += 1
+                return existing
+            lease = self.provider.acquire(task_id, image=image, capabilities=capabilities)
+            try:
+                environment = self.provider.create_environment(lease)
+            except Exception:
+                self.provider.release(lease)
+                raise
+            managed = DesktopSandboxLease(task_id=task_id, lease=lease, environment=environment)
+            self._leases[task_id] = managed
+            return managed
+
+    def get(self, task_id: str) -> DesktopSandboxLease | None:
+        with self._lock:
+            return self._leases.get(task_id)
+
+    def release(self, task_id: str) -> None:
+        with self._lock:
+            managed = self._leases.get(task_id)
+            if managed is None:
+                return
+            managed.references -= 1
+            if managed.references > 0:
+                return
+            self._leases.pop(task_id, None)
+        try:
+            cleanup = getattr(managed.environment, "cleanup", None)
+            if callable(cleanup):
+                cleanup()
+        finally:
+            self.provider.release(managed.lease)
+
+    def status(self, task_id: str | None = None) -> dict[str, Any]:
+        with self._lock:
+            leases = [self._leases[task_id]] if task_id in self._leases else list(self._leases.values()) if task_id is None else []
+            return {
+                "count": len(leases),
+                "leases": [
+                    {"task_id": item.task_id, "lease_id": item.lease.lease_id,
+                     "provider": item.lease.provider, "image": item.lease.image,
+                     "capabilities": sorted(item.lease.capabilities.to_capabilities()),
+                     "references": item.references}
+                    for item in leases
+                ],
+            }
+
+
+_manager: DesktopSandboxManager | None = None
+_manager_lock = threading.Lock()
+
+
+def get_desktop_sandbox_manager(provider: Any | None = None) -> DesktopSandboxManager:
+    """Return the process-wide manager, constructing the Modal PoC by default."""
+    global _manager
+    with _manager_lock:
+        if _manager is None:
+            if provider is None:
+                from tools.environments.modal_desktop import ModalDesktopProvider
+                provider = ModalDesktopProvider()
+            _manager = DesktopSandboxManager(provider)
+        return _manager

--- a/tools/environments/desktop_lease.py
+++ b/tools/environments/desktop_lease.py
@@ -84,12 +84,14 @@ _manager_lock = threading.Lock()
 
 
 def get_desktop_sandbox_manager(provider: Any | None = None) -> DesktopSandboxManager:
-    """Return the process-wide manager, constructing the Modal PoC by default."""
+    """Return the process-wide manager for the configured compute provider."""
     global _manager
     with _manager_lock:
         if _manager is None:
             if provider is None:
-                from tools.environments.modal_desktop import ModalDesktopProvider
-                provider = ModalDesktopProvider()
+                from hermes_cli.config import load_config_readonly
+                from tools.environments.cua_fleet import _provider_from_config
+
+                provider = _provider_from_config(load_config_readonly().get("compute", {}))
             _manager = DesktopSandboxManager(provider)
         return _manager

--- a/tools/environments/desktop_sandbox_tool.py
+++ b/tools/environments/desktop_sandbox_tool.py
@@ -1,0 +1,48 @@
+"""Status and lifecycle tool for the task-scoped desktop sandbox."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from tools.environments.desktop_lease import get_desktop_sandbox_manager
+from tools.registry import registry
+
+
+DESKTOP_SANDBOX_SCHEMA = {
+    "name": "desktop_sandbox",
+    "description": "Inspect or release the shared desktop sandbox for this task.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["status", "release"],
+                "description": "Use status to inspect the current task lease or release to end it.",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+def handle_desktop_sandbox(args: dict[str, Any], **kwargs: Any) -> str:
+    task_id = str(kwargs.get("task_id") or "default")
+    action = str(args.get("action") or "status")
+    manager = get_desktop_sandbox_manager()
+    if action == "release":
+        manager.release(task_id)
+        return json.dumps({"released": task_id})
+    if action == "status":
+        return json.dumps(manager.status(task_id))
+    return json.dumps({"error": f"unknown desktop_sandbox action: {action}"})
+
+
+registry.register(
+    name="desktop_sandbox",
+    toolset="desktop_sandbox",
+    schema=DESKTOP_SANDBOX_SCHEMA,
+    handler=handle_desktop_sandbox,
+    check_fn=lambda: True,
+    emoji="🖥️",
+)

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -12,7 +12,7 @@ import shlex
 import tarfile
 import threading
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 from hermes_constants import get_hermes_home
 from tools.environments.base import (
@@ -179,6 +179,7 @@ class ModalEnvironment(BaseEnvironment):
         modal_sandbox_kwargs: Optional[dict[str, Any]] = None,
         persistent_filesystem: bool = True,
         task_id: str = "default",
+        sandbox_command: Sequence[str] | None = None,
     ):
         super().__init__(cwd=cwd, timeout=timeout)
 
@@ -190,6 +191,7 @@ class ModalEnvironment(BaseEnvironment):
         self._sync_manager: FileSyncManager | None = None  # initialized after sandbox creation
 
         sandbox_kwargs = dict(modal_sandbox_kwargs or {})
+        self._sandbox_command = tuple(sandbox_command or ("sleep", "infinity"))
 
         restored_snapshot_id = None
         restored_from_legacy_key = False
@@ -246,7 +248,7 @@ class ModalEnvironment(BaseEnvironment):
                 existing_mounts.extend(cred_mounts)
                 create_kwargs["mounts"] = existing_mounts
             sandbox = await _modal.Sandbox.create.aio(
-                "sleep", "infinity",
+                *self._sandbox_command,
                 image=image_spec,
                 app=app,
                 timeout=int(create_kwargs.pop("timeout", 3600)),

--- a/tools/environments/modal_desktop.py
+++ b/tools/environments/modal_desktop.py
@@ -1,0 +1,182 @@
+"""Modal-backed desktop environment with a task-scoped CUA service."""
+
+from __future__ import annotations
+
+import base64
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from tools.computer_use.backend import ActionResult, CaptureResult, ComputerUseBackend, UIElement
+from tools.computer_use.transports.base import CuaToolTransport
+from tools.computer_use.transports.stdio import StdioMcpTransport
+from tools.environments.compute_provider import ComputeLease, EnvironmentCapabilities
+from tools.environments.modal import ModalEnvironment
+
+
+@dataclass(frozen=True)
+class ModalDesktopConfig:
+    image: str = "trycua/cua:latest"
+    cwd: str = "/root"
+    timeout: int = 60
+    persistent_filesystem: bool = True
+    cpu: float = 2
+    memory: int = 8192
+    cua_driver_command: tuple[str, ...] = ("cua-driver", "mcp")
+    sandbox_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+
+class _TransportComputerBackend(ComputerUseBackend):
+    """Adapt a CUA MCP transport to Hermes' synchronous backend contract."""
+
+    def __init__(self, transport: CuaToolTransport):
+        self.transport = transport
+
+    def start(self) -> None:
+        self.transport.start()
+
+    def stop(self) -> None:
+        self.transport.stop()
+
+    def is_available(self) -> bool:
+        return self.transport.is_alive()
+
+    def capture(self, mode: str = "som", app: Optional[str] = None, pid: Optional[int] = None,
+                window_id: Optional[int] = None) -> CaptureResult:
+        result = self.transport.call_tool("capture", {
+            "mode": mode, "app": app, "pid": pid, "window_id": window_id,
+        })
+        data = _result_data(result)
+        elements = [_element_from(item) for item in data.get("elements", []) if isinstance(item, Mapping)]
+        png_b64 = data.get("png_b64") or data.get("image")
+        if isinstance(png_b64, str) and png_b64.startswith("data:"):
+            png_b64 = png_b64.split(",", 1)[-1]
+        return CaptureResult(
+            mode=mode, width=int(data.get("width", 0)), height=int(data.get("height", 0)),
+            png_b64=png_b64 if isinstance(png_b64, str) else None, elements=elements,
+            app=str(data.get("app", app or "")), window_title=str(data.get("window_title", "")),
+        )
+
+    def click(self, **kwargs: Any) -> ActionResult:
+        return self._action("click", kwargs)
+
+    def drag(self, **kwargs: Any) -> ActionResult:
+        return self._action("drag", kwargs)
+
+    def scroll(self, **kwargs: Any) -> ActionResult:
+        return self._action("scroll", kwargs)
+
+    def type_text(self, text: str, **kwargs: Any) -> ActionResult:
+        return self._action("type_text", {"text": text, **kwargs})
+
+    def key(self, keys: str, **kwargs: Any) -> ActionResult:
+        return self._action("hotkey", {"keys": keys, **kwargs})
+
+    def list_apps(self) -> List[Dict[str, Any]]:
+        result = _result_data(self.transport.call_tool("list_apps", {}))
+        apps = result.get("apps", result.get("result", []))
+        return apps if isinstance(apps, list) else []
+
+    def list_windows(self) -> List[Dict[str, Any]]:
+        result = _result_data(self.transport.call_tool("list_windows", {}))
+        windows = result.get("windows", result.get("result", []))
+        return windows if isinstance(windows, list) else []
+
+    def focus_app(self, app: str, raise_window: bool = False) -> ActionResult:
+        return self._action("focus_app", {"app": app, "raise_window": raise_window})
+
+    def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
+        return self._action("set_value", {"value": value, "element": element})
+
+    def _action(self, action: str, arguments: Mapping[str, Any]) -> ActionResult:
+        data = _result_data(self.transport.call_tool(action, arguments))
+        return ActionResult(
+            ok=bool(data.get("ok", True)), action=action, message=str(data.get("message", "")),
+            meta=dict(data.get("meta", {})) if isinstance(data.get("meta"), Mapping) else {},
+        )
+
+
+def _result_data(result: Mapping[str, Any]) -> Mapping[str, Any]:
+    structured = result.get("structuredContent")
+    if isinstance(structured, Mapping):
+        return structured
+    return result
+
+
+def _element_from(value: Mapping[str, Any]) -> UIElement:
+    bounds = value.get("bounds", (0, 0, 0, 0))
+    if not isinstance(bounds, (list, tuple)) or len(bounds) != 4:
+        bounds = (0, 0, 0, 0)
+    return UIElement(
+        index=int(value.get("index", 0)), role=str(value.get("role", "")),
+        label=str(value.get("label", "")), bounds=tuple(int(part) for part in bounds),
+        app=str(value.get("app", "")), pid=int(value.get("pid", 0)),
+        window_id=int(value.get("window_id", 0)),
+    )
+
+
+class ModalDesktopEnvironment(ModalEnvironment):
+    """Modal terminal environment exposing the paired CUA driver backend."""
+
+    def __init__(self, *, compute_lease: ComputeLease, config: ModalDesktopConfig):
+        self._compute_lease = compute_lease
+        self._desktop_config = config
+        self._computer_backend: ComputerUseBackend | None = None
+        sandbox_kwargs = {"cpu": config.cpu, "memory": config.memory, **dict(config.sandbox_kwargs)}
+        super().__init__(
+            image=config.image, cwd=config.cwd, timeout=config.timeout,
+            modal_sandbox_kwargs=sandbox_kwargs,
+            persistent_filesystem=config.persistent_filesystem, task_id=compute_lease.task_id,
+        )
+
+    @property
+    def compute_lease(self) -> ComputeLease:
+        return self._compute_lease
+
+    def get_computer_backend(self) -> ComputerUseBackend:
+        if self._computer_backend is None:
+            # The image owns cua-driver. The default command preserves the
+            # existing stdio MCP contract while the lease owns its lifecycle.
+            self._computer_backend = _TransportComputerBackend(
+                StdioMcpTransport(self._desktop_config.cua_driver_command)
+            )
+            self._computer_backend.start()
+        return self._computer_backend
+
+    def cleanup(self):
+        if self._computer_backend is not None:
+            self._computer_backend.stop()
+        super().cleanup()
+
+
+class ModalDesktopProvider:
+    """Provision Modal desktop sandboxes and expose their shared lease."""
+
+    name = "modal"
+
+    def __init__(self, config: ModalDesktopConfig | None = None):
+        self.config = config or ModalDesktopConfig()
+
+    def acquire(self, task_id: str, *, image: str | None = None,
+                capabilities: Sequence[str] | None = None) -> ComputeLease:
+        enabled = EnvironmentCapabilities(computer_use=True)
+        requested = frozenset(capabilities or enabled.to_capabilities())
+        missing = requested - enabled.to_capabilities()
+        if missing:
+            raise ValueError(f"Modal desktop image lacks requested capabilities: {sorted(missing)}")
+        return ComputeLease(
+            task_id=task_id, lease_id=uuid.uuid4().hex, provider=self.name,
+            image=image or self.config.image, capabilities=enabled,
+        )
+
+    def create_environment(self, lease: ComputeLease) -> ModalDesktopEnvironment:
+        config = self.config if lease.image == self.config.image else ModalDesktopConfig(
+            image=lease.image, cwd=self.config.cwd, timeout=self.config.timeout,
+            persistent_filesystem=self.config.persistent_filesystem, cpu=self.config.cpu,
+            memory=self.config.memory, cua_driver_command=self.config.cua_driver_command,
+            sandbox_kwargs=self.config.sandbox_kwargs,
+        )
+        return ModalDesktopEnvironment(compute_lease=lease, config=config)
+
+    def release(self, lease: ComputeLease) -> None:
+        return None

--- a/tools/environments/modal_desktop.py
+++ b/tools/environments/modal_desktop.py
@@ -87,6 +87,39 @@ class _TransportComputerBackend(ComputerUseBackend):
     def focus_app(self, app: str, raise_window: bool = False) -> ActionResult:
         return self._action("focus_app", {"app": app, "raise_window": raise_window})
 
+    def launch_app(
+        self,
+        *,
+        bundle_id: Optional[str] = None,
+        name: Optional[str] = None,
+        urls: Optional[List[str]] = None,
+        additional_arguments: Optional[List[str]] = None,
+        creates_new_application_instance: bool = False,
+    ) -> Dict[str, Any]:
+        if not bundle_id and not name:
+            raise ValueError("launch_app requires either bundle_id or name")
+        arguments: Dict[str, Any] = {}
+        if bundle_id:
+            arguments["bundle_id"] = bundle_id
+        if name:
+            arguments["name"] = name
+        if urls:
+            arguments["urls"] = list(urls)
+        if additional_arguments:
+            arguments["additional_arguments"] = list(additional_arguments)
+        if creates_new_application_instance:
+            arguments["creates_new_application_instance"] = True
+        return dict(_result_data(self.transport.call_tool("launch_app", arguments)))
+
+    def kill_app(self, *, pid: int) -> ActionResult:
+        return self._action("kill_app", {"pid": int(pid)})
+
+    def bring_to_front(self, *, pid: int, window_id: Optional[int] = None) -> ActionResult:
+        arguments: Dict[str, Any] = {"pid": int(pid)}
+        if window_id is not None:
+            arguments["window_id"] = int(window_id)
+        return self._action("bring_to_front", arguments)
+
     def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
         return self._action("set_value", {"value": value, "element": element})
 

--- a/tools/environments/modal_desktop.py
+++ b/tools/environments/modal_desktop.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from tools.computer_use.backend import ActionResult, CaptureResult, ComputerUseBackend, UIElement
 from tools.computer_use.transports.base import CuaToolTransport
-from tools.computer_use.transports.stdio import StdioMcpTransport
+from tools.computer_use.transports.modal_sandbox import ModalSandboxMcpTransport
 from tools.environments.compute_provider import ComputeLease, EnvironmentCapabilities
 from tools.environments.modal import ModalEnvironment
 
@@ -22,7 +22,9 @@ class ModalDesktopConfig:
     persistent_filesystem: bool = True
     cpu: float = 2
     memory: int = 8192
-    cua_driver_command: tuple[str, ...] = ("cua-driver", "mcp")
+    cua_driver_runtime_command: tuple[str, ...] = ("/bin/cua-driver-mcp-runtime",)
+    cua_driver_port: int = 8080
+    cua_driver_path: str = "/mcp"
     sandbox_kwargs: Mapping[str, Any] = field(default_factory=dict)
 
 
@@ -123,10 +125,20 @@ class ModalDesktopEnvironment(ModalEnvironment):
         self._desktop_config = config
         self._computer_backend: ComputerUseBackend | None = None
         sandbox_kwargs = {"cpu": config.cpu, "memory": config.memory, **dict(config.sandbox_kwargs)}
+        configured_ports = sandbox_kwargs.pop("encrypted_ports", ())
+        if isinstance(configured_ports, (str, bytes)) or not isinstance(configured_ports, Sequence):
+            raise ValueError("modal.sandbox_kwargs.encrypted_ports must be a sequence")
+        encrypted_ports = {config.cua_driver_port}
+        for port in configured_ports:
+            if not isinstance(port, int):
+                raise ValueError("modal.sandbox_kwargs.encrypted_ports must contain integers")
+            encrypted_ports.add(port)
+        sandbox_kwargs["encrypted_ports"] = sorted(encrypted_ports)
         super().__init__(
             image=config.image, cwd=config.cwd, timeout=config.timeout,
             modal_sandbox_kwargs=sandbox_kwargs,
             persistent_filesystem=config.persistent_filesystem, task_id=compute_lease.task_id,
+            sandbox_command=config.cua_driver_runtime_command,
         )
 
     @property
@@ -135,10 +147,12 @@ class ModalDesktopEnvironment(ModalEnvironment):
 
     def get_computer_backend(self) -> ComputerUseBackend:
         if self._computer_backend is None:
-            # The image owns cua-driver. The default command preserves the
-            # existing stdio MCP contract while the lease owns its lifecycle.
             self._computer_backend = _TransportComputerBackend(
-                StdioMcpTransport(self._desktop_config.cua_driver_command)
+                ModalSandboxMcpTransport(
+                    self._sandbox, self._worker,
+                    port=self._desktop_config.cua_driver_port,
+                    path=self._desktop_config.cua_driver_path,
+                )
             )
             self._computer_backend.start()
         return self._computer_backend
@@ -173,7 +187,10 @@ class ModalDesktopProvider:
         config = self.config if lease.image == self.config.image else ModalDesktopConfig(
             image=lease.image, cwd=self.config.cwd, timeout=self.config.timeout,
             persistent_filesystem=self.config.persistent_filesystem, cpu=self.config.cpu,
-            memory=self.config.memory, cua_driver_command=self.config.cua_driver_command,
+            memory=self.config.memory,
+            cua_driver_runtime_command=self.config.cua_driver_runtime_command,
+            cua_driver_port=self.config.cua_driver_port,
+            cua_driver_path=self.config.cua_driver_path,
             sandbox_kwargs=self.config.sandbox_kwargs,
         )
         return ModalDesktopEnvironment(compute_lease=lease, config=config)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -254,7 +254,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Terminal backends ─────────────────────────────────────────────────
     "terminal.modal": ("modal==1.3.4",),
-    "terminal.cua_fleet": ("cua-fleet==0.0.5",),
+    "terminal.cua_fleet": ("cua-fleet==0.0.6",),
     "terminal.daytona": ("daytona==0.155.0",),
     "terminal.vercel": ("vercel==0.7.2",),
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -254,6 +254,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Terminal backends ─────────────────────────────────────────────────
     "terminal.modal": ("modal==1.3.4",),
+    "terminal.cua_fleet": ("cua-fleet==0.0.5",),
     "terminal.daytona": ("daytona==0.155.0",),
     "terminal.vercel": ("vercel==0.7.2",),
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -254,7 +254,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Terminal backends ─────────────────────────────────────────────────
     "terminal.modal": ("modal==1.3.4",),
-    "terminal.cua_fleet": ("cua-sandbox==0.1.20",),
+    "terminal.cua_fleet": ("cua-sandbox==0.1.21",),
     "terminal.daytona": ("daytona==0.155.0",),
     "terminal.vercel": ("vercel==0.7.2",),
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -254,7 +254,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Terminal backends ─────────────────────────────────────────────────
     "terminal.modal": ("modal==1.3.4",),
-    "terminal.cua_fleet": ("cua-fleet==0.0.6",),
+    "terminal.cua_fleet": ("cua-sandbox==0.1.20",),
     "terminal.daytona": ("daytona==0.155.0",),
     "terminal.vercel": ("vercel==0.7.2",),
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3224,6 +3224,9 @@ def check_terminal_requirements() -> bool:
             from agent.secret_scope import get_secret
             return get_secret("DAYTONA_API_KEY") is not None
 
+        elif env_type == "desktop":
+            return True
+
         else:
             logger.error(
                 "Unknown TERMINAL_ENV '%s'. Use one of: local, docker, singularity, "

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1365,11 +1365,7 @@ def _safe_getcwd() -> str:
 # cwd looks when it leaks toward a Linux container's ``-w`` flag.
 _HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")
 
-<<<<<<< HEAD
-_CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
-=======
-_CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "desktop"})
->>>>>>> df75c0559 (feat: add compute provider capability poc)
+_CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox", "desktop"})
 
 
 def _is_ssh_remote_tilde_cwd(backend: str, cwd: str) -> bool:
@@ -1471,11 +1467,7 @@ def _get_env_config() -> Dict[str, Any]:
     env_type = os.getenv("TERMINAL_ENV", "local")
     
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
-<<<<<<< HEAD
-    container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
-=======
-    container_backend = env_type in {"docker", "singularity", "modal", "daytona", "desktop"}
->>>>>>> df75c0559 (feat: add compute provider capability poc)
+    container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox", "desktop"}
     docker_backend = env_type == "docker"
 
     # Docker/container-only env vars may be bridged from config.yaml even when
@@ -1550,6 +1542,7 @@ def _get_env_config() -> Dict[str, Any]:
         "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
         "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
         "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
+        "desktop_image": os.getenv("TERMINAL_DESKTOP_IMAGE", ""),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
@@ -2327,6 +2320,8 @@ def terminal_tool(
             image = overrides.get("modal_image") or config["modal_image"]
         elif env_type == "daytona":
             image = overrides.get("daytona_image") or config["daytona_image"]
+        elif env_type == "desktop":
+            image = overrides.get("desktop_image") or config["desktop_image"]
         else:
             image = ""
 
@@ -2444,7 +2439,7 @@ def terminal_tool(
                             }
 
                         container_config = None
-                        if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
+                        if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox", "desktop"}:
                             container_config = {
                                 "container_cpu": config.get("container_cpu", 1),
                                 "container_memory": config.get("container_memory", 5120),

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1670,7 +1670,12 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     
     elif env_type == "desktop":
         from tools.environments.desktop_lease import get_desktop_sandbox_manager
-        return get_desktop_sandbox_manager().acquire(task_id, image=image).environment
+
+        manager = get_desktop_sandbox_manager()
+        managed = manager.get(task_id)
+        if managed is None:
+            managed = manager.acquire(task_id, image=image)
+        return managed.environment
 
     elif env_type == "modal":
         sandbox_kwargs = {}

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1365,7 +1365,11 @@ def _safe_getcwd() -> str:
 # cwd looks when it leaks toward a Linux container's ``-w`` flag.
 _HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")
 
+<<<<<<< HEAD
 _CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
+=======
+_CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "desktop"})
+>>>>>>> df75c0559 (feat: add compute provider capability poc)
 
 
 def _is_ssh_remote_tilde_cwd(backend: str, cwd: str) -> bool:
@@ -1467,7 +1471,11 @@ def _get_env_config() -> Dict[str, Any]:
     env_type = os.getenv("TERMINAL_ENV", "local")
     
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+<<<<<<< HEAD
     container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
+=======
+    container_backend = env_type in {"docker", "singularity", "modal", "daytona", "desktop"}
+>>>>>>> df75c0559 (feat: add compute provider capability poc)
     docker_backend = env_type == "docker"
 
     # Docker/container-only env vars may be bridged from config.yaml even when
@@ -1667,6 +1675,10 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             persistent_filesystem=persistent, task_id=task_id,
         )
     
+    elif env_type == "desktop":
+        from tools.environments.desktop_lease import get_desktop_sandbox_manager
+        return get_desktop_sandbox_manager().acquire(task_id, image=image).environment
+
     elif env_type == "modal":
         sandbox_kwargs = {}
         if cpu > 0:

--- a/toolsets.py
+++ b/toolsets.py
@@ -184,6 +184,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "desktop_sandbox": {
+        "description": "Shared leased desktop sandbox: terminal, files, and computer-use on one task-scoped environment",
+        "tools": ["desktop_sandbox"],
+        "includes": ["terminal", "file", "computer_use"],
+    },
+
     "terminal": {
         "description": "Terminal/command execution and process management tools",
         "tools": ["terminal", "process"],

--- a/uv.lock
+++ b/uv.lock
@@ -833,6 +833,22 @@ wheels = [
 ]
 
 [[package]]
+name = "cua-fleet"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "httpx" },
+    { name = "python-dateutil" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/b9/c422ab18a5fcb5867aca475b80897ff9068d6155ade8578b12a06c943414/cua_fleet-0.0.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e510abe08ab08bbf753ee430967673364ffba3627164f3367c3210a089dce3b8", size = 781058, upload-time = "2026-07-27T20:25:29.7Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/6f/34e9bb32b75b5403b53bc64c0ba136bd5c84a8784392ea47640632bf1ce7/cua_fleet-0.0.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:57a0a81fa2be56325c93256e2bc3e1bfc3af77a672ab0ccf361fe1448ebc42f5", size = 757511, upload-time = "2026-07-27T20:25:31.151Z" },
+    { url = "https://files.pythonhosted.org/packages/43/7f/f816a5af70991bbfa7013b16d1ff7e991075092f5c06245a3c61a9e2937b/cua_fleet-0.0.5-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:976ace24c31c11e5fadb3e848e8871f0aa5e9bf9c7c615bb33270f16a3a7f3e1", size = 829236, upload-time = "2026-07-27T20:25:32.282Z" },
+    { url = "https://files.pythonhosted.org/packages/93/56/38f72bb99213efc816ebf74000c5730362ddc80e07b4d2c53b0bf1af5230/cua_fleet-0.0.5-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:4432fcc373dd2a4436c1bd624ca6fb39f63916a0a35ac585b2a5deb625d2d11f", size = 910232, upload-time = "2026-07-27T20:25:33.741Z" },
+]
+
+[[package]]
 name = "darabonba-core"
 version = "1.0.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1633,6 +1649,9 @@ computer-use = [
     { name = "mcp" },
     { name = "starlette" },
 ]
+cua-fleet = [
+    { name = "cua-fleet" },
+]
 daytona = [
     { name = "daytona" },
 ]
@@ -1820,6 +1839,7 @@ requires-dist = [
     { name = "concurrent-log-handler", marker = "sys_platform == 'win32'", specifier = "==0.9.29" },
     { name = "croniter", specifier = "==6.0.0" },
     { name = "cryptography", specifier = "==48.0.1" },
+    { name = "cua-fleet", marker = "extra == 'cua-fleet'", specifier = "==0.0.5" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.155.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = "==1.8.20" },
     { name = "defusedxml", marker = "extra == 'wecom'", specifier = "==0.7.1" },
@@ -1936,7 +1956,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "cua-fleet", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -3997,7 +4017,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4052,7 +4072,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -834,7 +834,7 @@ wheels = [
 
 [[package]]
 name = "cua-fleet"
-version = "0.0.5"
+version = "0.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -842,10 +842,10 @@ dependencies = [
     { name = "python-dateutil" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/b9/c422ab18a5fcb5867aca475b80897ff9068d6155ade8578b12a06c943414/cua_fleet-0.0.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e510abe08ab08bbf753ee430967673364ffba3627164f3367c3210a089dce3b8", size = 781058, upload-time = "2026-07-27T20:25:29.7Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/6f/34e9bb32b75b5403b53bc64c0ba136bd5c84a8784392ea47640632bf1ce7/cua_fleet-0.0.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:57a0a81fa2be56325c93256e2bc3e1bfc3af77a672ab0ccf361fe1448ebc42f5", size = 757511, upload-time = "2026-07-27T20:25:31.151Z" },
-    { url = "https://files.pythonhosted.org/packages/43/7f/f816a5af70991bbfa7013b16d1ff7e991075092f5c06245a3c61a9e2937b/cua_fleet-0.0.5-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:976ace24c31c11e5fadb3e848e8871f0aa5e9bf9c7c615bb33270f16a3a7f3e1", size = 829236, upload-time = "2026-07-27T20:25:32.282Z" },
-    { url = "https://files.pythonhosted.org/packages/93/56/38f72bb99213efc816ebf74000c5730362ddc80e07b4d2c53b0bf1af5230/cua_fleet-0.0.5-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:4432fcc373dd2a4436c1bd624ca6fb39f63916a0a35ac585b2a5deb625d2d11f", size = 910232, upload-time = "2026-07-27T20:25:33.741Z" },
+    { url = "https://files.pythonhosted.org/packages/33/12/e0e08eb6b56e421c92815654f162ee1bcd9e5abb7dbc1e26e12f316dff46/cua_fleet-0.0.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4a292b0519eaa172c4d4d081e771e0a66e6cb964a2bb01fc2cbd68020c302c8a", size = 2123635, upload-time = "2026-08-01T02:21:37.116Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/53/398c64149eaf467e9d97fb0958ec97f5fab22a4c08a0a8c47cb72412532a/cua_fleet-0.0.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ed310ad529c6655a9fde8455fc764c2b7e53f5ca2581e39aec9e878296a0de6e", size = 2037302, upload-time = "2026-08-01T02:21:38.393Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c2/ac127bde7f2ffe1b2affe49e11b48d4053728c15d700b2b96190768d2296/cua_fleet-0.0.6-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:612c3d2cfe4b4a1356503a0ddee6518f9cc1d8e5c410124b68627a8650977237", size = 2300923, upload-time = "2026-08-01T02:21:39.561Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e1/67de4257140bc9d22f14cb9ee4d627d5e25cf0544aa323d4d6ff33a25c8e/cua_fleet-0.0.6-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:4d5119b7ff46bd2af9af1a2310c16b6993787bafa94f308512463929eddcc45a", size = 2355463, upload-time = "2026-08-01T02:21:40.87Z" },
 ]
 
 [[package]]
@@ -1839,7 +1839,7 @@ requires-dist = [
     { name = "concurrent-log-handler", marker = "sys_platform == 'win32'", specifier = "==0.9.29" },
     { name = "croniter", specifier = "==6.0.0" },
     { name = "cryptography", specifier = "==48.0.1" },
-    { name = "cua-fleet", marker = "extra == 'cua-fleet'", specifier = "==0.0.5" },
+    { name = "cua-fleet", marker = "extra == 'cua-fleet'", specifier = "==0.0.6" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.155.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = "==1.8.20" },
     { name = "defusedxml", marker = "extra == 'wecom'", specifier = "==0.7.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -8,12 +8,14 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-18T05:39:53.300543645Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
-nemo-relay = false
+cua-sandbox = false
 vercel = false
+nemo-relay = false
+cua-fleet = false
 huggingface-hub = false
 
 [manifest]
@@ -449,6 +451,15 @@ wheels = [
 ]
 
 [[package]]
+name = "automat"
+version = "25.4.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/0f/d40bbe294bbf004d436a8bcbcfaadca8b5140d39ad0ad3d73d1a8ba15f14/automat-25.4.16.tar.gz", hash = "sha256:0017591a5477066e90d26b0e696ddc143baafd87b588cfac8100bc6be9634de0", size = 129977, upload-time = "2025-04-16T20:12:16.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/ff/1175b0b7371e46244032d43a56862d0af455823b5280a50c63d99cc50f18/automat-25.4.16-py3-none-any.whl", hash = "sha256:04e9bce696a8d5671ee698005af6e5a9fa15354140a87f4870744604dcdd3ba1", size = 42842, upload-time = "2025-04-16T20:12:14.447Z" },
+]
+
+[[package]]
 name = "av"
 version = "17.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -518,6 +529,63 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7f/45/8ae61209bb9015f516102fa559a2914178da1d5868428bd86a1b4421141d/base58-2.1.1.tar.gz", hash = "sha256:c5d0cb3f5b6e81e8e35da5754388ddcc6d0d14b6c6a132cb93d69ed580a7278c", size = 6528, upload-time = "2021-10-30T22:12:17.858Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/45/ec96b29162a402fc4c1c5512d114d7b3787b9d1c2ec241d9568b4816ee23/base58-2.1.1-py3-none-any.whl", hash = "sha256:11a36f4d3ce51dfc1043f3218591ac4eb1ceb172919cebe05b52a5bcc8d245c2", size = 5621, upload-time = "2021-10-30T22:12:16.658Z" },
+]
+
+[[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/75/4aa9f5a4d40d762892066ba1046000b329c7cd58e888a6db878019b282dc/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:7edda91d5ab52b15636d9c30da87d2cc84f426c72b9dba7a9b4fe142ba11f534", size = 271180, upload-time = "2025-09-25T19:50:38.575Z" },
+    { url = "https://files.pythonhosted.org/packages/54/79/875f9558179573d40a9cc743038ac2bf67dfb79cecb1e8b5d70e88c94c3d/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:046ad6db88edb3c5ece4369af997938fb1c19d6a699b9c1b27b0db432faae4c4", size = 273791, upload-time = "2025-09-25T19:50:39.913Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/fe/975adb8c216174bf70fc17535f75e85ac06ed5252ea077be10d9cff5ce24/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:dcd58e2b3a908b5ecc9b9df2f0085592506ac2d5110786018ee5e160f28e0911", size = 270746, upload-time = "2025-09-25T19:50:43.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f8/972c96f5a2b6c4b3deca57009d93e946bbdbe2241dca9806d502f29dd3ee/bcrypt-5.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:6b8f520b61e8781efee73cba14e3e8c9556ccfb375623f4f97429544734545b4", size = 273375, upload-time = "2025-09-25T19:50:45.43Z" },
 ]
 
 [[package]]
@@ -748,6 +816,15 @@ wheels = [
 ]
 
 [[package]]
+name = "constantly"
+version = "23.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/6f/cb2a94494ff74aa9528a36c5b1422756330a75a8367bf20bd63171fc324d/constantly-23.10.4.tar.gz", hash = "sha256:aa92b70a33e2ac0bb33cd745eb61776594dc48764b06c35e0efd050b7f1c7cbd", size = 13300, upload-time = "2023-10-28T23:18:24.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/40/c199d095151addf69efdb4b9ca3a4f20f70e20508d6222bffb9b76f58573/constantly-23.10.4-py3-none-any.whl", hash = "sha256:3fd9b4d1c3dc1ec9757f3c52aef7e53ad9323dbe39f51dfd4c43853b68dfa3f9", size = 13547, upload-time = "2023-10-28T23:18:23.038Z" },
+]
+
+[[package]]
 name = "croniter"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -833,8 +910,35 @@ wheels = [
 ]
 
 [[package]]
+name = "cua-auto"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pillow" },
+    { name = "pynput" },
+    { name = "pyperclip" },
+    { name = "pywinctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/e8/98e6ecc7a3db4d7b4ba60f990423ad3556af018a750beb08900eef47e607/cua_auto-0.1.2.tar.gz", hash = "sha256:2c5ac6002b12d08b03940e1f8ee547ed206f8b20280380dc8a688b0ab4a56d34", size = 12574, upload-time = "2026-02-26T14:12:09.905Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/c3/f82cf30b457b9ff6fe3104caa9cd45d35edc1f184ff4b85fbcbbbc1f5262/cua_auto-0.1.2-py3-none-any.whl", hash = "sha256:d4e4bb9d5121791b6daf85779dd223f1aca9801836dd5bf2f322a01983c5328c", size = 13164, upload-time = "2026-02-26T14:12:08.802Z" },
+]
+
+[[package]]
+name = "cua-core"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "posthog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/82/ec371bde395bbbd326a3467a1702b34ab629defa0cc89bd81ac78507ca5a/cua_core-0.3.1.tar.gz", hash = "sha256:a8fc4204981b9d5b604bd2a34de0bb41cf926309e4dd9f364c827750a86408da", size = 10710, upload-time = "2026-04-15T21:39:49.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/90/5148998a26671855539e2c3a620f72ef51f83118beffdfb7e77893d4730b/cua_core-0.3.1-py3-none-any.whl", hash = "sha256:9191b8abf5e02ea6bf8ba21237e747d4e3b319f6f24d4e66e04b7606fcc449f6", size = 10239, upload-time = "2026-04-15T21:39:48.265Z" },
+]
+
+[[package]]
 name = "cua-fleet"
-version = "0.0.6"
+version = "0.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -842,10 +946,32 @@ dependencies = [
     { name = "python-dateutil" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/12/e0e08eb6b56e421c92815654f162ee1bcd9e5abb7dbc1e26e12f316dff46/cua_fleet-0.0.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4a292b0519eaa172c4d4d081e771e0a66e6cb964a2bb01fc2cbd68020c302c8a", size = 2123635, upload-time = "2026-08-01T02:21:37.116Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/53/398c64149eaf467e9d97fb0958ec97f5fab22a4c08a0a8c47cb72412532a/cua_fleet-0.0.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ed310ad529c6655a9fde8455fc764c2b7e53f5ca2581e39aec9e878296a0de6e", size = 2037302, upload-time = "2026-08-01T02:21:38.393Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c2/ac127bde7f2ffe1b2affe49e11b48d4053728c15d700b2b96190768d2296/cua_fleet-0.0.6-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:612c3d2cfe4b4a1356503a0ddee6518f9cc1d8e5c410124b68627a8650977237", size = 2300923, upload-time = "2026-08-01T02:21:39.561Z" },
-    { url = "https://files.pythonhosted.org/packages/33/e1/67de4257140bc9d22f14cb9ee4d627d5e25cf0544aa323d4d6ff33a25c8e/cua_fleet-0.0.6-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:4d5119b7ff46bd2af9af1a2310c16b6993787bafa94f308512463929eddcc45a", size = 2355463, upload-time = "2026-08-01T02:21:40.87Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9d/f1f800c746c3f4137d21864293db3d2cded36125dc4fd0547c9def35beff/cua_fleet-0.0.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d62ba6b263e858ff7157e1dfb317b1526a7b6fe2dba76479621490393efb2f8e", size = 2126597, upload-time = "2026-08-02T17:12:56.242Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ce/dedd4f4847bc1c7da18bd1f58d75c0c03da1fa50f30d0720a74dcf6705e3/cua_fleet-0.0.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4a3fd42fe75520ae0070935d13ce22e28b5c121852d6e39d65eed3df35cb3dd0", size = 2040766, upload-time = "2026-08-02T17:12:57.96Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/97/09faebc28ce1b2d7e6882861e6f9f1a3788abe5bc286e23a55e8d9b1caac/cua_fleet-0.0.8-py3-none-manylinux_2_34_aarch64.whl", hash = "sha256:776a1287c474362d76a5240dfd868be3ad29d36a51114519d2b06c8061f51036", size = 2304088, upload-time = "2026-08-02T17:13:00.066Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/36/0cd2f82e1cdd56e7330094ff3aa57ae9ab670b56e4e4500eb91e3e3f8580/cua_fleet-0.0.8-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:dee669f487ad3dafa176d80d236c5b5a89df0af8d46f86e756c720a1f683af36", size = 2357881, upload-time = "2026-08-02T17:13:01.999Z" },
+]
+
+[[package]]
+name = "cua-sandbox"
+version = "0.1.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cua-auto" },
+    { name = "cua-core" },
+    { name = "cua-fleet" },
+    { name = "grpcio" },
+    { name = "httpx" },
+    { name = "oras" },
+    { name = "paramiko" },
+    { name = "protobuf" },
+    { name = "pycdlib" },
+    { name = "vncdotool" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/68/7245d04fb2251a3af367509245a2dc28da3aab763ed612ad64a449e55300/cua_sandbox-0.1.21.tar.gz", hash = "sha256:ffb6e95746c3375195c8bb2a513b4facb755149ebc9557f35e35e5e923a4a1fd", size = 152418, upload-time = "2026-08-02T17:57:26.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/f3/3d074b9512909a0c9f2dd018669a0bdd22087600f66faa20be804e05d95a/cua_sandbox-0.1.21-py3-none-any.whl", hash = "sha256:85dba37f9b2e57d8ae719c55d77a15a704472f4e0479848709016a0d269e4e8a", size = 186034, upload-time = "2026-08-02T17:57:25.627Z" },
 ]
 
 [[package]]
@@ -1189,6 +1315,24 @@ wheels = [
 ]
 
 [[package]]
+name = "evdev"
+version = "1.9.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/f5/397b61091120a9ca5001041dd7bf76c385b3bfd67a0e5bcb74b852bd22a4/evdev-1.9.3.tar.gz", hash = "sha256:2c140e01ac8437758fa23fe5c871397412461f42d421aa20241dc8fe8cfccbc9", size = 32723, upload-time = "2026-02-05T21:54:24.987Z" }
+
+[[package]]
+name = "ewmhlib"
+version = "0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-xlib" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/3a/46ca34abf0725a754bc44ef474ad34aedcc3ea23b052d97b18b76715a6a9/EWMHlib-0.2-py3-none-any.whl", hash = "sha256:f5b07d8cfd4c7734462ee744c32d490f2f3233fa7ab354240069344208d2f6f5", size = 46657, upload-time = "2024-04-17T08:15:56.338Z" },
+]
+
+[[package]]
 name = "exa-py"
 version = "2.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1499,43 +1643,43 @@ wheels = [
 
 [[package]]
 name = "grpcio"
-version = "1.81.1"
+version = "1.78.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/ea/1c2fa386b718ff493225e61cfc052ef400b4d6ffc54cbe261026432624b5/grpcio-1.81.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:d71d30f2d92f67d944631c523713934fee37292469e182ebcd2c1dd8a64ce53f", size = 6093112, upload-time = "2026-06-11T12:44:52.131Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/18/acf45fa8bd1bc5d7b0c2fd3dc4c209379fbd5bb396b440b68a83342226b7/grpcio-1.81.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:b137f4bf3ada9dc44d411478decc6ff09a79ed30b306cd2abaa98408c3588137", size = 12074277, upload-time = "2026-06-11T12:44:55.354Z" },
-    { url = "https://files.pythonhosted.org/packages/48/d7/ee86a60699b7db039f772a2c4a7e4facc7138984ff42c0130933a0063884/grpcio-1.81.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a3acb384427816dd5d470f47e62137b87f74da694faa8a50147012cf40df276a", size = 6640348, upload-time = "2026-06-11T12:44:59.223Z" },
-    { url = "https://files.pythonhosted.org/packages/26/ee/d2de5e47378ffc207d476c230fea3be4d2601edbce9995f4fe45535d4896/grpcio-1.81.1-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f9a0ebbe45c29b5e5866593c12b78bd9035f0f0f0d4bc8361680cd580d99db49", size = 7331842, upload-time = "2026-06-11T12:45:02.001Z" },
-    { url = "https://files.pythonhosted.org/packages/23/d6/abeda5c2b896a0b341584fe5ac411bbf72e197a9a374c355fb90965e08d2/grpcio-1.81.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a37165cc80b1a368384b383e63a4c38116a10467ae44c904d2d7468c4470ec2", size = 6842229, upload-time = "2026-06-11T12:45:04.76Z" },
-    { url = "https://files.pythonhosted.org/packages/10/1c/1f0da7d590b4aeee006826ba568d0e419ca14b23e18f901a3da3e9fba613/grpcio-1.81.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6282caffb41ec326d4cb67ca9cf53b739d1b2f975a2acb498c7418e9f7d9a416", size = 7446096, upload-time = "2026-06-11T12:45:07.499Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/81/5c505d508f7c887aa7982d21443a4126597c80d34b0bcf40f9cec576d7f3/grpcio-1.81.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a35009284d0d3d5c2c9601c164a911b8b4331608d98a9a66d47d97bb2f522b70", size = 8445238, upload-time = "2026-06-11T12:45:10.243Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/b2/524847365122ee509ca17bcc4e092198b700e94af7bfd5bb5e6dd9f3ee66/grpcio-1.81.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1b22c80559854b789a01fd89e8929b3798a156c0829b5282a8939f33ad4115ad", size = 7873989, upload-time = "2026-06-11T12:45:13.102Z" },
-    { url = "https://files.pythonhosted.org/packages/18/fa/07c037c50b006909d1d13a5848774f8aa7b242f70dc03a035c64eea0e6db/grpcio-1.81.1-cp311-cp311-win32.whl", hash = "sha256:428bec0161b48d8cf583c068591bc0016d0d9cfff52462b72b3884861ea768c5", size = 4202223, upload-time = "2026-06-11T12:45:16.166Z" },
-    { url = "https://files.pythonhosted.org/packages/41/ed/6bff15376920942fac6b95b9802752b837437172c9e8fc2d3170546b89cc/grpcio-1.81.1-cp311-cp311-win_amd64.whl", hash = "sha256:30e825f6848d9f18bba350ed6c75c1b02a0b5184474a31db9a32b1fa66fd8c79", size = 4941303, upload-time = "2026-06-11T12:45:18.724Z" },
-    { url = "https://files.pythonhosted.org/packages/85/07/9a979c81738863a738dc23d65177056e71fbb2db817740ed870b33434e7a/grpcio-1.81.1-cp312-cp312-linux_armv7l.whl", hash = "sha256:8b39472beafc0bdcafc4c8c73ad082ebfdb449d566897a61e7acb4fa88089115", size = 6053264, upload-time = "2026-06-11T12:45:21.017Z" },
-    { url = "https://files.pythonhosted.org/packages/75/95/539706ca0d3bd40dbad583dc56fd883da941f37556b629132da5762781b9/grpcio-1.81.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:12b7524c88d4026d3dcb7b0ebe16b6714f3b4af402ddd0f0639ab064a00c87c3", size = 12052560, upload-time = "2026-06-11T12:45:23.652Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/44/f257b7e0bd69c93b06c6cb8ac8d1b901ccb42bedabd83c1a4c77a71f8810/grpcio-1.81.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1e123f9b37edb8375fd74130d1f69c944bbf0a7b06761ae7211154b8759e94d2", size = 6595983, upload-time = "2026-06-11T12:45:26.963Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/f3/19782aa04c960968bef8c5539329d8e3bbc3364e2e46d19eb5e5cc5e43b7/grpcio-1.81.1-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2c2e2ae6867c2966b8daccc836d54a13218e0007e9a490aeb81dd05be64d22d7", size = 7303455, upload-time = "2026-06-11T12:45:29.707Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/8c/dea020b6d91508cd84463917a63149ec196ee7db505d032ae43fcb3303b9/grpcio-1.81.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:766bc7c9a9c340342f4c864ccbda8e78111e4751f13b895812b9c148fb79e9d0", size = 6809167, upload-time = "2026-06-11T12:45:32.52Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/c7/3030dd940408083bd32cd95d634777a71605ade4887154d93e8a89244946/grpcio-1.81.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b259a04a737cb3496be0901328eb8b7552ed8df4865d8c8f1cf1bffcfc0776a3", size = 7412536, upload-time = "2026-06-11T12:45:35.403Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/dd/1172a9e42b168edcafefad6115346ef619a3fc02158bb170e66ced24bcdd/grpcio-1.81.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:85b10a45b8993d195c4f3ff57025b8d1e11834909ee475c403bfa60cb4caefaf", size = 8408276, upload-time = "2026-06-11T12:45:37.78Z" },
-    { url = "https://files.pythonhosted.org/packages/25/7a/71437c7f3596e5246155c515852795a85a1a8d228190212432b13b97a95d/grpcio-1.81.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8ea1936c26b99999b27479853039a7f34713f56c49375ad52b38535ec93a796c", size = 7849660, upload-time = "2026-06-11T12:45:40.627Z" },
-    { url = "https://files.pythonhosted.org/packages/65/40/7debc0da45d2efebafb82da75644be347497fe4ee250514b8cd3b86ae8bf/grpcio-1.81.1-cp312-cp312-win32.whl", hash = "sha256:a185a04039df6cae8648bc8ab6d6fde7bf94f7188ecf7828e76ac52eef1e41d6", size = 4185819, upload-time = "2026-06-11T12:45:43.027Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/b9/8fe3ba5ed462067774ebc1f9c7f26aa7ebcc280ddd476be107153de1339e/grpcio-1.81.1-cp312-cp312-win_amd64.whl", hash = "sha256:3ad74f8bb1a18963914c5452d289422830b39459e8776ebbcd207be1fbfb1d94", size = 4930461, upload-time = "2026-06-11T12:45:45.775Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/42/dcc2e4b600538ef18327c0839d56b7d3c3812337c5d710df5877dbb39b1e/grpcio-1.81.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b10e1ff4756ed27d5a29d7fc79cfce7ef1ff56ad20025b89bac7cf79e09abbbe", size = 6054466, upload-time = "2026-06-11T12:45:48.43Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/4a/a36e03210183a8a7d4c80c3936acee679f4bd77d5861f369db47b2cc5f05/grpcio-1.81.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:819edbdcb42ab8598b494bcf0222684bbb7a3c772bd1b1f0be7e029a6063c28e", size = 12048795, upload-time = "2026-06-11T12:45:54.011Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/d5/d68e30b29098f63beab6fe501100fe82674ff142b32c672532da86a99b3a/grpcio-1.81.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c5bf2dc311127d91230cc79b92188c082634a06cf66c5234db49a43b910183b0", size = 6599094, upload-time = "2026-06-11T12:45:57.799Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/b3/e837954d279754f638a11cca5dcf6b24a005efb398984cefaf7735945a54/grpcio-1.81.1-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e8ca6a1fcdb2943c9cbc1804a1baf3acb6071d72a471591678ded84218006e14", size = 7307182, upload-time = "2026-06-11T12:46:00.568Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/1e/b47957057e729adc6cdf519a47f8be2562b7140e280f1418443eb4022192/grpcio-1.81.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e64dd101d380a115cc5a0c7856788adb535f1a4e21fc543775602f8be95180ae", size = 6810962, upload-time = "2026-06-11T12:46:03.312Z" },
-    { url = "https://files.pythonhosted.org/packages/40/26/569868e364e05b19ec8f969da53d230bcd89c962cd198f7c29943155c4d3/grpcio-1.81.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:98a07f9bf591e3a8919797bee1c53f026ba4acd587e5a4404c8e57c9ec36b2a5", size = 7415698, upload-time = "2026-06-11T12:46:06.005Z" },
-    { url = "https://files.pythonhosted.org/packages/36/0c/5440a0582cb5653fc42a6e262eeb22700943313f8076f9dc927491b20a59/grpcio-1.81.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c261d74b1a945cf895a9d6eccd1685a8e837531beaab782da4d630a8d12deffb", size = 8407779, upload-time = "2026-06-11T12:46:08.84Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/aa/66fe9f39871d766987d869a03ee0842a026f499c7b1e62decb9e78a8088e/grpcio-1.81.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58ad1131c300d3c9b933802b3cc4dc69d380822935ba50b28703156ea826fbf7", size = 7844521, upload-time = "2026-06-11T12:46:12.171Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/9e/69bb7194861bcd28fb3193261d4f9c3831b4446993f002cf59068943e7ab/grpcio-1.81.1-cp313-cp313-win32.whl", hash = "sha256:78e29211f26da2fdd0e9c6d2b79f489476140cf7029b6a64808ade7ca4156a42", size = 4182786, upload-time = "2026-06-11T12:46:15.192Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/20/3da8bb0d637feccdc3e1e419bb511ce93651ce7d54164f95de22cc0b8b34/grpcio-1.81.1-cp313-cp313-win_amd64.whl", hash = "sha256:edb59506291b647a30884b1d51a599d605f40b20af4a7dc3d33786a47a31de60", size = 4928648, upload-time = "2026-06-11T12:46:17.823Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c7/d0b780a29b0837bf4ca9580904dfb275c1fc321ded7897d620af7047ec57/grpcio-1.78.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:2777b783f6c13b92bd7b716667452c329eefd646bfb3f2e9dabea2e05dbd34f6", size = 5951525, upload-time = "2026-02-06T09:55:01.989Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b1/96920bf2ee61df85a9503cb6f733fe711c0ff321a5a697d791b075673281/grpcio-1.78.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:9dca934f24c732750389ce49d638069c3892ad065df86cb465b3fa3012b70c9e", size = 11830418, upload-time = "2026-02-06T09:55:04.462Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0c/7c1528f098aeb75a97de2bae18c530f56959fb7ad6c882db45d9884d6edc/grpcio-1.78.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:459ab414b35f4496138d0ecd735fed26f1318af5e52cb1efbc82a09f0d5aa911", size = 6524477, upload-time = "2026-02-06T09:55:07.111Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/52/e7c1f3688f949058e19a011c4e0dec973da3d0ae5e033909677f967ae1f4/grpcio-1.78.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:082653eecbdf290e6e3e2c276ab2c54b9e7c299e07f4221872380312d8cf395e", size = 7198266, upload-time = "2026-02-06T09:55:10.016Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/61/8ac32517c1e856677282c34f2e7812d6c328fa02b8f4067ab80e77fdc9c9/grpcio-1.78.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:85f93781028ec63f383f6bc90db785a016319c561cc11151fbb7b34e0d012303", size = 6730552, upload-time = "2026-02-06T09:55:12.207Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/98/b8ee0158199250220734f620b12e4a345955ac7329cfd908d0bf0fda77f0/grpcio-1.78.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f12857d24d98441af6a1d5c87442d624411db486f7ba12550b07788f74b67b04", size = 7304296, upload-time = "2026-02-06T09:55:15.044Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/0f/7b72762e0d8840b58032a56fdbd02b78fc645b9fa993d71abf04edbc54f4/grpcio-1.78.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5397fff416b79e4b284959642a4e95ac4b0f1ece82c9993658e0e477d40551ec", size = 8288298, upload-time = "2026-02-06T09:55:17.276Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ae/ae4ce56bc5bb5caa3a486d60f5f6083ac3469228faa734362487176c15c5/grpcio-1.78.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:fbe6e89c7ffb48518384068321621b2a69cab509f58e40e4399fdd378fa6d074", size = 7730953, upload-time = "2026-02-06T09:55:19.545Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/6e/8052e3a28eb6a820c372b2eb4b5e32d195c661e137d3eca94d534a4cfd8a/grpcio-1.78.0-cp311-cp311-win32.whl", hash = "sha256:6092beabe1966a3229f599d7088b38dfc8ffa1608b5b5cdda31e591e6500f856", size = 4076503, upload-time = "2026-02-06T09:55:21.521Z" },
+    { url = "https://files.pythonhosted.org/packages/08/62/f22c98c5265dfad327251fa2f840b591b1df5f5e15d88b19c18c86965b27/grpcio-1.78.0-cp311-cp311-win_amd64.whl", hash = "sha256:1afa62af6e23f88629f2b29ec9e52ec7c65a7176c1e0a83292b93c76ca882558", size = 4799767, upload-time = "2026-02-06T09:55:24.107Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f4/7384ed0178203d6074446b3c4f46c90a22ddf7ae0b3aee521627f54cfc2a/grpcio-1.78.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:f9ab915a267fc47c7e88c387a3a28325b58c898e23d4995f765728f4e3dedb97", size = 5913985, upload-time = "2026-02-06T09:55:26.832Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ed/be1caa25f06594463f685b3790b320f18aea49b33166f4141bfdc2bfb236/grpcio-1.78.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3f8904a8165ab21e07e58bf3e30a73f4dffc7a1e0dbc32d51c61b5360d26f43e", size = 11811853, upload-time = "2026-02-06T09:55:29.224Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a7/f06d151afc4e64b7e3cc3e872d331d011c279aaab02831e40a81c691fb65/grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:859b13906ce098c0b493af92142ad051bf64c7870fa58a123911c88606714996", size = 6475766, upload-time = "2026-02-06T09:55:31.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a8/4482922da832ec0082d0f2cc3a10976d84a7424707f25780b82814aafc0a/grpcio-1.78.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b2342d87af32790f934a79c3112641e7b27d63c261b8b4395350dad43eff1dc7", size = 7170027, upload-time = "2026-02-06T09:55:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bf/f4a3b9693e35d25b24b0b39fa46d7d8a3c439e0a3036c3451764678fec20/grpcio-1.78.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12a771591ae40bc65ba67048fa52ef4f0e6db8279e595fd349f9dfddeef571f9", size = 6690766, upload-time = "2026-02-06T09:55:36.902Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/521875265cc99fe5ad4c5a17010018085cae2810a928bf15ebe7d8bcd9cc/grpcio-1.78.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:185dea0d5260cbb2d224c507bf2a5444d5abbb1fa3594c1ed7e4c709d5eb8383", size = 7266161, upload-time = "2026-02-06T09:55:39.824Z" },
+    { url = "https://files.pythonhosted.org/packages/05/86/296a82844fd40a4ad4a95f100b55044b4f817dece732bf686aea1a284147/grpcio-1.78.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51b13f9aed9d59ee389ad666b8c2214cc87b5de258fa712f9ab05f922e3896c6", size = 8253303, upload-time = "2026-02-06T09:55:42.353Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e4/ea3c0caf5468537f27ad5aab92b681ed7cc0ef5f8c9196d3fd42c8c2286b/grpcio-1.78.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd5f135b1bd58ab088930b3c613455796dfa0393626a6972663ccdda5b4ac6ce", size = 7698222, upload-time = "2026-02-06T09:55:44.629Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/47/7f05f81e4bb6b831e93271fb12fd52ba7b319b5402cbc101d588f435df00/grpcio-1.78.0-cp312-cp312-win32.whl", hash = "sha256:94309f498bcc07e5a7d16089ab984d42ad96af1d94b5a4eb966a266d9fcabf68", size = 4066123, upload-time = "2026-02-06T09:55:47.644Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e7/d6914822c88aa2974dbbd10903d801a28a19ce9cd8bad7e694cbbcf61528/grpcio-1.78.0-cp312-cp312-win_amd64.whl", hash = "sha256:9566fe4ababbb2610c39190791e5b829869351d14369603702e890ef3ad2d06e", size = 4797657, upload-time = "2026-02-06T09:55:49.86Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a9/8f75894993895f361ed8636cd9237f4ab39ef87fd30db17467235ed1c045/grpcio-1.78.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:ce3a90455492bf8bfa38e56fbbe1dbd4f872a3d8eeaf7337dc3b1c8aa28c271b", size = 5920143, upload-time = "2026-02-06T09:55:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/55/06/0b78408e938ac424100100fd081189451b472236e8a3a1f6500390dc4954/grpcio-1.78.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:2bf5e2e163b356978b23652c4818ce4759d40f4712ee9ec5a83c4be6f8c23a3a", size = 11803926, upload-time = "2026-02-06T09:55:55.494Z" },
+    { url = "https://files.pythonhosted.org/packages/88/93/b59fe7832ff6ae3c78b813ea43dac60e295fa03606d14d89d2e0ec29f4f3/grpcio-1.78.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8f2ac84905d12918e4e55a16da17939eb63e433dc11b677267c35568aa63fc84", size = 6478628, upload-time = "2026-02-06T09:55:58.533Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/df/e67e3734527f9926b7d9c0dde6cd998d1d26850c3ed8eeec81297967ac67/grpcio-1.78.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b58f37edab4a3881bc6c9bca52670610e0c9ca14e2ea3cf9debf185b870457fb", size = 7173574, upload-time = "2026-02-06T09:56:01.786Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/cc03fffb07bfba982a9ec097b164e8835546980aec25ecfa5f9c1a47e022/grpcio-1.78.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:735e38e176a88ce41840c21bb49098ab66177c64c82426e24e0082500cc68af5", size = 6692639, upload-time = "2026-02-06T09:56:04.529Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/9a/289c32e301b85bdb67d7ec68b752155e674ee3ba2173a1858f118e399ef3/grpcio-1.78.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2045397e63a7a0ee7957c25f7dbb36ddc110e0cfb418403d110c0a7a68a844e9", size = 7268838, upload-time = "2026-02-06T09:56:08.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/79/1be93f32add280461fa4773880196572563e9c8510861ac2da0ea0f892b6/grpcio-1.78.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a9f136fbafe7ccf4ac7e8e0c28b31066e810be52d6e344ef954a3a70234e1702", size = 8251878, upload-time = "2026-02-06T09:56:10.914Z" },
+    { url = "https://files.pythonhosted.org/packages/65/65/793f8e95296ab92e4164593674ae6291b204bb5f67f9d4a711489cd30ffa/grpcio-1.78.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:748b6138585379c737adc08aeffd21222abbda1a86a0dca2a39682feb9196c20", size = 7695412, upload-time = "2026-02-06T09:56:13.593Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/1e233fe697ecc82845942c2822ed06bb522e70d6771c28d5528e4c50f6a4/grpcio-1.78.0-cp313-cp313-win32.whl", hash = "sha256:271c73e6e5676afe4fc52907686670c7cea22ab2310b76a59b678403ed40d670", size = 4064899, upload-time = "2026-02-06T09:56:15.601Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/27/d86b89e36de8a951501fb06a0f38df19853210f341d0b28f83f4aa0ffa08/grpcio-1.78.0-cp313-cp313-win_amd64.whl", hash = "sha256:f2d4e43ee362adfc05994ed479334d5a451ab7bc3f3fee1b796b8ca66895acb4", size = 4797393, upload-time = "2026-02-06T09:56:17.882Z" },
 ]
 
 [[package]]
@@ -1650,7 +1794,7 @@ computer-use = [
     { name = "starlette" },
 ]
 cua-fleet = [
-    { name = "cua-fleet" },
+    { name = "cua-sandbox" },
 ]
 daytona = [
     { name = "daytona" },
@@ -1839,7 +1983,7 @@ requires-dist = [
     { name = "concurrent-log-handler", marker = "sys_platform == 'win32'", specifier = "==0.9.29" },
     { name = "croniter", specifier = "==6.0.0" },
     { name = "cryptography", specifier = "==48.0.1" },
-    { name = "cua-fleet", marker = "extra == 'cua-fleet'", specifier = "==0.0.6" },
+    { name = "cua-sandbox", marker = "extra == 'cua-fleet'", specifier = "==0.1.21" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.155.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = "==1.8.20" },
     { name = "defusedxml", marker = "extra == 'wecom'", specifier = "==0.7.1" },
@@ -2130,6 +2274,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hyperlink"
+version = "21.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/51/1947bd81d75af87e3bb9e34593a4cf118115a8feb451ce7a69044ef1412e/hyperlink-21.0.0.tar.gz", hash = "sha256:427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b", size = 140743, upload-time = "2021-01-08T05:51:20.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/aa/8caf6a0a3e62863cbb9dab27135660acba46903b703e224f14f447e57934/hyperlink-21.0.0-py2.py3-none-any.whl", hash = "sha256:e6b14c37ecb73e89c77d78cdb4c2cc8f3fb59a885c5b3f819ff4ed80f25af1b4", size = 74638, upload-time = "2021-01-08T05:51:22.906Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.15"
 source = { registry = "https://pypi.org/simple" }
@@ -2151,12 +2307,33 @@ wheels = [
 ]
 
 [[package]]
+name = "incremental"
+version = "24.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/3c/82e84109e02c492f382c711c58a3dd91badda6d746def81a1465f74dc9f5/incremental-24.11.0.tar.gz", hash = "sha256:87d3480dbb083c1d736222511a8cf380012a8176c2456d01ef483242abbbcf8c", size = 24000, upload-time = "2025-11-28T02:30:17.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/55/0f4df2a44053867ea9cbea73fc588b03c55605cd695cee0a3d86f0029cb2/incremental-24.11.0-py3-none-any.whl", hash = "sha256:a34450716b1c4341fe6676a0598e88a39e04189f4dce5dc96f656e040baa10b3", size = 21109, upload-time = "2025-11-28T02:30:16.442Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "invoke"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/227c48c5fe47fa178ccf1fda8f047d16c97ba926567b661e9ce2045c600c/invoke-3.0.3.tar.gz", hash = "sha256:437b6a622223824380bfb4e64f612711a6b648c795f565efc8625af66fb57f0c", size = 343419, upload-time = "2026-04-07T15:17:48.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl", hash = "sha256:f11327165e5cbb89b2ad1d88d3292b5113332c43b8553b494da435d6ec6f5053", size = 160958, upload-time = "2026-04-07T15:17:46.875Z" },
 ]
 
 [[package]]
@@ -3045,6 +3222,19 @@ wheels = [
 ]
 
 [[package]]
+name = "oras"
+version = "0.2.42"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/f9/e9226863b61d3e83d166e7a70a045fdacbb966dd7e7ecef81fed32cf67af/oras-0.2.42.tar.gz", hash = "sha256:51d17088e5dffdeb585dd930bdccb4329762bef4af3f18600392ebae525a9231", size = 58767, upload-time = "2026-03-09T22:31:23.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/3c/04dce40fe03276a5aaed0e2b49e59e385147f4e750e6960c477284cf5880/oras-0.2.42-py3-none-any.whl", hash = "sha256:d1e2184d42ce99258bd0ad56d932b0f4fce289bccf1b5094436a29579f385728", size = 71832, upload-time = "2026-03-09T22:31:22.145Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3068,6 +3258,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/24/50/fb9b28a679e01682006b5259abff96de3d16e114e9447a7793fec31715de/parallel_web-0.4.2.tar.gz", hash = "sha256:599b5a8f387dc35c7dc8c81e372eadf6958a40acacea58bf170dfc663c003da7", size = 140026, upload-time = "2026-03-09T22:24:35.448Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/3e/2218fa29637781b8e7ac35a928108ff2614ddd40879389d3af2caa725af5/parallel_web-0.4.2-py3-none-any.whl", hash = "sha256:aa3a4a9aecc08972c5ce9303271d4917903373dff4dd277d9a3e30f9cff53346", size = 144012, upload-time = "2026-03-09T22:24:33.979Z" },
+]
+
+[[package]]
+name = "paramiko"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bcrypt" },
+    { name = "cryptography" },
+    { name = "invoke" },
+    { name = "pynacl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/93/dcc25d52f49022ae6175d15e6bd751f1acc99b98bc61fc55e5155a7be2e7/paramiko-5.0.0.tar.gz", hash = "sha256:36763b5b95c2a0dcfdf1abc48e48156ee425b21efe2f0e787c2dd5a95c0e5e79", size = 1548586, upload-time = "2026-05-09T18:28:52.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/5b/eadf6d45de38d30ab603f49393b6cd2cbe7e233af8cf90197e32782b68a9/paramiko-5.0.0-py3-none-any.whl", hash = "sha256:b7044611c30140d9a75261653210e2002977b71a0497ff3ba0d98d7edbf62f7c", size = 208919, upload-time = "2026-05-09T18:28:50.295Z" },
 ]
 
 [[package]]
@@ -3253,17 +3458,17 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "6.33.5"
+version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c", size = 444465, upload-time = "2026-01-29T21:51:33.494Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/79/af92d0a8369732b027e6d6084251dd8e782c685c72da161bd4a2e00fbabb/protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b", size = 425769, upload-time = "2026-01-29T21:51:21.751Z" },
-    { url = "https://files.pythonhosted.org/packages/55/75/bb9bc917d10e9ee13dee8607eb9ab963b7cf8be607c46e7862c748aa2af7/protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c", size = 437118, upload-time = "2026-01-29T21:51:24.022Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5", size = 427766, upload-time = "2026-01-29T21:51:25.413Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/b1/c79468184310de09d75095ed1314b839eb2f72df71097db9d1404a1b2717/protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190", size = 324638, upload-time = "2026-01-29T21:51:26.423Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
-    { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -3328,6 +3533,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pycdlib"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/38/9d1ab6815f97700cff7b6425675e993d2d7421c0af7f70478617e4bcab4a/pycdlib-1.16.0.tar.gz", hash = "sha256:da02ce3d3a7cc1f879cd84db7bb39427a082cee0dbf0730fec89604039344058", size = 305934, upload-time = "2026-04-29T01:42:54.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/21/434b2f36cdbeb209dd95866c002b26a467c21f9c0f428d1509b46df27781/pycdlib-1.16.0-py2.py3-none-any.whl", hash = "sha256:17843829c6bf2fd365d3d2e49a94f06da82c999efc313b9f26b0ce59c0070785", size = 214861, upload-time = "2026-04-29T01:42:52.399Z" },
 ]
 
 [[package]]
@@ -3494,6 +3708,21 @@ crypto = [
 ]
 
 [[package]]
+name = "pymonctl"
+version = "0.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ewmhlib", marker = "sys_platform == 'linux'" },
+    { name = "pyobjc", marker = "sys_platform == 'darwin'" },
+    { name = "python-xlib", marker = "sys_platform == 'linux'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/13/076a20da28b82be281f7e43e16d9da0f545090f5d14b2125699232b9feba/PyMonCtl-0.92-py3-none-any.whl", hash = "sha256:2495d8dab78f9a7dbce37e74543e60b8bd404a35c3108935697dda7768611b5a", size = 45945, upload-time = "2024-04-22T10:07:09.566Z" },
+]
+
+[[package]]
 name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3517,12 +3746,2634 @@ wheels = [
 ]
 
 [[package]]
+name = "pynput"
+version = "1.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "evdev", marker = "'linux' in sys_platform" },
+    { name = "pyobjc-framework-applicationservices", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "python-xlib", marker = "'linux' in sys_platform" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/c6/e2d415610cfbc78308bee44218a46124aaa3301b1df08814df819b2254a1/pynput-1.8.2.tar.gz", hash = "sha256:f493c87157cd3861b4468f7f896857051762f44ed26f1b641e7cc5840a457087", size = 82818, upload-time = "2026-05-12T19:11:39.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/98/bbeb760852adb27f166ce1617f0e51aabb15f21b1e60ea703f2aed3c78ac/pynput-1.8.2-py2.py3-none-any.whl", hash = "sha256:8cc38cf13a6ab2749cb375678be8a0fd705d7ce49c8001ff5db4007a723bbef1", size = 92028, upload-time = "2026-05-12T19:11:37.89Z" },
+]
+
+[[package]]
+name = "pyobjc"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-accessibility", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-accounts", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-addressbook" },
+    { name = "pyobjc-framework-adservices", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-adsupport", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-applescriptkit" },
+    { name = "pyobjc-framework-applescriptobjc", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-applicationservices" },
+    { name = "pyobjc-framework-apptrackingtransparency", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-arkit", marker = "platform_release >= '25.0'" },
+    { name = "pyobjc-framework-audiovideobridging", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-authenticationservices", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-automaticassessmentconfiguration", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-automator" },
+    { name = "pyobjc-framework-avfoundation", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-avkit", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-avrouting", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-backgroundassets", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-browserenginekit", marker = "platform_release >= '23.4'" },
+    { name = "pyobjc-framework-businesschat", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-calendarstore", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-callkit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-carbon" },
+    { name = "pyobjc-framework-cfnetwork" },
+    { name = "pyobjc-framework-cinematic", marker = "platform_release >= '23.0'" },
+    { name = "pyobjc-framework-classkit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-cloudkit", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-collaboration", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-colorsync", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-compositorservices", marker = "platform_release >= '25.0'" },
+    { name = "pyobjc-framework-contacts", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-contactsui", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-coreaudio" },
+    { name = "pyobjc-framework-coreaudiokit" },
+    { name = "pyobjc-framework-corebluetooth", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-coredata" },
+    { name = "pyobjc-framework-corehaptics", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-corelocation", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-coremedia", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-coremediaio", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-coremidi" },
+    { name = "pyobjc-framework-coreml", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-coremotion", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-coreservices" },
+    { name = "pyobjc-framework-corespotlight", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-coretext" },
+    { name = "pyobjc-framework-corewlan", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-cryptotokenkit", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-datadetection", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-devicecheck", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-devicediscoveryextension", marker = "platform_release >= '24.0'" },
+    { name = "pyobjc-framework-dictionaryservices", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-discrecording" },
+    { name = "pyobjc-framework-discrecordingui" },
+    { name = "pyobjc-framework-diskarbitration" },
+    { name = "pyobjc-framework-dvdplayback" },
+    { name = "pyobjc-framework-eventkit", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-exceptionhandling" },
+    { name = "pyobjc-framework-executionpolicy", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-extensionkit", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-externalaccessory", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-fileprovider", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-fileproviderui", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-findersync", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-fsevents", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-fskit", marker = "platform_release >= '24.4'" },
+    { name = "pyobjc-framework-gamecenter", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-gamecontroller", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-gamekit", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-gameplaykit", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-gamesave", marker = "platform_release >= '25.0'" },
+    { name = "pyobjc-framework-healthkit", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-imagecapturecore", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-inputmethodkit", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-installerplugins" },
+    { name = "pyobjc-framework-instantmessage", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-intents", marker = "platform_release >= '16.0'" },
+    { name = "pyobjc-framework-intentsui", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-iobluetooth" },
+    { name = "pyobjc-framework-iobluetoothui" },
+    { name = "pyobjc-framework-iosurface", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-ituneslibrary", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-kernelmanagement", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-latentsemanticmapping" },
+    { name = "pyobjc-framework-launchservices" },
+    { name = "pyobjc-framework-libdispatch", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-libxpc", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-linkpresentation", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-localauthentication", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-localauthenticationembeddedui", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-mailkit", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-mapkit", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-mediaaccessibility", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-mediaextension", marker = "platform_release >= '24.0'" },
+    { name = "pyobjc-framework-medialibrary", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-mediaplayer", marker = "platform_release >= '16.0'" },
+    { name = "pyobjc-framework-mediatoolbox", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-metal", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-metalfx", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-metalkit", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-metalperformanceshaders", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-metalperformanceshadersgraph", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-metrickit", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-mlcompute", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-modelio", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-multipeerconnectivity", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-naturallanguage", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-netfs", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-network", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-networkextension", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-notificationcenter", marker = "platform_release >= '14.0'" },
+    { name = "pyobjc-framework-opendirectory", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-osakit" },
+    { name = "pyobjc-framework-oslog", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-passkit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-pencilkit", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-phase", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-photos", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-photosui", marker = "platform_release >= '15.0'" },
+    { name = "pyobjc-framework-preferencepanes" },
+    { name = "pyobjc-framework-pushkit", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-framework-quicklookthumbnailing", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-replaykit", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-safariservices", marker = "platform_release >= '16.0'" },
+    { name = "pyobjc-framework-safetykit", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-scenekit", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-screencapturekit", marker = "platform_release >= '21.4'" },
+    { name = "pyobjc-framework-screensaver" },
+    { name = "pyobjc-framework-screentime", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-scriptingbridge", marker = "platform_release >= '9.0'" },
+    { name = "pyobjc-framework-searchkit" },
+    { name = "pyobjc-framework-security" },
+    { name = "pyobjc-framework-securityfoundation" },
+    { name = "pyobjc-framework-securityinterface" },
+    { name = "pyobjc-framework-securityui", marker = "platform_release >= '24.4'" },
+    { name = "pyobjc-framework-sensitivecontentanalysis", marker = "platform_release >= '23.0'" },
+    { name = "pyobjc-framework-servicemanagement", marker = "platform_release >= '10.0'" },
+    { name = "pyobjc-framework-sharedwithyou", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-sharedwithyoucore", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-shazamkit", marker = "platform_release >= '21.0'" },
+    { name = "pyobjc-framework-social", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-soundanalysis", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-speech", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-spritekit", marker = "platform_release >= '13.0'" },
+    { name = "pyobjc-framework-storekit", marker = "platform_release >= '11.0'" },
+    { name = "pyobjc-framework-symbols", marker = "platform_release >= '23.0'" },
+    { name = "pyobjc-framework-syncservices" },
+    { name = "pyobjc-framework-systemconfiguration" },
+    { name = "pyobjc-framework-systemextensions", marker = "platform_release >= '19.0'" },
+    { name = "pyobjc-framework-threadnetwork", marker = "platform_release >= '22.0'" },
+    { name = "pyobjc-framework-uniformtypeidentifiers", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-usernotifications", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-usernotificationsui", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-videosubscriberaccount", marker = "platform_release >= '18.0'" },
+    { name = "pyobjc-framework-videotoolbox", marker = "platform_release >= '12.0'" },
+    { name = "pyobjc-framework-virtualization", marker = "platform_release >= '20.0'" },
+    { name = "pyobjc-framework-vision", marker = "platform_release >= '17.0'" },
+    { name = "pyobjc-framework-webkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/ef/b4e64fe87051e72608ed4134072e832e9eae28d97e9c9bb0870f01a18ac5/pyobjc-12.2.1.tar.gz", hash = "sha256:0b2cf49d24213e7604620c31863e7b4e42770c4442c10e59b18ad951cd200cd3", size = 12148, upload-time = "2026-06-19T16:19:38.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/a2/3878e4783c65eeb72a1c06de1f880ef573b9677198a3142ff5082c0810ac/pyobjc-12.2.1-py3-none-any.whl", hash = "sha256:edbbf9e2e249cd2fa660422c7d72e9fe5be1438deab38c64238b26f4c9db9421", size = 4262, upload-time = "2026-06-19T12:50:03.55Z" },
+]
+
+[[package]]
+name = "pyobjc-core"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/b1/729f7458a63758bd21716648a8abcd9a0c8f2d2e9897763c8a1a1c7fd31b/pyobjc_core-12.2.1.tar.gz", hash = "sha256:7a7b9b018402342cf32bf1956366896350fbe5c0478cb3ef59778f77abed7f07", size = 1063383, upload-time = "2026-06-19T16:19:39.357Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/87/16564ef5e4568ee0edd9e712d8111dc8b67621d6bb6ff430646ee2d637dd/pyobjc_core-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:24b76a63caf0b5369d4a377c7c0438cd70df81539057af3db839bfaa3579e04a", size = 6484662, upload-time = "2026-06-19T16:04:44.979Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/88/300ad283bed0c971c52dcac6f70113e138169d4ce6d856ddd03d16081e51/pyobjc_core-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a64232bb27ed101d4adc7d42b0e64a6d3331aac7bee7861c037a6777a163f10b", size = 6433347, upload-time = "2026-06-19T16:04:49.341Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/1e/b9b0ddffae66996b8779f1f7958adc9f21c13a0448cd3be8d7fe589b5b0f/pyobjc_core-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:af101222762665a4125157906cb4b23f5d5a63d3851d5e0504f72a1eaaa2cfd2", size = 6436004, upload-time = "2026-06-19T16:04:53.257Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/bd309ede07784c6e5fac4b440c90a5f72a66da7859ed303a9392fe8a5f3f/pyobjc_core-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:efe465e3ecc6fc73f7c7622620345d134a8d34564ab1c29d8247e45f4ed55071", size = 6687044, upload-time = "2026-06-19T16:04:57.42Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-accessibility"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/4b/b0a0f0183b359a07663ed31a3f790986cf880bda909b623fead15cb2afbd/pyobjc_framework_accessibility-12.2.1.tar.gz", hash = "sha256:1e0ad06b5b6ae623f443d15c11780f97908d5c41fdb79532e96c6a4a76066fd8", size = 34377, upload-time = "2026-06-19T16:19:40.592Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/b8/6937060aca105b75d17fcc296341c12ad2028ab901af784fec40d92c5be4/pyobjc_framework_accessibility-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b2064190604ed1ecfb05fc6a0fd04b7ceb2d9d3ebd02d6899607b5635ac9b12d", size = 11542, upload-time = "2026-06-19T16:05:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/43/22/28a3096e9bb6332d851a7bb4191d6591088165a8465d3540e82a7f3fd9fe/pyobjc_framework_accessibility-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a906f4d6447a6394f10fc7d77cfb755815fb07cdb97c9e3018bd7c528600df3f", size = 11570, upload-time = "2026-06-19T16:05:17.802Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/70/0630c4c67f262d3d018aee43d185d8e58a8aa32a34222be3177fe9a8c21a/pyobjc_framework_accessibility-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6814e863cc1a29e62d9ec97f7a9535598e46748b9d734cf0b903d190fe0e224", size = 11586, upload-time = "2026-06-19T16:05:18.772Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c4/6966cd83fb01c183d778799de67100761f7ffe9b7de34b543c4b5034c7a0/pyobjc_framework_accessibility-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5213d57f9b1d6a7b452af78f904e3eed1b4372e9a850e772cf275177038c8512", size = 11756, upload-time = "2026-06-19T16:05:19.545Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-accounts"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/14/6086edbaeb0f48ac1b915d38d11a36efd8de918277da86abc2058a50baad/pyobjc_framework_accounts-12.2.1.tar.gz", hash = "sha256:6e6d603e10182238cd77596380262a38cbb0a9141d1eca6bf522b2213c6d6751", size = 16209, upload-time = "2026-06-19T16:19:41.451Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/2b/f8138fa91af3ada0bae01dc5430f0f3a79daeabfd36e02ac165423f67041/pyobjc_framework_accounts-12.2.1-py2.py3-none-any.whl", hash = "sha256:b86cba0f2a9219a1c57aba6c0f0973f7a06f10bf9ccd39b74fdb567f9b34a041", size = 5133, upload-time = "2026-06-19T16:05:23.786Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-addressbook"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/20/70dad64d397f9ba513a314ad4d1e1f7e4903c21caee98dfab2f7a39aaedb/pyobjc_framework_addressbook-12.2.1.tar.gz", hash = "sha256:bb113fd5bcae93da00d67bf870704d2cfb73da49c4a281249d8a5abf9809aa91", size = 47685, upload-time = "2026-06-19T16:19:42.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/7a/1c3b84602dc52e68d4422088ade9323047d5ed2c8f877d67afb0b90b74b7/pyobjc_framework_addressbook-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9daf115aa1225ebc1d7946a82a7b553ddd4158dc82705e60bb8ca9ae2bb38788", size = 12823, upload-time = "2026-06-19T16:05:25.706Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/01/83d10cdd6bcec2b63ded8dc5dd1036fd0dc8b8bb2f3a00b2c57ea785c32e/pyobjc_framework_addressbook-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1bd586c3aa24345cc9e1cf31a8860cda1298cb92a70fe73b05bdf31cb69edcb2", size = 12835, upload-time = "2026-06-19T16:05:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/50/64/909d16cbf2efcd95807da7b9966d6de35225cad192444a93eb07c1c8de3e/pyobjc_framework_addressbook-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ca9a94a3d27cf9b9ae22ac8fc48bfce392757b283419ac38567eeac73b6f8ffc", size = 12853, upload-time = "2026-06-19T16:05:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b7/ac71ac95e5d1bae7aa4ec67e444683780274b826b0e6cad3d57252b29f1f/pyobjc_framework_addressbook-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:32a21916f38dff86226c37e0478dd86e8e5fa070403f8ca27dedf5b48f30a059", size = 13010, upload-time = "2026-06-19T16:05:28.426Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-adservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/de/6e9fa436a7aacaebe664c918dabfad14a19aa0f6ccaf24384d0c0b55b6f0/pyobjc_framework_adservices-12.2.1.tar.gz", hash = "sha256:6668fbef1b383c5cafae8479f4a8b53e824bd4d568611a53a3075e8c6dc4e39a", size = 12269, upload-time = "2026-06-19T16:19:43.102Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/43/c8d1a8be6faf0b3c60b28f8dbc31198ccbb72acdf0eb42fa8effbc9eaccd/pyobjc_framework_adservices-12.2.1-py2.py3-none-any.whl", hash = "sha256:631eaa86145179631624788ac1ee485fc79c2f9de347ab7d0cb3ea3413cd0cb1", size = 3510, upload-time = "2026-06-19T16:05:33.49Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-adsupport"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/53/d73eafbc080b7eed68917f6a62758dafca80c7a6ac98ef35660185f8ea89/pyobjc_framework_adsupport-12.2.1.tar.gz", hash = "sha256:c659ac447b1bb3b1a54add100d72932cfd50482384a97c22926d281c9d97a6c0", size = 12098, upload-time = "2026-06-19T16:19:43.985Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e309b2c03498b2d0848382aabea2b068f314c40dc58f1e3dbd5bedbddaf/pyobjc_framework_adsupport-12.2.1-py2.py3-none-any.whl", hash = "sha256:46a18c775a12565efbe46fbd0258ed63aa74002773362ff7d5e5be525013b221", size = 3424, upload-time = "2026-06-19T16:05:34.492Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-applescriptkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/04/187611b7f3e51532b45df08c3b22edd53f163f337a88d7c03c4dc904e2ed/pyobjc_framework_applescriptkit-12.2.1.tar.gz", hash = "sha256:fa3a55933ec090aebc695f3575a5afe8a2d37015162cd30e6c00948748d08f83", size = 11668, upload-time = "2026-06-19T16:19:44.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/82/f83a29b54c8fbf5a7a6cc53676767968fa970fa902b599ae92ecf4208fd1/pyobjc_framework_applescriptkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:db6a0aae4d9421068ed8a0838c509e3a7858813975dde40c40ef1dcc15328d1d", size = 4381, upload-time = "2026-06-19T16:05:35.356Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-applescriptobjc"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/b8/67273037f4f10334d9660001bf12f5cc8b483f9cf9c8df91aa39701bcce4/pyobjc_framework_applescriptobjc-12.2.1.tar.gz", hash = "sha256:c60b751a6c20148f23eb1d556aa36612c7e39b14e0bd87abaea53744ff8eabc9", size = 11777, upload-time = "2026-06-19T16:19:45.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/8f/d66814f05748297c1c281d3b2f4a96600d4a3de87c65b6abf6a92151cac0/pyobjc_framework_applescriptobjc-12.2.1-py2.py3-none-any.whl", hash = "sha256:59a3f7668b1f88707c06ae1cd263856ac29c2bf1650a9dbfa21288e0baebe298", size = 4479, upload-time = "2026-06-19T16:05:36.364Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-applicationservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coretext" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/4d/0ebdd8144aba94b8fe9828ccee5616a4bf53d1f8bc51cff55f3cce86d695/pyobjc_framework_applicationservices-12.2.1.tar.gz", hash = "sha256:048ea663c9ac75c44a15dc7d5b8d78cbb4c97bf1c76e83835e8d5498e184001f", size = 109342, upload-time = "2026-06-19T16:19:46.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/8a/5a9310929bb303c31c04a1c6dc7b3213c9bd964a692d024a00c0643af2c8/pyobjc_framework_applicationservices-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dabec481217b0d0c1ea835e9fef6b0681381b14b3f16a30d4a9d801ee3852dd2", size = 32715, upload-time = "2026-06-19T16:05:38.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/89/39a7462006afbc06c69029fe4181b7359a9da25ae7864ef75f9d3ffb9272/pyobjc_framework_applicationservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f519ced13888d03410cd7da1f08fc56ee2944099e607216cef7ca26ecfdef61b", size = 32764, upload-time = "2026-06-19T16:05:39.26Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/8e928d5e3025529ed92c6eb5fd88a5e6e485cc6df945c541f29b4af7f2c6/pyobjc_framework_applicationservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8749290f796e6cca341d443769b79329dde5d157bcc4413c1f7fdb68ea4a8e48", size = 32782, upload-time = "2026-06-19T16:05:40.284Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a5/c7b5a31777fe2ce7c07b9c16941ff4fbf0a150bf755164d96228d32ccb4f/pyobjc_framework_applicationservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9ee11677fbd6a0987234814c7dde88ffd11242e8c1f76952e6654ea07f2370ac", size = 33048, upload-time = "2026-06-19T16:05:41.308Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-apptrackingtransparency"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/c3/2f6b30c7010b32450769d679c30393a148d0b1531b31f1c0d3a600fc999b/pyobjc_framework_apptrackingtransparency-12.2.1.tar.gz", hash = "sha256:3eff48469eb07e4637408f410ce2690711f5c3de2fbfaa8844daa718ed3479f7", size = 12795, upload-time = "2026-06-19T16:19:47.034Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/2d/a78781f57f2c28155a60eb5ef255d50a7d34b036d16e395cdbc27c2c02da/pyobjc_framework_apptrackingtransparency-12.2.1-py2.py3-none-any.whl", hash = "sha256:29fb3e38e124932eb566a8427dc0db759eba63396cf530862b081432316ff863", size = 3930, upload-time = "2026-06-19T16:05:45.898Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-arkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/be/db21fafd315dc479925d79bd144f132cb38fb37583212753db8252b765d8/pyobjc_framework_arkit-12.2.1.tar.gz", hash = "sha256:ed4f67b1594a427b66ab751657ce6183a93a07ba32d3ba3bbefd7e0b4f6bf64d", size = 40145, upload-time = "2026-06-19T16:19:47.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/34/439b5e0505a369ab741daf65dee78a58e9110df79bf2fe20883b0c93666b/pyobjc_framework_arkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:2834c497fe9f6cbfcdfdcb0202945b7ad36708438afbc71c77186ce3fb972366", size = 8328, upload-time = "2026-06-19T16:05:47.05Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-audiovideobridging"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/6b/cacbe1a5f8e72c76f546689b551853e9312a00a612e8a2087e75f0dc1e3a/pyobjc_framework_audiovideobridging-12.2.1.tar.gz", hash = "sha256:7b6890ebfb1d346988dad7ff20182373c5c15026b1f9a50f64f654b4ff255e76", size = 44241, upload-time = "2026-06-19T16:19:48.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/97/770348fe032e648c09555b7c9611bdf61ac35a7909abea05980836ccd0c9/pyobjc_framework_audiovideobridging-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c0a62ec1acbf2182e272272a73e16cdc9a8de38d87a6f178c07ede661b01902b", size = 11077, upload-time = "2026-06-19T16:05:48.984Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/18/aa7624312ec1aff0243232c75e8f911441c64c417be5a2fd904b89e705a2/pyobjc_framework_audiovideobridging-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8a96bac7a308bed774a5332069ea013e999fa269d58ea67b67ef31dfde705186", size = 11085, upload-time = "2026-06-19T16:05:49.743Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/75/5221bb910b6d4d91bc0653eafa111fe125ca181da7254b4d1bd5e09dea5a/pyobjc_framework_audiovideobridging-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ceebe03b803be2684412050afc9e661d1e9fc7857ca34f27beff3a11b2cad773", size = 11098, upload-time = "2026-06-19T16:05:50.524Z" },
+    { url = "https://files.pythonhosted.org/packages/39/87/9fbd555fb110f3210a39405c604de75561f68e5cf8e1daeddf4101905f5a/pyobjc_framework_audiovideobridging-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:271d3a0a46cc13437b27c790bc7a5fd9dba8f445a743c243de2b41cc2b396aef", size = 11268, upload-time = "2026-06-19T16:05:51.378Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-authenticationservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/1f/fa7506fb8df1c30f7a1fddc9812705494421b2064391106dc00cac948ce8/pyobjc_framework_authenticationservices-12.2.1.tar.gz", hash = "sha256:da70cd842a41276e6f9958b1d3e227a3de452e696c56f8e2b439add45e578665", size = 75693, upload-time = "2026-06-19T16:19:49.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/0b/71951c26dc99ccca7afc5297e6805c2aee8842c887f42372355b2e8292f9/pyobjc_framework_authenticationservices-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0d1c679a6625ab639c42a2ea9e69d9b1d13c639effb2fec92176e107f53d4b90", size = 21286, upload-time = "2026-06-19T16:05:56.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/85/5019b9a1768b0b9e002029e036d7028312d5704ea48a18bb39e24d22c0dc/pyobjc_framework_authenticationservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ac2f78923734fb477ec4de4a2bea243ae418b33675c2ee62bf12ae333b31dad8", size = 21388, upload-time = "2026-06-19T16:05:57.874Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c1/98c8ec590df7d76f394b90e6bffacdaadcf30555e34b2955ac3348316845/pyobjc_framework_authenticationservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a3ec1ff47578c7163718aed572fb5d4902f2e33df0b178b01c00797b75802225", size = 21399, upload-time = "2026-06-19T16:05:58.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ee/6775170a378c836767c785b2b99294926c9ddd7f9d38a599e5cef52fe6d1/pyobjc_framework_authenticationservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:19194a7266ed75d9d083cf7e8b3d8ac3b241ae259d8c6cd3b4f68bda70751522", size = 21645, upload-time = "2026-06-19T16:05:59.537Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-automaticassessmentconfiguration"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/d1/1124aaf5aa1a35126836c623e30eb7ea47c9e64e758f7c3156aa61dbffbd/pyobjc_framework_automaticassessmentconfiguration-12.2.1.tar.gz", hash = "sha256:6888ec9846d04cb7983525d9a134b838044d9857182fe5404224c3071f4cc64f", size = 24775, upload-time = "2026-06-19T16:19:50.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/d4/cbae4c491afda8ce2bed85a0320cb7cc798fc62c2e1187b18d7eb0529f89/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2fa2291aec48dc6ef7ea1233399427f8cb15c3ec28ed937a8f0f0739c06361d5", size = 9364, upload-time = "2026-06-19T16:06:04.755Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f9/2e284b1b296745e899d1e920c163d3e0d1a7b1111b8735e3b2f9cb57e5d7/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:742f022d3a43478e6d322ea1d2d608080263de75456b5bae7a465a9f463089bf", size = 9382, upload-time = "2026-06-19T16:06:05.516Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a0/61e92054653173c358b17579058e7e5037679a43d0962fa0296070a0f2aa/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c4c233d052d699cf6db479dd8ac0a741fe920e192adc716121c8f4ff3f0ce864", size = 9393, upload-time = "2026-06-19T16:06:06.3Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a5/a5bfc8caa00251b2b1abc22d3a5ef28f4e40c14fad9a8ea1c4817d568495/pyobjc_framework_automaticassessmentconfiguration-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:90942b9e126b67f151f0965ca84e00795724a96971195e910137dff2c6c0a20b", size = 9547, upload-time = "2026-06-19T16:06:07.188Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-automator"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/2f/6669c037108799e2319894f21e0067c3119c2a185b18ca70aaf645309199/pyobjc_framework_automator-12.2.1.tar.gz", hash = "sha256:6ea468966d911292d73f52672603eee50bb4a3d651094f63de25dd6d5818d347", size = 188942, upload-time = "2026-06-19T16:19:51.099Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/40/0344eafeffe5b17edad349265349f6046acf1e36db825359cb453feb5d94/pyobjc_framework_automator-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c512602073fbb51e5c2c442628029ca7eb1d19a0c53632dbe9aa1b0c47454868", size = 10043, upload-time = "2026-06-19T16:06:13.138Z" },
+    { url = "https://files.pythonhosted.org/packages/67/3c/296fbea8ecdfb45944eeb427328d729280b1dd1a811563a40d8baa0b6fdf/pyobjc_framework_automator-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:275dad426c9cee7b683fa5f800e2779b565d1a1e75cb82bb79ad2289ed802f56", size = 10060, upload-time = "2026-06-19T16:06:13.935Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2c/4dfeec84201af81949f7edf670bffe7e88ce022402cab7f62a8ed2234b06/pyobjc_framework_automator-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b74cc160c2f751885d70b6db4d02506468ee4b149672ce06cace88484d8fa769", size = 10076, upload-time = "2026-06-19T16:06:14.725Z" },
+    { url = "https://files.pythonhosted.org/packages/96/62/349e5b92592094e7fe50fbd46e87fc1b5d1f9e09adb48a7e67d3afe4f721/pyobjc_framework_automator-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c41866f4068789acf653416e61ed914279f0d83e12f62b3d5c7eea658df8dbb2", size = 10220, upload-time = "2026-06-19T16:06:15.914Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-avfoundation"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreaudio" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/26/7616f0bc8e4eaaba948cf5d220c8f55e0f54f617a2812392a82f19c30f39/pyobjc_framework_avfoundation-12.2.1.tar.gz", hash = "sha256:2735e4f1c345d2b533541577e292f3ad2f75d19200eff99f1a2db16d78b4f1a3", size = 410329, upload-time = "2026-06-19T16:19:52.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/88/38ccef918dea4188e0001e644f3bc16e26d11959b04838e5e243798f703a/pyobjc_framework_avfoundation-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d3ce4b2bb2ae51ad5c27f1d2f2a623bef8b443bccc34423b5149df010f9f501c", size = 85536, upload-time = "2026-06-19T16:06:21.308Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bb/e427b2fd705e9dabbfa0ab89b863305788906e34064db2bb930f1c3ba216/pyobjc_framework_avfoundation-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f372800274df35f8d964cad0ad6da7636f1b6720e802e28e5a6bc1f16f16f135", size = 85578, upload-time = "2026-06-19T16:06:22.292Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f5/b38da31d9f95770d0f0f9b9724a898d240d6fb630796e04e9682384d086c/pyobjc_framework_avfoundation-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9291848b0f0f66031bd3af2549e1e0cdf43e4872b9c562bd29f0239c6ef2b75f", size = 85628, upload-time = "2026-06-19T16:06:23.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a4/f1bc5fc239015d8fb4414a83592d69b85b8bbdc68f2403c21dbcdcb8ce12/pyobjc_framework_avfoundation-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3e92a8502d389469b1307a6a2c386f20d2e77878c7e35e3e14120596b47eb205", size = 86077, upload-time = "2026-06-19T16:06:24.449Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-avkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/b2/8be6b94ad46e50f7f868b487b98ade01914809cf440d5ec892a16600d5c4/pyobjc_framework_avkit-12.2.1.tar.gz", hash = "sha256:9180734ba1ef34000ee0463727dbb73624cc4610a298447c8200aa8a7515e0b6", size = 33618, upload-time = "2026-06-19T16:19:53.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/d0/595fdb5f088b01f214822b3a36fb2fb91e420a46b5cff52c859ff6817506/pyobjc_framework_avkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5114a50272cc0afb7df802329b498fd4e8340adf5fc0614a251264b09ce3bb14", size = 12344, upload-time = "2026-06-19T16:06:30.76Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/62/ef72553ed6ff62578f9618551f84d76be247082f9c0baabf8b8672f65f29/pyobjc_framework_avkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f8514a6ca882e55738bf5c2c8fd498b4920b3344481ca6747b32526fe99ac7c4", size = 12375, upload-time = "2026-06-19T16:06:31.682Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/18/9812526e8246048e8873ca243868ed1766e4e25335e33deff79c2802ae3b/pyobjc_framework_avkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7743cd8455031f2580188d6428411516bd927fef619b3764c1450379f030ea75", size = 12387, upload-time = "2026-06-19T16:06:32.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ae/da5f02922f7ea01e4e36cb62029c8ea4110520bb4a0edd3f5b3cf761cb29/pyobjc_framework_avkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9dce2ef4ecb2dd97fecdb25eccf2c1506b5406699e5cf50c3124dc231e6729c0", size = 12575, upload-time = "2026-06-19T16:06:33.328Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-avrouting"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/74/75a7a33349407c3801fd014cfdfa6ceb3e8e83a020277d5e99eedb3a3728/pyobjc_framework_avrouting-12.2.1.tar.gz", hash = "sha256:8fd237f7a5c8d905f194fcdfeb6771e69c7106fc544c24e9725d952505f0fdc7", size = 20905, upload-time = "2026-06-19T16:19:54.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/63/6a6b596706bbe9335e8fc1b6d41f89afd94b09d876d69a9c77b6aabd2085/pyobjc_framework_avrouting-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccdd40b590221f2db3969bfc84782cb720163647b2e8aa4c6c623c59a4e07740", size = 8476, upload-time = "2026-06-19T16:06:39.353Z" },
+    { url = "https://files.pythonhosted.org/packages/df/73/b54c6d24904c3a2eef50a12f3ec0d77d7e2d74567164e088a26b3aac629a/pyobjc_framework_avrouting-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e31a7399fc04d8cdc63f2cd26809dc670acfd6bed4674288df4622c18123a43", size = 8493, upload-time = "2026-06-19T16:06:40.129Z" },
+    { url = "https://files.pythonhosted.org/packages/07/fd/69f18627456e0e9e5bb2838bd1c015c662fa351adb6162d03337a52eec81/pyobjc_framework_avrouting-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2678d7f058cde4156c6c78cc87d71636c432071d0eee10c0d4263a21e6ef23f3", size = 8509, upload-time = "2026-06-19T16:06:41.098Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/8d8122f40b14c69cdc6a86d5211998ecda10cd86bb3fa9c9f27c00c6c3f3/pyobjc_framework_avrouting-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:00401319b0fc450af6ea673af2733543b5e4a4e85b53a8ba15e42106f77a645f", size = 8673, upload-time = "2026-06-19T16:06:41.925Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-backgroundassets"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/92/2b680e44df5d3a81a2431acfbf6eb2e6fba93f1c382651a77040060d4a83/pyobjc_framework_backgroundassets-12.2.1.tar.gz", hash = "sha256:771fc7a45a10a4b4afb5465b1528958078f456629b63c36a7a43505f93acbaea", size = 29376, upload-time = "2026-06-19T16:19:55.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/02/9200ca88a64e1f0c74330c45610761914d5814aec48bf457d1fe6f9fbb78/pyobjc_framework_backgroundassets-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:071058cbf4a83f11d5abf39d04fb2e449938eb2c2180d4c9f4dd0568577c6c2d", size = 10928, upload-time = "2026-06-19T16:06:47.161Z" },
+    { url = "https://files.pythonhosted.org/packages/19/32/9a08bc3f2aa8eeb5d5be2801a5766a755856b079b3e7afbc1fe31d679dba/pyobjc_framework_backgroundassets-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:dac0d3a65a95ea886598f381080c4efffc3acfabcca3e692550fbe615627db7e", size = 10942, upload-time = "2026-06-19T16:06:47.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/89/4e42e961fd771db5c4ba3243ea499926b8242c681671818dcb613f41add7/pyobjc_framework_backgroundassets-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:bd07fcd0324ba4c6ba00c0eb3af6832f102e51895afd1933fe9c0c2efe9b9734", size = 10965, upload-time = "2026-06-19T16:06:48.669Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d8/c05a4e2433c1eb61773fb4f4ff46ef6dec4926af4aa98c8a6776bf3cb95f/pyobjc_framework_backgroundassets-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2730c6e01c16d9c42cc46b0c23d37b3ce9de70cd0a93a2f712f44a84bd786bb0", size = 11218, upload-time = "2026-06-19T16:06:49.531Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-browserenginekit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreaudio" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/45/955a13e96d79e369754a99ad185b59edb721e95196a893f215f299bcb9bc/pyobjc_framework_browserenginekit-12.2.1.tar.gz", hash = "sha256:6e07b9582fb7e9b9a9ea40280d5815e4130cd0f9194fdc6bdd3a3bc07d6d2f85", size = 32607, upload-time = "2026-06-19T16:19:55.949Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/ac/25182295ad94f504b1ab99f291e377d0e54ffeda7f95073a257403cdca43/pyobjc_framework_browserenginekit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ca3005e7b6bbeb790c9604eae3ff1f3f1bb6aa9e524a9b36606904147f0c2596", size = 11740, upload-time = "2026-06-19T16:06:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ff/f2ecf8207db7a91a7ae778d041cce343e847ee63fc5975fbe1d53d9b62a7/pyobjc_framework_browserenginekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a57b1e941107346d8b948201501654541ed40a361dac81c20c154d428b8a0c37", size = 11760, upload-time = "2026-06-19T16:06:55.761Z" },
+    { url = "https://files.pythonhosted.org/packages/18/98/ad604a0a16bce24d8297d4a651d6ad207137df507f59ff69271fad084bfa/pyobjc_framework_browserenginekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:eb7148c7f32c98d40046eb3338f7ceb1ab055edb122065a7b37cbc84865aa41a", size = 11782, upload-time = "2026-06-19T16:06:56.666Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c8/baae0dc88d8f52cfbdc5623e9ae718fc44c9d72b1c9edbd85a525fc47c6f/pyobjc_framework_browserenginekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:52b212f57572e5d3b31b2dafcbe6e1e47c4af025cb396aba90ac74101ae0e717", size = 11949, upload-time = "2026-06-19T16:06:57.487Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-businesschat"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/26/c92176248363ef510e991c7b537de7aaa4c66b232de1d6c7c527270d9911/pyobjc_framework_businesschat-12.2.1.tar.gz", hash = "sha256:2847c422d202fb8e1eb892c7151b2251b2880a5e6618b7affbdec2b5521a6072", size = 12409, upload-time = "2026-06-19T16:19:56.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/58/cbe465cb6fcd155af2de412982e59ee9cc354be1b477cb0441e089613f57/pyobjc_framework_businesschat-12.2.1-py2.py3-none-any.whl", hash = "sha256:61ef7e7fb1846a1731c7e7268e032ed6fd2e6df3de195c6c35d4df4c81e18801", size = 3501, upload-time = "2026-06-19T16:07:01.885Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-calendarstore"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/f7/65fe8ddcfd0e88442139b9dd737184aeb6f83d6748315061190ecd0987ad/pyobjc_framework_calendarstore-12.2.1.tar.gz", hash = "sha256:5659f2d59dd49423d3880295cd4b395a61c0b7aea8db654e63dab6dd32d28dee", size = 54448, upload-time = "2026-06-19T16:19:57.485Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/30/f11d28e0d4bea633a5a99e185b5574a8a04a0944372d05bd0a28167f2156/pyobjc_framework_calendarstore-12.2.1-py2.py3-none-any.whl", hash = "sha256:d144a2e2b2566b2954f0e365bf7592ccd17cb459165805ed73c6ed8d0feb2ede", size = 5312, upload-time = "2026-06-19T16:07:03.099Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-callkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/0b/0cef47cd370e195c113125205e83443e23a1da838df7419ad9131539b266/pyobjc_framework_callkit-12.2.1.tar.gz", hash = "sha256:66dfbb864c6aa253ff90ac91cdc23dc7158dee8eb76b1764126f2eae59e771a8", size = 32653, upload-time = "2026-06-19T16:19:58.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/c3/29d18f69cf2478b241844e303cf176e906eb1085795a2fe57e37b8679888/pyobjc_framework_callkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c3ebce966fc18c2d1a0aa36899f4c33c10b190e8b310d03649a65f61e437b91e", size = 11330, upload-time = "2026-06-19T16:07:05.031Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/6a/27a76b1153822a64624dffb9cf93e0f815e3e8d618e4c6e49101cb602645/pyobjc_framework_callkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e259627de99e751d2f05f39d135281a58f75a18d3c5ba9dda27c6bf88bc673a4", size = 11387, upload-time = "2026-06-19T16:07:05.784Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a5/c05d4ac28acdbd24c0eb80b73f6a2968943892a624a90289f7d46c07205d/pyobjc_framework_callkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:afeea8cf2d302994481ebc4e7889168138b2ba82892496866135ad666023e1ed", size = 11402, upload-time = "2026-06-19T16:07:06.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/20/2fe9ef2735187d4f587a7ae698de5eb34fdaa5cbdc1abb771b3c62d9e3b5/pyobjc_framework_callkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9cc081df5897d0253c4924ff6da6f7c5c03ab6bca07302c99eea6e26738050a4", size = 11616, upload-time = "2026-06-19T16:07:07.628Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-carbon"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/1f/c5df0b0f276542be355e56541af59ae77e98b22e5265d483601a2324c4e0/pyobjc_framework_carbon-12.2.1.tar.gz", hash = "sha256:a14ca4a45e697c2d187753bc851f3bb49d5bcf66d4ef1d2363fd9962417d8638", size = 39755, upload-time = "2026-06-19T16:19:59.099Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/6ec19751ee486409164e94ca6bba29050c491467540cefed1398ac520c09/pyobjc_framework_carbon-12.2.1-py2.py3-none-any.whl", hash = "sha256:603cf2bced196dd90d6400bcbca32ab573166fc4058193bfbd7c1bd95cdefd4c", size = 4646, upload-time = "2026-06-19T16:07:11.76Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cfnetwork"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/96/189e013d494489e6468d9b0b81c4b0e2f338574e1a777b7a43a6b37573e6/pyobjc_framework_cfnetwork-12.2.1.tar.gz", hash = "sha256:cadc9f65a97c20cf839259229c34ecdb5b54a3ade816c43374a1eb25d3900925", size = 47652, upload-time = "2026-06-19T16:20:00.352Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/6d/7eba39749600eb43df55445be2947826255469aa07402829c3fb23c6c9c6/pyobjc_framework_cfnetwork-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045913bd2535281a16be306fe87e0cd419a98273f44abb7e7058d67d71083324", size = 19975, upload-time = "2026-06-19T16:07:14.066Z" },
+    { url = "https://files.pythonhosted.org/packages/77/15/227b45b0780c1a0bab0b1e7343a59871d393150661e7e28b9e980c959a71/pyobjc_framework_cfnetwork-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f9be16c691c6f1f58e91551c9e67069abcbf3d5e9a789b1b95b1f84620f0308f", size = 20155, upload-time = "2026-06-19T16:07:15.201Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/17/1565bbd61caedeba02f86871a9db0dc3e103e5c0cb2e4264089741e4dc79/pyobjc_framework_cfnetwork-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e8efd441705148fc715c18e57c30c68da001465d2c443decbc56bd4417a8725a", size = 20173, upload-time = "2026-06-19T16:07:16.147Z" },
+    { url = "https://files.pythonhosted.org/packages/64/92/1d1fe63cad93c423f85ae41471bc1992902a7c3a90b106b1907fd460061b/pyobjc_framework_cfnetwork-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d040fd88f3b8e60f7c35096b0901cb6f05c0c5a7f0c90af783fab5547bed3061", size = 20473, upload-time = "2026-06-19T16:07:17.265Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cinematic"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/a942906b8753161e58b89e6d986dc24a435a8cbe6ab6ea80162d31b37895/pyobjc_framework_cinematic-12.2.1.tar.gz", hash = "sha256:cd251ded9393ff4a993a3689d4d3ce7ba3926e7f884f9cd333cf9610338ac28b", size = 24948, upload-time = "2026-06-19T16:20:01.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/e4/9a0d9725de7a31c08eb470b6ccd9c5f3628b972a6309b3214406ed9f74cd/pyobjc_framework_cinematic-12.2.1-py2.py3-none-any.whl", hash = "sha256:73720492fc29eee04cbbeae701dd21c5ddd56dc4e19e59b2af520b8f53a129a3", size = 5123, upload-time = "2026-06-19T16:07:23.663Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-classkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/33/d2933e1dcf122be5b785220713c80cf07a24d2e21bd429b39d723059f653/pyobjc_framework_classkit-12.2.1.tar.gz", hash = "sha256:2f14c6056486b274e487deabf2ce94ccf17db5df6cd332617592ff2d306d7b5c", size = 28972, upload-time = "2026-06-19T16:20:02.296Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/f9/1ad14ee12321a13eed23edd20e75af14ef62a3676459dc9dc8f8e3586ba2/pyobjc_framework_classkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:63b2669246b0545c0c8357cc73294fac902bfc8a69617b3012395dac974c0ec1", size = 8934, upload-time = "2026-06-19T16:07:25.787Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/62/2acd49bb925b8785a2051825bae02d7db2e92d7fa1573585ccdeb131e76c/pyobjc_framework_classkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f39c78209ad615bb1ef54a3b78b56438aa734bb01143d954ab29d9cee59ec34d", size = 8950, upload-time = "2026-06-19T16:07:26.848Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/2a/b7ff453762489443997a3d39d5b6e6865c736ed57db7be67cfab982106fc/pyobjc_framework_classkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b96d7b6416e954be53ac4fc1908bad22c6609d116dd50ef1f25f057bf8274625", size = 8964, upload-time = "2026-06-19T16:07:27.966Z" },
+    { url = "https://files.pythonhosted.org/packages/76/1f/83661aec2aa68f7c571370230a0dcca12f2c1b6bf615ab96ffbde12c2ea6/pyobjc_framework_classkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d689fb7bcf0120963b0d4518399c2440a4bf95378e9841289835846008bebac2", size = 9111, upload-time = "2026-06-19T16:07:28.953Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cloudkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-accounts" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coredata" },
+    { name = "pyobjc-framework-corelocation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/3a/ff99bc394e051086f7d63ade09460de85e2540cf823fb1cd759225f2c744/pyobjc_framework_cloudkit-12.2.1.tar.gz", hash = "sha256:7d3810347fe8de6171d8a4377916750b4ba3bfa874b5f8e5bd0ca6e62d2c4f43", size = 71962, upload-time = "2026-06-19T16:20:03.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/3e/093157f31d29e06bad916d12f6903bcae9c7708ff89fef5bb612cf305f44/pyobjc_framework_cloudkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:4badd0d3b9d78fab900415a2b0319579c5be3a30fa99e631a9065f3768076e35", size = 11437, upload-time = "2026-06-19T16:07:34.479Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/d6/dc66ea8519a0475efbccf73f82cc28066339bb300a27f5e1bf91ab1d7002/pyobjc_framework_cocoa-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dc6da84f4fc62cc25463bbb85e77a57b8d5ac6caf9a60702daf2edb601332f15", size = 387298, upload-time = "2026-06-19T16:07:37.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/cf/1b3b32b2f28f66cc053c3438ef4e6df36a1591945bf05e7399da18d74553/pyobjc_framework_cocoa-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:28b9b8bab1c36efb94744786918752d0c1842f5fbb67e7d5ca97b5f736512080", size = 388113, upload-time = "2026-06-19T16:07:38.9Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/46/68e8e4d926a2f70fed0437047bc3f9fe08af8fe620d94d80656ebc3cfa9b/pyobjc_framework_cocoa-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3b74a78fa7803e547b32e5e8ec1b49987b52fe318383e793bc6cd49b80efbd9f", size = 388183, upload-time = "2026-06-19T16:07:40.483Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/f3/dfc9af4c9eb2e5389c860ad5ef252be9fe456db09f39d537555dc5057aa1/pyobjc_framework_cocoa-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dc2eaca2f13c7bcd8e41e51a372e47825dea9dd3126108760eed7ba883d2945c", size = 392275, upload-time = "2026-06-19T16:07:42.078Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-collaboration"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/b0/9cd5d547543a87ab199a5dc6e4c489b01b825994b52b0d17d89abd7219c6/pyobjc_framework_collaboration-12.2.1.tar.gz", hash = "sha256:d293b191823cf8c5cc17e74279e640312961a9226da97e6258580d1b6085e1e4", size = 15065, upload-time = "2026-06-19T16:20:06.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/bd/7803dd4c6c472a610cd83f7ad7136b61b8bb3dab803a35a6ca4ed0561688/pyobjc_framework_collaboration-12.2.1-py2.py3-none-any.whl", hash = "sha256:03404e679dc77314ea94029c8e54dae25424194b5f39751fb6fa0eca4af99fdf", size = 4880, upload-time = "2026-06-19T16:07:48.59Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-colorsync"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/dd/8f292cc041fb2a836a3ee7432c3f64347a15b5b4d64278277e4954ba28e1/pyobjc_framework_colorsync-12.2.1.tar.gz", hash = "sha256:1e682586a319f49d3ee3c93e54a527a1ff93de06f653e77c0c4ff4d9671469f9", size = 26902, upload-time = "2026-06-19T16:20:07.213Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/99/9c1d4d010cf51b17aba298664ff2dac7818a3d568202d36b0587fd07fd5a/pyobjc_framework_colorsync-12.2.1-py2.py3-none-any.whl", hash = "sha256:0bafd1bfdf77687910e4a6f01c640ec47def060fb88e3abaddf4cd7e7d469e87", size = 6028, upload-time = "2026-06-19T16:07:49.817Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-compositorservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f3/2136460770ff0b32e64282eed79c37a07c1dfa9df761f2679462391d4ada/pyobjc_framework_compositorservices-12.2.1.tar.gz", hash = "sha256:683b765077ce3bf9b680bfce23124ace85208738ff3c14768e1ca80fd78c1565", size = 24941, upload-time = "2026-06-19T16:20:08.032Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/0a/2e3177c354db49ffe137410431baed816fca9101bee9da808a5e5cbab9e9/pyobjc_framework_compositorservices-12.2.1-py2.py3-none-any.whl", hash = "sha256:1c1cc5ca97e060afe2125b338651d5143f8f6b40e17748116dedc334449773d0", size = 5995, upload-time = "2026-06-19T16:07:50.803Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-contacts"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/e2/a9c33480e4f6de3f20e2d2668ea05520061b8eae31e8461b09940c01f2dc/pyobjc_framework_contacts-12.2.1.tar.gz", hash = "sha256:b009f1e85d672e659c30cefbba02a1825b4ca2b604e65826445fb8620159725e", size = 48701, upload-time = "2026-06-19T16:20:08.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/b9/6793fe551d7c2ddf202b6a787debf6d3da251ef8f13f4fd49e83ba92d512/pyobjc_framework_contacts-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:01fea11ba777721add31ccff3497334eb0fde7ba1c69cf2c845a85e1515d5c18", size = 12089, upload-time = "2026-06-19T16:07:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c1/c4435f4dfb8ef0038a9556d2472cd259322f73627c21f94f3e233bd73587/pyobjc_framework_contacts-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9e31c635d1a8ed48d0e3332120d0eafa6a5d40b30fe4832aaa700fa03fe14c8d", size = 12172, upload-time = "2026-06-19T16:07:53.999Z" },
+    { url = "https://files.pythonhosted.org/packages/50/0a/9a518f0ebecd5e27493230de7f5dc746b7abdf0ae3f192a14abc7c23cd15/pyobjc_framework_contacts-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:93facd1772971b6d88243fa28781498ab5f479c0fe286f8c03870f93c515b517", size = 12186, upload-time = "2026-06-19T16:07:54.774Z" },
+    { url = "https://files.pythonhosted.org/packages/73/74/57cbdbe46884d890e8321a9ea3cb85a163def2e0100bc38e14b41cdcde35/pyobjc_framework_contacts-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d0f73ff7f92986b5920155e9cb16bc74cf049e166e6bc2a7df1621135b4e6d79", size = 12351, upload-time = "2026-06-19T16:07:55.543Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-contactsui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-contacts" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/22/a01e677c4e44c3e03850c7765b4cc20e3b8fbad53ee92300eddd77dc8627/pyobjc_framework_contactsui-12.2.1.tar.gz", hash = "sha256:6ddfaf3d3f159bc4bb8ccd65414e94b4b6539a5588e84efb01838b19e3b1ba0b", size = 19329, upload-time = "2026-06-19T16:20:09.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/53/deaff064fd9e4ec7996e9e218ebc9ed60f9ba00e18b30e85b5cbcc1eeb65/pyobjc_framework_contactsui-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:92fcf91334dbad85da45d66b12e8ff9105e3ba6a204b07342463318f31758fb9", size = 7890, upload-time = "2026-06-19T16:08:01.353Z" },
+    { url = "https://files.pythonhosted.org/packages/73/1a/bbcf4c5a21ff5aeb93cec6f629fd9e4fc7806fa03d11711346449b0147ea/pyobjc_framework_contactsui-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1a447f3143759dc545a0a8caf23b3f6b5d4a27d50451046093a01f478a81bd8b", size = 7913, upload-time = "2026-06-19T16:08:02.133Z" },
+    { url = "https://files.pythonhosted.org/packages/05/16/617d8075fe65d3b27b5140da604531bb343f55eaa676ab88208d9c4e2ffa/pyobjc_framework_contactsui-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1cbdefbc77830205ca9e63360cad08562d7b97789a792e98ab2108c018f10768", size = 7926, upload-time = "2026-06-19T16:08:02.929Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2d/15210bf2f5b5b57b436231c7789239cdbfeca4ad82a0b2f41d1a55256a81/pyobjc_framework_contactsui-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:78452b5171a32d206a13d46ab7fdae60d87dd49802f531ced8646e6c71c25c57", size = 8073, upload-time = "2026-06-19T16:08:03.778Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreaudio"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/df/f1d402bb7b437374f942bb19410a955a74291867c77a920d9c13887d9e48/pyobjc_framework_coreaudio-12.2.1.tar.gz", hash = "sha256:7dfbf1851523aed453af43a628e057d8950d6e020574aa497a2e4f559b6383c8", size = 78690, upload-time = "2026-06-19T16:20:10.586Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/1f/853c498e18db8b6d9eb0cb2261bf8cda3948f2c925d1c820baaf96fdb54d/pyobjc_framework_coreaudio-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:214ce41d1ac3743377f607326d3ff70494dd6f75b2c575fe9c99d3890c545dee", size = 35149, upload-time = "2026-06-19T16:08:10.278Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c1/1fc7a344ac15646fdf78c91af81028113c87375036e505082cf1f90bd657/pyobjc_framework_coreaudio-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:41a0d8c3b3957f35f17370071aeef94e176d07c9e2130d0aeeb4b260117acd52", size = 35415, upload-time = "2026-06-19T16:08:11.329Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e4/71b2e3bd03f0404c89b432273d272dc5427185fd9ed828036730bfc9d057/pyobjc_framework_coreaudio-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6fb46bc090edcaefeb70be2c179071e7a758e3375aebd3338b11773e371c3dce", size = 35445, upload-time = "2026-06-19T16:08:12.455Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5b/07dc0bf9f79d3b76effba3f0a754be6fda0947848939236820c8e70ac896/pyobjc_framework_coreaudio-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d05e5fd58c1e5f48e7767b1f6182cf36ee9bff38568544d51f468b25ad90e334", size = 38205, upload-time = "2026-06-19T16:08:13.381Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreaudiokit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreaudio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/82/622a58a3aff47cfdad8cc3bf1c6a3a0c4d73d1cc3c71d050ac1bc0a62c6a/pyobjc_framework_coreaudiokit-12.2.1.tar.gz", hash = "sha256:61a5b796f8296ca5cb4779ec19391ad3a37f35c0c689a401d6e8d41cbe936f08", size = 20941, upload-time = "2026-06-19T16:20:11.407Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/41/0121efdb19535aacd8fcb1c03bc7cc6f2e1865fabd77316d33e6422f09ad/pyobjc_framework_coreaudiokit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c36db7e1c6606cd8dc3d50a503f596774d554476729dd5870d05c52aa2de4da1", size = 7273, upload-time = "2026-06-19T16:08:19.111Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/8f/78a68b53ee2227dd22939f8d435b5dc6252228fbcf5bbf497fe0d6a6b3a6/pyobjc_framework_coreaudiokit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fbc5f8f3b46645b1051658be8b172c85ed700a649ba3c4bcf68a5b8d3c09ecee", size = 7300, upload-time = "2026-06-19T16:08:19.882Z" },
+    { url = "https://files.pythonhosted.org/packages/44/46/5018ea6e71c3f29ef63241a28b20f67cec9236776d17a23e2d628171a0f6/pyobjc_framework_coreaudiokit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f6f4a3b5fac21170cce2f7585117c3fcce873ead84b4fe7e294dc823bff242dc", size = 7311, upload-time = "2026-06-19T16:08:20.701Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/fa/6ea54d77c2b557c568274ccf75306fff426b7e099a0cd0b7e2c9c28c6e78/pyobjc_framework_coreaudiokit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dbc7d4ef4d7af452ba45c14e5324c11865e170b3b15f35d9431c97431b208f58", size = 7467, upload-time = "2026-06-19T16:08:21.767Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corebluetooth"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/91/c76f3c5e8e80c7047e43c4c05b3e6fda9a7cefad5aae85487007674c966c/pyobjc_framework_corebluetooth-12.2.1.tar.gz", hash = "sha256:7dbb285295097205bebbcb11f55161e5faa02111108fb7b17536176e31971eb0", size = 37568, upload-time = "2026-06-19T16:20:12.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/ad/de57d9060e4c5e9ca1a9bdd5b6bd1bdb73b198c0c53953cac445d9b3a84b/pyobjc_framework_corebluetooth-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f11df7052fa2d0524a9dadbc9c578fd3b8f3a350431edfa4ffa9e0a74b6faa32", size = 13195, upload-time = "2026-06-19T16:08:26.961Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c4/7938016860850e28c001dc9b7c653352c43f7aebfffc6d3c5fd087281f22/pyobjc_framework_corebluetooth-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2f8d2ed65c0e98ba044b6a7fc2f9a290a5c579a28d33a57c642f8617ccbcca0f", size = 13217, upload-time = "2026-06-19T16:08:27.802Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/79/890a53ed45c1006eedcf60627b7d661c8696e5367723ceb25cc6a0216b30/pyobjc_framework_corebluetooth-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:30a26eef36c250fc14e73335641e24f764b32b7e42bae945a5d8a1c2347040b5", size = 13235, upload-time = "2026-06-19T16:08:28.727Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7a/40ffc3be8e31b1eb1f8f5eb2a58ef832287fb1ea6b3c452dc8b25b9e064b/pyobjc_framework_corebluetooth-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:756933b9ce6160a986c8877ab667659fa2d8e15aff28d0981b5284fbdd1ea735", size = 13416, upload-time = "2026-06-19T16:08:29.643Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coredata"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/cc/62113edb09c6f72922d800ad7dbd2b812e69f5933a245c59f2d33b214a47/pyobjc_framework_coredata-12.2.1.tar.gz", hash = "sha256:f357447b7955cfe5391dac4fe003b79ded307f4f00712dcfaec3d3ecfca30824", size = 143307, upload-time = "2026-06-19T16:20:13.096Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/b9/ab7be45781781fc68faf523b7cfcdaf05c2b307fbc49140905eb31f3ecf2/pyobjc_framework_coredata-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:382594752f87fba5b6804619507d54ab4b6d2b54b520bfa291b06003e36c4646", size = 16542, upload-time = "2026-06-19T16:08:35.388Z" },
+    { url = "https://files.pythonhosted.org/packages/32/17/87ef5c0edb220df910a4936ad23272f763065ee4817ad01107b19a8c78ff/pyobjc_framework_coredata-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:53093b9a500e82794b142bfe3c844414e46ccc2b2f9e1f5a998243646be59725", size = 16552, upload-time = "2026-06-19T16:08:36.178Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/90/6c0887e8cefd12b76e9c6104dd07a5251ff2d5fe47a27427b07754326d1e/pyobjc_framework_coredata-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a8353dbe4cb0cc6d5313d23e47ed6c00bfc5161c84777d1d3e21048522822feb", size = 16562, upload-time = "2026-06-19T16:08:37.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/70/60fa04f65640e76e2b49a2a2e297b54c0d980a2bd631c3e9b5c2d247e262/pyobjc_framework_coredata-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7be973a5f2f5646a64d4c25175ec7ca2584f3ccd2c8bea4c2abc702ca61884c5", size = 16722, upload-time = "2026-06-19T16:08:38.044Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corehaptics"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/1b/76c27ae0f86126802c7f82f21c67868467795810750d9d192006471aa965/pyobjc_framework_corehaptics-12.2.1.tar.gz", hash = "sha256:73ce1afcb0174add11fd6f05cc67d8a371802ce8e94ba9d4f65c7cee0f392b0f", size = 24886, upload-time = "2026-06-19T16:20:14.011Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/0c/23e82eded054389a686377ebce9b6f82d4fed4c445b004bb8385c3188bb1/pyobjc_framework_corehaptics-12.2.1-py2.py3-none-any.whl", hash = "sha256:d19505e9e38136f50fc551ad0e1849afd1656dce068c82018ad669d01128f8c9", size = 5434, upload-time = "2026-06-19T16:08:43.061Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corelocation"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/93/41d2ae5cf15a27ee1b51e167b538e50aa752597002878556ed49b3615573/pyobjc_framework_corelocation-12.2.1.tar.gz", hash = "sha256:10b3c206049b70cbab0f98b37bcd91ad97de5ab57041b18a60ab702629009a31", size = 60318, upload-time = "2026-06-19T16:20:14.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/75/7a72b5c8cd470eeadc40b9bf05cbabb5049372de0a44ced4a04489d5a165/pyobjc_framework_corelocation-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cc3f7d0a9dd54b99faf7020205b16576466aff70c7babe2a905b8818a0c1d80d", size = 12836, upload-time = "2026-06-19T16:08:44.911Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fc/4f6a89027995948270699c47a86583bfe586ac0c480cf8427fb708bf3a9c/pyobjc_framework_corelocation-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:683b6eb23db94ae6ca48e58089c4a9641fd90b1137e54c147ad56ed6db4bb570", size = 12857, upload-time = "2026-06-19T16:08:45.738Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/00/156e1d533f3167e638a8e649f02a422cd1f95270932fede56e6bcf46c878/pyobjc_framework_corelocation-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9f336ab0f9289d1909bf86cdd798ac4308166f6e90eecf07452d21182b9a7cba", size = 12874, upload-time = "2026-06-19T16:08:46.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/7519b4f9d4feeebfb770ed563b756c5dd370d9f4fa302425f05829a7d2d6/pyobjc_framework_corelocation-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ca3b36828b4324c058ccc289b33cbdb7986bf879719d99a735c3abcd1ceb6ad1", size = 13004, upload-time = "2026-06-19T16:08:47.482Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremedia"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/79/f501d730a9c320e0b2b3916e95f57e66dd6736d210a1aa5b63eb6c43e605/pyobjc_framework_coremedia-12.2.1.tar.gz", hash = "sha256:71b45f7cd52bd997d836c15a0e1016db90815a219dc87fd20435a6f08b87df7b", size = 98252, upload-time = "2026-06-19T16:20:15.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/34/8b97b76f0643e01c98d5c246b1ed74884f4b3c43dfff2a36886212e20dfa/pyobjc_framework_coremedia-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:38e03a92a7fdf43162faadf354a8497ae764e3b3be26a8ffb107ed5d743cac76", size = 29513, upload-time = "2026-06-19T16:08:52.69Z" },
+    { url = "https://files.pythonhosted.org/packages/af/17/6bf365530573a6b7719b5a47efe6c38ac8c42f6b556babe419f5de48a84c/pyobjc_framework_coremedia-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fd0e25bc704dd91882bc29d682880c42f712b39bdfe3d3168780d24a9d9eaf26", size = 29419, upload-time = "2026-06-19T16:08:53.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2a/9e5beae2961c9d22ce16258f39edae69996ee0167dd4cfe4e771454086c1/pyobjc_framework_coremedia-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:45878f686ce8ea1735ce382b34ef3a5852cafe0ae2a27a49c08701f4c3ab830b", size = 29431, upload-time = "2026-06-19T16:08:54.41Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/51/00b7f012e55475502296cc8ef276b94ad7d4d10d97ce2e88bf9d87f9b664/pyobjc_framework_coremedia-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9f2b30ef288c9f2fa1599a1cc5868f8cd949c7138a7f15244c7a6884afcef273", size = 29491, upload-time = "2026-06-19T16:08:55.297Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremediaio"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/8b/60e73d8049e9c123ff237694acea8752e9e8143864bfea4bab0bebb55db4/pyobjc_framework_coremediaio-12.2.1.tar.gz", hash = "sha256:edfd070544857b8e1d2ae55ed7c7eac9f513b4cd7c03ee79615c7d524e362d62", size = 56604, upload-time = "2026-06-19T16:20:16.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/9e/7bd5ca10c31a987b04c18a5b40dd7cb31fa7f13d221b4d209646d2b34c52/pyobjc_framework_coremediaio-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7525dff27f84f7cc007d2077787835cdf094ed925235e4f179bd6558a889b008", size = 17305, upload-time = "2026-06-19T16:09:00.583Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f2/95c8d8ef684b377d70b65ccea9cc8bb583eff79690d77a390fd52f190120/pyobjc_framework_coremediaio-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c60ecc49fa18a53c5bcf7f844554d5e24883d2b7d5537923dfe4e8512069a6a0", size = 17361, upload-time = "2026-06-19T16:09:01.421Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/85/ae2715fe1d788e166ef04d7080f09de5cf3a63fa83253bfde42027ccf089/pyobjc_framework_coremediaio-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:30cfc0e30b46d67668114d7d2bf0a66196928ad84db77d34a1615d3f1b661c46", size = 17324, upload-time = "2026-06-19T16:09:02.234Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/99/96f68d7d82978a568ffed99a8b42361343499af4e227a4f896351418462f/pyobjc_framework_coremediaio-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1dc37de0633e2daff4ae14640cec68e1b2c2d3b11f866f36961704abdfdabc38", size = 17646, upload-time = "2026-06-19T16:09:03.158Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremidi"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/77/c51599da17f742fdcaaa381a26daadc22c79739dcf7705f8faf29ca1692a/pyobjc_framework_coremidi-12.2.1.tar.gz", hash = "sha256:d9744001102f935646997136c3d7d0562088bafa1837e5ccc439b5c8ee9e032e", size = 63469, upload-time = "2026-06-19T16:20:17.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/5c/0fd7111ed45d665e9d82d8e03462c2c4e26115a16b1834c3045e1ebaba3e/pyobjc_framework_coremidi-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f8c42d469332e3e1811f69fb0dfbcc9ff5d98e3ee08348ccbcec90bd1bcd8288", size = 24491, upload-time = "2026-06-19T16:09:08.474Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/02/b6d415a946c0b48d555aa96b2e8b11f45965f1f21524d91a40821e60df14/pyobjc_framework_coremidi-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab57adc4104135ae0373781b055ceabd9ac45db48e171502fcce48317b5c8d51", size = 24581, upload-time = "2026-06-19T16:09:09.451Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f9/45acec2ddfaed67da0d1a9fedc954162b899ab4f8612593bbdfdc223345f/pyobjc_framework_coremidi-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b6596d9062221097164f8adb445530aca398f6abee0111178cefe37474ab8d2c", size = 24605, upload-time = "2026-06-19T16:09:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/05/557f0e27db08880e6f403b192dd5e99c6cc68717042b4f28208c6f80901e/pyobjc_framework_coremidi-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:25ad1c67e2e50b67d0569f832ae8531c2a9261a6740a1b88d311fda5211f6130", size = 24757, upload-time = "2026-06-19T16:09:11.436Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreml"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/1e/7d2db3e4468eb04cc92264be83113d86eea4f96302742437de695a445d6d/pyobjc_framework_coreml-12.2.1.tar.gz", hash = "sha256:ef3c2b6a160891b44173235603d10174929656b9c206d6f2f443fe2aa903c2cb", size = 49272, upload-time = "2026-06-19T16:20:18.459Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/93/1c5ca6b3cdb32d37b1df64d18d6e38b73ad7cf30b55ff51083093e5c8388/pyobjc_framework_coreml-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:711be8528b0cbbc49b5bd4669309f0ad0de6ed76499ffb706b0dd2f1b294293f", size = 11945, upload-time = "2026-06-19T16:09:17.464Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d9/d639ecf7f5730482c0be4a9a0e340a06d48fecad0976ca708cdfb4b79429/pyobjc_framework_coreml-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ca06f106c8d0e2e818212e6cfe9270bd333983ffd086be7b474fc9df34cbc5cc", size = 11973, upload-time = "2026-06-19T16:09:18.357Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a1/7f361206e202e84cf5695a8d1dc25810e8f58c4b9d043d10c0030a04dafe/pyobjc_framework_coreml-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4c9299321ced92439c203342183fdaa47aa8f125b6ef831c55bcc91a69e196e9", size = 11986, upload-time = "2026-06-19T16:09:19.211Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c4/763f7e8e8c63f4be106046dbca0cce3f33535c07dc5b079734951686dbd7/pyobjc_framework_coreml-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1ff65a16661abcc7c2dfe90e87b821d596bc17d1fed44c3a7ba36bd60b002a99", size = 12213, upload-time = "2026-06-19T16:09:19.991Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coremotion"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/d5/15d318ab0d12681ff5aa5c6799287480dff561e2b3a79d2befe1811b0453/pyobjc_framework_coremotion-12.2.1.tar.gz", hash = "sha256:21fd319d7313b9b03f062239f1c09e324969d5da0fe74842c92a2724381bf78e", size = 38049, upload-time = "2026-06-19T16:20:19.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/58afe54cdecca3715f3cb1cba9d340c9ff24d24b46b032bee9c21112fef8/pyobjc_framework_coremotion-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:71a33f6e33b47c132178bd7bcf8fdc0ff2e7dbc66bb0db01ec2bcc322910eb66", size = 10439, upload-time = "2026-06-19T16:09:25.249Z" },
+    { url = "https://files.pythonhosted.org/packages/58/28/a83a7ca091022d8b3df7ba1af2ad98b683f9db5c9e393e200c308a30f87e/pyobjc_framework_coremotion-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:05388142cc892b95e40fb626748a4af0816b285bf33f1fb3b8a856b964581433", size = 10456, upload-time = "2026-06-19T16:09:26.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/3f8e52e418be615aeb170541f873af739e756aab7d3610d707bfceb48698/pyobjc_framework_coremotion-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d18a90639934e0d4379cc6e632095cda1287c03054be73d79cb3eb680909445a", size = 10470, upload-time = "2026-06-19T16:09:26.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/0b/6c69a4eae1e6ef0de4afae1cbef99e45348b1dbc067648872da9a6903b44/pyobjc_framework_coremotion-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:848aa8c0d0af9beb909f28f7aa6555b62646ff34a73873f8820d330c3c3e5578", size = 10616, upload-time = "2026-06-19T16:09:27.622Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coreservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-fsevents" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/dd/d87ebbb99b1c277a519e1b7e0fb5efaf2e68833322d9c1eca5ecd79ed8b9/pyobjc_framework_coreservices-12.2.1.tar.gz", hash = "sha256:b4f052acd7346afa6f5441d32a19faaf080c3441cfaafad40c9b9a485b664554", size = 399935, upload-time = "2026-06-19T16:20:20.469Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/d8/0020ace0ab37bc81f865eaa6f5b2f7a27f5389a6179d6e231e647dd17f37/pyobjc_framework_coreservices-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ceec41060d4027c935069f109f85de5e5025cf9b78e5f141b9c29f797396a144", size = 30333, upload-time = "2026-06-19T16:09:33.075Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/46/21129f921528551b8aec853ebe9f21edad01bd7f4501743d0601b7ac7ccb/pyobjc_framework_coreservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:cf31f1d6e477414b7c5bd831df5864744a558eec5b055155fe6929ef1070d371", size = 30342, upload-time = "2026-06-19T16:09:33.961Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ad/aa9aea470acd79e69cac8dc561844236db307d6e93ad0e0140beed646f4d/pyobjc_framework_coreservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b911d08cf4e9fab5fd0992dc525bec02cc925102a42b2bdd4b77dd6a7b8ce70d", size = 30359, upload-time = "2026-06-19T16:09:34.884Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0b/67db0cd511e487a847e6ddf1a9e78baf5db210b848e48f782ad15e302b1f/pyobjc_framework_coreservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:aad43d280da1ba8f7a815de1935957f3f61b80eda15c5cac35cdf6a1b20f69ee", size = 30369, upload-time = "2026-06-19T16:09:35.701Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corespotlight"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/a5/89479d419712deef7e245a8284edfebc418297a17e3066a990ae88c3bf3d/pyobjc_framework_corespotlight-12.2.1.tar.gz", hash = "sha256:85d6080ff2f3a02593650eeb799d667be66383e8cd947abfec5e8ef8fd10d18b", size = 45685, upload-time = "2026-06-19T16:20:21.45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/2d/b9806f21d2bf98429bd7a4cb49f68352459d3333fe58fa30a24bf2a00f09/pyobjc_framework_corespotlight-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d5f9202b197d3863ac163a7b5eb3def8cea1bd58a7b7c930d53824300044be0e", size = 10004, upload-time = "2026-06-19T16:09:41.432Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/20/d6d9d96b4dba80f4030f6a94a322ef8dc384cf26e7a64f63b44d046f3b3e/pyobjc_framework_corespotlight-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:09b40a5982ca77c4b7119cb69765de4f7f565721bd3bfc724cfa9703abf15dc3", size = 10030, upload-time = "2026-06-19T16:09:42.158Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/0d/8390925cdd196a209ec2e11b0924060d6a0b12256084bf193107792e45ee/pyobjc_framework_corespotlight-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:76b6315e724f81d62af09673b78ae4e3370b58b8ed639a1a9d2dcb2621a044b2", size = 10043, upload-time = "2026-06-19T16:09:43.011Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2a/3b85888fefe9dd61c6c3ea264950b80ac17ff9a740cfffa4bf796e3174b1/pyobjc_framework_corespotlight-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3591127a7958299406f592027de570d5c8b6eb40a7a0667b912562a42007e67a", size = 10187, upload-time = "2026-06-19T16:09:43.829Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coretext"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/9c/4c7f452059dc1d3845b8e627b9113c247a997b9b07518e848c2ab7ff3149/pyobjc_framework_coretext-12.2.1.tar.gz", hash = "sha256:af740e784d7c592c34025ec7165f4f6c1a69b5a2d9075f06e41e4f77c212aed2", size = 97349, upload-time = "2026-06-19T16:20:22.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/53/c262cf5052c648c48b3f7562fcce188fb78ff94e44cf1c48fdfc62fdfcce/pyobjc_framework_coretext-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:02a448675d28005fdb88fb3c585572b02871e9e5d4d08f88334ec937ea5de6e7", size = 30022, upload-time = "2026-06-19T16:09:50.37Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/11/c1298c2ec3b0cd19a457a1fd0da47898f894a13df5516f80dc04d1a7a4d9/pyobjc_framework_coretext-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ac2ead13dfa4379a1566129d0e8a8ea778a2bcac9ac360a583360fd4f1ba39c6", size = 30123, upload-time = "2026-06-19T16:09:51.183Z" },
+    { url = "https://files.pythonhosted.org/packages/05/8c/154e8f34923b24aade64a20eca2b759f8f67e109654308103080751f246f/pyobjc_framework_coretext-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5c5a3c6e2d905a17efb15572dad97ce582feeab5c3b92537015445e0e0bb46de", size = 30116, upload-time = "2026-06-19T16:09:52.219Z" },
+    { url = "https://files.pythonhosted.org/packages/01/61/f53458c8f7fe74008e342946eca1fa82b777b284d4e13d8bd2e3e5724cab/pyobjc_framework_coretext-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:5c979058c77df8cd3dac5fd7db4c484f9886fbe09e2687bfaf269a856f631f78", size = 30659, upload-time = "2026-06-19T16:09:53.034Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-corewlan"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/4c/1ff3c5042ee2e8344b47978458af62a81ccc49894039fcfdf81d3ced4ee9/pyobjc_framework_corewlan-12.2.1.tar.gz", hash = "sha256:9a7ae402a55710392570a736a2bbe15f372325f941fb7074e682f75e4866c3fe", size = 35515, upload-time = "2026-06-19T16:20:23.401Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/66/7cc21bf2488373081ee8cfbeeaf7b371946bbbd8b6eb290d4e50d2f13e31/pyobjc_framework_corewlan-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2bd1d9aca137990eb8120725962091eb03e5604c8d3431915127826790356ec3", size = 9996, upload-time = "2026-06-19T16:09:58.296Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/7f8b6da97b41155cab6bbf3a6d611f9c0ad172fd790bc912cb76146a4557/pyobjc_framework_corewlan-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a7a980cd8eb5f879923afbe92bf088e585968b3cd3448b9f4a16d5158b59e6ec", size = 10014, upload-time = "2026-06-19T16:09:59.047Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/ad/1624d1d8d238cd7aa34b29154cd3d2ab7176c25aa84cbec9b85256de339e/pyobjc_framework_corewlan-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6c9597a5d8b9c7c9b01c28fc6fc6ccc4ec7ea2de83296d5f3f950fbd9c39b448", size = 10026, upload-time = "2026-06-19T16:09:59.849Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a9/f595af68e8975cef88088d963837eb37fb70aa8d1d42f3e42a62cf6c5e59/pyobjc_framework_corewlan-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8d91fd2396ddf71c8df01e36fc9b49a87a63de77220b39eb858f955cc2ebd593", size = 10174, upload-time = "2026-06-19T16:10:00.679Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cryptotokenkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/0f/697f89ccc2b4f6186b126d29d33def5d699ded72746c6c963aae2f8f4107/pyobjc_framework_cryptotokenkit-12.2.1.tar.gz", hash = "sha256:f5ad2a333ff4ba77d2ba901257836b13c1c93e62342dc092fe57dd67a97ceee7", size = 38273, upload-time = "2026-06-19T16:20:24.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/a0/4bb5e91f1ae45fa02883769bcdc54546729ec8931d2392a4db0e02273d20/pyobjc_framework_cryptotokenkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:60ab58babe44175a17aca22f49a2a4d18c24ec0987b1cbf68b5cd1a627e26830", size = 12689, upload-time = "2026-06-19T16:10:06.724Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/cbae3352cd1e68373e65b3cd110aadf3839d2b64c75e639f37b6b954b0c7/pyobjc_framework_cryptotokenkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bd2084fc176f32f5900a17da4d3b05c9563e43521c5df3c8563caef1ebb9f194", size = 12727, upload-time = "2026-06-19T16:10:07.62Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fe/211725952ed459efd0e29e40de11277e1102fd9280f6cf15270de939234f/pyobjc_framework_cryptotokenkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ad53981b7f6d0f8114579c7b93b46fd8ead341663df9ccd845f79633f66b4c79", size = 12740, upload-time = "2026-06-19T16:10:08.466Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/03/a30266392021c8f0f4b8ba64ee3839e051448397d413bcf8ec4e3ba314a2/pyobjc_framework_cryptotokenkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7177828df64d96737d523a5b2ec28d5d5b171dcc1045c486b1e460234519244f", size = 12926, upload-time = "2026-06-19T16:10:09.798Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-datadetection"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/f2/8c2ab85d3dc8022450af30d58b225bfd3e01693f50d383c80e7a905bcd81/pyobjc_framework_datadetection-12.2.1.tar.gz", hash = "sha256:b1059f9bcfab5a96606dfdde663f41dd8c23a33f8bc8c00371d68796476981cc", size = 12679, upload-time = "2026-06-19T16:20:25.331Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/fe/4eafd52ca2dedd34b564d7f4cc41da8ef8c071b3fb30e9e74faca1c77a3d/pyobjc_framework_datadetection-12.2.1-py2.py3-none-any.whl", hash = "sha256:c18b746a420e33d13689cbe64635249c492d3b58044089c5c8d6366b7bb46ed4", size = 3547, upload-time = "2026-06-19T16:10:14.839Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-devicecheck"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/c6/9784a80bf3bbd45b4982d9349280938bf70a0b7e15bccc8302ebf324c379/pyobjc_framework_devicecheck-12.2.1.tar.gz", hash = "sha256:f67a745b89cd2f3e307cabee018a509aff0561e3f747eb4dbfe84498f7f2ca90", size = 13321, upload-time = "2026-06-19T16:20:26.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/d5/79ee42be90a01fb0c6ae80b96bdc28160ca0fb415595438f503efe2502c0/pyobjc_framework_devicecheck-12.2.1-py2.py3-none-any.whl", hash = "sha256:085c91137b1583bcd62787a2788adc7a51b24d8c61fb7848fb607ce3bc49553f", size = 3708, upload-time = "2026-06-19T16:10:15.92Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-devicediscoveryextension"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/af/e5794d11e3e485c194f26563d04bcd4d729335ac221547e6d93109dd070c/pyobjc_framework_devicediscoveryextension-12.2.1.tar.gz", hash = "sha256:ccec236e790304c0bb880035b7f14738346c90d18cc4cb77b35169aa1035051e", size = 15767, upload-time = "2026-06-19T16:20:26.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/00/cf5ff4cb4a2c35b7e42e386dfaf7d7692410126c0643db29afa3b028c0a6/pyobjc_framework_devicediscoveryextension-12.2.1-py2.py3-none-any.whl", hash = "sha256:6e4dcee2810968bf1b076d3718ce037f65d770533534806866ad8391f9806bfb", size = 4346, upload-time = "2026-06-19T16:10:17.071Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-dictionaryservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-coreservices" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/2d/0c9cc7065a9d2d387be065ad3721b77876627541beee224bf86639c65f61/pyobjc_framework_dictionaryservices-12.2.1.tar.gz", hash = "sha256:631560760d58fe89af8332adee6dcaee35867cf13f4607f7b5c36e85fa4c1db9", size = 10712, upload-time = "2026-06-19T16:20:27.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/72/5a2edb46e216df811e73aa08c22f31aaa5209479a58941c1946bd0be92d7/pyobjc_framework_dictionaryservices-12.2.1-py2.py3-none-any.whl", hash = "sha256:2b9d3d09fc085d913f670e3069b6a88d35b76a03a5f37ce8636b47382dbb028d", size = 3956, upload-time = "2026-06-19T16:10:18.12Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-discrecording"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/ec/a7be70eb1c6700f446c68530e74bd71e9fde6ca2a5e76b237bae8fa980f1/pyobjc_framework_discrecording-12.2.1.tar.gz", hash = "sha256:2616daba51f50b8c6989d38d502ca98ed3ce53aee6b01c9457534267cbb1a4e2", size = 62013, upload-time = "2026-06-19T16:20:28.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/c0/83243a210288fb2a613b5a43602fe6baab6f94584d8ab66fe241325e469c/pyobjc_framework_discrecording-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b589f3aca1bc9dfb07ce9743b2a97ae4f0d0b6b5fc7f01fc5386db580b92e4cd", size = 14564, upload-time = "2026-06-19T16:10:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/23/68/4260e1493cd661f900cc4966a055f82cc9fbba7e311fae5c42190106d258/pyobjc_framework_discrecording-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ed929553896338cc0e5109c9b67c121dee2049e62735de94522795708d1b61e6", size = 14589, upload-time = "2026-06-19T16:10:21.373Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/76/207c9f94d956c40a19547456e8d301fbe21dbcc0df69944339960051623a/pyobjc_framework_discrecording-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8f6a590c94c53d6d0975b54218cf018f9660f145fe686992d377fbd7b9861706", size = 14591, upload-time = "2026-06-19T16:10:23.225Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ea/e5b722dd0daa4bb7c015d41e6c3e6f7013cd757bf27e18134f7954ae72ce/pyobjc_framework_discrecording-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dc5557015d2df515bfc75e96b287d1209b59afa2ce1a4566af32e9b8b49e2318", size = 14765, upload-time = "2026-06-19T16:10:24.106Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-discrecordingui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-discrecording" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/34/be343e4da6765228d1b6c6ac72a0c1c339ed8da931fa2701f28467c14aaa/pyobjc_framework_discrecordingui-12.2.1.tar.gz", hash = "sha256:1cf9e9e028c619f932ecf3ec0efc91227840bf6c6492c788cde91dc5c3744da6", size = 19538, upload-time = "2026-06-19T16:20:29.049Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/fa/5447695b7b646242b4f0e790b382c4432cc6e730152a19271896e4683a63/pyobjc_framework_discrecordingui-12.2.1-py2.py3-none-any.whl", hash = "sha256:a29bf02898481e6ee02a38ae932a35b9c6a4f68fe9c890504db18e94d15cfa45", size = 4723, upload-time = "2026-06-19T16:10:28.438Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-diskarbitration"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/25/d6a3231f7d81903e6cd6dd9674ef798d45dba2cf301dfb2224277e89c62f/pyobjc_framework_diskarbitration-12.2.1.tar.gz", hash = "sha256:b79a44c8a7791109371bb6aa78ee970c7cf0ee6a6ecdaf92ae3b9dcc4f57f469", size = 18174, upload-time = "2026-06-19T16:20:29.842Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/7e/c95163c4850fcd59f4d761ed0e453c50ab782914df478f53d402dd424314/pyobjc_framework_diskarbitration-12.2.1-py2.py3-none-any.whl", hash = "sha256:8fdde0943ca7499a246294d678b4f01c3f7c7569da19b029eeb31e4e9f01519c", size = 4914, upload-time = "2026-06-19T16:10:29.349Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-dvdplayback"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/de/281c85dbcde3422af95cb6cf4607abde52612bcaa66850b8c1e630f25152/pyobjc_framework_dvdplayback-12.2.1.tar.gz", hash = "sha256:cc715bce5edceaec078e3b39141a660cb4ca2fbe0afdf133bd2c531c170e45a6", size = 34829, upload-time = "2026-06-19T16:20:30.576Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/6c/ee10385cdd403471b205baf701890b5cb640a9dc357013d8a1801f1d5640/pyobjc_framework_dvdplayback-12.2.1-py2.py3-none-any.whl", hash = "sha256:56d737c2a1ffb1076d280b84906adc8091c055fcf6670367a902f38ea4877367", size = 8266, upload-time = "2026-06-19T16:10:30.25Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-eventkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/94/757c963beb0fb86891c3cd16db56d2e1cf746c24d8256023d6d7f4c83ef7/pyobjc_framework_eventkit-12.2.1.tar.gz", hash = "sha256:2528a61da2fed7d71933d7e5407414176cfcac2e03fdba4633633f0d646c75fa", size = 33775, upload-time = "2026-06-19T16:20:31.384Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/cf/504f2531b02010857df765ecebf41097fbd0bf1b803be47afec574199437/pyobjc_framework_eventkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:8efb71afaf9a97450ba701a6fee7de79e0cdefe6d71b5f6724e87b2fd68c5bd4", size = 6952, upload-time = "2026-06-19T16:10:31.307Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-exceptionhandling"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/59/ef544e804de32c5e437b9936742ae2bfdb6873ee1b284609a70e98855220/pyobjc_framework_exceptionhandling-12.2.1.tar.gz", hash = "sha256:aef051e1afda09853289f66d4e6c1b58cd924656afc2a1bec05b15e22e20e5f1", size = 17174, upload-time = "2026-06-19T16:20:32.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/46/f271631363bf830d520ed52bc0c5257cfcfe196859ab1b58720b023ae17d/pyobjc_framework_exceptionhandling-12.2.1-py2.py3-none-any.whl", hash = "sha256:b1d33ccb5ded605f2c92240c5719b64c45505f4c0dbc42b7d8595223b395540c", size = 7138, upload-time = "2026-06-19T16:10:32.352Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-executionpolicy"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/9e/c6f4962416713ee46ae5104b08091d3c1ff49fdcb69bf1edc03d2285b7e2/pyobjc_framework_executionpolicy-12.2.1.tar.gz", hash = "sha256:898d38b19e805e12da317930474f49a9f944f7e2335a9dc9c1644ecdd079d12e", size = 13043, upload-time = "2026-06-19T16:20:32.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/a4/7557a818158c59ed531ce0abbe7bfa8071c8657734b376dcf08a1bd54fc3/pyobjc_framework_executionpolicy-12.2.1-py2.py3-none-any.whl", hash = "sha256:493340d7311f6294feb93327c75675fff24859ad9bb3b87c0ce8d339850c4c93", size = 3798, upload-time = "2026-06-19T16:10:33.329Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-extensionkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/f3/51d50e7af4958d597d924fab765725746ed164ff02e59928296574f6e2d2/pyobjc_framework_extensionkit-12.2.1.tar.gz", hash = "sha256:9b8dea5867436ecfeefc7edb4cd8358c8e7741d31693047f1321e15dfc533540", size = 19239, upload-time = "2026-06-19T16:20:33.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/35/13c03829d2f8b70869da847d27552f0ff08c6b9431c0e58f02ca7ff3dcac/pyobjc_framework_extensionkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:047ebbbfdd61369dc8796a5754cc9b3a50104ccae1d4392f48d8f73ee9b6f859", size = 7941, upload-time = "2026-06-19T16:10:35.104Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d2/f859740c55b569857a2f969a39177fcceb64d41fc345fe39c7d27d48d3cf/pyobjc_framework_extensionkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9279dbc7e75f28b9b6553d351e48475fbf3841f9a30f4b503fe03e18c0ccb074", size = 7955, upload-time = "2026-06-19T16:10:36.008Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/18/c4162af7b93d92b0d6806bdbcfd16cbf0f3e5d6ff17e80b5feea4e0a2429/pyobjc_framework_extensionkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e29f5860aa6acb53582c2742e477922067b959046c1998ed7fd962898fd78855", size = 7970, upload-time = "2026-06-19T16:10:37.038Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/4c/472391557a3ff3f3e4fcfb683c34c7f3bf9abef7c8d0eff563cb11168cbb/pyobjc_framework_extensionkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b8dae4aa09e327a44b12c2e5c49250e3439fd98fd8eabd08ae97d4b71180aee2", size = 8108, upload-time = "2026-06-19T16:10:38.033Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-externalaccessory"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/e2/96f79a29c7bc6c229035dd8e92f4f73001affa8e642248cf7ab5bf03b2c8/pyobjc_framework_externalaccessory-12.2.1.tar.gz", hash = "sha256:49658d55b3401c03ef3523ab3b8e2ed082739e971a0070d81b16d06441ac8d03", size = 22011, upload-time = "2026-06-19T16:20:34.554Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/e3/c690f51e505dd826680a3094e9aa511f9d7507bca543e4f4184af23f1d82/pyobjc_framework_externalaccessory-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:787ea43ded7a7f5621cabc3578a7414298dbfd62c73c8418ddceb720c23388de", size = 8931, upload-time = "2026-06-19T16:10:43.842Z" },
+    { url = "https://files.pythonhosted.org/packages/42/29/cf69d3931127544a7a576a3c3fa4aede1808ef62ad3c77e3803414aefa68/pyobjc_framework_externalaccessory-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:47635ff739691b8446079b5018c71585dbf33c2d5eff6a34279efb0868caf432", size = 8951, upload-time = "2026-06-19T16:10:44.85Z" },
+    { url = "https://files.pythonhosted.org/packages/21/21/6cc05d60f54f317ab6f0c36d025951ec9ac15cb088b219d88add060051d7/pyobjc_framework_externalaccessory-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c61d2d3ee83d4c0fbe4ef427041fc911c0f168bc7f10f9b7ff9d502e1a9995c8", size = 8966, upload-time = "2026-06-19T16:10:45.619Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/5b/c2799931e1c456cf2748c8c81ed9ac8218bc55cf838f4d71d0355f52153f/pyobjc_framework_externalaccessory-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7cdaae96e146ffb1def2b14a0890555e4147ec77924fca241fb2361f93a36b31", size = 9124, upload-time = "2026-06-19T16:10:46.455Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fileprovider"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/15/d161117076a478299804b40720c5f110b4540f77ddb1b55e76b18dcc3ea8/pyobjc_framework_fileprovider-12.2.1.tar.gz", hash = "sha256:fd94e8941de50b6bc94ab8fbbf0f4605eca0602e4bd48088b8d6c1162115b506", size = 50576, upload-time = "2026-06-19T16:20:35.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/42/5848410e19ce30a784f30b586d762e1777a50ea74517dfd93a30dc0146cd/pyobjc_framework_fileprovider-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9fe7f23dc7bb3bb0a045ec443ff7a55eaf3e4007b2d9a99a79ff201c9536c58e", size = 21062, upload-time = "2026-06-19T16:10:51.862Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/79/d9b4d70c71f6828a6dd1393fcd2e956be2079203eebb33beab5880241df1/pyobjc_framework_fileprovider-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:772d963f342af3d2853e4b5a14788b0f72e3c25c457c301e27d8bcdefdbaca01", size = 21094, upload-time = "2026-06-19T16:10:52.811Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/89/fb75ac1019a89f5f10716d57af5a4a7fb5baa720278c688012f1acdc39ff/pyobjc_framework_fileprovider-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:95f7de1b2a048ac0edd1e02479b13956704b49521fabbd8e94e59564999204b2", size = 21100, upload-time = "2026-06-19T16:10:54.037Z" },
+    { url = "https://files.pythonhosted.org/packages/19/56/4565504252898725ff960d8511318314d10f1c0c887031e30d0e19ac477d/pyobjc_framework_fileprovider-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:fe700e447f54a6bca8fdd13a4c21bb93d26665cb4598b958e099d1aca870b109", size = 21385, upload-time = "2026-06-19T16:10:54.874Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fileproviderui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-fileprovider" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/4c/066d39b6d90f637fdb2d6ab8762ffb234b700e89e93cb7473729b49aa505/pyobjc_framework_fileproviderui-12.2.1.tar.gz", hash = "sha256:40d02bcb15e324af6c624c85f1d65d83f81f31dd72136b0e5ec87440dc0fba4c", size = 12863, upload-time = "2026-06-19T16:20:36.391Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/3c/a030778db1b6272a2ed420a4ebd00a9084df932580c039d48f7891cad100/pyobjc_framework_fileproviderui-12.2.1-py2.py3-none-any.whl", hash = "sha256:2ff2f939ece56f06eae58b9494743941e40500b042a0cf3a64dcf78179d3d79a", size = 3739, upload-time = "2026-06-19T16:10:59.201Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-findersync"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/8d/344b385f233b5843f05e7b78bea125123e22bc4c3b0e1eb93d3e55d9664c/pyobjc_framework_findersync-12.2.1.tar.gz", hash = "sha256:be3d41c9b836a53f24473e064ade6bd9ac071cc483377547cb6603e5a0de5d90", size = 14303, upload-time = "2026-06-19T16:20:37.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/73/eb80247a8fb7edd8565370dd7029e3f2e1ec76cc8f78efa1093f73328747/pyobjc_framework_findersync-12.2.1-py2.py3-none-any.whl", hash = "sha256:5b91a226b72a4c83a7ab5bf7e59164d59185021a396bd5804712ba8a55949db0", size = 4914, upload-time = "2026-06-19T16:11:00.173Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fsevents"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/fc/b31d09b6b58e50c8bcd16acf251d397bafc454bff9160f0e2c922cc9cbe4/pyobjc_framework_fsevents-12.2.1.tar.gz", hash = "sha256:f78c98f68bc643794668a9484fc348ef3e98df359db7d8726cada35310af93b4", size = 27163, upload-time = "2026-06-19T16:20:38.372Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/d4/f1e36b1d4b0216658999028aaeb322da1bae01dad1c8c033854c787977b2/pyobjc_framework_fsevents-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e78bd73365c3c0c42b3adfedbc8a66a7056ea16b84dea9f8af43635f931e48be", size = 13073, upload-time = "2026-06-19T16:11:02.224Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f0/a9025139c69511600b653e4e3bed2b009e0c1d901405cd9d48c6eacfae93/pyobjc_framework_fsevents-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5e863d5b188b4a7bccdda0cc1993b451768ca7425dd866a90a79857d459a2052", size = 13156, upload-time = "2026-06-19T16:11:03.048Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c2/bacaa5063b1e4ec270885fc0a268708c7cdf32b78b129fe753dca5daf470/pyobjc_framework_fsevents-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:11552274cdaa97ffa23aa1cb167a6cb03a4b0923330bb75e4757fdd38b61a796", size = 13160, upload-time = "2026-06-19T16:11:03.86Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/dd/1c376dd0b434ab505565e239e90fcb77a40d888b9fd052dda85b1820a1e6/pyobjc_framework_fsevents-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:11d13fc2b3bcaa2a746b1f28b95ce9fa9d9078a7da61d6cb4a2f6bc7c163f108", size = 13519, upload-time = "2026-06-19T16:11:04.773Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-fskit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/38/4d47e4c2ef4a0e474469a715e5244b8e8dde89edde12c94551c5ed3ff7b0/pyobjc_framework_fskit-12.2.1.tar.gz", hash = "sha256:2607cef80fabe2394b30e1e3c10dc942c709afdbe7baacd3f86112b38add942b", size = 49577, upload-time = "2026-06-19T16:20:39.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/4b/3548dddea2ea1ca25e874165f33f2a68adf042701bd2fb297732d77d1516/pyobjc_framework_fskit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:29cda74aaa693513121805726bf458d2a2b60008216f363709c8d224dd0afaea", size = 20587, upload-time = "2026-06-19T16:11:10.63Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6c/c43923e868f915f152cf67bacda50d6e8c44053f0b3b108a5c9a2edcbcb9/pyobjc_framework_fskit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:27deb130e5c3dab34689724a2da275ad83c579bc29da63904e0d2438b4d24ff9", size = 20605, upload-time = "2026-06-19T16:11:11.454Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d3/1148d635a3861e5f10d4cb23097ac797b0adb490922663acfad86b24e1f6/pyobjc_framework_fskit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b6094592998da2b3f61fd6a6599064e722ed91ef8a53e27b0c0cd080575cbb75", size = 20620, upload-time = "2026-06-19T16:11:12.278Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fc/a9a70c58484674873d48343bec31996f913d06071dc4575d6cc0dcdaf93c/pyobjc_framework_fskit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:58f9c31ad24af40b7f37000c31c684a4be1c2057345a921cb0fe57b111d62063", size = 20848, upload-time = "2026-06-19T16:11:13.187Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamecenter"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/5d/a2969d6cb14a9fe10a744a89daa2b671a4fb5dd25354e75511a65f7f8249/pyobjc_framework_gamecenter-12.2.1.tar.gz", hash = "sha256:70fff5b1c0ac9d622709b4deb8e0bdf47cfa43591f1438ce2c6099abd93bbfde", size = 32149, upload-time = "2026-06-19T16:20:40.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/38/f58a4e9ce61da62407a839991960301a61b8ca9568ee376d1e2334118df4/pyobjc_framework_gamecenter-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5aeb41658a2f0f3bc6b5a069f1c74324e3c37f662d54fbc458b0f6894581c006", size = 18843, upload-time = "2026-06-19T16:11:18.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/a5/b9a70c5e9e6ea55ffe9c7de8f3378473a4773d476aa25fe20bc5f0420c7d/pyobjc_framework_gamecenter-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e144d257b9461f8195512fb4b1a1cfd4cc0d603583ea039af7127a951ea7ad76", size = 18886, upload-time = "2026-06-19T16:11:19.608Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a5/a09890c3585740684c1a28620ef31bceaa4b455dd1aea59c95a1e30e6bba/pyobjc_framework_gamecenter-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:618fd07d19d715f172338a0d906f5a9e3dff67d3913e47d9033c0e7e4a6f5e88", size = 18889, upload-time = "2026-06-19T16:11:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/43/1b87ab10c0ccac15fa3daeb2bb0d915cb36c605d7c1ac24cd4eeaa3ba59b/pyobjc_framework_gamecenter-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8929a2ca38c79debb975bcd4bb15b0a3bde93f367f90e05cc530badeeae82b54", size = 19172, upload-time = "2026-06-19T16:11:21.461Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamecontroller"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/94/3f01f6a15b892402e9ec5dd5530e53ce7feab236c374236059ab10961ee7/pyobjc_framework_gamecontroller-12.2.1.tar.gz", hash = "sha256:d40667869da0ef5d9905b4b3c365e275f731758bc0b09f10f7dfba579b1ee7d0", size = 65320, upload-time = "2026-06-19T16:20:40.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/7d/074428109273999cbbd5e4484814207b284f29457a0b065cd97b99f4b03c/pyobjc_framework_gamecontroller-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ef83260973e620207b35bd3a4d68333d76c2e5463f0ca8405efd8327d27f8946", size = 21508, upload-time = "2026-06-19T16:11:26.899Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/97/a55cac5ba675a43b280454a50e377fd9733629d0afcf0bde51c042dd20b2/pyobjc_framework_gamecontroller-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:68d074ef1fbe4feb258e622f58764e79accd006ee39e069f8c50252b0657dff0", size = 21527, upload-time = "2026-06-19T16:11:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c9/55faa145c569b45b1f82d0437e89e84c5d42bcf3b822429eccfdb89643b7/pyobjc_framework_gamecontroller-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:94af74d0229d5ef06e71d2d005a56018930827435778c946cf28ee98914bd0fa", size = 21543, upload-time = "2026-06-19T16:11:28.656Z" },
+    { url = "https://files.pythonhosted.org/packages/01/29/115e4e4ce6d34095fdbc689c1963b6a8688beca380ca5db43b9be6ab3175/pyobjc_framework_gamecontroller-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:bb5704a35e501b8902e6210f1f11c7d7f55954dd906847cd6da2390b7176d357", size = 21784, upload-time = "2026-06-19T16:11:29.495Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamekit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/f3/6a4ae01c6a8e0e5b74e818694139edf9ebd395bbe04d275fb5f5e73ac919/pyobjc_framework_gamekit-12.2.1.tar.gz", hash = "sha256:e5e90dfa0eba5215406710d636c08ee9aa4ba886d9e0bf11849247b161aef1da", size = 82427, upload-time = "2026-06-19T16:20:41.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/1d/8f369bab83b5fc446de73164e612fa65ea96d83e0c3cd4fe5fd48339c555/pyobjc_framework_gamekit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7015d24515e6c069c1cd15c7f2921961c4b9bedc037c3475d068b3a9ce40d03e", size = 22554, upload-time = "2026-06-19T16:11:34.895Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/88/5c93226453c925d22a102df0aef522aac0786168171e1d49b3a15f5bd5fa/pyobjc_framework_gamekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d29a5ee705be7eb0e0fe46bd319462f8bb2f08c8761d65f0e22957f35b6db72a", size = 22586, upload-time = "2026-06-19T16:11:35.828Z" },
+    { url = "https://files.pythonhosted.org/packages/24/d3/467011b105702bfb1e1145bb20863f5c72c49b2ac8f206eb16ed2df76c87/pyobjc_framework_gamekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7fbfa5eeb6c97183aa65f88a8d904bffe79b56db2352dc03ac0a1104c8a6cc56", size = 22599, upload-time = "2026-06-19T16:11:36.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c4/4554e23d5115aa93d1d375c3e17a44c6363174e337754404ecc13d7dd367/pyobjc_framework_gamekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:21b5ca685cfcc64ed05f5dd7a07b6ee852a6bebe251980185e795cc7117fa949", size = 22886, upload-time = "2026-06-19T16:11:37.66Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gameplaykit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-spritekit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/fa/df67a7bd14b44808060dcf82da26492cd7365bd6759d9437a004fb761a32/pyobjc_framework_gameplaykit-12.2.1.tar.gz", hash = "sha256:6ef81407e241016853cfdc6e580503d2d75a452ab0028f5c83390f102685c853", size = 50742, upload-time = "2026-06-19T16:20:42.656Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/0a/552898c2b5585fcfc138b9e62bec6b2d0e85ac1147c59c4544dc45721971/pyobjc_framework_gameplaykit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3cfd99b4a37df41a72f7b15fbbd00abecb11021745bae4876e2d8517f75317a5", size = 13612, upload-time = "2026-06-19T16:11:43.358Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/23/d64fe0c702ff3ee8644bcde26e2c7d9062b19b7d40a60134ba2b4b353b45/pyobjc_framework_gameplaykit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e1ef41d991e29358a26c92916bcedf722568e50ee66eab3088d2e88b9d77d9e3", size = 13638, upload-time = "2026-06-19T16:11:44.269Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/27/4e0e8260e2f3b4a3e99ea756166c9d7b12a971d470376bf417aa4edea133/pyobjc_framework_gameplaykit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3b51b11e20066f10532c225262d05fa6711e49685f5ecd9519b6c12ef69efa68", size = 13646, upload-time = "2026-06-19T16:11:45.234Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/10/9f36ade305fcf88bc077924404df1f96ec61e6e6dae2cb7625abca1a077c/pyobjc_framework_gameplaykit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:95b06ed97e4e636140c5d28f507a298974413b501599cdcd2bb80fbc8fb85ae1", size = 13863, upload-time = "2026-06-19T16:11:46.257Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-gamesave"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/96/c4c604170d28f2a2cddb1217dd0d8340ef9435ab2cf1042d85b45a14c2ed/pyobjc_framework_gamesave-12.2.1.tar.gz", hash = "sha256:d317d37f2716194e61cc91e855d6054c3c2b7ceaa82aaeff9c688d9f2cc43a42", size = 13238, upload-time = "2026-06-19T16:20:43.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/4c/8fb1226802cf960ceaac85bbe7bb85aeb949f9c9ae477ecd35876a63eceb/pyobjc_framework_gamesave-12.2.1-py2.py3-none-any.whl", hash = "sha256:5d632ea0b62ef55b1b0f62e8ab6b9800bc14ca78f5a1bb629c95b28376b82379", size = 3750, upload-time = "2026-06-19T16:11:50.468Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-healthkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/a6/a7f9f6d525c19ff1b2533220058cc70ca5bf3976a6adbe2efaa66ff3a349/pyobjc_framework_healthkit-12.2.1.tar.gz", hash = "sha256:d0a8c956746e8705edbe76a046e8c17ab6d7ae2603d8436e4477d30573acb457", size = 116224, upload-time = "2026-06-19T16:20:44.519Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/4b/6d6cda4263f3a0952ddf7e750023c6af71bec74b18df77a0915a827784a8/pyobjc_framework_healthkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e4d0da98b552ba33532f37ab718bb3b77e15d3c0c1ab426e6d01522d2d256244", size = 22060, upload-time = "2026-06-19T16:11:52.762Z" },
+    { url = "https://files.pythonhosted.org/packages/92/f1/09a7ffbe1dec87ca60cb63c93b81b3f8e6b168e4e24c0fb244809a71bdee/pyobjc_framework_healthkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2c945edc98952bd7d1abad876ed7e36c3442ea6e6c1ec6718ab7554b8a47fba1", size = 22070, upload-time = "2026-06-19T16:11:53.843Z" },
+    { url = "https://files.pythonhosted.org/packages/94/91/31d4365275ce87ce1a0069a25ba1bc33e0ad205eacfe251633dcebd92171/pyobjc_framework_healthkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0408b552eb98319d83a106b25944d645dbe9927dff0ce9c701c25d472672aa63", size = 22083, upload-time = "2026-06-19T16:11:54.717Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c1/213460cfcc6f8f549c942873ed984f6aaa584c01f7874f012fb073693575/pyobjc_framework_healthkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:15d6a4a80a85e29d38371e98f70656a6b378cadbd9430579b9c15a46b81a0a2d", size = 22251, upload-time = "2026-06-19T16:11:55.52Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-imagecapturecore"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/fb/792b0945e2fb9de91b388e56603f5e6548573511cb40555ca0047d7f798b/pyobjc_framework_imagecapturecore-12.2.1.tar.gz", hash = "sha256:c1568be8cc0fd06046f7e344634951b3c02af3ad4f8a35fe1e2fecd9547b7042", size = 53435, upload-time = "2026-06-19T16:20:45.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/b3/05c58659d8c52516d5ed45cd49b49c574e68ec3c6131e34fc3193ea5fd0b/pyobjc_framework_imagecapturecore-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7d083a0b180b833cc06b6d5419d657b9b96629f24def0c666147acd95ec6c2d4", size = 16042, upload-time = "2026-06-19T16:12:00.891Z" },
+    { url = "https://files.pythonhosted.org/packages/69/cb/f542c35ad49f9f1e33b6e3d43860be84da2a24298579b7f508dd1f0a7e2a/pyobjc_framework_imagecapturecore-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:34165b84443a98ce8b7f12c12603cfbebe09bacc06f33ae1ed3774b649d0cec7", size = 16064, upload-time = "2026-06-19T16:12:01.886Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7a/fc4bf6e0973ef553be039d5651e22ea5802f8095154f41310c1df1a9bb2d/pyobjc_framework_imagecapturecore-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8f6882e96cf748096fce49adcddeb882090cb1adb9c6699d1b869866053365d9", size = 16081, upload-time = "2026-06-19T16:12:02.86Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/bb/a7d080589fe074ec317b4022603f60adbab4dd3f671dc16a7516157e16d5/pyobjc_framework_imagecapturecore-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b6339dd78448762e1c017698b32736b809048ae3b0e51d1c625c03f47e59de52", size = 16268, upload-time = "2026-06-19T16:12:03.729Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-inputmethodkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/9c/2bb0c543cfb7a1d38f4750b8b54c57663ec7c54f07499a3218c2a16e3e54/pyobjc_framework_inputmethodkit-12.2.1.tar.gz", hash = "sha256:008d792827ea1b11a051f4871c99c720ca5430395078158f082846cab43b04e1", size = 26255, upload-time = "2026-06-19T16:20:46.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/5f/d82e583e6131717ef7080807a7757ae429dbc0dcaf08e20fe33f42ee0fb3/pyobjc_framework_inputmethodkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ade69fed2930f32434707a39825665bdedb944e835c030c624da5e3a898e2b75", size = 9526, upload-time = "2026-06-19T16:12:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/06/54/eef2b45c70f0ebcc54db74b866753d7a140982519b18f738e9b6c00d7730/pyobjc_framework_inputmethodkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5c979473f54fa344cefc91525b2f7caadb682da7f7cc93f2bf49ba730569f05c", size = 9532, upload-time = "2026-06-19T16:12:09.889Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9b/338f8abbb7fdfecb8a89cd7ecaac0a1853d4a7399c77054b0875b3195e29/pyobjc_framework_inputmethodkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2fb01dfa2c624beafc25c9520806eaf2cc3212c7180a6623a1436d84e84ad84d", size = 9554, upload-time = "2026-06-19T16:12:10.749Z" },
+    { url = "https://files.pythonhosted.org/packages/85/2a/d65f3b8606d8f32ae125e434fdf7aeadc5de5ececfa0f543c7cfd1c65b65/pyobjc_framework_inputmethodkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8d02da4d81146258fae8f2571b47df41a912b0e1f84bb38384e1a4d858feaf28", size = 9715, upload-time = "2026-06-19T16:12:11.541Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-installerplugins"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/2e/23d4d49b755fc6e179956d745311115dbff6b43a505a8ad627a13a301082/pyobjc_framework_installerplugins-12.2.1.tar.gz", hash = "sha256:118ee84e6e7f6f7913ade58818bfd2c12e2078ff7f6090e4941df1e739c8685d", size = 25978, upload-time = "2026-06-19T16:20:47.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/16/7ae359b8f858d6caeb076d779ef1123ed2f1d287e5e9a7262f7355b25819/pyobjc_framework_installerplugins-12.2.1-py2.py3-none-any.whl", hash = "sha256:aef22bff292d3b8fb9cb655f868d041dcc76d3d6b47d3022557fe3f657c28c69", size = 4841, upload-time = "2026-06-19T16:12:15.946Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-instantmessage"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/66/89688001f6b1a76a09876b4fbe02760994b783d031e05b3d7e039514748a/pyobjc_framework_instantmessage-12.2.1.tar.gz", hash = "sha256:80d31bca02459c6d2364605b51a8064d0fbe3e7dba085b5b8ac59ee98157710c", size = 34047, upload-time = "2026-06-19T16:20:47.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/0e/b042906e81eb1865b123ef529516af7b2a2bc28f5bfbfd7b0e0d40a9f1de/pyobjc_framework_instantmessage-12.2.1-py2.py3-none-any.whl", hash = "sha256:42c7be0357b1d4e808b40c7d212f5d807e1901a87e0cbb6a215bd0232f87374d", size = 5464, upload-time = "2026-06-19T16:12:16.821Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-intents"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/a9/107e313345eef0a2be05017227073678b65b58f77af14312ff6403999856/pyobjc_framework_intents-12.2.1.tar.gz", hash = "sha256:579a36b1c2dae423ecf8f7fc02fc8a2a3d079366a073903ba323d40adeeabc2a", size = 187763, upload-time = "2026-06-19T16:20:48.645Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/3f/848e213c2e9424c5304aac6a4ac26f7ab53088bd58fd5a950c23246862e3/pyobjc_framework_intents-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b6e0687c4dd12ebfd8f057364b2fa7367d324957d514747d8dd109083486d422", size = 35259, upload-time = "2026-06-19T16:12:19.041Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/cd105a3a262e9048accde15734d84869ea6d2e1eae95a9f5c32dfcb9f2c1/pyobjc_framework_intents-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:440fb3b4f2ffe3184f3fc8ba0abba83a3a59ba63dad12a5bb2b6792eab8722eb", size = 35276, upload-time = "2026-06-19T16:12:19.958Z" },
+    { url = "https://files.pythonhosted.org/packages/28/22/4f3a7ca8f8fd8a646074f2e9fae8798d2c8e9378d8fa191085b2b1abaa27/pyobjc_framework_intents-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c21cf1db00b8c997d3e6cfde53ec135ddee5b03138cf184deb842dbc925c1286", size = 35293, upload-time = "2026-06-19T16:12:20.884Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ef/59efde70a85b826bd7328c2d77fd19163014b571f0dac1543c46a1fbd143/pyobjc_framework_intents-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:21ed7ca804106bb1a606c070a081d59dc93fb23bd570a802518a8ed36357c275", size = 35529, upload-time = "2026-06-19T16:12:21.746Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-intentsui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-intents" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/31/1426d5ca5dba96d82dc08c6f287361eec9c3d8008295403b015843bf7b51/pyobjc_framework_intentsui-12.2.1.tar.gz", hash = "sha256:ec1a0fa3861911da7e43abfb6f783052644d62f587554e15a06303a648f9f361", size = 20768, upload-time = "2026-06-19T16:20:49.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/14/8946ca41f1f9b113fc8df7da720b7813ff1851b1f14588cde54ba620e41b/pyobjc_framework_intentsui-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ecd53ed0f5f234d690985bee9eba1ee94f34b7d206f2d375fbcf6691fa446e84", size = 9027, upload-time = "2026-06-19T16:12:27.267Z" },
+    { url = "https://files.pythonhosted.org/packages/18/8e/6cb7c5e2a9cf64fd1bacdbe103dc0355f85fcebbcedafeacdca9ae3678c8/pyobjc_framework_intentsui-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b8f92e0018ca0d720f339b589ead6b46443b95f844258eb4f0a215101a74eb1b", size = 9047, upload-time = "2026-06-19T16:12:28.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/7b/06fa5e8a04202dc42ba0eb0887ee362016417074343602cd1ae97a811978/pyobjc_framework_intentsui-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3200f217607900018605f8b25a75d1e5b2b6739e2244b25147a77d9278ff745c", size = 9064, upload-time = "2026-06-19T16:12:28.935Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/bf/6bd5674aecf4f745fc1bd4ce0c5d75e4b562e43d8cdd65856d1665d998c3/pyobjc_framework_intentsui-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0af7ede17b56defe1c19426e5b5f2dd39d8215eeee30c6dcd1501dba609566d0", size = 9245, upload-time = "2026-06-19T16:12:29.777Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-iobluetooth"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/5c/acb79d6180b7dc243b82c129292fc2c9e1f695793165dd6e89f55a000a49/pyobjc_framework_iobluetooth-12.2.1.tar.gz", hash = "sha256:eb99c27187c68f984dee4e9ac620f5b210f11f821a2063b2fb9161359a1f1754", size = 174846, upload-time = "2026-06-19T16:20:50.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/0d/352fbaa3c33de658760e1de4e9c2276c77a1e6964d8f4aae38250f54f960/pyobjc_framework_iobluetooth-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e3c3fe2e35d4b20cf0ffafe1ee234bb250c742a3e348abb299df6e348e92922b", size = 40539, upload-time = "2026-06-19T16:12:35.521Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a0/59dd27082e6b01ab5f181a465ac86ce62ab5353d477254d78472afa7c26c/pyobjc_framework_iobluetooth-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8ca12b1ef8533fbd63c44c68ad80afe7ca0446f056399305e9f51f573c406b42", size = 40560, upload-time = "2026-06-19T16:12:36.361Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fb/aa00b0c445d1a20d8b67d67348c8890d122c1d1e76a5735b8e14c28649cc/pyobjc_framework_iobluetooth-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6d5e76af8d2f0ad9f0a25158c0aa6dafa2dc59c57135dd1d4f39aff89e898344", size = 40571, upload-time = "2026-06-19T16:12:37.155Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/be/8d058fb08b3ce438e9878ca27e6c91d4e89e7cca9de8eb281317ff3d022f/pyobjc_framework_iobluetooth-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:fed3eb2ce6aec555f1e22d04d06d2212a1d475740eaa2b832244198e09b5ce11", size = 40787, upload-time = "2026-06-19T16:12:38.145Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-iobluetoothui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-iobluetooth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/79/99c3fce73768d0fbbb9c2fbb9dda092c828c8d15e9e5ba4dd802b719582e/pyobjc_framework_iobluetoothui-12.2.1.tar.gz", hash = "sha256:53bbfa9451c3c1bb55e91f063bb0539509e1e2b11887736967cc218b93695087", size = 18013, upload-time = "2026-06-19T16:20:51.717Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/ea/015e595050aecaea98cfd9cb62d93bd86408af7550efc405d9bc661a69c2/pyobjc_framework_iobluetoothui-12.2.1-py2.py3-none-any.whl", hash = "sha256:321160ac3181349054d29f7804b24944549fe442f4d6840f9123bbcd48f62aee", size = 4066, upload-time = "2026-06-19T16:12:42.682Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-iosurface"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/bb/9f1b513ce177d725b6aa0936f69ece74afa695698ff2f59660b427824b4e/pyobjc_framework_iosurface-12.2.1.tar.gz", hash = "sha256:f886630d6f2419fed9f89152b1e738758b735219bd39506bc12c2e1f65456dea", size = 18604, upload-time = "2026-06-19T16:20:52.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/22/c1a95f27988883450ec1c8210f351da5fb006c753d686e8437426daf821b/pyobjc_framework_iosurface-12.2.1-py2.py3-none-any.whl", hash = "sha256:92cf617b6ad6c216ec5fcdd47584fa0744dc7ff38fee378b2689dfcf46194df1", size = 4925, upload-time = "2026-06-19T16:12:43.545Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-ituneslibrary"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/9d/1b18df4c94a4a45cb9fc86edf2656d1932c1f56c31dcf6ac673cd9138808/pyobjc_framework_ituneslibrary-12.2.1.tar.gz", hash = "sha256:be3afc865881c762765101be35f7216616c5eb4c76025f590e36fe1cbd2518fb", size = 26184, upload-time = "2026-06-19T16:20:53.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/7d/05c50a1bd493ccc1844a89461ad7eb82b7ea7a361ed219377f8abaa625c4/pyobjc_framework_ituneslibrary-12.2.1-py2.py3-none-any.whl", hash = "sha256:076712e495e2df43dad14e92167e468c4a46b9d06f1b84b98b2b65ff24285043", size = 5237, upload-time = "2026-06-19T16:12:44.426Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-kernelmanagement"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/34/21b155304cd14f2b6ed9b732c2925b1c23c6eb1a941676e83d972c14dddd/pyobjc_framework_kernelmanagement-12.2.1.tar.gz", hash = "sha256:49591c0603057d2ea2596b9b414c38fe521f506e1320753bb49ccb2262b97bdc", size = 11961, upload-time = "2026-06-19T16:20:53.903Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/57/4b0e4520f06f62e3a70eb50249efe750fd220fe23072e021048a23a2eeb1/pyobjc_framework_kernelmanagement-12.2.1-py2.py3-none-any.whl", hash = "sha256:9facdb93e49717a9e5999ab7b20cd1643ce00119f7b91c4933fec0fe3638edd1", size = 3696, upload-time = "2026-06-19T16:12:45.473Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-latentsemanticmapping"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/37/35c98e572e98df7763c6d7bc437c7aee7d5a36c030c51841d793d0e89939/pyobjc_framework_latentsemanticmapping-12.2.1.tar.gz", hash = "sha256:96e6b523c7fe7944cee30b723f035f9082500c3bf8ba8237013c8e37b112c493", size = 15906, upload-time = "2026-06-19T16:20:54.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/80/1e80736b58665094f12ed736f1d675a9658ebb992e33fea72cef35815010/pyobjc_framework_latentsemanticmapping-12.2.1-py2.py3-none-any.whl", hash = "sha256:7d7669ae5c6ca53e6aa7bd70ddfed23914a29169c3f57b94a40a0397abaa66e2", size = 5499, upload-time = "2026-06-19T16:12:46.356Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-launchservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-coreservices" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/8e/26d4adeb32fcde532d6e3afd342ebfe055017f183b2c2f730a28f1b3de84/pyobjc_framework_launchservices-12.2.1.tar.gz", hash = "sha256:1d288543c1c4e53e6e24314987e18904ada821d6bef5437e6bd9e8e6873fe4a6", size = 20834, upload-time = "2026-06-19T16:20:55.548Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/5f/6ef104cc5c2724d07ebd119ad20c80d40a964f1074e6c72053b5d658556c/pyobjc_framework_launchservices-12.2.1-py2.py3-none-any.whl", hash = "sha256:81ca37abab29e96ebd69e1d97d63789d729510a6fe1f6cd4041e5b24f340f115", size = 3934, upload-time = "2026-06-19T16:12:47.283Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-libdispatch"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/3f/561653aff3f19873457c95c053f0298da517be89fdfc0ec35115ed5b7030/pyobjc_framework_libdispatch-12.2.1.tar.gz", hash = "sha256:0d24eda41c6c258135077f60d410e704bc7b5a67adcb2ca463918896c7363795", size = 40336, upload-time = "2026-06-19T16:20:56.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/b0/dc263ed1cee54badccaf60f061de1e25bea95504984401a22bee274b5f59/pyobjc_framework_libdispatch-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0e295775c76eace23f60e53ef74b0f79429c665f91a870e4665c4b9887466efa", size = 20488, upload-time = "2026-06-19T16:12:49.441Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8f/42cfa987c07a2b5ce8c236a42b0fb388b8807dac72c25e004cd4905ea9a3/pyobjc_framework_libdispatch-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8f41b5021ff70bc51220a79b41ebd1eacb55fe3ceb67448594f30e491a2c42a5", size = 15656, upload-time = "2026-06-19T16:12:50.361Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/cfe97f1beb13f5b7ca5c4348158c2de886d58ffba5be09a9376557f7d6f6/pyobjc_framework_libdispatch-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9c0ebf99520083bf17c007a544c100056a0d4ae5c346fb89e1bdfe6d041f16f2", size = 15679, upload-time = "2026-06-19T16:12:51.28Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/de/ef6b51bc72fe5ac1df80c34b1b13a97d0922ddd6bc5d3ecf5ead1557bf34/pyobjc_framework_libdispatch-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3f56fd71b963a0b6e440ed2f0ea2fb635221758b7eb908ba38f96f5144b83ca3", size = 15946, upload-time = "2026-06-19T16:12:52.098Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-libxpc"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/e5/92d47d5387baa85461be9802dccd90f6fe9232a98878caad7ab899d207df/pyobjc_framework_libxpc-12.2.1.tar.gz", hash = "sha256:83b814672715ef1f4f83eaaae49416a77db38579e6f6af2e14cd328a76f5d598", size = 37265, upload-time = "2026-06-19T16:20:57.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/86/e5110414fab0191fa10c5f9901e5f9feb4c8dfb3df3c3099a23e7c2000da/pyobjc_framework_libxpc-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:157db58d0bf530d7a2838c3229aa5fdd973fc2359beaa557fa3ab370ca541637", size = 19649, upload-time = "2026-06-19T16:12:57.531Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/27/ab74145db0b6e9eafbcfe24ee5f906f1466ecfa40265b20120affb48f946/pyobjc_framework_libxpc-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:905964e12dd9180e70bc88bb04cdc02e4920a48a045e62ebb47f207ab3085376", size = 19774, upload-time = "2026-06-19T16:12:58.453Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3d/6432bb6e2333b3dcbc8da1fe26f4436895e3b7046efb70c4cd8c0ee92aea/pyobjc_framework_libxpc-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:158fd1b11eabc4c42d1bb60264ecd19871c3e24ab661e7c6d982bcb5b6cd8da7", size = 19780, upload-time = "2026-06-19T16:12:59.378Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a5/89cb0149bd82f25f2555e9195d7d8f24be979fd7e88ffda0db6e6e61cbc9/pyobjc_framework_libxpc-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:dad8ca82fe4162e85c9a6057382eaa6adc6b3aa22011e1e454d6eafb997dfc02", size = 20332, upload-time = "2026-06-19T16:13:00.296Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-linkpresentation"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/21/368316aa17c5a70a29fb5bc23d29e8608509de539ad5402b8e273dcae5f9/pyobjc_framework_linkpresentation-12.2.1.tar.gz", hash = "sha256:96f30800eef18543a4c75fff6b1a7cce7fcd649564784cc523341870908382c9", size = 13978, upload-time = "2026-06-19T16:20:57.903Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/14/76bdc42790ced9ab3be43a946a4466a0debc3d7e7642fa4836081768c382/pyobjc_framework_linkpresentation-12.2.1-py2.py3-none-any.whl", hash = "sha256:2299fc001002ecf501249a0a61bda35d50aae5057c9f2aca36274261add4fa4d", size = 3887, upload-time = "2026-06-19T16:13:05.149Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-localauthentication"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/e8/fcbea8814ab28d00e18e4f6fc84af2fbf58eee916bfe85a30685abef0729/pyobjc_framework_localauthentication-12.2.1.tar.gz", hash = "sha256:05162d6d603fe6a9bf8eba8d5df7da379bc2b8eaf2a405bf0132a71477f5ed1c", size = 33086, upload-time = "2026-06-19T16:20:58.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/d5/47486c13c3481ef868411f61dd4c4f99bc8a45f5fb2675da132160211817/pyobjc_framework_localauthentication-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:be6c72699cc3c3a970483f1cf7fce3b40663253202ac023b8439d34f93ea224a", size = 10896, upload-time = "2026-06-19T16:13:07.216Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/60/5c4f1fe4e70dc68ddb3d55dcb8f81ae7806972fa37108a0f9a394020e657/pyobjc_framework_localauthentication-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:591dc5bd8143868c0414a487c433d6c651c44c3f0ec751ad30ff3e0f4260db6a", size = 10905, upload-time = "2026-06-19T16:13:08.002Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/fc/ca8853e87bf1d1bcf2a1331eef8f410a7177aaee6f019c6ee99036d28592/pyobjc_framework_localauthentication-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:29d6de29ece22d49a95279de80405f1441ccec74ea30db5251ffa8f46c51ae94", size = 10920, upload-time = "2026-06-19T16:13:08.781Z" },
+    { url = "https://files.pythonhosted.org/packages/61/af/3a02c67f96bda4f1a2d3d3e5923e5ec70946b62e054ae64b6dfa81695ab9/pyobjc_framework_localauthentication-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:52f89e993950b66d2ec701fb2d5f523a5e6dfafb8e0da9c194aa4fc5aae3a30e", size = 11063, upload-time = "2026-06-19T16:13:09.615Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-localauthenticationembeddedui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-localauthentication" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/be/1cae60d052314b16e2e279cc187b918637e6afa7f3bc7aca6eb2ae6c2256/pyobjc_framework_localauthenticationembeddedui-12.2.1.tar.gz", hash = "sha256:f97666380541a40e593c7ed2214c11da30effcc909a4b13595220050a9888577", size = 14146, upload-time = "2026-06-19T16:20:59.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/c5/42b5b4260d20309ab9832c98bbb20585191248c846036e8975b9f194809e/pyobjc_framework_localauthenticationembeddedui-12.2.1-py2.py3-none-any.whl", hash = "sha256:a77da7a7471ee9277d4ae7269fb3d0bc508c5908e93ccf8e4cdf723bde21d1af", size = 4013, upload-time = "2026-06-19T16:13:13.559Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mailkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/09/49fc5fe2ba2489b2844e2a2f25cf526718f34c53847009fff2e9b1f94fc2/pyobjc_framework_mailkit-12.2.1.tar.gz", hash = "sha256:8a8e84f6828f13c7c67c6f8f299889127df05d25ffe52b6c942d69a329681c75", size = 23888, upload-time = "2026-06-19T16:21:00.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/cc/4a9e1f5a387df7e5bec26ad3488e414d6fb065c46131072d20f07a6314f8/pyobjc_framework_mailkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:e453e42d8ad97f58593296a85c71ec8c71378f8d5d79ac4548845f5dcba725b9", size = 5018, upload-time = "2026-06-19T16:13:14.528Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mapkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-corelocation" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/29/6f5a817054f8998629ae4c8146674a78850a56477ebbc8e6cad2732dad3c/pyobjc_framework_mapkit-12.2.1.tar.gz", hash = "sha256:b0d34e03e100adb471b91f0915b6ecb2266251886e54a1729ee534ec832ad392", size = 79578, upload-time = "2026-06-19T16:21:01.038Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/ae/8e0b03353841dbf36a380ea73fba3202c98ca94c47137fafaf04811a7b83/pyobjc_framework_mapkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c312c5ca0634c6676328c9b205d36fcd3138eacaf339480b9e9572e0c579e9d5", size = 22833, upload-time = "2026-06-19T16:13:16.587Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/29/45ae9a8e02b487270d29cc65e968cce3ea82c9b1fc6d208bc3d305c40f8d/pyobjc_framework_mapkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f423892cba28bef2becdc5cef9011e358f223b66478aecc8ae5e3083c8e1700f", size = 22863, upload-time = "2026-06-19T16:13:17.659Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/bdf2e3e7e6d5a05fb9fe11de7d8b85f75e49eaa3b31a8c7b45b2f28f804e/pyobjc_framework_mapkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e94362c148355d36aec29d7a77c14178e44e464504dd2cbcc8de28b18a5e00e8", size = 22890, upload-time = "2026-06-19T16:13:18.735Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a9/744ce0d68454c29522d8dd97a00f4a260cc06941763a2ac6cc189c653e66/pyobjc_framework_mapkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9c128d8e4af7698629545d5761cc1fca5a26a3e13121c2ff7c77e28308922b70", size = 23075, upload-time = "2026-06-19T16:13:19.855Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediaaccessibility"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/46/c07388b3911f10cf84347c0fc7b250792e6bdabbdd9a51083331b8ae58ff/pyobjc_framework_mediaaccessibility-12.2.1.tar.gz", hash = "sha256:6d816a09d874519bea85035db7c62c0566063a5be63e3ab25b2059205576ade8", size = 17250, upload-time = "2026-06-19T16:21:01.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/bd/bc6277582c43eb6b4916cbd411352bd5066fa3e1b48ed5add4e41932e4cd/pyobjc_framework_mediaaccessibility-12.2.1-py2.py3-none-any.whl", hash = "sha256:8543ff6664ce35815083ab10a6f4b1b9241594d60c27132e08385b0316d55013", size = 4847, upload-time = "2026-06-19T16:13:24.243Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediaextension"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/fd/8f2489cf3673a705d806124edb73ea27438919f58af1fa41dd789163838c/pyobjc_framework_mediaextension-12.2.1.tar.gz", hash = "sha256:d31057582878ec2574559ad253fd448de3f11a68e454d14f0665348c82b3dee0", size = 44554, upload-time = "2026-06-19T16:21:02.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/12/4606689b0259defde9897f6d046fbfa72360520a9a97e78c9739c760a314/pyobjc_framework_mediaextension-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e8d383f458e4812993a0b4132f128a588ea34d9be51644261ddd04f90cf530ed", size = 39032, upload-time = "2026-06-19T16:13:26.521Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/6e/3b9f69ef0caea40e6175e4226a9a8df7c7997cfb8dbe6ca430575c21b4df/pyobjc_framework_mediaextension-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bbf5ea3683dc5b6a2b0f218ec0e9935a21e6aebe7d00760be78395268fb04770", size = 39048, upload-time = "2026-06-19T16:13:28.614Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/02aa57d87451fab20d27c270545243e4868b2172b0519f75a1c7755a3e04/pyobjc_framework_mediaextension-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:600e289380d19b24d7166027988c63b5fa8cd297a379fa9538dd0bcffd527c0a", size = 39062, upload-time = "2026-06-19T16:13:29.79Z" },
+    { url = "https://files.pythonhosted.org/packages/05/4e/a338813ca7bb23e59d44c15eea0c43d2120de949c93acf408117b17f4051/pyobjc_framework_mediaextension-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c84027e9c775d51ae58c5c532935145ef1ddaae7b24b769e6ff7026b62a7e4ea", size = 39263, upload-time = "2026-06-19T16:13:31.184Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-medialibrary"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/3b/af0d8cf4bef550b77ecddea3db59bce0ab3ab5e22e258c583e92ba5a630a/pyobjc_framework_medialibrary-12.2.1.tar.gz", hash = "sha256:18fb56e727399f11ea588d2c512b7585147386892d72c65eb9c4b6387abd6643", size = 19052, upload-time = "2026-06-19T16:21:04.063Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/da/9f38ae220465c54ca064d24a0e42d93dc2da901ec811324c04d2ccc6a229/pyobjc_framework_medialibrary-12.2.1-py2.py3-none-any.whl", hash = "sha256:4d69f910f17bbccb4f815b171270b9279f9d7526b318cf45a7b2ddc84fc38d22", size = 4381, upload-time = "2026-06-19T16:13:36.34Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediaplayer"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/b1/eda7f1cbdb98a712239ea1a5deb12821d07055e16c51e8c25167fc801578/pyobjc_framework_mediaplayer-12.2.1.tar.gz", hash = "sha256:6acead24bb8f12e202976142db656c553b4a25ca2348165c35ce02862a93757a", size = 42670, upload-time = "2026-06-19T16:21:04.973Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/04/ca6e7b7c3827c3e835e81fadc7f3a26dd774a7a80fea7fce1cbd1ca044cd/pyobjc_framework_mediaplayer-12.2.1-py2.py3-none-any.whl", hash = "sha256:d37f5ede14fe70c547eac4abb49c9c96086f99acf8236985acadfcb07c851a5b", size = 7200, upload-time = "2026-06-19T16:13:37.48Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mediatoolbox"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/61/4970e65b4efa1aac9493dbf8420fcc5d053433bf21c19eeec6cc7c8f7fee/pyobjc_framework_mediatoolbox-12.2.1.tar.gz", hash = "sha256:f8757deb15870b7543e2880aa4e7bd248fbc92f6a55763a99fda3703b1b1327d", size = 22811, upload-time = "2026-06-19T16:21:05.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/25/3b6de68c2441d9b5abe78af9ffdaf581a2f4c7858c28516950c14bb73c28/pyobjc_framework_mediatoolbox-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0c5047e20a1affe434a4aa073ae9c1baea2b677f37a537b2dbe4d8552bc8f82d", size = 12686, upload-time = "2026-06-19T16:13:39.785Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8f/9ae04dce47a830fa5c0a43b23188f482694f1bc74bf77381888c08ac731e/pyobjc_framework_mediatoolbox-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2b4f70f6760c5cf49654f6256877e9875423507764af787c770e09214e5891dd", size = 12841, upload-time = "2026-06-19T16:13:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f8/f17e483d63424753f56b397bc93d510035b3bc5a579896eb127cf817b7a3/pyobjc_framework_mediatoolbox-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:53be99e67f027fedac2045c4efac256725e1f6a122830aa4733fc3db608fe014", size = 12854, upload-time = "2026-06-19T16:13:41.706Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d4/afc7d67f91f5efbc3d4885ad2e4ddc2598a500f15973936df47e6c8f4b88/pyobjc_framework_mediatoolbox-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6f3a58249339267f5c40dad9bc945642bf5fa167a9be74353f5c76ef42ed4510", size = 13440, upload-time = "2026-06-19T16:13:42.607Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metal"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/46/5920d6cb66cbbe298744889b10b3266b1408ad823855f55cdcb967c0d51d/pyobjc_framework_metal-12.2.1.tar.gz", hash = "sha256:cd362194bdb7fd2a9116b8dc1e6b14ce19629136304cdf6b88d105a969fda72c", size = 238139, upload-time = "2026-06-19T16:21:06.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/bc/fa4ddb10fbce1cdceb5fab0e1f2d5ceae90385f3ded8aec940da49e226f1/pyobjc_framework_metal-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:add59e48ca823d60bcf7e026baa2a95203b88c796b5febc140924fd9e5eb5821", size = 76004, upload-time = "2026-06-19T16:13:50.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b4/a56f0b69cd0ba016da9f2ab64776950a7ca8d7dbf7a4e03b1bdb2fffa947/pyobjc_framework_metal-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:92b1f2e8f4a86bd9ecf307144e1f2c5ccc451fc760534833ddcde58d7624c695", size = 75923, upload-time = "2026-06-19T16:13:51.542Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/6a6d547f11ea81d4ee1570d4092947d264e60f02288c119f14332ea3298c/pyobjc_framework_metal-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f39a87b50408afbfc8a78be0c0d164016f114c2f807eb35506051660b386931f", size = 75952, upload-time = "2026-06-19T16:13:52.471Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d5/0001ccf5217cde46c61140f062be050d6760359d2c4bd652b619cbd4361f/pyobjc_framework_metal-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:eb247c22391706162bcc14e6fd52101e632a51f3c0aeccb59cea549c019303ce", size = 76508, upload-time = "2026-06-19T16:13:53.398Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalfx"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/64/e64620b99d5fae9aa933e4d8189889275a89e4918773af64ea30b202aa89/pyobjc_framework_metalfx-12.2.1.tar.gz", hash = "sha256:c146060268f8c2941dba7695bb1511145035a8468b65d88a668b2eeb4ac8ea07", size = 33394, upload-time = "2026-06-19T16:21:07.855Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/73/1a5a3b967513abf7b270b83c7e3e8cef511f45f7d3805341fcba653ddcd1/pyobjc_framework_metalfx-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c8b17729b04033eedc6fd915f0d1ae09d7065d1e1301857b6e2e56f97270c8f5", size = 15047, upload-time = "2026-06-19T16:13:59.481Z" },
+    { url = "https://files.pythonhosted.org/packages/67/bd/8d0fe1c96e795e6ec5a78ffeb445e3651a3caed505d7c10e2eea67444306/pyobjc_framework_metalfx-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8c1b2b84cb3a2481d95c324cda82ecac6fbe7f6c6a2c05c960b956449cdad1ac", size = 15082, upload-time = "2026-06-19T16:14:00.439Z" },
+    { url = "https://files.pythonhosted.org/packages/92/69/97594e1276302d41ffbbdf065e4e4663fa34487749544f2a19ce3aa5eb46/pyobjc_framework_metalfx-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a4e6a33836b384f2627bb8c68f60365d85d135b6ecc4e3c63392c9ac30a597fa", size = 15096, upload-time = "2026-06-19T16:14:01.69Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b4/796b5f98983ab5354a145069dbaa3622cf57ffa238ce071ee75f717977de/pyobjc_framework_metalfx-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c213297c6738e92e2805ff6029c9b70c882c67d5799e574900941af2d02c13d6", size = 15308, upload-time = "2026-06-19T16:14:03.063Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/9e/18cd38c650176a9e4895f5b461c843e90fd85004a379fac799b710e813e4/pyobjc_framework_metalkit-12.2.1.tar.gz", hash = "sha256:f2f8e02f4ddeb1d49a5b3def09eddcb8a718289b6ed635fa5f1807165969e798", size = 28180, upload-time = "2026-06-19T16:21:08.766Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/be/a318901b833d9c84d2aa93ed46cd7efde582be33de1286f96ce6d57b99d2/pyobjc_framework_metalkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9ee027e7dfa9d5146a4032323f025c66051d0487523457975e05d97e62fae263", size = 8779, upload-time = "2026-06-19T16:14:08.907Z" },
+    { url = "https://files.pythonhosted.org/packages/90/e4/4b96ce6a2e396c4ff3d509d0b823a23765b03b5bf3608308b21023308822/pyobjc_framework_metalkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d81f90237743cfb7a65e92d8581d0298feb4d59a20b3995321bfac9eca458f6f", size = 8800, upload-time = "2026-06-19T16:14:09.924Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0b/73b19059dd6b638a9850f2e2d350e3dfc7244fef9d89f84fc079ae06c558/pyobjc_framework_metalkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd09232de0cdca092a79efa4e73ea12357b1db862527c9ce8172d0c2b688c5c7", size = 8812, upload-time = "2026-06-19T16:14:10.681Z" },
+    { url = "https://files.pythonhosted.org/packages/29/20/1df8c5a560709a81848b6098c99a761813aac3f29defd4847766649dbb25/pyobjc_framework_metalkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a90f5ade5946194025bbfd2981a4099062d671ab2667c95d6ce218c13cc3d032", size = 8969, upload-time = "2026-06-19T16:14:11.501Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalperformanceshaders"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-metal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/ff/6938291dd5a71e39f6948037dbb271993d86a3ecd7706e7cc38034feeaea/pyobjc_framework_metalperformanceshaders-12.2.1.tar.gz", hash = "sha256:a4395f8619ad6f1d382aab5cf116e058b18d3646bec6b730c77daa8f692b5de4", size = 190474, upload-time = "2026-06-19T16:21:09.743Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/b0/ed310b3a4cf06a16ca1e71c943c01955d734db172df043debf850ee719c6/pyobjc_framework_metalperformanceshaders-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:521d6a3ab80d76138754e7a1eaf02412d0d7502f5d486b4c3b7548d193b90457", size = 33927, upload-time = "2026-06-19T16:14:16.686Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9a/1d95d7a2c2855f9afb7a27378940f52ff87894d98e8bac6e98cb3a0099f2/pyobjc_framework_metalperformanceshaders-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6c679e85a4197302bdd7f9f9b17448c4df5c9a66e3ddb2d371814eb84a45261f", size = 34184, upload-time = "2026-06-19T16:14:17.743Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6e/40590459842bd635d0f5e77a520aca827af1331ef70e02955965f5122749/pyobjc_framework_metalperformanceshaders-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:856aa1b620ec04e64870694627435547affe350bda9e00e877e72ab518aec76e", size = 34198, upload-time = "2026-06-19T16:14:18.583Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/0f/f311b511eea76eaa7195164ea82133591c614bdbcf6efc069ef863dc0fa1/pyobjc_framework_metalperformanceshaders-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c1b094b81d0ed3f72b9345e7e4fbc47604934325d3695b4b8f2457701cf90fad", size = 34398, upload-time = "2026-06-19T16:14:19.437Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metalperformanceshadersgraph"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-metalperformanceshaders" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/11/15e3acf0636f9418384cd3e213296ad9882f546889865913cfaee2339ed6/pyobjc_framework_metalperformanceshadersgraph-12.2.1.tar.gz", hash = "sha256:656e70c86645814ef1d02bac74933eebc5ff6427100bee4a3bbffde921020ab6", size = 60199, upload-time = "2026-06-19T16:21:10.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/d5/6aa84d1d976ba8b97cdc6486f09aab85f20ea6ba5079086f1de4426cbb2e/pyobjc_framework_metalperformanceshadersgraph-12.2.1-py2.py3-none-any.whl", hash = "sha256:9ac2270c573e9399c02196ea1725bd3c7ed3699d71ee70286b1f78beb8afaf5e", size = 7134, upload-time = "2026-06-19T16:14:24.104Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-metrickit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/5d/1e0662fc1af513a08474ab7b9193012899e6930a490aefd9c2c531862a91/pyobjc_framework_metrickit-12.2.1.tar.gz", hash = "sha256:096878f3e750d12a7018b07ff3468d405ab3ac108f1aa92bc3123fd06934e344", size = 30581, upload-time = "2026-06-19T16:21:11.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/17/2a09f83953f702afa498032f22fa710bc17ae8055a6a82403e83c53f53b4/pyobjc_framework_metrickit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1167de9dfc42fddcdb0529b419d499b7c3e68c3f8f2828f93218360c9aaa0cd1", size = 8123, upload-time = "2026-06-19T16:14:26.1Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cd/e70cbd2ade0daf4e8130af6bb4a45793a077d7b064bb3fa04d4f65349936/pyobjc_framework_metrickit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ee7253c6451b99f43588be83460bdce90c1c2f94e10fe6cef294d0d44af771a7", size = 8141, upload-time = "2026-06-19T16:14:26.994Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/9c/651e524176ebce5eff66bc237212949ea247478849ef53308cae5ed8eb75/pyobjc_framework_metrickit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:62f6c2cc22017377e984fbea0ea6ee15b3c0fecda7fcc42e88d0beb5387ad3a4", size = 8150, upload-time = "2026-06-19T16:14:27.732Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/14/96162ec3e8d8a8131e86ea8459cd8a2c7ec6a28a6ac703d3cf7d6d11b710/pyobjc_framework_metrickit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1357f74151b851760b2520f20ffab69a6a85ed3c1aebd61164bb67e0be417375", size = 8292, upload-time = "2026-06-19T16:14:28.558Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-mlcompute"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/2d/16412fc8454bf987c64d7eb18ee0548198b35aad03b4d3cad6047fd18545/pyobjc_framework_mlcompute-12.2.1.tar.gz", hash = "sha256:4ee00b70d549619d63961864d9c2dd93b6db18d1c920242ae961517be7074f84", size = 55020, upload-time = "2026-06-19T16:21:12.198Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/9a/f7c94f4ca691822916509a260d9a18c58224b14845ae7dc7c2b56eb0b376/pyobjc_framework_mlcompute-12.2.1-py2.py3-none-any.whl", hash = "sha256:71517c5afdba1213aa4a832fcf3bc1cbe0efac7f4a42ea10cca33bbd4ad1db45", size = 9644, upload-time = "2026-06-19T16:14:32.481Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-modelio"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/a5/fbd7e593d0bf0f611b91758a855d1cad14b08f81609a588ce354b5677795/pyobjc_framework_modelio-12.2.1.tar.gz", hash = "sha256:d3706f803dc325c38536fb43fbd4174e958a95f92312a684ae152186661dff2b", size = 83795, upload-time = "2026-06-19T16:21:13.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/8d/64adc4f64bbb3517fe6951d9928aaf9fd4875e1f71b170de5b3348a4cece/pyobjc_framework_modelio-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5c035eb4598b61508d7180e8326f426918028ef7c8ba2ad933d29f343e9860a5", size = 20499, upload-time = "2026-06-19T16:14:34.513Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9b/acaef170056476aca099d56ec837f6f7bdc73c52507f14e577c8f14cb922/pyobjc_framework_modelio-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:82343edada3bb065317774a0f58c65f516fec6247113091da7029d06ad7e8431", size = 20511, upload-time = "2026-06-19T16:14:35.344Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/a7/6c23682a7b986165d6949e70d0cf9c30d1ff22ae369711b23699f22fef37/pyobjc_framework_modelio-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68b53d1aea59dcbe5682f753ded2d3dc4d54598f58a0defe9a1d3219c7a801b0", size = 20522, upload-time = "2026-06-19T16:14:36.155Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/1f/d3c3c89eb0d10b00ed139a4308a3d5e353663c16310628d69d1fae2b774f/pyobjc_framework_modelio-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1714a43c35bd4254f5fb51bc5d6b67dfcb2a6b20ff309d34ddd22f03bb1709b8", size = 20759, upload-time = "2026-06-19T16:14:38.045Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-multipeerconnectivity"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/5a/cf3fad5f570ad3aa43010ef03e948d4ac1f0a531d3b7d822f1c19004f59a/pyobjc_framework_multipeerconnectivity-12.2.1.tar.gz", hash = "sha256:06f9a354ef0ef77c45c98ba9ef92bc48961522d7b3ba322e56b4ee3d4a46413c", size = 26450, upload-time = "2026-06-19T16:21:14.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/a3/5edf042e97873d983da1509957667557aacf1750afdbd60d6e4dda055b51/pyobjc_framework_multipeerconnectivity-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:449c3e35eba88fc58e38fdf44e1afc41449eb7eea8c2c1120d19491579be1a70", size = 12012, upload-time = "2026-06-19T16:14:43.31Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2c/3b85949975b600497c7f1f928e2f35344b2b2654550abac1f07d83c0ee89/pyobjc_framework_multipeerconnectivity-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3180c51bb68ed87f53e7b805f3443a510d7db00a1c0344223eabb384123fa0cb", size = 12028, upload-time = "2026-06-19T16:14:44.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6b/546137c9aa171232ef6912f90bcd2cb2b4705d8ccc81cd498885d284d862/pyobjc_framework_multipeerconnectivity-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e566a2dd4ac9b95cc8b4739092501413a1d697a1c34126dce489cf55c0c71a53", size = 12047, upload-time = "2026-06-19T16:14:44.828Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cc/519061d373de8c779487b978eaa48cf60d9ec588f6dd2924dc9faefe8ebc/pyobjc_framework_multipeerconnectivity-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:87049bc0af02bb623bdd90573a6a2abaca7c967520db81477b05d0c38860aa37", size = 12229, upload-time = "2026-06-19T16:14:45.57Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-naturallanguage"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/12/de013ac3cdbdb3cc616dd373399df4eb34b4459f668456d81f7062bd49c4/pyobjc_framework_naturallanguage-12.2.1.tar.gz", hash = "sha256:fa2d9c7040dcbbe4c7bc83ddfb9e3da20edb49824de8c78d3574aec7065c4043", size = 27243, upload-time = "2026-06-19T16:21:15.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/5c/3c0692cc72de5b9cc6e55d262df6630f43040374eb7454382473067d3379/pyobjc_framework_naturallanguage-12.2.1-py2.py3-none-any.whl", hash = "sha256:5eed3750f7cbd6a9584f2b9942c4b26b7134ed15dc044815ac79841403048be9", size = 5460, upload-time = "2026-06-19T16:14:49.857Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-netfs"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/ad/28624d75b8339f70fc51bbac131d160a92b87c41ba5684a904304f8a6a09/pyobjc_framework_netfs-12.2.1.tar.gz", hash = "sha256:312b3a6ebcba6b3a03bdc7412560d8ddb5ac336c37a1205e32c6b58d831191f2", size = 15153, upload-time = "2026-06-19T16:21:15.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/e7/6396d25cbfa2237784ada5bcb870531be597b9dbf1a5c5d41d007921d2cc/pyobjc_framework_netfs-12.2.1-py2.py3-none-any.whl", hash = "sha256:04f8f1743f98af10d005f42ec30b26f147d3ee0365b1ff3df2babaf456c75e07", size = 4182, upload-time = "2026-06-19T16:14:50.78Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-network"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/32/6a69c5ccbaf38557f6a090b565ea12a773a64f3f29e87e625c03fa46c183/pyobjc_framework_network-12.2.1.tar.gz", hash = "sha256:0cbb405f304f25617f138a2556433e22d4f706e558a78201957f9e2ca3c9ae21", size = 62791, upload-time = "2026-06-19T16:21:16.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/83/b1ca408d1057c7e84e791ead11a365a110f3872d83c8f19ce1857994e908/pyobjc_framework_network-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2009d4aacca836bd6b6f0aa0b503cfe593488ed55b62d1e5d6a051b7f843f9e8", size = 19627, upload-time = "2026-06-19T16:14:52.858Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c8/098f41c92c847c4c7f0f3efa1bd243555926c34df95dc39d2103bc178710/pyobjc_framework_network-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45d0ad8977ac71624bb6bbd929df8768a39fc8c13e97712bd7d37a4b9b4061e2", size = 19652, upload-time = "2026-06-19T16:14:53.759Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1a/4580c0fc4433a9761812cf392b93d7c874be1cb2b34f52c6169621bc284b/pyobjc_framework_network-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ff15672b23decfd9ec9a0051ccd15f4abf098020c4700ff8d2466e597e747eb1", size = 19666, upload-time = "2026-06-19T16:14:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/00/724d2761f1af78b5f108804bdd68896a6d260fc472856c444dd495afef5d/pyobjc_framework_network-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9d2df906f6cb262c74ee6b28f80856eea52d07723c325a04e804357b77c9a335", size = 19735, upload-time = "2026-06-19T16:14:55.656Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-networkextension"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/38/7fdd6bce0c65c4ec01662e4489950b712034faa5adb59428a13ce9d56b0c/pyobjc_framework_networkextension-12.2.1.tar.gz", hash = "sha256:7858164a3e28dc81d317412123fcd664424da9afae63036e31979668ecd5972d", size = 81345, upload-time = "2026-06-19T16:21:17.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/7c/5f300ebc1d2bde42af0fad1830cf221ee5ccebba0eba3e568daec1cbc352/pyobjc_framework_networkextension-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:190db4aee1316c9d3d4da8e7a8fb44b98b70a6f6930f69baf7c9258082f7fc63", size = 14457, upload-time = "2026-06-19T16:15:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e9/084b993f44295a3c7a95434d4e655050655a6fae17d8488aea6ab9c65bec/pyobjc_framework_networkextension-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb4c79aae8bd30099a2373d379a7d3cbfc6c210fbcdcb766c58d209dfe710062", size = 14476, upload-time = "2026-06-19T16:15:01.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/26/09becc50d9ca9a00dde6ec835b3b49249b006bd162bf40beb05661897330/pyobjc_framework_networkextension-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:94e851bdcd902dfac889daa5017bb9e3bc7086332956d9ecc53ef087d332d1f3", size = 14490, upload-time = "2026-06-19T16:15:02.7Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/f9/f1aa8f1ec246ee79018d068beb38a25af39287c671f471545216e338d695/pyobjc_framework_networkextension-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:812cc5a68e464b1a0047048a46e0f1d44718cc39c37ab9d8d2827c34a37cc2a1", size = 14637, upload-time = "2026-06-19T16:15:03.586Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-notificationcenter"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/22/6e5b84c0b0b187525fe655508adba71fb208abb747326f2a9da84dd2d6b3/pyobjc_framework_notificationcenter-12.2.1.tar.gz", hash = "sha256:952d0bfff1653f16f9e79336c8eeb928ed517f0212c914191a925a85523b5af6", size = 22159, upload-time = "2026-06-19T16:21:18.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/f6/1f09a8c541da1050c911bb292574cefa60deb23d29c0663badc6b7718f8b/pyobjc_framework_notificationcenter-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:40a1a0bf0057d6ec1567b58947e6b3550b13ea5cffa721ad63b1c713a73276aa", size = 9881, upload-time = "2026-06-19T16:15:08.914Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f3/2e870eb44592692ff85e829b28f2004eece7e1b1c4578dfd715251649b5a/pyobjc_framework_notificationcenter-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0e86691f099a752a625b1a03a42f8cd8b28705bae5cb9924c988a7a8bc429d5c", size = 9900, upload-time = "2026-06-19T16:15:09.73Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/27/a56dece1c44638a8736a0878c8b52b153940183781a6065ca80fd38644b3/pyobjc_framework_notificationcenter-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:72187126a81e4a5f1fecab21b4740628dc6fa75a6a0471a0c115adfb49c04893", size = 9916, upload-time = "2026-06-19T16:15:10.75Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/37/1acb093763b4b83de911f53f28363bd4a81190511f7794235dd279d850d8/pyobjc_framework_notificationcenter-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c61e2dd16fe34410d972c57e62c6c4949f86e97b12fd1f1079b75ba409df7837", size = 10114, upload-time = "2026-06-19T16:15:11.543Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-opendirectory"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/02/df1979038cdc426990b364b2307ef33f5a6d915e70eda4791daf692024e7/pyobjc_framework_opendirectory-12.2.1.tar.gz", hash = "sha256:1b6dc2eea7857f05063f22e746ae66e8a2a135e41c62b7f3ca7c91f8a5ec5de0", size = 69907, upload-time = "2026-06-19T16:21:19.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/2a/e4bd17504ad233a38ea2d73a2b9914310c489a34f71418962bf99ff35799/pyobjc_framework_opendirectory-12.2.1-py2.py3-none-any.whl", hash = "sha256:2604cd01e236a1237ee6e52c689e60fb380807c5bda6981dab37dd14d89dd254", size = 11939, upload-time = "2026-06-19T16:15:15.771Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-osakit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/41/0a010e6e48e5bb248a8c4d6b7f71ecb1cf17c92b194db512b536f60a54a8/pyobjc_framework_osakit-12.2.1.tar.gz", hash = "sha256:6656e6dab5eb2b571cdcd0d68c0084fa2ac5f85f2f06423e132b410c44e87187", size = 18924, upload-time = "2026-06-19T16:21:20.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/ff/ba06033f6b8b5a43a188c810c4439a35cbc0baf90bfa90e4a1682260c1d7/pyobjc_framework_osakit-12.2.1-py2.py3-none-any.whl", hash = "sha256:00c1996bde228324665795f9fe9e129eccfbeab1c10d8ba34e1b1adae379b482", size = 4166, upload-time = "2026-06-19T16:15:16.725Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-oslog"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/3b/8a38104775d9472cc360018ca358325135779037122813f5d4cf0f1ce4f6/pyobjc_framework_oslog-12.2.1.tar.gz", hash = "sha256:423e19e08d3f01f3b0d53f2b4503322c0ef9d116c0a1f91fe36273232cf0ff22", size = 22322, upload-time = "2026-06-19T16:21:21.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/15/94c87fdaacac513dd737d86873e5c85683a4b2d247b86b778b73c11e533f/pyobjc_framework_oslog-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f54740a9a37deaa197b0af793a7fa0ecb909131199278ea00e833b2350516f06", size = 7889, upload-time = "2026-06-19T16:15:18.584Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c8/834e7bef1853a936a4bdb019f6e55f985ee3bd04ef6e7dc2a6f1a964e144/pyobjc_framework_oslog-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6cb3738d55676285692108f6cd43773ad9589030bda1077e8ff7080e44e635d0", size = 7910, upload-time = "2026-06-19T16:15:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/91/32/f6dc6ca6d9487e9be095193740263e59b700a239dac6b6a3bd75c30d7449/pyobjc_framework_oslog-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0ab4755e4b31d304d8eb04291470a7381d69b0381cec02242bdf37e2a492438", size = 7922, upload-time = "2026-06-19T16:15:20.191Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b7/937982d62f343fa41a3b0ccc3b481b73f804a04e185ebfd15044d21529ca/pyobjc_framework_oslog-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:bf2a170e8fcef12de89749f085d3ef52f0a3a7084a566f244377012301d91c63", size = 8104, upload-time = "2026-06-19T16:15:21.196Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-passkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/b9/5762ada91652118bd08b4bd236e4cff00edf5211403ee49cd8563a2330c2/pyobjc_framework_passkit-12.2.1.tar.gz", hash = "sha256:28de8925d89b705b9344e59498d15e5a10935e982b19eed10f0d498c5e670e7b", size = 68251, upload-time = "2026-06-19T16:21:21.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/65/8e8a038c97895a1f88593894b238663df1d21a4563a06fdc531e53914c04/pyobjc_framework_passkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:730c14e62f822053ed4502407da3b563bdaae0b55d1177ae2b12526fc2be90cc", size = 14456, upload-time = "2026-06-19T16:15:26.519Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b4/6f1fa4a3cfa23baef9eac38cf2df7b8dc8f64f99e0796c77cb909a6d95bf/pyobjc_framework_passkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:85df88aeba17f3aaa86f4eae1f0cba99ada8c18df7fd1ca49548276399417e26", size = 14472, upload-time = "2026-06-19T16:15:27.47Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/3500af51c2758b71cd2e3835a08df33cdce6b5c72b8275f7e1d776c0b610/pyobjc_framework_passkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:28e1c22d9476cdafe7839f368fd6e8c99f4925aa85e4f9126e5921f4c7e834a1", size = 14485, upload-time = "2026-06-19T16:15:28.371Z" },
+    { url = "https://files.pythonhosted.org/packages/df/2c/addcb03ccdd59685043af645974d56aeb9867ac87a9e29acb0cbfca88d97/pyobjc_framework_passkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e51509baa9f4883b1583c410dfcf8b68372a4457e13cd57f4c9490c6e9895e06", size = 14651, upload-time = "2026-06-19T16:15:29.194Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-pencilkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/6a/f8831e5b5bbdc3e999f3bd95c7e297bd8d8641ec3c1fcd153c77616e0e2f/pyobjc_framework_pencilkit-12.2.1.tar.gz", hash = "sha256:2545561beece43d63c745b6bbc4503cc7c55ad0792d4206916c75da26a4dca49", size = 20110, upload-time = "2026-06-19T16:21:22.756Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/c6/eb126b4b6e93ce53ba1451b04fb5a7724c9569e8ff185d34c56ebec869bb/pyobjc_framework_pencilkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:d8214b76615d7f0fb6295ee21c679edeb889a03f355c1774f792dfb93bd313a5", size = 4266, upload-time = "2026-06-19T16:15:34.139Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-phase"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-avfoundation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/61/1ecd9506eee8698ab1156a7d99980d668e22b73cde9638cec98cd3d610f4/pyobjc_framework_phase-12.2.1.tar.gz", hash = "sha256:31392185ec0d3b0c5974c9b71f0c540843b1bdd884819484e627c6c0d592388a", size = 40754, upload-time = "2026-06-19T16:21:23.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/b9/a09f9ec64fc04cbaf2070055fa44d03454f6592328493b940fd1496f4560/pyobjc_framework_phase-12.2.1-py2.py3-none-any.whl", hash = "sha256:426b407f9ff0fe2b55128e3c0e9a949db4b0a909ca095d65303c247865961dc2", size = 7211, upload-time = "2026-06-19T16:15:35.089Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-photos"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/cf/af57f3b72daec93cd92b091473cac35f7616aeb2db5e4ca3a25c984aa5d1/pyobjc_framework_photos-12.2.1.tar.gz", hash = "sha256:e405e612c48563609fe32da9aec9286ed8cab10e226dc58ae6910e141fc46f44", size = 58673, upload-time = "2026-06-19T16:21:24.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/0c/6a0ba1d041a1efa978244a6f74aa03247ec73621728c0df77f49a822044a/pyobjc_framework_photos-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6f90b2ae5080a8626d13e995334ed2e7fa0cf04bdb479d50f18398baa657c701", size = 12513, upload-time = "2026-06-19T16:15:36.972Z" },
+    { url = "https://files.pythonhosted.org/packages/08/cb/b141cb95f75e94578e28062a033b4ae3bacb5a0660452e04df728a8b8d25/pyobjc_framework_photos-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:516320e2d3ab7c73bb196f7eb46afa289654829013ae79a51d663700e15ddab0", size = 12549, upload-time = "2026-06-19T16:15:37.983Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2f/599c2bcddbd5514b0a670a022a27b60c04198eec91eec025b25738ae71a4/pyobjc_framework_photos-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8be8e21b65627b4c55367c51258c22f7d73d3dbf7412a341e49684a1da1b60bc", size = 12561, upload-time = "2026-06-19T16:15:38.754Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cc/a1c26f3dcc216f3973c1fa7bf19d05f995db70a783790ff682ef96f77c83/pyobjc_framework_photos-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:060ff64355662599bdc1413601c04f1e7d3b8b318d92dec9ab72bdf1cebc08fd", size = 12743, upload-time = "2026-06-19T16:15:39.565Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-photosui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/e0/5e8aa49c3fe59572f9097bcea75844352c33c88fbdfcc518c6eef7657c88/pyobjc_framework_photosui-12.2.1.tar.gz", hash = "sha256:cb37100f2c75640d036a9fecf476a6fb68d1cafb5878c0e3f7c47054a63218a1", size = 33856, upload-time = "2026-06-19T16:21:25.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/4b/e3f11f8cfa520535f3c2d62c43bf5a6492669ee49f8136d87f591de62ab7/pyobjc_framework_photosui-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3589035bf9ca764f5fa1d09bdec976dc5e2f25956ab4ac080a453ec93896fc52", size = 11782, upload-time = "2026-06-19T16:15:44.851Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8e/66323978657e7cb281aae60eb7d4cd1738c495b04b1e8a435cbbbd02dc00/pyobjc_framework_photosui-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a8f0723e75c73d1ed3a29f3a6d374ce2275cf95d32aa8880e1bafe90a0354462", size = 11804, upload-time = "2026-06-19T16:15:45.671Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d1/8ea0b4977612dfa496c73a08feeb197b9016c702e3cbf19360cb0268a9d4/pyobjc_framework_photosui-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:03ab0b9d9dcf3e50b62f8579ee11592d0049044044ec1a2b5eebce3e75d56893", size = 11816, upload-time = "2026-06-19T16:15:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8e/d68e34582ba82ff27c4d7e1b64332bd7b76c51eafed29efaf7f8944a941c/pyobjc_framework_photosui-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:872af4d088ded84a2a4cbc07aea10d98746221409d3179474e84c1a45f5f871c", size = 12013, upload-time = "2026-06-19T16:15:47.391Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-preferencepanes"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/f2/788a198c7b8c44a27c2b358c2cd846bbd97bb6d9c8c457cb248c3c0a8958/pyobjc_framework_preferencepanes-12.2.1.tar.gz", hash = "sha256:1b8e839b364b792441201c1112e17cd6d42f493987169da04ec65eda365d2ede", size = 25113, upload-time = "2026-06-19T16:21:26.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/b1/bc42da075faf6e4201bfe2ec4bfda95b71877a15df4a501977ef739b7128/pyobjc_framework_preferencepanes-12.2.1-py2.py3-none-any.whl", hash = "sha256:026ff87afba2d381e3d9dadc58957580558e1a705291da6794107220a3cd8102", size = 4829, upload-time = "2026-06-19T16:15:51.915Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-pushkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/dd/d0ad735548407e862717b7ef08a29dd51b3b9c1c1987ce43f76c25d72c34/pyobjc_framework_pushkit-12.2.1.tar.gz", hash = "sha256:12800cf33aadfdda5df3e487d4ce3d8a79a2a0efcebbd5b1e11a1ff8a1a4067c", size = 20464, upload-time = "2026-06-19T16:21:28.183Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/79/a3a754ffee2e97b20fbd0956fd3cb686b38eec771c6434d2311cf10631af/pyobjc_framework_pushkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:49262afcec0cedd434cd3d5215d343bead702706115ea00892f776777aef2cc1", size = 8290, upload-time = "2026-06-19T16:15:54.784Z" },
+    { url = "https://files.pythonhosted.org/packages/52/80/366a0f1210c433857f0639b040e643fc31accfaef38ab2ab5f6ee93733a1/pyobjc_framework_pushkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:675f65d1ce111debdd3e371a6e50296ef9345d8123311c658f16f3e9bf8cb106", size = 8305, upload-time = "2026-06-19T16:15:55.606Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/bf/69a637549c72fc4da253a1319e1cbeb13b0abcbdb24d09a3c21ddcb031a8/pyobjc_framework_pushkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c3feb1c38ccde8e24548e5a5032d5adc2cb354f1aaa0c7ebed6babd2fdb86cda", size = 8326, upload-time = "2026-06-19T16:15:56.429Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f9/28b5c789ec9167435f0a095cecab27230e41496c33c0a458df546754a2eb/pyobjc_framework_pushkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9dd060c626f17365803f5dbffe0ceb3062e3710886ee9a7c887f3f70b3285802", size = 8460, upload-time = "2026-06-19T16:15:57.351Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-quartz"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/08/527d1ff856e2f2446b5887be01989cc08f9adaf3de7d4eb13d07826c362f/pyobjc_framework_quartz-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:60f29408b4f9ed5391a29c6b63e2aa56ddfb8b66b3fb47962930427981e14462", size = 217998, upload-time = "2026-06-19T16:16:02.978Z" },
+    { url = "https://files.pythonhosted.org/packages/14/fc/d7c7b3134cdbd1a487f3f77b5be125d87a6c9e7d9411035739d99335cc0c/pyobjc_framework_quartz-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:de9c8cca7e95290c8d540466af11c7cdfe3a5458e6f56c34006d5b45243f9ed9", size = 219000, upload-time = "2026-06-19T16:16:04.29Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4b/861f91a1565d3189ee899e177b915551fb9a7e2ca25414025a8974f04e74/pyobjc_framework_quartz-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:54c9bc7f507192691841ee4eba5bf36990b259df83ac728efed2d7ea1cd021e4", size = 219403, upload-time = "2026-06-19T16:16:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b5/b27010d2f288737f627f74be6d5549f49c841542365c84b9a3011fe39ce7/pyobjc_framework_quartz-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:bfc0d2badd819823d21df8069dcf9544ce360ed747a8895c51bdb25d8d125f45", size = 224458, upload-time = "2026-06-19T16:16:07.252Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-quicklookthumbnailing"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/49/41d06038c50a750d6172b875d45ec8a180650b98c6e0d8cdce43b4120ef1/pyobjc_framework_quicklookthumbnailing-12.2.1.tar.gz", hash = "sha256:1b348b674569b8df40ef6acebbcdc4e7e8b347b0a437c824b35a6d6f91acc398", size = 15765, upload-time = "2026-06-19T16:21:31.579Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/1f/1a92542d6b2d879422a20c99124aad3d9e176a9ff65bdf0d1cecb381cbd1/pyobjc_framework_quicklookthumbnailing-12.2.1-py2.py3-none-any.whl", hash = "sha256:747a99db601e0a7ca48fbd32909c803f47211adc194a4c41a5b5430738b3464c", size = 4329, upload-time = "2026-06-19T16:16:15.183Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-replaykit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a0/2d5903651b581cc9c64cd08d67088310807a169e60465c46d016ac53e2dd/pyobjc_framework_replaykit-12.2.1.tar.gz", hash = "sha256:c5a712ff52ab58c58a53a27e47dba2d3823b13f2587a395855e9c4f0510af6a1", size = 27213, upload-time = "2026-06-19T16:21:32.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/6f/2319235ab2626251692091ebdfe9838863447014fca25a6e26677fab41a1/pyobjc_framework_replaykit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:07b4c27d67dec0dc68b0a352810d80fd95bd474a940bd0304ac182d39f9df664", size = 10143, upload-time = "2026-06-19T16:16:17.544Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c2/9e1c99f86d7a11925b0009fb9051bbd4f7e2cf512e8bb470131b9c87f79b/pyobjc_framework_replaykit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b682657b641df5a78195a8f8a7abc6be04aa445dfb73814c96a12d3f252fa5d8", size = 10176, upload-time = "2026-06-19T16:16:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/834b5e916fdcdccde827e2d5bb4137f5ae34b7e225cde1ed845f848f0336/pyobjc_framework_replaykit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:18d5cbdc48436f5f612f37163ab2315518220f88aae39d81c7fd1460da8ad510", size = 10190, upload-time = "2026-06-19T16:16:19.16Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7f/9b55c3b25cea2ee2506980b626256beff02541c978f55caf91f3643bff3f/pyobjc_framework_replaykit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:daaca45e9b94b2cdf6f76ecfdcccb51faf5342cbf8d7a4741ef361406376740e", size = 10368, upload-time = "2026-06-19T16:16:20.08Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-safariservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/8b/638f43f5f7936dc3919fbb7a76a1efb3826941e49df12bbbb4b95342a594/pyobjc_framework_safariservices-12.2.1.tar.gz", hash = "sha256:5da28790b389efa21a33d2d48d3322dc3670077ec9c8af9054824d42153e0298", size = 27306, upload-time = "2026-06-19T16:21:33.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/30/32ac369c880023b529a617e69b831e912611888349d4b9f768fbf2ebc9d8/pyobjc_framework_safariservices-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:491a02a10332bffd2a081d52e3bb788819d411433ef03103cea144390025f56b", size = 7339, upload-time = "2026-06-19T16:16:26.048Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/c60149609a5f7dd91e35d43a3317ab9bfcceffba6780254533d42945422f/pyobjc_framework_safariservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:46779f1c6a53fe561bafb95379a7bb66535938e622a23b8308f4125f443fa81a", size = 7344, upload-time = "2026-06-19T16:16:26.825Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7b/15dbacb24573d8fbdbc80685c440c5506829c9e36dc48b32d4f515a0190e/pyobjc_framework_safariservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:210ae2a93175fff88ccbc6c50a58ff981158a2d6bfe4edaa1880aa2fc5f4ccc4", size = 7362, upload-time = "2026-06-19T16:16:28.023Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d0/ee671fef9dfba5fb54cb8f00dd8f80b907ffe39acbba7e4b89d122a7b420/pyobjc_framework_safariservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:98dfc05920eff91fa5db9cc64cf764be8b588ae179ecf33985fa7a9f81e044ba", size = 7368, upload-time = "2026-06-19T16:16:29.179Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-safetykit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/57/ec33de6440eec0c805643dec1115d7a0cc21be8e8e13dfff52e66de6a0e3/pyobjc_framework_safetykit-12.2.1.tar.gz", hash = "sha256:33defe7e4155dff6abf0a2990bb2a918447b9339199ca92c2f3f219d48189ebf", size = 20855, upload-time = "2026-06-19T16:21:34.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/76/1291e7ae26ae34c1228b4f9f86fcc85a5171cb5abd6eb937f137db353f74/pyobjc_framework_safetykit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9cee8656c9c2867f4d972efde8dfaf308176fdd881f807b49b616d37a58daf8d", size = 8587, upload-time = "2026-06-19T16:16:34.656Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/41/ed6f62913c9b3bf2259de53caffd58758565625e0c04f1d970644452b53a/pyobjc_framework_safetykit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f5e757c9565d104c442b81babcbc4998daf0326b14d928dfae42c5459580a309", size = 8600, upload-time = "2026-06-19T16:16:35.639Z" },
+    { url = "https://files.pythonhosted.org/packages/db/08/81833a95ca16ce0379bbbfb8f1524f2d862942457f9f6f05d0c5c1bf1b41/pyobjc_framework_safetykit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:eb272c4f8304fc2c8db9652020b01f2a6026c91fca59072189264d03894293fb", size = 8614, upload-time = "2026-06-19T16:16:36.872Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/9d/6ff0294bfe087f428dd28861da0953c8bc7d0f540caf8cc4e724bc8550dd/pyobjc_framework_safetykit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0122066ee790375e97ef888af8134c13f00c3b890d44769c6c74f3b126438506", size = 8775, upload-time = "2026-06-19T16:16:37.789Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-scenekit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/4f/4c614327db5c8a9af6fd8995bacd5f4d3c331c1be66f29722bac3af594cb/pyobjc_framework_scenekit-12.2.1.tar.gz", hash = "sha256:9f5939ecdfa9c13347f6ab61173ba5eb386766cfebd82200fe7173f70aa34083", size = 132003, upload-time = "2026-06-19T16:21:35.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/27/ac8abf8c42aac47cf948dfec1746aad5e6b1110f2c11b6c45a82611b7f47/pyobjc_framework_scenekit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:41d1c000f2cce780fdc18419aad0b1cdad50f49317b38dedf9219ce5bcc5a659", size = 34761, upload-time = "2026-06-19T16:16:43.637Z" },
+    { url = "https://files.pythonhosted.org/packages/74/99/4c880fe6fa3bfcf980566b8d6b1e608a586d97f43bbeaf658a2889cc1ef8/pyobjc_framework_scenekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a79aabfbbaba44098e5cfaec2f87ae3d04a31f1e250283dcf7ab08cadceed1ab", size = 34816, upload-time = "2026-06-19T16:16:44.56Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/bd/e87bc4fce0ddc9806f31eedeffb5c8b9b309888026faf3ca4d1ae7414ee9/pyobjc_framework_scenekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6de30a01c643892bc1fa5f3254c17351ec9c72c7ab9af9c895290e8191dc057d", size = 34842, upload-time = "2026-06-19T16:16:45.406Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/2e/abf47653356f62712729828ee06a9bc1ee8c67b1e4bba96a37f0cfae39b0/pyobjc_framework_scenekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6cb7213c8f9c5d3a111b3850082f545001fbcea6173606e0986354350c83cbaa", size = 35158, upload-time = "2026-06-19T16:16:46.298Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-screencapturekit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/a6/b7e72e32d3334e13eae592cbcd9f3c060c43adf78ddfebd0eb9c6be0ab05/pyobjc_framework_screencapturekit-12.2.1.tar.gz", hash = "sha256:e419cbf9c2f9cbd172d1c6e5bc69a44e0a7d9e45cf43058d48eeda4f785ce860", size = 37840, upload-time = "2026-06-19T16:21:36.099Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/4e/020fdc67539a3b5879075b51ae052c97f9ce6ba4aaa4d37bc9be4d9fdf05/pyobjc_framework_screencapturekit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d9be9def5875e800581dade26b45ef66c735c12ceb4a17c5457bebac159903d9", size = 11566, upload-time = "2026-06-19T16:16:51.925Z" },
+    { url = "https://files.pythonhosted.org/packages/55/eb/76a25a68695f8502ca17ad0f482ed3e8d1714a7fdaed86728388778510c7/pyobjc_framework_screencapturekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:407dfcd80e493d11ce54163d4cc973119f6a507cd695875f4cdbfde6f2db42d8", size = 11596, upload-time = "2026-06-19T16:16:52.953Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/db/c65ea6d42f9873ee6a1d63d4db1db334d60536ba679382688647bd626cc0/pyobjc_framework_screencapturekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d23bc1d0ac0068f328a97c1ed95d611cb2b8517c76345ddbbd21e5e8bc85a898", size = 11616, upload-time = "2026-06-19T16:16:53.772Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8f/b57ec1a7632d7d49f01fc4b322c2c81fe62757c5ad78bd19f0fe085b6aed/pyobjc_framework_screencapturekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3269ee9ecc1cde271cffb1e763672469b70375fb6aff00394a0387cc622070ae", size = 11794, upload-time = "2026-06-19T16:16:54.604Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-screensaver"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/32/a3826be36a6473c6bed8f3a7cbd879b8feadfd83463cb1ff615aba66e414/pyobjc_framework_screensaver-12.2.1.tar.gz", hash = "sha256:15eba02075a065283e763c8087b9c6fa565907c95e0575a383c1a6ef4c9b1868", size = 22814, upload-time = "2026-06-19T16:21:36.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/c9/a2ad7ca6ad84d8379e1604718cd63205454d60f0978ad1aef5b585fad6f0/pyobjc_framework_screensaver-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:be8df2ca5d4765d2d64f0c130f0a1d9a748c6d965e8a0b45fed2ff12681682aa", size = 8571, upload-time = "2026-06-19T16:16:59.74Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3b/126bc97a45a4bc359e26e567da2518c6b891e842c1061ed1f942a1341b28/pyobjc_framework_screensaver-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8f43926bc686453af7798f460144beaaaea09ffc296bf20d1b38c9e420f94b4d", size = 8492, upload-time = "2026-06-19T16:17:00.568Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/06/33c369a75297e3b86ae977d473d24d2e141fe0e5c6663ab829b9e5960509/pyobjc_framework_screensaver-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7535dec51e71d41bbbf2100f49b26f8539e34fb34ec9943d7f075b8ebd46b26b", size = 8512, upload-time = "2026-06-19T16:17:01.332Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/f9/2617d0713f2b49a7acd2977f6f0b7f1cf7eb57e0ed6666b56a7e7bd1d5f6/pyobjc_framework_screensaver-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:3fe3232d9aebf919ca2413c373f96915e55b904a1ad362091e79d142e634841f", size = 8519, upload-time = "2026-06-19T16:17:02.142Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-screentime"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/93/27470ca21f4c596a0692a3e9cfcd45d38c3bab6f0566bbb5af4e3cfb8b98/pyobjc_framework_screentime-12.2.1.tar.gz", hash = "sha256:c97e700995c03183a1a73f2eaaf90f5ed66d68e8c2e40ff7ed2fddbc77ff7b2f", size = 14074, upload-time = "2026-06-19T16:21:37.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/75/d434c86454bf4c21855b69f145799699a2d1650067575c4eeeccc6738ff0/pyobjc_framework_screentime-12.2.1-py2.py3-none-any.whl", hash = "sha256:b252234f5f1e01d6f3dbfde44a6019169100c2337f24b65694ffdd6ddfaa3c4d", size = 4002, upload-time = "2026-06-19T16:17:06.29Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-scriptingbridge"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/97/908c6a8a4eb665c952dd8b6c670eb2ad40661c31721ed47470d1329115b3/pyobjc_framework_scriptingbridge-12.2.1.tar.gz", hash = "sha256:779b2238b33b61fb9ab4fc71d080e42ef7e27562506f5ca9d783effc4c769a5e", size = 21226, upload-time = "2026-06-19T16:21:38.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ca/27d6e825fb9ff1069ef94e8770d0851e3bce654b507c79c7dde39f81538e/pyobjc_framework_scriptingbridge-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:fbf6c59d27ee1b03ae14cdc3fb7330c2d5cc1a2cebbc438744550131b3e6f168", size = 8370, upload-time = "2026-06-19T16:17:08.124Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/aa/21a22afd311b14ea317c09aa6b238232f8d45e7795005f032c97bb9816db/pyobjc_framework_scriptingbridge-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:89153d5bbf44b2ab5a63b646712ecb86b1a64606c3082934ec5c6be4c8a192b4", size = 8381, upload-time = "2026-06-19T16:17:08.888Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3a/7e83276e69d5dca85597dbb5129fafd1f453bcd9c44f9ef1996292cc1fbe/pyobjc_framework_scriptingbridge-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:093ae30d045bd5348bed5fb34c826565d0d385305fb75159b46fc2bc1d7d226d", size = 8402, upload-time = "2026-06-19T16:17:09.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/44/64b578077c04d505849bed5ce06af49ebb3a8cb69fd4d2eb0b97b0c9243a/pyobjc_framework_scriptingbridge-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:2b620a2c3eccc446c21be0d93a343cdf709b1c300ccc8e83a4c0a7ba0c30e90b", size = 8551, upload-time = "2026-06-19T16:17:10.564Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-searchkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-coreservices" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/53/be9909e2c3672242d5a4f8223a5132d39f3ae9e9b82062e214ddc4db828b/pyobjc_framework_searchkit-12.2.1.tar.gz", hash = "sha256:1fe1ceb2db1d8c86f75484dd9f88ac39dd3d2cffba250498ba0e2312435214cf", size = 31141, upload-time = "2026-06-19T16:21:39.275Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/d2/10e5fc076f236f96fefea233cd31eb15374c393bd8d737cb41b49ac746a1/pyobjc_framework_searchkit-12.2.1-py2.py3-none-any.whl", hash = "sha256:936e41880d48da6742128bc900de37d14771e718087719589d589e858aa2ea60", size = 3760, upload-time = "2026-06-19T16:17:14.683Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-security"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/b8/4267b802d8dba6de468e7d0765b05cc4e146fa376ed9f55e0b6461016bef/pyobjc_framework_security-12.2.1.tar.gz", hash = "sha256:d7831b1537f4346892e7f2f0e2b09d79bee98919b0767f4061278d0e03028f2d", size = 181065, upload-time = "2026-06-19T16:21:40.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/ac/f2ff946edfaf16b4ce5e31afac5e519f83705c0f4842fd25134ecb8f2f4a/pyobjc_framework_security-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ce461296b003b2ba17c8b65f6339f9d2fd5dcfa2b3b52ddc0a696334cc8974c5", size = 41306, upload-time = "2026-06-19T16:17:16.816Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5b/2719bc4062e6c27083191fd20e365ae02d0bf1c22f4d1a88211e3d96b369/pyobjc_framework_security-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:76ff6e44e62d3e15651540493879bf16687d862c4f10f3cadade757811c8b8d0", size = 41300, upload-time = "2026-06-19T16:17:17.702Z" },
+    { url = "https://files.pythonhosted.org/packages/15/90/dccd4cd6877ef208957dc1f3675287d8614a4dcd2a3ee0a5e56f5fb5a1ba/pyobjc_framework_security-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:990013baba29d6f985d8950b23701129b2597b3d16f628b785fe97596d8a8de3", size = 41299, upload-time = "2026-06-19T16:17:18.511Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/af/f9e8040e0c3ef6a50392a46ad1df482a666aa615180d40730b00282ff81f/pyobjc_framework_security-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:066a3e5e9d368e7a6ba8dd52be2077a634ef12a54fbfcc78b3b8154a8f988a1d", size = 42179, upload-time = "2026-06-19T16:17:19.48Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-securityfoundation"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/9e/c1b6426d9ba602ceda4f5bf438705e05930d46c3ef561a89736e1b9cea51/pyobjc_framework_securityfoundation-12.2.1.tar.gz", hash = "sha256:b10f7c6f2fea27f105e69e0ef455df10e911748a4a414aff74f9dede48dd2cd3", size = 13103, upload-time = "2026-06-19T16:21:41.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/03/b439d6af2c215a59e71cdb2cf00959415f0dd1ec0fd84b0a517c403290a0/pyobjc_framework_securityfoundation-12.2.1-py2.py3-none-any.whl", hash = "sha256:4f3f52573805977e94f3b50af27cacbe2abdd05fd96fac4be746685e523e1e85", size = 3826, upload-time = "2026-06-19T16:17:24.38Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-securityinterface"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/24/5486d26d86abf4edb639de2eb5598b6c5cebe33a1aa19d55575694d72160/pyobjc_framework_securityinterface-12.2.1.tar.gz", hash = "sha256:08e58cc05741e8515f157854831063261a7247497c996a120f90148b8aa78842", size = 27798, upload-time = "2026-06-19T16:21:41.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/36/4591538165b110012f1bf442212404ae4af6ba3a4d8cb5a4cf7be611a00c/pyobjc_framework_securityinterface-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:db17172727a7799a38076b759c824b81ab5c2c4f49b8b71f4d6bba25f9697a7c", size = 10741, upload-time = "2026-06-19T16:17:26.227Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/46/8dcb2c1983ca1fcb8279de27264c4b5e00484caaf714c7b846c7800dc898/pyobjc_framework_securityinterface-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e15228ac342d553464f990435e81ee67c4f2fa5cca99388933cee72fd8764193", size = 10807, upload-time = "2026-06-19T16:17:26.996Z" },
+    { url = "https://files.pythonhosted.org/packages/19/13/3c18031c450eb8677f600f86af9c6569174d093dbf60af0bef202813b681/pyobjc_framework_securityinterface-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9b93c778e431c0290b0eaeefdd0e9f502a5defa172a82710d697537a4ff8db7c", size = 10820, upload-time = "2026-06-19T16:17:27.862Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/88/da14ec8edd7d22245bf3230a5b2c0127a73b7b8ae5d036053ce16a722e0e/pyobjc_framework_securityinterface-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:1bc4a9c50583bebc061b734e382389a50bd62ad5fdaadeb8585024278b96dea9", size = 11161, upload-time = "2026-06-19T16:17:28.683Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-securityui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-security" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/f9/5aed7140a5f22102cbffad47e1f8a6cc231a428b2021a1731925da9a78f1/pyobjc_framework_securityui-12.2.1.tar.gz", hash = "sha256:87b07746fb9ca7634c3c74f89bf6ab90dffbfe0c0ffb89551aefce0e35353a50", size = 12648, upload-time = "2026-06-19T16:21:42.645Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/c0/b166bb5b4f5fa80dbf9c09074d435c41b04dc741f8a4cd37b241a2c884ce/pyobjc_framework_securityui-12.2.1-py2.py3-none-any.whl", hash = "sha256:e1e0d9ff4671aff464b7af48b1e10bf9aeeffc1ee40c91fd1ac301ab19d87e45", size = 3626, upload-time = "2026-06-19T16:17:32.783Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-sensitivecontentanalysis"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/8e/50648c1e4029611acfa6a5cc6c20e3f36d9754414c7c9c690ef142ee1c6e/pyobjc_framework_sensitivecontentanalysis-12.2.1.tar.gz", hash = "sha256:e958e4333b72e7bd93a32be6c3118c50be8e98de6ca7a41bbf076a712ab2ca21", size = 14428, upload-time = "2026-06-19T16:21:43.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/38/ee90dce73e9eabcc5c80ee514b2affcc89dd3b47dfeaaaff20a1cb0b5e33/pyobjc_framework_sensitivecontentanalysis-12.2.1-py2.py3-none-any.whl", hash = "sha256:918c362c11673308191a9d94c2c59a368d4cc39e354694e1da5c99b3609cb47c", size = 4269, upload-time = "2026-06-19T16:17:33.696Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-servicemanagement"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/2b/289270180fc32c2297907e6576355aaabf004297d9830a62f9792a5bc95b/pyobjc_framework_servicemanagement-12.2.1.tar.gz", hash = "sha256:99ceee681fea1e57246d33acbe199100f2e35a09cac97ae1c271e34073c28763", size = 15295, upload-time = "2026-06-19T16:21:44.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/15/ba63887c27663a7107f289a44072c04c6b351b52177c63d8004640fa7325/pyobjc_framework_servicemanagement-12.2.1-py2.py3-none-any.whl", hash = "sha256:8c84c82a09bf00046ef2d43f910204cd362fd1eceb706176c30d079ee208f2ed", size = 5456, upload-time = "2026-06-19T16:17:34.619Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-sharedwithyou"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-sharedwithyoucore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/85/8a2d509a27814d56e064f15469b8fd9720ce5c7ec669bcb0cf4b2e800b25/pyobjc_framework_sharedwithyou-12.2.1.tar.gz", hash = "sha256:b1908b9822244ea31d4d546118389c69687982e5fa67bc72cbf1a9e09f1f84b3", size = 27310, upload-time = "2026-06-19T16:21:45.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/9f/6b4f112d25e6f7b78e60b4caf852b197416e4e5fc399c33becb67934d77f/pyobjc_framework_sharedwithyou-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6bd370918c4cedff2a2f6e15e22f6184e5431bd4624b0d270d6e518b6ffec8df", size = 8817, upload-time = "2026-06-19T16:17:36.462Z" },
+    { url = "https://files.pythonhosted.org/packages/46/47/d9810da0987abdf3b21df2d8d872e46f4d916a5fa45ab43370136375a7ae/pyobjc_framework_sharedwithyou-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:32188fc96282ba4d3686587d200d5c0304ec3e0cd5cfbb8d0bdadc5ab1fcb300", size = 8832, upload-time = "2026-06-19T16:17:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e1/bf963d03e57084970380d99af331cf5b6d3cb214a949fd8d8a7f266edd5e/pyobjc_framework_sharedwithyou-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:927a95d78693f2b2323dbc117d1fcf638612cbfb19d2fd0f6077c19c22eb92cd", size = 8846, upload-time = "2026-06-19T16:17:38.044Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6f/56ac0ba0950a3e20cc9e8993432466241b8b5fbb08867840dd796cbd9f38/pyobjc_framework_sharedwithyou-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:46d20007e80717f04506a7afee2b6bdcc5ca50a345d7a26fd3f0cd7d97e5cba0", size = 8984, upload-time = "2026-06-19T16:17:38.853Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-sharedwithyoucore"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/05/5e9ba6cdde040717004115a1254ee315434bf7df5f2ee9f9f9ce619bf6dd/pyobjc_framework_sharedwithyoucore-12.2.1.tar.gz", hash = "sha256:b8a4d2d79702756d9fffc5e17f83b45d52c469579acde873a487842ac334384c", size = 24333, upload-time = "2026-06-19T16:21:45.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/e3/e234ad577ab3efe97a3a1b0703e57430672ed14a70fccf345601adbbdecf/pyobjc_framework_sharedwithyoucore-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ac0e9812f970bba7f4db5c6332c9282c1b32456dadc2c88c82165712af341b5d", size = 8579, upload-time = "2026-06-19T16:17:43.976Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0b/c26f3af20af44e755f33ba8c75a5439bd8e2fd4bfd406da1211fc08dd8a4/pyobjc_framework_sharedwithyoucore-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:26d3c00be64f9e422be6a902dd2e95532c7ef4e6149ef756dfc2811a71a1c6e6", size = 8599, upload-time = "2026-06-19T16:17:44.808Z" },
+    { url = "https://files.pythonhosted.org/packages/07/26/fd4dd0b314bbe91b58cdc30b0621a8c6efee2fa9a9a75a4f985d9f14b492/pyobjc_framework_sharedwithyoucore-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:25d42419c12d964bcadce37a4cc2e3825d5227bd1bf00767902a702136bdc1c4", size = 8614, upload-time = "2026-06-19T16:17:45.633Z" },
+    { url = "https://files.pythonhosted.org/packages/08/90/d2177377c80ab30c30a292686e84b298b09c431303fa0c26ebdaf9fd5cca/pyobjc_framework_sharedwithyoucore-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c6ca2669c6c7d1a061acbf0c12c55aac3848a43d580b9aa96ffea69d36985086", size = 8748, upload-time = "2026-06-19T16:17:46.39Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-shazamkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/7b/12a46aee28ffc14a5118ab45be8f0f629feece3548df81d934e31e723ada/pyobjc_framework_shazamkit-12.2.1.tar.gz", hash = "sha256:4cfa9325e381e8b365b2d4725b9165a5e52f7986f28dcf23c3e7f0bd3bddf3aa", size = 26062, upload-time = "2026-06-19T16:21:46.513Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/78/3ae7f591a3bf96ddc0c31fa9524fa495b1f51910a110cb6725d8ab6a0bb7/pyobjc_framework_shazamkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cafe6fdaa478611ddbea6be8fe01373bf65b57f54bc6ca7f8a5580b2f75ca7c9", size = 8639, upload-time = "2026-06-19T16:17:51.337Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/24/7e327525ed03ed041fb97c5f32bd9e0ca79bd282f50d373be68f8f71f14c/pyobjc_framework_shazamkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ee31a56ae4d15401e10f79fa07f7f79c5cc747afa9a5ce581654f82ee5b3c6d9", size = 8661, upload-time = "2026-06-19T16:17:52.177Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a0/5247501e4d5482c0977025d9914d481ad5029f9f372a84475c01240940e2/pyobjc_framework_shazamkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6b5fcc07180a2fb5a1cef0f38cbdb24caa869e423f612116bc67135dee59b44d", size = 8675, upload-time = "2026-06-19T16:17:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d0/ad91bcaf2f43bbbc5a7b67cf1c0544e2dd875befb95664540346e9328324/pyobjc_framework_shazamkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0ccde3a967120d3285fcc40d48f34f345bc6f0b4accb4ff64799535030bc3e3a", size = 8820, upload-time = "2026-06-19T16:17:54.278Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-social"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/25/0a3ba41ba7aa0380968854a53f02e549afe0b5af89856abfcc2f8988e050/pyobjc_framework_social-12.2.1.tar.gz", hash = "sha256:c2877c7ddbed8f3ea17065687725df57243d25b64beb3b885e8a18482c24bf7f", size = 13751, upload-time = "2026-06-19T16:21:47.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/81/91b2b6420d8c72ffae0df08249d3f5bf8f6f2a2ba2f4f90d071855d74913/pyobjc_framework_social-12.2.1-py2.py3-none-any.whl", hash = "sha256:3d76bce48e3eced0683096a8f8d32ba233c44db8cb9469f881a783932f29c2f5", size = 4494, upload-time = "2026-06-19T16:17:58.466Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-soundanalysis"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/43/b6a1644c01010c50dd4a69b0e4ed144139d60d7900edae937486c62af73b/pyobjc_framework_soundanalysis-12.2.1.tar.gz", hash = "sha256:d17bdea63c2b910c2046ba43383b29b82d594a37feee4431d45b55adc08a3882", size = 15777, upload-time = "2026-06-19T16:21:47.973Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/16/2e8f86936aea345432c6d0d080513dc53eac417f4a485d9b8ffb2d5db885/pyobjc_framework_soundanalysis-12.2.1-py2.py3-none-any.whl", hash = "sha256:4385f492320a304bf64ca772e4a5b29d796f0fc160ff764ed060ac1456aa3cdc", size = 4244, upload-time = "2026-06-19T16:17:59.484Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-speech"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/fe/0d1f1710d77deb2aefbdcca344b682f86277a0cf2df55f49615bdee213e1/pyobjc_framework_speech-12.2.1.tar.gz", hash = "sha256:77e01c6e92b34e3bb47dc5b0c43a59cb7941a7eb6ce595ca3de3a686a5df21fa", size = 27772, upload-time = "2026-06-19T16:21:48.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/8a/f8391a8daa0743ab652a1ef1666b62d1dcfb526ebce2254d61e6d7c76adc/pyobjc_framework_speech-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:481ab813439be28ae7b93dd9de4d5a52e5d7351954f1555489b3bdb635dd8243", size = 9279, upload-time = "2026-06-19T16:18:01.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/10/0415e5368531cec9274b4d028d2075a2e3b9752af8d6c75aec75603fbee4/pyobjc_framework_speech-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:20e70519b54b09ca3ded0bf4b19dace1d39847caebebebdc4381f127dc58f33c", size = 9287, upload-time = "2026-06-19T16:18:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f1/b89ca277820479cba6aeab75ee50357efa902ea4d4a6f7871bc66c1c7403/pyobjc_framework_speech-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:774d6d07193fb49ffbc5c39447eafca21ca5b2058ae41f79af876aa6cce5d726", size = 9305, upload-time = "2026-06-19T16:18:03.253Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/be/dc1620d483e55337a529982c04d58edba4f77ec435c9700a78319171bcaa/pyobjc_framework_speech-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f425a3a11c282dfbcb0b3f3e218f5f155232c94406b31ec395c40aa9e309a0e0", size = 9465, upload-time = "2026-06-19T16:18:04.206Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-spritekit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/0a/3da8666b42a696b1d82a283ba442f2941060fa304359d4855c3c6072dd3d/pyobjc_framework_spritekit-12.2.1.tar.gz", hash = "sha256:989a25cb2e9d45ecb97655f55464e44a342eb525a891e46a563aae27c683eac0", size = 83906, upload-time = "2026-06-19T16:21:49.536Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/ef/260a6deff24f18e68e776288346624e6c36c20e85dc82db74e844182b1cb/pyobjc_framework_spritekit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a1744c4f79b33274c4957d609e8ff87a3c2920105222f4a38e6df870f5e8bc9b", size = 18584, upload-time = "2026-06-19T16:18:09.471Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/bb/d19a875a22e30759be9ec33c7f238126d14c5b9cde515fad9c708577585c/pyobjc_framework_spritekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:182326b96722731536018564a890fce1b6cd9860d5fde3e0c2dfe31c3108f7fd", size = 18650, upload-time = "2026-06-19T16:18:10.321Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e6/83366c41ed99c17d690aaf76574e083d885d00c96b615a8552f284b318df/pyobjc_framework_spritekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee809a16cb549197f124240d1387e0da8ad9dee9bd853ab302fd8538de2cc381", size = 18668, upload-time = "2026-06-19T16:18:11.573Z" },
+    { url = "https://files.pythonhosted.org/packages/05/58/76cb4ff81419708ef45095d588f9f73a75a7c6a4c1c0f3070f3ab981ae2d/pyobjc_framework_spritekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:780d80b09c3a5f368efd5d567291bdf52cc07da079e75260776904ff4c5bac17", size = 18935, upload-time = "2026-06-19T16:18:12.605Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-storekit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/2e/d299e11aefcc70414281e5f82e2297a314c108c5bf81091149f1c3f6411a/pyobjc_framework_storekit-12.2.1.tar.gz", hash = "sha256:5d3b306f08810c485a4bd184bc6e45cc92eaf4cb6d4b88bf701bcb854ab66f59", size = 40971, upload-time = "2026-06-19T16:21:50.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/ae/22edaf607a167973a5a857ef1c1a1c0b97f232d975953bc2ad6e05bce759/pyobjc_framework_storekit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b90d2187290f6bb4b943a313b7c2adfd4865c11c8173781e6d48c01154b6d9d1", size = 12893, upload-time = "2026-06-19T16:18:18.041Z" },
+    { url = "https://files.pythonhosted.org/packages/09/09/9cb870b865d1adb49a910df20b2347ceecd07d906e58b14a5c807bf67e30/pyobjc_framework_storekit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4394366c2d4442c41faadaa030202f4b8a6272b8ec25828a04504f5b40179b6e", size = 12903, upload-time = "2026-06-19T16:18:18.964Z" },
+    { url = "https://files.pythonhosted.org/packages/56/7a/931bc925612fd74d09679ec976c45bdb2e41492e63d287594e11e6b1d5ac/pyobjc_framework_storekit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3dab34b774ae217dfff0bc636925cd39c072300aed322e107936f15b9c2184ca", size = 12919, upload-time = "2026-06-19T16:18:19.987Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0b/eee8956c1d94824357ac92674ce9e4c96285612a22d290da00aad647291c/pyobjc_framework_storekit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:11a40b897ef4d042079daf2fc4d05fe910d6fc737fdf15d3873875721fcea69a", size = 13117, upload-time = "2026-06-19T16:18:20.999Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-symbols"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/1f/6575bd54a71ccae067b56cbe9277b65d095c9a9880c9e059d8d2e845a8ae/pyobjc_framework_symbols-12.2.1.tar.gz", hash = "sha256:c15d32ae7c94e0e95fd83bc2099437a70671b79d0f438a1b0cd1f3eb2cc6f365", size = 14778, upload-time = "2026-06-19T16:21:51.277Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/ae/163c7af387d5f65cbd55a5814596b1f4cb5c26b28e2e9ad6c2f331cc920b/pyobjc_framework_symbols-12.2.1-py2.py3-none-any.whl", hash = "sha256:95199cb08207680ee36bcfdc4cab5d4c5eaa0ae81e01b1a752066effa6c9b039", size = 3548, upload-time = "2026-06-19T16:18:25.705Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-syncservices"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coredata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/8d/ad9492c9f0a305e4a1e30968407385cd4bc61051a1a2f9c40677c964fff9/pyobjc_framework_syncservices-12.2.1.tar.gz", hash = "sha256:c351286f14d257e20f8305665825fd73f108c8f0d787e4643818dee5debb3511", size = 34867, upload-time = "2026-06-19T16:21:52.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/84/459e2c058d5d069b825afc722143afed6bc29347110abbc1f19b528835ce/pyobjc_framework_syncservices-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c4e2f5e4d2c72c6f4247bd8497a450a09652f84f6990a3ef089345f9a2475134", size = 13408, upload-time = "2026-06-19T16:18:28.336Z" },
+    { url = "https://files.pythonhosted.org/packages/37/43/504b6ef68ed22a3546aa42339f7e6c3d6953c856cbe28158ce231611eba3/pyobjc_framework_syncservices-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4cdce34f17d978f349e22dd6604a46bc01c25cd23142b856c393ffd28d6e687a", size = 13442, upload-time = "2026-06-19T16:18:29.174Z" },
+    { url = "https://files.pythonhosted.org/packages/da/de/feb58f62fb4a5a2970cb8660a48e4fd8f9480771c66a0c82ec3f87d25418/pyobjc_framework_syncservices-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4a569b68068163df043146b999b606e431b6cb4de4ccd24861031321fa442eda", size = 13455, upload-time = "2026-06-19T16:18:29.976Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/af/fd67ce6c70f9329261dff246322f08000fad6f96f940e8f0a3859c85d7ea/pyobjc_framework_syncservices-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8ade4390f80e4b8d9f94610a3310d1c4cadc195e7db09a9702bec39bd8a0aa8b", size = 13626, upload-time = "2026-06-19T16:18:31.254Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-systemconfiguration"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/6f/805ee24f58c13eb593e458ec1f79d94d3415edace02eec7c614ef3518f69/pyobjc_framework_systemconfiguration-12.2.1.tar.gz", hash = "sha256:877a90eafe3df72625e50d61fc9c6dbd40e8cdabab7c4101992090107bb71ddb", size = 63314, upload-time = "2026-06-19T16:21:53.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/95/50cab59ebfe08dd2c4856da113bb5f74102d915b699c2e3988af3550ccfc/pyobjc_framework_systemconfiguration-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:df9a278948483d40d56a780a99e692b9bdeb2be6279f8f59c96fbd31f620eb72", size = 21674, upload-time = "2026-06-19T16:18:36.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/7e/f153e2db0cc3724b6cd3c1e939149fb93a6d7b4b9c0ab75a8d7ecdadb02f/pyobjc_framework_systemconfiguration-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9671060ab587eaf485eb8e1d6b328d664ba4a210c4ebffbf7dd2705d741bf90a", size = 21570, upload-time = "2026-06-19T16:18:37.853Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/bb/ecff9943e5bd24b78319f683e9219209db502f46a3dff24d1e50bcf9d74c/pyobjc_framework_systemconfiguration-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:06e93a97364681543592bff38f801e2942eb272d68101ccbf3278a8fa043c645", size = 21565, upload-time = "2026-06-19T16:18:38.829Z" },
+    { url = "https://files.pythonhosted.org/packages/71/dc/ecc0b5a79d54507be2a3bb8a5088471bbd2a5bd8d2f89dd07538f3bf2551/pyobjc_framework_systemconfiguration-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e3aa4706f81d8334c717d44567314ebbdf03e62259ede99a89f4703789c212a2", size = 21979, upload-time = "2026-06-19T16:18:39.662Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-systemextensions"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/1b/6edbfef0f03ff67bc22ba03ac7027aee804ea5b16512dd9547dab5786c81/pyobjc_framework_systemextensions-12.2.1.tar.gz", hash = "sha256:4f9f6d729544acfab49fe02a4b38712112c51f07790f8d4bf7ac3bb18c334839", size = 21667, upload-time = "2026-06-19T16:21:53.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/30/d50fc19821ae25d43fb0bde681891fa4715d41783f96156dd7a1f77a3ca7/pyobjc_framework_systemextensions-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:21d5993eee958be7f445ec2f0616c4213773cbcd9213346f4ad367037e5acba0", size = 9208, upload-time = "2026-06-19T16:18:45.178Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/a70c451b3ae4cf8387b0f0d709754e8f87db7057f2e0bb5ab0d73f96cc98/pyobjc_framework_systemextensions-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b871a52125eff3c6ea10b769920d64fddcbc26a58bb3759545f914cf0c5cc9fa", size = 9221, upload-time = "2026-06-19T16:18:45.995Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/20ec0f1239d58a0f8ccaebfc545f27c26904faab81f4e6e7d07efeba1f71/pyobjc_framework_systemextensions-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ded8228991aedcc2b3f9d8c7a0af5f9e9cd9125af562d68817e6ce0bf8a2a713", size = 9239, upload-time = "2026-06-19T16:18:47.155Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/94/c6f40110f2da5bbea11f41ed906888aa726bc22b465b39027b1ea5d4c516/pyobjc_framework_systemextensions-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:ae954da6267be3d7bafd53ee8357c8b5d3c13dd56359a0d862b69f5cb7eea260", size = 9395, upload-time = "2026-06-19T16:18:48.452Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-threadnetwork"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ae/a2f44eade30d2231938acb81ef049f4172afd6e9acbdff55eca036e75038/pyobjc_framework_threadnetwork-12.2.1.tar.gz", hash = "sha256:98397cf45354750c4b5a1237f6961c616d12f3ad0a570b3808a03e5d3373f64a", size = 13341, upload-time = "2026-06-19T16:21:54.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/cd/822620f1c4f00e24fced4a267113a77d7fafe394d0b516b8c94ff01f62b0/pyobjc_framework_threadnetwork-12.2.1-py2.py3-none-any.whl", hash = "sha256:75afa29eb2884cb9c5ddf5bbc81fed7f45f168422ae897c1a791374152c9ffd0", size = 3827, upload-time = "2026-06-19T16:18:53.181Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-uniformtypeidentifiers"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/108fa1e5a3dd8aff626f98fb97de370323b290404b04ffa2ef9420665ed3/pyobjc_framework_uniformtypeidentifiers-12.2.1.tar.gz", hash = "sha256:1fb89d13aa3c2df8e6d6536f6df3493fe5a6caefd2a5adebf17c5af3b29ed4a2", size = 20679, upload-time = "2026-06-19T16:21:55.739Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/44/18a7b3c3b4f9f6784fddf64ed5a2c148577d0300705a50e8ab81da8fc71d/pyobjc_framework_uniformtypeidentifiers-12.2.1-py2.py3-none-any.whl", hash = "sha256:ea08413ad895a7dfea13670e26548bcf5b00154084cdfb5d8f96603320e77cf3", size = 5042, upload-time = "2026-06-19T16:18:54.085Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-usernotifications"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/77/bdd49a1fe4d89ce86078e94121cf6e9c7e2f733215556194da04c512075e/pyobjc_framework_usernotifications-12.2.1.tar.gz", hash = "sha256:64379ab6b603949ea20b7852343cbcff7403443b4876ec8ac0c03bd0f11b1b22", size = 33955, upload-time = "2026-06-19T16:21:56.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/a8/4de5e87308d3803b4c49acabf885d408ee490d2d019ad224c0f72da2235f/pyobjc_framework_usernotifications-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:74e7e7af3bd5842502ee553f4d0ec566f698195bb89ae925c91441c86a0aa5da", size = 10195, upload-time = "2026-06-19T16:18:56.111Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2d/c40189560f8db4ab9f29a9c79eb7b2d89544d80a27252de5112ebcabdd4b/pyobjc_framework_usernotifications-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:12fab51085e4796e04783e457d9355b805afbd1cb13bf9d207e5fb7e1a32fb36", size = 10211, upload-time = "2026-06-19T16:18:56.988Z" },
+    { url = "https://files.pythonhosted.org/packages/21/71/cff5abc272742148f086cf00b5625e6a7f23171dd7b23d075f16a26e47c9/pyobjc_framework_usernotifications-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:273ef82c7ddc1701d56b586cde2615360618c1b2d17fb5c24bac77a5f02b6092", size = 10221, upload-time = "2026-06-19T16:18:57.775Z" },
+    { url = "https://files.pythonhosted.org/packages/69/54/75b4c4c15dd4f4f3c190424244ca35976e3a29c51740b7648f3fa78eb73a/pyobjc_framework_usernotifications-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e872d65dc71bc297401819106b5e5c4b758aa38247d74284bce20e63a2bdbfa1", size = 10379, upload-time = "2026-06-19T16:18:58.507Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-usernotificationsui"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-usernotifications" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/9a/566813aed69566c68045fc080b2238f62df131826d16da42529e89d56434/pyobjc_framework_usernotificationsui-12.2.1.tar.gz", hash = "sha256:ea6aecea828e088416aa6d14055c023cac6aa03ea0cdded8baba679ce5414cc8", size = 13457, upload-time = "2026-06-19T16:21:57.294Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/4d/ae257ba381d779ff760eea94fc12df5aded3bbf9da4304f66f70962ad68c/pyobjc_framework_usernotificationsui-12.2.1-py2.py3-none-any.whl", hash = "sha256:25464587228e128758a1ea9d8b0abdb872d2a957d1c554d791796a39ddc0e4ce", size = 3953, upload-time = "2026-06-19T16:19:02.794Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-videosubscriberaccount"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/4a/b3485f9e123b05a44852f07ca9387d8ad719a3ecbe0a10e2d2f726a460ff/pyobjc_framework_videosubscriberaccount-12.2.1.tar.gz", hash = "sha256:7af53b410d3943be09d8601bd8d50fd0e193e4e5577fdaa2f801d7f9dbc0454d", size = 21346, upload-time = "2026-06-19T16:21:58.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/78/4dc23b84c668c10dfde26c861c697b4bd682d1d137422a0546e742c08455/pyobjc_framework_videosubscriberaccount-12.2.1-py2.py3-none-any.whl", hash = "sha256:ac43567833a4aa21fec81d39449d080b2cd58d6b02de76b57004067bdf37ba76", size = 4890, upload-time = "2026-06-19T16:19:03.85Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-videotoolbox"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coremedia" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/82/307369b27b00b38cf6b6e021fcdce0ae6f1a91f24fed9b090addbe90f1e2/pyobjc_framework_videotoolbox-12.2.1.tar.gz", hash = "sha256:83582abc25e55ed04f0267fa69923839d779a11da3d34ee8c93ad1a66439e48d", size = 64995, upload-time = "2026-06-19T16:21:59.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/0c/8693571c03dacaf86a21c79035dbc36e0fd39422f55251b8d1ed5c5dc0b2/pyobjc_framework_videotoolbox-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:eed49d96127b0a52afe88a78ee3ea28cbc39c8d274cab1c921cc64a46201b0d6", size = 18877, upload-time = "2026-06-19T16:19:05.803Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/64/804ef9bda687dd3ead9ecd9e2fe29842a5acaee95bfa5f5d6932716090e9/pyobjc_framework_videotoolbox-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:67e03405bf7ea4790688c3937c5838dd8e1d25aa95923a7bb71ba3c49031d1af", size = 19004, upload-time = "2026-06-19T16:19:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/eb/771c0564a82e4e9ff8a4369100d6a3720824ac65a8e899c70da970e89ed4/pyobjc_framework_videotoolbox-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:efead1dc80cfd7612b952e831bb1e4b3ce9b13e6e4848ee82c28fcd5eaf718d3", size = 19024, upload-time = "2026-06-19T16:19:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/e7/0725ee9ad4576c432fcc38f90c78b0f377034aa71460420d4dde649a1d00/pyobjc_framework_videotoolbox-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:45bb85a114280763e7b4b5f9f726be1b0ed97041ef3816e77fee2268211d6732", size = 19231, upload-time = "2026-06-19T16:19:08.338Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-virtualization"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/49/5c306fac7b85c4f875b01f38266b75b9b8ba80a9747bfcc692c9b83adffb/pyobjc_framework_virtualization-12.2.1.tar.gz", hash = "sha256:dd752180219ddc54112876576debca9f3316e91ce75afce622981eeb8c9a0f4a", size = 49190, upload-time = "2026-06-19T16:22:00.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/4a/eb0b108eb7720f647a26bbf6a477cec09f9138df93e470473fb35f96df0a/pyobjc_framework_virtualization-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0137793bee5c628b6f9e44a773e49e3f68f758ef5b08ce407a9910b907ee6092", size = 13592, upload-time = "2026-06-19T16:19:14.052Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/0a/d5e4670a5b12fa3150b25b7f7a7694a72d8895527d33c0e33d63753a7086/pyobjc_framework_virtualization-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6c90011e2f90dd5593996cb80f9c4739bd4a12db7303086678217a08909ee045", size = 13626, upload-time = "2026-06-19T16:19:15.082Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d3/fb9b5f4d457715d165293cf7112d7405128ab461c957c7dbe19d4dba5ca3/pyobjc_framework_virtualization-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee6423823b4b851d76567e44c649493eff6cda7ada94a86942a4c706f3e22f36", size = 13642, upload-time = "2026-06-19T16:19:16.051Z" },
+    { url = "https://files.pythonhosted.org/packages/20/8c/146a46d88eaa8071f36c28c759790ba853b5d4630d53f22d8d74a871f13b/pyobjc_framework_virtualization-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:862c7d9c8ddb47eb086bb55271459e6107be904c526bdd3d520787a89d4e6c72", size = 13841, upload-time = "2026-06-19T16:19:16.928Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-vision"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreml" },
+    { name = "pyobjc-framework-quartz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/7a/1fdffff1b6bf124b260a2169869f4b71a08b9f6603698f7dec990d5ae5f3/pyobjc_framework_vision-12.2.1.tar.gz", hash = "sha256:debfd59dd7d962a6053bf733370148c11a9ec44091b517a0966f48d81c305879", size = 72683, upload-time = "2026-06-19T16:22:01.102Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/dc/a4043619a8c1bae2ef0463ebf88b3d2d5973ad5809dcc5d2d5fc93f34151/pyobjc_framework_vision-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:86f221d7ced483e7292194293b791a255e0bd1e4011048533501679e378d40fd", size = 21794, upload-time = "2026-06-19T16:19:22.356Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/1b/ee3aa7d1517d2d161cd9c2d00b9fc19206d2472b4bb35e98835ec9992d02/pyobjc_framework_vision-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fa2e56d891eab12a0ddac2373c69957c108f70dea56f5a9a6081a3c2f905c98b", size = 16947, upload-time = "2026-06-19T16:19:23.209Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a0/1bc00a6b6031b7d6985a0547d2b41ed4ea029c3ffbfe31c8040bb14f6674/pyobjc_framework_vision-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a041188213ae84153d5fe74cd69468827c150cb7157e2649e40a2a3cedb8f55d", size = 16963, upload-time = "2026-06-19T16:19:23.99Z" },
+    { url = "https://files.pythonhosted.org/packages/59/af/e6618858bd8f9be6c58ea7238b7ec224d1a31df506dd912c41672fe4f369/pyobjc_framework_vision-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e288cb41349d6e84cfac0822a0c1fb476bf5fa094913b19e8c2899e90a1a9e8f", size = 17105, upload-time = "2026-06-19T16:19:24.817Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-webkit"
+version = "12.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/d2/b230c594f70ecb970b4cef67bae2648d1bfa5b381e9b7e3710bf24ec8887/pyobjc_framework_webkit-12.2.1.tar.gz", hash = "sha256:a56acae55b50d549b20dff2921ad1099add8fbc377d0de09ddc2ba50957f7def", size = 332374, upload-time = "2026-06-19T16:22:01.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/d3/2ab99d3975dd4624dd943e5a7c8d37e40258d3c9fcf4f26baf09a24e6c9b/pyobjc_framework_webkit-12.2.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:af5c4ccdf03845adac082823a3b4341b5b2fe62d2d664550afa705b5286a06fc", size = 50264, upload-time = "2026-06-19T16:19:30.607Z" },
+    { url = "https://files.pythonhosted.org/packages/84/47/7a2099eb2e062c6230a9440f1795cf34056ca5e16ef25c8aad7c059b8734/pyobjc_framework_webkit-12.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7e04dcc08cdc59380113ea1232af75a0a04c2426418ebe967b4c0045c973f776", size = 50372, upload-time = "2026-06-19T16:19:31.581Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a4/202ec288808011d3f459d000d593e88b1118f2d1d5a4dfaaf5232f2c2ac2/pyobjc_framework_webkit-12.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:23bee8bf7077f91da4e3ae54a00c7f5e4414319e15f98be8584dbd67c4043fae", size = 50387, upload-time = "2026-06-19T16:19:32.522Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a4/f796e94b43a66704b6ae17c747c7b97fd4b79348f1cfa9bef7b008aaa718/pyobjc_framework_webkit-12.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:00ffb254f97e9ffdd0a82c1faa61a07f6072ba900fa8aba70c83c21198b52e4e", size = 50853, upload-time = "2026-06-19T16:19:33.43Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
 ]
 
 [[package]]
@@ -3637,6 +6488,18 @@ webhooks = [
 ]
 
 [[package]]
+name = "python-xlib"
+version = "0.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/f5/8c0653e5bb54e0cbdfe27bf32d41f27bc4e12faa8742778c17f2a71be2c0/python-xlib-0.33.tar.gz", hash = "sha256:55af7906a2c75ce6cb280a584776080602444f75815a7aff4d287bb2d7018b32", size = 269068, upload-time = "2022-12-25T18:53:00.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl", hash = "sha256:c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398", size = 182185, upload-time = "2022-12-25T18:52:58.662Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3659,6 +6522,38 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
     { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
     { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+]
+
+[[package]]
+name = "pywinbox"
+version = "0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ewmhlib", marker = "sys_platform == 'linux'" },
+    { name = "pyobjc", marker = "sys_platform == 'darwin'" },
+    { name = "python-xlib", marker = "sys_platform == 'linux'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/37/d59397221e15d2a7f38afaa4e8e6b8c244d818044f7daa0bdc5988df0a69/PyWinBox-0.7-py3-none-any.whl", hash = "sha256:8b2506a8dd7afa0a910b368762adfac885274132ef9151b0c81b0d2c6ffd6f83", size = 12274, upload-time = "2024-04-17T10:10:31.899Z" },
+]
+
+[[package]]
+name = "pywinctl"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ewmhlib", marker = "sys_platform == 'linux'" },
+    { name = "pymonctl" },
+    { name = "pyobjc", marker = "sys_platform == 'darwin'" },
+    { name = "python-xlib", marker = "sys_platform == 'linux'" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "pywinbox" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/33/8e4f632210b28fc9e998a9ab990e7ed97ecd2800cc50038e3800e1d85dbe/PyWinCtl-0.4.1-py3-none-any.whl", hash = "sha256:4d875e22969e1c6239d8c73156193630aaab876366167b8d97716f956384b089", size = 63158, upload-time = "2024-09-23T08:33:39.881Z" },
 ]
 
 [[package]]
@@ -4460,6 +7355,24 @@ wheels = [
 ]
 
 [[package]]
+name = "twisted"
+version = "26.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "automat" },
+    { name = "constantly" },
+    { name = "hyperlink" },
+    { name = "incremental" },
+    { name = "typing-extensions" },
+    { name = "zope-interface" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/97/6e9beb1e78247ae6dc34114f27d538cf2cb183c4afcd3609dfdf2b0439c8/twisted-26.4.0.tar.gz", hash = "sha256:dbfd0fe1ee409d0243fdd7a6a6ff14f4948cec1fd78e0376291f805e1501fae9", size = 3575095, upload-time = "2026-05-11T11:24:51.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/57/bcf4e2370dd218c9aa68a9140a65d86729c73f1d529f7e94786c2766fc72/twisted-26.4.0-py3-none-any.whl", hash = "sha256:dc25ea0ebf6511c24f03232ee9f4afa54b291c5d897990e3a39cc4d14a1ef4c0", size = 3230362, upload-time = "2026-05-11T11:24:49.5Z" },
+]
+
+[[package]]
 name = "ty"
 version = "0.0.21"
 source = { registry = "https://pypi.org/simple" }
@@ -4711,15 +7624,29 @@ name = "vercel-workers"
 version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
-    { name = "vercel", marker = "python_full_version >= '3.12'" },
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "vercel" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/5a/2ae6debc94fcfd7ce06b0e4ac5505be29ca04e76d6c99af35d4372dd7eda/vercel_workers-0.0.25-py3-none-any.whl", hash = "sha256:6901228a90e83e292e6a176161e66e6a7c43d9f4fd9e13d6bd87092ad09ffd8b", size = 61680, upload-time = "2026-06-20T19:26:25.971Z" },
+]
+
+[[package]]
+name = "vncdotool"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pillow" },
+    { name = "twisted" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/aa/e1ff71ffff6e52678fb4f8401fc3a7de1a09eaca2ba3be320f351ee7a91b/vncdotool-1.3.0.tar.gz", hash = "sha256:63d39b3e9d0974df7af77ed971cf141383371a5a9ccc5232bb7ad25c33298ad6", size = 57909, upload-time = "2026-04-03T13:53:21.68Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/5e/9a6f1fcf51fb63a65f35477cbb7b80bc3820d0d4d7cc2ee7263e06d1ab2c/vncdotool-1.3.0-py3-none-any.whl", hash = "sha256:0950fe66342d09df9848117627c2ca1a4c368e0e6583d39ac749741c50ac96ac", size = 35020, upload-time = "2026-04-03T13:53:20.428Z" },
 ]
 
 [[package]]
@@ -4983,4 +7910,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+]
+
+[[package]]
+name = "zope-interface"
+version = "8.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/dc/50550cfcbb2ea3cbca5f1d7ed05c8aa840f831a0f2d63aec0a953f7c590e/zope_interface-8.5.tar.gz", hash = "sha256:7a3ba1c5877f0f3e3906b02ddf793abed2becc2948116414ce0e1dd820b68d6d", size = 257957, upload-time = "2026-05-26T06:50:14.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/f1/83ad110fb847413affe71609bb50e59e1aa082e1236030122227c7c283d3/zope_interface-8.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:afc66ccaef2a3c0bef6ca02aad40d29a39276389dad16a8eac36f9f385e4d057", size = 211426, upload-time = "2026-05-26T06:49:12.595Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a7/6b6e0c31ac240cb9fc015ae9ed45ca54be886c18fcf7bfa2377a4d7a8785/zope_interface-8.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c28044972187245d7a309e4699319bfdbd2ffcbf7176d1d4ddf5adffb2dea80f", size = 211850, upload-time = "2026-05-26T06:49:14.474Z" },
+    { url = "https://files.pythonhosted.org/packages/37/36/7599ecabcf80ce4fef2e1ef3c5ac0d4696b61f03f724cc44022f4d226af9/zope_interface-8.5-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:03bbecc7982af713d7499d4084bc03916413d17ffd45f89009348cc0c1d9e376", size = 260711, upload-time = "2026-05-26T06:49:16.568Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3e/1774b0ee46ccbb5498ee3c33ece40315b6ef58bc71957be94bd345340bc1/zope_interface-8.5-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bf917009a4a7457c7290225a019f4a0aa706d96accd2cfdba2418d3bc1fcde2f", size = 265277, upload-time = "2026-05-26T06:49:18.656Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/09/e533b2ffabaae4e5d5730d6768a591cf335defe8e37bec2ad905d09be656/zope_interface-8.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:31cff25b2aaedb5267e6e77b1e9be6b0ec4f622032de8a069202b8ffacda7dc2", size = 266369, upload-time = "2026-05-26T06:49:20.174Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4a/3ebe6a4c122b2d5340db45cbe7e490663d3228b172710ec71060cd5d541e/zope_interface-8.5-cp311-cp311-win_amd64.whl", hash = "sha256:17a3114bbdddb5e75e5784cdf318944636190cbbc72d357ef9fb1a8b0351f955", size = 215161, upload-time = "2026-05-26T06:49:21.799Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/056ad97af5b16db1975ee98ec7ab03d2ce3f3355efad904ced1dbce0e39f/zope_interface-8.5-cp311-cp311-win_arm64.whl", hash = "sha256:aab6bb5bee10f38ea688b95ba054396b67f613552d2c8378be7fcb2d2fba7646", size = 213481, upload-time = "2026-05-26T06:49:25.085Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/b84123a948f3162a34623e188922827cd845244fdd043ed20f8d02228caa/zope_interface-8.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:8e6ee90c2e6de7c37058d5fa41f123c8b13a312db8d1e0fb5840d7f4bcdff9c9", size = 212165, upload-time = "2026-05-26T06:49:26.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/cbceec44f1b27208a76c1a688c131302685852406a23df5aab68324109cc/zope_interface-8.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c1adc90d3576b3b4c4de4953e6002c37bef28b78d7fa54c1bbfd0c50f022fe7c", size = 212341, upload-time = "2026-05-26T06:49:28.182Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c3/005032195ff3b210c139b7c560ed5c534e844b0907d8e44d2b3d8919305e/zope_interface-8.5-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:e6347b8d8d12c5eca6502450a92be30079b7acfade2c4f693efa0deb8871b06e", size = 265296, upload-time = "2026-05-26T06:49:29.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/66/1036543d6a66bc04c19df3cf650f3ad938a002ab0a443c24e23e8de5e8b9/zope_interface-8.5-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5e970dabea777a24b0b0bbf9dae3ab75ce8b2d8e948edf4875627034b21f3560", size = 270689, upload-time = "2026-05-26T06:49:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/30/4c/8b56259558cace4414e753ca6740396a1f59d4a95ddb55b4658600408670/zope_interface-8.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f0b48ccadaa9839e09ff81e969703cecb3f402c813bfe8b958652e699bea69f5", size = 270280, upload-time = "2026-05-26T06:49:33.489Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ea/649908c83aa8fdb7faf2ddca4d3cf6fb8f2157121267dc56e8f72681e26c/zope_interface-8.5-cp312-cp312-win_amd64.whl", hash = "sha256:e0e311f1277468c08fd59a2b41f71b43d25dff639789d364747acd1705c0df6e", size = 215019, upload-time = "2026-05-26T06:49:35.607Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/97/da13037b4c563e4df32eedbc819f8c00b754af494f68211e3dffd48d52da/zope_interface-8.5-cp312-cp312-win_arm64.whl", hash = "sha256:652b73107a04159ec6c020db6c1543d4f1e8f4d069bd2aac88a947820923517b", size = 213569, upload-time = "2026-05-26T06:49:37.317Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8c/4c15755d701f2ec0e80d64a18e1ebaf5be2c584c0ec153fd516f5d13eada/zope_interface-8.5-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:28e80457c134d1fa57a7d758004dece348654e1b1467ac22dcdc20fc1d127c52", size = 212512, upload-time = "2026-05-26T06:49:38.996Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/2e/4360c54c465db042cc8fbeeec92abac28b4cedbf6ba63c1f092fd08a190f/zope_interface-8.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:09495ce9d559c06b70f2d4855b3e4f48a822a9ddc8be1d30c5b4e5be14ae1ace", size = 212541, upload-time = "2026-05-26T06:49:41.186Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a5/692a2b8d70f78e848793231d5fae5fecbf8d0cccd73430fdc34802a6d3c1/zope_interface-8.5-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:7849ad8fa90763cc1087f4dda78ca3a233e950b3e08fac7079297c9cafbbd7bb", size = 265191, upload-time = "2026-05-26T06:49:43.449Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8d/454a9cfc7a050c394ab4f11b3371f7897828b7415e096afff724637e65e0/zope_interface-8.5-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5578c9421ca409a1f39f153d6f7803e4cde01da592ec75a9ac5e1b777d18d33b", size = 270626, upload-time = "2026-05-26T06:49:45.425Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/db8409cfa3575b8e9b4800babd7d49f8228433cd1f0c56814bd0ada49c33/zope_interface-8.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e1bd7d96b4ca5fa311f54c9eac16dce4886b428c1531dbe06067763ccdf123b4", size = 270444, upload-time = "2026-05-26T06:49:47.025Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/df/a386940e41469ef615e100a216d8b386521e9e598817147f87932ca203c4/zope_interface-8.5-cp313-cp313-win_amd64.whl", hash = "sha256:0c8123d2a4dfde2a613c7cb772605477724782c20bc2e0ad1d9435376a6a44a3", size = 215021, upload-time = "2026-05-26T06:49:48.478Z" },
+    { url = "https://files.pythonhosted.org/packages/89/75/477eb5669b6b2a7a843decd1a075e9b1971a8720017654143a7183abd3d9/zope_interface-8.5-cp313-cp313-win_arm64.whl", hash = "sha256:6d02be14f3173c6c7288bc2fdf530090c01c3cf8764ad46c68024686f364278e", size = 213610, upload-time = "2026-05-26T06:49:50.01Z" },
 ]


### PR DESCRIPTION
## What
- expose CUA app lifecycle operations through the shared `computer_use` contract
- forward `launch_app`, `kill_app`, and `bring_to_front` over the Modal sandbox MCP transport
- retain clear unsupported responses for non-CUA backends

## Why
The Modal desktop adapter bound computer use to the correct lease but omitted `launch_app`, leaving a fresh CUA desktop unable to start Chromium through Hermes.

## Validation
- `uv run --extra dev pytest -q tests/environments/test_compute_provider.py tests/tools/test_computer_use.py` (110 passed)
- `uv run --extra dev ruff check tools/computer_use/backend.py tools/computer_use/schema.py tools/computer_use/tool.py tools/environments/modal_desktop.py tests/environments/test_compute_provider.py tests/tools/test_computer_use.py`
- `git diff --check`