### PR TITLE
chore: add contributor email mapping for szzhoujiarui

### DIFF
--- a/contributors/emails/szzhoujiarui@users.noreply.github.com
+++ b/contributors/emails/szzhoujiarui@users.noreply.github.com
@@ -1,0 +1,1 @@
+szzhoujiarui


### PR DESCRIPTION
Attribution mapping for @szzhoujiarui (bare-login noreply form, not auto-resolvable), needed by the #76072 salvage.