### PR TITLE
fix(desktop): restore conversation after tool tab switch

### DIFF
--- a/apps/desktop/e2e/pane-tab-roundtrip.spec.ts
+++ b/apps/desktop/e2e/pane-tab-roundtrip.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from './test'
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+
+let fixture: MockBackendFixture | null = null
+
+const PROMPT = 'E2E conversation survives stacked tool tab switches'
+
+test.beforeAll(async () => {
+  fixture = await setupMockBackend()
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+test('restores the conversation after visiting the terminal tab', async () => {
+  const page = fixture!.page
+  const composer = page.locator('[contenteditable="true"]').first()
+
+  await composer.click()
+  await composer.type(PROMPT)
+  await page.keyboard.press('Enter')
+  const transcript = page.locator('[data-slot="aui_thread-viewport"]')
+
+  await transcript.getByText(PROMPT).waitFor({ state: 'visible', timeout: 30_000 })
+  await transcript.getByText(/mock inference server/).waitFor({ state: 'visible', timeout: 60_000 })
+
+  await page.evaluate(() => {
+    localStorage.setItem(
+      'hermes.desktop.layoutTree.v2',
+      JSON.stringify({
+        active: 'workspace',
+        id: 'e2e-main',
+        panes: ['workspace', 'terminal', 'review'],
+        type: 'group'
+      })
+    )
+  })
+  await page.reload()
+  await waitForAppReady(fixture!, 120_000)
+  await transcript.getByText(PROMPT).waitFor({ state: 'visible', timeout: 60_000 })
+
+  await page.locator('[data-tree-tab="terminal"]').click()
+  await expect(page.locator('[data-tree-tab="terminal"]')).toHaveAttribute('data-active', 'true')
+
+  await page.locator('[data-tree-tab="workspace"]').click()
+  await expect(transcript.getByText(PROMPT)).toBeVisible()
+  await expect(page.locator('[data-slot="composer-root"]')).toBeVisible()
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -450,6 +450,10 @@ export function TreeGroup({
               const closeable = closeableTab(paneId)
               const title = paneFor(paneId)?.title ?? paneId
               const isSelected = tabSelection?.groupId === node.id && tabSelection.ids.has(paneId)
+              // The synthesized double-tap must stay on one tab. Two quick
+              // clicks on different tabs are navigation, not a request to
+              // hide the whole strip before the second tab activates.
+              const tabDoubleTap = { ...hideHeaderDoubleTap, key: `${hideHeaderDoubleTap.key}-${paneId}` }
 
               const tab = (
                 <PaneTab
@@ -517,7 +521,7 @@ export function TreeGroup({
                         e,
                         onTap,
                         stripRef.current ? { groupId: node.id, strip: stripRef.current } : undefined,
-                        hideHeaderDoubleTap,
+                        tabDoubleTap,
                         t.zones.tabCount(dragSelection.length),
                         dragSelection
                       )
@@ -529,13 +533,13 @@ export function TreeGroup({
                     // session drop language — link/stack/split); `false` defers
                     // to the generic pane move (the workspace tab on a fresh
                     // draft has no session to link).
-                    if (!chrome.tabDrag?.(e, onTap, hideHeaderDoubleTap)) {
+                    if (!chrome.tabDrag?.(e, onTap, tabDoubleTap)) {
                       startPaneDrag(
                         paneId,
                         e,
                         onTap,
                         stripRef.current ? { groupId: node.id, strip: stripRef.current } : undefined,
-                        hideHeaderDoubleTap,
+                        tabDoubleTap,
                         title
                       )
                     }


### PR DESCRIPTION
## Summary
- reproduces the blank conversation pane after switching to the terminal tab and back
- scopes synthesized double-tap detection to each pane tab, so two quick clicks on different tabs remain navigation instead of hiding the strip
- preserves the same per-tab key on both individual-tab and multi-tab drag paths after rebasing onto current `main`

## Test plan
- [x] RED: `uv run npx playwright test e2e/pane-tab-roundtrip.spec.ts --workers=1` — conversation remained hidden before the fix
- [x] `npm run typecheck`
- [x] `npx eslint src/components/pane-shell/tree/renderer/tree-group.tsx`
- [x] `npm run build`
- [x] `npx playwright test e2e/pane-tab-roundtrip.spec.ts --reporter=line` — 1 passed
- [x] GitHub Actions required checks passed

Closes #77437