### PR TITLE
fix(security): prevent multiplex dotenv credential leakage

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -483,10 +483,32 @@ def load_hermes_dotenv(
     - callers that only maintain the installation can set
       ``load_external_secrets=False`` to avoid loading optional secret-manager
       dependencies into the process that replaces that same environment.
+    - routed multiplex profile loads hydrate external sources into the
+      profile's private secret snapshot without mutating the shared process
+      environment; unscoped startup loads retain the normal behavior above.
     """
-    loaded: list[Path] = []
-
     home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+
+    # A multiplex gateway hosts every profile in one process.  While a routed
+    # profile-home override is active, copying that profile's .env into
+    # os.environ would expose its credentials to sibling turns and every
+    # subsequently spawned child.  An unscoped startup load remains process
+    # configuration and must retain the normal loading path.
+    # External secret sources still need their normal refresh path, so resolve
+    # them against the existing profile-local mapping instead of simply
+    # returning before all hydration work.
+    from agent.secret_scope import is_multiplex_active
+    from hermes_constants import get_hermes_home_override
+
+    if is_multiplex_active() and get_hermes_home_override() is not None:
+        if load_external_secrets:
+            from hermes_cli import _early_recovery
+
+            if not _early_recovery._should_skip_external_secret_sources():
+                hydrate_profile_secret_sources(home_path)
+        return []
+
+    loaded: list[Path] = []
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -471,10 +471,24 @@ def load_hermes_dotenv(
     - project `.env` acts as a dev fallback and only fills missing values when
       the user env exists.
     - if no user env exists, the project `.env` also overrides stale shell vars.
+    - multiplex gateways hydrate external sources into the profile's private
+      secret snapshot without mutating the shared process environment.
     """
-    loaded: list[Path] = []
-
     home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+
+    # A multiplex gateway hosts every profile in one process.  Once that mode
+    # is active, copying any routed profile's .env into os.environ would expose
+    # its credentials to sibling turns and every subsequently spawned child.
+    # External secret sources still need their normal refresh path, so resolve
+    # them against the existing profile-local mapping instead of simply
+    # returning before all hydration work.
+    from agent.secret_scope import is_multiplex_active
+
+    if is_multiplex_active():
+        hydrate_profile_secret_sources(home_path)
+        return []
+
+    loaded: list[Path] = []
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None
 

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from agent import secret_scope as ss
 
 
+
 @pytest.fixture(autouse=True)
 def _reset(monkeypatch):
     ss.set_multiplex_active(False)
@@ -86,6 +87,54 @@ class TestProfilePathResolutionUnderMultiplexScope:
 
         assert a_seen == prof_a / "skills"
         assert b_seen == prof_b / "skills"
+
+
+def test_turn_scoped_dotenv_reload_does_not_pollute_process_env(tmp_path, monkeypatch):
+    """A routed profile reload must stay inside its context-local scope.
+
+    ``load_hermes_dotenv`` has several lazy-import and cron call sites beyond
+    the gateway's guarded reload helper.  Any one of them can run during a
+    multiplexed turn, so the loader itself must not copy the active profile's
+    ``.env`` into the shared process environment.
+    """
+    import os
+
+    from agent.secret_scope import get_secret
+    from gateway.run import _profile_runtime_scope
+    from hermes_cli.env_loader import load_hermes_dotenv
+    from hermes_constants import get_hermes_home
+
+    profile_a = tmp_path / "profiles" / "a"
+    profile_b = tmp_path / "profiles" / "b"
+    profile_a.mkdir(parents=True)
+    profile_b.mkdir(parents=True)
+    (profile_a / ".env").write_text(
+        "PROFILE_SCOPED_API_KEY=secret-a\n"
+        "DISCORD_ALLOWED_CHANNELS=profile-a-only\n",
+        encoding="utf-8",
+    )
+    (profile_b / ".env").write_text(
+        "PROFILE_SCOPED_API_KEY=secret-b\n"
+        "DISCORD_ALLOWED_CHANNELS=profile-b-only\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("PROFILE_SCOPED_API_KEY", raising=False)
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "all-channels")
+
+    ss.set_multiplex_active(True)
+    with _profile_runtime_scope(profile_a):
+        assert get_secret("PROFILE_SCOPED_API_KEY") == "secret-a"
+        assert get_secret("DISCORD_ALLOWED_CHANNELS") == "profile-a-only"
+        assert load_hermes_dotenv(hermes_home=get_hermes_home()) == []
+        assert "PROFILE_SCOPED_API_KEY" not in os.environ
+        assert os.environ["DISCORD_ALLOWED_CHANNELS"] == "all-channels"
+
+    with _profile_runtime_scope(profile_b):
+        assert get_secret("PROFILE_SCOPED_API_KEY") == "secret-b"
+        assert get_secret("DISCORD_ALLOWED_CHANNELS") == "profile-b-only"
+        assert load_hermes_dotenv(hermes_home=get_hermes_home()) == []
+        assert "PROFILE_SCOPED_API_KEY" not in os.environ
+        assert os.environ["DISCORD_ALLOWED_CHANNELS"] == "all-channels"
 
 
 def test_cold_profile_hydrates_external_source_without_global_env(
@@ -164,5 +213,3 @@ def test_cold_profile_hydrates_external_source_without_global_env(
     assert calls["count"] == 1
     assert "TEST_PROVIDER_API_KEY" not in os.environ
     assert "EXPLICIT_API_KEY" not in os.environ
-
-

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -88,6 +88,45 @@ class TestProfilePathResolutionUnderMultiplexScope:
         assert b_seen == prof_b / "skills"
 
 
+def test_turn_scoped_dotenv_reload_does_not_pollute_process_env(tmp_path, monkeypatch):
+    """A routed profile reload must stay inside its context-local scope.
+
+    ``load_hermes_dotenv`` has several lazy-import and cron call sites beyond
+    the gateway's guarded reload helper.  Any one of them can run during a
+    multiplexed turn, so the loader itself must not copy the active profile's
+    ``.env`` into the shared process environment.
+    """
+    import os
+
+    from agent.secret_scope import get_secret
+    from gateway.run import _profile_runtime_scope
+    from hermes_cli.env_loader import load_hermes_dotenv
+    from hermes_constants import get_hermes_home
+
+    profile_a = tmp_path / "profiles" / "a"
+    profile_b = tmp_path / "profiles" / "b"
+    profile_a.mkdir(parents=True)
+    profile_b.mkdir(parents=True)
+    (profile_a / ".env").write_text(
+        "PROFILE_SCOPED_API_KEY=secret-a\n", encoding="utf-8"
+    )
+    (profile_b / ".env").write_text(
+        "PROFILE_SCOPED_API_KEY=secret-b\n", encoding="utf-8"
+    )
+    monkeypatch.delenv("PROFILE_SCOPED_API_KEY", raising=False)
+
+    ss.set_multiplex_active(True)
+    with _profile_runtime_scope(profile_a):
+        assert get_secret("PROFILE_SCOPED_API_KEY") == "secret-a"
+        assert load_hermes_dotenv(hermes_home=get_hermes_home()) == []
+        assert "PROFILE_SCOPED_API_KEY" not in os.environ
+
+    with _profile_runtime_scope(profile_b):
+        assert get_secret("PROFILE_SCOPED_API_KEY") == "secret-b"
+        assert load_hermes_dotenv(hermes_home=get_hermes_home()) == []
+        assert "PROFILE_SCOPED_API_KEY" not in os.environ
+
+
 def test_cold_profile_hydrates_external_source_without_global_env(
     tmp_path, monkeypatch
 ):
@@ -164,5 +203,4 @@ def test_cold_profile_hydrates_external_source_without_global_env(
     assert calls["count"] == 1
     assert "TEST_PROVIDER_API_KEY" not in os.environ
     assert "EXPLICIT_API_KEY" not in os.environ
-
 

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -174,6 +174,112 @@ def test_cold_profile_bitwarden_uses_profile_bootstrap_without_global_env(
     assert os.environ.get("ANTHROPIC_API_KEY") is None
 
 
+def test_multiplex_without_profile_scope_still_loads(tmp_path, monkeypatch):
+    """Multiplex startup without a routed profile scope still loads .env."""
+    from agent import secret_scope
+    from hermes_constants import get_hermes_home_override
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("DISCORD_ALLOWED_CHANNELS=123,456\n", encoding="utf-8")
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+
+    assert get_hermes_home_override() is None
+
+    was_active = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+    try:
+        loaded = env_loader.load_hermes_dotenv(hermes_home=tmp_path)
+    finally:
+        secret_scope.set_multiplex_active(was_active)
+
+    assert os.environ.get("DISCORD_ALLOWED_CHANNELS") == "123,456"
+    assert env_file in loaded
+
+
+def test_multiplex_dotenv_load_hydrates_sources_without_global_env(
+    tmp_path, monkeypatch
+):
+    """The safe multiplex path must still refresh profile secret sources."""
+    from agent import secret_scope
+    import agent.secret_sources.bitwarden as bw_module
+    from agent.secret_sources import registry as reg_module
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    monkeypatch.delenv("BWS_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    (tmp_path / ".env").write_text(
+        "BWS_ACCESS_TOKEN=profile-bootstrap\n", encoding="utf-8"
+    )
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: test-project\n"
+        "    access_token_env: BWS_ACCESS_TOKEN\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(bw_module, "find_bws", lambda **_kw: Path("/fake/bws"))
+    monkeypatch.setattr(
+        bw_module,
+        "fetch_bitwarden_secrets",
+        lambda **_kw: ({"ANTHROPIC_API_KEY": "profile-provider-key"}, []),
+    )
+    reg_module._reset_registry_for_tests()
+
+    was_active = secret_scope.is_multiplex_active()
+    home_token = set_hermes_home_override(tmp_path)
+    secret_scope.set_multiplex_active(True)
+    try:
+        assert env_loader.load_hermes_dotenv(hermes_home=tmp_path) == []
+    finally:
+        secret_scope.set_multiplex_active(was_active)
+        reset_hermes_home_override(home_token)
+
+    assert env_loader.get_secret_source_values(tmp_path) == {
+        "ANTHROPIC_API_KEY": "profile-provider-key"
+    }
+    assert os.environ.get("BWS_ACCESS_TOKEN") is None
+    assert os.environ.get("ANTHROPIC_API_KEY") is None
+
+
+def test_multiplex_scoped_load_respects_external_secret_opt_out(
+    tmp_path, monkeypatch
+):
+    """Updater opt-out must skip hydration without exporting profile dotenv."""
+    from agent import secret_scope
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    (tmp_path / ".env").write_text("PROFILE_ONLY=secret\n", encoding="utf-8")
+    monkeypatch.delenv("PROFILE_ONLY", raising=False)
+    hydration_calls = []
+    monkeypatch.setattr(
+        env_loader,
+        "hydrate_profile_secret_sources",
+        lambda home: hydration_calls.append(home),
+    )
+
+    was_active = secret_scope.is_multiplex_active()
+    home_token = set_hermes_home_override(tmp_path)
+    secret_scope.set_multiplex_active(True)
+    try:
+        assert env_loader.load_hermes_dotenv(
+            hermes_home=tmp_path,
+            load_external_secrets=False,
+        ) == []
+    finally:
+        secret_scope.set_multiplex_active(was_active)
+        reset_hermes_home_override(home_token)
+
+    assert hydration_calls == []
+    assert os.environ.get("PROFILE_ONLY") is None
+
+
 def test_cold_profile_hydration_seeds_op_env_bootstrap(tmp_path, monkeypatch):
     """The .op.env bootstrap file must feed cold-profile hydration.
 

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -174,6 +174,48 @@ def test_cold_profile_bitwarden_uses_profile_bootstrap_without_global_env(
     assert os.environ.get("ANTHROPIC_API_KEY") is None
 
 
+def test_multiplex_dotenv_load_hydrates_sources_without_global_env(
+    tmp_path, monkeypatch
+):
+    """The safe multiplex path must still refresh profile secret sources."""
+    from agent import secret_scope
+    import agent.secret_sources.bitwarden as bw_module
+    from agent.secret_sources import registry as reg_module
+
+    monkeypatch.delenv("BWS_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    (tmp_path / ".env").write_text(
+        "BWS_ACCESS_TOKEN=profile-bootstrap\n", encoding="utf-8"
+    )
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: test-project\n"
+        "    access_token_env: BWS_ACCESS_TOKEN\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(bw_module, "find_bws", lambda **_kw: Path("/fake/bws"))
+    monkeypatch.setattr(
+        bw_module,
+        "fetch_bitwarden_secrets",
+        lambda **_kw: ({"ANTHROPIC_API_KEY": "profile-provider-key"}, []),
+    )
+    reg_module._reset_registry_for_tests()
+
+    secret_scope.set_multiplex_active(True)
+    try:
+        assert env_loader.load_hermes_dotenv(hermes_home=tmp_path) == []
+    finally:
+        secret_scope.set_multiplex_active(False)
+
+    assert env_loader.get_secret_source_values(tmp_path) == {
+        "ANTHROPIC_API_KEY": "profile-provider-key"
+    }
+    assert os.environ.get("BWS_ACCESS_TOKEN") is None
+    assert os.environ.get("ANTHROPIC_API_KEY") is None
+
+
 def test_cold_profile_hydration_seeds_op_env_bootstrap(tmp_path, monkeypatch):
     """The .op.env bootstrap file must feed cold-profile hydration.
 


### PR DESCRIPTION
## What does this PR do?

Prevents turn-scoped `load_hermes_dotenv()` calls from copying a routed profile's credentials into process-global `os.environ` while a multiplex profile scope is active.

The root cause was that `load_hermes_dotenv()` always reached `_load_dotenv_with_fallback(..., override=True)`, even when the active Hermes home came from a routed multiplex profile. The gateway helper guarded one reload call site, but lazy imports, cron, and other callers could invoke the loader directly and bypass that guard.

The guard now lives at the shared loader boundary and requires both:

- multiplex mode is active; and
- a routed profile-home override is installed.

This keeps unscoped gateway startup loading unchanged. Inside a routed profile scope, the loader refreshes external secret providers through `hydrate_profile_secret_sources()`, which writes to the existing profile-private snapshot, and returns without mutating the shared process environment.

## Related Issue

Fixes #77562

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/env_loader.py`: skip process-global dotenv mutation only during an active routed multiplex profile scope, while retaining profile-private external-secret hydration.
- `tests/gateway/test_multiplex_credential_isolation.py`: prove two routed profiles retain distinct credentials and channel allowlists while the process-global allowlist remains unchanged.
- `tests/test_env_loader_secret_sources.py`: prove unscoped multiplex startup still loads `.env`, and routed profile loading still hydrates Bitwarden-backed credentials without exporting bootstrap/provider secrets globally.

## Review Follow-up

This revision addresses the startup-order concern raised by @DonShelly and @egilewski:

- the early return is now restricted by `get_hermes_home_override() is not None`;
- multiplex startup without a routed profile scope still loads `DISCORD_ALLOWED_CHANNELS`;
- the profile-private secret-source hydration path remains covered;
- the field scenario from #77970 is covered by distinct profile A/B `DISCORD_ALLOWED_CHANNELS` values plus an unchanged process-global value.

The routed-scope discriminator follows the boundary identified by @DonShelly in #77970, while this PR keeps its existing external secret-provider hydration behavior and coverage.

## How to Test

1. RED proof before narrowing the production guard:
   `scripts/run_tests.sh tests/test_env_loader_secret_sources.py -k multiplex_without_profile_scope_still_loads -q`
   failed because `DISCORD_ALLOWED_CHANNELS` remained unset instead of loading `123,456`.
2. Targeted regression files:
   `scripts/run_tests.sh tests/gateway/test_multiplex_credential_isolation.py tests/test_env_loader_secret_sources.py -q`
   → **25 passed**.
3. Broader affected-surface suite across env loader, secret scope, gateway, cron, and runtime profile isolation:
   → **91 passed** across 9 files.
4. Ruff, `git diff --check`, and `scripts/check-windows-footguns.py` on the three changed files:
   → all passed.
5. Repository-standard full suite:
   `scripts/run_tests.sh -j 16`
   → **30,678 passed, 22 failed, 264 skipped** across 2,816 files in 1,313.8s.
6. Re-ran all 16 files implicated by the full run with identical `-j 4` parameters on this branch and a clean `upstream/main` worktree at `762610538`:
   → both produced **698 passed, 21 failed, 6 skipped**, with the same failing tests and the same separate import-error file. The extra FIFO timing failure seen only in the 16-worker full run passed in both four-worker comparisons.

GitHub `main` advanced after that full comparison. The final commit was rebased onto `fe5e7799f`; none of the 20 intervening commits touched this PR's three files, and the 91-test affected-surface suite passed again after the rebase. The full-suite checkbox remains unchecked because the repository-wide suite has existing macOS/environment failures.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Python 3.11.15. Linux and Windows were not tested directly.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (function behavior documented in its docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python control flow; Windows footgun scan passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No screenshot is applicable because this is a process-level credential-isolation fix with no UI change.

```text
Targeted regression files: 25 passed, 0 failed
Broader affected-surface suite: 91 passed, 0 failed
Ruff: All checks passed
Windows footgun scan: No issues found
git diff --check: passed

Full repository suite (-j 16):
  2,816 files
  30,678 passed
  22 failed
  264 skipped
  1,313.8 seconds

Failed-file comparison (-j 4, same 16 files):
  fix branch:    698 passed, 21 failed, 6 skipped
  upstream/main: 698 passed, 21 failed, 6 skipped
```
