### PR TITLE
fix(desktop): CLI update handoff when staged hermes-setup is missing

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -218,6 +218,11 @@ import {
 } from './window-state'
 import { hiddenWindowsChildOptions } from './windows-child-options'
 import {
+  buildWindowsCliUpdateScript,
+  resolveHermesCliBinary as resolveHermesCliBinaryPath,
+  shouldUseWindowsCliUpdateHandoff
+} from './windows-cli-update-handoff'
+import {
   buildPathExtCandidates,
   chooseUpdaterArgs,
   getVenvSitePackagesEntries,
@@ -2861,31 +2866,38 @@ async function applyUpdates(opts = {}) {
     }
 
     if (!updater) {
-      // No staged updater binary — this is a CLI-installed user (they ran
-      // `hermes desktop`, never the Tauri installer that self-copies
-      // hermes-setup.exe into HERMES_HOME). They DO have a working `hermes`
-      // on PATH / in the venv, so the correct path is the one-liner in their
-      // native medium. We show the EXACT command, branch-pinned to the
-      // checkout they're on — bare `hermes update` defaults to main and would
-      // silently switch a bb/gui (or any non-main) install off-branch. Mirror
-      // the GUI button's contract: append --branch <current> for non-main
-      // checkouts, keep it bare for main so the card stays clean.
+      // No staged hermes-setup.exe. Prefer a detached CLI handoff when a
+      // working hermes is available (#46755 / #46779): quit first so the
+      // Windows venv shim unlocks, then run `hermes update` and relaunch.
+      // Only fall back to the manual dialog when no CLI can be resolved.
       const updateRoot = resolveUpdateRoot()
-      let command = 'hermes update'
+      let branch = 'main'
 
       try {
         const head = await runGit(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: updateRoot })
         const current = (head.stdout || '').trim()
 
         if (head.code === 0 && current && current !== 'HEAD') {
-          const branch = await resolveHealedBranch(updateRoot, current)
-
-          if (branch !== 'main') {
-            command = `hermes update --branch ${branch}`
-          }
+          branch = await resolveHealedBranch(updateRoot, current)
         }
       } catch {
-        // Best-effort: fall back to bare `hermes update` if branch detection fails.
+        // best effort — bare main
+      }
+
+      const hermesCli = resolveHermesCliBinary(updateRoot)
+
+      if (shouldUseWindowsCliUpdateHandoff({ isWindows: IS_WINDOWS, stagedUpdater: updater, hermesCli })) {
+        const handedOff = await handOffWindowsCliUpdate({ updateRoot, branch, hermesCli })
+
+        if (handedOff) {
+          return { ok: true, handedOff: true, via: 'cli' }
+        }
+      }
+
+      let command = 'hermes update'
+
+      if (branch && branch !== 'main') {
+        command = `hermes update --branch ${branch}`
       }
 
       rememberLog(`[updates] no staged updater; surfacing manual \`${command}\` for CLI install at ${updateRoot}`)
@@ -3132,16 +3144,137 @@ async function handOffWindowsBootstrapRecovery(reason) {
   return true
 }
 
-// Resolve the hermes CLI to drive an in-app update: prefer the venv shim in
-// the install we're updating, fall back to `hermes` on PATH.
+// Resolve the hermes CLI to drive an in-app / CLI handoff update: prefer the
+// venv shim in the install we're updating (Scripts on Windows, bin on POSIX),
+// fall back to `hermes` on PATH. See windows-cli-update-handoff.ts.
 function resolveHermesCliBinary(updateRoot) {
-  const venvHermes = path.join(updateRoot, 'venv', 'bin', 'hermes')
+  return resolveHermesCliBinaryPath(updateRoot, {
+    fileExists,
+    findOnPath,
+    isWindows: IS_WINDOWS
+  })
+}
 
-  if (fileExists(venvHermes)) {
-    return venvHermes
+/**
+ * Windows Update when hermes-setup.exe is missing but a hermes CLI exists
+ * (#46755 / #46779). Detach a cmd watcher that waits for this process to exit
+ * (shim unlock), runs `hermes update --yes`, then relaunches the desktop.
+ * Returns true when the handoff was spawned successfully.
+ */
+async function handOffWindowsCliUpdate({ updateRoot, branch, hermesCli }) {
+  const handoffConflict = updateHandoffConflict(HERMES_HOME)
+
+  if (handoffConflict) {
+    rememberLog(`[updates] refusing CLI hand-off: ${handoffConflict.message}`)
+    emitUpdateProgress({ stage: 'error', message: handoffConflict.message, percent: null })
+
+    return false
   }
 
-  return findOnPath('hermes') || null
+  preflightStateDb(HERMES_HOME, rememberLog)
+
+  const lock = await releaseBackendLockForUpdate(updateRoot)
+
+  if (!lock.unlocked) {
+    const message =
+      'Update aborted: another process is holding the Hermes install open ' +
+      '(a second Hermes window or a terminal running hermes?). Close it and retry.'
+
+    rememberLog(`[updates] CLI hand-off aborted: shim still locked at ${updateRoot}`)
+    emitUpdateProgress({ stage: 'error', message, percent: null })
+    startHermes().catch(() => {})
+
+    return false
+  }
+
+  if (IS_WINDOWS) {
+    const scanOutcome = await scanVenvBlockers(updateRoot)
+
+    if (scanOutcome.kind === 'blocked') {
+      const message = formatBlockerMessage(scanOutcome.result)
+      rememberLog(`[updates] CLI hand-off aborted: ${message}`)
+      emitUpdateProgress({ stage: 'error', message, percent: null })
+      startHermes().catch(() => {})
+
+      return false
+    }
+
+    if (scanOutcome.kind === 'probe-failure') {
+      const message = formatProbeFailedMessage()
+      rememberLog(`[updates] CLI hand-off venv-blocker probe failed: ${scanOutcome.error}`)
+      emitUpdateProgress({ stage: 'error', message, percent: null })
+      startHermes().catch(() => {})
+
+      return false
+    }
+  }
+
+  const scriptBody = buildWindowsCliUpdateScript({
+    desktopPid: process.pid,
+    hermesCmd: hermesCli,
+    updateRoot,
+    hermesHome: HERMES_HOME,
+    branch,
+    relaunchExe: process.execPath,
+    relaunchArgs: collectRelaunchArgs(process.argv.slice(1))
+  })
+
+  const scriptPath = path.join(app.getPath('temp'), `hermes-desktop-cli-update-${Date.now()}.cmd`)
+
+  try {
+    fs.writeFileSync(scriptPath, scriptBody, { encoding: 'utf8' })
+  } catch (err) {
+    rememberLog(`[updates] CLI hand-off script write failed: ${err?.message || err}`)
+
+    return false
+  }
+
+  const venvBin = path.join(updateRoot, 'venv', IS_WINDOWS ? 'Scripts' : 'bin')
+  let child
+
+  try {
+    child = spawn(
+      process.env.ComSpec || 'cmd.exe',
+      ['/d', '/c', scriptPath],
+      hiddenWindowsChildOptions({
+        cwd: updateRoot,
+        env: {
+          ...process.env,
+          HERMES_HOME,
+          PATH: pathWithHermesManagedNode(venvBin)
+        },
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: true
+      })
+    )
+    child.unref()
+  } catch (err) {
+    rememberLog(`[updates] CLI hand-off spawn failed: ${err?.message || err}`)
+
+    return false
+  }
+
+  if (Number.isInteger(child.pid)) {
+    writeUpdateMarker(HERMES_HOME, child.pid)
+  }
+
+  rememberLog(
+    `[updates] no staged updater; handed off to CLI watcher ${scriptPath} via ${hermesCli} (branch=${branch || 'main'})`
+  )
+  emitUpdateProgress({
+    stage: 'restart',
+    message:
+      'Updating Hermes — this window will close and reopen when the update finishes. Don’t reopen Hermes yourself.',
+    percent: 100
+  })
+
+  isQuittingForHandoff = true
+  setTimeout(() => {
+    app.quit()
+  }, UPDATE_HANDOFF_DWELL_MS)
+
+  return true
 }
 
 // Spawn a command and stream each output line to the update progress channel.

--- a/apps/desktop/electron/windows-cli-update-handoff.test.ts
+++ b/apps/desktop/electron/windows-cli-update-handoff.test.ts
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import {
+  buildWindowsCliUpdateScript,
+  resolveHermesCliBinary,
+  shouldUseWindowsCliUpdateHandoff
+} from './windows-cli-update-handoff'
+
+test('resolveHermesCliBinary prefers Windows venv Scripts hermes.exe', () => {
+  const root = 'C:\\Users\\apo\\AppData\\Local\\hermes\\hermes-agent'
+  const expected = path.win32.join(root, 'venv', 'Scripts', 'hermes.exe')
+  const seen: string[] = []
+
+  const resolved = resolveHermesCliBinary(root, {
+    isWindows: true,
+    fileExists: candidate => {
+      seen.push(candidate)
+
+      return candidate === expected
+    },
+    findOnPath: () => 'C:\\tools\\hermes.cmd'
+  })
+
+  assert.equal(resolved, expected)
+  assert.ok(seen[0].toLowerCase().includes('scripts'))
+  assert.ok(!seen.some(s => s.includes(`${path.sep}bin${path.sep}`)))
+})
+
+test('resolveHermesCliBinary falls back to PATH when venv shim is missing', () => {
+  const resolved = resolveHermesCliBinary('C:\\Hermes\\hermes-agent', {
+    isWindows: true,
+    fileExists: () => false,
+    findOnPath: name => (name === 'hermes' ? 'C:\\Tools\\hermes.cmd' : null)
+  })
+
+  assert.equal(resolved, 'C:\\Tools\\hermes.cmd')
+})
+
+test('resolveHermesCliBinary uses POSIX venv/bin/hermes off Windows', () => {
+  const root = '/home/apo/.hermes/hermes-agent'
+  const expected = path.posix.join(root, 'venv', 'bin', 'hermes')
+
+  const resolved = resolveHermesCliBinary(root, {
+    isWindows: false,
+    fileExists: candidate => candidate === expected,
+    findOnPath: () => '/usr/local/bin/hermes'
+  })
+
+  assert.equal(resolved, expected)
+})
+
+test('shouldUseWindowsCliUpdateHandoff only when Windows + no staged + has CLI', () => {
+  assert.equal(
+    shouldUseWindowsCliUpdateHandoff({
+      isWindows: true,
+      stagedUpdater: null,
+      hermesCli: 'C:\\venv\\Scripts\\hermes.exe'
+    }),
+    true
+  )
+  assert.equal(
+    shouldUseWindowsCliUpdateHandoff({
+      isWindows: true,
+      stagedUpdater: 'C:\\hermes\\hermes-setup.exe',
+      hermesCli: 'C:\\venv\\Scripts\\hermes.exe'
+    }),
+    false
+  )
+  assert.equal(
+    shouldUseWindowsCliUpdateHandoff({
+      isWindows: true,
+      stagedUpdater: null,
+      hermesCli: null
+    }),
+    false
+  )
+  assert.equal(
+    shouldUseWindowsCliUpdateHandoff({
+      isWindows: false,
+      stagedUpdater: null,
+      hermesCli: '/usr/bin/hermes'
+    }),
+    false
+  )
+})
+
+test('buildWindowsCliUpdateScript waits for desktop PID then runs branch-pinned update', () => {
+  const script = buildWindowsCliUpdateScript({
+    desktopPid: 4242,
+    hermesCmd: 'C:\\Hermes\\venv\\Scripts\\hermes.exe',
+    updateRoot: 'C:\\Hermes\\hermes-agent',
+    hermesHome: 'C:\\Hermes',
+    branch: 'bb/gui',
+    relaunchExe: 'C:\\Hermes\\Hermes\\Hermes.exe',
+    relaunchArgs: ['--some-flag']
+  })
+
+  assert.match(script, /@echo off/)
+  assert.match(script, /set "PID=4242"/)
+  assert.match(script, /set "HERMES_HOME=C:\\Hermes"/)
+  assert.match(script, /tasklist \/NH \/FI "PID eq %PID%"/)
+  assert.match(script, /cd \/d "C:\\Hermes\\hermes-agent"/)
+  assert.match(script, /"C:\\Hermes\\venv\\Scripts\\hermes\.exe" update --yes --branch bb\/gui/)
+  assert.match(script, /start "" "C:\\Hermes\\Hermes\\Hermes\.exe" "--some-flag"/)
+  assert.match(script, /del "%~f0"/)
+})
+
+test('buildWindowsCliUpdateScript omits --branch for main', () => {
+  const script = buildWindowsCliUpdateScript({
+    desktopPid: 1,
+    hermesCmd: 'hermes.cmd',
+    updateRoot: 'C:\\a',
+    hermesHome: 'C:\\h',
+    branch: 'main'
+  })
+
+  assert.match(script, /"hermes\.cmd" update --yes\r?$/m)
+  assert.doesNotMatch(script, /--branch/)
+})
+
+test('buildWindowsCliUpdateScript strips quote characters from paths', () => {
+  const script = buildWindowsCliUpdateScript({
+    desktopPid: 9,
+    hermesCmd: 'C:\\bad"quote\\hermes.exe',
+    updateRoot: 'C:\\root',
+    hermesHome: 'C:\\home'
+  })
+
+  assert.doesNotMatch(script, /bad"quote/)
+  assert.match(script, /badquote/)
+})

--- a/apps/desktop/electron/windows-cli-update-handoff.ts
+++ b/apps/desktop/electron/windows-cli-update-handoff.ts
@@ -1,0 +1,149 @@
+/**
+ * windows-cli-update-handoff.ts
+ *
+ * Pure helpers for the Windows Update path when the staged Tauri installer
+ * (`HERMES_HOME/hermes-setup.exe`) is missing.
+ *
+ * Background (#46755 / #46779)
+ * ---------------------------
+ * The GUI Update button prefers handing off to the staged hermes-setup binary.
+ * That binary is only written by a full bootstrap install. CLI-only installs
+ * and some CLI-driven rebuild paths never stage it, so `resolveStagedUpdaterBinary`
+ * returns null and the desktop used to surface a manual `hermes update` dialog
+ * forever — even when a working venv `hermes` is right there.
+ *
+ * Preferred contract (issue Option B): when the staged binary is absent but a
+ * hermes CLI is available, detach a small cmd watcher that:
+ *   1. waits for the desktop PID to exit (releases the Windows venv shim lock),
+ *   2. runs `hermes update --yes` (branch-pinned when needed),
+ *   3. relaunches the desktop executable.
+ *
+ * Kept electron-free so vitest can cover the script shape without booting the
+ * main process (same pattern as desktop-uninstall.ts / update-relaunch.ts).
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+export interface ResolveHermesCliBinaryDeps {
+  fileExists?: (candidate: string) => boolean
+  findOnPath?: (command: string) => string | null
+  isWindows?: boolean
+}
+
+/**
+ * Resolve a hermes CLI that can drive `hermes update` for the install at
+ * `updateRoot`. Prefer the venv shim inside that checkout; fall back to PATH.
+ *
+ * Windows venv layout is `venv/Scripts/hermes.exe` (not `venv/bin/hermes`).
+ * Looking only at the POSIX path made Windows CLI handoff always miss the
+ * local venv and depend on a PATH install.
+ */
+export function resolveHermesCliBinary(updateRoot: string, deps: ResolveHermesCliBinaryDeps = {}): string | null {
+  if (!updateRoot) {
+    return null
+  }
+
+  const isWindows = deps.isWindows ?? process.platform === 'win32'
+  const pathMod = isWindows ? path.win32 : path.posix
+
+  const fileExists =
+    deps.fileExists ??
+    ((candidate: string) => {
+      try {
+        return fs.statSync(candidate).isFile()
+      } catch {
+        return false
+      }
+    })
+
+  const findOnPath = deps.findOnPath ?? (() => null)
+
+  const candidates = isWindows
+    ? [
+        pathMod.join(updateRoot, 'venv', 'Scripts', 'hermes.exe'),
+        pathMod.join(updateRoot, 'venv', 'Scripts', 'hermes.cmd'),
+        pathMod.join(updateRoot, 'venv', 'Scripts', 'hermes.bat')
+      ]
+    : [pathMod.join(updateRoot, 'venv', 'bin', 'hermes')]
+
+  for (const candidate of candidates) {
+    if (fileExists(candidate)) {
+      return candidate
+    }
+  }
+
+  return findOnPath('hermes') || null
+}
+
+export interface BuildWindowsCliUpdateScriptOpts {
+  desktopPid: number
+  hermesCmd: string
+  updateRoot: string
+  hermesHome: string
+  /** Branch to pin, or null/empty/'main' for bare `hermes update`. */
+  branch?: string | null
+  /** Desktop executable to relaunch after a successful update. */
+  relaunchExe?: string | null
+  /** Extra args to pass the relaunched desktop (already filtered). */
+  relaunchArgs?: string[]
+}
+
+/**
+ * Build a cmd.exe watcher script for the no-staged-updater Windows path.
+ *
+ * Mirrors the wait/relaunch shape used by desktop-uninstall's Windows cleanup
+ * script: bounded PID wait, then work, then self-delete.
+ */
+export function buildWindowsCliUpdateScript(opts: BuildWindowsCliUpdateScriptOpts): string {
+  const pid = Number(opts.desktopPid) || 0
+  // cmd.exe has no real string escaping inside quotes; strip embedded quotes
+  // (Hermes install paths under %LOCALAPPDATA% never contain them).
+  const q = (s: string) => `"${String(s).replace(/"/g, '')}"`
+  const branch = (opts.branch || '').trim()
+  const branchArgs = branch && branch !== 'main' ? ` --branch ${branch.replace(/[^A-Za-z0-9._/-]/g, '')}` : ''
+
+  const lines = [
+    '@echo off',
+    'setlocal enableextensions',
+    `set "HERMES_HOME=${String(opts.hermesHome).replace(/"/g, '')}"`,
+    `set "PID=${pid}"`,
+    'set /a waited=0',
+    ':waitloop',
+    'rem Exact PID wait (same pattern as desktop-uninstall Windows cleanup).',
+    'tasklist /NH /FI "PID eq %PID%" 2>nul | findstr /r /c:" %PID% " >nul',
+    'if %ERRORLEVEL% neq 0 goto waited_done',
+    'set /a waited+=1',
+    'if %waited% geq 60 goto waited_done',
+    'timeout /t 1 /nobreak >nul',
+    'goto waitloop',
+    ':waited_done',
+    `cd /d ${q(opts.updateRoot)}`,
+    // hermes update already rebuilds desktop when a packaged app is present.
+    `${q(opts.hermesCmd)} update --yes${branchArgs}`
+  ]
+
+  if (opts.relaunchExe) {
+    const args = (opts.relaunchArgs || []).map(a => q(a)).join(' ')
+    // `start ""` is required so start does not treat the first quoted token
+    // as a window title.
+    lines.push(args ? `start "" ${q(opts.relaunchExe)} ${args}` : `start "" ${q(opts.relaunchExe)}`)
+  }
+
+  lines.push('del "%~f0"')
+  lines.push('')
+
+  return lines.join('\r\n')
+}
+
+/**
+ * Decide whether Windows should try the CLI handoff instead of the manual
+ * dialog. Pure boolean for tests.
+ */
+export function shouldUseWindowsCliUpdateHandoff(opts: {
+  isWindows: boolean
+  stagedUpdater: string | null | undefined
+  hermesCli: string | null | undefined
+}): boolean {
+  return Boolean(opts.isWindows && !opts.stagedUpdater && opts.hermesCli)
+}


### PR DESCRIPTION
## Summary

When Windows desktop cannot find the staged `hermes-setup.exe`, the Update button used to only show a manual `hermes update` dialog. That is the failure tracked in #46755 and the dupe #46779 (alt-glitch: same root cause after CLI / `--build-only` paths that never re-stage the binary).

If a working hermes CLI is available (venv `Scripts\\hermes.exe` or PATH), the button now detaches a small cmd watcher that:

1. waits for the desktop PID to exit (releases the Windows venv shim lock)
2. runs branch-pinned `hermes update --yes`
3. relaunches the desktop

Manual dialog remains only when no CLI can be resolved.

## Changes

- `apps/desktop/electron/windows-cli-update-handoff.ts`: pure helpers for CLI resolution, gate, and cmd script generation
- `apps/desktop/electron/windows-cli-update-handoff.test.ts`: 7 unit tests
- `apps/desktop/electron/main.ts`: wire handoff into `applyUpdates` when staged updater is missing; fix `resolveHermesCliBinary` to use Windows `venv/Scripts` (was POSIX-only `venv/bin`)

## Related

- Canonical: #46755
- Dupe (this thread): #46779 / alt-glitch comment
- Adjacent open work (not duplicated here):
  - #77435 restages a cargo-built installer from checkout after Tauri `--update` (only helps when cargo already built the binary)
  - #75793 detects/nags about a stale staged binary (read-only)

This PR takes issue Option B for the missing-binary case: drive update via hermes CLI after unlock, keep staged setup as the preferred path when present.

## Validation

```text
npx vitest run --project electron electron/windows-cli-update-handoff.test.ts electron/updater-process.test.ts
# 16 passed
```

Closes #46755
Closes #46779
