### PR TITLE
fix(photon): preserve playable voice upload filenames

### DIFF
--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -1056,7 +1056,15 @@ const server = http.createServer(async (req, res) => {
       // overrides only when Hermes supplied them so a known-good
       // inference isn't clobbered with an empty string.
       const opts = {};
-      if (name) opts.name = name;
+      if (kind === "voice") {
+        // spectrum-ts transcodes non-M4A bytes before upload but preserves the
+        // supplied filename. Keep converted voice payloads playable by giving
+        // them an M4A filename while retaining the source MIME below, which
+        // ensureM4a still needs to decide whether transcoding is required.
+        opts.name = name && /\.m4a$/i.test(name) ? name : "voice.m4a";
+      } else if (name) {
+        opts.name = name;
+      }
       if (mimeType) opts.mimeType = mimeType;
       const builder =
         kind === "voice"

--- a/tests/plugins/platforms/photon/test_voice_upload_filename.py
+++ b/tests/plugins/platforms/photon/test_voice_upload_filename.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+SIDECAR = (
+    Path(__file__).resolve().parents[4]
+    / "plugins"
+    / "platforms"
+    / "photon"
+    / "sidecar"
+    / "index.mjs"
+)
+
+
+def test_voice_upload_uses_m4a_name_without_overwriting_source_mime() -> None:
+    source = SIDECAR.read_text(encoding="utf-8")
+    voice_branch = 'if (kind === "voice") {'
+    m4a_fallback = 'opts.name = name && /\\.m4a$/i.test(name) ? name : "voice.m4a";'
+    mime_assignment = "if (mimeType) opts.mimeType = mimeType;"
+
+    assert voice_branch in source
+    assert m4a_fallback in source
+    assert mime_assignment in source
+    assert source.index(voice_branch) < source.index(m4a_fallback) < source.index(mime_assignment)


### PR DESCRIPTION
## Summary
- give Photon voice uploads an `.m4a` filename when Spectrum may transcode the payload
- preserve the original MIME override so Spectrum can still decide whether transcoding is required
- add a focused regression test for filename and MIME ordering

## Why
Spectrum can transcode non-M4A voice input to M4A bytes while preserving the supplied source filename. A converted payload sent with an `.mp3` name may render as a native iMessage voice item that cannot be played.

## Test plan
- `pytest -q tests/plugins/platforms/photon/test_voice_upload_filename.py`
- `pytest -q tests/plugins/platforms/photon` (130 passed)
- `node --check plugins/platforms/photon/sidecar/index.mjs`

## Privacy
The change and test use only generic filenames and contain no user identifiers, message content, credentials, local paths, or runtime data.