### PR TITLE
fix(auth): honor live dotenv in explicit provider gate (#77007)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1764,10 +1764,12 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
         from hermes_cli.providers import get_provider
         pconfig = get_provider(normalized)
     if pconfig and pconfig.auth_type == "api_key":
+        from hermes_cli.config import get_env_value_prefer_dotenv
+
         for env_var in pconfig.api_key_env_vars:
             if env_var in _IMPLICIT_ENV_VARS:
                 continue
-            if has_usable_secret(os.getenv(env_var, "")):
+            if has_usable_secret(get_env_value_prefer_dotenv(env_var) or ""):
                 return True
 
     # 4. Check persisted credential-pool entries that came from EXPLICIT flows
@@ -1786,8 +1788,11 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
                 # the user deletes the env var (#55790) — only count it when
                 # the referenced var still resolves to a usable secret NOW.
                 env_var = entry.get("source", "").split(":", 1)[1].strip()
-                if env_var and has_usable_secret(os.getenv(env_var, "")):
-                    return True
+                if env_var:
+                    from hermes_cli.config import get_env_value_prefer_dotenv
+
+                    if has_usable_secret(get_env_value_prefer_dotenv(env_var) or ""):
+                        return True
                 continue
             if (
                 source in {"device_code", "loopback_pkce", "hermes_pkce", "manual"}

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -17,6 +17,12 @@ def _write_auth_store(tmp_path, payload: dict) -> None:
     (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2))
 
 
+def _write_env(tmp_path, body: str) -> None:
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / ".env").write_text(body)
+
+
 @pytest.fixture(autouse=True)
 def _clean_anthropic_env(monkeypatch):
     """Strip Anthropic env vars so CI secrets don't leak into tests."""
@@ -97,6 +103,38 @@ def test_stale_env_pool_entry_does_not_count_when_var_unset(tmp_path, monkeypatc
     from hermes_cli.auth import is_provider_explicitly_configured
     assert is_provider_explicitly_configured("deepseek") is False
 
+
+def test_dotenv_api_key_counts_as_explicit_configuration(tmp_path, monkeypatch):
+    """Live .env edits should count immediately without a process restart (#77007)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_env(tmp_path, "ANTHROPIC_API_KEY=sk-live-dotenv\n")
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+
+    assert is_provider_explicitly_configured("anthropic") is True
+
+
+def test_env_seeded_pool_entry_resolves_live_dotenv_value(tmp_path, monkeypatch):
+    """Env-backed pool entries should reuse the live-dotenv credential resolver."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "providers": {},
+        "active_provider": None,
+        "credential_pool": {
+            "deepseek": [{
+                "id": "pool-1",
+                "source": "env:DEEPSEEK_API_KEY",
+                "auth_type": "api_key",
+            }],
+        },
+    })
+    _write_env(tmp_path, "DEEPSEEK_API_KEY=sk-live-dotenv\n")
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+
+    assert is_provider_explicitly_configured("deepseek") is True
 
 
 

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -208,6 +208,32 @@ def test_explicit_only_filters_ambient_credentials_but_keeps_current_and_custom_
     ]
 
 
+def test_explicit_only_accepts_live_dotenv_provider_without_restart(tmp_path, monkeypatch):
+    """Regression for #77007: explicit_only should reflect live .env edits."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / ".env").write_text("ANTHROPIC_API_KEY=sk-live-dotenv\n")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    rows = [
+        {"slug": "anthropic", "name": "Anthropic", "models": ["claude-sonnet-4.5"],
+         "total_models": 1, "is_current": False, "is_user_defined": False,
+         "source": "built-in"},
+    ]
+    ctx = _empty_ctx(provider="openai-codex", model="gpt-5.4")
+    with (
+        _list_auth_returning(rows),
+        patch("hermes_cli.config.read_raw_config", return_value={}),
+    ):
+        payload = build_models_payload(ctx, explicit_only=True)
+
+    assert [row["slug"] for row in payload["providers"]] == [
+        "anthropic",
+        "openai-codex",
+    ]
+
+
 
 # ─── picker_hints ──────────────────────────────────────────────────────
 
@@ -509,7 +535,5 @@ def _apply_featured_with_dates(rows, dates: dict[str, str]):
 
     with patch("agent.models_dev.get_model_info", side_effect=_fake_get_model_info):
         inventory._apply_featured(rows)
-
-
 
 


### PR DESCRIPTION
## What does this PR do?

Makes `is_provider_explicitly_configured()` use the live-dotenv credential resolver instead of `os.getenv()` for API-key providers and `env:`-seeded pool entries.

That means a key added to `~/.hermes/.env` while `hermes serve` is already running now counts as explicitly configured immediately, so `explicit_only` model pickers stop disagreeing with the runtime readiness checks.

## Related Issue

Fixes #77007

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- In `hermes_cli/auth.py`, switch provider API-key checks from `os.getenv()` to `get_env_value_prefer_dotenv()`.
- Apply the same live-dotenv resolver to `env:` credential-pool entries so stale process env does not block a newly added `.env` key.
- Add focused regressions in `tests/hermes_cli/test_auth_provider_gate.py` for both direct provider-key detection and env-seeded pool detection.
- Add an inventory-level regression in `tests/hermes_cli/test_inventory.py` proving `build_models_payload(..., explicit_only=True)` surfaces the provider immediately after a live `.env` edit, without a restart.

## How to Test

1. `~/.pyenv/versions/3.12.12/bin/python -m pytest tests/hermes_cli/test_auth_provider_gate.py tests/hermes_cli/test_inventory.py -q`
2. `~/.pyenv/versions/3.12.12/bin/python -m py_compile hermes_cli/auth.py tests/hermes_cli/test_auth_provider_gate.py tests/hermes_cli/test_inventory.py`
3. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] No docs/config/schema updates needed for this internal behavior fix
