### PR TITLE
fix(desktop): bridge WSL POSIX paths in file IPC reads, matching readDir

### DIFF
--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -352,3 +352,31 @@ test('resolveDirectoryForIpc accepts directory symlinks or junctions', async () 
     fs.rmSync(tempDir, { recursive: true, force: true })
   }
 })
+
+test('resolveRequestedPathForIpc bridges a WSL POSIX path to the host UNC form', () => {
+  // Regression: a WSL-hosted gateway reports `/home/<user>/…`. Without the
+  // bridge, `path.resolve` anchored those to the current drive on Windows
+  // (`C:\home\…`) and every file read ENOENTed — desktop plugins dropped
+  // silently because the loader swallows read failures. `readDirForIpc`
+  // bridged directories already; file reads did not.
+  const toUnc = (value: string) =>
+    value.startsWith('/') ? `\\\\wsl.localhost\\Ubuntu\\${value.replace(/^\/+/, '').replace(/\//g, '\\')}` : value
+
+  assert.equal(
+    resolveRequestedPathForIpc('/home/alex/.hermes/desktop-plugins/my-plugin/plugin.js', {
+      hostPathResolver: toUnc
+    }),
+    '\\\\wsl.localhost\\Ubuntu\\home\\alex\\.hermes\\desktop-plugins\\my-plugin\\plugin.js'
+  )
+})
+
+test('resolveRequestedPathForIpc leaves paths the host resolver passes through untouched', () => {
+  const identity = (value: string) => value
+
+  const resolved = resolveRequestedPathForIpc('nested/file.txt', {
+    baseDir: path.join(os.tmpdir(), 'hermes-host-passthrough'),
+    hostPathResolver: identity
+  })
+
+  assert.equal(resolved, path.join(os.tmpdir(), 'hermes-host-passthrough', 'nested', 'file.txt'))
+})

--- a/apps/desktop/electron/hardening.ts
+++ b/apps/desktop/electron/hardening.ts
@@ -3,6 +3,8 @@ import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { resolveLocalReadPath } from './wsl-path-bridge'
+
 const DEFAULT_FETCH_TIMEOUT_MS = 15_000
 // Default / floor / ceiling for Desktop's data-URL file load (composer attach,
 // image preview, etc.). The whole file is base64-buffered in main, so this is
@@ -172,7 +174,10 @@ function rejectUnsafePathSyntax(filePath, purpose = 'File read') {
   return raw
 }
 
-function resolveRequestedPathForIpc(filePath, options: { purpose?: string; baseDir?: fs.PathOrFileDescriptor } = {}) {
+function resolveRequestedPathForIpc(
+  filePath,
+  options: { baseDir?: fs.PathOrFileDescriptor; hostPathResolver?: (value: string) => string; purpose?: string } = {}
+) {
   const purpose = String(options.purpose || 'File read')
   let raw = rejectUnsafePathSyntax(filePath, purpose)
 
@@ -207,6 +212,21 @@ function resolveRequestedPathForIpc(filePath, options: { purpose?: string; baseD
   const safeBaseInput = rejectUnsafePathSyntax(baseInput, purpose)
   const resolvedBase = path.resolve(safeBaseInput)
   rejectUnsafePathSyntax(resolvedBase, purpose)
+
+  // A WSL-hosted gateway reports POSIX absolute paths (`/home/<user>/.hermes/…`).
+  // On Windows `path.resolve` would anchor those to the current drive
+  // (`C:\home\<user>\…`) and every read ENOENTs — desktop plugins, previews and
+  // file reads all silently disappear. Bridge to the UNC form FIRST so the rest
+  // of the hardening chain validates the path the host will actually open.
+  // `readDirForIpc` already does this for directories; file reads need it too.
+  const hostPath = (options.hostPathResolver || resolveLocalReadPath)(raw)
+
+  if (hostPath !== raw) {
+    rejectUnsafePathSyntax(hostPath, purpose)
+
+    return hostPath
+  }
+
   const resolvedPath = path.resolve(resolvedBase, raw)
   rejectUnsafePathSyntax(resolvedPath, purpose)
 


### PR DESCRIPTION
## Bug

When the desktop app runs on Windows and connects to a remote Hermes gateway running inside WSL, the gateway reports paths as POSIX absolutes (e.g. `/home/<user>/.hermes/desktop-plugins/...`). On Windows, `path.resolve` anchors those to the current Windows drive (`C:\home\<user>\...`), so every `readFileText`, file preview, and desktop plugin file read fails with `ENOENT`. Because the plugin loader silently swallows these read failures, the symptom is simply that plugins never appear and there is no error message.

## Fix

`readDirForIpc` already calls `resolveLocalReadPath` from `wsl-path-bridge.ts`; file-read paths did not. Apply the same bridge in `resolveRequestedPathForIpc` before `path.resolve` so that POSIX paths from the backend are translated to the Windows-UNC form the host can actually open.

## Changes

- `apps/desktop/electron/hardening.ts`: bridge WSL paths in `resolveRequestedPathForIpc`
- `apps/desktop/electron/hardening.test.ts`: two regression tests covering the UNC bridge and the pass-through/relative case

## Test Plan

- `npx vitest run --project electron` passes (796 tests)
- `npx eslint electron/hardening.ts electron/hardening.test.ts` passes with 0 errors/warnings
- `tsc -p tsconfig.electron.json --noEmit` reports no new errors from the changed files
