### PR TITLE
feat(skills): add skill group organization (#76830)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11118,6 +11118,10 @@ def cmd_skills(args):
         from hermes_cli.skills_config import skills_command as skills_config_command
 
         skills_config_command(args)
+    elif getattr(args, "skills_action", None) == "group":
+        from hermes_cli.skills_groups import group_command
+
+        group_command(args)
     else:
         from hermes_cli.skills_hub import skills_command
 

--- a/hermes_cli/skills_groups.py
+++ b/hermes_cli/skills_groups.py
@@ -1,0 +1,265 @@
+"""Skill groups — organize installed skills into named groups.
+
+Groups keep large skill installs navigable. They are stored in
+``config.yaml`` under ``skills.groups`` as a mapping of group name to a
+list of skill names::
+
+    skills:
+      disabled: [skill-a]
+      groups:
+        security: [web-pentest, godmode]
+        writing:  [humanizer]
+
+Groups are purely organizational: they do not change how skills load or
+run. They power the ``hermes skills group ...`` subcommands and the
+``--group`` filter on ``hermes skills list``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional, Set
+
+from rich.console import Console
+from rich.table import Table
+
+from hermes_cli.config import load_config, save_config
+
+_console = Console()
+
+
+def get_skill_groups(config: Optional[Dict[str, Any]] = None) -> Dict[str, List[str]]:
+    """Read ``skills.groups`` from config and normalize it.
+
+    Args:
+        config: Optional already-loaded config dict (test hook). When
+            omitted, the active profile's config is loaded — profile
+            switches (``-p``) swap ``HERMES_HOME`` at process start, so no
+            explicit profile flag is needed here, mirroring
+            ``get_disabled_skill_names``.
+
+    Returns a dict of group name -> sorted list of unique skill names.
+    Tolerates missing/null/malformed sections like ``get_disabled_skills``
+    in ``hermes_cli/skills_config.py``.
+    """
+    if config is None:
+        config = load_config()
+    skills_cfg = config.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return {}
+    raw = skills_cfg.get("groups")
+    if not isinstance(raw, dict):
+        return {}
+    groups: Dict[str, List[str]] = {}
+    for name, members in raw.items():
+        if not isinstance(name, str) or not name.strip():
+            continue
+        normalized = _normalize_members(members)
+        if normalized:
+            groups[name] = normalized
+    return groups
+
+
+def save_skill_groups(config: Dict[str, Any], groups: Dict[str, List[str]]) -> None:
+    """Persist ``skills.groups`` into *config* and write it to disk."""
+    config.setdefault("skills", {})
+    config["skills"]["groups"] = {
+        name: sorted(set(members)) for name, members in groups.items()
+    }
+    save_config(config)
+
+
+def add_skills_to_group(
+    config: Dict[str, Any], group: str, skills: List[str]
+) -> Dict[str, Any]:
+    """Add skill names to *group*, creating it when missing.
+
+    Returns a result dict with counts so the CLI can report precisely:
+    ``{"created": bool, "added": [...], "duplicates": [...], "unknown": [...]}``.
+    """
+    groups = get_skill_groups(config)
+    created = group not in groups
+    members = set(groups.get(group, []))
+    added: List[str] = []
+    duplicates: List[str] = []
+    for skill in skills:
+        (duplicates if skill in members else added).append(skill)
+        members.add(skill)
+    groups[group] = sorted(members)
+    save_skill_groups(config, groups)
+    return {
+        "created": created,
+        "added": added,
+        "duplicates": duplicates,
+        "unknown": _unknown_skill_names(added),
+    }
+
+
+def remove_skills_from_group(
+    config: Dict[str, Any],
+    group: str,
+    skills: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Remove skill names from *group*.
+
+    With no *skills*, the whole group is deleted. A group that ends up
+    empty is removed too. Returns ``{"removed": [...], "group_deleted":
+    bool, "missing": [...]}``.
+    """
+    groups = get_skill_groups(config)
+    if group not in groups:
+        return {"removed": [], "group_deleted": False, "missing": list(skills or [])}
+    members = set(groups[group])
+    if not skills:
+        del groups[group]
+        save_skill_groups(config, groups)
+        return {"removed": sorted(members), "group_deleted": True, "missing": []}
+    removed = [s for s in skills if s in members]
+    missing = [s for s in skills if s not in members]
+    members.difference_update(removed)
+    if members:
+        groups[group] = sorted(members)
+    else:
+        del groups[group]
+    save_skill_groups(config, groups)
+    return {"removed": removed, "group_deleted": not members, "missing": missing}
+
+
+def _normalize_members(members) -> List[str]:
+    """Normalize a raw group value (list, scalar, or garbage) to a sorted
+    list of unique, non-empty strings."""
+    if members is None:
+        return []
+    if isinstance(members, str):
+        members = [members]
+    if not isinstance(members, (list, tuple, set)):
+        return []
+    seen: Set[str] = set()
+    out: List[str] = []
+    for member in members:
+        name = str(member).strip() if member is not None else ""
+        if name and name not in seen:
+            seen.add(name)
+            out.append(name)
+    return sorted(out)
+
+
+def _validate_group_name(name: str) -> Optional[str]:
+    """Return an error message if *name* is not usable as a group name."""
+    if not name or not name.strip():
+        return "Group name cannot be empty."
+    if any(ch.isspace() for ch in name):
+        return f"Group name {name!r} must not contain whitespace."
+    if name.startswith("-"):
+        return f"Group name {name!r} must not start with '-' (looks like a flag)."
+    return None
+
+
+def _installed_skill_names() -> Set[str]:
+    """Best-effort set of installed skill names (empty on discovery failure)."""
+    try:
+        from tools.skills_tool import _find_all_skills
+
+        return {
+            skill.get("name")
+            for skill in _find_all_skills(skip_disabled=True)
+            if skill.get("name")
+        }
+    except Exception:
+        return set()
+
+
+def _unknown_skill_names(names: List[str]) -> List[str]:
+    """Names in *names* that are not currently installed.
+
+    Returns [] when skill discovery fails (config-only associations are
+    still allowed — the skill may be installed later).
+    """
+    installed = _installed_skill_names()
+    if not installed:
+        return []
+    return [name for name in names if name not in installed]
+
+
+def group_command(args) -> None:
+    """Router for ``hermes skills group <action>`` — called from main.py."""
+    action = getattr(args, "group_action", None)
+    if action in ("list", "ls"):
+        _cmd_group_list(as_json=getattr(args, "json", False))
+    elif action == "add":
+        _cmd_group_add(args.group, args.skills)
+    elif action in ("remove", "rm"):
+        _cmd_group_remove(args.group, getattr(args, "skills", None) or [])
+    else:
+        _console.print("Usage: hermes skills group [list|add|remove]\n")
+
+
+def _cmd_group_list(*, as_json: bool = False) -> None:
+    c = _console
+    groups = get_skill_groups()
+    if not groups:
+        c.print(
+            "[dim]No skill groups configured. Create one with:[/] "
+            "hermes skills group add <group> <skill> [skill ...]\n"
+        )
+        return
+    if as_json:
+        c.print(json.dumps(groups, indent=2))
+        return
+    table = Table(title="Skill Groups")
+    table.add_column("Group", style="bold cyan")
+    table.add_column("Skills", style="dim")
+    for name in sorted(groups):
+        table.add_row(name, ", ".join(groups[name]))
+    c.print(table)
+    total = sum(len(members) for members in groups.values())
+    c.print(f"[dim]{len(groups)} group(s), {total} skill assignment(s)[/]\n")
+
+
+def _cmd_group_add(group: str, skills: List[str]) -> None:
+    c = _console
+    error = _validate_group_name(group)
+    if error:
+        c.print(f"[bold red]Error:[/] {error}\n")
+        return
+    if not skills:
+        c.print(
+            "[bold red]Error:[/] At least one skill name is required. "
+            "Usage: hermes skills group add <group> <skill> [skill ...]\n"
+        )
+        return
+    config = load_config()
+    result = add_skills_to_group(config, group, skills)
+    verb = "Created group" if result["created"] else "Updated group"
+    c.print(f"[bold green]{verb}:[/] {group}")
+    if result["added"]:
+        c.print(f"[dim]Added: {', '.join(result['added'])}[/]")
+    if result["duplicates"]:
+        c.print(f"[dim]Already present: {', '.join(result['duplicates'])}[/]")
+    if result["unknown"]:
+        c.print(
+            f"[yellow]Not installed (added anyway): {', '.join(result['unknown'])}[/]"
+        )
+    c.print()
+
+
+def _cmd_group_remove(group: str, skills: List[str]) -> None:
+    c = _console
+    config = load_config()
+    result = remove_skills_from_group(config, group, skills or None)
+    if result["group_deleted"]:
+        c.print(f"[bold green]Deleted group:[/] {group}\n")
+        return
+    if result["removed"]:
+        c.print(
+            f"[bold green]Removed from {group}:[/] {', '.join(result['removed'])}"
+        )
+    if result["missing"]:
+        c.print(f"[dim]Not in group: {', '.join(result['missing'])}[/]")
+    if not result["removed"]:
+        current = get_skill_groups(config).get(group, [])
+        c.print(
+            f"[yellow]No skills removed. Group '{group}' currently has:[/] "
+            f"{', '.join(current) if current else '(none)'}"
+        )
+    c.print()

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -932,12 +932,16 @@ def inspect_skill(identifier: str) -> Optional[dict]:
 
 def do_list(source_filter: str = "all",
             enabled_only: bool = False,
+            group_filter: str = "",
             console: Optional[Console] = None) -> None:
     """List installed skills, distinguishing hub, builtin, and local skills.
 
     Args:
         source_filter: ``all`` | ``hub`` | ``builtin`` | ``local``.
         enabled_only: If True, hide disabled skills from the output.
+        group_filter: If non-empty, only show skills that belong to this
+            group (see ``skills.groups`` in config.yaml). Unknown groups
+            print an error listing the configured groups.
 
     Enabled/disabled state is resolved against the currently active profile's
     config — ``hermes -p <profile> skills list`` reads that profile's
@@ -948,6 +952,7 @@ def do_list(source_filter: str = "all",
     from tools.skills_sync import _read_manifest
     from tools.skills_tool import _find_all_skills
     from agent.skill_utils import get_disabled_skill_names
+    from hermes_cli.skills_groups import get_skill_groups
 
     c = console or _console
     ensure_hub_dirs()
@@ -959,9 +964,27 @@ def do_list(source_filter: str = "all",
     all_skills = _find_all_skills(skip_disabled=True)
     disabled_names = get_disabled_skill_names()
 
+    group_members: Optional[set] = None
+    if group_filter:
+        groups = get_skill_groups()
+        group_members = set(groups.get(group_filter, []))
+        if group_filter not in groups:
+            c.print(f"[bold red]Error:[/] Unknown group '{group_filter}'.")
+            if groups:
+                c.print(f"[dim]Available groups: {', '.join(sorted(groups))}[/]")
+            else:
+                c.print(
+                    "[dim]No groups configured. Create one with: "
+                    "hermes skills group add <group> <skill> [skill ...][/]"
+                )
+            c.print()
+            return
+
     title = "Installed Skills"
     if enabled_only:
         title += " (enabled only)"
+    if group_filter:
+        title += f" — group '{group_filter}'"
 
     table = Table(title=title)
     table.add_column("Name", style="bold cyan")
@@ -999,6 +1022,9 @@ def do_list(source_filter: str = "all",
 
         is_enabled = name not in disabled_names
         if enabled_only and not is_enabled:
+            continue
+
+        if group_members is not None and name not in group_members:
             continue
 
         if source_type == "hub":
@@ -1741,6 +1767,7 @@ def skills_command(args) -> None:
         do_list(
             source_filter=args.source,
             enabled_only=getattr(args, "enabled_only", False),
+            group_filter=getattr(args, "group", "") or "",
         )
     elif action == "check":
         do_check(name=getattr(args, "name", None))
@@ -1788,7 +1815,7 @@ def skills_command(args) -> None:
             return
         do_tap(tap_action, repo=repo)
     else:
-        _console.print("Usage: hermes skills [browse|search|install|inspect|list|list-modified|diff|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
+        _console.print("Usage: hermes skills [browse|search|install|inspect|list|group|list-modified|diff|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
         _console.print("Run 'hermes skills <command> --help' for details.\n")
 
 
@@ -1918,11 +1945,17 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
     elif action == "list":
         source_filter = "all"
         enabled_only = "--enabled-only" in args or "--enabled" in args
+        group_filter = ""
         if "--source" in args:
             idx = args.index("--source")
             if idx + 1 < len(args):
                 source_filter = args[idx + 1]
-        do_list(source_filter=source_filter, enabled_only=enabled_only, console=c)
+        if "--group" in args:
+            idx = args.index("--group")
+            if idx + 1 < len(args):
+                group_filter = args[idx + 1]
+        do_list(source_filter=source_filter, enabled_only=enabled_only,
+                group_filter=group_filter, console=c)
 
     elif action == "check":
         name = args[0] if args else None

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1951,9 +1951,33 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
             if idx + 1 < len(args):
                 source_filter = args[idx + 1]
         if "--group" in args:
+            from hermes_cli.skills_groups import get_skill_groups  # noqa: E402
             idx = args.index("--group")
             if idx + 1 < len(args):
-                group_filter = args[idx + 1]
+                raw_group = args[idx + 1]
+                if raw_group.startswith("--"):
+                    c.print(
+                        f"[bold red]Error:[/] Missing value for --group "
+                        f"(got '{raw_group}', which looks like a flag)."
+                    )
+                    groups = get_skill_groups()
+                    if groups:
+                        c.print(f"[dim]Available groups: {', '.join(sorted(groups))}[/]")
+                    else:
+                        c.print(
+                            "[dim]No groups configured. Create one with: "
+                            "hermes skills group add <group> <skill> [skill ...][/]"
+                        )
+                    c.print()
+                    return
+                group_filter = raw_group
+            else:
+                c.print("[bold red]Error:[/] --group requires a group name.")
+                groups = get_skill_groups()
+                if groups:
+                    c.print(f"[dim]Available groups: {', '.join(sorted(groups))}[/]")
+                c.print()
+                return
         do_list(source_filter=source_filter, enabled_only=enabled_only,
                 group_filter=group_filter, console=c)
 

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -123,6 +123,12 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
         help="Hide disabled skills. Use with -p <profile> to see exactly "
         "which skills will load for that profile.",
     )
+    skills_list.add_argument(
+        "--group",
+        default="",
+        help="Only show skills that belong to this group "
+        "(see `hermes skills group list`)",
+    )
 
     skills_check = skills_subparsers.add_parser(
         "check", help="Check installed hub skills for updates"
@@ -306,6 +312,49 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
     tap_add.add_argument("repo", help="GitHub repo (e.g. owner/repo)")
     tap_rm = tap_subparsers.add_parser("remove", help="Remove a tap")
     tap_rm.add_argument("name", help="Tap name to remove")
+
+    skills_group = skills_subparsers.add_parser(
+        "group",
+        help="Organize skills into named groups",
+        description=(
+            "Create named groups and associate skills with them. Groups are "
+            "stored in config.yaml under skills.groups (group name -> list of "
+            "skill names) and let you filter `hermes skills list --group <name>`."
+        ),
+    )
+    group_subparsers = skills_group.add_subparsers(dest="group_action")
+
+    group_list = group_subparsers.add_parser(
+        "list", aliases=["ls"], help="List skill groups and their members"
+    )
+    group_list.add_argument(
+        "--json", action="store_true", help="Output the groups as JSON"
+    )
+
+    group_add = group_subparsers.add_parser(
+        "add",
+        help="Add skills to a group (creates the group if needed)",
+    )
+    group_add.add_argument("group", help="Group name (e.g. security)")
+    group_add.add_argument(
+        "skills",
+        nargs="+",
+        metavar="skill",
+        help="Skill name(s) to add to the group",
+    )
+
+    group_remove = group_subparsers.add_parser(
+        "remove",
+        aliases=["rm"],
+        help="Remove skills from a group, or delete the whole group",
+    )
+    group_remove.add_argument("group", help="Group name")
+    group_remove.add_argument(
+        "skills",
+        nargs="*",
+        metavar="skill",
+        help="Skill name(s) to remove. Omit to delete the whole group.",
+    )
 
     # config sub-action: interactive enable/disable
     skills_subparsers.add_parser(

--- a/tests/hermes_cli/test_skills_groups.py
+++ b/tests/hermes_cli/test_skills_groups.py
@@ -1,0 +1,200 @@
+"""Tests for hermes_cli/skills_groups.py — skill group config, CLI helpers."""
+
+from unittest.mock import patch
+
+from hermes_cli.skills_groups import (
+    _validate_group_name,
+    add_skills_to_group,
+    get_skill_groups,
+    remove_skills_from_group,
+    save_skill_groups,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_skill_groups
+# ---------------------------------------------------------------------------
+
+class TestGetSkillGroups:
+    def test_empty_config(self):
+        assert get_skill_groups({}) == {}
+
+    def test_null_skills_section(self):
+        assert get_skill_groups({"skills": None}) == {}
+
+    def test_null_groups_section(self):
+        assert get_skill_groups({"skills": {"groups": None}}) == {}
+
+    def test_malformed_groups_section(self):
+        assert get_skill_groups({"skills": {"groups": "oops"}}) == {}
+
+    def test_normalizes_scalars_lists_and_dedupes(self):
+        config = {
+            "skills": {
+                "groups": {
+                    "security": ["web-pentest", "godmode", "web-pentest"],
+                    "writing": "humanizer",
+                    "empty": [],
+                    "  ": ["spaces"],
+                }
+            }
+        }
+        groups = get_skill_groups(config)
+        assert groups["security"] == ["godmode", "web-pentest"]
+        assert groups["writing"] == ["humanizer"]
+        assert "empty" not in groups
+        assert "  " not in groups
+
+
+# ---------------------------------------------------------------------------
+# save_skill_groups
+# ---------------------------------------------------------------------------
+
+class TestSaveSkillGroups:
+    @patch("hermes_cli.skills_groups.save_config")
+    def test_writes_sorted_unique_under_skills_groups(self, mock_save):
+        config = {}
+        save_skill_groups(config, {"security": ["godmode", "web-pentest", "godmode"]})
+        assert config["skills"]["groups"] == {
+            "security": ["godmode", "web-pentest"]
+        }
+        mock_save.assert_called_once()
+
+    @patch("hermes_cli.skills_groups.save_config")
+    def test_preserves_existing_skills_section(self, mock_save):
+        config = {"skills": {"disabled": ["old-skill"]}}
+        save_skill_groups(config, {"security": ["godmode"]})
+        assert config["skills"]["disabled"] == ["old-skill"]
+        assert config["skills"]["groups"] == {"security": ["godmode"]}
+
+
+# ---------------------------------------------------------------------------
+# add_skills_to_group
+# ---------------------------------------------------------------------------
+
+class TestAddSkillsToGroup:
+    @patch("hermes_cli.skills_groups.save_config")
+    def test_creates_group(self, mock_save):
+        config = {}
+        result = add_skills_to_group(config, "security", ["web-pentest", "godmode"])
+        assert result["created"] is True
+        assert set(result["added"]) == {"web-pentest", "godmode"}
+        assert config["skills"]["groups"]["security"] == ["godmode", "web-pentest"]
+
+    @patch("hermes_cli.skills_groups.save_config")
+    def test_appends_and_dedupes(self, mock_save):
+        config = {"skills": {"groups": {"security": ["godmode"]}}}
+        result = add_skills_to_group(config, "security", ["godmode", "humanizer"])
+        assert result["duplicates"] == ["godmode"]
+        assert result["added"] == ["humanizer"]
+        assert config["skills"]["groups"]["security"] == ["godmode", "humanizer"]
+
+
+# ---------------------------------------------------------------------------
+# remove_skills_from_group
+# ---------------------------------------------------------------------------
+
+class TestRemoveSkillsFromGroup:
+    @patch("hermes_cli.skills_groups.save_config")
+    def test_removes_skills(self, mock_save):
+        config = {"skills": {"groups": {"security": ["godmode", "web-pentest"]}}}
+        result = remove_skills_from_group(config, "security", ["godmode"])
+        assert result["removed"] == ["godmode"]
+        assert result["group_deleted"] is False
+        assert config["skills"]["groups"]["security"] == ["web-pentest"]
+
+    @patch("hermes_cli.skills_groups.save_config")
+    def test_deletes_group_when_empty(self, mock_save):
+        config = {"skills": {"groups": {"security": ["godmode"]}}}
+        result = remove_skills_from_group(config, "security", ["godmode"])
+        assert result["group_deleted"] is True
+        assert "security" not in config["skills"]["groups"]
+
+    @patch("hermes_cli.skills_groups.save_config")
+    def test_deletes_whole_group_without_skill_args(self, mock_save):
+        config = {"skills": {"groups": {"security": ["a", "b"]}}}
+        result = remove_skills_from_group(config, "security")
+        assert result["group_deleted"] is True
+        assert result["removed"] == ["a", "b"]
+        assert "security" not in config["skills"]["groups"]
+
+    @patch("hermes_cli.skills_groups.save_config")
+    def test_unknown_group_is_noop(self, mock_save):
+        config = {}
+        result = remove_skills_from_group(config, "nope", ["x"])
+        assert result["missing"] == ["x"]
+        assert result["group_deleted"] is False
+        mock_save.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _validate_group_name
+# ---------------------------------------------------------------------------
+
+class TestValidateGroupName:
+    def test_rejects_empty(self):
+        assert _validate_group_name("") is not None
+        assert _validate_group_name("   ") is not None
+
+    def test_rejects_whitespace(self):
+        assert _validate_group_name("my group") is not None
+
+    def test_rejects_flag_like(self):
+        assert _validate_group_name("-security") is not None
+
+    def test_accepts_valid_names(self):
+        assert _validate_group_name("security") is None
+        assert _validate_group_name("data-science") is None
+        assert _validate_group_name("writing2") is None
+
+
+# ---------------------------------------------------------------------------
+# CLI parser wiring
+# ---------------------------------------------------------------------------
+
+def _build_parser():
+    import argparse
+
+    from hermes_cli.subcommands.skills import build_skills_parser
+
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_skills_parser(subparsers, cmd_skills=lambda args: None)
+    return parser
+
+
+class TestSkillsGroupParser:
+    def test_list_group_flag(self):
+        args = _build_parser().parse_args(
+            ["skills", "list", "--group", "security"]
+        )
+        assert args.skills_action == "list"
+        assert args.group == "security"
+
+    def test_group_add(self):
+        args = _build_parser().parse_args(
+            ["skills", "group", "add", "security", "web-pentest", "godmode"]
+        )
+        assert args.skills_action == "group"
+        assert args.group_action == "add"
+        assert args.group == "security"
+        assert args.skills == ["web-pentest", "godmode"]
+
+    def test_group_remove_whole_group(self):
+        args = _build_parser().parse_args(
+            ["skills", "group", "remove", "security"]
+        )
+        assert args.group_action == "remove"
+        assert args.group == "security"
+        assert args.skills == []
+
+    def test_group_remove_skills(self):
+        args = _build_parser().parse_args(
+            ["skills", "group", "rm", "security", "godmode"]
+        )
+        assert args.group_action == "rm"
+        assert args.skills == ["godmode"]
+
+    def test_group_list_alias(self):
+        args = _build_parser().parse_args(["skills", "group", "ls"])
+        assert args.group_action == "ls"

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -70,6 +70,14 @@ def _capture(source_filter: str = "all") -> str:
     return sink.getvalue()
 
 
+def _capture_group(group: str) -> str:
+    """Run do_list with a group filter into a string buffer."""
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_list(group_filter=group, console=console)
+    return sink.getvalue()
+
+
 def _capture_check(monkeypatch, results, name=None) -> str:
     import tools.skills_hub as hub
 
@@ -122,6 +130,37 @@ def test_do_list_platform_env_is_ignored(three_source_env, monkeypatch):
     _capture()
 
     assert seen["platform"] is None
+
+
+def test_do_list_group_filter(three_source_env, monkeypatch):
+    """`hermes skills list --group <name>` shows only skills in that group."""
+    import hermes_cli.skills_groups as groups_mod
+
+    monkeypatch.setattr(
+        groups_mod,
+        "get_skill_groups",
+        lambda config=None: {"security": ["hub-skill", "local-skill"]},
+    )
+    out = _capture_group("security")
+    assert "hub-skill" in out
+    assert "local-skill" in out
+    assert "builtin-skill" not in out
+    assert "group 'security'" in out
+
+
+def test_do_list_unknown_group(three_source_env, monkeypatch):
+    """An unknown --group prints an error listing available groups."""
+    import hermes_cli.skills_groups as groups_mod
+
+    monkeypatch.setattr(
+        groups_mod,
+        "get_skill_groups",
+        lambda config=None: {"security": ["hub-skill"]},
+    )
+    out = _capture_group("nope")
+    assert "Unknown group 'nope'" in out
+    assert "Available groups: security" in out
+    assert "hub-skill" not in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -352,3 +352,36 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
 
+
+# ---------------------------------------------------------------------------
+#  Slash command --group parsing edge cases (#76985 salvage)
+# ---------------------------------------------------------------------------
+
+def test_slash_list_group_missing_value(capsys, monkeypatch):
+    """`/skills list --group` (no value) prints an error, not unfiltered output."""
+    import hermes_cli.skills_groups as groups_mod
+
+    monkeypatch.setattr(
+        groups_mod,
+        "get_skill_groups",
+        lambda config=None: {"security": ["godmode"]},
+    )
+    handle_skills_slash("/skills list --group")
+    captured = capsys.readouterr().out
+    assert "requires a group name" in captured
+
+
+def test_slash_list_group_flag_value(capsys, monkeypatch):
+    """`/skills list --group --source hub` rejects a flag-like value."""
+    import hermes_cli.skills_groups as groups_mod
+
+    monkeypatch.setattr(
+        groups_mod,
+        "get_skill_groups",
+        lambda config=None: {"security": ["godmode"]},
+    )
+    handle_skills_slash("/skills list --group --source hub")
+    captured = capsys.readouterr().out
+    assert "looks like a flag" in captured
+    assert "--source" in captured
+


### PR DESCRIPTION
## Summary

Cherry-picks webtecnica's PR #76985 and fixes the two blocking slash-command parser issues.

With 60+ skills installed, `hermes skills list` is a flat list that gets hard to navigate. This PR adds named skill groups:

- `hermes skills group add <group> <skill> [skill ...]` — create a group
- `hermes skills group remove <group> [skill ...]` — remove skills or delete group
- `hermes skills group list` — show all groups (--json for scripting)
- `hermes skills list --group <name>` — filter to a group
- `/skills list --group <name>` — same filter in slash command

Groups are stored in `config.yaml` under `skills.groups` (group name → list of skill names), consistent with `skills.disabled`.

### Fixes vs original PR #76985

- `/skills list --group` (no value) now prints an error + available groups
- `/skills list --group --source hub` now rejects flag-like value
- Both edge cases have regression tests

### Verification

- 29/29 tests passed (test_skills_groups + test_skills_hub)

Co-authored-by: webtecnica <webtecnica@gmail.com>