### PR TITLE
fix(gateway): default systemd gateway must ignore active_profile

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -636,17 +636,31 @@ def _apply_profile_override() -> None:
 
     # 2. If no flag, check active_profile in the hermes root.
     #
-    # EXCEPTION: a supervised s6 gateway child (exported by the container
-    # run-script as HERMES_S6_SUPERVISED_CHILD=1) must NOT follow the sticky
-    # active_profile. Each supervised slot has a fixed profile identity: named
-    # slots pass ``-p <name>`` explicitly (handled in step 1 above), and the
-    # reserved ``gateway-default`` slot runs bare ``hermes gateway run`` to mean
-    # "the root HERMES_HOME profile". If the reserved default child read
-    # active_profile here, switching the active profile (e.g. via the dashboard)
-    # would silently redirect the default gateway into that profile — yielding a
-    # duplicate gateway for the active profile and no real default gateway. See
-    # the "Docker & Profiles & Dashboard" report.
-    if profile_name is None and not os.environ.get("HERMES_S6_SUPERVISED_CHILD"):
+    # EXCEPTION: a supervised gateway must NOT follow the sticky active_profile.
+    # Each supervised slot has a fixed profile identity: named slots pass
+    # ``-p <name>`` explicitly (handled in step 1 above), and the reserved
+    # default slot runs bare ``hermes gateway run`` to mean "the root
+    # HERMES_HOME profile". If the reserved default child read active_profile
+    # here, switching the active profile (e.g. via the dashboard) would
+    # silently redirect the default gateway into that profile — yielding a
+    # duplicate gateway for the active profile and no real default gateway.
+    # See the "Docker & Profiles & Dashboard" report.
+    #
+    # The supervised guard is signalled by EITHER of two sentinels:
+    #   - HERMES_S6_SUPERVISED_CHILD — exported by the s6-overlay container
+    #     run-script (Docker image, the original case).
+    #   - INVOCATION_ID — set unconditionally by systemd for every unit it
+    #     launches. A default gateway installed as a systemd unit (the
+    #     documented bare-metal setup) runs with a fixed HERMES_HOME passed
+    #     by the unit file; following active_profile would redirect it into
+    #     a sibling profile on every `hermes profile use`, crashing both the
+    #     default and the named service (stale gateway.lock). This is the same
+    #     failure mode the s6 guard prevents, just on a different supervisor.
+    _supervised = (
+        os.environ.get("HERMES_S6_SUPERVISED_CHILD")
+        or os.environ.get("INVOCATION_ID")
+    )
+    if profile_name is None and not _supervised:
         try:
             from hermes_constants import get_default_hermes_root
 

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 def _run_apply_profile_override(
     tmp_path, monkeypatch, *, hermes_home: str | None, active_profile: str | None,
     argv: list[str] | None = None,
+    invocation_id: str | None = None,
 ):
     """Run _apply_profile_override in isolation.
 
@@ -40,6 +41,11 @@ def _run_apply_profile_override(
         monkeypatch.setenv("HERMES_HOME", hermes_home)
     else:
         monkeypatch.delenv("HERMES_HOME", raising=False)
+
+    if invocation_id is not None:
+        monkeypatch.setenv("INVOCATION_ID", invocation_id)
+    else:
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
 
     monkeypatch.setattr(sys, "argv", argv or ["hermes", "gateway", "start"])
 
@@ -155,6 +161,66 @@ class TestSupervisedChildIgnoresStickyProfile:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.delenv("HERMES_HOME", raising=False)
         monkeypatch.setenv("HERMES_S6_SUPERVISED_CHILD", "1")
+        monkeypatch.setattr(sys, "argv", ["hermes", "-p", "coder", "gateway", "run"])
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        result = os.environ.get("HERMES_HOME")
+        assert result is not None
+        assert result.endswith("coder")
+
+
+class TestSystemdSupervisedIgnoresStickyProfile:
+    """A bare-metal systemd default gateway must not follow active_profile.
+
+    systemd sets ``INVOCATION_ID`` for every unit it launches. A default
+    gateway installed as a systemd unit (the documented bare-metal setup)
+    runs with a fixed HERMES_HOME passed by the unit file; following the
+    sticky ``active_profile`` on every ``hermes profile use`` redirects the
+    default gateway into the named profile's HERMES_HOME, producing a
+    duplicate gateway (the default now serves the named profile) and a
+    crash-loop on the named service (stale ``gateway.lock`` held by the
+    redirected default). This is the same failure mode the s6 guard
+    prevents; ``INVOCATION_ID`` is the systemd equivalent of the s6 sentinel.
+    """
+
+    def test_systemd_default_gateway_ignores_active_profile(
+        self, tmp_path, monkeypatch
+    ):
+        """A bare ``hermes gateway run`` under systemd (INVOCATION_ID set)
+        must NOT redirect to active_profile, even when it points at a
+        non-default profile."""
+        result = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile="sam",
+            argv=["hermes", "gateway", "run"],
+            invocation_id="abc-123-def",  # simulate systemd
+        )
+
+        # HERMES_HOME must NOT point into profiles/sam — the default gateway
+        # stays on the root HERMES_HOME profile.
+        if result is not None:
+            assert not result.endswith("sam"), (
+                f"systemd default gateway was redirected to {result!r}; "
+                "it must ignore active_profile when INVOCATION_ID is set"
+            )
+
+    def test_systemd_named_profile_flag_still_wins(self, tmp_path, monkeypatch):
+        """A systemd named-profile service passes ``-p <name>`` explicitly;
+        that must still resolve (the INVOCATION_ID guard only skips the
+        sticky active_profile fallback, never an explicit flag)."""
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+        (hermes_root / "active_profile").write_text("briefer")
+        (hermes_root / "profiles" / "briefer").mkdir(parents=True, exist_ok=True)
+        (hermes_root / "profiles" / "coder").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setenv("INVOCATION_ID", "abc-123-def")
         monkeypatch.setattr(sys, "argv", ["hermes", "-p", "coder", "gateway", "run"])
 
         from hermes_cli.main import _apply_profile_override


### PR DESCRIPTION
## Problem

A default Hermes gateway installed as a bare-metal systemd unit crash-loops whenever the user switches the active profile via `hermes profile use <X>` or the dashboard.

The existing guarded block in `_apply_profile_override()` only skips the sticky `active_profile` lookup when `HERMES_S6_SUPERVISED_CHILD` is set — a sentinel exported exclusively by the Docker s6-overlay run-script. There is **no equivalent for the documented bare-metal systemd setup**.

On a systemd-managed fleet, every unit is launched with `INVOCATION_ID` set. But the default gateway (which, unlike named profile services, has no `--profile` flag) still falls through to the `active_profile` lookup. Switching the active profile then silently redirects the default gateway's `HERMES_HOME` into the sibling profile's directory:

1. The default process resolves the sibling's token and acquires its `gateway.lock`.
2. The named profile service can no longer start — it finds a live PID in its `gateway.lock` and exits with "Gateway already running (PID <sibling>)".
3. systemd relaunches it → same failure → crash-loop (thousands observed; one fleet ran 12h+ before being noticed).

This is the exact failure mode the s6 guard was written to prevent, just on a different supervisor.

## Fix

Extend the supervised guard to also recognise `INVOCATION_ID`, which systemd sets unconditionally for every unit it launches ("the systemd equivalent of the s6 sentinel"). The default gateway now behaves under systemd exactly as it already does under s6: it honours an explicit `--profile` flag but ignores the sticky `active_profile` fallback.

`​`​`​`python
_supervised = (
    os.environ.get("HERMES_S6_SUPERVISED_CHILD")
    or os.environ.get("INVOCATION_ID")
)
if profile_name is None and not _supervised:
    ...
`​`​`​

## Why INVOCATION_ID is the right signal

- **Universal**: systemd sets it for every unit, with no opt-in.
- **Already used elsewhere in the codebase**: `gateway/restart.py` already treats `INVOCATION_ID` as a "running under a supervisor" signal.
- **Narrow scope**: an interactive `hermes gateway run` from a shell has no `INVOCATION_ID`, so the sticky-profile behaviour is fully preserved. Only supervised units are affected — which is precisely the intent.

No new env var, no new concept, no config knob. 4 lines of substance.

## Tests

Two regression tests added to `tests/hermes_cli/test_apply_profile_override.py`:

- `test_systemd_default_gateway_ignores_active_profile`: a bare `hermes gateway run` with `INVOCATION_ID` set and `active_profile=sam` must NOT redirect `HERMES_HOME` into `profiles/sam`.
- `test_systemd_named_profile_flag_still_wins`: a systemd named-profile service (`-p coder`) must still resolve under `INVOCATION_ID`.

All 6 tests in the file pass.

## Checklist

- [x] Bug reproduced on a real multi-profile systemd fleet
- [x] Root cause traced (strace-confirmed)
- [x] Fix is 4 lines of substance, no new env var or concept
- [x] Regression tests added (2 new, all 6 pass)
- [x] Existing s6 behaviour preserved
- [x] Interactive CLI behaviour preserved
