### PR TITLE
fix(whatsapp): populate botIds on poll vote events

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -345,6 +345,17 @@ function enqueuePollUpdateEvent({ key, update, selectedOptions, aggregation }) {
   const dedupeId = `poll:${pollId}:${senderId}:${selectedOptions.join('|')}`;
   if (recentlyProcessedPollUpdates.has(dedupeId)) return;
   recentlyProcessedPollUpdates.remember(dedupeId);
+  // Every poll reaching this point was sent by us (recentlySentIds check
+  // above), so the vote is inherently a reply to our own message. Populate
+  // botIds/quotedParticipant so the gateway's reply-to-bot/mention gate
+  // recognizes it — otherwise a poll vote in a mention-gated group
+  // (require_mention: true) satisfies none of "/command", "@mention", or
+  // "reply to bot" and is silently dropped before the agent ever sees it,
+  // leaving any clarify() question that used the poll stuck forever.
+  const botIds = Array.from(new Set([
+    normalizeWhatsAppId(sock?.user?.id),
+    normalizeWhatsAppId(sock?.user?.lid),
+  ].filter(Boolean)));
   const event = {
     messageId: `${pollId || 'poll'}:update:${Date.now()}`,
     chatId,
@@ -368,11 +379,11 @@ function enqueuePollUpdateEvent({ key, update, selectedOptions, aggregation }) {
     mediaUrls: [],
     mentionedIds: [],
     quotedMessageId: pollId,
-    quotedParticipant: '',
+    quotedParticipant: botIds[0] || '',
     quotedRemoteJid: chatId,
     quotedText: '',
     hasQuotedMessage: !!pollId,
-    botIds: [],
+    botIds,
     timestamp: Math.floor(Date.now() / 1000),
   };
   messageQueue.push(event);

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -343,6 +343,17 @@ function enqueuePollUpdateEvent({ key, update, selectedOptions, aggregation }) {
   const dedupeId = `poll:${pollId}:${senderId}:${selectedOptions.join('|')}`;
   if (recentlyProcessedPollUpdates.has(dedupeId)) return;
   recentlyProcessedPollUpdates.remember(dedupeId);
+  // Every poll reaching this point was sent by us (recentlySentIds check
+  // above), so the vote is inherently a reply to our own message. Populate
+  // botIds/quotedParticipant so the gateway's reply-to-bot/mention gate
+  // recognizes it — otherwise a poll vote in a mention-gated group
+  // (require_mention: true) satisfies none of "/command", "@mention", or
+  // "reply to bot" and is silently dropped before the agent ever sees it,
+  // leaving any clarify() question that used the poll stuck forever.
+  const botIds = Array.from(new Set([
+    normalizeWhatsAppId(sock?.user?.id),
+    normalizeWhatsAppId(sock?.user?.lid),
+  ].filter(Boolean)));
   const event = {
     messageId: `${pollId || 'poll'}:update:${Date.now()}`,
     chatId,
@@ -366,11 +377,11 @@ function enqueuePollUpdateEvent({ key, update, selectedOptions, aggregation }) {
     mediaUrls: [],
     mentionedIds: [],
     quotedMessageId: pollId,
-    quotedParticipant: '',
+    quotedParticipant: botIds[0] || '',
     quotedRemoteJid: chatId,
     quotedText: '',
     hasQuotedMessage: !!pollId,
-    botIds: [],
+    botIds,
     timestamp: Math.floor(Date.now() / 1000),
   };
   messageQueue.push(event);

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -137,6 +137,42 @@ def test_mention_stripping_removes_bot_phone_from_body():
     assert "weather" in cleaned
 
 
+def test_poll_vote_on_own_poll_passes_mention_gate_in_group():
+    # scripts/whatsapp-bridge/bridge.js's enqueuePollUpdateEvent used to
+    # hardcode botIds: [] and quotedParticipant: '' for every poll vote,
+    # even though a vote is only ever surfaced for polls the bot itself
+    # sent (gated upstream by recentlySentIds.has(pollId)). In a
+    # mention-gated group the vote's text (the chosen option) satisfies
+    # none of "/command", "@mention", or "reply to bot", so it was
+    # silently dropped before the agent ever saw it — any clarify()
+    # question rendered as a poll then hung forever. The fix populates
+    # botIds/quotedParticipant from the bot's own identity, since the vote
+    # is inherently a reply to the bot's poll message.
+    adapter = _make_adapter(require_mention=True, group_policy="open")
+
+    # Old (buggy) bridge.js shape: blank botIds/quotedParticipant on every
+    # poll vote event, regardless of whose poll it was.
+    buggy_poll_vote_event = _group_message(
+        "Dogs - Leia",
+        mediaType="poll_update",
+        quotedParticipant="",
+        botIds=[],
+        hasQuotedMessage=True,
+    )
+    assert adapter._should_process_message(buggy_poll_vote_event) is False
+
+    # Fixed shape: botIds/quotedParticipant populated from the bot's own
+    # identity, since every event reaching this path is a vote on a poll
+    # the bot itself sent.
+    fixed_poll_vote_event = _group_message(
+        "Dogs - Leia",
+        mediaType="poll_update",
+        quotedParticipant="15551230000@s.whatsapp.net",
+        hasQuotedMessage=True,
+    )
+    assert adapter._should_process_message(fixed_poll_vote_event) is True
+
+
 # --- New dm_policy tests ---
 
 


### PR DESCRIPTION
## Summary

`enqueuePollUpdateEvent` (`scripts/whatsapp-bridge/bridge.js`) hardcoded `botIds: []` and `quotedParticipant: ''` for every poll vote event, even though this function only ever runs for polls Hermes itself sent (gated a few lines above by `recentlySentIds.has(pollId)`).

In a mention-gated group (`require_mention: true`), the gateway's `_should_process_message` requires one of: a `/`command, an @-mention, a reply-to-bot match, or a configured wake word. A poll vote's body is just the chosen option text (e.g. "Dogs - Leia"), which satisfies none of those, and the blank `botIds`/`quotedParticipant` meant the reply-to-bot check always failed too. The vote was silently dropped before the agent ever saw it, so any `clarify()` question rendered as a poll hung indefinitely once posted to a mention-gated group — no error on either side, the user just sees an unanswered poll and the agent sits waiting forever.

Since every vote reaching this function belongs to a poll the bot itself sent, this populates `botIds`/`quotedParticipant` from the bot's own identity (`sock.user.id` / `sock.user.lid`), matching the pattern already used for regular messages elsewhere in the file.

## Test plan

- `uv run pytest tests/gateway/test_whatsapp_group_gating.py` — new case `test_poll_vote_on_own_poll_passes_mention_gate_in_group` asserts the old blank-`botIds`/`quotedParticipant` shape is rejected by `_should_process_message` in a mention-gated group, and the fixed shape (populated from the bot's identity) is accepted. 11/11 passed.
- `node --check scripts/whatsapp-bridge/bridge.js` — parses OK.
- `node --test scripts/whatsapp-bridge/bridge.native.test.mjs` — unaffected, still passing (this function lives in `bridge.js` itself, which can't be unit-imported directly since it starts a live Baileys socket on load; the meaningful regression sits at the Python gating layer where the bug actually manifested).