### PR TITLE
fix(api_server): hydrate /v1/runs session history + membrane TG outbox

### DIFF
--- a/gateway/membrane_outbound.py
+++ b/gateway/membrane_outbound.py
@@ -1,0 +1,249 @@
+"""Queue for Telegram membrane (L2) outbound deliveries from L1 seats.
+
+Membrane L1 seats speak Telegram through a shared L2 router that alone
+holds the fleet bot token. Interactive replies flow L2→L1→L2, but cron /
+async delivery call ``PlatformAdapter.send()`` on the L1 ``api_server``
+adapter — which cannot talk to Telegram Bot API.
+
+This module gives L1 a durable outbox. L2 polls ``GET /v1/membrane/outbound``
+(via the existing reverse tunnels) and delivers with the fleet token.
+
+Fail-open for the agent path: enqueue errors are logged, never raise into
+cron/send callers unless the caller needs the bool return.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sqlite3
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_DB_LOCK = threading.Lock()
+_MAX_ROWS = 200
+_RETENTION_SECONDS = 3 * 24 * 60 * 60
+
+# chat_id shapes produced by tg_router session_id / cron origin
+_TELEGRAM_DM_RE = re.compile(r"^(?:telegram:dm:)?(\d+)$", re.I)
+
+
+def parse_telegram_chat_id(chat_id: Any) -> Optional[str]:
+    """Return bare numeric Telegram chat/user id, or None if not a TG DM target."""
+    if chat_id is None:
+        return None
+    s = str(chat_id).strip()
+    m = _TELEGRAM_DM_RE.match(s)
+    return m.group(1) if m else None
+
+
+def _db_path():
+    return get_hermes_home() / "state.db"
+
+
+def _connect() -> sqlite3.Connection:
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path), timeout=10)
+    try:
+        from hermes_state import apply_wal_with_fallback
+
+        apply_wal_with_fallback(conn, db_label="state.db (membrane_outbound)")
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS membrane_outbound (
+                id TEXT PRIMARY KEY,
+                chat_id TEXT NOT NULL,
+                thread_id TEXT,
+                content TEXT NOT NULL,
+                metadata_json TEXT,
+                state TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                claimed_at REAL,
+                claim_token TEXT,
+                last_error TEXT
+            )"""
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_membrane_outbound_state "
+            "ON membrane_outbound(state, created_at)"
+        )
+    except Exception:
+        conn.close()
+        raise
+    return conn
+
+
+@contextmanager
+def _transaction() -> Iterator[sqlite3.Connection]:
+    conn = _connect()
+    try:
+        with conn:
+            yield conn
+    finally:
+        conn.close()
+
+
+def enqueue(
+    *,
+    chat_id: str,
+    content: str,
+    thread_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Enqueue a membrane TG delivery. Returns row id or None on failure."""
+    tg_chat = parse_telegram_chat_id(chat_id)
+    if not tg_chat:
+        return None
+    text = (content or "").strip()
+    if not text:
+        return None
+    now = time.time()
+    row_id = f"mo_{uuid.uuid4().hex[:20]}"
+    meta_json = json.dumps(metadata or {}, ensure_ascii=False, default=str)
+    try:
+        with _DB_LOCK, _transaction() as conn:
+            conn.execute(
+                """INSERT INTO membrane_outbound
+                   (id, chat_id, thread_id, content, metadata_json, state,
+                    created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, 'pending', ?, ?)""",
+                (
+                    row_id,
+                    tg_chat,
+                    str(thread_id) if thread_id is not None else None,
+                    text,
+                    meta_json,
+                    now,
+                    now,
+                ),
+            )
+            _prune(conn, now)
+        logger.info(
+            "membrane_outbound enqueued id=%s chat_id=%s chars=%d",
+            row_id,
+            tg_chat,
+            len(text),
+        )
+        return row_id
+    except Exception:
+        logger.warning("membrane_outbound enqueue failed", exc_info=True)
+        return None
+
+
+def list_pending(limit: int = 20) -> List[Dict[str, Any]]:
+    """Return pending (and stale claimed) rows oldest-first without claiming."""
+    limit = max(1, min(int(limit or 20), 100))
+    now = time.time()
+    stale_before = now - 120.0  # reclaim claims older than 2 min
+    with _DB_LOCK, _transaction() as conn:
+        rows = conn.execute(
+            """SELECT id, chat_id, thread_id, content, metadata_json,
+                      state, created_at
+               FROM membrane_outbound
+               WHERE state = 'pending'
+                  OR (state = 'claimed' AND claimed_at IS NOT NULL AND claimed_at < ?)
+               ORDER BY created_at ASC
+               LIMIT ?""",
+            (stale_before, limit),
+        ).fetchall()
+    out: List[Dict[str, Any]] = []
+    for r in rows:
+        try:
+            meta = json.loads(r[4] or "{}")
+        except json.JSONDecodeError:
+            meta = {}
+        out.append(
+            {
+                "id": r[0],
+                "chat_id": r[1],
+                "thread_id": r[2],
+                "content": r[3],
+                "metadata": meta,
+                "state": r[5],
+                "created_at": r[6],
+            }
+        )
+    return out
+
+
+def claim(ids: List[str], *, claim_token: Optional[str] = None) -> List[str]:
+    """Mark rows claimed. Returns ids successfully claimed."""
+    if not ids:
+        return []
+    token = claim_token or uuid.uuid4().hex
+    now = time.time()
+    claimed: List[str] = []
+    with _DB_LOCK, _transaction() as conn:
+        for oid in ids:
+            cur = conn.execute(
+                """UPDATE membrane_outbound
+                   SET state='claimed', claimed_at=?, claim_token=?, updated_at=?
+                   WHERE id=? AND state IN ('pending', 'claimed')""",
+                (now, token, now, oid),
+            )
+            if cur.rowcount:
+                claimed.append(oid)
+    return claimed
+
+
+def ack(ids: List[str], *, ok: bool = True, error: Optional[str] = None) -> int:
+    """Mark claimed rows delivered or re-queue on failure."""
+    if not ids:
+        return 0
+    now = time.time()
+    n = 0
+    with _DB_LOCK, _transaction() as conn:
+        for oid in ids:
+            if ok:
+                cur = conn.execute(
+                    """UPDATE membrane_outbound
+                       SET state='delivered', updated_at=?, last_error=NULL
+                       WHERE id=?""",
+                    (now, oid),
+                )
+            else:
+                cur = conn.execute(
+                    """UPDATE membrane_outbound
+                       SET state='pending', claimed_at=NULL, claim_token=NULL,
+                           updated_at=?, last_error=?
+                       WHERE id=?""",
+                    (now, (error or "delivery_failed")[:500], oid),
+                )
+            n += cur.rowcount
+        _prune(conn, now)
+    return n
+
+
+def _prune(conn: sqlite3.Connection, now: float) -> None:
+    cutoff = now - _RETENTION_SECONDS
+    conn.execute(
+        """DELETE FROM membrane_outbound
+           WHERE state='delivered' AND updated_at < ?""",
+        (cutoff,),
+    )
+    total = conn.execute("SELECT COUNT(*) FROM membrane_outbound").fetchone()[0]
+    excess = max(0, total - _MAX_ROWS)
+    if excess:
+        conn.execute(
+            """DELETE FROM membrane_outbound WHERE id IN (
+                 SELECT id FROM membrane_outbound
+                 ORDER BY CASE state
+                            WHEN 'delivered' THEN 0
+                            ELSE 1
+                          END, updated_at ASC
+                 LIMIT ?)""",
+            (excess,),
+        )
+
+
+def is_membrane_telegram_target(chat_id: Any) -> bool:
+    return parse_telegram_chat_id(chat_id) is not None

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -19,6 +19,8 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
 - POST /v1/runs/{run_id}/approval — resolve a pending run approval
 - POST /v1/runs/{run_id}/stop       — interrupt a running agent
+- GET  /v1/membrane/outbound       — list pending membrane TG outbox (L2 poller)
+- POST /v1/membrane/outbound/ack   — ack delivered membrane outbox rows
 - GET  /health                     — health check
 - GET  /health/detailed            — rich status for cross-container dashboard probing
 
@@ -1975,6 +1977,8 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
             ("POST", "/v1/runs/{run_id}/approval", self._handle_run_approval),
             ("POST", "/v1/runs/{run_id}/stop", self._handle_stop_run),
+            ("GET", "/v1/membrane/outbound", self._handle_membrane_outbound_list),
+            ("POST", "/v1/membrane/outbound/ack", self._handle_membrane_outbound_ack),
         ]
         if _CRON_AVAILABLE:
             # Chronos managed-cron fire webhook (NAS → agent). Authenticated
@@ -6281,7 +6285,8 @@ class APIServerAdapter(BasePlatformAdapter):
         previous_response_id = body.get("previous_response_id")
 
         # Accept explicit conversation_history from the request body.
-        # Precedence: explicit conversation_history > previous_response_id.
+        # Precedence: explicit conversation_history > previous_response_id >
+        # multi-message input array > SessionDB load when session_id is set.
         conversation_history: List[Dict[str, str]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
@@ -6324,7 +6329,32 @@ class APIServerAdapter(BasePlatformAdapter):
                         )
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
-        session_id = body.get("session_id") or stored_session_id
+        # Client-provided session_id (e.g. tg_router membrane: telegram:dm:<uid>).
+        # When no history was supplied in the body, hydrate from SessionDB so
+        # consecutive /v1/runs share context — same contract as X-Hermes-Session-Id
+        # on /v1/chat/completions. Without this, every membrane turn lands with
+        # history=0 even though messages are persisted under the stable session_id.
+        client_session_id = body.get("session_id") or stored_session_id
+        if client_session_id is not None:
+            client_session_id = str(client_session_id).strip() or None
+        if not conversation_history and client_session_id:
+            try:
+                loaded = await self._conversation_history_for_session(client_session_id)
+                if loaded:
+                    conversation_history = list(loaded)
+                    logger.info(
+                        "Hydrated %d history message(s) from SessionDB for session_id=%s",
+                        len(conversation_history),
+                        client_session_id,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to load session history for /v1/runs session_id=%s: %s",
+                    client_session_id,
+                    exc,
+                )
+
+        session_id = client_session_id
         route = self._resolve_route(body.get("model"))
         agent_overrides = _request_agent_overrides(body, virtual_model=self._model_name)
         selection_error = self._request_route_conflict_error(
@@ -7130,9 +7160,85 @@ class APIServerAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """
-        Not used — HTTP request/response cycle handles delivery directly.
+        Push outbound text for membrane Telegram targets into the L1 outbox.
+
+        The HTTP API itself is request/response (interactive replies are pulled
+        by the caller of /v1/runs). Cron and async delivery still call
+        ``adapter.send()`` with the origin chat id stamped by tg_router
+        (``telegram:dm:<uid>``). Those cannot reach Bot API from L1 — the fleet
+        token lives only on L2 — so we durable-queue and let L2 poll
+        ``GET /v1/membrane/outbound``.
         """
-        return SendResult(success=False, error="API server uses HTTP request/response, not send()")
+        from gateway.membrane_outbound import enqueue, is_membrane_telegram_target
+
+        if is_membrane_telegram_target(chat_id):
+            meta = dict(metadata or {})
+            if reply_to and "reply_to" not in meta:
+                meta["reply_to"] = reply_to
+            row_id = enqueue(
+                chat_id=str(chat_id),
+                content=content or "",
+                thread_id=meta.get("thread_id"),
+                metadata=meta,
+            )
+            if row_id:
+                return SendResult(success=True, message_id=row_id)
+            return SendResult(
+                success=False,
+                error="membrane outbound enqueue failed",
+            )
+        return SendResult(
+            success=False,
+            error="API server uses HTTP request/response, not send()",
+        )
+
+    async def _handle_membrane_outbound_list(self, request: "web.Request") -> "web.Response":
+        """GET /v1/membrane/outbound — L2 poller pulls pending TG deliveries."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            limit = int(request.query.get("limit") or 20)
+        except (TypeError, ValueError):
+            limit = 20
+        from gateway.membrane_outbound import claim, list_pending
+
+        pending = await asyncio.to_thread(list_pending, limit)
+        ids = [p["id"] for p in pending if p.get("id")]
+        claim_token = request.headers.get("X-Hermes-Claim-Token") or None
+        claimed_ids = await asyncio.to_thread(claim, ids, claim_token=claim_token) if ids else []
+        claimed_set = set(claimed_ids)
+        items = [p for p in pending if p.get("id") in claimed_set]
+        return web.json_response(
+            {
+                "object": "hermes.membrane_outbound.list",
+                "items": items,
+                "count": len(items),
+            }
+        )
+
+    async def _handle_membrane_outbound_ack(self, request: "web.Request") -> "web.Response":
+        """POST /v1/membrane/outbound/ack — L2 confirms Bot API delivery."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+        ids = body.get("ids") or body.get("id") or []
+        if isinstance(ids, str):
+            ids = [ids]
+        if not isinstance(ids, list) or not ids:
+            return web.json_response(_openai_error("Missing 'ids'"), status=400)
+        ok = body.get("ok", True)
+        if isinstance(ok, str):
+            ok = ok.strip().lower() not in {"0", "false", "no", "off"}
+        error = body.get("error")
+        from gateway.membrane_outbound import ack
+
+        n = await asyncio.to_thread(ack, [str(i) for i in ids], ok=bool(ok), error=error)
+        return web.json_response({"object": "hermes.membrane_outbound.ack", "acked": n})
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about the API server."""

--- a/tests/gateway/test_api_server_membrane.py
+++ b/tests/gateway/test_api_server_membrane.py
@@ -1,0 +1,165 @@
+"""Tests for /v1/runs session history hydration + membrane outbound send path."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    cors_middleware,
+    security_headers_middleware,
+)
+from gateway.platforms.base import SendResult
+
+
+def _make_adapter(api_key: str = "sk-secret") -> APIServerAdapter:
+    config = PlatformConfig(enabled=True, extra={"key": api_key} if api_key else {})
+    return APIServerAdapter(config)
+
+
+def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
+    app.router.add_get("/v1/membrane/outbound", adapter._handle_membrane_outbound_list)
+    app.router.add_post("/v1/membrane/outbound/ack", adapter._handle_membrane_outbound_ack)
+    return app
+
+
+class TestRunsSessionHistoryHydration:
+    @pytest.mark.asyncio
+    async def test_session_id_loads_history_from_db(self):
+        """Membrane path: body.session_id + empty history → SessionDB hydrate."""
+        adapter = _make_adapter()
+        db_history = [
+            {"role": "user", "content": "ticket de caisse ..."},
+            {"role": "assistant", "content": "total 351 €"},
+        ]
+        captured = {}
+
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _run(user_message=None, conversation_history=None, task_id=None):
+                    captured["user_message"] = user_message
+                    captured["conversation_history"] = conversation_history
+                    return {"final_response": "ok prix inclus"}
+
+                mock_agent.run_conversation.side_effect = _run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                with patch.object(
+                    adapter,
+                    "_conversation_history_for_session",
+                    new_callable=AsyncMock,
+                    return_value=db_history,
+                ) as mock_load:
+                    auth = {"Authorization": "Bearer sk-secret"}
+                    resp = await cli.post(
+                        "/v1/runs",
+                        headers=auth,
+                        json={
+                            "input": "le prix inclut deja la multiplication",
+                            "session_id": "telegram:dm:8078895371",
+                        },
+                    )
+                    assert resp.status == 202
+                    data = await resp.json()
+                    run_id = data["run_id"]
+                    for _ in range(40):
+                        st = await (await cli.get(f"/v1/runs/{run_id}", headers=auth)).json()
+                        if st.get("status") == "completed":
+                            break
+                        await asyncio.sleep(0.05)
+
+                mock_load.assert_awaited()
+                assert mock_load.await_args.args[0] == "telegram:dm:8078895371"
+
+        assert captured["user_message"] == "le prix inclut deja la multiplication"
+        assert captured["conversation_history"] == db_history
+
+    @pytest.mark.asyncio
+    async def test_explicit_history_skips_db_load(self):
+        adapter = _make_adapter()
+        body_history = [{"role": "user", "content": "from body"}]
+        captured = {}
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _run(user_message=None, conversation_history=None, task_id=None):
+                    captured["history"] = conversation_history
+                    return {"final_response": "ok"}
+
+                mock_agent.run_conversation.side_effect = _run
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                with patch.object(
+                    adapter,
+                    "_conversation_history_for_session",
+                    new_callable=AsyncMock,
+                ) as mock_load:
+                    auth = {"Authorization": "Bearer sk-secret"}
+                    resp = await cli.post(
+                        "/v1/runs",
+                        headers=auth,
+                        json={
+                            "input": "hi",
+                            "session_id": "telegram:dm:1",
+                            "conversation_history": body_history,
+                        },
+                    )
+                    assert resp.status == 202
+                    data = await resp.json()
+                    for _ in range(40):
+                        st = await (
+                            await cli.get(f"/v1/runs/{data['run_id']}", headers=auth)
+                        ).json()
+                        if st.get("status") == "completed":
+                            break
+                        await asyncio.sleep(0.05)
+                mock_load.assert_not_awaited()
+
+        assert captured["history"] == body_history
+
+
+class TestApiServerMembraneSend:
+    @pytest.mark.asyncio
+    async def test_send_enqueues_telegram_dm_target(self):
+        adapter = _make_adapter()
+        with patch(
+            "gateway.membrane_outbound.enqueue", return_value="mo_abc"
+        ) as mock_enq:
+            result = await adapter.send(
+                "telegram:dm:8078895371",
+                "cron veille report",
+            )
+        assert isinstance(result, SendResult)
+        assert result.success is True
+        assert result.message_id == "mo_abc"
+        mock_enq.assert_called_once()
+        assert mock_enq.call_args.kwargs["chat_id"] == "telegram:dm:8078895371"
+
+    @pytest.mark.asyncio
+    async def test_send_non_telegram_still_rejected(self):
+        adapter = _make_adapter()
+        result = await adapter.send("not-a-tg-target", "hi")
+        assert result.success is False
+        assert "HTTP request/response" in (result.error or "")

--- a/tests/gateway/test_membrane_outbound.py
+++ b/tests/gateway/test_membrane_outbound.py
@@ -1,0 +1,55 @@
+"""Unit tests for gateway.membrane_outbound outbox."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from gateway import membrane_outbound as mo
+
+
+@pytest.fixture()
+def tmp_hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # hermes_constants reads env at call time via get_hermes_home
+    yield home
+
+
+def test_parse_telegram_chat_id():
+    assert mo.parse_telegram_chat_id("telegram:dm:8078895371") == "8078895371"
+    assert mo.parse_telegram_chat_id("8078895371") == "8078895371"
+    assert mo.parse_telegram_chat_id("api_server:foo") is None
+    assert mo.parse_telegram_chat_id("") is None
+
+
+def test_enqueue_list_claim_ack(tmp_hermes_home):
+    rid = mo.enqueue(
+        chat_id="telegram:dm:42",
+        content="hello cron",
+        metadata={"source": "test"},
+    )
+    assert rid and rid.startswith("mo_")
+    pending = mo.list_pending()
+    assert len(pending) == 1
+    assert pending[0]["chat_id"] == "42"
+    assert pending[0]["content"] == "hello cron"
+
+    claimed = mo.claim([rid])
+    assert claimed == [rid]
+
+    n = mo.ack([rid], ok=True)
+    assert n == 1
+    assert mo.list_pending() == []
+
+
+def test_ack_failure_requeues(tmp_hermes_home):
+    rid = mo.enqueue(chat_id="42", content="retry me")
+    mo.claim([rid])
+    mo.ack([rid], ok=False, error="bot 429")
+    pending = mo.list_pending()
+    assert len(pending) == 1
+    assert pending[0]["id"] == rid


### PR DESCRIPTION
## Summary
- **P0:** `/v1/runs` now hydrates conversation history from SessionDB when a stable `session_id` is provided and the body has no explicit `conversation_history`. Fixes membrane/bridge deployments where every turn landed with `history=0` despite persisted messages.
- **P0bis:** `api_server.send()` for Telegram DM targets enqueues into a durable L1 outbox; L2 polls `GET /v1/membrane/outbound` (+ ack) so cron/async delivery works without putting the fleet bot token on L1.
- Unit tests for hydrate precedence and outbox claim/ack.

## Context
AAAS shared Telegram membrane: L2 posts `session_id=telegram:dm:<uid>` + latest input only. Without hydrate, clients saw a new context on every message. Live smoke after deploy: fresh session T1 `history=0` → T2 `Hydrated 2` and recall OK.

## Test plan
- [x] `pytest tests/gateway/test_api_server_membrane.py tests/gateway/test_membrane_outbound.py` (7 passed)
- [x] Live membrane seat: consecutive `/v1/runs` with same `session_id` show `Hydrated N` / `history>0`
- [x] Outbox path: enqueue via send → L2 claim/deliver/ack