### PR TITLE
perf(models)+fix(session-search): Copilot catalog TTL cache; ANSI-strip recall (#40276 extract-salvage)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -7,6 +7,7 @@ Add, remove, or reorder entries here — both `hermes setup` and
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -3465,10 +3466,37 @@ def _copilot_catalog_item_is_text_model(item: dict[str, Any]) -> bool:
     return True
 
 
+# Module-level cache for the GitHub Copilot /models catalog.
+# The picker path can ask for it multiple times in one process via:
+#   list_authenticated_providers -> cached_provider_model_ids -> provider_model_ids -> _fetch_github_models
+# and later get_copilot_model_context()/normalize helpers. Cache the raw filtered
+# catalog for a short TTL so we don't pay repeated TLS handshakes on every picker open.
+# Keyed by the api_key used for the successful fetch so a credential swap
+# mid-process never serves the previous account's catalog. Uses a monotonic
+# clock so wall-clock adjustments can't extend the TTL. Lock-free like the
+# other module caches here — a racing thread at worst duplicates one fetch.
+_github_model_catalog_cache: Optional[list[dict[str, Any]]] = None
+_github_model_catalog_cache_key: Optional[str] = None
+_github_model_catalog_cache_time: float = 0.0
+_GITHUB_MODEL_CATALOG_CACHE_TTL = 300  # 5 minutes
+
+
 def fetch_github_model_catalog(
     api_key: Optional[str] = None, timeout: float = 5.0
 ) -> Optional[list[dict[str, Any]]]:
     """Fetch the live GitHub Copilot model catalog for this account."""
+    global _github_model_catalog_cache, _github_model_catalog_cache_key
+    global _github_model_catalog_cache_time
+
+    if (
+        _github_model_catalog_cache is not None
+        and _github_model_catalog_cache_key == api_key
+        and (time.monotonic() - _github_model_catalog_cache_time) < _GITHUB_MODEL_CATALOG_CACHE_TTL
+    ):
+        # Deep copy: catalog items are dicts, and a shallow copy would let
+        # callers mutate the cached entries in place.
+        return copy.deepcopy(_github_model_catalog_cache)
+
     attempts: list[dict[str, str]] = []
     if api_key:
         attempts.append({
@@ -3494,6 +3522,9 @@ def fetch_github_model_catalog(
                     seen_ids.add(model_id)
                     models.append(item)
                 if models:
+                    _github_model_catalog_cache = copy.deepcopy(models)
+                    _github_model_catalog_cache_key = api_key
+                    _github_model_catalog_cache_time = time.monotonic()
                     return models
         except Exception:
             continue

--- a/tests/hermes_cli/test_copilot_context.py
+++ b/tests/hermes_cli/test_copilot_context.py
@@ -81,6 +81,125 @@ class TestGetCopilotModelContext:
         assert mock_fetch.call_count == 2
 
 
+
+    @patch("hermes_cli.models._urlopen_model_catalog_request")
+    def test_fetch_github_model_catalog_uses_short_lived_cache(self, mock_urlopen):
+        import json as _json
+        import hermes_cli.models as mod
+
+        mod._github_model_catalog_cache = None
+        mod._github_model_catalog_cache_key = None
+        mod._github_model_catalog_cache_time = 0.0
+
+        payload = {
+            "data": [
+                {
+                    "id": "gpt-4.1",
+                    "model_picker_enabled": True,
+                    "supported_endpoints": ["/chat/completions"],
+                }
+            ]
+        }
+
+        class _Resp:
+            def __enter__(self):
+                return self
+            def __exit__(self, *args):
+                return False
+            def read(self):
+                return _json.dumps(payload).encode()
+
+        mock_urlopen.return_value = _Resp()
+
+        first = mod.fetch_github_model_catalog(api_key="token")
+        second = mod.fetch_github_model_catalog(api_key="token")
+
+        assert [item["id"] for item in first] == ["gpt-4.1"]
+        assert [item["id"] for item in second] == ["gpt-4.1"]
+        assert mock_urlopen.call_count == 1
+
+        # Cached copies are independent — mutating the result must not
+        # poison the cache.
+        second[0]["id"] = "mutated"
+        third = mod.fetch_github_model_catalog(api_key="token")
+        assert [item["id"] for item in third] == ["gpt-4.1"]
+        assert mock_urlopen.call_count == 1
+
+    @patch("hermes_cli.models._urlopen_model_catalog_request")
+    def test_fetch_github_model_catalog_cache_expires_after_ttl(self, mock_urlopen):
+        import json as _json
+        import time as _time
+        import hermes_cli.models as mod
+
+        mod._github_model_catalog_cache = None
+        mod._github_model_catalog_cache_key = None
+        mod._github_model_catalog_cache_time = 0.0
+
+        payload = {
+            "data": [
+                {
+                    "id": "gpt-4.1",
+                    "model_picker_enabled": True,
+                    "supported_endpoints": ["/chat/completions"],
+                }
+            ]
+        }
+
+        class _Resp:
+            def __enter__(self):
+                return self
+            def __exit__(self, *args):
+                return False
+            def read(self):
+                return _json.dumps(payload).encode()
+
+        mock_urlopen.return_value = _Resp()
+
+        mod.fetch_github_model_catalog(api_key="token")
+        assert mock_urlopen.call_count == 1
+
+        # Age the entry past the TTL (monotonic clock) — next call re-fetches.
+        mod._github_model_catalog_cache_time = (
+            _time.monotonic() - mod._GITHUB_MODEL_CATALOG_CACHE_TTL - 1
+        )
+        mod.fetch_github_model_catalog(api_key="token")
+        assert mock_urlopen.call_count == 2
+
+    @patch("hermes_cli.models._urlopen_model_catalog_request")
+    def test_fetch_github_model_catalog_cache_misses_on_credential_change(self, mock_urlopen):
+        import json as _json
+        import hermes_cli.models as mod
+
+        mod._github_model_catalog_cache = None
+        mod._github_model_catalog_cache_key = None
+        mod._github_model_catalog_cache_time = 0.0
+
+        payload = {
+            "data": [
+                {
+                    "id": "gpt-4.1",
+                    "model_picker_enabled": True,
+                    "supported_endpoints": ["/chat/completions"],
+                }
+            ]
+        }
+
+        class _Resp:
+            def __enter__(self):
+                return self
+            def __exit__(self, *args):
+                return False
+            def read(self):
+                return _json.dumps(payload).encode()
+
+        mock_urlopen.return_value = _Resp()
+
+        mod.fetch_github_model_catalog(api_key="token-a")
+        assert mock_urlopen.call_count == 1
+        # A different token must not be served the previous account's catalog.
+        mod.fetch_github_model_catalog(api_key="token-b")
+        assert mock_urlopen.call_count == 2
+
     @patch("hermes_cli.models.fetch_github_model_catalog", return_value=[])
     def test_returns_none_for_empty_catalog(self, mock_fetch):
         assert get_copilot_model_context("gpt-4.1") is None

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -272,6 +272,19 @@ class TestReadShape:
         assert len(result["messages"]) == 5
         assert result["session_meta"]["title"] == "Building the Modpack"
 
+    def test_read_strips_ansi_sequences_from_messages(self, db):
+        db.create_session("s_ansi", source="cli")
+        db.append_message("s_ansi", role="user", content="plain")
+        db.append_message(
+            "s_ansi", role="assistant", content="\u001b[31mred text\u001b[0m and more"
+        )
+        db._conn.commit()
+        result = json.loads(session_search(session_id="s_ansi", db=db))
+        assert result["success"] is True
+        rendered = [m["content"] for m in result["messages"] if m.get("content")]
+        assert any(text == "red text and more" for text in rendered)
+        assert all("\u001b" not in text for text in rendered)
+
     def test_read_truncates_large_session(self, db):
         db.create_session("s_big", source="cli")
         for i in range(50):

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -247,6 +247,12 @@ def _shape_message(
     is added so callers know the payload was bounded.
     """
     raw_content = m.get("content")
+    if isinstance(raw_content, str) and "\x1b" in raw_content:
+        # Recalled messages can carry ANSI escape sequences (e.g. archived
+        # terminal output). Strip them before returning content to the model.
+        from tools.ansi_strip import strip_ansi
+
+        raw_content = strip_ansi(raw_content)
     if max_content_len and raw_content and len(raw_content) > max_content_len:
         content = raw_content[:max_content_len] + "…"
         truncated = True


### PR DESCRIPTION
Extract-salvage of #40276 by @Xue-1997 — the PR's two still-novel pieces, both commits authored as Xue-1997.

## Context — what survived a 9,558-commit drift

The PR's core (tool-discovery caching, selective get_definitions lookup, config-fingerprint tool-defs caching, context-length resolution, ollama-probe skip, skill-manifest invalidation) all landed on main independently in equal-or-better form since June — verified group by group. Two pieces main still lacks:

1. Copilot model-catalog TTL cache (hermes_cli/models.py): the picker re-fetched the GitHub /models catalog with a fresh TLS handshake on every open. 5-minute module cache, keyed by the api_key used for the fetch (a credential swap mid-process can never serve the previous account's catalog), monotonic clock, lock-free — matching the file's four precedent module caches (_openrouter_catalog_cache, _ai_gateway_catalog_cache, _free_tier_cache TTL=180, _nous_recommended_cache TTL=600).
2. ANSI-strip in session_search recall: recalled messages could carry raw escape sequences into the prompt. Uses the shared tools.ansi_strip.strip_ansi (the repo-wide ECMA-48 stripper) — no duplicate regex.

Deliberately NOT extracted (with reasons, so nothing is silently dropped): lazy websockets/cron/delegate imports (main mooted or explicitly rejects them by design — eager import comments), memory diff-injection (violates the byte-stable system-prompt invariant), skills-index compression (product-taste call, not a mechanical fix).

## Verification

- 45 targeted + 134 adjacent tests green (randomized AND fixed order); ruff clean.
- Mutation checks: cache disabled → cache tests fail; strip removed → recall test fails; restored green.
- Simplify pass: no material findings (test proportionality, TTL house-style, copy-independence all verified).

Closes #40276.
