### PR TITLE
docs(readme): add Phoenix to Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ scripts/run_tests.sh
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🔌 [Phoenix](https://github.com/xyaz1313/phoenix) — Plugin adding tiered model routing, circuit-breaker guardrails, self-healing error recovery, checkpoint reminders, and adaptive approval trust to Hermes Agent, via official plugin hooks only.
 
 ---
 


### PR DESCRIPTION
## Summary
Adds Phoenix to the README's Community section, following the same one-line format as the existing entries (HermesClaw, computer-use-linux).

Phoenix is a Hermes Agent plugin adding tiered model routing, circuit-breaker guardrails, self-healing error recovery, checkpoint reminders (nudges users toward Hermes's native checkpoint/rollback), and adaptive approval trust (auto-relaxes repeated tool-approval prompts, never for hardline-blocked commands). It's built entirely on official plugin hooks (`pre_tool_call`, `post_api_request`, `transform_llm_output`, `post_approval_response`, etc.) with no modifications to Hermes core.

- Repo: https://github.com/xyaz1313/phoenix
- 257 automated tests
- CC BY-NC 4.0 license

## Test plan
- [x] Docs-only change, no code touched
- [x] Verified the added line matches the existing bullet format/style in the Community section