### PR TITLE
fix(memory): fill agent_workspace from HERMES_KANBAN_BOARD for kanban workers

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1737,7 +1737,12 @@ def init_agent(
                         from hermes_cli.profiles import get_active_profile_name
                         _profile = get_active_profile_name()
                         _init_kwargs["agent_identity"] = _profile
-                        _init_kwargs["agent_workspace"] = "hermes"
+                        # Kanban worker processes get HERMES_KANBAN_BOARD pinned
+                        # by the dispatcher, so using it here lets memory
+                        # providers scope storage per board via their
+                        # {workspace} placeholder.  Unset (normal CLI/gateway
+                        # runs) falls back to "hermes", the previous behavior.
+                        _init_kwargs["agent_workspace"] = os.environ.get("HERMES_KANBAN_BOARD") or "hermes"
                     except Exception:
                         pass
                     agent._memory_manager.initialize_all(**_init_kwargs)

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1737,11 +1737,14 @@ def init_agent(
                         from hermes_cli.profiles import get_active_profile_name
                         _profile = get_active_profile_name()
                         _init_kwargs["agent_identity"] = _profile
-                        # Kanban worker processes get HERMES_KANBAN_BOARD pinned
-                        # by the dispatcher, so using it here lets memory
-                        # providers scope storage per board via their
-                        # {workspace} placeholder.  Unset (normal CLI/gateway
-                        # runs) falls back to "hermes", the previous behavior.
+                        # HERMES_KANBAN_BOARD is pinned both by the dispatcher
+                        # (worker processes) and by _pin_kanban_board_env() in
+                        # cmd_chat (hermes_cli/main.py) at chat boot, so a normal
+                        # CLI chat resolves to the current board slug ("default"
+                        # on a pristine install) and memory providers scope
+                        # storage per board via their {workspace} placeholder.
+                        # The "hermes" fallback only applies where the var is
+                        # genuinely unset (library/SDK, some gateway paths).
                         _init_kwargs["agent_workspace"] = os.environ.get("HERMES_KANBAN_BOARD") or "hermes"
                     except Exception:
                         pass

--- a/tests/agent/test_agent_workspace_kanban_board.py
+++ b/tests/agent/test_agent_workspace_kanban_board.py
@@ -1,0 +1,119 @@
+"""Regression test: ``agent_workspace`` must follow the active kanban board.
+
+Memory providers document a ``{workspace}`` placeholder for their bank/namespace
+templates (e.g. ``bank_id_template: hermes-{workspace}``), fed from the
+``agent_workspace`` kwarg passed to ``MemoryProvider.initialize()``.  That kwarg
+used to be hardcoded to ``"hermes"``, so the placeholder could never distinguish
+anything: kanban workers running on different boards all shared a single memory
+bank even when operators configured a per-workspace template.
+
+``agent_workspace`` now follows ``HERMES_KANBAN_BOARD`` — the env var the kanban
+dispatcher pins into worker processes — and falls back to ``"hermes"`` when the
+var is unset, preserving the previous behavior for plain CLI/gateway runs.
+"""
+
+import json
+
+from agent.memory_provider import MemoryProvider
+from run_agent import AIAgent
+
+
+class _FakeOpenAI:
+    def __init__(self, **kw):
+        self.api_key = kw.get("api_key", "test")
+        self.base_url = kw.get("base_url", "http://test")
+
+    def close(self):
+        pass
+
+
+class RecordingProvider(MemoryProvider):
+    """Minimal provider that records what initialize() receives."""
+
+    def __init__(self, name="recording"):
+        self._name = name
+        self._init_kwargs = {}
+        self._init_session_id = None
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._init_session_id = session_id
+        self._init_kwargs = dict(kwargs)
+
+    def system_prompt_block(self) -> str:
+        return ""
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        return ""
+
+    def sync_turn(self, user_content, assistant_content, *, session_id=""):
+        pass
+
+    def get_tool_schemas(self):
+        return []
+
+    def handle_tool_call(self, tool_name, args, **kwargs):
+        return json.dumps({})
+
+    def shutdown(self):
+        pass
+
+
+def _make_agent_with_recording_provider(monkeypatch, tmp_path):
+    """Build an AIAgent whose only memory provider is a RecordingProvider."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hm"))
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: [])
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
+
+    # agent_init imports both of these lazily inside init_agent(), so patching
+    # the module attributes is what actually takes effect.
+    import hermes_cli.config
+    import plugins.memory
+
+    monkeypatch.setattr(
+        hermes_cli.config,
+        "load_config_readonly",
+        lambda *a, **kw: {"memory": {"provider": "recording"}},
+    )
+    provider = RecordingProvider()
+    monkeypatch.setattr(
+        plugins.memory, "load_memory_provider", lambda *a, **kw: provider
+    )
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="http://test",
+        provider="openrouter",
+        api_mode="chat_completions",
+        max_iterations=1,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=False,
+    )
+    return agent, provider
+
+
+def test_agent_workspace_defaults_to_hermes(monkeypatch, tmp_path):
+    """No board pinned (plain CLI run) -> previous behavior is preserved."""
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    _agent, provider = _make_agent_with_recording_provider(monkeypatch, tmp_path)
+
+    assert provider._init_kwargs.get("agent_workspace") == "hermes"
+
+
+def test_agent_workspace_follows_kanban_board(monkeypatch, tmp_path):
+    """A kanban worker's pinned board scopes the provider's workspace."""
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "my-project-board")
+    _agent, provider = _make_agent_with_recording_provider(monkeypatch, tmp_path)
+
+    assert provider._init_kwargs.get("agent_workspace") == "my-project-board", (
+        "agent_workspace must follow HERMES_KANBAN_BOARD so memory providers "
+        "can scope storage per board via the {workspace} placeholder"
+    )

--- a/tests/agent/test_agent_workspace_kanban_board.py
+++ b/tests/agent/test_agent_workspace_kanban_board.py
@@ -7,12 +7,17 @@ used to be hardcoded to ``"hermes"``, so the placeholder could never distinguish
 anything: kanban workers running on different boards all shared a single memory
 bank even when operators configured a per-workspace template.
 
-``agent_workspace`` now follows ``HERMES_KANBAN_BOARD`` — the env var the kanban
-dispatcher pins into worker processes — and falls back to ``"hermes"`` when the
-var is unset, preserving the previous behavior for plain CLI/gateway runs.
+``agent_workspace`` now follows ``HERMES_KANBAN_BOARD``.  That env var is pinned
+by the kanban dispatcher for worker processes *and* by ``_pin_kanban_board_env()``
+in ``cmd_chat`` at chat boot, so a plain ``hermes`` CLI chat resolves
+``agent_workspace`` to the current board slug (``"default"`` on a pristine
+install), not to ``"hermes"``.  The ``"hermes"`` fallback only covers contexts
+where the var is genuinely unset — SDK/library construction and some gateway
+paths.
 """
 
 import json
+import os
 
 from agent.memory_provider import MemoryProvider
 from run_agent import AIAgent
@@ -117,3 +122,28 @@ def test_agent_workspace_follows_kanban_board(monkeypatch, tmp_path):
         "agent_workspace must follow HERMES_KANBAN_BOARD so memory providers "
         "can scope storage per board via the {workspace} placeholder"
     )
+
+
+def test_agent_workspace_follows_chat_boot_pin(monkeypatch, tmp_path):
+    """A real ``hermes`` chat boot pins the board, so the workspace is its slug.
+
+    ``cmd_chat`` calls ``_pin_kanban_board_env()`` before constructing the agent,
+    which writes ``get_current_board()`` into the environment — ``"default"`` on a
+    pristine install.  This locks in that documented CLI-chat behavior end to end
+    so a future change to the pin path cannot silently move operators' bank ids
+    (e.g. ``bank_id_template: hermes-{workspace}``) without a failing test.
+    """
+    from hermes_cli.main import _pin_kanban_board_env
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hm"))
+    # setenv-then-delenv so monkeypatch records a restore entry even when the var
+    # starts unset -- the pin below writes straight to os.environ.
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "")
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+
+    _pin_kanban_board_env()
+    assert os.environ["HERMES_KANBAN_BOARD"] == "default"
+
+    _agent, provider = _make_agent_with_recording_provider(monkeypatch, tmp_path)
+
+    assert provider._init_kwargs.get("agent_workspace") == "default"


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the `{workspace}` placeholder in memory-provider templates could never resolve to anything other than the hardcoded string `"hermes"`.

`agent_init.py` sets `agent_workspace` on the kwargs passed to `MemoryProvider.initialize()`, but it was hardcoded:

```python
_init_kwargs["agent_workspace"] = "hermes"
```

The Hindsight provider (`plugins/memory/hindsight/__init__.py`, `_resolve_bank_id_template`) documents this kwarg as the source of the `{workspace}` bank-id placeholder:

> `{workspace}` — Hermes workspace name (from agent_workspace)

Since nothing ever filled it with anything else, an operator configuring `bank_id_template: hermes-{workspace}` to isolate memory banks per project/board got a single shared bank for all of them — the placeholder silently rendered `"hermes"` everywhere.

The kanban dispatcher pins the active board slug into every worker process via the `HERMES_KANBAN_BOARD` env var (see `hermes_cli/kanban_db.py`). This PR uses it as the workspace value, so kanban workers scope their memory provider storage per board.

### Behavior-change note (read this before merging)

This is **not** a pure no-op fallback for every non-worker context. `HERMES_KANBAN_BOARD` is pinned in two places:

1. by the kanban dispatcher for worker processes, and
2. by `_pin_kanban_board_env()` in `cmd_chat` (`hermes_cli/main.py`) at **every normal CLI chat boot** — it writes `get_current_board()` into the env var when unset.

Consequence: in a normal `hermes` CLI chat, `agent_workspace` now resolves to the current board slug — `"default"` on a pristine install — **not** `"hermes"`. Operators using `bank_id_template: hermes-{workspace}` will see their bank id change once, from `hermes-hermes` to `hermes-<board>` (e.g. `hermes-default`) on their first CLI chat after upgrading.

This one-time silent migration is intended: per-board isolation is precisely the point of the `{workspace}` placeholder, and chat sessions already resolve their kanban tools to that same board via the identical pin. The `"hermes"` fallback now only applies where `HERMES_KANBAN_BOARD` is genuinely unset — library/SDK construction of `AIAgent` and some gateway paths. The code comment and the tests document this explicitly.

## Related Issue

None found — the bug was identified while auditing why `{workspace}` never rendered differently across boards.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/agent_init.py` — `agent_workspace` now reads `os.environ.get("HERMES_KANBAN_BOARD") or "hermes"` instead of the hardcoded `"hermes"` (one-line change plus explanatory comment; `os` already imported). The comment documents both pin sites (dispatcher + `cmd_chat` boot) and that the `"hermes"` fallback covers only genuinely-unset contexts.
- `tests/agent/test_agent_workspace_kanban_board.py` (new) — builds an `AIAgent` hermetically (temp `HERMES_HOME`, fake OpenAI, empty tool defs) with a recording `MemoryProvider` wired in via the same path `init_agent` uses (`hermes_cli.config.load_config_readonly` + `plugins.memory.load_memory_provider`), and asserts:
  1. `agent_workspace == "hermes"` when `HERMES_KANBAN_BOARD` is unset (SDK/library context),
  2. `agent_workspace == "my-project-board"` when the dispatcher-style env var is set,
  3. end-to-end chat-boot pin: calling the real `hermes_cli.main._pin_kanban_board_env()` with a pristine temp `HERMES_HOME` pins `HERMES_KANBAN_BOARD` to `"default"` and `agent_workspace` resolves to `"default"` — locking in the documented CLI-chat behavior.

## How to Test

1. Check out this branch and run the new tests:
   `scripts/run_tests.sh tests/agent/test_agent_workspace_kanban_board.py -q` → 3 tests pass.
2. Negative control: revert the one-line change in `agent/agent_init.py` and re-run — `test_agent_workspace_follows_kanban_board` fails on clean main, confirming the test pins the fix.
3. E2E with Hindsight: configure `bank_id_template: hermes-{workspace}`, run a kanban worker on a board (dispatcher sets `HERMES_KANBAN_BOARD=<board>`) — the provider resolves its bank from the board slug instead of `hermes`.
4. CLI-chat path: with `bank_id_template: hermes-{workspace}` and a pristine `HERMES_HOME`, start `hermes` chat — the bank resolves to `hermes-default` (the pinned board), per the behavior-change note above.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran the touched areas via `scripts/run_tests.sh`: 71 tests passed across `tests/agent/test_agent_workspace_kanban_board.py`, `tests/plugins/memory/test_hindsight_provider.py`, `tests/agent/test_memory_user_id.py`, `tests/agent/test_skip_memory_store_65429.py`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux 6.8)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: the `{workspace}` placeholder is already documented correctly; this fix makes it work. N/A.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: no config keys added. N/A.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A. N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A: `os.environ.get` is platform-neutral. N/A.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A. N/A.

## Screenshots / Logs

Test run (canonical runner, per-file isolation):

```
scripts/run_tests.sh tests/agent/test_agent_workspace_kanban_board.py \
  tests/plugins/memory/test_hindsight_provider.py \
  tests/agent/test_memory_user_id.py tests/agent/test_skip_memory_store_65429.py -q

=== Summary: 4 files, 71 tests passed, 0 failed (100% complete) in 6.4s (8 workers) ===
```
