### PR TITLE
fix(gateway): scope GATEWAY_ALLOW_ALL_USERS in self-gating adapters' open-DM gate

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -3195,7 +3195,11 @@ class QQAdapter(BasePlatformAdapter):
         return stripped
 
     def _open_dm_opted_in(self) -> bool:
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        # GATEWAY_ALLOW_ALL_USERS must go through the profile-scoped resolver
+        # too, exactly like the QQ_ALLOW_ALL_USERS read below. A raw os.getenv
+        # here let a secondary multiplex profile inherit the DEFAULT profile's
+        # process-env opt-in and open its DMs to everyone (cross-profile leak).
+        if _resolve_qq_secret("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
             return True
         return _resolve_qq_secret("QQ_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
 

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1507,9 +1507,16 @@ class WeixinAdapter(BasePlatformAdapter):
             await self.handle_message(event)
 
     def _open_dm_opted_in(self) -> bool:
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        # Read allow-all through the profile-scoped helper, not raw os.getenv:
+        # under multiplexing a secondary profile that never opted in would
+        # otherwise inherit the DEFAULT profile's process-env
+        # GATEWAY_ALLOW_ALL_USERS / WEIXIN_ALLOW_ALL_USERS and open its DMs to
+        # everyone (cross-profile authz leak). ``_wx_secret`` is scope-
+        # authoritative under multiplex and falls back to os.environ only for
+        # the unscoped default-profile path.
+        if (_wx_secret("GATEWAY_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}:
             return True
-        return os.getenv("WEIXIN_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return (_wx_secret("WEIXIN_ALLOW_ALL_USERS", "") or "").lower() in {"true", "1", "yes"}
 
     def _is_dm_allowed(self, sender_id: str) -> bool:
         if self._dm_policy == "disabled":

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -208,7 +208,12 @@ class WhatsAppBehaviorMixin:
 
     # ------------------------------------------------------------------ gating
     def _open_dm_opted_in(self) -> bool:
-        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
+        # GATEWAY_ALLOW_ALL_USERS must go through the profile-scoped resolver
+        # too, exactly like the WHATSAPP_ALLOW_ALL_USERS read below. A raw
+        # os.getenv here let a secondary multiplex profile inherit the DEFAULT
+        # profile's process-env opt-in and open its DMs to everyone
+        # (cross-profile leak).
+        if (_get_wsecret("GATEWAY_ALLOW_ALL_USERS", default="") or "").lower() in {"true", "1", "yes"}:
             return True
         return (_get_wsecret("WHATSAPP_ALLOW_ALL_USERS", default="") or "").lower() in {"true", "1", "yes"}
 

--- a/tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py
+++ b/tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py
@@ -156,3 +156,44 @@ class TestWhatsAppCloudAdapterUsesSecretScope:
             assert _get_wsecret("WHATSAPP_DM_POLICY", default="pairing") == "allowlist"
         finally:
             ss.reset_secret_scope(tok)
+
+
+class TestWhatsAppOpenDmAllowAllScope:
+    """WhatsApp enforces its own access policy, so ``_open_dm_opted_in`` is the
+    intake gate for open-DM mode. GATEWAY_ALLOW_ALL_USERS must be read through
+    ``_get_wsecret`` (like WHATSAPP_ALLOW_ALL_USERS), so a secondary multiplex
+    profile can't inherit the default profile's process-env opt-in.
+    ``_open_dm_opted_in`` reads no instance state, so bind it to a bare object.
+    """
+
+    def test_scoped_miss_does_not_inherit_gateway_allow_all(self, monkeypatch):
+        from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")  # default profile
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({})  # secondary profile: no opt-in
+        try:
+            assert WhatsAppBehaviorMixin._open_dm_opted_in(object()) is False
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_scoped_opt_in_is_honored(self):
+        from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"GATEWAY_ALLOW_ALL_USERS": "true"})
+        try:
+            assert WhatsAppBehaviorMixin._open_dm_opted_in(object()) is True
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_unscoped_default_profile_uses_environ(self, monkeypatch):
+        from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope(None)
+        try:
+            assert WhatsAppBehaviorMixin._open_dm_opted_in(object()) is True
+        finally:
+            ss.reset_secret_scope(tok)

--- a/tests/gateway/test_qqbot_scope_paths.py
+++ b/tests/gateway/test_qqbot_scope_paths.py
@@ -266,3 +266,44 @@ class TestDirectSendScope:
         assert captured, "token request never issued"
         assert captured[0]["appId"] == "env-app"
         assert captured[0]["clientSecret"] == "env-secret"
+
+
+class TestQQOpenDmAllowAllScope:
+    """QQ enforces its own access policy, so ``_open_dm_opted_in`` is the intake
+    gate for open-DM mode. GATEWAY_ALLOW_ALL_USERS must be read through the
+    scoped resolver (like QQ_ALLOW_ALL_USERS), so a secondary multiplex profile
+    can't inherit the default profile's process-env opt-in. ``_open_dm_opted_in``
+    reads no instance state, so bind it to a bare object.
+    """
+
+    def test_scoped_miss_does_not_inherit_gateway_allow_all(self, monkeypatch):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")  # default profile
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({})  # secondary profile: no opt-in
+        try:
+            assert QQAdapter._open_dm_opted_in(object()) is False
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_scoped_opt_in_is_honored(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"GATEWAY_ALLOW_ALL_USERS": "true"})
+        try:
+            assert QQAdapter._open_dm_opted_in(object()) is True
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_unscoped_default_profile_uses_environ(self, monkeypatch):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope(None)
+        try:
+            assert QQAdapter._open_dm_opted_in(object()) is True
+        finally:
+            ss.reset_secret_scope(tok)

--- a/tests/gateway/test_weixin_secret_scope.py
+++ b/tests/gateway/test_weixin_secret_scope.py
@@ -101,3 +101,47 @@ class TestWeixinAdapterConstructionScope:
             secret_scope.reset_secret_scope(token)
         assert adapter._account_id == "env-account"
         assert adapter._token == "env-token"
+
+
+class TestWeixinOpenDmAllowAllScope:
+    """``_open_dm_opted_in`` gates open-DM access at intake (Weixin enforces its
+    own access policy). It must read the allow-all flags through the scoped
+    helper: a secondary multiplex profile that never opted in must NOT inherit
+    the default profile's process-env GATEWAY_ALLOW_ALL_USERS / WEIXIN_ALLOW_ALL_USERS.
+    """
+
+    def test_scoped_miss_does_not_inherit_gateway_allow_all(self, multiplex_on, monkeypatch):
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")  # default profile opted in
+        adapter = WeixinAdapter(PlatformConfig(enabled=True))
+        token = secret_scope.set_secret_scope({})  # secondary profile: no opt-in
+        try:
+            assert adapter._open_dm_opted_in() is False
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+    def test_scoped_miss_does_not_inherit_platform_allow_all(self, multiplex_on, monkeypatch):
+        monkeypatch.setenv("WEIXIN_ALLOW_ALL_USERS", "true")
+        adapter = WeixinAdapter(PlatformConfig(enabled=True))
+        token = secret_scope.set_secret_scope({})
+        try:
+            assert adapter._open_dm_opted_in() is False
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+    def test_scoped_opt_in_is_honored(self, multiplex_on):
+        adapter = WeixinAdapter(PlatformConfig(enabled=True))
+        token = secret_scope.set_secret_scope({"GATEWAY_ALLOW_ALL_USERS": "true"})
+        try:
+            assert adapter._open_dm_opted_in() is True
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+    def test_unscoped_default_profile_uses_environ(self, multiplex_on, monkeypatch):
+        """Default-profile adapter runs unscoped; os.environ is its own value."""
+        monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+        adapter = WeixinAdapter(PlatformConfig(enabled=True))
+        token = secret_scope.set_secret_scope(None)
+        try:
+            assert adapter._open_dm_opted_in() is True
+        finally:
+            secret_scope.reset_secret_scope(token)


### PR DESCRIPTION
## What

Weixin, QQ, and WhatsApp adapters enforce their own access policy (`enforces_own_access_policy=True`), so the central `authz_mixin` gate **defers to them** and `_open_dm_opted_in()` is the intake gate that decides whether an open-DM policy accepts a sender.

Each adapter already has a profile-scoped secret helper (`_wx_secret` / `_resolve_qq_secret` / `_get_wsecret`) and reads its per-platform `*_ALLOW_ALL_USERS` flag through it — but reads the global `GATEWAY_ALLOW_ALL_USERS` via **raw `os.getenv`**.

Under `gateway.multiplex_profiles` that raw read is a **cross-profile authorization leak**: a secondary profile that never opted in inherits the DEFAULT profile's process-env `GATEWAY_ALLOW_ALL_USERS=true` and opens its DMs to everyone.

The inconsistency is visible inside a single method:

```python
# qqbot/adapter.py  _open_dm_opted_in
if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:   # ← raw, leaks
    return True
return _resolve_qq_secret("QQ_ALLOW_ALL_USERS", "").lower() in {"true", ...}    # ← scoped, correct
```

Same shape in WhatsApp (`_get_wsecret` for `WHATSAPP_ALLOW_ALL_USERS` but raw `GATEWAY_ALLOW_ALL_USERS`); Weixin read **both** flags raw.

Reproduced — secondary scope with no opt-in, `GATEWAY_ALLOW_ALL_USERS=true` in `os.environ`:

```
_open_dm_opted_in()  ->  True   (before: inherits the default profile — LEAK)
_open_dm_opted_in()  ->  False  (after:  scoped miss is authoritative)
```

## Fix

Route `GATEWAY_ALLOW_ALL_USERS` (and Weixin's `WEIXIN_ALLOW_ALL_USERS`) through each adapter's own scoped helper, which is authoritative under multiplex and falls back to `os.environ` only on the unscoped default-profile path — exactly the pattern the sibling `*_ALLOW_ALL_USERS` read on the adjacent line already uses.

Sibling of the central-gate fix in #70122; the deferral to `enforces_own_access_policy` adapters leaves this intake gate uncovered there. `yuanbao` is intentionally left out — it has no profile-scoped helper, so whether it runs multiplex-scoped is unproven; converting it belongs in a separate change.

## Tests

Added to the three existing adapter scope-test files (`test_weixin_secret_scope.py`, `test_qqbot_scope_paths.py`, `test_75349_whatsapp_multiplex_secret_scope.py`):

- a secondary scope with no opt-in must **not** inherit the default profile's `GATEWAY_ALLOW_ALL_USERS` (and, for Weixin, `WEIXIN_ALLOW_ALL_USERS`)
- a scoped opt-in **is** honored
- the unscoped default-profile path still reads `os.environ` (unchanged)

```
scripts/run_tests.sh tests/gateway/test_weixin_secret_scope.py \
  tests/gateway/test_qqbot_scope_paths.py \
  tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py
=== 31 passed ===

# without the fix
=== 7 failed ===   (scoped-miss leak + scoped-opt-in, per adapter)
```

Broader gateway auth/policy sweep — `test_weixin`, `test_config_driven_access_policy`, `test_own_policy_startup_gate`, `test_allowlist_startup_check`, plus the three scope files: **86 passed, 0 failed**. No regressions.