### PR TITLE
fix(update): re-sync Node.js deps on already-current checkout (#77211)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3931,6 +3931,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     "long-lived processes still use the previous runtime."
                 )
                 print("  Restart each of them to pick up the repaired runtime.")
+            # Even when the checkout is current, a previous `hermes update`
+            # may have failed at the Node.js dependency step (e.g. EBADENGINE
+            # from a system node/npm mismatch).  Re-run the check so that
+            # fixing npm and re-running `hermes update` actually repairs the
+            # Node deps — otherwise the "Already up to date" return silently
+            # leaves node_modules stale (#77211).
+            _update_node_dependencies()
             _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
             return
 


### PR DESCRIPTION
## Problem

When `hermes update` runs on a checkout that is already current (0 new commits), it only health-checks the Python venv and returns. If a previous update partially failed at the Node.js dependency step (e.g. `EBADENGINE` because system node/npm no longer satisfies the repo's `engines` field), the update prints:

> Fix npm and re-run `hermes update`.

…but re-running `hermes update` after fixing npm is a **no-op**. The "Already up to date!" path never invokes `_update_node_dependencies()`, leaving node_modules stale.

## Fix

Call `_update_node_dependencies()` in the already-current-checkout path before returning. When node_modules are already up to date this is a fast no-op (lockfile hash comparison skips `npm install`); when a previous install failed, it re-runs the dependency sync.

**1 line of functional code added** (+ 6 lines of comment) in `hermes_cli/update_cmd.py`.

Fixes #77211