### PR TITLE
fix(file-tools): recover search_files dot pattern

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -466,6 +466,25 @@ class TestSearchFilesFallbackHiddenPaths:
         assert result.error is None
         assert set(result.files) == {str(visible_file), str(visible_nested_file)}
 
+    def test_dot_pattern_falls_back_to_all_files(self, tmp_path, monkeypatch):
+        root = tmp_path / "repo"
+        root.mkdir()
+        visible_file = root / "agent.log"
+        visible_nested_file = root / "nested" / "visible.log"
+        hidden_dir_file = root / ".hidden" / "secret.log"
+
+        for p in [visible_file, visible_nested_file, hidden_dir_file]:
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("x")
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+        result = ops._search_files(".", str(root), limit=50, offset=0)
+
+        assert result.error is None
+        assert set(result.files) == {str(visible_file), str(visible_nested_file)}
+        assert "Interpreted file-search pattern '.' as '*'" in (result.warning or "")
+
 
 class TestShellFileOpsWriteDenied:
     def test_write_file_denied_path(self, file_ops):

--- a/tests/tools/test_search_zero_match_and_multipath.py
+++ b/tests/tools/test_search_zero_match_and_multipath.py
@@ -95,6 +95,16 @@ class TestMultiPathRecovery:
         assert "a.py" in blob
 
 
+class TestFilesTargetPatternRecovery:
+    def test_dot_pattern_lists_files_with_warning(self, proj):
+        r = json.loads(search_tool(".", path=str(proj / "proj"), target="files", task_id="t-files-dot"))
+        assert "error" not in r
+        assert r["total_count"] >= 2
+        blob = json.dumps(r)
+        assert "a.py" in blob and "b.py" in blob
+        assert "Interpreted file-search pattern '.' as '*'" in r.get("warning", "")
+
+
 class TestZeroMatchProbeEngineParity:
     """The hint must be attached on BOTH search engines' code paths.
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2341,11 +2341,12 @@ class ShellFileOperations(FileOperations):
 
     def _search_files(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
         """Search for files by name pattern (glob-like)."""
+        normalized_pattern, pattern_warning = self._normalize_file_search_pattern(pattern)
         # Auto-prepend **/ for recursive search if not already present
-        if not pattern.startswith('**/') and '/' not in pattern:
-            search_pattern = pattern
+        if not normalized_pattern.startswith('**/') and '/' not in normalized_pattern:
+            search_pattern = normalized_pattern
         else:
-            search_pattern = pattern.split('/')[-1]
+            search_pattern = normalized_pattern.split('/')[-1]
 
         search_root = Path(path)
         has_hidden_path_ancestor = any(
@@ -2357,7 +2358,12 @@ class ShellFileOperations(FileOperations):
         # default, and has parallel directory traversal (~200x faster than
         # find on wide trees).  Mirrors _search_content which already uses rg.
         if self._has_command('rg'):
-            return self._search_files_rg(search_pattern, path, limit, offset)
+            result = self._search_files_rg(search_pattern, path, limit, offset)
+            if pattern_warning:
+                result.warning = (
+                    pattern_warning if not result.warning else f"{result.warning} {pattern_warning}"
+                )
+            return result
 
         # Fallback: find (slower, no .gitignore awareness)
         if not self._has_command('find'):
@@ -2423,7 +2429,18 @@ class ShellFileOperations(FileOperations):
             total_count=len(files),
             truncated=bool(limit_reason),
             limit_reason=limit_reason,
+            warning=pattern_warning,
         )
+
+    def _normalize_file_search_pattern(self, pattern: str) -> tuple[str, Optional[str]]:
+        """Recover common "list files here" shorthands for ``target='files'``."""
+        raw = (pattern or "").strip()
+        if raw in {".", "./", ".\\"}:
+            return (
+                "*",
+                "Interpreted file-search pattern '.' as '*' to list files in the target path.",
+            )
+        return pattern, None
 
     def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
         """Search for files by name using ripgrep's --files mode.


### PR DESCRIPTION
## Summary
- recover `search_files(target="files")` when callers pass `pattern="."` to mean "list files here" by interpreting it as `*`
- attach an explicit warning so the model can learn the expected glob form instead of silently treating the recovered behavior as native
- cover both the ripgrep path and the `find` fallback with regression tests

## Reproduction
On current `main`, `search_files(pattern=".", target="files", path=<dir>)` silently returns `total_count=0` even when the directory contains visible files. I reproduced that locally on August 3, 2026 before the fix.

## Testing
- `.venv/bin/pytest tests/tools/test_search_zero_match_and_multipath.py tests/tools/test_file_operations.py -q`
- manual repro via `tools.file_tools.search_tool()` showing `pattern="."` now returns files plus a warning

Fixes #77423