### PR TITLE
fix(gateway): use drain-aware SIGUSR1 in launchd restart from fresh shells

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4543,6 +4543,20 @@ def launchd_restart():
             _clear_launchd_unsupported_marker()
             return
         if pid is not None:
+            # The ancestor-guarded request above only succeeds when this CLI
+            # is a descendant of the gateway (in-band self-restart). From a
+            # fresh shell the gateway is a sibling under launchd, so the guard
+            # fails and we used to drop straight to SIGTERM, killing in-flight
+            # agent runs without draining them (#27745). Reach the same
+            # drain-aware SIGUSR1 path systemd_restart() uses before falling
+            # back: the gateway refuses new turns, finishes in-flight work,
+            # runs its stop() cleanup, then exits; launchd's unconditional
+            # KeepAlive relaunches it.
+            wait_budget = _get_restart_exit_wait_budget()
+            if _graceful_restart_via_sigusr1(pid, wait_budget):
+                print("✓ Service restart requested — gateway drained; launchd will relaunch it")
+                _clear_launchd_unsupported_marker()
+                return
             # Announce the drain BEFORE waiting on it. This wait can run for
             # the full drain budget (180s by default) while the old gateway
             # finishes in-flight agent runs, and it streams into surfaces with

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -576,6 +576,130 @@ class TestGatewaySystemServiceRouting:
         assert run_calls == []
 
 
+class TestLaunchdRestartDrainAwareRestart:
+    """launchd_restart must use the drain-aware SIGUSR1 helper for callers
+    that are not gateway descendants (fresh shells), and keep the in-band
+    ancestor fast path and SIGTERM fallback intact (#27745)."""
+
+    def _patch_launchd_restart_basics(self, monkeypatch, calls):
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 27.0)
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda: 321,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_clear_launchd_unsupported_marker",
+            lambda: calls.append(("clear",)),
+        )
+
+    def test_launchd_restart_from_fresh_shell_uses_drain_aware_sigusr1(self, monkeypatch, capsys):
+        calls = []
+        self._patch_launchd_restart_basics(monkeypatch, calls)
+        # Fresh shell: the calling CLI is NOT a gateway descendant, so the
+        # ancestor-guarded helper must return False and the drain-aware
+        # helper must be used instead (the #27745 regression).
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda pid: calls.append(("self", pid)) or False,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "terminate_pid",
+            lambda pid, force=False: calls.append(("term", pid, force)),
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **k: calls.append(("run", a[0])),
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert ("graceful", 321, 27.0) in calls
+        assert not any(c[0] == "term" for c in calls)
+        assert not any(c[0] == "run" for c in calls)
+        out = capsys.readouterr().out.lower()
+        assert "drained" in out
+
+    def test_launchd_restart_preserves_in_band_ancestor_self_restart(self, monkeypatch, capsys):
+        calls = []
+        self._patch_launchd_restart_basics(monkeypatch, calls)
+        # In-band: the CLI IS a gateway descendant, so the ancestor-guarded
+        # fast path must return immediately and never reach the drain-aware
+        # helper (the gateway drains itself after the signal).
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda pid: calls.append(("self", pid)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *a, **k: calls.append(("run", a[0])),
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert ("self", 321) in calls
+        assert not any(c[0] == "graceful" for c in calls)
+        assert not any(c[0] == "run" for c in calls)
+        assert "restart requested" in capsys.readouterr().out.lower()
+
+    def test_launchd_restart_falls_back_to_sigterm_when_sigusr1_unavailable(self, monkeypatch, capsys):
+        calls = []
+        self._patch_launchd_restart_basics(monkeypatch, calls)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda pid: calls.append(("self", pid)) or False,
+        )
+        # SIGUSR1 unsupported or drain timed out: fall back to SIGTERM +
+        # kickstart, preserving the pre-existing recovery path.
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or False,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "terminate_pid",
+            lambda pid, force=False: calls.append(("term", pid, force)),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_gateway_exit",
+            lambda timeout, force_after=None: calls.append(("wait", timeout)) or True,
+        )
+
+        def fake_run(cmd, **kwargs):
+            calls.append(("run", cmd))
+            return SimpleNamespace(stdout="", returncode=0)
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        assert ("graceful", 321, 27.0) in calls
+        assert ("term", 321, False) in calls
+        assert any(c[0] == "run" and "kickstart" in c[1] for c in calls)
+        assert "service restarted" in capsys.readouterr().out.lower()
+
+
 class TestDetectVenvDir:
     """Tests for _detect_venv_dir() virtualenv detection."""
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -241,7 +241,7 @@ Subcommands:
 | `run` | Run the gateway in the foreground. Recommended for WSL, Docker, and Termux. |
 | `start` | Start the installed systemd/launchd background service. |
 | `stop` | Stop the service (or foreground process). |
-| `restart` | Restart the service. |
+| `restart` | Restart the service. Drains in-flight agent runs first (SIGUSR1; waits for active turns plus the drain budget, plus headroom), falling back to a forced restart if the drain does not complete. |
 | `status` | Show service status. |
 | `list` | List **all profiles** and whether each profile's gateway is currently running (with PID where available). Handy when you run multiple profiles side-by-side and want a single overview. |
 | `install` | Install as a systemd (Linux) or launchd (macOS) background service. |


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #11932 #25966 #27745 #35178 #56524
## What changed and why

`hermes gateway restart` on macOS (launchd) never drained in-flight agent runs when invoked from a fresh shell. `launchd_restart()` only reached the drain-aware path through `_request_gateway_self_restart()`, which is ancestor-guarded: it succeeds only when the calling CLI is a descendant of the gateway (in-band self-restart). From a fresh shell the gateway is a sibling under launchd, the guard fails, and the function fell straight through to `terminate_pid(pid, force=False)` — SIGTERM, no SIGUSR1, no drain, no cleanup tail. In-flight agent runs were killed mid-turn and the shutdown notification/cleanup stanza never ran.

This change routes the fresh-shell case through `_graceful_restart_via_sigusr1()` — the same unconditional drain-aware helper `systemd_restart()` and the `hermes update` flow already use — with the same exit-wait budget (`_get_restart_exit_wait_budget()`), and only falls back to SIGTERM + `launchctl kickstart -k` when the drain does not complete. The in-band ancestor fast path and the SIGTERM fallback are both preserved.

This is upstream of the two related-but-distinct issues the reporter flagged: #11932 (in-band SIGUSR1 early-return, already closed as resolved on main) and #25966 (drain-budget race on the SIGTERM fallback path). With this fix the SIGUSR1 path actually fires for fresh shells, so neither the post-SIGUSR1 relaunch nor the SIGTERM-fallback timing is silently skipped anymore.

## How to test

- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py` — 3 new regression tests in `TestLaunchdRestartDrainAwareRestart`:
  - `test_launchd_restart_from_fresh_shell_uses_drain_aware_sigusr1` — fresh shell (ancestor guard False) must reach `_graceful_restart_via_sigusr1(pid, budget)` and never SIGTERM (this test FAILS on unpatched main, reproducing #27745).
  - `test_launchd_restart_preserves_in_band_ancestor_self_restart` — in-band path unchanged.
  - `test_launchd_restart_falls_back_to_sigterm_when_sigusr1_unavailable` — SIGTERM + kickstart fallback preserved when the drain fails.
- On macOS with a launchd-managed gateway: run `hermes gateway restart` from a normal terminal while an agent run is in flight; the gateway should now log the graceful-restart (SIGUSR1 → drain → exit-75) stanza instead of the SIGTERM shutdown stanza.

## What platforms tested

- Windows 10 native (git-bash): rebase onto current main, `git diff --check` clean, `check-windows-footguns.py --diff` clean. File suite: 41 passed / 32 failed — the 32 failures are pre-existing Windows/POSIX-shim environment failures identical on clean main (systemd/dbus/pwd/grp tests); RED proof: the 2 new regression tests fail on unpatched main and pass with the fix.
- The changed path is macOS-only (launchd); CI runs the full suite on Linux/macOS including these tests.

## Why this matters to users

Before: on macOS, `hermes gateway restart` from a terminal (or from the desktop updater, or from a messaging session where the agent shells out to `hermes gateway restart`) killed any in-flight agent run mid-turn — no graceful drain, no cleanup, and the gateway exited via plain SIGTERM. Users on WeChat/Telegram could even lose the gateway entirely (the drzeast-png reproduction in #27745: SIGTERM exit-0 with `KeepAlive.SuccessfulExit=false` semantics leaves the service dead and messages unanswered).

After: the restart asks the gateway to finish what it's doing (SIGUSR1 → drain with the standard budget), and only force-restarts if the drain stalls. Restarting the gateway no longer destroys in-flight work, matching the behavior macOS users already got from `hermes update` and Linux systemd users always had.

## Related issues

Fixes #27745

Supersedes the stale competing PR #35178 (CONFLICTING since 2026-07-13; it replaces the ancestor fast path entirely and uses the short `drain_timeout` instead of the exit-wait budget, so it would regress the in-band case and re-introduce the #25966 deadline race).

Related, not closed by this PR (distinct bug classes, same function): #25966 (SIGTERM-fallback deadline race), #56524 (in-band update drain timeout).
