### PR TITLE
fix(gateway): gate compaction completion notice under compression.progress_notices

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -48,6 +48,7 @@ from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union,
 
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
 from agent.conversation_compression import (
+    COMPACTION_DONE_STATUS,
     COMPACTION_STATUS,
     COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE,
     COMPRESSION_RETRY_MESSAGES_STATUS_TEMPLATE,
@@ -169,6 +170,7 @@ _COMPRESSION_PROGRESS_STATUS_RE = re.compile(
         _status_template_to_regex(_template)
         for _template in (
             COMPACTION_STATUS,
+            COMPACTION_DONE_STATUS,
             PRE_API_COMPRESSION_STATUS_TEMPLATE,
             PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,
             IDLE_COMPACTION_STATUS_TEMPLATE,

--- a/tests/gateway/test_compression_progress_notices.py
+++ b/tests/gateway/test_compression_progress_notices.py
@@ -78,22 +78,24 @@ def test_enabled_still_suppresses_non_compression_noise(
 
 @pytest.mark.parametrize("enabled", [True, False], ids=["enabled", "default"])
 @pytest.mark.parametrize("platform", CHAT_PLATFORMS)
-def test_compaction_completion_notice_reaches_chat(monkeypatch, platform, enabled):
-    """The #69546 'compacted' lifecycle edge is deliverable on chat surfaces.
+def test_compaction_completion_notice_respects_progress_notices_gate(
+    monkeypatch, platform, enabled
+):
+    """The #69546 'compacted' lifecycle edge follows the opt-in gate.
 
-    COMPACTION_DONE_STATUS already flows through the status callback on
-    compaction completion and is not matched by the noise regex — the opt-in
-    gate must not change that in either mode, so users who enable
-    progress_notices see the completion stat notice paired with the start.
+    With ``compression.progress_notices: false`` the completion notice is
+    routine compression chatter and must stay suppressed. With ``true`` it
+    is delivered, paired with the start notice.
     """
     monkeypatch.setattr(
         gateway_run,
         "_load_gateway_config",
         lambda: {"compression": {"progress_notices": enabled}},
     )
+    expected = COMPACTION_DONE_STATUS if enabled else None
     assert (
         _prepare_gateway_status_message(platform, "compacted", COMPACTION_DONE_STATUS)
-        == COMPACTION_DONE_STATUS
+        == expected
     )
 
 


### PR DESCRIPTION
Closes #77549.

- Add `COMPACTION_DONE_STATUS` to `_COMPRESSION_PROGRESS_STATUS_RE`
- Import `COMPACTION_DONE_STATUS` in `gateway/run.py`
- Update test to assert completion notice respects `progress_notices` flag

With `compression.progress_notices: false`, both routine compression start and completion notices are now suppressed. With `true`, both are delivered.