### PR TITLE
fix(desktop): detach global new sessions from projects

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1667,9 +1667,22 @@ describe('createBackendSessionForSend workspace target', () => {
   })
 })
 describe('selectSidebarItem', () => {
+  afterEach(() => {
+    cleanup()
+    $currentCwd.set('')
+    setNewChatWorkspaceTarget(undefined)
+    $projectScope.set(ALL_PROJECTS)
+  })
+
   it('starts the global New session entry detached from the focused workspace', async () => {
     const navigate = vi.fn()
-    const requestGateway = vi.fn(async () => ({}) as never)
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        return { session_id: RUNTIME_SESSION_ID, stored_session_id: null } as never
+      }
+
+      return {} as never
+    })
     let handle: HarnessHandle | null = null
 
     $projectScope.set(ALL_PROJECTS)
@@ -1685,6 +1698,15 @@ describe('selectSidebarItem', () => {
 
     expect($currentCwd.get()).toBe('')
     expect($newChatWorkspaceTarget.get()).toBeNull()
+
+    await act(async () => {
+      await handle!.createBackendSessionForSend()
+    })
+
+    expect(requestGateway).toHaveBeenCalledWith(
+      'session.create',
+      expect.not.objectContaining({ cwd: expect.anything() })
+    )
   })
 
   it('fronts the workspace pane when navigating to a sidebar route (issue #72602)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1667,6 +1667,26 @@ describe('createBackendSessionForSend workspace target', () => {
   })
 })
 describe('selectSidebarItem', () => {
+  it('starts the global New session entry detached from the focused workspace', async () => {
+    const navigate = vi.fn()
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+
+    $projectScope.set(ALL_PROJECTS)
+    $currentCwd.set('/work/adaptit-ai-first-assessment')
+    $newChatWorkspaceTarget.set(undefined)
+
+    render(<Harness navigate={navigate} onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    act(() => {
+      handle!.selectSidebarItem({ action: 'new-session', icon: (() => null) as never, id: 'new', label: 'New session' })
+    })
+
+    expect($currentCwd.get()).toBe('')
+    expect($newChatWorkspaceTarget.get()).toBeNull()
+  })
+
   it('fronts the workspace pane when navigating to a sidebar route (issue #72602)', async () => {
     const navigate = vi.fn()
     const requestGateway = vi.fn(async () => ({}) as never)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -453,7 +453,11 @@ export function useSessionActions({
   const selectSidebarItem = useCallback(
     (item: SidebarNavItem) => {
       if (item.action === 'new-session') {
-        startFreshSessionDraft()
+        // The global New session entry is the escape hatch from the current
+        // workspace. Project/worktree add buttons pass an explicit path through
+        // startSessionInWorkspace; this route must be explicitly detached so an
+        // unrelated chat cannot inherit the focused session's repository.
+        startFreshSessionDraft({ workspaceTarget: null })
 
         return
       }


### PR DESCRIPTION
## Summary
- make the global New session action clear the focused Project/workspace target
- preserve explicit Project + behaviour for Project-rooted sessions
- add a regression test that failed before the fix and passes after it

## Verification
- `npx vitest run --project ui src/app/session/hooks/use-session-actions.test.tsx` - 41 passed
- `npm run --workspace apps/desktop test:ui` - 3,312 passed across 384 files
- `npm run --workspace apps/desktop typecheck` - passed
- `npm run --workspace apps/desktop lint` - zero errors (existing repository warnings only)
- `git diff --check` - passed

## Scope
This intentionally does not add historical session moves. A safe move operation must update the full compression lineage, synchronise any live gateway session, and preserve cwd-relative attachments; that will be a separate change.