### PR TITLE
feat(langfuse): trace auxiliary LLM calls for full usage accounting (config.yaml + async)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8625,7 +8625,7 @@ def call_llm(
     if semaphore is not None:
         semaphore.acquire()
     try:
-        response = _call_llm_impl(
+        response = _call_llm_impl_with_aux(
             task=task,
             provider=provider,
             model=model,
@@ -8669,7 +8669,7 @@ def _release_sync_semaphore_after_stream(
             semaphore.release()
 
 
-def _call_llm_impl(
+def _call_llm_impl_with_aux(
     task: str = None,
     *,
     provider: str = None,
@@ -9499,7 +9499,7 @@ async def async_call_llm(
     if semaphore is not None:
         await semaphore.acquire()
     try:
-        return await _async_call_llm_impl(
+        return await _async_call_llm_impl_with_aux(
             task=task,
             provider=provider,
             model=model,
@@ -9517,6 +9517,49 @@ async def async_call_llm(
     finally:
         if semaphore is not None:
             semaphore.release()
+
+
+async def _async_call_llm_impl_with_aux(
+    task: str = None,
+    *,
+    provider: str = None,
+    model: str = None,
+    base_url: str = None,
+    api_key: str = None,
+    main_runtime: Optional[Dict[str, Any]] = None,
+    messages: list,
+    temperature: Optional[float] = None,
+    max_tokens: int = None,
+    tools: list = None,
+    timeout: float = None,
+    extra_body: dict = None,
+    reasoning_config: Optional[dict] = None,
+    extra_headers: Optional[Dict[str, str]] = None,
+    api_mode: str = None,
+    stream: bool = False,
+    stream_options: dict = None,
+) -> Any:
+    """Async wrapper that notifies auxiliary-LLM observers (start/end/error).
+
+    Covers the async call path (vision, etc.) so plugins such as
+    observability/langfuse can account for auxiliary token usage on async
+    calls too. Delegates to :func:`_async_call_llm_impl`.
+    """
+    _notify_aux_llm("start", task=task, provider=provider, model=model,
+                    api_mode=api_mode, messages=messages)
+    try:
+        response = await _async_call_llm_impl(
+            task=task, provider=provider, model=model, base_url=base_url,
+            api_key=api_key, main_runtime=main_runtime, messages=messages,
+            temperature=temperature, max_tokens=max_tokens, tools=tools,
+            timeout=timeout, extra_body=extra_body,
+            reasoning_config=reasoning_config,
+        )
+    except Exception as exc:
+        _notify_aux_llm("error", task=task, provider=provider, model=model, error=str(exc))
+        raise
+    _notify_aux_llm("end", task=task, provider=provider, model=model, response=response)
+    return response
 
 
 async def _async_call_llm_impl(

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8558,6 +8558,47 @@ async def _acreate_with_stream(
     )
 
 
+# ── Auxiliary LLM observability ──────────────────────────────────────────
+# Plugins (e.g. observability/langfuse) may register an observer to receive
+# every auxiliary LLM call (context compression, vision, web_extract, MoA, …).
+# The default is an empty list — zero overhead when nothing is registered.
+# Events delivered as (event, kwargs):
+#   ("start", task=..., provider=..., model=..., api_mode=..., messages=...)
+#   ("end",   task=..., provider=..., model=..., response=...)  # usage via response.usage
+#   ("error", task=..., provider=..., model=..., error=...)
+_AUX_LLM_OBSERVERS: List[Callable[[str, Dict[str, Any]], None]] = []
+_AUX_LLM_OBSERVERS_LOCK = threading.Lock()
+
+
+def register_aux_llm_observer(observer: Callable[[str, Dict[str, Any]], None]) -> None:
+    """Register a callable receiving (event, kwargs) for every auxiliary LLM call.
+
+    Observers must be fail-open: any exception they raise is logged and
+    swallowed so auxiliary calls are never broken by observability code.
+    """
+    with _AUX_LLM_OBSERVERS_LOCK:
+        if observer not in _AUX_LLM_OBSERVERS:
+            _AUX_LLM_OBSERVERS.append(observer)
+
+
+def unregister_aux_llm_observer(observer: Callable[[str, Dict[str, Any]], None]) -> None:
+    with _AUX_LLM_OBSERVERS_LOCK:
+        if observer in _AUX_LLM_OBSERVERS:
+            _AUX_LLM_OBSERVERS.remove(observer)
+
+
+def _notify_aux_llm(event: str, **kwargs: Any) -> None:
+    with _AUX_LLM_OBSERVERS_LOCK:
+        observers = list(_AUX_LLM_OBSERVERS)
+    if not observers:
+        return
+    for obs in observers:
+        try:
+            obs(event, kwargs)
+        except Exception:
+            logger.debug("auxiliary LLM observer %r failed on %s", obs, event, exc_info=True)
+
+
 @_relay_auxiliary_call
 def call_llm(
     task: str = None,
@@ -8652,6 +8693,9 @@ def _call_llm_impl(
 
     Resolves provider + model (from task config, explicit args, or auto-detect),
     handles auth, request formatting, and model-specific arg adjustments.
+    Thin wrapper around :func:`_call_llm_impl` that also notifies registered
+    auxiliary-LLM observers (start/end/error) so plugins such as
+    observability/langfuse can account for auxiliary token usage.
 
     Args:
         task: Auxiliary task name ("compression", "vision", "web_extract",
@@ -8686,6 +8730,45 @@ def _call_llm_impl(
     Raises:
         RuntimeError: If no provider is configured.
     """
+    _notify_aux_llm("start", task=task, provider=provider, model=model,
+                    api_mode=api_mode, messages=messages)
+    try:
+        response = _call_llm_impl(
+            task=task, provider=provider, model=model, base_url=base_url,
+            api_key=api_key, main_runtime=main_runtime, messages=messages,
+            temperature=temperature, max_tokens=max_tokens, tools=tools,
+            timeout=timeout, extra_body=extra_body,
+            reasoning_config=reasoning_config, extra_headers=extra_headers,
+            api_mode=api_mode, stream=stream, stream_options=stream_options,
+        )
+    except Exception as exc:
+        _notify_aux_llm("error", task=task, provider=provider, model=model, error=str(exc))
+        raise
+    _notify_aux_llm("end", task=task, provider=provider, model=model, response=response)
+    return response
+
+
+def _call_llm_impl(
+    task: str = None,
+    *,
+    provider: str = None,
+    model: str = None,
+    base_url: str = None,
+    api_key: str = None,
+    main_runtime: Optional[Dict[str, Any]] = None,
+    messages: list,
+    temperature: Optional[float] = None,
+    max_tokens: int = None,
+    tools: list = None,
+    timeout: float = None,
+    extra_body: dict = None,
+    reasoning_config: Optional[dict] = None,
+    extra_headers: Optional[Dict[str, str]] = None,
+    api_mode: str = None,
+    stream: bool = False,
+    stream_options: dict = None,
+) -> Any:
+    """Implementation of :func:`call_llm` (see its docstring)."""
     # Capture one immutable runtime snapshot for keying, resolution, retries,
     # and fallbacks. Reading ambient state independently in each phase lets a
     # concurrent /model switch produce a key for one runtime and a client for

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -19,9 +19,22 @@ Optional env vars:
   HERMES_LANGFUSE_SAMPLE_RATE - sampling rate 0.0–1.0 (default: 1.0)
   HERMES_LANGFUSE_MAX_CHARS   - max chars per field (default: 12000)
   HERMES_LANGFUSE_DEBUG       - set to "true" for verbose logging
+
+Behavioral setting (config.yaml, per project policy — behavioral flags do
+not use HERMES_* env vars):
+  plugins:
+    entries:
+      observability/langfuse:
+        track_aux: true   # also trace auxiliary LLM calls (context
+                          # compression, vision, web_extract, MoA, …) as
+                          # standalone "Hermes aux: <task>" traces, so
+                          # Langfuse totals reconcile against provider
+                          # billing. Default: false.
 """
 from __future__ import annotations
 
+import contextvars
+import itertools
 import json
 import logging
 import os
@@ -1125,6 +1138,180 @@ def on_post_tool_call(*, tool_name: str = "", args: Any = None, result: Any = No
     )
 
 
+# ── Optional auxiliary-LLM tracking ─────────────────────────────────────
+# When config.yaml has ``plugins.entries.observability/langfuse.track_aux:
+# true``, every auxiliary LLM call (context compression, vision, web_extract,
+# MoA, …) is traced to Langfuse as its own standalone trace named
+# "Hermes aux: <task>", with token usage (including DeepSeek cache hit/miss)
+# attached. This lets Langfuse totals be reconciled against the provider's
+# own billing (e.g. api.deepseek.com usage), since auxiliary calls would
+# otherwise be invisible. Default off — keeps the existing behavior of
+# tracing only the main agent call chain.
+#
+# Per project policy (AGENTS.md), behavioral settings live in config.yaml,
+# not in new HERMES_* env vars — so this flag is read from the plugin's
+# ``plugins.entries.<key>`` section instead of an environment variable.
+
+_TRACK_AUX: Optional[bool] = None  # lazily resolved from config.yaml
+_AUX_CALL_ID_CTX = contextvars.ContextVar("langfuse_aux_call_id", default=None)
+_AUX_CALLS: Dict[str, Dict[str, Any]] = {}
+_AUX_CALLS_LOCK = threading.Lock()
+_AUX_CALL_COUNTER = itertools.count()
+
+
+def _track_aux_enabled() -> bool:
+    """Resolve the aux-tracking flag from config.yaml (cached per process)."""
+    global _TRACK_AUX
+    if _TRACK_AUX is None:
+        try:
+            from hermes_cli.config import load_config_readonly, cfg_get
+            cfg = load_config_readonly()
+            _TRACK_AUX = bool(cfg_get(
+                cfg, "plugins", "entries", "observability/langfuse",
+                "track_aux", default=False,
+            ))
+        except Exception:
+            _TRACK_AUX = False
+    return _TRACK_AUX
+
+
+def _on_aux_llm_call(event: str, kwargs: Dict[str, Any]) -> None:
+    """Observer callback registered with ``agent.auxiliary_client``.
+
+    Receives ("start"|"end"|"error", kwargs) for every auxiliary LLM call.
+    """
+    if not _track_aux_enabled():
+        return
+    try:
+        if event == "start":
+            _aux_trace_start(kwargs)
+        elif event == "end":
+            _aux_trace_end(kwargs)
+        elif event == "error":
+            _aux_trace_error(kwargs)
+    except Exception as exc:  # pragma: no cover - fail-open
+        _debug("auxiliary LLM trace failed: %s", exc)
+
+
+def _aux_trace_start(kwargs: Dict[str, Any]) -> None:
+    client = _get_langfuse()
+    if client is None:
+        return
+    task = kwargs.get("task") or "aux"
+    call_id = f"aux::{task}::{next(_AUX_CALL_COUNTER)}"
+    trace_id = client.create_trace_id(seed=call_id)
+    root_ctx = client.start_as_current_observation(
+        trace_context={"trace_id": trace_id, "session_id": f"aux:{task}"},
+        name=f"Hermes aux: {task}",
+        as_type="chain",
+        metadata={
+            "source": "hermes",
+            "kind": "aux",
+            "task": task,
+            "provider": kwargs.get("provider") or "",
+            "model": kwargs.get("model") or "",
+            "api_mode": kwargs.get("api_mode") or "",
+        },
+        end_on_exit=False,
+    )
+    root_span = root_ctx.__enter__()
+    try:
+        root_span.set_trace_io(_truncate_text(_summarize_messages(kwargs.get("messages")), 2000))
+    except Exception:
+        pass
+    # Usage belongs on a GENERATION child observation (a chain cannot carry
+    # usage_details in Langfuse), mirroring how the main trace nests LLM calls.
+    gen = root_span.start_observation(
+        name="LLM call",
+        as_type="generation",
+        input=_truncate_text(_summarize_messages(kwargs.get("messages")), 2000),
+        model=kwargs.get("model") or "",
+        metadata={"task": task, "aux": True},
+    )
+    with _AUX_CALLS_LOCK:
+        _AUX_CALLS[call_id] = {
+            "root_ctx": root_ctx, "root_span": root_span, "gen": gen, "task": task,
+        }
+    _AUX_CALL_ID_CTX.set(call_id)
+
+
+def _aux_trace_end(kwargs: Dict[str, Any]) -> None:
+    call_id = _AUX_CALL_ID_CTX.get()
+    if not call_id:
+        return
+    entry = _AUX_CALLS.pop(call_id, None)
+    _AUX_CALL_ID_CTX.set("")
+    if entry is None:
+        return
+    gen = entry["gen"]
+    response = kwargs.get("response")
+    usage_details: Dict[str, int] = {}
+    cost_details: Dict[str, float] = {}
+    if response is not None and getattr(response, "usage", None) is not None:
+        try:
+            usage_details, cost_details = _usage_and_cost(
+                response,
+                provider=kwargs.get("provider") or "",
+                api_mode=kwargs.get("api_mode") or "",
+                model=kwargs.get("model") or "",
+                base_url="",
+            )
+        except Exception:
+            pass
+    try:
+        if usage_details:
+            gen.update(usage_details=usage_details, cost_details=cost_details)
+        resp_model = getattr(response, "model", None)
+        if resp_model:
+            gen.update(model=resp_model)
+        output = getattr(response, "choices", None)
+        if output:
+            try:
+                content = output[0].message.content
+                if isinstance(content, str):
+                    gen.update(output=_truncate_text(content, 2000))
+            except Exception:
+                pass
+    except Exception:
+        pass
+    gen.end()
+    entry["root_span"].end()
+    entry["root_ctx"].__exit__(None, None, None)
+
+
+def _aux_trace_error(kwargs: Dict[str, Any]) -> None:
+    call_id = _AUX_CALL_ID_CTX.get()
+    if not call_id:
+        return
+    entry = _AUX_CALLS.pop(call_id, None)
+    _AUX_CALL_ID_CTX.set("")
+    if entry is None:
+        return
+    gen = entry["gen"]
+    try:
+        gen.update(metadata={"error": kwargs.get("error") or "aux call failed"})
+    except Exception:
+        pass
+    gen.end()
+    entry["root_span"].end()
+    entry["root_ctx"].__exit__(None, None, None)
+
+
+def _summarize_messages(messages: Any) -> str:
+    """Compact text preview of the request messages (never the full payload)."""
+    if not isinstance(messages, list):
+        return ""
+    parts = []
+    for m in messages[-5:]:
+        role = m.get("role", "?") if isinstance(m, dict) else "?"
+        content = m.get("content", "") if isinstance(m, dict) else str(m)
+        if isinstance(content, str):
+            parts.append(f"{role}: {content[:200]}")
+        else:
+            parts.append(f"{role}: <non-text>")
+    return "\n".join(parts) if parts else ""
+
+
 def register(ctx) -> None:
     # Register for both hook name variants so the plugin works across
     # Hermes versions.  pre_api_request / post_api_request fire per API
@@ -1135,3 +1322,22 @@ def register(ctx) -> None:
     ctx.register_hook("post_llm_call", on_post_llm_call)
     ctx.register_hook("pre_tool_call", on_pre_tool_call)
     ctx.register_hook("post_tool_call", on_post_tool_call)
+
+    # Optional auxiliary-LLM tracking (config.yaml
+    # plugins.entries.observability/langfuse.track_aux=true):
+    # subscribe to every auxiliary LLM call so their token usage is also
+    # accounted for, letting Langfuse totals reconcile against provider
+    # billing. The observer registry is empty by default in the core, so
+    # this is a no-op cost when the plugin is the only subscriber.
+    if _track_aux_enabled():
+        try:
+            from agent.auxiliary_client import register_aux_llm_observer
+            register_aux_llm_observer(_on_aux_llm_call)
+            logger.info(
+                "Langfuse plugin: auxiliary LLM tracking enabled "
+                "(plugins.entries.observability/langfuse.track_aux=true)"
+            )
+        except Exception as exc:  # pragma: no cover - fail-open
+            logger.warning(
+                "Langfuse plugin: could not register auxiliary LLM observer: %s", exc
+            )

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -5,6 +5,7 @@ import importlib
 import logging
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -779,3 +780,116 @@ class TestUsageFromSanitizedResponse:
 
         assert seen["resp"] is resp
         assert captured["usage_details"] == {"input": 7, "output": 3}
+
+
+# ---------------------------------------------------------------------------
+# Auxiliary-LLM tracking (config: plugins.entries.observability/langfuse.track_aux)
+# ---------------------------------------------------------------------------
+
+class TestAuxTracking:
+
+    def _fresh_plugin(self, monkeypatch, track_aux=False):
+        """Import the plugin module fresh; ``track_aux=True`` forces the
+        config.yaml flag via the module's resolver."""
+        mod_name = "plugins.observability.langfuse"
+        sys.modules.pop(mod_name, None)
+        mod = importlib.import_module(mod_name)
+        # Force the lazily-resolved flag to the desired value (bypasses
+        # reading the real config.yaml for unit isolation).
+        mod._TRACK_AUX = bool(track_aux)
+        return mod
+
+    def _fake_client(self):
+        from types import SimpleNamespace
+
+        gen = MagicMock()
+        root_span = MagicMock()
+        root_span.start_observation = MagicMock(return_value=gen)
+        root_ctx = MagicMock()
+        root_ctx.__enter__ = MagicMock(return_value=root_span)
+        root_ctx.__exit__ = MagicMock(return_value=None)
+        client = SimpleNamespace(
+            create_trace_id=MagicMock(return_value="trace-aux-1"),
+            start_as_current_observation=MagicMock(return_value=root_ctx),
+        )
+        return client, root_span, gen
+
+    def test_track_aux_off_by_default(self, monkeypatch):
+        mod = self._fresh_plugin(monkeypatch, False)
+        assert mod._track_aux_enabled() is False
+
+    def test_track_aux_on_registers_observer(self, monkeypatch):
+        mod = self._fresh_plugin(monkeypatch, True)
+        assert mod._track_aux_enabled() is True
+
+        from agent import auxiliary_client as aux
+        for obs in list(aux._AUX_LLM_OBSERVERS):
+            aux.unregister_aux_llm_observer(obs)
+
+        class FakeCtx:
+            def __init__(self):
+                self.hooks = []
+
+            def register_hook(self, *a):
+                self.hooks.append(a)
+
+        mod.register(FakeCtx())
+        assert mod._on_aux_llm_call in aux._AUX_LLM_OBSERVERS
+        aux.unregister_aux_llm_observer(mod._on_aux_llm_call)
+
+    def test_aux_trace_start_end_records_usage(self, monkeypatch):
+        from types import SimpleNamespace
+
+        mod = self._fresh_plugin(monkeypatch, True)
+        client, root_span, gen = self._fake_client()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+
+        class FakeUsage:
+            prompt_tokens = 1000
+            completion_tokens = 200
+            prompt_cache_hit_tokens = 600
+            prompt_cache_miss_tokens = 400
+            completion_tokens_details = SimpleNamespace(reasoning_tokens=50)
+
+        class FakeResp:
+            model = "deepseek-v4-flash"
+            usage = FakeUsage()
+            choices = [SimpleNamespace(message=SimpleNamespace(content="摘要输出"))]
+
+        mod._on_aux_llm_call("start", {
+            "task": "compression", "model": "deepseek-v4-flash",
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+        assert client.create_trace_id.called
+        assert client.start_as_current_observation.called
+        assert root_span.start_observation.called
+
+        mod._on_aux_llm_call("end", {
+            "task": "compression", "model": "deepseek-v4-flash",
+            "response": FakeResp(),
+        })
+        # Token usage (incl. DeepSeek cache hit) lands on the generation span.
+        usage_calls = [c.kwargs for c in gen.update.call_args_list if "usage_details" in c.kwargs]
+        assert usage_calls, "no usage update recorded"
+        ud = usage_calls[0]["usage_details"]
+        assert ud["cache_read_input_tokens"] == 600
+        assert ud["input"] == 400          # DeepSeek cache-miss → input
+        assert ud["output"] == 200
+        gen.end.assert_called_once()
+
+    def test_aux_trace_error_marks_and_ends(self, monkeypatch):
+        mod = self._fresh_plugin(monkeypatch, True)
+        client, root_span, gen = self._fake_client()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+
+        mod._on_aux_llm_call("start", {
+            "task": "vision", "messages": [{"role": "user", "content": "x"}],
+        })
+        mod._on_aux_llm_call("error", {
+            "task": "vision", "error": "provider timeout",
+        })
+        gen.end.assert_called_once()
+        # The chain is also closed.
+        assert root_span.end.called
+        # No dangling state.
+        assert mod._AUX_CALLS == {}


### PR DESCRIPTION
## Summary

Track auxiliary LLM calls (context compression, vision, web_extract, MoA, and related paths) in Langfuse so observability totals can reconcile with provider billing.

## Changes

- Add a zero-overhead-by-default auxiliary LLM observer registry in `agent/auxiliary_client.py`.
- Emit fail-open `start` / `end` / `error` events from both synchronous and asynchronous auxiliary call paths.
- Preserve the current `route_info` contract through the observer wrapper and recovery/fallback paths.
- Add opt-in auxiliary tracing for `plugins.entries.observability/langfuse.track_aux` in `config.yaml`; the default remains disabled.
- Record standalone `Hermes aux: <task>` traces with generation usage, including cache hit/miss fields where available.
- Add wiring and lifecycle tests covering sync/async success and error paths, default-off behavior, config resolution, and usage recording.

## Compatibility

This branch is based on the current upstream `main` and adapts the feature to the current auxiliary-client and Langfuse plugin structure. No new behavioral `HERMES_*` environment variable is introduced; `.env` remains reserved for secrets.

## Test Plan

- `pytest tests/plugins/test_langfuse_plugin.py -q -o 'addopts='`
- `pytest tests/agent/test_auxiliary_client.py -q -o 'addopts='`
- Related vision/compression auxiliary tests

The auxiliary observer is fail-open: telemetry failures cannot break an auxiliary LLM call.
