### PR TITLE
fix(cron): resolve bash for .sh jobs via shared Windows-aware resolver (#46332)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2274,20 +2274,32 @@ def _run_job_script(
     # choice explicit here keeps the allowed surface small and auditable.
     suffix = path.suffix.lower()
     if suffix in {".sh", ".bash"}:
-        # Resolve bash dynamically so Windows (Git Bash) and Linux/macOS
-        # all work.  On native Windows without Git for Windows installed
-        # shutil.which returns None — fall back to a clear error rather
-        # than a FileNotFoundError with a confusing "[WinError 2]"
-        # traceback.
-        _bash = shutil.which("bash") or (
-            "/bin/bash" if os.path.isfile("/bin/bash") else None
-        )
+        # Resolve bash through the shared, Windows-aware resolver
+        # (tools/environments/local._find_bash: Hermes portable Git →
+        # Git for Windows install dirs → PATH lookup with a start probe),
+        # so cron .sh jobs never pick the System32 WSL launcher when Git
+        # Bash exists.  On native Windows with no usable bash the resolver
+        # raises — surface the actionable error rather than a confusing
+        # "[WinError 2]" traceback (or a WSL stub that exits 1).
+        try:
+            from tools.environments.local import _find_bash
+
+            _bash = _find_bash()
+        except RuntimeError:
+            # Windows with no Git Bash installed — the WSL launcher is the
+            # only "bash" on PATH and cannot start; fall through to the
+            # clear error below instead of spawning it.
+            _bash = None
+        except Exception:
+            _bash = shutil.which("bash") or (
+                "/bin/bash" if os.path.isfile("/bin/bash") else None
+            )
         if _bash is None:
             return False, (
-                f"Cannot run .sh/.bash script {path.name!r}: bash not found on PATH. "
+                f"Cannot run .sh/.bash script {path.name!r}: bash not found. "
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
-        )
+            )
         argv = [_bash, str(path)]
         env_overlay: dict[str, str] = {}
     else:

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -118,3 +118,108 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     ok, output = _run_job_script("/etc/passwd")
     assert ok is False
     assert "Blocked" in output or "outside" in output
+
+
+# ---------------------------------------------------------------------------
+# _run_job_script: bash resolution must go through the shared Windows-aware
+# resolver, not a raw PATH lookup (issue #46332 — WSL launcher picked over
+# Git Bash on native Windows).
+# ---------------------------------------------------------------------------
+
+
+class TestRunJobScriptBashResolver:
+    """Regression tests for the .sh/.bash interpreter resolution (Layer 1 of
+    issue #46332): cron jobs must use the shared ``_find_bash()`` resolver
+    (portable Git -> Git for Windows -> PATH-with-start-probe), never a raw
+    ``shutil.which("bash")`` that lands on the System32 WSL launcher."""
+
+    def _write_script(self, hermes_env) -> str:
+        script_path = hermes_env / "scripts" / "cron-resolver.sh"
+        script_path.write_text("#!/bin/bash\necho resolver ok\n")
+        return str(script_path)
+
+    def _fake_run(self, captured):
+        class _FakeResult:
+            returncode = 0
+            stdout = "resolver ok\n"
+            stderr = ""
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            return _FakeResult()
+
+        return fake_run
+
+    def test_shared_resolver_beats_raw_which_on_windows(
+        self, hermes_env, monkeypatch
+    ):
+        """The bug: raw shutil.which('bash') on Windows returns the WSL
+        launcher (C:\\Windows\\System32\\bash.exe). The fix: the shared
+        resolver's answer must win."""
+        from cron.scheduler import _run_job_script
+        import tools.environments.local as local_mod
+
+        script = self._write_script(hermes_env)
+        git_bash = "C:/Program Files/Git/bin/bash.exe"
+
+        # Raw PATH lookup would return the WSL launcher — must be ignored.
+        monkeypatch.setattr(
+            "cron.scheduler.shutil.which", lambda name: r"C:\Windows\System32\bash.exe"
+        )
+        monkeypatch.setattr(local_mod, "_find_bash", lambda: git_bash)
+
+        captured = {}
+        monkeypatch.setattr(
+            "cron.scheduler.subprocess.run", self._fake_run(captured)
+        )
+
+        ok, _ = _run_job_script(script)
+        assert ok is True
+        assert captured["argv"][0] == git_bash
+
+    def test_runtime_error_from_resolver_gives_clear_error(
+        self, hermes_env, monkeypatch
+    ):
+        """No usable bash anywhere (only a WSL stub that cannot start): the
+        resolver raises RuntimeError and the job reports the actionable
+        message instead of spawning the stub."""
+        from cron.scheduler import _run_job_script
+        import tools.environments.local as local_mod
+
+        script = self._write_script(hermes_env)
+
+        def _no_bash():
+            raise RuntimeError("no usable bash")
+
+        monkeypatch.setattr(local_mod, "_find_bash", _no_bash)
+
+        ok, message = _run_job_script(script)
+        assert ok is False
+        assert "bash not found" in message
+
+    def test_unexpected_resolver_failure_falls_back_to_path_lookup(
+        self, hermes_env, monkeypatch
+    ):
+        """A non-RuntimeError resolver failure (e.g. module unavailable in an
+        embedded context) degrades to the historical PATH lookup."""
+        from cron.scheduler import _run_job_script
+        import tools.environments.local as local_mod
+
+        script = self._write_script(hermes_env)
+
+        def _boom():
+            raise ImportError("module unavailable")
+
+        monkeypatch.setattr(local_mod, "_find_bash", _boom)
+        monkeypatch.setattr(
+            "cron.scheduler.shutil.which", lambda name: "/usr/bin/bash"
+        )
+
+        captured = {}
+        monkeypatch.setattr(
+            "cron.scheduler.subprocess.run", self._fake_run(captured)
+        )
+
+        ok, _ = _run_job_script(script)
+        assert ok is True
+        assert captured["argv"][0] == "/usr/bin/bash"


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #23405 #23489 #44350 #46332 #46364 #47837 #52204 #60617 #72697 #77393
## What does this PR do?

Fixes Layer 1 of issue **#46332** (the interpreter-selection half): cron `.sh`/`.bash` jobs on native Windows must resolve bash through the repository's **shared Windows-aware resolver**, never a raw `shutil.which("bash")` that lands on the System32 WSL launcher.

`cron/scheduler.py` `_run_job_script()` still did:

```python
_bash = shutil.which("bash") or ("/bin/bash" if os.path.isfile("/bin/bash") else None)
```

On Windows 10/11, `shutil.which("bash")` returns `C:\Windows\System32\bash.exe` (the WSL launcher — on PATH by default, ahead of Git for Windows). With no distro installed it exits 1; with a distro it cannot run Windows paths at all — either way, `.sh` cron watchdogs fail with exit 127 even though Git Bash is installed.

Now it routes through `tools.environments.local._find_bash()` — the shared resolver that already encodes the correct precedence (Hermes portable Git → Git for Windows install dirs → PATH lookup with a start probe), merged via #47837:

- `RuntimeError` (Windows, no usable bash anywhere — the only "bash" is a WSL stub that cannot start) → the actionable error message, instead of spawning the stub.
- Any other resolver failure (e.g. module unavailable in an embedded context) → degrades to the historical PATH lookup, unchanged behavior.

Layer 2 (Windows bash-path conversion) is already covered by the sibling PR **#77393** (`_bash_safe_path`, the MSYS convention) — this PR deliberately does **not** re-touch that line, so the two halves merge without colliding.

## Addressing existing review commentary

> **@GottZ (#46332 triage, 2026-07-28):** "The reported cause requires both a Git-Bash-aware shared resolver that cannot stop at a WSL launcher and a Windows-only Bash-path conversion; #52204 is the closest consolidated implementation, but its PATH continuation still needs correction."

This PR implements exactly the first requirement by **reusing** the shared resolver instead of re-implementing precedence — sidestepping the PATH-continuation flaw the triage flagged in #52204. The path conversion half ships separately in #77393.

> **@teknium1 (review of #72697):** that diff "bypasses the repository's shared configured/PortableGit/known-install resolver precedence and ... its POSIX-host test cannot exercise Windows serialization."

Agreed — this PR does the opposite: it calls the shared resolver directly (full PortableGit/known-install precedence inherited), and the regression tests force the Windows resolution path via monkeypatched `_find_bash`/`shutil.which` on any host.

## Prior art and consolidation map

The #46332 umbrella has accumulated 13+ PRs. Current state on this class:

| Half | Canonical | Status |
|---|---|---|
| Layer 1 (resolver) | **this PR** | open, suite green locally |
| Layer 2 (path form) | **#77393** | open, all CI green, `CLEAN` |
| Stale/superseded | #44350, #23405, #23489 (path-only, May base) | reconciled → close |
| Stale/superseded | #46364, #52204 (resolver, Jun/Jul base, now conflicting), #60617 (no CI), #72697 (partial per review) | reconciled → close |

Credit where due: **#46364** (Tranquil-Flow) and **#52204** (Frowtek) diagnosed the cron-side launcher selection and proposed Git-Bash-over-WSL resolution; **#60617** (paulhopcraft-dot) proposed skipping the launcher stub. This PR builds on their diagnosis with the already-merged shared resolver, which covers their cases and the portable-Git install location theirs missed.

## How to Test

1. `uv run --frozen pytest -q tests/cron/test_cron_no_agent.py tests/cron/test_scheduler.py`
2. `uv run --frozen ruff check cron/scheduler.py tests/cron/test_cron_no_agent.py`

Verified locally on this branch (Windows host, main venv): **71 passed** (cron suite incl. 3 new resolver regression tests), ruff clean, `git diff --check` clean. The regression tests force the Windows resolution path via monkeypatches so they exercise the fix on any host; the shared resolver itself is covered by its own test file (`tests/tools/test_windows_native_support.py`).

## Checklist

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Fixes the whole class slice (one site; the sibling class site `tools/approval.py` hint is covered by #77393)
- [x] Tests added (resolver-wins-over-which, RuntimeError message, fallback)
- [x] Suite green: cron 71 passed
- [x] `git diff --check` clean, ruff clean
- [x] No new env vars, reuses existing machinery
- [x] Docs: N/A — user-facing guidance ("install Git for Windows; the scheduler will say so explicitly when bash itself is missing") already shipped in #77393's cron.md note and the existing error text

Fixes #46332
