### PR TITLE
fix(gateway): restart owned system service without root

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -252,6 +252,65 @@ def _request_gateway_self_restart(pid: int) -> bool:
     return True
 
 
+def _request_owned_systemd_gateway_restart(pid: int) -> bool:
+    """Request a restart from a same-user systemd sibling without root.
+
+    The dashboard backend is a sibling of the gateway, not its ancestor, so it
+    cannot use ``_request_gateway_self_restart``.  Permit this narrow path only
+    when systemd identifies ``pid`` as this service's MainPID, the unit and the
+    live process both belong to the current user, and systemd is configured to
+    restart the process after its planned SIGUSR1 exit.
+    """
+    if pid <= 0 or not hasattr(signal, "SIGUSR1"):
+        return False
+    try:
+        result = _run_systemctl(
+            [
+                "show",
+                get_service_name(),
+                "--property=MainPID",
+                "--property=User",
+                "--property=Restart",
+            ],
+            system=True,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if result.returncode != 0:
+        return False
+
+    properties = {}
+    for line in (result.stdout or "").splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            properties[key] = value
+    if properties.get("MainPID") != str(pid) or properties.get("Restart") != "always":
+        return False
+
+    try:
+        import pwd
+
+        current_uid = os.geteuid()
+        if pwd.getpwnam(properties["User"]).pw_uid != current_uid:
+            return False
+        if os.stat(f"/proc/{pid}").st_uid != current_uid:
+            return False
+    except (KeyError, OSError):
+        return False
+
+    try:
+        os.kill(pid, signal.SIGUSR1)  # POSIX-only, guarded by hasattr(signal, "SIGUSR1") above
+    except (ProcessLookupError, PermissionError, OSError):
+        return False
+    return True
+
+
 def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
     """Send SIGUSR1 to a gateway PID and wait for it to exit gracefully.
 
@@ -3465,6 +3524,16 @@ def systemd_stop(system: bool = False):
 def systemd_restart(system: bool = False):
     system = _select_systemd_scope(system)
     if system:
+        if os.geteuid() != 0:
+            from gateway.status import get_running_pid
+
+            pid = get_running_pid() or _systemd_main_pid(system=True)
+            if pid is not None and _request_owned_systemd_gateway_restart(pid):
+                print(
+                    f"✓ System gateway graceful restart requested (PID {pid}); "
+                    "systemd will relaunch it after drain"
+                )
+                return
         _require_root_for_system_service("restart")
     else:
         _preflight_user_systemd()

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -490,6 +490,78 @@ class TestGatewayServiceDetection:
 
 
 class TestGatewaySystemServiceRouting:
+    def test_owned_systemd_gateway_restart_signals_only_matching_service(self, monkeypatch):
+        systemctl_calls = []
+        signals = []
+
+        def fake_systemctl(args, **kwargs):
+            systemctl_calls.append((args, kwargs))
+            return SimpleNamespace(
+                returncode=0,
+                stdout="MainPID=654\nUser=aliops\nRestart=always\n",
+            )
+
+        monkeypatch.setattr(gateway_cli, "_run_systemctl", fake_systemctl)
+        monkeypatch.setattr(gateway_cli, "get_service_name", lambda: "hermes-gateway.service")
+        monkeypatch.setattr(gateway_cli.os, "geteuid", lambda: 1001)
+        monkeypatch.setattr(gateway_cli.os, "stat", lambda path: SimpleNamespace(st_uid=1001))
+        monkeypatch.setattr(pwd, "getpwnam", lambda name: SimpleNamespace(pw_uid=1001))
+        monkeypatch.setattr(gateway_cli.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+        assert gateway_cli._request_owned_systemd_gateway_restart(654) is True
+        assert systemctl_calls[0][0] == [
+            "show",
+            "hermes-gateway.service",
+            "--property=MainPID",
+            "--property=User",
+            "--property=Restart",
+        ]
+        assert systemctl_calls[0][1]["system"] is True
+        assert signals == [(654, gateway_cli.signal.SIGUSR1)]
+
+    def test_owned_systemd_gateway_restart_refuses_mismatched_main_pid(self, monkeypatch):
+        signals = []
+
+        monkeypatch.setattr(
+            gateway_cli,
+            "_run_systemctl",
+            lambda *args, **kwargs: SimpleNamespace(
+                returncode=0,
+                stdout="MainPID=655\nUser=aliops\nRestart=always\n",
+            ),
+        )
+        monkeypatch.setattr(gateway_cli.os, "kill", lambda pid, sig: signals.append((pid, sig)))
+
+        assert gateway_cli._request_owned_systemd_gateway_restart(654) is False
+        assert signals == []
+
+    def test_systemd_restart_allows_owned_service_without_root(self, monkeypatch, capsys):
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: True)
+        monkeypatch.setattr(gateway_cli.os, "geteuid", lambda: 1001)
+        monkeypatch.setattr(status, "get_running_pid", lambda: 654)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_owned_systemd_gateway_restart",
+            lambda pid: calls.append(pid) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_require_root_for_system_service",
+            lambda action: (_ for _ in ()).throw(AssertionError("should not require root")),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "refresh_systemd_unit_if_needed",
+            lambda system=False: (_ for _ in ()).throw(AssertionError("should not refresh")),
+        )
+
+        gateway_cli.systemd_restart()
+
+        assert calls == [654]
+        assert "graceful restart requested" in capsys.readouterr().out
+
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):
         calls = []
 


### PR DESCRIPTION
## Summary
- allow the Desktop/CLI restart path to request a graceful restart for the verified same-user systemd gateway
- require an exact systemd MainPID match, matching unit/process ownership, and `Restart=always` before signalling
- preserve the existing root-required path for every other system service

## Verification
- `python -m pytest tests/hermes_cli/test_gateway_service.py -q` — 73 passed
- `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- live systemd verification: the gateway restarted gracefully and returned to `active (running)`

## Safety
This does not grant general systemd control to unprivileged callers. It only sends `SIGUSR1` to the currently verified gateway MainPID when all ownership and restart-policy checks pass.