### PR TITLE
fix(acp): preserve named custom provider identity

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -425,6 +425,25 @@ class SessionManager:
         provider = getattr(state.agent, "provider", None)
         base_url = getattr(state.agent, "base_url", None)
         api_mode = getattr(state.agent, "api_mode", None)
+        # Named custom providers normalize to the runtime bucket ``custom``
+        # after client construction. Persisting that bare bucket loses the
+        # provider identity (and therefore its credential pool) when ACP
+        # recreates the agent for the next turn. Recover the durable
+        # ``custom:<name>`` identity from the endpoint/model before writing
+        # session metadata. This mirrors the TUI session-healing path.
+        if isinstance(provider, str) and provider.strip().lower() == "custom":
+            try:
+                from hermes_cli.runtime_provider import canonical_custom_identity
+
+                provider = canonical_custom_identity(
+                    base_url=base_url,
+                    model=model_str,
+                ) or provider
+            except Exception:
+                logger.debug(
+                    "Failed to canonicalize ACP custom provider identity",
+                    exc_info=True,
+                )
         if isinstance(provider, str) and provider.strip():
             session_meta["provider"] = provider.strip()
         if isinstance(base_url, str) and base_url.strip():

--- a/tests/acp/test_session_db_private_access.py
+++ b/tests/acp/test_session_db_private_access.py
@@ -178,3 +178,46 @@ class TestPersistRoundTrip:
         assert row["model"] == "stored-model", (
             "COALESCE must preserve the existing model when new value is NULL"
         )
+
+    def test_named_custom_provider_identity_survives_persist(self, tmp_path):
+        """ACP must not persist the non-routable bare ``custom`` bucket."""
+        db = _tmp_db(tmp_path)
+        manager = SessionManager(agent_factory=_mock_agent, db=db)
+        state = manager.create_session()
+        state.model = "example-model"
+        state.agent.provider = "custom"
+        state.agent.base_url = "https://gateway.example.invalid/anthropic/v1"
+        state.agent.api_mode = "anthropic_messages"
+
+        with patch(
+            "hermes_cli.runtime_provider.canonical_custom_identity",
+            return_value="custom:example-gateway",
+        ) as canonicalize:
+            manager.save_session(state.session_id)
+
+        row = db.get_session(state.session_id)
+        metadata = json.loads(row["model_config"])
+        assert metadata["provider"] == "custom:example-gateway"
+        canonicalize.assert_called_once_with(
+            base_url=state.agent.base_url,
+            model="example-model",
+        )
+
+    def test_non_custom_provider_identity_is_unchanged(self, tmp_path):
+        """Built-in providers bypass custom identity recovery."""
+        db = _tmp_db(tmp_path)
+        manager = SessionManager(agent_factory=_mock_agent, db=db)
+        state = manager.create_session()
+        state.agent.provider = "anthropic"
+        state.agent.base_url = "https://api.anthropic.com"
+        state.agent.api_mode = "anthropic_messages"
+
+        with patch(
+            "hermes_cli.runtime_provider.canonical_custom_identity",
+        ) as canonicalize:
+            manager.save_session(state.session_id)
+
+        row = db.get_session(state.session_id)
+        metadata = json.loads(row["model_config"])
+        assert metadata["provider"] == "anthropic"
+        canonicalize.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Preserves the canonical `custom:<name>` identity when ACP persists a session backed by a named custom provider.

Named custom providers normalize to the runtime bucket `custom` after client construction. ACP previously persisted that bare runtime value in `model_config.provider`. When the next ACP process restored the session, `resolve_runtime_provider(requested="custom")` could no longer recover the named provider's credential pool. For Anthropic-compatible custom endpoints, the restored base URL and `anthropic_messages` mode remained while the API key was lost, causing the Anthropic SDK to reject the request before delivery.

The fix reuses `canonical_custom_identity()` before ACP writes session metadata, matching the existing TUI session-healing behavior. It only runs for the bare `custom` runtime bucket and falls back safely when no configured identity can be recovered.

This is related to `4a1bff642ae6f588d6b7f7cbc4797b7c989f99c7`, which fixed canonical custom identity recovery for TUI paths; ACP persistence did not use the same canonicalization.

## Related Issue

No existing matching issue or PR found after searching open and closed results.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/session.py`: canonicalize a bare custom provider from its persisted endpoint/model before writing ACP session metadata.
- `tests/acp/test_session_db_private_access.py`: cover named custom-provider identity persistence and verify built-in providers remain unchanged.

## How to Test

1. Configure a named custom provider using `api_mode: anthropic_messages` and select it as `custom:<name>`.
2. Start an ACP session and complete one prompt so the session is persisted.
3. Resume the same ACP session for a second prompt.
4. Verify `model_config.provider` remains `custom:<name>` and the named credential pool is resolved on restore.

Automated checks run on macOS:

```text
scripts/run_tests.sh tests/acp/ -q
128 passed, 0 failed

scripts/run_tests.sh \
  tests/acp/test_session_db_private_access.py \
  tests/hermes_cli/test_canonical_custom_identity.py -q
16 passed, 0 failed
```

The full `scripts/run_tests.sh -q` run was also attempted. It reached 5,327 passing tests before being stopped after an unrelated deterministic failure in `tests/agent/test_vision_routing_31179.py::TestTextOnlyMainSkippedForVision::test_text_only_main_skipped_when_no_aggregator`. That file fails identically when rerun alone and does not import or exercise the ACP persistence code changed here.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — full run is currently blocked by the unrelated deterministic failure documented above
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing configuration or interface changed
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow changed
- [x] Cross-platform impact considered: the change is platform-independent metadata normalization
- [x] Tool descriptions/schemas: N/A; no tool behavior changed

## Screenshots / Logs

Original failure on the second ACP turn:

```text
Could not resolve authentication method. Expected either api_key or auth_token
to be set. Or for one of the X-Api-Key or Authorization headers to be
explicitly omitted.
```

No credentials or endpoint values are included in this PR.
