### PR TITLE
perf(mcp): lazy server startup from fingerprint-keyed schema cache (#56832 extract-salvage)

### DIFF
--- a/tests/tools/test_mcp_lazy_start.py
+++ b/tests/tools/test_mcp_lazy_start.py
@@ -232,11 +232,15 @@ class TestLazyFirstUseConnect:
         mock_run.assert_not_called()
 
     def test_lazy_connect_success_clears_lazy_state(self):
-        mcp._lazy_server_configs["playwright"] = {"command": "npx", "lazy": True}
+        config = {"command": "npx", "lazy": True}
+        mcp._lazy_server_configs["playwright"] = dict(config)
         mcp._lazy_server_fingerprints["playwright"] = "abc"
         mcp._lazy_server_tool_names["playwright"] = ["mcp_playwright_browser_navigate"]
 
-        connected = SimpleNamespace(session=MagicMock())
+        connected = SimpleNamespace(
+            session=MagicMock(),
+            _registered_tool_names=["mcp_playwright_browser_navigate"],
+        )
 
         def _fake_run(coro_or_factory, timeout=30):
             mcp._servers["playwright"] = connected
@@ -251,6 +255,37 @@ class TestLazyFirstUseConnect:
         assert "playwright" not in mcp._lazy_server_configs
         assert "playwright" not in mcp._lazy_server_fingerprints
         assert "playwright" not in mcp._lazy_server_tool_names
+
+    def test_lazy_connect_deregisters_phantom_cached_tools(self):
+        # Stale-cache reconciliation: the cached manifest advertised tool X,
+        # but the live server only registers tool Y → X must be deregistered
+        # after the first-use connect so the model stops seeing a phantom.
+        from tools.registry import registry
+
+        mcp._lazy_server_configs["playwright"] = {"command": "npx", "lazy": True}
+        mcp._lazy_server_fingerprints["playwright"] = "stale-fp"
+        mcp._lazy_server_tool_names["playwright"] = [
+            "mcp_playwright_tool_x",
+            "mcp_playwright_tool_y",
+        ]
+
+        connected = SimpleNamespace(
+            session=MagicMock(),
+            _registered_tool_names=["mcp_playwright_tool_y"],
+        )
+
+        def _fake_run(coro_or_factory, timeout=30):
+            mcp._servers["playwright"] = connected
+            coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+            coro.close()
+            return ["mcp_playwright_tool_y"]
+
+        with patch.object(mcp, "_ensure_mcp_loop"), \
+             patch.object(mcp, "_run_on_mcp_loop", side_effect=_fake_run), \
+             patch.object(registry, "deregister") as mock_dereg:
+            assert mcp._ensure_lazy_server_connected("playwright") is True
+
+        mock_dereg.assert_called_once_with("mcp_playwright_tool_x")
 
     def test_lazy_connect_failure_records_cooldown(self):
         mcp._lazy_server_configs["playwright"] = {"command": "npx", "lazy": True}
@@ -268,6 +303,21 @@ class TestLazyFirstUseConnect:
         mock_record.assert_called_once_with("playwright")
         # Config retained so a later call can retry after cooldown.
         assert "playwright" in mcp._lazy_server_configs
+
+
+class TestCacheLoadDescriptionScan:
+    def test_scan_runs_on_cache_load_path(self):
+        # Defense-in-depth: the cache file is user-writable JSON, so the
+        # cache-load registration path must run the same injection scan as
+        # eager discovery.
+        entry = _fake_cache_entry()
+        config = {"command": "npx", "args": [], "lazy": True}
+        with patch.object(mcp, "_scan_mcp_description", return_value=[]) as mock_scan, \
+             patch.object(mcp, "_convert_mcp_schema", side_effect=RuntimeError("stop")), \
+             pytest.raises(RuntimeError):
+            mcp._register_from_cache_sync("playwright", config, entry)
+
+        mock_scan.assert_called_once_with("playwright", "browser_navigate", "Navigate")
 
 
 class TestResolveServerLazy:

--- a/tests/tools/test_mcp_lazy_start.py
+++ b/tests/tools/test_mcp_lazy_start.py
@@ -1,0 +1,281 @@
+"""Behavior-contract tests for lazy MCP server startup (#56832).
+
+A server configured with ``lazy: true`` whose config fingerprint matches an
+on-disk schema-cache entry registers its tools WITHOUT spawning/connecting;
+the first real call (raw tool OR resource/prompt utility) routes through the
+existing connect path.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import tools.mcp_tool as mcp
+
+
+@pytest.fixture(autouse=True)
+def _reset_mcp_state():
+    old_servers = dict(mcp._servers)
+    old_lazy = dict(mcp._lazy_server_configs)
+    old_fps = dict(mcp._lazy_server_fingerprints)
+    old_names = dict(mcp._lazy_server_tool_names)
+    old_connecting = set(mcp._server_connecting)
+    yield
+    mcp._servers.clear()
+    mcp._servers.update(old_servers)
+    mcp._lazy_server_configs.clear()
+    mcp._lazy_server_configs.update(old_lazy)
+    mcp._lazy_server_fingerprints.clear()
+    mcp._lazy_server_fingerprints.update(old_fps)
+    mcp._lazy_server_tool_names.clear()
+    mcp._lazy_server_tool_names.update(old_names)
+    mcp._server_connecting.clear()
+    mcp._server_connecting.update(old_connecting)
+
+
+def _fake_cache_entry():
+    return {
+        "fingerprint": "abc",
+        "tools": [
+            {
+                "name": "browser_navigate",
+                "description": "Navigate",
+                "inputSchema": {"type": "object", "properties": {}},
+            }
+        ],
+        "utility_tools": [],
+    }
+
+
+def _lazy_config():
+    return {
+        "playwright": {
+            "command": "npx",
+            "args": ["-y", "@playwright/mcp"],
+            "lazy": True,
+        }
+    }
+
+
+class TestLazyMcpRegistration:
+    def test_registers_from_cache_without_connect(self):
+        config = _lazy_config()
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_schema_cache.config_fingerprint", return_value="abc"), \
+             patch("tools.mcp_schema_cache.get_cached_entry", return_value=_fake_cache_entry()), \
+             patch(
+                 "tools.mcp_tool._register_from_cache_sync",
+                 return_value=["mcp_playwright_browser_navigate"],
+             ) as mock_register, \
+             patch("tools.mcp_tool._discover_and_register_server", new_callable=AsyncMock) as mock_discover, \
+             patch("tools.mcp_tool._ensure_mcp_loop") as mock_loop, \
+             patch("tools.mcp_tool._run_on_mcp_loop") as mock_run:
+
+            mcp.register_mcp_servers(config)
+
+        mock_register.assert_called_once()
+        mock_discover.assert_not_called()
+        mock_run.assert_not_called()
+        mock_loop.assert_not_called()
+
+    def test_cache_miss_falls_back_to_eager_connect(self):
+        config = _lazy_config()
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_schema_cache.config_fingerprint", return_value="abc"), \
+             patch("tools.mcp_schema_cache.get_cached_entry", return_value=None), \
+             patch("tools.mcp_tool._ensure_mcp_loop"), \
+             patch("tools.mcp_tool._run_on_mcp_loop") as mock_run:
+
+            mcp.register_mcp_servers(config)
+
+        mock_run.assert_called_once()
+
+    def test_non_lazy_server_never_touches_cache(self):
+        config = {"playwright": {"command": "npx", "args": []}}
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_schema_cache.get_cached_entry") as mock_get, \
+             patch("tools.mcp_tool._ensure_mcp_loop"), \
+             patch("tools.mcp_tool._run_on_mcp_loop") as mock_run:
+
+            mcp.register_mcp_servers(config)
+
+        mock_get.assert_not_called()
+        mock_run.assert_called_once()
+
+    def test_lazy_server_not_reregistered_on_second_pass(self):
+        config = _lazy_config()
+        mcp._lazy_server_configs["playwright"] = dict(config["playwright"])
+        mcp._lazy_server_tool_names["playwright"] = ["mcp_playwright_browser_navigate"]
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_tool._register_from_cache_sync") as mock_register, \
+             patch("tools.mcp_tool._run_on_mcp_loop") as mock_run:
+
+            names = mcp.register_mcp_servers(config)
+
+        mock_register.assert_not_called()
+        mock_run.assert_not_called()
+        assert "mcp_playwright_browser_navigate" in names
+
+
+class TestLazyFirstUseConnect:
+    def _connected_server(self):
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(
+            return_value=SimpleNamespace(isError=False, content=[], structuredContent=None)
+        )
+        connected = SimpleNamespace(
+            session=mock_session,
+            _rpc_lock=MagicMock(),
+            _pending_call_context=None,
+        )
+        connected._rpc_lock.__aenter__ = AsyncMock(return_value=None)
+        connected._rpc_lock.__aexit__ = AsyncMock(return_value=None)
+        return connected
+
+    @staticmethod
+    def _run_on_loop(coro_or_factory, timeout=120):
+        import asyncio
+
+        coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def test_tool_handler_lazy_connects_on_first_call(self):
+        config = {"command": "npx", "args": [], "lazy": True, "timeout": 5}
+        mcp._lazy_server_configs["playwright"] = dict(config)
+        mcp._lazy_server_fingerprints["playwright"] = "abc"
+
+        connected = self._connected_server()
+
+        def _connect(name):
+            mcp._servers["playwright"] = connected
+            return True
+
+        with patch.object(mcp, "_ensure_lazy_server_connected", side_effect=_connect) as mock_connect, \
+             patch.object(mcp, "_run_on_mcp_loop", side_effect=self._run_on_loop):
+            handler = mcp._make_tool_handler("playwright", "browser_navigate", 5)
+            out = handler({}, task_id="t1")
+
+        mock_connect.assert_called_once_with("playwright")
+        payload = json.loads(out)
+        assert "error" not in payload
+        assert payload.get("result") == ""
+
+    def test_list_resources_handler_lazy_connects_on_first_call(self):
+        # Regression for the resource/prompt gap: utility handlers must also
+        # route through the first-use connect path, or the first
+        # list_resources/get_prompt on a lazy server fails.
+        config = {"command": "npx", "args": [], "lazy": True, "timeout": 5}
+        mcp._lazy_server_configs["playwright"] = dict(config)
+
+        connected = self._connected_server()
+        connected.session.list_resources = AsyncMock()
+
+        def _connect(name):
+            mcp._servers["playwright"] = connected
+            return True
+
+        async def _fake_paginate(list_method, items_attr, server_name):
+            return [SimpleNamespace(uri="file:///a", name="a", description="", mimeType="")]
+
+        with patch.object(mcp, "_ensure_lazy_server_connected", side_effect=_connect) as mock_connect, \
+             patch.object(mcp, "_paginate_full_list", side_effect=_fake_paginate), \
+             patch.object(mcp, "_run_on_mcp_loop", side_effect=self._run_on_loop):
+            handler = mcp._make_list_resources_handler("playwright", 5)
+            out = handler({})
+
+        mock_connect.assert_called_once_with("playwright")
+        payload = json.loads(out)
+        assert "error" not in payload
+        assert payload["resources"][0]["uri"] == "file:///a"
+
+    def test_get_prompt_handler_lazy_connects_on_first_call(self):
+        config = {"command": "npx", "args": [], "lazy": True, "timeout": 5}
+        mcp._lazy_server_configs["playwright"] = dict(config)
+
+        connected = self._connected_server()
+        connected.session.get_prompt = AsyncMock(
+            return_value=SimpleNamespace(messages=[])
+        )
+
+        def _connect(name):
+            mcp._servers["playwright"] = connected
+            return True
+
+        with patch.object(mcp, "_ensure_lazy_server_connected", side_effect=_connect) as mock_connect, \
+             patch.object(mcp, "_run_on_mcp_loop", side_effect=self._run_on_loop):
+            handler = mcp._make_get_prompt_handler("playwright", 5)
+            out = handler({"name": "greeting"})
+
+        mock_connect.assert_called_once_with("playwright")
+        payload = json.loads(out)
+        assert "error" not in payload
+
+    def test_check_fn_passes_for_lazy_registered_server(self):
+        mcp._lazy_server_configs["playwright"] = {"lazy": True}
+        mcp._lazy_server_fingerprints["playwright"] = "abc"
+        assert mcp._make_check_fn("playwright")() is True
+
+    def test_check_fn_fails_for_unknown_server(self):
+        assert mcp._make_check_fn("nope")() is False
+
+    def test_lazy_connect_respects_connect_cooldown(self):
+        mcp._lazy_server_configs["playwright"] = {"command": "npx", "lazy": True}
+        with patch.object(mcp, "_connect_cooldown_active", return_value=True), \
+             patch.object(mcp, "_run_on_mcp_loop") as mock_run:
+            assert mcp._ensure_lazy_server_connected("playwright") is False
+        mock_run.assert_not_called()
+
+    def test_lazy_connect_success_clears_lazy_state(self):
+        mcp._lazy_server_configs["playwright"] = {"command": "npx", "lazy": True}
+        mcp._lazy_server_fingerprints["playwright"] = "abc"
+        mcp._lazy_server_tool_names["playwright"] = ["mcp_playwright_browser_navigate"]
+
+        connected = SimpleNamespace(session=MagicMock())
+
+        def _fake_run(coro_or_factory, timeout=30):
+            mcp._servers["playwright"] = connected
+            coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+            coro.close()
+            return ["mcp_playwright_browser_navigate"]
+
+        with patch.object(mcp, "_ensure_mcp_loop"), \
+             patch.object(mcp, "_run_on_mcp_loop", side_effect=_fake_run):
+            assert mcp._ensure_lazy_server_connected("playwright") is True
+
+        assert "playwright" not in mcp._lazy_server_configs
+        assert "playwright" not in mcp._lazy_server_fingerprints
+        assert "playwright" not in mcp._lazy_server_tool_names
+
+    def test_lazy_connect_failure_records_cooldown(self):
+        mcp._lazy_server_configs["playwright"] = {"command": "npx", "lazy": True}
+
+        def _fake_run(coro_or_factory, timeout=30):
+            coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+            coro.close()
+            raise RuntimeError("spawn failed")
+
+        with patch.object(mcp, "_ensure_mcp_loop"), \
+             patch.object(mcp, "_run_on_mcp_loop", side_effect=_fake_run), \
+             patch.object(mcp, "_record_connect_failure") as mock_record:
+            assert mcp._ensure_lazy_server_connected("playwright") is False
+
+        mock_record.assert_called_once_with("playwright")
+        # Config retained so a later call can retry after cooldown.
+        assert "playwright" in mcp._lazy_server_configs
+
+
+class TestResolveServerLazy:
+    def test_default_off(self):
+        assert mcp._resolve_server_lazy("s", {"command": "npx"}) is False
+
+    def test_explicit_true(self):
+        assert mcp._resolve_server_lazy("s", {"command": "npx", "lazy": True}) is True
+
+    def test_explicit_false(self):
+        assert mcp._resolve_server_lazy("s", {"command": "npx", "lazy": False}) is False

--- a/tests/tools/test_mcp_schema_cache.py
+++ b/tests/tools/test_mcp_schema_cache.py
@@ -1,0 +1,74 @@
+"""Unit tests for the on-disk MCP schema cache (tools/mcp_schema_cache.py).
+
+The module landed in #56832's extraction without its tests; these cover the
+fingerprint keying, read/write round-trip, and invalidation behavior.
+"""
+
+import tools.mcp_schema_cache as msc
+
+
+class TestConfigFingerprint:
+    def test_stable_for_same_config(self):
+        cfg = {"command": "npx", "args": ["-y", "@playwright/mcp"]}
+        assert msc.config_fingerprint(cfg) == msc.config_fingerprint(dict(cfg))
+
+    def test_changes_when_connection_config_changes(self):
+        base = {"command": "npx", "args": ["-y", "@playwright/mcp"]}
+        assert msc.config_fingerprint(base) != msc.config_fingerprint(
+            {**base, "args": ["-y", "@playwright/mcp", "--headless"]}
+        )
+        assert msc.config_fingerprint(base) != msc.config_fingerprint(
+            {**base, "command": "uvx"}
+        )
+        assert msc.config_fingerprint(base) != msc.config_fingerprint(
+            {**base, "tools": {"include": ["a"]}}
+        )
+
+    def test_ignores_non_connection_keys(self):
+        base = {"command": "npx", "args": []}
+        assert msc.config_fingerprint(base) == msc.config_fingerprint(
+            {**base, "timeout": 5, "enabled": True, "lazy": True}
+        )
+
+
+class TestCacheRoundTrip:
+    def _isolate(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(msc, "_cache_path", lambda: tmp_path / "cache.json")
+
+    def test_write_then_read_with_matching_fingerprint(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        tools = [{"name": "t1", "description": "d", "inputSchema": {"type": "object"}}]
+        msc.write_cache_entry("srv", "fp1", tools=tools, utility_tools=[])
+        entry = msc.get_cached_entry("srv", "fp1")
+        assert entry is not None
+        assert msc.tools_from_cache_entry(entry) == tools
+        assert msc.utility_tools_from_cache_entry(entry) == []
+        assert msc.has_cached_entry("srv", "fp1")
+
+    def test_fingerprint_mismatch_returns_none(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        msc.write_cache_entry("srv", "fp1", tools=[], utility_tools=[])
+        assert msc.get_cached_entry("srv", "OTHER") is None
+        assert not msc.has_cached_entry("srv", "OTHER")
+
+    def test_missing_server_returns_none(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        assert msc.get_cached_entry("nope", "fp") is None
+
+    def test_clear_cache_entry(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        msc.write_cache_entry("srv", "fp1", tools=[], utility_tools=[])
+        msc.clear_cache_entry("srv")
+        assert msc.get_cached_entry("srv", "fp1") is None
+
+    def test_corrupt_cache_file_is_tolerated(self, monkeypatch, tmp_path):
+        self._isolate(monkeypatch, tmp_path)
+        (tmp_path / "cache.json").write_text("{not json", encoding="utf-8")
+        assert msc.get_cached_entry("srv", "fp") is None
+        # And writes recover the file.
+        msc.write_cache_entry("srv", "fp", tools=[], utility_tools=[])
+        assert msc.has_cached_entry("srv", "fp")
+
+    def test_malformed_entry_shapes_are_tolerated(self):
+        assert msc.tools_from_cache_entry({"tools": "nope"}) == []
+        assert msc.utility_tools_from_cache_entry({}) == []

--- a/tests/tools/test_mcp_schema_cache.py
+++ b/tests/tools/test_mcp_schema_cache.py
@@ -72,3 +72,41 @@ class TestCacheRoundTrip:
     def test_malformed_entry_shapes_are_tolerated(self):
         assert msc.tools_from_cache_entry({"tools": "nope"}) == []
         assert msc.utility_tools_from_cache_entry({}) == []
+
+
+class TestCacheFileLocation:
+    def test_cache_lives_under_hermes_home_cache_dir_with_0600(
+        self, monkeypatch, tmp_path
+    ):
+        # Real path (no _cache_path monkeypatch): HERMES_HOME/cache/…, 0o600,
+        # matching the discovery-cache precedent in tools/registry.py.
+        import hermes_constants
+
+        monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+        path = msc._cache_path()
+        assert path == tmp_path / "cache" / "mcp_schema_cache.json"
+        msc.write_cache_entry("srv", "fp", tools=[], utility_tools=[])
+        assert path.exists()
+        assert (path.stat().st_mode & 0o777) == 0o600
+
+
+class TestWriteSkip:
+    def test_identical_payload_skips_rewrite(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(msc, "_cache_path", lambda: tmp_path / "cache.json")
+        saves = []
+        real_save = msc._save_all
+
+        def _counting_save(data):
+            saves.append(1)
+            real_save(data)
+
+        monkeypatch.setattr(msc, "_save_all", _counting_save)
+        tools = [{"name": "t1", "description": "d", "inputSchema": {}}]
+        msc.write_cache_entry("srv", "fp1", tools=tools, utility_tools=[])
+        assert len(saves) == 1
+        # Identical payload (reconnect / list_changed refresh) → no rewrite.
+        msc.write_cache_entry("srv", "fp1", tools=list(tools), utility_tools=[])
+        assert len(saves) == 1
+        # Changed payload → rewrite.
+        msc.write_cache_entry("srv", "fp2", tools=tools, utility_tools=[])
+        assert len(saves) == 2

--- a/tools/mcp_schema_cache.py
+++ b/tools/mcp_schema_cache.py
@@ -1,0 +1,114 @@
+"""Persistent MCP tool-schema cache for lazy server startup.
+
+Stores per-server tool manifests on disk so Hermes can register MCP tools
+into the agent snapshot without spawning the stdio child process at idle
+dashboard startup. Cache entries are keyed by server name + a fingerprint
+of the connection config (command/args/url/tools filters).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_CACHE_FILENAME = "mcp_schema_cache.json"
+_cache_lock = threading.Lock()
+
+
+def _cache_path() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / _CACHE_FILENAME
+
+
+def config_fingerprint(config: dict) -> str:
+    """Stable hash of the connection-defining parts of an MCP server config."""
+    tools_filter = config.get("tools") or {}
+    payload = {
+        "command": config.get("command"),
+        "args": config.get("args") or [],
+        "url": config.get("url"),
+        "transport": config.get("transport"),
+        "tools_include": sorted(tools_filter.get("include") or []),
+        "tools_exclude": sorted(tools_filter.get("exclude") or []),
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _load_all() -> Dict[str, Any]:
+    path = _cache_path()
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not read MCP schema cache %s: %s", path, exc)
+        return {}
+
+
+def _save_all(data: Dict[str, Any]) -> None:
+    path = _cache_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    tmp.replace(path)
+
+
+def get_cached_entry(server_name: str, fingerprint: str) -> Optional[dict]:
+    """Return cached entry when fingerprint matches, else None."""
+    with _cache_lock:
+        entry = _load_all().get(server_name)
+    if not isinstance(entry, dict):
+        return None
+    if entry.get("fingerprint") != fingerprint:
+        return None
+    return entry
+
+
+def has_cached_entry(server_name: str, fingerprint: str) -> bool:
+    return get_cached_entry(server_name, fingerprint) is not None
+
+
+def write_cache_entry(
+    server_name: str,
+    fingerprint: str,
+    *,
+    tools: List[dict],
+    utility_tools: Optional[List[dict]] = None,
+) -> None:
+    """Persist tool schemas after a successful live connect."""
+    with _cache_lock:
+        data = _load_all()
+        data[server_name] = {
+            "fingerprint": fingerprint,
+            "tools": tools,
+            "utility_tools": utility_tools or [],
+        }
+        _save_all(data)
+
+
+def clear_cache_entry(server_name: str) -> None:
+    with _cache_lock:
+        data = _load_all()
+        if server_name in data:
+            del data[server_name]
+            _save_all(data)
+
+
+def tools_from_cache_entry(entry: dict) -> List[dict]:
+    """Return cached MCP tool dicts (name, description, inputSchema)."""
+    tools = entry.get("tools")
+    return list(tools) if isinstance(tools, list) else []
+
+
+def utility_tools_from_cache_entry(entry: dict) -> List[dict]:
+    util = entry.get("utility_tools")
+    return list(util) if isinstance(util, list) else []

--- a/tools/mcp_schema_cache.py
+++ b/tools/mcp_schema_cache.py
@@ -24,7 +24,7 @@ _cache_lock = threading.Lock()
 def _cache_path() -> Path:
     from hermes_constants import get_hermes_home
 
-    return get_hermes_home() / _CACHE_FILENAME
+    return get_hermes_home() / "cache" / _CACHE_FILENAME
 
 
 def config_fingerprint(config: dict) -> str:
@@ -55,11 +55,12 @@ def _load_all() -> Dict[str, Any]:
 
 
 def _save_all(data: Dict[str, Any]) -> None:
-    path = _cache_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
-    tmp.replace(path)
+    from utils import atomic_json_write
+
+    # Cache dir + 0o600: sibling precedent in tools/registry.py
+    # _save_discovery_cache; the cache file is trusted input on the lazy
+    # registration path, so keep it user-only.
+    atomic_json_write(_cache_path(), data, mode=0o600)
 
 
 def get_cached_entry(server_name: str, fingerprint: str) -> Optional[dict]:
@@ -85,13 +86,19 @@ def write_cache_entry(
     utility_tools: Optional[List[dict]] = None,
 ) -> None:
     """Persist tool schemas after a successful live connect."""
+    entry = {
+        "fingerprint": fingerprint,
+        "tools": tools,
+        "utility_tools": utility_tools or [],
+    }
     with _cache_lock:
         data = _load_all()
-        data[server_name] = {
-            "fingerprint": fingerprint,
-            "tools": tools,
-            "utility_tools": utility_tools or [],
-        }
+        # Write-through fires on every registration (reconnects,
+        # list_changed refreshes); skip the load-all+rewrite churn when the
+        # entry is byte-identical to what is already on disk.
+        if data.get(server_name) == entry:
+            return
+        data[server_name] = entry
         _save_all(data)
 
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4821,9 +4821,28 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
         _server_connecting.discard(server_name)
         _clear_connect_failure(server_name)
         _lazy_server_configs.pop(server_name, None)
-        _lazy_server_fingerprints.pop(server_name, None)
-        _lazy_server_tool_names.pop(server_name, None)
+        stale_fingerprint = _lazy_server_fingerprints.pop(server_name, None)
+        cached_names = _lazy_server_tool_names.pop(server_name, None) or []
         server = _servers.get(server_name)
+        live_names = set(
+            getattr(server, "_registered_tool_names", []) or []
+        )
+    # Stale-cache reconciliation: the cached manifest may advertise tools
+    # the live server no longer serves. Deregister those phantoms so the
+    # model stops seeing tools that can never succeed.
+    phantom_names = [n for n in cached_names if n not in live_names]
+    if phantom_names:
+        from tools.registry import registry
+
+        for tool_name in phantom_names:
+            registry.deregister(tool_name)
+            _forget_mcp_tool_server(tool_name)
+        logger.info(
+            "MCP server '%s': deregistered %d phantom cached tool(s) not "
+            "served live (stale schema-cache fingerprint %s): %s",
+            server_name, len(phantom_names), stale_fingerprint,
+            ", ".join(phantom_names),
+        )
     return server is not None and server.session is not None
 
 
@@ -6061,6 +6080,9 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             raw.get("description") or "",
             raw_schema if isinstance(raw_schema, dict) else {},
         )
+        # Defense-in-depth: the cache file is user-writable JSON, so run the
+        # same injection scan the eager discovery path applies.
+        _scan_mcp_description(name, mcp_tool.name, mcp_tool.description or "")
         schema = _convert_mcp_schema(name, mcp_tool)
         registry_name = schema["name"]
         existing_toolset = registry.get_toolset_for_tool(registry_name)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3532,6 +3532,12 @@ class MCPServerTask:
 _servers: Dict[str, MCPServerTask] = {}
 _server_connecting: set[str] = set()
 _server_connect_errors: Dict[str, str] = {}
+# Lazy MCP startup (#56832): servers whose tools were registered from the
+# on-disk schema cache without spawning/connecting. Keyed by server name;
+# entries are popped once a real connection is established on first use.
+_lazy_server_configs: Dict[str, dict] = {}
+_lazy_server_fingerprints: Dict[str, str] = {}
+_lazy_server_tool_names: Dict[str, List[str]] = {}
 # Discovery installs a task-local claim before calling ``_connect_server`` so
 # it can retain a recoverable parked task without making standalone probe calls
 # publish failed servers into module-global ownership.
@@ -4758,10 +4764,84 @@ def _request_lazy_reconnect(server_name: str, server: MCPServerTask) -> bool:
         return False
 
 
-def _get_connected_server_for_call(server_name: str) -> Optional[MCPServerTask]:
-    """Return a connected server, lazily reconnecting recycled stdio state."""
+def _resolve_server_lazy(name: str, config: dict) -> bool:
+    """True when this server defers spawn/connect until first tool use.
+
+    Gated per-server by ``mcp_servers.<name>.lazy`` in config (default OFF),
+    following the same per-server key pattern as ``idle_timeout_seconds``.
+    Design from #56832 (Vansh5632).
+    """
+    return _parse_boolish(config.get("lazy", False), default=False)
+
+
+def _ensure_lazy_server_connected(server_name: str) -> bool:
+    """Connect a lazily-registered MCP server on demand (sync, blocks caller).
+
+    Composes with the existing connect machinery: respects the per-server
+    connect cooldown (#50394), the ``_server_connecting`` dedup set, and
+    routes through ``_discover_and_register_server`` so parked/recycle/
+    cooldown bookkeeping stays in one place. Returns True when a live
+    session is available afterwards.
+    """
     with _lock:
         server = _servers.get(server_name)
+        if server is not None and server.session is not None:
+            return True
+        config = _lazy_server_configs.get(server_name)
+        if not config:
+            return False
+        if _connect_cooldown_active(server_name):
+            return False
+        if server_name in _server_connecting:
+            return False
+        _server_connecting.add(server_name)
+        _server_connect_errors.pop(server_name, None)
+
+    logger.info("MCP server '%s': lazy start on first use", server_name)
+    _ensure_mcp_loop()
+    connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+
+    async def _connect():
+        return await _discover_and_register_server(server_name, config)
+
+    try:
+        _run_on_mcp_loop(_connect, timeout=float(connect_timeout) + 30.0)
+    except BaseException as exc:
+        message = _format_connect_error(exc)
+        with _lock:
+            _server_connecting.discard(server_name)
+            _server_connect_errors[server_name] = message
+            _record_connect_failure(server_name)
+        logger.warning(
+            "Lazy MCP connect failed for '%s': %s", server_name, message,
+        )
+        return False
+
+    with _lock:
+        _server_connecting.discard(server_name)
+        _clear_connect_failure(server_name)
+        _lazy_server_configs.pop(server_name, None)
+        _lazy_server_fingerprints.pop(server_name, None)
+        _lazy_server_tool_names.pop(server_name, None)
+        server = _servers.get(server_name)
+    return server is not None and server.session is not None
+
+
+def _get_connected_server_for_call(server_name: str) -> Optional[MCPServerTask]:
+    """Return a connected server, lazily reconnecting recycled stdio state.
+
+    Also the single first-use connect point for lazy (schema-cache
+    registered) servers, so raw tool calls AND the resource/prompt utility
+    handlers all trigger the deferred spawn (#56832).
+    """
+    with _lock:
+        server = _servers.get(server_name)
+        is_lazy = server_name in _lazy_server_configs
+    if is_lazy and (server is None or server.session is None):
+        _ensure_lazy_server_connected(server_name)
+        with _lock:
+            server = _servers.get(server_name)
+        return server
     if server is not None and server.session is None and server._is_recycled_stdio():
         _request_lazy_reconnect(server_name, server)
         with _lock:
@@ -5240,10 +5320,13 @@ def _make_check_fn(server_name: str):
     def _check() -> bool:
         with _lock:
             server = _servers.get(server_name)
-        return (
-            server is not None
-            and (server.session is not None or server._is_recycled_stdio())
-        )
+            if server is not None and (
+                server.session is not None or server._is_recycled_stdio()
+            ):
+                return True
+            # Lazy (schema-cache registered) servers are available: the
+            # first real call spawns/connects them (#56832).
+            return server_name in _lazy_server_configs
 
     return _check
 
@@ -5692,6 +5775,16 @@ def _existing_tool_names() -> List[str]:
         for mcp_tool in server._tools:
             schema = _convert_mcp_schema(server.name, mcp_tool)
             names.append(schema["name"])
+    # Lazy servers registered from the schema cache have no MCPServerTask
+    # yet — their tools live in the registry only (#56832).
+    with _lock:
+        lazy_names = [
+            n
+            for sname, tool_names in _lazy_server_tool_names.items()
+            if sname not in _servers
+            for n in tool_names
+        ]
+    names.extend(lazy_names)
     return names
 
 
@@ -5879,7 +5972,162 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
 
     if registered_names:
         registry.register_toolset_alias(name, toolset_name)
+        # Write-through (#56832): refresh the on-disk schema cache after a
+        # live connect so the next startup can lazily register this server
+        # without spawning it. Cache failures never break registration.
+        try:
+            from tools.mcp_schema_cache import config_fingerprint, write_cache_entry
 
+            tools_payload: List[dict] = []
+            for mcp_tool in server._tools:
+                if not _should_register(mcp_tool.name):
+                    continue
+                schema_obj = getattr(mcp_tool, "inputSchema", None)
+                tools_payload.append({
+                    "name": mcp_tool.name,
+                    "description": mcp_tool.description or "",
+                    "inputSchema": schema_obj if isinstance(schema_obj, dict) else {},
+                })
+            utility_payload = [
+                {"schema": entry["schema"], "handler_key": entry["handler_key"]}
+                for entry in _select_utility_schemas(name, server, config)
+            ]
+            write_cache_entry(
+                name,
+                config_fingerprint(config),
+                tools=tools_payload,
+                utility_tools=utility_payload,
+            )
+        except Exception as exc:
+            logger.debug("MCP schema cache write failed for '%s': %s", name, exc)
+
+    return registered_names
+
+
+class _CachedMCPTool:
+    """Minimal stand-in for MCP Tool objects loaded from the schema cache."""
+
+    __slots__ = ("name", "description", "inputSchema")
+
+    def __init__(self, name: str, description: str, inputSchema: dict):
+        self.name = name
+        self.description = description
+        self.inputSchema = inputSchema or {}
+
+
+def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]:
+    """Register a server's tools from a cached manifest, no child process.
+
+    Lazy startup (#56832, design by Vansh5632): tools appear in the registry
+    immediately; the first real call routes through
+    ``_get_connected_server_for_call`` → ``_ensure_lazy_server_connected``.
+    """
+    from tools.registry import registry
+    from tools.mcp_schema_cache import (
+        config_fingerprint,
+        tools_from_cache_entry,
+        utility_tools_from_cache_entry,
+    )
+
+    registered_names: List[str] = []
+    toolset_name = f"mcp-{name}"
+    fingerprint = config_fingerprint(config)
+    tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
+    tools_filter = config.get("tools") or {}
+    include_set = _normalize_name_filter(
+        tools_filter.get("include"), f"mcp_servers.{name}.tools.include"
+    )
+    exclude_set = _normalize_name_filter(
+        tools_filter.get("exclude"), f"mcp_servers.{name}.tools.exclude"
+    )
+
+    def _should_register(tool_name: str) -> bool:
+        if include_set:
+            return matches_name_filter(tool_name, include_set)
+        if exclude_set:
+            return not matches_name_filter(tool_name, exclude_set)
+        return True
+
+    check_fn = _make_check_fn(name)
+    for raw in tools_from_cache_entry(entry):
+        if not isinstance(raw, dict):
+            continue
+        raw_name = raw.get("name")
+        if not raw_name or not _should_register(raw_name):
+            continue
+        raw_schema = raw.get("inputSchema")
+        mcp_tool = _CachedMCPTool(
+            raw_name,
+            raw.get("description") or "",
+            raw_schema if isinstance(raw_schema, dict) else {},
+        )
+        schema = _convert_mcp_schema(name, mcp_tool)
+        registry_name = schema["name"]
+        existing_toolset = registry.get_toolset_for_tool(registry_name)
+        if existing_toolset and existing_toolset != toolset_name:
+            logger.warning(
+                "MCP server '%s' (lazy): cached tool '%s' collides with "
+                "toolset '%s' — skipping",
+                name, registry_name, existing_toolset,
+            )
+            continue
+        registry.register(
+            name=registry_name,
+            toolset=toolset_name,
+            schema=schema,
+            handler=_make_tool_handler(name, raw_name, tool_timeout),
+            check_fn=check_fn,
+            is_async=False,
+            description=schema["description"],
+        )
+        if registry.get_toolset_for_tool(registry_name) != toolset_name:
+            continue
+        _track_mcp_tool_server(registry_name, name)
+        registered_names.append(registry_name)
+
+    handler_factories = {
+        "list_resources": _make_list_resources_handler,
+        "read_resource": _make_read_resource_handler,
+        "list_prompts": _make_list_prompts_handler,
+        "get_prompt": _make_get_prompt_handler,
+    }
+    for raw in utility_tools_from_cache_entry(entry):
+        if not isinstance(raw, dict):
+            continue
+        schema = raw.get("schema")
+        handler_key = raw.get("handler_key")
+        if not isinstance(schema, dict) or handler_key not in handler_factories:
+            continue
+        util_name = schema.get("name") or ""
+        if not util_name:
+            continue
+        existing_toolset = registry.get_toolset_for_tool(util_name)
+        if existing_toolset and existing_toolset != toolset_name:
+            continue
+        registry.register(
+            name=util_name,
+            toolset=toolset_name,
+            schema=schema,
+            handler=handler_factories[handler_key](name, tool_timeout),
+            check_fn=check_fn,
+            is_async=False,
+            description=schema.get("description") or "",
+        )
+        if registry.get_toolset_for_tool(util_name) != toolset_name:
+            continue
+        _track_mcp_tool_server(util_name, name)
+        registered_names.append(util_name)
+
+    if registered_names:
+        registry.register_toolset_alias(name, toolset_name)
+        with _lock:
+            _lazy_server_configs[name] = dict(config)
+            _lazy_server_fingerprints[name] = fingerprint
+            _lazy_server_tool_names[name] = list(registered_names)
+        logger.info(
+            "MCP server '%s' (lazy): registered %d tool(s) from schema cache",
+            name, len(registered_names),
+        )
     return registered_names
 
 async def _discover_and_register_server(name: str, config: dict) -> List[str]:
@@ -5980,6 +6228,9 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
             for k, v in servers.items()
             if k not in _servers
             and k not in connecting
+            # Servers already lazily registered from the schema cache are
+            # not re-registered; they connect on first tool use (#56832).
+            and k not in _lazy_server_configs
             and _parse_boolish(v.get("enabled", True), default=True)
             # Skip a server still serving its post-failure backoff. Without
             # this, a server that fails to connect (and is therefore never
@@ -6013,6 +6264,51 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         _signal_reconnect(srv)
 
     if not new_servers:
+        return _existing_tool_names()
+
+    # Lazy startup (#56832): servers gated with ``lazy: true`` whose config
+    # fingerprint matches a valid on-disk schema-cache entry register their
+    # tools from cache WITHOUT spawning/connecting. A missing or stale cache
+    # entry falls back to the normal eager connect below (which write-through
+    # refreshes the cache for next time).
+    eager_servers: Dict[str, dict] = dict(new_servers)
+    lazy_registered = 0
+    lazy_server_count = 0
+    try:
+        from tools.mcp_schema_cache import config_fingerprint, get_cached_entry
+    except Exception:  # pragma: no cover - cache module missing
+        config_fingerprint = None  # type: ignore[assignment]
+        get_cached_entry = None  # type: ignore[assignment]
+    if config_fingerprint is not None and get_cached_entry is not None:
+        for name, cfg in new_servers.items():
+            if not _resolve_server_lazy(name, cfg):
+                continue
+            entry = get_cached_entry(name, config_fingerprint(cfg))
+            if not entry:
+                continue
+            with _lock:
+                _server_connecting.discard(name)
+            try:
+                names = _register_from_cache_sync(name, cfg, entry)
+            except Exception as exc:
+                logger.warning(
+                    "Failed lazy MCP registration for '%s': %s", name, exc,
+                )
+                with _lock:
+                    _server_connecting.add(name)
+                continue
+            eager_servers.pop(name, None)
+            lazy_registered += len(names)
+            lazy_server_count += 1
+    new_servers = eager_servers
+
+    if not new_servers:
+        if lazy_registered:
+            logger.info(
+                "MCP: registered %d lazy tool(s) from schema cache "
+                "(no processes spawned)",
+                lazy_registered,
+            )
         return _existing_tool_names()
 
     # Start the background event loop for MCP connections
@@ -6103,8 +6399,10 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
             for n in connected
         )
     failed = len(new_servers) - len(connected)
+    new_tool_count += lazy_registered
+    connected_count = len(connected) + lazy_server_count
     if new_tool_count or failed:
-        summary = f"MCP: registered {new_tool_count} tool(s) from {len(connected)} server(s)"
+        summary = f"MCP: registered {new_tool_count} tool(s) from {connected_count} server(s)"
         if failed:
             summary += f" ({failed} failed)"
         logger.info(summary)


### PR DESCRIPTION
Extract-salvage of #56832 by @Vansh5632 — the PR's still-novel core (lazy MCP startup), with the schema-cache module cherry-picked under their authorship and the wiring re-derived onto main's current connect machinery.

## Context — what this changes for users

Every desktop/dashboard start spawns EVERY configured stdio MCP child (Playwright, etc.) and fetches schemas, even for servers the session never touches — main's idle recycle only reclaims them after opt-in idle windows, never avoids the initial spawn. With mcp_servers.<name>.lazy: true (default OFF), a server whose config fingerprint matches a valid on-disk schema-cache entry registers its tools WITHOUT spawning; the child starts on first actual tool use.

## Scope honesty — the full 4-group map of the original PR

- Lazy MCP startup: extracted here (the PR's real value; main had nothing equivalent).
- Runtime trim group: superseded by #76905 (context.memory_trim — richer telemetry + lifecycle coverage).
- Session-DB perf group: superseded on main (read-only opens, session_count_by_source, schema-v23 last_active SQL helpers).
- mimalloc preload group: genuinely NOT covered by anything on main (allocator substitution at spawn ≠ runtime trim) but requires a maintainer security decision (allow-dyld-environment-variables entitlement + build-host mimalloc staging) and a CJS→ESM port — deliberately left out; flagged for human review.

## Design (from #56832) + re-derivation notes

- Registration-from-cache in register_mcp_servers; miss/stale falls back to eager connect with write-through refresh.
- First tool use routes through _ensure_lazy_server_connected, composing with main's connect cooldown (#50394) and _server_connecting dedup — no duplicated connect path.
- resource/prompt utility handlers (list_resources/get_prompt) also connect-on-first-use — closes the gap flagged in the original sweeper review.
- check_fn stays a pure dict-membership: tools list as available pre-connect without triggering a spawn.

## Review follow-ups folded (simplify pass)

- Phantom-tool reconciliation: cached tools the live server no longer offers are deregistered after first-use connect (were permanent registry ghosts burning circuit-breaker strikes).
- atomic_json_write + cache/ location + 0o600 (registry discovery-cache precedent); no secrets persisted (command/args/env only hashed into the fingerprint, never stored).
- Cache-load path runs the same prompt-injection description scan as the eager path (the cache file is user-writable JSON).
- Write-through skips byte-identical rewrites (flapping stdio servers no longer hammer the disk).

## Verification

- 444 mcp tests green (28 lazy/cache incl. 4 new guards); ruff clean.
- Mutation checks: cache-read disabled → registration test fails; connect bypassed → 3 first-use tests fail; phantom-dereg disabled → its test fails; write-skip disabled → its test fails; all restored green.

Attribution mapping for Vansh5632 landed in #77492.

Closes #56832.
