### PR TITLE
fix(tools): stop one SSH session cleanup from killing other live sessions to the same host

### DIFF
--- a/tests/tools/test_sync_back_backends.py
+++ b/tests/tools/test_sync_back_backends.py
@@ -231,13 +231,11 @@ class TestSSHCleanup:
 
         first = SSHEnvironment(host="h", user="u")
         second = SSHEnvironment(host="h", user="u")
-        assert first.control_socket == second.control_socket
+        shared_socket = first.control_socket
+        assert shared_socket == second.control_socket
 
-        import tempfile
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".sock") as tmp:
-            shared_socket = Path(tmp.name)
-        first.control_socket = shared_socket
-        second.control_socket = shared_socket
+        shared_socket.parent.mkdir(parents=True, exist_ok=True)
+        shared_socket.touch()
 
         exit_calls = []
 
@@ -269,9 +267,8 @@ class TestSSHCleanup:
 
         env = SSHEnvironment(host="h", user="u")
 
-        import tempfile
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".sock") as tmp:
-            env.control_socket = Path(tmp.name)
+        env.control_socket.parent.mkdir(parents=True, exist_ok=True)
+        env.control_socket.touch()
 
         exit_calls = []
 

--- a/tests/tools/test_sync_back_backends.py
+++ b/tests/tools/test_sync_back_backends.py
@@ -16,6 +16,13 @@ from tools.environments.ssh import SSHEnvironment
 # ── SSH helpers ──────────────────────────────────────────────────────
 
 
+@pytest.fixture(autouse=True)
+def _reset_ssh_control_socket_refcounts():
+    ssh_env._control_socket_refcounts.clear()
+    yield
+    ssh_env._control_socket_refcounts.clear()
+
+
 @pytest.fixture
 def ssh_mock_env(monkeypatch):
     """Create an SSHEnvironment with mocked connection/sync."""
@@ -204,6 +211,81 @@ class TestSSHCleanup:
             env.cleanup()
 
         assert call_order.index("sync_back") < call_order.index("control_exit")
+
+    def test_ssh_shared_control_socket_skips_mux_teardown_until_last_holder(
+        self, monkeypatch,
+    ):
+        """cleanup() of one SSHEnvironment must not exit a mux still held by another."""
+        monkeypatch.setattr(ssh_env.shutil, "which", lambda _name: "/usr/bin/ssh")
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_establish_connection", lambda self: None)
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_detect_remote_home", lambda self: "/home/u")
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_ensure_remote_dirs", lambda self: None)
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "init_session", lambda self: None)
+        monkeypatch.setattr(
+            ssh_env, "FileSyncManager",
+            lambda **kw: type("M", (), {
+                "sync": lambda self, **k: None,
+                "sync_back": lambda self: None,
+            })(),
+        )
+
+        first = SSHEnvironment(host="h", user="u")
+        second = SSHEnvironment(host="h", user="u")
+        assert first.control_socket == second.control_socket
+
+        import tempfile
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".sock") as tmp:
+            shared_socket = Path(tmp.name)
+        first.control_socket = shared_socket
+        second.control_socket = shared_socket
+
+        exit_calls = []
+
+        def mock_run(cmd, **kwargs):
+            cmd_str = " ".join(cmd)
+            if "-O" in cmd and "exit" in cmd_str:
+                exit_calls.append(cmd_str)
+            return subprocess.CompletedProcess([], 0)
+
+        with patch.object(subprocess, "run", side_effect=mock_run):
+            first.cleanup()
+            assert exit_calls == []
+            second.cleanup()
+            assert len(exit_calls) == 1
+
+    def test_ssh_cleanup_is_idempotent_for_control_socket(self, monkeypatch):
+        monkeypatch.setattr(ssh_env.shutil, "which", lambda _name: "/usr/bin/ssh")
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_establish_connection", lambda self: None)
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_detect_remote_home", lambda self: "/home/u")
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_ensure_remote_dirs", lambda self: None)
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "init_session", lambda self: None)
+        monkeypatch.setattr(
+            ssh_env, "FileSyncManager",
+            lambda **kw: type("M", (), {
+                "sync": lambda self, **k: None,
+                "sync_back": lambda self: None,
+            })(),
+        )
+
+        env = SSHEnvironment(host="h", user="u")
+
+        import tempfile
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".sock") as tmp:
+            env.control_socket = Path(tmp.name)
+
+        exit_calls = []
+
+        def mock_run(cmd, **kwargs):
+            cmd_str = " ".join(cmd)
+            if "-O" in cmd and "exit" in cmd_str:
+                exit_calls.append(cmd_str)
+            return subprocess.CompletedProcess([], 0)
+
+        with patch.object(subprocess, "run", side_effect=mock_run):
+            env.cleanup()
+            env.cleanup()
+
+        assert len(exit_calls) == 1
 
 
 # =====================================================================

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -7,6 +7,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+import threading
 from pathlib import Path
 
 from tools.environments.base import BaseEnvironment, _popen_bash
@@ -19,6 +20,36 @@ from tools.environments.file_sync import (
 )
 
 logger = logging.getLogger(__name__)
+
+_control_socket_refcounts: dict[Path, int] = {}
+_control_socket_lock = threading.Lock()
+
+
+def _control_socket_path(user: str, host: str, port: int) -> Path:
+    """Return the deterministic ControlMaster socket path for *user@host:port*."""
+    control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
+    _socket_id = hashlib.sha256(
+        f"{user}@{host}:{port}".encode()
+    ).hexdigest()[:16]
+    return control_dir / f"{_socket_id}.sock"
+
+
+def _acquire_control_socket(control_socket: Path) -> None:
+    with _control_socket_lock:
+        _control_socket_refcounts[control_socket] = (
+            _control_socket_refcounts.get(control_socket, 0) + 1
+        )
+
+
+def _release_control_socket(control_socket: Path) -> bool:
+    """Drop one holder. Return True when the mux should be torn down."""
+    with _control_socket_lock:
+        count = _control_socket_refcounts.get(control_socket, 0)
+        if count <= 1:
+            _control_socket_refcounts.pop(control_socket, None)
+            return True
+        _control_socket_refcounts[control_socket] = count - 1
+        return False
 
 
 def _ensure_ssh_available() -> None:
@@ -60,10 +91,8 @@ class SSHEnvironment(BaseEnvironment):
         # deeply-nested $TMPDIR (e.g. /var/folders/xx/yy/T/). Hashing the
         # triple keeps the path stable across reconnects so ControlMaster
         # reuse still works.
-        _socket_id = hashlib.sha256(
-            f"{user}@{host}:{port}".encode()
-        ).hexdigest()[:16]
-        self.control_socket = self.control_dir / f"{_socket_id}.sock"
+        self.control_socket = _control_socket_path(user, host, port)
+        self._control_socket_released = False
         _ensure_ssh_available()
         self._establish_connection()
         self._remote_home = self._detect_remote_home()
@@ -79,6 +108,7 @@ class SSHEnvironment(BaseEnvironment):
         self._sync_manager.sync(force=True)
 
         self.init_session()
+        _acquire_control_socket(self.control_socket)
 
     def _build_ssh_command(self, extra_args: list | None = None) -> list:
         cmd = ["ssh"]
@@ -356,6 +386,13 @@ class SSHEnvironment(BaseEnvironment):
         if self._sync_manager:
             logger.info("SSH: syncing files from sandbox...")
             self._sync_manager.sync_back()
+
+        if self._control_socket_released:
+            return
+        self._control_socket_released = True
+
+        if not _release_control_socket(self.control_socket):
+            return
 
         if self.control_socket.exists():
             try:


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where cleaning up one SSH terminal environment could kill the shared OpenSSH ControlMaster connection still used by another live environment targeting the same remote host.

Multiple `SSHEnvironment` instances for the same `user@host:port` intentionally share one deterministic ControlMaster socket path (for connection reuse and macOS sun_path limits). Previously, `cleanup()` always ran `ssh -O exit` and unlinked that socket, so idle reaper cleanup or teardown of one isolated task could drop in-flight SSH commands in a sibling task.

This change adds a process-local refcount on the control socket path. `cleanup()` tears down the mux only when the last holder releases it. Each instance remains idempotent via `_control_socket_released`.

**Bug Cause:** ControlMaster socket path is keyed only by `user@host:port`, but `cleanup()` had no shared ownership tracking.

**Reproduction Steps:**
1. Configure `TERMINAL_ENV=ssh` with a reachable remote host.
2. Create two isolated task environments to the same host (for example parallel RL rollouts with per-task env overrides registered via `register_task_env_overrides`, so each task gets its own `SSHEnvironment` instead of collapsing to `"default"`).
3. Start a long-running remote command in task B.
4. Call `cleanup()` on task A (manually via `cleanup_vm`, or wait for the idle reaper on an inactive task A).

**Fix:** Acquire a refcount when an `SSHEnvironment` finishes initialization; decrement on `cleanup()` and run `ssh -O exit` plus socket unlink only when the refcount reaches zero.

## Related Issue

Fixes #77506

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/ssh.py`: extract `_control_socket_path`, add thread-safe refcount helpers, gate mux teardown on last release, guard repeated `cleanup()` on the same instance.
- `tests/tools/test_sync_back_backends.py`: add shared-mux and idempotent cleanup tests; autouse fixture resets module-level refcounts between tests.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_sync_back_backends.py::TestSSHCleanup -q`
2. Run `scripts/run_tests.sh tests/tools/test_ssh_environment.py -q`
3. Optional manual check on an SSH backend: create two isolated task envs to the same host, run a long command in one, cleanup the other, confirm the live task keeps working until its own env is cleaned up.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

N/A
