### PR TITLE
fix(codex): preserve a symlinked ~/.codex/config.toml through the runtime migration

### DIFF
--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -730,27 +730,18 @@ def migrate(
 
     try:
         codex_home.mkdir(parents=True, exist_ok=True)
-        # Atomic write: write to a temp file in the same directory then
-        # rename. Same-directory rename is atomic on POSIX and ReplaceFile
-        # on Windows. Avoids leaving a half-written config.toml that
-        # codex would refuse to load if we crash mid-write.
-        import tempfile
-        tmp_fd, tmp_path_str = tempfile.mkstemp(
-            prefix=".config.toml.", dir=str(codex_home)
-        )
-        tmp_path = Path(tmp_path_str)
-        try:
-            with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
-                fh.write(new_text)
-            tmp_path.replace(target)
-        except Exception:
-            # Clean up the temp file if the rename didn't happen.
-            try:
-                if tmp_path.exists():
-                    tmp_path.unlink()
-            except Exception:
-                pass
-            raise
+        # Atomic write via the shared helper: temp file in the same
+        # directory, flush + fsync, then rename. Avoids leaving a
+        # half-written config.toml that codex would refuse to load if we
+        # crash mid-write.
+        #
+        # This must go through atomic_replace rather than a bare rename:
+        # config.toml is the user's own hand-maintained codex config, and
+        # renaming onto the path would replace a symlink with a regular
+        # file, detaching dotfiles/chezmoi/stow deployments and stranding
+        # the real file on stale content (GitHub #16743).
+        from utils import atomic_write_text
+        atomic_write_text(target, new_text)
         report.written = True
     except Exception as exc:
         report.errors.append(f"could not write {target}: {exc}")

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 
 import pytest
 
@@ -70,22 +71,23 @@ class TestTomlValueFormatter:
                 default_permission_profile=None)
         # config.toml should exist
         assert (tmp_path / "config.toml").exists()
-        # And no .config.toml.* temp files left behind
+        # And no temp files left behind. Match any dot-prefixed leftover
+        # rather than one writer's prefix, so this stays meaningful if the
+        # temp-name scheme changes.
         leftover = [p.name for p in tmp_path.iterdir()
-                    if p.name.startswith(".config.toml.")]
+                    if p.name.startswith(".")]
         assert leftover == [], f"temp file leaked after migration: {leftover}"
 
     def test_atomic_write_cleanup_on_rename_failure(self, tmp_path, monkeypatch):
         """If rename fails partway through (out of disk, permissions,
         crash), the temp file must be cleaned up. Otherwise repeated
-        failed migrations would pile up .config.toml.* files."""
-        from pathlib import Path as _Path
-        original_replace = _Path.replace
-
-        def failing_replace(self, target):
+        failed migrations would pile up temp files in ~/.codex."""
+        def failing_replace(src, dst, **kwargs):
             raise OSError("simulated disk full")
 
-        monkeypatch.setattr(_Path, "replace", failing_replace)
+        # The write goes through utils.atomic_replace, which renames with
+        # os.replace -- patch at that level rather than pathlib's wrapper.
+        monkeypatch.setattr(os, "replace", failing_replace)
         report = migrate(
             {"mcp_servers": {"x": {"command": "y"}}},
             codex_home=tmp_path,
@@ -97,9 +99,44 @@ class TestTomlValueFormatter:
         assert any("simulated disk full" in e for e in report.errors)
         # And no leaked temp file
         leftover = [p.name for p in tmp_path.iterdir()
-                    if p.name.startswith(".config.toml.")]
+                    if p.name.startswith(".")]
         assert leftover == [], f"temp files leaked: {leftover}"
 
+    @pytest.mark.skipif(os.name == "nt",
+                        reason="POSIX symlink semantics")
+    def test_migrate_preserves_symlinked_config_toml(self, tmp_path):
+        """A symlinked ~/.codex/config.toml must survive the migration.
+
+        Renaming onto the link path replaces the link itself with a
+        regular file, detaching dotfiles/chezmoi/stow deployments and
+        leaving the real file on stale pre-migration content."""
+        real_dir = tmp_path / "dotfiles"
+        real_dir.mkdir()
+        real = real_dir / "config.toml"
+        real.write_text('[mcp_servers.mine]\ncommand = "x"\n', encoding="utf-8")
+
+        codex_home = tmp_path / "codex"
+        codex_home.mkdir()
+        (codex_home / "config.toml").symlink_to(real)
+
+        report = migrate(
+            {"mcp_servers": {"a": {"command": "b"}}},
+            codex_home=codex_home,
+            discover_plugins=False,
+            expose_hermes_tools=False,
+            default_permission_profile=None,
+        )
+
+        assert report.errors == []
+        assert report.written is True
+        # The link itself must still be a link, pointing where it did.
+        assert (codex_home / "config.toml").is_symlink()
+        assert (codex_home / "config.toml").resolve() == real.resolve()
+        # And the migration must have landed in the real file.
+        real_text = real.read_text(encoding="utf-8")
+        assert "mcp_servers.a" in real_text
+        # The user's own pre-existing entry is preserved.
+        assert "mcp_servers.mine" in real_text
 
 
 class TestRenderToml:


### PR DESCRIPTION
## This is a sibling follow-up to commit `e75336d59`

- **What the parent covered:** `e75336d59` (`fix(cli): preserve symlinked config.yaml in the migration script's atomic write`) fixed exactly this root cause in the openclaw migration script — a temp-file writer that renamed onto a user-owned config path, destroying the symlink when that path was a managed/dotfiles deployment.
- **What the parent did NOT touch:** it only covered `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py`, and because that file is a standalone stdlib-only script it had to inline the symlink-resolving logic.
- **What this adds:** the same defect in the codex runtime migration's rewrite of `~/.codex/config.toml`. This one lives in `hermes_cli/`, so instead of re-inlining anything it simply routes through the existing shared `utils.atomic_write_text` chokepoint.

## What does this PR do?

`migrate()` in `hermes_cli/codex_runtime_plugin_migration.py` rewrites `~/.codex/config.toml` — the user's own hand-maintained Codex CLI config — through a hand-rolled temp-file writer that ends in `tmp_path.replace(target)`.

Renaming *onto* the path replaces whatever is at it. When a user keeps `~/.codex/config.toml` symlinked into a dotfiles repo (chezmoi, stow, a managed profile package), the symlink itself is replaced by a regular file:

- the deployment silently detaches — the dotfiles repo no longer tracks the live file;
- the real file keeps its **stale pre-migration** content;
- the next `chezmoi apply` / `stow` either errors on the unexpected regular file or reverts the MCP servers Hermes just migrated in, taking codex's whole tool surface with it.

It is not a one-shot risk: the migration re-runs on every `/codex-runtime codex_app_server` invocation even when the runtime is already enabled (`hermes_cli/codex_runtime_switch.py:198`, *"re-applying migration"*). The command reports success and prints the config path while this happens, so there is no signal to the user.

The same writer also never called `flush()`/`fsync()` before the rename, so the crash-safety its own comment promised ("avoids leaving a half-written config.toml that codex would refuse to load if we crash mid-write") was not actually delivered.

**The repo already states this invariant against itself.** `utils.atomic_replace` (`utils.py:91`) documents that `os.replace` "replaced with a regular file — silently detaching managed deployments that symlink `config.yaml` / `SOUL.md` / `auth.json` etc." (GitHub #16743), and `utils.atomic_write_text` (`utils.py:139`) exists "so that every destructive file rewrite in the codebase shares one implementation." This writer was a holdout from that chokepoint.

## Related Issue

Related: #16743 — the same invariant, documented in `utils.atomic_replace`'s own docstring for `~/.hermes/` config files. This PR applies it to `~/.codex/config.toml`. (Not marked `Fixes`, since that issue covers the `~/.hermes/` side.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/codex_runtime_plugin_migration.py` — replaced the hand-rolled `tempfile.mkstemp` + `tmp_path.replace(target)` block in `migrate()` with `from utils import atomic_write_text` + `atomic_write_text(target, new_text)`. This supplies parent `mkdir`, **flush + fsync**, and the symlink-preserving `atomic_replace`, including its `EXDEV`/`EBUSY` copy fallback — which matters here precisely because resolving the symlink can land the real file on a different device. Failure reporting is deliberately unchanged: the outer `try`/`except` still records `could not write <target>` into `report.errors`, and `report.written` is still set only on success.
- `tests/hermes_cli/test_codex_runtime_plugin_migration.py` — added `test_migrate_preserves_symlinked_config_toml`, plus two repairs described below.

### Test repairs (these two were coupled to the hand-rolled writer)

Both are repointed at the **syscall boundary** rather than at the new implementation, so they now hold regardless of which writer is underneath — verified by running them against both the old and new production code:

- `test_atomic_write_cleanup_on_rename_failure` monkeypatched `pathlib.Path.replace`. The shared helper renames via `os.replace`, so the patch would no longer intercept and the test would go **red**. It now patches `os.replace`, which is what performs the rename in either implementation. (It also dropped an unused `original_replace` local.)
- `test_atomic_write_no_temp_leak_on_success` scanned only for leftovers named `.config.toml.*`. The shared helper's temp prefix is `.tmp_`, so the assertion would have gone silently **vacuous** — passing while checking nothing. It now rejects any dot-prefixed leftover, which stays meaningful under any temp-name scheme.

### Scope

I swept every `tempfile.mkstemp` site that reaches a rename and checked each for both fsync and `atomic_replace`. This writer was the only one rewriting a **pre-existing, user-owned** file without the shared helper. `hermes_cli/config.py` (`.env`), `hermes_cli/webhook.py`, `hermes_cli/env_loader.py`, `gateway/session.py` and `gateway/pairing.py` already route through `atomic_replace` and are unchanged. Sites that mint a fresh randomized name, or that rewrite a regenerable derived cache, do not share this failure mode and are left alone.

## How to Test

Reproduction, against `main`:

1. `mkdir -p /tmp/dotfiles && printf '[mcp_servers.mine]\ncommand = "x"\n' > /tmp/dotfiles/config.toml`
2. `ln -s /tmp/dotfiles/config.toml ~/.codex/config.toml` (back up any real one first)
3. Run `/codex-runtime codex_app_server`, or call `migrate(...)` directly.
4. On `main`: `ls -l ~/.codex/config.toml` is now a **regular file**, and `/tmp/dotfiles/config.toml` still holds only the original `mcp_servers.mine` — the migration went to the wrong inode and the link is gone. With this PR: the path is still a symlink and `/tmp/dotfiles/config.toml` contains the managed block.

Automated — `tests/hermes_cli/test_codex_runtime_plugin_migration.py::TestTomlValueFormatter::test_migrate_preserves_symlinked_config_toml`, verified in both directions in its final location:

- **Before the production change** (test file as merged, `migrate()` reverted to the parent commit): `1 failed, 20 passed`, failing on `assert (codex_home / "config.toml").is_symlink()` → `AssertionError: assert False`. Note that `report.errors == []` and `report.written is True` both pass first — the migration reports **success** while destroying the link, which is the user-facing shape of the bug.
- **After:** `21 passed in 0.79s`.

The test is `skipif(os.name == "nt")`, mirroring the Windows guard the parent commit used, since it depends on POSIX symlink semantics.

Adjacent suites run green (29 passed): `test_codex_runtime_switch.py`, `test_atomic_json_write.py`, `test_atomic_yaml_write.py`, `test_update_zip_atomic_replace.py`, `test_stale_utils_module_import.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the touched file plus the adjacent suites listed above (50 tests, all green) rather than the full suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the replaced inline comment now explains why the shared helper is required here; no user-facing docs describe this writer
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the production path is unchanged on Windows beyond gaining fsync (`atomic_replace` falls back to a plain `os.replace` for non-symlink targets); the new test is POSIX-only via `skipif`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
