### PR TITLE
fix(security): create plaintext transcript artifacts owner-only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,12 @@ hermes-*/*
 examples/
 tests/quick_test_dataset.jsonl
 tests/sample_dataset.jsonl
+# Agent trajectory exports (AIAgent(save_trajectories=True) /
+# `run_agent.py --save_trajectories`). These append to the CWD, so a run
+# inside this checkout drops a full transcript — tool results and tool-call
+# arguments verbatim — next to the source. Never an artifact of the repo.
+trajectory_samples.jsonl
+failed_trajectories.jsonl
 run_datagen_kimik2-thinking.sh
 run_datagen_megascience_glm4-6.sh
 run_datagen_sonnet.sh

--- a/agent/moa_trace.py
+++ b/agent/moa_trace.py
@@ -124,7 +124,11 @@ def save_moa_turn(
     if base is None:
         return
     try:
-        base.mkdir(parents=True, exist_ok=True)
+        # Trace records embed the full messages every reference model saw.
+        # Create the directory owner-only (mode applies to dirs this call
+        # creates; an existing dir keeps its permissions) and the JSONL
+        # owner-only on first write.
+        base.mkdir(parents=True, exist_ok=True, mode=0o700)
         path = base / f"{_sanitize_session_id(session_id)}.jsonl"
         # output_location tells an offline reader where the acting text lives:
         # embedded here when we have it (both non-streaming inline capture and
@@ -161,7 +165,9 @@ def save_moa_turn(
                 "output_location": _output_location,
             },
         }
-        with path.open("a", encoding="utf-8") as f:
+        from utils import open_private_append
+
+        with open_private_append(path) as f:
             f.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
     except Exception as exc:  # pragma: no cover - tracing must never break a turn
         logger.debug("MoA trace write failed (session=%s): %s", session_id, exc)

--- a/agent/moa_trace.py
+++ b/agent/moa_trace.py
@@ -64,6 +64,39 @@ def _sanitize_session_id(session_id: Optional[str]) -> str:
     return "".join(c if (c.isalnum() or c in "-_.") else "_" for c in str(session_id))
 
 
+def _managed_install() -> bool:
+    """True when a package manager (NixOS) owns this install's modes.
+
+    Mirrors the check ``hermes_cli.config._secure_dir`` makes internally, read
+    here so the *creation* mode honours the same carve-out as reconciliation.
+    Import is local and failure means "not managed": an unimportable config
+    module is the single-user source-install case, where 0700 is correct.
+
+    Why the trace dir needs the carve-out at creation: ``nix/nixosModules.nix``
+    runs the gateway with ``UMask = "0007"`` precisely so "files created by the
+    gateway should be group-writable so interactive users in the hermes group
+    can read/write them", pins ``stateDir/.hermes`` to 2770 (setgid,
+    group-rwx), and avoids ``chown -R`` to keep the setgid bit alive "for group
+    access by hostUsers" — who get a ``~/.hermes`` symlink to that same
+    stateDir. Gateway and interactive CLI therefore share one ``$HERMES_HOME``,
+    so a 0700 trace dir created by whichever ran first locks the other out with
+    EACCES: the tracing feature itself, not just its permissions. Omitting the
+    mode lets the inherited setgid + umask land 2770, matching
+    ``ensure_hermes_home``'s managed branch and its ``logs/curator`` lazy-mkdir
+    precedent in ``hermes_cli.config``.
+
+    Deliberately a local helper. ``hermes_cli.config.secure_mkdir`` (PR #77655)
+    centralises exactly this branch, but it is not on ``main`` yet, so importing
+    it would couple this PR's merge to that one. Consolidate when it lands.
+    """
+    try:
+        from hermes_cli.config import is_managed
+
+        return bool(is_managed())
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
 def _slot_trace(acct: Any, label: str) -> dict[str, Any]:
     """Render one reference's _RefAccounting into a full trace dict.
 
@@ -124,11 +157,34 @@ def save_moa_turn(
     if base is None:
         return
     try:
-        # Trace records embed the full messages every reference model saw.
-        # Create the directory owner-only (mode applies to dirs this call
-        # creates; an existing dir keeps its permissions) and the JSONL
-        # owner-only on first write.
-        base.mkdir(parents=True, exist_ok=True, mode=0o700)
+        # Trace records embed the full messages every reference model saw, so
+        # create the directory owner-only and the JSONL owner-only on first
+        # write. Two limits on that ``mode``, both deliberate:
+        #
+        # * It applies only to the *final* component. ``Path.mkdir(parents=
+        #   True, mode=…)`` creates intermediates at the umask default, so a
+        #   ``moa.trace_dir`` override of ``a/b/traces`` leaves ``a`` and ``b``
+        #   at 0755 (measured). Harmless — the leaf stays 0700 and the JSONL
+        #   0600, so traversal into the traces themselves is still blocked —
+        #   but it is not the blanket "dirs this call creates" guarantee the
+        #   original comment claimed.
+        # * An existing dir keeps its permissions (``exist_ok=True`` does not
+        #   re-apply ``mode``), matching ``open_private_append``'s create-only
+        #   contract: never fight a mode the user widened on purpose.
+        #
+        # Managed mode is carved out at creation, not just at reconciliation.
+        # ``moa-traces`` is NOT among the dirs ``nix/nixosModules.nix``
+        # pre-creates via ``systemd.tmpfiles`` (stateDir, .hermes, cron,
+        # sessions, logs, memories, plugins — all 2770), so on a managed host it
+        # is always made lazily here and this ``mode`` is the only thing setting
+        # it. See ``_managed_install`` for why forcing 0700 there breaks the
+        # module's hermes-group sharing. ``HERMES_HOME_MODE`` is deliberately
+        # not honoured: that hatch exists so a web server can *traverse*
+        # HERMES_HOME to reach a served subdir, and nothing is served from here.
+        if _managed_install():
+            base.mkdir(parents=True, exist_ok=True)
+        else:
+            base.mkdir(parents=True, exist_ok=True, mode=0o700)
         path = base / f"{_sanitize_session_id(session_id)}.jsonl"
         # output_location tells an offline reader where the acting text lives:
         # embedded here when we have it (both non-streaming inline capture and

--- a/agent/trajectory.py
+++ b/agent/trajectory.py
@@ -49,7 +49,15 @@ def save_trajectory(trajectory: List[Dict[str, Any]], model: str,
     }
 
     try:
-        with open(filename, "a", encoding="utf-8") as f:
+        # Trajectories carry full tool results and tool-call arguments. A bare
+        # append open would create the file with umask permissions (0o644 on a
+        # default install), leaving a complete transcript readable by every
+        # local account — and these land in the CWD, not under the 0o700
+        # HERMES_HOME. Create new files owner-only; an existing file the user
+        # deliberately widened is left alone (see open_private_append).
+        from utils import open_private_append
+
+        with open_private_append(filename) as f:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
         logger.info("Trajectory saved to %s", filename)
     except Exception as e:

--- a/cli.py
+++ b/cli.py
@@ -8321,12 +8321,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             from utils import atomic_json_write
 
             # The snapshot is a full plaintext transcript. Write it owner-only
-            # (0600) rather than at umask default (0644) — the enclosing
-            # HERMES_HOME is 0700, but the snapshot is the artifact users copy
-            # out to share, so its own mode is what travels with it. Content is
-            # deliberately verbatim: this exports the same history the session
-            # DB replays, and masking it here would make the export lossy
-            # against the thing it snapshots (see #43083).
+            # (0600) rather than at umask default (0644). Don't lean on the
+            # enclosing directory for this: ensure_hermes_home() does chmod
+            # HERMES_HOME itself owner-only, but that is 0750/2770 in managed
+            # (NixOS) mode, overridable via HERMES_HOME_MODE (e.g. 0701 for web
+            # server traversal), and this saved_dir is created by the bare
+            # mkdir above at umask default (0755) either way. The file's own
+            # mode is the part that holds across deployments — and it is what
+            # travels with the snapshot when users copy it out to share.
+            # Content is deliberately verbatim: this exports the same history
+            # the session DB replays, and masking it here would make the export
+            # lossy against the thing it snapshots (see #43083).
             atomic_json_write(
                 path,
                 {

--- a/cli.py
+++ b/cli.py
@@ -8318,13 +8318,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         path = saved_dir / f"hermes_conversation_{timestamp}.json"
 
         try:
-            with open(path, "w", encoding="utf-8") as f:
-                json.dump({
+            from utils import atomic_json_write
+
+            # The snapshot is a full plaintext transcript. Write it owner-only
+            # (0600) rather than at umask default (0644) — the enclosing
+            # HERMES_HOME is 0700, but the snapshot is the artifact users copy
+            # out to share, so its own mode is what travels with it. Content is
+            # deliberately verbatim: this exports the same history the session
+            # DB replays, and masking it here would make the export lossy
+            # against the thing it snapshots (see #43083).
+            atomic_json_write(
+                path,
+                {
                     "model": self.model,
                     "session_id": self.session_id,
                     "session_start": self.session_start.isoformat(),
                     "messages": self.conversation_history,
-                }, f, indent=2, ensure_ascii=False)
+                },
+                mode=0o600,
+            )
             print(f"(^_^)v Conversation snapshot saved to: {path}")
             if self.session_id:
                 print(f"       Resume the live session with: hermes --resume {self.session_id}")

--- a/cli.py
+++ b/cli.py
@@ -8323,12 +8323,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # The snapshot is a full plaintext transcript. Write it owner-only
             # (0600) rather than at umask default (0644). Don't lean on the
             # enclosing directory for this: ensure_hermes_home() does chmod
-            # HERMES_HOME itself owner-only, but that is 0750/2770 in managed
-            # (NixOS) mode, overridable via HERMES_HOME_MODE (e.g. 0701 for web
-            # server traversal), and this saved_dir is created by the bare
-            # mkdir above at umask default (0755) either way. The file's own
-            # mode is the part that holds across deployments — and it is what
-            # travels with the snapshot when users copy it out to share.
+            # HERMES_HOME itself owner-only on a source install, where that is
+            # overridable via HERMES_HOME_MODE (e.g. 0701 for web server
+            # traversal); in managed (NixOS) mode it chmods nothing at all —
+            # _secure_dir() returns early and nix/nixosModules.nix pins
+            # HERMES_HOME to 2770 instead (setgid, group-rwx, so the gateway and
+            # interactive hermes-group users can share state). And saved_dir
+            # itself is created by the bare mkdir above at whatever the umask
+            # allows: measured 0755 on a default install, 0770 under the managed
+            # unit's UMask = "0007". So no enclosing directory here is reliably
+            # owner-only. The file's own mode is the part that holds across
+            # deployments — and it is what travels with the snapshot when users
+            # copy it out to share.
             # Content is deliberately verbatim: this exports the same history
             # the session DB replays, and masking it here would make the export
             # lossy against the thing it snapshots (see #43083).

--- a/tests/hermes_cli/test_atomic_json_write.py
+++ b/tests/hermes_cli/test_atomic_json_write.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import stat
 from pathlib import Path
 from unittest.mock import patch
 
@@ -9,9 +10,110 @@ import pytest
 
 from utils import atomic_json_write
 
+posix_only = pytest.mark.skipif(
+    os.name != "posix",
+    reason="POSIX permission bits; Windows honours only the read-only bit",
+)
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
 
 class TestAtomicJsonWrite:
     """Core atomic write behavior."""
+
+    @posix_only
+    def test_mode_overrides_a_pre_existing_permissive_mode(self, tmp_path):
+        """``mode=`` must win over the mode an existing target already has.
+
+        This is the *only* case where the argument changes the result, and it
+        was untested — which made ``mode=`` deletable everywhere without a
+        single failure. Measured behaviour of the four combinations:
+
+        ==========================  ==========  ==========
+        target                      no ``mode=``  ``mode=0o600``
+        ==========================  ==========  ==========
+        fresh file                  0o600       0o600
+        existing 0o644              0o644       0o600
+        ==========================  ==========  ==========
+
+        On a fresh file the argument is a no-op: ``tempfile.mkstemp`` already
+        creates at 0o600 and passing ``mode`` forces ``original_mode = None`` so
+        ``_restore_file_mode`` returns early. Every caller that only ever writes
+        a brand-new file therefore looks correct with or without it. What the
+        argument actually buys is *overwrite*, where the default behaviour is to
+        **preserve** the existing mode.
+
+        That path is reachable in production. ``/save`` names its snapshot
+        ``hermes_conversation_%Y%m%d_%H%M%S.json`` — second resolution, so two
+        saves in the same second hit the same file — and a snapshot left at
+        0o644 by a pre-hardening Hermes would otherwise keep 0o644 while
+        receiving a fresh full transcript. Asserting it on the helper covers
+        every caller that passes a mode, not just this one.
+        """
+        target = tmp_path / "snapshot.json"
+        target.write_text(json.dumps({"old": True}), encoding="utf-8")
+        os.chmod(target, 0o644)
+
+        atomic_json_write(target, {"new": True}, mode=0o600)
+
+        assert _mode(target) == 0o600, (
+            f"mode= did not override the pre-existing 0o644 ({oct(_mode(target))}); "
+            "atomic_json_write preserves the target's mode by default, so "
+            "without this the argument has no observable effect on any path"
+        )
+        assert json.loads(target.read_text(encoding="utf-8")) == {"new": True}
+
+    @posix_only
+    def test_existing_mode_is_preserved_when_no_mode_requested(self, tmp_path):
+        """The contrast case that makes the test above meaningful.
+
+        Default behaviour is deliberate preservation: ``_preserve_file_mode`` /
+        ``_restore_file_mode`` reinstate the target's original bits after the
+        replace, so callers that have no opinion don't silently re-tighten a
+        file the user widened. Pinning it here is what proves the sibling test
+        is observing ``mode=`` and not just ``mkstemp``'s 0o600.
+        """
+        target = tmp_path / "shared.json"
+        target.write_text(json.dumps({"old": True}), encoding="utf-8")
+        os.chmod(target, 0o644)
+
+        atomic_json_write(target, {"new": True})
+
+        assert _mode(target) == 0o644, (
+            "an existing file's mode must survive a write that requests none"
+        )
+
+    @posix_only
+    def test_mode_is_applied_verbatim_not_merely_left_at_mkstemp_default(
+        self, tmp_path
+    ):
+        """``mode=`` must set exactly the mode asked for, via a real chmod.
+
+        Needed because ``mode=0o600`` — the value every caller in the tree
+        happens to use — is indistinguishable from doing nothing at all. Four
+        mechanisms converge on it: ``mkstemp`` creates the temp file at 0o600,
+        passing ``mode`` sets ``original_mode = None`` so the preserve/restore
+        path is skipped, then ``fchmod`` and the post-replace ``os.chmod`` each
+        set it again. Disabling *both* chmod calls still yields 0o600, so the
+        sibling tests above cannot distinguish "chmod ran" from "mkstemp's
+        default survived".
+
+        0o640 is a mode ``mkstemp`` cannot produce, so only an actual chmod can
+        get there. That pins the contract as "the file ends up at ``mode``"
+        rather than the much weaker "the file ends up no wider than 0o600",
+        which is what the other assertions really prove.
+        """
+        target = tmp_path / "group_readable.json"
+
+        atomic_json_write(target, {"shared": True}, mode=0o640)
+
+        assert _mode(target) == 0o640, (
+            f"requested 0o640 but got {oct(_mode(target))}; mode= is not being "
+            "applied by chmod — the observed bits are just mkstemp's 0o600 "
+            "default surviving the replace"
+        )
 
 
 

--- a/tests/test_transcript_artifact_file_modes.py
+++ b/tests/test_transcript_artifact_file_modes.py
@@ -44,6 +44,56 @@ def permissive_umask():
         os.umask(previous)
 
 
+@pytest.fixture
+def managed_nixos_home(tmp_path, monkeypatch):
+    """Simulate a managed NixOS install that shares state via the hermes group.
+
+    Reproduces the three conditions ``nix/nixosModules.nix`` actually creates,
+    all of which have to hold together for this to be a real reproduction:
+
+    * ``HERMES_MANAGED=nixos``, as the systemd unit sets;
+    * the parent at ``2770`` — setgid, group-rwx — which ``systemd.tmpfiles``
+      pins for ``stateDir/.hermes`` in ``nix/nixosModules.nix`` so the gateway
+      and interactive ``hostUsers`` share it;
+    * ``umask 0007``, which the same module sets on the unit via
+      ``UMask = "0007"``, commented "files created by the gateway should be
+      group-writable so interactive users in the hermes group can read/write
+      them".
+
+    Setting only the env var would pass for the wrong reason: with a default
+    ``umask 022`` and a non-setgid parent, a fresh dir lands 0755 and any
+    "group access survived" assertion is satisfied by the ambient umask rather
+    than by the carve-out under test.
+
+    The dirs those tmpfiles rules DO pre-create are present; ``moa-traces`` is
+    deliberately absent, because it is NOT in those rules. On a managed host it
+    is therefore always created lazily at runtime, which is why the creation
+    mode — not just the reconciliation — has to honour managed mode.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_MANAGED", "nixos")
+    os.chmod(home, 0o2770)
+    # The dirs the tmpfiles rules DO pre-create, at the 2770 they pin. Present
+    # so the fixture is a real managed host and not a half-built one, which
+    # makes ``moa-traces``'s absence the *only* difference between it and its
+    # siblings — the whole claim under test. Load-bearing, not decoration:
+    # ``load_config()`` runs ``ensure_hermes_home()``, whose managed branch
+    # raises when they are missing, and ``_traces_enabled_and_dir()`` swallows
+    # that and returns None. Drop them and the test fails on "managed mode must
+    # still create the trace dir" rather than passing while creating nothing.
+    for subdir in ("cron", "sessions", "logs", "memories", "plugins"):
+        d = home / subdir
+        d.mkdir(parents=True, exist_ok=True)
+        os.chmod(d, 0o2770)
+    previous = os.umask(0o007)
+    try:
+        yield home
+    finally:
+        os.umask(previous)
+
+
 def _mode(path: Path) -> int:
     return stat.S_IMODE(path.stat().st_mode)
 
@@ -84,10 +134,38 @@ def test_trajectory_jsonl_appends_and_keeps_content_verbatim(
     save_trajectory([{"from": "human", "value": "first"}], "m", True)
     save_trajectory([{"from": "human", "value": "second"}], "m", True)
 
-    lines = (tmp_path / "trajectory_samples.jsonl").read_text().strip().splitlines()
+    lines = (
+        (tmp_path / "trajectory_samples.jsonl")
+        .read_text(encoding="utf-8")
+        .strip()
+        .splitlines()
+    )
     assert len(lines) == 2, lines
     assert json.loads(lines[0])["conversations"][0]["value"] == "first"
     assert json.loads(lines[1])["conversations"][0]["value"] == "second"
+
+
+@posix_only
+def test_failed_trajectory_jsonl_created_owner_only(
+    tmp_path, monkeypatch, permissive_umask
+):
+    """The ``completed=False`` branch writes a different filename.
+
+    ``save_trajectory`` picks ``failed_trajectories.jsonl`` instead of
+    ``trajectory_samples.jsonl`` when the run did not complete. Both go through
+    the same hardened open, but only the success filename was asserted, so the
+    failure path was covered by implication rather than by a test. A failed
+    trajectory holds the same verbatim tool output as a successful one — often
+    more of it, since failures are what people debug and share.
+    """
+    monkeypatch.chdir(tmp_path)
+    from agent.trajectory import save_trajectory
+
+    save_trajectory([{"from": "human", "value": "boom"}], "m", False)
+
+    written = tmp_path / "failed_trajectories.jsonl"
+    assert written.is_file(), list(tmp_path.iterdir())
+    _assert_owner_only(written)
 
 
 @posix_only
@@ -99,7 +177,7 @@ def test_trajectory_existing_relaxed_file_is_not_retightened(
     from agent.trajectory import save_trajectory
 
     target = tmp_path / "trajectory_samples.jsonl"
-    target.write_text("")
+    target.write_text("", encoding="utf-8")
     os.chmod(target, 0o644)
 
     save_trajectory([{"from": "human", "value": "hi"}], "m", True)
@@ -142,8 +220,67 @@ def test_save_conversation_snapshot_owner_only(tmp_path, monkeypatch, permissive
     _assert_owner_only(files[0])
 
     # Export stays verbatim: it snapshots the history the session DB replays.
-    payload = json.loads(files[0].read_text())
+    payload = json.loads(files[0].read_text(encoding="utf-8"))
     assert payload["messages"] == history
+
+
+@posix_only
+def test_save_conversation_retightens_a_pre_existing_permissive_snapshot(
+    tmp_path, monkeypatch, permissive_umask
+):
+    """Overwriting an already-0644 snapshot must drop it to 0600.
+
+    The sibling test above writes a *fresh* file, and on a fresh file
+    ``atomic_json_write``'s ``mode=`` argument is a no-op: ``mkstemp`` already
+    creates at 0600 and passing ``mode`` short-circuits the preserve/restore
+    path. So a fresh-file assertion cannot tell whether ``mode=0o600`` is
+    present at the call site at all — deleting it keeps that test green.
+
+    Overwrite is the case that distinguishes them, because the default
+    behaviour is to *preserve* the target's existing mode. It is reachable:
+    the snapshot name has second resolution
+    (``hermes_conversation_%Y%m%d_%H%M%S.json``), so two ``/save`` calls in the
+    same second land on the same path, and a snapshot written by a pre-fix
+    Hermes sits there at 0644 — receiving a fresh full transcript while keeping
+    world-readable bits.
+
+    The timestamp is frozen rather than raced so the collision is deterministic
+    instead of dependent on wall-clock luck.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import cli
+
+    frozen = datetime(2026, 1, 1, 12, 0, 0)
+
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return frozen
+
+    monkeypatch.setattr(cli, "datetime", _FrozenDatetime)
+
+    target = home / "sessions" / "saved" / "hermes_conversation_20260101_120000.json"
+    target.parent.mkdir(parents=True)
+    target.write_text(json.dumps({"messages": ["stale"]}), encoding="utf-8")
+    os.chmod(target, 0o644)
+
+    history = [{"role": "user", "content": "fresh transcript"}]
+    stub = SimpleNamespace(
+        conversation_history=history,
+        model="test-model",
+        session_id="20260101_120000_abc123",
+        session_start=frozen,
+    )
+    cli.HermesCLI.save_conversation(stub)
+
+    assert json.loads(target.read_text(encoding="utf-8"))["messages"] == history, (
+        "the overwrite did not land on the pre-existing path; the timestamp "
+        "collision this test depends on did not happen"
+    )
+    _assert_owner_only(target)
 
 
 @posix_only
@@ -175,4 +312,69 @@ def test_moa_trace_jsonl_and_dir_owner_only(tmp_path, monkeypatch, permissive_um
     dir_mode = _mode(trace_dir)
     assert not dir_mode & (stat.S_IRWXG | stat.S_IRWXO), (
         f"moa-traces dir is group/other-accessible ({oct(dir_mode)})"
+    )
+
+
+@posix_only
+def test_moa_trace_managed_mode_fresh_dir_keeps_group_sharing(managed_nixos_home):
+    """A *newly created* trace dir on NixOS must stay group-shareable.
+
+    This is the managed counterpart to the test above, and it is the case that
+    matters on a managed host: ``moa-traces`` is not among the directories
+    ``nix/nixosModules.nix`` pre-creates via ``systemd.tmpfiles`` (stateDir,
+    .hermes, cron, sessions, logs, memories, plugins — all 2770), so it is
+    always created lazily here and the mode passed at creation is the only
+    thing that decides it. There is no reconciliation step to fall back on.
+
+    Forcing 0700 here would not be cosmetic. The module shares ``$HERMES_HOME``
+    between the gateway service and interactive ``hostUsers`` through the hermes
+    group — 2770 + ``UMask = "0007"`` + a deliberate refusal to ``chown -R``,
+    which strips setgid — and hostUsers get a ``~/.hermes`` symlink to that same
+    stateDir. A 0700 trace dir created by whichever side runs first locks the
+    other out with EACCES: the tracing feature itself, not just its permissions.
+
+    Asserts group access survives rather than a literal octal: the exact bits
+    depend on the inherited setgid and umask, and the contract is "the group can
+    still get in", not "it is precisely 2770".
+
+    Nothing is stubbed here. The claim under test is specifically that the
+    *default*, ``get_hermes_home()``-derived ``moa-traces`` path is created
+    lazily on a managed host, so the whole chain has to be real code: a real
+    ``config.yaml`` turns the opt-in on, real ``load_config()`` reads it (which
+    also runs ``ensure_hermes_home()``'s managed branch against the fixture's
+    tmpfiles skeleton), and real ``_traces_enabled_and_dir()`` derives the path.
+    """
+    import agent.moa_trace as moa_trace
+
+    trace_dir = managed_nixos_home / "moa-traces"
+    assert not trace_dir.exists(), "fixture precondition: dir must be absent"
+
+    (managed_nixos_home / "config.yaml").write_text(
+        "moa:\n  save_traces: true\n  trace_dir: ''\n", encoding="utf-8"
+    )
+
+    moa_trace.save_moa_turn(
+        session_id="sess-1",
+        preset_name="default",
+        reference_outputs=[],
+        aggregator_label="agg",
+        aggregator_model="m",
+        aggregator_provider="p",
+        aggregator_temperature=0.7,
+        aggregator_input_messages=[{"role": "user", "content": "hi"}],
+        aggregator_output="hello",
+        aggregator_streamed=False,
+    )
+
+    assert trace_dir.is_dir(), "managed mode must still create the trace dir"
+    dir_mode = _mode(trace_dir)
+    assert dir_mode & stat.S_IRWXG, (
+        f"fresh managed-mode {trace_dir} dropped group access ({oct(dir_mode)}); "
+        "the NixOS module's hermes-group sharing (2770 + UMask=0007) is broken, "
+        "so an interactive hostUsers CLI and the gateway can no longer share "
+        "the trace dir — one locks the other out with EACCES"
+    )
+    assert not dir_mode & stat.S_IRWXO, (
+        f"managed mode must not widen to other ({oct(dir_mode)}); the umask "
+        "0007 the unit sets is what bounds this, and it excludes other"
     )

--- a/tests/test_transcript_artifact_file_modes.py
+++ b/tests/test_transcript_artifact_file_modes.py
@@ -1,0 +1,181 @@
+"""Plaintext transcript artifacts must be created owner-only.
+
+``/save`` snapshots, agent trajectories, and MoA traces all persist verbatim
+conversation content — message text, tool results, tool-call arguments. Each
+was created through a bare ``open()``/``json.dump()``, so its permissions came
+from the process umask (0o644 on a default install), leaving a full transcript
+readable by every local account. Trajectories are the sharpest case: they
+append to the CWD rather than the 0o700 ``HERMES_HOME``.
+
+These tests assert the *contract* (no group/other bits on a freshly created
+artifact), not a specific octal, and they exercise the real write paths against
+a temp home with a deliberately permissive umask so a regression to
+umask-derived modes fails here.
+
+Content is intentionally NOT asserted to be redacted. These artifacts export
+the same history the session DB replays, and masking a credential in a replayed
+path poisons the replay (#43083) — see ``test_tool_call_arg_no_redaction.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+posix_only = pytest.mark.skipif(
+    os.name != "posix",
+    reason="POSIX permission bits; Windows at-rest protection is ACL-based",
+)
+
+
+@pytest.fixture
+def permissive_umask():
+    """Force a umask that would yield world-readable files if mode were unset."""
+    previous = os.umask(0o022)
+    try:
+        yield
+    finally:
+        os.umask(previous)
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def _assert_owner_only(path: Path) -> None:
+    mode = _mode(path)
+    assert not mode & (stat.S_IRWXG | stat.S_IRWXO), (
+        f"{path.name} is group/other-accessible ({oct(mode)}); a plaintext "
+        "transcript artifact must be created owner-only"
+    )
+
+
+@posix_only
+def test_trajectory_jsonl_created_owner_only(tmp_path, monkeypatch, permissive_umask):
+    """save_trajectory writes to the CWD — the new file must not be 0o644."""
+    monkeypatch.chdir(tmp_path)
+    from agent.trajectory import save_trajectory
+
+    save_trajectory(
+        [{"from": "human", "value": "hi"}, {"from": "gpt", "value": "hello"}],
+        "test-model",
+        True,
+    )
+
+    written = tmp_path / "trajectory_samples.jsonl"
+    assert written.is_file(), list(tmp_path.iterdir())
+    _assert_owner_only(written)
+
+
+@posix_only
+def test_trajectory_jsonl_appends_and_keeps_content_verbatim(
+    tmp_path, monkeypatch, permissive_umask
+):
+    """Hardening the mode must not change append semantics or content."""
+    monkeypatch.chdir(tmp_path)
+    from agent.trajectory import save_trajectory
+
+    save_trajectory([{"from": "human", "value": "first"}], "m", True)
+    save_trajectory([{"from": "human", "value": "second"}], "m", True)
+
+    lines = (tmp_path / "trajectory_samples.jsonl").read_text().strip().splitlines()
+    assert len(lines) == 2, lines
+    assert json.loads(lines[0])["conversations"][0]["value"] == "first"
+    assert json.loads(lines[1])["conversations"][0]["value"] == "second"
+
+
+@posix_only
+def test_trajectory_existing_relaxed_file_is_not_retightened(
+    tmp_path, monkeypatch, permissive_umask
+):
+    """A file the user deliberately widened keeps its mode (opt-in export)."""
+    monkeypatch.chdir(tmp_path)
+    from agent.trajectory import save_trajectory
+
+    target = tmp_path / "trajectory_samples.jsonl"
+    target.write_text("")
+    os.chmod(target, 0o644)
+
+    save_trajectory([{"from": "human", "value": "hi"}], "m", True)
+
+    assert _mode(target) == 0o644, (
+        "an existing trajectory file's permissions must be left as the user "
+        "set them; only creation applies the private mode"
+    )
+
+
+@posix_only
+def test_save_conversation_snapshot_owner_only(tmp_path, monkeypatch, permissive_umask):
+    """/save writes a full transcript — the snapshot must be owner-only."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import hermes_constants
+
+    if hasattr(hermes_constants, "_hermes_home_cache"):
+        hermes_constants._hermes_home_cache = None
+    for mod in [m for m in sys.modules if m.startswith("cli") or m == "hermes_constants"]:
+        sys.modules.pop(mod, None)
+
+    import cli
+
+    history = [
+        {"role": "user", "content": "deploy with PGPASSWORD=hunter2"},
+        {"role": "assistant", "content": "done"},
+    ]
+    stub = SimpleNamespace(
+        conversation_history=history,
+        model="test-model",
+        session_id="20260101_120000_abc123",
+        session_start=datetime(2026, 1, 1, 12, 0, 0),
+    )
+    cli.HermesCLI.save_conversation(stub)
+
+    files = list((home / "sessions" / "saved").glob("hermes_conversation_*.json"))
+    assert len(files) == 1, files
+    _assert_owner_only(files[0])
+
+    # Export stays verbatim: it snapshots the history the session DB replays.
+    payload = json.loads(files[0].read_text())
+    assert payload["messages"] == history
+
+
+@posix_only
+def test_moa_trace_jsonl_and_dir_owner_only(tmp_path, monkeypatch, permissive_umask):
+    """MoA traces embed every reference model's full input messages."""
+    import agent.moa_trace as moa_trace
+
+    trace_dir = tmp_path / "moa-traces"
+    monkeypatch.setattr(
+        moa_trace, "_traces_enabled_and_dir", lambda: trace_dir
+    )
+
+    moa_trace.save_moa_turn(
+        session_id="sess-1",
+        preset_name="default",
+        reference_outputs=[],
+        aggregator_label="agg",
+        aggregator_model="m",
+        aggregator_provider="p",
+        aggregator_temperature=0.7,
+        aggregator_input_messages=[{"role": "user", "content": "hi"}],
+        aggregator_output="hello",
+        aggregator_streamed=False,
+    )
+
+    written = trace_dir / "sess-1.jsonl"
+    assert written.is_file(), list(trace_dir.iterdir())
+    _assert_owner_only(written)
+    dir_mode = _mode(trace_dir)
+    assert not dir_mode & (stat.S_IRWXG | stat.S_IRWXO), (
+        f"moa-traces dir is group/other-accessible ({oct(dir_mode)})"
+    )

--- a/tests/test_transcript_artifact_file_modes.py
+++ b/tests/test_transcript_artifact_file_modes.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import json
 import os
 import stat
-import sys
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -116,16 +115,14 @@ def test_save_conversation_snapshot_owner_only(tmp_path, monkeypatch, permissive
     """/save writes a full transcript — the snapshot must be owner-only."""
     home = tmp_path / ".hermes"
     home.mkdir()
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HERMES_HOME", str(home))
 
-    import hermes_constants
-
-    if hasattr(hermes_constants, "_hermes_home_cache"):
-        hermes_constants._hermes_home_cache = None
-    for mod in [m for m in sys.modules if m.startswith("cli") or m == "hermes_constants"]:
-        sys.modules.pop(mod, None)
-
+    # No sys.modules purge and no Path.home patch here: save_conversation
+    # resolves the directory through get_hermes_home() at call time, and that
+    # reads HERMES_HOME from the environment on every call with no caching, so
+    # the setenv above is sufficient no matter how early cli was imported.
+    # Purging modules by ``startswith("cli")`` would also evict click and its
+    # submodules, breaking module identity for the rest of the suite.
     import cli
 
     history = [

--- a/utils.py
+++ b/utils.py
@@ -171,6 +171,37 @@ def atomic_write_text(
         raise
 
 
+def open_private_append(
+    path: Union[str, Path],
+    *,
+    encoding: str = "utf-8",
+    mode: int = 0o600,
+):
+    """Open *path* for appending, creating it owner-only when it's new.
+
+    Append-mode transcript artifacts (agent trajectories, MoA traces) are
+    created by a bare ``open(..., "a")`` in most codebases, which derives
+    permissions from the process umask — typically 0o644, i.e. readable by
+    every local account. These files carry full tool output and message
+    content, so a fresh one should start owner-only.
+
+    Only the *creating* open applies ``mode``: an existing file keeps whatever
+    permissions it has. That is deliberate. These artifacts are explicit
+    opt-in exports (``save_trajectories``, ``moa.save_traces``) that users
+    legitimately relax to share or to feed a training pipeline, and silently
+    re-tightening a file the user widened on purpose would fight that.
+
+    ``mode`` is advisory on Windows, where ``os.open`` honours only the
+    read-only bit; at-rest protection there comes from ACLs, not POSIX bits.
+    """
+    path = Path(path)
+
+    def _opener(target: str, flags: int) -> int:
+        return os.open(target, flags, mode)
+
+    return open(path, "a", encoding=encoding, opener=_opener)
+
+
 def atomic_json_write(
     path: Union[str, Path],
     data: Any,


### PR DESCRIPTION
## What does this PR do?

`/save` snapshots, agent trajectories, and MoA traces each persist **verbatim** conversation content — message text, tool results, tool-call arguments — through a bare `open()` / `json.dump()`. Permissions therefore came from the process umask, i.e. `0o644` on a default install.

Trajectories are the sharpest case: `save_trajectory()` appends to the **CWD**, not to the `0o700` `HERMES_HOME`. A run inside a checkout drops a world-readable full transcript next to the source, and neither filename was gitignored.

**Scoped to file modes only.** Content is deliberately *not* redacted:

- These artifacts export the same history the session DB replays, and masking a credential in a replayed path poisons the replay — that's #43083, guarded by `tests/agent/test_tool_call_arg_no_redaction.py`.
- Trajectories (training data) and MoA traces (offline end-to-end audit) exist to be full-fidelity; redacting them unconditionally would defeat the feature.
- Trace redaction is already available opt-in as `moa.privacy_filter: display`.

## Related Issue

Refs #77472 (partial — the file-mode items only; the "exact-value redaction on every persistence path" ask is deliberately not implemented, for the reasons above)

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `utils.py` — new `open_private_append()` for append-mode artifacts. Only the *creating* open applies the mode: a file the user deliberately relaxed (to share, or to feed a training pipeline) keeps its permissions. Mode is advisory on Windows, where at-rest protection is ACL-based.
- `cli.py` (`save_conversation`) — write the snapshot via `atomic_json_write(..., mode=0o600)`. This also closes a truncated-file window: the old `json.dump` wrote in place, so a serialization failure mid-write left a partial snapshot behind. Now the temp file is discarded and the same `(x_x) Failed to save:` message is printed.
- `agent/trajectory.py` — create `trajectory_samples.jsonl` / `failed_trajectories.jsonl` owner-only.
- `agent/moa_trace.py` — create the trace JSONL owner-only and `moa-traces/` as `0o700`, **except on a managed (NixOS) install**, where the mode is omitted so the module's configured setgid + umask decide. See "Managed-mode carve-out" below.
- `.gitignore` — ignore both trajectory filenames.
- `tests/test_transcript_artifact_file_modes.py` — new.

## How to Test

1. `scripts/run_tests.sh tests/test_transcript_artifact_file_modes.py tests/hermes_cli/test_atomic_json_write.py` — 14 tests (was 8: 5 + 3). They assert the *contract* (no group/other bits on a freshly created artifact) rather than freezing an octal, run under a deliberately permissive `umask 0o022`, and exercise the real write paths so a regression to umask-derived modes fails here.
2. Regression check on the paths touched: `scripts/run_tests.sh tests/cli/test_save_conversation_location.py tests/agent/test_moa_trace_streamed_capture.py tests/test_trajectory_compressor.py tests/test_trajectory_compressor_async.py` — 33 passed.
3. Shared-helper blast radius: `scripts/run_tests.sh tests/hermes_cli/test_atomic_json_write.py tests/test_atomic_replace_symlinks.py tests/hermes_cli/test_atomic_yaml_write.py tests/test_stale_utils_module_import.py tests/test_utils_truthy_values.py` — 22 passed. Plus `scripts/run_tests.sh -k moa` (2999 files) — exit 0.
4. Manual, real config gate (not monkeypatched) — temp `HERMES_HOME`, `moa.save_traces: true`, `umask 022`:

   ```
   resolved trace dir: <tmp>/.hermes/moa-traces
   dir  mode: 0o700
   file mode: 0o600
   full-fidelity input preserved: token sk-proj-aaaaaa ...
   ```

5. Manual `/save`: snapshot lands at `0o600`; with non-serializable content it prints `(x_x) Failed to save: Object of type Unserializable is not JSON serializable` and leaves no partial or `.tmp` file behind.

Review follow-up (second commit): the `/save` test no longer purges
`sys.modules` before importing `cli`. The filter was `m.startswith("cli")`,
which also matched `click` and its 11 submodules and broke class identity for
the rest of the suite. It was unnecessary — the autouse `_hermetic_environment`
fixture (`tests/conftest.py:441`) already redirects `HERMES_HOME`,
`get_hermes_home()` re-reads the env var on every call with no caching, and
`save_conversation` resolves it at call time. Teeth check after the edit:
restoring the pre-fix `open(path, "w") + json.dump` makes
`test_save_conversation_snapshot_owner_only` fail with
`hermes_conversation_*.json is group/other-accessible (0o644)`.

Pre-existing unrelated failure, present on clean `main` before this branch and unchanged by it: `tests/agent/test_compression_concurrent_fork.py::test_fence_cancelled_compression_leaves_lock_reacquirable`.

## Managed-mode carve-out, and the `mode=` wiring gap (third commit)

A full-suite verification pass (2514 files / 23624 passed on this branch at
merge base `3572d4bca`, 2026-08-01; 39 failures, all 39 reproducing
identically at that same merge base) found three defects in this PR's own
work. None of them were catchable by the suite as it stood. `upstream/main`
has since advanced past that base — 2551 raw `tests/` files at `3572d4bca`
versus 2630 today — so absolute counts from a re-run will not match these.

**1. `moa-traces/` was revoking NixOS group access.** `mode=0o700` was passed
to `base.mkdir` unconditionally, with no managed-mode carve-out.
`nix/nixosModules.nix` pre-creates only stateDir, `.hermes`, cron, sessions,
logs, memories, plugins (2770 — setgid, group-rwx) via `systemd.tmpfiles`;
`moa-traces` is **not** among them, so on a managed host it is created lazily
here and that `mode` was the only thing setting it. The same module runs the
gateway with `UMask = "0007"` specifically so "files created by the gateway
should be group-writable so interactive users in the hermes group can
read/write them", and avoids `chown -R` to keep the setgid bit alive "for group
access by hostUsers" — who get a `~/.hermes` symlink to that same stateDir.
Gateway and interactive CLI therefore share one `$HERMES_HOME`, and a `0700`
dir created by whichever ran first locked the other out with `EACCES` — the
tracing feature itself, not just its permissions.

`ensure_hermes_home` already branches on `is_managed()` at its own creation
site, and its `logs/curator` lazy mkdir deliberately lets the configured umask
decide inside an already-secured parent. This follows that precedent at the
creation site rather than only at reconciliation.

Measured on the real `save_moa_turn` path under a temp `HERMES_HOME`:

| scenario | merge base | before this commit | after |
|---|---|---|---|
| unmanaged, `umask 022` | `0o755` | `0o700` | `0o700` |
| unmanaged, `umask 077` | `0o700` | `0o700` | `0o700` |
| **managed, `umask 0007`, parent 2770, dir absent** | `0o770` | **`0o700`** | **`0o770`** |
| managed, dir pre-existing `0750` | `0o750` | `0o750` | `0o750` |
| `HERMES_HOME_MODE=0701` (unmanaged) | `0o755` | `0o700` | `0o700` |

The trace JSONL is `0o600` in every row after the fix. `HERMES_HOME_MODE` is
deliberately **not** honored: that hatch exists so a web server can *traverse*
`HERMES_HOME` to reach a served subdirectory, and nothing is served out of
`moa-traces`.

**2. `mode=0o600` in `save_conversation` was untested.** Stripping it left
2514 files / 23624 tests green. `mkstemp` creates at `0600` and passing `mode`
forces `original_mode = None` so `_restore_file_mode` returns early — so on a
*fresh* file the argument does nothing, and `/save`'s only test wrote a fresh
file:

| target | no `mode=` | `mode=0o600` |
|---|---|---|
| fresh file | `0o600` | `0o600` (identical — no-op) |
| existing `0o644` | `0o644` | `0o600` (the only case it changes) |

What the argument buys is the **overwrite** path, where `atomic_json_write`
otherwise *preserves* the existing mode. That path is reachable: the snapshot
name has second resolution (`hermes_conversation_%Y%m%d_%H%M%S.json`), so two
`/save` calls in the same second land on the same file, and a `0644` snapshot
left by a pre-fix Hermes would keep `0644` while receiving a fresh full
transcript. Now tested at both levels — on the helper (covering every caller
that passes a mode, including a `0o640` case `mkstemp` cannot produce, so only
a real chmod reaches it) and on the `/save` wiring itself with a frozen
timestamp. Also names `failed_trajectories.jsonl` (the `completed=False`
branch), hardened by the same line as `trajectory_samples.jsonl` but previously
asserted only by implication.

**3. Two comments failed measurement.** "mode applies to dirs this call
creates" is false for intermediates: `pathlib.mkdir(parents=True, mode=…)`
applies the mode to the final component only, so a nested `moa.trace_dir`
override leaves intermediates at `0o755` (measured on `shared/audit/moa`: leaf
`0o700`, `audit/` and `shared/` `0o755`). No security impact — the leaf stays
`0o700` and the JSONL `0o600`, so traversal into the traces is still blocked —
but the guarantee was overstated. In `cli.py`, `2770` is HERMES_HOME's managed
mode (`0750` applies to `${stateDir}/home`, a different path), `HERMES_HOME_MODE`
does not apply in managed mode at all since `_secure_dir` returns early, and
`saved_dir` is not `0755` "either way" — it measures `0o755` by default and
`0o770` under the managed unit's `UMask`. Both load-bearing conclusions stand;
only the parenthetical octals were wrong.

`sessions/saved` is still `0o755` and is deliberately left for a follow-up —
it is a directory-mode issue, not a file mode, and out of this PR's scope.

**Teeth, per mechanism.** Each was reverted individually and confirmed to fail
with a diagnostic naming the cause, then restored byte-identically (checksums
verified):

| reverted mechanism | result |
|---|---|
| unconditional `mode=0o700` restored | managed test fails: "dropped group access (0o700) … locks the other out with EACCES" |
| `mode=` dropped entirely | unmanaged test fails: "moa-traces dir is group/other-accessible (0o755)" |
| `mode=0o600` removed from `/save` | **only** the new overwrite test fails (`0o644`); the pre-existing fresh-file test stays green — the reported gap, reproduced |
| `open_private_append` → bare `open` | trajectory, failed-trajectory and moa-trace tests fail |
| both chmods disabled in `atomic_json_write` | `0o640` assertion fails ("just mkstemp's 0o600 default surviving") |
| tmpfiles skeleton removed from the fixture | managed test fails on "must still create the trace dir" — the fixture is load-bearing, not decoration |

The managed test reproduces all three real conditions together
(`HERMES_MANAGED=nixos`, parent `2770`, `umask 0007`, dir absent) and stubs
nothing: a real `config.yaml` opens the gate, real `load_config()` reads it, and
real `_traces_enabled_and_dir()` derives the path. Setting only the env var
would pass for the wrong reason, since a default `umask 022` yields `0755` and
satisfies "group access survived" by ambient umask rather than by the carve-out.

`_managed_install()` is a deliberate local helper: `hermes_cli.config`'s
`secure_mkdir` (#77655) centralizes exactly this branch, but it is not on `main`
yet, so importing it would couple this PR's merge to that one. Consolidate when
it lands.

Verified: ruff 0.16.1 clean on all four changed files,
`check-windows-footguns.py --diff upstream/main` and `check_subprocess_stdin.py`
clean, 9-file helper regression set 67/67, and a 68-file sweep of
moa / `save_conversation` / managed-mode tests at 1397 passed / 1 failed — that
one (Linux-only systemd restart) reproducing identically at the untouched merge
base.

## Precedent for this exact pattern

This isn't a new convention — `gateway/shutdown_flush.py` already writes a
secret-bearing artifact the same way:

- line 44: `flush_dir.mkdir(parents=True, exist_ok=True, mode=0o700)` (`72024950c`, "fix(gateway): harden shutdown message flush")
- line 70: `atomic_json_write(final_path, payload, mode=0o600, default=str)` (`720cdd1d1`, "refactor: use atomic_json_write instead of hand-rolled _write_payload")

Same two primitives, same modes, same reasoning: pending gateway messages are
verbatim user content, so the directory is created `0o700` and each payload
`0o600`. `atomic_json_write`'s `mode=` parameter exists for precisely this
("avoiding chmod-after-write TOCTOU exposure for secret-bearing files" — its
own docstring). This PR applies the established pattern to three artifact
paths that were missed, plus one append-mode helper for the JSONL cases
`atomic_json_write` can't cover.

## Why this isn't a reversal of #74897

#74897 moved `write_file`'s new files *off* a hardcoded `0600` and onto
umask-derived `0644` (then #74918 hardened the arithmetic into `chmod "=rw"`).
Both are already in this branch's base, so the direction looks opposite. It
isn't the same class of file:

|  | #74897 (`write_file`) | this PR |
|---|---|---|
| Who chose the path | the user | the agent (fixed filenames / `HERMES_HOME`) |
| What it is | a user document written on request | a transcript artifact emitted as a side effect |
| Who reads it | other processes, by design (Obsidian LiveSync, Docker volumes, NAS mounts) | the owner, replaying or auditing their own session |
| Cost of `0600` | breaks a documented interop contract — the bug in #70856 | none known |

`write_file` is a general-purpose file writer; forcing `0600` there broke
cross-process readers, which is exactly why #74897 was right. These four
paths are agent-generated secret-bearing artifacts — `save_trajectory()`
appends a full transcript to the **CWD** under a fixed filename the user never
named. No cross-process reader is implied by that, and there was no interop
contract to break.

The two changes also agree on the invariant #74897 actually protected:
**never override permissions the user set.** #74897's regression guard is
"overwrite 0755 file → preserved". `open_private_append()` applies its mode
only on the *creating* `os.open`, so an existing file is never re-tightened —
asserted directly by
`test_trajectory_existing_relaxed_file_is_not_retightened` (writes the file,
chmods it `0644`, appends, asserts still `0644`). A user who widens a
trajectory to feed a training pipeline keeps that. The `/save` snapshot is a
fresh timestamped filename every time, so it has no pre-existing mode to
preserve.

Narrow reading: this PR only changes what mode a file is *born* with on paths
where the agent picked the name.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant suites via `scripts/run_tests.sh` and they pass (see above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 27.0 (Darwin 27.0.0, arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new helper explain the create-only-mode contract) — behavior is unchanged for users, no user-facing doc edit needed
- [x] `cli-config.yaml.example` — N/A (no config keys added; this is not env/config surface)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform: POSIX mode bits are advisory on Windows (`os.open` honours only the read-only bit), so the tests are `skipif(os.name != "posix")` and the helper's docstring says so. Windows at-rest protection is ACL-based and is deliberately left to the sibling PR #77527 (`enforce owner-only ACLs on Windows in _secure_file`) rather than duplicated here — one Windows ACL implementation, in the shared helper, not two. No behavior change on any platform beyond the permission bits.



