### PR TITLE
feat(plugin-llm): add strict single-attempt execution mode

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1689,6 +1689,7 @@ class _AnthropicCompletionsAdapter:
         from agent.anthropic_adapter import build_anthropic_kwargs, create_anthropic_message
         from agent.transports import get_transport
 
+        strict_single_attempt = bool(kwargs.pop("_strict_single_attempt", False))
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
         tools = kwargs.get("tools")
@@ -1777,6 +1778,11 @@ class _AnthropicCompletionsAdapter:
         response = create_anthropic_message(
             self._client,
             anthropic_kwargs,
+            # The shared helper normally prefers streaming and retries once via
+            # messages.create() when a gateway rejects streaming. Strict mode
+            # must initiate only one physical request, so start with the
+            # non-streaming Messages call and surface any error unchanged.
+            prefer_stream=not strict_single_attempt,
             # Tick the aux forward-progress hook per streamed event so hosts
             # watching liveness (gateway session hygiene) don't kill a
             # slow-but-generating summary model. No-op when no hook is
@@ -8517,6 +8523,8 @@ def _strict_sync_completion(
 
     audit.record_attempt()
     try:
+        if isinstance(client, AnthropicAuxiliaryClient):
+            kwargs = {**kwargs, "_strict_single_attempt": True}
         base_url = str(getattr(client, "base_url", resolved_base_url) or "")
         if _provider_requires_stream(dispatched_provider, base_url):
             response = _create_with_progress(
@@ -8565,6 +8573,8 @@ async def _strict_async_completion(
 
     audit.record_attempt()
     try:
+        if isinstance(client, AsyncAnthropicAuxiliaryClient):
+            kwargs = {**kwargs, "_strict_single_attempt": True}
         base_url = str(getattr(client, "base_url", resolved_base_url) or "")
         force_stream = _provider_requires_stream(dispatched_provider, base_url)
         if force_stream and not isinstance(client, (

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -112,6 +112,16 @@ class _OpenAIProxy:
 OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
 from agent.credential_pool import load_pool
+from agent.llm_execution import (
+    LlmExecutionAudit,
+    LlmExecutionMode,
+    StrictExecutionConfigurationError,
+    StrictExecutionUnsupported,
+    _allow_fallback,
+    _allow_retry,
+    require_matching_strict_route,
+    validate_strict_request,
+)
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
@@ -8435,6 +8445,149 @@ async def _acreate_with_stream(
     )
 
 
+_STRICT_SUPPORTED_CLIENT_NAMES = frozenset({
+    "AnthropicAuxiliaryClient",
+    "AsyncAnthropicAuxiliaryClient",
+    "CodexAuxiliaryClient",
+    "AsyncCodexAuxiliaryClient",
+})
+
+
+def _strict_transport_supported(client: Any) -> bool:
+    """Return whether the transport exposes a provable one-invocation seam.
+
+    OpenAI SDK clients and Hermes's native Anthropic/Codex adapters all disable
+    SDK retries and expose one ``create`` call per invocation. Other adapters
+    (notably external-process and virtual providers) may hide their own retry or
+    routing behavior, so strict mode rejects them before dispatch. Tests may
+    opt a fake transport in with ``_hermes_strict_single_attempt_supported``.
+    """
+
+    if bool(getattr(client, "_hermes_strict_single_attempt_supported", False)):
+        return True
+    client_type = type(client)
+    if client_type.__name__ in _STRICT_SUPPORTED_CLIENT_NAMES:
+        real_client = getattr(client, "_real_client", None)
+        return getattr(real_client, "max_retries", None) == 0
+    return (
+        client_type.__module__.split(".", 1)[0] == "openai"
+        and getattr(client, "max_retries", None) == 0
+    )
+
+
+def _prepare_execution_audit(
+    execution_mode: LlmExecutionMode | str,
+    execution_audit: Optional[LlmExecutionAudit],
+    *,
+    provider: Optional[str],
+    model: Optional[str],
+) -> tuple[LlmExecutionMode, LlmExecutionAudit]:
+    mode = validate_strict_request(
+        execution_mode,
+        provider=provider,
+        model=model,
+    )
+    audit = execution_audit or LlmExecutionAudit()
+    audit.begin(mode, provider=provider, model=model)
+    return mode, audit
+
+
+def _strict_sync_completion(
+    client: Any,
+    kwargs: Dict[str, Any],
+    *,
+    task: Optional[str],
+    requested_provider: str,
+    requested_model: str,
+    dispatched_provider: str,
+    dispatched_model: str,
+    resolved_base_url: Optional[str],
+    audit: LlmExecutionAudit,
+) -> Any:
+    require_matching_strict_route(
+        audit,
+        provider=dispatched_provider,
+        model=dispatched_model,
+    )
+    if not _strict_transport_supported(client):
+        raise StrictExecutionUnsupported(
+            "strict_single_attempt is unsupported for transport "
+            f"{type(client).__module__}.{type(client).__name__}"
+        )
+
+    audit.record_attempt()
+    try:
+        base_url = str(getattr(client, "base_url", resolved_base_url) or "")
+        if _provider_requires_stream(dispatched_provider, base_url):
+            response = _create_with_progress(
+                client,
+                kwargs,
+                task,
+                force_stream=True,
+            )
+        else:
+            response = client.chat.completions.create(**kwargs)
+        response = _validate_llm_response(
+            response,
+            task,
+            provider=dispatched_provider,
+            base_url=base_url,
+        )
+    except Exception as exc:
+        audit.record_failure(exc)
+        raise
+    audit.record_response(response)
+    return response
+
+
+async def _strict_async_completion(
+    client: Any,
+    kwargs: Dict[str, Any],
+    *,
+    task: Optional[str],
+    requested_provider: str,
+    requested_model: str,
+    dispatched_provider: str,
+    dispatched_model: str,
+    resolved_base_url: Optional[str],
+    audit: LlmExecutionAudit,
+) -> Any:
+    require_matching_strict_route(
+        audit,
+        provider=dispatched_provider,
+        model=dispatched_model,
+    )
+    if not _strict_transport_supported(client):
+        raise StrictExecutionUnsupported(
+            "strict_single_attempt is unsupported for transport "
+            f"{type(client).__module__}.{type(client).__name__}"
+        )
+
+    audit.record_attempt()
+    try:
+        base_url = str(getattr(client, "base_url", resolved_base_url) or "")
+        force_stream = _provider_requires_stream(dispatched_provider, base_url)
+        if force_stream and not isinstance(client, (
+            AsyncCodexAuxiliaryClient,
+            AsyncAnthropicAuxiliaryClient,
+            AsyncBedrockAuxiliaryClient,
+        )):
+            response = await _acreate_with_stream(client, kwargs, task)
+        else:
+            response = await client.chat.completions.create(**kwargs)
+        response = _validate_llm_response(
+            response,
+            task,
+            provider=dispatched_provider,
+            base_url=base_url,
+        )
+    except Exception as exc:
+        audit.record_failure(exc)
+        raise
+    audit.record_response(response)
+    return response
+
+
 @_relay_auxiliary_call
 def call_llm(
     task: str = None,
@@ -8455,6 +8608,8 @@ def call_llm(
     api_mode: str = None,
     stream: bool = False,
     stream_options: dict = None,
+    execution_mode: LlmExecutionMode | str = LlmExecutionMode.DEFAULT,
+    execution_audit: Optional[LlmExecutionAudit] = None,
 ) -> Any:
     """Centralized synchronous LLM call.
 
@@ -8486,6 +8641,11 @@ def call_llm(
             output can stream to the user.
         stream_options: Passed through to the request when stream is True
             (e.g. {"include_usage": True}).
+        execution_mode: Host retry/fallback policy. The default preserves the
+            existing resilient behavior. ``strict_single_attempt`` requires an
+            explicit provider and model and dispatches at most once.
+        execution_audit: Optional mutable, secret-free audit record populated
+            by strict execution without changing the response return type.
 
     Returns:
         Response object with .choices[0].message.content, OR — when stream=True —
@@ -8494,6 +8654,17 @@ def call_llm(
     Raises:
         RuntimeError: If no provider is configured.
     """
+    resolved_execution_mode, execution_audit = _prepare_execution_audit(
+        execution_mode,
+        execution_audit,
+        provider=provider,
+        model=model,
+    )
+    if not _allow_retry(resolved_execution_mode) and stream:
+        raise StrictExecutionUnsupported(
+            "strict_single_attempt does not return a caller-consumed raw stream"
+        )
+
     # Capture one immutable runtime snapshot for keying, resolution, retries,
     # and fallbacks. Reading ambient state independently in each phase lets a
     # concurrent /model switch produce a key for one runtime and a client for
@@ -8515,7 +8686,12 @@ def call_llm(
             async_mode=False,
             main_runtime=main_runtime,
         )
-        if client is None and resolved_provider != "auto" and not resolved_base_url:
+        if (
+            client is None
+            and resolved_provider != "auto"
+            and not resolved_base_url
+            and _allow_fallback(resolved_execution_mode)
+        ):
             logger.warning(
                 "Vision provider %s unavailable, falling back to auto vision backends",
                 resolved_provider,
@@ -8542,6 +8718,10 @@ def call_llm(
             main_runtime=main_runtime,
         )
         if client is None:
+            if not _allow_fallback(resolved_execution_mode):
+                raise StrictExecutionConfigurationError(
+                    f"Strict provider {resolved_provider!r} has no usable client"
+                )
             # When the user explicitly chose a non-OpenRouter provider but no
             # credentials were found, honor the task fallback_chain before
             # raising.  Missing raw env keys are recoverable for auxiliary
@@ -8605,6 +8785,19 @@ def call_llm(
     _client_base = str(getattr(client, "base_url", "") or "")
     if _is_anthropic_compat_endpoint(resolved_provider, _client_base):
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
+
+    if not _allow_retry(resolved_execution_mode):
+        return _strict_sync_completion(
+            client,
+            kwargs,
+            task=task,
+            requested_provider=str(provider),
+            requested_model=str(model),
+            dispatched_provider=resolved_provider,
+            dispatched_model=str(final_model or ""),
+            resolved_base_url=resolved_base_url,
+            audit=execution_audit,
+        )
 
     # Streaming path: return the raw SDK Stream iterator directly. This is used by
     # the MoA aggregator so its tokens stream to the user. It deliberately skips
@@ -9218,11 +9411,20 @@ async def async_call_llm(
     timeout: float = None,
     extra_body: dict = None,
     reasoning_config: Optional[dict] = None,
+    execution_mode: LlmExecutionMode | str = LlmExecutionMode.DEFAULT,
+    execution_audit: Optional[LlmExecutionAudit] = None,
 ) -> Any:
     """Centralized asynchronous LLM call.
 
     Same as call_llm() but async. See call_llm() for full documentation.
     """
+    resolved_execution_mode, execution_audit = _prepare_execution_audit(
+        execution_mode,
+        execution_audit,
+        provider=provider,
+        model=model,
+    )
+
     # Keep every async phase on the same runtime identity, even if another
     # session switches models while this task is awaiting network I/O.
     main_runtime = _normalize_main_runtime(main_runtime)
@@ -9240,7 +9442,12 @@ async def async_call_llm(
             async_mode=True,
             main_runtime=main_runtime,
         )
-        if client is None and resolved_provider != "auto" and not resolved_base_url:
+        if (
+            client is None
+            and resolved_provider != "auto"
+            and not resolved_base_url
+            and _allow_fallback(resolved_execution_mode)
+        ):
             logger.warning(
                 "Vision provider %s unavailable, falling back to auto vision backends",
                 resolved_provider,
@@ -9268,6 +9475,10 @@ async def async_call_llm(
             main_runtime=main_runtime,
         )
         if client is None:
+            if not _allow_fallback(resolved_execution_mode):
+                raise StrictExecutionConfigurationError(
+                    f"Strict provider {resolved_provider!r} has no usable client"
+                )
             _explicit = (resolved_provider or "").strip().lower()
             if _explicit and _explicit not in {"auto", "openrouter", "custom"}:
                 fb_client, fb_model, fb_label = _try_configured_fallback_for_unavailable_client(
@@ -9314,6 +9525,19 @@ async def async_call_llm(
     # Convert image blocks for Anthropic-compatible endpoints (e.g. MiniMax)
     if _is_anthropic_compat_endpoint(resolved_provider, _client_base):
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
+
+    if not _allow_retry(resolved_execution_mode):
+        return await _strict_async_completion(
+            client,
+            kwargs,
+            task=task,
+            requested_provider=str(provider),
+            requested_model=str(model),
+            dispatched_provider=resolved_provider,
+            dispatched_model=str(final_model or ""),
+            resolved_base_url=resolved_base_url,
+            audit=execution_audit,
+        )
 
     try:
         # Retry ONCE on the same provider for a transient transport blip

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -231,6 +231,30 @@ def _create_openai_client(*, api_key: str, base_url: str, **kwargs: Any) -> Any:
     return OpenAI(api_key=api_key, base_url=base_url, **kwargs)
 
 
+def _mark_resolved_api_mode(client: Any, api_mode: Optional[str]) -> Any:
+    """Carry non-secret resolver transport metadata with a concrete client."""
+
+    mode = str(api_mode or "").strip().lower()
+    if mode:
+        try:
+            setattr(client, "_hermes_resolved_api_mode", mode)
+        except Exception:
+            logger.debug(
+                "Auxiliary client does not accept resolved API mode metadata",
+                exc_info=True,
+            )
+    return client
+
+
+def _inherit_resolved_api_mode(source: Any, target: Any) -> Any:
+    """Preserve resolver transport metadata across sync-to-async wrapping."""
+
+    return _mark_resolved_api_mode(
+        target,
+        getattr(source, "_hermes_resolved_api_mode", None),
+    )
+
+
 # ── Interrupt protection for atomic auxiliary tasks ──────────────────────
 # Some auxiliary tasks must NOT be aborted mid-flight by a gateway interrupt
 # (e.g. an incoming user message while the agent is busy). Context
@@ -3465,20 +3489,22 @@ def _try_azure_foundry(
         # GPT-5.x / o-series / codex models on Azure Foundry are
         # Responses-API-only — wrap so chat.completions.create() is
         # translated to /responses behind the scenes.
-        return CodexAuxiliaryClient(client, final_model), final_model
+        client = CodexAuxiliaryClient(client, final_model)
+        return _mark_resolved_api_mode(client, runtime_api_mode), final_model
 
     if runtime_api_mode == "anthropic_messages":
         # Forward ``api_key`` verbatim — for static keys it's a string,
         # for Entra ID it's a callable. ``_maybe_wrap_anthropic`` →
         # ``build_anthropic_client`` detects the callable and installs
         # the bearer-injecting httpx hook.
-        return _maybe_wrap_anthropic(
+        client = _maybe_wrap_anthropic(
             client, final_model, api_key,
             base_url, runtime_api_mode,
-        ), final_model
+        )
+        return _mark_resolved_api_mode(client, runtime_api_mode), final_model
 
     # chat_completions — return the plain OpenAI client.
-    return client, final_model
+    return _mark_resolved_api_mode(client, runtime_api_mode), final_model
 
 
 def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optional[str]]:
@@ -5590,16 +5616,20 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     from openai import AsyncOpenAI
 
     if isinstance(sync_client, CodexAuxiliaryClient):
-        return AsyncCodexAuxiliaryClient(sync_client), model
+        async_client = AsyncCodexAuxiliaryClient(sync_client)
+        return _inherit_resolved_api_mode(sync_client, async_client), model
     if isinstance(sync_client, AnthropicAuxiliaryClient):
-        return AsyncAnthropicAuxiliaryClient(sync_client), model
+        async_client = AsyncAnthropicAuxiliaryClient(sync_client)
+        return _inherit_resolved_api_mode(sync_client, async_client), model
     if isinstance(sync_client, BedrockAuxiliaryClient):
-        return AsyncBedrockAuxiliaryClient(sync_client), model
+        async_client = AsyncBedrockAuxiliaryClient(sync_client)
+        return _inherit_resolved_api_mode(sync_client, async_client), model
     try:
         from agent.gemini_native_adapter import GeminiNativeClient, AsyncGeminiNativeClient
 
         if isinstance(sync_client, GeminiNativeClient):
-            return AsyncGeminiNativeClient(sync_client), model
+            async_client = AsyncGeminiNativeClient(sync_client)
+            return _inherit_resolved_api_mode(sync_client, async_client), model
     except ImportError:
         pass
     try:
@@ -5654,7 +5684,8 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     # See _create_openai_client: disable SDK-internal retries so Hermes owns
     # the auxiliary retry/timeout budget (issue #54465).
     async_kwargs.setdefault("max_retries", 0)
-    return AsyncOpenAI(**async_kwargs), model
+    async_client = AsyncOpenAI(**async_kwargs)
+    return _inherit_resolved_api_mode(sync_client, async_client), model
 
 
 def _normalize_resolved_model(model_name: Optional[str], provider: str) -> Optional[str]:
@@ -5899,6 +5930,7 @@ def resolve_provider_client(
         client = _maybe_wrap_anthropic(
             client, final_model, api_key_str, base_url_str, portal_mode,
         )
+        client = _mark_resolved_api_mode(client, portal_mode)
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
@@ -8458,6 +8490,120 @@ _STRICT_SUPPORTED_CLIENT_NAMES = frozenset({
     "AsyncCodexAuxiliaryClient",
 })
 
+_STRICT_EARLY_ROUTER_PROVIDERS = frozenset({
+    "auto",
+    "custom",
+    "moa",
+    "nous",
+    "openai-codex",
+    "openrouter",
+    "xai-oauth",
+})
+
+
+def _strict_named_custom_entry(provider: str) -> Optional[Dict[str, Any]]:
+    """Resolve the same named-custom precedence used by the client router."""
+
+    raw_provider = str(provider or "").strip().lower()
+    normalized_provider = _normalize_aux_provider(raw_provider)
+    if normalized_provider in _STRICT_EARLY_ROUTER_PROVIDERS:
+        return None
+    try:
+        from hermes_cli.runtime_provider import _get_named_custom_provider
+
+        if raw_provider and raw_provider != normalized_provider:
+            entry = _get_named_custom_provider(raw_provider)
+            if entry is not None:
+                return entry
+        return _get_named_custom_provider(normalized_provider)
+    except (ImportError, TypeError, ValueError):
+        return None
+
+
+def _strict_declared_api_mode(
+    provider: str,
+    api_mode: Optional[str],
+) -> Optional[str]:
+    """Return an explicit or named-provider wire mode for fail-closed checks."""
+
+    declared = str(api_mode or "").strip().lower()
+    if declared:
+        return declared
+    entry = _strict_named_custom_entry(provider)
+    if entry is None:
+        return None
+    return str(entry.get("api_mode") or "").strip().lower() or None
+
+
+def _strict_canonical_provider(
+    provider: str,
+    *,
+    preserve_custom_prefix: bool = False,
+) -> str:
+    """Canonicalize built-in aliases without hiding named custom providers."""
+
+    raw_provider = str(provider or "").strip().lower()
+    normalized_provider = _normalize_aux_provider(raw_provider)
+    if preserve_custom_prefix and raw_provider.startswith("custom:"):
+        return raw_provider
+    if normalized_provider in _STRICT_EARLY_ROUTER_PROVIDERS:
+        return normalized_provider
+    if raw_provider != normalized_provider:
+        entry = _strict_named_custom_entry(raw_provider)
+        if entry is not None:
+            return raw_provider
+    return normalized_provider
+
+
+def _require_strict_transport_api_mode(
+    client: Any,
+    *,
+    api_mode: Optional[str],
+    base_url: str,
+) -> None:
+    """Reject any configured wire-mode downgrade before outbound dispatch."""
+
+    mode = str(api_mode or "").strip().lower()
+    resolver_mode = str(
+        getattr(client, "_hermes_resolved_api_mode", None) or ""
+    ).strip().lower()
+    if mode and resolver_mode and mode != resolver_mode:
+        raise StrictExecutionUnsupported(
+            "strict_single_attempt API mode changed during client resolution"
+        )
+    mode = mode or resolver_mode
+    if not mode and _endpoint_speaks_anthropic_messages(base_url):
+        mode = "anthropic_messages"
+    if not mode:
+        return
+
+    is_anthropic = isinstance(
+        client,
+        (AnthropicAuxiliaryClient, AsyncAnthropicAuxiliaryClient),
+    )
+    is_codex = isinstance(
+        client,
+        (CodexAuxiliaryClient, AsyncCodexAuxiliaryClient),
+    )
+    if mode == "anthropic_messages" and is_anthropic:
+        return
+    if mode == "codex_responses" and is_codex:
+        return
+    if mode == "chat_completions" and not is_anthropic and not is_codex:
+        return
+    if mode not in {
+        "anthropic_messages",
+        "chat_completions",
+        "codex_responses",
+    }:
+        raise StrictExecutionUnsupported(
+            f"strict_single_attempt does not recognize API mode {mode!r}"
+        )
+    raise StrictExecutionUnsupported(
+        "strict_single_attempt transport does not match configured API mode "
+        f"{mode!r}"
+    )
+
 
 def _strict_transport_supported(client: Any) -> bool:
     """Return whether the transport exposes a provable one-invocation seam.
@@ -8508,12 +8654,23 @@ def _strict_sync_completion(
     dispatched_provider: str,
     dispatched_model: str,
     resolved_base_url: Optional[str],
+    resolved_api_mode: Optional[str],
     audit: LlmExecutionAudit,
 ) -> Any:
     require_matching_strict_route(
         audit,
         provider=dispatched_provider,
         model=dispatched_model,
+        requested_provider_for_match=_strict_canonical_provider(
+            requested_provider,
+            preserve_custom_prefix=True,
+        ),
+    )
+    base_url = str(getattr(client, "base_url", resolved_base_url) or "")
+    _require_strict_transport_api_mode(
+        client,
+        api_mode=resolved_api_mode,
+        base_url=base_url,
     )
     if not _strict_transport_supported(client):
         raise StrictExecutionUnsupported(
@@ -8525,7 +8682,6 @@ def _strict_sync_completion(
     try:
         if isinstance(client, AnthropicAuxiliaryClient):
             kwargs = {**kwargs, "_strict_single_attempt": True}
-        base_url = str(getattr(client, "base_url", resolved_base_url) or "")
         if _provider_requires_stream(dispatched_provider, base_url):
             response = _create_with_progress(
                 client,
@@ -8558,12 +8714,23 @@ async def _strict_async_completion(
     dispatched_provider: str,
     dispatched_model: str,
     resolved_base_url: Optional[str],
+    resolved_api_mode: Optional[str],
     audit: LlmExecutionAudit,
 ) -> Any:
     require_matching_strict_route(
         audit,
         provider=dispatched_provider,
         model=dispatched_model,
+        requested_provider_for_match=_strict_canonical_provider(
+            requested_provider,
+            preserve_custom_prefix=True,
+        ),
+    )
+    base_url = str(getattr(client, "base_url", resolved_base_url) or "")
+    _require_strict_transport_api_mode(
+        client,
+        api_mode=resolved_api_mode,
+        base_url=base_url,
     )
     if not _strict_transport_supported(client):
         raise StrictExecutionUnsupported(
@@ -8575,7 +8742,6 @@ async def _strict_async_completion(
     try:
         if isinstance(client, AsyncAnthropicAuxiliaryClient):
             kwargs = {**kwargs, "_strict_single_attempt": True}
-        base_url = str(getattr(client, "base_url", resolved_base_url) or "")
         force_stream = _provider_requires_stream(dispatched_provider, base_url)
         if force_stream and not isinstance(client, (
             AsyncCodexAuxiliaryClient,
@@ -8697,6 +8863,11 @@ def call_llm(
         resolved_api_mode = resolved_api_mode or custom_mode
     if api_mode:
         resolved_api_mode = api_mode
+    if not _allow_retry(resolved_execution_mode):
+        resolved_api_mode = _strict_declared_api_mode(
+            resolved_provider,
+            resolved_api_mode,
+        )
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
@@ -8810,7 +8981,6 @@ def call_llm(
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
 
     if not _allow_retry(resolved_execution_mode):
-        strict_provider_label = resolved_provider
         requested_provider = str(provider or "").strip().lower()
         direct_base = _AUX_DIRECT_API_BASE_URLS.get(requested_provider, "")
         if (
@@ -8819,6 +8989,8 @@ def call_llm(
             and str(resolved_base_url or "").rstrip("/") == direct_base.rstrip("/")
         ):
             strict_provider_label = str(provider).strip()
+        else:
+            strict_provider_label = _strict_canonical_provider(resolved_provider)
         return _strict_sync_completion(
             client,
             kwargs,
@@ -8828,6 +9000,7 @@ def call_llm(
             dispatched_provider=strict_provider_label,
             dispatched_model=str(final_model or ""),
             resolved_base_url=resolved_base_url,
+            resolved_api_mode=resolved_api_mode,
             audit=execution_audit,
         )
 
@@ -9475,6 +9648,11 @@ async def async_call_llm(
         resolved_base_url = custom_base
         resolved_api_key = custom_key
         resolved_api_mode = resolved_api_mode or custom_mode
+    if not _allow_retry(resolved_execution_mode):
+        resolved_api_mode = _strict_declared_api_mode(
+            resolved_provider,
+            resolved_api_mode,
+        )
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
@@ -9572,7 +9750,6 @@ async def async_call_llm(
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
 
     if not _allow_retry(resolved_execution_mode):
-        strict_provider_label = resolved_provider
         requested_provider = str(provider or "").strip().lower()
         direct_base = _AUX_DIRECT_API_BASE_URLS.get(requested_provider, "")
         if (
@@ -9581,6 +9758,8 @@ async def async_call_llm(
             and str(resolved_base_url or "").rstrip("/") == direct_base.rstrip("/")
         ):
             strict_provider_label = str(provider).strip()
+        else:
+            strict_provider_label = _strict_canonical_provider(resolved_provider)
         return await _strict_async_completion(
             client,
             kwargs,
@@ -9590,6 +9769,7 @@ async def async_call_llm(
             dispatched_provider=strict_provider_label,
             dispatched_model=str(final_model or ""),
             resolved_base_url=resolved_base_url,
+            resolved_api_mode=resolved_api_mode,
             audit=execution_audit,
         )
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8672,6 +8672,19 @@ def call_llm(
     main_runtime = _normalize_main_runtime(main_runtime)
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
+    if (
+        not _allow_fallback(resolved_execution_mode)
+        and resolved_provider == "custom"
+        and not resolved_base_url
+    ):
+        custom_base, custom_key, custom_mode = _resolve_custom_runtime()
+        if not custom_base or not custom_key:
+            raise StrictExecutionConfigurationError(
+                "Strict custom provider has no explicit configured endpoint"
+            )
+        resolved_base_url = custom_base
+        resolved_api_key = custom_key
+        resolved_api_mode = resolved_api_mode or custom_mode
     if api_mode:
         resolved_api_mode = api_mode
     effective_extra_body = _get_task_extra_body(task)
@@ -8787,13 +8800,22 @@ def call_llm(
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
 
     if not _allow_retry(resolved_execution_mode):
+        strict_provider_label = resolved_provider
+        requested_provider = str(provider or "").strip().lower()
+        direct_base = _AUX_DIRECT_API_BASE_URLS.get(requested_provider, "")
+        if (
+            resolved_provider == "custom"
+            and direct_base
+            and str(resolved_base_url or "").rstrip("/") == direct_base.rstrip("/")
+        ):
+            strict_provider_label = str(provider).strip()
         return _strict_sync_completion(
             client,
             kwargs,
             task=task,
             requested_provider=str(provider),
             requested_model=str(model),
-            dispatched_provider=resolved_provider,
+            dispatched_provider=strict_provider_label,
             dispatched_model=str(final_model or ""),
             resolved_base_url=resolved_base_url,
             audit=execution_audit,
@@ -9430,6 +9452,19 @@ async def async_call_llm(
     main_runtime = _normalize_main_runtime(main_runtime)
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
+    if (
+        not _allow_fallback(resolved_execution_mode)
+        and resolved_provider == "custom"
+        and not resolved_base_url
+    ):
+        custom_base, custom_key, custom_mode = _resolve_custom_runtime()
+        if not custom_base or not custom_key:
+            raise StrictExecutionConfigurationError(
+                "Strict custom provider has no explicit configured endpoint"
+            )
+        resolved_base_url = custom_base
+        resolved_api_key = custom_key
+        resolved_api_mode = resolved_api_mode or custom_mode
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
@@ -9527,13 +9562,22 @@ async def async_call_llm(
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
 
     if not _allow_retry(resolved_execution_mode):
+        strict_provider_label = resolved_provider
+        requested_provider = str(provider or "").strip().lower()
+        direct_base = _AUX_DIRECT_API_BASE_URLS.get(requested_provider, "")
+        if (
+            resolved_provider == "custom"
+            and direct_base
+            and str(resolved_base_url or "").rstrip("/") == direct_base.rstrip("/")
+        ):
+            strict_provider_label = str(provider).strip()
         return await _strict_async_completion(
             client,
             kwargs,
             task=task,
             requested_provider=str(provider),
             requested_model=str(model),
-            dispatched_provider=resolved_provider,
+            dispatched_provider=strict_provider_label,
             dispatched_model=str(final_model or ""),
             resolved_base_url=resolved_base_url,
             audit=execution_audit,

--- a/agent/llm_execution.py
+++ b/agent/llm_execution.py
@@ -67,6 +67,16 @@ class LlmExecutionAudit:
         self.execution_mode = resolved_mode.value
         self.requested_provider = str(provider or "").strip()
         self.requested_model = str(model or "").strip()
+        self.dispatched_provider = ""
+        self.dispatched_model = ""
+        self.response_provider = ""
+        self.response_model = ""
+        self.attempt_count = 0
+        self.fallback_used = False
+        self.credential_rotation_used = False
+        self.route_changed = False
+        self.delivery_ambiguous = False
+        self.strict_contract_satisfied = False
 
     def record_dispatch(self, provider: str | None, model: str | None) -> None:
         self.dispatched_provider = str(provider or "").strip()
@@ -154,9 +164,10 @@ def validate_strict_request(
             "strict_single_attempt requires an explicit provider other than "
             "'auto' or 'main'"
         )
-    if not model_text:
+    if not model_text or model_text.lower() in {"auto", "main"}:
         raise StrictExecutionConfigurationError(
-            "strict_single_attempt requires an explicit model"
+            "strict_single_attempt requires an explicit model other than "
+            "'auto' or 'main'"
         )
     return resolved_mode
 

--- a/agent/llm_execution.py
+++ b/agent/llm_execution.py
@@ -1,0 +1,222 @@
+"""Execution policy primitives shared by host-owned LLM call surfaces.
+
+The default policy deliberately carries no new behavior.  Strict execution is
+an opt-in client-side contract: Hermes dispatches one explicit route at most
+once and does not enter its retry, credential-rotation, or fallback recovery
+chains.  A provider may still accept a request before a timeout or connection
+failure becomes visible to the client, so strict execution is not an
+exactly-once delivery guarantee.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from typing import Any
+
+
+class LlmExecutionMode(StrEnum):
+    """Host policy for one LLM invocation."""
+
+    DEFAULT = "default"
+    STRICT_SINGLE_ATTEMPT = "strict_single_attempt"
+
+
+class LlmExecutionPolicyError(RuntimeError):
+    """Base class for execution-policy failures."""
+
+
+class StrictExecutionConfigurationError(LlmExecutionPolicyError, ValueError):
+    """Strict execution was requested without a usable explicit route."""
+
+
+class StrictExecutionUnsupported(LlmExecutionPolicyError):
+    """The selected transport cannot prove the strict host contract."""
+
+
+class StrictExecutionRouteMismatch(LlmExecutionPolicyError):
+    """Route resolution changed the provider or model requested by the caller."""
+
+
+@dataclass
+class LlmExecutionAudit:
+    """Secret-free execution facts for one host-owned LLM call."""
+
+    execution_mode: str = LlmExecutionMode.DEFAULT.value
+    requested_provider: str = ""
+    requested_model: str = ""
+    dispatched_provider: str = ""
+    dispatched_model: str = ""
+    response_provider: str = ""
+    response_model: str = ""
+    attempt_count: int = 0
+    fallback_used: bool = False
+    credential_rotation_used: bool = False
+    route_changed: bool = False
+    delivery_ambiguous: bool = False
+    strict_contract_satisfied: bool = False
+
+    def begin(
+        self,
+        mode: LlmExecutionMode | str,
+        *,
+        provider: str | None,
+        model: str | None,
+    ) -> None:
+        resolved_mode = coerce_execution_mode(mode)
+        self.execution_mode = resolved_mode.value
+        self.requested_provider = str(provider or "").strip()
+        self.requested_model = str(model or "").strip()
+
+    def record_dispatch(self, provider: str | None, model: str | None) -> None:
+        self.dispatched_provider = str(provider or "").strip()
+        self.dispatched_model = str(model or "").strip()
+        self.route_changed = not routes_match(
+            self.requested_provider,
+            self.requested_model,
+            self.dispatched_provider,
+            self.dispatched_model,
+        )
+
+    def record_attempt(self) -> None:
+        self.attempt_count += 1
+
+    def record_response(self, response: Any) -> None:
+        response_provider = getattr(response, "provider", None)
+        response_model = getattr(response, "model", None)
+        self.response_provider = str(
+            response_provider or self.dispatched_provider
+        ).strip()
+        self.response_model = str(response_model or self.dispatched_model).strip()
+        self.strict_contract_satisfied = (
+            _strict_mode(self.execution_mode)
+            and self.attempt_count == 1
+            and not self.fallback_used
+            and not self.credential_rotation_used
+            and not self.route_changed
+        )
+
+    def record_failure(self, exc: BaseException) -> None:
+        self.delivery_ambiguous = _delivery_may_be_ambiguous(exc)
+        self.strict_contract_satisfied = (
+            _strict_mode(self.execution_mode)
+            and self.attempt_count <= 1
+            and not self.fallback_used
+            and not self.credential_rotation_used
+            and not self.route_changed
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def coerce_execution_mode(mode: LlmExecutionMode | str) -> LlmExecutionMode:
+    """Normalize a public execution mode or fail before route resolution."""
+
+    if isinstance(mode, LlmExecutionMode):
+        return mode
+    try:
+        return LlmExecutionMode(str(mode).strip().lower())
+    except ValueError as exc:
+        choices = ", ".join(item.value for item in LlmExecutionMode)
+        raise LlmExecutionPolicyError(
+            f"Unknown LLM execution mode {mode!r}; expected one of: {choices}"
+        ) from exc
+
+
+def _strict_mode(mode: LlmExecutionMode | str) -> bool:
+    return coerce_execution_mode(mode) is LlmExecutionMode.STRICT_SINGLE_ATTEMPT
+
+
+def _allow_retry(mode: LlmExecutionMode | str) -> bool:
+    return not _strict_mode(mode)
+
+
+def _allow_fallback(mode: LlmExecutionMode | str) -> bool:
+    return not _strict_mode(mode)
+
+
+def validate_strict_request(
+    mode: LlmExecutionMode | str,
+    *,
+    provider: str | None,
+    model: str | None,
+) -> LlmExecutionMode:
+    """Validate strict route inputs without reading config or credentials."""
+
+    resolved_mode = coerce_execution_mode(mode)
+    if resolved_mode is not LlmExecutionMode.STRICT_SINGLE_ATTEMPT:
+        return resolved_mode
+    provider_text = str(provider or "").strip()
+    model_text = str(model or "").strip()
+    if not provider_text or provider_text.lower() in {"auto", "main"}:
+        raise StrictExecutionConfigurationError(
+            "strict_single_attempt requires an explicit provider other than "
+            "'auto' or 'main'"
+        )
+    if not model_text:
+        raise StrictExecutionConfigurationError(
+            "strict_single_attempt requires an explicit model"
+        )
+    return resolved_mode
+
+
+def routes_match(
+    requested_provider: str | None,
+    requested_model: str | None,
+    dispatched_provider: str | None,
+    dispatched_model: str | None,
+) -> bool:
+    """Compare providers case-insensitively and model identifiers literally."""
+
+    return (
+        str(requested_provider or "").strip().lower()
+        == str(dispatched_provider or "").strip().lower()
+        and str(requested_model or "").strip()
+        == str(dispatched_model or "").strip()
+    )
+
+
+def require_matching_strict_route(
+    audit: LlmExecutionAudit,
+    *,
+    provider: str | None,
+    model: str | None,
+) -> None:
+    audit.record_dispatch(provider, model)
+    if audit.route_changed:
+        audit.strict_contract_satisfied = False
+        raise StrictExecutionRouteMismatch(
+            "strict_single_attempt route resolution changed "
+            f"{audit.requested_provider!r}/{audit.requested_model!r} to "
+            f"{audit.dispatched_provider!r}/{audit.dispatched_model!r}"
+        )
+
+
+def _delivery_may_be_ambiguous(exc: BaseException) -> bool:
+    """Conservatively classify failures that may happen after server receipt."""
+
+    name = type(exc).__name__.lower()
+    message = str(exc).lower()
+    markers = (
+        "timeout",
+        "timed out",
+        "connection",
+        "connecterror",
+        "readerror",
+        "writeerror",
+        "remoteprotocol",
+        "incomplete read",
+        "stream closed",
+    )
+    return any(marker in name or marker in message for marker in markers)
+
+
+__all__ = [
+    "LlmExecutionAudit",
+    "LlmExecutionMode",
+    "LlmExecutionPolicyError",
+    "StrictExecutionConfigurationError",
+    "StrictExecutionRouteMismatch",
+    "StrictExecutionUnsupported",
+]

--- a/agent/llm_execution.py
+++ b/agent/llm_execution.py
@@ -94,10 +94,14 @@ class LlmExecutionAudit:
     def record_response(self, response: Any) -> None:
         response_provider = getattr(response, "provider", None)
         response_model = getattr(response, "model", None)
-        self.response_provider = str(
-            response_provider or self.dispatched_provider
-        ).strip()
-        self.response_model = str(response_model or self.dispatched_model).strip()
+        self.response_provider = str(response_provider or "").strip()
+        self.response_model = str(response_model or "").strip()
+        if self.response_provider and (
+            self.response_provider.lower() != self.dispatched_provider.lower()
+        ):
+            self.route_changed = True
+        if self.response_model and self.response_model != self.dispatched_model:
+            self.route_changed = True
         self.strict_contract_satisfied = (
             _strict_mode(self.execution_mode)
             and self.attempt_count == 1
@@ -192,8 +196,16 @@ def require_matching_strict_route(
     *,
     provider: str | None,
     model: str | None,
+    requested_provider_for_match: str | None = None,
 ) -> None:
     audit.record_dispatch(provider, model)
+    if requested_provider_for_match is not None:
+        audit.route_changed = not routes_match(
+            requested_provider_for_match,
+            audit.requested_model,
+            audit.dispatched_provider,
+            audit.dispatched_model,
+        )
     if audit.route_changed:
         audit.strict_contract_satisfied = False
         raise StrictExecutionRouteMismatch(
@@ -201,6 +213,20 @@ def require_matching_strict_route(
             f"{audit.requested_provider!r}/{audit.requested_model!r} to "
             f"{audit.dispatched_provider!r}/{audit.dispatched_model!r}"
         )
+
+
+def attach_execution_audit(
+    exc: BaseException,
+    audit: LlmExecutionAudit,
+) -> None:
+    """Expose a secret-free strict audit without replacing the error type."""
+
+    try:
+        setattr(exc, "execution_audit", audit.as_dict())
+    except Exception:
+        # Some third-party exception implementations may reject attributes.
+        # The original exception must still propagate unchanged.
+        pass
 
 
 def _delivery_may_be_ambiguous(exc: BaseException) -> bool:
@@ -229,4 +255,5 @@ __all__ = [
     "StrictExecutionConfigurationError",
     "StrictExecutionRouteMismatch",
     "StrictExecutionUnsupported",
+    "attach_execution_audit",
 ]

--- a/agent/llm_execution.py
+++ b/agent/llm_execution.py
@@ -183,8 +183,7 @@ def routes_match(
     return (
         str(requested_provider or "").strip().lower()
         == str(dispatched_provider or "").strip().lower()
-        and str(requested_model or "").strip()
-        == str(dispatched_model or "").strip()
+        and str(requested_model or "").strip() == str(dispatched_model or "").strip()
     )
 
 

--- a/agent/plugin_llm.py
+++ b/agent/plugin_llm.py
@@ -688,7 +688,7 @@ class PluginLlm:
                 "plugin_id": self._plugin_id,
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
-                **execution_audit.as_dict(),
+                **self._strict_audit_fields(execution_audit),
             },
         )
         logger.info(
@@ -787,7 +787,7 @@ class PluginLlm:
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
                 "schema_name": schema_name or "",
-                **execution_audit.as_dict(),
+                **self._strict_audit_fields(execution_audit),
             },
         )
         logger.info(
@@ -849,7 +849,7 @@ class PluginLlm:
                 "plugin_id": self._plugin_id,
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
-                **execution_audit.as_dict(),
+                **self._strict_audit_fields(execution_audit),
             },
         )
 
@@ -928,11 +928,17 @@ class PluginLlm:
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
                 "schema_name": schema_name or "",
-                **execution_audit.as_dict(),
+                **self._strict_audit_fields(execution_audit),
             },
         )
 
     # -- internals ---------------------------------------------------------
+
+    @staticmethod
+    def _strict_audit_fields(audit: LlmExecutionAudit) -> Dict[str, Any]:
+        """Keep the observable default-mode audit mapping byte-compatible."""
+
+        return audit.as_dict() if _strict_mode(audit.execution_mode) else {}
 
     @staticmethod
     def _new_execution_audit(

--- a/agent/plugin_llm.py
+++ b/agent/plugin_llm.py
@@ -74,6 +74,7 @@ from agent.llm_execution import (
     StrictExecutionRouteMismatch,
     StrictExecutionUnsupported,
     _strict_mode,
+    attach_execution_audit,
     require_matching_strict_route,
     validate_strict_request,
 )
@@ -1013,24 +1014,30 @@ class PluginLlm:
         ``agent.auxiliary_client`` to avoid circular deps at plugin
         discovery time."""
         if self._sync_caller is not None:
-            if execution_audit is not None and _strict_mode(execution_mode):
+            strict_execution = _strict_mode(execution_mode)
+            if execution_audit is not None and strict_execution:
                 execution_audit.record_attempt()
+            caller_kwargs = {
+                "messages": messages,
+                "provider_override": provider_override,
+                "model_override": model_override,
+                "profile_override": profile_override,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "timeout": timeout,
+                "extra_body": extra_body,
+            }
+            if strict_execution:
+                caller_kwargs.update({
+                    "execution_mode": execution_mode,
+                    "execution_audit": execution_audit,
+                })
             try:
-                provider, model, response = self._sync_caller(
-                    messages=messages,
-                    provider_override=provider_override,
-                    model_override=model_override,
-                    profile_override=profile_override,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    timeout=timeout,
-                    extra_body=extra_body,
-                    execution_mode=execution_mode,
-                    execution_audit=execution_audit,
-                )
+                provider, model, response = self._sync_caller(**caller_kwargs)
             except Exception as exc:
-                if execution_audit is not None and _strict_mode(execution_mode):
+                if execution_audit is not None and strict_execution:
                     execution_audit.record_failure(exc)
+                    attach_execution_audit(exc, execution_audit)
                 raise
             if execution_audit is not None:
                 self._record_injected_result(
@@ -1044,18 +1051,23 @@ class PluginLlm:
         merged_extra = dict(extra_body or {})
         if profile_override:
             merged_extra.setdefault("metadata", {})["auth_profile"] = profile_override
-        response = call_llm(
-            task=None,
-            provider=provider_override,
-            model=model_override,
-            messages=messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            timeout=timeout,
-            extra_body=merged_extra or None,
-            execution_mode=execution_mode,
-            execution_audit=execution_audit,
-        )
+        try:
+            response = call_llm(
+                task=None,
+                provider=provider_override,
+                model=model_override,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                timeout=timeout,
+                extra_body=merged_extra or None,
+                execution_mode=execution_mode,
+                execution_audit=execution_audit,
+            )
+        except Exception as exc:
+            if execution_audit is not None and _strict_mode(execution_mode):
+                attach_execution_audit(exc, execution_audit)
+            raise
         provider, model = _resolve_attribution(
             provider_override=provider_override,
             model_override=model_override,
@@ -1078,24 +1090,30 @@ class PluginLlm:
         execution_audit: Optional[LlmExecutionAudit] = None,
     ) -> tuple[str, str, Any]:
         if self._async_caller is not None:
-            if execution_audit is not None and _strict_mode(execution_mode):
+            strict_execution = _strict_mode(execution_mode)
+            if execution_audit is not None and strict_execution:
                 execution_audit.record_attempt()
+            caller_kwargs = {
+                "messages": messages,
+                "provider_override": provider_override,
+                "model_override": model_override,
+                "profile_override": profile_override,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "timeout": timeout,
+                "extra_body": extra_body,
+            }
+            if strict_execution:
+                caller_kwargs.update({
+                    "execution_mode": execution_mode,
+                    "execution_audit": execution_audit,
+                })
             try:
-                provider, model, response = await self._async_caller(
-                    messages=messages,
-                    provider_override=provider_override,
-                    model_override=model_override,
-                    profile_override=profile_override,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    timeout=timeout,
-                    extra_body=extra_body,
-                    execution_mode=execution_mode,
-                    execution_audit=execution_audit,
-                )
+                provider, model, response = await self._async_caller(**caller_kwargs)
             except Exception as exc:
-                if execution_audit is not None and _strict_mode(execution_mode):
+                if execution_audit is not None and strict_execution:
                     execution_audit.record_failure(exc)
+                    attach_execution_audit(exc, execution_audit)
                 raise
             if execution_audit is not None:
                 self._record_injected_result(
@@ -1109,18 +1127,23 @@ class PluginLlm:
         merged_extra = dict(extra_body or {})
         if profile_override:
             merged_extra.setdefault("metadata", {})["auth_profile"] = profile_override
-        response = await async_call_llm(
-            task=None,
-            provider=provider_override,
-            model=model_override,
-            messages=messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            timeout=timeout,
-            extra_body=merged_extra or None,
-            execution_mode=execution_mode,
-            execution_audit=execution_audit,
-        )
+        try:
+            response = await async_call_llm(
+                task=None,
+                provider=provider_override,
+                model=model_override,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                timeout=timeout,
+                extra_body=merged_extra or None,
+                execution_mode=execution_mode,
+                execution_audit=execution_audit,
+            )
+        except Exception as exc:
+            if execution_audit is not None and _strict_mode(execution_mode):
+                attach_execution_audit(exc, execution_audit)
+            raise
         provider, model = _resolve_attribution(
             provider_override=provider_override,
             model_override=model_override,

--- a/agent/plugin_llm.py
+++ b/agent/plugin_llm.py
@@ -66,6 +66,18 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Union
 
+from agent.llm_execution import (
+    LlmExecutionAudit,
+    LlmExecutionMode,
+    LlmExecutionPolicyError,
+    StrictExecutionConfigurationError,
+    StrictExecutionRouteMismatch,
+    StrictExecutionUnsupported,
+    _strict_mode,
+    require_matching_strict_route,
+    validate_strict_request,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -631,6 +643,7 @@ class PluginLlm:
         agent_id: Optional[str] = None,
         profile: Optional[str] = None,
         purpose: Optional[str] = None,
+        execution_mode: LlmExecutionMode | str = LlmExecutionMode.DEFAULT,
     ) -> PluginLlmCompleteResult:
         """Run a host-owned chat completion against the user's active model.
 
@@ -649,6 +662,9 @@ class PluginLlm:
             requested_agent_id=agent_id,
             requested_profile=profile,
         )
+        execution_audit = self._new_execution_audit(
+            execution_mode, provider=eff_provider, model=eff_model
+        )
         real_provider, real_model, response = self._invoke_sync(
             messages=messages,
             provider_override=eff_provider,
@@ -657,6 +673,8 @@ class PluginLlm:
             temperature=temperature,
             max_tokens=max_tokens,
             timeout=timeout,
+            execution_mode=execution_mode,
+            execution_audit=execution_audit,
         )
         text = _extract_text(response)
         usage = _extract_usage(response)
@@ -670,6 +688,7 @@ class PluginLlm:
                 "plugin_id": self._plugin_id,
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
+                **execution_audit.as_dict(),
             },
         )
         logger.info(
@@ -697,6 +716,7 @@ class PluginLlm:
         agent_id: Optional[str] = None,
         profile: Optional[str] = None,
         purpose: Optional[str] = None,
+        execution_mode: LlmExecutionMode | str = LlmExecutionMode.DEFAULT,
     ) -> PluginLlmStructuredResult:
         """Run a bounded host-owned structured completion.
 
@@ -723,6 +743,9 @@ class PluginLlm:
             requested_agent_id=agent_id,
             requested_profile=profile,
         )
+        execution_audit = self._new_execution_audit(
+            execution_mode, provider=eff_provider, model=eff_model
+        )
 
         messages = _build_structured_messages(
             instructions=instructions,
@@ -743,6 +766,8 @@ class PluginLlm:
             max_tokens=max_tokens,
             timeout=timeout,
             extra_body=extra_body,
+            execution_mode=execution_mode,
+            execution_audit=execution_audit,
         )
         text = _extract_text(response)
         usage = _extract_usage(response)
@@ -762,6 +787,7 @@ class PluginLlm:
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
                 "schema_name": schema_name or "",
+                **execution_audit.as_dict(),
             },
         )
         logger.info(
@@ -786,6 +812,7 @@ class PluginLlm:
         agent_id: Optional[str] = None,
         profile: Optional[str] = None,
         purpose: Optional[str] = None,
+        execution_mode: LlmExecutionMode | str = LlmExecutionMode.DEFAULT,
     ) -> PluginLlmCompleteResult:
         """Async sibling of :meth:`complete`."""
         policy = self._policy_loader(self._plugin_id)
@@ -796,6 +823,9 @@ class PluginLlm:
             requested_agent_id=agent_id,
             requested_profile=profile,
         )
+        execution_audit = self._new_execution_audit(
+            execution_mode, provider=eff_provider, model=eff_model
+        )
         real_provider, real_model, response = await self._invoke_async(
             messages=messages,
             provider_override=eff_provider,
@@ -804,6 +834,8 @@ class PluginLlm:
             temperature=temperature,
             max_tokens=max_tokens,
             timeout=timeout,
+            execution_mode=execution_mode,
+            execution_audit=execution_audit,
         )
         text = _extract_text(response)
         usage = _extract_usage(response)
@@ -817,6 +849,7 @@ class PluginLlm:
                 "plugin_id": self._plugin_id,
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
+                **execution_audit.as_dict(),
             },
         )
 
@@ -837,6 +870,7 @@ class PluginLlm:
         agent_id: Optional[str] = None,
         profile: Optional[str] = None,
         purpose: Optional[str] = None,
+        execution_mode: LlmExecutionMode | str = LlmExecutionMode.DEFAULT,
     ) -> PluginLlmStructuredResult:
         """Async sibling of :meth:`complete_structured`."""
         if not instructions or not instructions.strip():
@@ -851,6 +885,9 @@ class PluginLlm:
             requested_model=model,
             requested_agent_id=agent_id,
             requested_profile=profile,
+        )
+        execution_audit = self._new_execution_audit(
+            execution_mode, provider=eff_provider, model=eff_model
         )
         messages = _build_structured_messages(
             instructions=instructions,
@@ -870,6 +907,8 @@ class PluginLlm:
             max_tokens=max_tokens,
             timeout=timeout,
             extra_body=extra_body,
+            execution_mode=execution_mode,
+            execution_audit=execution_audit,
         )
         text = _extract_text(response)
         usage = _extract_usage(response)
@@ -889,10 +928,44 @@ class PluginLlm:
                 "purpose": purpose or "",
                 "profile": eff_profile or "",
                 "schema_name": schema_name or "",
+                **execution_audit.as_dict(),
             },
         )
 
     # -- internals ---------------------------------------------------------
+
+    @staticmethod
+    def _new_execution_audit(
+        execution_mode: LlmExecutionMode | str,
+        *,
+        provider: Optional[str],
+        model: Optional[str],
+    ) -> LlmExecutionAudit:
+        validate_strict_request(
+            execution_mode,
+            provider=provider,
+            model=model,
+        )
+        audit = LlmExecutionAudit()
+        audit.begin(execution_mode, provider=provider, model=model)
+        return audit
+
+    @staticmethod
+    def _record_injected_result(
+        audit: LlmExecutionAudit,
+        *,
+        provider: str,
+        model: str,
+        response: Any,
+    ) -> None:
+        if _strict_mode(audit.execution_mode):
+            require_matching_strict_route(audit, provider=provider, model=model)
+            audit.record_response(response)
+            return
+        audit.dispatched_provider = provider
+        audit.dispatched_model = model
+        audit.response_provider = str(getattr(response, "provider", None) or provider)
+        audit.response_model = str(getattr(response, "model", None) or model)
 
     @staticmethod
     def _json_response_format(
@@ -927,21 +1000,40 @@ class PluginLlm:
         max_tokens: Optional[int],
         timeout: Optional[float],
         extra_body: Optional[Dict[str, Any]] = None,
+        execution_mode: LlmExecutionMode | str = LlmExecutionMode.DEFAULT,
+        execution_audit: Optional[LlmExecutionAudit] = None,
     ) -> tuple[str, str, Any]:
         """Invoke the host's ``call_llm``. Lazy-imports
         ``agent.auxiliary_client`` to avoid circular deps at plugin
         discovery time."""
         if self._sync_caller is not None:
-            return self._sync_caller(
-                messages=messages,
-                provider_override=provider_override,
-                model_override=model_override,
-                profile_override=profile_override,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                timeout=timeout,
-                extra_body=extra_body,
-            )
+            if execution_audit is not None and _strict_mode(execution_mode):
+                execution_audit.record_attempt()
+            try:
+                provider, model, response = self._sync_caller(
+                    messages=messages,
+                    provider_override=provider_override,
+                    model_override=model_override,
+                    profile_override=profile_override,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    timeout=timeout,
+                    extra_body=extra_body,
+                    execution_mode=execution_mode,
+                    execution_audit=execution_audit,
+                )
+            except Exception as exc:
+                if execution_audit is not None and _strict_mode(execution_mode):
+                    execution_audit.record_failure(exc)
+                raise
+            if execution_audit is not None:
+                self._record_injected_result(
+                    execution_audit,
+                    provider=provider,
+                    model=model,
+                    response=response,
+                )
+            return provider, model, response
         from agent.auxiliary_client import call_llm
         merged_extra = dict(extra_body or {})
         if profile_override:
@@ -955,6 +1047,8 @@ class PluginLlm:
             max_tokens=max_tokens,
             timeout=timeout,
             extra_body=merged_extra or None,
+            execution_mode=execution_mode,
+            execution_audit=execution_audit,
         )
         provider, model = _resolve_attribution(
             provider_override=provider_override,
@@ -974,18 +1068,37 @@ class PluginLlm:
         max_tokens: Optional[int],
         timeout: Optional[float],
         extra_body: Optional[Dict[str, Any]] = None,
+        execution_mode: LlmExecutionMode | str = LlmExecutionMode.DEFAULT,
+        execution_audit: Optional[LlmExecutionAudit] = None,
     ) -> tuple[str, str, Any]:
         if self._async_caller is not None:
-            return await self._async_caller(
-                messages=messages,
-                provider_override=provider_override,
-                model_override=model_override,
-                profile_override=profile_override,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                timeout=timeout,
-                extra_body=extra_body,
-            )
+            if execution_audit is not None and _strict_mode(execution_mode):
+                execution_audit.record_attempt()
+            try:
+                provider, model, response = await self._async_caller(
+                    messages=messages,
+                    provider_override=provider_override,
+                    model_override=model_override,
+                    profile_override=profile_override,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    timeout=timeout,
+                    extra_body=extra_body,
+                    execution_mode=execution_mode,
+                    execution_audit=execution_audit,
+                )
+            except Exception as exc:
+                if execution_audit is not None and _strict_mode(execution_mode):
+                    execution_audit.record_failure(exc)
+                raise
+            if execution_audit is not None:
+                self._record_injected_result(
+                    execution_audit,
+                    provider=provider,
+                    model=model,
+                    response=response,
+                )
+            return provider, model, response
         from agent.auxiliary_client import async_call_llm
         merged_extra = dict(extra_body or {})
         if profile_override:
@@ -999,6 +1112,8 @@ class PluginLlm:
             max_tokens=max_tokens,
             timeout=timeout,
             extra_body=merged_extra or None,
+            execution_mode=execution_mode,
+            execution_audit=execution_audit,
         )
         provider, model = _resolve_attribution(
             provider_override=provider_override,
@@ -1042,5 +1157,10 @@ __all__ = [
     "PluginLlmCompleteResult",
     "PluginLlmStructuredResult",
     "PluginLlmTrustError",
+    "LlmExecutionMode",
+    "LlmExecutionPolicyError",
+    "StrictExecutionConfigurationError",
+    "StrictExecutionUnsupported",
+    "StrictExecutionRouteMismatch",
     "make_plugin_llm_for_test",
 ]

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4413,6 +4413,14 @@ def _strict_response(model="test-model"):
 
 def _install_strict_client(monkeypatch, client):
     monkeypatch.setattr(
+        "agent.auxiliary_client._resolve_custom_runtime",
+        lambda: (
+            "https://strict.invalid/v1",
+            "test-only-placeholder",
+            "chat_completions",
+        ),
+    )
+    monkeypatch.setattr(
         "agent.auxiliary_client._get_cached_client",
         lambda *_args, **_kwargs: (client, "test-model"),
     )
@@ -4540,7 +4548,9 @@ class TestStrictSingleAttemptExecution:
         assert completions.calls == 1
         assert audit.delivery_ambiguous is True
 
-    @pytest.mark.parametrize("provider", ["custom", "qwen-oauth", "xai-oauth"])
+    @pytest.mark.parametrize(
+        "provider", ["openai", "custom", "qwen-oauth", "xai-oauth"]
+    )
     def test_strict_openai_compatible_and_oauth_routes_use_one_call(
         self, monkeypatch, provider
     ):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -11,6 +11,7 @@ import pytest
 
 from agent.auxiliary_client import (
     _NOUS_MODEL,
+    AnthropicAuxiliaryClient,
     CodexAuxiliaryClient,
     get_text_auxiliary_client,
     get_available_vision_backends,
@@ -37,6 +38,11 @@ from agent.auxiliary_client import (
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
     _pool_runtime_base_url,
+)
+from agent.llm_execution import (
+    LlmExecutionAudit,
+    LlmExecutionMode,
+    StrictExecutionUnsupported,
 )
 
 
@@ -4363,3 +4369,255 @@ class TestAsynchronousFallbackCachePlans:
         wire_tools = client.chat.completions.create.call_args.kwargs["tools"]
         assert "cache_control" in wire_tools[-1]
         assert "cache_control" not in tools[-1]
+
+
+class _StrictSyncCompletions:
+    def __init__(self, outcome):
+        self.outcome = outcome
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        if isinstance(self.outcome, BaseException):
+            raise self.outcome
+        return self.outcome
+
+
+class _StrictAsyncCompletions:
+    def __init__(self, outcome):
+        self.outcome = outcome
+        self.calls = 0
+
+    async def create(self, **_kwargs):
+        self.calls += 1
+        if isinstance(self.outcome, BaseException):
+            raise self.outcome
+        return self.outcome
+
+
+class _StrictFakeClient:
+    _hermes_strict_single_attempt_supported = True
+
+    def __init__(self, completions):
+        self.base_url = "https://strict.invalid/v1"
+        self.chat = SimpleNamespace(completions=completions)
+
+
+def _strict_response(model="test-model"):
+    return SimpleNamespace(
+        model=model,
+        choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+        usage=None,
+    )
+
+
+def _install_strict_client(monkeypatch, client):
+    monkeypatch.setattr(
+        "agent.auxiliary_client._get_cached_client",
+        lambda *_args, **_kwargs: (client, "test-model"),
+    )
+    for name in (
+        "_try_configured_fallback_chain",
+        "_try_main_fallback_chain",
+        "_try_payment_fallback",
+        "_try_main_agent_model_fallback",
+    ):
+        monkeypatch.setattr(
+            f"agent.auxiliary_client.{name}",
+            lambda *_args, _name=name, **_kwargs: pytest.fail(
+                f"strict execution entered fallback {_name}"
+            ),
+        )
+    monkeypatch.setattr(
+        "agent.auxiliary_client._recover_provider_pool",
+        lambda *_args, **_kwargs: pytest.fail(
+            "strict execution entered credential rotation"
+        ),
+    )
+
+
+class TestStrictSingleAttemptExecution:
+    @pytest.mark.parametrize(
+        ("provider", "client_type"),
+        [
+            ("anthropic", AnthropicAuxiliaryClient),
+            ("openai-codex", CodexAuxiliaryClient),
+        ],
+    )
+    def test_native_adapter_strict_support_is_one_call(
+        self, monkeypatch, provider, client_type
+    ):
+        completions = _StrictSyncCompletions(_strict_response())
+        client = object.__new__(client_type)
+        client.chat = SimpleNamespace(completions=completions)
+        client.base_url = "https://strict.invalid/v1"
+        client._real_client = SimpleNamespace(max_retries=0)
+        _install_strict_client(monkeypatch, client)
+
+        response = call_llm(
+            provider=provider,
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            execution_mode="strict_single_attempt",
+        )
+
+        assert response.model == "test-model"
+        assert completions.calls == 1
+
+    def test_strict_success_is_one_outbound_call(self, monkeypatch):
+        completions = _StrictSyncCompletions(_strict_response())
+        _install_strict_client(monkeypatch, _StrictFakeClient(completions))
+        audit = LlmExecutionAudit()
+
+        response = call_llm(
+            provider="test-provider",
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            execution_mode=LlmExecutionMode.STRICT_SINGLE_ATTEMPT,
+            execution_audit=audit,
+        )
+
+        assert response.model == "test-model"
+        assert completions.calls == 1
+        assert audit.attempt_count == 1
+        assert audit.strict_contract_satisfied is True
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            RuntimeError("402 insufficient credit"),
+            RuntimeError("429 rate limit"),
+            RuntimeError("500 server error"),
+            RuntimeError("unsupported temperature parameter"),
+            RuntimeError("response_format is unsupported"),
+            RuntimeError("401 invalid credential"),
+        ],
+    )
+    def test_strict_failures_do_not_retry_rotate_or_fallback(
+        self, monkeypatch, error
+    ):
+        completions = _StrictSyncCompletions(error)
+        _install_strict_client(monkeypatch, _StrictFakeClient(completions))
+        audit = LlmExecutionAudit()
+
+        with pytest.raises(RuntimeError, match=str(error)):
+            call_llm(
+                provider="test-provider",
+                model="test-model",
+                messages=[{"role": "user", "content": "hi"}],
+                temperature=0.2,
+                extra_body={"response_format": {"type": "json_object"}},
+                execution_mode="strict_single_attempt",
+                execution_audit=audit,
+            )
+
+        assert completions.calls == 1
+        assert audit.attempt_count == 1
+        assert audit.fallback_used is False
+        assert audit.credential_rotation_used is False
+        assert audit.strict_contract_satisfied is True
+
+    @pytest.mark.parametrize(
+        "error",
+        [TimeoutError("request timed out"), RuntimeError("connection reset")],
+    )
+    def test_strict_transport_failure_is_delivery_ambiguous(
+        self, monkeypatch, error
+    ):
+        completions = _StrictSyncCompletions(error)
+        _install_strict_client(monkeypatch, _StrictFakeClient(completions))
+        audit = LlmExecutionAudit()
+
+        with pytest.raises(type(error)):
+            call_llm(
+                provider="test-provider",
+                model="test-model",
+                messages=[{"role": "user", "content": "hi"}],
+                execution_mode="strict_single_attempt",
+                execution_audit=audit,
+            )
+
+        assert completions.calls == 1
+        assert audit.delivery_ambiguous is True
+
+    @pytest.mark.parametrize("provider", ["custom", "qwen-oauth", "xai-oauth"])
+    def test_strict_openai_compatible_and_oauth_routes_use_one_call(
+        self, monkeypatch, provider
+    ):
+        completions = _StrictSyncCompletions(_strict_response())
+        _install_strict_client(monkeypatch, _StrictFakeClient(completions))
+
+        response = call_llm(
+            provider=provider,
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            execution_mode="strict_single_attempt",
+        )
+
+        assert response.model == "test-model"
+        assert completions.calls == 1
+
+    def test_unproven_transport_is_rejected_before_outbound(self, monkeypatch):
+        completions = _StrictSyncCompletions(_strict_response())
+
+        class ExternalProcessClient:
+            def __init__(self):
+                self.base_url = "external-process://provider"
+                self.chat = SimpleNamespace(completions=completions)
+
+        client = ExternalProcessClient()
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client",
+            lambda *_args, **_kwargs: (client, "test-model"),
+        )
+
+        with pytest.raises(StrictExecutionUnsupported, match="ExternalProcessClient"):
+            call_llm(
+                provider="external-provider",
+                model="test-model",
+                messages=[{"role": "user", "content": "hi"}],
+                execution_mode="strict_single_attempt",
+            )
+        assert completions.calls == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "outcome",
+        [
+            _strict_response(),
+            RuntimeError("402 insufficient credit"),
+            RuntimeError("429 rate limit"),
+            RuntimeError("500 server error"),
+            TimeoutError("request timed out"),
+        ],
+    )
+    async def test_async_strict_never_exceeds_one_call(
+        self, monkeypatch, outcome
+    ):
+        completions = _StrictAsyncCompletions(outcome)
+        _install_strict_client(monkeypatch, _StrictFakeClient(completions))
+        audit = LlmExecutionAudit()
+
+        if isinstance(outcome, BaseException):
+            with pytest.raises(type(outcome)):
+                await async_call_llm(
+                    provider="test-provider",
+                    model="test-model",
+                    messages=[{"role": "user", "content": "hi"}],
+                    execution_mode="strict_single_attempt",
+                    execution_audit=audit,
+                )
+        else:
+            response = await async_call_llm(
+                provider="test-provider",
+                model="test-model",
+                messages=[{"role": "user", "content": "hi"}],
+                execution_mode="strict_single_attempt",
+                execution_audit=audit,
+            )
+            assert response.model == "test-model"
+
+        assert completions.calls == 1
+        assert audit.attempt_count == 1
+        if isinstance(outcome, TimeoutError):
+            assert audit.delivery_ambiguous is True

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -43,6 +43,7 @@ from agent.auxiliary_client import (
 from agent.llm_execution import (
     LlmExecutionAudit,
     LlmExecutionMode,
+    StrictExecutionRouteMismatch,
     StrictExecutionUnsupported,
 )
 
@@ -4406,9 +4407,10 @@ class _StrictFakeClient:
         self.chat = SimpleNamespace(completions=completions)
 
 
-def _strict_response(model="test-model"):
+def _strict_response(model="test-model", provider=None):
     return SimpleNamespace(
         model=model,
+        provider=provider,
         choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
         usage=None,
     )
@@ -4536,6 +4538,56 @@ class TestStrictSingleAttemptExecution:
         assert response.model == "test-model"
         assert completions.calls == 1
         assert audit.attempt_count == 1
+        assert audit.response_provider == ""
+        assert audit.response_model == "test-model"
+        assert audit.strict_contract_satisfied is True
+
+    def test_strict_response_route_mismatch_is_not_reported_as_satisfied(
+        self, monkeypatch
+    ):
+        completions = _StrictSyncCompletions(
+            _strict_response(model="other-model", provider="other-provider")
+        )
+        _install_strict_client(monkeypatch, _StrictFakeClient(completions))
+        audit = LlmExecutionAudit()
+
+        call_llm(
+            provider="test-provider",
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            execution_mode="strict_single_attempt",
+            execution_audit=audit,
+        )
+
+        assert completions.calls == 1
+        assert audit.response_provider == "other-provider"
+        assert audit.response_model == "other-model"
+        assert audit.route_changed is True
+        assert audit.strict_contract_satisfied is False
+
+    @pytest.mark.parametrize(
+        ("requested_provider", "canonical_provider"),
+        [("codex", "openai-codex"), ("github", "copilot")],
+    )
+    def test_strict_alias_records_canonical_dispatch_without_route_change(
+        self, monkeypatch, requested_provider, canonical_provider
+    ):
+        completions = _StrictSyncCompletions(_strict_response())
+        _install_strict_client(monkeypatch, _StrictFakeClient(completions))
+        audit = LlmExecutionAudit()
+
+        call_llm(
+            provider=requested_provider,
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            execution_mode="strict_single_attempt",
+            execution_audit=audit,
+        )
+
+        assert completions.calls == 1
+        assert audit.requested_provider == requested_provider
+        assert audit.dispatched_provider == canonical_provider
+        assert audit.route_changed is False
         assert audit.strict_contract_satisfied is True
 
     @pytest.mark.parametrize(
@@ -4636,6 +4688,95 @@ class TestStrictSingleAttemptExecution:
                 messages=[{"role": "user", "content": "hi"}],
                 execution_mode="strict_single_attempt",
             )
+        assert completions.calls == 0
+
+    @pytest.mark.parametrize("api_mode", ["anthropic_messages", "codex_responses"])
+    def test_strict_transport_downgrade_is_rejected_before_outbound(
+        self, monkeypatch, api_mode
+    ):
+        completions = _StrictSyncCompletions(_strict_response())
+        _install_strict_client(monkeypatch, _StrictFakeClient(completions))
+        audit = LlmExecutionAudit()
+
+        with pytest.raises(StrictExecutionUnsupported, match="configured API mode"):
+            call_llm(
+                provider="test-provider",
+                model="test-model",
+                api_mode=api_mode,
+                messages=[{"role": "user", "content": "hi"}],
+                execution_mode="strict_single_attempt",
+                execution_audit=audit,
+            )
+
+        assert completions.calls == 0
+        assert audit.attempt_count == 0
+
+    def test_named_custom_transport_downgrade_is_rejected_before_outbound(
+        self, monkeypatch
+    ):
+        completions = _StrictSyncCompletions(_strict_response())
+        _install_strict_client(monkeypatch, _StrictFakeClient(completions))
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda name: (
+                {"name": name, "api_mode": "anthropic_messages"}
+                if name == "named-provider"
+                else None
+            ),
+        )
+
+        with pytest.raises(StrictExecutionUnsupported, match="configured API mode"):
+            call_llm(
+                provider="named-provider",
+                model="test-model",
+                messages=[{"role": "user", "content": "hi"}],
+                execution_mode="strict_single_attempt",
+            )
+
+        assert completions.calls == 0
+
+    def test_resolver_api_mode_downgrade_is_rejected_before_outbound(
+        self, monkeypatch
+    ):
+        completions = _StrictSyncCompletions(_strict_response())
+        client = _StrictFakeClient(completions)
+        client._hermes_resolved_api_mode = "anthropic_messages"
+        _install_strict_client(monkeypatch, client)
+
+        with pytest.raises(StrictExecutionUnsupported, match="configured API mode"):
+            call_llm(
+                provider="nous",
+                model="test-model",
+                messages=[{"role": "user", "content": "hi"}],
+                execution_mode="strict_single_attempt",
+            )
+
+        assert completions.calls == 0
+
+    def test_custom_prefix_cannot_hide_early_builtin_route(self, monkeypatch):
+        completions = _StrictSyncCompletions(_strict_response())
+        _install_strict_client(monkeypatch, _StrictFakeClient(completions))
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            lambda name: (
+                {
+                    "name": "openrouter",
+                    "base_url": "https://named.invalid/v1",
+                    "api_mode": "chat_completions",
+                }
+                if name in {"custom:openrouter", "openrouter"}
+                else None
+            ),
+        )
+
+        with pytest.raises(StrictExecutionRouteMismatch, match="route resolution"):
+            call_llm(
+                provider="custom:openrouter",
+                model="test-model",
+                messages=[{"role": "user", "content": "hi"}],
+                execution_mode="strict_single_attempt",
+            )
+
         assert completions.calls == 0
 
     @pytest.mark.asyncio

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -37,6 +37,7 @@ from agent.auxiliary_client import (
     _resolve_task_provider_model,
     _resolve_xai_oauth_for_aux,
     _CodexCompletionsAdapter,
+    _AnthropicCompletionsAdapter,
     _pool_runtime_base_url,
 )
 from agent.llm_execution import (
@@ -4375,9 +4376,11 @@ class _StrictSyncCompletions:
     def __init__(self, outcome):
         self.outcome = outcome
         self.calls = 0
+        self.last_kwargs = {}
 
-    def create(self, **_kwargs):
+    def create(self, **kwargs):
         self.calls += 1
+        self.last_kwargs = kwargs
         if isinstance(self.outcome, BaseException):
             raise self.outcome
         return self.outcome
@@ -4445,6 +4448,49 @@ def _install_strict_client(monkeypatch, client):
 
 
 class TestStrictSingleAttemptExecution:
+    def test_anthropic_adapter_disables_stream_fallback_in_strict_mode(
+        self, monkeypatch
+    ):
+        captured = {}
+
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.build_anthropic_kwargs",
+            lambda **kwargs: kwargs,
+        )
+
+        def fake_create(_client, _kwargs, **options):
+            captured.update(options)
+            return SimpleNamespace(usage=None)
+
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.create_anthropic_message",
+            fake_create,
+        )
+        monkeypatch.setattr(
+            "agent.transports.get_transport",
+            lambda _name: SimpleNamespace(
+                normalize_response=lambda _response, **_kwargs: SimpleNamespace(
+                    content="ok",
+                    tool_calls=[],
+                    reasoning=None,
+                    finish_reason="stop",
+                )
+            ),
+        )
+        adapter = _AnthropicCompletionsAdapter(
+            SimpleNamespace(),
+            "test-model",
+        )
+
+        response = adapter.create(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            _strict_single_attempt=True,
+        )
+
+        assert response.choices[0].message.content == "ok"
+        assert captured["prefer_stream"] is False
+
     @pytest.mark.parametrize(
         ("provider", "client_type"),
         [
@@ -4471,6 +4517,8 @@ class TestStrictSingleAttemptExecution:
 
         assert response.model == "test-model"
         assert completions.calls == 1
+        if provider == "anthropic":
+            assert completions.last_kwargs["_strict_single_attempt"] is True
 
     def test_strict_success_is_one_outbound_call(self, monkeypatch):
         completions = _StrictSyncCompletions(_strict_response())

--- a/tests/agent/test_plugin_llm.py
+++ b/tests/agent/test_plugin_llm.py
@@ -292,6 +292,13 @@ class TestPluginLlmFacade:
                 provider="test-provider",
                 execution_mode=LlmExecutionMode.STRICT_SINGLE_ATTEMPT,
             )
+        with pytest.raises(StrictExecutionConfigurationError, match="explicit model"):
+            llm.complete(
+                [{"role": "user", "content": "hi"}],
+                provider="test-provider",
+                model="auto",
+                execution_mode=LlmExecutionMode.STRICT_SINGLE_ATTEMPT,
+            )
 
     @pytest.mark.parametrize("provider", ["auto", "main", " AUTO "])
     def test_strict_mode_rejects_implicit_provider_names(self, provider):

--- a/tests/agent/test_plugin_llm.py
+++ b/tests/agent/test_plugin_llm.py
@@ -371,8 +371,8 @@ class TestPluginLlmFacade:
             "requested_model": "test-model",
             "dispatched_provider": "test-provider",
             "dispatched_model": "test-model",
-            "response_provider": "test-provider",
-            "response_model": "test-model",
+            "response_provider": "",
+            "response_model": "",
             "attempt_count": 1,
             "fallback_used": False,
             "credential_rotation_used": False,
@@ -380,6 +380,68 @@ class TestPluginLlmFacade:
             "delivery_ambiguous": False,
             "strict_contract_satisfied": True,
         }
+
+    def test_strict_failure_exposes_audit_without_replacing_exception(self):
+        def fake_caller(**_kwargs):
+            raise TimeoutError("request timed out")
+
+        llm = make_plugin_llm_for_test(
+            plugin_id="strict-plugin",
+            policy=_trusted_policy("strict-plugin"),
+            sync_caller=fake_caller,
+        )
+
+        for invoke in (
+            lambda: llm.complete(
+                [{"role": "user", "content": "hi"}],
+                provider="test-provider",
+                model="test-model",
+                execution_mode="strict_single_attempt",
+            ),
+            lambda: llm.complete_structured(
+                instructions="Return one result",
+                input=[{"type": "text", "text": "input"}],
+                provider="test-provider",
+                model="test-model",
+                execution_mode="strict_single_attempt",
+            ),
+        ):
+            with pytest.raises(TimeoutError) as caught:
+                invoke()
+            assert caught.value.execution_audit["attempt_count"] == 1
+            assert caught.value.execution_audit["delivery_ambiguous"] is True
+
+    def test_default_mode_keeps_injected_caller_signature_compatible(self):
+        def old_signature_caller(
+            *,
+            messages,
+            provider_override,
+            model_override,
+            profile_override,
+            temperature,
+            max_tokens,
+            timeout,
+            extra_body,
+        ):
+            assert messages
+            assert provider_override is None
+            assert model_override is None
+            assert profile_override is None
+            assert temperature is None
+            assert max_tokens is None
+            assert timeout is None
+            assert extra_body is None
+            return "openai", "gpt-4o", _fake_response("compatible")
+
+        llm = make_plugin_llm_for_test(
+            plugin_id="legacy-plugin",
+            policy=_trusted_policy("legacy-plugin"),
+            sync_caller=old_signature_caller,
+        )
+
+        result = llm.complete([{"role": "user", "content": "hi"}])
+
+        assert result.text == "compatible"
 
     def test_complete_uses_active_model_by_default(self):
         captured: dict = {}
@@ -526,6 +588,72 @@ class TestAsyncSurface:
         assert captured["execution_mode"] == "strict_single_attempt"
         assert result.audit["attempt_count"] == 1
         assert result.audit["strict_contract_satisfied"] is True
+
+    def test_async_strict_failures_expose_audit_for_both_methods(self):
+        async def fake_async(**_kwargs):
+            raise TimeoutError("connection timed out")
+
+        llm = make_plugin_llm_for_test(
+            plugin_id="strict-plugin",
+            policy=_trusted_policy("strict-plugin"),
+            async_caller=fake_async,
+        )
+
+        async def run() -> None:
+            calls = (
+                llm.acomplete(
+                    [{"role": "user", "content": "hi"}],
+                    provider="test-provider",
+                    model="test-model",
+                    execution_mode="strict_single_attempt",
+                ),
+                llm.acomplete_structured(
+                    instructions="Return one result",
+                    input=[{"type": "text", "text": "input"}],
+                    provider="test-provider",
+                    model="test-model",
+                    execution_mode="strict_single_attempt",
+                ),
+            )
+            for call in calls:
+                with pytest.raises(TimeoutError) as caught:
+                    await call
+                assert caught.value.execution_audit["attempt_count"] == 1
+                assert caught.value.execution_audit["delivery_ambiguous"] is True
+
+        asyncio.run(run())
+
+    def test_async_default_keeps_injected_caller_signature_compatible(self):
+        async def old_signature_caller(
+            *,
+            messages,
+            provider_override,
+            model_override,
+            profile_override,
+            temperature,
+            max_tokens,
+            timeout,
+            extra_body,
+        ):
+            assert messages
+            assert provider_override is None
+            assert model_override is None
+            assert profile_override is None
+            assert temperature is None
+            assert max_tokens is None
+            assert timeout is None
+            assert extra_body is None
+            return "openai", "gpt-4o", _fake_response("compatible")
+
+        llm = make_plugin_llm_for_test(
+            plugin_id="legacy-plugin",
+            policy=_trusted_policy("legacy-plugin"),
+            async_caller=old_signature_caller,
+        )
+
+        result = asyncio.run(llm.acomplete([{"role": "user", "content": "hi"}]))
+
+        assert result.text == "compatible"
 
     def test_acomplete_uses_async_caller(self):
         async def fake_async(**_kwargs):

--- a/tests/agent/test_plugin_llm.py
+++ b/tests/agent/test_plugin_llm.py
@@ -17,12 +17,14 @@ from unittest.mock import MagicMock
 import pytest
 
 from agent.plugin_llm import (
+    LlmExecutionMode,
     PluginLlm,
     PluginLlmCompleteResult,
     PluginLlmImageInput,
     PluginLlmStructuredResult,
     PluginLlmTextInput,
     PluginLlmTrustError,
+    StrictExecutionConfigurationError,
     _build_structured_messages,
     _check_overrides,
     _coerce_allowlist,
@@ -271,6 +273,107 @@ class TestJsonParsing:
 
 
 class TestPluginLlmFacade:
+    def test_strict_mode_requires_explicit_provider_and_model(self):
+        llm = make_plugin_llm_for_test(
+            plugin_id="strict-plugin",
+            policy=_trusted_policy("strict-plugin"),
+            sync_caller=lambda **_: ("unused", "unused", _fake_response("unused")),
+        )
+
+        with pytest.raises(StrictExecutionConfigurationError, match="provider"):
+            llm.complete(
+                [{"role": "user", "content": "hi"}],
+                model="test-model",
+                execution_mode=LlmExecutionMode.STRICT_SINGLE_ATTEMPT,
+            )
+        with pytest.raises(StrictExecutionConfigurationError, match="model"):
+            llm.complete(
+                [{"role": "user", "content": "hi"}],
+                provider="test-provider",
+                execution_mode=LlmExecutionMode.STRICT_SINGLE_ATTEMPT,
+            )
+
+    @pytest.mark.parametrize("provider", ["auto", "main", " AUTO "])
+    def test_strict_mode_rejects_implicit_provider_names(self, provider):
+        llm = make_plugin_llm_for_test(
+            plugin_id="strict-plugin",
+            policy=_trusted_policy("strict-plugin"),
+            sync_caller=lambda **_: ("unused", "unused", _fake_response("unused")),
+        )
+
+        with pytest.raises(StrictExecutionConfigurationError, match="explicit provider"):
+            llm.complete(
+                [{"role": "user", "content": "hi"}],
+                provider=provider,
+                model="test-model",
+                execution_mode="strict_single_attempt",
+            )
+
+    def test_strict_mode_obeys_existing_trust_gate_before_call(self):
+        calls = []
+
+        def fake_caller(**kwargs):
+            calls.append(kwargs)
+            return "test-provider", "test-model", _fake_response("unused")
+
+        llm = make_plugin_llm_for_test(
+            plugin_id="locked-plugin",
+            policy=_TrustPolicy(plugin_id="locked-plugin"),
+            sync_caller=fake_caller,
+        )
+
+        with pytest.raises(PluginLlmTrustError, match="provider"):
+            llm.complete(
+                [{"role": "user", "content": "hi"}],
+                provider="test-provider",
+                model="test-model",
+                execution_mode=LlmExecutionMode.STRICT_SINGLE_ATTEMPT,
+            )
+        assert calls == []
+
+    def test_strict_mode_populates_audit_and_preserves_structured_parsing(self):
+        captured = {}
+
+        def fake_caller(**kwargs):
+            captured.update(kwargs)
+            return "test-provider", "test-model", _fake_response('{"ok": true}')
+
+        llm = make_plugin_llm_for_test(
+            plugin_id="strict-plugin",
+            policy=_trusted_policy("strict-plugin"),
+            sync_caller=fake_caller,
+        )
+        result = llm.complete_structured(
+            instructions="Return one result",
+            input=[{"type": "text", "text": "input"}],
+            json_mode=True,
+            provider="test-provider",
+            model="test-model",
+            execution_mode=LlmExecutionMode.STRICT_SINGLE_ATTEMPT,
+        )
+
+        assert result.parsed == {"ok": True}
+        assert captured["execution_mode"] is LlmExecutionMode.STRICT_SINGLE_ATTEMPT
+        assert result.audit == {
+            "plugin_id": "strict-plugin",
+            "purpose": "",
+            "profile": "",
+            "schema_name": "",
+            "execution_mode": "strict_single_attempt",
+            "requested_provider": "test-provider",
+            "requested_model": "test-model",
+            "dispatched_provider": "test-provider",
+            "dispatched_model": "test-model",
+            "response_provider": "test-provider",
+            "response_model": "test-model",
+            "attempt_count": 1,
+            "fallback_used": False,
+            "credential_rotation_used": False,
+            "route_changed": False,
+            "delivery_ambiguous": False,
+            "strict_contract_satisfied": True,
+        }
+
     def test_complete_uses_active_model_by_default(self):
         captured: dict = {}
 
@@ -388,6 +491,30 @@ class TestPluginLlmFacade:
 
 
 class TestAsyncSurface:
+    def test_acomplete_passes_strict_mode_and_populates_audit(self):
+        captured = {}
+
+        async def fake_async(**kwargs):
+            captured.update(kwargs)
+            return "test-provider", "test-model", _fake_response("async strict")
+
+        llm = make_plugin_llm_for_test(
+            plugin_id="strict-plugin",
+            policy=_trusted_policy("strict-plugin"),
+            async_caller=fake_async,
+        )
+
+        result = asyncio.run(llm.acomplete(
+            [{"role": "user", "content": "hi"}],
+            provider="test-provider",
+            model="test-model",
+            execution_mode="strict_single_attempt",
+        ))
+
+        assert captured["execution_mode"] == "strict_single_attempt"
+        assert result.audit["attempt_count"] == 1
+        assert result.audit["strict_contract_satisfied"] is True
+
     def test_acomplete_uses_async_caller(self):
         async def fake_async(**_kwargs):
             return "openai", "gpt-4o", _fake_response("async hello")

--- a/tests/agent/test_plugin_llm.py
+++ b/tests/agent/test_plugin_llm.py
@@ -401,6 +401,11 @@ class TestPluginLlmFacade:
         assert captured["profile_override"] is None
         assert result.usage.input_tokens == 4
         assert result.usage.total_tokens == 10
+        assert result.audit == {
+            "plugin_id": "my-plugin",
+            "purpose": "",
+            "profile": "",
+        }
 
 
 

--- a/website/docs/developer-guide/plugin-llm-access.md
+++ b/website/docs/developer-guide/plugin-llm-access.md
@@ -127,16 +127,19 @@ Local JSON parsing and schema validation still run after a successful response.
 
 This is not a provider-side exactly-once guarantee. A provider may accept a
 request before the client observes a timeout or broken connection, so those
-failures are reported with `delivery_ambiguous=True` and are never retried
-automatically.
+failures are never retried automatically. The original exception type is
+preserved and its secret-free `execution_audit` attribute reports
+`delivery_ambiguous=True`.
 
 Strict support is transport-specific. OpenAI-compatible clients, native
 Anthropic, and the OpenAI Codex transport are accepted only when the host can
 verify that SDK retries are disabled. OAuth and custom endpoints are supported
 when they resolve to one of those verified transports without changing the
-requested provider/model. External-process, virtual, or other adapters that
-cannot prove a single physical invocation raise `StrictExecutionUnsupported`
-before outbound dispatch.
+requested provider/model. A caller-, model-, or runtime-selected API mode must
+also match the concrete transport; downgrades fail before outbound dispatch.
+External-process, virtual, or other adapters that cannot prove a single
+physical invocation raise `StrictExecutionUnsupported` before outbound
+dispatch.
 
 Every strict result adds these stable fields to `result.audit`:
 
@@ -145,13 +148,17 @@ Every strict result adds these stable fields to `result.audit`:
 | `execution_mode` | `strict_single_attempt` for this contract |
 | `requested_provider`, `requested_model` | Explicit route supplied by the plugin |
 | `dispatched_provider`, `dispatched_model` | Route verified immediately before dispatch |
-| `response_provider`, `response_model` | Provider/model attribution returned or observed |
+| `response_provider`, `response_model` | Attribution declared by the response; empty when absent |
 | `attempt_count` | Host outbound invocation count; never greater than one |
 | `fallback_used` | Whether host fallback ran; always false in strict mode |
 | `credential_rotation_used` | Whether post-failure rotation ran; always false in strict mode |
 | `route_changed` | Whether resolution changed the requested route |
 | `delivery_ambiguous` | Whether transport failure may have followed provider receipt |
 | `strict_contract_satisfied` | Whether the host honored the strict execution policy |
+
+The host does not copy requested or dispatched values into missing response
+attribution. If a response declares a different provider or model,
+`route_changed` is true and `strict_contract_satisfied` is false.
 
 ## Quick start
 

--- a/website/docs/developer-guide/plugin-llm-access.md
+++ b/website/docs/developer-guide/plugin-llm-access.md
@@ -94,6 +94,65 @@ model couldn't produce valid JSON, `result.parsed` is `None` and
   default posture is "use what the user is using." Operators opt in
   to specific overrides, per plugin, in `config.yaml`.
 
+## Execution modes
+
+The default mode keeps Hermes' existing resilient behavior: host-owned route
+resolution, transient retry, credential recovery, and provider/model fallback.
+It remains the recommended mode for most plugins, and callers that omit
+`execution_mode` behave exactly as before.
+
+Audit-sensitive workflows can opt into a separate client-side contract:
+
+```python
+from agent.plugin_llm import LlmExecutionMode
+
+result = ctx.llm.complete_structured(
+    instructions="Extract one typed result.",
+    input=[{"type": "text", "text": body}],
+    json_schema=SCHEMA,
+    provider="test-provider",
+    model="test-model",
+    execution_mode=LlmExecutionMode.STRICT_SINGLE_ATTEMPT,
+    purpose="evaluation.single-route",
+)
+```
+
+`strict_single_attempt` requires an explicit provider and model. Both values
+must still pass the existing per-plugin trust gate; strict mode does not add or
+bypass any trust permission. The host then initiates at most one outbound
+provider invocation on that exact route. It does not perform a same-provider
+retry, provider or model fallback, post-failure credential rotation,
+unsupported-parameter retry, response-format downgrade, or repair LLM call.
+Local JSON parsing and schema validation still run after a successful response.
+
+This is not a provider-side exactly-once guarantee. A provider may accept a
+request before the client observes a timeout or broken connection, so those
+failures are reported with `delivery_ambiguous=True` and are never retried
+automatically.
+
+Strict support is transport-specific. OpenAI-compatible clients, native
+Anthropic, and the OpenAI Codex transport are accepted only when the host can
+verify that SDK retries are disabled. OAuth and custom endpoints are supported
+when they resolve to one of those verified transports without changing the
+requested provider/model. External-process, virtual, or other adapters that
+cannot prove a single physical invocation raise `StrictExecutionUnsupported`
+before outbound dispatch.
+
+Every strict result adds these stable fields to `result.audit`:
+
+| Field | Meaning |
+|---|---|
+| `execution_mode` | `strict_single_attempt` for this contract |
+| `requested_provider`, `requested_model` | Explicit route supplied by the plugin |
+| `dispatched_provider`, `dispatched_model` | Route verified immediately before dispatch |
+| `response_provider`, `response_model` | Provider/model attribution returned or observed |
+| `attempt_count` | Host outbound invocation count; never greater than one |
+| `fallback_used` | Whether host fallback ran; always false in strict mode |
+| `credential_rotation_used` | Whether post-failure rotation ran; always false in strict mode |
+| `route_changed` | Whether resolution changed the requested route |
+| `delivery_ambiguous` | Whether transport failure may have followed provider receipt |
+| `strict_contract_satisfied` | Whether the host honored the strict execution policy |
+
 ## Quick start
 
 Two complete plugins below — one chat, one structured. Both ship
@@ -223,6 +282,7 @@ result = ctx.llm.complete(
     agent_id=None,         # optional, gated
     profile=None,          # optional, gated — explicit auth-profile name
     purpose="optional-audit-string",
+    execution_mode="default", # or LlmExecutionMode.STRICT_SINGLE_ATTEMPT
 )
 # → PluginLlmCompleteResult(text, provider, model, agent_id, usage, audit)
 ```
@@ -260,6 +320,7 @@ result = ctx.llm.complete_structured(
     agent_id=None,
     profile=None,
     purpose=None,
+    execution_mode="default",
 )
 # → PluginLlmStructuredResult(text, provider, model, agent_id,
 #                             usage, parsed, content_type, audit)
@@ -297,7 +358,7 @@ class PluginLlmCompleteResult:
     model: str                   # whatever the provider returned for this call
     agent_id: str                # whose model/auth was used
     usage: PluginLlmUsage        # tokens + cache + cost estimate
-    audit: Dict[str, Any]        # plugin_id, purpose, profile
+    audit: Dict[str, Any]        # plugin metadata + execution audit fields
 
 @dataclass
 class PluginLlmStructuredResult:
@@ -408,7 +469,7 @@ don't have to:
 * **Vision routing.** When image input is supplied and the user's
   active text model is text-only, the host falls back to the
   configured vision model automatically.
-* **Fallback chain.** If the user's primary provider 5xxs or 429s,
+* **Fallback chain (default mode).** If the user's primary provider 5xxs or 429s,
   the request goes through Hermes' usual aggregator-aware fallback
   before it returns an error to the plugin.
 * **Timeout.** Honours your `timeout=` argument, falling back to
@@ -432,7 +493,10 @@ don't have to:
   empty inputs and on schema-validation failure. `PluginLlmTrustError`
   fires when the trust gate denies an override. Anything else
   (provider 5xx, no credentials configured, timeout) raises whatever
-  `auxiliary_client.call_llm()` raises.
+  `auxiliary_client.call_llm()` raises. Strict configuration, unsupported
+  transports, and route changes raise `StrictExecutionConfigurationError`,
+  `StrictExecutionUnsupported`, and `StrictExecutionRouteMismatch`
+  respectively, before an unverified outbound call.
 * **Cost.** Every call runs against the user's paid provider. Don't
   loop on `complete()` for every gateway message without thinking
   about token spend.


### PR DESCRIPTION
## Summary

Adds an opt-in `strict_single_attempt` execution mode to the public Plugin LLM facade for sync/async and structured/unstructured calls.

## Motivation

Plugins sometimes need a fail-closed inference contract: an explicitly selected provider and model, no host-side rerouting, and a machine-readable audit of the route actually attempted.

## Strict contract

- Requires an explicit provider and model.
- Allows at most one host outbound request.
- Disables host retry, provider/model fallback, and credential rotation for that request.
- Rejects implicit, aliased, colliding custom-provider, or transport-mismatched routes before outbound I/O.
- Keeps local JSON parsing and JSON Schema validation available after the response.
- Returns a secret-free execution audit covering requested, dispatched, and response-attributed route identity.
- Attaches the same audit to strict provider exceptions without replacing their original exception type.

## Default behavior

The existing default execution path is unchanged. Retry, fallback, credential rotation, and legacy injected-caller call signatures remain intact unless `execution_mode="strict_single_attempt"` is explicitly requested.

## Provider support

Strict mode validates the configured API mode, resolver-derived mode, and concrete transport before the attempt. OpenAI-compatible chat, Anthropic Messages, Codex Responses, named custom providers, and runtime-derived Nous/Azure routes are covered by zero-outbound and one-attempt tests.

## Audit semantics

The audit distinguishes requested, dispatched, and response-attributed provider/model values. Missing response attribution remains missing; a mismatch marks the route changed and the strict contract unsatisfied. Transport errors are marked delivery-ambiguous because a client timeout cannot prove whether the provider received the request.

## Testing

- Strict-focused tests: 39 passed.
- Changed-file targeted tests: 236 passed.
- Agent suite: 3,690 passed; seven initial failures were investigated. Six were caused by the optional Anthropic SDK being absent from one worktree and passed after installing the locked extra. The remaining credential-pool failure reproduces unchanged on the upstream base.
- Ruff, compileall, and `git diff --check`: passed.
- Docusaurus production build: passed; pre-existing translated-site broken-link warnings remain.
- All tests use fakes/mocks; no provider request or credential was used.

## Limitations

- “Single attempt” is a host-side guarantee, not exactly-once delivery. Timeout and connection-loss outcomes can be delivery-ambiguous.
- Local response parsing and schema validation may fail after the single provider response; they do not trigger another outbound request.
- Strict mode intentionally fails closed when route identity or transport mode cannot be established before dispatch.

## Scope

This is a generic Plugin LLM API change only. It does not add product- or integration-specific orchestration behavior.
