### PR TITLE
fix(web): warn on ignored website blocklist keys (#76946)

### DIFF
--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -106,6 +106,33 @@ def test_load_website_blocklist_wraps_shared_file_read_errors(tmp_path, monkeypa
     assert result["rules"] == []  # shared file rules skipped
 
 
+def test_load_website_blocklist_warns_and_ignores_unknown_keys(tmp_path, caplog):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "security": {
+                    "website_blocklist": {
+                        "enabled": True,
+                        "domains": ["example.com"],
+                        "shared_file": "typo.txt",
+                        "allowed": ["example.org"],
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("WARNING"):
+        policy = load_website_blocklist(config_path)
+
+    assert policy["enabled"] is True
+    assert {rule["pattern"] for rule in policy["rules"]} == {"example.com"}
+    assert "Unknown security.website_blocklist keys ignored: allowed, shared_file" in caplog.text
+
+
 def test_check_website_access_blocks_scheme_less_urls(tmp_path):
     config_path = tmp_path / "config.yaml"
     config_path.write_text(

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -27,6 +27,7 @@ _DEFAULT_WEBSITE_BLOCKLIST = {
     "domains": [],
     "shared_files": [],
 }
+_KNOWN_WEBSITE_BLOCKLIST_KEYS = frozenset(_DEFAULT_WEBSITE_BLOCKLIST)
 
 # Cache: parsed policy + timestamp.  Avoids re-reading config.yaml on every
 # URL check (a multi-URL extract with 50 pages would otherwise mean 51 YAML parses).
@@ -123,8 +124,17 @@ def _load_policy_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
     if not isinstance(website_blocklist, dict):
         raise WebsitePolicyError("security.website_blocklist must be a mapping")
 
+    unknown_keys = sorted(set(website_blocklist) - _KNOWN_WEBSITE_BLOCKLIST_KEYS)
+    if unknown_keys:
+        logger.warning(
+            "Unknown security.website_blocklist keys ignored: %s",
+            ", ".join(unknown_keys),
+        )
+
     policy = dict(_DEFAULT_WEBSITE_BLOCKLIST)
-    policy.update(website_blocklist)
+    for key in _KNOWN_WEBSITE_BLOCKLIST_KEYS:
+        if key in website_blocklist:
+            policy[key] = website_blocklist[key]
     return policy
 
 


### PR DESCRIPTION
## What does this PR do?

Turns silent `security.website_blocklist` typos into a visible warning. Unknown keys are now logged and ignored instead of being carried through the config merge with no effect, so a misspelled key like `shared_file` no longer looks like a successfully deployed website policy.

## Related Issue

Fixes #76946

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- In `tools/website_policy.py`, warn on unknown `security.website_blocklist` keys and ignore them instead of silently merging them into the intermediate policy dict.
- Limit the config merge to the supported keys: `enabled`, `domains`, and `shared_files`.
- Add a focused regression in `tests/tools/test_website_policy.py` that covers the typo/invented-key path and asserts the warning text.

## How to Test

1. `~/.pyenv/versions/3.12.12/bin/python -m pytest tests/tools/test_website_policy.py`
2. `~/.pyenv/versions/3.12.12/bin/python -m py_compile tools/website_policy.py tests/tools/test_website_policy.py`
3. Create a config with `security.website_blocklist.shared_file` instead of `shared_files`, then call `load_website_blocklist()` and confirm:
   - the valid keys still load
   - the typo is ignored
   - a warning is emitted naming the unknown keys

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
