### PR TITLE
fix(buzz): preserve routes across interactive gateway flows

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5671,6 +5671,7 @@ class BasePlatformAdapter(ABC):
                     _clarify_route_scope = _clarify_mod.build_route_scope(
                         platform=event.source.platform,
                         chat_id=event.source.chat_id,
+                        chat_type=event.source.chat_type,
                         thread_id=event.source.thread_id,
                         message_id=event.message_id,
                     )

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5668,10 +5668,17 @@ class BasePlatformAdapter(ABC):
             if not cmd:
                 try:
                     from tools import clarify_gateway as _clarify_mod
+                    _clarify_route_scope = _clarify_mod.build_route_scope(
+                        platform=event.source.platform,
+                        chat_id=event.source.chat_id,
+                        thread_id=event.source.thread_id,
+                        message_id=event.message_id,
+                    )
                     _has_text_clarify = (
                         _clarify_mod.get_pending_for_session(
                             session_key,
                             include_choice_prompts=True,
+                            route_scope=_clarify_route_scope,
                         ) is not None
                     )
                 except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12736,6 +12736,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await self.async_session_store.mark_resume_pending(
                         _sk,
                         "restart_timeout" if self._restart_requested else "shutdown_timeout",
+                        source=self._get_cached_session_source(_sk),
                     )
                     _pre_drain_keys.append(_sk)
                 except Exception as _e:
@@ -12813,7 +12814,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if _agent is _AGENT_PENDING_SENTINEL:
                         continue
                     try:
-                        await self.async_session_store.mark_resume_pending(_sk, _resume_reason)
+                        await self.async_session_store.mark_resume_pending(
+                            _sk,
+                            _resume_reason,
+                            source=self._get_cached_session_source(_sk),
+                        )
                     except Exception as _e:
                         logger.debug(
                             "mark_resume_pending failed for %s: %s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4864,6 +4864,12 @@ class TurnRunner:
                 question=question,
                 choices=list(choices) if choices else None,
                 multi_select=bool(multi_select),
+                route_scope=_clarify_mod.build_route_scope(
+                    platform=ctx.source.platform,
+                    chat_id=ctx.source.chat_id,
+                    thread_id=ctx.source.thread_id,
+                    message_id=ctx.event_message_id,
+                ),
             )
 
             # Pause typing — like approval, we don't want a "thinking..."
@@ -14456,8 +14462,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _clarify_mod = None
         try:
             from tools import clarify_gateway as _clarify_mod
+            _clarify_route_scope = _clarify_mod.build_route_scope(
+                platform=source.platform,
+                chat_id=source.chat_id,
+                thread_id=source.thread_id,
+                message_id=event.message_id,
+            )
             _pending_clarify = _clarify_mod.get_pending_for_session(
-                _quick_key, include_choice_prompts=True,
+                _quick_key,
+                include_choice_prompts=True,
+                route_scope=_clarify_route_scope,
             )
         except Exception:
             _pending_clarify = None
@@ -14478,7 +14492,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # with an empty response.
             if _raw_clarify_reply and not _raw_clarify_reply.startswith("/"):
                 _resolved = _clarify_mod.resolve_text_response_for_session(
-                    _quick_key, _raw_clarify_reply,
+                    _quick_key,
+                    _raw_clarify_reply,
+                    route_scope=_clarify_route_scope,
                 )
                 if _resolved:
                     logger.info(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4867,6 +4867,7 @@ class TurnRunner:
                 route_scope=_clarify_mod.build_route_scope(
                     platform=ctx.source.platform,
                     chat_id=ctx.source.chat_id,
+                    chat_type=ctx.source.chat_type,
                     thread_id=ctx.source.thread_id,
                     message_id=ctx.event_message_id,
                 ),
@@ -8730,17 +8731,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key, exc_info=True,
             )
 
-        # A Buzz channel can share one conversational session across several
-        # threads. If this message belongs to a different route than the
-        # pending clarify, do not redirect its text into the blocked run. Wake
-        # that run with an internal cancellation response and let the base
-        # adapter queue this event as a separate routed follow-up turn.
+        # A pending Buzz channel clarify belongs to one thread. If this message
+        # belongs to a different route, do not redirect its text into the
+        # blocked run. Wake that run with an internal cancellation response and
+        # let the base adapter queue this event as a separate routed follow-up
+        # turn. Buzz DMs remain session-scoped and have no route filter.
         try:
             from tools import clarify_gateway as _clarify_mod
 
             _clarify_route_scope = _clarify_mod.build_route_scope(
                 platform=event.source.platform,
                 chat_id=event.source.chat_id,
+                chat_type=event.source.chat_type,
                 thread_id=event.source.thread_id,
                 message_id=event.message_id,
             )
@@ -14506,6 +14508,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _clarify_route_scope = _clarify_mod.build_route_scope(
                 platform=source.platform,
                 chat_id=source.chat_id,
+                chat_type=source.chat_type,
                 thread_id=source.thread_id,
                 message_id=event.message_id,
             )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8730,6 +8730,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key, exc_info=True,
             )
 
+        # A Buzz channel can share one conversational session across several
+        # threads. If this message belongs to a different route than the
+        # pending clarify, do not redirect its text into the blocked run. Wake
+        # that run with an internal cancellation response and let the base
+        # adapter queue this event as a separate routed follow-up turn.
+        try:
+            from tools import clarify_gateway as _clarify_mod
+
+            _clarify_route_scope = _clarify_mod.build_route_scope(
+                platform=event.source.platform,
+                chat_id=event.source.chat_id,
+                thread_id=event.source.thread_id,
+                message_id=event.message_id,
+            )
+            if _clarify_mod.resolve_pending_outside_route(
+                session_key,
+                _clarify_route_scope,
+                "[The user continued in a different conversation route. "
+                "Do not treat that message as this clarification's answer. "
+                "End this turn without a substantive reply.]",
+            ):
+                logger.info(
+                    "Released pending clarify for cross-route Buzz follow-up: "
+                    "session=%s route=%s",
+                    session_key,
+                    _clarify_route_scope,
+                )
+                return False
+        except Exception:
+            logger.warning(
+                "Cross-route clarify release failed for session %s; "
+                "falling through to busy handling",
+                session_key,
+                exc_info=True,
+            )
+
         # Normal busy case (agent actively running a task)
         adapter = self._adapter_for_source(event.source)
         if not adapter:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2752,13 +2752,18 @@ class SessionStore:
         self,
         session_key: str,
         reason: str = "restart_timeout",
+        *,
+        source: Optional[SessionSource] = None,
     ) -> bool:
         """Mark a session as resumable after a restart interruption.
 
         Unlike ``suspend_session()``, this preserves the existing
         ``session_id`` and the transcript.  The next call to
         ``get_or_create_session()`` for this key returns the same entry
-        so the user auto-resumes on the same conversation lane.
+        so the user auto-resumes on the same conversation lane.  When supplied,
+        ``source`` snapshots the active turn's exact delivery route so a shared
+        channel session resumes in its current thread rather than its older
+        session origin.
 
         Returns True if the session existed and was marked.
         """
@@ -2770,6 +2775,10 @@ class SessionStore:
                 # forced-wipe signal (from /stop or stuck-loop escalation).
                 if entry.suspended:
                     return False
+                if source is not None:
+                    entry.origin = replace(source)
+                    entry.platform = source.platform
+                    entry.chat_type = source.chat_type
                 entry.resume_pending = True
                 entry.resume_reason = reason
                 entry.last_resume_marked_at = _now()

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -344,6 +344,25 @@ def _parse_json_list(stdout: str) -> List[dict]:
     return [item for item in data if isinstance(item, dict)]
 
 
+def _event_reply_target(event: dict) -> str:
+    """Return the Nostr event id that a channel message replies to."""
+    tags = event.get("tags")
+    if not isinstance(tags, list):
+        return ""
+    root_target = ""
+    reply_target = ""
+    for tag in tags:
+        if not isinstance(tag, list) or len(tag) < 2 or tag[0] != "e":
+            continue
+        target = str(tag[1] or "")
+        marker = str(tag[3] or "") if len(tag) > 3 else ""
+        if marker == "root":
+            root_target = target
+        elif marker == "reply" or not marker:
+            reply_target = target
+    return root_target or reply_target
+
+
 # ---------------------------------------------------------------------------
 # Buzz Adapter
 # ---------------------------------------------------------------------------
@@ -1056,6 +1075,7 @@ class BuzzAdapter(BasePlatformAdapter):
             user_name=await self._resolve_user_name(pubkey),
             message_id=event_id,
             created_at=created_at,
+            thread_id=_event_reply_target(event),
         )
 
     # ── DM classification (issue #68871) ──────────────────────────────────
@@ -1219,6 +1239,7 @@ class BuzzAdapter(BasePlatformAdapter):
         user_name: str,
         message_id: str,
         created_at: int,
+        thread_id: Optional[str] = None,
     ) -> None:
         """Build a MessageEvent and hand it to the base class handler."""
         if not self._message_handler:
@@ -1230,6 +1251,7 @@ class BuzzAdapter(BasePlatformAdapter):
             chat_type=chat_type,
             user_id=user_id,
             user_name=user_name,
+            thread_id=thread_id,
         )
 
         event = MessageEvent(

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1245,13 +1245,20 @@ class BuzzAdapter(BasePlatformAdapter):
         if not self._message_handler:
             return
 
+        # Buzz channel replies are flat under the initiating event. Treat a
+        # top-level channel event as its own root so the initiating command and
+        # later replies resolve to one thread-scoped gateway session. DMs keep
+        # their existing conversation-wide session semantics.
+        effective_thread_id = thread_id or (
+            message_id if chat_type == "group" else None
+        )
         source = self.build_source(
             chat_id=chat_id,
             chat_name=self._channel_names.get(chat_id, chat_id),
             chat_type=chat_type,
             user_id=user_id,
             user_name=user_name,
-            thread_id=thread_id,
+            thread_id=effective_thread_id,
         )
 
         event = MessageEvent(

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -98,6 +98,56 @@ def _make_adapter(platform_val="telegram"):
 class TestBusySessionAck:
     """User sends a message while agent is running — should get acknowledgment."""
 
+    @pytest.mark.asyncio
+    async def test_buzz_other_route_releases_clarify_without_redirecting_text(self):
+        from tools import clarify_gateway as cm
+
+        cm._entries.clear()
+        cm._session_index.clear()
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter("buzz")
+        source = SessionSource(
+            platform=Platform("buzz"),
+            chat_id="buzz-channel",
+            chat_type="group",
+            user_id="user1",
+        )
+        event = MessageEvent(
+            text="unrelated new root",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="new-root",
+        )
+        session_key = build_session_key(source)
+        runner.adapters[source.platform] = adapter
+
+        agent = MagicMock()
+        agent._supports_active_turn_redirect = True
+        agent.redirect = MagicMock(return_value=True)
+        runner._running_agents[session_key] = agent
+        entry = cm.register(
+            "clarify-old-root",
+            session_key,
+            "Answer in the old thread",
+            None,
+            route_scope={
+                "platform": "buzz",
+                "chat_id": "buzz-channel",
+                "thread_id": "old-root",
+            },
+        )
+
+        handled = await runner._handle_active_session_busy_message(event, session_key)
+
+        assert handled is False
+        assert entry.event.is_set()
+        assert "different conversation route" in (entry.response or "")
+        agent.redirect.assert_not_called()
+        adapter._send_with_retry.assert_not_awaited()
+        cm._entries.clear()
+        cm._session_index.clear()
+
 
     @pytest.mark.asyncio
     async def test_telegram_grace_followups_respect_queue_fifo(self, monkeypatch):

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -243,6 +243,22 @@ class TestMentionGating:
         await self._poll_with(adapter, _event("e1", content="hey @Chip can you help?", created_at=10))
         assert len(adapter._dispatched) == 1
 
+    @pytest.mark.asyncio
+    async def test_reply_root_propagates_to_dispatched_thread_id(self, adapter):
+        root_id = "f" * 64
+        await self._poll_with(
+            adapter,
+            _tagged_event(
+                "e1",
+                CHANNEL,
+                content="@Chip same-thread answer",
+                created_at=10,
+                reply_to=root_id,
+            ),
+        )
+
+        assert adapter._dispatched[0]["thread_id"] == root_id
+
 
     @pytest.mark.asyncio
     async def test_allowlist_blocks_unauthorized(self, adapter):

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -6,6 +6,7 @@ import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
+from gateway.session import build_session_key
 from tests.gateway._plugin_adapter_loader import load_plugin_adapter
 
 # Load plugins/platforms/buzz/adapter.py under a unique module name
@@ -258,6 +259,56 @@ class TestMentionGating:
         )
 
         assert adapter._dispatched[0]["thread_id"] == root_id
+
+    @pytest.mark.asyncio
+    async def test_top_level_command_confirmation_reply_uses_same_session(self):
+        """A reply to a top-level Buzz command must see its pending confirm."""
+        from tools import slash_confirm
+
+        adapter = _make_adapter()
+        dispatched = []
+
+        async def capture(event):
+            dispatched.append(event)
+
+        adapter._message_handler = capture
+        root_id = "f" * 64
+        reply_id = "e" * 64
+
+        await adapter._dispatch_message(
+            text="/new",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="tester",
+            message_id=root_id,
+            created_at=10,
+        )
+        await adapter._dispatch_message(
+            text="/always",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="tester",
+            message_id=reply_id,
+            created_at=11,
+            thread_id=root_id,
+        )
+
+        root_key = build_session_key(dispatched[0].source)
+        reply_key = build_session_key(dispatched[1].source)
+        slash_confirm.clear(root_key)
+
+        async def handler(_choice):
+            return "approved"
+
+        try:
+            slash_confirm.register(root_key, "confirm-1", "new", handler)
+            assert reply_key == root_key
+            assert slash_confirm.get_pending(reply_key) is not None
+        finally:
+            slash_confirm.clear(root_key)
+            slash_confirm.clear(reply_key)
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_clarify_active_session_bypass.py
+++ b/tests/gateway/test_clarify_active_session_bypass.py
@@ -61,6 +61,20 @@ def _buzz_thread_event(text="same-thread answer"):
     )
 
 
+def _buzz_dm_event(text="dm answer"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform("buzz"),
+            chat_id="buzz-dm",
+            chat_type="dm",
+            user_id="buzz-user",
+        ),
+        message_id="fresh-dm-message",
+    )
+
+
 def _clear_clarify_state():
     from tools import clarify_gateway as cm
 
@@ -136,3 +150,36 @@ async def test_active_session_routes_same_thread_buzz_clarify_reply_to_runner():
     assert adapter._pending_messages == {}
 
 
+@pytest.mark.asyncio
+async def test_active_buzz_dm_routes_untagged_clarify_reply_to_runner():
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _ClarifyBypassAdapter(Platform("buzz"))
+    adapter._message_handler = AsyncMock(return_value="")
+    adapter._busy_session_handler = AsyncMock(return_value=True)
+    event = _buzz_dm_event()
+    session_key = build_session_key(
+        event.source,
+        group_sessions_per_user=adapter.config.extra.get("group_sessions_per_user", True),
+        thread_sessions_per_user=adapter.config.extra.get("thread_sessions_per_user", False),
+    )
+    adapter._active_sessions[session_key] = asyncio.Event()
+    cm.register("clarify-buzz-dm", session_key, "Answer in this DM", None)
+
+    def route_scope_spy(
+        *, platform, chat_id, chat_type, thread_id=None, message_id=None
+    ):
+        assert str(getattr(platform, "value", platform)) == "buzz"
+        assert chat_id == "buzz-dm"
+        assert chat_type == "dm"
+        assert thread_id is None
+        assert message_id == "fresh-dm-message"
+        return None
+
+    with patch.object(cm, "build_route_scope", route_scope_spy):
+        await adapter.handle_message(event)
+
+    adapter._message_handler.assert_awaited_once_with(event)
+    adapter._busy_session_handler.assert_not_awaited()
+    assert adapter._pending_messages == {}

--- a/tests/gateway/test_clarify_active_session_bypass.py
+++ b/tests/gateway/test_clarify_active_session_bypass.py
@@ -16,8 +16,8 @@ from gateway.session import SessionSource, build_session_key
 
 
 class _ClarifyBypassAdapter(BasePlatformAdapter):
-    def __init__(self):
-        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(PlatformConfig(enabled=True, token="test"), platform)
 
     async def connect(self):
         return True
@@ -43,6 +43,21 @@ def _event(text="custom answer"):
             user_id="user1",
         ),
         message_id="msg1",
+    )
+
+
+def _buzz_thread_event(text="same-thread answer"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform("buzz"),
+            chat_id="buzz-channel",
+            chat_type="group",
+            user_id="buzz-user",
+            thread_id="original-root",
+        ),
+        message_id="reply-event",
     )
 
 
@@ -79,6 +94,40 @@ async def test_active_session_routes_typed_choice_clarify_reply_to_runner_not_bu
     )
     adapter._active_sessions[session_key] = asyncio.Event()
     cm.register("clarify-1", session_key, "Pick one", ["A", "B"])
+
+    await adapter.handle_message(event)
+
+    adapter._message_handler.assert_awaited_once_with(event)
+    adapter._busy_session_handler.assert_not_awaited()
+    assert adapter._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_active_session_routes_same_thread_buzz_clarify_reply_to_runner():
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _ClarifyBypassAdapter(Platform("buzz"))
+    adapter._message_handler = AsyncMock(return_value="")
+    adapter._busy_session_handler = AsyncMock(return_value=True)
+    event = _buzz_thread_event()
+    session_key = build_session_key(
+        event.source,
+        group_sessions_per_user=adapter.config.extra.get("group_sessions_per_user", True),
+        thread_sessions_per_user=adapter.config.extra.get("thread_sessions_per_user", False),
+    )
+    adapter._active_sessions[session_key] = asyncio.Event()
+    cm.register(
+        "clarify-buzz",
+        session_key,
+        "Answer in this thread",
+        None,
+        route_scope={
+            "platform": "buzz",
+            "chat_id": "buzz-channel",
+            "thread_id": "original-root",
+        },
+    )
 
     await adapter.handle_message(event)
 

--- a/tests/gateway/test_clarify_thread_followup_not_swallowed.py
+++ b/tests/gateway/test_clarify_thread_followup_not_swallowed.py
@@ -72,6 +72,21 @@ def _event(text):
     )
 
 
+def _buzz_event(text, *, message_id, thread_id=None):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform("buzz"),
+            chat_id="buzz-channel",
+            chat_type="group",
+            user_id="buzz-user",
+            thread_id=thread_id,
+        ),
+        message_id=message_id,
+    )
+
+
 def _clear_clarify_state():
     from tools import clarify_gateway as cm
 
@@ -150,6 +165,78 @@ async def test_prose_still_accepted_after_other_flips_text_capture():
     assert entry is not None
     assert entry.event.is_set()
     assert entry.response == "a carousel actually"
+    _clear_clarify_state()
+
+
+@pytest.mark.asyncio
+async def test_buzz_top_level_post_does_not_answer_clarify_from_another_thread():
+    """A new Buzz root must not resume a clarify owned by another thread."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _StubAdapter()
+    runner = _make_runner(adapter)
+    entry = cm.register(
+        "cl-buzz",
+        SESSION_KEY,
+        "What should I do next?",
+        None,
+        route_scope={
+            "platform": "buzz",
+            "chat_id": "buzz-channel",
+            "thread_id": "original-root",
+        },
+    )
+    assert entry.awaiting_text is True
+
+    unrelated = _buzz_event(
+        "Why did that appear in the channel?",
+        message_id="new-top-level-root",
+    )
+    with pytest.raises(_FellThroughIntercept):
+        await _dispatch(runner, unrelated)
+
+    with cm._lock:
+        entry = cm._entries.get("cl-buzz")
+    assert entry is not None
+    assert not entry.event.is_set()
+    _clear_clarify_state()
+
+
+@pytest.mark.asyncio
+async def test_buzz_same_thread_reply_resolves_pending_clarify():
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _StubAdapter()
+    runner = _make_runner(adapter)
+    cm.register(
+        "cl-buzz-same-thread",
+        SESSION_KEY,
+        "What should I do next?",
+        None,
+        route_scope={
+            "platform": "buzz",
+            "chat_id": "buzz-channel",
+            "thread_id": "original-root",
+        },
+    )
+
+    result = await _dispatch(
+        runner,
+        _buzz_event(
+            "Continue with the audit",
+            message_id="reply-event",
+            thread_id="original-root",
+        ),
+    )
+
+    assert result == ""
+    with cm._lock:
+        entry = cm._entries.get("cl-buzz-same-thread")
+    assert entry is not None
+    assert entry.event.is_set()
+    assert entry.response == "Continue with the audit"
     _clear_clarify_state()
 
 

--- a/tests/gateway/test_clarify_thread_followup_not_swallowed.py
+++ b/tests/gateway/test_clarify_thread_followup_not_swallowed.py
@@ -87,6 +87,20 @@ def _buzz_event(text, *, message_id, thread_id=None):
     )
 
 
+def _buzz_dm_event(text, *, message_id):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform("buzz"),
+            chat_id="buzz-dm",
+            chat_type="dm",
+            user_id="buzz-user",
+        ),
+        message_id=message_id,
+    )
+
+
 def _clear_clarify_state():
     from tools import clarify_gateway as cm
 
@@ -237,6 +251,44 @@ async def test_buzz_same_thread_reply_resolves_pending_clarify():
     assert entry is not None
     assert entry.event.is_set()
     assert entry.response == "Continue with the audit"
+    _clear_clarify_state()
+
+
+@pytest.mark.asyncio
+async def test_untagged_buzz_dm_reply_resolves_session_scoped_clarify():
+    """A fresh DM answer must not be mistaken for an unrelated Buzz route."""
+    _clear_clarify_state()
+    from tools import clarify_gateway as cm
+
+    adapter = _StubAdapter()
+    runner = _make_runner(adapter)
+    entry = cm.register(
+        "cl-buzz-dm",
+        SESSION_KEY,
+        "What should I do next?",
+        None,
+        route_scope=None,
+    )
+
+    def route_scope_spy(
+        *, platform, chat_id, chat_type, thread_id=None, message_id=None
+    ):
+        assert str(getattr(platform, "value", platform)) == "buzz"
+        assert chat_id == "buzz-dm"
+        assert chat_type == "dm"
+        assert thread_id is None
+        assert message_id == "fresh-dm-message"
+        return None
+
+    with patch.object(cm, "build_route_scope", route_scope_spy):
+        result = await _dispatch(
+            runner,
+            _buzz_dm_event("Continue in this DM", message_id="fresh-dm-message"),
+        )
+
+    assert result == ""
+    assert entry.event.is_set()
+    assert entry.response == "Continue in this DM"
     _clear_clarify_state()
 
 

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -222,6 +222,34 @@ class TestMarkResumePending:
         store.mark_resume_pending(entry.session_key, reason="shutdown_timeout")
         assert store._entries[entry.session_key].resume_reason == "shutdown_timeout"
 
+    def test_persists_latest_delivery_source_for_restart_resume(self, tmp_path):
+        """A shared channel session must resume in its active thread, not its stale origin."""
+        store = _make_store(tmp_path)
+        original = SessionSource(
+            platform=Platform("buzz"),
+            chat_id="channel-1",
+            chat_type="group",
+            user_id="u1",
+        )
+        entry = store.get_or_create_session(original)
+        latest = SessionSource(
+            platform=Platform("buzz"),
+            chat_id="channel-1",
+            chat_type="group",
+            user_id="u1",
+            thread_id="thread-root",
+            message_id="trigger-event",
+        )
+
+        assert store.mark_resume_pending(
+            entry.session_key,
+            source=latest,
+        ) is True
+
+        restored = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        restored._ensure_loaded()
+        assert restored._entries[entry.session_key].origin == latest
+
 
 class TestClearResumePending:
 
@@ -552,6 +580,12 @@ async def test_drain_timeout_marks_resume_pending():
         session_key_one: running_agent,
         session_key_two: MagicMock(),
     }
+    live_sources = {
+        session_key_one: make_restart_source(chat_id="A", thread_id="thread-a"),
+        session_key_two: make_restart_source(chat_id="B", thread_id="thread-b"),
+    }
+    for session_key, source in live_sources.items():
+        runner._cache_session_source(session_key, source)
 
     # Plug a mock session_store that records marks.
     session_store = MagicMock()
@@ -569,6 +603,7 @@ async def test_drain_timeout_marks_resume_pending():
     assert marked == {session_key_one, session_key_two}
     for args in calls:
         assert args[0][1] == "shutdown_timeout"
+        assert args.kwargs["source"] == live_sources[args[0][0]]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_clarify_gateway.py
+++ b/tests/tools/test_clarify_gateway.py
@@ -72,6 +72,39 @@ class TestClarifyPrimitive:
         assert pending is not None
         assert pending.clarify_id == "id3b"
 
+    def test_untagged_buzz_dm_messages_share_session_scoped_clarify(self):
+        """Fresh Buzz DM events must not derive per-message clarify routes."""
+        from tools import clarify_gateway as cm
+
+        registration_scope = cm.build_route_scope(
+            platform="buzz",
+            chat_id="dm-chat",
+            chat_type="dm",
+            message_id="trigger-message",
+        )
+        answer_scope = cm.build_route_scope(
+            platform="buzz",
+            chat_id="dm-chat",
+            chat_type="dm",
+            message_id="answer-message",
+        )
+
+        assert registration_scope is None
+        assert answer_scope is None
+        entry = cm.register(
+            "dm-clarify",
+            "buzz-dm-session",
+            "What next?",
+            None,
+            route_scope=registration_scope,
+        )
+        assert cm.resolve_text_response_for_session(
+            "buzz-dm-session",
+            "Continue",
+            route_scope=answer_scope,
+        ) is True
+        assert entry.response == "Continue"
+
 
     def test_clear_session_cancels_pending_entries(self):
         """clear_session unblocks blocked threads with empty response."""

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -78,17 +78,22 @@ def build_route_scope(
     *,
     platform: Any,
     chat_id: Any,
+    chat_type: Any = None,
     thread_id: Any = None,
     message_id: Any = None,
 ) -> Optional[Dict[str, str]]:
     """Return the bounded interactive scope for thread-aware platforms.
 
-    Buzz intentionally shares conversational sessions across a channel, but
-    pending interactive prompts must remain bound to the thread that displayed
-    them. A top-level triggering event becomes that thread's root.
+    Buzz channel prompts are bound to the thread that displayed them. A
+    top-level channel event becomes that thread's root. Buzz DMs keep their
+    existing conversation-wide session semantics and therefore need no
+    additional route scope.
     """
     platform_value = getattr(platform, "value", platform)
     if str(platform_value or "").strip().lower() != "buzz":
+        return None
+    normalized_chat_type = str(chat_type or "").strip().lower()
+    if normalized_chat_type in {"dm", "private"}:
         return None
     normalized_chat_id = str(chat_id or "").strip()
     normalized_thread_id = str(thread_id or message_id or "").strip()

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -35,7 +35,7 @@ import logging
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +55,7 @@ class _ClarifyEntry:
     event: threading.Event = field(default_factory=threading.Event)
     response: Optional[str] = None
     awaiting_text: bool = False  # set when user picked "Other" or clarify is open-ended
+    route_scope: Optional[Dict[str, str]] = None
 
     def signature(self) -> Dict[str, object]:
         return {
@@ -73,6 +74,43 @@ _entries: Dict[str, _ClarifyEntry] = {}
 _session_index: Dict[str, List[str]] = {}
 
 
+def build_route_scope(
+    *,
+    platform: Any,
+    chat_id: Any,
+    thread_id: Any = None,
+    message_id: Any = None,
+) -> Optional[Dict[str, str]]:
+    """Return the bounded interactive scope for thread-aware platforms.
+
+    Buzz intentionally shares conversational sessions across a channel, but
+    pending interactive prompts must remain bound to the thread that displayed
+    them. A top-level triggering event becomes that thread's root.
+    """
+    platform_value = getattr(platform, "value", platform)
+    if str(platform_value or "").strip().lower() != "buzz":
+        return None
+    normalized_chat_id = str(chat_id or "").strip()
+    normalized_thread_id = str(thread_id or message_id or "").strip()
+    if not normalized_chat_id or not normalized_thread_id:
+        return None
+    return {
+        "platform": "buzz",
+        "chat_id": normalized_chat_id,
+        "thread_id": normalized_thread_id,
+    }
+
+
+def _normalize_route_scope(route_scope: Any) -> Optional[Dict[str, str]]:
+    if not isinstance(route_scope, dict):
+        return None
+    return build_route_scope(
+        platform=route_scope.get("platform"),
+        chat_id=route_scope.get("chat_id"),
+        thread_id=route_scope.get("thread_id"),
+    )
+
+
 # =========================================================================
 # Public API — agent-thread side
 # =========================================================================
@@ -83,6 +121,7 @@ def register(
     question: str,
     choices: Optional[List[str]],
     multi_select: bool = False,
+    route_scope: Optional[Dict[str, str]] = None,
 ) -> _ClarifyEntry:
     """Register a pending clarify request and return the entry.
 
@@ -97,6 +136,7 @@ def register(
         multi_select=bool(multi_select) and bool(choices),
         # Open-ended (no choices) → next message IS the response, no buttons needed.
         awaiting_text=not bool(choices),
+        route_scope=_normalize_route_scope(route_scope),
     )
     with _lock:
         _entries[clarify_id] = entry
@@ -180,6 +220,7 @@ def get_pending_for_session(
     session_key: str,
     *,
     include_choice_prompts: bool = False,
+    route_scope: Optional[Dict[str, str]] = None,
 ) -> Optional[_ClarifyEntry]:
     """Return the oldest pending clarify entry for a session, or None.
 
@@ -190,11 +231,17 @@ def get_pending_for_session(
     oldest unresolved clarify is returned so the text can resolve it instead
     of being queued as an unrelated follow-up turn.
     """
+    normalized_route_scope = _normalize_route_scope(route_scope)
     with _lock:
         ids = _session_index.get(session_key) or []
         for cid in ids:
             entry = _entries.get(cid)
             if entry is None:
+                continue
+            if (
+                entry.route_scope is not None
+                and entry.route_scope != normalized_route_scope
+            ):
                 continue
             if include_choice_prompts or entry.awaiting_text:
                 return entry
@@ -313,13 +360,22 @@ def _coerce_multi_select_text(entry: _ClarifyEntry, text: str) -> Optional[str]:
     return _json.dumps(selected, ensure_ascii=False)
 
 
-def resolve_text_response_for_session(session_key: str, response: str) -> bool:
+def resolve_text_response_for_session(
+    session_key: str,
+    response: str,
+    *,
+    route_scope: Optional[Dict[str, str]] = None,
+) -> bool:
     """Resolve the oldest pending clarify in ``session_key`` from typed text.
 
     Returns False if no pending clarify exists or if the response was rejected
     (arbitrary prose for native interactive multi-choice clarifies).
     """
-    entry = get_pending_for_session(session_key, include_choice_prompts=True)
+    entry = get_pending_for_session(
+        session_key,
+        include_choice_prompts=True,
+        route_scope=route_scope,
+    )
     if entry is None:
         return False
 

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -248,6 +248,36 @@ def get_pending_for_session(
         return None
 
 
+def resolve_pending_outside_route(
+    session_key: str,
+    route_scope: Optional[Dict[str, str]],
+    response: str,
+) -> bool:
+    """Resolve a scoped clarify when the user continues on another route.
+
+    The unrelated message is not used as the clarify answer. The supplied
+    internal response only releases the blocked turn so the adapter can queue
+    the new routed event as its own follow-up turn.
+    """
+    normalized_route_scope = _normalize_route_scope(route_scope)
+    if normalized_route_scope is None:
+        return False
+    with _lock:
+        ids = _session_index.get(session_key) or []
+        for cid in ids:
+            entry = _entries.get(cid)
+            if (
+                entry is None
+                or entry.route_scope is None
+                or entry.route_scope == normalized_route_scope
+            ):
+                continue
+            entry.response = str(response)
+            entry.event.set()
+            return True
+    return False
+
+
 def _coerce_text_response(entry: _ClarifyEntry, response: str) -> Optional[str]:
     """Map typed choice replies to canonical choice text, otherwise keep or reject custom text.
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -105,10 +105,10 @@ gateway:
 
 Pending interactive questions are scoped to the Buzz thread where Hermes sent
 them. A reply in that thread can answer the pending prompt, while an unrelated
-top-level channel post starts its own conversation instead of being consumed as
-the answer to an older clarification. Hermes can still share conversation
-history across Buzz threads; only the pending interaction and its delivery route
-are thread-scoped.
+top-level channel post cancels the old pending interaction and is queued as its
+own routed turn instead of being consumed as the clarification answer. Hermes
+can still share conversation history across Buzz threads; only the pending
+interaction and its delivery route are thread-scoped.
 
 ## Access control
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -101,6 +101,15 @@ gateway:
 - Direct messages always reach the agent, no mention needed.
 - The agent's own messages are never dispatched back to it (self-echo suppression by pubkey), and every event is de-duplicated by event id against a per-channel high-water mark.
 
+### Threads and interactive prompts
+
+Pending interactive questions are scoped to the Buzz thread where Hermes sent
+them. A reply in that thread can answer the pending prompt, while an unrelated
+top-level channel post starts its own conversation instead of being consumed as
+the answer to an older clarification. Hermes can still share conversation
+history across Buzz threads; only the pending interaction and its delivery route
+are thread-scoped.
+
 ## Access control
 
 By default the allow-list is empty, which means every community member who mentions the agent gets a response only if `BUZZ_ALLOW_ALL_USERS=true`; otherwise restrict access by listing npubs or hex pubkeys in `BUZZ_ALLOWED_USERS` (or `allowed_users` in config.yaml). Community membership itself is enforced by the relay — only members can post.

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -104,11 +104,12 @@ gateway:
 ### Threads and interactive prompts
 
 Pending interactive questions are scoped to the Buzz thread where Hermes sent
-them. A reply in that thread can answer the pending prompt, while an unrelated
-top-level channel post cancels the old pending interaction and is queued as its
-own routed turn instead of being consumed as the clarification answer. Hermes
-can still share conversation history across Buzz threads; only the pending
-interaction and its delivery route are thread-scoped.
+them. A top-level channel event is treated as its own thread root, so the
+initiating command and replies such as `/approve`, `/always`, and `/cancel`
+resolve to the same gateway session. An unrelated top-level channel post
+cancels the old pending interaction and is queued as its own routed turn
+instead of being consumed as the clarification answer. Each Buzz thread keeps
+its own conversation history and delivery route.
 
 ## Access control
 


### PR DESCRIPTION
## Summary

Fix Buzz thread-route continuity across interactive Gateway flows:

- keep blocked clarification follow-ups and restart recovery on their originating route
- treat each top-level Buzz channel event as its own synthetic thread root, so a destructive command and its threaded `/approve`, `/always`, or `/cancel` reply resolve under the same session key
- keep unrelated top-level roots as independent sessions with independently pending clarifications
- keep Buzz DMs conversation-scoped, including untagged clarification replies
- retain current `main`'s Nostr thread-root parsing instead of duplicating it
- document the resulting thread/session behavior

## User-visible failures

A top-level destructive command could display:

```text
Reply `/approve`, `/always`, or `/cancel`.
```

but reject the user's threaded response as:

```text
Unknown command `/always`.
```

The initiating event had `thread_id=None`, while the reply carried the initiating event as its root. That produced different session keys, so the pending confirmation was invisible.

The same route mismatch also affected blocked clarifications and restart recovery: replies could be consumed by the wrong pending interaction or delivered outside the route where the interaction began.

## Approach

- Buzz channel roots use their own event ID as the effective thread ID; replies reuse current `main`'s parsed Nostr root ID.
- Pending Buzz channel clarifications retain an explicit `{platform, chat_id, thread_id}` route scope.
- An unrelated channel root cannot answer or cancel another thread's pending interaction.
- Clarification resolution remains first-writer-wins, so a late route event cannot overwrite an accepted answer.
- Buzz `dm` and `private` chats deliberately receive no extra route scope, preserving their existing conversation-wide semantics.
- Restart recovery persists and restores the pending delivery route.
- The earlier `_event_reply_target` / NIP-10 derivation was removed because current `main` already supplies `_extract_thread_root`.

## Compatibility note

This intentionally changes Buzz channel history semantics: each new top-level channel post starts a separate thread-scoped Gateway session, and replies under that post reuse it. Existing channel sessions are therefore re-keyed after upgrade. Separate roots remain independently pending until answered or timed out. Buzz does not currently expose a Slack-style `reply_in_thread=false` opt-out.

Direct-message session behavior is unchanged.

## Tests

Added regression coverage for:

- top-level command ↔ threaded confirmation session-key continuity
- same-thread versus unrelated-root clarification isolation
- first-writer-wins clarification resolution
- independent pending clarifications under separate roots
- blocked-session clarification bypass
- untagged Buzz DM clarification replies at the primitive, runner-intercept, and base-adapter layers
- restart recovery delivery routes

Local verification at exact SHA `b61a9d0564dcbe8ededdfe790dc75d9b1e3e0031`:

- focused Buzz/clarification/restart suite: **281 passed**
- full Gateway candidate suite: **7,288 passed, 3 failed, 36 skipped**
- the lease-timeout failure passed immediately when rerun alone: **13 passed**
- the remaining two WeCom callback failures reproduce on exact `upstream/main` in this environment because `defusedxml` is unavailable
- Ruff, Python compilation, and `git diff --check`: passed

Independent exact-head review returned **APPROVE** with no blocking findings.