### PR TITLE
fix(web): preserve npm engine diagnostics on dashboard install

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5714,7 +5714,14 @@ def _do_build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
             env=build_env,
         )
 
-    r1 = _install_web_deps(silent=True)
+    # First install runs with capture_output=True inside
+    # _run_npm_install_deterministic, so success stays quiet without
+    # --silent. Passing --silent here empties stdout/stderr on
+    # engine-strict rejection, which blinds maybe_repair_npm_engine
+    # (is_ebadengine("") is False) and leaves users with only
+    # "Web UI npm install failed". Same class of bug as the TUI path
+    # (PR #76074); dashboard / hermes web hit this one.
+    r1 = _install_web_deps(silent=False)
     if r1.returncode != 0:
         _say(
             f"  {'✗' if fatal else '⚠'} Web UI npm install failed"

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -150,8 +150,66 @@ class TestBuildWebUISkipsWhenFresh:
         assert result is True
         args, kwargs = mock_run.call_args
         assert "--workspace" not in args[0]
-        assert args[0] == ["/usr/bin/npm", "ci", "--include=dev", "--silent", "--prefer-offline"]
+        # --silent must not be present: capture_output already keeps success
+        # quiet, and --silent swallows EBADENGINE text that
+        # maybe_repair_npm_engine needs (sibling of TUI fix PR #76074).
+        # --prefer-offline is still expected (perf #39267).
+        # Don't hardcode the npm binary path: _resolve_node_runtime_npm may
+        # return a managed/system path even when shutil.which is patched.
+        assert args[0][1:] == ["ci", "--include=dev", "--prefer-offline"]
+        assert "--silent" not in args[0]
         assert kwargs["cwd"] == web_dir
+
+    def test_web_install_preserves_engine_failure_for_recovery(
+        self, tmp_path, monkeypatch
+    ):
+        """First web install must retain npm's EBADENGINE diagnostic.
+
+        With --silent, npm exits non-zero and capture_output receives empty
+        stdout/stderr, so maybe_repair_npm_engine never sees the failure and
+        cannot provision a managed runtime. hermes dashboard then dies with
+        only "Web UI npm install failed". Sibling of the TUI fix in PR #76074.
+        """
+        from hermes_cli import npm_engine
+
+        web_dir, _ = _make_web_dir(tmp_path)
+        (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+        monkeypatch.delenv("TERMUX_VERSION", raising=False)
+        monkeypatch.setenv("PREFIX", "/usr")
+
+        engine_error = (
+            "npm error code EBADENGINE\n"
+            'npm error notsup Required: {"node":">=22.22.0","npm":"<11.10.0 || >=11.17.0"}\n'
+            'npm error notsup Actual: {"node":"v25.9.0","npm":"11.14.1"}\n'
+        )
+        npm_path = "/usr/bin/npm"
+
+        def fake_run(cmd, **kwargs):
+            stderr = "" if "--silent" in cmd else engine_error
+            return __import__("subprocess").CompletedProcess(
+                cmd, 1, stdout="", stderr=stderr
+            )
+
+        seen: dict = {}
+
+        def fake_repair(npm, output, **_kwargs):
+            seen["npm"] = npm
+            seen["output"] = output
+            return None
+
+        build_cp = __import__("subprocess").CompletedProcess(
+            [], 0, stdout="", stderr=""
+        )
+        with patch("hermes_cli.main._resolve_node_runtime_npm", return_value=npm_path), \
+             patch("hermes_cli.main.subprocess.run", side_effect=fake_run), \
+             patch("hermes_cli.main._run_with_idle_timeout", return_value=build_cp), \
+             patch.object(npm_engine, "maybe_repair_npm_engine", side_effect=fake_repair):
+            result = _build_web_ui(web_dir, fatal=True)
+
+        assert result is False
+        assert seen.get("npm") == npm_path
+        assert "EBADENGINE" in (seen.get("output") or "")
+        assert "--silent" not in (seen.get("output") or "no-silent-marker")
 
     def test_web_build_uses_idle_timeout_helper(self, tmp_path):
         """npm run build now goes through _run_with_idle_timeout (issue #33788).


### PR DESCRIPTION
## What does this PR do?

Preserves npm engine diagnostics during the web UI (dashboard) dependency install so `maybe_repair_npm_engine` can self-heal.

The first web install in `_do_build_web_ui` passed `--silent` into a `capture_output=True` `npm ci`/`npm install`. When `engine-strict=true` rejects an out-of-range system npm, npm exits non-zero **with empty stdout/stderr under `--silent`**. That blinds `maybe_repair_npm_engine` (`is_ebadengine("")` is false), so Hermes neither upgrades a managed npm nor provisions a managed Node tree. `hermes dashboard` dies with only:

```text
✗ Web UI npm install failed
  Run manually:  npm install --workspace web && npm run build -w web
```

Success stays quiet without `--silent` because output is already captured. Failures retain the diagnostic the existing recovery path needs.

This is the **dashboard / hermes web** sibling of the open TUI fix in #76074 (which only touches the TUI startup install). Both paths had the same `--silent` + capture blindness; that PR covers TUI, this one covers web.

## Related Issue

No issue filed. Complementary to #76074.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/main.py` — first web install uses `silent=False` (no `--silent`); capture_output already quiets success
- `tests/hermes_cli/test_web_ui_build.py` — update lockfile install assertion; add regression test that EBADENGINE text reaches `maybe_repair_npm_engine`

## How to Test

### Manual (Windows 11 repro we hit)

1. System npm in the excluded engines band (we had node v25.9.0 / npm 11.14.1 vs required `npm <11.10.0 || >=11.17.0`)
2. No healthy managed tree at `$HERMES_HOME/node` (or delete it to force the path)
3. Run `hermes dashboard`
4. **Before:** opaque `Web UI npm install failed` with no EBADENGINE text and no managed-node provision
5. **After:** install retains EBADENGINE; recovery provisions/upgrades managed npm and retries

Empirical check of the silence bug itself:

```text
npm install --workspace web --silent   → exit 1, 0 bytes of output
npm install --workspace web            → exit 1, EBADENGINE present
```

### Automated

```text
python -m pytest tests/hermes_cli/test_web_ui_build.py::TestBuildWebUISkipsWhenFresh::test_web_install_omits_workspace_when_web_has_own_lockfile tests/hermes_cli/test_web_ui_build.py::TestBuildWebUISkipsWhenFresh::test_web_install_preserves_engine_failure_for_recovery tests/hermes_cli/test_npm_engine.py -q -o "addopts="
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — #76074 is the TUI sibling (does not touch `_do_build_web_ui`)
- [x] My PR contains only changes related to this fix
- [x] Focused tests pass on Windows 11 (full suite left to CI)
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: `--silent` swallowing is npm-wide; repro was Windows
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Pre-fix (opaque failure):

```text
PS C:\Users\Greg> hermes dashboard
→ Building web UI...
  ✗ Web UI npm install failed
  Run manually:  npm install --workspace web && npm run build -w web
```

Post managed-node provision + this class of fix, install/build succeeds and dashboard binds.

---

Nevermore Team I, C, G 🐦‍⬛