### PR TITLE
feat(desktop): minimize to system tray on window close

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -27,7 +27,8 @@ import {
   screen,
   session,
   shell,
-  systemPreferences
+  systemPreferences,
+  Tray
 } from 'electron'
 import nodePty from 'node-pty'
 
@@ -1048,6 +1049,8 @@ function registerMediaProtocol() {
 }
 
 let mainWindow = null
+let appTray = null
+let isQuitting = false
 const backendConnectionState = createBackendConnectionState<ReturnType<typeof spawn>, any>()
 const remoteLiveness = new RemoteLivenessTracker()
 const remoteRevalidation = new RemoteRevalidationCoordinator()
@@ -9344,7 +9347,14 @@ function createWindow() {
   mainWindow.on('moved', schedulePersistWindowState)
   mainWindow.on('maximize', schedulePersistWindowState)
   mainWindow.on('unmaximize', schedulePersistWindowState)
-  mainWindow.on('close', () => schedulePersistWindowState.flush())
+  mainWindow.on('close', (event) => {
+    if (!isQuitting) {
+      event.preventDefault()
+      mainWindow.hide()
+      return
+    }
+    schedulePersistWindowState.flush()
+  })
 
   // the closed wrapper remains truthy, so clear only the window this callback owns.
   const createdMainWindow = mainWindow
@@ -9361,6 +9371,49 @@ function createWindow() {
 
   streamThrottle.register(mainWindow)
   wireCommonWindowHandlers(mainWindow, zoomWiringForWindowKind('chat'))
+
+  // System tray: minimize to tray on close instead of quitting
+  if (!appTray) {
+    const iconPath = getAppIconPath()
+    let trayIcon
+    if (iconPath) {
+      trayIcon = nativeImage.createFromPath(iconPath).resize({ width: 16, height: 16 })
+    } else {
+      // Fallback: 16x1 transparent pixel — Electron needs a non-empty image
+      trayIcon = nativeImage.createFromBuffer(
+        Buffer.from('iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAFJJREFUOE9jZKAQMFJqABMDA8N/RkZGamk2YGBg+M/IwMBALQ0MDAz/mRgYGKiloQoNDQ3/z5gxg1oa/jMwMPxnZGCglgYGBob/DFQy4D8DAwMAtpoMDwd7XZcAAAAASUVORK5CYII=', 'base64')
+      ).resize({ width: 16, height: 16 })
+    }
+    appTray = new Tray(trayIcon)
+
+    const contextMenu = Menu.buildFromTemplate([
+      {
+        label: '显示 Hermes',
+        click: () => {
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.show()
+            mainWindow.focus()
+          }
+        }
+      },
+      { type: 'separator' },
+      {
+        label: '退出',
+        click: () => {
+          isQuitting = true
+          app.quit()
+        }
+      }
+    ])
+    appTray.setToolTip('Hermes Agent')
+    appTray.setContextMenu(contextMenu)
+    appTray.on('double-click', () => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.show()
+        mainWindow.focus()
+      }
+    })
+  }
 
   mainWindow.webContents.on('render-process-gone', (_event, details) => {
     rememberLog(`[renderer] render-process-gone reason=${details?.reason} exitCode=${details?.exitCode}`)
@@ -12006,14 +12059,20 @@ app.on('before-quit', event => {
   stopAllPoolBackends()
 })
 
+app.on('before-quit', () => {
+  isQuitting = true
+  // Clean up tray
+  if (appTray) {
+    appTray.destroy()
+    appTray = null
+  }
+})
+
 app.on('window-all-closed', () => {
-  // macOS convention: keep the process alive in the Dock when the user closes
-  // the last window. But when we're handing off to a detached updater / swap /
-  // uninstall script, the process MUST exit so the script can replace or remove
-  // the bundle and relaunch — without this the script's PID-wait spins to its
-  // full timeout and the user is left with an invisible app (or an uninstall
-  // that appears to do nothing).
   if (process.platform !== 'darwin' || isQuittingForHandoff) {
-    app.quit()
+    if (!appTray || isQuitting) {
+      app.quit()
+    }
+    // Otherwise (tray exists, not quitting): window hidden to tray — keep alive
   }
 })


### PR DESCRIPTION
## Summary

Clicking the close button (×) now hides the Hermes window to the system tray instead of quitting the app. The tray icon supports double-click to restore and a right-click menu with **显示 Hermes** (show) / **退出** (quit).

## Changes (`apps/desktop/electron/main.ts`, +68/-9)

- **`close` handler** — `event.preventDefault()` + `mainWindow.hide()` unless `isQuitting`
- **Tray** — created once in `createWindow()` using the app icon resized to 16px, with a transparent 1×1 fallback when the icon path is unavailable; tooltip + context menu + double-click restore
- **`before-quit`** — sets `isQuitting`, destroys the tray
- **`window-all-closed`** — process stays alive while the tray exists (non-darwin), preserving the existing macOS convention branch

## Why this differs from the existing open PRs (#39468, #43536, #63064, #63663)

I'm aware several open PRs already implement minimize-to-tray. Points where this implementation differs:

1. **Handoff safety preserved** — the updater-swap / uninstall paths set `isQuittingForHandoff` and call `app.quit()`; the tray's `isQuitting` flag is set in `before-quit`, so a hidden-to-tray window never blocks the detached-handoff exit (the old `window-all-closed` comment about PID-wait timeouts is still honored). Verified against all 5 `isQuittingForHandoff` call sites.
2. **Tray icon fallback** — a 16×1 transparent-pixel buffer when `getAppIconPath()` returns nothing, so the tray never crashes on icon-less builds.
3. **Explicit quit affordance** — tray context menu (show/quit) plus double-click restore, in addition to close-to-hide.

## Verification

- `node scripts/bundle-electron-main.mjs` — compiles clean (dist/electron-main.mjs)
- `tsc --noEmit` — 0 errors in `electron/main.ts` (the 9 renderer errors in `src/components`/`src/debug` are pre-existing on main)
- `npx vitest run electron/window-state.test.ts electron/main-window-lifecycle.test.ts electron/link-title-window.test.ts` — 28 tests pass (15 + 4 + 9)

## Notes

- Behavior applies on all platforms; on macOS the close button now hides to tray (previously the window-all-closed convention kept the app alive without a tray), which matches the tray pattern of other desktop apps.
- Local testing: close-to-hide, double-click restore, tray-menu quit all verified on Windows.