### PR TITLE
fix(tts): forward DeepInfra language hint

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1205,6 +1205,7 @@ stt:
 #     # live result.
 #     model: ""
 #     voice: "default"
+#     language: "PT_BR"  # Language hint for realtime-tts-2; ignored by unsupported models.
 
 # Image generation. Each provider plugin reads its own ``image_gen.<name>``
 # block; deepinfra discovers models live from

--- a/tests/tools/test_tts_deepinfra.py
+++ b/tests/tools/test_tts_deepinfra.py
@@ -1,9 +1,9 @@
 """Tests for the DeepInfra TTS provider.
 
 ``_generate_deepinfra_tts`` is a thin shim that resolves credentials/model
-then delegates to ``_generate_openai_tts``. These two tests pin the
-delegation happy path and the no-hardcoded-fallback contract; shared
-infrastructure (catalog fetch + tag filter) is covered in
+then delegates to ``_generate_openai_tts``. These tests pin language
+propagation, provider isolation, and the no-hardcoded-fallback contract;
+shared infrastructure (catalog fetch + tag filter) is covered in
 ``tests/hermes_cli/test_api_key_providers.py``.
 """
 
@@ -32,6 +32,53 @@ def test_raises_when_no_model_resolvable(monkeypatch, tmp_path):
     from tools.tts_tool import _generate_deepinfra_tts
     with pytest.raises(ValueError, match="No DeepInfra TTS model available"):
         _generate_deepinfra_tts("hi", str(tmp_path / "out.mp3"), {})
+
+
+def test_forwards_language_hint_to_deepinfra_request(monkeypatch, tmp_path):
+    from tools import tts_tool
+
+    response = MagicMock()
+    client = MagicMock()
+    client.audio.speech.create.return_value = response
+    client_factory = MagicMock(return_value=client)
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: client_factory)
+
+    output_path = tmp_path / "out.mp3"
+    tts_tool._generate_deepinfra_tts(
+        "Olá",
+        str(output_path),
+        {
+            "provider": "deepinfra",
+            "deepinfra": {
+                "model": "inworld-ai/realtime-tts-2",
+                "voice": "Heitor",
+                "language": "PT_BR",
+            },
+        },
+    )
+
+    create_kwargs = client.audio.speech.create.call_args.kwargs
+    assert create_kwargs["extra_body"] == {"language": "PT_BR"}
+
+
+def test_deepinfra_does_not_inherit_openai_language(monkeypatch, tmp_path):
+    from tools import tts_tool
+
+    client = MagicMock()
+    client_factory = MagicMock(return_value=client)
+    monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: client_factory)
+
+    tts_tool._generate_deepinfra_tts(
+        "Olá",
+        str(tmp_path / "out.mp3"),
+        {
+            "openai": {"language": "en"},
+            "deepinfra": {"model": "inworld-ai/realtime-tts-2"},
+        },
+    )
+
+    create_kwargs = client.audio.speech.create.call_args.kwargs
+    assert "extra_body" not in create_kwargs
 
 
 def test_requirements_follow_explicit_deepinfra_provider(monkeypatch):

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1467,6 +1467,7 @@ def _generate_openai_tts(
     voice: Optional[str] = None,
     speed: Optional[float] = None,
     instructions: Optional[str] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
 ) -> str:
     """Generate audio via the OpenAI ``audio.speech.create`` SDK shape.
 
@@ -1492,6 +1493,9 @@ def _generate_openai_tts(
             truthy; omitted otherwise so ``tts-1``/``tts-1-hd`` and strict
             OpenAI-compatible servers that reject unknown kwargs are
             unaffected.
+        extra_body: Optional provider-specific request fields. These are
+            sent instead of inheriting ``tts.openai.language``; an empty dict
+            keeps provider configuration isolated without adding request fields.
 
     Returns:
         Path to the saved audio file.
@@ -1522,7 +1526,7 @@ def _generate_openai_tts(
     if speed is None:
         speed_default = tts_config.get("speed", 1.0) if isinstance(tts_config, dict) else 1.0
         speed = float(oai_config.get("speed", speed_default))
-    language = oai_config.get("language")
+    language = oai_config.get("language") if extra_body is None else None
 
     # The managed OpenAI audio gateway only proxies MANAGED_OPENAI_TTS_MODELS.
     # A model set for direct OpenAI (e.g. "tts-1-hd") 400s there with
@@ -1558,8 +1562,13 @@ def _generate_openai_tts(
             create_kwargs["speed"] = max(0.25, min(4.0, speed))
         if instructions:
             create_kwargs["instructions"] = instructions
+        request_extra_body: Dict[str, Any] = {}
         if language:
-            create_kwargs["extra_body"] = {"lang_code": language}
+            request_extra_body["lang_code"] = language
+        if extra_body:
+            request_extra_body.update(extra_body)
+        if request_extra_body:
+            create_kwargs["extra_body"] = request_extra_body
         response = client.audio.speech.create(**create_kwargs)
 
         response.stream_to_file(output_path)
@@ -1616,6 +1625,7 @@ def _generate_deepinfra_tts(text: str, output_path: str, tts_config: Dict[str, A
                 "api.deepinfra.com so the live catalog can be fetched."
             )
         model = candidates[0]
+    language = di_config.get("language")
     return _generate_openai_tts(
         text,
         output_path,
@@ -1625,6 +1635,7 @@ def _generate_deepinfra_tts(text: str, output_path: str, tts_config: Dict[str, A
         model=model,
         voice=di_config.get("voice", DEFAULT_DEEPINFRA_TTS_VOICE),
         speed=float(di_config.get("speed", tts_config.get("speed", 1.0))),
+        extra_body={"language": language} if language else {},
     )
 
 


### PR DESCRIPTION
## What does this PR do?

DeepInfra's `inworld-ai/realtime-tts-2` accepts a provider-specific `language` hint (for example `PT_BR`), but Hermes dropped `tts.deepinfra.language` when the DeepInfra shim delegated to the shared OpenAI-compatible TTS helper. As a result, users could configure the language without it reaching the speech request.

This fix adds an optional provider-specific `extra_body` to the shared helper and forwards DeepInfra's language as:

```json
{"language": "PT_BR"}
```

The provider boundary is explicit: DeepInfra does not inherit `tts.openai.language`, while direct OpenAI-compatible calls keep their existing `{"lang_code": ...}` behavior. When no DeepInfra language is configured, no `extra_body` is sent, preserving compatibility with strict endpoints.

## Related Issue

N/A — no matching open or closed issue/PR was found after searching for DeepInfra TTS language, Inworld TTS, `extra_body`, and `realtime-tts-2`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/tts_tool.py`
  - accepts optional provider-specific `extra_body` in `_generate_openai_tts`;
  - preserves the existing OpenAI-compatible `lang_code` path;
  - forwards `tts.deepinfra.language` as DeepInfra's `language` field;
  - prevents `tts.openai.language` from leaking into DeepInfra requests;
  - omits `extra_body` when DeepInfra has no language hint.
- `tests/tools/test_tts_deepinfra.py`
  - verifies `PT_BR` reaches the final SDK request;
  - verifies DeepInfra does not inherit OpenAI's language configuration.
- `cli-config.yaml.example`
  - documents the optional DeepInfra language hint.

## How to Test

1. Configure DeepInfra TTS:

   ```yaml
   tts:
     provider: deepinfra
     deepinfra:
       model: inworld-ai/realtime-tts-2
       voice: Heitor
       language: PT_BR
   ```

2. Run the TTS suite:

   ```bash
   scripts/run_tests.sh tests/tools/test_tts*.py -q
   ```

   Result: **27 files, 238 tests passed, 0 failed**.

3. Run lint and portability checks:

   ```bash
   ruff check tools/tts_tool.py tests/tools/test_tts_deepinfra.py
   python -m py_compile tools/tts_tool.py tests/tools/test_tts_deepinfra.py
   python scripts/check-windows-footguns.py tools/tts_tool.py tests/tools/test_tts_deepinfra.py
   git diff --check
   ```

   Result: all checks passed.

4. Live E2E on Ubuntu/Linux with DeepInfra `inworld-ai/realtime-tts-2`, voice `Heitor`, language `PT_BR`:
   - generated MP3 successfully;
   - duration: 4.728 seconds;
   - size: 75,648 bytes;
   - validated by `ffprobe` as MP3.

Full-suite note: the repository-wide runner was also attempted from current `upstream/main`; unrelated pre-existing/environment-dependent failures occurred in agent credential/provider tests and non-TTS tool suites. All 27 TTS test files pass, and none of the observed repository-wide failures touch this diff.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — see full-suite note above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux 6.8, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `cli-config.yaml.example` and function docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — Windows footgun scan passed; request payload change is platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model-facing schema change

## Screenshots / Logs

```text
TTS suite: 27 files, 238 tests passed, 0 failed
Ruff: All checks passed
Windows footguns: No Windows footguns found
Live DeepInfra output: MP3, 4.728 s, 75,648 bytes
```
