### PR TITLE
fix(desktop): default <option> color/background to skin tokens (#77429)

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2952,3 +2952,46 @@ html:has([data-hud-shell]) [data-slot='popover-content'] {
 [data-hud-shell] [data-slot='composer-bounds'] *::-webkit-scrollbar {
   display: none;
 }
+
+/* Native `<select>` dropdown contrast (issue #77429).
+ *
+ * The Quick Entry overlay and any other surface that uses a plain HTML
+ * `<select>` renders its `<option>` list in a browser-native popup that
+ * does NOT inherit the `<select>`'s `color` style on Chromium — options
+ * fall back to OS default colors, which against a dark skin paint at very
+ * low contrast (faded purple/grey that nearly matches the popover fill).
+ *
+ * This rule gives the native popup a sensible default that tracks the same
+ * skin tokens the rest of the surface uses, so a `<select>` rendered with
+ * `--foreground`/`--background` (or their plain-color fallbacks) reads
+ * correctly on dark *and* light skins without each surface having to wire
+ * up a custom Radix-style listbox.
+ *
+ * Browser support: Chromium / Electron honors `option` color and
+ * background-color on the open popup on macOS / Windows 10+ / most Linux
+ * Blink builds. Firefox honors it too. The native arrow UI still uses OS
+ * chrome, which is the intended compromise.
+ */
+select {
+  color: var(--foreground, #e6e6e6);
+  background-color: var(--background, transparent);
+}
+
+option {
+  color: var(--ui-text-primary, #e6e6e6);
+  background-color: var(--ui-bg-elevated, var(--ui-bg-chrome, #1f1f23));
+}
+
+/* The selected option in the open popup gets the same accent as the
+ * closed `<select>` for a continuous "this is the current value" cue
+ * across open/close states. */
+option:checked {
+  color: var(--dt-foreground, #fcfcfc);
+  background-color: var(--dt-primary, #4f8cff);
+}
+
+/* Disabled options (e.g. an offline session in the picker) should not read
+ * as primary text — match the muted-foreground token. */
+option:disabled {
+  color: var(--muted-foreground, #8a8a8a);
+}


### PR DESCRIPTION
## Summary

The Quick Entry overlay's "Send to" `<select>` renders its `<option>` list in a Chromium-native popup that does **not** inherit the `<select>`'s `color` on macOS / Windows / Linux Blink builds — options fall back to OS default colors. Against a dark skin this paints the unselected items in a faded purple/grey that nearly matches the popover fill. The currently-selected option is still readable (native accent highlight), but every other option is barely visible. Issue #77429.

## Fix

Add a global opt-in `select` / `option` rule in `apps/desktop/src/styles.css` that threads the same skin tokens the rest of the surface uses:

- `select` → `var(--foreground)` / `var(--background)` so the closed control stays consistent with the inline inlined styles Quick Entry already uses (and the open popup inherits `color`).
- `option` → `var(--ui-text-primary)` on `var(--ui-bg-elevated)` so each list item reads with primary-text contrast on the same elevated surface as the closed `<select>`'s shell.
- `option:checked` → primary accent on `--dt-foreground`, mirroring the closed `<select>`'s accent on the currently selected value.
- `option:disabled` → `muted-foreground`, so offline / unavailable sessions don't read as primary.

The fallback colors (`#e6e6e6` / `#1f1f23`) preserve contrast for any deployment where the skin tokens haven't been resolved yet (e.g. a custom user theme mid-load).

## Browser support

Chromium, Electron, and Firefox all honor `option { color; background-color }` on the native popup. The OS chrome (scrollbar, arrow, focus ring) stays untouched — that's the intentional compromise. The underlying bug is purely the contrast inside the popup.

## Test plan

Local: render the Quick Entry overlay in dark mode on Electron 30 and open the dropdown —

- selected option reads white-on-accent ✓
- every other option reads high-contrast primary text on the elevated surface ✓

Manual-only — no automated UI test framework hooked up for this surface today, and the change is a CSS rule that can only be eyeballed across light/dark/HC themes. The PR ships with the bug screenshot as a comment on issue #77429 so reviewers can confirm before/after.

## Files

- `apps/desktop/src/styles.css` — one rule block (+43 / -0) at the bottom of the file. No component touched, no behavior contract change beyond "native `<select>` popups track the active skin".

## NOT doing X

- Not swapping the `<select>` for a controlled Radix / `ActionsContextMenu` listbox. That's the proper fix per AGENTS.md ("Keep the waist narrow, grow at the edges") — but it's a multi-file rewrite of `quick-entry-app.tsx` + a new listbox primitive + e2e coverage. Filing as a follow-up if the global rule isn't enough on every skin.
- Not touching the `<select>`'s existing inline `style={{ color: 'var(--foreground, #eee)' }}`. The inline style still wins for the closed control (where Electron honors it); the new global rule takes over for the open popup (where it doesn't).
- Not adding `[data-slot='select-content']` overrides — those are for the shadcn `Select` primitive (Radix Portal), which already honors `--ui-text-primary` / `--ui-bg-elevated` and renders through the React tree. The bug only manifests for the plain `<select>`/`<option>` pair Quick Entry uses.