### PR TITLE
fix(model_metadata): localhost->127.0.0.1 at both outbound probe sites (#61528 salvage)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -836,7 +836,10 @@ def _localhost_to_ipv4(url: str) -> str:
     ``http://localhost...`` (e.g. ``?upstream=http://localhost:11434``)
     passes through untouched.
     """
-    if not url:
+    if not url or not isinstance(url, str):
+        # Non-string values (test doubles, lazily-resolved config objects)
+        # previously flowed through these call sites untouched — keep that
+        # contract; re.sub would raise TypeError.
         return url
     return re.sub(
         r"^(https?://)localhost(?=[:/]|$)",

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1184,7 +1184,11 @@ def fetch_endpoint_model_metadata(
             last_error = exc
 
     for candidate in candidates:
-        url = candidate.rstrip("/") + "/models"
+        # normalized/candidates stay unrewritten (cache key stability); only
+        # the outbound request target is IPv4-resolved to skip the multi-second
+        # dual-stack IPv6 connect timeout (see _localhost_to_ipv4).
+        request_candidate = _localhost_to_ipv4(candidate)
+        url = request_candidate.rstrip("/") + "/models"
         response = None
         try:
             response = requests.get(
@@ -1230,7 +1234,7 @@ def fetch_endpoint_model_metadata(
             if is_llamacpp:
                 try:
                     # Try /v1/props first (current llama.cpp); fall back to /props for older builds
-                    base = candidate.rstrip("/").replace("/v1", "")
+                    base = request_candidate.rstrip("/").replace("/v1", "")
                     _verify = _resolve_requests_verify()
                     props_resp = requests.get(base + "/v1/props", headers=headers, timeout=5, verify=_verify)
                     if not props_resp.ok:

--- a/tests/agent/test_probe_cache_followups.py
+++ b/tests/agent/test_probe_cache_followups.py
@@ -186,6 +186,61 @@ class TestLocalhostIPv4SiblingSites:
 
         assert client.post.call_args[0][0].startswith("http://127.0.0.1:11434")
 
+    def test_fetch_endpoint_model_metadata_generic_probe_uses_ipv4(self):
+        """The generic (non-LM-Studio) /models fetch loop must also rewrite
+        localhost->127.0.0.1 before probing, like the LM Studio branch above."""
+        from agent import model_metadata
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        model_metadata._endpoint_model_metadata_cache.clear()
+        model_metadata._endpoint_model_metadata_cache_time.clear()
+
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"data": []}
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch("agent.model_metadata.requests.get", return_value=resp) as mock_get:
+            fetch_endpoint_model_metadata("http://localhost:8000/v1")
+
+        assert mock_get.call_args[0][0].startswith("http://127.0.0.1:8000")
+
+    def test_fetch_endpoint_model_metadata_llamacpp_props_followup_uses_ipv4(self):
+        """The llama.cpp /props context-length follow-up must also rewrite
+        localhost->127.0.0.1 before probing, not just the initial /models call."""
+        from agent import model_metadata
+        from agent.model_metadata import fetch_endpoint_model_metadata
+
+        model_metadata._endpoint_model_metadata_cache.clear()
+        model_metadata._endpoint_model_metadata_cache_time.clear()
+
+        models_resp = MagicMock()
+        models_resp.status_code = 200
+        models_resp.raise_for_status = MagicMock()
+        models_resp.json.return_value = {
+            "data": [{"id": "llama-3-8b", "owned_by": "llamacpp"}],
+        }
+
+        props_resp = MagicMock()
+        props_resp.ok = True
+        props_resp.json.return_value = {
+            "default_generation_settings": {"n_ctx": 32768},
+            "model_alias": "llama-3-8b",
+        }
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value=None), \
+             patch(
+                 "agent.model_metadata.requests.get",
+                 side_effect=[models_resp, props_resp],
+             ) as mock_get:
+            result = fetch_endpoint_model_metadata("http://localhost:8000/v1")
+
+        assert mock_get.call_count == 2
+        props_call_url = mock_get.call_args_list[1][0][0]
+        assert props_call_url.startswith("http://127.0.0.1:8000")
+        assert result["llama-3-8b"]["context_length"] == 32768
+
 
 
 class TestContextCacheKeyNormalization:


### PR DESCRIPTION
Salvage of #61528 by @pierrenode — mechanism re-derived onto main's current fetch sites with authorship preserved (original conflicts; 5,436 commits behind).

## Context — what this changes for users

On dual-stack machines, httpx/requests resolve 'localhost' IPv6-first; when the local server (LM Studio, llama.cpp, ollama) listens on IPv4 only, every metadata probe pays an IPv6 connection timeout first. Measured on this Mac (dead port): localhost 32.9ms vs 127.0.0.1 0.1ms per connect — and on Windows the stall is ~2s per probe.

Applied at BOTH of main's current outbound URL builders in fetch_endpoint_model_metadata (the generic /models loop AND the llama.cpp /v1/props follow-up — whole bug class), reusing the existing _localhost_to_ipv4 helper that main already has for detect_local_server_type. Cache keys keep the un-rewritten URL so localhost and 127.0.0.1 share entries.

## Verification

10 tests green (2 new sibling-site guards); mutation: rewrite disabled -> exactly the 2 new tests fail; restore green; ruff clean.

Closes #61528.