### PR TITLE
fix(update): purge site-packages dist-info without RECORD

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -27,6 +27,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -1225,6 +1226,10 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False):
     update_managed_uv()
 
     uv_bin = ensure_uv()
+
+    # Interrupted installs can leave dist-info without RECORD; purge before
+    # uv tries to uninstall/replace those packages (#77432).
+    _heal_stale_distinfo_without_record(_m().PROJECT_ROOT)
 
     pip_cmd = [_m().sys.executable, "-m", "pip"]
     if not uv_bin:
@@ -3354,6 +3359,76 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
         return False, "; ".join(missing[:4])
     return True, ""
 
+def _purge_site_packages_missing_record(site_packages: Path) -> list[str]:
+    """Remove distributions whose dist-info lacks a RECORD file.
+
+    An interrupted ``uv pip install`` can leave package files + dist-info with
+    no RECORD. uv then refuses to uninstall/replace the package and the next
+    install collides with stale files (Windows: Access Denied on ``.pyd``) —
+    stranding the venv (#77432). Deleting those trees is safe: the upcoming
+    dependency sync reinstalls them from a clean state.
+    """
+    purged: list[str] = []
+    if not site_packages.is_dir():
+        return purged
+
+    for dist_info in sorted(site_packages.glob("*.dist-info")):
+        if not dist_info.is_dir():
+            continue
+        if (dist_info / "RECORD").is_file():
+            continue
+
+        stem = dist_info.name[: -len(".dist-info")]
+        # ``cryptography-49.0.0`` → name ``cryptography``; keep the rest of the
+        # stem as version (PEP 427 / wheel naming).
+        match = re.match(r"^(.+)-(\d.*)$", stem)
+        dist_name = match.group(1) if match else stem
+        candidates = {
+            dist_name,
+            dist_name.replace("-", "_"),
+            dist_name.replace("_", "-"),
+        }
+        for cand in candidates:
+            pkg_dir = site_packages / cand
+            if pkg_dir.exists():
+                shutil.rmtree(pkg_dir, ignore_errors=True)
+        data_dir = site_packages / f"{stem}.data"
+        if data_dir.exists():
+            shutil.rmtree(data_dir, ignore_errors=True)
+        shutil.rmtree(dist_info, ignore_errors=True)
+        purged.append(dist_name)
+
+    return purged
+
+
+def _heal_stale_distinfo_without_record(project_root: Path | None = None) -> list[str]:
+    """Scan the install venv for missing-RECORD dist-info and purge them."""
+    root = Path(project_root) if project_root is not None else Path(_m().PROJECT_ROOT)
+    venv = root / "venv"
+    site_dirs: list[Path] = []
+    win_sp = venv / "Lib" / "site-packages"
+    if win_sp.is_dir():
+        site_dirs.append(win_sp)
+    site_dirs.extend(sorted(venv.glob("lib/python*/site-packages")))
+
+    purged: list[str] = []
+    seen: set[str] = set()
+    for site in site_dirs:
+        for name in _purge_site_packages_missing_record(site):
+            if name not in seen:
+                seen.add(name)
+                purged.append(name)
+
+    if purged:
+        shown = ", ".join(purged[:8])
+        extra = f" (+{len(purged) - 8} more)" if len(purged) > 8 else ""
+        print(
+            f"  → Removed {len(purged)} package(s) with missing RECORD "
+            f"(heal interrupted install): {shown}{extra}"
+        )
+    return purged
+
+
 def _detect_venv_python_processes(
     *, exclude_pids: set[int] | None = None
 ) -> list[tuple[int, str, str]]:
@@ -5089,6 +5164,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         cwd=_m().PROJECT_ROOT,
                         check=False,
                     )
+                # Heal dist-info without RECORD before uv tries to uninstall
+                # (interrupted prior install strands Windows venvs — #77432).
+                _heal_stale_distinfo_without_record(_m().PROJECT_ROOT)
                 if repair_uv:
                     repair_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
                     _m()._install_python_dependencies_with_optional_fallback(
@@ -5346,6 +5424,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
         update_managed_uv()
 
         uv_bin = ensure_uv()
+
+        # Interrupted installs can leave dist-info without RECORD; purge before
+        # uv tries to uninstall/replace those packages (#77432).
+        _heal_stale_distinfo_without_record(_m().PROJECT_ROOT)
 
         pip_cmd = [sys.executable, "-m", "pip"]
         if not uv_bin:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -27,6 +27,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -891,6 +892,10 @@ def _update_via_zip(args):
     update_managed_uv()
 
     uv_bin = ensure_uv()
+
+    # Interrupted installs can leave dist-info without RECORD; purge before
+    # uv tries to uninstall/replace those packages (#77432).
+    _heal_stale_distinfo_without_record(_m().PROJECT_ROOT)
 
     pip_cmd = [_m().sys.executable, "-m", "pip"]
     if not uv_bin:
@@ -2829,6 +2834,76 @@ def _venv_core_imports_healthy() -> tuple[bool, str]:
         return False, "; ".join(missing[:4])
     return True, ""
 
+def _purge_site_packages_missing_record(site_packages: Path) -> list[str]:
+    """Remove distributions whose dist-info lacks a RECORD file.
+
+    An interrupted ``uv pip install`` can leave package files + dist-info with
+    no RECORD. uv then refuses to uninstall/replace the package and the next
+    install collides with stale files (Windows: Access Denied on ``.pyd``) —
+    stranding the venv (#77432). Deleting those trees is safe: the upcoming
+    dependency sync reinstalls them from a clean state.
+    """
+    purged: list[str] = []
+    if not site_packages.is_dir():
+        return purged
+
+    for dist_info in sorted(site_packages.glob("*.dist-info")):
+        if not dist_info.is_dir():
+            continue
+        if (dist_info / "RECORD").is_file():
+            continue
+
+        stem = dist_info.name[: -len(".dist-info")]
+        # ``cryptography-49.0.0`` → name ``cryptography``; keep the rest of the
+        # stem as version (PEP 427 / wheel naming).
+        match = re.match(r"^(.+)-(\d.*)$", stem)
+        dist_name = match.group(1) if match else stem
+        candidates = {
+            dist_name,
+            dist_name.replace("-", "_"),
+            dist_name.replace("_", "-"),
+        }
+        for cand in candidates:
+            pkg_dir = site_packages / cand
+            if pkg_dir.exists():
+                shutil.rmtree(pkg_dir, ignore_errors=True)
+        data_dir = site_packages / f"{stem}.data"
+        if data_dir.exists():
+            shutil.rmtree(data_dir, ignore_errors=True)
+        shutil.rmtree(dist_info, ignore_errors=True)
+        purged.append(dist_name)
+
+    return purged
+
+
+def _heal_stale_distinfo_without_record(project_root: Path | None = None) -> list[str]:
+    """Scan the install venv for missing-RECORD dist-info and purge them."""
+    root = Path(project_root) if project_root is not None else Path(_m().PROJECT_ROOT)
+    venv = root / "venv"
+    site_dirs: list[Path] = []
+    win_sp = venv / "Lib" / "site-packages"
+    if win_sp.is_dir():
+        site_dirs.append(win_sp)
+    site_dirs.extend(sorted(venv.glob("lib/python*/site-packages")))
+
+    purged: list[str] = []
+    seen: set[str] = set()
+    for site in site_dirs:
+        for name in _purge_site_packages_missing_record(site):
+            if name not in seen:
+                seen.add(name)
+                purged.append(name)
+
+    if purged:
+        shown = ", ".join(purged[:8])
+        extra = f" (+{len(purged) - 8} more)" if len(purged) > 8 else ""
+        print(
+            f"  → Removed {len(purged)} package(s) with missing RECORD "
+            f"(heal interrupted install): {shown}{extra}"
+        )
+    return purged
+
+
 def _detect_venv_python_processes(
     *, exclude_pids: set[int] | None = None
 ) -> list[tuple[int, str, str]]:
@@ -3903,6 +3978,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         cwd=_m().PROJECT_ROOT,
                         check=False,
                     )
+                # Heal dist-info without RECORD before uv tries to uninstall
+                # (interrupted prior install strands Windows venvs — #77432).
+                _heal_stale_distinfo_without_record(_m().PROJECT_ROOT)
                 if repair_uv:
                     repair_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
                     _m()._install_python_dependencies_with_optional_fallback(
@@ -4081,6 +4159,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
         update_managed_uv()
 
         uv_bin = ensure_uv()
+
+        # Interrupted installs can leave dist-info without RECORD; purge before
+        # uv tries to uninstall/replace those packages (#77432).
+        _heal_stale_distinfo_without_record(_m().PROJECT_ROOT)
 
         pip_cmd = [sys.executable, "-m", "pip"]
         if not uv_bin:

--- a/tests/hermes_cli/test_purge_distinfo_without_record.py
+++ b/tests/hermes_cli/test_purge_distinfo_without_record.py
@@ -1,0 +1,54 @@
+"""#77432: purge site-packages dist-info that lack RECORD before uv reinstall."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import hermes_cli.update_cmd as update_cmd
+
+
+def _make_dist(site: Path, name: str, version: str, *, with_record: bool) -> Path:
+    dist_info = site / f"{name}-{version}.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(f"Name: {name}\nVersion: {version}\n", encoding="utf-8")
+    if with_record:
+        (dist_info / "RECORD").write_text(f"{name}/__init__.py,,\n", encoding="utf-8")
+    pkg = site / name.replace("-", "_")
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text("# pkg\n", encoding="utf-8")
+    return dist_info
+
+
+def test_purge_removes_missing_record_and_keeps_healthy(tmp_path: Path):
+    site = tmp_path / "site-packages"
+    site.mkdir()
+    _make_dist(site, "cryptography", "49.0.0", with_record=False)
+    _make_dist(site, "healthy", "1.0.0", with_record=True)
+
+    purged = update_cmd._purge_site_packages_missing_record(site)
+
+    assert purged == ["cryptography"]
+    assert not (site / "cryptography-49.0.0.dist-info").exists()
+    assert not (site / "cryptography").exists()
+    assert (site / "healthy-1.0.0.dist-info" / "RECORD").is_file()
+    assert (site / "healthy" / "__init__.py").is_file()
+
+
+def test_heal_scans_windows_and_posix_site_packages(tmp_path: Path, monkeypatch):
+    root = tmp_path / "checkout"
+    win_sp = root / "venv" / "Lib" / "site-packages"
+    posix_sp = root / "venv" / "lib" / "python3.11" / "site-packages"
+    win_sp.mkdir(parents=True)
+    posix_sp.mkdir(parents=True)
+    _make_dist(win_sp, "cryptography", "49.0.0", with_record=False)
+    _make_dist(posix_sp, "broken_pkg", "2.0", with_record=False)
+
+    fake_main = type("M", (), {"PROJECT_ROOT": root})()
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_main)
+
+    purged = update_cmd._heal_stale_distinfo_without_record(root)
+
+    assert "cryptography" in purged
+    assert "broken_pkg" in purged
+    assert not (win_sp / "cryptography-49.0.0.dist-info").exists()
+    assert not (posix_sp / "broken_pkg-2.0.dist-info").exists()


### PR DESCRIPTION
## Summary
A stale `*.dist-info` without `RECORD` (typical after a killed `hermes update`) blocks `uv` uninstall/replace. The next install collides with leftover package files — observed on Windows with `cryptography/_rust.pyd` (Access Denied) after #77394.

## Changes
- `_purge_site_packages_missing_record` / `_heal_stale_distinfo_without_record`
- Run heal before dependency install/repair paths in the update pipeline
- Unit tests for purge + Windows/POSIX site-packages scan

## Test plan
- [x] `pytest tests/hermes_cli/test_purge_distinfo_without_record.py`

Fixes #77432