### PR TITLE
fix(desktop): bound in-flight turn journal retention and purge it on delete

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -4,8 +4,14 @@ import { useEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
-import { getSession, getSessionMessages, type SessionInfo } from '@/hermes'
+import { deleteSession, getSession, getSessionMessages, type SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import {
+  JOURNAL_PERSIST_THROTTLE_MS,
+  JOURNAL_STORAGE_KEY,
+  persistInFlightTurnState,
+  readInFlightTurnJournal
+} from '@/lib/inflight-turn-journal'
 import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
 import { $activeGatewayProfile, $newChatProfile, ensureGatewayProfile } from '@/store/profile'
 import { $projectScope, $projectTree, ALL_PROJECTS } from '@/store/projects'
@@ -1682,5 +1688,153 @@ describe('selectSidebarItem', () => {
     expect(navigate).toHaveBeenCalledWith('/skills', undefined)
     expect(noteActiveTreeGroup).toHaveBeenCalledWith(null)
     expect(revealTreePane).toHaveBeenCalledWith('workspace')
+  })
+})
+
+// ── Deleting a session must reach its LOCAL copies ────────────────────────────
+// The in-flight turn journal keeps the running turn's tail — the user's prompt
+// plus assistant rows including tool-call args — unredacted in localStorage,
+// bounded only by retention (`lib/inflight-turn-journal.ts`). The journal module
+// tests prove `purgeInFlightTurnJournals` works; they cannot prove a DELETE
+// invokes it. Without an assertion here the call can be dropped from this hook
+// and the whole module suite still passes, which is how the original defect
+// (delete cleared the sibling composer queue but not the journal) shipped.
+describe('removeSession purges local session state', () => {
+  afterEach(() => {
+    cleanup()
+    setActiveSessionId(null)
+    setSelectedStoredSessionId(null)
+    setMessages([])
+    setSessions([])
+    window.localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  function DeleteHarness({
+    onReady,
+    requestGateway
+  }: {
+    onReady: (remove: (storedSessionId: string) => Promise<void>) => void
+    requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+  }) {
+    const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+
+    const actions = useSessionActions({
+      activeSessionId: RUNTIME_ID,
+      activeSessionIdRef: ref<string | null>(RUNTIME_ID),
+      busyRef: ref(false),
+      creatingSessionRef: ref(false),
+      ensureSessionState: () => ({}) as ClientSessionState,
+      getRouteToken: () => 'token',
+      getRoutedStoredSessionId: () => null,
+      navigate: vi.fn() as never,
+      requestGateway,
+      resetViewSync: vi.fn(),
+      runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
+      selectedStoredSessionId: 'stored-del',
+      selectedStoredSessionIdRef: ref<string | null>('stored-del'),
+      sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
+      syncSessionStateToView: vi.fn(),
+      updateSessionState: () => ({}) as ClientSessionState
+    })
+
+    useEffect(() => {
+      onReady(actions.removeSession)
+    }, [actions, onReady])
+
+    return null
+  }
+
+  const RUNTIME_ID = 'runtime-del'
+
+  /** Journal a live turn the way `useSessionStateCache` does, then let the
+   *  throttle land so the tail is genuinely on disk before the delete. */
+  function journalLiveTurn(storedSessionId: string, runtimeSessionId: null | string): void {
+    vi.useFakeTimers()
+    persistInFlightTurnState(
+      {
+        awaitingResponse: false,
+        busy: true,
+        messages: [
+          { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'PGPASSWORD=hunter2 psql -h prod' }] },
+          { id: 'assistant-stream-1', role: 'assistant', parts: [{ type: 'text', text: 'working' }], pending: true }
+        ],
+        storedSessionId,
+        streamId: 'assistant-stream-1',
+        turnStartedAt: 1
+      },
+      runtimeSessionId
+    )
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+    vi.useRealTimers()
+  }
+
+  async function deleteVia(storedSessionId: string): Promise<void> {
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let remove: ((storedSessionId: string) => Promise<void>) | null = null
+
+    render(<DeleteHarness onReady={r => (remove = r)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(remove).not.toBeNull())
+    await act(async () => {
+      await remove!(storedSessionId)
+    })
+  }
+
+  it('clears the journaled in-flight tail for the deleted session', async () => {
+    setSessions([storedSession({ id: 'stored-del' })])
+    setSelectedStoredSessionId('stored-del')
+    setActiveSessionId(RUNTIME_ID)
+    journalLiveTurn('stored-del', RUNTIME_ID)
+
+    expect(readInFlightTurnJournal('stored-del')).not.toBeNull()
+
+    await deleteVia('stored-del')
+
+    expect(vi.mocked(deleteSession)).toHaveBeenCalledWith('stored-del', undefined)
+    expect(readInFlightTurnJournal('stored-del')).toBeNull()
+    expect(window.localStorage.getItem(JOURNAL_STORAGE_KEY)).toBeNull()
+  })
+
+  // A compression rotation leaves the turn journaled under an INTERMEDIATE tip
+  // that is in neither `$sessions` nor `removedIds`. It is reachable only via
+  // the closing runtime id recorded on the entry — so the delete has to pass it.
+  it('reaches a tail stranded under a rotated stored id via the closing runtime id', async () => {
+    setSessions([storedSession({ id: 'stored-del' })])
+    setSelectedStoredSessionId('stored-del')
+    setActiveSessionId(RUNTIME_ID)
+    journalLiveTurn('rotated-tip', RUNTIME_ID)
+
+    expect(readInFlightTurnJournal('rotated-tip')).not.toBeNull()
+
+    await deleteVia('stored-del')
+
+    expect(readInFlightTurnJournal('rotated-tip')).toBeNull()
+  })
+
+  it('leaves another session journal untouched', async () => {
+    setSessions([storedSession({ id: 'stored-del' }), storedSession({ id: 'stored-other' })])
+    setSelectedStoredSessionId('stored-del')
+    setActiveSessionId(RUNTIME_ID)
+    journalLiveTurn('stored-other', 'runtime-other')
+    journalLiveTurn('stored-del', RUNTIME_ID)
+
+    await deleteVia('stored-del')
+
+    expect(readInFlightTurnJournal('stored-del')).toBeNull()
+    expect(readInFlightTurnJournal('stored-other')).not.toBeNull()
+  })
+
+  // Rollback path: a failed delete restores the row, so the journal it would
+  // recover from must NOT have been dropped on the way.
+  it('keeps the journal when the delete RPC fails', async () => {
+    setSessions([storedSession({ id: 'stored-del' })])
+    setSelectedStoredSessionId('stored-del')
+    setActiveSessionId(RUNTIME_ID)
+    journalLiveTurn('stored-del', RUNTIME_ID)
+    vi.mocked(deleteSession).mockRejectedValueOnce(new Error('backend down'))
+
+    await deleteVia('stored-del')
+
+    expect(readInFlightTurnJournal('stored-del')).not.toBeNull()
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -7,7 +7,7 @@ import { deleteSession, getSessionMessages, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
-import { recoverInFlightTurnJournal } from '@/lib/inflight-turn-journal'
+import { purgeInFlightTurnJournals, recoverInFlightTurnJournal } from '@/lib/inflight-turn-journal'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { migrateSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
@@ -1341,6 +1341,13 @@ export function useSessionActions({
 
         await deleteSession(storedSessionId, removed?.profile)
         clearQueuedPrompts(storedSessionId)
+        // The journaled in-flight tail holds this session's prompt and tool
+        // calls in localStorage; a deleted session must not leave that behind
+        // to age out on its own. Pass the runtime id too: it is not a journal
+        // key, but entries record it, so it reaches a tail stranded under an
+        // intermediate stored id that compression rotated past — an id that is
+        // in neither `$sessions` nor `removedIds`, so nothing else can name it.
+        purgeInFlightTurnJournals([...removedIds, closingRuntimeId])
 
         if (closingRuntimeId) {
           clearQueuedPrompts(closingRuntimeId)

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -4,6 +4,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
 import {
+  JOURNAL_MAX_AGE_MS,
+  JOURNAL_PERSIST_THROTTLE_MS,
+  JOURNAL_STORAGE_KEY,
+  persistInFlightTurnState,
+  readInFlightTurnJournal
+} from '@/lib/inflight-turn-journal'
+import {
   $activeSessionStoredIdRotation,
   $currentFastMode,
   $currentModel,
@@ -491,5 +498,126 @@ describe('useSessionStateCache — cross-thread error isolation', () => {
     // check must reject it instead of allowing a submit into stored-B.
     cache.runtimeIdByStoredSessionIdRef.current.set('stored-A', 'runtime-B')
     expect(cache.getRuntimeIdForStoredSession('stored-A')).toBeNull()
+  })
+})
+
+// ── The journal's two wiring obligations this hook owns ───────────────────────
+// Both are call-site plumbing that the journal's own module tests cannot reach:
+// they can prove the sweep and the rotation link WORK, never that this hook
+// invokes them. Each was mutated away against the whole desktop suite and
+// nothing failed before these tests existed.
+describe('useSessionStateCache — in-flight turn journal wiring', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    setActiveSessionId(null)
+    window.localStorage.clear()
+    vi.useRealTimers()
+  })
+
+  function tail(): ChatMessage[] {
+    return [
+      userMessage('u1', 'PGPASSWORD=hunter2 psql -h prod'),
+      { id: 'assistant-stream-1', role: 'assistant', parts: [{ type: 'text', text: 'working' }], pending: true }
+    ]
+  }
+
+  /** Write a journal entry directly, then age it past the retention window in
+   *  one raw write — going through the public API would re-enter the sweep. */
+  function seedExpiredEntry(storedSessionId: string): void {
+    vi.useFakeTimers()
+    persistInFlightTurnState({
+      awaitingResponse: false,
+      busy: true,
+      messages: tail(),
+      storedSessionId,
+      streamId: 'assistant-stream-1',
+      turnStartedAt: 1
+    })
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+    vi.useRealTimers()
+
+    const raw = JSON.parse(window.localStorage.getItem(JOURNAL_STORAGE_KEY)!)
+    raw.entries[storedSessionId].updatedAt = Date.now() - (JOURNAL_MAX_AGE_MS + 60 * 60 * 1000)
+    window.localStorage.setItem(JOURNAL_STORAGE_KEY, JSON.stringify(raw))
+  }
+
+  // The journal's load-time sweep only runs when something else calls into the
+  // module. A user who launches into a fresh draft and never opens a session
+  // would never sweep, which would make the retention bound — the whole
+  // confidentiality argument for storing an unredacted prompt at rest —
+  // contingent on unrelated activity. Mounting this hook is what makes it
+  // unconditional, so mounting alone has to be enough.
+  it('sweeps an expired journal entry on mount without any session being opened', () => {
+    seedExpiredEntry('stored-stale')
+
+    expect(window.localStorage.getItem(JOURNAL_STORAGE_KEY)).not.toBeNull()
+
+    render(<Harness activeSessionId={null} onReady={() => undefined} selectedStoredSessionId={null} />)
+
+    expect(window.localStorage.getItem(JOURNAL_STORAGE_KEY)).toBeNull()
+  })
+
+  it('leaves a live journal entry alone on mount', () => {
+    vi.useFakeTimers()
+    persistInFlightTurnState({
+      awaitingResponse: false,
+      busy: true,
+      messages: tail(),
+      storedSessionId: 'stored-live',
+      streamId: 'assistant-stream-1',
+      turnStartedAt: 1
+    })
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+    vi.useRealTimers()
+
+    render(<Harness activeSessionId={null} onReady={() => undefined} selectedStoredSessionId={null} />)
+
+    expect(readInFlightTurnJournal('stored-live')).not.toBeNull()
+  })
+
+  // The RUNTIME id is what makes a rotated key reachable: the stored id rotates
+  // mid-turn (compression forks a continuation), so without the runtime id
+  // recorded on the entry, the superseded key is in neither `$sessions` nor a
+  // delete's `removedIds` and NO call site can name it. If this hook stops
+  // supplying it, every rotation test in the journal module still passes —
+  // they pass the id explicitly — while the real app silently orphans tails.
+  it('passes the runtime id to the journal, so a rotated key stays reachable', () => {
+    vi.useFakeTimers()
+    let cache!: Cache
+
+    setActiveSessionId('runtime-J')
+    render(
+      <Harness activeSessionId="runtime-J" onReady={value => (cache = value)} selectedStoredSessionId="stored-J1" />
+    )
+
+    act(() => {
+      cache.updateSessionState(
+        'runtime-J',
+        state => ({ ...state, busy: true, messages: tail(), streamId: 'assistant-stream-1' }),
+        'stored-J1'
+      )
+      vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+    })
+
+    expect(readInFlightTurnJournal('stored-J1')?.runtimeSessionId).toBe('runtime-J')
+
+    // Compression rotates the stored tip; the same live turn keeps streaming.
+    act(() => {
+      cache.updateSessionState(
+        'runtime-J',
+        state => ({ ...state, busy: true, messages: tail(), streamId: 'assistant-stream-1' }),
+        'stored-J2'
+      )
+      vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+    })
+
+    // The rotation link is what lets the write path drop the key it superseded,
+    // so the pre-rotation tail is not stranded holding the same prompt.
+    expect(readInFlightTurnJournal('stored-J1')).toBeNull()
+    expect(readInFlightTurnJournal('stored-J2')?.runtimeSessionId).toBe('runtime-J')
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -4,7 +4,7 @@ import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { preserveLocalAssistantErrors } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
-import { persistInFlightTurnState } from '@/lib/inflight-turn-journal'
+import { persistInFlightTurnState, sweepExpiredInFlightTurnJournals } from '@/lib/inflight-turn-journal'
 import { setMutableRef } from '@/lib/mutable-ref'
 import {
   $activeSessionId,
@@ -56,6 +56,14 @@ export function useSessionStateCache({
   const busy = useStore($busy)
   const activeSessionIdRef = useRef<string | null>(activeSessionId)
   const selectedStoredSessionIdRef = useRef<string | null>(selectedStoredSessionId)
+
+  // The journal's retention window is its whole confidentiality bound, so it
+  // must not depend on the user happening to open a session: the sweep inside
+  // the journal's own load only runs when some other call reaches it. This hook
+  // owns the write path, so it is where the bound gets made unconditional.
+  useEffect(() => {
+    sweepExpiredInFlightTurnJournals()
+  }, [])
 
   // Mirror the latest prop into its ref synchronously during render — not via
   // a passive useEffect, which only fires a frame after paint and left the
@@ -303,7 +311,11 @@ export function useSessionStateCache({
       // Crash-survivable turn progress: journal the running turn's visible
       // tail (throttled localStorage write; cleared the moment the turn
       // settles) so a renderer/app death mid-turn can be recovered on resume.
-      persistInFlightTurnState(next)
+      // The RUNTIME id is passed because `next.storedSessionId` ROTATES mid-turn
+      // (see `ensureSessionState` above): it is the journal's only rotation-proof
+      // link back to the key this write supersedes, so the old key cannot be
+      // stranded holding the same prompt and tool args.
+      persistInFlightTurnState(next, sessionId)
       // Publishing to $sessionStates automatically fires transition side-effects
       // (watchdog, settle grace, unread marker, compression id rotation) inside
       // publishSessionState — no manual transition call needed.

--- a/apps/desktop/src/app/settings/sessions-settings.test.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  JOURNAL_PERSIST_THROTTLE_MS,
+  JOURNAL_STORAGE_KEY,
+  persistInFlightTurnState,
+  readInFlightTurnJournal
+} from '@/lib/inflight-turn-journal'
+import { enqueueQueuedPrompt, getQueuedPrompts } from '@/store/composer-queue'
+import type { SessionInfo } from '@/types/hermes'
+
+import { SessionsSettings } from './sessions-settings'
+
+/**
+ * The archived-sessions delete is the SECOND delete surface. Its journal purge
+ * and its queued-prompt clear are call-site wiring: the journal module tests
+ * call `purgeInFlightTurnJournals` directly and `composer-queue` tests call
+ * `clearQueuedPrompts` directly, so both can be deleted from this component with
+ * every other suite still green. That is exactly how the original defect shipped
+ * — the sidebar delete cleared the composer queue, this one cleared neither.
+ *
+ * Both stores are keyed on either the stored tip or the durable lineage root
+ * (`resolveComposerSessionKey`), so both ids have to be cleared, and both are
+ * asserted here.
+ */
+const mocks = vi.hoisted(() => ({
+  deleteSession: vi.fn(),
+  listAllProfileSessions: vi.fn(),
+  notifyError: vi.fn(),
+  setSessionArchived: vi.fn()
+}))
+
+// Partial mock: `@/store/profile` subscribes to `setApiRequestProfile` at import
+// time, so a bare factory drops real exports the store graph needs.
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  deleteSession: (id: string, profile?: null | string) => mocks.deleteSession(id, profile),
+  getHermesConfigRecord: vi.fn().mockResolvedValue({}),
+  listAllProfileSessions: (limit: number, offset: number, archived: string) =>
+    mocks.listAllProfileSessions(limit, offset, archived),
+  saveHermesConfig: vi.fn().mockResolvedValue(undefined),
+  setSessionArchived: (id: string, archived: boolean, profile?: null | string) =>
+    mocks.setSessionArchived(id, archived, profile)
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: (...args: unknown[]) => mocks.notifyError(...args)
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      settings: {
+        sessions: {
+          archivedIntro: 'Archived chats',
+          archivedTitle: 'Archived',
+          autoArchiveDaysLabel: 'Days',
+          autoArchiveDaysUnit: 'days',
+          autoArchiveDesc: 'Hide old chats',
+          autoArchiveFailed: 'Auto-archive failed',
+          autoArchiveTitle: 'Auto-archive',
+          change: 'Change',
+          choose: 'Choose',
+          clear: 'Clear',
+          clearDirFailed: 'Clear failed',
+          defaultDirDesc: 'Default folder',
+          defaultDirTitle: 'Default project folder',
+          defaultDirUpdated: 'Updated',
+          defaultsTo: (label: string) => `Defaults to ${label}`,
+          deleteConfirm: (title: string) => `Delete ${title}?`,
+          deleteFailed: 'Delete failed',
+          deletePermanently: 'Delete permanently',
+          emptyArchivedDesc: 'No archived chats',
+          emptyArchivedTitle: 'Nothing archived',
+          failedLoad: 'Load failed',
+          loading: 'Loading',
+          messages: (count: number) => `${count} messages`,
+          notSet: 'Not set',
+          restored: 'Restored',
+          unarchive: 'Unarchive',
+          unarchiveFailed: 'Unarchive failed',
+          updateDirFailed: 'Update failed'
+        }
+      }
+    }
+  })
+}))
+
+const STORED_ID = 'stored-archived'
+const LINEAGE_ROOT_ID = 'root-archived'
+const SECRET_PROMPT = 'PGPASSWORD=hunter2 psql -h prod'
+
+function archivedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    _lineage_root_id: LINEAGE_ROOT_ID,
+    archived: true,
+    ended_at: null,
+    id: STORED_ID,
+    input_tokens: 0,
+    is_active: false,
+    last_active: 1,
+    message_count: 2,
+    model: null,
+    output_tokens: 0,
+    preview: 'archived preview',
+    source: 'desktop',
+    started_at: 1,
+    title: 'Archived chat',
+    tool_call_count: 0,
+    ...overrides
+  } as SessionInfo
+}
+
+/** Journal a live turn the way `useSessionStateCache` does, then let the
+ *  throttle land so the unredacted tail is genuinely on disk. */
+function journalTail(storedSessionId: string): void {
+  vi.useFakeTimers()
+  persistInFlightTurnState({
+    awaitingResponse: false,
+    busy: true,
+    messages: [
+      { id: 'u1', role: 'user', parts: [{ type: 'text', text: SECRET_PROMPT }] },
+      { id: 'assistant-stream-1', role: 'assistant', parts: [{ type: 'text', text: 'working' }], pending: true }
+    ],
+    storedSessionId,
+    streamId: 'assistant-stream-1',
+    turnStartedAt: 1
+  })
+  vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+  vi.useRealTimers()
+}
+
+async function deleteArchivedRow(): Promise<void> {
+  render(
+    <MemoryRouter>
+      <SessionsSettings />
+    </MemoryRouter>
+  )
+
+  const button = await screen.findByLabelText('Delete permanently')
+  fireEvent.click(button)
+  await waitFor(() => expect(mocks.deleteSession).toHaveBeenCalledWith(STORED_ID, undefined))
+}
+
+describe('SessionsSettings archived delete purges local session state', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    mocks.deleteSession.mockReset().mockResolvedValue(undefined)
+    mocks.listAllProfileSessions.mockReset().mockResolvedValue({ sessions: [archivedSession()] })
+    mocks.notifyError.mockReset()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    cleanup()
+    window.localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('clears the journaled in-flight tail for the deleted session', async () => {
+    journalTail(STORED_ID)
+    expect(readInFlightTurnJournal(STORED_ID)).not.toBeNull()
+
+    await deleteArchivedRow()
+
+    await waitFor(() => expect(readInFlightTurnJournal(STORED_ID)).toBeNull())
+    expect(window.localStorage.getItem(JOURNAL_STORAGE_KEY)).toBeNull()
+  })
+
+  // The journal keys on the stored tip, but a compression rotation can leave the
+  // tail under the lineage root instead, so the delete has to name both.
+  it('clears a tail journaled under the lineage root id', async () => {
+    journalTail(LINEAGE_ROOT_ID)
+    expect(readInFlightTurnJournal(LINEAGE_ROOT_ID)).not.toBeNull()
+
+    await deleteArchivedRow()
+
+    await waitFor(() => expect(readInFlightTurnJournal(LINEAGE_ROOT_ID)).toBeNull())
+  })
+
+  // The clear this surface was ALSO missing: the sidebar delete already dropped
+  // queued prompts, the settings delete left them holding the user's text.
+  it('clears queued prompts for the stored id and the lineage root', async () => {
+    enqueueQueuedPrompt(STORED_ID, { attachments: [], text: 'queued under the tip' })
+    enqueueQueuedPrompt(LINEAGE_ROOT_ID, { attachments: [], text: 'queued under the root' })
+    expect(getQueuedPrompts(STORED_ID)).toHaveLength(1)
+    expect(getQueuedPrompts(LINEAGE_ROOT_ID)).toHaveLength(1)
+
+    await deleteArchivedRow()
+
+    await waitFor(() => expect(getQueuedPrompts(STORED_ID)).toHaveLength(0))
+    expect(getQueuedPrompts(LINEAGE_ROOT_ID)).toHaveLength(0)
+  })
+
+  it('leaves an unrelated session journal and queue intact', async () => {
+    journalTail('stored-other')
+    enqueueQueuedPrompt('stored-other', { attachments: [], text: 'someone else' })
+
+    await deleteArchivedRow()
+
+    await waitFor(() => expect(mocks.deleteSession).toHaveBeenCalled())
+    expect(readInFlightTurnJournal('stored-other')).not.toBeNull()
+    expect(getQueuedPrompts('stored-other')).toHaveLength(1)
+  })
+
+  // A failed delete keeps the row, so the local copies it would recover from
+  // must survive too.
+  it('keeps the journal and queue when the delete RPC fails', async () => {
+    mocks.deleteSession.mockRejectedValueOnce(new Error('backend down'))
+    journalTail(STORED_ID)
+    enqueueQueuedPrompt(STORED_ID, { attachments: [], text: 'still queued' })
+
+    await deleteArchivedRow()
+
+    await waitFor(() => expect(mocks.notifyError).toHaveBeenCalled())
+    expect(readInFlightTurnJournal(STORED_ID)).not.toBeNull()
+    expect(getQueuedPrompts(STORED_ID)).toHaveLength(1)
+  })
+})

--- a/apps/desktop/src/app/settings/sessions-settings.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.tsx
@@ -15,6 +15,8 @@ import { sessionTitle } from '@/lib/chat-runtime'
 import { pathLeaf } from '@/lib/display-path'
 import { triggerHaptic } from '@/lib/haptics'
 import { Archive, ArchiveOff, FolderOpen, Loader2, Trash2 } from '@/lib/icons'
+import { purgeInFlightTurnJournals } from '@/lib/inflight-turn-journal'
+import { clearQueuedPrompts } from '@/store/composer-queue'
 import { notify, notifyError } from '@/store/notifications'
 import { untombstoneSessions } from '@/store/projects'
 import { applyConfiguredDefaultProjectDir, ensureDefaultWorkspaceCwd, setSessions } from '@/store/session'
@@ -83,6 +85,14 @@ export function SessionsSettings() {
 
       try {
         await deleteSession(session.id, session.profile)
+        // Same contract as the sidebar delete: a deleted session must not leave
+        // a copy of the user's prompt text in localStorage. Both stores hold it —
+        // the journal keeps the in-flight tail, the composer queue keeps unsent
+        // entries — and both are keyed on either the stored tip or the durable
+        // lineage root (`resolveComposerSessionKey`), so both ids are cleared.
+        purgeInFlightTurnJournals([session.id, session._lineage_root_id])
+        clearQueuedPrompts(session.id)
+        clearQueuedPrompts(session._lineage_root_id)
         setLocalSessions(prev => prev.filter(s => s.id !== session.id))
         triggerHaptic('warning')
       } catch (err) {

--- a/apps/desktop/src/lib/inflight-turn-journal.test.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.test.ts
@@ -1,16 +1,29 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ChatMessage } from '@/lib/chat-messages'
+import { type ChatMessage, chatMessageText } from '@/lib/chat-messages'
 import {
   clearInFlightTurnJournal,
+  JOURNAL_MAX_AGE_MS,
+  JOURNAL_PERSIST_THROTTLE_MS,
+  JOURNAL_STORAGE_KEY,
   type JournalableSessionState,
   mergeInFlightMessages,
   persistInFlightTurnState,
+  purgeInFlightTurnJournals,
   readInFlightTurnJournal,
-  recoverInFlightTurnJournal
+  recoverInFlightTurnJournal,
+  sweepExpiredInFlightTurnJournals
 } from '@/lib/inflight-turn-journal'
 
-const STORAGE_KEY = 'hermes.desktop.inflightTurnJournal.v1'
+function storedEntries(): Record<string, { runtimeSessionId?: null | string; updatedAt: number }> {
+  const raw = window.localStorage.getItem(JOURNAL_STORAGE_KEY)
+
+  return raw ? JSON.parse(raw).entries : {}
+}
+
+function storedKeys(): string[] {
+  return Object.keys(storedEntries())
+}
 
 function user(id: string, text: string): ChatMessage {
   return { id, role: 'user', parts: [{ type: 'text', text }] }
@@ -60,7 +73,7 @@ describe('persistInFlightTurnState', () => {
 
     expect(readInFlightTurnJournal('stored-1')).toBeNull()
 
-    vi.advanceTimersByTime(400)
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
 
     const entry = readInFlightTurnJournal('stored-1')
     expect(entry).not.toBeNull()
@@ -80,7 +93,7 @@ describe('persistInFlightTurnState', () => {
       })
     )
 
-    vi.advanceTimersByTime(400)
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
 
     const entry = readInFlightTurnJournal('stored-1')
     const tail = entry?.messages.find(m => m.role === 'assistant')
@@ -89,7 +102,7 @@ describe('persistInFlightTurnState', () => {
 
   it('clears the entry the moment the turn settles, cancelling pending writes', () => {
     persistInFlightTurnState(journalState())
-    vi.advanceTimersByTime(400)
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
     expect(readInFlightTurnJournal('stored-1')).not.toBeNull()
 
     persistInFlightTurnState(journalState({ messages: [] }))
@@ -104,17 +117,17 @@ describe('persistInFlightTurnState', () => {
   it('does not journal a turn with no recoverable assistant content yet', () => {
     persistInFlightTurnState(journalState({ messages: [user('u1', 'do the thing')], streamId: null }))
 
-    vi.advanceTimersByTime(400)
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
     expect(readInFlightTurnJournal('stored-1')).toBeNull()
   })
 
   it('expires entries older than the max age', () => {
     persistInFlightTurnState(journalState())
-    vi.advanceTimersByTime(400)
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
 
-    const raw = JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)
-    raw.entries['stored-1'].updatedAt = Date.now() - 8 * 24 * 60 * 60 * 1000
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(raw))
+    const raw = JSON.parse(window.localStorage.getItem(JOURNAL_STORAGE_KEY)!)
+    raw.entries['stored-1'].updatedAt = Date.now() - (JOURNAL_MAX_AGE_MS + 60_000)
+    window.localStorage.setItem(JOURNAL_STORAGE_KEY, JSON.stringify(raw))
 
     expect(readInFlightTurnJournal('stored-1')).toBeNull()
   })
@@ -123,7 +136,7 @@ describe('persistInFlightTurnState', () => {
 describe('recoverInFlightTurnJournal', () => {
   function journalEntry(messages: ChatMessage[]) {
     persistInFlightTurnState(journalState({ messages, streamId: messages.at(-1)?.id ?? null }))
-    vi.advanceTimersByTime(400)
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
   }
 
   it('is a reference-preserving no-op when nothing is journaled', () => {
@@ -266,7 +279,7 @@ describe('mid-turn redirect corrections', () => {
       streamId: 'assistant-stream-1',
       turnStartedAt: Date.now()
     })
-    vi.advanceTimersByTime(400)
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
 
     const journaled = readInFlightTurnJournal('stored-redirect')?.messages ?? []
 
@@ -291,10 +304,434 @@ describe('mid-turn redirect corrections', () => {
       streamId: 'assistant-stream-1',
       turnStartedAt: Date.now()
     })
-    vi.advanceTimersByTime(400)
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
 
     const journaled = readInFlightTurnJournal('stored-boundary')?.messages ?? []
 
     expect(journaled.map(message => message.id)).toEqual(['user-1', 'assistant-stream-1'])
+  })
+})
+
+// #77486 proposed redacting the journal. It must NOT be redacted: this tail is
+// replayed, so masking it poisons the replay exactly as #43083 documents for
+// tool-call args (tests/agent/test_tool_call_arg_no_redaction.py). The
+// confidentiality axis is RETENTION. These tests pin both halves of that
+// bargain — content survives verbatim, exposure is bounded.
+describe('journal replay fidelity (no redaction)', () => {
+  const SECRET_PROMPT = "run PGPASSWORD='honchorulez' psql -h 127.0.0.1"
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    purgeInFlightTurnJournals(['stored-replay'])
+    vi.useRealTimers()
+  })
+
+  function journalSecretTurn(): void {
+    persistInFlightTurnState({
+      awaitingResponse: false,
+      busy: true,
+      messages: [
+        user('user-1', SECRET_PROMPT),
+        {
+          id: 'assistant-stream-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-call',
+              toolCallId: 'tc-1',
+              toolName: 'terminal',
+              args: { command: SECRET_PROMPT }
+            }
+          ],
+          pending: true
+        }
+      ],
+      storedSessionId: 'stored-replay',
+      streamId: 'assistant-stream-1',
+      turnStartedAt: 1000
+    })
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+  }
+
+  /** The extraction `planReload` / `planRestore` perform on the recovered
+   *  transcript before handing text to `prompt.submit`
+   *  (use-prompt-actions/rewind.ts:125 — `chatMessageText(userMessage).trim()`).
+   *  Uses the REAL extractor. A mirrored copy here would buy nothing and could
+   *  drift: `inflight-turn-journal.ts` already imports `chatMessageText` from
+   *  `chat-messages.ts` at runtime, so the module is in this suite's graph
+   *  either way, and `chat-messages.ts` touches no `localStorage`. */
+  function replayedPromptText(messages: ChatMessage[]): string {
+    const userMessage = [...messages].reverse().find(message => message.role === 'user')
+
+    return userMessage ? chatMessageText(userMessage).trim() : ''
+  }
+
+  // The load-bearing contract: a recovered transcript is what Retry/Regenerate
+  // resubmits. The reload planner reads the user row back out and hands its text to
+  // `prompt.submit`, so a redacted journal would send `***` to the model as the
+  // user's real prompt on the next turn.
+  it('round-trips a recovered prompt back to the submit text byte-for-byte', () => {
+    journalSecretTurn()
+
+    const recovered = recoverInFlightTurnJournal('stored-replay', [], { keepPending: true })
+
+    expect(recovered.applied).toBe(true)
+    expect(replayedPromptText(recovered.messages)).toBe(SECRET_PROMPT)
+    expect(replayedPromptText(recovered.messages)).not.toContain('***')
+  })
+
+  it('recovers tool-call args verbatim so replayed structure stays executable', () => {
+    journalSecretTurn()
+
+    const recovered = recoverInFlightTurnJournal('stored-replay', [], { keepPending: true })
+
+    const toolPart = recovered.messages
+      .flatMap(message => message.parts)
+      .find((part): part is Extract<typeof part, { type: 'tool-call' }> => part.type === 'tool-call')
+
+    expect(toolPart?.args).toEqual({ command: SECRET_PROMPT })
+  })
+})
+
+describe('journal retention (the confidentiality axis)', () => {
+  const HOUR_MS = 60 * 60 * 1000
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    purgeInFlightTurnJournals(['stored-a', 'stored-b', 'stored-keep'])
+    vi.useRealTimers()
+  })
+
+  function seed(storedSessionId: string): void {
+    persistInFlightTurnState(journalState({ storedSessionId }))
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+  }
+
+  /** Backdate entries in ONE direct write. Ageing them via the public API would
+   *  re-enter `loadStore`, which now sweeps — the later seed would evict the
+   *  earlier aged entry before the test could establish its precondition. */
+  function backdate(ids: string[], ageMs: number): void {
+    const raw = JSON.parse(window.localStorage.getItem(JOURNAL_STORAGE_KEY)!)
+
+    for (const id of ids) {
+      raw.entries[id].updatedAt = Date.now() - ageMs
+    }
+
+    window.localStorage.setItem(JOURNAL_STORAGE_KEY, JSON.stringify(raw))
+  }
+
+  /** Overwrite one entry field directly, bypassing the writer — this is how a
+   *  truncated store, a hand edit, or a backward clock step presents on load. */
+  function corrupt(id: string, patch: Record<string, unknown>): void {
+    const raw = JSON.parse(window.localStorage.getItem(JOURNAL_STORAGE_KEY)!)
+
+    Object.assign(raw.entries[id], patch)
+    window.localStorage.setItem(JOURNAL_STORAGE_KEY, JSON.stringify(raw))
+  }
+
+  // Asserted RELATIVE to the constant, not against 20h/30h literals: a literal
+  // pins the window from both sides, so any legitimate retune breaks a test that
+  // has no opinion about the exact value. What the feature promises is
+  // "recoverable inside the window, gone outside it".
+  it('recovers a tail inside the retention window', () => {
+    seed('stored-a')
+    backdate(['stored-a'], JOURNAL_MAX_AGE_MS - HOUR_MS)
+
+    expect(readInFlightTurnJournal('stored-a')).not.toBeNull()
+  })
+
+  it('drops a tail past the retention window', () => {
+    seed('stored-a')
+    backdate(['stored-a'], JOURNAL_MAX_AGE_MS + HOUR_MS)
+
+    expect(readInFlightTurnJournal('stored-a')).toBeNull()
+  })
+
+  // The one directional assertion: tightening the window stays free, loosening
+  // it past a day trips a deliberate review. An unredacted prompt at rest is
+  // what is being bounded.
+  it('keeps the retention ceiling at or under a day', () => {
+    expect(JOURNAL_MAX_AGE_MS).toBeLessThanOrEqual(24 * HOUR_MS)
+  })
+
+  // `now - updatedAt > MAX_AGE_MS` fails OPEN on all three of these: every
+  // comparison against NaN is false, and so is every negative delta. The store
+  // envelope is validated on load but individual entries were not, so ONE bad
+  // entry pinned its unredacted tail to disk permanently and the sweep walked
+  // straight past it. Retention is the whole confidentiality argument here, so
+  // an entry that cannot be dated inside the window must not be kept.
+  it('drops an entry with no updatedAt instead of retaining it forever', () => {
+    seed('stored-a')
+    corrupt('stored-a', { updatedAt: undefined })
+
+    expect(readInFlightTurnJournal('stored-a')).toBeNull()
+    expect(storedKeys()).toEqual([])
+  })
+
+  it('drops an entry with a non-numeric updatedAt', () => {
+    seed('stored-a')
+    corrupt('stored-a', { updatedAt: '2026-05-01T00:00:00Z' })
+
+    expect(readInFlightTurnJournal('stored-a')).toBeNull()
+    expect(storedKeys()).toEqual([])
+  })
+
+  // A wall clock steps backward for real reasons: an NTP correction, a VM
+  // snapshot restore, a dual-boot RTC write. A far-future stamp is a clock we
+  // cannot reason about, so the tail goes rather than waiting for the clock to
+  // catch up — which may be never.
+  it('drops a future-dated entry left by a backward clock step', () => {
+    seed('stored-a')
+    corrupt('stored-a', { updatedAt: Date.now() + 3 * JOURNAL_MAX_AGE_MS })
+
+    expect(readInFlightTurnJournal('stored-a')).toBeNull()
+    expect(storedKeys()).toEqual([])
+  })
+
+  // The other half of that call: a sub-second correction during a LIVE turn must
+  // not delete the turn the user is watching. Small skew stays recoverable.
+  it('keeps an entry a small clock correction pushed slightly into the future', () => {
+    seed('stored-a')
+    corrupt('stored-a', { updatedAt: Date.now() + 2_000 })
+
+    expect(readInFlightTurnJournal('stored-a')).not.toBeNull()
+  })
+
+  // A structurally unusable entry cannot be replayed (and throws in the merge),
+  // so keeping it buys nothing and costs disk.
+  it('drops a structurally invalid entry', () => {
+    seed('stored-a')
+    corrupt('stored-a', { messages: 'not-an-array' })
+
+    expect(readInFlightTurnJournal('stored-a')).toBeNull()
+    expect(storedKeys()).toEqual([])
+  })
+
+  // Nothing imports this module at boot, so the load-time sweep only runs once
+  // some other call reaches it. A user who launches into a fresh draft and never
+  // opens a session would never sweep — the bound has to hold without depending
+  // on unrelated activity.
+  it('sweeps without a session id so the bound does not need a session to be opened', () => {
+    seed('stored-a')
+    backdate(['stored-a'], JOURNAL_MAX_AGE_MS + HOUR_MS)
+
+    sweepExpiredInFlightTurnJournals()
+
+    expect(storedKeys()).toEqual([])
+  })
+
+  // The bug this fixes: expiry was only evaluated for the key being read, so a
+  // session that crashed mid-turn and was never reopened kept its unredacted
+  // tail on disk forever. Any load must sweep every expired entry off disk.
+  it('sweeps expired entries for OTHER sessions off disk on any load', () => {
+    seed('stored-keep')
+    seed('stored-a')
+    seed('stored-b')
+    backdate(['stored-a', 'stored-b'], JOURNAL_MAX_AGE_MS + HOUR_MS)
+
+    expect(storedKeys().sort()).toEqual(['stored-a', 'stored-b', 'stored-keep'])
+
+    // Read an unrelated key — the stale siblings must still be evicted.
+    readInFlightTurnJournal('stored-keep')
+
+    expect(storedKeys()).toEqual(['stored-keep'])
+  })
+})
+
+describe('purgeInFlightTurnJournals', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    purgeInFlightTurnJournals(['stored-doomed', 'stored-lineage', 'stored-survivor'])
+    vi.useRealTimers()
+  })
+
+  // Deleting a session removes its authoritative history; the local tail must
+  // go with it instead of waiting to age out.
+  it('drops every id a deleted session may be journaled under, keeping others', () => {
+    persistInFlightTurnState(journalState({ storedSessionId: 'stored-doomed' }))
+    persistInFlightTurnState(journalState({ storedSessionId: 'stored-lineage' }))
+    persistInFlightTurnState(journalState({ storedSessionId: 'stored-survivor' }))
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+
+    expect(storedKeys().sort()).toEqual(['stored-doomed', 'stored-lineage', 'stored-survivor'])
+
+    // Mirrors the call site: stored tip + lineage root + a null runtime id.
+    purgeInFlightTurnJournals(['stored-doomed', 'stored-lineage', null, undefined])
+
+    expect(storedKeys()).toEqual(['stored-survivor'])
+  })
+
+  // A throttled write already in flight must not resurrect the entry after the
+  // session is gone.
+  it('cancels a pending throttled write so a purged entry cannot come back', () => {
+    persistInFlightTurnState(journalState({ storedSessionId: 'stored-doomed' }))
+
+    expect(vi.getTimerCount()).toBe(1)
+
+    purgeInFlightTurnJournals(['stored-doomed'])
+
+    // Assert the TIMER, not just the map. `persistLatest.delete` alone already
+    // starves the callback via its `if (latest)` guard, so an entry-only
+    // assertion passes even with the `clearTimeout` removed — it would pin map
+    // eviction while the docstring sells cancellation.
+    expect(vi.getTimerCount()).toBe(0)
+
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+
+    expect(readInFlightTurnJournal('stored-doomed')).toBeNull()
+    expect(storedKeys()).toEqual([])
+  })
+
+  it('is a no-op for unknown ids', () => {
+    persistInFlightTurnState(journalState({ storedSessionId: 'stored-survivor' }))
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+
+    purgeInFlightTurnJournals(['never-journaled'])
+
+    expect(storedKeys()).toEqual(['stored-survivor'])
+  })
+})
+
+// A stored session id ROTATES mid-turn: auto-compression forks a continuation
+// and `ensureSessionState` swaps `storedSessionId` on the live state
+// (use-session-state-cache.ts). The journal keys on that rotating tip, so one
+// turn can own more than one key — and an INTERMEDIATE tip is in neither
+// `$sessions` nor a delete's `removedIds`, so no call site can name it. Left
+// unlinked, it holds the unredacted prompt and tool args for the full retention
+// window and survives the user's delete gesture.
+describe('stored-id rotation mid-turn', () => {
+  const RUNTIME_ID = 'runtime-7'
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    purgeInFlightTurnJournals(['tip-1', 'tip-2', 'tip-3', 'other-tip', RUNTIME_ID, 'runtime-8', 'runtime-other'])
+    vi.useRealTimers()
+  })
+
+  /** One session-state commit, as `updateSessionState` performs it: the state
+   *  carries the CURRENT stored tip, the runtime id does not rotate. */
+  function commit(storedSessionId: string, runtimeSessionId: null | string = RUNTIME_ID): void {
+    persistInFlightTurnState(journalState({ storedSessionId }), runtimeSessionId)
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+  }
+
+  function settle(storedSessionId: string, runtimeSessionId: null | string = RUNTIME_ID): void {
+    persistInFlightTurnState(
+      journalState({ awaitingResponse: false, busy: false, storedSessionId, streamId: null }),
+      runtimeSessionId
+    )
+  }
+
+  it('leaves no orphaned key when the tip rotates mid-turn', () => {
+    commit('tip-1')
+    expect(storedKeys()).toEqual(['tip-1'])
+
+    // Compression rotates the tip; the same turn keeps streaming.
+    commit('tip-2')
+    expect(storedKeys()).toEqual(['tip-2'])
+
+    settle('tip-2')
+    expect(storedKeys()).toEqual([])
+  })
+
+  it('leaves no orphan across repeated rotations in one turn', () => {
+    commit('tip-1')
+    commit('tip-2')
+    commit('tip-3')
+
+    expect(storedKeys()).toEqual(['tip-3'])
+  })
+
+  /** Both keys of ONE rotated turn on disk under the same runtime id — the
+   *  state a process leaves when it dies after the rotation write but before
+   *  the turn settles. Built through the real writer, then the swept key is put
+   *  back, because a live rotation self-cleans. */
+  function seedCrashedRotation(): void {
+    commit('tip-1')
+    const orphaned = { ...storedEntries() }
+
+    commit('tip-2')
+    window.localStorage.setItem(
+      JOURNAL_STORAGE_KEY,
+      JSON.stringify({ entries: { ...storedEntries(), ...orphaned }, version: 1 })
+    )
+  }
+
+  // A resume mints a NEW runtime id, so the first post-crash write cannot reach
+  // the previous process's keys by its own id. It ADOPTS the runtime id recorded
+  // on the key it is writing, which is what links it to the sibling left behind.
+  it('drains a rotation sibling left by a previous process on the next write', () => {
+    seedCrashedRotation()
+
+    expect(storedKeys().sort()).toEqual(['tip-1', 'tip-2'])
+
+    commit('tip-2', 'runtime-8')
+
+    expect(storedKeys()).toEqual(['tip-2'])
+  })
+
+  // Same reach on the settle path: the turn ending must not leave the sibling.
+  it('drains a rotation sibling when the turn settles', () => {
+    seedCrashedRotation()
+
+    settle('tip-2')
+
+    expect(storedKeys()).toEqual([])
+  })
+
+  it('never touches an unrelated session journaled under its own runtime', () => {
+    commit('other-tip', 'runtime-other')
+    commit('tip-1')
+    commit('tip-2')
+
+    expect(storedKeys().sort()).toEqual(['other-tip', 'tip-2'])
+
+    purgeInFlightTurnJournals(['tip-2', RUNTIME_ID])
+
+    expect(storedKeys()).toEqual(['other-tip'])
+  })
+
+  // The reviewer's simulation, as a contract. Before the fix the sequence ended
+  // with tip-1 surviving the delete; the delete's id set (removedIds + the
+  // closing runtime id) cannot name an intermediate tip, so the runtime link
+  // recorded on the entry is what reaches it.
+  it('purges a pre-existing rotation orphan via the runtime id a delete holds', () => {
+    seedCrashedRotation()
+
+    expect(storedKeys().sort()).toEqual(['tip-1', 'tip-2'])
+
+    // What removeSession passes: removedIds (the tip it knows + lineage root) and
+    // the closing runtime id. 'tip-1' is in none of them.
+    purgeInFlightTurnJournals(['tip-2', 'root-0', RUNTIME_ID])
+
+    expect(storedKeys()).toEqual([])
+  })
+
+  // Recovery is the feature retention protects — a rotated turn must still be
+  // recoverable under the tip a resume actually asks for.
+  it('keeps the rotated turn recoverable under the live tip', () => {
+    commit('tip-1')
+    commit('tip-2')
+
+    const recovered = recoverInFlightTurnJournal('tip-2', [], { keepPending: true })
+
+    expect(recovered.applied).toBe(true)
+    expect(recovered.messages.map(message => message.role)).toEqual(['user', 'assistant'])
   })
 })

--- a/apps/desktop/src/lib/inflight-turn-journal.test.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.test.ts
@@ -546,6 +546,107 @@ describe('journal retention (the confidentiality axis)', () => {
   })
 })
 
+// Entry-level expiry made every INDIVIDUAL entry ageable, but the store
+// ENVELOPE had the same fail-open shape one level up: an unparseable or
+// foreign-version blob was answered with an empty store and left on disk, so
+// `pruneExpiredEntries({})` swept 0 of 0, the `if (expired)` flush never fired,
+// and the plaintext prompt + tool args stayed forever — beyond the reach of
+// expiry AND of an explicit delete, since the purge loads through the same
+// function and sees an empty store. Retention is the whole confidentiality
+// argument for this file, so a state retention cannot reach is a hole in it.
+//
+// No corruption is needed to get here: a future STORE_VERSION bump, or a user
+// downgrading the app after a newer version wrote entries, lands on the exact
+// same branch.
+describe('journal store envelope (retention must reach it too)', () => {
+  const SECRET = 'PGPASSWORD=hunter2 psql -h prod'
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+    vi.useRealTimers()
+  })
+
+  /** A real journal blob written by the real writer, so the fixture carries the
+   *  same plaintext an actual crashed turn would leave behind. */
+  function seededRaw(): string {
+    persistInFlightTurnState(
+      journalState({
+        messages: [user('u1', SECRET), assistant('assistant-stream-1', 'working', { pending: true })],
+        storedSessionId: 'stored-a'
+      })
+    )
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+
+    const raw = window.localStorage.getItem(JOURNAL_STORAGE_KEY)!
+
+    expect(raw).toContain(SECRET)
+
+    return raw
+  }
+
+  it('discards an unparseable store instead of leaving the plaintext on disk', () => {
+    const raw = seededRaw()
+    // Truncated blob: an interrupted write, a quota kill mid-`setItem`, a
+    // half-synced leveldb file.
+    window.localStorage.setItem(JOURNAL_STORAGE_KEY, raw.slice(0, Math.floor(raw.length / 2)))
+
+    sweepExpiredInFlightTurnJournals()
+
+    expect(window.localStorage.getItem(JOURNAL_STORAGE_KEY)).toBeNull()
+  })
+
+  it('discards a store written by a FUTURE version rather than stranding it unreadable', () => {
+    const raw = seededRaw()
+    const parsed = JSON.parse(raw)
+
+    // What a downgrade sees: v2 wrote this, v1 is now reading it. v1 cannot
+    // replay it and its very next write overwrites the key wholesale anyway, so
+    // "keeping" it only means keeping unreadable plaintext at rest.
+    window.localStorage.setItem(JOURNAL_STORAGE_KEY, JSON.stringify({ ...parsed, version: 99 }))
+
+    sweepExpiredInFlightTurnJournals()
+
+    expect(window.localStorage.getItem(JOURNAL_STORAGE_KEY)).toBeNull()
+  })
+
+  // `typeof null === 'object'` and `Array.isArray(null) === false`, so a null
+  // `entries` passed the envelope guard and threw inside the sweep — landing in
+  // the same silent fail-open path.
+  it('discards a store whose entries map is null', () => {
+    seededRaw()
+    window.localStorage.setItem(JOURNAL_STORAGE_KEY, JSON.stringify({ entries: null, version: 1 }))
+
+    sweepExpiredInFlightTurnJournals()
+
+    expect(window.localStorage.getItem(JOURNAL_STORAGE_KEY)).toBeNull()
+  })
+
+  // The delete gesture is the user's explicit "remove this now". It must not be
+  // silently defeated by a blob shape the reader happens not to understand.
+  it('lets an explicit purge reach a corrupt store it cannot enumerate', () => {
+    const raw = seededRaw()
+    window.localStorage.setItem(JOURNAL_STORAGE_KEY, raw.slice(0, Math.floor(raw.length / 2)))
+
+    purgeInFlightTurnJournals(['stored-a'])
+
+    expect(window.localStorage.getItem(JOURNAL_STORAGE_KEY)).toBeNull()
+  })
+
+  it('leaves a well-formed current-version store alone', () => {
+    seededRaw()
+
+    sweepExpiredInFlightTurnJournals()
+
+    expect(storedKeys()).toEqual(['stored-a'])
+    expect(readInFlightTurnJournal('stored-a')).not.toBeNull()
+  })
+})
+
 describe('purgeInFlightTurnJournals', () => {
   beforeEach(() => {
     window.localStorage.clear()
@@ -733,5 +834,56 @@ describe('stored-id rotation mid-turn', () => {
 
     expect(recovered.applied).toBe(true)
     expect(recovered.messages.map(message => message.role)).toEqual(['user', 'assistant'])
+  })
+
+  // A purge cancels the pending writes it can SEE: the ids it was handed, plus
+  // whatever `linkedKeys` finds ON DISK. A write that rotated to a brand-new tip
+  // and is still inside the 400ms throttle is in neither set — the new key has
+  // never been written, and the sidebar row still carries the old tip, so the
+  // delete names the pre-rotation ids. The purge emptied the store and then the
+  // throttle fired and put the turn straight back, AFTER an explicit delete.
+  // `persistLatest` already knows that pending write's runtime id, so the purge
+  // expands over it and not only over what happens to be on disk.
+  it('cannot be resurrected by a write that rotated to an unwritten tip', () => {
+    commit('tip-1')
+    expect(storedKeys()).toEqual(['tip-1'])
+
+    // Compression rotates to tip-2 and schedules the write; nothing on disk yet.
+    persistInFlightTurnState(journalState({ storedSessionId: 'tip-2' }), RUNTIME_ID)
+    expect(storedKeys()).toEqual(['tip-1'])
+
+    // The user deletes. The row still carries the OLD tip, so this is exactly
+    // what removeSession passes: removedIds + the closing runtime id.
+    purgeInFlightTurnJournals(['tip-1', RUNTIME_ID])
+
+    expect(storedKeys()).toEqual([])
+
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+
+    expect(storedKeys()).toEqual([])
+    expect(window.localStorage.getItem(JOURNAL_STORAGE_KEY)).toBeNull()
+  })
+
+  // Same window, reached from the settle path rather than a delete.
+  it('does not let a rotated pending write survive the turn settling', () => {
+    commit('tip-1')
+    persistInFlightTurnState(journalState({ storedSessionId: 'tip-2' }), RUNTIME_ID)
+
+    clearInFlightTurnJournal('tip-1')
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+
+    expect(storedKeys()).toEqual([])
+  })
+
+  // The guard must stay narrow: cancelling by runtime closure must not reach a
+  // DIFFERENT session's pending write.
+  it('leaves an unrelated session pending write intact', () => {
+    commit('tip-1')
+    persistInFlightTurnState(journalState({ storedSessionId: 'other-tip' }), 'runtime-other')
+
+    purgeInFlightTurnJournals(['tip-1', RUNTIME_ID])
+    vi.advanceTimersByTime(JOURNAL_PERSIST_THROTTLE_MS)
+
+    expect(storedKeys()).toEqual(['other-tip'])
   })
 })

--- a/apps/desktop/src/lib/inflight-turn-journal.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.ts
@@ -14,19 +14,98 @@ import { type ChatMessage, type ChatMessagePart, chatMessageText } from '@/lib/c
  * full part structure.
  *
  * Best-effort by design: storage failures must never break chat streaming.
+ *
+ * ## Why the journaled tail is NOT redacted
+ *
+ * This tail is a REPLAY path, not a display log, so masking its content would
+ * corrupt the thing it exists to restore:
+ *
+ * - The recovered user row is what `planReload` / `planRestore` read back out
+ *   of the transcript and resubmit verbatim as `prompt.submit { text }`
+ *   (`use-prompt-actions/rewind.ts`). A journaled `***` would be sent to the
+ *   model as the user's actual prompt on the next Retry.
+ * - The recovered tool-call parts are the structure the backend's text-only
+ *   `inflight` snapshot cannot carry — the whole reason this journal exists.
+ *
+ * This is the desktop instance of the rule established by #43083
+ * (`tests/agent/test_tool_call_arg_no_redaction.py`): redacting a value inside
+ * a path that is replayed poisons the replay. Confidentiality here is bounded
+ * by RETENTION, not by rewriting content. Four mechanisms carry that bargain,
+ * and every one of them is load-bearing:
+ *
+ * 1. Expiry sweeps EVERY entry on any load, and fails closed — an entry that
+ *    cannot be positively dated inside the window is dropped (`isExpired`).
+ * 2. The entry is cleared the moment the turn settles or recovery reports
+ *    `caughtUp`.
+ * 3. Deleting a session purges it (`purgeInFlightTurnJournals`).
+ * 4. A stored-id rotation mid-turn self-cleans the key it supersedes, so a
+ *    rotation cannot strand a tail under a key nobody can name.
+ *
+ * Do not add masking here. Do weigh a change that weakens any of the four as a
+ * security change.
  */
 
-const STORAGE_KEY = 'hermes.desktop.inflightTurnJournal.v1'
+export const JOURNAL_STORAGE_KEY = 'hermes.desktop.inflightTurnJournal.v1'
 const STORE_VERSION = 1
 const MAX_ENTRIES = 24
-const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+/** A journaled tail is only worth replaying across an app restart: once the
+ *  backend settles the turn, its committed reply is authoritative and recovery
+ *  reports `caughtUp`. A day covers "it died last night, I reopened it this
+ *  morning" while keeping unredacted prompts/tool args at rest for hours
+ *  rather than a week.
+ *
+ *  DELIBERATELY NOT CONFIGURABLE. This is a renderer-local security floor, not
+ *  a behavioral preference: retention is the whole confidentiality argument for
+ *  storing an unredacted prompt at rest, so a `config.yaml` knob here would
+ *  mostly give users a way to weaken their own protection. Tightening it is
+ *  free (the test asserts a ceiling, not the literal); loosening it should
+ *  require a deliberate review.
+ *
+ *  Accepted tradeoff: a turn parked over a weekend (~63h) now ages out where
+ *  the old 7-day window would still have recovered it. A tail that old is
+ *  almost always already superseded by the backend's committed reply, and an
+ *  unredacted prompt sitting on disk for a week to serve that case is the
+ *  worse half of the bargain. */
+export const JOURNAL_MAX_AGE_MS = 24 * 60 * 60 * 1000
 /** Streaming repaints arrive every ~33ms; localStorage writes are synchronous.
  *  Trailing-edge throttle keeps the journal off the hot path — a crash costs at
  *  most this much of the newest tail. */
-const PERSIST_THROTTLE_MS = 400
+export const JOURNAL_PERSIST_THROTTLE_MS = 400
+/** How far a journal timestamp may sit in the future before the entry is
+ *  treated as unusable rather than fresh. A wall clock can step BACKWARD at
+ *  runtime (an NTP correction, a VM snapshot restore, a dual-boot RTC write),
+ *  which makes an already-written entry look future-dated. A small tolerance
+ *  keeps an ordinary sub-second correction from expiring the turn that is
+ *  streaming right now; anything beyond it is a clock we cannot reason about,
+ *  so the entry is dropped rather than pinned to disk (see `isExpired`). */
+const CLOCK_SKEW_TOLERANCE_MS = 5 * 60 * 1000
 
 export interface InFlightTurnSnapshot {
   messages: ChatMessage[]
+  /** The RUNTIME session id that journaled this entry, when the writer knew it.
+   *
+   *  The store keys on the STORED session id because that is the only identity
+   *  a fresh process has on resume — but the stored id ROTATES mid-turn (auto
+   *  compression forks a continuation, `use-session-state-cache.ts`
+   *  `ensureSessionState`), so one live turn can touch more than one key. The
+   *  runtime id does not rotate, so recording it here is what makes the
+   *  superseded key reachable: from any surviving entry of the turn we can
+   *  enumerate its siblings and drop them (see `linkedKeys`). Without it an
+   *  intermediate tip is in neither `$sessions` nor a delete's `removedIds`,
+   *  and NO call site can name it.
+   *
+   *  Optional: entries written before this field existed (or by a caller that
+   *  has no runtime id) simply carry no link and behave as they did before.
+   *
+   *  Known residual gap, stated rather than papered over: if the app dies inside
+   *  the throttle window right after a SECOND-or-later rotation — so the new tip
+   *  was never written — the old tip is on disk under a runtime id that no
+   *  longer exists, and the next process has no entry to adopt it from. That one
+   *  orphan is reachable only by its own key (a delete names the first rotation's
+   *  old tip, since that IS the lineage root) or by expiry. It is bounded by
+   *  `JOURNAL_MAX_AGE_MS`, which is why retention is the floor and this link is
+   *  the optimization on top of it — not the other way round. */
+  runtimeSessionId?: null | string
   streamId: null | string
   turnStartedAt: null | number
   updatedAt: number
@@ -68,6 +147,36 @@ function emptyStore(): JournalStore {
   return { entries: {}, version: STORE_VERSION }
 }
 
+/** Drop every entry past `JOURNAL_MAX_AGE_MS`, not just the one being read.
+ *
+ * Expiry used to be checked only for the key a caller asked for (plus whatever
+ * `saveStore` happened to filter on the next write), so a session that crashed
+ * mid-turn and was never reopened kept its unredacted tail on disk
+ * indefinitely — no read, no write, no prune. Sweeping on load makes the
+ * retention window a real bound instead of an opportunistic one. */
+function pruneExpiredEntries(entries: Record<string, InFlightTurnSnapshot>): {
+  entries: Record<string, InFlightTurnSnapshot>
+  expired: boolean
+} {
+  const kept = Object.entries(entries).filter(([, entry]) => !isExpired(entry))
+
+  return {
+    entries: kept.length === Object.keys(entries).length ? entries : Object.fromEntries(kept),
+    expired: kept.length !== Object.keys(entries).length
+  }
+}
+
+/** Sweep expired entries off disk without needing a session id.
+ *
+ * The sweep inside `loadStore` only runs when something else already calls into
+ * this module (a resume, a state commit, a delete). A user who launches into a
+ * fresh draft and never opens a session would never sweep, which would leave
+ * the retention bound conditional on unrelated activity. The session-state
+ * cache calls this once on mount so the bound holds unconditionally. */
+export function sweepExpiredInFlightTurnJournals(): void {
+  loadStore()
+}
+
 function loadStore(): JournalStore {
   const store = storage()
 
@@ -76,7 +185,7 @@ function loadStore(): JournalStore {
   }
 
   try {
-    const raw = store.getItem(STORAGE_KEY)
+    const raw = store.getItem(JOURNAL_STORAGE_KEY)
 
     if (!raw) {
       return emptyStore()
@@ -93,10 +202,16 @@ function loadStore(): JournalStore {
       return emptyStore()
     }
 
-    return {
-      entries: parsed.entries as Record<string, InFlightTurnSnapshot>,
-      version: STORE_VERSION
+    const { entries, expired } = pruneExpiredEntries(parsed.entries as Record<string, InFlightTurnSnapshot>)
+    const journal: JournalStore = { entries, version: STORE_VERSION }
+
+    // Flush the sweep so the expired tail leaves disk on this load, even if the
+    // caller never writes. `saveStore` is already failure-tolerant.
+    if (expired) {
+      saveStore(journal)
     }
+
+    return journal
   } catch {
     return emptyStore()
   }
@@ -118,19 +233,44 @@ function saveStore(journal: JournalStore): void {
     )
 
     if (Object.keys(entries).length === 0) {
-      store.removeItem(STORAGE_KEY)
+      store.removeItem(JOURNAL_STORAGE_KEY)
 
       return
     }
 
-    store.setItem(STORAGE_KEY, JSON.stringify({ entries, version: STORE_VERSION }))
+    store.setItem(JOURNAL_STORAGE_KEY, JSON.stringify({ entries, version: STORE_VERSION }))
   } catch {
     // Quota/private-mode failures: the journal is a recovery aid, not truth.
   }
 }
 
+/** Fail CLOSED: anything we cannot positively date within the window is
+ *  expired.
+ *
+ *  `now - entry.updatedAt > MAX_AGE_MS` alone fails OPEN in three ways, because
+ *  every comparison against `NaN` — and every negative delta — is `false`:
+ *
+ *  - `updatedAt` missing or non-numeric (a hand-edited or truncated store, a
+ *    future schema change) → `NaN > MAX_AGE_MS` is `false` → retained forever.
+ *  - `updatedAt` in the future (the wall clock stepped backward) → negative
+ *    delta → retained until the clock catches up, which may be never.
+ *
+ *  `loadStore` validates the store envelope but not individual entries, so one
+ *  such entry pinned its unredacted tail to disk permanently and the retention
+ *  sweep walked straight past it. Retention is the entire confidentiality
+ *  argument for this file, so an entry that cannot be aged must not be kept.
+ *
+ *  Structurally unusable entries are folded into the same predicate: an entry
+ *  whose `messages` is not an array cannot be replayed (and would throw in the
+ *  merge), so keeping it buys nothing and costs disk. */
 function isExpired(entry: InFlightTurnSnapshot, now = Date.now()): boolean {
-  return now - entry.updatedAt > MAX_AGE_MS
+  if (!entry || typeof entry !== 'object' || !Array.isArray(entry.messages)) {
+    return true
+  }
+
+  const age = now - entry.updatedAt
+
+  return !Number.isFinite(age) || age < -CLOCK_SKEW_TOLERANCE_MS || age > JOURNAL_MAX_AGE_MS
 }
 
 function cloneMessages(messages: ChatMessage[]): ChatMessage[] {
@@ -393,9 +533,90 @@ export function mergeInFlightMessages(
 }
 
 const persistTimers = new Map<string, ReturnType<typeof setTimeout>>()
-const persistLatest = new Map<string, JournalableSessionState>()
+const persistLatest = new Map<string, { runtimeSessionId: null | string; state: JournalableSessionState }>()
 
-function writeSnapshot(storedSessionId: string, state: JournalableSessionState): void {
+/** Every key that belongs to the same live turn as `seedIds`.
+ *
+ *  The store keys on the rotating stored id, so one turn can own several keys
+ *  (see `InFlightTurnSnapshot.runtimeSessionId`). Expansion is: the named ids,
+ *  plus every entry whose `runtimeSessionId` matches either a named id or the
+ *  runtime id recorded on a named entry. That closure is what lets a caller
+ *  drain a rotated turn while naming only the id it happens to hold. */
+function linkedKeys(
+  entries: Record<string, InFlightTurnSnapshot>,
+  seedIds: readonly string[],
+  extraRuntimeIds: readonly (null | string | undefined)[] = []
+): string[] {
+  const named = new Set(seedIds)
+  const runtimes = new Set<string>()
+
+  for (const id of [...seedIds, ...extraRuntimeIds]) {
+    // A caller-held id may itself BE a runtime id (a delete passes the closing
+    // runtime id), which is how a rotation orphan gets reached when the
+    // intermediate tip is in neither $sessions nor the delete's removedIds.
+    if (id) {
+      runtimes.add(id)
+    }
+  }
+
+  for (const id of named) {
+    const runtimeSessionId = entries[id]?.runtimeSessionId
+
+    if (runtimeSessionId) {
+      runtimes.add(runtimeSessionId)
+    }
+  }
+
+  return Object.keys(entries).filter(key => {
+    const runtimeSessionId = entries[key]?.runtimeSessionId
+
+    return named.has(key) || (Boolean(runtimeSessionId) && runtimes.has(runtimeSessionId as string))
+  })
+}
+
+/** Drop a throttled write that is about to be superseded, so it cannot land
+ *  after the entry it targets has been removed. */
+function dropPendingWrite(storedSessionId: string): void {
+  const timer = persistTimers.get(storedSessionId)
+
+  if (timer) {
+    clearTimeout(timer)
+    persistTimers.delete(storedSessionId)
+  }
+
+  persistLatest.delete(storedSessionId)
+}
+
+/** Remove `seedIds` and every key linked to the same turn. Returns the keys
+ *  actually dropped. */
+function purgeLinkedEntries(
+  seedIds: readonly (null | string | undefined)[],
+  extraRuntimeIds: readonly (null | string | undefined)[] = []
+): string[] {
+  const ids = [...new Set(seedIds.filter((id): id is string => Boolean(id)))]
+
+  for (const id of ids) {
+    dropPendingWrite(id)
+  }
+
+  const journal = loadStore()
+  const doomed = linkedKeys(journal.entries, ids, extraRuntimeIds)
+
+  if (doomed.length === 0) {
+    return []
+  }
+
+  for (const key of doomed) {
+    dropPendingWrite(key)
+    delete journal.entries[key]
+  }
+
+  saveStore(journal)
+
+  return doomed
+}
+
+function writeSnapshot(storedSessionId: string, state: JournalableSessionState, runtimeSessionId: null | string): void {
   const tail = recoverableTail(state.messages, state.streamId)
 
   if (tail.length === 0) {
@@ -404,8 +625,32 @@ function writeSnapshot(storedSessionId: string, state: JournalableSessionState):
 
   const journal = loadStore()
 
+  // Self-clean the rotation. The stored id rotates mid-turn (auto compression),
+  // so this write may be landing under a NEW key while the turn's previous key
+  // still holds the same prompt and tool args. Nothing else would ever clear it:
+  // settle only clears the current id, and an intermediate tip is not in
+  // $sessions, so no delete can name it. Sweep the turn's other keys here, where
+  // the link is still known.
+  //
+  // `previousRuntimeSessionId` handles the resume case: this key's existing
+  // entry was written by the PREVIOUS process under a now-dead runtime id, and
+  // adopting it lets the first post-crash write drain orphans that process left.
+  const previousRuntimeSessionId = journal.entries[storedSessionId]?.runtimeSessionId
+
+  const superseded = runtimeSessionId
+    ? linkedKeys(journal.entries, [storedSessionId], [runtimeSessionId, previousRuntimeSessionId]).filter(
+        key => key !== storedSessionId
+      )
+    : []
+
+  for (const key of superseded) {
+    dropPendingWrite(key)
+    delete journal.entries[key]
+  }
+
   journal.entries[storedSessionId] = {
     messages: tail,
+    ...(runtimeSessionId ? { runtimeSessionId } : {}),
     streamId: state.streamId,
     turnStartedAt: state.turnStartedAt,
     updatedAt: Date.now()
@@ -414,8 +659,13 @@ function writeSnapshot(storedSessionId: string, state: JournalableSessionState):
 }
 
 /** Persist the running turn's visible tail (throttled), or clear the entry the
- *  moment the turn settles. Call on every session-state commit. */
-export function persistInFlightTurnState(state: JournalableSessionState): void {
+ *  moment the turn settles. Call on every session-state commit.
+ *
+ *  `runtimeSessionId` is the session's RUNTIME id (the one that does not rotate
+ *  when compression forks a continuation). It is optional only so tests and
+ *  non-runtime callers stay simple — pass it from the real write path, or a
+ *  rotated key has no link and can orphan. */
+export function persistInFlightTurnState(state: JournalableSessionState, runtimeSessionId: null | string = null): void {
   const storedSessionId = state.storedSessionId
 
   if (!storedSessionId) {
@@ -428,7 +678,7 @@ export function persistInFlightTurnState(state: JournalableSessionState): void {
     return
   }
 
-  persistLatest.set(storedSessionId, state)
+  persistLatest.set(storedSessionId, { runtimeSessionId, state })
 
   if (persistTimers.has(storedSessionId)) {
     return
@@ -443,9 +693,9 @@ export function persistInFlightTurnState(state: JournalableSessionState): void {
       persistLatest.delete(storedSessionId)
 
       if (latest) {
-        writeSnapshot(storedSessionId, latest)
+        writeSnapshot(storedSessionId, latest.state, latest.runtimeSessionId)
       }
-    }, PERSIST_THROTTLE_MS)
+    }, JOURNAL_PERSIST_THROTTLE_MS)
   )
 }
 
@@ -503,26 +753,32 @@ export function recoverInFlightTurnJournal(
   }
 }
 
+/** Clear a settled turn's journal entry — and any key the same turn left behind
+ *  when the stored id rotated mid-turn, which `storedSessionId` alone does not
+ *  name (see `InFlightTurnSnapshot.runtimeSessionId`). */
 export function clearInFlightTurnJournal(storedSessionId: null | string): void {
-  if (!storedSessionId) {
-    return
-  }
+  purgeLinkedEntries([storedSessionId])
+}
 
-  const timer = persistTimers.get(storedSessionId)
-
-  if (timer) {
-    clearTimeout(timer)
-    persistTimers.delete(storedSessionId)
-  }
-
-  persistLatest.delete(storedSessionId)
-
-  const journal = loadStore()
-
-  if (!(storedSessionId in journal.entries)) {
-    return
-  }
-
-  delete journal.entries[storedSessionId]
-  saveStore(journal)
+/** Purge journaled tails for a deleted session.
+ *
+ *  Deleting a session removes its authoritative history, but the journal used
+ *  to keep that turn's prompt and tool calls in localStorage until the entry
+ *  aged out — the delete gesture did not reach the local copy (the sibling
+ *  `composer-queue` store was already cleared here; this one was missed).
+ *
+ *  Coverage, stated precisely, because retention is the confidentiality
+ *  argument for this file and an overclaiming docstring is worse than none:
+ *  this drains every id passed in, PLUS every entry linked to one of them by
+ *  `runtimeSessionId`. The link is what covers compression rotation — a turn
+ *  whose stored id rotated has a key that is in neither `$sessions` nor a
+ *  delete's `removedIds`, so no caller can name it directly. An entry written
+ *  with no runtime id (pre-existing store, non-runtime caller) is only reachable
+ *  by its own key; pass every id you hold.
+ *
+ *  Callers pass a list because a session has more than one identity: the stored
+ *  tip rotates on compression, the lineage root differs from it, and the runtime
+ *  id is a third. All of them drain in a single load/save. */
+export function purgeInFlightTurnJournals(sessionIds: readonly (null | string | undefined)[]): void {
+  purgeLinkedEntries(sessionIds)
 }

--- a/apps/desktop/src/lib/inflight-turn-journal.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.ts
@@ -33,13 +33,26 @@ import { type ChatMessage, type ChatMessagePart, chatMessageText } from '@/lib/c
  * by RETENTION, not by rewriting content. Four mechanisms carry that bargain,
  * and every one of them is load-bearing:
  *
- * 1. Expiry sweeps EVERY entry on any load, and fails closed — an entry that
- *    cannot be positively dated inside the window is dropped (`isExpired`).
+ * 1. Expiry sweeps EVERY entry on any load, and fails closed at BOTH levels —
+ *    an entry that cannot be positively dated inside the window is dropped
+ *    (`isExpired`), and a store whose envelope cannot be read as a journal at
+ *    all is discarded rather than left on disk unreadable (`discardStore`).
  * 2. The entry is cleared the moment the turn settles or recovery reports
  *    `caughtUp`.
  * 3. Deleting a session purges it (`purgeInFlightTurnJournals`).
- * 4. A stored-id rotation mid-turn self-cleans the key it supersedes, so a
- *    rotation cannot strand a tail under a key nobody can name.
+ * 4. A stored-id rotation mid-turn self-cleans the key it supersedes, and a
+ *    purge expands over pending writes by runtime id as well as over what is on
+ *    disk, so a rotation cannot leave a tail behind a settle or a delete. One
+ *    narrow residual case remains and is documented at
+ *    `InFlightTurnSnapshot.runtimeSessionId`: a crash inside the throttle
+ *    window right after a SECOND-or-later rotation. That one is reachable by
+ *    its own key or by expiry, which is why retention is the floor.
+ *
+ * Every one of the four is also asserted at its CALL SITE, not only in this
+ * module: the boot sweep and the runtime-id plumbing in
+ * `use-session-state-cache.test.tsx`, and both delete surfaces in
+ * `use-session-actions.test.tsx` / `sessions-settings.test.tsx`. A module test
+ * can prove a mechanism works; only a call-site test proves it is wired.
  *
  * Do not add masking here. Do weigh a change that weakens any of the four as a
  * security change.
@@ -104,7 +117,13 @@ export interface InFlightTurnSnapshot {
    *  orphan is reachable only by its own key (a delete names the first rotation's
    *  old tip, since that IS the lineage root) or by expiry. It is bounded by
    *  `JOURNAL_MAX_AGE_MS`, which is why retention is the floor and this link is
-   *  the optimization on top of it — not the other way round. */
+   *  the optimization on top of it — not the other way round.
+   *
+   *  A pending write inside the throttle window is a separate matter and IS
+   *  covered: `purgeLinkedEntries` expands over `persistLatest` by runtime id,
+   *  so a write that rotated to a key which is not yet on disk cannot land after
+   *  a settle or a user delete. The gap above is specifically about a process
+   *  that DIED, leaving no in-memory link for anyone to expand over. */
   runtimeSessionId?: null | string
   streamId: null | string
   turnStartedAt: null | number
@@ -145,6 +164,42 @@ function storage(): Storage | null {
 
 function emptyStore(): JournalStore {
   return { entries: {}, version: STORE_VERSION }
+}
+
+/** Drop the whole blob and answer with an empty store.
+ *
+ *  Reached when the persisted journal cannot be read as a journal at all: it
+ *  does not parse, its envelope is the wrong shape, or it carries a version this
+ *  build does not know. Returning `emptyStore()` without removing it used to
+ *  leave that blob on disk permanently — the sweep below then pruned 0 of 0
+ *  entries, so nothing flushed, and even an explicit `purgeInFlightTurnJournals`
+ *  naming the exact ids loaded through here and saw an empty store. The
+ *  unredacted prompt and tool args outlived both expiry and the user's delete
+ *  gesture, which is the same fail-open shape that was fixed one level down for
+ *  individual entries.
+ *
+ *  Discarding costs nothing that was recoverable: a blob we cannot enumerate is
+ *  by definition unreplayable — the identical argument the entry-level
+ *  structural-validity guard already makes in `isExpired`.
+ *
+ *  A FUTURE-version store is discarded too, deliberately. It looks like the one
+ *  case with something to lose (downgrade the app, then upgrade again), but the
+ *  loss is not real: `saveStore` rewrites this single key wholesale, so the
+ *  first journalled turn after the downgrade overwrites the newer blob anyway —
+ *  keeping it only buys a window where unreadable plaintext sits at rest. What
+ *  it would cost is the retention bound, which is this file's entire
+ *  confidentiality argument. A schema change that genuinely must preserve old
+ *  data has a cheaper tool: `JOURNAL_STORAGE_KEY` is itself version-suffixed, so
+ *  bump the key and migrate deliberately instead of relying on a reader that
+ *  cannot parse the data to babysit it. */
+function discardStore(store: Storage): JournalStore {
+  try {
+    store.removeItem(JOURNAL_STORAGE_KEY)
+  } catch {
+    // Best-effort, same contract as `saveStore`.
+  }
+
+  return emptyStore()
 }
 
 /** Drop every entry past `JOURNAL_MAX_AGE_MS`, not just the one being read.
@@ -191,18 +246,27 @@ function loadStore(): JournalStore {
       return emptyStore()
     }
 
-    const parsed = JSON.parse(raw)
+    let parsed: unknown
 
-    if (
-      !parsed ||
-      parsed.version !== STORE_VERSION ||
-      typeof parsed.entries !== 'object' ||
-      Array.isArray(parsed.entries)
-    ) {
-      return emptyStore()
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      return discardStore(store)
     }
 
-    const { entries, expired } = pruneExpiredEntries(parsed.entries as Record<string, InFlightTurnSnapshot>)
+    const envelope = parsed as null | Partial<JournalStore>
+
+    if (
+      !envelope ||
+      envelope.version !== STORE_VERSION ||
+      !envelope.entries ||
+      typeof envelope.entries !== 'object' ||
+      Array.isArray(envelope.entries)
+    ) {
+      return discardStore(store)
+    }
+
+    const { entries, expired } = pruneExpiredEntries(envelope.entries as Record<string, InFlightTurnSnapshot>)
     const journal: JournalStore = { entries, version: STORE_VERSION }
 
     // Flush the sweep so the expired tail leaves disk on this load, even if the
@@ -247,7 +311,7 @@ function saveStore(journal: JournalStore): void {
 /** Fail CLOSED: anything we cannot positively date within the window is
  *  expired.
  *
- *  `now - entry.updatedAt > MAX_AGE_MS` alone fails OPEN in three ways, because
+ *  `now - entry.updatedAt > MAX_AGE_MS` alone fails OPEN in two ways, because
  *  every comparison against `NaN` — and every negative delta — is `false`:
  *
  *  - `updatedAt` missing or non-numeric (a hand-edited or truncated store, a
@@ -255,10 +319,11 @@ function saveStore(journal: JournalStore): void {
  *  - `updatedAt` in the future (the wall clock stepped backward) → negative
  *    delta → retained until the clock catches up, which may be never.
  *
- *  `loadStore` validates the store envelope but not individual entries, so one
+ *  `loadStore` validated the store envelope but not individual entries, so one
  *  such entry pinned its unredacted tail to disk permanently and the retention
  *  sweep walked straight past it. Retention is the entire confidentiality
  *  argument for this file, so an entry that cannot be aged must not be kept.
+ *  The envelope had the mirror-image hole one level up — see `discardStore`.
  *
  *  Structurally unusable entries are folded into the same predicate: an entry
  *  whose `messages` is not an array cannot be replayed (and would throw in the
@@ -535,6 +600,37 @@ export function mergeInFlightMessages(
 const persistTimers = new Map<string, ReturnType<typeof setTimeout>>()
 const persistLatest = new Map<string, { runtimeSessionId: null | string; state: JournalableSessionState }>()
 
+/** Every runtime id that identifies the same live turn as `seedIds`.
+ *
+ *  A caller-held id may itself BE a runtime id (a delete passes the closing
+ *  runtime id), which is how a rotation orphan gets reached when the
+ *  intermediate tip is in neither $sessions nor the delete's removedIds. On top
+ *  of that, any on-disk entry the caller DID name contributes the runtime id it
+ *  recorded. */
+function runtimeClosure(
+  entries: Record<string, InFlightTurnSnapshot>,
+  seedIds: readonly string[],
+  extraRuntimeIds: readonly (null | string | undefined)[] = []
+): Set<string> {
+  const runtimes = new Set<string>()
+
+  for (const id of [...seedIds, ...extraRuntimeIds]) {
+    if (id) {
+      runtimes.add(id)
+    }
+  }
+
+  for (const id of seedIds) {
+    const runtimeSessionId = entries[id]?.runtimeSessionId
+
+    if (runtimeSessionId) {
+      runtimes.add(runtimeSessionId)
+    }
+  }
+
+  return runtimes
+}
+
 /** Every key that belongs to the same live turn as `seedIds`.
  *
  *  The store keys on the rotating stored id, so one turn can own several keys
@@ -548,24 +644,7 @@ function linkedKeys(
   extraRuntimeIds: readonly (null | string | undefined)[] = []
 ): string[] {
   const named = new Set(seedIds)
-  const runtimes = new Set<string>()
-
-  for (const id of [...seedIds, ...extraRuntimeIds]) {
-    // A caller-held id may itself BE a runtime id (a delete passes the closing
-    // runtime id), which is how a rotation orphan gets reached when the
-    // intermediate tip is in neither $sessions nor the delete's removedIds.
-    if (id) {
-      runtimes.add(id)
-    }
-  }
-
-  for (const id of named) {
-    const runtimeSessionId = entries[id]?.runtimeSessionId
-
-    if (runtimeSessionId) {
-      runtimes.add(runtimeSessionId)
-    }
-  }
+  const runtimes = runtimeClosure(entries, seedIds, extraRuntimeIds)
 
   return Object.keys(entries).filter(key => {
     const runtimeSessionId = entries[key]?.runtimeSessionId
@@ -600,6 +679,28 @@ function purgeLinkedEntries(
   }
 
   const journal = loadStore()
+
+  // Cancel pending writes by RUNTIME id, not only by key. A throttled write
+  // that rotated to a brand-new tip is invisible to everything below: its key
+  // has never been written, so `linkedKeys` cannot see it, and the caller cannot
+  // name it either — a delete reads the sidebar row, which still carries the
+  // pre-rotation tip. Purging then emptied the store and the throttle fired
+  // afterwards, putting the turn back on disk AFTER an explicit user delete.
+  // `persistLatest` is the one place that already knows which runtime that
+  // pending write belongs to, so expand over it.
+  //
+  // Narrow by construction: one runtime id owns at most one live turn, so this
+  // can only ever cancel a write for the turn being purged.
+  const runtimes = runtimeClosure(journal.entries, ids, extraRuntimeIds)
+
+  for (const [key, pending] of [...persistLatest]) {
+    const runtimeSessionId = pending.runtimeSessionId
+
+    if (runtimeSessionId && runtimes.has(runtimeSessionId)) {
+      dropPendingWrite(key)
+    }
+  }
+
   const doomed = linkedKeys(journal.entries, ids, extraRuntimeIds)
 
   if (doomed.length === 0) {
@@ -770,11 +871,18 @@ export function clearInFlightTurnJournal(storedSessionId: null | string): void {
  *  Coverage, stated precisely, because retention is the confidentiality
  *  argument for this file and an overclaiming docstring is worse than none:
  *  this drains every id passed in, PLUS every entry linked to one of them by
- *  `runtimeSessionId`. The link is what covers compression rotation — a turn
+ *  `runtimeSessionId`, PLUS any throttled write still pending for one of those
+ *  runtime ids. The link is what covers compression rotation — a turn
  *  whose stored id rotated has a key that is in neither `$sessions` nor a
  *  delete's `removedIds`, so no caller can name it directly. An entry written
  *  with no runtime id (pre-existing store, non-runtime caller) is only reachable
  *  by its own key; pass every id you hold.
+ *
+ *  What it does NOT cover: a pending write with no runtime id recorded and a key
+ *  the caller did not name. Nothing links such a write to the turn, so it lands
+ *  and then ages out under `JOURNAL_MAX_AGE_MS`. The real write path always
+ *  supplies the runtime id (`use-session-state-cache.ts`), so this is a
+ *  test-and-legacy shape rather than a live one.
  *
  *  Callers pass a list because a session has more than one identity: the stored
  *  tip rotates on compression, the lineage root differs from it, and the runtime


### PR DESCRIPTION
## What does this PR do?

The desktop in-flight-turn journal persists the full turn tail — the user prompt plus assistant rows including tool-call args — unencrypted in `localStorage` (Chromium leveldb). Three real defects, **none of them the one that was reported**:

1. **Expiry was enforced only for the key being read.** A session that crashed mid-turn and was never reopened kept its unredacted tail on disk *indefinitely* — no read, no write, no prune.
2. **`isExpired` failed open.** It was `now - entry.updatedAt > MAX_AGE_MS`. Every comparison against `NaN` is `false`, and so is every negative delta, so a missing, non-numeric, or future-dated stamp (a backward NTP correction, a VM snapshot restore, a dual-boot RTC write) pinned an entry to disk permanently and the retention sweep walked straight past it. `loadStore` validated the store envelope but never individual entries.
3. **Deleting a session did not clear its journal.** The sidebar delete already clears the sibling `localStorage` store — `clearQueuedPrompts(storedSessionId)` at [use-session-actions/index.ts:1343](https://github.com/NousResearch/hermes-agent/blob/main/apps/desktop/src/app/session/hooks/use-session-actions/index.ts#L1343) — but the journal, which holds strictly more sensitive content (prompt text *and* tool-call args), was missed. The archived-sessions settings path cleared neither.
4. **The store envelope failed open — the one path where the plaintext was never bounded at all.** `loadStore` returned `emptyStore()` when `JSON.parse` threw **or** when `parsed.version !== STORE_VERSION`, *without removing the offending blob*. The sweep then pruned 0 of 0 entries, so nothing flushed, and an explicit `purgeInFlightTurnJournals` naming the exact ids also loaded through `loadStore` and saw an empty store. The unredacted prompt and tool-call args outlived expiry **and** the user's delete gesture — permanently. Measured before the fix:

   ```
   Q1 (truncated JSON) still on disk after sweep: true
   Q1 secret survives an explicit purge:          true
   Q2 (version: 99) secret survives sweep:        true
   ```

   This made the module header's own "fails closed" claim false: retention is the entire confidentiality argument for this file, and the envelope was the one level where retention could not reach. Both paths now route through a named `discardStore` that does `store.removeItem(JOURNAL_STORAGE_KEY)` — the mirror image of the entry-level fix in (2), one level up.

### Why retention, and not the redaction the issue asked for

This is the part worth reviewing hardest, because it inverts the proposed fix.

**The journal is a model-replay path, not a display log.** The recovered user row is read back by `planReload` ([rewind.ts:125](https://github.com/NousResearch/hermes-agent/blob/main/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.ts#L125), `chatMessageText(userMessage).trim()`) and submitted verbatim as `prompt.submit { text: plan.text }` ([use-prompt-actions/index.ts:792](https://github.com/NousResearch/hermes-agent/blob/main/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts#L792)). A journaled `***` would be sent to the model as the user's actual prompt on the next Retry.

That is exactly the failure mode of **#43083**, already guarded in-tree by `tests/agent/test_tool_call_arg_no_redaction.py`, whose docstring states the mechanism: masking a credential poisons the replay, because "the model reads back its own `PGPASSWORD='***' psql ...` call and copies the placeholder into the next tool call, breaking every credential-dependent command on the second turn." Redacting tool-call args is separately self-defeating — carrying the part structure that the backend's text-only `inflight` snapshot cannot is this module's stated reason to exist, and `state.db` holds those same args verbatim by design.

Two fidelity tests are included precisely so this PR can be checked for *not* having broken replay: a credential survives byte-for-byte from journal through recovery into the resubmit text, and tool-call args round-trip verbatim.

**Being straight about what this buys.** Bounded retention shrinks the exposure window; it does **not** remove the exposure. Within 24h the plaintext is still in leveldb. If the goal is at-rest confidentiality rather than a shorter window, the answer is *encrypting* the journal — recoverable **and** unreadable — not redacting it. That is a larger, separate change: `safeStorage` is main-process-only, so it would need an IPC round-trip out of the renderer, and it is not attempted here.

### Session-id rotation (why entries now record a runtime id)

Stored session ids rotate mid-turn when auto-compression forks a continuation, and the journal keys on the rotating tip — so one live turn can own several keys, and a rotation left an orphan under the old tip that **neither** delete surface could enumerate (an intermediate tip is in neither `$sessions` nor a delete's `removedIds`). Entries now record the non-rotating **runtime** session id, and the write path sweeps the keys it supersedes.

**Re-keying on the lineage root was considered and rejected.** `resolveComposerSessionKey` ([store/session.ts:239](https://github.com/NousResearch/hermes-agent/blob/main/apps/desktop/src/store/session.ts#L239)) falls back to the tip when the new tip row is not yet in `$sessions` — which is exactly the mid-rotation write window — and a cold boot can reach recovery before `$sessions` hydrates, silently losing a tail stored under the root.

**One residual gap, documented in the source rather than hidden:** if the app dies inside the 400ms throttle window right after a *second-or-later* rotation, the old tip sits under a runtime id that no longer exists and the next process has no entry to adopt it from. That orphan is reachable only by its own key or by expiry. It is bounded by `JOURNAL_MAX_AGE_MS` — which is the point: retention is the floor, and the runtime link is the optimization on top of it, not the other way round.

### Two deliberate design calls

- **The 24h window is a constant, not a `config.yaml` key.** It is a renderer-local security *floor*, not a behavioral preference: retention is the entire confidentiality argument for storing an unredacted prompt at rest, so a config knob here mostly gives users a way to weaken their own protection. Tightening it stays free (the test asserts a directional ceiling, not the literal); loosening it trips review.
- **Accepted tradeoff, recorded:** a turn parked over a weekend (~63h) now ages out where the old 7-day window would still have recovered it. A tail that old is almost always already superseded by the backend's committed reply, and an unredacted prompt sitting on disk for a week to serve that case is the worse half of the bargain.

## Related Issue

Reported as **#77486**, which proposed "journal redaction" — that is the wrong axis here, for the reasons above, so this PR deliberately does **not** claim `Fixes #77486`. It addresses one of that issue's three claims and inverts the suggested fix. The other two claims are handled separately: the browser-profile/media-cache modes are #77579, and the `connection.json` token is a desktop file-mode change in #77622.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/inflight-turn-journal.ts`
  - `pruneExpiredEntries` + sweep on **every** load, flushing to disk only when something actually dropped, so an abandoned session's tail leaves disk even if the caller never writes.
  - `isExpired` now **fails closed**: non-finite ages and future-dated stamps expire, with a named 5-minute `CLOCK_SKEW_TOLERANCE_MS` so a sub-second backward NTP step cannot expire the turn the user is watching right now. Structurally unusable entries (`messages` not an array) fold into the same predicate — they cannot be replayed, so keeping them buys nothing.
  - `JOURNAL_MAX_AGE_MS` 7 days → 24 hours, documented as a deliberately non-configurable security floor.
  - `sweepExpiredInFlightTurnJournals()` — sweep without needing a session id.
  - `purgeInFlightTurnJournals(ids)` — drain a deleted session's tails; `linkedKeys` expands the id set over `runtimeSessionId` so a rotation orphan is reachable.
  - `dropPendingWrite` cancels the throttled timer, so a purged entry cannot be resurrected by a write that was already in flight.
  - `discardStore` — the envelope now **fails closed too**: a blob that does not parse, has the wrong shape, or carries an unknown version is removed from disk rather than left there unreadable. A blob we cannot enumerate is by definition unreplayable, so discarding costs nothing recoverable — the same argument the entry-level guard already makes.
  - `purgeLinkedEntries` expands over `persistLatest` by runtime id, not only over what is on disk. A throttled write that rotated to a brand-new tip was invisible to both the caller (a delete reads the sidebar row, which still carries the pre-rotation tip) and to `linkedKeys` (its key was never written), so the purge emptied the store and the throttle then fired *afterwards*, putting the turn back on disk after an explicit user delete.
  - A module header explaining why masking must not be added here, and which four mechanisms carry the confidentiality bargain instead.
- `apps/desktop/src/app/session/hooks/use-session-state-cache.ts` — sweep once on mount so the bound is unconditional rather than contingent on the user happening to open a session; pass the runtime id into `persistInFlightTurnState`.
- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts` — sidebar delete purges the journal for `removedIds` + the closing runtime id.
- `apps/desktop/src/app/settings/sessions-settings.tsx` — archived-sessions delete purges the journal **and** adds the `clearQueuedPrompts` calls this path was also missing.
- `apps/desktop/src/lib/inflight-turn-journal.test.ts` — **15 → 45 tests** (15 is the count on the pristine merge base `b45d886`; an earlier revision of this body said "23 → 37", which was wrong on both ends): retention/fail-closed, the store envelope, both delete surfaces, rotation orphans, and the two no-redaction fidelity tests.

### Call-site coverage: the wiring, not just the module

A module test can prove a mechanism works; only a call-site test proves it is **wired**. Before this, module-level tests were thorough enough to mask the fact that every call site was untested — the headline defect (delete does not purge the journal) could be reverted at **both** delete surfaces with the full 3333-test suite still green. Three files close that:

- `apps/desktop/src/app/settings/sessions-settings.test.tsx` — **new file; `sessions-settings.tsx` previously had no test file at all.** Covers the archived-delete purge, both `clearQueuedPrompts` ids, the lineage-root tail, and that a failed delete RPC leaves the journal and queue intact.
- `apps/desktop/src/app/session/hooks/use-session-actions.test.tsx` — the sidebar delete purges the tail, reaches a tail stranded under a rotated stored id via the closing runtime id, and leaves an unrelated session's journal untouched.
- `apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx` — the boot-time sweep fires on mount with no session opened, and the runtime id is actually passed at the real write path.

## How to Test

Reproduce the leak first (Desktop, DevTools console):

1. Start a turn that runs a tool with a credential in its args, then kill the app mid-turn (before the turn settles).
2. `JSON.parse(localStorage['hermes.desktop.inflightTurnJournal.v1'])` → the entry holds the prompt text and tool-call args verbatim.
3. **Before this change:** delete that session from the sidebar (or Settings → Sessions → archived) and re-read the key — the entry is still there. Hand-edit an entry's `updatedAt` to `undefined`, a string, or `Date.now() + 10 * 86400000`, reload, and it never expires.
4. **After this change:** the delete drains it immediately, and an entry that cannot be positively dated inside the window is dropped on the next load.

Automated (from `apps/desktop`):

```
npx vitest run --project ui src/lib/inflight-turn-journal.test.ts   # 45 passed (15 on merge base b45d886)
npx vitest run --project ui src/lib                                  # 634 passed / 66 files
npx vitest run --project ui src/app/session src/app/settings         # 671 passed / 62 files
npx vitest run --project ui                                          # 3352 passed (3311 on merge base)
npx vitest run --project electron                                    # 935 passed / 2 skipped
npx tsc -p . --noEmit                                                # exit 0
npx eslint src/                                                      # 0 errors (90 pre-existing warnings, none in these files)
python -m pytest tests/agent/test_tool_call_arg_no_redaction.py -q   # 1 passed (the #43083 precedent still holds)
```

All counts above are measured at head `da5b0cada` on both Node 22.23.1 and Node 26.5.0. The full `ui` run has one unrelated pre-existing flake — `src/lib/markdown-blocks.test.ts`, a property-fuzz test that exceeds its 30s budget only under full-suite CPU contention and passes standalone (6 passed, 17.5s); that file is not touched by this PR.

Every new test was proven to have teeth by reintroducing the bug and watching it fail — `isExpired` back to `age > MAX_AGE_MS` → 3 fail; structural guard removed → 1 fail; rotation sweep in `writeSnapshot` disabled → 4 fail; purge-side link expansion disabled → 2 fail; `clearTimeout` removed from `dropPendingWrite` → 1 fail; the load-sweep flush removed → 6 fail. Assertions are relative to the exported constants rather than frozen literals, with one directional ceiling (`≤ 24h`) so tightening the window stays free.

The envelope fix and all five call-site mechanisms were mutation-tested the same way, each independently, restoring the file to a byte-identical SHA-256 after every run. The two `discardStore` call sites are separate failure modes, so each was reverted on its own:

| Mutation | Red | Caught by |
|---|---|---|
| parse-failure path → `emptyStore()` | 2 failed / 43 passed | `discards an unparseable store instead of leaving the plaintext on disk`; `lets an explicit purge reach a corrupt store it cannot enumerate` |
| version-mismatch path → `emptyStore()` | 2 failed / 43 passed | `discards a store written by a FUTURE version rather than stranding it unreadable`; `discards a store whose entries map is null` |
| boot-time sweep `useEffect` removed | 1 failed / 14 passed | `sweeps an expired journal entry on mount without any session being opened` |
| runtime id dropped at the write path | 1 failed / 14 passed | `passes the runtime id to the journal, so a rotated key stays reachable` |
| `purgeInFlightTurnJournals` removed from `sessions-settings` | 2 failed / 3 passed | `clears the journaled in-flight tail for the deleted session`; `clears a tail journaled under the lineage root id` |
| `clearQueuedPrompts` removed from `sessions-settings` | 2 failed / 3 passed | `clears queued prompts for the stored id and the lineage root`; `keeps the journal and queue when the delete RPC fails` |
| `purgeInFlightTurnJournals` removed from the sidebar delete | 3 failed / 41 passed | `clears the journaled in-flight tail for the deleted session`; `reaches a tail stranded under a rotated stored id via the closing runtime id`; `leaves another session journal untouched` |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run.** This is a TypeScript-only change in `apps/desktop/src`; I ran the desktop vitest suites above plus the one Python test this PR's reasoning depends on (`tests/agent/test_tool_call_arg_no_redaction.py`, 1 passed). I did not run the full Python suite.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.x, arm64), Node 22.23.1 and Node 26.5.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the rationale lives in the module docstrings, including the "do not add masking here" note and the residual-gap disclosure
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — **N/A on purpose**: the retention window is deliberately not a config key (see above)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the change is renderer-side `localStorage` logic with no platform-specific paths or APIs; behavior is identical on all three Electron platforms
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Teeth checks (each bug reintroduced, then reverted byte-identically):

```
isExpired → age > MAX_AGE_MS                    Tests  3 failed | 34 passed (37)
  × drops an entry with no updatedAt instead of retaining it forever
  × drops an entry with a non-numeric updatedAt
  × drops a future-dated entry left by a backward clock step

structural guard removed                        Tests  1 failed | 36 passed (37)
  × drops a structurally invalid entry

writeSnapshot rotation sweep disabled           Tests  4 failed | 33 passed (37)
  × leaves no orphaned key when the tip rotates mid-turn
  × leaves no orphan across repeated rotations in one turn
  × drains a rotation sibling left by a previous process on the next write
  × never touches an unrelated session journaled under its own runtime

purge-side link expansion disabled              Tests  2 failed | 35 passed (37)
  × drains a rotation sibling when the turn settles
  × purges a pre-existing rotation orphan via the runtime id a delete holds

clearTimeout removed from dropPendingWrite      Tests  1 failed | 36 passed (37)
  × cancels a pending throttled write so a purged entry cannot come back

load-sweep flush removed (extra check)          Tests  6 failed | 31 passed (37)
  × the four fail-closed cases + both sweep cases — the flush, not just the
    in-memory prune, is what gets the expired tail off disk
```
