### PR TITLE
fix(stt): thread confidence thresholds into faster-whisper's own gate (salvage #74193)

### DIFF
--- a/tests/tools/test_stt_silence_hallucinations.py
+++ b/tests/tools/test_stt_silence_hallucinations.py
@@ -41,6 +41,28 @@ class TestBuildLocalTranscribeKwargs:
         )
 
 
+    def test_confidence_thresholds_default_to_faster_whisper_values(self):
+        kwargs = build_local_transcribe_kwargs({})
+        assert kwargs["no_speech_threshold"] == _NO_SPEECH_PROB_THRESHOLD_DEFAULT
+        assert kwargs["log_prob_threshold"] == _LOGPROB_THRESHOLD_DEFAULT
+
+    def test_confidence_thresholds_configurable_reach_model_gate(self):
+        # The same stt.local knobs the post-filter reads must also be threaded
+        # into faster-whisper's internal gate, or non-English speech is dropped
+        # before it ever reaches our segment filter.
+        kwargs = build_local_transcribe_kwargs(
+            {"local": {"no_speech_prob_threshold": 0.9, "logprob_threshold": -2.0}}
+        )
+        assert kwargs["no_speech_threshold"] == 0.9
+        assert kwargs["log_prob_threshold"] == -2.0
+
+    def test_confidence_thresholds_garbage_falls_back(self):
+        kwargs = build_local_transcribe_kwargs(
+            {"local": {"no_speech_prob_threshold": "nope", "logprob_threshold": None}}
+        )
+        assert kwargs["no_speech_threshold"] == _NO_SPEECH_PROB_THRESHOLD_DEFAULT
+        assert kwargs["log_prob_threshold"] == _LOGPROB_THRESHOLD_DEFAULT
+
     def test_language_and_prompt_resolved(self, monkeypatch):
         monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
         cfg = {"language": "en", "local": {"initial_prompt": "Hermes glossary"}}
@@ -99,6 +121,8 @@ class TestTranscribeLocalWiring:
         assert captured["vad_filter"] is True
         assert captured["vad_parameters"] == {"min_silence_duration_ms": 500}
         assert captured["condition_on_previous_text"] is False
+        assert captured["no_speech_threshold"] == _NO_SPEECH_PROB_THRESHOLD_DEFAULT
+        assert captured["log_prob_threshold"] == _LOGPROB_THRESHOLD_DEFAULT
 
 
     def test_hallucinated_segments_filtered_from_transcript(self, monkeypatch):

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1541,6 +1541,19 @@ def build_local_transcribe_kwargs(stt_config: Optional[Dict[str, Any]] = None) -
     else:
         kwargs["vad_filter"] = False
 
+    # Push the confidence gate down into faster-whisper itself. Without this the
+    # library's own internal defaults (no_speech_threshold=0.6, log_prob_
+    # threshold=-1.0) drop low-confidence segments BEFORE they reach our
+    # _is_hallucinated_segment post-filter, so the ``stt.local`` threshold knobs
+    # were dead for that first gate. Non-English speech decodes at a lower
+    # avg_logprob, so the English-tuned defaults silently discard whole
+    # utterances. Mapping the same config values through keeps both gates in
+    # sync and makes the knobs actually usable. Defaults are unchanged, so
+    # behavior is identical unless a user tunes them.
+    no_speech_threshold, log_prob_threshold = _confidence_thresholds(local_cfg)
+    kwargs["no_speech_threshold"] = no_speech_threshold
+    kwargs["log_prob_threshold"] = log_prob_threshold
+
     forced_lang = _resolve_stt_language("local", stt_config)
     if forced_lang:
         kwargs["language"] = forced_lang


### PR DESCRIPTION
Salvages #74193 by @PRATHAMESH75 — commit cherry-picked to preserve authorship, rebased onto current main (the original's stale-base fork CI cannot satisfy current required checks). Fixes #74178.

## Context — what this fixes, for whom

Anyone using local STT (faster-whisper) with non-English speech or tuned confidence thresholds: the `stt.local.no_speech_prob_threshold` and `stt.local.logprob_threshold` config knobs only fed the POST-transcription hallucination filter, while faster-whisper's own internal gate ran first with hardcoded defaults (0.6 / -1.0) and silently dropped low-confidence segments — non-English speech decodes at lower avg_logprob, so the config knobs were dead exactly where they mattered.

## What the fix does (kept verbatim)

Threads both config values into `model.transcribe()` via faster-whisper's documented `no_speech_threshold` / `log_prob_threshold` kwargs, reusing the existing `_confidence_thresholds()` helper. Defaults unchanged — behavior is identical unless a user tunes the knobs. Verified against faster-whisper's own source that both kwargs gate segment retention exactly as the PR claims.

## Verification

- `tests/tools/test_stt_silence_hallucinations.py`: 11 passed on current main (incl. the PR's 4 wiring tests: defaults, configurable, garbage fallback, kwargs-reach-model)
- Mutation check: revert `tools/transcription_tools.py` to main → 4 tests fail; restore → 11 pass
- Premise re-verified on current main: `build_local_transcribe_kwargs` still omits both kwargs
- ruff clean

Closes #74193 (superseded by this salvage — original author credited via cherry-pick authorship).
