### PR TITLE
feat(a2a): inject conversation history on context resume (multi-turn)

### DIFF
--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -729,9 +729,17 @@ class A2AAdapter(BasePlatformAdapter):
                 "Empty task — nothing to do.", created_at=rec["created_iso"],
             ), None
 
+        # Multi-turn: when a caller reuses a contextId, prepend the prior
+        # conversation so the agent sees the full thread. The original
+        # message (not the augmented copy) is what gets audited and
+        # persisted, so history never accumulates injected prefixes.
+        original_text = text
+        history = protocol.format_history(context_id)
+        if history:
+            text = history + text
         framed = security.wrap_inbound(peer, text)
-        security.audit("inbound", peer, task_id, text)
-        protocol.persist_message(context_id, "user", text, task_id)
+        security.audit("inbound", peer, task_id, original_text)
+        protocol.persist_message(context_id, "user", original_text, task_id)
         protocol.metrics.inbound_total += 1
 
         rec = self.tasks.create(task_id, context_id, peer, *self._scope_for_agent(agent))

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -508,9 +508,18 @@ class A2AAdapter(BasePlatformAdapter):
                                   f"{max_turns} turns. Start a new context or increase A2A_MAX_PINGPONG_TURNS.")
         if not text:
             return self._end_task(rec, protocol.STATE_REJECTED, "Empty task — nothing to do.")
+
+        # Multi-turn: when a caller reuses a contextId, prepend the prior
+        # conversation so the agent sees the full thread. The original
+        # message (not the augmented copy) is what gets audited and
+        # persisted, so history never accumulates injected prefixes.
+        original_text = text
+        history = protocol.format_history(context_id)
+        if history:
+            text = history + text
         framed = security.wrap_inbound(peer, text)
-        security.audit("inbound", peer, task_id, text)
-        protocol.persist_message(context_id, "user", text, task_id)
+        security.audit("inbound", peer, task_id, original_text)
+        protocol.persist_message(context_id, "user", original_text, task_id)
         protocol.metrics.inbound_total += 1
         self._register_inline_push(task_id, params, agent=agent)
         if not agent.get("local", True):

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -74,6 +74,9 @@ ERR_UNTRUSTED_PEER = -32052
 _DEFAULT_MAX_PINGPONG = 5
 _HARD_MAX_PINGPONG = 20
 
+_DEFAULT_HISTORY_LIMIT = 20
+_HARD_HISTORY_LIMIT = 200
+
 
 def max_pingpong_turns() -> int:
     try:
@@ -81,6 +84,20 @@ def max_pingpong_turns() -> int:
         return max(1, min(v, _HARD_MAX_PINGPONG))
     except (ValueError, TypeError):
         return _DEFAULT_MAX_PINGPONG
+
+
+def history_injection_limit() -> int:
+    """Max prior messages prepended when a caller resumes a context_id.
+
+    The agent sees the full thread on multi-turn continuations instead of
+    only the latest message. 0 disables injection. Bounded so a long-lived
+    context cannot balloon a single prompt.
+    """
+    try:
+        v = int(os.getenv("A2A_HISTORY_INJECTION_LIMIT", str(_DEFAULT_HISTORY_LIMIT)))
+        return max(0, min(v, _HARD_HISTORY_LIMIT))
+    except (ValueError, TypeError):
+        return _DEFAULT_HISTORY_LIMIT
 
 
 def now_iso() -> str:
@@ -832,6 +849,30 @@ def load_conversation(context_id: str, limit: int = 50) -> list[dict]:
     except Exception:
         return []
     return out[-limit:]
+
+
+def format_history(context_id: str, limit: Optional[int] = None) -> str:
+    """Render prior messages of a resumed context as a plain-text prefix.
+
+    Returns "" when the context has no history yet (or when injection is
+    disabled via ``limit <= 0``). The adapter prepends this to an inbound
+    message when a caller reuses a ``contextId``, so the agent sees the
+    full thread (multi-turn) instead of only the latest message. Lines are
+    ``role: text`` with the A2A roles ``user`` / ``assistant``; non-user
+    roles are treated as assistant output.
+    """
+    limit = limit if limit is not None else history_injection_limit()
+    if limit <= 0:
+        return ""
+    recs = load_conversation(context_id, limit=limit)
+    if not recs:
+        return ""
+    lines = []
+    for rec in recs:
+        role = rec.get("role")
+        label = "user" if role == "user" else "assistant"
+        lines.append(f"{label}: {rec.get('text', '')}")
+    return "\n".join(lines) + "\n\n"
 
 
 def list_conversations() -> list[str]:

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -40,6 +40,9 @@ ERR_UNAUTHORIZED, ERR_RATE_LIMITED, ERR_UNTRUSTED_PEER = -32050, -32051, -32052
 _DEFAULT_MAX_PINGPONG, _HARD_MAX_PINGPONG = 5, 20
 _RATE_LIMIT_DEFAULT, _RATE_WINDOW = 60, 60.0  # requests per minute, window seconds
 
+# Multi-turn history injection: max prior messages prepended when a caller resumes a context.
+_DEFAULT_HISTORY_LIMIT, _HARD_HISTORY_LIMIT = 20, 200
+
 
 def _env_int(name: str, default: int) -> int:
     return _coerce_int(os.getenv(name, default), default)
@@ -48,6 +51,17 @@ def _env_int(name: str, default: int) -> int:
 def max_pingpong_turns() -> int:
     v = _env_int("A2A_MAX_PINGPONG_TURNS", _DEFAULT_MAX_PINGPONG)
     return max(1, min(v, _HARD_MAX_PINGPONG))
+
+
+def history_injection_limit() -> int:
+    """Max prior messages prepended when a caller resumes a context_id.
+
+    The agent sees the full thread on multi-turn continuations instead of only
+    the latest message. 0 disables injection. Bounded so a long-lived context
+    cannot balloon a single prompt.
+    """
+    v = _env_int("A2A_HISTORY_INJECTION_LIMIT", _DEFAULT_HISTORY_LIMIT)
+    return max(0, min(v, _HARD_HISTORY_LIMIT))
 
 
 def now_iso() -> str:
@@ -470,6 +484,30 @@ def load_conversation(context_id: str, limit: int = 50) -> list[dict]:
 def list_conversations() -> list[str]:
     """Context-ids that have persisted conversations."""
     return sorted(p.stem for p in (_hermes_home() / "a2a_conversations").glob("*.jsonl"))
+
+
+def format_history(context_id: str, limit: Optional[int] = None) -> str:
+    """Render prior messages of a resumed context as a plain-text prefix.
+
+    Returns "" when the context has no history yet (or when injection is
+    disabled via ``limit <= 0``). The adapter prepends this to an inbound
+    message when a caller reuses a ``contextId``, so the agent sees the full
+    thread (multi-turn) instead of only the latest message. Lines are
+    ``role: text`` with the A2A roles ``user`` / ``assistant``; non-user roles
+    are treated as assistant output.
+    """
+    limit = limit if limit is not None else history_injection_limit()
+    if limit <= 0:
+        return ""
+    recs = load_conversation(context_id, limit=limit)
+    if not recs:
+        return ""
+    lines = []
+    for rec in recs:
+        role = rec.get("role")
+        label = "user" if role == "user" else "assistant"
+        lines.append(f"{label}: {rec.get('text', '')}")
+    return "\n".join(lines) + "\n\n"
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/tests/plugins/test_a2a_multiturn.py
+++ b/tests/plugins/test_a2a_multiturn.py
@@ -1,0 +1,170 @@
+"""Multi-turn history injection tests for the A2A platform plugin.
+
+When a caller reuses a ``contextId`` (multi-turn continuation), the adapter
+prepends the persisted conversation so the agent sees the full thread. The
+original message — not the augmented copy — is what gets audited and
+persisted, so injected history never accumulates in the on-disk log.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import Future
+from types import SimpleNamespace
+
+import pytest
+
+from plugins.platforms.a2a import protocol, security
+
+
+def _send_params(text: str, context_id: str) -> dict:
+    return {
+        "message": {
+            "role": "user",
+            "parts": [{"text": text, "mediaType": "text/plain"}],
+        },
+        "contextId": context_id,
+    }
+
+
+class TestFormatHistory:
+    def test_empty_when_no_history(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(protocol, "_conv_dir", lambda: tmp_path)
+        assert protocol.format_history("ctx-none", limit=20) == ""
+
+    def test_roles_rendered_user_assistant(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(protocol, "_conv_dir", lambda: tmp_path)
+        protocol.persist_message("ctx-a", "user", "hello")
+        protocol.persist_message("ctx-a", "agent", "hi there")
+        assert protocol.format_history("ctx-a", limit=20) == (
+            "user: hello\nassistant: hi there\n\n"
+        )
+
+    def test_limit_keeps_only_recent(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(protocol, "_conv_dir", lambda: tmp_path)
+        for i in range(5):
+            protocol.persist_message("ctx-b", "user", f"msg-{i}")
+        out = protocol.format_history("ctx-b", limit=2)
+        assert "msg-0" not in out
+        assert "msg-4" in out
+
+    def test_default_limit_from_env(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(protocol, "_conv_dir", lambda: tmp_path)
+        monkeypatch.setenv("A2A_HISTORY_INJECTION_LIMIT", "3")
+        for i in range(5):
+            protocol.persist_message("ctx-c", "user", f"msg-{i}")
+        out = protocol.format_history("ctx-c")
+        assert "msg-0" not in out
+        assert "msg-4" in out
+
+    def test_zero_limit_disables(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(protocol, "_conv_dir", lambda: tmp_path)
+        protocol.persist_message("ctx-d", "user", "hello")
+        assert protocol.format_history("ctx-d", limit=0) == ""
+
+
+def _bare_adapter():
+    from plugins.platforms.a2a.adapter import A2AAdapter
+    from gateway.config import PlatformConfig
+
+    return A2AAdapter(PlatformConfig(enabled=True))
+
+
+class TestInboundHistoryInjection:
+    def _drive(self, adapter, monkeypatch):
+        """Run _prepare_task with dispatch captured; return the event text list."""
+        seen_events = []
+
+        async def fake_handle(event):
+            seen_events.append(event)
+
+        adapter.handle_message = fake_handle
+        adapter._message_handler = lambda event: None
+        adapter._loop = asyncio.new_event_loop()
+
+        captured_coros = []
+
+        def fake_schedule(coro, loop):
+            captured_coros.append(coro)
+            return SimpleNamespace(done=lambda: True)
+
+        monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", fake_schedule)
+        return seen_events, captured_coros
+
+    def test_new_context_no_injection(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(protocol, "_conv_dir", lambda: tmp_path)
+        adapter = _bare_adapter()
+        seen, coros = self._drive(adapter, monkeypatch)
+
+        task, pending = adapter._prepare_task(
+            _send_params("first question", "ctx-new"), peer="peer-x"
+        )
+        assert pending is not None
+        asyncio.run(coros[0])
+        text = seen[0].text
+        assert "first question" in text
+        assert not text.startswith("user:")
+
+    def test_resume_injects_history_into_agent_text(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(protocol, "_conv_dir", lambda: tmp_path)
+        protocol.persist_message("ctx-mt", "user", "first question")
+        protocol.persist_message("ctx-mt", "agent", "first answer")
+
+        adapter = _bare_adapter()
+        seen, coros = self._drive(adapter, monkeypatch)
+
+        task, pending = adapter._prepare_task(
+            _send_params("second question", "ctx-mt"), peer="peer-x"
+        )
+        assert pending is not None
+        asyncio.run(coros[0])
+        text = seen[0].text
+        assert "first question" in text
+        assert "first answer" in text
+        assert "second question" in text
+        assert text.index("first question") < text.index("second question")
+
+    def test_persist_and_audit_store_original_not_augmented(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(protocol, "_conv_dir", lambda: tmp_path)
+        protocol.persist_message("ctx-keep", "user", "first question")
+        protocol.persist_message("ctx-keep", "agent", "first answer")
+
+        audited = []
+        monkeypatch.setattr(security, "audit", lambda *a, **k: audited.append(a))
+        adapter = _bare_adapter()
+        seen, coros = self._drive(adapter, monkeypatch)
+
+        task, pending = adapter._prepare_task(
+            _send_params("second question", "ctx-keep"), peer="peer-x"
+        )
+        assert pending is not None
+        asyncio.run(coros[0])
+
+        # Agent saw the augmented text (wrap_inbound adds its own prefix)…
+        assert "user: first question" in seen[0].text
+        assert "second question" in seen[0].text
+        # …but the persisted log and audit trail carry only the original.
+        recs = protocol.load_conversation("ctx-keep", limit=50)
+        assert recs[-1]["role"] == "user"
+        assert recs[-1]["text"] == "second question"
+        assert any("second question" in a[3] for a in audited)
+        assert all("first question" not in a[3] for a in audited)
+
+    def test_resume_does_not_duplicate_injected_prefix(self, monkeypatch, tmp_path):
+        """A third turn must not re-inject the already-injected prefix."""
+        monkeypatch.setattr(protocol, "_conv_dir", lambda: tmp_path)
+        adapter = _bare_adapter()
+        seen, coros = self._drive(adapter, monkeypatch)
+
+        for i, text in enumerate(["q1", "q2", "q3"]):
+            task, pending = adapter._prepare_task(
+                _send_params(text, "ctx-loop"), peer="peer-x"
+            )
+            assert pending is not None
+            asyncio.run(coros[-1])
+
+        # After three turns the on-disk log holds exactly the three originals.
+        recs = protocol.load_conversation("ctx-loop", limit=50)
+        assert [r["text"] for r in recs] == ["q1", "q2", "q3"]

--- a/tests/plugins/test_a2a_multiturn.py
+++ b/tests/plugins/test_a2a_multiturn.py
@@ -1,0 +1,170 @@
+"""Multi-turn history injection tests for the A2A platform plugin.
+
+When a caller reuses a ``contextId`` (multi-turn continuation), the adapter
+prepends the persisted conversation so the agent sees the full thread. The
+original message — not the augmented copy — is what gets audited and
+persisted, so injected history never accumulates in the on-disk log.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import Future
+from types import SimpleNamespace
+
+import pytest
+
+from plugins.platforms.a2a import protocol, security
+
+
+def _send_params(text: str, context_id: str) -> dict:
+    return {
+        "message": {
+            "role": "user",
+            "parts": [{"text": text, "mediaType": "text/plain"}],
+        },
+        "contextId": context_id,
+    }
+
+
+class TestFormatHistory:
+    def test_empty_when_no_history(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(protocol, "_hermes_home", lambda: tmp_path)
+        assert protocol.format_history("ctx-none", limit=20) == ""
+
+    def test_roles_rendered_user_assistant(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(protocol, "_hermes_home", lambda: tmp_path)
+        protocol.persist_message("ctx-a", "user", "hello")
+        protocol.persist_message("ctx-a", "agent", "hi there")
+        assert protocol.format_history("ctx-a", limit=20) == (
+            "user: hello\nassistant: hi there\n\n"
+        )
+
+    def test_limit_keeps_only_recent(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(protocol, "_hermes_home", lambda: tmp_path)
+        for i in range(5):
+            protocol.persist_message("ctx-b", "user", f"msg-{i}")
+        out = protocol.format_history("ctx-b", limit=2)
+        assert "msg-0" not in out
+        assert "msg-4" in out
+
+    def test_default_limit_from_env(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(protocol, "_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("A2A_HISTORY_INJECTION_LIMIT", "3")
+        for i in range(5):
+            protocol.persist_message("ctx-c", "user", f"msg-{i}")
+        out = protocol.format_history("ctx-c")
+        assert "msg-0" not in out
+        assert "msg-4" in out
+
+    def test_zero_limit_disables(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(protocol, "_hermes_home", lambda: tmp_path)
+        protocol.persist_message("ctx-d", "user", "hello")
+        assert protocol.format_history("ctx-d", limit=0) == ""
+
+
+def _bare_adapter():
+    from plugins.platforms.a2a.adapter import A2AAdapter
+    from gateway.config import PlatformConfig
+
+    return A2AAdapter(PlatformConfig(enabled=True))
+
+
+class TestInboundHistoryInjection:
+    def _drive(self, adapter, monkeypatch):
+        """Run _prepare_task with dispatch captured; return the event text list."""
+        seen_events = []
+
+        async def fake_handle(event):
+            seen_events.append(event)
+
+        adapter.handle_message = fake_handle
+        adapter._message_handler = lambda event: None
+        adapter._loop = asyncio.new_event_loop()
+
+        captured_coros = []
+
+        def fake_schedule(coro, loop):
+            captured_coros.append(coro)
+            return SimpleNamespace(done=lambda: True)
+
+        monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", fake_schedule)
+        return seen_events, captured_coros
+
+    def test_new_context_no_injection(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(protocol, "_hermes_home", lambda: tmp_path)
+        adapter = _bare_adapter()
+        seen, coros = self._drive(adapter, monkeypatch)
+
+        task, pending = adapter._prepare_task(
+            _send_params("first question", "ctx-new"), peer="peer-x"
+        )
+        assert pending is not None
+        asyncio.run(coros[0])
+        text = seen[0].text
+        assert "first question" in text
+        assert not text.startswith("user:")
+
+    def test_resume_injects_history_into_agent_text(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(protocol, "_hermes_home", lambda: tmp_path)
+        protocol.persist_message("ctx-mt", "user", "first question")
+        protocol.persist_message("ctx-mt", "agent", "first answer")
+
+        adapter = _bare_adapter()
+        seen, coros = self._drive(adapter, monkeypatch)
+
+        task, pending = adapter._prepare_task(
+            _send_params("second question", "ctx-mt"), peer="peer-x"
+        )
+        assert pending is not None
+        asyncio.run(coros[0])
+        text = seen[0].text
+        assert "first question" in text
+        assert "first answer" in text
+        assert "second question" in text
+        assert text.index("first question") < text.index("second question")
+
+    def test_persist_and_audit_store_original_not_augmented(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(protocol, "_hermes_home", lambda: tmp_path)
+        protocol.persist_message("ctx-keep", "user", "first question")
+        protocol.persist_message("ctx-keep", "agent", "first answer")
+
+        audited = []
+        monkeypatch.setattr(security, "audit", lambda *a, **k: audited.append(a))
+        adapter = _bare_adapter()
+        seen, coros = self._drive(adapter, monkeypatch)
+
+        task, pending = adapter._prepare_task(
+            _send_params("second question", "ctx-keep"), peer="peer-x"
+        )
+        assert pending is not None
+        asyncio.run(coros[0])
+
+        # Agent saw the augmented text (wrap_inbound adds its own prefix)…
+        assert "user: first question" in seen[0].text
+        assert "second question" in seen[0].text
+        # …but the persisted log and audit trail carry only the original.
+        recs = protocol.load_conversation("ctx-keep", limit=50)
+        assert recs[-1]["role"] == "user"
+        assert recs[-1]["text"] == "second question"
+        assert any("second question" in a[3] for a in audited)
+        assert all("first question" not in a[3] for a in audited)
+
+    def test_resume_does_not_duplicate_injected_prefix(self, monkeypatch, tmp_path):
+        """A third turn must not re-inject the already-injected prefix."""
+        monkeypatch.setattr(protocol, "_hermes_home", lambda: tmp_path)
+        adapter = _bare_adapter()
+        seen, coros = self._drive(adapter, monkeypatch)
+
+        for i, text in enumerate(["q1", "q2", "q3"]):
+            task, pending = adapter._prepare_task(
+                _send_params(text, "ctx-loop"), peer="peer-x"
+            )
+            assert pending is not None
+            asyncio.run(coros[-1])
+
+        # After three turns the on-disk log holds exactly the three originals.
+        recs = protocol.load_conversation("ctx-loop", limit=50)
+        assert [r["text"] for r in recs] == ["q1", "q2", "q3"]


### PR DESCRIPTION
## Summary

Multi-turn support for the A2A plugin that landed in #77109: when a caller **reuses a `contextId`**, the persisted conversation is prepended to the inbound message so the agent sees the full thread — not just the latest message.

Built on top of the merged official plugin (`plugins/platforms/a2a/`), which already persists every exchange to disk (`persist_message` / `load_conversation`). This PR adds the missing read-back half of multi-turn.

## Changes

- **`protocol.format_history(context_id, limit=None)`** — renders prior messages as `role: text` lines (`user:` / `assistant:`). Empty string when the context has no history. Bounded by `A2A_HISTORY_INJECTION_LIMIT` env (default 20, max 200, `0` disables injection entirely).
- **`adapter._prepare_task()`** — on inbound `message/send`, if history exists for the context, prepend it to the text that goes to the agent. The **original** message is what gets audited and persisted, so injected prefixes never accumulate in the on-disk log (verified across 3+ turns).
- **`tests/plugins/test_a2a_multiturn.py`** — 9 tests: empty history, role rendering, limit + env override, injection on resume, original-only persistence/audit, no duplicate-prefix growth.

## Why it matters

A2A peers that hold a `contextId` open across multiple `message/send` calls (the standard multi-turn pattern) currently get a stateless agent — the agent answers each message as if it were the first. With this, a resumed context behaves like a conversation thread.

## Non-goals (unchanged from #64982)

- No a2a-sdk dependency, no new deps at all (stdlib only).
- No behavior change for new contexts (no history → no injection).
- Turn-cap / anti-loop protection is untouched.

## Verification

- `tests/plugins/test_a2a_multiturn.py`: 9 passed
- Official suite `test_a2a_plugin.py` + `test_a2a_phase23.py`: 151 passed, 0 regressions
- `ruff check` clean on all touched files

Supersedes #64982 (multi-turn conversation support) — same intent, rebased onto the merged official plugin.
