### PR TITLE
fix: preserve secret provenance on failed refresh (#77529)

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -634,15 +634,27 @@ def _apply_external_secret_sources(home_path: Path) -> None:
     except ImportError:
         return
 
+    # Snapshot current provenance for keys still in os.environ before the
+    # refresh.  If the refresh fails for a source, we can restore
+    # last-known-good provenance so _build_safe_env() still trusts those
+    # keys.  (#77529)
+    _stale_provenance: dict[str, str] = {
+        k: v for k, v in _SECRET_SOURCES.items() if k in os.environ
+    }
+
     try:
         report = apply_all(cfg, home_path)
     except Exception:  # noqa: BLE001 — belt-and-braces; apply_all shouldn't raise
+        # Refresh completely failed — restore last-known-good provenance so
+        # MCP children still receive secrets whose values remain in env.
+        _SECRET_SOURCES.update(_stale_provenance)
         return
 
     if not report.sources:
         # Config parsed but no source is enabled: keep retrying cheaply
         # (no fetch happens for disabled sources) so flipping a source on
         # mid-process takes effect on the next call.
+        _SECRET_SOURCES.update(_stale_provenance)
         return
 
     # A real fetch attempt happened (success OR error).  Mark the home now
@@ -667,6 +679,14 @@ def _apply_external_secret_sources(home_path: Path) -> None:
             if name in os.environ:
                 values[name] = os.environ[name]
         _SECRET_SOURCE_VALUES_BY_HOME[home_key] = values
+
+    # Partial-failure provenance preservation: when some sources succeed
+    # and others fail, report.provenance only covers the successful ones.
+    # Restore last-known-good provenance for keys whose values are still
+    # in os.environ but weren't refreshed.  (#77529)
+    for key, source in _stale_provenance.items():
+        if key not in _SECRET_SOURCES and key in os.environ:
+            _SECRET_SOURCES[key] = source
 
     for src in report.sources:
         if src.applied:


### PR DESCRIPTION
## Summary

When `reset_secret_source_cache()` clears `_SECRET_SOURCES` and the subsequent `load_hermes_dotenv()` fails to re-fetch (e.g., external secret source auth expired), provenance was permanently lost while the previously resolved values remained in `os.environ`.

`_build_safe_env()` then relies on the missing runtime provenance (`get_secret_source()` returns `None`) and strips those variables from the MCP child environment, causing "No access token available" errors even though the secret value is still present in the Gateway process.

## Root Cause

The interaction between:
1. `reset_secret_source_cache()` clearing `_SECRET_SOURCES` (the provenance registry)
2. `load_hermes_dotenv()` -> `_apply_external_secret_sources()` -> `apply_all()` failing for a source
3. `_build_safe_env()` filtering env vars based on `get_secret_source(key)`

After a failed refresh, the secret value is still in `os.environ` but its provenance is gone, so MCP children are denied the credential.

## Fix

Snapshot `_SECRET_SOURCES` entries for keys still in `os.environ` before the refresh attempt. After `apply_all()`, restore last-known-good provenance for keys whose values survived but whose source failed to refresh. This handles both:

- **Total refresh failure** (`apply_all()` raises): restore all stale provenance
- **Partial failure** (some sources succeed, others error): restore provenance only for keys from the failed sources

## Changes

- `hermes_cli/env_loader.py`: In `_apply_external_secret_sources()`, snapshot provenance before `apply_all()`, restore on failure, and merge partial-failure provenance after success

## Test Plan

- [x] `uv run pytest tests/test_env_loader_secret_sources.py` - 18 passed
- [x] `uv run pytest tests/test_env_loader_applied_homes.py` - 5 passed
- [x] `uv run pytest tests/secret_sources/` - 42 passed
- [x] `uv run pytest tests/test_command_secret_source.py` - 11 passed

Fixes #77529