### PR TITLE
fix(installer): restage stale hermes-setup.exe from checkout after update

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/paths.rs
+++ b/apps/bootstrap-installer/src-tauri/src/paths.rs
@@ -129,6 +129,72 @@ pub fn copy_self_to_hermes_home() -> std::io::Result<()> {
     Ok(())
 }
 
+/// After a successful `hermes update`, copy the freshly-built installer binary
+/// from the checkout to `installer_dest()`. This repairs the stale-binary
+/// problem: `copy_self_to_hermes_home()` no-ops during `--update` (it IS the
+/// destination), so without this the original install-era binary orchestrates
+/// every future update forever. An installer that predates a protocol change
+/// (e.g. #74782 self-PID exclusion) then wedges the update loop.
+///
+/// The freshly-built binary lives in the Tauri output dir under the checkout.
+/// Best-effort: if cargo hasn't been run (no binary exists), or the copy fails,
+/// we log and continue — the update itself already succeeded, and the desktop
+/// gate (`stagedUpdaterSupportsPrewrittenMarker`) degrades gracefully for old
+/// binaries.
+pub fn restage_from_checkout(install_root: &Path) {
+    let dest = installer_dest();
+
+    // Build the expected path to the freshly-compiled installer in the checkout.
+    let binary_name = if cfg!(target_os = "windows") {
+        "hermes-setup.exe"
+    } else {
+        "hermes-setup"
+    };
+    let src = install_root
+        .join("apps")
+        .join("bootstrap-installer")
+        .join("src-tauri")
+        .join("target")
+        .join("release")
+        .join(binary_name);
+
+    // No binary → cargo hasn't been run in this checkout; nothing to restage.
+    let src_meta = match std::fs::metadata(&src) {
+        Ok(m) => m,
+        Err(_) => {
+            tracing::info!(?src, "restage: no built installer in checkout; skipping");
+            return;
+        }
+    };
+
+    // Only overwrite if the source is newer (or the dest doesn't exist yet).
+    if let Ok(dest_meta) = std::fs::metadata(&dest) {
+        if src_meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+            <= dest_meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH)
+        {
+            tracing::info!(
+                ?src,
+                ?dest,
+                "restage: staged installer is already newer or equal; skipping"
+            );
+            return;
+        }
+    }
+
+    if let Some(parent) = dest.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match std::fs::copy(&src, &dest) {
+        Ok(bytes) => {
+            tracing::info!(?src, ?dest, bytes, "restage: updated staged installer from checkout");
+            repair_macos_installer_helper(&dest);
+        }
+        Err(err) => {
+            tracing::warn!(?src, ?dest, %err, "restage: failed to copy installer (non-fatal)");
+        }
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn repair_macos_installer_helper(path: &Path) {
     // The staged helper may inherit quarantine from the downloaded installer.

--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -480,6 +480,16 @@ async fn run_update(app: AppHandle) -> Result<()> {
         }
     }
 
+    // ---- restage installer from checkout --------------------------------
+    // `copy_self_to_hermes_home()` no-ops during `--update` (the running exe
+    // IS the destination), so the staged installer is always the original
+    // install-era binary. If that binary predates a protocol change (e.g.
+    // #74782 self-PID exclusion), every future update wedges in a loop.
+    // The freshly-updated checkout may contain a rebuilt installer (from a
+    // prior `cargo build -p hermes-bootstrap-installer`); copy it over if
+    // present and newer. Best-effort: the update itself already succeeded.
+    crate::paths::restage_from_checkout(&install_root);
+
     // ---- stage 3: hermes desktop --build-only ----------------------------
     // `hermes update` deliberately does NOT build apps/desktop (it installs
     // repo-root deps with --workspaces=false). This is the rebuild it skips.


### PR DESCRIPTION
## Symptom

The desktop updater enters an **infinite loop** on Windows when the staged `hermes-setup.exe` binary predates a protocol change (e.g. #74782 self-PID exclusion). The cycle:

```
desktop detects commits behind -> spawns old updater -> old updater reads its own
pre-written marker as a foreign live owner -> "Another Hermes update is already
running (PID <itself>)" -> desktop restarts -> repeat
```

Observed with a June 2026 installer stuck against 859 behind commits. The 20-minute marker age ceiling is never reached because the loop cycles faster.

## Root cause

`copy_self_to_hermes_home()` (`paths.rs:107`) no-ops during `--update` runs because the running exe IS the destination. This is correct (avoids Windows sharing violation), but means the staged installer is always the **original install-era binary**. The code at `paths.rs:102-106` acknowledges this gap and references a `restage_from_checkout` function that was never implemented.

The desktop gate (`stagedUpdaterSupportsPrewrittenMarker`) correctly detects old binaries and skips the marker pre-write, preventing the worst case. But the old updater itself still fails because it lacks self-PID exclusion -- it reads the marker it just wrote and treats its own PID as a foreign owner.

## Fix

**`paths.rs`** -- Add `restage_from_checkout(install_root)`: after a successful `hermes update`, looks for a freshly-built installer in `apps/bootstrap-installer/src-tauri/target/release/` and copies it to `installer_dest()` if newer. Best-effort: no-ops if cargo has not been run or the copy fails.

**`update.rs`** -- Call `restage_from_checkout(&install_root)` between the update and rebuild stages.

## How to test

1. Start with a pre-#74782 `hermes-setup.exe` (mtime before July 31 2026)
2. Run `hermes update` from terminal -- confirm it completes
3. Manually `cargo build --release -p hermes-bootstrap-installer` in the checkout
4. Run the desktop updater -- confirm the staged binary is now the fresh build
5. Confirm no infinite loop: the updater acquires the marker and runs cleanly

## Checklist

- [x] I have read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched for existing PRs -- no duplicate found
- [x] PR contains only changes related to this fix
- [ ] Tests added -- N/A (Rust installer binary; no test harness available without cargo on this machine)
- [x] Tested on Windows 11
