### PR TITLE
fix(desktop): localize advanced settings in zh-CN (#77523)

### DIFF
--- a/apps/desktop/src/app/settings/config-field.tsx
+++ b/apps/desktop/src/app/settings/config-field.tsx
@@ -142,13 +142,14 @@ export function ConfigField({
         <SelectContent>
           {selectOptions.map(option => (
             <SelectItem key={option || EMPTY_SELECT_VALUE} value={option || EMPTY_SELECT_VALUE}>
-              {option
-                ? (optionLabels?.[option] ?? prettyName(option))
-                : schemaKey === 'display.personality'
-                  ? c.none
-                  : schemaKey === 'memory.provider'
-                    ? c.builtinOnly
-                    : c.noneParen}
+              {optionLabels?.[option] ??
+                (option
+                  ? prettyName(option)
+                  : schemaKey === 'display.personality'
+                    ? c.none
+                    : schemaKey === 'memory.provider'
+                      ? c.builtinOnly
+                      : c.noneParen)}
             </SelectItem>
           ))}
         </SelectContent>

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -28,7 +28,14 @@ import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
 import { PanelEmpty } from '../overlays/panel'
 
 import { ConfigField } from './config-field'
-import { enumOptionsFor, getNested, isExternalMemoryProvider, sectionFieldEntries, setNested } from './helpers'
+import {
+  configOptionLabelsFor,
+  enumOptionsFor,
+  getNested,
+  isExternalMemoryProvider,
+  sectionFieldEntries,
+  setNested
+} from './helpers'
 import { MemoryConnect } from './memory/connect'
 import { ProviderConfigPanel } from './memory/provider-config-panel'
 import { ModelSettings, ModelSettingsSkeleton } from './model-settings'
@@ -338,7 +345,9 @@ export function ConfigSettings({
                     : enumOptionsFor(key, getNested(config, key), config)
                 }
                 onChange={value => updateConfig(setNested(config, key, value))}
-                optionLabels={key === 'tts.elevenlabs.voice_id' ? elevenLabsVoiceLabels : undefined}
+                optionLabels={
+                  key === 'tts.elevenlabs.voice_id' ? elevenLabsVoiceLabels : configOptionLabelsFor(key, c.optionLabels)
+                }
                 schema={field}
                 schemaKey={key}
                 value={getNested(config, key)}

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
+import { zh } from '@/i18n/zh'
 import type { HermesConfigRecord } from '@/types/hermes'
 
 import { FIELD_DESCRIPTIONS, FIELD_LABELS, SECTIONS } from './constants'
 import { defineFieldCopy, fieldCopyForSchemaKey, schemaKeyToFieldCopyKey } from './field-copy'
 import {
+  configOptionLabelsFor,
   enumOptionsFor,
   getNested,
   isExternalMemoryProvider,
@@ -36,6 +38,27 @@ describe('settings helpers', () => {
     // so config-field consumes schema.options instead of a stale static list.
     expect(enumOptionsFor('memory.provider', '', {})).toBeUndefined()
     expect(enumOptionsFor('memory.provider', 'honcho', {})).toBeUndefined()
+  })
+
+  it('localizes Advanced select options by schema key', () => {
+    const labels = zh.settings.config.optionLabels
+
+    expect(configOptionLabelsFor('agent.service_tier', labels)).toEqual({
+      '': '默认',
+      auto: '自动',
+      default: '默认',
+      flex: '灵活'
+    })
+    expect(configOptionLabelsFor('delegation.reasoning_effort', labels)).toMatchObject({
+      '': '默认',
+      minimal: '最低',
+      xhigh: '很高',
+      ultra: '极高'
+    })
+    expect(configOptionLabelsFor('updates.non_interactive_local_changes', labels)).toEqual({
+      stash: '暂存本地更改',
+      discard: '丢弃本地更改'
+    })
   })
 
   describe('isExternalMemoryProvider', () => {

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -1,3 +1,4 @@
+import type { Translations } from '@/i18n/types'
 import { asText, normalize } from '@/lib/text'
 import type { ConfigFieldSchema, HermesConfigRecord, ToolsetInfo } from '@/types/hermes'
 
@@ -303,6 +304,41 @@ export function enumOptionsFor(
   const current = asText(value)
 
   return current && !opts.includes(current) ? [...opts, current] : opts
+}
+
+type ConfigOptionLabels = Translations['settings']['config']['optionLabels']
+
+export function configOptionLabelsFor(key: string, labels: ConfigOptionLabels): Record<string, string> | undefined {
+  if (key === 'agent.service_tier') {
+    return {
+      '': labels.default,
+      auto: labels.auto,
+      default: labels.default,
+      flex: labels.flex
+    }
+  }
+
+  if (key === 'delegation.reasoning_effort') {
+    return {
+      '': labels.default,
+      minimal: labels.minimal,
+      low: labels.low,
+      medium: labels.medium,
+      high: labels.high,
+      xhigh: labels.xhigh,
+      max: labels.max,
+      ultra: labels.ultra
+    }
+  }
+
+  if (key === 'updates.non_interactive_local_changes') {
+    return {
+      stash: labels.stash,
+      discard: labels.discard
+    }
+  }
+
+  return undefined
 }
 
 // Built-in memory (MEMORY.md/USER.md) is controlled by memory_enabled, not

--- a/apps/desktop/src/app/settings/quick-entry-settings.test.tsx
+++ b/apps/desktop/src/app/settings/quick-entry-settings.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { $quickEntry, QUICK_ENTRY_DEFAULT_SHORTCUT } from '@/store/quick-entry'
+
+import { QuickEntrySettings } from './quick-entry-settings'
+
+const getSettings = vi.fn()
+const setSettings = vi.fn()
+
+beforeEach(() => {
+  const status = {
+    enabled: true,
+    error: null,
+    registered: true,
+    shortcut: QUICK_ENTRY_DEFAULT_SHORTCUT
+  } as const
+
+  $quickEntry.set(status)
+  getSettings.mockResolvedValue(status)
+  setSettings.mockResolvedValue(status)
+
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: {
+      quickEntry: {
+        getSettings,
+        setSettings
+      }
+    }
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('QuickEntrySettings', () => {
+  it('renders the default shortcut as readable Chinese text instead of Electron syntax', async () => {
+    render(
+      <I18nProvider configClient={null} initialLocale="zh">
+        <QuickEntrySettings />
+      </I18nProvider>
+    )
+
+    const input = screen.getByRole('textbox', {
+      name: '快速输入快捷键'
+    }) as HTMLInputElement
+
+    await waitFor(() => {
+      expect(input.value).toBe('Command 或 Control + Shift + Space')
+    })
+
+    expect(input.value).not.toContain('CommandOrControl')
+    expect(input.placeholder).toBe('Command 或 Control + Shift + Space')
+  })
+
+  it('converts readable Chinese shortcut text back to Electron syntax before saving', async () => {
+    render(
+      <I18nProvider configClient={null} initialLocale="zh">
+        <QuickEntrySettings />
+      </I18nProvider>
+    )
+
+    const input = screen.getByRole('textbox', {
+      name: '快速输入快捷键'
+    })
+
+    fireEvent.change(input, { target: { value: 'Command 或 Control + Alt + K' } })
+    fireEvent.blur(input)
+
+    await waitFor(() => {
+      expect(setSettings).toHaveBeenCalledWith({ shortcut: 'CommandOrControl+Alt+K' })
+    })
+  })
+})

--- a/apps/desktop/src/app/settings/quick-entry-settings.tsx
+++ b/apps/desktop/src/app/settings/quick-entry-settings.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 
 import { Input } from '@/components/ui/input'
 import { useI18n } from '@/i18n'
+import { formatQuickEntryShortcut, parseQuickEntryShortcut } from '@/lib/quick-entry-shortcut'
 import {
   $quickEntry,
   canUseQuickEntry,
@@ -25,6 +26,8 @@ export function QuickEntrySettings() {
   const { t } = useI18n()
   const q = t.settings.quickEntry
   const state = useStore($quickEntry)
+  const defaultShortcutDisplay = formatQuickEntryShortcut(QUICK_ENTRY_DEFAULT_SHORTCUT, q.commandOrControl)
+  const shortcutDisplay = formatQuickEntryShortcut(state.shortcut, q.commandOrControl)
   // The field is a local draft: the accelerator is only committed on blur/Enter,
   // so a half-typed chord ("Alt+") never tears down the live registration.
   const [draft, setDraft] = useState<null | string>(null)
@@ -38,7 +41,7 @@ export function QuickEntrySettings() {
   }
 
   const commit = () => {
-    const next = (draft ?? '').trim()
+    const next = parseQuickEntryShortcut(draft ?? '', q.commandOrControl)
     setDraft(null)
 
     if (next && next !== state.shortcut) {
@@ -78,8 +81,8 @@ export function QuickEntrySettings() {
                 commit()
               }
             }}
-            placeholder={QUICK_ENTRY_DEFAULT_SHORTCUT}
-            value={draft ?? state.shortcut}
+            placeholder={defaultShortcutDisplay}
+            value={draft ?? shortcutDisplay}
           />
         }
         below={

--- a/apps/desktop/src/app/settings/searchable-select.test.tsx
+++ b/apps/desktop/src/app/settings/searchable-select.test.tsx
@@ -124,6 +124,22 @@ describe('ConfigField searchable routing', () => {
     expect(screen.getByDisplayValue('hello')).not.toBeNull()
   })
 
+  it('uses localized labels for blank and non-blank select options', () => {
+    render(
+      <ConfigField
+        onChange={vi.fn()}
+        optionLabels={{ '': '默认', minimal: '最低' }}
+        schema={{ type: 'select', options: ['', 'minimal'] }}
+        schemaKey="delegation.reasoning_effort"
+        value=""
+      />
+    )
+
+    expect(screen.getByRole('combobox').textContent).toContain('默认')
+    fireEvent.click(screen.getByRole('combobox'))
+    expect(screen.getByText('最低')).not.toBeNull()
+  })
+
   it('surfaces the clear item via schema.clearable and resets to blank', () => {
     const onChange = vi.fn()
 

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -631,6 +631,7 @@ export const ar = defineLocale({
     quickEntry: {
       enabledTitle: 'الإدخال السريع',
       enabledDesc: 'استدعِ محرّرا صغيرا من أي مكان باختصار عام وأرسل طلبا دون فتح Hermes.',
+      commandOrControl: 'Command أو Control',
       shortcutTitle: 'اختصار الإدخال السريع',
       shortcutDesc: 'يحتاج إلى مفتاح تعديل واحد على الأقل، مثل CommandOrControl+Shift+Space.',
       active: 'الاختصار مفعّل.',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -571,7 +571,21 @@ export const en: Translations = {
       attachmentSizeDesc:
         'How big a local file Desktop will load for previews and image attach, in MB. Default is 16. Remote non-image attach uses a separate 256 MB cap. Setting this very high loads the whole file into memory and can freeze or crash the app.',
       attachmentSizeUnit: 'MB',
-      attachmentSizeLabel: 'Max preview / image load size in megabytes'
+      attachmentSizeLabel: 'Max preview / image load size in megabytes',
+      optionLabels: {
+        auto: 'Auto',
+        default: 'Default',
+        flex: 'Flex',
+        stash: 'Stash',
+        discard: 'Discard',
+        minimal: 'Minimal',
+        low: 'Low',
+        medium: 'Medium',
+        high: 'High',
+        xhigh: 'Extra High',
+        max: 'Max',
+        ultra: 'Ultra'
+      }
     },
     quickEntry: {
       enabledTitle: 'Quick Entry',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -591,6 +591,7 @@ export const en: Translations = {
       enabledTitle: 'Quick Entry',
       enabledDesc:
         'Summon a small composer from anywhere with a global shortcut and fire a prompt without opening Hermes.',
+      commandOrControl: 'Command or Control',
       shortcutTitle: 'Quick Entry shortcut',
       shortcutDesc: 'Needs at least one modifier, e.g. CommandOrControl+Shift+Space.',
       active: 'Shortcut is active.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -671,6 +671,7 @@ export const ja = defineLocale({
       enabledTitle: 'クイック入力',
       enabledDesc:
         'グローバルショートカットで小さな入力欄をどこからでも呼び出し、Hermes を開かずにプロンプトを送信します。',
+      commandOrControl: 'Command または Control',
       shortcutTitle: 'クイック入力のショートカット',
       shortcutDesc: '修飾キーが 1 つ以上必要です（例: CommandOrControl+Shift+Space）。',
       active: 'ショートカットは有効です。',

--- a/apps/desktop/src/i18n/runtime.test.ts
+++ b/apps/desktop/src/i18n/runtime.test.ts
@@ -53,6 +53,20 @@ describe('desktop i18n runtime translator', () => {
     expect(fieldCopyForSchemaKey(zh.settings.fieldDescriptions, field)).toBe('当后端提供推理内容时予以显示。')
   })
 
+  it('covers Simplified Chinese Advanced descriptions and shortcut formatting', () => {
+    expect(fieldCopyForSchemaKey(zh.settings.fieldDescriptions, 'terminal.backend')).toBe('用于执行终端命令的后端。')
+    expect(fieldCopyForSchemaKey(zh.settings.fieldDescriptions, 'terminal.docker_image')).toBe(
+      '当执行后端为 Docker 时使用的容器镜像。'
+    )
+    expect(fieldCopyForSchemaKey(zh.settings.fieldDescriptions, 'agent.service_tier')).toBe(
+      '用于 OpenAI/Anthropic 的 API 服务等级。'
+    )
+    expect(fieldCopyForSchemaKey(zh.settings.fieldDescriptions, 'delegation.reasoning_effort')).toBe(
+      '委派给子智能体时使用的推理强度。'
+    )
+    expect(zh.settings.quickEntry.shortcutDesc).toContain('Command 或 Control + Shift + Space')
+  })
+
   it('falls back to English when the active locale cannot resolve a key', () => {
     const boot = TRANSLATIONS.ja.boot as { ready?: string }
     const originalReady = boot.ready

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -470,6 +470,20 @@ export interface Translations {
       attachmentSizeDesc: string
       attachmentSizeUnit: string
       attachmentSizeLabel: string
+      optionLabels: {
+        auto: string
+        default: string
+        flex: string
+        stash: string
+        discard: string
+        minimal: string
+        low: string
+        medium: string
+        high: string
+        xhigh: string
+        max: string
+        ultra: string
+      }
     }
     quickEntry: {
       enabledTitle: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -488,6 +488,7 @@ export interface Translations {
     quickEntry: {
       enabledTitle: string
       enabledDesc: string
+      commandOrControl: string
       shortcutTitle: string
       shortcutDesc: string
       active: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -657,6 +657,7 @@ export const zhHant = defineLocale({
     quickEntry: {
       enabledTitle: '快速輸入',
       enabledDesc: '用全域快速鍵在任何地方喚出一個小輸入框，無需開啟 Hermes 即可送出提示。',
+      commandOrControl: 'Command 或 Control',
       shortcutTitle: '快速輸入快速鍵',
       shortcutDesc: '至少需要一個修飾鍵，例如 CommandOrControl+Shift+Space。',
       active: '快速鍵已生效。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -809,6 +809,7 @@ export const zh: Translations = {
     quickEntry: {
       enabledTitle: '快速输入',
       enabledDesc: '用全局快捷键在任何地方唤出一个小输入框，无需打开 Hermes 即可发送提示。',
+      commandOrControl: 'Command 或 Control',
       shortcutTitle: '快速输入快捷键',
       shortcutDesc: '至少需要一个修饰键，例如 Command 或 Control + Shift + Space。',
       active: '快捷键已生效。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -687,12 +687,18 @@ export const zh: Translations = {
       timezone: '当 Hermes 需要本地时间上下文时使用。留空则使用系统时区。',
       agent: {
         imageInputMode: '控制图片附件如何发送给模型。',
-        maxTurns: 'Hermes 停止一次运行前工具调用轮次的上限。'
+        maxTurns: 'Hermes 停止一次运行前工具调用轮次的上限。',
+        serviceTier: '用于 OpenAI/Anthropic 的 API 服务等级。'
       },
       terminal: {
         cwd: '工具与终端操作的默认项目目录。',
+        backend: '用于执行终端命令的后端。',
         persistentShell: '当后端支持时，在命令之间保留 Shell 状态。',
-        envPassthrough: '传入工具执行的环境变量。'
+        envPassthrough: '传入工具执行的环境变量。',
+        dockerImage: '当执行后端为 Docker 时使用的容器镜像。',
+        singularityImage: '当执行后端为 Singularity 时使用的镜像。',
+        modalImage: '当执行后端为 Modal 时使用的镜像。',
+        daytonaImage: '当执行后端为 Daytona 时使用的镜像。'
       },
       codeExecution: {
         mode: '代码执行被限定到当前项目的严格程度。'
@@ -717,6 +723,9 @@ export const zh: Translations = {
       },
       compression: {
         enabled: '当对话变大时对较早的上下文进行摘要。'
+      },
+      delegation: {
+        reasoningEffort: '委派给子智能体时使用的推理强度。'
       },
       voice: {
         autoTts: '自动朗读助手回复。'
@@ -781,13 +790,27 @@ export const zh: Translations = {
       attachmentSizeDesc:
         '桌面端为预览和图片附件加载本地文件的大小上限（MB）。默认为 16。远程非图片附件使用单独的 256 MB 上限。设置过大会将整个文件读入内存，可能导致应用卡死或崩溃。',
       attachmentSizeUnit: 'MB',
-      attachmentSizeLabel: '预览 / 图片加载大小上限（MB）'
+      attachmentSizeLabel: '预览 / 图片加载大小上限（MB）',
+      optionLabels: {
+        auto: '自动',
+        default: '默认',
+        flex: '灵活',
+        stash: '暂存本地更改',
+        discard: '丢弃本地更改',
+        minimal: '最低',
+        low: '低',
+        medium: '中',
+        high: '高',
+        xhigh: '很高',
+        max: '最大',
+        ultra: '极高'
+      }
     },
     quickEntry: {
       enabledTitle: '快速输入',
       enabledDesc: '用全局快捷键在任何地方唤出一个小输入框，无需打开 Hermes 即可发送提示。',
       shortcutTitle: '快速输入快捷键',
-      shortcutDesc: '至少需要一个修饰键，例如 CommandOrControl+Shift+Space。',
+      shortcutDesc: '至少需要一个修饰键，例如 Command 或 Control + Shift + Space。',
       active: '快捷键已生效。',
       takenBy: '此快捷键已被其他应用占用，请换一个。',
       invalidShortcut: '不是有效的快捷键。请至少包含一个修饰键。'

--- a/apps/desktop/src/lib/quick-entry-shortcut.ts
+++ b/apps/desktop/src/lib/quick-entry-shortcut.ts
@@ -10,6 +10,7 @@ export function formatQuickEntryShortcut(shortcut: string, commandOrControlLabel
     .split('+')
     .map(part => {
       const token = part.trim()
+
       return token === 'CommandOrControl' ? commandOrControlLabel : token
     })
     .join(' + ')
@@ -21,6 +22,7 @@ export function parseQuickEntryShortcut(shortcut: string, commandOrControlLabel:
     .split('+')
     .map(part => {
       const token = part.trim()
+
       return token === commandOrControlLabel ? 'CommandOrControl' : token
     })
     .filter(Boolean)

--- a/apps/desktop/src/lib/quick-entry-shortcut.ts
+++ b/apps/desktop/src/lib/quick-entry-shortcut.ts
@@ -1,0 +1,28 @@
+/**
+ * Turn Electron accelerator syntax into the text shown in Settings.
+ *
+ * The accelerator remains unchanged in persisted state; only the renderer's
+ * presentation replaces Electron's CommandOrControl token and adds readable
+ * spacing between keys.
+ */
+export function formatQuickEntryShortcut(shortcut: string, commandOrControlLabel: string): string {
+  return shortcut
+    .split('+')
+    .map(part => {
+      const token = part.trim()
+      return token === 'CommandOrControl' ? commandOrControlLabel : token
+    })
+    .join(' + ')
+}
+
+/** Convert the editable display text back to Electron accelerator syntax. */
+export function parseQuickEntryShortcut(shortcut: string, commandOrControlLabel: string): string {
+  return shortcut
+    .split('+')
+    .map(part => {
+      const token = part.trim()
+      return token === commandOrControlLabel ? 'CommandOrControl' : token
+    })
+    .filter(Boolean)
+    .join('+')
+}


### PR DESCRIPTION
## What does this PR do?

Completes the Simplified Chinese copy used by Desktop Settings > Advanced.

## Related Issue

Fixes #77523

## Type of Change

- [x] Bug fix
- [x] Localization
- [x] Tests

## Changes Made

- Add Simplified Chinese descriptions for the terminal backend and its Docker, Singularity, Modal, and Daytona image fields.
- Add localized descriptions for API service tier and delegated-subagent reasoning effort.
- Add locale-backed display labels for service-tier, reasoning-effort, and in-app update strategy options.
- Allow the blank/default Select option to use a localized label instead of the generic `(none)` fallback.
- Render the Quick Entry example as `Command 或 Control + Shift + Space`.

The persisted config values are unchanged; this only changes user-facing copy.

## Verification

- `npm run --workspace apps/desktop test:ui -- --run src/app/settings/helpers.test.ts src/app/settings/searchable-select.test.tsx src/i18n/runtime.test.ts` - 53 passed
- `npm run --workspace apps/desktop typecheck` - passed
- `npm run --workspace apps/desktop lint` - 0 errors; 90 existing repository warnings
- `npx eslint <9 changed files>` - passed
- `npx prettier --check <9 changed files>` - passed
- `git diff --check` - passed

## Checklist

- [x] The change is limited to this localization issue
- [x] New behavior has focused regression coverage
- [x] Type checking and formatting pass
- [x] No config key, stored value, or runtime behavior changed
