### PR TITLE
fix(providers): stop forwarding provider_routing prefs to Nous Portal

### DIFF
--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -43,9 +43,10 @@ class NousProfile(ProviderProfile):
         sticky_key = get_conversation_context() or session_id
         if sticky_key:
             body["session_id"] = sticky_key
-        provider_preferences = context.get("provider_preferences")
-        if provider_preferences:
-            body["provider"] = provider_preferences
+        # Nous Portal inference rejects caller-supplied provider routing prefs
+        # (only/ignore/order/sort/data_collection/zdr/require_parameters) with
+        # HTTP 400 — routing is decided centrally per model. provider_routing
+        # from config.yaml is OpenRouter-only, so it is not forwarded here.
         return body
 
     def build_api_kwargs_extras(

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -133,6 +133,15 @@ class TestNousProfile:
         body = p.build_extra_body()
         assert body["tags"] == nous_portal_tags()
 
+    def test_extra_body_ignores_provider_preferences(self):
+        """Nous Portal rejects caller-supplied provider routing prefs (HTTP 400)."""
+        p = get_provider_profile("nous")
+        body = p.build_extra_body(
+            provider_preferences={"allow": ["anthropic"], "sort": "price"}
+        )
+        assert "provider" not in body
+        assert "tags" in body
+
 
 
 

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -117,6 +117,19 @@ class TestNousParity:
         )
         assert kw["extra_body"]["tags"] == nous_portal_tags()
 
+    def test_provider_preferences_not_forwarded(self, transport):
+        """Nous Portal rejects provider routing prefs — they must not reach extra_body."""
+        prefs = {"allow": ["anthropic"], "sort": "price"}
+        kw = transport.build_kwargs(
+            model="hermes-3-llama-3.1-405b",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("nous"),
+            provider_preferences=prefs,
+        )
+        assert "provider" not in kw["extra_body"]
+        assert kw["extra_body"]["tags"]
+
 
 
 


### PR DESCRIPTION
## Summary

Fixes #77564. The Nous provider profile forwards caller-supplied `provider_routing` preferences (`provider_preferences`) into the request body as `provider`, which the Nous Portal inference endpoint rejects with HTTP 400 — routing there is decided centrally per model.

## Root Cause

`plugins/model-providers/nous/__init__.py::build_extra_body` copied the OpenRouter behavior and set `body["provider"] = provider_preferences` whenever the prefs were present in context. The Portal rejects these fields:

> HTTP 400: This endpoint does not honor caller-supplied provider routing preferences (e.g. only, ignore, order, data_collection, zdr, require_parameters, sort). Routing is decided centrally per model...

The non-profile transport path (`agent/transports/chat_completions.py:444-445`) already gates this behind `is_openrouter`, so the profile was inconsistent with the transport it replaces. `provider_routing` in `config.yaml` is OpenRouter-specific config.

## Change

- **`plugins/model-providers/nous/__init__.py`**: `build_extra_body` no longer forwards `provider_preferences`; it returns only the portal tags (plus the existing `session_id` sticky-routing key, which is unrelated to routing prefs). Added an explanatory comment.
- **OpenRouter profile unchanged** — it still forwards prefs.
- **Tests**: added `TestNousProfile::test_extra_body_ignores_provider_preferences` and `TestNousParity::test_provider_preferences_not_forwarded` asserting the nous profile does *not* emit `provider` in `extra_body`; existing OpenRouter forwarding tests still pass unchanged.

## Verification

- `tests/providers/test_provider_profiles.py` + `tests/providers/test_transport_parity.py`: **25 passed** (incl. both new inverted tests; OpenRouter `test_provider_preferences` / `test_extra_body_with_prefs` still assert forwarding).
- Full `tests/providers/` + `tests/agent/transports/test_chat_completions.py`: **79 passed**.
- Nous-specific suites (auth, fallback, wire, credits, account): **95 passed**.

## Closes

Closes #77564
