### PR TITLE
fix(gateway): scope pairing allowlist writes to profile

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -146,7 +146,7 @@ def _user_ids_match(platform: str, left: str, right: str) -> bool:
     return bool(left_aliases and right_aliases and (left_aliases & right_aliases))
 
 
-def _read_allowlist_env(env_var: str) -> str:
+def _read_allowlist_env(env_var: str, *, home: Optional[Path] = None) -> str:
     """Read a platform allowlist env var through the profile secret scope.
 
     Under multiplexing the process env may hold ANOTHER profile's allowlist
@@ -155,11 +155,18 @@ def _read_allowlist_env(env_var: str) -> str:
     borrowing the process value.  Unscoped callers (single-profile CLI /
     admin endpoints) keep the legacy ``os.getenv`` read.
 
-    TODO(profile-secrets): the grant mirror below still WRITES through
-    ``hermes_cli.config.save_env_value`` / ``remove_env_value``, which target
-    the root ``.env`` — those writes need a profile-aware counterpart before
-    pairing grants can be mirrored correctly under multiplexing.
+    When ``home`` is explicit, read that profile's file directly. A named
+    ``PairingStore`` can be called from an unscoped dashboard/admin path, so
+    neither the current task's secret scope nor ``os.environ`` identifies the
+    target profile reliably.
     """
+    if home is not None:
+        try:
+            from agent.secret_scope import load_env_file
+
+            return (load_env_file(Path(home) / ".env").get(env_var) or "").strip()
+        except Exception:
+            return ""
     try:
         from agent.secret_scope import UnscopedSecretError, get_secret
 
@@ -172,7 +179,9 @@ def _read_allowlist_env(env_var: str) -> str:
     return (os.getenv(env_var) or "").strip()
 
 
-def _sync_allowlist_add(platform: str, user_id: str) -> None:
+def _sync_allowlist_add(
+    platform: str, user_id: str, *, home: Optional[Path] = None
+) -> None:
     """Add ``user_id`` to the platform allowlist env var IF one is configured.
 
     Option (i): only materialize the grant into the allowlist when the operator
@@ -184,7 +193,7 @@ def _sync_allowlist_add(platform: str, user_id: str) -> None:
     env_var = _allowlist_env_for_platform(platform)
     if not env_var:
         return
-    current = _read_allowlist_env(env_var)
+    current = _read_allowlist_env(env_var, home=home)
     if not current:
         return  # No allowlist configured — leave the gateway open (option i).
     ids = _split_allowlist(current)
@@ -194,15 +203,18 @@ def _sync_allowlist_add(platform: str, user_id: str) -> None:
     try:
         from hermes_cli.config import save_env_value
 
-        save_env_value(env_var, ",".join(ids))
+        if home is None:
+            save_env_value(env_var, ",".join(ids))
+        else:
+            save_env_value(env_var, ",".join(ids), home=home)
     except Exception:
         # Best-effort: the pairing store grant still authorizes via the union,
         # so a failure here degrades to "grant recorded but not mirrored".
         pass
 
 
-def _iter_live_gateway_adapters():
-    """Yield adapters from the in-process GatewayRunner, if one is running."""
+def _iter_live_gateway_adapters(profile: Optional[str] = None):
+    """Yield live adapters, optionally restricted to one multiplex profile."""
     try:
         from gateway.run import _gateway_runner_ref
 
@@ -212,10 +224,30 @@ def _iter_live_gateway_adapters():
     if runner is None:
         return
     adapters = getattr(runner, "adapters", None) or {}
+    profile_adapters = getattr(runner, "_profile_adapters", None) or {}
+
+    if profile:
+        mapping = profile_adapters.get(profile)
+        if mapping is not None:
+            for adapter in mapping.values():
+                if adapter is not None:
+                    yield adapter
+            return
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            active = get_active_profile_name() or "default"
+        except Exception:
+            active = ""
+        if profile == active:
+            for adapter in adapters.values():
+                if adapter is not None:
+                    yield adapter
+        return
+
     for adapter in adapters.values():
         if adapter is not None:
             yield adapter
-    profile_adapters = getattr(runner, "_profile_adapters", None) or {}
     for mapping in profile_adapters.values():
         for adapter in (mapping or {}).values():
             if adapter is not None:
@@ -258,7 +290,9 @@ def _purge_allowlist_entries(entries, platform: str, user_id: str):
     return entries
 
 
-def _sync_live_adapter_allowlist_remove(platform: str, user_id: str) -> None:
+def _sync_live_adapter_allowlist_remove(
+    platform: str, user_id: str, *, profile: Optional[str] = None
+) -> None:
     """Clear revoked principals from in-process adapter allowlist snapshots.
 
     ``WhatsAppAdapter`` (and Cloud) snapshot ``_allow_from`` at construction.
@@ -269,7 +303,7 @@ def _sync_live_adapter_allowlist_remove(platform: str, user_id: str) -> None:
     platform_name = (platform or "").strip().lower()
     if not platform_name or not str(user_id or "").strip():
         return
-    for adapter in _iter_live_gateway_adapters():
+    for adapter in _iter_live_gateway_adapters(profile):
         if _adapter_platform_name(adapter) != platform_name:
             continue
         if hasattr(adapter, "_allow_from"):
@@ -289,7 +323,13 @@ def _sync_live_adapter_allowlist_remove(platform: str, user_id: str) -> None:
                 pass
 
 
-def _sync_allowlist_remove(platform: str, user_id: str) -> None:
+def _sync_allowlist_remove(
+    platform: str,
+    user_id: str,
+    *,
+    home: Optional[Path] = None,
+    profile: Optional[str] = None,
+) -> None:
     """Remove ``user_id`` (and WhatsApp alias equivalents) from the allowlist.
 
     Matching must mirror PairingStore / authz WhatsApp alias rules: approve
@@ -304,7 +344,7 @@ def _sync_allowlist_remove(platform: str, user_id: str) -> None:
     env_var = _allowlist_env_for_platform(platform)
     if not env_var:
         return
-    current = _read_allowlist_env(env_var)
+    current = _read_allowlist_env(env_var, home=home)
     if not current:
         return  # No allowlist configured — do not touch config-only snapshots.
     ids = _split_allowlist(current)
@@ -319,12 +359,17 @@ def _sync_allowlist_remove(platform: str, user_id: str) -> None:
         from hermes_cli.config import save_env_value, remove_env_value
 
         if remaining:
-            save_env_value(env_var, ",".join(remaining))
-        else:
+            if home is None:
+                save_env_value(env_var, ",".join(remaining))
+            else:
+                save_env_value(env_var, ",".join(remaining), home=home)
+        elif home is None:
             remove_env_value(env_var)
+        else:
+            remove_env_value(env_var, home=home)
     except Exception:
         pass
-    _sync_live_adapter_allowlist_remove(platform, user_id)
+    _sync_live_adapter_allowlist_remove(platform, user_id, profile=profile)
 
 
 def _load_json_file(path: Path) -> dict:
@@ -433,8 +478,12 @@ class PairingStore:
                 "pairing",
                 home=profile_home,
             )
+            # Every explicit profile store uses file-scoped env I/O. Only
+            # PairingStore() keeps the legacy process-env synchronization.
+            self._env_home = profile_home
         else:
             self._dir = PAIRING_DIR
+            self._env_home = None
         self._dir.mkdir(parents=True, exist_ok=True)
         if profile:
             # Explicit stores must resolve exactly as a standalone
@@ -552,7 +601,9 @@ class PairingStore:
         # Mirror the grant into the operator's allowlist when one is configured
         # (option i), so the pairing store and the allowlist stay a single
         # visible source of truth. No-op on open gateways.
-        _sync_allowlist_add(platform, normalized_user_id)
+        _sync_allowlist_add(
+            platform, normalized_user_id, home=self._env_home
+        )
 
     def revoke(self, platform: str, user_id: str) -> bool:
         """Remove a user from the approved list. Returns True if found."""
@@ -571,7 +622,12 @@ class PairingStore:
                 # Keep the allowlist mirror in sync: revoking a paired user
                 # also removes the entry the approval added (option i). No-op if
                 # the user was added to the allowlist by other means.
-                _sync_allowlist_remove(platform, user_id)
+                _sync_allowlist_remove(
+                    platform,
+                    user_id,
+                    home=self._env_home,
+                    profile=self._profile,
+                )
                 return True
         return False
 

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -176,7 +176,7 @@ def _user_ids_match(platform: str, left: str, right: str) -> bool:
     return bool(left_aliases and right_aliases and (left_aliases & right_aliases))
 
 
-def _read_allowlist_env(env_var: str) -> str:
+def _read_allowlist_env(env_var: str, *, home: Optional[Path] = None) -> str:
     """Read a platform allowlist env var through the profile secret scope.
 
     Under multiplexing the process env may hold ANOTHER profile's allowlist
@@ -185,11 +185,18 @@ def _read_allowlist_env(env_var: str) -> str:
     borrowing the process value.  Unscoped callers (single-profile CLI /
     admin endpoints) keep the legacy ``os.getenv`` read.
 
-    TODO(profile-secrets): the grant mirror below still WRITES through
-    ``hermes_cli.config.save_env_value`` / ``remove_env_value``, which target
-    the root ``.env`` — those writes need a profile-aware counterpart before
-    pairing grants can be mirrored correctly under multiplexing.
+    When ``home`` is explicit, read that profile's file directly. A named
+    ``PairingStore`` can be called from an unscoped dashboard/admin path, so
+    neither the current task's secret scope nor ``os.environ`` identifies the
+    target profile reliably.
     """
+    if home is not None:
+        try:
+            from agent.secret_scope import load_env_file
+
+            return (load_env_file(Path(home) / ".env").get(env_var) or "").strip()
+        except Exception:
+            return ""
     try:
         from agent.secret_scope import UnscopedSecretError, get_secret
 
@@ -202,7 +209,9 @@ def _read_allowlist_env(env_var: str) -> str:
     return (os.getenv(env_var) or "").strip()
 
 
-def _sync_allowlist_add(platform: str, user_id: str) -> None:
+def _sync_allowlist_add(
+    platform: str, user_id: str, *, home: Optional[Path] = None
+) -> None:
     """Add ``user_id`` to the platform allowlist env var IF one is configured.
 
     Option (i): only materialize the grant into the allowlist when the operator
@@ -214,7 +223,7 @@ def _sync_allowlist_add(platform: str, user_id: str) -> None:
     env_var = _allowlist_env_for_platform(platform)
     if not env_var:
         return
-    current = _read_allowlist_env(env_var)
+    current = _read_allowlist_env(env_var, home=home)
     if not current:
         return  # No allowlist configured — leave the gateway open (option i).
     ids = _split_allowlist(current)
@@ -224,15 +233,18 @@ def _sync_allowlist_add(platform: str, user_id: str) -> None:
     try:
         from hermes_cli.config import save_env_value
 
-        save_env_value(env_var, ",".join(ids))
+        if home is None:
+            save_env_value(env_var, ",".join(ids))
+        else:
+            save_env_value(env_var, ",".join(ids), home=home)
     except Exception:
         # Best-effort: the pairing store grant still authorizes via the union,
         # so a failure here degrades to "grant recorded but not mirrored".
         pass
 
 
-def _iter_live_gateway_adapters():
-    """Yield adapters from the in-process GatewayRunner, if one is running."""
+def _iter_live_gateway_adapters(profile: Optional[str] = None):
+    """Yield live adapters, optionally restricted to one multiplex profile."""
     try:
         from gateway.run import _gateway_runner_ref
 
@@ -242,10 +254,30 @@ def _iter_live_gateway_adapters():
     if runner is None:
         return
     adapters = getattr(runner, "adapters", None) or {}
+    profile_adapters = getattr(runner, "_profile_adapters", None) or {}
+
+    if profile:
+        mapping = profile_adapters.get(profile)
+        if mapping is not None:
+            for adapter in mapping.values():
+                if adapter is not None:
+                    yield adapter
+            return
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            active = get_active_profile_name() or "default"
+        except Exception:
+            active = ""
+        if profile == active:
+            for adapter in adapters.values():
+                if adapter is not None:
+                    yield adapter
+        return
+
     for adapter in adapters.values():
         if adapter is not None:
             yield adapter
-    profile_adapters = getattr(runner, "_profile_adapters", None) or {}
     for mapping in profile_adapters.values():
         for adapter in (mapping or {}).values():
             if adapter is not None:
@@ -288,7 +320,9 @@ def _purge_allowlist_entries(entries, platform: str, user_id: str):
     return entries
 
 
-def _sync_live_adapter_allowlist_remove(platform: str, user_id: str) -> None:
+def _sync_live_adapter_allowlist_remove(
+    platform: str, user_id: str, *, profile: Optional[str] = None
+) -> None:
     """Clear revoked principals from in-process adapter allowlist snapshots.
 
     ``WhatsAppAdapter`` (and Cloud) snapshot ``_allow_from`` at construction.
@@ -299,7 +333,7 @@ def _sync_live_adapter_allowlist_remove(platform: str, user_id: str) -> None:
     platform_name = (platform or "").strip().lower()
     if not platform_name or not str(user_id or "").strip():
         return
-    for adapter in _iter_live_gateway_adapters():
+    for adapter in _iter_live_gateway_adapters(profile):
         if _adapter_platform_name(adapter) != platform_name:
             continue
         if hasattr(adapter, "_allow_from"):
@@ -319,7 +353,13 @@ def _sync_live_adapter_allowlist_remove(platform: str, user_id: str) -> None:
                 pass
 
 
-def _sync_allowlist_remove(platform: str, user_id: str) -> None:
+def _sync_allowlist_remove(
+    platform: str,
+    user_id: str,
+    *,
+    home: Optional[Path] = None,
+    profile: Optional[str] = None,
+) -> None:
     """Remove ``user_id`` (and WhatsApp alias equivalents) from the allowlist.
 
     Matching must mirror PairingStore / authz WhatsApp alias rules: approve
@@ -334,7 +374,7 @@ def _sync_allowlist_remove(platform: str, user_id: str) -> None:
     env_var = _allowlist_env_for_platform(platform)
     if not env_var:
         return
-    current = _read_allowlist_env(env_var)
+    current = _read_allowlist_env(env_var, home=home)
     if not current:
         return  # No allowlist configured — do not touch config-only snapshots.
     ids = _split_allowlist(current)
@@ -349,12 +389,17 @@ def _sync_allowlist_remove(platform: str, user_id: str) -> None:
         from hermes_cli.config import save_env_value, remove_env_value
 
         if remaining:
-            save_env_value(env_var, ",".join(remaining))
-        else:
+            if home is None:
+                save_env_value(env_var, ",".join(remaining))
+            else:
+                save_env_value(env_var, ",".join(remaining), home=home)
+        elif home is None:
             remove_env_value(env_var)
+        else:
+            remove_env_value(env_var, home=home)
     except Exception:
         pass
-    _sync_live_adapter_allowlist_remove(platform, user_id)
+    _sync_live_adapter_allowlist_remove(platform, user_id, profile=profile)
 
 
 def _load_json_file(path: Path) -> dict:
@@ -463,8 +508,12 @@ class PairingStore:
                 "pairing",
                 home=profile_home,
             )
+            # Every explicit profile store uses file-scoped env I/O. Only
+            # PairingStore() keeps the legacy process-env synchronization.
+            self._env_home = profile_home
         else:
             self._dir = _default_pairing_dir()
+            self._env_home = None
         self._dir.mkdir(parents=True, exist_ok=True)
         if profile:
             # Explicit stores must resolve exactly as a standalone
@@ -582,7 +631,9 @@ class PairingStore:
         # Mirror the grant into the operator's allowlist when one is configured
         # (option i), so the pairing store and the allowlist stay a single
         # visible source of truth. No-op on open gateways.
-        _sync_allowlist_add(platform, normalized_user_id)
+        _sync_allowlist_add(
+            platform, normalized_user_id, home=self._env_home
+        )
 
     def revoke(self, platform: str, user_id: str) -> bool:
         """Remove a user from the approved list. Returns True if found."""
@@ -601,7 +652,12 @@ class PairingStore:
                 # Keep the allowlist mirror in sync: revoking a paired user
                 # also removes the entry the approval added (option i). No-op if
                 # the user was added to the allowlist by other means.
-                _sync_allowlist_remove(platform, user_id)
+                _sync_allowlist_remove(
+                    platform,
+                    user_id,
+                    home=self._env_home,
+                    profile=self._profile,
+                )
                 return True
         return False
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3862,8 +3862,14 @@ def _env_line_defines_key(line: str, key: str) -> bool:
     return stripped.startswith(f"{key}=")
 
 
-def save_env_value(key: str, value: str):
-    """Save or update a value in ~/.hermes/.env."""
+def save_env_value(key: str, value: str, *, home: Optional[Path] = None):
+    """Save or update a value in a Hermes ``.env`` file.
+
+    With no explicit ``home``, preserve the legacy behavior: write the active
+    Hermes home's ``.env`` and update ``os.environ``. An explicit home is for
+    profile-scoped writers in a multiplexed process; it writes only that
+    home's file and never mutates process-global environment state.
+    """
     if is_managed():
         managed_error(f"set {key}")
         return
@@ -3886,8 +3892,12 @@ def save_env_value(key: str, value: str):
     value = value.replace("\n", "").replace("\r", "")
     # API keys / tokens must be ASCII — strip non-ASCII with a warning.
     value = _check_non_ascii_credential(key, value)
-    ensure_hermes_home()
-    env_path = get_env_path()
+    if home is None:
+        ensure_hermes_home()
+        env_path = get_env_path()
+    else:
+        env_path = Path(home) / ".env"
+        env_path.parent.mkdir(parents=True, exist_ok=True)
 
     # On Windows, open() defaults to the system locale (cp1252) which can
     # cause OSError errno 22 on UTF-8 .env files.
@@ -3952,7 +3962,8 @@ def save_env_value(key: str, value: str):
             pass
         raise
 
-    os.environ[key] = value
+    if home is None:
+        os.environ[key] = value
     invalidate_env_cache()
 
 
@@ -3975,8 +3986,11 @@ def custom_endpoint_key_env(identity: str) -> str:
     return f"HERMES_CUSTOM_{slug}_API_KEY" if slug else "HERMES_CUSTOM_API_KEY"
 
 
-def remove_env_value(key: str) -> bool:
-    """Remove a key from ~/.hermes/.env and os.environ.
+def remove_env_value(key: str, *, home: Optional[Path] = None) -> bool:
+    """Remove a key from a Hermes ``.env`` file.
+
+    With no explicit ``home``, also remove the key from ``os.environ``. An
+    explicit profile home never mutates process-global environment state.
 
     Returns True if the key was found and removed, False otherwise.
     """
@@ -3997,9 +4011,10 @@ def remove_env_value(key: str) -> bool:
         return False
     if not _ENV_VAR_NAME_RE.match(key):
         raise ValueError(f"Invalid environment variable name: {key!r}")
-    env_path = get_env_path()
+    env_path = get_env_path() if home is None else Path(home) / ".env"
     if not env_path.exists():
-        os.environ.pop(key, None)
+        if home is None:
+            os.environ.pop(key, None)
         return False
 
     read_kw = {"encoding": "utf-8-sig", "errors": "replace"}
@@ -4043,7 +4058,8 @@ def remove_env_value(key: str) -> bool:
                 pass
             raise
 
-    os.environ.pop(key, None)
+    if home is None:
+        os.environ.pop(key, None)
     invalidate_env_cache()
     return found
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4224,8 +4224,14 @@ def _env_line_defines_key(line: str, key: str) -> bool:
     return stripped.startswith(f"{key}=")
 
 
-def save_env_value(key: str, value: str):
-    """Save or update a value in ~/.hermes/.env."""
+def save_env_value(key: str, value: str, *, home: Optional[Path] = None):
+    """Save or update a value in a Hermes ``.env`` file.
+
+    With no explicit ``home``, preserve the legacy behavior: write the active
+    Hermes home's ``.env`` and update ``os.environ``. An explicit home is for
+    profile-scoped writers in a multiplexed process; it writes only that
+    home's file and never mutates process-global environment state.
+    """
     if is_managed():
         managed_error(f"set {key}")
         return
@@ -4248,8 +4254,12 @@ def save_env_value(key: str, value: str):
     value = value.replace("\n", "").replace("\r", "")
     # API keys / tokens must be ASCII — strip non-ASCII with a warning.
     value = _check_non_ascii_credential(key, value)
-    ensure_hermes_home()
-    env_path = get_env_path()
+    if home is None:
+        ensure_hermes_home()
+        env_path = get_env_path()
+    else:
+        env_path = Path(home) / ".env"
+        env_path.parent.mkdir(parents=True, exist_ok=True)
 
     # On Windows, open() defaults to the system locale (cp1252) which can
     # cause OSError errno 22 on UTF-8 .env files.
@@ -4314,7 +4324,8 @@ def save_env_value(key: str, value: str):
             pass
         raise
 
-    os.environ[key] = value
+    if home is None:
+        os.environ[key] = value
     invalidate_env_cache()
 
 
@@ -4337,8 +4348,11 @@ def custom_endpoint_key_env(identity: str) -> str:
     return f"HERMES_CUSTOM_{slug}_API_KEY" if slug else "HERMES_CUSTOM_API_KEY"
 
 
-def remove_env_value(key: str) -> bool:
-    """Remove a key from ~/.hermes/.env and os.environ.
+def remove_env_value(key: str, *, home: Optional[Path] = None) -> bool:
+    """Remove a key from a Hermes ``.env`` file.
+
+    With no explicit ``home``, also remove the key from ``os.environ``. An
+    explicit profile home never mutates process-global environment state.
 
     Returns True if the key was found and removed, False otherwise.
     """
@@ -4359,9 +4373,10 @@ def remove_env_value(key: str) -> bool:
         return False
     if not _ENV_VAR_NAME_RE.match(key):
         raise ValueError(f"Invalid environment variable name: {key!r}")
-    env_path = get_env_path()
+    env_path = get_env_path() if home is None else Path(home) / ".env"
     if not env_path.exists():
-        os.environ.pop(key, None)
+        if home is None:
+            os.environ.pop(key, None)
         return False
 
     read_kw = {"encoding": "utf-8-sig", "errors": "replace"}
@@ -4405,7 +4420,8 @@ def remove_env_value(key: str) -> bool:
                 pass
             raise
 
-    os.environ.pop(key, None)
+    if home is None:
+        os.environ.pop(key, None)
     invalidate_env_cache()
     return found
 

--- a/tests/gateway/test_pairing_allowlist_bypass.py
+++ b/tests/gateway/test_pairing_allowlist_bypass.py
@@ -140,6 +140,29 @@ def test_profile_approval_mirrors_only_profile_allowlist(tmp_path, monkeypatch):
     assert os.environ["TELEGRAM_ALLOWED_USERS"] == "root-owner"
 
 
+def test_explicit_default_profile_approval_keeps_process_env_scoped(
+    tmp_path, monkeypatch
+):
+    """An explicit default profile is scoped; only PairingStore() is legacy."""
+    root = tmp_path / ".hermes"
+    root.mkdir()
+    root_env = root / ".env"
+    root_env.write_text("TELEGRAM_ALLOWED_USERS=file-owner\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "process-owner")
+
+    from gateway.pairing import PairingStore
+
+    _approve_new_user(
+        PairingStore(profile="default"), "telegram", "new-default-user"
+    )
+
+    assert root_env.read_text(encoding="utf-8") == (
+        "TELEGRAM_ALLOWED_USERS=file-owner,new-default-user\n"
+    )
+    assert os.environ["TELEGRAM_ALLOWED_USERS"] == "process-owner"
+
+
 def test_profile_revoke_updates_only_profile_allowlist(tmp_path, monkeypatch):
     """A named profile revoke must leave root disk and process env untouched."""
     root = tmp_path / ".hermes"
@@ -151,7 +174,7 @@ def test_profile_revoke_updates_only_profile_allowlist(tmp_path, monkeypatch):
         "TELEGRAM_ALLOWED_USERS=root-owner,revoked-user\n", encoding="utf-8"
     )
     profile_env.write_text(
-        "TELEGRAM_ALLOWED_USERS=profile-owner,revoked-user\n", encoding="utf-8"
+        "TELEGRAM_ALLOWED_USERS=revoked-user\n", encoding="utf-8"
     )
     monkeypatch.setenv("HERMES_HOME", str(root))
     monkeypatch.setenv(
@@ -167,9 +190,7 @@ def test_profile_revoke_updates_only_profile_allowlist(tmp_path, monkeypatch):
     )
 
     assert profile_store.revoke("telegram", "revoked-user") is True
-    assert profile_env.read_text(encoding="utf-8") == (
-        "TELEGRAM_ALLOWED_USERS=profile-owner\n"
-    )
+    assert profile_env.read_text(encoding="utf-8") == ""
     assert root_env.read_text(encoding="utf-8") == (
         "TELEGRAM_ALLOWED_USERS=root-owner,revoked-user\n"
     )
@@ -365,6 +386,61 @@ def test_revoke_whatsapp_sole_entry_denies_live_adapter_without_restart(
             chat_type="dm",
         )
     ) is False
+
+
+def test_profile_revoke_purges_only_that_profile_live_adapter(tmp_path, monkeypatch):
+    """A profile revoke must not deny the same principal in sibling adapters."""
+    from types import SimpleNamespace
+
+    from gateway.config import Platform
+    from gateway.pairing import PairingStore
+    import gateway.run as gateway_run
+
+    root = tmp_path / ".hermes"
+    profile_home = root / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    (profile_home / ".env").write_text(
+        "WHATSAPP_ALLOWED_USERS=15551234567\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    def live_adapter():
+        return SimpleNamespace(
+            platform=Platform.WHATSAPP,
+            _allow_from={"15551234567"},
+            config=SimpleNamespace(extra={"allow_from": ["15551234567"]}),
+        )
+
+    primary = live_adapter()
+    worker = live_adapter()
+    sibling = live_adapter()
+    runner = SimpleNamespace(
+        adapters={Platform.WHATSAPP: primary},
+        _profile_adapters={
+            "worker": {Platform.WHATSAPP: worker},
+            "sibling": {Platform.WHATSAPP: sibling},
+        },
+    )
+    monkeypatch.setattr(gateway_run, "_gateway_runner_ref", lambda: runner)
+
+    profile_store = PairingStore(profile="worker")
+    profile_store._save_json(
+        profile_store._approved_path("whatsapp"),
+        {
+            "15551234567": {
+                "user_name": "",
+                "approved_at": 1.0,
+            }
+        },
+    )
+
+    assert profile_store.revoke("whatsapp", "15551234567") is True
+    assert worker._allow_from == set()
+    assert worker.config.extra["allow_from"] == []
+    assert primary._allow_from == {"15551234567"}
+    assert primary.config.extra["allow_from"] == ["15551234567"]
+    assert sibling._allow_from == {"15551234567"}
+    assert sibling.config.extra["allow_from"] == ["15551234567"]
 
 
 def test_whatsapp_live_allowlist_keeps_explicit_config_over_env(monkeypatch):

--- a/tests/gateway/test_pairing_allowlist_bypass.py
+++ b/tests/gateway/test_pairing_allowlist_bypass.py
@@ -112,6 +112,70 @@ def test_approval_adds_to_configured_allowlist(store, monkeypatch):
     assert captured.get("TELEGRAM_ALLOWED_USERS") == "owner1,newuser99"
 
 
+def test_profile_approval_mirrors_only_profile_allowlist(tmp_path, monkeypatch):
+    """A named profile grant must not read or overwrite the root allowlist."""
+    root = tmp_path / ".hermes"
+    profile_home = root / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    root_env = root / ".env"
+    profile_env = profile_home / ".env"
+    root_env.write_text("TELEGRAM_ALLOWED_USERS=root-owner\n", encoding="utf-8")
+    profile_env.write_text(
+        "TELEGRAM_ALLOWED_USERS=profile-owner\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "root-owner")
+
+    from gateway.pairing import PairingStore
+
+    profile_store = PairingStore(profile="worker")
+    _approve_new_user(profile_store, "telegram", "new-profile-user")
+
+    assert profile_env.read_text(encoding="utf-8") == (
+        "TELEGRAM_ALLOWED_USERS=profile-owner,new-profile-user\n"
+    )
+    assert root_env.read_text(encoding="utf-8") == (
+        "TELEGRAM_ALLOWED_USERS=root-owner\n"
+    )
+    assert os.environ["TELEGRAM_ALLOWED_USERS"] == "root-owner"
+
+
+def test_profile_revoke_updates_only_profile_allowlist(tmp_path, monkeypatch):
+    """A named profile revoke must leave root disk and process env untouched."""
+    root = tmp_path / ".hermes"
+    profile_home = root / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    root_env = root / ".env"
+    profile_env = profile_home / ".env"
+    root_env.write_text(
+        "TELEGRAM_ALLOWED_USERS=root-owner,revoked-user\n", encoding="utf-8"
+    )
+    profile_env.write_text(
+        "TELEGRAM_ALLOWED_USERS=profile-owner,revoked-user\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv(
+        "TELEGRAM_ALLOWED_USERS", "root-owner,revoked-user"
+    )
+
+    from gateway.pairing import PairingStore
+
+    profile_store = PairingStore(profile="worker")
+    profile_store._save_json(
+        profile_store._approved_path("telegram"),
+        {"revoked-user": {"user_name": "", "approved_at": 1.0}},
+    )
+
+    assert profile_store.revoke("telegram", "revoked-user") is True
+    assert profile_env.read_text(encoding="utf-8") == (
+        "TELEGRAM_ALLOWED_USERS=profile-owner\n"
+    )
+    assert root_env.read_text(encoding="utf-8") == (
+        "TELEGRAM_ALLOWED_USERS=root-owner,revoked-user\n"
+    )
+    assert os.environ["TELEGRAM_ALLOWED_USERS"] == "root-owner,revoked-user"
+
+
 def test_revoke_removes_from_allowlist(store, monkeypatch):
     monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "owner1,newuser99")
     saved = {}


### PR DESCRIPTION
## Summary
- route explicit `PairingStore(profile=...)` allowlist reads and writes through that profile home
- keep profile-scoped writes out of process-global `os.environ`, including explicit `profile="default"` operations
- scope live adapter revocation to the selected profile so sibling profiles retain their own grants

## Root cause
The pairing mirror resolved allowlists from the current secret scope/process environment, then called config writers that derived `.env` from the current Hermes home. Dashboard/admin operations construct a named `PairingStore` outside that profile runtime scope, so a secondary-profile approval could read and overwrite the root allowlist.

## RED / GREEN evidence
- RED: named-profile approval read `root-owner` and wrote the root `.env`; named-profile revoke left the profile `.env` unchanged
- RED: profile revoke purged the same WhatsApp principal from primary and sibling live adapter snapshots
- RED: explicit `profile="default"` approval borrowed `process-owner` instead of reading the default profile file
- GREEN: `scripts/run_tests.sh` passed 148 tests across pairing, multiplex pairing/authz/adapter registry, config, and messaging-profile dashboard suites
- GREEN: `ruff check` passed for all changed files

Closes #77490