### PR TITLE
fix(desktop): eliminate sidebar scroll jitter during dynamic sizing

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.test.tsx
@@ -1,0 +1,113 @@
+import type * as ReactVirtual from '@tanstack/react-virtual'
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SessionInfo } from '@/hermes'
+import type { SidebarListRow } from '@/lib/session-date-groups'
+
+import { VirtualSessionList } from './virtual-session-list'
+
+type EstimateSize = (index: number) => number
+
+let lastEstimateSize: EstimateSize | undefined
+let lastGap: number | undefined
+
+vi.mock('@tanstack/react-virtual', async importOriginal => {
+  const actual = await importOriginal<typeof ReactVirtual>()
+
+  return {
+    ...actual,
+    useVirtualizer: (opts: Parameters<typeof actual.useVirtualizer>[0]) => {
+      lastEstimateSize = opts.estimateSize as EstimateSize
+      lastGap = opts.gap
+
+      return actual.useVirtualizer(opts)
+    }
+  }
+})
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      sidebar: {
+        dateDivider: {
+          today: 'Today',
+          yesterday: 'Yesterday'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('./chrome', () => ({
+  SidebarDateDivider: () => <div data-testid="date-divider" />
+}))
+
+vi.mock('./session-row', () => ({
+  SidebarSessionRow: () => <div data-testid="session-row" />
+}))
+
+function makeSession(id: string): SessionInfo {
+  return {
+    archived: false,
+    cwd: '/tmp',
+    ended_at: null,
+    id,
+    input_tokens: 0,
+    is_active: false,
+    last_active: 1_000,
+    message_count: 1,
+    model: 'claude',
+    output_tokens: 0,
+    preview: 'preview',
+    source: 'cli',
+    started_at: 1_000,
+    title: id,
+    tool_call_count: 0
+  }
+}
+
+const dividerRow: SidebarListRow = { key: 'today', kind: 'divider', label: 'Today' }
+const sessionRow: SidebarListRow = { entry: { session: makeSession('sess-1') }, kind: 'session' }
+
+function renderList(card = false) {
+  return render(
+    <VirtualSessionList
+      activeSessionId={null}
+      card={card}
+      onArchiveSession={() => undefined}
+      onDeleteSession={() => undefined}
+      onResumeSession={() => undefined}
+      onTogglePin={() => undefined}
+      pinned={false}
+      rows={[dividerRow, sessionRow]}
+      sortable={false}
+    />
+  )
+}
+
+describe('VirtualSessionList size contract', () => {
+  beforeEach(() => {
+    lastEstimateSize = undefined
+    lastGap = undefined
+  })
+
+  afterEach(cleanup)
+
+  it('estimates divider / compact / card rows separately so a merge cannot drop one axis', () => {
+    renderList(false)
+    expect(lastEstimateSize?.(0)).toBe(26)
+    expect(lastEstimateSize?.(1)).toBe(28)
+
+    cleanup()
+    renderList(true)
+    expect(lastEstimateSize?.(0)).toBe(26)
+    expect(lastEstimateSize?.(1)).toBe(66)
+  })
+
+  it('disables native overflow anchoring and matches gap-px in the virtualizer', () => {
+    const { container } = renderList(false)
+    expect(container.firstElementChild?.className).toContain('[overflow-anchor:none]')
+    expect(lastGap).toBe(1)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -47,6 +47,8 @@ export interface VirtualSessionListProps {
 }
 
 const ROW_ESTIMATE_PX = 28
+// Date dividers are shorter than session rows (label + tight padding).
+const DIVIDER_ROW_ESTIMATE_PX = 26
 // Matches the card's typical rendered height (four lines when a preview
 // exists) so long card lists don't jump under the scroll thumb before
 // self-measurement catches up.
@@ -74,7 +76,12 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
 
   const virtualizer = useVirtualizer({
     count: listRows.length,
-    estimateSize: () => (card ? CARD_ROW_ESTIMATE_PX : ROW_ESTIMATE_PX),
+    estimateSize: index =>
+      listRows[index]?.kind === 'divider'
+        ? DIVIDER_ROW_ESTIMATE_PX
+        : card
+          ? CARD_ROW_ESTIMATE_PX
+          : ROW_ESTIMATE_PX,
     getItemKey: index => {
       const row = listRows[index]
 
@@ -83,6 +90,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     getScrollElement: () => scrollerRef.current,
     // jsdom-friendly default; the real rect takes over on first observe.
     initialRect: { height: 600, width: 240 },
+    gap: 1,
     overscan: OVERSCAN_ROWS
   })
 
@@ -159,7 +167,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
       // hover — and the wrapper no longer stacks a second scroller, so the
       // double-gutter this class change was reaching for is already gone.
       className={cn(
-        'scrollbar-fade relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain',
+        'scrollbar-fade relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain [overflow-anchor:none]',
         className
       )}
       ref={scrollerRef}

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -65,7 +65,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
 
   const virtualizer = useVirtualizer({
     count: listRows.length,
-    estimateSize: () => ROW_ESTIMATE_PX,
+    estimateSize: index => (listRows[index]?.kind === 'divider' ? 26 : ROW_ESTIMATE_PX),
     getItemKey: index => {
       const row = listRows[index]
 
@@ -74,6 +74,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     getScrollElement: () => scrollerRef.current,
     // jsdom-friendly default; the real rect takes over on first observe.
     initialRect: { height: 600, width: 240 },
+    gap: 1,
     overscan: OVERSCAN_ROWS
   })
 
@@ -142,7 +143,10 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   // just consume that context via useSortable.
   return (
     <div
-      className={cn('relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain', className)}
+      className={cn(
+        'relative min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain [overflow-anchor:none]',
+        className
+      )}
       ref={scrollerRef}
     >
       <div className="grid gap-px" style={{ paddingBottom: `${paddingBottom}px`, paddingTop: `${paddingTop}px` }}>


### PR DESCRIPTION
## What does this PR do?

Stops the Desktop sessions sidebar from jumping/flickering while you scroll a long virtualized list. Native scroll anchoring was fighting the virtualizer’s padding updates, and date-divider rows were estimated at the session-row height.

Rebased onto current `main` so inbox-style card rows keep the 66px estimate. A naive replay of the original `estimateSize` line would have sized every non-divider row at 28px, including cards.

Not in this PR: mouse-wheel dead-zones once the list is long (~25+ sessions), where the wheel stops mid-list but dragging the scrollbar still works. Tracked as #84964.

## Related Issue

Fixes #77505

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx`: disable native scroll anchoring on the virtual list container.
- Same file: `estimateSize` is divider 26px / compact session 28px / card session 66px.
- Same file: set the virtualizer `gap` to 1px to match the existing `gap-px` row layout.
- `apps/desktop/src/app/chat/sidebar/virtual-session-list.test.tsx`: contract test so a future merge cannot drop the card or divider branch.

## How to Test

1. Open Hermes Desktop with enough sessions for the sidebar to virtualize (25+), including several date dividers.
2. Scroll up and down past the dividers with the wheel and with arrow keys.
3. The list should no longer jump or flicker as rows are measured.
4. With inbox-style session cards enabled, card rows should still estimate at card height (no compact-row snap).
5. Unit: from `apps/desktop`, `npx vitest run --project ui src/app/chat/sidebar/virtual-session-list.test.tsx` — 2 passed.

This PR does **not** claim that mid-list wheel stalls are gone. If the wheel stops while scrollbar drag still works, that is #84964.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (Desktop UI only; Python suite not in this diff)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, vitest UI project

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
