### PR TITLE
fix(dashboard): fold aux usage into one card per model

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14133,27 +14133,12 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
         """, (cutoff,))
         raw_rows = [dict(r) for r in cur.fetchall()]
 
-        # Add auxiliary usage as (model, provider) rows so aux-only models
-        # (dedicated vision/compression models) appear on the Models page
-        # instead of being invisible (issue #23270). Keyed by
-        # model+billing_provider to match the GROUP BY above.
-        for aux in _aux_usage_rows(db, cutoff):
-            raw_rows.append({
-                "model": aux.get("model") or "unknown",
-                "billing_provider": aux.get("billing_provider") or "",
-                "input_tokens": aux.get("input_tokens") or 0,
-                "output_tokens": aux.get("output_tokens") or 0,
-                "cache_read_tokens": aux.get("cache_read_tokens") or 0,
-                "reasoning_tokens": aux.get("reasoning_tokens") or 0,
-                "estimated_cost": aux.get("estimated_cost") or 0,
-                "actual_cost": 0,
-                "sessions": aux.get("sessions") or 0,
-                "api_calls": aux.get("api_calls") or 0,
-                "tool_calls": 0,
-                "last_used_at": aux.get("last_used_at"),
-                "avg_tokens_per_session": 0,
-                "aux_task": aux.get("task") or "",
-            })
+        # Auxiliary usage (vision, compression, title_generation, approval, ...)
+        # lives only in session_model_usage, never in the sessions counters.
+        # It must be folded INTO the per-model row — appending each (model,
+        # task) as its own row makes the Models page show one card per aux
+        # task (issue: duplicate "deepseek-v4" cards). Fetch here, merge below.
+        aux_rows = _aux_usage_rows(db, cutoff)
 
         # Session rows can be created before the first billable provider call
         # finishes. If that early row records only the model name, and a later
@@ -14213,6 +14198,46 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
                 )
             else:
                 rows.extend(model_rows)
+
+        # Fold auxiliary usage into the per-model rows (issue #23270).
+        # Aux calls never touch the sessions counters, so this is add-only.
+        # Models that ONLY appear via aux calls get their own entry; models
+        # with both main + aux usage get the aux tokens merged into the one
+        # card instead of splitting into a card per aux task.
+        if aux_rows:
+            by_name: Dict[str, List[Dict[str, Any]]] = {}
+            for row in rows:
+                by_name.setdefault(row.get("model") or "", []).append(row)
+            for aux in aux_rows:
+                model = aux.get("model") or "unknown"
+                candidates = by_name.get(model)
+                if candidates:
+                    target = candidates[0]
+                else:
+                    target = {
+                        "model": model,
+                        "billing_provider": aux.get("billing_provider") or "",
+                        "input_tokens": 0,
+                        "output_tokens": 0,
+                        "cache_read_tokens": 0,
+                        "reasoning_tokens": 0,
+                        "estimated_cost": 0,
+                        "actual_cost": 0,
+                        "sessions": 0,
+                        "api_calls": 0,
+                        "tool_calls": 0,
+                        "last_used_at": 0,
+                        "avg_tokens_per_session": 0,
+                    }
+                    rows.append(target)
+                    by_name.setdefault(model, []).append(target)
+                for key in ("input_tokens", "output_tokens", "cache_read_tokens",
+                            "reasoning_tokens", "estimated_cost", "actual_cost",
+                            "sessions", "api_calls"):
+                    target[key] = (target.get(key) or 0) + (aux.get(key) or 0)
+                target["last_used_at"] = max(
+                    target.get("last_used_at") or 0, aux.get("last_used_at") or 0
+                )
 
         rows.sort(
             key=lambda r: (r.get("input_tokens") or 0) + (r.get("output_tokens") or 0),

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2192,6 +2192,57 @@ class TestNewEndpoints:
         assert top_skill["total_count"] == 1
         assert top_skill["last_used_at"] is not None
 
+    def test_models_analytics_folds_aux_usage_into_single_card(self):
+        """Aux usage must fold into the model's one card, not split per task.
+
+        Regression: _get_models_analytics used to append each (model, task)
+        aux row as its own entry, so a model with vision + compression usage
+        rendered as one card per aux task (duplicate model cards).
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="aux-fold-test",
+                source="cli",
+                model="deepseek-v4",
+            )
+            db.update_token_counts(
+                "aux-fold-test",
+                input_tokens=1000,
+                output_tokens=100,
+                billing_provider="opencode-zen",
+                api_call_count=5,
+            )
+            db.record_auxiliary_usage(
+                "aux-fold-test", "vision", model="deepseek-v4",
+                billing_provider="opencode-zen",
+                input_tokens=200, output_tokens=20,
+            )
+            db.record_auxiliary_usage(
+                "aux-fold-test", "compression", model="deepseek-v4",
+                billing_provider="opencode-zen",
+                input_tokens=300, output_tokens=30,
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/analytics/models?days=7")
+        assert resp.status_code == 200
+
+        rows = [
+            row for row in resp.json()["models"]
+            if row["model"] == "deepseek-v4"
+        ]
+        # One card, not one per aux task (vision + compression + main).
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["provider"] == "opencode-zen"
+        assert row["input_tokens"] == 1500
+        assert row["output_tokens"] == 150
+        assert row["api_calls"] == 7
+
 
 # ---------------------------------------------------------------------------
 # Model context length: normalize/denormalize + /api/model/info


### PR DESCRIPTION
## What does this PR do?

Fixes duplicate model cards on the dashboard Models page (`/api/analytics/models`).

The bug: a model that does auxiliary work (vision, compression, title generation) rendered once per task. One session where `deepseek-v4` handled main + vision + compression showed up as three separate cards, each with a fraction of the real totals.

Root cause is in `_get_models_analytics()` (`hermes_cli/web_server.py`, ~L14106). When aux support landed (#23270), the function appended each `(model, task)` row from `session_model_usage` as its own entry in the models list. The frontend (`web/src/pages/ModelsPage.tsx`) has no dedup — it paints whatever the API returns.

The fix fetches aux rows up front and folds them into the single per-model card: tokens, costs, sessions, and API calls are summed, `last_used_at` takes the max. Aux calls never touch the `sessions` counters, so this is add-only and can't double count. A model that only appears via aux calls still gets its own entry, so nothing that #23270 made visible disappears.

Note: `/api/analytics/usage` never had this bug — it merges aux rows via `_merge_aux_into_by_model`. This PR brings the Models page in line with it.

## Related Issue

No issue filed for the regression. Searched open and merged PRs before opening:

- #71802 (open) switches the main analytics query to `session_model_usage` for provider attribution, but deliberately keeps aux rows appended (`u.task = ''` filter + separate aux handling) — the duplicate cards survive it.
- #45582 (merged) folds session-only zero-token rows into the accounted provider row — a different duplicate shape, not the aux-task one.
- #23270 (closed) is the feature that introduced the append behavior.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: `_get_models_analytics()` now folds aux rows into the per-model card instead of appending a row per `(model, task)`. Aux-only models keep their own entry.
- `tests/hermes_cli/test_web_server.py`: regression test — one session with main + vision + compression usage for the same model asserts exactly one card with merged totals.

## How to Test

Reproduction: run a session where the same model handles an aux task (vision, compression, title_generation), then open the dashboard Models page. Without the fix you get one card per task; with it, one card with the combined numbers.

Verification done:

1. New regression test fails on `main` without the fix, passes with it (red-green confirmed)
2. Analytics and aux-accounting suites green: `test_web_server.py -k "analytics or models"` (2 passed), `test_aux_usage_accounting.py` (9 passed)

Platform tested: Fedora 44 x86_64.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — full suite not run; targeted analytics + aux suites green
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora 44 x86_64

### Documentation & Housekeeping

- [x] N/A for all: no new config keys, no architecture changes, no tool behavior changes, no new skills

## Notes

Authored with AI assistance (Hermes Agent); the diff, reproduction, and test were verified manually before submitting.
