### PR TITLE
perf(zai): parallelize endpoint detection probes (salvage #7821)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -698,11 +698,17 @@ def detect_zai_endpoint(api_key: str, timeout: float = 8.0) -> Optional[Dict[str
     """
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
-    with ThreadPoolExecutor(max_workers=len(ZAI_ENDPOINTS)) as pool:
+    # No `with` block: a context manager would join ALL probe threads on
+    # exit, defeating the early return below. shutdown(wait=False) lets the
+    # surviving daemon-style probes drain in the background instead of
+    # blocking the caller on slow/unreachable endpoints.
+    pool = ThreadPoolExecutor(max_workers=len(ZAI_ENDPOINTS))
+    try:
         futures = {
             pool.submit(_probe_single_zai_endpoint, api_key, ep, timeout): ep[0]
             for ep in ZAI_ENDPOINTS
         }
+        by_id = {ep_id: f for f, ep_id in futures.items()}
         results: Dict[str, Dict[str, str]] = {}
         for future in as_completed(futures):
             ep_id = futures[future]
@@ -712,12 +718,24 @@ def detect_zai_endpoint(api_key: str, timeout: float = 8.0) -> Optional[Dict[str
                     results[ep_id] = result
             except Exception:
                 pass
+            # Early exit in PRIORITY order: walk endpoints highest-priority
+            # first; if one has succeeded and every higher-priority probe
+            # has already finished (without success), no later completion
+            # can win — return now instead of waiting out slow endpoints
+            # (main's sequential loop also stopped at first success).
+            for ep in ZAI_ENDPOINTS:
+                if not by_id[ep[0]].done():
+                    break  # a higher-priority probe is still in flight
+                if ep[0] in results:
+                    return results[ep[0]]
 
-    # Return first match in priority order (ZAI_ENDPOINTS list order)
-    for ep in ZAI_ENDPOINTS:
-        if ep[0] in results:
-            return results[ep[0]]
-    return None
+        # All probes finished: first match in priority order, if any.
+        for ep in ZAI_ENDPOINTS:
+            if ep[0] in results:
+                return results[ep[0]]
+        return None
+    finally:
+        pool.shutdown(wait=False)
 
 
 def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> str:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -648,41 +648,75 @@ ZAI_ENDPOINTS = [
 ]
 
 
+def _probe_single_zai_endpoint(
+    api_key: str, endpoint: tuple, timeout: float,
+) -> Optional[Dict[str, str]]:
+    """Probe a single Z.AI endpoint. Returns endpoint info dict or None.
+
+    Preserves the per-endpoint candidate-model loop: endpoints carry a
+    ``probe_models`` LIST and each model is tried in order until one
+    succeeds (some plans only accept newer/older GLM slugs).
+    """
+    ep_id, base_url, probe_models, label = endpoint
+    for model in probe_models:
+        try:
+            resp = httpx.post(
+                f"{base_url}/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": model,
+                    "stream": False,
+                    "max_tokens": 1,
+                    "messages": [{"role": "user", "content": "ping"}],
+                },
+                timeout=timeout,
+            )
+            if resp.status_code == 200:
+                logger.debug("Z.AI endpoint probe: %s (%s) model=%s OK", ep_id, base_url, model)
+                return {
+                    "id": ep_id,
+                    "base_url": base_url,
+                    "model": model,
+                    "label": label,
+                }
+            logger.debug("Z.AI endpoint probe: %s model=%s returned %s", ep_id, model, resp.status_code)
+        except Exception as exc:
+            logger.debug("Z.AI endpoint probe: %s model=%s failed: %s", ep_id, model, exc)
+    return None
+
+
 def detect_zai_endpoint(api_key: str, timeout: float = 8.0) -> Optional[Dict[str, str]]:
-    """Probe z.ai endpoints to find one that accepts this API key.
+    """Probe z.ai endpoints in parallel to find one that accepts this API key.
 
     Returns {"id": ..., "base_url": ..., "model": ..., "label": ...} for the
-    first working endpoint, or None if all fail.  For endpoints with multiple
-    candidate models, tries each in order and returns the first that succeeds.
+    first working endpoint (in ZAI_ENDPOINTS priority order), or None if all
+    fail.  For endpoints with multiple candidate models, each worker tries
+    its endpoint's models in order and returns the first that succeeds.
     """
-    for ep_id, base_url, probe_models, label in ZAI_ENDPOINTS:
-        for model in probe_models:
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    with ThreadPoolExecutor(max_workers=len(ZAI_ENDPOINTS)) as pool:
+        futures = {
+            pool.submit(_probe_single_zai_endpoint, api_key, ep, timeout): ep[0]
+            for ep in ZAI_ENDPOINTS
+        }
+        results: Dict[str, Dict[str, str]] = {}
+        for future in as_completed(futures):
+            ep_id = futures[future]
             try:
-                resp = httpx.post(
-                    f"{base_url}/chat/completions",
-                    headers={
-                        "Authorization": f"Bearer {api_key}",
-                        "Content-Type": "application/json",
-                    },
-                    json={
-                        "model": model,
-                        "stream": False,
-                        "max_tokens": 1,
-                        "messages": [{"role": "user", "content": "ping"}],
-                    },
-                    timeout=timeout,
-                )
-                if resp.status_code == 200:
-                    logger.debug("Z.AI endpoint probe: %s (%s) model=%s OK", ep_id, base_url, model)
-                    return {
-                        "id": ep_id,
-                        "base_url": base_url,
-                        "model": model,
-                        "label": label,
-                    }
-                logger.debug("Z.AI endpoint probe: %s model=%s returned %s", ep_id, model, resp.status_code)
-            except Exception as exc:
-                logger.debug("Z.AI endpoint probe: %s model=%s failed: %s", ep_id, model, exc)
+                result = future.result()
+                if result is not None:
+                    results[ep_id] = result
+            except Exception:
+                pass
+
+    # Return first match in priority order (ZAI_ENDPOINTS list order)
+    for ep in ZAI_ENDPOINTS:
+        if ep[0] in results:
+            return results[ep[0]]
     return None
 
 

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -643,6 +643,76 @@ class TestZaiEndpointAutoDetect:
         assert creds["api_key"] == ""
 
 
+class TestZaiParallelProbe:
+    """detect_zai_endpoint probes endpoints in parallel workers.
+
+    Contract under test: (1) each endpoint worker preserves the per-endpoint
+    candidate-model fallback loop, (2) when several endpoints succeed the
+    winner is chosen by ZAI_ENDPOINTS priority order (not completion order).
+    """
+
+    def _mock_post(self, ok):
+        """Return an httpx.post replacement; `ok` maps (base_url, model) -> bool."""
+        import httpx as _httpx
+
+        def _post(url, headers=None, json=None, timeout=None):
+            base = url.rsplit("/chat/completions", 1)[0]
+            code = 200 if ok.get((base, json["model"])) else 401
+            request = _httpx.Request("POST", url)
+            return _httpx.Response(code, request=request, json={})
+
+        return _post
+
+    def test_candidate_model_fallback_within_endpoint(self, monkeypatch):
+        """A worker must try its endpoint's later candidate models when the
+        first ones fail — the fallback the scalar-model version dropped."""
+        from hermes_cli.auth import ZAI_ENDPOINTS, detect_zai_endpoint
+
+        coding_global = next(ep for ep in ZAI_ENDPOINTS if ep[0] == "coding-global")
+        base = coding_global[1]
+        last_model = coding_global[2][-1]
+        # Only the LAST candidate model of coding-global succeeds.
+        monkeypatch.setattr(
+            "hermes_cli.auth.httpx.post",
+            self._mock_post({(base, last_model): True}),
+        )
+        result = detect_zai_endpoint("test-key", timeout=1.0)
+        assert result is not None
+        assert result["id"] == "coding-global"
+        assert result["model"] == last_model
+
+    def test_priority_order_wins_over_completion_order(self, monkeypatch):
+        """When multiple endpoints accept the key, the FIRST in
+        ZAI_ENDPOINTS order must win, even if another finishes earlier."""
+        import time as _time
+
+        from hermes_cli.auth import ZAI_ENDPOINTS, detect_zai_endpoint
+
+        first = ZAI_ENDPOINTS[0]
+        last = ZAI_ENDPOINTS[-1]
+        ok = {
+            (first[1], first[2][0]): True,
+            (last[1], last[2][0]): True,
+        }
+        inner = self._mock_post(ok)
+
+        def _slow_first(url, headers=None, json=None, timeout=None):
+            if url.startswith(first[1]):
+                _time.sleep(0.15)  # first-priority endpoint finishes LAST
+            return inner(url, headers=headers, json=json, timeout=timeout)
+
+        monkeypatch.setattr("hermes_cli.auth.httpx.post", _slow_first)
+        result = detect_zai_endpoint("test-key", timeout=1.0)
+        assert result is not None
+        assert result["id"] == first[0]
+
+    def test_all_fail_returns_none(self, monkeypatch):
+        from hermes_cli.auth import detect_zai_endpoint
+
+        monkeypatch.setattr("hermes_cli.auth.httpx.post", self._mock_post({}))
+        assert detect_zai_endpoint("bad-key", timeout=1.0) is None
+
+
 # =============================================================================
 # Kimi / Moonshot model list isolation tests
 # =============================================================================

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -712,6 +712,28 @@ class TestZaiParallelProbe:
         monkeypatch.setattr("hermes_cli.auth.httpx.post", self._mock_post({}))
         assert detect_zai_endpoint("bad-key", timeout=1.0) is None
 
+    def test_early_exit_does_not_wait_for_slow_losers(self, monkeypatch):
+        """When the highest-priority endpoint succeeds fast, the caller must
+        return without waiting for slow lower-priority probes to finish."""
+        import time as _time
+
+        from hermes_cli.auth import ZAI_ENDPOINTS, detect_zai_endpoint
+
+        first = ZAI_ENDPOINTS[0]
+        inner = self._mock_post({(first[1], first[2][0]): True})
+
+        def _slow_losers(url, headers=None, json=None, timeout=None):
+            if not url.startswith(first[1]):
+                _time.sleep(2.0)  # slow lower-priority endpoints
+            return inner(url, headers=headers, json=json, timeout=timeout)
+
+        monkeypatch.setattr("hermes_cli.auth.httpx.post", _slow_losers)
+        t0 = _time.perf_counter()
+        result = detect_zai_endpoint("test-key", timeout=5.0)
+        elapsed = _time.perf_counter() - t0
+        assert result is not None and result["id"] == first[0]
+        assert elapsed < 1.5, f"early exit failed: waited {elapsed:.2f}s for losers"
+
 
 # =============================================================================
 # Kimi / Moonshot model list isolation tests


### PR DESCRIPTION
Salvage of #7821 by @light-merlin-dark — original commit cherry-picked (authorship preserved) + a rebase-fold commit adapting it to current main.

## What this does for users

`hermes setup` / first-start with a Z.AI key probes up to 4 endpoints (global/cn × standard/coding-plan) to find which one accepts the key — sequentially on main, so a key that only works on the LAST endpoint waits through every earlier probe (and each probe can burn up to the 8s timeout on slow/unreachable regional endpoints). This parallelizes the probes with one worker per endpoint while keeping selection DETERMINISTIC: first match in ZAI_ENDPOINTS priority order wins, not completion order.

## Rebase fold (the sweeper's review point, addressed)

Current main's `ZAI_ENDPOINTS` third field is a `probe_models` LIST (candidate-model fallback per endpoint); the original PR predates that and treated it as one scalar model. The fold restores the per-endpoint candidate loop inside each worker — behavior-identical to main's fallback semantics, just parallel across endpoints.

## Measured impact

Mocked httpx.post with 200ms per probe, only the last-priority endpoint's first model succeeding (worst case for sequential), median of 3:

- main (sequential): 1.42s
- this PR (parallel): 0.82s → **−42%**

Honest caveat: mocked RTT, and the win scales with per-probe latency (real WAN probes to bigmodel.cn from outside China regularly hit multi-second latencies or the full 8s timeout, where parallel ≈ max(probe) instead of sum(probes) — up to ~4× there); with a fast key on the FIRST endpoint, sequential was already optimal and the parallel version is a wash. The probe only runs when the endpoint isn't already cached in auth.json (keyed on key hash), so this is a first-run/setup-path win, not per-turn.

## Verification

- 101 passed (`tests/hermes_cli/test_api_key_providers.py`), incl. 3 new tests
- Mutation-checked both new contracts: (a) returning by completion order → priority test fails; (b) probing only the first candidate model (the original PR's regression) → fallback test fails
- Attribution chore #77601 merged (light-merlin-dark → AUTHOR_MAP)

Closes #7821.

## Post-review fold (simplify pass)

The efficiency reviewer caught a real regression vs main in the COMMON case: the as_completed drain + `with`-join waited for ALL probes even after the highest-priority endpoint had already won, while sequential main returned at first success. Folded an early exit (return as soon as a success is unbeatable in priority order; pool shutdown(wait=False) so losers drain in the background). Mutation-checked: removing the early exit fails the new timing test (8.2s vs <1.5s). Worst case (last-priority endpoint wins) re-measured unchanged: 0.81s vs main's 1.42s.
