### PR TITLE
fix(credential_pool): check copilot suppression before token exchange (salvage #76341)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2387,17 +2387,33 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # env vars (COPILOT_GITHUB_TOKEN / GH_TOKEN).  They don't live in
         # the auth store or credential pool, so we resolve them here.
         try:
-            from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
+            from hermes_cli.copilot_auth import (
+                COPILOT_ENV_VARS,
+                resolve_copilot_token,
+                get_copilot_api_token,
+            )
+            # All-sources suppression gate BEFORE any work — including the
+            # `gh auth token` subprocess spawn.  resolve_copilot_token()
+            # shells out (~30ms), and the exchange retries 3x with backoff
+            # (~13s worst case); a user who suppressed every copilot source
+            # (hermes auth remove copilot gh_cli) must not pay either on
+            # every pool load (model picker open, /model, agent startup).
+            # Enumerating the full source space here matches what
+            # credential_sources._remove_copilot_gh suppresses, so an
+            # all-suppressed check is stable.
+            copilot_sources = ["gh_cli"] + [f"env:{v}" for v in COPILOT_ENV_VARS]
+            if all(_is_suppressed(provider, s) for s in copilot_sources):
+                return changed, active_sources
             token, source = resolve_copilot_token()
             if token:
                 source_name = "gh_cli" if "gh" in source.lower() else f"env:{source}"
-                # Suppression gate BEFORE the network exchange.  The
-                # exchange retries 3x with backoff (~13s worst case), so a
-                # source the user already suppressed (hermes auth remove
-                # copilot gh_cli) must not burn that dead time on every pool
-                # load (model picker open, /model, agent startup) just to
-                # have the entry discarded afterwards.  This is the same
-                # early-gate pattern every other singleton branch uses.
+                # Per-source suppression gate (a user may suppress only the
+                # gh CLI path and keep an env var, or vice versa) BEFORE the
+                # network exchange.  The exchange retries 3x with backoff
+                # (~13s worst case), so a source the user already suppressed
+                # must not burn that dead time just to have the entry
+                # discarded afterwards.  Same early-gate pattern every other
+                # singleton branch uses.
                 if _is_suppressed(provider, source_name):
                     return changed, active_sources
                 api_token, enterprise_base_url = get_copilot_api_token(token)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2395,7 +2395,7 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
             # All-sources suppression gate BEFORE any work — including the
             # `gh auth token` subprocess spawn.  resolve_copilot_token()
             # shells out (~30ms), and the exchange retries 3x with backoff
-            # (~13s worst case); a user who suppressed every copilot source
+            # (~35s worst case); a user who suppressed every copilot source
             # (hermes auth remove copilot gh_cli) must not pay either on
             # every pool load (model picker open, /model, agent startup).
             # Enumerating the full source space here matches what
@@ -2406,11 +2406,17 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                 return changed, active_sources
             token, source = resolve_copilot_token()
             if token:
-                source_name = "gh_cli" if "gh" in source.lower() else f"env:{source}"
+                # ``resolve_copilot_token`` returns exactly "gh auth token"
+                # for the CLI path; env-sourced tokens return the var name.
+                # Match exactly — a substring test classifies GH_TOKEN and
+                # GITHUB_TOKEN as gh_cli, silently bypassing a user's
+                # per-env-var suppression.
+                source_name = "gh_cli" if source == "gh auth token" else f"env:{source}"
                 # Per-source suppression gate (a user may suppress only the
                 # gh CLI path and keep an env var, or vice versa) BEFORE the
-                # network exchange.  The exchange retries 3x with backoff
-                # (~13s worst case), so a source the user already suppressed
+                # network exchange.  The exchange retries 3x with 10s
+                # timeouts and 4.5s total backoff (~35s worst case), so a
+                # source the user already suppressed
                 # must not burn that dead time just to have the entry
                 # discarded afterwards.  Same early-gate pattern every other
                 # singleton branch uses.

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2390,6 +2390,16 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
             from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
             token, source = resolve_copilot_token()
             if token:
+                source_name = "gh_cli" if "gh" in source.lower() else f"env:{source}"
+                # Suppression gate BEFORE the network exchange.  The
+                # exchange retries 3x with backoff (~13s worst case), so a
+                # source the user already suppressed (hermes auth remove
+                # copilot gh_cli) must not burn that dead time on every pool
+                # load (model picker open, /model, agent startup) just to
+                # have the entry discarded afterwards.  This is the same
+                # early-gate pattern every other singleton branch uses.
+                if _is_suppressed(provider, source_name):
+                    return changed, active_sources
                 api_token, enterprise_base_url = get_copilot_api_token(token)
                 # Observability: get_copilot_api_token falls back to returning
                 # the RAW token when the exchange fails. A raw ~40-char token
@@ -2405,27 +2415,25 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                         "unavailable); enterprise-only models may 400 with "
                         "model_not_available_for_integrator until exchange recovers."
                     )
-                source_name = "gh_cli" if "gh" in source.lower() else f"env:{source}"
-                if not _is_suppressed(provider, source_name):
-                    active_sources.add(source_name)
-                    pconfig = PROVIDER_REGISTRY.get(provider)
-                    # Use enterprise base URL from token exchange if available,
-                    # otherwise fall back to the provider's default.
-                    effective_base_url = enterprise_base_url or (
-                        pconfig.inference_base_url if pconfig else ""
-                    )
-                    changed |= _upsert_entry(
-                        entries,
-                        provider,
-                        source_name,
-                        {
-                            "source": source_name,
-                            "auth_type": AUTH_TYPE_API_KEY,
-                            "access_token": api_token,
-                            "base_url": effective_base_url,
-                            "label": source,
-                        },
-                    )
+                active_sources.add(source_name)
+                pconfig = PROVIDER_REGISTRY.get(provider)
+                # Use enterprise base URL from token exchange if available,
+                # otherwise fall back to the provider's default.
+                effective_base_url = enterprise_base_url or (
+                    pconfig.inference_base_url if pconfig else ""
+                )
+                changed |= _upsert_entry(
+                    entries,
+                    provider,
+                    source_name,
+                    {
+                        "source": source_name,
+                        "auth_type": AUTH_TYPE_API_KEY,
+                        "access_token": api_token,
+                        "base_url": effective_base_url,
+                        "label": source,
+                    },
+                )
         except Exception as exc:
             logger.debug("Copilot token seed failed: %s", exc)
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1352,6 +1352,51 @@ def test_load_pool_seeds_copilot_via_gh_auth_token(tmp_path, monkeypatch):
     assert entries[0].base_url == "https://api.githubcopilot.com"
 
 
+def test_load_pool_skips_exchange_for_suppressed_copilot(tmp_path, monkeypatch):
+    """A suppressed copilot source must NOT run the token exchange.
+
+    Regression test: the suppression gate used to sit AFTER
+    ``get_copilot_api_token`` (which retries 3x with backoff, ~13s worst
+    case), so every pool load — model picker open, /model, agent startup —
+    burned the full exchange dead time for a source the user had already
+    removed with ``hermes auth remove copilot gh_cli``.  The gate must run
+    BEFORE the network call.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {},
+            "suppressed_sources": {"copilot": ["gh_cli"]},
+        },
+    )
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("gho_fake_token_abc123", "gh auth token"),
+    )
+
+    exchange_called = False
+
+    def _boom(token):
+        nonlocal exchange_called
+        exchange_called = True
+        raise AssertionError("exchange must not run for a suppressed source")
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.get_copilot_api_token",
+        _boom,
+    )
+
+    from agent.credential_pool import load_pool
+    pool = load_pool("copilot")
+
+    assert not exchange_called
+    assert not pool.has_credentials()
+    assert pool.entries() == []
+
+
 
 
 def test_load_pool_seeds_qwen_oauth_via_cli_tokens(tmp_path, monkeypatch):

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1397,6 +1397,106 @@ def test_load_pool_skips_exchange_for_suppressed_copilot(tmp_path, monkeypatch):
     assert pool.entries() == []
 
 
+def test_load_pool_respects_env_var_copilot_suppression(tmp_path, monkeypatch):
+    """Suppressing env:GH_TOKEN must gate a GH_TOKEN-sourced token.
+
+    Regression test for the source_name classification: a substring match
+    (``"gh" in source.lower()``) classified GH_TOKEN/GITHUB_TOKEN as gh_cli,
+    so a user's env-var-specific suppression was silently bypassed and the
+    exchange ran anyway.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {},
+            "suppressed_sources": {"copilot": ["env:GH_TOKEN"]},
+        },
+    )
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("gho_fake_token_env", "GH_TOKEN"),
+    )
+
+    exchange_called = False
+
+    def _boom(token):
+        nonlocal exchange_called
+        exchange_called = True
+        raise AssertionError("exchange must not run for a suppressed env source")
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.get_copilot_api_token",
+        _boom,
+    )
+
+    from agent.credential_pool import load_pool
+    pool = load_pool("copilot")
+
+    assert not exchange_called
+    assert pool.entries() == []
+
+
+def test_load_pool_gh_cli_suppression_does_not_block_env_tokens(tmp_path, monkeypatch):
+    """Suppressing gh_cli must NOT swallow an env-var-sourced token.
+
+    The inverse of the substring bug: GH_TOKEN misclassified as gh_cli meant
+    suppressing the CLI path also silently dropped env tokens.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {},
+            "suppressed_sources": {"copilot": ["gh_cli"]},
+        },
+    )
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("gho_fake_token_env", "GH_TOKEN"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.get_copilot_api_token",
+        lambda token: ("capi_exchanged_token", None),
+    )
+
+    from agent.credential_pool import load_pool
+    pool = load_pool("copilot")
+
+    assert [e.source for e in pool.entries()] == ["env:GH_TOKEN"]
+
+
+def test_load_pool_skips_resolve_when_all_copilot_sources_suppressed(tmp_path, monkeypatch):
+    """With every copilot source suppressed, resolve_copilot_token (which
+    shells out to ``gh auth token``) must not run at all."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from hermes_cli.copilot_auth import COPILOT_ENV_VARS
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {},
+            "suppressed_sources": {
+                "copilot": ["gh_cli"] + [f"env:{v}" for v in COPILOT_ENV_VARS],
+            },
+        },
+    )
+
+    def _boom():
+        raise AssertionError("resolve_copilot_token must not run when all sources are suppressed")
+
+    monkeypatch.setattr("hermes_cli.copilot_auth.resolve_copilot_token", _boom)
+
+    from agent.credential_pool import load_pool
+    pool = load_pool("copilot")
+
+    assert pool.entries() == []
+
+
 
 
 def test_load_pool_seeds_qwen_oauth_via_cli_tokens(tmp_path, monkeypatch):


### PR DESCRIPTION
Salvages #76341 by @wangyunyou — both commits cherry-picked to preserve authorship, plus one review-fold commit fixing a classification bug the early gate made decisive.

## Context — what this fixes, for whom

Anyone with a suppressed copilot source (`hermes auth remove copilot gh_cli`): every `load_pool("copilot")` — model picker open, `/model`, agent startup — ran the full token exchange (3 retries x 10s timeouts + 4.5s backoff, ~35s worst case) and THEN discarded the result at the post-exchange suppression check. The PR moves the gate before the network call and adds an all-sources early exit that skips even the `gh auth token` subprocess.

## Review fold (the salvage's addition)

The per-source gate classifies with `"gh" in source.lower()` — which classifies `GH_TOKEN` and `GITHUB_TOKEN` as `gh_cli` (substring match). Pre-existing on main, but this PR makes the classification decide whether the exchange runs at all: a user who suppressed `env:GH_TOKEN` would have the suppression silently bypassed, and one who suppressed `gh_cli` would silently lose env-sourced tokens. Fixed to match `resolve_copilot_token`'s exact `"gh auth token"` sentinel, with 3 regression tests (env-var suppression gates the exchange / gh_cli suppression doesn't swallow env tokens / all-sources suppression skips the resolve subprocess). Also corrected the "~13s" worst-case comment (actual: ~35s from copilot_auth's constants).

## Verification

- `tests/agent/test_credential_pool.py -k "copilot or suppress"`: 5 passed (PR's regression test + 3 new + 1 adjacent)
- Mutation check: revert credential_pool.py to main → 3 tests fail; restore → 5 pass
- ruff clean
- Merge-order note: this is the first of the credential_pool trio (#76341 → #67642 → #71775); it touches only `_seed_from_singletons`, no overlap with the other two.

Closes #76341 (superseded by this salvage — original author credited via cherry-pick authorship).
