### PR TITLE
fix(platforms/line): import the real config env helpers (salvage #32706)

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -1695,13 +1695,13 @@ def interactive_setup() -> None:
     print()
 
     try:
-        from hermes_cli.config import get_env_var, set_env_var
+        from hermes_cli.config import get_env_value as _get_env, save_env_value as _set_env
     except ImportError:
         print("hermes_cli.config not available; set LINE_* vars manually in ~/.hermes/.env")
         return
 
     def _prompt(var: str, prompt: str, *, secret: bool = False) -> None:
-        existing = get_env_var(var) if callable(get_env_var) else None
+        existing = _get_env(var) if callable(_get_env) else None
         suffix = " [keep current]" if existing else ""
         try:
             if secret:
@@ -1713,7 +1713,7 @@ def interactive_setup() -> None:
             print()
             return
         if value:
-            set_env_var(var, value)
+            _set_env(var, value)
 
     _prompt("LINE_CHANNEL_ACCESS_TOKEN", "Channel access token", secret=True)
     _prompt("LINE_CHANNEL_SECRET", "Channel secret", secret=True)


### PR DESCRIPTION
Extract-salvage of the one still-live fix from #32706 by @ErnestHysa — commit cherry-picked verbatim (authorship preserved).

## What this does for users

The LINE adapter's interactive setup (`hermes setup` → LINE channel) crashes with `ImportError: cannot import name 'get_env_var' from 'hermes_cli.config'` — the adapter imports two functions that don't exist. This has been broken since the functions were renamed; anyone setting up LINE hits it. Fixed to import the real `get_env_value` / `save_env_value` (verified live: both import and are callable on current main; the adapter's setup path parses and the plugin test suite passes).

Whole-bug-class check: grepped all of plugins/, gateway/, hermes_cli/, tools/ for other `get_env_var`/`set_env_var` importers — LINE's adapter is the only broken site.

## Why the rest of #32706 is not salvaged

The remaining hunks (queue.Queue maxsize bounds + run_in_executor pool cap, N9/N10) change blocking semantics: a bounded `queue.Queue.put()` BLOCKS the producer thread when full — for the touched sites (gateway stream consumer, TUI server, copilot/codex transports) that converts slow-consumer memory growth into producer-thread deadlock with no overflow policy, and the PR ships no tests for the full-queue behavior. The executor cap premise is also stale (the default pool is already bounded on current Python). Plus the PR carries 1,600 lines of findings artifacts (findings.md, pr-body-*.txt) that don't belong in the tree.

## Verification

- 20 plugin tests pass (`tests/plugins/ -k line`); adapter parses; no stale `get_env_var` references remain
- Live import probe: `from hermes_cli.config import get_env_value, save_env_value` resolves on current main

Closes #32706.
