### PR TITLE
fix(guard): lifecycle guard false-positive on full paths

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -56,7 +56,7 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # `start` is intentionally excluded: starting a gateway from inside a
     # gateway is benign (a no-op or "already running" error), and a
     # legitimate cron job might start a sibling profile's gateway.
-    r"(?:hermes\s+gateway\s+(?:restart|stop))"
+    r"(?:^|[\s;&|\n])hermes\s+gateway\s+(?:restart|stop)\b"
     # Branch B: launchctl ops on a hermes-gateway label. macOS launchd
     # labels look like `ai.hermes.gateway` / `hermes-gateway`. Requiring the
     # gateway identifier prevents blocking unrelated hermes services (e.g.


### PR DESCRIPTION
## Summary

Tighten regex from `r"(?:hermes\s+gateway\s+(?:restart|stop))"` to `r"(?:^|[\s;&|\n])hermes\s+gateway\s+(?:restart|stop)\b"`.

Stops false positives on `/usr/bin/hermes gateway restart` etc.

## Related

Closes #77173

## Validation

- Python syntax check passed
- Clean rebase on current main (fe6330de0)