### PR TITLE
feat(discord): support per-guild/per-server configuration overrides

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1436,6 +1436,12 @@ class DiscordAdapter(BasePlatformAdapter):
             return False, False
 
         role_authorized = False
+        msg_guild = getattr(message, "guild", None)
+        _guild_id = (
+            str(msg_guild.id)
+            if msg_guild is not None and getattr(msg_guild, "id", None) is not None
+            else None
+        )
         if getattr(message.author, "bot", False):
             allow_bots = self._get_allow_bots()
             if allow_bots == "none":
@@ -1448,7 +1454,6 @@ class DiscordAdapter(BasePlatformAdapter):
             ):
                 return False, False
         else:
-            msg_guild = getattr(message, "guild", None)
             is_dm = isinstance(message.channel, discord.DMChannel) or msg_guild is None
             msg_channel_ids = None
             if not is_dm:
@@ -1484,7 +1489,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 parent_id = None
                 if hasattr(message.channel, "parent_id") and message.channel.parent_id:
                     parent_id = str(message.channel.parent_id)
-                free_channels = self._discord_free_response_channels()
+                free_channels = self._discord_free_response_channels(_guild_id)
                 channel_keys = self._discord_channel_keys(message, parent_id)
                 if "*" not in free_channels and not (channel_keys & free_channels):
                     return False, False
@@ -2115,7 +2120,16 @@ class DiscordAdapter(BasePlatformAdapter):
         raw = self._gate_env("DISCORD_MISSED_MESSAGE_BACKFILL_CHANNELS")
         if not raw.strip():
             allowed = self._get_allowed_channels()
-            return allowed | self._discord_free_response_channels()
+            free = self._discord_free_response_channels()
+            # Guild-scoped allow/free lists must be scanned too, otherwise a
+            # guild with per-guild channel policy would be invisible to the
+            # recovery sweep after a reconnect.
+            for cfg in self._discord_guild_configs():
+                if "allowed_channels" in cfg:
+                    allowed |= self._gate_csv_set(cfg["allowed_channels"])
+                if "free_response_channels" in cfg:
+                    free |= self._gate_csv_set(cfg["free_response_channels"])
+            return allowed | free
         return {item.strip() for item in raw.split(",") if item.strip()}
 
     def _missed_message_backfill_window_seconds(self) -> float:
@@ -2289,17 +2303,23 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _dispatch_recovered_message(self, message: Any) -> bool:
         """Run one recovered message through the live Discord ingress gates."""
+        msg_guild = getattr(message, "guild", None)
+        _guild_id = (
+            str(msg_guild.id)
+            if msg_guild is not None and getattr(msg_guild, "id", None) is not None
+            else None
+        )
         if not isinstance(message.channel, discord.DMChannel):
             parent_id = self._get_parent_channel_id(message.channel)
             channel_keys = self._discord_channel_keys(message, parent_id)
-            free_channels = self._discord_free_response_channels()
+            free_channels = self._discord_free_response_channels(_guild_id)
             in_bot_thread = (
                 isinstance(message.channel, discord.Thread)
                 and str(message.channel.id) in self._threads
                 and not self._discord_thread_require_mention()
             )
             if (
-                self._discord_require_mention()
+                self._discord_require_mention(_guild_id)
                 and "*" not in free_channels
                 and not (channel_keys & free_channels)
                 and not in_bot_thread
@@ -4533,11 +4553,17 @@ class DiscordAdapter(BasePlatformAdapter):
             except OSError:
                 pass
 
-    def _discord_channel_ids_allowed(self, channel_ids: set[str]) -> bool:
-        """True when *channel_ids* intersect ``DISCORD_ALLOWED_CHANNELS``."""
+    def _discord_channel_ids_allowed(
+        self, channel_ids: set[str], guild_id: str | None = None,
+    ) -> bool:
+        """True when *channel_ids* intersect the effective allowed-channel list.
+
+        *guild_id* scopes the lookup to ``discord.guilds:<guild_id>:allowed_channels``
+        when configured; otherwise the global gate applies unchanged.
+        """
         if not channel_ids:
             return False
-        allowed = self._get_allowed_channels()
+        allowed = self._get_allowed_channels(guild_id)
         if not allowed:
             return False
         if "*" in allowed:
@@ -4615,7 +4641,14 @@ class DiscordAdapter(BasePlatformAdapter):
             if (
                 not is_dm
                 and channel_ids is not None
-                and self._discord_channel_ids_allowed(channel_ids)
+                and self._discord_channel_ids_allowed(
+                    channel_ids,
+                    guild_id=(
+                        str(guild.id)
+                        if guild is not None and getattr(guild, "id", None) is not None
+                        else None
+                    ),
+                )
             ):
                 return True
             return False
@@ -4682,6 +4715,12 @@ class DiscordAdapter(BasePlatformAdapter):
             return
         if self._get_allowed_channels():
             return
+        # A per-guild allowlist counts as configured for the warning.
+        if any(
+            self._gate_csv_set(cfg.get("allowed_channels"))
+            for cfg in self._discord_guild_configs()
+        ):
+            return
         if self._discord_allow_all_users():
             return
         if self._gateway_allow_all_users():
@@ -4734,6 +4773,13 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         chan_obj = getattr(interaction, "channel", None)
         in_dm = isinstance(chan_obj, discord.DMChannel) if chan_obj is not None else False
+        interaction_guild = getattr(interaction, "guild", None)
+        _guild_id = (
+            str(interaction_guild.id)
+            if interaction_guild is not None
+            and getattr(interaction_guild, "id", None) is not None
+            else None
+        )
 
         channel_ids: set = set()
         channel_keys: set = set()
@@ -4763,7 +4809,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 else None,
             )
 
-            allowed = self._get_allowed_channels()
+            allowed = self._get_allowed_channels(_guild_id)
             if allowed:
                 if "*" not in allowed:
                     if not channel_ids:
@@ -4779,7 +4825,7 @@ class DiscordAdapter(BasePlatformAdapter):
             # Ignored beats allowed: even when a thread's parent channel
             # is on the allowlist, an explicit DISCORD_IGNORED_CHANNELS
             # entry on the thread or its parent rejects the interaction.
-            ignored = self._get_ignored_channels()
+            ignored = self._get_ignored_channels(_guild_id)
             if ignored and channel_ids:
                 if "*" in ignored or (channel_keys & ignored):
                     return (False, "channel in DISCORD_IGNORED_CHANNELS")
@@ -4799,8 +4845,8 @@ class DiscordAdapter(BasePlatformAdapter):
         user_id = str(user.id)
         # Pass guild + is_dm so role check is scoped to the originating
         # guild and cross-guild DM bypass (#12136) can't land via the
-        # slash surface either.
-        interaction_guild = getattr(interaction, "guild", None)
+        # slash surface either. ``interaction_guild`` was resolved above
+        # for per-guild config lookups.
         if not self._is_allowed_user(
             user_id,
             author=user,
@@ -6099,9 +6145,48 @@ class DiscordAdapter(BasePlatformAdapter):
         from gateway.platforms.base import resolve_channel_prompt
         return resolve_channel_prompt(self.config.extra, channel_id, parent_id)
 
-    def _discord_require_mention(self) -> bool:
-        """Return whether Discord channel messages require a bot mention."""
-        configured = self.config.extra.get("require_mention")
+    # ── per-guild configuration (issue #23051) ─────────────────────────
+    # ``discord.guilds:<guild_id>:`` blocks (string-normalized by
+    # ``_apply_yaml_config``) override the global Discord settings per
+    # server. Every accessor below accepts an optional ``guild_id``; when
+    # the guild has no override block the global resolution is unchanged,
+    # so single-guild deployments see zero behavior difference.
+
+    def _discord_guild_config(self, guild_id: str | None) -> dict:
+        """Return the per-guild override dict for *guild_id*, or ``{}``.
+
+        ``None`` (DMs, unknown guild, or no ``guilds`` config) yields an
+        empty dict so callers fall through to global settings unchanged.
+        """
+        if guild_id is None:
+            return {}
+        extra = getattr(getattr(self, "config", None), "extra", None)
+        if not isinstance(extra, dict):
+            return {}
+        guilds = extra.get("guilds")
+        if not isinstance(guilds, dict):
+            return {}
+        entry = guilds.get(str(guild_id))
+        return entry if isinstance(entry, dict) else {}
+
+    def _discord_guild_configs(self) -> list:
+        """All per-guild override dicts (for scans that span guilds)."""
+        extra = getattr(getattr(self, "config", None), "extra", None)
+        if not isinstance(extra, dict):
+            return []
+        guilds = extra.get("guilds")
+        if not isinstance(guilds, dict):
+            return []
+        return [cfg for cfg in guilds.values() if isinstance(cfg, dict)]
+
+    def _discord_require_mention(self, guild_id: str | None = None) -> bool:
+        """Return whether Discord channel messages require a bot mention.
+
+        Per-guild override: ``discord.guilds:<guild_id>:require_mention``.
+        """
+        configured = self._discord_guild_config(guild_id).get("require_mention")
+        if configured is None:
+            configured = self.config.extra.get("require_mention")
         if configured is not None:
             if isinstance(configured, str):
                 return configured.lower() not in {"false", "0", "no", "off"}
@@ -6210,16 +6295,25 @@ class DiscordAdapter(BasePlatformAdapter):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
 
-    def _get_allowed_channels(self) -> set:
-        """This adapter's DISCORD_ALLOWED_CHANNELS gate (per-profile)."""
+    def _get_allowed_channels(self, guild_id: str | None = None) -> set:
+        """This adapter's DISCORD_ALLOWED_CHANNELS gate (per-profile, per-guild)."""
+        guild_cfg = self._discord_guild_config(guild_id)
+        if "allowed_channels" in guild_cfg:
+            return self._gate_csv_set(guild_cfg["allowed_channels"])
         return self._gate_csv_set(self._gate_raw("allowed_channels", "DISCORD_ALLOWED_CHANNELS"))
 
-    def _get_ignored_channels(self) -> set:
-        """This adapter's DISCORD_IGNORED_CHANNELS gate (per-profile)."""
+    def _get_ignored_channels(self, guild_id: str | None = None) -> set:
+        """This adapter's DISCORD_IGNORED_CHANNELS gate (per-profile, per-guild)."""
+        guild_cfg = self._discord_guild_config(guild_id)
+        if "ignored_channels" in guild_cfg:
+            return self._gate_csv_set(guild_cfg["ignored_channels"])
         return self._gate_csv_set(self._gate_raw("ignored_channels", "DISCORD_IGNORED_CHANNELS"))
 
-    def _get_no_thread_channels(self) -> set:
-        """This adapter's DISCORD_NO_THREAD_CHANNELS list (per-profile)."""
+    def _get_no_thread_channels(self, guild_id: str | None = None) -> set:
+        """This adapter's DISCORD_NO_THREAD_CHANNELS list (per-profile, per-guild)."""
+        guild_cfg = self._discord_guild_config(guild_id)
+        if "no_thread_channels" in guild_cfg:
+            return self._gate_csv_set(guild_cfg["no_thread_channels"])
         return self._gate_csv_set(self._gate_raw("no_thread_channels", "DISCORD_NO_THREAD_CHANNELS"))
 
     def _get_allowed_users(self) -> set:
@@ -6256,16 +6350,21 @@ class DiscordAdapter(BasePlatformAdapter):
         """Per-profile DISCORD_ALLOW_BOTS mode (none|mentions|all)."""
         return self._gate_env("DISCORD_ALLOW_BOTS", "none").lower().strip() or "none"
 
-    def _discord_free_response_channels(self) -> set:
+    def _discord_free_response_channels(self, guild_id: str | None = None) -> set:
         """Return Discord channel IDs/names where no bot mention is required.
 
         A single ``"*"`` entry (either from a list or a comma-separated
         string) is preserved in the returned set so callers can short-circuit
         on wildcard membership, consistent with ``allowed_channels``.
+        Per-guild override: ``discord.guilds:<guild_id>:free_response_channels``.
         """
-        raw = self.config.extra.get("free_response_channels")
-        if raw is None:
-            raw = self._gate_env("DISCORD_FREE_RESPONSE_CHANNELS")
+        guild_cfg = self._discord_guild_config(guild_id)
+        if "free_response_channels" in guild_cfg:
+            raw = guild_cfg["free_response_channels"]
+        else:
+            raw = self.config.extra.get("free_response_channels")
+            if raw is None:
+                raw = self._gate_env("DISCORD_FREE_RESPONSE_CHANNELS")
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         # Coerce non-list scalars (str/int/float) to str before splitting.
@@ -6278,6 +6377,20 @@ class DiscordAdapter(BasePlatformAdapter):
         if s:
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
+
+    def _discord_auto_thread(self, guild_id: str | None = None) -> bool:
+        """Return whether auto-threading is enabled for *guild_id*.
+
+        Per-guild override: ``discord.guilds:<guild_id>:auto_thread``.
+        Falls back to ``DISCORD_AUTO_THREAD`` (default ``true``), matching
+        the historical behavior.
+        """
+        raw = self._discord_guild_config(guild_id).get("auto_thread")
+        if raw is None:
+            raw = os.getenv("DISCORD_AUTO_THREAD", "true")
+        if isinstance(raw, str):
+            return raw.lower() in {"true", "1", "yes"}
+        return bool(raw)
 
     def _raw_mentioned_user_ids(self, message: Any) -> set:
         """Extract Discord user-mention IDs directly from raw message content.
@@ -7667,27 +7780,33 @@ class DiscordAdapter(BasePlatformAdapter):
                 normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
             message.content = normalized_content
         if not isinstance(message.channel, discord.DMChannel):
+            _msg_guild = getattr(message, "guild", None)
+            _guild_id = (
+                str(_msg_guild.id)
+                if _msg_guild is not None and getattr(_msg_guild, "id", None) is not None
+                else None
+            )
             channel_ids = {str(message.channel.id)}
             if parent_channel_id:
                 channel_ids.add(parent_channel_id)
             channel_keys = self._discord_channel_keys(message, parent_channel_id)
 
             # Check allowed channels - if set, only respond in these channels
-            allowed_channels = self._get_allowed_channels()
+            allowed_channels = self._get_allowed_channels(_guild_id)
             if allowed_channels:
                 if "*" not in allowed_channels and not (channel_keys & allowed_channels):
                     logger.debug("[%s] Ignoring message in non-allowed channel: %s", self.name, channel_keys)
                     return False
 
             # Check ignored channels - never respond even when mentioned
-            ignored_channels = self._get_ignored_channels()
+            ignored_channels = self._get_ignored_channels(_guild_id)
             if "*" in ignored_channels or (channel_keys & ignored_channels):
                 logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_keys)
                 return False
 
-            free_channels = self._discord_free_response_channels()
+            free_channels = self._discord_free_response_channels(_guild_id)
 
-            require_mention = self._discord_require_mention()
+            require_mention = self._discord_require_mention(_guild_id)
             # Voice-linked text channels act as free-response while voice is active.
             # Only the exact bound channel gets the exemption, not sibling threads.
             voice_linked_ids = {str(ch_id) for ch_id in self._voice_text_channels.values()}
@@ -7719,9 +7838,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # no_thread_channels: channels where bot responds directly without thread.
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
-            no_thread_channels = self._get_no_thread_channels()
+            no_thread_channels = self._get_no_thread_channels(_guild_id)
             skip_thread = bool(channel_keys & no_thread_channels) or is_free_channel
-            auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
+            auto_thread = self._discord_auto_thread(_guild_id)
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
                 thread = await self._auto_create_thread(message)
@@ -9982,6 +10101,18 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         seeded_extra["no_thread_channels"] = str(ntc)
         if not _skip_env_bridge and not os.getenv("DISCORD_NO_THREAD_CHANNELS"):
             os.environ["DISCORD_NO_THREAD_CHANNELS"] = str(ntc)
+    # guilds: per-guild override blocks (guild_id → settings dict) for
+    # require_mention, allowed_channels, ignored_channels,
+    # free_response_channels, no_thread_channels, auto_thread. Guild IDs are
+    # string-normalized here — YAML parses bare snowflake numbers as int and
+    # Discord IDs can exceed 64-bit signed range. Seeded into
+    # PlatformConfig.extra only: per-guild policy is per-profile (multiplex
+    # isolation), so it deliberately never touches process-global env.
+    guilds_cfg = discord_cfg.get("guilds")
+    if isinstance(guilds_cfg, dict):
+        seeded_extra["guilds"] = {
+            str(gid): cfg for gid, cfg in guilds_cfg.items() if isinstance(cfg, dict)
+        }
     # history_backfill: recover missed channel messages for shared sessions
     # when require_mention is active.  Fetches messages between bot turns
     # and prepends them to the user message for context.

--- a/tests/gateway/test_discord_per_guild_config.py
+++ b/tests/gateway/test_discord_per_guild_config.py
@@ -1,0 +1,614 @@
+"""Tests for per-guild/per-server Discord configuration overrides (issue #23051).
+
+Guild-scoped config under ``discord.guilds:<guild_id>:`` allows different
+mention rules, channel lists, and threading behavior per Discord server.
+
+Resolution priority: per-guild → global (config extra / env) → default.
+Single-guild deployments without a ``guilds`` block see zero behavior change.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+import sys
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_discord_mock():
+    """Install a mock discord module when discord.py isn't available."""
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.MessageType = SimpleNamespace(default=1, reply=2)
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+_GATE_ENV_VARS = [
+    "DISCORD_REQUIRE_MENTION",
+    "DISCORD_FREE_RESPONSE_CHANNELS",
+    "DISCORD_ALLOWED_CHANNELS",
+    "DISCORD_IGNORED_CHANNELS",
+    "DISCORD_NO_THREAD_CHANNELS",
+    "DISCORD_AUTO_THREAD",
+    "DISCORD_ALLOW_ALL_USERS",
+    "DISCORD_ALLOWED_USERS",
+    "DISCORD_ALLOWED_ROLES",
+    "DISCORD_IGNORE_NO_MENTION",
+    "GATEWAY_ALLOW_ALL_USERS",
+]
+
+
+class FakeDMChannel:
+    def __init__(self, channel_id: int = 1, name: str = "dm"):
+        self.id = channel_id
+        self.name = name
+
+
+class FakeGuild:
+    def __init__(self, guild_id: int = 100, name: str = "Guild 100"):
+        self.id = guild_id
+        self.name = name
+
+
+class FakeTextChannel:
+    def __init__(
+        self,
+        channel_id: int = 1,
+        name: str = "general",
+        guild_name: str = "Hermes Server",
+        guild_id: int = 100,
+    ):
+        self.id = channel_id
+        self.name = name
+        self.guild = FakeGuild(guild_id=guild_id, name=guild_name)
+        self.topic = None
+
+    def history(self, *, limit, before, after=None, oldest_first=None):
+        async def _iter():
+            return
+            yield
+        return _iter()
+
+
+class FakeForumChannel:
+    def __init__(
+        self,
+        channel_id: int = 1,
+        name: str = "support-forum",
+        guild_name: str = "Hermes Server",
+        guild_id: int = 100,
+    ):
+        self.id = channel_id
+        self.name = name
+        self.guild = FakeGuild(guild_id=guild_id, name=guild_name)
+        self.type = 15
+        self.topic = None
+
+
+class FakeThread:
+    def __init__(
+        self,
+        channel_id: int = 1,
+        name: str = "thread",
+        parent=None,
+        guild_name: str = "Hermes Server",
+        guild_id: int = 100,
+    ):
+        self.id = channel_id
+        self.name = name
+        self.parent = parent
+        self.parent_id = getattr(parent, "id", None)
+        self.guild = getattr(parent, "guild", None) or FakeGuild(guild_id=guild_id, name=guild_name)
+        self.topic = None
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    for var in _GATE_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(discord_platform.discord, "DMChannel", FakeDMChannel, raising=False)
+    monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
+    monkeypatch.setattr(discord_platform.discord, "ForumChannel", FakeForumChannel, raising=False)
+
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = DiscordAdapter(config)
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+    adapter._text_batch_delay_seconds = 0  # disable batching for tests
+    adapter.handle_message = AsyncMock()
+    adapter._auto_create_thread = AsyncMock(return_value=FakeThread(channel_id=999))
+    return adapter
+
+
+def make_message(*, channel, content: str, mentions=None, msg_type=None):
+    author = SimpleNamespace(id=42, display_name="Jezza", name="Jezza")
+    guild = getattr(channel, "guild", None)
+    return SimpleNamespace(
+        id=123,
+        content=content,
+        mentions=list(mentions or []),
+        attachments=[],
+        reference=None,
+        created_at=datetime.now(timezone.utc),
+        channel=channel,
+        author=author,
+        guild=guild,
+        type=msg_type if msg_type is not None else discord_platform.discord.MessageType.default,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _discord_guild_config
+# ---------------------------------------------------------------------------
+
+
+def test_guild_config_returns_entry(adapter):
+    adapter.config.extra["guilds"] = {
+        "100": {"require_mention": False},
+    }
+    assert adapter._discord_guild_config("100") == {"require_mention": False}
+
+
+def test_guild_config_accepts_numeric_lookup(adapter):
+    """Guild IDs are stored as strings; int lookups must normalize too."""
+    adapter.config.extra["guilds"] = {
+        "100": {"require_mention": False},
+    }
+    assert adapter._discord_guild_config(100) == {"require_mention": False}
+
+
+def test_guild_config_returns_empty_for_unknown(adapter):
+    adapter.config.extra["guilds"] = {"100": {"require_mention": False}}
+    assert adapter._discord_guild_config("999") == {}
+
+
+def test_guild_config_returns_empty_for_none(adapter):
+    adapter.config.extra["guilds"] = {"100": {"require_mention": False}}
+    assert adapter._discord_guild_config(None) == {}
+
+
+def test_guild_config_returns_empty_for_missing_key(adapter):
+    assert adapter._discord_guild_config("100") == {}
+
+
+def test_guild_config_returns_empty_for_non_dict_entry(adapter):
+    adapter.config.extra["guilds"] = {"100": "oops"}
+    assert adapter._discord_guild_config("100") == {}
+
+
+# ---------------------------------------------------------------------------
+# _apply_yaml_config guild seeding
+# ---------------------------------------------------------------------------
+
+
+def test_apply_yaml_config_seeds_string_normalized_guilds(monkeypatch):
+    """Bare snowflake int keys must be string-normalized (64-bit overflow)."""
+    for var in _GATE_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    seeded = discord_platform._apply_yaml_config(
+        {},
+        {
+            "require_mention": True,
+            "guilds": {
+                100: {"require_mention": False},
+                "101": {"free_response_channels": ["11", "12"]},
+                "not-a-dict": "ignored",
+            },
+        },
+    )
+    assert seeded["guilds"] == {
+        "100": {"require_mention": False},
+        "101": {"free_response_channels": ["11", "12"]},
+    }
+
+
+def test_apply_yaml_config_skips_missing_guilds(monkeypatch):
+    for var in _GATE_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    seeded = discord_platform._apply_yaml_config({}, {"require_mention": False})
+    # No seeded extras (require_mention is env-bridged only) → None return.
+    assert not seeded or "guilds" not in seeded
+
+
+# ---------------------------------------------------------------------------
+# _discord_require_mention
+# ---------------------------------------------------------------------------
+
+
+def test_require_mention_guild_override_wins_over_global(adapter):
+    adapter.config.extra["require_mention"] = True
+    adapter.config.extra["guilds"] = {"100": {"require_mention": False}}
+    assert adapter._discord_require_mention("100") is False
+    assert adapter._discord_require_mention("999") is True
+
+
+def test_require_mention_guild_string_override(adapter):
+    adapter.config.extra["guilds"] = {"100": {"require_mention": "false"}}
+    assert adapter._discord_require_mention("100") is False
+
+
+def test_require_mention_falls_back_to_env_without_guild(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    assert adapter._discord_require_mention(None) is False
+    assert adapter._discord_require_mention("100") is False
+
+
+def test_require_mention_default_true(adapter):
+    assert adapter._discord_require_mention() is True
+    assert adapter._discord_require_mention("100") is True
+
+
+# ---------------------------------------------------------------------------
+# Channel-set accessors
+# ---------------------------------------------------------------------------
+
+
+def test_allowed_channels_guild_override(adapter):
+    adapter.config.extra["allowed_channels"] = "1000"
+    adapter.config.extra["guilds"] = {"100": {"allowed_channels": ["2000"]}}
+    assert adapter._get_allowed_channels("100") == {"2000"}
+    assert adapter._get_allowed_channels("999") == {"1000"}
+    assert adapter._get_allowed_channels() == {"1000"}
+
+
+def test_allowed_channels_guild_csv_override(adapter):
+    adapter.config.extra["guilds"] = {"100": {"allowed_channels": "2000,2001"}}
+    assert adapter._get_allowed_channels("100") == {"2000", "2001"}
+
+
+def test_allowed_channels_guild_wildcard(adapter):
+    adapter.config.extra["guilds"] = {"100": {"allowed_channels": "*"}}
+    assert adapter._get_allowed_channels("100") == {"*"}
+
+
+def test_allowed_channels_guild_override_beats_env(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "3000")
+    adapter.config.extra["guilds"] = {"100": {"allowed_channels": ["2000"]}}
+    assert adapter._get_allowed_channels("100") == {"2000"}
+    assert adapter._get_allowed_channels("999") == {"3000"}
+
+
+def test_ignored_channels_guild_override(adapter):
+    adapter.config.extra["ignored_channels"] = "1000"
+    adapter.config.extra["guilds"] = {"100": {"ignored_channels": ["2000"]}}
+    assert adapter._get_ignored_channels("100") == {"2000"}
+    assert adapter._get_ignored_channels("999") == {"1000"}
+
+
+def test_no_thread_channels_guild_override(adapter):
+    adapter.config.extra["no_thread_channels"] = "1000"
+    adapter.config.extra["guilds"] = {"100": {"no_thread_channels": ["2000"]}}
+    assert adapter._get_no_thread_channels("100") == {"2000"}
+    assert adapter._get_no_thread_channels("999") == {"1000"}
+
+
+def test_free_response_channels_guild_override(adapter):
+    adapter.config.extra["free_response_channels"] = "1000"
+    adapter.config.extra["guilds"] = {"100": {"free_response_channels": ["2000"]}}
+    assert adapter._discord_free_response_channels("100") == {"2000"}
+    assert adapter._discord_free_response_channels("999") == {"1000"}
+
+
+def test_free_response_channels_guild_wildcard(adapter):
+    adapter.config.extra["guilds"] = {"100": {"free_response_channels": ["*"]}}
+    assert adapter._discord_free_response_channels("100") == {"*"}
+
+
+def test_free_response_channels_guild_numeric_scalar(adapter):
+    adapter.config.extra["guilds"] = {"100": {"free_response_channels": 1491973769726791812}}
+    assert adapter._discord_free_response_channels("100") == {"1491973769726791812"}
+
+
+# ---------------------------------------------------------------------------
+# _discord_auto_thread
+# ---------------------------------------------------------------------------
+
+
+def test_auto_thread_guild_override(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    adapter.config.extra["guilds"] = {"100": {"auto_thread": False}}
+    assert adapter._discord_auto_thread("100") is False
+    assert adapter._discord_auto_thread("999") is True
+
+
+def test_auto_thread_guild_string_override(adapter):
+    adapter.config.extra["guilds"] = {"100": {"auto_thread": "no"}}
+    assert adapter._discord_auto_thread("100") is False
+
+
+def test_auto_thread_default_true(adapter):
+    assert adapter._discord_auto_thread() is True
+
+
+# ---------------------------------------------------------------------------
+# _discord_channel_ids_allowed (fail-closed admission gate)
+# ---------------------------------------------------------------------------
+
+
+def test_channel_ids_allowed_scoped_to_guild(adapter):
+    adapter.config.extra["allowed_channels"] = "1000"
+    adapter.config.extra["guilds"] = {"100": {"allowed_channels": ["2000"]}}
+    # Guild 100's own allowlist admits its channel...
+    assert adapter._discord_channel_ids_allowed({"2000"}, guild_id="100") is True
+    # ...but not a channel that only the global list admits.
+    assert adapter._discord_channel_ids_allowed({"1000"}, guild_id="100") is False
+    # No guild context → global list.
+    assert adapter._discord_channel_ids_allowed({"1000"}) is True
+    assert adapter._discord_channel_ids_allowed({"1000"}, guild_id="999") is True
+
+
+def test_channel_ids_allowed_guild_wildcard(adapter):
+    adapter.config.extra["guilds"] = {"100": {"allowed_channels": ["*"]}}
+    assert adapter._discord_channel_ids_allowed({"anything"}, guild_id="100") is True
+
+
+# ---------------------------------------------------------------------------
+# _handle_message end-to-end paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_message_guild_free_response_without_mention(adapter):
+    """Guild-scoped free_response_channels admit unmentioned messages."""
+    adapter.config.extra["guilds"] = {
+        "100": {"free_response_channels": ["2000"]},
+    }
+    message = make_message(
+        channel=FakeTextChannel(channel_id=2000, guild_id=100),
+        content="hello",
+    )
+    await adapter._handle_message(message)
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_guild_require_mention_true_blocks(adapter):
+    """Guild-scoped require_mention: true overrides a global false."""
+    adapter.config.extra["require_mention"] = False
+    adapter.config.extra["guilds"] = {
+        "100": {"require_mention": True},
+    }
+    message = make_message(
+        channel=FakeTextChannel(channel_id=2000, guild_id=100),
+        content="hello",
+    )
+    await adapter._handle_message(message)
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_guild_require_mention_false_admits(adapter):
+    """Guild-scoped require_mention: false admits unmentioned messages."""
+    adapter.config.extra["require_mention"] = True
+    adapter.config.extra["guilds"] = {
+        "100": {"require_mention": False},
+    }
+    message = make_message(
+        channel=FakeTextChannel(channel_id=2000, guild_id=100),
+        content="hello",
+    )
+    await adapter._handle_message(message)
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_guild_allowed_channels_scoped(adapter):
+    """A guild-scoped allowlist replaces the global list for that guild only."""
+    adapter.config.extra["allowed_channels"] = ["3000"]
+    adapter.config.extra["guilds"] = {
+        "100": {"allowed_channels": ["2000"]},
+    }
+    bot_user = adapter._client.user
+
+    # Guild 100: the per-guild override admits only channel 2000 (the
+    # global 3000 entry does NOT apply to this guild).
+    in_guild = make_message(
+        channel=FakeTextChannel(channel_id=2000, guild_id=100),
+        content=f"<@{bot_user.id}> hello",
+        mentions=[bot_user],
+    )
+    await adapter._handle_message(in_guild)
+    adapter.handle_message.assert_awaited_once()
+
+    adapter.handle_message.reset_mock()
+    global_only = make_message(
+        channel=FakeTextChannel(channel_id=3000, guild_id=100),
+        content=f"<@{bot_user.id}> hello",
+        mentions=[bot_user],
+    )
+    await adapter._handle_message(global_only)
+    adapter.handle_message.assert_not_awaited()
+
+    # Guild 200 has no override block: the global allowlist still applies.
+    adapter.handle_message.reset_mock()
+    other_guild_global = make_message(
+        channel=FakeTextChannel(channel_id=3000, guild_id=200),
+        content=f"<@{bot_user.id}> hello",
+        mentions=[bot_user],
+    )
+    await adapter._handle_message(other_guild_global)
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_guild_ignored_channel_blocks_even_with_mention(adapter):
+    """Guild-scoped ignored_channels drop even @mentioned messages."""
+    adapter.config.extra["guilds"] = {
+        "100": {"ignored_channels": ["2000"]},
+    }
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=2000, guild_id=100),
+        content=f"<@{bot_user.id}> hello",
+        mentions=[bot_user],
+    )
+    await adapter._handle_message(message)
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_guild_ignored_does_not_leak_to_other_guild(adapter):
+    """ignored_channels for one guild must not silence the same channel elsewhere."""
+    adapter.config.extra["require_mention"] = False
+    adapter.config.extra["guilds"] = {
+        "100": {"ignored_channels": ["2000"]},
+    }
+    message = make_message(
+        channel=FakeTextChannel(channel_id=2000, guild_id=200),
+        content="hello",
+    )
+    await adapter._handle_message(message)
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_guild_no_thread_skips_auto_thread(adapter):
+    """Guild-scoped no_thread_channels skip auto-threading for that guild."""
+    adapter.config.extra["require_mention"] = False
+    adapter.config.extra["guilds"] = {
+        "100": {"no_thread_channels": ["2000"]},
+    }
+    message = make_message(
+        channel=FakeTextChannel(channel_id=2000, guild_id=100),
+        content="hello",
+    )
+    await adapter._handle_message(message)
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_guild_auto_thread_false_skips(adapter):
+    """Guild-scoped auto_thread: false disables auto-threading for that guild."""
+    adapter.config.extra["require_mention"] = False
+    adapter.config.extra["guilds"] = {
+        "100": {"auto_thread": False},
+    }
+    message = make_message(
+        channel=FakeTextChannel(channel_id=2000, guild_id=100),
+        content="hello",
+    )
+    await adapter._handle_message(message)
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_other_guild_still_auto_threads(adapter):
+    """Guilds without an auto_thread override keep the global default."""
+    adapter.config.extra["require_mention"] = False
+    adapter.config.extra["guilds"] = {
+        "100": {"auto_thread": False},
+    }
+    message = make_message(
+        channel=FakeTextChannel(channel_id=2000, guild_id=200),
+        content="hello",
+    )
+    await adapter._handle_message(message)
+    adapter._auto_create_thread.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _discord_message_admission pre-dispatch gate
+# ---------------------------------------------------------------------------
+
+
+def _admission_ready_adapter(adapter):
+    """Bypass user/role allowlist for admission-focused tests.
+
+    The fixture author is user id ``42`` (see ``make_message``); granting it
+    here keeps ``_is_allowed_user`` from fail-closing before the
+    free-response mention gate under test is reached.
+    """
+    adapter._allowed_user_ids = {"42"}
+    adapter._allowed_role_ids = set()
+    adapter._is_pairing_approved_user = lambda user_id: False
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_admission_guild_free_response_accepts_mention_of_other_user(adapter):
+    """Mentioning another user in a guild free-response channel is admitted."""
+    _admission_ready_adapter(adapter)
+    adapter.config.extra["guilds"] = {
+        "100": {"free_response_channels": ["2000"]},
+    }
+    other = SimpleNamespace(id=1, bot=False)
+    message = make_message(
+        channel=FakeTextChannel(channel_id=2000, guild_id=100),
+        content="<@1> hello",
+        mentions=[other],
+    )
+    admitted, role_authorized = await asyncio_ctx(adapter, message)
+    assert admitted is True
+    assert role_authorized is False
+
+
+@pytest.mark.asyncio
+async def test_admission_guild_free_response_rejects_other_guild(adapter):
+    """Mentioning another user outside the guild's free-response list is dropped."""
+    _admission_ready_adapter(adapter)
+    adapter.config.extra["guilds"] = {
+        "100": {"free_response_channels": ["2000"]},
+    }
+    other = SimpleNamespace(id=1, bot=False)
+    message = make_message(
+        channel=FakeTextChannel(channel_id=3000, guild_id=100),
+        content="<@1> hello",
+        mentions=[other],
+    )
+    admitted, _ = await asyncio_ctx(adapter, message)
+    assert admitted is False
+
+
+# ---------------------------------------------------------------------------
+# _missed_message_backfill_channels union
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_channels_union_includes_guild_scoped_lists(adapter):
+    adapter.config.extra["allowed_channels"] = "1000"
+    adapter.config.extra["free_response_channels"] = "1001"
+    adapter.config.extra["guilds"] = {
+        "100": {"allowed_channels": ["2000"], "free_response_channels": ["2001"]},
+    }
+    assert adapter._missed_message_backfill_channels() == {
+        "1000", "1001", "2000", "2001",
+    }
+
+
+async def asyncio_ctx(adapter, message):
+    """Thin wrapper so admission tests read as plain async asserts."""
+    return adapter._discord_message_admission(message, claim=False)

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -455,6 +455,35 @@ discord:
 
 Useful for channels dedicated to bot interaction where threads would add unnecessary noise.
 
+#### `discord.guilds`
+
+**Type:** mapping of guild ID → settings — **Default:** `{}`
+
+Per-guild overrides for the settings above. Key the map by Discord server (guild) ID, and each entry accepts the same keys as the global `discord` block — `require_mention`, `allowed_channels`, `ignored_channels`, `free_response_channels`, `no_thread_channels`, and `auto_thread`. Guild entries take priority over the global setting for messages and slash commands in that server; everything else keeps the global behavior. This lets one bot behave differently in each server it is invited to (e.g. free responses in your own server, mention-gated elsewhere):
+
+```yaml
+discord:
+  require_mention: true            # global default
+  guilds:
+    "123456789012345678":          # your home server: relaxed
+      require_mention: false
+      free_response_channels:
+        - 111111111111111111       # announcements channel
+    "876543210987654321":          # a public server: locked down
+      require_mention: true
+      allowed_channels:
+        - 222222222222222222       # bot only answers here
+        - 333333333333333333
+      auto_thread: false
+```
+
+Notes:
+
+- Guild IDs are strings. Quote them in YAML — Discord snowflake IDs can exceed 64-bit signed range and bare numbers may be misparsed.
+- DM channels have no guild and always use the global settings.
+- A guild-scoped `allowed_channels` acts as that server's fail-closed whitelist, just like the global one. If a guild has no `allowed_channels` entry, the global allowlist (or `DISCORD_ALLOWED_CHANNELS`) still applies to it.
+- Per-guild config is read from `config.yaml` only; there is no per-guild environment variable form.
+
 #### `discord.channel_prompts`
 
 **Type:** mapping — **Default:** `{}`


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #23051 #23052
## Summary

The Discord adapter currently applies every channel/mention/threading setting globally — one `discord.require_mention`, one `allowed_channels` list — across every server the bot is in. This PR adds per-guild (per-server) configuration overrides keyed by guild ID, so a single bot can behave differently in each server it is invited to.

```yaml
discord:
  require_mention: true            # global default
  guilds:
    "123456789012345678":          # your home server: relaxed
      require_mention: false
      free_response_channels:
        - 111111111111111111
    "876543210987654321":          # a public server: locked down
      require_mention: true
      allowed_channels:
        - 222222222222222222
      auto_thread: false
```

Fixes #23051
Closes #23052

## What changed and why

- `plugins/platforms/discord/adapter.py` — new `_discord_guild_config()` / `_discord_guild_configs()` accessors plus per-guild resolution in every setting read site: `_discord_require_mention`, `_get_allowed_channels`, `_get_ignored_channels`, `_get_no_thread_channels`, `_discord_free_response_channels`, and a new `_discord_auto_thread`. Guild ID is resolved on the message path, slash-authorization path, recovered-message (backfill) path, and allowed-user path. Priority chain everywhere: **per-guild block → global config → env var → default**, so single-guild deployments see zero behavior change.
- `_apply_yaml_config` seeds `discord.guilds` into `PlatformConfig.extra` with string-normalized guild IDs (YAML parses bare snowflake numbers as int; Discord IDs can exceed 64-bit signed range). Per-guild policy deliberately lives in per-profile `extra`, never process-global env — multiplex isolation preserved.
- The missed-message backfill sweep now scans guild-scoped allow/free lists too, so a guild with per-guild channel policy isn't invisible to recovery after reconnect.
- The no-allowlist security warning now recognizes a per-guild allowlist as "configured", preserving the fail-closed warning semantics.

## How to test

1. Configure `discord.guilds` with two guild blocks (one relaxed, one locked down) as in the YAML above.
2. Send a message in each server: the relaxed server should respond without mention; the locked-down server should require mention and gate on its own `allowed_channels`.
3. Run the suite: `scripts/run_tests.sh tests/gateway/test_discord_per_guild_config.py` (38 new tests) — covers per-guild isolation, priority chain, all six settings, wildcard handling, DM fallback, and backfill scanning.
4. Full Discord suite: `scripts/run_tests.sh tests/gateway/test_discord_*.py` — 258 passed; the 8 document/attachment failures reproduce byte-identical on clean main (pre-existing Windows env flakes).

## Why this matters to users

**Before:** a multi-guild Discord bot had one global policy — if `require_mention` was on for your private server, it was on in every server, and channel allowlists applied everywhere at once. Running the same bot across servers meant either locking everything down to the strictest common denominator or not using channel gating at all.

**After:** you configure each server independently. Keep your home server free-form (no mention required, open channels), lock a public server to mention-only with a strict channel allowlist, and disable auto-threading where it's noise — all in one `config.yaml`, no env vars, no code changes. Servers you don't list keep today's exact behavior.

## What platforms tested on

- Windows 10 native (git-bash), Python 3.12.12, discord.py 2.7.1
- 38/38 new per-guild tests pass; 258 passed across the full `test_discord_*.py` glob (8 pre-existing env-flake failures reproduce identically on clean main)
- `git diff --check` clean; rebased onto current main (2ba064bc5)
