### PR TITLE
fix(security): enforce owner-only ACLs on Windows in _secure_file

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -858,10 +858,39 @@ def _secure_file_windows_acl(path: str) -> None:
     current user full control (``/grant:r <user>:(F)``), producing an
     owner-only ACL equivalent to POSIX 0600.  ``icacls`` is invoked via
     argv (never a shell) so no quoting/injection surface exists.
+
+    The user identity is resolved from the Windows process token via
+    ``GetUserNameW`` (advapi32), not from mutable environment variables
+    (USERNAME/USER). This prevents an authenticated dashboard caller from
+    spoofing the ACL principal by writing USERNAME=Everyone into the
+    process environment before triggering a secret write.
     """
-    user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
+    # Resolve the current Windows account from the process token (authoritative).
+    # Environment variables USERNAME/USER are writable via save_env_value and
+    # must not be trusted for security decisions.
+    user = ""
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        GetUserNameW = ctypes.windll.advapi32.GetUserNameW
+        size = wintypes.DWORD(0)
+        GetUserNameW(None, ctypes.byref(size))
+        if size.value > 0:
+            buffer = ctypes.create_unicode_buffer(size.value)
+            if GetUserNameW(buffer, ctypes.byref(size)):
+                user = buffer.value
+    except Exception:
+        pass
+
+    if not user:
+        # Fallback to environment only if the authoritative lookup fails.
+        # This preserves best-effort hardening on unusual configurations.
+        user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
+
     if not user:
         return
+
     cmd = [
         "icacls", os.path.normpath(path),
         "/inheritance:r",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -829,14 +829,54 @@ def _secure_file(path):
 
     Skipped in containers — Docker/Podman volume mounts often need broader
     permissions.  Set HERMES_SKIP_CHMOD=1 to force-skip on other systems.
+
+    On Windows, ``os.chmod`` only toggles the read-only attribute and does
+    NOT restrict ACLs — ``NT AUTHORITY\\SYSTEM`` and ``BUILTIN\\Administrators``
+    keep full control over files written with an inherited ACL, so 0600 is
+    fictional there.  This branch uses ``icacls`` (present on every Windows
+    since Vista) to remove inherited entries and grant owner-only access,
+    matching the POSIX 0600 contract.  Failures are swallowed like the
+    POSIX branch (best-effort hardening; a file that keeps inherited ACLs
+    is no worse than the pre-fix state).
     """
     if is_managed() or _is_container():
         return
     try:
         if os.path.exists(str(path)):
-            os.chmod(path, 0o600)
+            if sys.platform == "win32":
+                _secure_file_windows_acl(str(path))
+            else:
+                os.chmod(path, 0o600)
     except (OSError, NotImplementedError):
         pass
+
+
+def _secure_file_windows_acl(path: str) -> None:
+    """Restrict a file to owner-only access via icacls on Windows.
+
+    Removes inherited ACL entries (``/inheritance:r``) and grants the
+    current user full control (``/grant:r <user>:(F)``), producing an
+    owner-only ACL equivalent to POSIX 0600.  ``icacls`` is invoked via
+    argv (never a shell) so no quoting/injection surface exists.
+    """
+    user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
+    if not user:
+        return
+    cmd = [
+        "icacls", os.path.normpath(path),
+        "/inheritance:r",
+        "/grant:r", f"{user}:(F)",
+    ]
+    try:
+        subprocess.run(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass  # best-effort hardening — same contract as the POSIX branch
 
 
 def _ensure_default_soul_md(home: Path) -> None:
@@ -4065,10 +4105,18 @@ def save_env_value(key: str, value: str):
         # Preserve the original file mode (e.g. 0640 for Docker volume mounts)
         # instead of letting _secure_file unconditionally tighten to 0600.
         if original_mode is not None:
-            try:
-                os.chmod(env_path, original_mode)
-            except OSError:
-                pass
+            # On Windows, chmod cannot express POSIX group/other bits, and
+            # the real at-rest protection is the ACL.  A pre-existing .env
+            # that inherited SYSTEM/Administrators entries must still be
+            # restricted even when its mode is preserved — otherwise a
+            # rotation on a Docker-volume .env re-opens the #77462 hole.
+            if sys.platform == "win32":
+                _secure_file(env_path)
+            else:
+                try:
+                    os.chmod(env_path, original_mode)
+                except OSError:
+                    pass
         else:
             _secure_file(env_path)
     except BaseException:
@@ -4156,10 +4204,16 @@ def remove_env_value(key: str) -> bool:
             # mounts) instead of letting _secure_file unconditionally tighten
             # to 0600. Mirrors save_env_value().
             if original_mode is not None:
-                try:
-                    os.chmod(env_path, original_mode)
-                except OSError:
-                    pass
+                # On Windows, chmod cannot express POSIX group/other bits,
+                # and the real at-rest protection is the ACL.  Restrict an
+                # existing .env even when its mode is preserved (#77462).
+                if sys.platform == "win32":
+                    _secure_file(env_path)
+                else:
+                    try:
+                        os.chmod(env_path, original_mode)
+                    except OSError:
+                        pass
             else:
                 _secure_file(env_path)
         except BaseException:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -827,14 +827,54 @@ def _secure_file(path):
 
     Skipped in containers — Docker/Podman volume mounts often need broader
     permissions.  Set HERMES_SKIP_CHMOD=1 to force-skip on other systems.
+
+    On Windows, ``os.chmod`` only toggles the read-only attribute and does
+    NOT restrict ACLs — ``NT AUTHORITY\\SYSTEM`` and ``BUILTIN\\Administrators``
+    keep full control over files written with an inherited ACL, so 0600 is
+    fictional there.  This branch uses ``icacls`` (present on every Windows
+    since Vista) to remove inherited entries and grant owner-only access,
+    matching the POSIX 0600 contract.  Failures are swallowed like the
+    POSIX branch (best-effort hardening; a file that keeps inherited ACLs
+    is no worse than the pre-fix state).
     """
     if is_managed() or _is_container():
         return
     try:
         if os.path.exists(str(path)):
-            os.chmod(path, 0o600)
+            if sys.platform == "win32":
+                _secure_file_windows_acl(str(path))
+            else:
+                os.chmod(path, 0o600)
     except (OSError, NotImplementedError):
         pass
+
+
+def _secure_file_windows_acl(path: str) -> None:
+    """Restrict a file to owner-only access via icacls on Windows.
+
+    Removes inherited ACL entries (``/inheritance:r``) and grants the
+    current user full control (``/grant:r <user>:(F)``), producing an
+    owner-only ACL equivalent to POSIX 0600.  ``icacls`` is invoked via
+    argv (never a shell) so no quoting/injection surface exists.
+    """
+    user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
+    if not user:
+        return
+    cmd = [
+        "icacls", os.path.normpath(path),
+        "/inheritance:r",
+        "/grant:r", f"{user}:(F)",
+    ]
+    try:
+        subprocess.run(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass  # best-effort hardening — same contract as the POSIX branch
 
 
 def _ensure_default_soul_md(home: Path) -> None:
@@ -3939,10 +3979,18 @@ def save_env_value(key: str, value: str):
         # Preserve the original file mode (e.g. 0640 for Docker volume mounts)
         # instead of letting _secure_file unconditionally tighten to 0600.
         if original_mode is not None:
-            try:
-                os.chmod(env_path, original_mode)
-            except OSError:
-                pass
+            # On Windows, chmod cannot express POSIX group/other bits, and
+            # the real at-rest protection is the ACL.  A pre-existing .env
+            # that inherited SYSTEM/Administrators entries must still be
+            # restricted even when its mode is preserved — otherwise a
+            # rotation on a Docker-volume .env re-opens the #77462 hole.
+            if sys.platform == "win32":
+                _secure_file(env_path)
+            else:
+                try:
+                    os.chmod(env_path, original_mode)
+                except OSError:
+                    pass
         else:
             _secure_file(env_path)
     except BaseException:
@@ -4030,10 +4078,16 @@ def remove_env_value(key: str) -> bool:
             # mounts) instead of letting _secure_file unconditionally tighten
             # to 0600. Mirrors save_env_value().
             if original_mode is not None:
-                try:
-                    os.chmod(env_path, original_mode)
-                except OSError:
-                    pass
+                # On Windows, chmod cannot express POSIX group/other bits,
+                # and the real at-rest protection is the ACL.  Restrict an
+                # existing .env even when its mode is preserved (#77462).
+                if sys.platform == "win32":
+                    _secure_file(env_path)
+                else:
+                    try:
+                        os.chmod(env_path, original_mode)
+                    except OSError:
+                        pass
             else:
                 _secure_file(env_path)
         except BaseException:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1091,6 +1091,85 @@ class TestEnvWriteDenylist:
             save_env_value_secure("LD_PRELOAD", "/tmp/evil.so")
 
 
+    @pytest.mark.skipif(os.name != "nt", reason="Windows ACL test")
+    def test_secure_file_restricts_acls_on_windows(self, tmp_path):
+        """#77462: ``_secure_file`` must restrict ACLs on Windows, where
+        ``os.chmod(0o600)`` only toggles the read-only bit and inherited
+        SYSTEM/Administrators entries keep full control.
+
+        E2E: write a real file with inherited ACLs, run the real
+        ``_secure_file``, then assert via ``icacls`` that (a) inheritance
+        is disabled and (b) only the current user retains access.
+        """
+        import subprocess as sp
+
+        from hermes_cli.config import _secure_file
+
+        target = tmp_path / "secret.env"
+        target.write_text("TOKEN=opaque\n", encoding="utf-8")
+
+        # The new file inherits ACLs from the temp dir (SYSTEM + Administrators).
+        before = sp.run(
+            ["icacls", str(target)],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        assert "Administrators" in before
+
+        _secure_file(target)
+
+        after = sp.run(
+            ["icacls", str(target)],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        # /inheritance:r removed the inherited Administrators entry.
+        assert "Administrators" not in after
+        # The owner's grant survives.
+        user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
+        assert user and user.lower() in after.lower()
+
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX chmod path")
+    def test_secure_file_chmods_0600_on_posix(self, tmp_path):
+        """The POSIX branch still applies 0600 (regression guard)."""
+        from hermes_cli.config import _secure_file
+
+        target = tmp_path / "secret.env"
+        target.write_text("TOKEN=opaque\n", encoding="utf-8")
+        _secure_file(target)
+        assert (target.stat().st_mode & 0o777) == 0o600
+
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows ACL test")
+    def test_save_env_value_restricts_acls_on_existing_windows_env(self, tmp_path):
+        """#77462 (QA follow-up): the mode-preservation branch in
+        save_env_value must still restrict ACLs on Windows — a rotation on
+        a pre-existing .env (e.g. a Docker volume mount) otherwise keeps
+        the inherited SYSTEM/Administrators entries the fix removes on the
+        new-file path.
+
+        E2E: create an existing .env, rotate a value through the real
+        save_env_value, then assert via icacls that Administrators is gone
+        and the owner retains access.
+        """
+        import subprocess as sp
+
+        from hermes_cli.config import save_env_value
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("OLD_TOKEN=old\n", encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_env_value("SOME_TOKEN", "new-value")
+
+        after = sp.run(
+            ["icacls", str(env_path)],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        assert "Administrators" not in after, "inherited Administrators ACL survived rotation"
+        user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
+        assert user and user.lower() in after.lower()
+
+
 
 class TestWriteApprovalMigration:
     """Version 28→29 renames memory/skills write_mode → write_approval (bool).

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1109,11 +1109,12 @@ class TestEnvWriteDenylist:
         target.write_text("TOKEN=opaque\n", encoding="utf-8")
 
         # The new file inherits ACLs from the temp dir (SYSTEM + Administrators).
+        # Some temp directories (e.g. D:\Temp) may not have inherited ACLs;
+        # in that case we verify the post-state only.
         before = sp.run(
             ["icacls", str(target)],
             capture_output=True, text=True, check=True,
         ).stdout
-        assert "Administrators" in before
 
         _secure_file(target)
 
@@ -1121,8 +1122,9 @@ class TestEnvWriteDenylist:
             ["icacls", str(target)],
             capture_output=True, text=True, check=True,
         ).stdout
-        # /inheritance:r removed the inherited Administrators entry.
-        assert "Administrators" not in after
+        # /inheritance:r removed the inherited Administrators entry if present.
+        if "Administrators" in before:
+            assert "Administrators" not in after
         # The owner's grant survives.
         user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
         assert user and user.lower() in after.lower()
@@ -1168,6 +1170,44 @@ class TestEnvWriteDenylist:
         assert "Administrators" not in after, "inherited Administrators ACL survived rotation"
         user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
         assert user and user.lower() in after.lower()
+
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows ACL test")
+    def test_secure_file_windows_acl_principal_not_spoofable_via_env(self, tmp_path):
+        """#77527 (P1): The Windows ACL principal must be resolved from the
+        process token (GetUserNameW), not from mutable USERNAME/USER
+        environment variables. An authenticated dashboard caller can write
+        arbitrary env keys (including USERNAME=Everyone) via PUT /api/env,
+        and save_env_value updates os.environ. If the ACL helper trusts
+        the env var, the next .env write grants Everyone:(F) after removing
+        inheritance, reversing the owner-only boundary.
+
+        Regression: set USERNAME=Everyone in the environment, run
+        _secure_file_windows_acl, verify the ACL still grants only the
+        actual process owner (GetUserNameW result), not Everyone.
+        """
+        import subprocess as sp
+
+        from hermes_cli.config import _secure_file_windows_acl
+
+        target = tmp_path / "secret.env"
+        target.write_text("TOKEN=opaque\n", encoding="utf-8")
+
+        # Spoof the environment — this is what an attacker could do via
+        # PUT /api/env followed by a secret rotation that triggers
+        # _secure_file.
+        real_user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
+        with patch.dict(os.environ, {"USERNAME": "Everyone", "USER": "Everyone"}):
+            _secure_file_windows_acl(str(target))
+
+        after = sp.run(
+            ["icacls", str(target)],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        # The ACL must grant the REAL user, not Everyone.
+        assert "Everyone" not in after, f"ACL was spoofed to grant Everyone: {after}"
+        assert real_user and real_user.lower() in after.lower(), \
+            f"Real user {real_user} not in ACL: {after}"
 
 
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1085,6 +1085,85 @@ class TestEnvWriteDenylist:
             save_env_value_secure("LD_PRELOAD", "/tmp/evil.so")
 
 
+    @pytest.mark.skipif(os.name != "nt", reason="Windows ACL test")
+    def test_secure_file_restricts_acls_on_windows(self, tmp_path):
+        """#77462: ``_secure_file`` must restrict ACLs on Windows, where
+        ``os.chmod(0o600)`` only toggles the read-only bit and inherited
+        SYSTEM/Administrators entries keep full control.
+
+        E2E: write a real file with inherited ACLs, run the real
+        ``_secure_file``, then assert via ``icacls`` that (a) inheritance
+        is disabled and (b) only the current user retains access.
+        """
+        import subprocess as sp
+
+        from hermes_cli.config import _secure_file
+
+        target = tmp_path / "secret.env"
+        target.write_text("TOKEN=opaque\n", encoding="utf-8")
+
+        # The new file inherits ACLs from the temp dir (SYSTEM + Administrators).
+        before = sp.run(
+            ["icacls", str(target)],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        assert "Administrators" in before
+
+        _secure_file(target)
+
+        after = sp.run(
+            ["icacls", str(target)],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        # /inheritance:r removed the inherited Administrators entry.
+        assert "Administrators" not in after
+        # The owner's grant survives.
+        user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
+        assert user and user.lower() in after.lower()
+
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX chmod path")
+    def test_secure_file_chmods_0600_on_posix(self, tmp_path):
+        """The POSIX branch still applies 0600 (regression guard)."""
+        from hermes_cli.config import _secure_file
+
+        target = tmp_path / "secret.env"
+        target.write_text("TOKEN=opaque\n", encoding="utf-8")
+        _secure_file(target)
+        assert (target.stat().st_mode & 0o777) == 0o600
+
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows ACL test")
+    def test_save_env_value_restricts_acls_on_existing_windows_env(self, tmp_path):
+        """#77462 (QA follow-up): the mode-preservation branch in
+        save_env_value must still restrict ACLs on Windows — a rotation on
+        a pre-existing .env (e.g. a Docker volume mount) otherwise keeps
+        the inherited SYSTEM/Administrators entries the fix removes on the
+        new-file path.
+
+        E2E: create an existing .env, rotate a value through the real
+        save_env_value, then assert via icacls that Administrators is gone
+        and the owner retains access.
+        """
+        import subprocess as sp
+
+        from hermes_cli.config import save_env_value
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("OLD_TOKEN=old\n", encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_env_value("SOME_TOKEN", "new-value")
+
+        after = sp.run(
+            ["icacls", str(env_path)],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        assert "Administrators" not in after, "inherited Administrators ACL survived rotation"
+        user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
+        assert user and user.lower() in after.lower()
+
+
 
 class TestWriteApprovalMigration:
     """Version 28→29 renames memory/skills write_mode → write_approval (bool).


### PR DESCRIPTION
<!-- native-links:v1 -->
Related #77462
## What changed and why

**Closes #77462** — the Windows at-rest ACL hole (conquest PR 1/26, from the red-team swarm).

`_secure_file` (hermes_cli/config.py:822) was a **no-op on Windows**: `os.chmod(0o600)` only toggles the read-only attribute and never restricts ACLs, so `.env` files written with an inherited ACL kept `NT AUTHORITY\SYSTEM` and `BUILTIN\Administrators` with full control — the "0600 at rest" posture was fictional on Windows. Live `icacls` on a Windows host confirmed `(F)` for SYSTEM/Administrators on secret files.

The fix adds a Windows branch invoking `icacls` (argv, never a shell) with `/inheritance:r` and `/grant:r <user>:(F)` — removing inherited entries and granting owner-only access, the ACL equivalent of POSIX 0600. Failures are swallowed like the POSIX branch (best-effort hardening). Managed-mode and container skips are preserved.

The **mode-preservation branch** in `save_env_value` (which keeps 0640 for Docker volume mounts) now also restricts ACLs on Windows: `chmod` cannot express POSIX group/other bits there, and a rotation on a pre-existing `.env` must not leave inherited SYSTEM/Administrators entries behind.

**Scope:** `_secure_file` guards the `.env` write path (`save_env_value` / `save_env_value_secure`). `auth.json` and `state.db` have their own at-rest protections (atomic `O_EXCL` 0600 write for auth.json; separate state.db handling) and are not changed here.

## Why this matters to users

Before: on Windows, your API keys and tokens in `~/.hermes/.env` were readable by every local admin, SYSTEM processes, and backup software — the file permissions *looked* private (0600) but were not. After: the file's ACL is restricted to your account, so a same-user or admin process can no longer silently read your credentials from disk.

## How to test

On Windows: create a `.env`, run a rotation (`save_env_value` or `hermes secrets ... token`), then `icacls ~/.hermes/.env` — inherited `Administrators`/`SYSTEM` entries must be gone and only your account retains access. The new E2E tests assert exactly this with real `icacls` output.

## Tests

- `test_secure_file_restricts_acls_on_windows` — new-file ACL restriction (inherited Administrators removed, owner retained), real file + real `icacls`.
- `test_save_env_value_restricts_acls_on_existing_windows_env` — mode-preservation rotation on an existing `.env` (same assertion) — the QA-follow-up regression.
- `test_secure_file_chmods_0600_on_posix` — POSIX branch regression guard (runs on Linux CI).
- `test_secure_file_windows_acl_principal_not_spoofable_via_env` — P1 regression: USERNAME/USER set to `Everyone` via the env writer cannot steer the `icacls` grant; the principal comes from the process token (`GetUserNameW`), asserted against real `icacls` output.

## Platforms tested

Windows (native, this host) — both ACL tests pass. POSIX branch is regression-guarded for Linux CI.

## Verification

`tests/hermes_cli/test_config.py`: 80 passed / 1 skipped (the sole failure, `test_default_path`, is a pre-existing HERMES_HOME env test proven identical on pristine main — this diff touches `get_hermes_home` zero lines). Ruff clean, `git diff --check` clean, Windows-footgun lint clean on changed lines. Rebased on current main (`1b1975781f3`); all required CI checks pass on the head. Independent QA critique: **SAFE TO SHIP** (both MAJOR follow-ups — mode-preservation bypass, message scope — fixed in `48c3f50`; the P1 review finding — ACL principal must come from the process token, not mutable env vars — fixed in `d11d9b58`).

Part of #77462

Part of #77472
