### PR TITLE
perf(gateway): reuse loaded turn config for timestamp check (#65645 salvage)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4965,7 +4965,7 @@ class TurnRunner:
         agent_history, observed_group_context = _build_gateway_agent_history(
             ctx.history,
             channel_prompt=ctx.channel_prompt,
-            inject_timestamps=_message_timestamps_enabled(_load_gateway_config()),
+            inject_timestamps=_message_timestamps_enabled(ctx.user_config),
         )
 
         # FTS write-corruption guard (#50502): when message persistence


### PR DESCRIPTION
Salvage of #65645 by @MaartenDMT — 1-line intent re-derived onto current main with authorship preserved (original was 4,708 commits behind; the touched function moved into TurnContext).

The timestamp check in the gateway message path re-loaded config via _load_gateway_config() when the already-loaded ctx.user_config was in scope. Reuse it. 19 gateway tests green.

Closes #65645.