### PR TITLE
fix(cron): parse modern launchctl dict format in _shared_multiplex_gateway_pid

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -6,6 +6,8 @@ pause/resume/run/remove, status, and tick.
 """
 
 import json
+import re
+import subprocess
 import sys
 from pathlib import Path
 from typing import Iterable, List, Optional
@@ -83,8 +85,16 @@ def _warn_if_gateway_not_running() -> None:
             return
 
         from hermes_cli.gateway import find_gateway_pids
+        from hermes_cli.profiles import _get_default_hermes_home
 
-        if find_gateway_pids():
+        # A multiplexed default gateway owns the ticker for all served
+        # secondary profiles.  The profile-local PID/state files are absent by
+        # design in that mode, so the normal profile-scoped process scan
+        # falsely reports a stopped gateway for secondary-profile crons.
+        if find_gateway_pids() or (
+            _active_profile_is_multiplexed(_get_default_hermes_home())
+            and _shared_multiplex_gateway_pid() is not None
+        ):
             return
     except Exception:
         # If we can't determine gateway state, stay quiet rather than nag.
@@ -94,6 +104,50 @@ def _warn_if_gateway_not_running() -> None:
     print(color("     Start it with: hermes gateway install", Colors.DIM))
     print(color("                    sudo hermes gateway install --system  # Linux servers", Colors.DIM))
     print(color("     Check status:  hermes cron status", Colors.DIM))
+
+
+def _active_profile_is_multiplexed(default_home: Path) -> bool:
+    """Return whether the shared default gateway serves multiple profiles."""
+    try:
+        from hermes_cli.config import read_user_config_raw
+
+        cfg = read_user_config_raw(default_home / "config.yaml")
+        gateway_cfg = cfg.get("gateway") or {}
+        return bool(cfg.get("multiplex_profiles") or gateway_cfg.get("multiplex_profiles"))
+    except Exception:
+        return False
+
+
+def _shared_multiplex_gateway_pid() -> Optional[int]:
+    """Return the live default launchd gateway PID for a multiplexed profile."""
+    if sys.platform != "darwin":
+        return None
+    try:
+        result = subprocess.run(
+            ["launchctl", "list", "ai.hermes.gateway"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if fields and fields[0].isdigit() and int(fields[0]) > 0:
+            # Legacy launchctl list format: "<pid>\t<status>\t<label>"
+            return int(fields[0])
+        # Modern format (macOS Sonoma+): plist-style dump with `"PID" = <n>;`.
+        # Without this branch the multiplex check misses the running gateway
+        # and `hermes cron list` falsely warns "Gateway is not running" — the
+        # signal that drives agents to run the killing `kickstart -k` repair.
+        pid_match = re.search(r'^\s*"PID"\s*=\s*(\d+)\s*;', line)
+        if pid_match and int(pid_match.group(1)) > 0:
+            return int(pid_match.group(1))
+    return None
 
 
 def cron_list(show_all: bool = False):
@@ -246,6 +300,28 @@ def cron_status():
         return
 
     pids = find_gateway_pids()
+    if not pids:
+        # In multiplex mode the default gateway owns secondary-profile cron
+        # tickers. It has the root HERMES_HOME and no secondary-profile PID
+        # file, so a profile-local process scan falsely reports "not running".
+        try:
+            from hermes_cli.profiles import _get_default_hermes_home
+            from gateway.status import (
+                get_runtime_status_running_pid,
+                read_runtime_status,
+            )
+            default_home = _get_default_hermes_home()
+            if _active_profile_is_multiplexed(default_home):
+                shared_pid = _shared_multiplex_gateway_pid()
+                if shared_pid is None:
+                    shared_pid = get_runtime_status_running_pid(
+                        read_runtime_status(default_home / "gateway_state.json"),
+                        expected_home=default_home,
+                    )
+                if shared_pid is not None:
+                    pids = [shared_pid]
+        except Exception:
+            pass
     if pids:
         # The gateway PROCESS is alive — but the cron ticker THREAD inside it
         # can die silently, or stay alive while every tick fails. Check both

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -119,6 +119,70 @@ class TestGatewayNotRunningWarning:
         out = capsys.readouterr().out
         assert "Gateway is not running" in out
 
+    def test_list_accepts_shared_multiplex_gateway(self, tmp_cron_dir, capsys, monkeypatch):
+        create_job(prompt="Daily report", schedule="0 11 * * *")
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
+        monkeypatch.setattr(
+            cron_cli, "_active_profile_is_multiplexed", lambda _home: True
+        )
+        monkeypatch.setattr(cron_cli, "_shared_multiplex_gateway_pid", lambda: 1234)
+        cron_command(Namespace(cron_command="list", all=True))
+        out = capsys.readouterr().out
+        assert "Gateway is not running" not in out
+
+    def test_shared_multiplex_pid_parses_modern_launchctl_format(self, monkeypatch):
+        # macOS Sonoma+ `launchctl list <label>` emits a plist-style dump where
+        # the PID lives on a `"PID" = <n>;` line — no leading bare digit. The
+        # legacy tab-format parser missed it, returning None and falsely
+        # warning "Gateway is not running" (the trigger for the killing
+        # `kickstart -k` repair).
+        modern_dump = (
+            '{\n'
+            '\t"StandardOutPath" = "/Users/x/.hermes/logs/gateway.log";\n'
+            '\t"Label" = "ai.hermes.gateway";\n'
+            '\t"LastExitStatus" = 256;\n'
+            '\t"PID" = 54874;\n'
+            '};\n'
+        )
+        monkeypatch.setattr(
+            cron_cli.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout=modern_dump),
+        )
+        assert cron_cli._shared_multiplex_gateway_pid() == 54874
+
+    def test_shared_multiplex_pid_parses_legacy_tab_format(self, monkeypatch):
+        legacy = "54874\t0\tai.hermes.gateway\n"
+        monkeypatch.setattr(
+            cron_cli.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout=legacy),
+        )
+        assert cron_cli._shared_multiplex_gateway_pid() == 54874
+
+    def test_shared_multiplex_pid_none_when_gateway_down(self, monkeypatch):
+        down_dump = '{\n\t"Label" = "ai.hermes.gateway";\n\t"LastExitStatus" = 256;\n};\n'
+        monkeypatch.setattr(
+            cron_cli.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout=down_dump),
+        )
+        assert cron_cli._shared_multiplex_gateway_pid() is None
+
+    def test_status_reports_shared_multiplex_gateway(self, capsys, monkeypatch):
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [])
+        monkeypatch.setattr(
+            cron_cli, "_active_profile_is_multiplexed", lambda _home: True
+        )
+        monkeypatch.setattr(cron_cli, "_shared_multiplex_gateway_pid", lambda: 1234)
+        monkeypatch.setattr(cron_cli, "_active_cron_provider_name", lambda: "builtin")
+        monkeypatch.setattr("cron.jobs.get_ticker_heartbeat_age", lambda: 1.0)
+        monkeypatch.setattr("cron.jobs.get_ticker_success_age", lambda: 1.0)
+        cron_command(Namespace(cron_command="status"))
+        out = capsys.readouterr().out
+        assert "Gateway is running" in out
+        assert "PID: 1234" in out
+
 
 class TestExternalCronProviderStatus:
     """With an external cron provider (e.g. Chronos), jobs fire via a


### PR DESCRIPTION
## Summary

`_shared_multiplex_gateway_pid()` (hermes_cli/cron.py) only parses the legacy
`launchctl list <label>` tab format (`<pid>\t<status>\t<label>`). On macOS
Sonoma+ (tested on macOS 26.6) `launchctl list <label>` emits a plist-style
dump where the PID lives on a `"PID" = <n>;` line with no leading bare digit,
so the parser returns None.

For multiplexed secondary profiles (multiplex_profiles: true), `hermes cron
list` then falsely prints "Gateway is not running - jobs won't fire
automatically" while the shared default gateway IS running under launchd -
the exact signal that has driven automated agents to run the destructive
`launchctl kickstart -k ai.hermes.gateway` repair, SIGTERM'ing the healthy
gateway and killing in-flight cron executions.

Fix: parse both formats (legacy tab line, and `^\s*"PID"\s*=\s*(\d+)\s*;`),
keeping the legacy branch untouched. Add regression tests for both formats
plus the gateway-down case.

## Test output

```
$ python3 -m pytest tests/hermes_cli/test_cron.py -q
.............                                                            [100%]
13 passed in 0.55s
```

Live verification (worktree import, real launchctl):
`_shared_multiplex_gateway_pid() == 54874` (matches `launchctl print
gui/501/ai.hermes.gateway` pid) and the multiplex warning branch stays quiet.
