### PR TITLE
fix(desktop): drain Windows update process trees

### DIFF
--- a/apps/desktop/electron/backend-child.ts
+++ b/apps/desktop/electron/backend-child.ts
@@ -24,8 +24,18 @@ export interface StopBackendChildDeps {
   forceKillProcessTree: (pid: number) => void
 }
 
-export interface KillableChild {
+export interface StopBackendTreesForUpdateDeps {
+  /** Synchronous Windows taskkill /T /F implementation. */
+  forceKillProcessTree: (pid: number) => void
+  /** Clears and stops the desktop's pooled backends. */
+  stopAllPoolBackends: () => void
+}
+
+export interface BackendProcessRoot {
   pid?: number | null
+}
+
+export interface KillableChild extends BackendProcessRoot {
   killed?: boolean
   kill: (signal: string) => void
 }
@@ -52,4 +62,24 @@ export function stopBackendChild(child: KillableChild | null | undefined, deps: 
   } catch {
     // Already gone.
   }
+}
+
+/**
+ * Stop every backend tree owned by a Windows Desktop update hand-off.
+ *
+ * Tree-kill the primary root while its PID is still live, then delegate pool
+ * teardown to the existing routine that tree-kills each pooled root exactly
+ * once before mutating its registry. In particular, do not signal the primary
+ * first: if that root exits before taskkill /T runs, Windows can no longer
+ * enumerate its MCP grandchildren and they survive with the venv locked.
+ */
+export function stopBackendTreesForUpdate(
+  primary: BackendProcessRoot | null | undefined,
+  deps: StopBackendTreesForUpdateDeps
+): void {
+  if (primary && Number.isInteger(primary.pid)) {
+    deps.forceKillProcessTree(primary.pid as number)
+  }
+
+  deps.stopAllPoolBackends()
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -32,7 +32,7 @@ import {
 import nodePty from 'node-pty'
 
 import { classifyActiveRuntime } from './active-runtime-state'
-import { stopBackendChild as stopBackendChildImpl } from './backend-child'
+import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
@@ -2752,34 +2752,12 @@ async function releaseBackendLock(updateRoot, tag) {
     return { unlocked: true }
   }
 
-  // Collect every backend PID the desktop owns: primary window backend + pool.
-  const pids = []
   const hermesProcess = backendConnectionState.getProcess()
 
-  if (hermesProcess && Number.isInteger(hermesProcess.pid)) {
-    pids.push(hermesProcess.pid)
-  }
-
-  for (const entry of backendPool.values()) {
-    if (entry.process && Number.isInteger(entry.process.pid)) {
-      pids.push(entry.process.pid)
-    }
-  }
-
-  // Graceful first (lets Python flush), then tree-kill to catch grandchildren.
-  if (hermesProcess && !hermesProcess.killed) {
-    try {
-      hermesProcess.kill('SIGTERM')
-    } catch {
-      void 0
-    }
-  }
-
-  stopAllPoolBackends()
-
-  for (const pid of pids) {
-    forceKillProcessTree(pid)
-  }
+  stopBackendTreesForUpdate(hermesProcess, {
+    forceKillProcessTree,
+    stopAllPoolBackends
+  })
 
   const shim = venvHermesShimPath(updateRoot)
   const deadlineMs = Date.now() + 15000

--- a/apps/desktop/electron/windows-child-options.test.ts
+++ b/apps/desktop/electron/windows-child-options.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { stopBackendChild } from './backend-child'
+import { stopBackendChild, stopBackendTreesForUpdate } from './backend-child'
 import { hiddenWindowsChildOptions } from './windows-child-options'
 
 test('hiddenWindowsChildOptions adds windowsHide:true on Windows when unset', () => {
@@ -129,4 +129,23 @@ test('stopBackendChild swallows errors thrown by the kill strategy', () => {
       isWindows: false
     })
   })
+})
+
+test('Windows update tree-kills captured roots without pre-signalling the primary backend', () => {
+  const primary = makeChild({ pid: 101 })
+  const pooled = makeChild({ pid: 202 })
+  const events: string[] = []
+
+  stopBackendTreesForUpdate(primary.child, {
+    forceKillProcessTree: pid => events.push(`tree:${pid}`),
+    stopAllPoolBackends: () => {
+      events.push('pool-stop')
+      // Production stopAllPoolBackends() already tree-kills every pool root.
+      events.push(`tree:${pooled.child.pid}`)
+    }
+  })
+
+  assert.deepEqual(events, ['tree:101', 'pool-stop', 'tree:202'])
+  assert.deepEqual(primary.calls, [], 'the primary root must not be signalled before taskkill /T sees it')
+  assert.deepEqual(pooled.calls, [])
 })

--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -126,6 +126,37 @@ def _is_pausable_gateway(cmdline: str) -> bool:
     return looks_like_gateway_command_line(cmdline)
 
 
+def _has_pausable_gateway_ancestor(pid: int) -> bool:
+    """Return True when *pid* is inside a live pausable gateway tree.
+
+    Gateways spawn venv-backed grandchildren such as MCP servers whose own
+    argv does not mention ``gateway run``. The downstream updater force-kills
+    the gateway tree, so those descendants share its pause ownership and must
+    not dead-end Desktop preflight before that pause can run.
+
+    Fail closed: an unavailable process, unreadable ancestry/cmdline, or parser
+    failure leaves the process classified as a blocker.
+    """
+    try:
+        import psutil  # noqa: PLC0415
+
+        parents = psutil.Process(int(pid)).parents()
+    except Exception:
+        return False
+
+    for parent in parents:
+        try:
+            parts = parent.cmdline()
+        except Exception:
+            return False
+        if not parts:
+            return False
+        cmdline = " ".join(str(part) for part in parts)
+        if _is_pausable_gateway(cmdline):
+            return True
+    return False
+
+
 def main() -> None:
     """Entry point.  Prints one JSON doc to stdout.  Exits 0 for valid scan."""
     try:
@@ -140,22 +171,25 @@ def main() -> None:
     except Exception as exc:
         _emit_probe_fail(f"scan aborted: {exc}")
 
-    processes = [
-        {
-            "pid": pid,
-            "name": name,
-            "cmdline": _redact_sensitive_cmdline(cmdline),
-        }
-        for pid, name, cmdline in matches
-        if not _is_pausable_gateway(cmdline)
-    ]
-    exempted = sum(1 for _pid, _name, cmdline in matches if _is_pausable_gateway(cmdline))
+    processes = []
+    exempted = 0
+    for pid, name, cmdline in matches:
+        if _is_pausable_gateway(cmdline) or _has_pausable_gateway_ancestor(pid):
+            exempted += 1
+            continue
+        processes.append(
+            {
+                "pid": pid,
+                "name": name,
+                "cmdline": _redact_sensitive_cmdline(cmdline),
+            }
+        )
     data = {
         "ok": True,
         "blocked": bool(processes),
         "processes": processes,
-        # Diagnostic only: gateway processes present but not counted as
-        # blockers because the downstream updater pauses them itself.
+        # Diagnostic only: gateway processes and their descendants are not
+        # blockers because the downstream updater pauses their whole trees.
         "pausable_gateways": exempted,
     }
     print(json.dumps(data))

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -33,6 +33,27 @@ def _psutil_fake() -> dict:
     return {"psutil": types.SimpleNamespace(Process=lambda *a: MagicMock())}
 
 
+def _psutil_with_parent_argv(parent_argv_by_pid: dict[int, list[str]]):
+    """Return a psutil stand-in exposing one live parent per candidate PID."""
+
+    class FakeParent:
+        def __init__(self, argv: list[str]):
+            self._argv = argv
+
+        def cmdline(self):
+            return self._argv
+
+    class FakeProcess:
+        def __init__(self, pid: int):
+            self._pid = pid
+
+        def parents(self):
+            argv = parent_argv_by_pid.get(self._pid)
+            return [FakeParent(argv)] if argv else []
+
+    return types.SimpleNamespace(Process=FakeProcess)
+
+
 
 
 
@@ -151,10 +172,13 @@ def test_is_pausable_gateway_rejects_everything_else(cmdline: str) -> None:
     assert _is_pausable_gateway(cmdline) is False
 
 
-def _run_main_with_detector(monkeypatch, capsys, matches):
+def _run_main_with_detector(monkeypatch, capsys, matches, *, psutil_module=None):
     """Run main() with the process detector patched to return *matches*."""
-    for name, mod in _psutil_fake().items():
-        monkeypatch.setitem(sys.modules, name, mod)
+    monkeypatch.setitem(
+        sys.modules,
+        "psutil",
+        psutil_module if psutil_module is not None else _psutil_fake()["psutil"],
+    )
     import hermes_cli.main as cli_main
 
     monkeypatch.setattr(cli_main, "_detect_venv_python_processes", lambda: matches)
@@ -211,4 +235,83 @@ def test_main_desktop_serve_backend_still_blocks(monkeypatch, capsys):
     assert code == 0
     assert data["blocked"] is True
     assert [p["pid"] for p in data["processes"]] == [78]
+    assert data["pausable_gateways"] == 0
+
+
+def test_main_exempts_gateway_descendant_but_not_desktop_descendant(
+    monkeypatch, capsys
+):
+    """MCP children inherit update ownership from a recognized live ancestor.
+
+    The downstream updater tree-kills gateway roots, so their descendants must
+    not dead-end Desktop preflight. A Desktop ``serve`` descendant has no such
+    downstream owner and must continue blocking.
+    """
+    gateway_child = (
+        90,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m agent_reach.integrations.mcp_server",
+    )
+    desktop_child = (
+        91,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m agent_reach.integrations.mcp_server",
+    )
+    psutil_module = _psutil_with_parent_argv(
+        {
+            90: ["python.exe", "-m", "hermes_cli.main", "gateway", "run"],
+            91: ["python.exe", "-m", "hermes_cli.main", "serve"],
+        }
+    )
+
+    code, data = _run_main_with_detector(
+        monkeypatch,
+        capsys,
+        [gateway_child, desktop_child],
+        psutil_module=psutil_module,
+    )
+
+    assert code == 0
+    assert data["blocked"] is True
+    assert [p["pid"] for p in data["processes"]] == [91]
+    assert data["pausable_gateways"] == 1
+
+
+def test_main_keeps_descendant_blocking_when_nearer_ancestor_is_unreadable(
+    monkeypatch, capsys
+):
+    """Never skip an ancestry read failure to trust an older gateway ancestor."""
+
+    class UnreadableParent:
+        def cmdline(self):
+            raise PermissionError("access denied")
+
+    class GatewayParent:
+        def cmdline(self):
+            return ["python.exe", "-m", "hermes_cli.main", "gateway", "run"]
+
+    class Process:
+        def __init__(self, pid):
+            assert pid == 92
+
+        def parents(self):
+            return [UnreadableParent(), GatewayParent()]
+
+    psutil_module = types.SimpleNamespace(Process=Process)
+    child = (
+        92,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m agent_reach.integrations.mcp_server",
+    )
+
+    code, data = _run_main_with_detector(
+        monkeypatch,
+        capsys,
+        [child],
+        psutil_module=psutil_module,
+    )
+
+    assert code == 0
+    assert data["blocked"] is True
+    assert [p["pid"] for p in data["processes"]] == [92]
     assert data["pausable_gateways"] == 0


### PR DESCRIPTION
## Summary

- prevent the Windows Desktop updater from pre-signalling its primary backend before `taskkill /T` can enumerate descendants
- tree-kill the primary Desktop backend while its root PID is live, then delegate pooled backends to their existing one-pass tree teardown
- classify venv holders under a live `gateway run` ancestor as gateway-owned so Desktop preflight can reach the downstream gateway pause that tree-kills them
- keep fail-closed behavior for Desktop/`serve` descendants, REPLs, unrelated scripts, and unreadable process ancestry
- add behavior-level regressions covering Desktop teardown order and gateway-vs-Desktop MCP ownership

## Root cause

On Windows, the update hand-off called `hermesProcess.kill('SIGTERM')` before its `taskkill /T /F` sweep. If the Desktop backend root exited between those operations, `taskkill` could no longer resolve that root's process tree. An MCP grandchild (observed with `python.exe -m agent_reach.integrations.mcp_server`) remained alive and kept native files in the Hermes venv locked.

A second ownership gap affected the separately supervised gateway: Desktop preflight exempted the gateway launcher/worker because the CLI updater pauses them downstream, but still reported the gateway's MCP descendants as blockers. That aborted the hand-off before the gateway pause could run. The scanner now follows live ancestry and exempts only descendants of a canonical `gateway run` process; failures to read or classify ancestry remain blocking.

Together these bugs forced manual Task Manager cleanup even though both process trees were Hermes-managed.

A controlled Windows reproduction repeated each sequence three times:

- signal parent, then `taskkill /T`: root was already gone and the child survived in 3/3 runs
- direct `taskkill /T`: the complete tree terminated in 3/3 runs

This complements the transient process-table retry work discussed in #74805: the surviving MCP child is a real orphan, not merely a killed PID that has not disappeared yet.

## Test plan

- `npx vitest run --project electron electron/windows-child-options.test.ts` — 13/13 pass
- `python -m pytest tests/hermes_cli/test_scan_venv_blockers.py tests/hermes_cli/test_update_concurrent_quarantine.py -q` — 36/36 pass
- live production scanner on Windows: gateway-owned MCP descendant exempted while Desktop-owned MCP descendant remains blocking until Desktop teardown
- `npm run typecheck` — pass
- `npx eslint electron/main.ts electron/backend-child.ts electron/windows-child-options.test.ts` — pass
- `ruff check hermes_cli/_scan_venv_blockers.py tests/hermes_cli/test_scan_venv_blockers.py` — pass
- `git diff --check` — pass
- broad Electron test run compared against a clean baseline on the same Windows host; unrelated Windows path/SSH failures reproduce without this patch

Refs #74805
