### PR TITLE
fix(gateway): profile-scoped allowlist env writes for pairing grants (#77490)

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -38,6 +38,7 @@ from hermes_constants import (
     get_hermes_dir,
     get_hermes_home,
 )
+from hermes_constants import set_hermes_home_override, reset_hermes_home_override
 from utils import atomic_replace
 
 logger = logging.getLogger(__name__)
@@ -172,7 +173,9 @@ def _read_allowlist_env(env_var: str) -> str:
     return (os.getenv(env_var) or "").strip()
 
 
-def _sync_allowlist_add(platform: str, user_id: str) -> None:
+def _sync_allowlist_add(
+    platform: str, user_id: str, *, profile: Optional[str] = None
+) -> None:
     """Add ``user_id`` to the platform allowlist env var IF one is configured.
 
     Option (i): only materialize the grant into the allowlist when the operator
@@ -180,6 +183,11 @@ def _sync_allowlist_add(platform: str, user_id: str) -> None:
     allowlist) we do nothing — the pairing store remains the grant record and
     the authz union honors it, so we never silently convert an open gateway into
     a locked one on first pairing.
+
+    When ``profile`` is set, the allowlist write targets the profile's own
+    ``.env`` (``<HERMES_HOME>/profiles/<profile>/.env``) instead of the root
+    ``.env``, preventing cross-profile credential leakage under multiplexing
+    (``#77490``).
     """
     env_var = _allowlist_env_for_platform(platform)
     if not env_var:
@@ -194,7 +202,16 @@ def _sync_allowlist_add(platform: str, user_id: str) -> None:
     try:
         from hermes_cli.config import save_env_value
 
-        save_env_value(env_var, ",".join(ids))
+        if profile:
+            hermes_home = get_hermes_home()
+            profile_home = hermes_home / "profiles" / profile
+            token = set_hermes_home_override(str(profile_home))
+            try:
+                save_env_value(env_var, ",".join(ids))
+            finally:
+                reset_hermes_home_override(token)
+        else:
+            save_env_value(env_var, ",".join(ids))
     except Exception:
         # Best-effort: the pairing store grant still authorizes via the union,
         # so a failure here degrades to "grant recorded but not mirrored".
@@ -289,7 +306,9 @@ def _sync_live_adapter_allowlist_remove(platform: str, user_id: str) -> None:
                 pass
 
 
-def _sync_allowlist_remove(platform: str, user_id: str) -> None:
+def _sync_allowlist_remove(
+    platform: str, user_id: str, *, profile: Optional[str] = None
+) -> None:
     """Remove ``user_id`` (and WhatsApp alias equivalents) from the allowlist.
 
     Matching must mirror PairingStore / authz WhatsApp alias rules: approve
@@ -300,6 +319,10 @@ def _sync_allowlist_remove(platform: str, user_id: str) -> None:
     Also clears matching entries from any in-process platform adapter
     ``_allow_from`` snapshot so sole-entry revocation is effective without a
     gateway restart.
+
+    When ``profile`` is set, the removal targets the profile's own ``.env``
+    (``<HERMES_HOME>/profiles/<profile>/.env``) instead of the root ``.env``,
+    preventing cross-profile credential leakage under multiplexing (``#77490``).
     """
     env_var = _allowlist_env_for_platform(platform)
     if not env_var:
@@ -318,10 +341,22 @@ def _sync_allowlist_remove(platform: str, user_id: str) -> None:
     try:
         from hermes_cli.config import save_env_value, remove_env_value
 
-        if remaining:
-            save_env_value(env_var, ",".join(remaining))
+        def _write(value_remaining: bool) -> None:
+            if value_remaining:
+                save_env_value(env_var, ",".join(remaining))
+            else:
+                remove_env_value(env_var)
+
+        if profile:
+            hermes_home = get_hermes_home()
+            profile_home = hermes_home / "profiles" / profile
+            token = set_hermes_home_override(str(profile_home))
+            try:
+                _write(bool(remaining))
+            finally:
+                reset_hermes_home_override(token)
         else:
-            remove_env_value(env_var)
+            _write(bool(remaining))
     except Exception:
         pass
     _sync_live_adapter_allowlist_remove(platform, user_id)
@@ -552,7 +587,7 @@ class PairingStore:
         # Mirror the grant into the operator's allowlist when one is configured
         # (option i), so the pairing store and the allowlist stay a single
         # visible source of truth. No-op on open gateways.
-        _sync_allowlist_add(platform, normalized_user_id)
+        _sync_allowlist_add(platform, normalized_user_id, profile=self._profile)
 
     def revoke(self, platform: str, user_id: str) -> bool:
         """Remove a user from the approved list. Returns True if found."""
@@ -571,7 +606,7 @@ class PairingStore:
                 # Keep the allowlist mirror in sync: revoking a paired user
                 # also removes the entry the approval added (option i). No-op if
                 # the user was added to the allowlist by other means.
-                _sync_allowlist_remove(platform, user_id)
+                _sync_allowlist_remove(platform, user_id, profile=self._profile)
                 return True
         return False
 

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -156,10 +156,13 @@ def _read_allowlist_env(env_var: str) -> str:
     borrowing the process value.  Unscoped callers (single-profile CLI /
     admin endpoints) keep the legacy ``os.getenv`` read.
 
-    TODO(profile-secrets): the grant mirror below still WRITES through
-    ``hermes_cli.config.save_env_value`` / ``remove_env_value``, which target
-    the root ``.env`` — those writes need a profile-aware counterpart before
-    pairing grants can be mirrored correctly under multiplexing.
+    NOTE: profile-scoped callers must NOT use this helper — the dashboard
+    approval path does not install the requested profile's secret scope, so
+    this read falls back to the process environment (the root allowlist) and
+    the subsequent profile-scoped write copies that root value into the
+    profile's ``.env``, clobbering the profile's own allowlist. Use
+    :func:`_read_profile_allowlist_env` so read and write resolve the same
+    scope (``#77490`` follow-up review).
     """
     try:
         from agent.secret_scope import UnscopedSecretError, get_secret
@@ -171,6 +174,36 @@ def _read_allowlist_env(env_var: str) -> str:
     except Exception:
         pass
     return (os.getenv(env_var) or "").strip()
+
+
+def _profile_home_dir(profile: str) -> Path:
+    """Resolve a profile's home directory the same way ``PairingStore`` does.
+
+    Uses ``get_default_hermes_root()`` (not ``get_hermes_home()``) so the
+    resolution stays correct even when the current process ``HERMES_HOME`` is
+    itself a profile home — nesting ``profiles`` under a profile home would
+    silently write to the wrong ``.env`` (``#77490``).
+    """
+    root = get_default_hermes_root()
+    return root if profile == "default" else root / "profiles" / profile
+
+
+def _read_profile_allowlist_env(env_var: str, profile: str) -> str:
+    """Read an allowlist env var from a profile's OWN ``.env`` file.
+
+    The grant mirror WRITES into the profile ``.env``, so the starting value
+    must come from the same file — not the process environment / installed
+    secret scope, which may hold the root (or another profile's) allowlist.
+    Reading and writing different scopes is exactly the cross-profile grant
+    leak ``#77490`` follow-up flagged.
+    """
+    try:
+        from agent.secret_scope import load_env_file
+
+        secrets = load_env_file(_profile_home_dir(profile) / ".env")
+        return (secrets.get(env_var) or "").strip()
+    except Exception:
+        return ""
 
 
 def _sync_allowlist_add(
@@ -192,7 +225,14 @@ def _sync_allowlist_add(
     env_var = _allowlist_env_for_platform(platform)
     if not env_var:
         return
-    current = _read_allowlist_env(env_var)
+    if profile:
+        # Read AND write must resolve the same profile scope. The dashboard
+        # approval path does not install the profile's secret scope, so the
+        # unscoped read would fall back to the process/root allowlist and copy
+        # root grants into the profile .env (#77490 follow-up review).
+        current = _read_profile_allowlist_env(env_var, profile)
+    else:
+        current = _read_allowlist_env(env_var)
     if not current:
         return  # No allowlist configured — leave the gateway open (option i).
     ids = _split_allowlist(current)
@@ -203,9 +243,7 @@ def _sync_allowlist_add(
         from hermes_cli.config import save_env_value
 
         if profile:
-            hermes_home = get_hermes_home()
-            profile_home = hermes_home / "profiles" / profile
-            token = set_hermes_home_override(str(profile_home))
+            token = set_hermes_home_override(str(_profile_home_dir(profile)))
             try:
                 save_env_value(env_var, ",".join(ids))
             finally:
@@ -327,7 +365,14 @@ def _sync_allowlist_remove(
     env_var = _allowlist_env_for_platform(platform)
     if not env_var:
         return
-    current = _read_allowlist_env(env_var)
+    if profile:
+        # Read AND write must resolve the same profile scope (see
+        # _sync_allowlist_add) — otherwise the unscoped read falls back to
+        # the process/root allowlist and the profile write removes the wrong
+        # entries / copies root grants across the boundary (#77490).
+        current = _read_profile_allowlist_env(env_var, profile)
+    else:
+        current = _read_allowlist_env(env_var)
     if not current:
         return  # No allowlist configured — do not touch config-only snapshots.
     ids = _split_allowlist(current)
@@ -348,9 +393,7 @@ def _sync_allowlist_remove(
                 remove_env_value(env_var)
 
         if profile:
-            hermes_home = get_hermes_home()
-            profile_home = hermes_home / "profiles" / profile
-            token = set_hermes_home_override(str(profile_home))
+            token = set_hermes_home_override(str(_profile_home_dir(profile)))
             try:
                 _write(bool(remaining))
             finally:

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -678,3 +678,119 @@ class TestProfileScopedStorage:
         )
 
 
+
+# ---------------------------------------------------------------------------
+# Profile-scoped allowlist env writes (#77490 regression tests)
+# ---------------------------------------------------------------------------
+
+
+class TestProfileScopedAllowlistWrites:
+    """_sync_allowlist_add/remove with profile= writes to the profile's own
+    .env instead of the root .env, preventing cross-profile credential
+    leakage under multiplexing (issue #77490).
+    """
+
+    def test_sync_allowlist_add_scopes_to_profile_env(self, tmp_path, monkeypatch):
+        from hermes_constants import get_hermes_home
+        from gateway.pairing import _sync_allowlist_add
+
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+        # Root .env exists with TELEGRAM_ALLOWED_USERS already set.
+        root_env = tmp_path / ".env"
+        root_env.write_text("TELEGRAM_ALLOWED_USERS=owner1\n", encoding="utf-8")
+
+        # Profile .env also has the same var.
+        profile_env_dir = tmp_path / "profiles" / "coder"
+        profile_env_dir.mkdir(parents=True)
+        profile_env = profile_env_dir / ".env"
+        profile_env.write_text("TELEGRAM_ALLOWED_USERS=owner2\n", encoding="utf-8")
+
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "owner1")
+
+        saved = {}
+        import hermes_cli.config as cfg
+
+        def fake_save(key, value):
+            saved[key] = value
+            os.environ[key] = value
+
+        monkeypatch.setattr(cfg, "save_env_value", fake_save)
+
+        _sync_allowlist_add("telegram", "newuser", profile="coder")
+        # The write should have been scoped to the coder profile.
+        # save_env_value receives the value; the caller can verify the
+        # override was applied.
+        assert saved.get("TELEGRAM_ALLOWED_USERS") == "owner1,newuser"
+
+    def test_sync_allowlist_add_no_profile_uses_root_env(self, tmp_path, monkeypatch):
+        from gateway.pairing import _sync_allowlist_add
+
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "owner1")
+
+        saved = {}
+        import hermes_cli.config as cfg
+
+        monkeypatch.setattr(cfg, "save_env_value", lambda k, v: saved.__setitem__(k, v))
+
+        # No profile passed — should write to root.
+        _sync_allowlist_add("telegram", "newuser")
+        assert saved.get("TELEGRAM_ALLOWED_USERS") == "owner1,newuser"
+
+    def test_sync_allowlist_remove_scopes_to_profile_env(self, tmp_path, monkeypatch):
+        from gateway.pairing import _sync_allowlist_remove
+
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "owner1,newuser")
+
+        removed = []
+        saved = {}
+        import hermes_cli.config as cfg
+
+        monkeypatch.setattr(cfg, "remove_env_value", lambda k: removed.append(k))
+        monkeypatch.setattr(cfg, "save_env_value", lambda k, v: saved.__setitem__(k, v))
+
+        # Removing "newuser" should leave "owner1" and call save_env_value
+        # scoped to the profile's .env.
+        _sync_allowlist_remove("telegram", "newuser", profile="coder")
+        assert saved.get("TELEGRAM_ALLOWED_USERS") == "owner1"
+        assert "TELEGRAM_ALLOWED_USERS" not in removed
+
+    def test_sync_allowlist_remove_env_var_when_list_empties_profile(self, tmp_path, monkeypatch):
+        from gateway.pairing import _sync_allowlist_remove
+
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "onlyuser")
+
+        removed = []
+        import hermes_cli.config as cfg
+
+        monkeypatch.setattr(cfg, "remove_env_value", lambda k: removed.append(k))
+
+        _sync_allowlist_remove("telegram", "onlyuser", profile="coder")
+        # The list is empty after removal, so remove_env_value should fire.
+        assert "TELEGRAM_ALLOWED_USERS" in removed
+
+    def test_profile_approve_invokes_sync_with_profile(self, tmp_path, monkeypatch):
+        """PairingStore.approve() passes profile to _sync_allowlist_add."""
+        from hermes_constants import get_hermes_home
+        from gateway.pairing import PairingStore
+
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "owner1")
+
+        profiles_seen = []
+
+        import gateway.pairing as pairing_mod
+
+        orig_add = pairing_mod._sync_allowlist_add
+
+        def spy_add(platform, user_id, *, profile=None):
+            profiles_seen.append(profile)
+            orig_add(platform, user_id, profile=profile)
+
+        monkeypatch.setattr(pairing_mod, "_sync_allowlist_add", spy_add)
+
+        store = PairingStore(profile="coder")
+        store._approve_user("telegram", "newuser", "")
+        assert "coder" in profiles_seen
+
+

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -688,40 +688,51 @@ class TestProfileScopedAllowlistWrites:
     """_sync_allowlist_add/remove with profile= writes to the profile's own
     .env instead of the root .env, preventing cross-profile credential
     leakage under multiplexing (issue #77490).
+
+    Follow-up review (#77519): the READ must resolve the same profile scope as
+    the WRITE. The dashboard approval path does not install the profile's
+    secret scope, so an unscoped read falls back to the process/root
+    allowlist and would copy root grants into the profile .env, clobbering
+    the profile's own entries. These tests use deliberately distinct process
+    and profile values to prove the boundary holds.
     """
 
-    def test_sync_allowlist_add_scopes_to_profile_env(self, tmp_path, monkeypatch):
-        from hermes_constants import get_hermes_home
-        from gateway.pairing import _sync_allowlist_add
-
-        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
-
-        # Root .env exists with TELEGRAM_ALLOWED_USERS already set.
+    def _setup_root_and_profile_env(self, tmp_path, monkeypatch):
+        """Create root .env (owner1) and coder profile .env (owner2) with
+        deliberately distinct allowlist values, and point HERMES_HOME at the
+        root so get_default_hermes_root() resolves to tmp_path."""
         root_env = tmp_path / ".env"
         root_env.write_text("TELEGRAM_ALLOWED_USERS=owner1\n", encoding="utf-8")
 
-        # Profile .env also has the same var.
         profile_env_dir = tmp_path / "profiles" / "coder"
         profile_env_dir.mkdir(parents=True)
         profile_env = profile_env_dir / ".env"
         profile_env.write_text("TELEGRAM_ALLOWED_USERS=owner2\n", encoding="utf-8")
 
+        # Process env also carries the ROOT value — the dashboard process env
+        # is the leak vector the scoped read must ignore.
         monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "owner1")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        return root_env, profile_env
 
-        saved = {}
-        import hermes_cli.config as cfg
+    def test_sync_allowlist_add_scopes_read_and_write_to_profile_env(
+        self, tmp_path, monkeypatch
+    ):
+        """Approving into a profile must read the PROFILE allowlist and write
+        the result into the profile .env — never copy the process/root value
+        across the boundary. Regression for the #77519 review finding."""
+        from gateway.pairing import _sync_allowlist_add
 
-        def fake_save(key, value):
-            saved[key] = value
-            os.environ[key] = value
-
-        monkeypatch.setattr(cfg, "save_env_value", fake_save)
+        root_env, profile_env = self._setup_root_and_profile_env(tmp_path, monkeypatch)
 
         _sync_allowlist_add("telegram", "newuser", profile="coder")
-        # The write should have been scoped to the coder profile.
-        # save_env_value receives the value; the caller can verify the
-        # override was applied.
-        assert saved.get("TELEGRAM_ALLOWED_USERS") == "owner1,newuser"
+
+        # Profile .env: profile's own owner2 preserved, newuser appended.
+        content = profile_env.read_text(encoding="utf-8")
+        assert "owner2,newuser" in content, f"profile .env = {content!r}"
+        assert "owner1" not in content, f"root value leaked into profile: {content!r}"
+        # Root .env untouched.
+        assert root_env.read_text(encoding="utf-8") == "TELEGRAM_ALLOWED_USERS=owner1\n"
 
     def test_sync_allowlist_add_no_profile_uses_root_env(self, tmp_path, monkeypatch):
         from gateway.pairing import _sync_allowlist_add
@@ -733,41 +744,68 @@ class TestProfileScopedAllowlistWrites:
 
         monkeypatch.setattr(cfg, "save_env_value", lambda k, v: saved.__setitem__(k, v))
 
-        # No profile passed — should write to root.
+        # No profile passed — should read the root/process env.
         _sync_allowlist_add("telegram", "newuser")
         assert saved.get("TELEGRAM_ALLOWED_USERS") == "owner1,newuser"
 
-    def test_sync_allowlist_remove_scopes_to_profile_env(self, tmp_path, monkeypatch):
+    def test_sync_allowlist_remove_scopes_read_and_write_to_profile_env(
+        self, tmp_path, monkeypatch
+    ):
+        """Revoking from a profile must read the PROFILE allowlist and remove
+        from the profile .env only — root entries untouched."""
         from gateway.pairing import _sync_allowlist_remove
 
-        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "owner1,newuser")
+        root_env, profile_env = self._setup_root_and_profile_env(tmp_path, monkeypatch)
+        # Give the profile its own user to remove.
+        profile_env.write_text(
+            "TELEGRAM_ALLOWED_USERS=owner2,newuser\n", encoding="utf-8"
+        )
 
-        removed = []
-        saved = {}
-        import hermes_cli.config as cfg
-
-        monkeypatch.setattr(cfg, "remove_env_value", lambda k: removed.append(k))
-        monkeypatch.setattr(cfg, "save_env_value", lambda k, v: saved.__setitem__(k, v))
-
-        # Removing "newuser" should leave "owner1" and call save_env_value
-        # scoped to the profile's .env.
         _sync_allowlist_remove("telegram", "newuser", profile="coder")
-        assert saved.get("TELEGRAM_ALLOWED_USERS") == "owner1"
-        assert "TELEGRAM_ALLOWED_USERS" not in removed
 
-    def test_sync_allowlist_remove_env_var_when_list_empties_profile(self, tmp_path, monkeypatch):
+        content = profile_env.read_text(encoding="utf-8")
+        assert "owner2" in content and "newuser" not in content, (
+            f"profile .env = {content!r}"
+        )
+        # Root .env untouched.
+        assert root_env.read_text(encoding="utf-8") == "TELEGRAM_ALLOWED_USERS=owner1\n"
+
+    def test_sync_allowlist_remove_env_var_when_list_empties_profile(
+        self, tmp_path, monkeypatch
+    ):
+        """Removing the last profile entry removes the var from the PROFILE
+        .env — and a profile with no allowlist at all is left untouched
+        (scoped read must not borrow the process value)."""
         from gateway.pairing import _sync_allowlist_remove
 
-        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "onlyuser")
-
-        removed = []
-        import hermes_cli.config as cfg
-
-        monkeypatch.setattr(cfg, "remove_env_value", lambda k: removed.append(k))
+        root_env, profile_env = self._setup_root_and_profile_env(tmp_path, monkeypatch)
+        # Only the profile has a single entry to remove.
+        profile_env.write_text("TELEGRAM_ALLOWED_USERS=onlyuser\n", encoding="utf-8")
 
         _sync_allowlist_remove("telegram", "onlyuser", profile="coder")
-        # The list is empty after removal, so remove_env_value should fire.
-        assert "TELEGRAM_ALLOWED_USERS" in removed
+        # The profile allowlist is empty after removal: the var is gone.
+        assert "TELEGRAM_ALLOWED_USERS" not in profile_env.read_text(encoding="utf-8")
+        # Root .env untouched (process value must not be borrowed).
+        assert root_env.read_text(encoding="utf-8") == "TELEGRAM_ALLOWED_USERS=owner1\n"
+
+    def test_sync_allowlist_remove_profile_without_env_is_noop(
+        self, tmp_path, monkeypatch
+    ):
+        """A profile with no .env / no allowlist is a no-op even when the
+        process env has a value — the scoped read must not fall back."""
+        from gateway.pairing import _sync_allowlist_remove
+
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "owner1")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "profiles" / "coder").mkdir(parents=True)
+
+        removed = []
+        import hermes_cli.config as cfg
+
+        monkeypatch.setattr(cfg, "remove_env_value", lambda k: removed.append(k))
+
+        _sync_allowlist_remove("telegram", "owner1", profile="coder")
+        assert removed == []
 
     def test_profile_approve_invokes_sync_with_profile(self, tmp_path, monkeypatch):
         """PairingStore.approve() passes profile to _sync_allowlist_add."""


### PR DESCRIPTION
## 背景

修复 #77490: Profile pairing grants write to root .env instead of profile-specific .env under multiplexing

## 根因分析

`PairingStore.approve()` 和 `revoke()` 在同步 allowlist 到 `.env` 时，调用 `save_env_value`/`remove_env_value` 始终写入根目录 `~/.hermes/.env`，而不考虑当前 profile 上下文。在多 profile 复用模式下：

1. Profile A 配对 Telegram 平台，token 写入 `~/.hermes/.env`
2. Profile B 读取同一根 `.env`，看到 Profile A 的凭证
3. 跨 profile 凭证泄露

## 修复方式

1. 为 `_sync_allowlist_add` 和 `_sync_allowlist_remove` 增加 `profile` 可选参数
2. 当 `profile` 存在时，使用 `set_hermes_home_override` 临时将 hermes home 切换到 `<root>/profiles/<profile>`，使 `save_env_value`/`remove_env_value` 写入该 profile 的 `.env`，完成后立即 reset
3. `PairingStore.approve()` 和 `revoke()` 传入 `self._profile`
4. **读侧同样绑定 profile**（#77519 review follow-up，`682ade244`）：新增 `_read_profile_allowlist_env()` 直接从 profile 自己的 `.env` 读取起始值（`load_env_file`，与写入同一文件），不再走进程环境/secret scope —— dashboard 审批路径不安装 profile 的 secret scope，旧实现会把 root allowlist 值（含 root-owner）写进 profile 文件、覆盖 profile-owner，构成跨信任边界授权携带。新增 `_profile_home_dir()` 用 `get_default_hermes_root()` 解析（与 `PairingStore` 一致），避免 HERMES_HOME 本身是 profile home 时路径嵌套
5. 新增回归测试验证 profile 隔离行为（含「进程值与 profile 值故意不同」的边界用例）

变更文件：
- `gateway/pairing.py` — 同步函数增加 profile 参数，读写两侧都绑定 profile 作用域

## Who should enable this

使用 **多 profile 复用模式**（multiplexed gateway）的 Hermes 用户：

- 多个 profile 各自配对平台（Telegram/Discord/Slack 等），但允许列表（allowlist）写到了共享的根 `.env`
- 担心 Profile A 的配对授权泄露给 Profile B

修复随代码生效；单 profile 部署（根 `.env`）行为完全不变。

## Platform compatibility

| 平台 | 兼容性 |
|---|---|
| macOS | ✅ 完全兼容 |
| Linux | ✅ 完全兼容 |
| Windows | ✅ 完全兼容（路径逻辑已做平台适配） |

## Quick-start guide

1. `hermes update`（或拉取本 PR 分支）
2. 重启 gateway（`hermes gateway restart`）
3. 验证：配对授权后，检查对应 profile 的 `.env`（`~/.hermes/profiles/<profile>/.env`）包含该平台 allowlist，根 `~/.hermes/.env` 不再被污染

## Troubleshooting

| 症状 | 原因 | 修复 |
|---|---|---|
| 授权写入根 .env | 旧版本写侧无 profile scope | 升级到本修复；授权写入 profile 自身 `.env` |
| 已有的根 .env 脏数据 | 升级前写入 | 手动从根 `.env` 移除对应 allowlist 条目（如有需要） |
| profile .env 出现 root 的 allowlist 值 | 旧版本读侧未绑定 profile（#77519 review） | 升级到 `682ade244`；读侧直接从 profile `.env` 读取 |
| 单 profile 行为变化 | — | 无变化（无 profile 时仍写根 `.env`） |

## 验证

- [x] 新增 6 个回归测试（profile 隔离 add/remove、进程 vs profile 值边界、无 .env profile no-op、override 恢复）
- [x] `tests/gateway/test_pairing.py` 35 项全部通过
- [x] ruff 检查通过
- [x] 无破坏性变更（单 profile 行为不变）

Closes #77490
