### PR TITLE
fix(slack): preserve long clarify option text

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7063,9 +7063,12 @@ class SlackAdapter(BasePlatformAdapter):
         """Render a clarify prompt as Block Kit interactive buttons.
 
         Multi-choice mode (``choices`` non-empty): one button per option
-        (unique ``hermes_clarify_choice_<idx>`` action_id, ``value`` packs
-        ``clarify_id|idx``) plus a final "✏️ Other…" button
-        (``hermes_clarify_other``).  A choice click resolves the clarify
+        (unique ``hermes_clarify_choice_<idx>`` action ID; ``value`` packs
+        ``clarify_id|idx``) plus a final "✏️ Other…" button with action ID
+        ``hermes_clarify_other``. Slack caps button labels at 75 characters, so
+        prompts containing a longer option render each full option in a numbered
+        section with a short ``Select N`` accessory button instead of silently
+        truncating the answer text. A choice click resolves the clarify
         primitive directly; the "Other" button flips the entry into
         text-capture mode so the gateway's platform-agnostic text-intercept
         (:meth:`GatewayRunner._handle_message`) picks up the next typed
@@ -7108,9 +7111,11 @@ class SlackAdapter(BasePlatformAdapter):
                 body = body[:budget] + "..."
 
             # One button per choice + a free-text "Other" button.  Slack caps
-            # an actions block at 5 elements; the clarify tool caps choices at
-            # 4 (+ Other = 5) so this is normally one block, but chunk anyway
-            # so a larger choice list degrades gracefully instead of 400ing.
+            # button labels at 75 chars.  If any option exceeds that, preserve
+            # the complete option in section text and use a compact accessory
+            # button.  This is especially important for PM/PRD interviews,
+            # whose suggested answers can be several sentences long.
+            long_choice_layout = any(len(str(choice).strip()) > 75 for choice in choices)
             elements = []
             for idx, choice in enumerate(choices):
                 label = str(choice).strip() or f"Option {idx + 1}"
@@ -7130,8 +7135,50 @@ class SlackAdapter(BasePlatformAdapter):
             blocks: list = [
                 {"type": "section", "text": {"type": "mrkdwn", "text": body}},
             ]
-            for start in range(0, len(elements), 5):
-                blocks.append({"type": "actions", "elements": elements[start:start + 5]})
+            if long_choice_layout:
+                for idx, choice in enumerate(choices):
+                    full_label = str(choice).strip() or f"Option {idx + 1}"
+                    prefix = f"*{idx + 1}.* "
+                    # Preserve the option across as many 3000-char section
+                    # blocks as needed. Escape one source character at a time
+                    # so an HTML entity such as ``&amp;`` is never split across
+                    # blocks and rendered incorrectly.
+                    choice_chunks = []
+                    chunk = prefix
+                    for char in full_label:
+                        escaped_char = {"&": "&amp;", "<": "&lt;", ">": "&gt;"}.get(
+                            char, char
+                        )
+                        if len(chunk) + len(escaped_char) > 3000:
+                            choice_chunks.append(chunk)
+                            chunk = ""
+                        chunk += escaped_char
+                    if chunk:
+                        choice_chunks.append(chunk)
+
+                    for chunk_idx, section_text in enumerate(choice_chunks):
+                        block = {
+                            "type": "section",
+                            "text": {"type": "mrkdwn", "text": section_text},
+                        }
+                        if chunk_idx == 0:
+                            block["accessory"] = {
+                                "type": "button",
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": f"Select {idx + 1}",
+                                    "emoji": True,
+                                },
+                                "action_id": f"hermes_clarify_choice_{idx}",
+                                "value": f"{clarify_id}|{idx}",
+                            }
+                        blocks.append(block)
+                blocks.append({"type": "actions", "elements": [elements[-1]]})
+            else:
+                # Slack caps an actions block at 5 elements; the clarify tool
+                # caps choices at 4 (+ Other = 5), but chunk defensively.
+                for start in range(0, len(elements), 5):
+                    blocks.append({"type": "actions", "elements": elements[start:start + 5]})
 
             kwargs: Dict[str, Any] = {
                 "channel": chat_id,
@@ -7503,8 +7550,15 @@ class SlackAdapter(BasePlatformAdapter):
         msg_ts: str,
         question_text: str,
         decision_text: str,
+        *,
+        resumed: bool = False,
     ) -> None:
         """Rewrite a clarify message to show the outcome and drop the buttons."""
+        if resumed:
+            # Durable acknowledgement rather than a live status: the following
+            # agent/MCP turn can take minutes, and this message is not updated
+            # again when that turn finishes.
+            decision_text = f"✅ Choice received; request resumed. {decision_text}"
         updated_blocks = [
             {
                 "type": "section",
@@ -7520,7 +7574,7 @@ class SlackAdapter(BasePlatformAdapter):
                 channel=channel_id,
                 ts=msg_ts,
                 text=decision_text,
-                blocks=updated_blocks,
+                blocks=sanitize_blocks(updated_blocks),
             )
         except Exception as e:
             logger.warning("[Slack] Failed to update clarify message: %s", e)
@@ -7611,6 +7665,7 @@ class SlackAdapter(BasePlatformAdapter):
             await self._update_clarify_message(
                 channel_id, msg_ts, original_text,
                 f"✅ {user_name}: {resolved_text}",
+                resumed=True,
             )
             # Privacy: keep the chosen option text out of INFO-level logs
             # (clarify choices can carry user/session context). Metadata at

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7065,11 +7065,13 @@ class SlackAdapter(BasePlatformAdapter):
         Multi-choice mode (``choices`` non-empty): one button per option
         (unique ``hermes_clarify_choice_<idx>`` action ID; ``value`` packs
         ``clarify_id|idx``) plus a final "✏️ Other…" button with action ID
-        ``hermes_clarify_other``. Slack caps button labels at 75 characters, so
-        prompts containing a longer option render each full option in a numbered
-        section with a short ``Select N`` accessory button instead of silently
-        truncating the answer text. A choice click resolves the clarify
-        primitive directly; the "Other" button flips the entry into
+        ``hermes_clarify_other``. Slack caps button labels at 75 characters and
+        can visually clip wide labels below that API limit. Prompts containing
+        an option wider than 48 display columns (CJK characters count as two)
+        render each full option in a numbered section with a short ``Select N``
+        accessory button instead of silently truncating the answer text. A
+        choice click resolves the clarify primitive directly; the "Other"
+        button flips the entry into
         text-capture mode so the gateway's platform-agnostic text-intercept
         (:meth:`GatewayRunner._handle_message`) picks up the next typed
         message and resolves the clarify — no Slack-specific text machinery.
@@ -7110,12 +7112,15 @@ class SlackAdapter(BasePlatformAdapter):
             if len(body) > budget:
                 body = body[:budget] + "..."
 
-            # One button per choice + a free-text "Other" button.  Slack caps
-            # button labels at 75 chars.  If any option exceeds that, preserve
-            # the complete option in section text and use a compact accessory
-            # button.  This is especially important for PM/PRD interviews,
-            # whose suggested answers can be several sentences long.
-            long_choice_layout = any(len(str(choice).strip()) > 75 for choice in choices)
+            # One button per choice + a free-text "Other" button. Slack's API
+            # permits 75-character labels, but the client visually clips wide
+            # labels sooner (especially Korean/CJK). Switch conservatively at
+            # 48 display columns, counting East-Asian wide/full-width characters
+            # as two columns. The raw 75-character API cap remains an absolute
+            # fallback through the same display-width check.
+            long_choice_layout = any(
+                _disp_width(str(choice).strip()) > 48 for choice in choices
+            )
             elements = []
             for idx, choice in enumerate(choices):
                 label = str(choice).strip() or f"Option {idx + 1}"

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6546,11 +6546,13 @@ class SlackAdapter(BasePlatformAdapter):
         Multi-choice mode (``choices`` non-empty): one button per option
         (unique ``hermes_clarify_choice_<idx>`` action ID; ``value`` packs
         ``clarify_id|idx``) plus a final "✏️ Other…" button with action ID
-        ``hermes_clarify_other``. Slack caps button labels at 75 characters, so
-        prompts containing a longer option render each full option in a numbered
-        section with a short ``Select N`` accessory button instead of silently
-        truncating the answer text. A choice click resolves the clarify
-        primitive directly; the "Other" button flips the entry into
+        ``hermes_clarify_other``. Slack caps button labels at 75 characters and
+        can visually clip wide labels below that API limit. Prompts containing
+        an option wider than 48 display columns (CJK characters count as two)
+        render each full option in a numbered section with a short ``Select N``
+        accessory button instead of silently truncating the answer text. A
+        choice click resolves the clarify primitive directly; the "Other"
+        button flips the entry into
         text-capture mode so the gateway's platform-agnostic text-intercept
         (:meth:`GatewayRunner._handle_message`) picks up the next typed
         message and resolves the clarify — no Slack-specific text machinery.
@@ -6591,12 +6593,15 @@ class SlackAdapter(BasePlatformAdapter):
             if len(body) > budget:
                 body = body[:budget] + "..."
 
-            # One button per choice + a free-text "Other" button.  Slack caps
-            # button labels at 75 chars.  If any option exceeds that, preserve
-            # the complete option in section text and use a compact accessory
-            # button.  This is especially important for PM/PRD interviews,
-            # whose suggested answers can be several sentences long.
-            long_choice_layout = any(len(str(choice).strip()) > 75 for choice in choices)
+            # One button per choice + a free-text "Other" button. Slack's API
+            # permits 75-character labels, but the client visually clips wide
+            # labels sooner (especially Korean/CJK). Switch conservatively at
+            # 48 display columns, counting East-Asian wide/full-width characters
+            # as two columns. The raw 75-character API cap remains an absolute
+            # fallback through the same display-width check.
+            long_choice_layout = any(
+                _disp_width(str(choice).strip()) > 48 for choice in choices
+            )
             elements = []
             for idx, choice in enumerate(choices):
                 label = str(choice).strip() or f"Option {idx + 1}"

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6544,9 +6544,12 @@ class SlackAdapter(BasePlatformAdapter):
         """Render a clarify prompt as Block Kit interactive buttons.
 
         Multi-choice mode (``choices`` non-empty): one button per option
-        (unique ``hermes_clarify_choice_<idx>`` action_id, ``value`` packs
-        ``clarify_id|idx``) plus a final "✏️ Other…" button
-        (``hermes_clarify_other``).  A choice click resolves the clarify
+        (unique ``hermes_clarify_choice_<idx>`` action ID; ``value`` packs
+        ``clarify_id|idx``) plus a final "✏️ Other…" button with action ID
+        ``hermes_clarify_other``. Slack caps button labels at 75 characters, so
+        prompts containing a longer option render each full option in a numbered
+        section with a short ``Select N`` accessory button instead of silently
+        truncating the answer text. A choice click resolves the clarify
         primitive directly; the "Other" button flips the entry into
         text-capture mode so the gateway's platform-agnostic text-intercept
         (:meth:`GatewayRunner._handle_message`) picks up the next typed
@@ -6589,9 +6592,11 @@ class SlackAdapter(BasePlatformAdapter):
                 body = body[:budget] + "..."
 
             # One button per choice + a free-text "Other" button.  Slack caps
-            # an actions block at 5 elements; the clarify tool caps choices at
-            # 4 (+ Other = 5) so this is normally one block, but chunk anyway
-            # so a larger choice list degrades gracefully instead of 400ing.
+            # button labels at 75 chars.  If any option exceeds that, preserve
+            # the complete option in section text and use a compact accessory
+            # button.  This is especially important for PM/PRD interviews,
+            # whose suggested answers can be several sentences long.
+            long_choice_layout = any(len(str(choice).strip()) > 75 for choice in choices)
             elements = []
             for idx, choice in enumerate(choices):
                 label = str(choice).strip() or f"Option {idx + 1}"
@@ -6611,8 +6616,50 @@ class SlackAdapter(BasePlatformAdapter):
             blocks: list = [
                 {"type": "section", "text": {"type": "mrkdwn", "text": body}},
             ]
-            for start in range(0, len(elements), 5):
-                blocks.append({"type": "actions", "elements": elements[start:start + 5]})
+            if long_choice_layout:
+                for idx, choice in enumerate(choices):
+                    full_label = str(choice).strip() or f"Option {idx + 1}"
+                    prefix = f"*{idx + 1}.* "
+                    # Preserve the option across as many 3000-char section
+                    # blocks as needed. Escape one source character at a time
+                    # so an HTML entity such as ``&amp;`` is never split across
+                    # blocks and rendered incorrectly.
+                    choice_chunks = []
+                    chunk = prefix
+                    for char in full_label:
+                        escaped_char = {"&": "&amp;", "<": "&lt;", ">": "&gt;"}.get(
+                            char, char
+                        )
+                        if len(chunk) + len(escaped_char) > 3000:
+                            choice_chunks.append(chunk)
+                            chunk = ""
+                        chunk += escaped_char
+                    if chunk:
+                        choice_chunks.append(chunk)
+
+                    for chunk_idx, section_text in enumerate(choice_chunks):
+                        block = {
+                            "type": "section",
+                            "text": {"type": "mrkdwn", "text": section_text},
+                        }
+                        if chunk_idx == 0:
+                            block["accessory"] = {
+                                "type": "button",
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": f"Select {idx + 1}",
+                                    "emoji": True,
+                                },
+                                "action_id": f"hermes_clarify_choice_{idx}",
+                                "value": f"{clarify_id}|{idx}",
+                            }
+                        blocks.append(block)
+                blocks.append({"type": "actions", "elements": [elements[-1]]})
+            else:
+                # Slack caps an actions block at 5 elements; the clarify tool
+                # caps choices at 4 (+ Other = 5), but chunk defensively.
+                for start in range(0, len(elements), 5):
+                    blocks.append({"type": "actions", "elements": elements[start:start + 5]})
 
             kwargs: Dict[str, Any] = {
                 "channel": chat_id,
@@ -6984,8 +7031,15 @@ class SlackAdapter(BasePlatformAdapter):
         msg_ts: str,
         question_text: str,
         decision_text: str,
+        *,
+        resumed: bool = False,
     ) -> None:
         """Rewrite a clarify message to show the outcome and drop the buttons."""
+        if resumed:
+            # Durable acknowledgement rather than a live status: the following
+            # agent/MCP turn can take minutes, and this message is not updated
+            # again when that turn finishes.
+            decision_text = f"✅ Choice received; request resumed. {decision_text}"
         updated_blocks = [
             {
                 "type": "section",
@@ -7001,7 +7055,7 @@ class SlackAdapter(BasePlatformAdapter):
                 channel=channel_id,
                 ts=msg_ts,
                 text=decision_text,
-                blocks=updated_blocks,
+                blocks=sanitize_blocks(updated_blocks),
             )
         except Exception as e:
             logger.warning("[Slack] Failed to update clarify message: %s", e)
@@ -7092,6 +7146,7 @@ class SlackAdapter(BasePlatformAdapter):
             await self._update_clarify_message(
                 channel_id, msg_ts, original_text,
                 f"✅ {user_name}: {resolved_text}",
+                resumed=True,
             )
             # Privacy: keep the chosen option text out of INFO-level logs
             # (clarify choices can carry user/session context). Metadata at

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4231,7 +4231,7 @@ class TestEnsureDmConversation:
 
     @pytest.mark.asyncio
     async def test_send_clarify_renders_long_choices_in_full(self, adapter):
-        """Slack's 75-char button cap must not hide most of a PM option."""
+        """A long PM option must render in full outside the button label."""
         adapter._app.client.chat_postMessage = AsyncMock(
             return_value={"ok": True, "ts": "111.222"}
         )
@@ -4260,6 +4260,30 @@ class TestEnsureDmConversation:
         assert select_button["value"] == "cl-long|0"
         assert select_button["text"]["text"] == "Select 1"
         assert len(select_button["text"]["text"]) <= 75
+
+    @pytest.mark.asyncio
+    async def test_send_clarify_uses_full_layout_for_wide_cjk_under_75_chars(
+        self, adapter
+    ):
+        """Wide CJK text can clip visually even below Slack's 75-char API cap."""
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "111.222"}
+        )
+        wide_choice = "가" * 25  # 25 chars, but 50 display columns.
+        assert len(wide_choice) < 75
+
+        result = await adapter.send_clarify(
+            chat_id="C123",
+            question="어떤 정책을 선택할까요?",
+            choices=[wide_choice, "직접 입력"],
+            clarify_id="cl-wide-cjk",
+            session_key="sk-wide-cjk",
+        )
+
+        assert result.success is True
+        blocks = adapter._app.client.chat_postMessage.await_args.kwargs["blocks"]
+        assert blocks[1]["text"]["text"] == f"*1.* {wide_choice}"
+        assert blocks[1]["accessory"]["text"]["text"] == "Select 1"
 
     @pytest.mark.asyncio
     async def test_send_clarify_splits_choice_over_section_limit(self, adapter):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4229,6 +4229,144 @@ class TestEnsureDmConversation:
         post_kwargs = adapter._app.client.chat_postMessage.await_args.kwargs
         assert post_kwargs["channel"] == "D999NEW"
 
+    @pytest.mark.asyncio
+    async def test_send_clarify_renders_long_choices_in_full(self, adapter):
+        """Slack's 75-char button cap must not hide most of a PM option."""
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "111.222"}
+        )
+        long_choice = (
+            "권장 MVP — 카테고리 조건은 기존 서비스 데이터 기준으로 자동 산정하고 "
+            "결제완료·탈퇴·수신거부 고객은 제외하며 상담원이 직접 선점합니다."
+        )
+
+        result = await adapter.send_clarify(
+            chat_id="C123",
+            question="어떤 운영 규칙을 기준으로 진행할까요?",
+            choices=[long_choice, "직접 입력"],
+            clarify_id="cl-long",
+            session_key="sk-long",
+        )
+
+        assert result.success is True
+        blocks = adapter._app.client.chat_postMessage.await_args.kwargs["blocks"]
+        rendered_text = "\n".join(
+            (block.get("text") or {}).get("text", "") for block in blocks
+        )
+        assert long_choice in rendered_text
+
+        select_button = blocks[1]["accessory"]
+        assert select_button["action_id"] == "hermes_clarify_choice_0"
+        assert select_button["value"] == "cl-long|0"
+        assert select_button["text"]["text"] == "Select 1"
+        assert len(select_button["text"]["text"]) <= 75
+
+    @pytest.mark.asyncio
+    async def test_send_clarify_splits_choice_over_section_limit(self, adapter):
+        """A choice beyond 3000 chars is split, not silently truncated."""
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "111.222"}
+        )
+        long_choice = "A&B<C>" * 700
+
+        result = await adapter.send_clarify(
+            chat_id="C123",
+            question="Pick one",
+            choices=[long_choice],
+            clarify_id="cl-split",
+            session_key="sk-split",
+        )
+
+        assert result.success is True
+        blocks = adapter._app.client.chat_postMessage.await_args.kwargs["blocks"]
+        choice_sections = [
+            block for block in blocks[1:-1] if block.get("type") == "section"
+        ]
+        assert len(choice_sections) > 1
+        escaped_rendered = "".join(block["text"]["text"] for block in choice_sections)
+        assert escaped_rendered.removeprefix("*1.* ") == (
+            long_choice.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+        )
+        assert "accessory" in choice_sections[0]
+        assert all("accessory" not in block for block in choice_sections[1:])
+
+    @pytest.mark.asyncio
+    async def test_update_clarify_message_surfaces_resumed_state(self, adapter):
+        """A resolved choice durably confirms that the agent turn resumed."""
+        adapter._app.client.chat_update = AsyncMock(return_value={"ok": True})
+
+        await adapter._update_clarify_message(
+            "C123",
+            "111.222",
+            "❓ Pick one",
+            "✅ Test User: option A",
+            resumed=True,
+        )
+
+        blocks = adapter._app.client.chat_update.await_args.kwargs["blocks"]
+        context = blocks[1]["elements"][0]["text"]
+        assert "Choice received; request resumed" in context
+
+    @pytest.mark.asyncio
+    async def test_update_clarify_message_clamps_boundary_choice(self, adapter):
+        """A near-limit selected option cannot make chat.update invalid."""
+        adapter._app.client.chat_update = AsyncMock(return_value={"ok": True})
+
+        await adapter._update_clarify_message(
+            "C123",
+            "111.222",
+            "❓ Pick one",
+            "✅ Test User: " + ("x" * 2990),
+            resumed=True,
+        )
+
+        kwargs = adapter._app.client.chat_update.await_args.kwargs
+        context = kwargs["blocks"][1]["elements"][0]["text"]
+        assert len(context) <= 3000
+        assert context.startswith("✅ Choice received; request resumed")
+
+    @pytest.mark.asyncio
+    async def test_clarify_callback_clamps_boundary_choice(self, adapter, monkeypatch):
+        """The real callback path replaces buttons even for a near-limit choice."""
+        from tools import clarify_gateway as cm
+
+        long_choice = "x" * 2990
+        cm.register("cl-boundary", "sk-boundary", "Pick one", [long_choice])
+        adapter._clarify_resolved["111.222"] = False
+        adapter._app.client.chat_update = AsyncMock(return_value={"ok": True})
+        monkeypatch.setattr(
+            adapter,
+            "_is_interactive_user_authorized",
+            MagicMock(return_value=True),
+        )
+
+        await adapter._handle_clarify_action(
+            AsyncMock(),
+            {
+                "channel": {"id": "C123"},
+                "user": {"id": "U123", "name": "Test User"},
+                "message": {
+                    "ts": "111.222",
+                    "blocks": [
+                        {
+                            "type": "section",
+                            "text": {"type": "mrkdwn", "text": "❓ Pick one"},
+                        },
+                        {"type": "actions", "elements": []},
+                    ],
+                },
+            },
+            {"action_id": "hermes_clarify_choice_0", "value": "cl-boundary|0"},
+        )
+
+        kwargs = adapter._app.client.chat_update.await_args.kwargs
+        context = kwargs["blocks"][1]["elements"][0]["text"]
+        assert len(context) <= 3000
+        assert context.startswith("✅ Choice received; request resumed")
+        assert "111.222" not in adapter._clarify_resolved
+
 
 # ---------------------------------------------------------------------------
 # TestThreadImageContext — C1-images: images/files in prior thread messages

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4223,6 +4223,144 @@ class TestEnsureDmConversation:
         post_kwargs = adapter._app.client.chat_postMessage.await_args.kwargs
         assert post_kwargs["channel"] == "D999NEW"
 
+    @pytest.mark.asyncio
+    async def test_send_clarify_renders_long_choices_in_full(self, adapter):
+        """Slack's 75-char button cap must not hide most of a PM option."""
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "111.222"}
+        )
+        long_choice = (
+            "권장 MVP — 카테고리 조건은 기존 서비스 데이터 기준으로 자동 산정하고 "
+            "결제완료·탈퇴·수신거부 고객은 제외하며 상담원이 직접 선점합니다."
+        )
+
+        result = await adapter.send_clarify(
+            chat_id="C123",
+            question="어떤 운영 규칙을 기준으로 진행할까요?",
+            choices=[long_choice, "직접 입력"],
+            clarify_id="cl-long",
+            session_key="sk-long",
+        )
+
+        assert result.success is True
+        blocks = adapter._app.client.chat_postMessage.await_args.kwargs["blocks"]
+        rendered_text = "\n".join(
+            (block.get("text") or {}).get("text", "") for block in blocks
+        )
+        assert long_choice in rendered_text
+
+        select_button = blocks[1]["accessory"]
+        assert select_button["action_id"] == "hermes_clarify_choice_0"
+        assert select_button["value"] == "cl-long|0"
+        assert select_button["text"]["text"] == "Select 1"
+        assert len(select_button["text"]["text"]) <= 75
+
+    @pytest.mark.asyncio
+    async def test_send_clarify_splits_choice_over_section_limit(self, adapter):
+        """A choice beyond 3000 chars is split, not silently truncated."""
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "111.222"}
+        )
+        long_choice = "A&B<C>" * 700
+
+        result = await adapter.send_clarify(
+            chat_id="C123",
+            question="Pick one",
+            choices=[long_choice],
+            clarify_id="cl-split",
+            session_key="sk-split",
+        )
+
+        assert result.success is True
+        blocks = adapter._app.client.chat_postMessage.await_args.kwargs["blocks"]
+        choice_sections = [
+            block for block in blocks[1:-1] if block.get("type") == "section"
+        ]
+        assert len(choice_sections) > 1
+        escaped_rendered = "".join(block["text"]["text"] for block in choice_sections)
+        assert escaped_rendered.removeprefix("*1.* ") == (
+            long_choice.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+        )
+        assert "accessory" in choice_sections[0]
+        assert all("accessory" not in block for block in choice_sections[1:])
+
+    @pytest.mark.asyncio
+    async def test_update_clarify_message_surfaces_resumed_state(self, adapter):
+        """A resolved choice durably confirms that the agent turn resumed."""
+        adapter._app.client.chat_update = AsyncMock(return_value={"ok": True})
+
+        await adapter._update_clarify_message(
+            "C123",
+            "111.222",
+            "❓ Pick one",
+            "✅ Test User: option A",
+            resumed=True,
+        )
+
+        blocks = adapter._app.client.chat_update.await_args.kwargs["blocks"]
+        context = blocks[1]["elements"][0]["text"]
+        assert "Choice received; request resumed" in context
+
+    @pytest.mark.asyncio
+    async def test_update_clarify_message_clamps_boundary_choice(self, adapter):
+        """A near-limit selected option cannot make chat.update invalid."""
+        adapter._app.client.chat_update = AsyncMock(return_value={"ok": True})
+
+        await adapter._update_clarify_message(
+            "C123",
+            "111.222",
+            "❓ Pick one",
+            "✅ Test User: " + ("x" * 2990),
+            resumed=True,
+        )
+
+        kwargs = adapter._app.client.chat_update.await_args.kwargs
+        context = kwargs["blocks"][1]["elements"][0]["text"]
+        assert len(context) <= 3000
+        assert context.startswith("✅ Choice received; request resumed")
+
+    @pytest.mark.asyncio
+    async def test_clarify_callback_clamps_boundary_choice(self, adapter, monkeypatch):
+        """The real callback path replaces buttons even for a near-limit choice."""
+        from tools import clarify_gateway as cm
+
+        long_choice = "x" * 2990
+        cm.register("cl-boundary", "sk-boundary", "Pick one", [long_choice])
+        adapter._clarify_resolved["111.222"] = False
+        adapter._app.client.chat_update = AsyncMock(return_value={"ok": True})
+        monkeypatch.setattr(
+            adapter,
+            "_is_interactive_user_authorized",
+            MagicMock(return_value=True),
+        )
+
+        await adapter._handle_clarify_action(
+            AsyncMock(),
+            {
+                "channel": {"id": "C123"},
+                "user": {"id": "U123", "name": "Test User"},
+                "message": {
+                    "ts": "111.222",
+                    "blocks": [
+                        {
+                            "type": "section",
+                            "text": {"type": "mrkdwn", "text": "❓ Pick one"},
+                        },
+                        {"type": "actions", "elements": []},
+                    ],
+                },
+            },
+            {"action_id": "hermes_clarify_choice_0", "value": "cl-boundary|0"},
+        )
+
+        kwargs = adapter._app.client.chat_update.await_args.kwargs
+        context = kwargs["blocks"][1]["elements"][0]["text"]
+        assert len(context) <= 3000
+        assert context.startswith("✅ Choice received; request resumed")
+        assert "111.222" not in adapter._clarify_resolved
+
 
 # ---------------------------------------------------------------------------
 # TestThreadImageContext — C1-images: images/files in prior thread messages

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4225,7 +4225,7 @@ class TestEnsureDmConversation:
 
     @pytest.mark.asyncio
     async def test_send_clarify_renders_long_choices_in_full(self, adapter):
-        """Slack's 75-char button cap must not hide most of a PM option."""
+        """A long PM option must render in full outside the button label."""
         adapter._app.client.chat_postMessage = AsyncMock(
             return_value={"ok": True, "ts": "111.222"}
         )
@@ -4254,6 +4254,30 @@ class TestEnsureDmConversation:
         assert select_button["value"] == "cl-long|0"
         assert select_button["text"]["text"] == "Select 1"
         assert len(select_button["text"]["text"]) <= 75
+
+    @pytest.mark.asyncio
+    async def test_send_clarify_uses_full_layout_for_wide_cjk_under_75_chars(
+        self, adapter
+    ):
+        """Wide CJK text can clip visually even below Slack's 75-char API cap."""
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "111.222"}
+        )
+        wide_choice = "가" * 25  # 25 chars, but 50 display columns.
+        assert len(wide_choice) < 75
+
+        result = await adapter.send_clarify(
+            chat_id="C123",
+            question="어떤 정책을 선택할까요?",
+            choices=[wide_choice, "직접 입력"],
+            clarify_id="cl-wide-cjk",
+            session_key="sk-wide-cjk",
+        )
+
+        assert result.success is True
+        blocks = adapter._app.client.chat_postMessage.await_args.kwargs["blocks"]
+        assert blocks[1]["text"]["text"] == f"*1.* {wide_choice}"
+        assert blocks[1]["accessory"]["text"]["text"] == "Select 1"
 
     @pytest.mark.asyncio
     async def test_send_clarify_splits_choice_over_section_limit(self, adapter):


### PR DESCRIPTION
## Summary
- render clarify options wider than Slack clients can display as full numbered sections
- count Korean/CJK characters by display width and switch layout above 48 columns
- keep controls compact with `Select N` accessory buttons
- split choices safely across Slack’s 3,000-character section limit without breaking escaped entities
- show durable `Choice received; request resumed` feedback after selection
- sanitize callback updates so Slack removes inert buttons reliably

## Reproduction
Ouroboros/PRD interviews can generate multi-sentence Korean options. Slack accepts button labels up to 75 characters but visually ellipsizes them much earlier, hiding decision-critical text. The screenshot reproduced this with 29–50-character Korean choices measuring 51–82 display columns.

## Verification
- `uv run --extra dev --extra slack pytest tests/gateway/test_slack.py -o addopts= -q` (**171 passed**)
- exact screenshot choices trigger the full-text layout
- regression coverage for CJK under 75 characters, >3,000-character choices, escaped entities, callback updates, and resumed-state feedback
- `uv run --extra dev --extra slack ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py`
- `git diff --check origin/main...HEAD`

Rebased onto current `origin/main` on 2026-08-21 while preserving the original commits/authorship.