### PR TITLE
fix(cron): hard-abort when all declared skills fail to load

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -158,6 +158,16 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
+class CronSkillLoadError(Exception):
+    """Raised when every skill declared on a cron job fails to load.
+
+    Caught in ``run_job`` so the scheduler delivers a structured error
+    instead of invoking the LLM with a contextless prompt that often
+    returns ``[SILENT]`` and hides multi-week monitoring outages (#77362).
+    Partial load failures still proceed with a notice (loaded skills only).
+    """
+
+
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
@@ -2576,6 +2586,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
 
     parts = []
     skipped: list[str] = []
+    skip_errors: list[str] = []
     for skill_name in skill_names:
         # Cron jobs historically accepted only skill names here, but the CLI/gateway
         # slash-command path lets bundles shadow skills with the same slug. Mirror
@@ -2600,6 +2611,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 skill_name,
             )
             skipped.append(skill_name)
+            skip_errors.append(f"bundle '{skill_name}' could not load any skills")
             continue
 
         try:
@@ -2607,11 +2619,13 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         except (json.JSONDecodeError, TypeError):
             logger.warning("Cron job '%s': skill '%s' returned invalid JSON, skipping", job.get("name", job.get("id")), skill_name)
             skipped.append(skill_name)
+            skip_errors.append(f"skill '{skill_name}' returned invalid JSON")
             continue
         if not loaded.get("success"):
             error = loaded.get("error") or f"Failed to load skill '{skill_name}'"
             logger.warning("Cron job '%s': skill not found, skipping — %s", job.get("name", job.get("id")), error)
             skipped.append(skill_name)
+            skip_errors.append(str(error))
             continue
 
         # Bump usage so the curator sees this skill as actively used.
@@ -2629,6 +2643,17 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 "",
                 content,
             ]
+        )
+
+    # All declared skills failed → hard-abort. A contextless LLM often returns
+    # [SILENT] and the failure is invisible for weeks (#77362). Partial failures
+    # still proceed with the loaded subset + a user-visible notice.
+    if skill_names and len(skipped) == len(skill_names) and not parts:
+        job_label = job.get("name") or job.get("id") or "cron-job"
+        detail = "; ".join(skip_errors) if skip_errors else ", ".join(skipped)
+        raise CronSkillLoadError(
+            f"Cron job '{job_label}' aborted: failed to load all declared "
+            f"skills ({', '.join(skipped)}). {detail}"
         )
 
     if skipped:
@@ -2986,6 +3011,27 @@ def run_job(
 
     try:
         prompt = _build_job_prompt(job, prerun_script=prerun_script)
+    except CronSkillLoadError as skill_exc:
+        # Every declared skill failed to load. Do not call the LLM with a
+        # contextless prompt (that path often returns [SILENT] and hides
+        # multi-week monitoring outages — #77362). Deliver a structured error.
+        logger.warning(
+            "Job '%s' (ID: %s): aborted — all skills failed to load — %s",
+            job_name, job_id, skill_exc,
+        )
+        failed_doc = (
+            f"# Cron Job: {job_name}\n\n"
+            f"**Job ID:** {job_id}\n"
+            f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+            f"**Status:** ERROR\n\n"
+            "ERROR: Cron job aborted.\n"
+            "Failed to load all declared skills — the agent was NOT run "
+            "(no skill context would have been available).\n\n"
+            f"**Details:** {skill_exc}\n\n"
+            "Fix the skill path(s), resolve name collisions (flat file vs "
+            "directory), or remove the skills entry from this job."
+        )
+        return False, failed_doc, str(skill_exc), str(skill_exc)
     except CronPromptInjectionBlocked as block_exc:
         # Assembled prompt (user prompt + loaded skill content) tripped the
         # injection scanner. Refuse to run the agent this tick and surface

--- a/tests/cron/test_cron_prompt_injection_skill.py
+++ b/tests/cron/test_cron_prompt_injection_skill.py
@@ -228,7 +228,8 @@ class TestBuildJobPromptScansSkillContent:
         with pytest.raises(scheduler.CronPromptInjectionBlocked):
             scheduler._build_job_prompt(job)
 
-    def test_missing_skill_does_not_crash(self, cron_env):
+    def test_all_missing_skills_abort_with_cron_skill_load_error(self, cron_env):
+        """All declared skills missing → hard-abort (no contextless LLM) (#77362)."""
         _, scheduler = cron_env
         job = {
             "id": "job-missing",
@@ -236,10 +237,26 @@ class TestBuildJobPromptScansSkillContent:
             "prompt": "run task",
             "skills": ["does-not-exist"],
         }
-        # Should not raise — missing skills are skipped with a notice.
+        with pytest.raises(scheduler.CronSkillLoadError) as exc_info:
+            scheduler._build_job_prompt(job)
+        assert "does-not-exist" in str(exc_info.value)
+        assert "aborted" in str(exc_info.value).lower()
+
+    def test_partial_missing_skill_still_injects_notice(self, cron_env):
+        """One good skill + one missing → proceed with skip notice."""
+        hermes_home, scheduler = cron_env
+        _plant_skill(hermes_home, "good-skill", "Do the good thing.")
+        job = {
+            "id": "job-partial",
+            "name": "partial",
+            "prompt": "run task",
+            "skills": ["good-skill", "does-not-exist"],
+        }
         prompt = scheduler._build_job_prompt(job)
         assert prompt is not None
-        assert "could not be found" in prompt
+        assert "Do the good thing." in prompt
+        assert "does-not-exist" in prompt
+        assert "could not be found" in prompt or "skipped" in prompt.lower()
 
 
     def test_bundle_name_shadows_skill_name_for_cron_jobs(self, cron_env):

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1099,18 +1099,38 @@ class TestRunJobWakeGate:
 
 
 class TestBuildJobPromptMissingSkill:
-    """Verify that a missing skill logs a warning and does not crash the job."""
+    """All-skills-failed aborts; partial failure still proceeds with a notice."""
 
     def _missing_skill_view(self, name: str) -> str:
         return json.dumps({"success": False, "error": f"Skill '{name}' not found."})
 
+    def test_all_skills_failed_raises_cron_skill_load_error(self):
+        """When every declared skill fails, refuse a contextless LLM run (#77362)."""
+        from cron.scheduler import CronSkillLoadError
 
-    def test_missing_skill_injects_user_notice_into_prompt(self):
-        """A system notice about the missing skill is injected into the prompt."""
         with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
-            result = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
+            with pytest.raises(CronSkillLoadError) as exc_info:
+                _build_job_prompt(
+                    {"name": "weekly-monitor", "skills": ["ghost-skill"], "prompt": "do something"}
+                )
+        assert "ghost-skill" in str(exc_info.value)
+        assert "aborted" in str(exc_info.value).lower()
+
+    def test_partial_skill_failure_injects_notice_and_proceeds(self):
+        """Some skills loaded → keep going with a user-visible skip notice."""
+
+        def _view(name: str) -> str:
+            if name == "good-skill":
+                return json.dumps({"success": True, "content": "Do the good thing."})
+            return json.dumps({"success": False, "error": f"Skill '{name}' not found."})
+
+        with patch("tools.skills_tool.skill_view", side_effect=_view):
+            result = _build_job_prompt(
+                {"skills": ["good-skill", "ghost-skill"], "prompt": "do something"}
+            )
+        assert "Do the good thing." in result
         assert "ghost-skill" in result
-        assert "not found" in result.lower() or "skipped" in result.lower()
+        assert "skipped" in result.lower() or "not found" in result.lower()
 
 
 class TestBuildJobPromptAbsoluteSkillPath:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -490,6 +490,41 @@ class TestRunJobSessionPersistence:
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
 
+    def test_run_job_all_skills_failed_skips_agent_and_surfaces_skill_name(self, tmp_path):
+        """#77362: all skills missing → fail closed, no AIAgent, not [SILENT]."""
+        from cron.scheduler import SILENT_MARKER, _summarize_cron_failure_for_delivery
+
+        job = {
+            "id": "skill-fail-job",
+            "name": "weekly-monitor",
+            "prompt": "do the weekly report",
+            "skills": ["weekly-market-risk-monitor"],
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=MagicMock()), \
+             patch(
+                 "tools.skills_tool.skill_view",
+                 return_value='{"success": false, "error": "Skill not found."}',
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            success, output, final_response, error = run_job(job)
+
+        assert success is False
+        assert mock_agent_cls.call_count == 0
+        assert error is not None
+        assert "weekly-market-risk-monitor" in error
+        assert "aborted" in error.lower() or "failed to load" in error.lower()
+        # Failed jobs always deliver a failure summary — never silence.
+        assert not (final_response or "").strip().upper().startswith(SILENT_MARKER)
+        deliver_content = _summarize_cron_failure_for_delivery(job, error)
+        assert deliver_content.strip()
+        assert "weekly-monitor" in deliver_content or "weekly-market-risk-monitor" in deliver_content
+        assert SILENT_MARKER not in deliver_content
+
 
     @contextlib.contextmanager
     def _run_job_patches(self, tmp_path, extra=()):


### PR DESCRIPTION
## Summary
When every skill declared on a cron job fails to load, the scheduler still invoked the LLM with a contextless prompt. Monitoring jobs often returned `[SILENT]`, suppressing delivery for weeks (#77362).

## Changes
- Raise `CronSkillLoadError` when all declared skills fail and no skill context was loaded
- Catch in `run_job` and return a structured error doc (no agent run)
- Partial failures still proceed with the existing skip notice
- Tests for all-failed abort and partial-failure notice

## Test plan
- [x] `pytest tests/cron/test_scheduler.py::TestBuildJobPromptMissingSkill`

Fixes #77362