### PR TITLE
fix(desktop): show status bar by default (#77594)

### DIFF
--- a/apps/desktop/src/store/statusbar-prefs.test.ts
+++ b/apps/desktop/src/store/statusbar-prefs.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const LEGACY_STATUSBAR_VISIBLE_STORAGE_KEY = 'hermes.desktop.statusbarVisible'
+const STATUSBAR_VISIBLE_STORAGE_KEY = 'hermes.desktop.statusbarVisible.v2'
+
+async function loadStatusbarPrefs() {
+  vi.resetModules()
+
+  return import('./statusbar-prefs')
+}
+
+afterEach(() => {
+  window.localStorage.removeItem(LEGACY_STATUSBAR_VISIBLE_STORAGE_KEY)
+  window.localStorage.removeItem(STATUSBAR_VISIBLE_STORAGE_KEY)
+})
+
+describe('statusbar visibility preference', () => {
+  it('shows the statusbar when a user has no stored preference', async () => {
+    window.localStorage.removeItem(STATUSBAR_VISIBLE_STORAGE_KEY)
+
+    expect((await loadStatusbarPrefs()).$statusbarVisible.get()).toBe(true)
+  })
+
+  it('resets the legacy default that was persisted before user interaction', async () => {
+    window.localStorage.setItem(LEGACY_STATUSBAR_VISIBLE_STORAGE_KEY, 'false')
+
+    expect((await loadStatusbarPrefs()).$statusbarVisible.get()).toBe(true)
+  })
+
+  it('preserves an explicit choice to hide the statusbar', async () => {
+    window.localStorage.setItem(STATUSBAR_VISIBLE_STORAGE_KEY, 'false')
+
+    expect((await loadStatusbarPrefs()).$statusbarVisible.get()).toBe(false)
+  })
+
+  it('persists a new hide choice across reloads', async () => {
+    const prefs = await loadStatusbarPrefs()
+
+    prefs.toggleStatusbarVisible()
+
+    expect(window.localStorage.getItem(STATUSBAR_VISIBLE_STORAGE_KEY)).toBe('false')
+    expect((await loadStatusbarPrefs()).$statusbarVisible.get()).toBe(false)
+  })
+})

--- a/apps/desktop/src/store/statusbar-prefs.ts
+++ b/apps/desktop/src/store/statusbar-prefs.ts
@@ -1,13 +1,15 @@
 import { Codecs, persistentAtom } from '@/lib/persisted'
 
 const STATUSBAR_HIDDEN_STORAGE_KEY = 'hermes.desktop.statusbarHidden'
-const STATUSBAR_VISIBLE_STORAGE_KEY = 'hermes.desktop.statusbarVisible'
+// The legacy key cannot distinguish a user choice from the false fallback that
+// v0.19.1 persisted during module initialization. A fresh key resets that
+// ambiguous value once; subsequent explicit hide choices remain persistent.
+const STATUSBAR_VISIBLE_STORAGE_KEY = 'hermes.desktop.statusbarVisible.v2'
 
-// Whole-bar visibility, VS Code's `workbench.statusBar.visible`. Off by default
-// — the bar is opt-in. Hiding it unmounts the bar (its 15s status poll goes with
-// it), so the way back is the `view.toggleStatusbar` keybind or the ⌘K row,
-// never the bar itself.
-export const $statusbarVisible = persistentAtom(STATUSBAR_VISIBLE_STORAGE_KEY, false, Codecs.bool)
+// Whole-bar visibility, VS Code's `workbench.statusBar.visible`. Hiding it
+// unmounts the bar (its 15s status poll goes with it), so the way back is the
+// `view.toggleStatusbar` keybind or the ⌘K row — never the bar itself.
+export const $statusbarVisible = persistentAtom(STATUSBAR_VISIBLE_STORAGE_KEY, true, Codecs.bool)
 
 export function toggleStatusbarVisible() {
   $statusbarVisible.set(!$statusbarVisible.get())


### PR DESCRIPTION
## What does this PR do?

Restores the Desktop status bar for fresh users and for users whose v0.19.1 launch persisted the old `false` fallback before any interaction.

The legacy key cannot distinguish that implicit fallback from a deliberate hide, so this change uses a v2 visibility key and performs a one-time reset to visible. Choices made through `view.toggleStatusbar` after the upgrade are stored under v2 and remain persistent.

## Related Issue

Fixes #77594

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/statusbar-prefs.ts`: use a v2 visibility key with a `true` fallback so the ambiguous v0.19.1 value is reset once.
- `apps/desktop/src/store/statusbar-prefs.test.ts`: cover fresh installs, the legacy false migration, explicit v2 hides, and persistence across reloads.

This does not change per-item visibility defaults or remove the existing hide/toggle behavior.

## How to Test

1. Remove `hermes.desktop.statusbarVisible` from local storage and launch Desktop; the status bar is visible.
2. Hide the status bar through its menu or `view.toggleStatusbar`, then reload; it remains hidden.
3. Run:

```text
npm --workspace apps/desktop exec -- vitest run --project ui src/store/statusbar-prefs.test.ts src/app/shell/statusbar-visibility.test.tsx
# 2 files, 11 tests passed

npm --workspace apps/desktop run typecheck
# passed

npm --workspace apps/desktop exec -- eslint src/store/statusbar-prefs.ts src/store/statusbar-prefs.test.ts
# passed

npm --workspace apps/desktop exec -- prettier --check src/store/statusbar-prefs.ts src/store/statusbar-prefs.test.ts
# passed
```

The full Desktop UI suite completed with 3310 passing tests and 3 unrelated existing failures in `billing/index.test.tsx` and `lib/time.test.ts`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the applicable Desktop tests and type checks; results are documented above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no config key or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer persistence behavior is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A; this restores the existing status bar without changing its visual design.