### PR TITLE
fix(dashboard): translate Shift+Enter to the TUI newline sequence

### DIFF
--- a/web/src/lib/terminalKeys.test.ts
+++ b/web/src/lib/terminalKeys.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { SHIFT_ENTER_SEQUENCE, shiftEnterSequence } from "./terminalKeys";
+
+describe("shiftEnterSequence", () => {
+  it("maps Shift+Enter to the TUI sequence", () => {
+    expect(shiftEnterSequence({ key: "Enter", shiftKey: true })).toBe(
+      SHIFT_ENTER_SEQUENCE,
+    );
+  });
+
+  it("returns null for bare Enter", () => {
+    expect(shiftEnterSequence({ key: "Enter", shiftKey: false })).toBeNull();
+  });
+
+  it("returns null for non-Enter keys even with Shift held", () => {
+    expect(shiftEnterSequence({ key: "Enter", shiftKey: false })).toBeNull();
+    expect(shiftEnterSequence({ key: "a", shiftKey: true })).toBeNull();
+  });
+
+  it("emits the exact sequence the TUI parser recognises (ESC[13;2u)", () => {
+    expect(SHIFT_ENTER_SEQUENCE).toBe("\u001b[13;2u");
+  });
+});

--- a/web/src/lib/terminalKeys.ts
+++ b/web/src/lib/terminalKeys.ts
@@ -1,0 +1,31 @@
+/**
+ * Terminal key mapping for the embedded TUI (xterm.js).
+ *
+ * xterm.js collapses Shift+Enter into a bare `\r` — it never emits the
+ * modified-key sequence the Hermes TUI expects for a multiline line break.
+ * The dashboard therefore translates the DOM keydown into the sequence the
+ * TUI already understands (see ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts:
+ * `ESC[13;2u` = Shift+Enter, and ui-tui/src/components/textInput.tsx, where
+ * `k.return && k.shift` inserts `\n` instead of submitting).
+ */
+export const SHIFT_ENTER_SEQUENCE = "\x1b[13;2u";
+
+/** Minimal keyboard-event shape the mapping reads. */
+export interface ShiftEnterCandidate {
+  key: string;
+  shiftKey: boolean;
+}
+
+/**
+ * Returns the terminal sequence to feed the PTY when the keydown is
+ * Shift+Enter, or `null` for any other key. Pure, so it is unit-testable
+ * without a DOM.
+ */
+export function shiftEnterSequence(
+  ev: ShiftEnterCandidate,
+): string | null {
+  if (ev.key === "Enter" && ev.shiftKey) {
+    return SHIFT_ENTER_SEQUENCE;
+  }
+  return null;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -55,6 +55,7 @@ import {
   transferMayContainImage,
   uploadChatImage,
 } from "@/lib/chatImagePaste";
+import { shiftEnterSequence } from "@/lib/terminalKeys";
 import { PluginSlot } from "@/plugins";
 import { useTheme } from "@/themes";
 import { useProfileScope } from "@/contexts/useProfileScope";
@@ -695,6 +696,18 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             console.warn("[dashboard clipboard] paste failed:", message);
           }
         })();
+        return false;
+      }
+
+      // Shift+Enter must reach the TUI as a newline, not a submit. xterm.js
+      // collapses Shift+Enter into a bare \r (identical to plain Enter), so
+      // the TUI's multiline composer never sees the modifier and sends the
+      // message instead of inserting a line break. Translate the DOM keydown
+      // into the modified-key sequence the TUI already parses (ESC[13;2u).
+      const tuiSequence = shiftEnterSequence(ev);
+      if (tuiSequence) {
+        ev.preventDefault();
+        term.input(tuiSequence);
         return false;
       }
 


### PR DESCRIPTION
## Problème

Sur le dashboard web (`hermes dashboard`), **Shift+Entrée n'insère pas de nouvelle ligne** dans le champ de chat — il se comporte comme Entrée seul (envoie le message).

### Cause racine

Le dashboard embarque le TUI Hermes dans un terminal **xterm.js** (`ChatPage.tsx` : *« embeds `hermes --tui` inside the dashboard »*). Les frappes passent par xterm.js → WebSocket → PTY → TUI.

Le TUI **gère correctement** Shift+Entrée (`ui-tui/src/components/textInput.tsx`, `k.return && k.shift` → insertion de `\n`, sinon `cbSubmit`) et attend la séquence modifiée `ESC[13;2u` (reconnue dans `ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts`).

Mais **xterm.js réduit Shift+Entrée à un simple `\r`** (identique à Entrée) — il n'émet jamais `ESC[13;2u`. Le TUI reçoit donc un Entrée simple et envoie le message au lieu d'insérer un saut de ligne.

## Correctif

Dans le handler `attachCustomKeyEventHandler` existant de `ChatPage.tsx`, intercepter le keydown Shift+Entrée et l'injecter dans le terminal via `term.input("\x1b[13;2u")` — la séquence que le TUI sait déjà interpréter.

La logique de mapping est extraite dans une fonction pure `shiftEnterSequence()` (`web/src/lib/terminalKeys.ts`) pour être testable, avec couverture vitest.

## Tests

```bash
cd web && npx vitest run src/lib/terminalKeys.test.ts
# ✓ 4 tests passed
```

`tsc -p . --noEmit` : aucune erreur.

## Impact

- Aucun changement de comportement pour les autres touches (copy/paste, Ctrl+C SIGINT conservés)
- Shift+Entrée fonctionne maintenant comme attendu dans le TUI embarqué (multiligne)
- Entrée seul continue d'envoyer