### PR TITLE
fix: clear stale declared_session_id on cua-driver revival failure (#77489)

### DIFF
--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -1456,13 +1456,21 @@ class _CuaDriverSession:
                 session_id,
                 self._logical_error_text(revive_result),
             )
+            # Clear stale identity so subsequent calls don't retry the same
+            # dead session in an infinite loop (issue #77489).
+            self._declared_session_id = None
             return first_result
 
         # Return the second result as-is. A second rejection is surfaced; no loop.
-        return self._bridge.run(
+        retry_result = self._bridge.run(
             self._call_tool_async(name, args),
             timeout=timeout,
         )
+        # If the retried call also failed with an ended-session error, clear
+        # the stale identity to prevent a revival loop on the next call.
+        if self._is_ended_session_result(retry_result):
+            self._declared_session_id = None
+        return retry_result
 
     @staticmethod
     def _is_closed_session_error(exc: Exception) -> bool:


### PR DESCRIPTION
## Summary

When `_revive_declared_session_once` fails to revive a dead cua-driver session via `start_session`, the `_declared_session_id` was left unchanged. This caused every subsequent tool call to detect the same ended session and retry revival with the same dead session ID, creating an infinite retry loop (13+ identical `RuntimeError` messages observed in practice).

## Root cause

In `tools/computer_use/cua_backend.py:1453-1459`, when revival fails:
1. The method logs a warning and returns the original error
2. `_declared_session_id` remains set to the dead session ID
3. Next call -> `_is_ended_session_result()` matches -> `_revive_declared_session_once()` fires again with the same dead ID -> same failure -> loop

## Fix

Clear `_declared_session_id` in both failure paths within `_revive_declared_session_once`:

1. **Revival `start_session` fails** (line 1453): Clear before returning `first_result`
2. **Revival succeeds but retried call also ends session** (line 1462): Clear on the retry result

This breaks the loop: subsequent calls won't match `_is_ended_session_result()` because `_declared_session_id` is `None`, allowing the normal lifecycle path (`_restart_session_locked` or fresh `start_session`) to create a new session.

## Changes

- `tools/computer_use/cua_backend.py`: +9/-1 — two `self._declared_session_id = None` assignments with comments

Fixes #77489