### PR TITLE
fix(tools): reuse the subscription-feature snapshot in toolset listing (salvage #76072)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3095,6 +3095,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 _get_effective_configurable_toolsets,
                 _get_platform_tools,
                 _toolset_has_keys,
+                get_nous_subscription_features,
             )
             from toolsets import resolve_toolset
 
@@ -3104,6 +3105,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "api_server",
                 include_default_mcp_servers=False,
             )
+            features = get_nous_subscription_features(config)
             data: List[Dict[str, Any]] = []
             for name, label, desc in _get_effective_configurable_toolsets():
                 try:
@@ -3116,7 +3118,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "label": label,
                     "description": desc,
                     "enabled": is_enabled,
-                    "configured": _toolset_has_keys(name, config),
+                    "configured": _toolset_has_keys(name, config, features=features),
                     "tools": tools,
                 })
         except Exception:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -26,6 +26,7 @@ from hermes_cli.config import (
 from hermes_cli.colors import Colors, color
 from hermes_cli.nous_subscription import (
     MANAGED_FEATURE_COVERAGE_CATEGORY,
+    NousSubscriptionFeatures,
     apply_nous_managed_defaults,
     get_nous_subscription_features,
 )
@@ -2618,6 +2619,7 @@ def _toolset_has_keys(
     config: dict = None,
     *,
     force_fresh: bool = False,
+    features: Optional[NousSubscriptionFeatures] = None,
 ) -> bool:
     """Check if a toolset's required API keys are configured."""
     if config is None:
@@ -2633,7 +2635,10 @@ def _toolset_has_keys(
             return False
 
     if ts_key in {"web", "image_gen", "video_gen", "tts", "stt", "browser"}:
-        features = get_nous_subscription_features(config, force_fresh=force_fresh)
+        if features is None:
+            features = get_nous_subscription_features(
+                config, force_fresh=force_fresh
+            )
         feature = features.features.get(ts_key)
         if feature and (feature.available or feature.managed_by_nous):
             return True
@@ -2641,7 +2646,12 @@ def _toolset_has_keys(
     # Check TOOL_CATEGORIES first (provider-aware)
     cat = TOOL_CATEGORIES.get(ts_key)
     if cat:
-        for provider in _visible_providers(cat, config, force_fresh=force_fresh):
+        for provider in _visible_providers(
+            cat,
+            config,
+            force_fresh=force_fresh,
+            features=features,
+        ):
             env_vars = provider.get("env_vars", [])
             if not env_vars:
                 return True  # No-key provider (e.g. Local Browser, Edge TTS)
@@ -3076,6 +3086,7 @@ def _visible_providers(
     config: dict,
     *,
     force_fresh: bool = False,
+    features: Optional[NousSubscriptionFeatures] = None,
 ) -> list[dict]:
     """Return provider entries visible for the current auth/config state.
 
@@ -3085,7 +3096,8 @@ def _visible_providers(
     login + entitlement check (see ``_configure_provider``); the row only
     *activates* the gateway once paid access is confirmed.
     """
-    features = get_nous_subscription_features(config, force_fresh=force_fresh)
+    if features is None:
+        features = get_nous_subscription_features(config, force_fresh=force_fresh)
     acct = features.account_info
     # Pool-only users (entitled to managed tools via the free tool pool but with
     # no paid access) get image gen but NOT video gen — the pool doesn't fund

--- a/hermes_cli/web_routers/tools.py
+++ b/hermes_cli/web_routers/tools.py
@@ -58,6 +58,7 @@ async def get_toolsets(profile: Optional[str] = None):
         _get_platform_tools,
         _toolset_configuration_platform,
         _toolset_has_keys,
+        get_nous_subscription_features,
         gui_toolset_label,
     )
     from hermes_cli.platforms import platform_label
@@ -77,6 +78,7 @@ async def get_toolsets(profile: Optional[str] = None):
             )
             for platform in target_platforms
         }
+        features = get_nous_subscription_features(config)
     result = []
     for name, label, desc in toolset_rows:
         try:
@@ -104,7 +106,7 @@ async def get_toolsets(profile: Optional[str] = None):
             ),
             "enabled": is_enabled,
             "available": is_enabled,
-            "configured": _toolset_has_keys(name, config),
+            "configured": _toolset_has_keys(name, config, features=features),
             "tools": tools,
         })
     return result

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -913,6 +913,7 @@ class TestToolsetsEndpoint:
             ("default", "Default Tools", "Core tools"),
             ("web", "Web Tools", "Search and extract"),
         ]
+        feature_snapshot = object()
         with patch(
             "hermes_cli.tools_config._get_effective_configurable_toolsets",
             return_value=fake_toolsets,
@@ -920,9 +921,12 @@ class TestToolsetsEndpoint:
             "hermes_cli.tools_config._get_platform_tools",
             return_value={"default"},
         ), patch(
+            "hermes_cli.tools_config.get_nous_subscription_features",
+            return_value=feature_snapshot,
+        ) as resolve_features, patch(
             "hermes_cli.tools_config._toolset_has_keys",
             return_value=True,
-        ), patch(
+        ) as has_keys, patch(
             "toolsets.resolve_toolset",
             side_effect=lambda name: {
                 "default": ["terminal", "read_file"],
@@ -942,6 +946,13 @@ class TestToolsetsEndpoint:
                 assert by_name["web"]["enabled"] is False
                 assert by_name["web"]["tools"] == ["web_search"]
                 assert by_name["default"]["configured"] is True
+
+        resolve_features.assert_called_once()
+        assert has_keys.call_count == len(fake_toolsets)
+        assert all(
+            call.kwargs["features"] is feature_snapshot
+            for call in has_keys.call_args_list
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -2845,5 +2856,4 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -6,7 +6,8 @@ from unittest.mock import patch
 
 import pytest
 
-from hermes_cli.nous_account import NousPortalAccountInfo
+from hermes_cli.nous_account import NousPortalAccountInfo, NousToolAccessInfo
+from hermes_cli.nous_subscription import NousSubscriptionFeatures
 from hermes_cli.tools_config import (
     _DEFAULT_OFF_TOOLSETS,
     _RECENTLY_SHIPPED_TOOLSETS,
@@ -542,6 +543,74 @@ def _fake_features(*, logged_in: bool, paid: bool = True):
         )
     )
     return SimpleNamespace(nous_auth_present=logged_in, account_info=account)
+
+
+def test_visible_providers_reuses_logged_out_feature_snapshot(monkeypatch):
+    import hermes_cli.tools_config as tools_config
+
+    account = NousPortalAccountInfo(
+        logged_in=False,
+        source="none",
+        fresh=False,
+        paid_service_access=None,
+    )
+    features = NousSubscriptionFeatures(
+        subscribed=False,
+        nous_auth_present=False,
+        provider_is_nous=False,
+        features={},
+        account_info=account,
+    )
+    monkeypatch.setattr(
+        tools_config,
+        "get_nous_subscription_features",
+        lambda *args, **kwargs: pytest.fail("feature snapshot was resolved again"),
+    )
+
+    providers = _visible_providers(
+        TOOL_CATEGORIES["image_gen"], {}, features=features
+    )
+
+    assert any(
+        provider.get("managed_nous_feature") == "image_gen"
+        for provider in providers
+    )
+
+
+def test_visible_providers_reuses_pool_video_feature_snapshot(monkeypatch):
+    import hermes_cli.tools_config as tools_config
+
+    account = NousPortalAccountInfo(
+        logged_in=True,
+        source="jwt",
+        fresh=False,
+        paid_service_access=False,
+        tool_access=NousToolAccessInfo(
+            enabled=True,
+            coverage={"fal-video": False},
+        ),
+    )
+    features = NousSubscriptionFeatures(
+        subscribed=True,
+        nous_auth_present=True,
+        provider_is_nous=False,
+        features={},
+        account_info=account,
+    )
+    monkeypatch.setattr(
+        tools_config,
+        "get_nous_subscription_features",
+        lambda *args, **kwargs: pytest.fail("feature snapshot was resolved again"),
+    )
+
+    providers = _visible_providers(
+        TOOL_CATEGORIES["video_gen"], {}, features=features
+    )
+
+    assert not any(
+        provider.get("managed_nous_feature") == "video_gen"
+        for provider in providers
+    )
 
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1948,6 +1948,36 @@ class TestNewEndpoints:
             config["platform_toolsets"]["discord"]
         )
 
+    def test_toolsets_resolve_subscription_features_once(self, monkeypatch):
+        import hermes_cli.tools_config as tools_config
+        from hermes_cli.nous_subscription import NousSubscriptionFeatures
+
+        calls = 0
+        features = NousSubscriptionFeatures(
+            subscribed=False,
+            nous_auth_present=False,
+            provider_is_nous=False,
+            features={},
+            account_info=None,
+        )
+
+        def resolve_features(config, *, force_fresh=False):
+            nonlocal calls
+            calls += 1
+            return features
+
+        monkeypatch.setattr(
+            tools_config,
+            "get_nous_subscription_features",
+            resolve_features,
+        )
+
+        resp = self.client.get("/api/tools/toolsets")
+
+        assert resp.status_code == 200
+        assert resp.json()
+        assert calls == 1
+
 
     def test_get_toolset_config_returns_provider_matrix(self):
         """GET .../config returns provider rows with structured env_vars."""


### PR DESCRIPTION
Salvages #76072 by @szzhoujiarui — both real commits cherry-picked in order to preserve authorship (the branch's third commit was a merge commit, excluded; the one conflict was a trailing-blank-line collision in test_web_server.py).

## Context — what this fixes, for whom

Anyone opening the tools page (web dashboard or Desktop) or hitting the toolsets API: `_handle_toolsets` and `get_toolsets` called `_toolset_has_keys()` once per toolset (~27), and each call resolved `get_nous_subscription_features()` — portal/entitlement state with potential network/file I/O — plus `_visible_providers()` inside resolved it AGAIN. Up to 2N resolutions per listing request; measured 10 → 1 on the api_server endpoint in review.

## What the fix does (kept verbatim)

Adds an optional keyword-only `features` param to `_toolset_has_keys()` / `_visible_providers()`, resolves the snapshot once at the top of each endpoint, threads it through. `features=None` preserves old behavior exactly — backwards-compatible by construction; `force_fresh` semantics preserved.

## Whole-bug-class note (review finding, deliberate scope)

Three MORE genuine per-item loops remain unfixed on main — `_prompt_toolset_checklist` (9 resolutions), `_reconfigure_tool` (10), `_toolset_needs_configuration_prompt` ×4 sites (11) — but all are interactive-CLI paths (setup wizard/prompts) where a human is between iterations, not request-serving endpoints. The PR's extensible param pattern makes those a mechanical follow-up; left out deliberately rather than growing a verified diff.

## Verification

- Touched-suite runs on current main: 248 passed, 1 skipped (test_web_server.py, test_api_server.py, test_tools_config.py, web_routers tools tests); the single failure (`TestHealthDetailedEndpoint::test_health_detailed_returns_ok`) is pre-existing and fails identically on clean upstream/main (env-dependent)
- Seam sweep: all 5 test files referencing `_toolset_has_keys`/`_visible_providers` green (41 passed) — the keyword-only param breaks no call-shape assertions
- Mutation check: revert the 3 production files to main → both snapshot-reuse tests fail; restore → pass
- ruff clean

Closes #76072 (superseded by this salvage — original author credited via cherry-pick authorship).
