### PR TITLE
fix(cron): hard-abort when all declared skills fail to load (#77362)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -158,6 +158,17 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
+class CronAllSkillsFailed(Exception):
+    """Raised by _build_job_prompt when every declared skill failed to load.
+
+    Without this guard the scheduler falls through to a contextless LLM call
+    that has no idea how to perform the task, often returns ``[SILENT]``, and
+    suppresses delivery — producing a silent multi-week failure
+    indistinguishable from "nothing happened" (#77362).  Caught in ``run_job``
+    so the operator sees a clear "skills missing" delivery instead of silence.
+    """
+
+
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
@@ -2631,6 +2642,16 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
             ]
         )
 
+    if skipped and len(skipped) == len(skill_names):
+        # Every declared skill failed to load — abort instead of falling
+        # through to a contextless LLM call that returns [SILENT] and
+        # suppresses delivery for weeks (#77362).
+        raise CronAllSkillsFailed(
+            f"All {len(skipped)} skill(s) failed to load and were skipped: "
+            f"{', '.join(skipped)}.  "
+            f"The job cannot run without its required skill context."
+        )
+
     if skipped:
         notice = (
             f"[IMPORTANT: The following skill(s) were listed for this job but could not be found "
@@ -3009,6 +3030,24 @@ def run_job(
             "the threat pattern (`tools/cronjob_tools.py::_CRON_THREAT_PATTERNS`)."
         )
         return False, blocked_doc, "", str(block_exc)
+    except CronAllSkillsFailed as skill_exc:
+        # Every declared skill failed to load — the job has no usable skill
+        # context.  Abort with a delivered error instead of running a
+        # contextless LLM that returns [SILENT] (#77362).
+        logger.error(
+            "Job '%s' (ID: %s): all skills failed to load — %s",
+            job_name, job_id, skill_exc,
+        )
+        error_doc = (
+            f"# Cron Job: {job_name}\n\n"
+            f"**Job ID:** {job_id}\n"
+            f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+            f"**Status:** SKIPPED — all skills failed to load\n\n"
+            f"{skill_exc}\n\n"
+            "Fix the skill references in this job (check for typos, "
+            "ambiguous names, or missing files) and re-enable it."
+        )
+        return False, error_doc, "", str(skill_exc)
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
         return True, "", SILENT_MARKER, None


### PR DESCRIPTION
## Problem

When a cron job declares skills and **all** of them fail to load (missing file, ambiguous resolution, invalid JSON), the scheduler logs a warning but still invokes the LLM with the user's raw prompt minus all skill context. A contextless LLM has no idea how to perform the task, frequently returns `[SILENT]` (which the cron hint instructs it to do when there's "nothing to report"), and delivery is suppressed — producing a **silent multi-week failure** indistinguishable from "nothing happened".

**Real-world impact:** A weekly market risk monitor was silently broken for **3 consecutive weeks** because a flat-file skill collided with a directory stub, causing `skill_view()` to return `{"success": false}`. No alert reached the user.

## Fix

Add `CronAllSkillsFailed` exception, raised when every declared skill is in the `skipped` list. The caller (`run_job`) catches it and returns a delivered error document so the operator sees a clear "skills missing" failure instead of silence.

**3 changes in `cron/scheduler.py`:**

1. New `CronAllSkillsFailed` exception class (parallel to existing `CronPromptInjectionBlocked`)
2. Guard in `_build_job_prompt()`: after the skill-loading loop, if `len(skipped) == len(skill_names)`, raise
3. Catch in `run_job()`: log error, build descriptive error doc, return `(False, error_doc, "", error_str)`

**Partial failures** (some skills load, some don't) still work as before — only the ALL-failed case is hardened.

Fixes #77362