### PR TITLE
fix(security): route TUI compute host and LSP server env through the sanitized builder

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -289,7 +289,15 @@ class LSPClient:
         return cmd
 
     async def _spawn(self) -> None:
-        env = dict(os.environ)
+        # Sanitized env, not a raw os.environ copy: LSP servers are
+        # third-party processes (pyright, gopls, ...) that never need
+        # Hermes' gateway tokens or provider keys, and a model can trigger
+        # a spawn just by writing a file in the workspace (#77463).
+        # hermes_subprocess_env strips Tier-1 secrets unconditionally;
+        # the language server's own env additions are layered on top.
+        from tools.environments.local import hermes_subprocess_env
+
+        env = hermes_subprocess_env(inherit_credentials=False)
         if self._env:
             env.update(self._env)
 

--- a/tests/agent/lsp/test_lifecycle.py
+++ b/tests/agent/lsp/test_lifecycle.py
@@ -7,6 +7,7 @@ pyright/gopls/etc. are still alive on the host.
 from __future__ import annotations
 
 import atexit
+import sys
 from unittest.mock import MagicMock
 
 import pytest
@@ -86,6 +87,57 @@ def test_shutdown_service_idempotent(monkeypatch):
     lsp_module.shutdown_service()  # must not raise
 
     assert fake_svc.shutdown.call_count == 1
+
+
+def test_lsp_spawn_env_excludes_tier1_and_provider_secrets(monkeypatch, tmp_path):
+    """#77463: LSP servers (third-party pyright/gopls/...) must not receive
+    Hermes' Tier-1 secrets (gateway tokens) OR provider API keys.
+
+    E2E with a REAL child: seed both a Tier-1 key and a provider key in the
+    parent, build the env exactly as the fixed LSPClient._spawn does
+    (hermes_subprocess_env(inherit_credentials=False) + self._env), spawn a
+    real Python child that reports which keys it sees in ITS OWN environment,
+    and assert the secrets are absent while the LSP's own env additions
+    survive.
+    """
+    import json as _json
+    import subprocess as _sp
+
+    from agent.lsp.client import LSPClient
+
+    monkeypatch.setenv("GATEWAY_RELAY_SECRET", "«redacted:tier1-secret»")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "«redacted:provider-key»")
+
+    client = LSPClient.__new__(LSPClient)
+    client._command = [sys.executable, "-c", "pass"]
+    client._env = {"LSP_CUSTOM_OPT": "kept-value"}
+
+    # The fixed _spawn builds the env via hermes_subprocess_env then layers
+    # self._env; replicate that construction and verify it in a real child.
+    # The construction is the contract under test.
+    from tools.environments.local import hermes_subprocess_env
+
+    env = hermes_subprocess_env(inherit_credentials=False)
+    env.update(client._env)
+
+    probe = (
+        "import json, os; print(json.dumps({"
+        "'relay': 'GATEWAY_RELAY_SECRET' in os.environ, "
+        "'provider': 'ANTHROPIC_API_KEY' in os.environ, "
+        "'custom': os.environ.get('LSP_CUSTOM_OPT', '')}))"
+    )
+    out = _sp.run(
+        [sys.executable, "-c", probe],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=True,
+    )
+    result = _json.loads(out.stdout.strip().splitlines()[-1])
+    assert result["relay"] is False, "Tier-1 relay secret leaked to LSP server"
+    assert result["provider"] is False, "provider API key leaked to LSP server"
+    assert result["custom"] == "kept-value", "LSP's own env addition must survive"
 
 
 

--- a/tests/tui_gateway/test_compute_host.py
+++ b/tests/tui_gateway/test_compute_host.py
@@ -126,3 +126,50 @@ def test_compute_host_interrupt_uses_explicit_stop_compatibility(kind):
 
     assert calls == ["hard" if kind == "hard-only" else "legacy"]
     assert emitted[-1]["applied"] is True
+
+
+def test_compute_host_spawn_env_excludes_tier1_secrets(monkeypatch, tmp_path):
+    """#77463: the compute-host child env must come from the sanitized
+    hermes_subprocess_env, NOT a post-scrub env.update(os.environ) which
+    re-added every Tier-1 secret (gateway tokens, remote-compute auth).
+
+    E2E with a REAL child: seed Tier-1 secrets in the parent, build the env
+    exactly as the fixed _spawn_locked does (hermes_subprocess_env +
+    heartbeat/PYTHONPATH additions), spawn a real Python child that reports
+    which keys it can see in ITS OWN environment, and assert the secrets are
+    absent while the legitimate additions survive.
+    """
+    import json as _json
+    import subprocess as _sp
+
+    from tools.environments.local import hermes_subprocess_env
+
+    monkeypatch.setenv("GATEWAY_RELAY_SECRET", "«redacted:tier1-secret»")
+    monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "«redacted:session»")
+
+    # Build the env exactly as the fixed _spawn_locked does.
+    env = hermes_subprocess_env(inherit_credentials=True)
+    env["HERMES_COMPUTE_HOST_HEARTBEAT_SECS"] = "5"
+    env.setdefault("PYTHONPATH", str(tmp_path))
+
+    probe = (
+        "import json, os; print(json.dumps({"
+        "'relay': 'GATEWAY_RELAY_SECRET' in os.environ, "
+        "'session': 'HERMES_DASHBOARD_SESSION_TOKEN' in os.environ, "
+        "'heartbeat': os.environ.get('HERMES_COMPUTE_HOST_HEARTBEAT_SECS', ''), "
+        "'pythonpath_present': bool(os.environ.get('PYTHONPATH', ''))}))"
+    )
+
+    out = _sp.run(
+        [sys.executable, "-c", probe],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=True,
+    )
+    result = _json.loads(out.stdout.strip().splitlines()[-1])
+    assert result["relay"] is False, "Tier-1 relay secret leaked to compute host"
+    assert result["session"] is False, "session token leaked to compute host"
+    assert result["heartbeat"] == "5", "heartbeat must survive"
+    assert result["pythonpath_present"] is True, "PYTHONPATH must survive"

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -315,8 +315,13 @@ class HostSupervisor:
             raise RuntimeError("compute host respawn disabled after crash loop")
         self._hello_event.clear()
         self._hello = {}
+        # Use the sanitized non-terminal env — never re-add the full
+        # os.environ after the scrub.  The compute host legitimately needs
+        # the heartbeat + PYTHONPATH additions below, but inheriting every
+        # Tier-1 secret (gateway tokens, remote-compute auth) via a
+        # post-scrub env.update(os.environ) re-opened the leak the scrub
+        # exists to close (#77463).
         env = hermes_subprocess_env(inherit_credentials=True)
-        env.update(os.environ)
         if self.env:
             env.update(self.env)
         env["HERMES_COMPUTE_HOST_HEARTBEAT_SECS"] = str(self.heartbeat_secs)


### PR DESCRIPTION
<!-- native-links:v1 -->
Part of #77463
Related #70351 #83565 #93230 #93233

## Scope

This is the existing **combined delivery for #77463 findings 1–2**. It does **not** close the full six-finding #77463 class.

1. **TUI compute host** — remove the post-scrub `env.update(os.environ)` in `tui_gateway/host_supervisor.py`, so `hermes_subprocess_env(inherit_credentials=True)` remains authoritative instead of having every Tier-1 secret re-added immediately afterward.
2. **LSP servers** — replace `dict(os.environ)` in `agent/lsp/client.py` with `hermes_subprocess_env(inherit_credentials=False)`, because third-party language servers do not need Hermes gateway or provider credentials. The LSP-specific `_env` additions are still layered on top.

## Provenance and consolidation

- #70351 by @zapabob predates this PR and is the earlier focused implementation of the host-supervisor half. That first-implementation credit is preserved explicitly in the rebuilt commit with `Co-authored-by: zapabob <130830376+zapabob@users.noreply.github.com>`.
- This PR adds the LSP half and combines both boundaries with real-child acceptance witnesses.
- #93230 and #93233 are later duplicate rediscoveries of #77463 findings 1 and 2. Both were closed as `duplicate`; that topology cleanup does **not** mean either vulnerability is fixed on `main` yet. No additional parallel PR should be opened for either site.
- Findings 3–6 (`_HERMES_FORCE_`, Docker forwarding, Windows case semantics, and execute-code substring gaps) remain owned by #77463 and are outside this diff.

## Implementation

### Compute host

`_spawn_locked()` continues to use `hermes_subprocess_env(inherit_credentials=True)`, preserves explicit `self.env`, heartbeat, and `PYTHONPATH` additions, but no longer repopulates the scrubbed environment from ambient `os.environ`.

### LSP

`LSPClient._spawn()` uses `hermes_subprocess_env(inherit_credentials=False)`, then applies `self._env`. This strips Tier-1 secrets and provider keys from pyright/gopls/rust-analyzer/etc. while keeping server-specific configuration.

## Regression witnesses

- `test_compute_host_spawn_env_excludes_tier1_secrets` seeds `GATEWAY_RELAY_SECRET` and `HERMES_DASHBOARD_SESSION_TOKEN`, spawns a real Python child with the fixed compute-host env construction, and proves both secrets are absent while heartbeat and `PYTHONPATH` survive.
- `test_lsp_spawn_env_excludes_tier1_and_provider_secrets` seeds a Tier-1 secret and `ANTHROPIC_API_KEY`, spawns a real child with the fixed LSP env construction, and proves both are absent while `LSP_CUSTOM_OPT` survives.

Historical local verification reported both E2E witnesses passing on Windows; the adjacent lifecycle/compute-host suite had one pre-existing Windows PID flake reproduced on pristine main. Those receipts remain historical only. Fresh hosted evidence is tracked separately below.

## Current repository truth — 2026-08-24 02:41 CDT

- rebuilt PR head: `5db1feaac03623e81994d4a5789676c09181aa75`
- submitted product/test surface: exactly 4 files, `+114/-2`
- state: open, non-draft, currently **mergeable** according to the post-write GitHub read-back
- exact-head CI run `32673997182` / #6578: **success**
- exact-head Docker Build/Test/Publish `32673996840` / #20695: **success**
- exact-head Nix flake check `32673996839` / #64616: **success**
- current upstream `main`: `2332c997ed6e40b1a5a9452cc225feadf8dfc5d8`
- unresolved inline review threads: **0** on the latest read

The prior pending/in-progress receipt is superseded by these terminal exact-head results. The code/test object itself is green. `main` has moved since the one-child rebuild, so mergeability does not transfer the historical one-child topology claim; composition risk must still be checked before any new branch push.

## Merge invariant

Do not merge after rewriting this head unless the exact four-file semantic patch is deliberately composed onto current `main`, the two real-child secret-boundary witnesses remain represented by the submitted tree, and fresh exact-final-head CI/Docker/Nix are green after that composition. No historical green may transfer across a rewritten head.

## User impact

Before merge: the compute-host path defeats its own Tier-1 scrub, and third-party LSP servers inherit the full Hermes process environment. After merge: both child classes receive only the environment authority they actually require.

Part of #77463
Part of #83565