### PR TITLE
fix(search): steer suspicious file-search globs (#77423)

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -427,6 +427,30 @@ class TestSearchFilesFallbackHiddenPaths:
     def _make_env(self):
         return make_real_subprocess_env("/")
 
+    @pytest.mark.parametrize("pattern", [".", "./", ".\\"])
+    def test_current_directory_pattern_on_find_backend_lists_visible_files(
+        self,
+        tmp_path,
+        monkeypatch,
+        pattern,
+    ):
+        root = tmp_path / "repo"
+        root.mkdir()
+        visible_file = root / "agent.log"
+        visible_nested_file = root / "nested" / "visible.log"
+
+        for p in [visible_file, visible_nested_file]:
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("x", encoding="utf-8")
+
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+        result = ops.search(pattern, target="files", path=str(root))
+
+        assert result.error is None
+        assert set(result.files) == {str(visible_file), str(visible_nested_file)}
+        assert f"interpreted {pattern!r} as '*'" in (result.warning or "")
+
     def test_hidden_root_with_hidden_ancestor_includes_files(self, tmp_path, monkeypatch):
         """Fallback find should include visible files when path is inside hidden root."""
         root = tmp_path / ".hermes" / "logs"
@@ -438,7 +462,7 @@ class TestSearchFilesFallbackHiddenPaths:
 
         for p in [visible_file, nested_hidden_file, visible_nested_file, hidden_dir_file]:
             p.parent.mkdir(parents=True, exist_ok=True)
-            p.write_text("x")
+            p.write_text("x", encoding="utf-8")
 
         ops = ShellFileOperations(self._make_env())
         monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
@@ -457,7 +481,7 @@ class TestSearchFilesFallbackHiddenPaths:
 
         for p in [visible_file, visible_nested_file, hidden_dir_file]:
             p.parent.mkdir(parents=True, exist_ok=True)
-            p.write_text("x")
+            p.write_text("x", encoding="utf-8")
 
         ops = ShellFileOperations(self._make_env())
         monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
@@ -607,7 +631,7 @@ class TestAtomicWriteNewFilePermissions:
         mode preservation (e.g. an executable script stays 0755)."""
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         dest = tmp_path / "existing.sh"
-        dest.write_text("#!/bin/sh\n")
+        dest.write_text("#!/bin/sh\n", encoding="utf-8")
         dest.chmod(0o755)
 
         result = ops.write_file(str(dest), "#!/bin/sh\necho updated\n")
@@ -628,7 +652,7 @@ class TestAtomicWriteThroughSymlink:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         real = tmp_path / "real.txt"
         link = tmp_path / "link.txt"
-        real.write_text("original\n")
+        real.write_text("original\n", encoding="utf-8")
         link.symlink_to(real)
 
         result = ops.write_file(str(link), "newcontent\n")

--- a/tests/tools/test_search_zero_match_and_multipath.py
+++ b/tests/tools/test_search_zero_match_and_multipath.py
@@ -13,11 +13,11 @@ def proj(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
     d = tmp_path / "proj"
     d.mkdir()
-    (d / "a.py").write_text("TOKEN_ALPHA = 'find_me_value'\nother = 1\n")
-    (d / "b.py").write_text("x = compute(TOKEN_ALPHA)\n")
+    (d / "a.py").write_text("TOKEN_ALPHA = 'find_me_value'\nother = 1\n", encoding="utf-8")
+    (d / "b.py").write_text("x = compute(TOKEN_ALPHA)\n", encoding="utf-8")
     e = tmp_path / "extra"
     e.mkdir()
-    (e / "c.txt").write_text("TOKEN_ALPHA appears here too\n")
+    (e / "c.txt").write_text("TOKEN_ALPHA appears here too\n", encoding="utf-8")
     return tmp_path
 
 
@@ -29,7 +29,7 @@ class TestZeroMatchProbe:
 
     def test_regex_metachar_literal_hint(self, proj):
         d = proj / "proj"
-        (d / "meta.py").write_text("result = lookup[key+1]\n")
+        (d / "meta.py").write_text("result = lookup[key+1]\n", encoding="utf-8")
         r = json.loads(search_tool("lookup[key+1]", path=str(d), task_id="t-zm"))
         assert r["total_count"] == 0
         assert "literal match" in r.get("warning", "")
@@ -42,7 +42,10 @@ class TestZeroMatchProbe:
     def test_hidden_only_match_gets_hint(self, proj):
         d = proj / "proj"
         (d / ".secretdir").mkdir()
-        (d / ".secretdir" / "conf.cfg").write_text("HIDDEN_ONLY_TOKEN = true\n")
+        (d / ".secretdir" / "conf.cfg").write_text(
+            "HIDDEN_ONLY_TOKEN = true\n",
+            encoding="utf-8",
+        )
         r = json.loads(search_tool("HIDDEN_ONLY_TOKEN", path=str(d), task_id="t-zm"))
         assert r["total_count"] == 0
         assert "hidden or gitignored" in r.get("warning", "")
@@ -93,6 +96,33 @@ class TestMultiPathRecovery:
         assert "error" not in r
         blob = json.dumps(r)
         assert "a.py" in blob
+
+
+class TestFilesTargetGlobHints:
+    @pytest.mark.parametrize("pattern", [".", "./", ".\\"])
+    def test_current_directory_pattern_lists_all_visible_files_with_warning(self, proj, pattern):
+        r = json.loads(
+            search_tool(pattern, path=str(proj / "proj"), target="files", task_id="t-files")
+        )
+        assert r["total_count"] == 2
+        blob = json.dumps(r)
+        assert "a.py" in blob and "b.py" in blob
+        assert f"interpreted {pattern!r} as '*'" in r.get("warning", "")
+
+    def test_bare_literal_zero_match_gets_glob_hint(self, proj):
+        r = json.loads(
+            search_tool("token_alpha", path=str(proj / "proj"), target="files", task_id="t-files")
+        )
+        assert r["total_count"] == 0
+        warning = r.get("warning", "")
+        assert "target='files' uses glob syntax" in warning
+        assert "*token_alpha*" in warning
+        assert "*.md" in warning
+
+    def test_matching_glob_keeps_warning_clear(self, proj):
+        r = json.loads(search_tool("*.py", path=str(proj / "proj"), target="files", task_id="t-files"))
+        assert r["total_count"] == 2
+        assert "warning" not in r
 
 
 class TestZeroMatchProbeEngineParity:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2296,6 +2296,59 @@ class ShellFileOperations(FileOperations):
         merged.warning = note
         return merged
 
+    def _normalize_file_search_pattern(self, pattern: str) -> tuple[str, Optional[str]]:
+        """Normalize common non-glob shortcuts for ``target='files'``."""
+        stripped = pattern.strip()
+        if stripped in {".", "./", ".\\"}:
+            return (
+                "*",
+                f"target='files' expects a glob; interpreted {stripped!r} as '*' to list "
+                "all visible files. Use '*.md' to filter by extension or "
+                "'*name*' to match a substring.",
+            )
+        return pattern, None
+
+    def _zero_file_match_probe(self, pattern: str) -> Optional[str]:
+        """Return glob guidance for suspicious zero-match file searches."""
+        stripped = pattern.strip()
+        if not stripped or "/" in stripped:
+            return None
+        if stripped == ".*":
+            return (
+                "0 file matches. target='files' uses glob syntax for visible "
+                "files; use '*' to list all visible files or '*.md' to filter "
+                "by extension."
+            )
+        if re.search(r"[(){}+^$|\\]", stripped):
+            return (
+                f"0 file matches for pattern {pattern!r}. target='files' uses "
+                "glob syntax, not regex. Use '*' wildcards such as '*.md' or "
+                "'*config*'."
+            )
+        if not any(ch in stripped for ch in "*?["):
+            return (
+                f"0 file matches for pattern {pattern!r}. target='files' uses "
+                "glob syntax. Try '*' to list all visible files, '*.md' to "
+                f"filter by extension, or '*{stripped}*' to match a substring."
+            )
+        return None
+
+    def _finalize_file_search_result(
+        self,
+        result: SearchResult,
+        original_pattern: str,
+        pattern_warning: Optional[str],
+    ) -> SearchResult:
+        if pattern_warning:
+            result.warning = (
+                pattern_warning if not result.warning else f"{result.warning} {pattern_warning}"
+            )
+        elif not result.error and result.total_count == 0 and not result.files:
+            hint = self._zero_file_match_probe(original_pattern)
+            if hint:
+                result.warning = hint if not result.warning else f"{result.warning} {hint}"
+        return result
+
     def _zero_match_probe(self, pattern: str, path: str,
                           file_glob: Optional[str]) -> Optional[str]:
         """Return a hint for a 0-match content search, or None.
@@ -2372,6 +2425,9 @@ class ShellFileOperations(FileOperations):
 
     def _search_files(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
         """Search for files by name pattern (glob-like)."""
+        original_pattern = pattern
+        pattern, pattern_warning = self._normalize_file_search_pattern(pattern)
+
         # Auto-prepend **/ for recursive search if not already present
         if not pattern.startswith('**/') and '/' not in pattern:
             search_pattern = pattern
@@ -2388,14 +2444,22 @@ class ShellFileOperations(FileOperations):
         # default, and has parallel directory traversal (~200x faster than
         # find on wide trees).  Mirrors _search_content which already uses rg.
         if self._has_command('rg'):
-            return self._search_files_rg(search_pattern, path, limit, offset)
+            return self._finalize_file_search_result(
+                self._search_files_rg(search_pattern, path, limit, offset),
+                original_pattern,
+                pattern_warning,
+            )
 
         # Fallback: find (slower, no .gitignore awareness)
         if not self._has_command('find'):
-            return SearchResult(
-                error="File search requires 'rg' (ripgrep) or 'find'. "
-                      "Install ripgrep for best results: "
-                      "https://github.com/BurntSushi/ripgrep#installation"
+            return self._finalize_file_search_result(
+                SearchResult(
+                    error="File search requires 'rg' (ripgrep) or 'find'. "
+                          "Install ripgrep for best results: "
+                          "https://github.com/BurntSushi/ripgrep#installation"
+                ),
+                original_pattern,
+                pattern_warning,
             )
 
         # Exclude hidden directories (matching ripgrep's default behavior).
@@ -2449,11 +2513,15 @@ class ShellFileOperations(FileOperations):
             files = filtered_files[offset:offset + limit]
         # pagination for standard roots is already applied in shell
 
-        return SearchResult(
-            files=files,
-            total_count=len(files),
-            truncated=bool(limit_reason),
-            limit_reason=limit_reason,
+        return self._finalize_file_search_result(
+            SearchResult(
+                files=files,
+                total_count=len(files),
+                truncated=bool(limit_reason),
+                limit_reason=limit_reason,
+            ),
+            original_pattern,
+            pattern_warning,
         )
 
     def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2505,7 +2505,7 @@ SEARCH_FILES_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
-            "pattern": {"type": "string", "description": "Regex pattern for content search, or glob pattern (e.g., '*.py') for file search"},
+            "pattern": {"type": "string", "description": "Regex pattern for content search, or glob pattern (e.g., '*.py') for file search. When target='files', use '*' to list all visible files."},
             "target": {"type": "string", "enum": ["content", "files"], "description": "'content' searches inside file contents, 'files' searches for files by name", "default": "content"},
             "path": {"type": "string", "description": "Directory or file to search in (default: current working directory)", "default": "."},
             "file_glob": {"type": "string", "description": "Filter files by pattern in grep mode (e.g., '*.py' to only search Python files)"},


### PR DESCRIPTION
## What does this PR do?

Fixes #77423 by making `search_files(..., target="files")` recover common
current-directory shorthand and explain other suspicious zero-match patterns.

The file-search path expects glob syntax. On current `main`, callers that pass
`.`, `./`, or `.\` can receive zero results even when the directory contains
visible files, which is indistinguishable from a genuinely empty directory.

## Changes

- Normalize `.`, `./`, and `.\` to `*` before either the ripgrep or `find`
  backend runs.
- Preserve the original shorthand in an actionable warning.
- Add zero-match guidance for bare literals, regex-like input, and `.*`.
- Clarify the `target="files"` glob contract in the tool schema.
- Use explicit UTF-8 encoding in the touched cross-platform test fixtures.

## Consolidation

Repository triage identified this PR as the broader consolidation target for
#77423. It now incorporates the additional `./` and `.\` normalization that
was unique to #77439 while retaining this branch's broader diagnostics and
tool-schema guidance. `..` remains unchanged because it is ambiguous between a
pattern and a request to retarget the search root.

## Verification

```text
scripts/run_tests.sh \
  tests/tools/test_search_zero_match_and_multipath.py \
  tests/tools/test_file_operations.py \
  -k 'FilesTargetGlobHints or SearchFilesFallbackHiddenPaths or ZeroMatchProbeEngineParity or MultiPathRecovery' -q
# 20 passed

uv run ruff check \
  tools/file_operations.py \
  tests/tools/test_search_zero_match_and_multipath.py \
  tests/tools/test_file_operations.py
# All checks passed

.venv/bin/python scripts/check-windows-footguns.py --diff origin/main
# No Windows footguns found

git diff --check
# passed
```

The behavior tests cover both the real `search_tool` path and the `find`
fallback for all three current-directory spellings.

## Scope

- No path retargeting.
- No change to content-search regex behavior.
- No change to valid file globs.
