### PR TITLE
feat(image): parallelize image_generate batches + serialize FileSyncManager cycles (salvage #33971)

### DIFF
--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -48,6 +48,7 @@ _PARALLEL_SAFE_TOOLS = frozenset({
     "ha_get_state",
     "ha_list_entities",
     "ha_list_services",
+    "image_generate",
     "read_file",
     "search_files",
     "session_search",

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -93,6 +93,7 @@ def _budget_for_agent(agent) -> BudgetConfig:
 # Maximum number of concurrent worker threads for parallel tool execution.
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.
 _MAX_TOOL_WORKERS = 8
+_DEFAULT_IMAGE_PARALLEL_REQUESTS = 4
 # Keep this above the stock auxiliary.web_extract timeout (360s) so the batch
 # guard does not preempt a slow-but-valid summarization attempt.
 _DEFAULT_CONCURRENT_TOOL_TIMEOUT_S = 420.0
@@ -157,6 +158,43 @@ def _flush_session_db_after_tool_progress(
         agent._incremental_persistence_failed = True
         logger.warning("Incremental tool-call persistence failed after %s: %s", stage, exc)
         return False
+
+
+def _image_generate_parallel_limit() -> int:
+    """Return the configured image-generation parallelism cap.
+
+    Image-generation calls are slow enough that concurrent execution is useful,
+    but backend bursts can hit TTFB or rate-limit failures. Keep the default
+    intentionally conservative while allowing users to tune it per install.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        image_gen = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        value = (
+            image_gen.get("max_parallel_requests")
+            if isinstance(image_gen, dict)
+            else None
+        )
+    except Exception:
+        value = None
+
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        limit = _DEFAULT_IMAGE_PARALLEL_REQUESTS
+    return max(1, min(limit, _MAX_TOOL_WORKERS))
+
+
+def _max_workers_for_tool_batch(runnable_calls) -> int:
+    """Return the worker cap for a concurrent tool batch."""
+    if not runnable_calls:
+        return 0
+    max_workers = _MAX_TOOL_WORKERS
+    if any(name == "image_generate" for _, _, name, _ in runnable_calls):
+        max_workers = min(max_workers, _image_generate_parallel_limit())
+    return min(len(runnable_calls), max_workers)
 
 
 def _ra():
@@ -922,7 +960,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         timeout_s = _resolve_concurrent_tool_timeout()
         deadline = time.monotonic() + timeout_s if timeout_s is not None else None
         if runnable_calls:
-            max_workers = min(len(runnable_calls), _MAX_TOOL_WORKERS)
+            max_workers = _max_workers_for_tool_batch(runnable_calls)
             # Daemon workers: an interrupted/timed-out batch is abandoned with
             # shutdown(wait=False), but stdlib ThreadPoolExecutor workers are
             # non-daemon and registered in concurrent.futures' atexit hook,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -192,7 +192,10 @@ def _max_workers_for_tool_batch(runnable_calls) -> int:
     if not runnable_calls:
         return 0
     max_workers = _MAX_TOOL_WORKERS
-    if any(name == "image_generate" for _, _, name, _ in runnable_calls):
+    if any(
+        (call[2] if len(call) >= 3 else None) == "image_generate"
+        for call in runnable_calls
+    ):
         max_workers = min(max_workers, _image_generate_parallel_limit())
     return min(len(runnable_calls), max_workers)
 

--- a/tests/run_agent/test_image_generate_parallel.py
+++ b/tests/run_agent/test_image_generate_parallel.py
@@ -1,0 +1,97 @@
+"""Regression tests for parallel image-generation tool batches."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import run_agent
+from agent import tool_executor
+
+
+def _tool_call(name: str, args: dict, call_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=call_id,
+        function=SimpleNamespace(
+            name=name,
+            arguments=json.dumps(args),
+        ),
+    )
+
+
+def test_image_generate_batch_routes_to_concurrent_executor():
+    agent = SimpleNamespace()
+    agent._execute_tool_calls = run_agent.AIAgent._execute_tool_calls.__get__(agent)
+    agent._execute_tool_calls_concurrent = MagicMock()
+    agent._execute_tool_calls_sequential = MagicMock()
+    assistant_message = SimpleNamespace(
+        tool_calls=[
+            _tool_call("image_generate", {"prompt": "variation one"}, "img_1"),
+            _tool_call("image_generate", {"prompt": "variation two"}, "img_2"),
+        ],
+    )
+
+    agent._execute_tool_calls(assistant_message, [], "task-image-batch")
+
+    agent._execute_tool_calls_concurrent.assert_called_once()
+    agent._execute_tool_calls_sequential.assert_not_called()
+
+
+def test_image_generate_parallel_worker_cap_defaults_to_four():
+    runnable_calls = [
+        (
+            0,
+            _tool_call("image_generate", {"prompt": "one"}, "img_1"),
+            "image_generate",
+            {},
+        ),
+        (
+            1,
+            _tool_call("image_generate", {"prompt": "two"}, "img_2"),
+            "image_generate",
+            {},
+        ),
+        (
+            2,
+            _tool_call("image_generate", {"prompt": "three"}, "img_3"),
+            "image_generate",
+            {},
+        ),
+        (
+            3,
+            _tool_call("image_generate", {"prompt": "four"}, "img_4"),
+            "image_generate",
+            {},
+        ),
+        (
+            4,
+            _tool_call("image_generate", {"prompt": "five"}, "img_5"),
+            "image_generate",
+            {},
+        ),
+    ]
+
+    with patch("hermes_cli.config.load_config", return_value={}):
+        assert tool_executor._max_workers_for_tool_batch(runnable_calls) == 4
+
+
+def test_image_generate_parallel_worker_cap_can_be_configured_lower():
+    runnable_calls = [
+        (
+            0,
+            _tool_call("image_generate", {"prompt": "one"}, "img_1"),
+            "image_generate",
+            {},
+        ),
+        (
+            1,
+            _tool_call("image_generate", {"prompt": "two"}, "img_2"),
+            "image_generate",
+            {},
+        ),
+    ]
+
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"image_gen": {"max_parallel_requests": 1}},
+    ):
+        assert tool_executor._max_workers_for_tool_batch(runnable_calls) == 1

--- a/tests/tools/test_file_sync.py
+++ b/tests/tools/test_file_sync.py
@@ -1,8 +1,10 @@
 """Tests for FileSyncManager — mtime tracking, deletion detection, transactional rollback."""
 
+import concurrent.futures
 import io
 import os
 import tarfile
+import threading
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -259,6 +261,59 @@ class TestEdgeCases:
 
         mgr.sync(force=True)
         upload.assert_not_called()  # _file_mtime_key returns None, skipped
+
+
+class TestConcurrency:
+    def test_sync_back_waits_for_active_sync_transaction(self, tmp_path):
+        initial_file = tmp_path / "initial.png"
+        new_file = tmp_path / "new.png"
+        initial_file.write_bytes(b"initial")
+        upload_started = threading.Event()
+        release_upload = threading.Event()
+        sync_back_transport_started = threading.Event()
+        overlap_detected = threading.Event()
+        download_calls = []
+
+        def get_files():
+            return [
+                (str(path), f"/root/.hermes/cache/images/{path.name}")
+                for path in sorted(tmp_path.glob("*.png"))
+            ]
+
+        def upload(host_path, _remote_path):
+            if host_path == str(new_file):
+                upload_started.set()
+                sync_back_transport_started.wait(timeout=1.0)
+                release_upload.set()
+
+        def bulk_download(destination):
+            if not release_upload.is_set():
+                overlap_detected.set()
+            sync_back_transport_started.set()
+            download_calls.append(destination)
+            with tarfile.open(destination, "w"):
+                pass
+
+        mgr = FileSyncManager(
+            get_files_fn=get_files,
+            upload_fn=upload,
+            delete_fn=MagicMock(),
+            bulk_download_fn=bulk_download,
+        )
+        mgr.sync(force=True)
+        new_file.write_bytes(b"new")
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            sync_future = executor.submit(mgr.sync, force=True)
+            assert upload_started.wait(timeout=2.0)
+
+            sync_back_future = executor.submit(mgr.sync_back, hermes_home=tmp_path)
+
+            sync_future.result(timeout=3.0)
+            sync_back_future.result(timeout=3.0)
+
+        assert len(download_calls) == 1
+        assert not overlap_detected.is_set()
 
 
 class TestSyncBackSecurity:

--- a/tests/tools/test_image_generation_artifacts.py
+++ b/tests/tools/test_image_generation_artifacts.py
@@ -1,4 +1,6 @@
+import concurrent.futures
 import json
+import threading
 from types import SimpleNamespace
 
 
@@ -36,6 +38,79 @@ def test_postprocess_adds_agent_visible_image_for_active_ssh_env(monkeypatch, tm
         "/home/remotesshuser/.hermes/cache/images/xai_grok-imagine-image_test.jpg"
     )
     assert sync_calls == [True]
+
+
+def test_concurrent_image_results_preserve_shared_remote_sync_state(monkeypatch, tmp_path):
+    from tools import image_generation_tool
+    from tools.environments import file_sync
+
+    hermes_home = tmp_path / ".hermes"
+    image_dir = hermes_home / "cache" / "images"
+    image_dir.mkdir(parents=True)
+    first_image = image_dir / "first.png"
+    second_image = image_dir / "second.png"
+    first_image.write_bytes(b"first")
+
+    first_upload_started = threading.Event()
+    second_sync_finished = threading.Event()
+    worker = threading.local()
+
+    def get_files():
+        return [
+            (
+                str(path),
+                f"/home/remote/.hermes/cache/images/{path.name}",
+            )
+            for path in sorted(image_dir.iterdir())
+        ]
+
+    def upload(_host_path, _remote_path):
+        if worker.label == "first":
+            first_upload_started.set()
+            # Without transaction serialization, the second sync commits its
+            # newer snapshot before this first sync resumes and overwrites it.
+            second_sync_finished.wait(timeout=1.0)
+
+    sync_manager = file_sync.FileSyncManager(
+        get_files_fn=get_files,
+        upload_fn=upload,
+        delete_fn=lambda _paths: None,
+    )
+    env = SimpleNamespace(
+        _remote_home="/home/remote",
+        _sync_manager=sync_manager,
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(file_sync, "_credential_host_paths", lambda: set())
+    monkeypatch.setattr(image_generation_tool, "_active_terminal_env", lambda _task_id: env)
+
+    def postprocess(label, image_path):
+        worker.label = label
+        try:
+            raw = json.dumps({"success": True, "image": str(image_path)})
+            return image_generation_tool._postprocess_image_generate_result(
+                raw,
+                task_id="shared-task",
+            )
+        finally:
+            if label == "second":
+                second_sync_finished.set()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        first_future = executor.submit(postprocess, "first", first_image)
+        assert first_upload_started.wait(timeout=2.0)
+
+        second_image.write_bytes(b"second")
+        second_future = executor.submit(postprocess, "second", second_image)
+
+        first_future.result(timeout=3.0)
+        second_future.result(timeout=3.0)
+
+    assert set(sync_manager._synced_files) == {
+        "/home/remote/.hermes/cache/images/first.png",
+        "/home/remote/.hermes/cache/images/second.png",
+    }
 
 
 def test_handle_image_generate_postprocesses_plugin_result(monkeypatch, tmp_path):

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -156,6 +156,7 @@ class FileSyncManager:
         self._bulk_upload_fn = bulk_upload_fn
         self._bulk_download_fn = bulk_download_fn
         self._delete_fn = delete_fn
+        self._transaction_lock = threading.Lock()
         self._synced_files: dict[str, tuple[float, int]] = {}  # remote_path -> (mtime, size)
         self._pushed_hashes: dict[str, str] = {}  # remote_path -> sha256 hex digest
         self._upload_only_host_paths: set[str] = set()
@@ -171,6 +172,11 @@ class FileSyncManager:
         Transactional: state only committed if ALL operations succeed.
         On failure, state rolls back so the next cycle retries everything.
         """
+        with self._transaction_lock:
+            self._sync_transaction(force=force)
+
+    def _sync_transaction(self, *, force: bool = False) -> None:
+        """Execute one sync cycle while holding the per-manager lock."""
         if not force and not os.environ.get(_FORCE_SYNC_ENV):
             now = _monotonic()
             if now - self._last_sync_time < self._sync_interval:
@@ -257,6 +263,11 @@ class FileSyncManager:
         Protected against SIGINT (defers the signal until complete) and
         serialized across concurrent gateway sandboxes via file lock.
         """
+        with self._transaction_lock:
+            self._sync_back_transaction(hermes_home=hermes_home)
+
+    def _sync_back_transaction(self, hermes_home: Path | None = None) -> None:
+        """Execute sync-back against a stable snapshot of manager state."""
         if self._bulk_download_fn is None:
             return
 

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -64,7 +64,12 @@ Your selection is saved to `config.yaml`:
 image_gen:
   model: fal-ai/flux-2/klein/9b
   use_gateway: false            # true if using Nous Subscription
+  max_parallel_requests: 4      # concurrent images in one tool-call batch
 ```
+
+`max_parallel_requests` defaults to `4`. Hermes clamps it to at least one and
+to the global tool-worker limit, so image providers receive bounded parallel
+requests without allowing an image batch to bypass the agent's concurrency cap.
 
 ### GPT-Image Quality
 


### PR DESCRIPTION
Salvage of #33971 by @EndeavorYen — both commits cherry-picked verbatim (authorship preserved); the only conflict was test-file context drift (main deleted 3 stale postprocess tests that sat in the hunk's context; resolution keeps only the PR's new test).

## What this does for users

1. `image_generate` joins `_PARALLEL_SAFE_TOOLS`: when the model requests several images in one turn, they generate CONCURRENTLY instead of one-after-another. Generation latency is network-bound (seconds per image), so a 4-image batch completes in ~1× single-image latency instead of ~4×.
2. Worker cap is configurable via `image_gen.max_parallel_requests` in config.yaml (default 4, clamped 1..8) — follows the documented convention that `image_gen` is an intentionally-absent DEFAULT_CONFIG root; documented in the website image-generation docs.
3. Fixes a REAL race the parallelism would otherwise widen: `FileSyncManager.sync()`/`sync_back()` had no in-process serialization (the existing `fcntl.flock` is cross-process, `sync_back`-only, and a no-op on Windows). Concurrent artifact syncs could drop files from `_synced_files` (lost update). Now serialized by a `threading.Lock`.

## Verification

- 21 passed (`test_file_sync.py` + `test_image_generation_artifacts.py` + new `test_image_generate_parallel.py`)
- MUTATION-VERIFIED: reverting only the file_sync lock makes both new concurrency tests fail with the real lost-update (`second.png` dropped from `_synced_files`) — the tests bind the race, they are not change-detectors
- Parallel-safety of the handler traced end-to-end: per-task-env FileSyncManager (covered by the new lock), managed FAL client (already lock-guarded, httpx thread-safe), filename collisions impossible (`<prefix>_<ts>_<uuid4[:8]>`), config read is mtime-cached (stat + deepcopy per batch, no YAML parse)
- Routing verified: 2+ image_generate calls form one `("parallel", …)` segment → `_execute_tool_calls_concurrent`; mixed batches take the same executor per segment

Honest caveat on the cap: a mixed batch (images + fast reads) shares one worker pool per parallel segment, so `max_parallel_requests: 1` serializes unrelated tools in that segment — blunt but user-opted-in and clamped ≥1; reads drain in milliseconds through remaining slots at the default of 4.

Closes #33971.
