### PR TITLE
refactor(gateway): extract transient-error helpers from run.py (slice 5 of #54962)

### DIFF
--- a/gateway/error_helpers.py
+++ b/gateway/error_helpers.py
@@ -1,0 +1,94 @@
+"""Transient-error classification + loop handler extracted from gateway/run.py (#54962).
+
+Fifth slice of the gateway god-file unpacking: the transient network
+error classifier and the asyncio loop-level exception handler that uses
+it. The classifier is a pure function (walk the cause chain, match known
+transient exception class names); the handler wires it into the event
+loop's safety net so a transient peer error can never kill the gateway
+process (#31066 / #31110).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _is_transient_network_error(exc: BaseException) -> bool:
+    """Return True for transient network errors safe to log + swallow.
+
+    The crash class targeted by #31066 / #31110: an unhandled Telegram
+    ``TimedOut`` (or peer ``NetworkError`` / ``httpx`` connection error)
+    propagating to the event loop and killing the entire gateway
+    process. These are by definition transient — the next poll cycle or
+    user action recovers — so they must never crash the process.
+
+    Walk the exception cause chain so wrapped errors (e.g. PTB's
+    ``NetworkError`` wrapping ``httpx.ConnectError``) are still
+    classified. The chain is bounded to avoid pathological cycles.
+    """
+    seen: set[int] = set()
+    cur: Optional[BaseException] = exc
+    depth = 0
+    transient_class_names = {
+        "TimedOut",
+        "NetworkError",
+        "ReadError",
+        "WriteError",
+        "ConnectError",
+        "ConnectTimeout",
+        "ReadTimeout",
+        "WriteTimeout",
+        "PoolTimeout",
+        "RemoteProtocolError",
+        "ServerDisconnectedError",
+        "ClientConnectorError",
+        "ClientOSError",
+    }
+    while cur is not None and depth < 12:
+        ident = id(cur)
+        if ident in seen:
+            break
+        seen.add(ident)
+        depth += 1
+        name = type(cur).__name__
+        if name in transient_class_names:
+            return True
+        cur = cur.__cause__ or cur.__context__
+    return False
+
+
+def _gateway_loop_exception_handler(
+    loop: "asyncio.AbstractEventLoop", context: Dict[str, Any]
+) -> None:
+    """Loop-level safety net for transient network errors.
+
+    Installed once during :func:`start_gateway`. Catches the
+    ``telegram.error.TimedOut`` crash class (issues #31066 / #31110)
+    and any peer transient network error before it can kill the
+    gateway process. Logs at WARNING with full traceback so the
+    originating call site stays diagnosable; non-transient errors
+    are forwarded to the default loop handler so real bugs still
+    surface.
+    """
+    exc = context.get("exception")
+    if exc is not None and _is_transient_network_error(exc):
+        task = context.get("future") or context.get("task")
+        task_name = ""
+        if task is not None:
+            try:
+                task_name = task.get_name() if hasattr(task, "get_name") else repr(task)
+            except Exception:
+                task_name = repr(task)
+        logger.warning(
+            "Gateway swallowed transient network error from %s: %s: %s",
+            task_name or "<unknown task>",
+            type(exc).__name__,
+            exc,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+        return
+    # Fall back to the default handler for anything we don't recognise.
+    loop.default_exception_handler(context)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -367,82 +367,11 @@ def _seed_hygiene_system_prompt(
     return bool(stored_prompt)
 
 
-def _is_transient_network_error(exc: BaseException) -> bool:
-    """Return True for transient network errors safe to log + swallow.
-
-    The crash class targeted by #31066 / #31110: an unhandled Telegram
-    ``TimedOut`` (or peer ``NetworkError`` / ``httpx`` connection error)
-    propagating to the event loop and killing the entire gateway
-    process. These are by definition transient — the next poll cycle or
-    user action recovers — so they must never crash the process.
-
-    Walk the exception cause chain so wrapped errors (e.g. PTB's
-    ``NetworkError`` wrapping ``httpx.ConnectError``) are still
-    classified. The chain is bounded to avoid pathological cycles.
-    """
-    seen: set[int] = set()
-    cur: Optional[BaseException] = exc
-    depth = 0
-    transient_class_names = {
-        "TimedOut",
-        "NetworkError",
-        "ReadError",
-        "WriteError",
-        "ConnectError",
-        "ConnectTimeout",
-        "ReadTimeout",
-        "WriteTimeout",
-        "PoolTimeout",
-        "RemoteProtocolError",
-        "ServerDisconnectedError",
-        "ClientConnectorError",
-        "ClientOSError",
-    }
-    while cur is not None and depth < 12:
-        ident = id(cur)
-        if ident in seen:
-            break
-        seen.add(ident)
-        depth += 1
-        name = type(cur).__name__
-        if name in transient_class_names:
-            return True
-        cur = cur.__cause__ or cur.__context__
-    return False
-
-
-def _gateway_loop_exception_handler(
-    loop: "asyncio.AbstractEventLoop", context: Dict[str, Any]
-) -> None:
-    """Loop-level safety net for transient network errors.
-
-    Installed once during :func:`start_gateway`. Catches the
-    ``telegram.error.TimedOut`` crash class (issues #31066 / #31110)
-    and any peer transient network error before it can kill the
-    gateway process. Logs at WARNING with full traceback so the
-    originating call site stays diagnosable; non-transient errors
-    are forwarded to the default loop handler so real bugs still
-    surface.
-    """
-    exc = context.get("exception")
-    if exc is not None and _is_transient_network_error(exc):
-        task = context.get("future") or context.get("task")
-        task_name = ""
-        if task is not None:
-            try:
-                task_name = task.get_name() if hasattr(task, "get_name") else repr(task)
-            except Exception:
-                task_name = repr(task)
-        logger.warning(
-            "Gateway swallowed transient network error from %s: %s: %s",
-            task_name or "<unknown task>",
-            type(exc).__name__,
-            exc,
-            exc_info=(type(exc), exc, exc.__traceback__),
-        )
-        return
-    # Fall back to the default handler for anything we don't recognise.
-    loop.default_exception_handler(context)
+# --- Transient-error helpers (extracted to gateway.error_helpers) ---
+from gateway.error_helpers import (  # noqa: E402
+    _gateway_loop_exception_handler,
+    _is_transient_network_error,
+)
 
 
 def _redact_gateway_user_facing_secrets(text: str) -> str:


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #31066 #31110 #54962 #55138 #77433 #77438 #77450 #77452
## What does this PR do?

Fifth slice of the **Extract Gateway Platform Routing from
gateway/run.py** refactor (#54962, #55138) — standalone PR for the
**transient-error helper cluster** (follow-up to #77433 slice 1, #77438
slice 2, #77452 slice 3, #77450 slice 4).

This slice pulls the transient-error safety-net helpers out of the
god-file into `gateway/error_helpers.py`:

- `_is_transient_network_error` — pure classifier: walks the exception
  cause chain (bounded, cycle-safe) and matches known transient class
  names (TimedOut, NetworkError, httpx connect/timeout errors) — the
  #31066/#31110 gateway-crash class
- `_gateway_loop_exception_handler` — the asyncio loop-level safety net
  that swallows transient errors (WARNING log with traceback) and
  forwards everything else to the default handler

**No behavior change**: byte-identical extraction (AST-verified against
origin/main). `gateway/run.py` shrinks by 76 lines; the helpers are
imported at the extraction point so the loop-install site and existing
tests stay green.

### Scope honesty

The full platform-routing extraction from a 26.7K-line file is a
multi-PR effort. This is slice 5, standalone, same verified pattern as
slices 1-4 (module + import + shrink + AST-fidelity). Platform adapters
and the dispatch loop remain for follow-up slices.

## How to test

```bash
pytest tests/gateway/test_loop_exception_handler.py -q
# 8 passed
```

## What platforms were tested?

- Windows 11 native: both files parse, imports resolve, both functions
  AST-identical to origin/main, 8 tests pass, `git diff --check` clean,
  attribution audit clean.

## Why this matters

Every slice shrinks the largest file in the codebase and gives extracted
helpers direct coverage. `gateway/run.py` is down ~450 lines across
slices 1-5, with more to come.

Part of #54962
Part of #55138 (Extract Gateway Platform Routing)

- [x] Refactor (no behavior change)
- [ ] Bug fix
- [ ] Breaking change

## Checklist

- [x] Code follows repo style (extraction, no new deps)
- [x] Self-review complete
- [x] Existing tests cover the extracted helpers (8 pass)
- [x] `git diff --check` clean
- [x] Attribution audit clean

Part of #78647
