### PR TITLE
feat(cli): alert when interactive input is required

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1383,6 +1383,12 @@ display:
   #   false: Silent (default)
   bell_on_complete: false
 
+  # Emit a terminal notification whenever Hermes blocks on an interactive
+  # prompt (clarify, approval, sudo, secret capture, or confirmation).
+  # Sends OSC 9 for notification-aware terminals and BEL as a universal
+  # fallback. Disabled automatically when stdout is not a TTY.
+  input_alert: true
+
   # Show model reasoning/thinking before each response.
   # When enabled, a dim box shows the model's thought process above the response.
   # Toggle at runtime with /reasoning show or /reasoning hide.

--- a/cli.py
+++ b/cli.py
@@ -2863,6 +2863,40 @@ def _accent_hex() -> str:
         return "#FFBF00"
 
 
+def _notify_input_needed(body: str = "Hermes needs your input") -> None:
+    """Best-effort OSC 9 + BEL alert for blocking interactive prompts."""
+    try:
+        from hermes_cli.config import load_config_readonly
+        display = (load_config_readonly() or {}).get("display", {})
+        if not display.get("input_alert", True) or not sys.stdout.isatty():
+            return
+    except Exception:
+        return
+
+    safe_body = re.sub(r"[\x00-\x1f\x7f]", "", body)
+    osc9 = f"\x1b]9;{safe_body}\x07"
+    try:
+        with open("/dev/tty", "w", buffering=1, encoding="utf-8") as tty:
+            tty.write(osc9)
+            tty.write("\a")
+        return
+    except Exception:
+        pass
+
+    # /dev/tty is absent on native Windows and can be unavailable in sandboxes.
+    # Keep OSC 9 and BEL independent so either can fail without suppressing the
+    # other signal.
+    try:
+        sys.stdout.write(osc9)
+    except Exception:
+        pass
+    try:
+        sys.stdout.write("\a")
+        sys.stdout.flush()
+    except Exception:
+        pass
+
+
 def _rich_text_from_ansi(text: str) -> _RichText:
     """Safely render assistant/tool output that may contain ANSI escapes.
 
@@ -8707,6 +8741,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # If prompt_toolkit is not running (unit tests / non-interactive calls),
         # keep the simple stdin fallback.
         if not getattr(self, "_app", None):
+            _notify_input_needed(f"Hermes: {title}")
             return self._prompt_text_input("Choice [1/2/3]: ")
 
         try:
@@ -8724,6 +8759,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if sys.platform == "win32" and not in_main_thread:
                 self._invalidate()
                 return None
+            _notify_input_needed(f"Hermes: {title}")
             return self._prompt_text_input("Choice [1/2/3]: ")
 
         if not in_main_thread and app_loop is None:
@@ -8770,6 +8806,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if not _run_on_app_loop(_setup_modal):
             return _stdin_fallback()
 
+        _notify_input_needed(f"Hermes: {title}")
         _last_countdown_refresh = _time.monotonic()
         try:
             while True:
@@ -13142,6 +13179,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # thread. Modal prompts must paint at once and must not be gated by the
         # _invalidate throttle / resize guard — see _paint_now / _invalidate (#41098).
         self._paint_now()
+        _notify_input_needed("Hermes: clarify question")
 
         # Poll for the user's response. The countdown in the hint line updates
         # on each repaint; refresh it once a second so the timer stays visible
@@ -13199,6 +13237,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Modal prompt — paint immediately, bypassing the throttle/resize guard
         # so the prompt can't be dropped and time out unseen (#41098).
         self._paint_now()
+        _notify_input_needed("Hermes: sudo password")
 
         while True:
             try:
@@ -13267,6 +13306,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # the command is denied on timeout without the user ever seeing it
             # (#41098). The countdown refreshes below paint the same way.
             self._paint_now()
+            _notify_input_needed("Hermes: command approval")
 
             _last_countdown_refresh = _time.monotonic()
             while True:
@@ -13536,6 +13576,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         return lines
 
     def _secret_capture_callback(self, var_name: str, prompt: str, metadata=None) -> dict:
+        _notify_input_needed(f"Hermes: secret needed ({var_name})")
         return prompt_for_secret(self, var_name, prompt, metadata)
 
     def _capture_modal_input_snapshot(self) -> None:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4336,7 +4336,8 @@ def show_config():
     display = config.get('display', {})
     print(f"  Personality:  {display.get('personality') or 'none'}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', True) else 'off'}")
-    print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
+    print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'} (turn-end), "
+          f"{'on' if display.get('input_alert', True) else 'off'} (input alert)")
     ump = display.get('user_message_preview', {}) if isinstance(display.get('user_message_preview', {}), dict) else {}
     ump_first = ump.get('first_lines', 2)
     ump_last = ump.get('last_lines', 2)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1108,6 +1108,9 @@ DEFAULT_CONFIG = {
         # dashboard. Set false to suppress the hint.
         "tui_agents_nudge": True,
         "bell_on_complete": False,
+        # Alert whenever Hermes blocks on interactive input. OSC 9 reaches
+        # notification-aware terminals; BEL remains the universal fallback.
+        "input_alert": True,
         # Stream the model's reasoning/thinking live before the response.
         # Default ON: on thinking models the reasoning phase can run tens of
         # seconds, and with this off the user stares at a spinner the whole

--- a/tests/cli/test_cli_input_alert.py
+++ b/tests/cli/test_cli_input_alert.py
@@ -1,0 +1,177 @@
+"""Tests for the unified input-needed terminal alert."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, mock_open, patch
+
+import cli as cli_module
+from hermes_cli import config as config_module
+
+
+def _set_enabled(monkeypatch, enabled: bool):
+    monkeypatch.setattr(
+        config_module,
+        "load_config_readonly",
+        lambda: {"display": {"input_alert": enabled}},
+    )
+
+
+def test_notify_writes_osc9_and_bel_to_tty(monkeypatch):
+    _set_enabled(monkeypatch, True)
+    fake_tty = MagicMock()
+    opened = mock_open()
+    opened.return_value.__enter__.return_value = fake_tty
+
+    with patch("cli.sys.stdout.isatty", return_value=True), patch("builtins.open", opened):
+        cli_module._notify_input_needed("hello world")
+
+    opened.assert_called_once_with("/dev/tty", "w", buffering=1, encoding="utf-8")
+    assert [call.args[0] for call in fake_tty.write.call_args_list] == [
+        "\x1b]9;hello world\x07",
+        "\a",
+    ]
+
+
+def test_notify_disabled_via_config(monkeypatch):
+    _set_enabled(monkeypatch, False)
+
+    with patch("cli.sys.stdout.isatty", return_value=True), patch("builtins.open") as opened:
+        cli_module._notify_input_needed("hello")
+
+    opened.assert_not_called()
+
+
+def test_notify_skipped_when_stdout_not_tty(monkeypatch):
+    _set_enabled(monkeypatch, True)
+
+    with patch("cli.sys.stdout.isatty", return_value=False), patch("builtins.open") as opened:
+        cli_module._notify_input_needed("hello")
+
+    opened.assert_not_called()
+
+
+def test_notify_falls_back_to_stdout_when_tty_open_fails(monkeypatch):
+    _set_enabled(monkeypatch, True)
+
+    with (
+        patch("cli.sys.stdout.isatty", return_value=True),
+        patch("builtins.open", side_effect=OSError("no tty")),
+        patch("cli.sys.stdout.write") as write,
+        patch("cli.sys.stdout.flush") as flush,
+    ):
+        cli_module._notify_input_needed("hello")
+
+    assert [call.args[0] for call in write.call_args_list] == [
+        "\x1b]9;hello\x07",
+        "\a",
+    ]
+    flush.assert_called_once_with()
+
+
+def test_notify_fallback_bel_survives_osc_write_error(monkeypatch):
+    _set_enabled(monkeypatch, True)
+    write = MagicMock(side_effect=[OSError("OSC unsupported"), None])
+
+    with (
+        patch("cli.sys.stdout.isatty", return_value=True),
+        patch("builtins.open", side_effect=OSError("no tty")),
+        patch("cli.sys.stdout.write", write),
+        patch("cli.sys.stdout.flush") as flush,
+    ):
+        cli_module._notify_input_needed("hello")
+
+    assert write.call_args_list[1].args[0] == "\a"
+    flush.assert_called_once_with()
+
+
+def test_notify_reads_current_config_on_each_call(monkeypatch):
+    enabled = False
+    monkeypatch.setattr(
+        config_module,
+        "load_config_readonly",
+        lambda: {"display": {"input_alert": enabled}},
+    )
+    fake_tty = MagicMock()
+    opened = mock_open()
+    opened.return_value.__enter__.return_value = fake_tty
+
+    with patch("cli.sys.stdout.isatty", return_value=True), patch("builtins.open", opened):
+        cli_module._notify_input_needed("first")
+        enabled = True
+        cli_module._notify_input_needed("second")
+
+    opened.assert_called_once()
+
+
+def test_notify_sanitizes_control_chars(monkeypatch):
+    _set_enabled(monkeypatch, True)
+    fake_tty = MagicMock()
+    opened = mock_open()
+    opened.return_value.__enter__.return_value = fake_tty
+
+    with patch("cli.sys.stdout.isatty", return_value=True), patch("builtins.open", opened):
+        cli_module._notify_input_needed("hello\x1b[2J\x07world\x00")
+
+    payload = fake_tty.write.call_args_list[0].args[0]
+    body = payload.removeprefix("\x1b]9;").removesuffix("\x07")
+    assert body == "hello[2Jworld"
+
+
+def test_slash_confirmation_alerts_before_no_app_fallback():
+    cli = object.__new__(cli_module.HermesCLI)
+    cli._app = None
+    cli._prompt_text_input = MagicMock(return_value="1")
+
+    with patch("cli._notify_input_needed") as notify:
+        result = cli._prompt_text_input_modal(
+            title="Reset session",
+            detail="Continue?",
+            choices=[("1", "yes", "Yes")],
+        )
+
+    assert result == "1"
+    notify.assert_called_once_with("Hermes: Reset session")
+
+
+def test_slash_confirmation_alerts_before_scheduling_failure_fallback():
+    cli = object.__new__(cli_module.HermesCLI)
+    loop = MagicMock()
+    loop.call_soon_threadsafe.side_effect = RuntimeError("closed")
+    cli._app = MagicMock(loop=loop)
+    cli._invalidate = MagicMock()
+    cli._prompt_text_input = MagicMock(return_value="1")
+
+    with (
+        patch("cli.threading.current_thread", return_value=object()),
+        patch("cli.threading.main_thread", return_value=object()),
+        patch("cli._notify_input_needed") as notify,
+    ):
+        result = cli._prompt_text_input_modal(
+            title="Reset session",
+            detail="Continue?",
+            choices=[("1", "yes", "Yes")],
+        )
+
+    assert result == "1"
+    notify.assert_called_once_with("Hermes: Reset session")
+
+
+def test_windows_off_main_thread_cancellation_does_not_alert():
+    cli = object.__new__(cli_module.HermesCLI)
+    cli._app = MagicMock(loop=None)
+    cli._invalidate = MagicMock()
+    cli._prompt_text_input = MagicMock()
+
+    with (
+        patch("cli.threading.current_thread", return_value=object()),
+        patch("cli.threading.main_thread", return_value=object()),
+        patch("cli.sys.platform", "win32"),
+        patch("cli._notify_input_needed") as notify,
+    ):
+        result = cli._prompt_text_input_modal(
+            title="Reset session",
+            detail="Continue?",
+            choices=[("1", "yes", "Yes")],
+        )
+
+    assert result is None
+    notify.assert_not_called()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2634,6 +2634,24 @@ def prompt_dangerous_approval(command: str, description: str,
 
     os.environ["HERMES_SPINNER_PAUSE"] = "1"
     try:
+        # This raw-input fallback bypasses HermesCLI's modal callbacks, so emit
+        # its own BEL when the unified input alert is enabled.
+        try:
+            from hermes_cli.config import load_config_readonly as _load_cfg
+            input_alert = (_load_cfg() or {}).get("display", {}).get("input_alert", True)
+        except Exception:
+            input_alert = True
+        if input_alert and sys.stdout.isatty():
+            try:
+                sys.stdout.write("\x1b]9;Hermes: command approval\x07")
+            except Exception:
+                pass
+            try:
+                sys.stdout.write("\a")
+                sys.stdout.flush()
+            except Exception:
+                pass
+
         # Resolve the active UI language once per prompt so we don't re-read
         # config/YAML inside the retry loop below.
         from agent.i18n import t

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1614,6 +1614,7 @@ display:
   compact: false          # Compact output mode (less whitespace)
   resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
+  input_alert: true       # Notify with OSC 9 + BEL whenever Hermes needs interactive input
   show_reasoning: true    # Show model reasoning/thinking above each response (default: true; toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
   show_cost: false        # Show estimated $ cost in the CLI status bar


### PR DESCRIPTION
## Summary
- add a `display.input_alert` config option, enabled by default
- emit OSC 9 plus BEL when CLI clarify, approval, sudo, secret, or selection prompts need attention
- cover the non-modal approval fallback and sanitize notification text

## Motivation
Long-running terminal sessions can finish background work and then wait indefinitely for user input without attracting attention. This provides a best-effort terminal-native notification while remaining silent for non-TTY output and allowing users to disable it.

## Verification
- `tests/cli/test_cli_input_alert.py`: 10 passed
- targeted local Hermes suite: 667 passed
- TUI typecheck/build and 170 focused tests passed