### PR TITLE
docs(google-workspace): remove nonexistent --services/--format flags from SKILL.md + anti-drift test

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -61,15 +61,16 @@ Calendar/Drive/Sheets/Docs?"**
   Passwords) and takes 2 minutes to set up. No Google Cloud project needed.
   Load the himalaya skill and follow its setup instructions.
 
-- **Email + Calendar** → Continue with this skill, but use
-  `--services email,calendar` during auth so the consent screen only asks for
-  the scopes they actually need.
+- **Email + Calendar** → Continue with this skill. The current setup helper
+  requests the standard Google Workspace scope set; Google may still let the
+  user deselect individual permissions on the consent screen.
 
-- **Calendar/Drive/Sheets/Docs only** → Continue with this skill and use a
-  narrower `--services` set like `calendar,drive,sheets,docs`.
+- **Calendar/Drive/Sheets/Docs only** → Continue with this skill. If the user
+  deselects unused permissions on the Google consent screen, Hermes stores the
+  subset Google actually grants and warns if some services may be unavailable.
 
-- **Full Workspace access** → Continue with this skill and use the default
-  `all` service set.
+- **Full Workspace access** → Continue with this skill and approve the full
+  scope set on the consent screen.
 
 **Question 2: "Does your Google account use Advanced Protection (hardware
 security keys required to sign in)? If you're not sure, you probably don't
@@ -116,19 +117,17 @@ explicit (for example `~/Downloads/hermes-google-client-secret.json`), then run
 
 ### Step 3: Get authorization URL
 
-Use the service set chosen in Step 1. Examples:
+Run:
 
 ```bash
-$GSETUP --auth-url --services email,calendar --format json
-$GSETUP --auth-url --services calendar,drive,sheets,docs --format json
-$GSETUP --auth-url --services all --format json
+$GSETUP --auth-url
 ```
 
-This returns JSON with an `auth_url` field and also saves the exact URL to
-`~/.hermes/google_oauth_last_url.txt`.
+This prints the OAuth URL as plain text and saves the pending PKCE verifier to
+`~/.hermes/google_oauth_pending.json` for the later code exchange.
 
 Agent rules for this step:
-- Extract the `auth_url` field and send that exact URL to the user as a single line.
+- Send the printed URL to the user as a single line.
 - Tell the user that the browser will likely fail on `http://localhost:1` after approval, and that this is expected.
 - Tell them to copy the ENTIRE redirected URL from the browser address bar.
 - If the user gets `Error 403: access_denied`, send them directly to `https://console.cloud.google.com/auth/audience` to add themselves as a test user.
@@ -141,13 +140,13 @@ pending OAuth session locally so `--auth-code` can complete the PKCE exchange
 later, even on headless systems:
 
 ```bash
-$GSETUP --auth-code "THE_URL_OR_CODE_THE_USER_PASTED" --format json
+$GSETUP --auth-code "THE_URL_OR_CODE_THE_USER_PASTED"
 ```
 
-If `--auth-code` fails because the code expired, was already used, or came from
-an older browser tab, it now returns a fresh `fresh_auth_url`. In that case,
-immediately send the new URL to the user and have them retry with the newest
-browser redirect only.
+If `--auth-code` fails because the code expired, was already used, came from
+an older browser tab, or otherwise cannot be exchanged, run `--auth-url` again,
+send the fresh URL to the user, and have them retry with the newest browser
+redirect only.
 
 ### Step 5: Verify
 

--- a/tests/skills/test_google_workspace_setup.py
+++ b/tests/skills/test_google_workspace_setup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import shlex
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 
@@ -12,6 +13,11 @@ import pytest
 SETUP_PATH = (
     Path(__file__).resolve().parents[2]
     / "skills/productivity/google-workspace/scripts/setup.py"
+)
+
+SKILL_DOC_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/google-workspace/SKILL.md"
 )
 
 
@@ -88,3 +94,44 @@ def test_installer_repairs_stale_transitives(setup_module, monkeypatch):
             "pyasn1==0.6.4",
         ]
     ]
+
+
+def test_skill_doc_references_only_supported_setup_flags(setup_module, capsys):
+    """Anti-drift guard (#35560/#74128): every $GSETUP invocation shown in
+    SKILL.md must use flags setup.py actually supports.
+
+    Before the fix, SKILL.md documented --services/--format, which setup.py
+    never implemented — following the skill's auth flow failed with argparse
+    'unrecognized arguments'. This test parses every documented $GSETUP line
+    and fails on any flag the script doesn't define.
+    """
+    parser = setup_module.get_argument_parser() if hasattr(setup_module, "get_argument_parser") else None
+    if parser is None:
+        # Fall back to introspecting the argparse parser main() builds.
+        import contextlib
+        import io
+        import re
+
+        src = SETUP_PATH.read_text(encoding="utf-8")
+        m = re.search(r"parser\.add_argument\(.*?--([a-z-]+)", src, re.S)
+        supported = set(re.findall(r'add_argument\(\s*"(--[a-z0-9-]+)"', src))
+        assert supported, "could not extract supported flags from setup.py"
+    else:
+        supported = {a for a in parser._option_string_actions}
+
+    doc_text = SKILL_DOC_PATH.read_text(encoding="utf-8")
+    setup_lines = [line.strip() for line in doc_text.splitlines() if "$GSETUP" in line]
+    assert setup_lines, "SKILL.md must document at least one $GSETUP invocation"
+
+    unsupported = []
+    for line in setup_lines:
+        command_tail = line.split("$GSETUP", 1)[1].replace("`", "")
+        args = shlex.split(command_tail)
+        for arg in args:
+            if arg.startswith("--") and arg not in supported:
+                unsupported.append((line, arg))
+
+    assert unsupported == [], (
+        "SKILL.md references setup.py flags that don't exist: "
+        f"{unsupported}. Fix the doc (or add the flag)."
+    )


### PR DESCRIPTION
<!-- native-links:v1 -->
Related #35560 #35565 #74128
## What does this PR do?

Fixes the bundled `google-workspace` skill's **broken documented auth flow**
(#35560, #74128): `SKILL.md` instructed agents to run `setup.py` with
`--services` and `--format` flags that **setup.py never implemented** —
following the skill as written failed with argparse `unrecognized arguments`,
and the agent's service-bundle choice offer was fiction.

### The fix

- **`skills/productivity/google-workspace/SKILL.md`** — removed the
  nonexistent `--services`/`--format` flags from every documented
  `$GSETUP` invocation. The setup helper requests the standard Workspace
  scope set; the consent screen lets users deselect individual scopes, and
  the skill now describes that real behavior instead of a flag that doesn't
  exist.
- **`tests/skills/test_google_workspace_setup.py`** — added a durable
  **anti-drift guard**: it parses every `$GSETUP` line in SKILL.md and
  fails if any documented flag isn't supported by setup.py's argparse
  parser. This prevents the doc/script divergence from silently
  re-occurring.

### Credit

The SKILL.md correction is cherry-picked from **#35565 by @BROCCOLO1D**
(authorship preserved). The conformance test was ported into the current
test file (the PR's original test file was renamed on main) to preserve
the anti-drift guard.

## How to test

```bash
pytest tests/skills/test_google_workspace_setup.py -q
# 3 passed (2 existing + the new doc-conformance guard)
```

The conformance test fails loudly if anyone reintroduces an unsupported
flag into SKILL.md.

## Current landing gate — refreshed 2026-09-12

- **Exact head:** `43c2c1daa9044b71df5173628a92ad16bbc7f456` (single commit, base `d1afa160…` at PR open).
- **Current main:** `f364c19775617acb6c16140b790cda9fb05e1906` — the 7,511+ commits since base include **zero changes** to `skills/productivity/google-workspace/SKILL.md` or the google-workspace test file (verified via the base→main file compare), so the PR diff applies cleanly against the tree it will merge into.
- **Hosted checks:** 27 success / 12 skipped / 1 neutral on this head; no failing checks.
- **Mergeability:** MERGEABLE at review time.
- **Body SHA discipline:** this section replaces the stale-body gap — all pins above are current as of 2026-09-12 refresh; re-verify at merge time.

## What platforms were tested?

- Windows 11 native: 3 passed, `git diff --check` clean, attribution audit clean.

## Why this matters to users

Before: a fresh Google Workspace user following the skill's OAuth flow
hit `unrecognized arguments: --services` the moment they ran the setup
helper — the documented path was dead, and the agent's "which service
bundle?" question offered choices the tool couldn't honor.

After: the documented commands run exactly as written, the consent screen
handles scope selection, and the conformance test keeps the doc honest.

Fixes #35560
Closes #74128

- [x] Bug fix (docs; non-breaking)
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] Code follows repo style (no new env vars)
- [x] Self-review complete
- [x] Tests added (doc↔script conformance guard)
- [x] Suite green: 3 passed
- [x] `git diff --check` clean
- [x] Credit: doc fix from #35565 by @BROCCOLO1D, cherry-picked with authorship preserved
- [x] Exact-current landing evidence refreshed (2026-09-12): head `43c2c1da…`, main `f364c197…`, zero overlap-file movement, 27 hosted checks green

Part of #21860
Part of #21861