### PR TITLE
[docs] Fix Weixin streaming support in zh-Hans documentation

### DIFF
--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/index.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/index.md
@@ -29,7 +29,7 @@ description: "通过 Telegram、Discord、Slack、WhatsApp、Signal、SMS、Emai
 | Feishu/Lark | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | WeCom | ✅ | ✅ | ✅ | — | — | — | — |
 | WeCom Callback | — | — | — | — | — | — | — |
-| Weixin | ✅ | ✅ | ✅ | — | — | ✅ | ✅ |
+| Weixin | ✅ | ✅ | ✅ | — | — | ✅ | — |
 | BlueBubbles | — | ✅ | ✅ | — | ✅ | ✅ | — |
 | QQ | ✅ | ✅ | ✅ | — | — | ✅ | — |
 | Yuanbao | ✅ | ✅ | ✅ | — | — | ✅ | ✅ |


### PR DESCRIPTION
## Summary

Closes #77416

The zh-Hans Messaging Gateway documentation incorrectly lists Weixin as supporting ✅ Streaming. This PR corrects that to — (not supported).

## Changes

- Update platform comparison table: Weixin streaming changed from ✅ to —

## Rationale

WeChat/Weixin does not support editing sent messages, so streaming via message editing is not possible. The code explicitly sets `SUPPORTS_MESSAGE_EDITING = False` for Weixin (see `gateway/platforms/weixin.py` L1180-1182).