### PR TITLE
fix(terminal): normalize session key in clear_session_cwd and guard shared env mutation

### DIFF
--- a/tests/tools/test_session_cwd_store.py
+++ b/tests/tools/test_session_cwd_store.py
@@ -141,6 +141,38 @@ class TestFileToolsReadTheRecord:
         assert not str(resolved).startswith(str(wt_b))
 
 
+    def test_clear_normalizes_falsy_key_like_record_does(self):
+        """clear_session_cwd must normalize None/empty to 'default' so
+        clear_task_env_overrides actually removes the record it wrote."""
+        tt.record_session_cwd(None, "/wt/default")
+        assert tt.get_session_cwd(None) == "/wt/default"
+        tt.clear_session_cwd(None)
+        assert tt.get_session_cwd(None) is None
+
+        tt.record_session_cwd("", "/wt/empty")
+        assert tt.get_session_cwd("") == "/wt/empty"
+        tt.clear_session_cwd("")
+        assert tt.get_session_cwd("") is None
+
+
+    def test_env_cwd_not_mutated_for_shared_default_container(self, monkeypatch):
+        """register_task_env_overrides must not mutate env.cwd when the
+        container is shared (default). The session record is the source of
+        truth; mutating the shared env leaks one session's cwd to others."""
+        class _Env:
+            cwd = "/shared/default"
+
+        shared_env = _Env()
+        monkeypatch.setattr(tt, "_active_environments", {"default": shared_env})
+        monkeypatch.setattr(tt, "_task_env_overrides", {})
+
+        tt.register_task_env_overrides("sess-a", {"cwd": "/wt/a"})
+        # Session record must be written.
+        assert tt.get_session_cwd("sess-a") == "/wt/a"
+        # The shared env's cwd must NOT be mutated.
+        assert shared_env.cwd == "/shared/default"
+
+
 class TestDelegateSeedsChildRecord:
     def test_child_record_seeded_from_parent_then_isolated(self):
         tt.record_session_cwd("parent-task", "/parent/worktree")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1206,8 +1206,9 @@ def get_session_cwd(session_key: Optional[str]) -> Optional[str]:
 
 def clear_session_cwd(session_key: str) -> None:
     """Drop a session's cwd record (session teardown)."""
+    key = str(session_key or "default")
     with _session_cwd_lock:
-        _session_cwd.pop(session_key, None)
+        _session_cwd.pop(key, None)
 
 
 def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
@@ -1238,16 +1239,18 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         # A registered workspace cwd IS the session's working directory until
         # a `cd` changes it.
         record_session_cwd(task_id, new_cwd)
-        # The live env is cached under the raw task_id for per-session surfaces
-        # (ACP/gateway/dashboard) and under the collapsed container id for
-        # isolation-keyed rollouts. Try the raw id first, then the container id,
-        # so a CWD-only override (which collapses to "default") still finds and
-        # updates the originating session's env.
+        # For a per-task (non-default) container the env is truly isolated;
+        # update its cwd so env-side seeding stays consistent.  For the
+        # shared default container, the session record (already written
+        # above) is the single source of truth — mutating env.cwd would
+        # leak one session's cwd into every other session sharing the
+        # container.
         container_id = _resolve_container_task_id(task_id)
-        with _env_lock:
-            env = _active_environments.get(task_id) or _active_environments.get(container_id)
-        if env is not None and getattr(env, "cwd", None) is not None:
-            env.cwd = new_cwd
+        if container_id != "default":
+            with _env_lock:
+                env = _active_environments.get(container_id)
+            if env is not None and getattr(env, "cwd", None) is not None:
+                env.cwd = new_cwd
 
 
 def clear_task_env_overrides(task_id: str):


### PR DESCRIPTION
Two cwd-handling bugs:

1. register_task_env_overrides was mutating env.cwd on the shared container. For CWD-only overrides the container id collapses to 'default', so one session's cwd leaked into every other session sharing the container.

2. clear_session_cwd popped the raw key verbatim but record_session_cwd normalizes None/empty to 'default'. clear_task_env_overrides calling clear_session_cwd(task_id) with a falsy task_id never removed the record it wrote.