### PR TITLE
fix(webhook): verify Juniper Mist v2 signatures

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1067,6 +1067,14 @@ class WebhookAdapter(BasePlatformAdapter):
         if gl_token:
             return _hmac_str_equal(gl_token, secret)
 
+        # Juniper Mist: X-Mist-Signature-v2 = <hex HMAC-SHA256 of raw body>
+        mist_sig_v2 = request.headers.get("X-Mist-Signature-v2", "")
+        if mist_sig_v2:
+            expected_mist_v2 = hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return _hmac_str_equal(mist_sig_v2, expected_mist_v2)
+
         # Generic V2: X-Webhook-Signature-V2 = <hex HMAC-SHA256 of "<timestamp>.<body>">
         #             X-Webhook-Timestamp = <unix seconds> (required for V2)
         # Checked independently of (and before) legacy V1 below — a sender

--- a/tests/gateway/test_webhook_signature_rate_limit.py
+++ b/tests/gateway/test_webhook_signature_rate_limit.py
@@ -53,6 +53,11 @@ def _github_signature(body: bytes, secret: str) -> str:
     ).hexdigest()
 
 
+def _mist_signature_v2(body: bytes, secret: str) -> str:
+    """Compute Mist's X-Mist-Signature-v2 HMAC-SHA256 digest."""
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
 SIMPLE_PAYLOAD = {"event": "test", "data": "hello"}
 
 
@@ -138,5 +143,78 @@ class TestSignatureBeforeRateLimit:
 
         # The valid event should have been captured
         assert len(captured_events) == 1
+
+
+class TestMistSignature:
+    @pytest.mark.asyncio
+    async def test_valid_mist_v2_signature_is_accepted(self):
+        secret = "mist-test-secret"
+        route_name = "mist"
+        adapter = _make_adapter(
+            {
+                route_name: {
+                    "secret": secret,
+                    "prompt": "Mist topic: {topic}",
+                    "deliver": "log",
+                }
+            }
+        )
+        captured_events = []
+
+        async def _capture(event):
+            captured_events.append(event)
+
+        adapter.handle_message = _capture
+        body = json.dumps({"topic": "alarms", "events": []}).encode()
+
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            resp = await cli.post(
+                f"/webhooks/{route_name}",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Mist-Signature-v2": _mist_signature_v2(body, secret),
+                },
+            )
+
+            assert resp.status == 202
+
+        assert len(captured_events) == 1
+
+    @pytest.mark.asyncio
+    async def test_mist_v2_signature_rejects_tampered_body(self):
+        secret = "mist-test-secret"
+        route_name = "mist"
+        adapter = _make_adapter(
+            {
+                route_name: {
+                    "secret": secret,
+                    "prompt": "Mist topic: {topic}",
+                    "deliver": "log",
+                }
+            }
+        )
+        captured_events = []
+
+        async def _capture(event):
+            captured_events.append(event)
+
+        adapter.handle_message = _capture
+        original = json.dumps({"topic": "alarms", "events": []}).encode()
+        tampered = json.dumps({"topic": "alarms", "events": [{"evil": True}]}).encode()
+
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            resp = await cli.post(
+                f"/webhooks/{route_name}",
+                data=tampered,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Mist-Signature-v2": _mist_signature_v2(original, secret),
+                },
+            )
+
+            assert resp.status == 401
+
+        assert captured_events == []
 
 


### PR DESCRIPTION
## Summary
- accept Juniper Mist `X-Mist-Signature-v2` webhook signatures
- verify the documented raw-body HMAC-SHA256 hex digest with constant-time comparison
- add positive and tampered-body regression coverage

## Problem
Mist signs webhook bodies with `X-Mist-Signature-v2`, but the generic webhook adapter did not recognize that header, so correctly signed Mist deliveries were rejected with HTTP 401.

## Test plan
- [x] RED: valid Mist v2 signature returned 401 before implementation
- [x] `tests/gateway/test_webhook_signature_rate_limit.py` — 3 passed
- [x] webhook-focused suite — 65 passed before the additional tamper regression
- [x] Ruff check passes for both changed files
- [x] Live provider acceptance: Mist ping traversed Cloudflare Access and Hermes and returned HTTP 200; tampered local body returned 401

No signature secrets or environment-specific configuration are included.