### PR TITLE
fix(security): create browser-profile and media-cache artifacts owner-only

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -133,6 +133,69 @@ def chrome_debug_data_dir() -> str:
     return str(get_hermes_home() / "chrome-debug")
 
 
+def _ensure_chrome_debug_data_dir(data_dir: str) -> None:
+    """Create the Chromium user-data-dir owner-only (0700).
+
+    ``chrome-debug`` is a real Chromium profile: Cookies, Login Data, and
+    Local Storage live here. Created with a bare ``os.makedirs`` it inherited
+    the umask and landed 0755, so every other local account could list and
+    read those stores. ``HERMES_HOME`` is 0700 by default, which contains the
+    damage — but the documented ``HERMES_HOME_MODE=0701`` hatch (so nginx can
+    traverse to a served subdirectory) makes a 0755 child genuinely
+    world-readable. Defence in depth, at the one directory where the payoff
+    for reading it is a logged-in session.
+
+    The mode is passed to ``os.makedirs`` so it is set *at creation* — no
+    window where the profile sits world-readable before a follow-up chmod.
+    Policy is then reconciled by ``hermes_cli.config._secure_dir``, the house
+    helper, rather than a hand-rolled chmod: it skips managed/NixOS installs,
+    honours ``HERMES_HOME_MODE``, and applies ``HERMES_UID``/``HERMES_GID``
+    ownership so a root-created dir does not lock out uid-mapped Docker
+    workers (#34107).
+
+    Reconciling unconditionally also heals a profile an older Hermes left at
+    0755, which is the whole point — the exposure is on disk already. It is
+    safe against a *running* browser: only group/other bits are dropped, the
+    owner keeps ``rwx``, and POSIX checks the mode at ``open()`` rather than
+    on already-open descriptors, so an attached Chromium keeps reading and
+    writing its profile. On Windows POSIX mode bits are advisory (``chmod``
+    only toggles the read-only flag), so this is best-effort there and the
+    directory keeps its inherited ACLs.
+    """
+    os.makedirs(data_dir, mode=0o700, exist_ok=True)
+    try:
+        from hermes_cli.config import _secure_dir
+
+        _secure_dir(data_dir)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("browser debug launch: profile dir chmod skipped: %s", exc)
+
+
+def _open_launch_stderr_log(path: str):
+    """Open the launch stderr log owner-only (0600), truncating as before.
+
+    Opened with a plain ``open(path, "wb")`` this landed 0644 under a default
+    umask — a fixed, guessable name inside the profile dir hardened just
+    above. Under ``HERMES_HOME_MODE=0701`` the directory is traversable but
+    unlistable, so a predictable filename is exactly the case that stays
+    reachable; the uuid-named files elsewhere in the profile do not.
+
+    The mode is passed to ``os.open`` so it applies at creation. ``O_TRUNC``
+    keeps the existing per-candidate overwrite semantics, and on an
+    already-existing log the inode's mode is left alone — matching
+    ``tools.computer_use.tool._write_private_bytes``, the house pattern for
+    bytes Hermes itself writes. Falls back to a plain open rather than
+    failing the launch, since losing the diagnostic log is better than
+    losing the browser.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    try:
+        fd = os.open(path, flags, 0o600)
+    except OSError:
+        return open(path, "wb")
+    return os.fdopen(fd, "wb")
+
+
 def _chrome_debug_args(port: int) -> list[str]:
     return [
         f"--remote-debugging-port={port}",
@@ -375,12 +438,12 @@ def launch_chrome_debug(
         return result
 
     data_dir = chrome_debug_data_dir()
-    os.makedirs(data_dir, exist_ok=True)
+    _ensure_chrome_debug_data_dir(data_dir)
     stderr_path = os.path.join(data_dir, _LAUNCH_STDERR_LOG)
 
     for candidate in candidates:
         try:
-            with open(stderr_path, "wb") as stderr_file:
+            with _open_launch_stderr_log(stderr_path) as stderr_file:
                 proc = subprocess.Popen(
                     [candidate, *_chrome_debug_args(port)],
                     stdout=subprocess.DEVNULL,

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -218,20 +218,66 @@ def _open_launch_stderr_log(path: str):
     unlistable, so a predictable filename is exactly the case that stays
     reachable; the uuid-named files elsewhere in the profile do not.
 
-    The mode is passed to ``os.open`` so it applies at creation. ``O_TRUNC``
-    keeps the existing per-candidate overwrite semantics, and on an
-    already-existing log the inode's mode is left alone — matching
-    ``tools.computer_use.tool._write_private_bytes``, the house pattern for
-    bytes Hermes itself writes. Falls back to a plain open rather than
-    failing the launch, since losing the diagnostic log is better than
-    losing the browser.
+    Two halves, covering different installs:
+
+    * **At creation** the mode is passed to ``os.open``, so the file is never
+      briefly group/other-readable. ``O_TRUNC`` keeps the existing
+      per-candidate overwrite semantics.
+    * **On an already-existing log** ``O_CREAT`` applies ``mode`` only to a
+      file it actually creates, so the inode keeps whatever it had. An older
+      Hermes left this file at 0644 on disk, so creation-time hardening alone
+      would leave every *upgrading* install exposed at the one path in this
+      change with a guessable name — the exposure this is meant to close is
+      already on disk. ``hermes_cli.config._secure_file`` reconciles it, for
+      the same reason ``_ensure_chrome_debug_data_dir`` delegates to
+      ``_secure_dir``: that helper is the single owner of the owner-only file
+      policy. It skips managed/NixOS installs and containers, where broader
+      modes are deliberate, and it is where Windows ACL enforcement lands
+      (#77527) — so delegating inherits that instead of needing a second
+      implementation here. A hand-rolled ``os.chmod(path, 0o600)`` would
+      fight all three.
+
+    Ordering matters: the reconcile runs *after* the truncating open and
+    *before* any bytes are written, so the tighten lands while the file is
+    empty and no fresh Chromium stderr ever sits in a widely-readable file.
+    It is safe against a *running* browser for the same reason the directory
+    tighten is — only group/other bits drop, the owner keeps ``rw``, and POSIX
+    checks the mode at ``open()`` rather than on already-open descriptors.
+
+    **The managed/NixOS carve-out applies at creation here too**, not only at
+    reconciliation — the same defect the profile directory had. This log is
+    created lazily at runtime and is not covered by the module's
+    ``systemd.tmpfiles`` rules, so on a managed host a hardcoded 0600 would be
+    the only thing setting its mode. There the gateway and an interactive
+    ``hostUsers`` CLI share one ``$HERMES_HOME`` at two uids through the hermes
+    group; a 0600 log created by whichever ran first makes the other's
+    truncating open fail with ``EACCES`` — and because every candidate binary
+    reuses this one path, that fails *the whole launch*, not merely the
+    diagnostic. Omitting the explicit mode lets the service's
+    ``UMask = "0007"`` land 0660, which is what the merge base produced.
     """
+    managed = _managed_install()
+    # 0o666 rather than 0o600 on managed installs so the configured umask
+    # decides, matching the merge base's plain open() and the carve-out
+    # _ensure_chrome_debug_data_dir applies to the directory.
+    create_mode = 0o666 if managed else 0o600
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
     try:
-        fd = os.open(path, flags, 0o600)
+        fd = os.open(path, flags, create_mode)
     except OSError:
-        return open(path, "wb")
-    return os.fdopen(fd, "wb")
+        # Same fallback the pre-fix code had: let a genuinely unopenable path
+        # surface to launch_chrome_debug's per-candidate handler.
+        handle = open(path, "wb")
+    else:
+        handle = os.fdopen(fd, "wb")
+    if not managed:
+        try:
+            from hermes_cli.config import _secure_file
+
+            _secure_file(path)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("browser debug launch: stderr log chmod skipped: %s", exc)
+    return handle
 
 
 def _chrome_debug_args(port: int) -> list[str]:

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -133,8 +133,24 @@ def chrome_debug_data_dir() -> str:
     return str(get_hermes_home() / "chrome-debug")
 
 
+def _managed_install() -> bool:
+    """True when a package manager (NixOS) owns this install's modes.
+
+    Read once per creation so the *creation* mode honours the same carve-out
+    ``hermes_cli.config._secure_dir`` applies to reconciliation. Import is
+    local and failure means "not managed": an unimportable config module is
+    the single-user source-install case, where 0700 is the right default.
+    """
+    try:
+        from hermes_cli.config import is_managed
+
+        return bool(is_managed())
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
 def _ensure_chrome_debug_data_dir(data_dir: str) -> None:
-    """Create the Chromium user-data-dir owner-only (0700).
+    """Create the Chromium user-data-dir owner-only (0700), except managed.
 
     ``chrome-debug`` is a real Chromium profile: Cookies, Login Data, and
     Local Storage live here. Created with a bare ``os.makedirs`` it inherited
@@ -153,6 +169,23 @@ def _ensure_chrome_debug_data_dir(data_dir: str) -> None:
     ownership so a root-created dir does not lock out uid-mapped Docker
     workers (#34107).
 
+    **Managed installs are skipped at creation too, not just at
+    reconciliation.** ``_secure_dir`` returns early under ``is_managed()``
+    because the NixOS module deliberately shares state group-wise, and
+    ``chrome-debug`` is *not* one of the directories its ``systemd.tmpfiles``
+    rules pre-create — it is made lazily at runtime, so a hardcoded 0700 here
+    would be the only thing setting its mode and would silently override that
+    design. The module pins ``stateDir/.hermes`` to ``2770`` (setgid,
+    group-rwx), runs the gateway with ``UMask = "0007"`` precisely so "files
+    created by the gateway should be group-writable so interactive users in
+    the hermes group can read/write them", and avoids ``chown -R`` to keep
+    the setgid bit alive. On such a host the gateway and a hostUsers CLI share
+    one ``$HERMES_HOME`` through the hermes group, so a 0700 profile created
+    by whichever ran first locks the other out of the browser entirely.
+    Omitting the explicit mode there lets the inherited setgid + umask land
+    2770, matching ``ensure_hermes_home``'s managed branch and the
+    ``logs/curator`` lazy-mkdir precedent in ``hermes_cli.config``.
+
     Reconciling unconditionally also heals a profile an older Hermes left at
     0755, which is the whole point — the exposure is on disk already. It is
     safe against a *running* browser: only group/other bits are dropped, the
@@ -162,6 +195,11 @@ def _ensure_chrome_debug_data_dir(data_dir: str) -> None:
     only toggles the read-only flag), so this is best-effort there and the
     directory keeps its inherited ACLs.
     """
+    if _managed_install():
+        # Managed mode: let the NixOS-configured umask/setgid decide, and
+        # skip _secure_dir (which no-ops here anyway).
+        os.makedirs(data_dir, exist_ok=True)
+        return
     os.makedirs(data_dir, mode=0o700, exist_ok=True)
     try:
         from hermes_cli.config import _secure_dir

--- a/tests/computer_use/test_computer_use_vision_cache_permissions.py
+++ b/tests/computer_use/test_computer_use_vision_cache_permissions.py
@@ -1,0 +1,233 @@
+"""At-rest permissions for the vision scratch cache created by ``computer_use``.
+
+Scope: this file guards **``tools/computer_use/tool.py``** — its
+``_vision_cache_dir`` / ``_write_private_bytes`` helpers, which materialise
+desktop captures. The sibling suite
+``tests/tools/test_vision_tools_media_cache_permissions.py`` guards the *other*
+creator of the same ``cache/vision`` directory, ``tools/vision_tools.py``, and
+owns the cross-module agreement test. Both suites are kept deliberately:
+either module can win the race to create the shared directory, so each
+creation site needs its own guard.
+
+A desktop capture is as sensitive as whatever was on screen when it was
+taken. These tests pin the *contract* — no group/other bits — rather than a
+frozen octal, and they run the real creation path under a deliberately
+permissive ``umask 022`` so a regression back to umask-derived modes fails
+here instead of silently shipping.
+
+POSIX-only: mode bits are advisory on Windows, where at-rest protection is
+ACL-based and ``os.chmod`` only toggles the read-only flag.
+"""
+
+import os
+import stat
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.name != "posix",
+    reason="POSIX mode bits; Windows at-rest protection is ACL-based",
+)
+
+GROUP_OTHER_BITS = (
+    stat.S_IRGRP
+    | stat.S_IWGRP
+    | stat.S_IXGRP
+    | stat.S_IROTH
+    | stat.S_IWOTH
+    | stat.S_IXOTH
+)
+
+
+def _mode(path):
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+@pytest.fixture
+def permissive_umask():
+    """Force a world-readable-by-default umask for the duration of a test."""
+    previous = os.umask(0o022)
+    try:
+        yield
+    finally:
+        os.umask(previous)
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir(mode=0o700)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # Never let the ambient environment silently disable the hardening.
+    # tests/conftest.py blanks HERMES_CONTAINER / HERMES_HOME_MODE /
+    # HERMES_MANAGED, but NOT HERMES_SKIP_CHMOD. HERMES_MANAGED is repeated
+    # here anyway so the fixture is self-contained: without it, a developer
+    # shell on a managed install would make _secure_dir a no-op and the
+    # healing test below would fail for the wrong reason.
+    monkeypatch.delenv("HERMES_CONTAINER", raising=False)
+    monkeypatch.delenv("HERMES_SKIP_CHMOD", raising=False)
+    monkeypatch.delenv("HERMES_HOME_MODE", raising=False)
+    monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    return home
+
+
+def test_fresh_vision_cache_dir_has_no_group_or_other_access(
+    hermes_home, permissive_umask
+):
+    """A freshly created cache dir must not be readable by group/other."""
+    from tools.computer_use.tool import _vision_cache_dir
+
+    cache_dir = _vision_cache_dir()
+
+    assert cache_dir.is_dir()
+    mode = _mode(cache_dir)
+    assert not (
+        mode & GROUP_OTHER_BITS
+    ), f"vision cache dir {cache_dir} is group/other-accessible: {oct(mode)}"
+
+
+def test_vision_cache_dir_creation_is_not_umask_derived(hermes_home, permissive_umask):
+    """The mode must come from the code, not from the ambient umask.
+
+    Under ``umask 022`` a bare ``mkdir`` yields 0755. Asserting the owner
+    keeps full access while group/other get nothing proves the mode was set
+    deliberately at creation.
+    """
+    from tools.computer_use.tool import _vision_cache_dir
+
+    mode = _mode(_vision_cache_dir())
+
+    assert mode & stat.S_IRWXU == stat.S_IRWXU, "owner must retain full access"
+    assert mode & GROUP_OTHER_BITS == 0, f"umask-derived mode leaked: {oct(mode)}"
+
+
+def test_preexisting_world_readable_cache_dir_is_healed(hermes_home, permissive_umask):
+    """An older Hermes left 0755 behind; the next call must tighten it."""
+    from tools.computer_use.tool import _vision_cache_dir
+
+    legacy = hermes_home / "cache" / "vision"
+    legacy.mkdir(parents=True)
+    os.chmod(legacy, 0o755)
+    assert _mode(legacy) & stat.S_IROTH, "fixture precondition: starts world-readable"
+
+    cache_dir = _vision_cache_dir()
+
+    assert cache_dir == legacy
+    assert not (
+        _mode(cache_dir) & GROUP_OTHER_BITS
+    ), f"pre-existing dir left exposed: {oct(_mode(cache_dir))}"
+
+
+def test_captured_frame_is_written_owner_only(hermes_home, permissive_umask):
+    """The screenshot bytes themselves must not land 0644."""
+    from tools.computer_use.tool import _vision_cache_dir, _write_private_bytes
+
+    target = _vision_cache_dir() / "capture.png"
+    _write_private_bytes(target, b"\x89PNG\r\n\x1a\n fake frame")
+
+    assert target.read_bytes().endswith(b"fake frame")
+    mode = _mode(target)
+    assert not (
+        mode & GROUP_OTHER_BITS
+    ), f"captured frame {target} is group/other-readable: {oct(mode)}"
+
+
+def test_pre_fix_call_shapes_would_violate_the_contract(hermes_home, permissive_umask):
+    """Guard against a vacuous suite.
+
+    These are the exact pre-fix call shapes for the dir and the frame. If
+    neither leaks group/other bits under ``umask 022`` any more, then the
+    fixture — not the fix — is what the tests above are measuring, and they
+    prove nothing.
+    """
+    from hermes_constants import get_hermes_dir
+
+    pre_fix_dir = get_hermes_dir("cache/pre-fix-shape", "temp_pre_fix_shape")
+    pre_fix_dir.mkdir(parents=True, exist_ok=True)
+    dir_mode = _mode(pre_fix_dir)
+    assert dir_mode & GROUP_OTHER_BITS, (
+        "pre-fix mkdir shape no longer leaks group/other bits under umask 022; "
+        f"got {oct(dir_mode)} — the dir-mode tests here would be vacuous"
+    )
+
+    pre_fix_frame = pre_fix_dir / "capture.png"
+    pre_fix_frame.write_bytes(b"\x89PNG\r\n\x1a\n fake frame")
+    frame_mode = _mode(pre_fix_frame)
+    assert frame_mode & GROUP_OTHER_BITS, (
+        "pre-fix write_bytes shape no longer leaks group/other bits under "
+        f"umask 022; got {oct(frame_mode)} — the frame-mode test would be vacuous"
+    )
+
+
+def test_private_write_overwrites_and_stays_readable(hermes_home, permissive_umask):
+    """A permission fix that breaks the read path is the wrong fix.
+
+    The capture is written and then read straight back by
+    ``_route_capture_through_aux_vision`` (it hands the path to
+    ``vision_analyze_tool``), so truncating rewrite plus owner read must both
+    keep working.
+    """
+    from tools.computer_use.tool import _vision_cache_dir, _write_private_bytes
+
+    target = _vision_cache_dir() / "reused.png"
+    _write_private_bytes(target, b"first-and-longer-frame")
+    _write_private_bytes(target, b"second")
+
+    assert target.read_bytes() == b"second", "O_TRUNC rewrite must not leave residue"
+    assert _mode(target) & stat.S_IRUSR, "owner must still be able to read it back"
+
+
+def test_managed_mode_leaves_existing_permissions_alone(
+    hermes_home, permissive_umask, monkeypatch
+):
+    """Managed/NixOS installs own their own modes; we must not fight them.
+
+    The NixOS activation script deliberately sets group-readable modes so
+    interactive users in the hermes group can share state with the gateway
+    service. The house helper skips tightening there, and so must we.
+    """
+    monkeypatch.setenv("HERMES_MANAGED", "nixos")
+    legacy = hermes_home / "cache" / "vision"
+    legacy.mkdir(parents=True)
+    os.chmod(legacy, 0o750)
+
+    from tools.computer_use.tool import _vision_cache_dir
+
+    assert _mode(_vision_cache_dir()) == 0o750, "managed-mode permissions overridden"
+
+
+def test_home_mode_override_is_honored(hermes_home, permissive_umask, monkeypatch):
+    """The documented web-server traversal hatch still applies.
+
+    Deployments that need nginx/caddy to traverse HERMES_HOME set
+    HERMES_HOME_MODE. Delegating to the house helper keeps one source of
+    truth for that knob instead of hardcoding a mode this module invented.
+    """
+    monkeypatch.setenv("HERMES_HOME_MODE", "0701")
+    from tools.computer_use.tool import _vision_cache_dir
+
+    mode = _mode(_vision_cache_dir())
+
+    assert mode == 0o701
+    # Execute-only: traversal without directory listing. Frames stay 0600.
+    assert not (mode & (stat.S_IRGRP | stat.S_IROTH)), "listing must stay closed"
+
+
+def test_container_deployments_still_get_a_usable_directory(
+    hermes_home, permissive_umask, monkeypatch
+):
+    """A container/volume-mount deployment must not crash or lose the dir.
+
+    ``_secure_dir`` checks ``is_managed()`` only — unlike ``_secure_file`` it
+    does **not** consult ``_is_container()``, so the cache is still tightened
+    to 0700 here. That adds no new restriction: ``ensure_hermes_home`` already
+    puts HERMES_HOME and every standard subdir at 0700 in a container, and
+    multi-UID deployments are served by ``HERMES_UID``/``HERMES_GID`` or
+    ``HERMES_HOME_MODE``, both of which ``_secure_dir`` honours. So this
+    asserts the weaker, true contract: the directory exists and nothing raised.
+    """
+    monkeypatch.setenv("HERMES_CONTAINER", "1")
+    monkeypatch.setenv("HERMES_SKIP_CHMOD", "1")
+    from tools.computer_use.tool import _vision_cache_dir
+
+    assert _vision_cache_dir().is_dir()

--- a/tests/computer_use/test_computer_use_vision_cache_permissions.py
+++ b/tests/computer_use/test_computer_use_vision_cache_permissions.py
@@ -71,6 +71,57 @@ def hermes_home(tmp_path, monkeypatch):
     return home
 
 
+@pytest.fixture
+def neutralized_secure_dir(monkeypatch):
+    """Make the post-creation reconciliation step a no-op.
+
+    ``_vision_cache_dir`` hardens twice over: ``mode=`` on the ``mkdir`` call,
+    then ``hermes_cli.config._secure_dir`` to reconcile policy. Either
+    mechanism alone satisfies a plain "is it 0700?" assertion, so the two mask
+    each other — with the reconciler in play every mode assertion in this file
+    stays green even if ``mode=`` is deleted.
+
+    Stubbing the reconciler out isolates the creation mode as the *only* thing
+    that can produce the observed bits. Patched on ``hermes_cli.config``
+    rather than on the caller because the production code imports it lazily
+    inside the function, so the attribute is resolved at call time.
+    """
+    import hermes_cli.config as hermes_config
+
+    calls = []
+
+    def _recording_noop(path):
+        calls.append(str(path))
+
+    monkeypatch.setattr(hermes_config, "_secure_dir", _recording_noop)
+    return calls
+
+
+@pytest.fixture
+def managed_nixos_home(hermes_home, monkeypatch):
+    """Simulate a managed NixOS install that shares state via the hermes group.
+
+    Reproduces the two conditions ``nix/nixosModules.nix`` actually creates:
+
+    * ``systemd.tmpfiles`` pins ``stateDir/.hermes`` to ``2770`` — setgid,
+      group-rwx — so the gateway and interactive ``hostUsers`` share it;
+    * the service runs with ``UMask = "0007"``, commented "files created by
+      the gateway should be group-writable so interactive users in the hermes
+      group can read/write them".
+
+    ``cache/vision`` is *not* in those tmpfiles rules, so it is created lazily
+    at runtime under exactly this umask — which is why the creation mode, not
+    just the reconciliation, has to honour the carve-out.
+    """
+    monkeypatch.setenv("HERMES_MANAGED", "nixos")
+    os.chmod(hermes_home, 0o2770)
+    previous = os.umask(0o007)
+    try:
+        yield hermes_home
+    finally:
+        os.umask(previous)
+
+
 def test_fresh_vision_cache_dir_has_no_group_or_other_access(
     hermes_home, permissive_umask
 ):
@@ -194,6 +245,96 @@ def test_managed_mode_leaves_existing_permissions_alone(
     from tools.computer_use.tool import _vision_cache_dir
 
     assert _mode(_vision_cache_dir()) == 0o750, "managed-mode permissions overridden"
+
+
+def test_creation_mode_alone_yields_owner_only(hermes_home, neutralized_secure_dir):
+    """``mode=`` on the ``mkdir`` call must be doing real work by itself.
+
+    Two mechanisms harden this directory and either one satisfies a bare
+    "is it 0700?" check, so they mask each other: with ``_secure_dir`` in play
+    every mode assertion in this file stays green even if ``mode=`` is deleted.
+    Here the reconciler is stubbed to a no-op, so the only thing that can
+    produce owner-only bits is the mode passed at creation.
+
+    This is the TOCTOU guarantee made observable. The window ``mode=`` closes —
+    the instant between ``mkdir`` and a follow-up ``chmod`` where the captures
+    directory sits world-readable — cannot be asserted by racing creation, but
+    "correct without any chmod at all" is exactly equivalent and is
+    deterministic.
+
+    Deliberately not stacked with ``permissive_umask`` so a 0700 result cannot
+    be an accident of a restrictive ambient umask on the machine running the
+    suite; the sibling test below forces the umask wide open instead.
+    """
+    from tools.computer_use.tool import _vision_cache_dir
+
+    cache_dir = _vision_cache_dir()
+
+    assert cache_dir.is_dir()
+    assert neutralized_secure_dir == [
+        str(cache_dir)
+    ], "reconciler stub was not exercised; this test is not isolating creation"
+    mode = _mode(cache_dir)
+    assert mode & GROUP_OTHER_BITS == 0, (
+        f"with the reconciler neutralized {cache_dir} is group/other-accessible "
+        f"({oct(mode)}) — the mode= on mkdir is not being applied, so the "
+        "mkdir->chmod TOCTOU window is open"
+    )
+    assert mode & stat.S_IRWXU == stat.S_IRWXU, "owner must retain full access"
+
+
+def test_creation_mode_is_not_inherited_from_a_permissive_umask(
+    hermes_home, permissive_umask, neutralized_secure_dir
+):
+    """Same isolation, with the umask forced wide open.
+
+    Together with the test above this pins the claim precisely: 0700 comes from
+    the ``mode=`` argument, not from the ambient umask and not from the
+    reconciler. ``Path.mkdir`` masks its ``mode`` with the umask, so ``mode=``
+    of 0700 under ``umask 022`` still yields 0700 — but a *missing* ``mode=``
+    yields 0755 and fails here.
+    """
+    from tools.computer_use.tool import _vision_cache_dir
+
+    mode = _mode(_vision_cache_dir())
+
+    assert neutralized_secure_dir, "reconciler stub was not exercised"
+    assert (
+        mode & GROUP_OTHER_BITS == 0
+    ), f"umask-derived mode leaked with the reconciler neutralized: {oct(mode)}"
+
+
+def test_managed_mode_fresh_cache_keeps_group_sharing(managed_nixos_home):
+    """A *newly created* cache on NixOS must stay group-shareable.
+
+    The sibling test above covers a pre-existing directory, where
+    ``_secure_dir``'s ``is_managed()`` early return is enough. This is the
+    other managed path: the directory does not exist yet, so the mode passed at
+    *creation* is the only thing that decides it — and ``cache/vision`` is not
+    among the directories ``nix/nixosModules.nix`` pre-creates via
+    ``systemd.tmpfiles``, so on a managed host it is always this path.
+
+    Forcing 0700 here would not merely be cosmetic. The module shares
+    ``$HERMES_HOME`` between the gateway service and interactive ``hostUsers``
+    through the hermes group (``2770`` + ``UMask = "0007"`` + a deliberate
+    refusal to ``chown -R``, which strips setgid). A 0700 cache created by
+    whichever side runs first makes the capture path fail with EACCES for the
+    other.
+    """
+    from tools.computer_use.tool import _vision_cache_dir
+
+    expected = managed_nixos_home / "cache" / "vision"
+    assert not expected.exists(), "fixture precondition: dir must be absent"
+
+    cache_dir = _vision_cache_dir()
+
+    assert cache_dir.is_dir(), "managed mode must still create the cache dir"
+    mode = _mode(cache_dir)
+    assert mode & stat.S_IRWXG, (
+        f"fresh managed-mode {cache_dir} dropped group access ({oct(mode)}); the "
+        "NixOS module's hermes-group sharing (2770 + UMask=0007) is broken, so "
+        "an interactive hostUsers CLI and the gateway can no longer share it"
+    )
 
 
 def test_home_mode_override_is_honored(hermes_home, permissive_umask, monkeypatch):

--- a/tests/hermes_cli/test_browser_connect_profile_permissions.py
+++ b/tests/hermes_cli/test_browser_connect_profile_permissions.py
@@ -1,0 +1,351 @@
+"""At-rest permissions for the Chromium debug profile Hermes launches into.
+
+``$HERMES_HOME/chrome-debug`` is a real Chromium user-data-dir — it is what
+``--user-data-dir`` points at (``_chrome_debug_args``), so Cookies, Login Data
+and Local Storage live there. Created with a bare ``os.makedirs`` it inherited
+the umask and landed 0755.
+
+``HERMES_HOME`` is 0700 by default, so default-config exposure is narrow and
+this is defence in depth. The concrete scenario is the documented
+``HERMES_HOME_MODE=0701`` hatch (letting nginx/caddy traverse HERMES_HOME to
+reach a served subdirectory), where a 0755 child really is world-readable.
+
+These tests pin the *contract* — no group/other bits on a freshly created
+profile — rather than a frozen octal, and they run the real
+``launch_chrome_debug`` path under a deliberately permissive ``umask 022`` so
+a regression back to umask-derived modes fails here.
+
+POSIX-only: mode bits are advisory on Windows, where at-rest protection is
+ACL-based and ``os.chmod`` only toggles the read-only flag.
+"""
+
+import os
+import stat
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.name != "posix",
+    reason="POSIX mode bits; Windows at-rest protection is ACL-based",
+)
+
+GROUP_OTHER_BITS = (
+    stat.S_IRGRP
+    | stat.S_IWGRP
+    | stat.S_IXGRP
+    | stat.S_IROTH
+    | stat.S_IWOTH
+    | stat.S_IXOTH
+)
+
+
+def _mode(path):
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+@pytest.fixture
+def permissive_umask():
+    """Force a world-readable-by-default umask for the duration of a test."""
+    previous = os.umask(0o022)
+    try:
+        yield
+    finally:
+        os.umask(previous)
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir(mode=0o700)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # Never let the ambient environment silently disable the hardening.
+    monkeypatch.delenv("HERMES_CONTAINER", raising=False)
+    monkeypatch.delenv("HERMES_SKIP_CHMOD", raising=False)
+    monkeypatch.delenv("HERMES_HOME_MODE", raising=False)
+    monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    return home
+
+
+@pytest.fixture
+def no_browser_installed(monkeypatch):
+    """Drive the real launch path with a binary that cannot spawn.
+
+    ``launch_chrome_debug`` creates the profile dir before it tries any
+    candidate, so a guaranteed-failing candidate exercises the real creation
+    code without starting a browser on the test machine.
+    """
+    import hermes_cli.browser_connect as browser_connect
+
+    monkeypatch.setattr(
+        browser_connect,
+        "get_chrome_debug_candidates",
+        lambda system=None: ["/nonexistent/definitely-not-a-browser"],
+    )
+
+
+def test_launch_creates_profile_dir_without_group_or_other_access(
+    hermes_home, permissive_umask, no_browser_installed
+):
+    """The real launch path must not leave the profile world-readable."""
+    from hermes_cli.browser_connect import chrome_debug_data_dir, launch_chrome_debug
+
+    launch_chrome_debug(port=59991, system="Darwin")
+
+    profile = hermes_home / "chrome-debug"
+    assert profile.is_dir(), "launch must still create the user-data-dir"
+    assert str(profile) == chrome_debug_data_dir()
+    mode = _mode(profile)
+    assert not (
+        mode & GROUP_OTHER_BITS
+    ), f"Chromium profile {profile} is group/other-accessible: {oct(mode)}"
+
+
+def test_profile_mode_is_not_umask_derived(hermes_home, permissive_umask):
+    """The mode must come from the code, not the ambient umask.
+
+    Owner keeps full access (Chromium has to read and write its own profile)
+    while group/other get nothing, which is only true if the mode was set
+    deliberately at creation.
+    """
+    from hermes_cli.browser_connect import (
+        _ensure_chrome_debug_data_dir,
+        chrome_debug_data_dir,
+    )
+
+    _ensure_chrome_debug_data_dir(chrome_debug_data_dir())
+
+    mode = _mode(hermes_home / "chrome-debug")
+    assert mode & stat.S_IRWXU == stat.S_IRWXU, "owner must retain full access"
+    assert mode & GROUP_OTHER_BITS == 0, f"umask-derived mode leaked: {oct(mode)}"
+
+
+def test_bare_makedirs_would_violate_the_contract(hermes_home, permissive_umask):
+    """Guard against a vacuous suite.
+
+    This is the exact pre-fix call shape. If it stops producing group/other
+    bits under ``umask 022`` then the fixture — not the fix — is what the
+    other tests are measuring, and they prove nothing.
+    """
+    legacy_shape = hermes_home / "chrome-debug-pre-fix-shape"
+    os.makedirs(legacy_shape, exist_ok=True)
+
+    mode = _mode(legacy_shape)
+    assert mode & GROUP_OTHER_BITS, (
+        "pre-fix call shape no longer leaks group/other bits under umask 022; "
+        f"got {oct(mode)} — the permission tests here would be vacuous"
+    )
+
+
+def test_preexisting_world_readable_profile_is_healed(hermes_home, permissive_umask):
+    """An older Hermes already left 0755 on disk; the next launch tightens it.
+
+    The exposure this fixes is retroactive, so creation-time hardening alone
+    would leave every existing install exposed. Reconciling is safe against a
+    *running* Chromium: only group/other bits drop, the owner keeps ``rwx``,
+    and POSIX evaluates the mode at ``open()`` rather than on already-open
+    descriptors — see ``test_running_browser_keeps_profile_access``.
+    """
+    from hermes_cli.browser_connect import (
+        _ensure_chrome_debug_data_dir,
+        chrome_debug_data_dir,
+    )
+
+    profile = hermes_home / "chrome-debug"
+    profile.mkdir()
+    os.chmod(profile, 0o755)
+    assert _mode(profile) & stat.S_IROTH, "fixture precondition: starts world-readable"
+
+    _ensure_chrome_debug_data_dir(chrome_debug_data_dir())
+
+    assert not (
+        _mode(profile) & GROUP_OTHER_BITS
+    ), f"pre-existing profile left exposed: {oct(_mode(profile))}"
+
+
+def test_running_browser_keeps_profile_access(hermes_home, permissive_umask):
+    """Tightening a live profile must not break the browser attached to it.
+
+    Stands in for a running Chromium: an open descriptor on a profile store
+    plus a fresh file created after the tighten. Both must succeed, because
+    the owner's bits are untouched.
+    """
+    from hermes_cli.browser_connect import (
+        _ensure_chrome_debug_data_dir,
+        chrome_debug_data_dir,
+    )
+
+    profile = hermes_home / "chrome-debug"
+    profile.mkdir()
+    os.chmod(profile, 0o755)
+    cookies = profile / "Cookies"
+    fd = os.open(str(cookies), os.O_WRONLY | os.O_CREAT, 0o600)
+    try:
+        os.write(fd, b"session-before")
+
+        _ensure_chrome_debug_data_dir(chrome_debug_data_dir())
+
+        os.write(fd, b"|session-after")
+    finally:
+        os.close(fd)
+
+    assert cookies.read_bytes() == b"session-before|session-after"
+    # A new tab writing a new store must still work.
+    (profile / "Local Storage").write_bytes(b"new-store")
+    assert (profile / "Local Storage").read_bytes() == b"new-store"
+    assert sorted(p.name for p in profile.iterdir()) == ["Cookies", "Local Storage"]
+
+
+def test_launch_still_writes_its_stderr_log(
+    hermes_home, permissive_umask, no_browser_installed
+):
+    """A permission fix that breaks the feature is the wrong fix.
+
+    ``launch_chrome_debug`` opens a stderr log *inside* the profile dir to
+    capture why a candidate died. Tightening the directory must not make that
+    unwritable, or every launch diagnostic is lost.
+    """
+    from hermes_cli.browser_connect import _LAUNCH_STDERR_LOG, launch_chrome_debug
+
+    result = launch_chrome_debug(port=59992, system="Darwin")
+
+    assert result.launched is False, "no real browser should have started"
+    assert (hermes_home / "chrome-debug" / _LAUNCH_STDERR_LOG).exists()
+
+
+def test_launch_stderr_log_is_written_owner_only(
+    hermes_home, permissive_umask, no_browser_installed
+):
+    """The launch log must not land 0644 inside the hardened profile dir.
+
+    Unlike the uuid-named scratch files elsewhere, ``launch-stderr.log`` has a
+    fixed, guessable name — so under ``HERMES_HOME_MODE=0701`` (directory
+    traversable but unlistable) it is the one file in here an unrelated local
+    account could actually open. It carries Chromium's stderr, which routinely
+    includes the profile path and extension/keychain diagnostics.
+    """
+    from hermes_cli.browser_connect import _LAUNCH_STDERR_LOG, launch_chrome_debug
+
+    launch_chrome_debug(port=59994, system="Darwin")
+
+    log = hermes_home / "chrome-debug" / _LAUNCH_STDERR_LOG
+    mode = _mode(log)
+    assert not (
+        mode & GROUP_OTHER_BITS
+    ), f"launch log {log} is group/other-readable: {oct(mode)}"
+
+
+def test_plain_open_of_stderr_log_would_violate_the_contract(
+    hermes_home, permissive_umask
+):
+    """Vacuity guard for the log-mode contract.
+
+    ``open(path, "wb")`` is the exact pre-fix call shape. If it stops leaking
+    group/other bits under ``umask 022``, the assertion above proves nothing.
+    """
+    profile = hermes_home / "chrome-debug"
+    profile.mkdir(mode=0o700)
+    legacy_shape = profile / "pre-fix-shape.log"
+    with open(legacy_shape, "wb") as fh:
+        fh.write(b"chromium stderr")
+
+    mode = _mode(legacy_shape)
+    assert mode & GROUP_OTHER_BITS, (
+        "pre-fix open() shape no longer leaks group/other bits under umask 022; "
+        f"got {oct(mode)} — the log-mode test would be vacuous"
+    )
+
+
+def test_stderr_log_is_truncated_per_candidate(hermes_home, permissive_umask):
+    """Hardening the log must not turn the overwrite into an append.
+
+    ``launch_chrome_debug`` reuses one log path across candidates and reads the
+    tail back to explain a failure. If a second open appended instead of
+    truncating, the reported tail would be the *previous* candidate's stderr.
+    """
+    from hermes_cli.browser_connect import _open_launch_stderr_log, _read_stderr_tail
+
+    profile = hermes_home / "chrome-debug"
+    profile.mkdir(mode=0o700)
+    log = profile / "launch-stderr.log"
+
+    with _open_launch_stderr_log(str(log)) as fh:
+        fh.write(b"first-candidate-stderr-and-longer")
+    with _open_launch_stderr_log(str(log)) as fh:
+        fh.write(b"second")
+
+    assert log.read_bytes() == b"second", "O_TRUNC lost: log now appends"
+    assert _read_stderr_tail(str(log)) == "second", "diagnostic tail must still read"
+    assert not (_mode(log) & GROUP_OTHER_BITS), "reopen must not widen the mode"
+
+
+def test_managed_mode_leaves_existing_permissions_alone(
+    hermes_home, permissive_umask, monkeypatch
+):
+    """Managed/NixOS installs own their own modes; we must not fight them.
+
+    The NixOS activation script deliberately sets group-readable modes so
+    interactive users in the hermes group can share state with the gateway
+    service. Delegating to the house helper inherits that carve-out.
+    """
+    monkeypatch.setenv("HERMES_MANAGED", "nixos")
+    profile = hermes_home / "chrome-debug"
+    profile.mkdir()
+    os.chmod(profile, 0o750)
+
+    from hermes_cli.browser_connect import (
+        _ensure_chrome_debug_data_dir,
+        chrome_debug_data_dir,
+    )
+
+    _ensure_chrome_debug_data_dir(chrome_debug_data_dir())
+
+    assert _mode(profile) == 0o750, "managed-mode permissions overridden"
+
+
+def test_home_mode_override_is_honored(hermes_home, permissive_umask, monkeypatch):
+    """The documented web-server traversal hatch still applies.
+
+    Delegating to the house helper keeps one source of truth for this knob
+    instead of hardcoding a mode this module invented.
+    """
+    monkeypatch.setenv("HERMES_HOME_MODE", "0701")
+
+    from hermes_cli.browser_connect import (
+        _ensure_chrome_debug_data_dir,
+        chrome_debug_data_dir,
+    )
+
+    _ensure_chrome_debug_data_dir(chrome_debug_data_dir())
+
+    mode = _mode(hermes_home / "chrome-debug")
+    assert mode == 0o701
+    # Execute-only: traversal without a directory listing.
+    assert not (mode & (stat.S_IRGRP | stat.S_IROTH)), "listing must stay closed"
+
+
+def test_container_deployments_still_get_a_usable_profile(
+    hermes_home, permissive_umask, monkeypatch
+):
+    """A container/volume-mount deployment must not crash or lose the dir.
+
+    Note what this does and does not claim. ``_secure_dir`` checks
+    ``is_managed()`` only — unlike ``_secure_file`` it does **not** consult
+    ``_is_container()``, so the profile dir is still tightened to 0700 here.
+    That is fine rather than a carve-out being violated: ``ensure_hermes_home``
+    already puts HERMES_HOME and every standard subdir at 0700 in a container,
+    so a 0700 child adds no new restriction. Multi-UID deployments are served
+    by ``HERMES_UID``/``HERMES_GID`` or ``HERMES_HOME_MODE``, both of which
+    ``_secure_dir`` honours. So this asserts the weaker, true contract: the
+    directory still exists and nothing raised.
+    """
+    monkeypatch.setenv("HERMES_CONTAINER", "1")
+    monkeypatch.setenv("HERMES_SKIP_CHMOD", "1")
+
+    from hermes_cli.browser_connect import (
+        _ensure_chrome_debug_data_dir,
+        chrome_debug_data_dir,
+    )
+
+    _ensure_chrome_debug_data_dir(chrome_debug_data_dir())
+
+    assert (hermes_home / "chrome-debug").is_dir()

--- a/tests/hermes_cli/test_browser_connect_profile_permissions.py
+++ b/tests/hermes_cli/test_browser_connect_profile_permissions.py
@@ -504,3 +504,226 @@ def test_container_deployments_still_get_a_usable_profile(
     _ensure_chrome_debug_data_dir(chrome_debug_data_dir())
 
     assert (hermes_home / "chrome-debug").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# launch-stderr.log: the mode of an *already existing* log.
+#
+# Creation-time hardening covers a fresh install. It does nothing for the case
+# that actually matters here: an older Hermes wrote this file with a plain
+# open() and left it 0644 on disk. ``O_CREAT`` applies its mode argument only
+# to a file it creates, so an upgrading user kept the exact exposure this
+# change claims to close — and this is the one artifact in it with a fixed,
+# guessable name, so it is the one another local account can open by guess
+# under the ``HERMES_HOME_MODE=0701`` hatch without a listable directory.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def non_container_host(monkeypatch):
+    """Pin ``_is_container()`` to False so the reconcile is not skipped.
+
+    ``_secure_file`` (unlike ``_secure_dir``) returns early inside a
+    container, and it sniffs for one via ``/.dockerenv`` and
+    ``/proc/1/cgroup`` — not just the env vars the ``hermes_home`` fixture
+    clears. On a developer laptop neither exists, but CI running the suite
+    *inside* a container would silently skip the tighten and fail the healing
+    assertion for an ambient reason that has nothing to do with this code.
+    Pinning it makes the test assert the policy instead of the host it runs
+    on; the container carve-out gets its own test below.
+    """
+    import hermes_cli.config as hermes_config
+
+    monkeypatch.setattr(hermes_config, "_is_container", lambda: False)
+
+
+def test_preexisting_group_readable_stderr_log_is_healed(
+    hermes_home, permissive_umask, non_container_host
+):
+    """A log an older Hermes left readable must end up owner-only.
+
+    This is the contract, not an octal: after the call, no group or other bit
+    survives, and the owner can still read and write. Asserting the bits
+    rather than ``== 0o600`` keeps ``HERMES_HOME_MODE``-style policy changes
+    from making this a change-detector.
+    """
+    from hermes_cli.browser_connect import _open_launch_stderr_log
+
+    profile = hermes_home / "chrome-debug"
+    profile.mkdir(mode=0o700)
+    log = profile / "launch-stderr.log"
+    # Exactly what the pre-fix code produced under a default umask.
+    with open(log, "wb") as fh:
+        fh.write(b"chromium stderr from an older hermes")
+    os.chmod(log, 0o644)
+    assert _mode(log) & GROUP_OTHER_BITS, "fixture precondition: starts exposed"
+
+    with _open_launch_stderr_log(str(log)) as fh:
+        fh.write(b"stderr from this launch")
+
+    mode = _mode(log)
+    assert not (mode & GROUP_OTHER_BITS), (
+        f"pre-existing launch log left exposed: {oct(mode)} — an upgrading "
+        "install keeps the exposure this change is supposed to close"
+    )
+    # The fix must not cost the owner access to their own diagnostic.
+    assert mode & stat.S_IRUSR and mode & stat.S_IWUSR
+    assert log.read_bytes() == b"stderr from this launch"
+
+
+def test_stderr_log_is_not_left_exposed_while_it_holds_bytes(
+    hermes_home, permissive_umask, non_container_host
+):
+    """No window where *this launch's* stderr sits in a readable file.
+
+    Reconciling after the write would leave real Chromium stderr readable for
+    the lifetime of the launch. The tighten therefore has to happen while the
+    file is still empty — ``O_TRUNC`` has already emptied it by then, so this
+    asserts the ordering, which is the part that makes the fix a fix rather
+    than a narrowing of the window.
+    """
+    from hermes_cli.browser_connect import _open_launch_stderr_log
+
+    profile = hermes_home / "chrome-debug"
+    profile.mkdir(mode=0o700)
+    log = profile / "launch-stderr.log"
+    with open(log, "wb") as fh:
+        fh.write(b"previous-launch stderr")
+    os.chmod(log, 0o644)
+
+    handle = _open_launch_stderr_log(str(log))
+    try:
+        # State the caller sees before it writes a single byte.
+        assert not (_mode(log) & GROUP_OTHER_BITS), (
+            f"log still group/other-readable at the moment it is handed to "
+            f"the caller: {oct(_mode(log))}"
+        )
+        assert log.stat().st_size == 0, "O_TRUNC should have emptied it"
+        handle.write(b"fresh stderr")
+    finally:
+        handle.close()
+
+    assert not (_mode(log) & GROUP_OTHER_BITS)
+
+
+def test_reconciling_the_log_keeps_a_running_browsers_handle_working(
+    hermes_home, permissive_umask, non_container_host
+):
+    """Tightening a live log must not break a Chromium already writing to it.
+
+    Same argument the profile directory makes: only group/other bits drop, the
+    owner keeps ``rw``, and POSIX checks the mode at ``open()`` rather than on
+    an already-open descriptor. Stands in for a browser from a previous
+    candidate still holding the log open.
+    """
+    from hermes_cli.browser_connect import _open_launch_stderr_log
+
+    profile = hermes_home / "chrome-debug"
+    profile.mkdir(mode=0o700)
+    log = profile / "launch-stderr.log"
+    with open(log, "wb") as fh:
+        fh.write(b"")
+    os.chmod(log, 0o644)
+
+    held = os.open(str(log), os.O_WRONLY | os.O_APPEND)
+    try:
+        os.write(held, b"before-tighten")
+
+        with _open_launch_stderr_log(str(log)) as fh:
+            fh.write(b"")
+
+        # The pre-existing descriptor must still be writable.
+        os.write(held, b"|after-tighten")
+    finally:
+        os.close(held)
+
+    assert not (_mode(log) & GROUP_OTHER_BITS)
+    assert log.read_bytes().endswith(b"|after-tighten")
+
+
+def test_managed_mode_leaves_an_existing_stderr_log_alone(
+    hermes_home, permissive_umask, monkeypatch
+):
+    """Managed/NixOS installs own their modes for the log as well as the dir.
+
+    Delegating to ``_secure_file`` inherits the carve-out rather than
+    re-deciding it here, so a group-readable log an administrator's
+    configuration produced stays that way.
+    """
+    monkeypatch.setenv("HERMES_MANAGED", "nixos")
+
+    from hermes_cli.browser_connect import _open_launch_stderr_log
+
+    profile = hermes_home / "chrome-debug"
+    profile.mkdir(mode=0o770)
+    log = profile / "launch-stderr.log"
+    with open(log, "wb") as fh:
+        fh.write(b"gateway-written stderr")
+    os.chmod(log, 0o660)
+
+    with _open_launch_stderr_log(str(log)) as fh:
+        fh.write(b"next launch")
+
+    assert _mode(log) == 0o660, (
+        f"managed-mode log permissions overridden: {oct(_mode(log))}; the "
+        "NixOS module shares state through the hermes group on purpose"
+    )
+
+
+def test_managed_mode_fresh_stderr_log_keeps_group_sharing(managed_nixos_home):
+    """A *fresh* log on a managed host must not lock the other uid out.
+
+    The carve-out has to cover creation, not only reconciliation — the same
+    defect the profile directory had before it was fixed. ``launch-stderr.log``
+    is created lazily at runtime and is not in the module's
+    ``systemd.tmpfiles`` rules, so a hardcoded 0600 would be the only thing
+    setting its mode. On such a host the gateway and an interactive
+    ``hostUsers`` CLI share one ``$HERMES_HOME`` at two uids through the hermes
+    group, and *every candidate binary reuses this one path* — so a 0600 log
+    created by whichever ran first makes the other's truncating open fail with
+    EACCES and takes down the whole launch, not just the diagnostic.
+    """
+    from hermes_cli.browser_connect import _open_launch_stderr_log
+
+    profile = managed_nixos_home / "chrome-debug"
+    profile.mkdir(mode=0o770)
+    log = profile / "launch-stderr.log"
+
+    with _open_launch_stderr_log(str(log)) as fh:
+        fh.write(b"stderr")
+
+    mode = _mode(log)
+    assert mode & stat.S_IRGRP and mode & stat.S_IWGRP, (
+        f"fresh managed-mode launch log dropped group access ({oct(mode)}); "
+        "the NixOS module's UMask=0007 exists so an interactive hostUsers CLI "
+        "and the gateway can both write it — losing that fails the launch, "
+        "not just the diagnostic"
+    )
+
+
+def test_container_deployments_keep_an_existing_log_usable(
+    hermes_home, permissive_umask, monkeypatch
+):
+    """Containers keep their broader modes, by the house helper's own rule.
+
+    ``_secure_file`` skips containers because volume-mounted state is often
+    read by a second UID. Asserting the skip here documents that this is the
+    shared policy being inherited, not an accident of this call site — and
+    that nothing raises when the tighten is declined.
+    """
+    monkeypatch.setenv("HERMES_CONTAINER", "1")
+
+    from hermes_cli.browser_connect import _open_launch_stderr_log
+
+    profile = hermes_home / "chrome-debug"
+    profile.mkdir(mode=0o700)
+    log = profile / "launch-stderr.log"
+    with open(log, "wb") as fh:
+        fh.write(b"volume-mounted stderr")
+    os.chmod(log, 0o644)
+
+    with _open_launch_stderr_log(str(log)) as fh:
+        fh.write(b"next launch")
+
+    assert _mode(log) == 0o644, "container carve-out not inherited"
+    assert log.read_bytes() == b"next launch", "log must still be writable"

--- a/tests/hermes_cli/test_browser_connect_profile_permissions.py
+++ b/tests/hermes_cli/test_browser_connect_profile_permissions.py
@@ -83,6 +83,59 @@ def no_browser_installed(monkeypatch):
     )
 
 
+@pytest.fixture
+def neutralized_secure_dir(monkeypatch):
+    """Make the post-creation reconciliation step a no-op.
+
+    ``_ensure_chrome_debug_data_dir`` hardens twice over: ``mode=`` on the
+    ``makedirs`` call, then ``hermes_cli.config._secure_dir`` to reconcile
+    policy. Either mechanism alone satisfies a plain "is it 0700?" assertion,
+    so the two mask each other and a test that only checks the final mode
+    cannot tell which one did the work — deleting ``mode=`` keeps every such
+    test green.
+
+    Stubbing the reconciler out isolates the creation mode as the *only*
+    thing that can produce the observed bits. ``_secure_dir`` is patched on
+    ``hermes_cli.config`` (not on the caller) because the production code
+    imports it lazily inside the function, so the attribute is resolved at
+    call time.
+    """
+    import hermes_cli.config as hermes_config
+
+    calls = []
+
+    def _recording_noop(path):
+        calls.append(str(path))
+
+    monkeypatch.setattr(hermes_config, "_secure_dir", _recording_noop)
+    return calls
+
+
+@pytest.fixture
+def managed_nixos_home(hermes_home, monkeypatch):
+    """Simulate a managed NixOS install that shares state via the hermes group.
+
+    Reproduces the two conditions ``nix/nixosModules.nix`` actually creates:
+
+    * ``systemd.tmpfiles`` pins ``stateDir/.hermes`` to ``2770`` — setgid,
+      group-rwx — so the gateway and interactive ``hostUsers`` share it;
+    * the service runs with ``UMask = "0007"``, commented "files created by
+      the gateway should be group-writable so interactive users in the hermes
+      group can read/write them".
+
+    ``chrome-debug`` is *not* in those tmpfiles rules, so it is created
+    lazily at runtime under exactly this umask — which is why the creation
+    mode, not just the reconciliation, has to honour the carve-out.
+    """
+    monkeypatch.setenv("HERMES_MANAGED", "nixos")
+    os.chmod(hermes_home, 0o2770)
+    previous = os.umask(0o007)
+    try:
+        yield hermes_home
+    finally:
+        os.umask(previous)
+
+
 def test_launch_creates_profile_dir_without_group_or_other_access(
     hermes_home, permissive_umask, no_browser_installed
 ):
@@ -300,6 +353,108 @@ def test_managed_mode_leaves_existing_permissions_alone(
     _ensure_chrome_debug_data_dir(chrome_debug_data_dir())
 
     assert _mode(profile) == 0o750, "managed-mode permissions overridden"
+
+
+def test_creation_mode_alone_yields_owner_only(hermes_home, neutralized_secure_dir):
+    """``mode=`` on the ``makedirs`` call must be doing real work by itself.
+
+    Two mechanisms harden this directory and either one satisfies a bare
+    "is it 0700?" check, so they mask each other: with ``_secure_dir`` in play
+    every mode assertion in this file stays green even if ``mode=`` is deleted.
+    Here the reconciler is stubbed to a no-op, so the only thing that can
+    produce owner-only bits is the mode passed at creation.
+
+    This is the TOCTOU guarantee made observable. The window that ``mode=``
+    closes — the instant between ``mkdir`` and a follow-up ``chmod`` where the
+    profile sits world-readable — cannot be asserted by racing creation, but
+    "correct without any chmod at all" is exactly equivalent and is
+    deterministic.
+
+    Deliberately not stacked with ``permissive_umask``: the umask is left
+    alone so a 0700 result cannot be an accident of a restrictive ambient
+    umask on the machine running the suite. See
+    ``test_creation_mode_is_not_inherited_from_a_permissive_umask``.
+    """
+    from hermes_cli.browser_connect import (
+        _ensure_chrome_debug_data_dir,
+        chrome_debug_data_dir,
+    )
+
+    _ensure_chrome_debug_data_dir(chrome_debug_data_dir())
+
+    profile = hermes_home / "chrome-debug"
+    assert profile.is_dir()
+    assert neutralized_secure_dir == [
+        str(profile)
+    ], "reconciler stub was not exercised; this test is not isolating creation"
+    mode = _mode(profile)
+    assert mode & GROUP_OTHER_BITS == 0, (
+        "with the reconciler neutralized the profile is group/other-accessible "
+        f"({oct(mode)}) — the mode= on makedirs is not being applied, so the "
+        "mkdir->chmod TOCTOU window is open"
+    )
+    assert mode & stat.S_IRWXU == stat.S_IRWXU, "owner must retain full access"
+
+
+def test_creation_mode_is_not_inherited_from_a_permissive_umask(
+    hermes_home, permissive_umask, neutralized_secure_dir
+):
+    """Same isolation, with the umask forced wide open.
+
+    Together with the test above this pins the claim precisely: 0700 comes
+    from the ``mode=`` argument, not from the ambient umask and not from the
+    reconciler. ``os.makedirs`` masks its ``mode`` with the umask, so a
+    ``mode=`` of 0700 under ``umask 022`` still yields 0700 — but a *missing*
+    ``mode=`` yields 0755 and fails here.
+    """
+    from hermes_cli.browser_connect import (
+        _ensure_chrome_debug_data_dir,
+        chrome_debug_data_dir,
+    )
+
+    _ensure_chrome_debug_data_dir(chrome_debug_data_dir())
+
+    mode = _mode(hermes_home / "chrome-debug")
+    assert neutralized_secure_dir, "reconciler stub was not exercised"
+    assert mode & GROUP_OTHER_BITS == 0, (
+        f"umask-derived mode leaked with the reconciler neutralized: {oct(mode)}"
+    )
+
+
+def test_managed_mode_fresh_profile_keeps_group_sharing(managed_nixos_home):
+    """A *newly created* profile on NixOS must stay group-shareable.
+
+    The sibling test above covers a pre-existing directory, where
+    ``_secure_dir``'s ``is_managed()`` early return is enough. This is the
+    other managed path: the directory does not exist yet, so the mode passed
+    at *creation* is the only thing that decides it — and ``chrome-debug`` is
+    not among the directories ``nix/nixosModules.nix`` pre-creates via
+    ``systemd.tmpfiles``, so on a managed host it is always this path.
+
+    Forcing 0700 here would not merely be cosmetic. The module shares
+    ``$HERMES_HOME`` between the gateway service and interactive ``hostUsers``
+    through the hermes group (``2770`` + ``UMask = "0007"`` + a deliberate
+    refusal to ``chown -R``, which would strip setgid). A 0700 profile created
+    by whichever side runs first locks the other out of the browser entirely
+    with EACCES — a permission "fix" that destroys the feature it protects.
+    """
+    from hermes_cli.browser_connect import (
+        _ensure_chrome_debug_data_dir,
+        chrome_debug_data_dir,
+    )
+
+    profile = managed_nixos_home / "chrome-debug"
+    assert not profile.exists(), "fixture precondition: dir must be absent"
+
+    _ensure_chrome_debug_data_dir(chrome_debug_data_dir())
+
+    assert profile.is_dir(), "managed mode must still create the profile dir"
+    mode = _mode(profile)
+    assert mode & stat.S_IRWXG, (
+        f"fresh managed-mode profile dropped group access ({oct(mode)}); the "
+        "NixOS module's hermes-group sharing (2770 + UMask=0007) is broken, so "
+        "an interactive hostUsers CLI and the gateway can no longer share it"
+    )
 
 
 def test_home_mode_override_is_honored(hermes_home, permissive_umask, monkeypatch):

--- a/tests/tools/test_vision_tools_media_cache_permissions.py
+++ b/tests/tools/test_vision_tools_media_cache_permissions.py
@@ -74,6 +74,57 @@ def hermes_home(tmp_path, monkeypatch):
     return home
 
 
+@pytest.fixture
+def neutralized_secure_dir(monkeypatch):
+    """Make the post-creation reconciliation step a no-op.
+
+    ``_secure_cache_dir`` hardens twice over: ``mode=`` on the ``mkdir`` call,
+    then ``hermes_cli.config._secure_dir`` to reconcile policy. Either
+    mechanism alone satisfies a plain "is it 0700?" assertion, so the two mask
+    each other — with the reconciler in play every mode assertion in this file
+    stays green even if ``mode=`` is deleted.
+
+    Stubbing the reconciler out isolates the creation mode as the *only* thing
+    that can produce the observed bits. Patched on ``hermes_cli.config``
+    rather than on the caller because the production code imports it lazily
+    inside the function, so the attribute is resolved at call time.
+    """
+    import hermes_cli.config as hermes_config
+
+    calls = []
+
+    def _recording_noop(path):
+        calls.append(str(path))
+
+    monkeypatch.setattr(hermes_config, "_secure_dir", _recording_noop)
+    return calls
+
+
+@pytest.fixture
+def managed_nixos_home(hermes_home, monkeypatch):
+    """Simulate a managed NixOS install that shares state via the hermes group.
+
+    Reproduces the two conditions ``nix/nixosModules.nix`` actually creates:
+
+    * ``systemd.tmpfiles`` pins ``stateDir/.hermes`` to ``2770`` — setgid,
+      group-rwx — so the gateway and interactive ``hostUsers`` share it;
+    * the service runs with ``UMask = "0007"``, commented "files created by
+      the gateway should be group-writable so interactive users in the hermes
+      group can read/write them".
+
+    ``cache/vision`` and ``cache/video`` are *not* in those tmpfiles rules, so
+    they are created lazily at runtime under exactly this umask — which is why
+    the creation mode, not just the reconciliation, has to honour the carve-out.
+    """
+    monkeypatch.setenv("HERMES_MANAGED", "nixos")
+    os.chmod(hermes_home, 0o2770)
+    previous = os.umask(0o007)
+    try:
+        yield hermes_home
+    finally:
+        os.umask(previous)
+
+
 @pytest.mark.parametrize(
     "new_subpath,old_name",
     [("cache/vision", "temp_vision_images"), ("cache/video", "temp_video_files")],
@@ -360,6 +411,135 @@ def test_managed_mode_leaves_existing_permissions_alone(
     assert (
         _mode(_secure_cache_dir("cache/vision", "temp_vision_images")) == 0o750
     ), "managed-mode permissions overridden"
+
+
+@pytest.mark.parametrize(
+    "new_subpath,old_name",
+    [("cache/vision", "temp_vision_images"), ("cache/video", "temp_video_files")],
+)
+def test_creation_mode_alone_yields_owner_only(
+    hermes_home, neutralized_secure_dir, new_subpath, old_name
+):
+    """``mode=`` on the ``mkdir`` call must be doing real work by itself.
+
+    Two mechanisms harden these directories and either one satisfies a bare
+    "is it 0700?" check, so they mask each other: with ``_secure_dir`` in play
+    every mode assertion in this file stays green even if ``mode=`` is deleted.
+    Here the reconciler is stubbed to a no-op, so the only thing that can
+    produce owner-only bits is the mode passed at creation.
+
+    This is the TOCTOU guarantee made observable. The window ``mode=`` closes —
+    the instant between ``mkdir`` and a follow-up ``chmod`` where the cache
+    sits world-readable — cannot be asserted by racing creation, but "correct
+    without any chmod at all" is exactly equivalent and is deterministic.
+
+    Deliberately not stacked with ``permissive_umask`` so a 0700 result cannot
+    be an accident of a restrictive ambient umask on the machine running the
+    suite; the sibling test below forces the umask wide open instead.
+    """
+    from tools.vision_tools import _secure_cache_dir
+
+    cache_dir = _secure_cache_dir(new_subpath, old_name)
+
+    assert cache_dir.is_dir()
+    assert neutralized_secure_dir == [
+        str(cache_dir)
+    ], "reconciler stub was not exercised; this test is not isolating creation"
+    mode = _mode(cache_dir)
+    assert mode & GROUP_OTHER_BITS == 0, (
+        f"with the reconciler neutralized {cache_dir} is group/other-accessible "
+        f"({oct(mode)}) — the mode= on mkdir is not being applied, so the "
+        "mkdir->chmod TOCTOU window is open"
+    )
+    assert mode & stat.S_IRWXU == stat.S_IRWXU, "owner must retain full access"
+
+
+def test_creation_mode_is_not_inherited_from_a_permissive_umask(
+    hermes_home, permissive_umask, neutralized_secure_dir
+):
+    """Same isolation, with the umask forced wide open.
+
+    Together with the test above this pins the claim precisely: 0700 comes from
+    the ``mode=`` argument, not from the ambient umask and not from the
+    reconciler. ``Path.mkdir`` masks its ``mode`` with the umask, so ``mode=``
+    of 0700 under ``umask 022`` still yields 0700 — but a *missing* ``mode=``
+    yields 0755 and fails here.
+    """
+    from tools.vision_tools import _secure_cache_dir
+
+    mode = _mode(_secure_cache_dir("cache/vision", "temp_vision_images"))
+
+    assert neutralized_secure_dir, "reconciler stub was not exercised"
+    assert (
+        mode & GROUP_OTHER_BITS == 0
+    ), f"umask-derived mode leaked with the reconciler neutralized: {oct(mode)}"
+
+
+@pytest.mark.parametrize(
+    "new_subpath,old_name",
+    [("cache/vision", "temp_vision_images"), ("cache/video", "temp_video_files")],
+)
+def test_managed_mode_fresh_cache_keeps_group_sharing(
+    managed_nixos_home, new_subpath, old_name
+):
+    """A *newly created* cache on NixOS must stay group-shareable.
+
+    The sibling test above covers a pre-existing directory, where
+    ``_secure_dir``'s ``is_managed()`` early return is enough. This is the
+    other managed path: the directory does not exist yet, so the mode passed
+    at *creation* is the only thing that decides it — and neither
+    ``cache/vision`` nor ``cache/video`` is among the directories
+    ``nix/nixosModules.nix`` pre-creates via ``systemd.tmpfiles``, so on a
+    managed host it is always this path.
+
+    Forcing 0700 here would not merely be cosmetic. The module shares
+    ``$HERMES_HOME`` between the gateway service and interactive ``hostUsers``
+    through the hermes group (``2770`` + ``UMask = "0007"`` + a deliberate
+    refusal to ``chown -R``, which strips setgid). A 0700 cache created by
+    whichever side runs first makes vision fail with EACCES for the other.
+    """
+    from tools.vision_tools import _secure_cache_dir
+
+    expected = managed_nixos_home / new_subpath
+    assert not expected.exists(), "fixture precondition: dir must be absent"
+
+    cache_dir = _secure_cache_dir(new_subpath, old_name)
+
+    assert cache_dir.is_dir(), "managed mode must still create the cache dir"
+    mode = _mode(cache_dir)
+    assert mode & stat.S_IRWXG, (
+        f"fresh managed-mode {cache_dir} dropped group access ({oct(mode)}); the "
+        "NixOS module's hermes-group sharing (2770 + UMask=0007) is broken, so "
+        "an interactive hostUsers CLI and the gateway can no longer share it"
+    )
+
+
+def test_managed_mode_fresh_cache_agrees_across_both_creators(managed_nixos_home):
+    """The two creators of ``cache/vision`` must agree on managed mode too.
+
+    ``test_agrees_with_computer_use_cache_hardening`` pins this for the default
+    install. Managed mode is the case where they could silently diverge: if one
+    module honours the carve-out at creation and the other does not, whichever
+    wins the race decides whether the hermes group keeps access.
+    """
+    from tools.computer_use.tool import _vision_cache_dir
+    from tools.vision_tools import _secure_cache_dir
+
+    from_vision_tools = _secure_cache_dir("cache/vision", "temp_vision_images")
+    mode_after_vision_tools = _mode(from_vision_tools)
+
+    from_computer_use = _vision_cache_dir()
+
+    assert from_computer_use == from_vision_tools, "same directory expected"
+    assert mode_after_vision_tools == _mode(from_computer_use), (
+        "the two creators of cache/vision disagree on managed-mode creation: "
+        f"vision_tools={oct(mode_after_vision_tools)} "
+        f"computer_use={oct(_mode(from_computer_use))}"
+    )
+    assert mode_after_vision_tools & stat.S_IRWXG, (
+        "both creators dropped hermes-group access on a managed install: "
+        f"{oct(mode_after_vision_tools)}"
+    )
 
 
 def test_home_mode_override_is_honored(hermes_home, permissive_umask, monkeypatch):

--- a/tests/tools/test_vision_tools_media_cache_permissions.py
+++ b/tests/tools/test_vision_tools_media_cache_permissions.py
@@ -1,0 +1,396 @@
+"""At-rest permissions for the media caches created by ``tools.vision_tools``.
+
+Scope: this file guards **``tools/vision_tools.py``** — its
+``_secure_cache_dir`` / ``_write_private_bytes`` / ``_precreate_private_file``
+helpers and the four call sites that use them. The sibling suite
+``tests/computer_use/test_computer_use_vision_cache_permissions.py`` guards the
+*other* creator of ``cache/vision``, ``tools/computer_use/tool.py``. Both are
+kept because either module can win the race to create that shared directory;
+``test_agrees_with_computer_use_cache_hardening`` below is the seam that pins
+them together.
+
+``$HERMES_HOME/cache/vision`` and ``cache/video`` hold whatever the agent was
+asked to look at — a private attachment, an internal screenshot, a document
+scan. Created with a bare ``mkdir(parents=True, exist_ok=True)`` they inherited
+the umask and landed 0755, and the temp files inside landed 0644.
+
+``HERMES_HOME`` is 0700 by default, so default-config exposure is narrow and
+this is defence in depth. The concrete scenario is the documented
+``HERMES_HOME_MODE=0701`` hatch (letting nginx/caddy traverse HERMES_HOME to
+reach a served subdirectory), where a 0755 child really is world-readable.
+
+POSIX-only: mode bits are advisory on Windows, where at-rest protection is
+ACL-based and ``os.chmod`` only toggles the read-only flag.
+"""
+
+import os
+import stat
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.name != "posix",
+    reason="POSIX mode bits; Windows at-rest protection is ACL-based",
+)
+
+GROUP_OTHER_BITS = (
+    stat.S_IRGRP
+    | stat.S_IWGRP
+    | stat.S_IXGRP
+    | stat.S_IROTH
+    | stat.S_IWOTH
+    | stat.S_IXOTH
+)
+
+
+def _mode(path):
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+@pytest.fixture
+def permissive_umask():
+    """Force a world-readable-by-default umask for the duration of a test."""
+    previous = os.umask(0o022)
+    try:
+        yield
+    finally:
+        os.umask(previous)
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    home.mkdir(mode=0o700)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # Never let the ambient environment silently disable the hardening.
+    # tests/conftest.py blanks HERMES_CONTAINER / HERMES_HOME_MODE /
+    # HERMES_MANAGED, but NOT HERMES_SKIP_CHMOD — so this is load-bearing,
+    # not belt-and-braces.
+    monkeypatch.delenv("HERMES_CONTAINER", raising=False)
+    monkeypatch.delenv("HERMES_SKIP_CHMOD", raising=False)
+    monkeypatch.delenv("HERMES_HOME_MODE", raising=False)
+    monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    return home
+
+
+@pytest.mark.parametrize(
+    "new_subpath,old_name",
+    [("cache/vision", "temp_vision_images"), ("cache/video", "temp_video_files")],
+)
+def test_fresh_media_cache_dir_has_no_group_or_other_access(
+    hermes_home, permissive_umask, new_subpath, old_name
+):
+    """Every media cache this module creates must be owner-only."""
+    from tools.vision_tools import _secure_cache_dir
+
+    cache_dir = _secure_cache_dir(new_subpath, old_name)
+
+    assert cache_dir.is_dir()
+    mode = _mode(cache_dir)
+    assert not (
+        mode & GROUP_OTHER_BITS
+    ), f"media cache {cache_dir} is group/other-accessible: {oct(mode)}"
+
+
+def test_media_cache_mode_is_not_umask_derived(hermes_home, permissive_umask):
+    """The mode must come from the code, not the ambient umask."""
+    from tools.vision_tools import _secure_cache_dir
+
+    mode = _mode(_secure_cache_dir("cache/vision", "temp_vision_images"))
+
+    assert mode & stat.S_IRWXU == stat.S_IRWXU, "owner must retain full access"
+    assert mode & GROUP_OTHER_BITS == 0, f"umask-derived mode leaked: {oct(mode)}"
+
+
+def test_bare_mkdir_would_violate_the_contract(hermes_home, permissive_umask):
+    """Guard against a vacuous suite.
+
+    This is the exact pre-fix call shape. If it stops producing group/other
+    bits under ``umask 022`` then the fixture — not the fix — is what the
+    other tests are measuring, and they prove nothing.
+    """
+    from hermes_constants import get_hermes_dir
+
+    pre_fix = get_hermes_dir("cache/pre-fix-shape", "temp_pre_fix_shape")
+    pre_fix.mkdir(parents=True, exist_ok=True)
+
+    mode = _mode(pre_fix)
+    assert mode & GROUP_OTHER_BITS, (
+        "pre-fix call shape no longer leaks group/other bits under umask 022; "
+        f"got {oct(mode)} — the permission tests here would be vacuous"
+    )
+
+
+def test_preexisting_world_readable_cache_dir_is_healed(hermes_home, permissive_umask):
+    """An older Hermes left 0755 behind; the next call must tighten it.
+
+    Safe to do retroactively here specifically because this is Hermes-private
+    scratch the same user re-reads in the same call — there is no user-shared
+    content to strand.
+    """
+    from tools.vision_tools import _secure_cache_dir
+
+    legacy = hermes_home / "cache" / "vision"
+    legacy.mkdir(parents=True)
+    os.chmod(legacy, 0o755)
+    assert _mode(legacy) & stat.S_IROTH, "fixture precondition: starts world-readable"
+
+    cache_dir = _secure_cache_dir("cache/vision", "temp_vision_images")
+
+    assert cache_dir == legacy
+    assert not (
+        _mode(cache_dir) & GROUP_OTHER_BITS
+    ), f"pre-existing dir left exposed: {oct(_mode(cache_dir))}"
+
+
+def test_downloaded_media_bytes_are_written_owner_only(hermes_home, permissive_umask):
+    """The downloaded bytes themselves must not land 0644.
+
+    ``tools.computer_use.tool`` already writes 0600 into this directory; one
+    directory with two file-mode conventions is the inconsistency that rots.
+    """
+    from tools.vision_tools import _secure_cache_dir, _write_private_bytes
+
+    target = _secure_cache_dir("cache/vision", "temp_vision_images") / "temp_image.img"
+    _write_private_bytes(target, b"\x89PNG\r\n\x1a\n private attachment")
+
+    assert target.read_bytes().endswith(b"private attachment")
+    mode = _mode(target)
+    assert not (
+        mode & GROUP_OTHER_BITS
+    ), f"cached media {target} is group/other-readable: {oct(mode)}"
+
+
+def test_private_write_overwrites_and_stays_readable(hermes_home, permissive_umask):
+    """A permission fix that breaks the read path is the wrong fix.
+
+    The vision pipeline writes the temp file then reads it straight back
+    (base64-embed / MIME sniff), and re-uses the same name shape on retry, so
+    truncating rewrite plus owner read must both keep working.
+    """
+    from tools.vision_tools import _secure_cache_dir, _write_private_bytes
+
+    target = _secure_cache_dir("cache/vision", "temp_vision_images") / "reused.img"
+    _write_private_bytes(target, b"first-and-longer-payload")
+    _write_private_bytes(target, b"second")
+
+    assert target.read_bytes() == b"second", "O_TRUNC rewrite must not leave residue"
+    assert _mode(target) & stat.S_IRUSR, "owner must still be able to read it back"
+
+
+def test_real_conversion_path_creates_hardened_cache(
+    hermes_home, permissive_umask, tmp_path
+):
+    """Drive a real caller, not just the helper.
+
+    ``_normalize_to_supported_image`` is the network-free entry point that
+    materialises a converted PNG into the cache. Exercising it proves the
+    hardening is actually wired into the production path and that conversion
+    still works afterwards.
+    """
+    pytest.importorskip("PIL")
+    from PIL import Image
+
+    from tools.vision_tools import _normalize_to_supported_image
+
+    source = tmp_path / "input.bmp"
+    Image.new("RGB", (4, 4), (10, 20, 30)).save(source, format="BMP")
+
+    out_path, mime, error = _normalize_to_supported_image(source, "image/bmp")
+
+    assert error is None, f"conversion broke: {error}"
+    assert mime == "image/png"
+    assert out_path is not None and out_path.exists(), "converted file must exist"
+    # The feature still works: the result is a readable PNG.
+    with Image.open(out_path) as converted:
+        assert converted.size == (4, 4)
+
+    cache_dir = hermes_home / "cache" / "vision"
+    assert out_path.parent == cache_dir
+    assert not (
+        _mode(cache_dir) & GROUP_OTHER_BITS
+    ), f"production path left cache exposed: {oct(_mode(cache_dir))}"
+
+
+def test_agrees_with_computer_use_cache_hardening(hermes_home, permissive_umask):
+    """Both creators of ``cache/vision`` must land the same mode.
+
+    Either module can win the race to create this directory. If they disagree,
+    whichever runs first decides whether the captures are exposed.
+    """
+    from tools.computer_use.tool import _vision_cache_dir
+    from tools.vision_tools import _secure_cache_dir
+
+    from_vision_tools = _secure_cache_dir("cache/vision", "temp_vision_images")
+    mode_after_vision_tools = _mode(from_vision_tools)
+
+    from_computer_use = _vision_cache_dir()
+
+    assert from_computer_use == from_vision_tools, "same directory expected"
+    assert mode_after_vision_tools == _mode(from_computer_use), (
+        "the two creators of cache/vision disagree on mode: "
+        f"vision_tools={oct(mode_after_vision_tools)} "
+        f"computer_use={oct(_mode(from_computer_use))}"
+    )
+
+
+def test_downloaded_video_lands_owner_only(hermes_home, permissive_umask):
+    """The real video download path must not leave the .mp4 at 0644.
+
+    ``_download_video`` ends in ``destination.write_bytes()``, which derives a
+    fresh file's mode from the umask. ``video_analyze_tool`` pre-creates the
+    target 0600 so the write inherits that inode's mode instead. Only the HTTP
+    client is faked here — the pre-create, the guard, and the real write all
+    execute.
+    """
+    import asyncio
+
+    from tools.vision_tools import (
+        _download_video,
+        _precreate_private_file,
+        _secure_cache_dir,
+    )
+
+    target = _secure_cache_dir("cache/video", "temp_video_files") / "temp_video_x.mp4"
+
+    class FakeResponse:
+        url = "https://allowed.test/clip.mp4"
+        headers = {"content-length": "9"}
+        content = b"fake-mp4-"
+
+        def raise_for_status(self):
+            return None
+
+    def fake_client(**_kwargs):
+        client = AsyncMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        client.get = AsyncMock(return_value=FakeResponse())
+        return client
+
+    with (
+        patch("tools.vision_tools.check_website_access", return_value=None),
+        patch("tools.url_safety.create_ssrf_safe_async_client", side_effect=fake_client),
+    ):
+        _precreate_private_file(target)
+        asyncio.run(_download_video("https://allowed.test/clip.mp4", target, max_retries=1))
+
+    assert target.read_bytes() == b"fake-mp4-", "the download must still land"
+    mode = _mode(target)
+    assert not (
+        mode & GROUP_OTHER_BITS
+    ), f"downloaded video {target} is group/other-readable: {oct(mode)}"
+
+
+def test_unprepared_write_bytes_would_violate_the_contract(
+    hermes_home, permissive_umask
+):
+    """Vacuity guard for the video-file contract.
+
+    Without the pre-create, ``write_bytes`` on a fresh path is the pre-fix
+    shape. If that stops leaking group/other bits under ``umask 022``, the
+    test above proves nothing.
+    """
+    from tools.vision_tools import _secure_cache_dir
+
+    pre_fix = _secure_cache_dir("cache/video", "temp_video_files") / "pre-fix-shape.mp4"
+    pre_fix.write_bytes(b"fake-mp4-")
+
+    mode = _mode(pre_fix)
+    assert mode & GROUP_OTHER_BITS, (
+        "pre-fix write_bytes shape no longer leaks group/other bits under "
+        f"umask 022; got {oct(mode)} — the video-mode test would be vacuous"
+    )
+
+
+def test_precreate_does_not_clobber_an_existing_file(hermes_home, permissive_umask):
+    """The pre-create must be additive, never destructive.
+
+    It runs on a uuid path that should not exist, but it is ``O_EXCL`` so that
+    a collision (or a caller reusing a path) can never truncate real bytes.
+    """
+    from tools.vision_tools import _precreate_private_file, _secure_cache_dir
+
+    existing = _secure_cache_dir("cache/video", "temp_video_files") / "existing.mp4"
+    existing.write_bytes(b"do-not-lose-me")
+
+    _precreate_private_file(existing)
+
+    assert existing.read_bytes() == b"do-not-lose-me", "pre-create truncated a file"
+
+
+def test_failed_download_leaves_no_precreated_stub(hermes_home, permissive_umask):
+    """Pre-creating the target must not litter the cache when a download fails.
+
+    Creating the file before the download introduces an empty stub that did not
+    exist before this change, so the existing cleanup has to cover it. Drives
+    the real ``video_analyze_tool`` error path.
+    """
+    import asyncio
+
+    from tools.vision_tools import video_analyze_tool
+
+    async def boom(*_args, **_kwargs):
+        raise RuntimeError("download exploded")
+
+    with (
+        patch("tools.vision_tools._validate_image_url_async", AsyncMock(return_value=True)),
+        patch("tools.vision_tools.check_website_access", return_value=None),
+        patch("tools.vision_tools._download_video", side_effect=boom),
+    ):
+        asyncio.run(video_analyze_tool("https://allowed.test/clip.mp4", "describe"))
+
+    cache_dir = hermes_home / "cache" / "video"
+    leftovers = sorted(p.name for p in cache_dir.iterdir()) if cache_dir.exists() else []
+    assert leftovers == [], f"failed download left a stub behind: {leftovers}"
+
+
+def test_managed_mode_leaves_existing_permissions_alone(
+    hermes_home, permissive_umask, monkeypatch
+):
+    """Managed/NixOS installs own their own modes; we must not fight them."""
+    monkeypatch.setenv("HERMES_MANAGED", "nixos")
+    legacy = hermes_home / "cache" / "vision"
+    legacy.mkdir(parents=True)
+    os.chmod(legacy, 0o750)
+
+    from tools.vision_tools import _secure_cache_dir
+
+    assert (
+        _mode(_secure_cache_dir("cache/vision", "temp_vision_images")) == 0o750
+    ), "managed-mode permissions overridden"
+
+
+def test_home_mode_override_is_honored(hermes_home, permissive_umask, monkeypatch):
+    """The documented web-server traversal hatch still applies."""
+    monkeypatch.setenv("HERMES_HOME_MODE", "0701")
+
+    from tools.vision_tools import _secure_cache_dir
+
+    mode = _mode(_secure_cache_dir("cache/vision", "temp_vision_images"))
+
+    assert mode == 0o701
+    # Execute-only: traversal without a directory listing. Files stay 0600.
+    assert not (mode & (stat.S_IRGRP | stat.S_IROTH)), "listing must stay closed"
+
+
+def test_container_deployments_still_get_a_usable_directory(
+    hermes_home, permissive_umask, monkeypatch
+):
+    """A container/volume-mount deployment must not crash or lose the dir.
+
+    ``_secure_dir`` checks ``is_managed()`` only — unlike ``_secure_file`` it
+    does **not** consult ``_is_container()``, so the cache is still tightened
+    to 0700 here. That adds no new restriction: ``ensure_hermes_home`` already
+    puts HERMES_HOME and every standard subdir at 0700 in a container, and
+    multi-UID deployments are served by ``HERMES_UID``/``HERMES_GID`` or
+    ``HERMES_HOME_MODE``, both of which ``_secure_dir`` honours. So this
+    asserts the weaker, true contract: the directory exists and nothing raised.
+    """
+    monkeypatch.setenv("HERMES_CONTAINER", "1")
+    monkeypatch.setenv("HERMES_SKIP_CHMOD", "1")
+
+    from tools.vision_tools import _secure_cache_dir
+
+    assert _secure_cache_dir("cache/vision", "temp_vision_images").is_dir()

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -1203,7 +1203,8 @@ def _vision_cache_dir():
     if _managed_install():
         cache_dir.mkdir(parents=True, exist_ok=True)
         return cache_dir
-    # mode= is honored only for the leaf and is not masked by umask.
+    # mode= is honored only for the leaf and is not further masked by umask
+    # for the bits we care about; _secure_dir reconciles anything unusual.
     cache_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     try:
         from hermes_cli.config import _secure_dir

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -1145,6 +1145,67 @@ def _capture_after_mode() -> str:
     return mode if mode in {"som", "vision", "ax"} else "som"
 
 
+def _vision_cache_dir():
+    """Return the vision scratch dir, created owner-only.
+
+    A desktop capture is as sensitive as the screen it came from — an open
+    password manager, a private chat, a bank tab. The umask-derived 0755 this
+    used to get made every local account able to list (and read) those frames
+    whenever ``HERMES_HOME`` itself is traversable, which is exactly what the
+    documented ``HERMES_HOME_MODE=0701`` web-server escape hatch arranges.
+
+    The mode is set *at creation* so there is no window between mkdir and
+    chmod where the directory sits world-readable. Policy is then reconciled
+    by ``hermes_cli.config._secure_dir`` — the house helper — on every call,
+    which is what keeps this correct for deployments that are not a single
+    desktop user:
+
+    * managed/NixOS installs are skipped (the activation script owns modes);
+    * ``HERMES_HOME_MODE`` stays honored for the web-server traversal hatch;
+    * ``HERMES_UID``/``HERMES_GID`` ownership is applied, so a root-created
+      dir does not lock out uid-mapped Docker workers (#34107).
+
+    Running it unconditionally also heals a directory an older Hermes left at
+    0755. That retroactive tighten is safe *here* specifically because this
+    is Hermes-private scratch whose files are unlinked in the same call —
+    there is no user-shared content to strand. A directory a user may have
+    deliberately relaxed (a browser profile, a served asset dir) would not
+    qualify.
+    """
+    from hermes_constants import get_hermes_dir
+
+    cache_dir = get_hermes_dir("cache/vision", "temp_vision_images")
+    # mode= is honored only for the leaf and is not masked by umask.
+    cache_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        from hermes_cli.config import _secure_dir
+
+        _secure_dir(cache_dir)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("computer_use: vision cache chmod skipped: %s", exc)
+    return cache_dir
+
+
+def _write_private_bytes(path, data: bytes) -> None:
+    """Write ``data`` to ``path`` with owner-only (0600) permissions.
+
+    ``Path.write_bytes`` would land 0644 under a default umask. POSIX mode
+    bits are advisory on Windows (``os.chmod`` there only toggles the
+    read-only flag), so this is a best-effort narrowing that falls back to a
+    plain write rather than failing the capture.
+    """
+    import os as _os_priv
+
+    flags = _os_priv.O_WRONLY | _os_priv.O_CREAT | _os_priv.O_TRUNC
+    try:
+        fd = _os_priv.open(str(path), flags, 0o600)
+    except OSError:
+        path.write_bytes(data)
+        return
+    with _os_priv.fdopen(fd, "wb") as handle:
+        handle.write(data)
+
+
 def _route_capture_through_aux_vision(
     cap: CaptureResult,
     summary: str,
@@ -1169,7 +1230,6 @@ def _route_capture_through_aux_vision(
         import os as _os
         import uuid as _uuid
 
-        from hermes_constants import get_hermes_dir
         from model_tools import _run_async
         from tools.vision_tools import vision_analyze_tool
     except Exception as exc:  # pragma: no cover - defensive
@@ -1192,11 +1252,10 @@ def _route_capture_through_aux_vision(
             ext = ".jpg"
         else:
             ext = ".png"
-        cache_dir = get_hermes_dir("cache/vision", "temp_vision_images")
-        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_dir = _vision_cache_dir()
         temp_image_path = cache_dir / f"computer_use_{_uuid.uuid4().hex}{ext}"
         raw = _shrink_capture_for_vision(raw, ext)
-        temp_image_path.write_bytes(raw)
+        _write_private_bytes(temp_image_path, raw)
 
         prompt = (
             "Describe what is visible in this desktop application screenshot in "

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -1145,6 +1145,22 @@ def _capture_after_mode() -> str:
     return mode if mode in {"som", "vision", "ax"} else "som"
 
 
+def _managed_install() -> bool:
+    """True when a package manager (NixOS) owns this install's modes.
+
+    Mirrors the check ``hermes_cli.config._secure_dir`` makes internally, read
+    here so the *creation* mode honours the same carve-out as reconciliation.
+    Import is local and failure means "not managed": an unimportable config
+    module is the single-user source-install case, where 0700 is correct.
+    """
+    try:
+        from hermes_cli.config import is_managed
+
+        return bool(is_managed())
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
 def _vision_cache_dir():
     """Return the vision scratch dir, created owner-only.
 
@@ -1160,7 +1176,16 @@ def _vision_cache_dir():
     which is what keeps this correct for deployments that are not a single
     desktop user:
 
-    * managed/NixOS installs are skipped (the activation script owns modes);
+    * managed/NixOS installs are skipped — at *creation* as well as at
+      reconciliation. ``cache/vision`` is not one of the directories the
+      module's ``systemd.tmpfiles`` rules pre-create, so it is made lazily at
+      runtime and a hardcoded 0700 would be the only thing setting its mode.
+      The module pins ``stateDir/.hermes`` to ``2770`` and runs the gateway
+      with ``UMask = "0007"`` so "interactive users in the hermes group can
+      read/write" gateway-created state; the gateway and a hostUsers CLI
+      share one ``$HERMES_HOME``, so a 0700 cache locks whichever ran second
+      out with EACCES. Skipping the explicit mode lets the inherited setgid +
+      umask land 2770, matching ``ensure_hermes_home``'s managed branch;
     * ``HERMES_HOME_MODE`` stays honored for the web-server traversal hatch;
     * ``HERMES_UID``/``HERMES_GID`` ownership is applied, so a root-created
       dir does not lock out uid-mapped Docker workers (#34107).
@@ -1175,6 +1200,9 @@ def _vision_cache_dir():
     from hermes_constants import get_hermes_dir
 
     cache_dir = get_hermes_dir("cache/vision", "temp_vision_images")
+    if _managed_install():
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        return cache_dir
     # mode= is honored only for the leaf and is not masked by umask.
     cache_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     try:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -71,6 +71,96 @@ logger = logging.getLogger(__name__)
 
 _debug = DebugSession("vision_tools", env_var="VISION_TOOLS_DEBUG")
 
+
+def _secure_cache_dir(new_subpath: str, old_name: str) -> Path:
+    """Resolve a Hermes media cache dir and create it owner-only (0700).
+
+    A downloaded image or video is as sensitive as whatever the user pointed
+    the agent at — a private attachment, an internal screenshot, a document
+    scan. Created with a bare ``mkdir(parents=True, exist_ok=True)`` these
+    inherited the umask and landed 0755, readable by every other local
+    account. ``HERMES_HOME`` is 0700 by default so default-config exposure is
+    narrow; the concrete scenario is the documented ``HERMES_HOME_MODE=0701``
+    hatch (letting nginx/caddy traverse to a served subdirectory), where a
+    0755 child really is world-readable.
+
+    The mode is passed to ``mkdir`` so it is set *at creation*, leaving no
+    window where the directory sits world-readable before a follow-up chmod.
+    Policy is then reconciled through ``hermes_cli.config._secure_dir`` — the
+    house helper — rather than a hand-rolled chmod, which is what keeps this
+    correct off a single-user desktop: managed/NixOS installs are skipped,
+    ``HERMES_HOME_MODE`` stays honoured, and ``HERMES_UID``/``HERMES_GID``
+    ownership is applied so a root-created dir does not lock out uid-mapped
+    Docker workers (#34107).
+
+    Running it unconditionally also heals a directory an older Hermes left at
+    0755. That retroactive tighten is safe *here* because this is
+    Hermes-private scratch that the same user re-reads in the same call —
+    there is no user-shared content to strand. Note ``parents=True`` applies
+    the mode to the leaf only, so an intermediate ``cache/`` keeps its default
+    mode; it is shared with other subsystems and holds only directory names.
+
+    This deliberately mirrors ``tools.computer_use.tool._vision_cache_dir``,
+    which hardens the same ``cache/vision`` directory. See the module note in
+    that function; the two are kept behaviourally identical so the pair can be
+    collapsed into one shared helper next to ``_secure_dir``.
+    """
+    cache_dir = get_hermes_dir(new_subpath, old_name)
+    # mode= is honored only for the leaf and is not further masked by umask
+    # for the bits we care about; _secure_dir reconciles anything unusual.
+    cache_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        from hermes_cli.config import _secure_dir
+
+        _secure_dir(cache_dir)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("vision: cache dir chmod skipped: %s", exc)
+    return cache_dir
+
+
+def _write_private_bytes(path: Path, data: bytes) -> None:
+    """Write ``data`` to ``path`` with owner-only (0600) permissions.
+
+    ``Path.write_bytes`` lands 0644 under a default umask. The enclosing cache
+    dir is 0700, so this matters only under ``HERMES_HOME_MODE=0701`` — but
+    ``tools.computer_use.tool`` already writes 0600 into this very directory,
+    and one directory with two different file-mode conventions is the kind of
+    inconsistency that rots. 0600 keeps the write bit set, so it does not trip
+    the Windows read-only flag; POSIX mode bits are advisory there anyway, so
+    this degrades to a plain write rather than failing the download.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    try:
+        fd = os.open(str(path), flags, 0o600)
+    except OSError:
+        path.write_bytes(data)
+        return
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(data)
+
+
+def _precreate_private_file(path: Path) -> None:
+    """Create ``path`` empty and owner-only (0600) if it does not exist yet.
+
+    For byte paths Hermes does not write itself: ``_download_video`` finishes
+    with ``destination.write_bytes()``, and writing to an existing file
+    preserves that inode's mode rather than re-deriving one from the umask.
+    Creating the file 0600 up front therefore hands the download a private
+    target without changing the helper's caller-supplied-destination
+    contract, and without a chmod-after-write window.
+
+    Best-effort by design: a failure here must not fail the download, and on
+    Windows POSIX mode bits are advisory anyway (``os.chmod`` only toggles
+    the read-only flag), so this degrades to a plain download.
+    """
+    try:
+        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except OSError as exc:
+        logger.debug("vision: private pre-create skipped for %s: %s", path, exc)
+        return
+    os.close(fd)
+
+
 # Configurable HTTP download timeout for _download_image().
 # Separate from auxiliary.vision.timeout which governs the LLM API call.
 # Resolution: config.yaml auxiliary.vision.download_timeout → env var → 30s default.
@@ -340,8 +430,7 @@ def _normalize_to_supported_image(
     if detected_mime in _ANTHROPIC_SUPPORTED_MEDIA_TYPES:
         return image_path, detected_mime, None
 
-    out_dir = get_hermes_dir("cache/vision", "temp_vision_images")
-    out_dir.mkdir(parents=True, exist_ok=True)
+    out_dir = _secure_cache_dir("cache/vision", "temp_vision_images")
     out_path = out_dir / f"converted_{uuid.uuid4()}.png"
 
     # SVG: needs a rasterizer (Pillow cannot render SVG).
@@ -420,7 +509,11 @@ async def _download_image(image_url: str, destination: Path, max_retries: int = 
     """
     import asyncio
     
-    # Create parent directories if they don't exist
+    # Create parent directories if they don't exist. Deliberately NOT hardened
+    # to 0700: ``destination`` is caller-supplied and often outside
+    # HERMES_HOME (tools/image_source.py passes a NamedTemporaryFile under
+    # /tmp, mode 1777). Callers that download into a Hermes-owned cache get
+    # the tightened dir from _secure_cache_dir() before calling in.
     destination.parent.mkdir(parents=True, exist_ok=True)
     
     async def _ssrf_redirect_guard(response):
@@ -997,10 +1090,9 @@ async def _vision_analyze_native(
 
         detected_mime_type = resolved.mime
         image_size_bytes = len(resolved.data)
-        temp_dir = get_hermes_dir("cache/vision", "temp_vision_images")
-        temp_dir.mkdir(parents=True, exist_ok=True)
+        temp_dir = _secure_cache_dir("cache/vision", "temp_vision_images")
         temp_image_path = temp_dir / f"temp_image_{uuid.uuid4()}.img"
-        await asyncio.to_thread(temp_image_path.write_bytes, resolved.data)
+        await asyncio.to_thread(_write_private_bytes, temp_image_path, resolved.data)
         should_cleanup = True
 
         # Normalize unsupported formats (SVG, BMP, ...) to PNG BEFORE embedding.
@@ -1167,10 +1259,9 @@ async def vision_analyze_tool(
             raise ValueError(str(exc))
 
         detected_mime_type = resolved.mime
-        temp_dir = get_hermes_dir("cache/vision", "temp_vision_images")
-        temp_dir.mkdir(parents=True, exist_ok=True)
+        temp_dir = _secure_cache_dir("cache/vision", "temp_vision_images")
         temp_image_path = temp_dir / f"temp_image_{uuid.uuid4()}.img"
-        await asyncio.to_thread(temp_image_path.write_bytes, resolved.data)
+        await asyncio.to_thread(_write_private_bytes, temp_image_path, resolved.data)
         should_cleanup = True
 
         # Get image file size for logging
@@ -1583,6 +1674,7 @@ async def _download_video(video_url: str, destination: Path, max_retries: int = 
     """Download video from URL with SSRF protection and retry."""
     import asyncio
 
+    # Caller-supplied destination — see the note in _download_image().
     destination.parent.mkdir(parents=True, exist_ok=True)
 
     async def _ssrf_redirect_guard(response):
@@ -1702,8 +1794,21 @@ async def video_analyze_tool(
             blocked = check_website_access(video_url)
             if blocked:
                 raise PermissionError(blocked["message"])
-            temp_dir = get_hermes_dir("cache/video", "temp_video_files")
+            # Hardened here rather than in _download_video: that helper takes a
+            # caller-supplied destination (tools/image_source.py hands it a
+            # NamedTemporaryFile under /tmp), and chmod-ing an arbitrary
+            # caller's parent directory to 0700 would be a destructive side
+            # effect on a path Hermes does not own.
+            temp_dir = _secure_cache_dir("cache/video", "temp_video_files")
             temp_video_path = temp_dir / f"temp_video_{uuid.uuid4()}.mp4"
+            # Pre-create owner-only so the downloaded bytes land 0600 like the
+            # image path's _write_private_bytes: _download_video finishes with
+            # ``destination.write_bytes()``, which preserves an existing
+            # inode's mode instead of re-applying the umask. Doing it here
+            # rather than inside _download_video keeps that helper's
+            # caller-supplied destination contract intact (tools/image_source
+            # hands its sibling a /tmp NamedTemporaryFile it owns the mode of).
+            _precreate_private_file(temp_video_path)
             await _download_video(video_url, temp_video_path)
             should_cleanup = True
         else:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -72,8 +72,24 @@ logger = logging.getLogger(__name__)
 _debug = DebugSession("vision_tools", env_var="VISION_TOOLS_DEBUG")
 
 
+def _managed_install() -> bool:
+    """True when a package manager (NixOS) owns this install's modes.
+
+    Mirrors the check ``hermes_cli.config._secure_dir`` makes internally, read
+    here so the *creation* mode honours the same carve-out as reconciliation.
+    Import is local and failure means "not managed": an unimportable config
+    module is the single-user source-install case, where 0700 is correct.
+    """
+    try:
+        from hermes_cli.config import is_managed
+
+        return bool(is_managed())
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
 def _secure_cache_dir(new_subpath: str, old_name: str) -> Path:
-    """Resolve a Hermes media cache dir and create it owner-only (0700).
+    """Resolve a Hermes media cache dir, creating it owner-only (0700).
 
     A downloaded image or video is as sensitive as whatever the user pointed
     the agent at — a private attachment, an internal screenshot, a document
@@ -93,6 +109,20 @@ def _secure_cache_dir(new_subpath: str, old_name: str) -> Path:
     ownership is applied so a root-created dir does not lock out uid-mapped
     Docker workers (#34107).
 
+    The managed/NixOS carve-out applies to **creation as well as
+    reconciliation**. ``cache/vision`` and ``cache/video`` are not among the
+    directories the NixOS module's ``systemd.tmpfiles`` rules pre-create, so
+    they are made lazily at runtime; a hardcoded 0700 here would be the only
+    thing setting their mode and would silently override a design that pins
+    ``stateDir/.hermes`` to ``2770`` and runs the gateway with
+    ``UMask = "0007"`` so "interactive users in the hermes group can read/write"
+    gateway-created state. On such a host the gateway and a hostUsers CLI
+    share one ``$HERMES_HOME``, so a 0700 cache created by whichever ran
+    first makes vision fail with EACCES for the other. Skipping the explicit
+    mode there lets the inherited setgid + umask land 2770, matching
+    ``ensure_hermes_home``'s managed branch and its ``logs/curator``
+    lazy-mkdir precedent.
+
     Running it unconditionally also heals a directory an older Hermes left at
     0755. That retroactive tighten is safe *here* because this is
     Hermes-private scratch that the same user re-reads in the same call —
@@ -106,6 +136,11 @@ def _secure_cache_dir(new_subpath: str, old_name: str) -> Path:
     collapsed into one shared helper next to ``_secure_dir``.
     """
     cache_dir = get_hermes_dir(new_subpath, old_name)
+    if _managed_install():
+        # Managed mode: the NixOS-configured umask/setgid owns the mode, and
+        # _secure_dir would no-op anyway.
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        return cache_dir
     # mode= is honored only for the leaf and is not further masked by umask
     # for the bits we care about; _secure_dir reconciles anything unusual.
     cache_dir.mkdir(parents=True, exist_ok=True, mode=0o700)


### PR DESCRIPTION
## What does this PR do?

Chromium's user-data-dir (`$HERMES_HOME/chrome-debug`) and the vision/video caches were pre-created with a bare `mkdir`, so they inherited the umask and landed 0755 with 0644 files. Measured under `umask 022` against a fresh `HERMES_HOME`:

| path | before | after |
|---|---|---|
| `chrome-debug/` | 0755 | 0700 |
| `chrome-debug/launch-stderr.log` | 0644 | 0600 |
| `cache/vision/` | 0755 | 0700 |
| `cache/video/` | 0755 | 0700 |
| `cache/vision/temp_image_*.img` | 0644 | 0600 |
| `cache/video/temp_video_*.mp4` | 0644 | 0600 |

**The strongest argument here is not the threat model — it's that we were overriding the browser.** Given the directory to create itself, Chromium chooses 0700. Hermes pre-creating it at 0755 was downgrading the browser's own choice on its Cookies / Login Data / Local Storage. Verified with real Chrome 150.0.7871.187 headless against an isolated temp profile: CDP reachable, `Local State` + `Default` written, exit 0.

### Severity: defense-in-depth, not a live breach

I'd rather you get an accurate number than an inflated one. `HERMES_HOME` is 0700 by default, so another local account cannot traverse in, and the cache filenames are uuid4 — so under the default config this is not remotely exploitable.

The concrete exposure is the **documented `HERMES_HOME_MODE=0701` traversal hatch** (`_secure_dir`, `hermes_cli/config.py:765`), which exists so nginx/caddy can traverse `HERMES_HOME` to reach a served subdirectory. Under it, a 0755 child is genuinely world-readable. `launch-stderr.log` is the one file with a **fixed, guessable** name, so it is the one another account can open by guess without a listable directory; everything else in the caches is uuid-named.

### Approach

- **Mode is set at creation** (`makedirs(mode=…)` / `mkdir(mode=…)` / `os.open(…, 0o600)`), so there is no chmod-after-create window where a *new* artifact sits world-readable. One deliberate exception: `launch-stderr.log` also gets a `_secure_file()` reconcile after the truncating open, because `O_CREAT` applies its mode only to a file it actually creates — see "Follow-up: the existing log" below.
- **Policy is reconciled by the house helper `hermes_cli.config._secure_dir`**, not a hand-rolled chmod. That matters: it skips managed/NixOS installs, honors `HERMES_HOME_MODE`, and applies the `HERMES_UID`/`HERMES_GID` chown from #34107 — a hand-rolled `chmod(0o700)` would lock out uid-mapped Docker workers. This matches the in-tree precedent in `gateway/shutdown_flush.py:44` (`mkdir(parents=True, exist_ok=True, mode=0o700)`) and `:67` (`atomic_json_write(…, mode=0o600)`).
- **Reconciling unconditionally also heals a profile an older Hermes already left at 0755**, which is the point — that exposure is on disk today. It is safe against a *running* Chromium: only group/other bits drop, the owner keeps `rwx`, and POSIX checks mode at `open()` rather than on already-open descriptors.
- **The managed/NixOS carve-out applies at creation, not only at reconciliation** — see the section below. This was a real defect in the first push of this PR, caught by a follow-up review.
- **Windows is best-effort.** POSIX mode bits are advisory there (`chmod` only toggles the read-only flag), so the tests are `skipif(os.name != "posix")`. Windows ACL enforcement is deliberately left to the sibling PR **#77527** (`enforce owner-only ACLs on Windows in _secure_file`) rather than duplicated here — one Windows ACL implementation, in the shared helper, not two.

### Managed/NixOS: the carve-out has to cover creation too

The first push of this PR had a docstring that claimed "managed/NixOS installs are skipped (the activation script owns modes)". That was **true of the `_secure_dir` reconciliation and false of the creation** — `mode=0o700` was passed unconditionally, so on a managed install it was the *only* thing setting the mode. Fixed here, because the group sharing it broke is intentional design.

`nix/nixosModules.nix` pre-creates only `stateDir`, `.hermes`, `cron`, `sessions`, `logs`, `memories`, `plugins` at `2770` (setgid + group-rwx) via `systemd.tmpfiles` (~line 711). **`chrome-debug`, `cache/vision` and `cache/video` are not in those rules** — they are created lazily at runtime, under the service's `UMask = "0007"`, which the module comments as *"files created by the gateway should be group-writable so interactive users in the hermes group can read/write them"* (line 907). The activation script also deliberately avoids `chown -R` because it strips setgid, *"destroying the 2770 permissions the NixOS activation script sets for group access by hostUsers"* (line 136), and `container.hostUsers` get a `~/.hermes` symlink to that same `stateDir`.

So this is not a cosmetic mode difference. On a managed host the gateway service and an interactive hermes-group CLI **share one `$HERMES_HOME`**. A 0700 directory created by whichever ran first locks the other out with `EACCES` — losing the browser and the vision path, not merely their permission bits. Measured under real managed conditions (2770 parent, `umask 0007`), directory absent:

| | fresh `chrome-debug` | fresh `cache/vision` |
|---|---|---|
| merge base | `0o770` (group-rwx) | `0o770` (group-rwx) |
| this PR, first push | `0o700` (no group access) | `0o700` (no group access) |
| this PR, now | `0o770` (group-rwx) | `0o770` (group-rwx) |

`ensure_hermes_home` already branches on `is_managed()` at its own creation site (`hermes_cli/config.py:896`), and its `logs/curator` lazy `mkdir` inside an already-secured parent (`:931`) is the direct precedent for letting the configured umask decide. Each of the three sites now does the same via a local `_managed_install()`.

I considered keeping the unconditional 0700 and correcting only the docstrings — a browser profile holding Cookies and Login Data is defensibly better off owner-only, and Chromium itself picks 0700. I did not, for two reasons: the rubric rejects "fixes" that destroy the feature they secure, and honoring the carve-out only widens access on hosts where an administrator explicitly configured group sharing. It never widens the default install, where 0700 still holds.

**Non-managed behavior is unchanged by this follow-up.** Re-measured under `umask 022` against a temp `HERMES_HOME`, all three directories:

| scenario | result |
|---|---|
| default | `0o700` |
| `HERMES_SKIP_CHMOD=1` | `0o700` |
| `HERMES_CONTAINER=1` | `0o700` |
| `HERMES_HOME_MODE=0701` | `0o701` |
| managed, pre-existing `0750` dir | left at `0o750` |
| managed, dir absent | umask-derived (`0o755` at `umask 022`; `0o770` under the module's `UMask=0007`) — matches the merge base exactly |

The last row is the changed one, and it is a restoration: the merge base also yields `0o755` there under `umask 022`. Managed installs run the gateway at `UMask=0007`, which is where the group-rwx comes from.

### Why this isn't the reverse of #74897

#74897 deliberately moved `write_file`'s new files *from* 0600 *to* umask-derived 0644 because hardcoded 0600 broke cross-process readers (Obsidian LiveSync, Docker volumes, NAS mounts), and #74918 then hardened that arithmetic. If you worked on those, this PR will pattern-match to a decision you just made in the opposite direction — so, the distinction:

`write_file` writes to a **user-chosen destination** with an implied interop contract; the user picked that path precisely so other tools would read it. These are **Hermes-private scratch** (`cache/vision`, `cache/video` — files this same call unlinks) and **a browser profile Chromium itself creates at 0700**. There is no cross-process reader by design; the vision cache files are written and re-read inside one call. The interop concern that drove #74897 doesn't have a consumer here.

Where the same concern *does* apply, I left it alone: `_download_image` / `_download_video` take a caller-supplied `destination` (`tools/image_source.py` hands them a `NamedTemporaryFile` under `/tmp`), so hardening moved to the Hermes-owned cache dir at the call site instead of chmod-ing an arbitrary caller's parent directory.

### Scope

Scoped to bytes Hermes itself writes. `converted_*.png` deliberately stays 0644: it's emitted by PIL / `rsvg-convert` / `inkscape`, not by Hermes, and pre-creating it would either add a chmod-after-write window or leave empty stubs when an optional rasterizer is missing — which the existing `st_size > 0` success check keys off. Worth a follow-up, not worth breaking the rasterizer fallback.

`tools/computer_use/browser_route.py` is **untouched**.

## Related Issue

Reported as **#77486**, but both halves of that report's third bullet are wrong, so I'm not claiming to close it:

- It cites `HERMES_HOME/browser-profiles/*`. **`browser-profiles` exists nowhere in the repo or its history** — `rg 'browser-profiles'` → 0 matches, `git log --all -S 'browser-profiles'` → 0 commits. The real path is `$HERMES_HOME/chrome-debug`.
- It cites `browser_route.py:343-392` as the location. That file imports only `dataclasses` and `typing` — no `os`, no `pathlib`, no `open`, no `mkdir` — so it **cannot** set a permission. The cited lines are an argument validator (`profile_mode` / `profile_name` checks).

So this fixes the real instance of the bug class the reporter was gesturing at, at the paths that actually exist. It does **not** address the other half of that bullet: **Chromium's own Cookies / Login Data encryption is OS-keychain-backed and owned by the browser process, so it is not fixable from Hermes.** This PR changes permissions only and promises nothing about encryption. The Electron `connection.json` / journal items in #77486 are also out of scope here.

No `Fixes #…` line on purpose: the issue as filed is not what this fixes. Context only — refs #77486, and Windows ACLs are deferred to #77527.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/browser_connect.py` — new `_ensure_chrome_debug_data_dir()` (`makedirs(mode=0o700)` + `_secure_dir` reconcile) and `_open_launch_stderr_log()`, which does both halves: `os.open(…, create_mode)` with `O_TRUNC` for a fresh log (preserving the existing per-candidate overwrite semantics), and a `hermes_cli.config._secure_file()` reconcile for a log that already exists at `0644`. `create_mode` is `0o600` unmanaged and `0o666` on a managed install, so the configured umask decides there. `launch_chrome_debug` calls both.
- `tools/vision_tools.py` — new `_secure_cache_dir()`, `_write_private_bytes()`, `_precreate_private_file()`; the three `get_hermes_dir("cache/vision"…)` / `cache/video` call sites now route through them. `_download_image` / `_download_video` keep their umask-derived `destination.parent.mkdir` with a comment explaining why (caller-supplied paths, often `/tmp`).
- `tools/computer_use/tool.py` — new `_vision_cache_dir()` and `_write_private_bytes()`; the aux-vision capture route uses them instead of a bare `mkdir` + `write_bytes`.
- All three production files also gained a local `_managed_install()` helper so the *creation* mode honors the same managed/NixOS carve-out `_secure_dir` applies to reconciliation (see the managed-mode section above).
- `tests/hermes_cli/test_browser_connect_profile_permissions.py` (21), `tests/tools/test_vision_tools_media_cache_permissions.py` (22), `tests/computer_use/test_computer_use_vision_cache_permissions.py` (12) — new. **55 total** (49 before the existing-log follow-up).

Tests assert the **contract** (no group/other bits; owner retains access) rather than freezing an octal, and each file carries an explicit anti-vacuity test that runs the *pre-fix call shape* and asserts it still leaks group/other bits under `umask 022` — so if a future fixture change made these tests measure the fixture instead of the fix, that guard fails first. Managed-mode, `HERMES_HOME_MODE` override, and container deployments each have a test.

### `mode=` now has teeth, and so does managed fresh-creation

Two overlapping mechanisms harden each directory — `mode=` at creation and `_secure_dir` afterwards — and **they were masking each other.** Mutation-tested against the first push: stripping `mode=0o700` from all three creation sites left **37/37 green**, so nothing in the suite caught `mode=` being deleted. (Stripping `_secure_dir` instead failed 6, so only that half was actually pinned.) `mode=` is not dead code — it closes the mkdir→chmod TOCTOU window — but an untested mechanism is one a future refactor removes silently.

The new tests stub the reconciler to a recording no-op, which leaves the creation mode as the only thing that can produce owner-only bits. The racing window itself is not directly assertable, but *"correct with no chmod at all"* is exactly equivalent and is deterministic. Each file gets a pair: one with the ambient umask untouched, one under a forced `umask 022`, so a green result cannot be an artifact of a restrictive umask on the machine running the suite.

Both new groups are proven non-vacuous, in opposite directions:

| mutation | result |
|---|---|
| strip `mode=0o700` from all three sites | the 6 new creation-isolation tests fail; **nothing else does** |
| restore the unconditional `mode=0o700` (drop the managed carve-out) | the 5 new managed-fresh-creation tests fail |

### Follow-up: the existing log (`4195f1e98`)

Copilot flagged that `_open_launch_stderr_log()` left an *already existing* log's mode alone. It was right, and it was the case that mattered.

`O_CREAT` applies its `mode` argument only to a file it actually creates, so a pre-existing `0644` log stayed `0644` — measured against a temp `HERMES_HOME` under `umask 022`:

| case | previous push | now |
|---|---|---|
| pre-existing `launch-stderr.log` at `0644` | `0644` (unchanged) | **`0600`** |
| freshly created log | `0600` | `0600` |

`launch-stderr.log` is the one artifact here with a **fixed, guessable** name — everything else is uuid4 — so under the `HERMES_HOME_MODE=0701` hatch it is the one file another local account can open by guess without a listable directory. An older Hermes wrote it with a plain `open()` and left it `0644` on disk, so every *upgrading* install kept exactly the exposure this PR claims to close. That also contradicted this PR's own rationale for reconciling the profile directory unconditionally ("that exposure is on disk today").

Reconciled through `hermes_cli.config._secure_file` rather than a hand-rolled `os.chmod`, matching how the other three sites delegate to `_secure_dir`: that helper skips managed installs and containers (`hermes_cli/config.py:830`), and it is where Windows ACL enforcement would land (#77527). The reconcile runs *after* the truncating open and *before* any bytes are written, so the tighten lands while the file is empty, and it is best-effort (`except Exception` → `logger.debug`).

The managed carve-out extends to the log's creation too — the same defect the directories had. Measured under real managed conditions (`0o2770` parent, `UMask=0007`): merge base `0o660`, previous push `0o600`, now `0o660`. That regression was launch-breaking, not cosmetic: every candidate binary reuses this one log path, so an `EACCES` opening it makes `launch_chrome_debug` report spawn-failed for every candidate (reproduced: `launched=False`).

Also corrects a docstring in `tools/computer_use/tool.py` that claimed `mode=` "is not masked by umask" — `mkdir(mode=)` *is* subject to umask; it just cannot widen group/other from `0o700`. Now matches the already-correct wording in `tools/vision_tools.py`. Swept the tree for the same inaccurate claim: zero other occurrences, and the four other `mkdir(mode=0o700)` sites carry no umask claim at all.

6 new tests, 4 of which fail without this commit. Non-managed behaviour re-measured across all six scenarios and all three directories: byte-identical.

## How to Test

1. `./scripts/run_tests.sh tests/hermes_cli/test_browser_connect_profile_permissions.py tests/tools/test_vision_tools_media_cache_permissions.py tests/computer_use/test_computer_use_vision_cache_permissions.py -q` → **55 passed** (was 49 before the existing-log follow-up, 37 before the managed-mode + `mode=` coverage follow-up).
2. Reproduce the original symptom on `main`: with the three production files reverted to `main`, the same three files go **6 passed / 31 failed** (browser 9, vision_tools 14, computer_use 8).
3. Confirm each half of the browser hunk is load-bearing: drop the `_secure_dir` reconcile (keep `mode=0o700`) → 2 fail (`…profile_is_healed`, `…home_mode_override_is_honored`); make it a bare `os.makedirs(data_dir, exist_ok=True)` → 4 fail (adds `…without_group_or_other_access`, `…not_umask_derived`).
   With the follow-up in place, `mode=` is pinned on its own: strip it from all three sites → the 6 `…creation_mode_alone_yields_owner_only` / `…creation_mode_is_not_inherited_from_a_permissive_umask` tests fail and nothing else does. Restore the unconditional `mode=0o700` → the 5 `…managed_mode_fresh_*` tests fail.
4. Manual, real browser: `umask 022`, fresh `HERMES_HOME`, `hermes` → `browser.manage connect` (or call `launch_chrome_debug`), then `stat -f '%Sp %N' "$HERMES_HOME/chrome-debug" "$HERMES_HOME/chrome-debug/launch-stderr.log"` → `drwx------` / `-rw-------`, and Chrome still reaches CDP and writes `Local State` + `Default`.
5. Regression sweep: `rg -l 'browser_connect|vision_tools|computer_use' tests` → 44 files → **1299 passed, 3 failed**. All 3 are pre-existing on `main` (verified by reverting the production files in the same worktree and re-running): `tests/tools/test_computer_use.py::TestCaptureAppFilterNoMatch::test_linux_default_capture_skips_gnome_shell_helper` and two `tests/test_model_tools_async_bridge.py::TestVisionDispatchLoopSafety` failures.
6. Managed-mode behavior, which no octal in the table above covers on its own: with `HERMES_MANAGED=nixos`, `$HERMES_HOME` at `2770` and `umask 0007` (the module's tmpfiles rule + service `UMask`), create the dirs fresh → `chrome-debug` and `cache/vision` both land `0o770`, identical to the merge base. Before this follow-up they landed `0o700`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the target suites + a 44-file regression sweep via `scripts/run_tests.sh` (CI parity); 3 failures are pre-existing baseline, proven identical with the production files reverted. A full-suite run on this branch came back 25167 passed / 32 failed with **all 32 reproducing at the merge base**.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0 (Darwin 27.0.0, arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on all new helpers explain the mode choice, why `_secure_dir` rather than a hand-rolled chmod, and (corrected in the follow-up) exactly what managed/NixOS installs do at creation vs at reconciliation; no user-facing doc change (no config keys, no behavior a user configures) — otherwise N/A
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact: POSIX enforces; Windows mode bits are advisory so it degrades to a plain create and keeps inherited ACLs, with tests `skipif(os.name != "posix")`. Windows ACLs deferred to #77527. Managed/NixOS is skipped at both creation and reconciliation — including the lazily-created dirs its tmpfiles rules don't cover — and `HERMES_HOME_MODE` is honored via `_secure_dir`; containers keep a usable directory (tested).
- [x] N/A — no tool description/schema change; all five helpers are module-private

## Screenshots / Logs

Fix applied:

```
=== Summary: 3 files, 55 tests passed, 0 failed (100% complete) in 1.3s (24 workers) ===
```

Same three files with the production hunks reverted to `main` (proof the tests are non-vacuous):

```
=== Summary: 3 files, 6 tests passed, 31 failed (100% complete) in 1.1s (24 workers) ===
  tests/computer_use/test_computer_use_vision_cache_permissions.py  (8 tests failed)
  tests/hermes_cli/test_browser_connect_profile_permissions.py      (9 tests failed)
  tests/tools/test_vision_tools_media_cache_permissions.py          (14 tests failed)
```

`mode=0o700` stripped from all three creation sites, `_secure_dir` left in place (the mutation that used to leave 37/37 green):

```
=== Summary: 3 files, 43 tests passed, 6 failed (100% complete) in 8.8s (24 workers) ===
  FAILED …test_browser_connect_profile_permissions.py::test_creation_mode_alone_yields_owner_only
  FAILED …test_browser_connect_profile_permissions.py::test_creation_mode_is_not_inherited_from_a_permissive_umask
  FAILED …test_computer_use_vision_cache_permissions.py::test_creation_mode_alone_yields_owner_only
  FAILED …test_computer_use_vision_cache_permissions.py::test_creation_mode_is_not_inherited_from_a_permissive_umask
  FAILED …test_vision_tools_media_cache_permissions.py::test_creation_mode_alone_yields_owner_only[cache/vision-temp_vision_images]
  FAILED …test_vision_tools_media_cache_permissions.py::test_creation_mode_alone_yields_owner_only[cache/video-temp_video_files]
  FAILED …test_vision_tools_media_cache_permissions.py::test_creation_mode_is_not_inherited_from_a_permissive_umask
```

Managed carve-out reverted to the first push's unconditional `mode=0o700`:

```
=== Summary: 3 files, 44 tests passed, 5 failed (100% complete) in 1.9s (24 workers) ===
  FAILED …test_browser_connect_profile_permissions.py::test_managed_mode_fresh_profile_keeps_group_sharing
  FAILED …test_computer_use_vision_cache_permissions.py::test_managed_mode_fresh_cache_keeps_group_sharing
  FAILED …test_vision_tools_media_cache_permissions.py::test_managed_mode_fresh_cache_keeps_group_sharing[cache/vision-temp_vision_images]
  FAILED …test_vision_tools_media_cache_permissions.py::test_managed_mode_fresh_cache_keeps_group_sharing[cache/video-temp_video_files]
  FAILED …test_vision_tools_media_cache_permissions.py::test_managed_mode_fresh_cache_agrees_across_both_creators

AssertionError: fresh managed-mode profile dropped group access (0o700); the NixOS
module's hermes-group sharing (2770 + UMask=0007) is broken, so an interactive
hostUsers CLI and the gateway can no longer share it
```

Regression sweep (44 files touching `browser_connect` / `vision_tools` / `computer_use`):

```
=== Summary: 44 files, 1299 tests passed, 3 failed (100% complete) in 29.3s (24 workers) ===
  tests/test_model_tools_async_bridge.py  (2 tests failed)   ← pre-existing on main
  tests/tools/test_computer_use.py        (1 test failed)    ← pre-existing on main
```

Managed/NixOS, fresh dirs, real conditions (`$HERMES_HOME` at 2770 + `umask 0007`) — before and after the follow-up:

```
[merge base] .hermes      = 0o2770+setgid (group-rwx)
[merge base] chrome-debug = 0o770 (group-rwx)
[merge base] cache/vision = 0o770 (group-rwx)

[first push] chrome-debug = 0o700 (NO group access)   ← the defect
[first push] cache/vision = 0o700 (NO group access)

[now]        chrome-debug = 0o770 (group-rwx)
[now]        cache/vision = 0o770 (group-rwx)
```

`ruff check` on all six changed files: `All checks passed!` (ruff 0.16.1; the repo selects only `PLW1514`). `scripts/check-windows-footguns.py` → `✓ No Windows footguns found (3 file(s) scanned).` and `scripts/check_subprocess_stdin.py` → `✅ All TUI-context subprocess calls have explicit stdin=`.

