### PR TITLE
chore: add contributor email mapping for wangyunyou

### DIFF
--- a/contributors/emails/wangyunyou@leoao.com
+++ b/contributors/emails/wangyunyou@leoao.com
@@ -1,0 +1,1 @@
+wangyunyou


### PR DESCRIPTION
Attribution mapping for @wangyunyou (wangyunyou@leoao.com), needed by the #76341 salvage.