### PR TITLE
perf(providers): cache provider list snapshots (#39314 salvage)

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 
 _REGISTRY: dict[str, ProviderProfile] = {}
 _ALIASES: dict[str, str] = {}
+_PROVIDER_LIST_CACHE: list[ProviderProfile] | None = None
 _discovered = False
 
 # Repo-root ``plugins/model-providers/`` — populated at discovery time.
@@ -57,9 +58,11 @@ def register_provider(profile: ProviderProfile) -> None:
     plugins under ``$HERMES_HOME/plugins/model-providers/`` can override
     bundled profiles without editing repo code.
     """
+    global _PROVIDER_LIST_CACHE
     _REGISTRY[profile.name] = profile
     for alias in profile.aliases:
         _ALIASES[alias] = profile.name
+    _PROVIDER_LIST_CACHE = None
 
 
 def get_provider_profile(name: str) -> ProviderProfile | None:
@@ -75,8 +78,11 @@ def get_provider_profile(name: str) -> ProviderProfile | None:
 
 def list_providers() -> list[ProviderProfile]:
     """Return all registered provider profiles (one per canonical name)."""
+    global _PROVIDER_LIST_CACHE
     if not _discovered:
         _discover_providers()
+    if _PROVIDER_LIST_CACHE is not None:
+        return list(_PROVIDER_LIST_CACHE)
     # Deduplicate: _REGISTRY has canonical names; _ALIASES points to same objects
     seen: set[int] = set()
     result: list[ProviderProfile] = []
@@ -85,7 +91,8 @@ def list_providers() -> list[ProviderProfile]:
         if pid not in seen:
             seen.add(pid)
             result.append(profile)
-    return result
+    _PROVIDER_LIST_CACHE = result
+    return list(result)
 
 
 def _user_plugins_dir() -> Path | None:

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -21,6 +21,7 @@ def _clear_provider_caches():
     import providers as _pkg
     _pkg._REGISTRY.clear()
     _pkg._ALIASES.clear()
+    _pkg._PROVIDER_LIST_CACHE = None
     _pkg._discovered = False
     # Evict any cached plugin modules so the next import re-executes.
     for mod in list(sys.modules.keys()):

--- a/tests/providers/test_provider_registry.py
+++ b/tests/providers/test_provider_registry.py
@@ -1,0 +1,61 @@
+import pytest
+
+from providers import ProviderProfile
+import providers
+
+
+@pytest.fixture(autouse=True)
+def isolate_provider_registry():
+    registry = providers._REGISTRY.copy()
+    aliases = providers._ALIASES.copy()
+    provider_list_cache = (
+        None
+        if providers._PROVIDER_LIST_CACHE is None
+        else list(providers._PROVIDER_LIST_CACHE)
+    )
+    discovered = providers._discovered
+
+    yield
+
+    providers._REGISTRY.clear()
+    providers._REGISTRY.update(registry)
+    providers._ALIASES.clear()
+    providers._ALIASES.update(aliases)
+    providers._PROVIDER_LIST_CACHE = provider_list_cache
+    providers._discovered = discovered
+
+
+def _profile(name: str, *aliases: str) -> ProviderProfile:
+    return ProviderProfile(name=name, aliases=aliases)
+
+
+def _reset_registry() -> None:
+    providers._REGISTRY.clear()
+    providers._ALIASES.clear()
+    providers._PROVIDER_LIST_CACHE = None
+    providers._discovered = True
+
+
+def test_list_providers_reuses_cached_snapshot_until_registration_changes():
+    _reset_registry()
+    first = _profile("alpha")
+    providers.register_provider(first)
+
+    listed = providers.list_providers()
+    listed.clear()
+
+    assert providers.list_providers() == [first]
+
+    second = _profile("beta")
+    providers.register_provider(second)
+
+    assert providers.list_providers() == [first, second]
+
+
+def test_list_providers_dedupes_aliases_in_cached_snapshot():
+    _reset_registry()
+    profile = _profile("kimi", "moonshot", "kimi-k2")
+    providers.register_provider(profile)
+
+    assert providers.get_provider_profile("moonshot") is profile
+    assert providers.list_providers() == [profile]

--- a/tests/providers/test_provider_registry.py
+++ b/tests/providers/test_provider_registry.py
@@ -46,6 +46,11 @@ def test_list_providers_reuses_cached_snapshot_until_registration_changes():
 
     assert providers.list_providers() == [first]
 
+    # Hit-path copy guard: mutating a CACHED return must not corrupt the
+    # module-level snapshot for later callers (aliasing bug class).
+    providers.list_providers().clear()
+    assert providers.list_providers() == [first]
+
     second = _profile("beta")
     providers.register_provider(second)
 


### PR DESCRIPTION
Salvage of #39314 by @yyzquwu — commit cherry-picked to preserve authorship, plus one test-only follow-up commit.

## Context — what this changes for users

list_providers() rebuilt + deduped the provider list on every call; picker paths (setup, tools_config, provider_catalog) call it in loops. This caches the snapshot and invalidates on register_provider.

## Measured impact

- before: 44.47 ms / 20k calls (2.2 us/call), median of 5, 37 providers registered
- after: 1.54 ms / 20k calls (0.08 us/call)
- delta: ~29x faster
- caveat: absolute win is micro per-call; matters on picker paths that enumerate in loops, not per-turn.

## Review verification

- Invalidation trace: cache busts on register_provider; _REGISTRY has no other production mutator (config edits never fed the registry even pre-PR — no new staleness).
- Review follow-up folded (test-only): the hit-path defensive copy (return list(cache)) was untested — an aliasing mutation (return cache directly) survived the suite and would corrupt the global cache for every later caller. 1-line test pins it; mutation-checked.

Closes #39314.