### PR TITLE
perf(cli): npm --prefer-offline during update (#39399 salvage)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5710,7 +5710,7 @@ def _do_build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
         return _run_npm_install_deterministic(
             npm,
             npm_cwd,
-            extra_args=(*npm_workspace_args, "--silent") if silent else npm_workspace_args,
+            extra_args=(*npm_workspace_args, "--silent", "--prefer-offline") if silent else (*npm_workspace_args, "--prefer-offline"),
             env=build_env,
         )
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2089,7 +2089,7 @@ def _update_node_dependencies() -> list[str]:
         print("    deps). Fix npm and re-run `hermes update`.")
         return list(labels)
 
-    extra_args = ["--no-fund", "--no-audit", "--progress=false"]
+    extra_args = ["--no-fund", "--no-audit", "--prefer-offline", "--progress=false"]
 
     from hermes_constants import with_hermes_node_path
 

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -150,7 +150,7 @@ class TestBuildWebUISkipsWhenFresh:
         assert result is True
         args, kwargs = mock_run.call_args
         assert "--workspace" not in args[0]
-        assert args[0] == ["/usr/bin/npm", "ci", "--include=dev", "--silent"]
+        assert args[0] == ["/usr/bin/npm", "ci", "--include=dev", "--silent", "--prefer-offline"]
         assert kwargs["cwd"] == web_dir
 
     def test_web_build_uses_idle_timeout_helper(self, tmp_path):


### PR DESCRIPTION
Salvage of #39399 by @rodboev — re-derived onto current main with authorship preserved (original was 5,721 commits behind; the npm invocation moved into _run_npm_install_deterministic).

npm install during 'hermes update' now passes --prefer-offline: npm consults its local cache before hitting the registry, cutting update time on repeat updates and making updates resilient to registry latency. Covers both call sites (root + workspace). 22 tests green (incl. the PR's test-expectation update, mirrored).

Closes #39399.