### PR TITLE
fix(buzz): implement send_image_file for local uploads

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -702,6 +702,29 @@ class BuzzAdapter(BasePlatformAdapter):
         text = f"{caption}\n{image_url}" if caption else image_url
         return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
 
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Local-file image send — ``send_images`` dispatches ``file://`` here.
+
+        Without this override, base ``PlatformAdapter.send_image_file`` posts
+        the generic "Couldn't deliver the image attachment" stub even though
+        ``send_image`` already uploads local paths via the Buzz CLI (#77392).
+        """
+        return await self.send_image(
+            chat_id=chat_id,
+            image_url=str(image_path),
+            caption=caption,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         chat_id = str(chat_id)
         state = self._channel_state.get(chat_id)

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -421,6 +421,22 @@ class TestBuzzAdapterSend:
         args, _stdin = cli.calls[0]
         assert args[args.index("--file") + 1] == str(img)
 
+    @pytest.mark.asyncio
+    async def test_send_image_file_delegates_to_local_upload(self, tmp_path):
+        """file:// dispatch hits send_image_file — must not use base stub (#77392)."""
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt127", "message": ""})
+        adapter._run_cli = cli
+        result = await adapter.send_image_file(CHANNEL, str(img), caption="via file path")
+        assert result.success is True
+        assert result.message_id == "evt127"
+        args, stdin = cli.calls[0]
+        assert args[args.index("--file") + 1] == str(img)
+        assert stdin == "via file path"
+
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
`PlatformAdapter.send_images` routes local files through `send_image_file`. Buzz only implemented `send_image`, so local image delivery fell through to the base stub ("Couldn't deliver the image attachment") even though CLI `--file` upload already works in `send_image` (#77392).

## Changes
- Override `send_image_file` to delegate to `send_image` with the local path
- Regression test that the CLI receives `--file`

## Test plan
- [x] `pytest tests/gateway/test_buzz_adapter.py -k send_image`

Fixes #77392