### PR TITLE
fix(kanban): normalize empty list assignee filters

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -111,6 +111,73 @@ def test_list_filters_tasks(monkeypatch, worker_env):
     assert tenant_ids == [c]
 
 
+@pytest.mark.parametrize(
+    "args",
+    [
+        {},
+        {"assignee": None},
+        {"assignee": ""},
+        {"assignee": " \t "},
+        {"assignee": "none"},
+        {"assignee": "-"},
+        {"assignee": "null"},
+    ],
+    ids=["omitted", "none", "empty", "whitespace", "none-sentinel", "dash", "null"],
+)
+def test_list_empty_assignee_values_do_not_filter(monkeypatch, worker_env, args):
+    """Model-produced empty sentinels have the same meaning as omission."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        first = kb.create_task(conn, title="first", assignee="factory")
+        second = kb.create_task(conn, title="second", assignee="reviewer")
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+
+    result = json.loads(kt._handle_list({**args, "status": "ready"}))
+
+    assert [task["id"] for task in result["tasks"]] == [first, second]
+
+
+def test_list_nonempty_assignee_remains_a_real_filter(monkeypatch, worker_env):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        factory = kb.create_task(conn, title="factory", assignee="factory")
+        kb.create_task(conn, title="reviewer", assignee="reviewer")
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+
+    mixed_case = json.loads(
+        kt._handle_list({"assignee": "FaCtOrY", "status": "ready"})
+    )
+    missing = json.loads(
+        kt._handle_list({"assignee": "missing-profile", "status": "ready"})
+    )
+
+    assert [task["id"] for task in mixed_case["tasks"]] == [factory]
+    assert missing["tasks"] == []
+
+
+def test_empty_assignee_is_still_invalid_for_database_writes(worker_env):
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        with pytest.raises(ValueError, match="profile name cannot be empty"):
+            kb.create_task(conn, title="invalid", assignee="  ")
+    finally:
+        conn.close()
+
+
 def test_complete_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_complete({

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -559,7 +559,7 @@ def _handle_list(args: dict, **kw) -> str:
     guard = _require_orchestrator_tool("kanban_list")
     if guard:
         return guard
-    assignee = args.get("assignee")
+    assignee = _normalize_profile(args.get("assignee"))
     status = args.get("status")
     tenant = args.get("tenant")
     include_archived, bool_error = _parse_bool_arg(args, "include_archived")


### PR DESCRIPTION
## What does this PR do?

Normalizes the optional `assignee` argument at the `kanban_list` tool boundary. Model-generated empty values now have the same meaning as omitting the filter, while database write paths keep rejecting invalid empty profile names.

The existing `_normalize_profile()` helper already defines the tool-input semantics for `None`, blank strings, whitespace, `none`, `-`, and `null`. Applying it before `list_tasks()` fixes the list behavior without broadening the database API contract.

## Related Issue

No existing issue or pull request covering this case was found.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Normalize `kanban_list` assignee input in `tools/kanban_tools.py`.
- Cover omitted, null, blank, whitespace, and supported sentinel values.
- Confirm mixed-case valid filters and non-matching non-empty filters remain real filters.
- Confirm database writes still reject a blank assignee.

## How to Test

1. Run `.venv/bin/pytest tests/tools/test_kanban_tools.py -q`.
2. Run `.venv/bin/pytest tests/hermes_cli/test_kanban_db.py -q`.
3. Run `.venv/bin/pytest tests/hermes_cli/test_kanban_core_functionality.py -q`.
4. Run `.venv/bin/ruff check tools/kanban_tools.py tests/tools/test_kanban_tools.py`.

Focused result: 89 passed, 1 skipped; Ruff passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Documentation update is not applicable
- [x] `cli-config.yaml.example` update is not applicable
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are not applicable
- [x] Cross-platform impact was considered; the change is platform-independent Python input normalization
- [x] Tool description/schema update is not applicable

## Screenshots / Logs

Not applicable.
