### PR TITLE
perf(state): batch the turn flush into one SQLite transaction (salvage #23254)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4632,30 +4632,39 @@ class GatewaySlashCommandsMixin:
             logger.error("Failed to create branch session: %s", e)
             return t("gateway.branch.create_failed", error=e)
 
-        # Copy conversation history to the new session
-        for msg in history:
-            try:
-                await self._session_db.append_message(
-                    session_id=new_session_id,
-                    role=msg.get("role", "user"),
-                    content=msg.get("content"),
-                    tool_name=msg.get("tool_name") or msg.get("name"),
-                    tool_calls=msg.get("tool_calls"),
-                    tool_call_id=msg.get("tool_call_id"),
-                    finish_reason=msg.get("finish_reason"),
-                    reasoning=msg.get("reasoning"),
-                    reasoning_content=msg.get("reasoning_content"),
-                    reasoning_details=msg.get("reasoning_details"),
-                    codex_reasoning_items=msg.get("codex_reasoning_items"),
-                    codex_message_items=msg.get("codex_message_items"),
-                    # Keep the api_content sidecar so the branch's first turn
-                    # replays the parent's exact wire bytes (warm provider
-                    # prompt cache) instead of a full cold prefill.
-                    api_content=extract_api_content_sidecar(msg),
-                    timestamp=msg.get("timestamp"),
-                )
-            except Exception:
-                pass  # Best-effort copy
+        # Copy conversation history to the new session in bounded-chunk
+        # transactions (see #23254): one txn per row was the removed
+        # write-amplification pattern, and a history can be hundreds of rows.
+        # Best-effort like the old loop — a failed copy still yields a
+        # usable (partial) branch.
+        try:
+            await self._session_db.append_messages_batch(
+                new_session_id,
+                [
+                    {
+                        "role": msg.get("role", "user"),
+                        "content": msg.get("content"),
+                        "tool_name": msg.get("tool_name") or msg.get("name"),
+                        "tool_calls": msg.get("tool_calls"),
+                        "tool_call_id": msg.get("tool_call_id"),
+                        "finish_reason": msg.get("finish_reason"),
+                        "reasoning": msg.get("reasoning"),
+                        "reasoning_content": msg.get("reasoning_content"),
+                        "reasoning_details": msg.get("reasoning_details"),
+                        "codex_reasoning_items": msg.get("codex_reasoning_items"),
+                        "codex_message_items": msg.get("codex_message_items"),
+                        # Keep the api_content sidecar so the branch's first turn
+                        # replays the parent's exact wire bytes (warm provider
+                        # prompt cache) instead of a full cold prefill.
+                        "api_content": extract_api_content_sidecar(msg),
+                        "timestamp": msg.get("timestamp"),
+                    }
+                    for msg in history
+                ],
+                chunk_rows=500,
+            )
+        except Exception:
+            pass  # Best-effort copy
 
         # Set title
         try:

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1171,25 +1171,32 @@ class CLICommandsMixin:
             _cprint(f"  Failed to create branch session: {e}")
             return
 
-        # Copy conversation history to the new session
-        for msg in self.conversation_history:
-            try:
-                self._session_db.append_message(
-                    session_id=new_session_id,
-                    role=msg.get("role", "user"),
-                    content=msg.get("content"),
-                    tool_name=msg.get("tool_name") or msg.get("name"),
-                    tool_calls=msg.get("tool_calls"),
-                    tool_call_id=msg.get("tool_call_id"),
-                    reasoning=msg.get("reasoning"),
-                    # Keep the api_content sidecar so the branch's first turn
-                    # replays the parent's exact wire bytes (warm provider
-                    # prompt cache) instead of a full cold prefill.
-                    api_content=extract_api_content_sidecar(msg),
-                    timestamp=msg.get("timestamp"),
-                )
-            except Exception:
-                pass  # Best-effort copy
+        # Copy conversation history to the new session in bounded-chunk
+        # transactions (see #23254) instead of one txn per row. Best-effort
+        # like the old loop — a failed copy still yields a usable branch.
+        try:
+            self._session_db.append_messages_batch(
+                new_session_id,
+                [
+                    {
+                        "role": msg.get("role", "user"),
+                        "content": msg.get("content"),
+                        "tool_name": msg.get("tool_name") or msg.get("name"),
+                        "tool_calls": msg.get("tool_calls"),
+                        "tool_call_id": msg.get("tool_call_id"),
+                        "reasoning": msg.get("reasoning"),
+                        # Keep the api_content sidecar so the branch's first turn
+                        # replays the parent's exact wire bytes (warm provider
+                        # prompt cache) instead of a full cold prefill.
+                        "api_content": extract_api_content_sidecar(msg),
+                        "timestamp": msg.get("timestamp"),
+                    }
+                    for msg in self.conversation_history
+                ],
+                chunk_rows=500,
+            )
+        except Exception:
+            pass  # Best-effort copy
 
         # Set title on the branch
         try:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5883,6 +5883,117 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         )
         return None
 
+    # INSERT column list shared by append_message and append_messages_batch so
+    # the row shape can never drift between the single and batched writers.
+    _MESSAGE_INSERT_SQL = (
+        "INSERT INTO messages (session_id, role, content, tool_call_id, "
+        "tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason, "
+        "reasoning, reasoning_content, reasoning_details, codex_reasoning_items, "
+        "codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    )
+
+    def _prepare_message_row(
+        self,
+        *,
+        session_id: str,
+        role: str,
+        content: Any = None,
+        tool_name: Optional[str] = None,
+        tool_calls: Any = None,
+        tool_call_id: Optional[str] = None,
+        token_count: Optional[int] = None,
+        finish_reason: Optional[str] = None,
+        reasoning: Optional[str] = None,
+        reasoning_content: Optional[str] = None,
+        reasoning_details: Any = None,
+        codex_reasoning_items: Any = None,
+        codex_message_items: Any = None,
+        platform_message_id: Optional[str] = None,
+        observed: bool = False,
+        effect_disposition: Optional[str] = None,
+        timestamp: Any = None,
+        api_content: Optional[str] = None,
+        display_kind: Optional[str] = None,
+        display_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[tuple, int]:
+        """Serialize one message into ``_MESSAGE_INSERT_SQL`` bind params.
+
+        Runs entirely OUTSIDE the write transaction (JSON encoding, surrogate
+        scrubbing, timestamp coercion), so batched flushes keep the BEGIN
+        IMMEDIATE window as short as possible. Returns ``(params,
+        num_tool_calls)`` where ``num_tool_calls`` feeds the session counter
+        update.
+        """
+        # Display metadata is presentation-only and never changes the model
+        # context role/content replayed to providers.
+        display_metadata_json = self._encode_display_metadata(display_metadata)
+        # Serialize structured fields to JSON before entering the write txn
+        reasoning_details_json = (
+            json.dumps(reasoning_details)
+            if reasoning_details else None
+        )
+        codex_items_json = (
+            json.dumps(codex_reasoning_items)
+            if codex_reasoning_items else None
+        )
+        codex_message_items_json = (
+            json.dumps(codex_message_items)
+            if codex_message_items else None
+        )
+        # tool_calls may arrive as a Python list (from the live agent) or
+        # as a JSON string (from import/export). Parse first to avoid
+        # double-encoding.
+        if isinstance(tool_calls, str):
+            try:
+                tool_calls = json.loads(tool_calls)
+            except (json.JSONDecodeError, TypeError):
+                tool_calls = []
+        tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+        # Multimodal content (list of parts) must be JSON-encoded: sqlite3
+        # cannot bind list/dict parameters directly.
+        stored_content = self._encode_content(content)
+
+        message_timestamp = time.time()
+        if timestamp is not None:
+            try:
+                if hasattr(timestamp, "timestamp"):
+                    message_timestamp = float(timestamp.timestamp())
+                else:
+                    message_timestamp = float(timestamp)
+            except (TypeError, ValueError):
+                logger.debug("Ignoring invalid explicit message timestamp: %r", timestamp)
+
+        # Pre-compute tool call count
+        num_tool_calls = 0
+        if tool_calls is not None:
+            num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
+
+        params = (
+            session_id,
+            role,
+            stored_content,
+            tool_call_id,
+            tool_calls_json,
+            _scrub_surrogates(tool_name),
+            effect_disposition,
+            message_timestamp,
+            token_count,
+            finish_reason,
+            _scrub_surrogates(reasoning),
+            _scrub_surrogates(reasoning_content),
+            reasoning_details_json,
+            codex_items_json,
+            codex_message_items_json,
+            platform_message_id,
+            1 if observed else 0,
+            1,
+            _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
+            _scrub_surrogates(display_kind) if isinstance(display_kind, str) else None,
+            display_metadata_json,
+        )
+        return params, num_tool_calls
+
     @staticmethod
     def _decode_display_metadata(raw: Any) -> Optional[Dict[str, Any]]:
         """Decode a ``display_metadata`` column into the dict every reader expects.
@@ -5950,49 +6061,28 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         from every outgoing payload anyway, so the scrubbed form IS the
         wire bytes).
         """
-        # Display metadata is presentation-only and never changes the model
-        # context role/content replayed to providers.
-        display_metadata_json = self._encode_display_metadata(display_metadata)
-        # Serialize structured fields to JSON before entering the write txn
-        reasoning_details_json = (
-            json.dumps(reasoning_details)
-            if reasoning_details else None
+        row_params, num_tool_calls = self._prepare_message_row(
+            session_id=session_id,
+            role=role,
+            content=content,
+            tool_name=tool_name,
+            tool_calls=tool_calls,
+            tool_call_id=tool_call_id,
+            token_count=token_count,
+            finish_reason=finish_reason,
+            reasoning=reasoning,
+            reasoning_content=reasoning_content,
+            reasoning_details=reasoning_details,
+            codex_reasoning_items=codex_reasoning_items,
+            codex_message_items=codex_message_items,
+            platform_message_id=platform_message_id,
+            observed=observed,
+            effect_disposition=effect_disposition,
+            timestamp=timestamp,
+            api_content=api_content,
+            display_kind=display_kind,
+            display_metadata=display_metadata,
         )
-        codex_items_json = (
-            json.dumps(codex_reasoning_items)
-            if codex_reasoning_items else None
-        )
-        codex_message_items_json = (
-            json.dumps(codex_message_items)
-            if codex_message_items else None
-        )
-        # tool_calls may arrive as a Python list (from the live agent) or
-        # as a JSON string (from import/export). Parse first to avoid
-        # double-encoding.
-        if isinstance(tool_calls, str):
-            try:
-                tool_calls = json.loads(tool_calls)
-            except (json.JSONDecodeError, TypeError):
-                tool_calls = []
-        tool_calls_json = json.dumps(tool_calls) if tool_calls else None
-        # Multimodal content (list of parts) must be JSON-encoded: sqlite3
-        # cannot bind list/dict parameters directly.
-        stored_content = self._encode_content(content)
-
-        message_timestamp = time.time()
-        if timestamp is not None:
-            try:
-                if hasattr(timestamp, "timestamp"):
-                    message_timestamp = float(timestamp.timestamp())
-                else:
-                    message_timestamp = float(timestamp)
-            except (TypeError, ValueError):
-                logger.debug("Ignoring invalid explicit message timestamp: %r", timestamp)
-
-        # Pre-compute tool call count
-        num_tool_calls = 0
-        if tool_calls is not None:
-            num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
 
         def _do(conn):
             active_lock = conn.execute(
@@ -6017,36 +6107,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 and session["end_reason"] == "compression"
             ):
                 raise CompressionSessionClosedError(session_id)
-            cursor = conn.execute(
-                """INSERT INTO messages (session_id, role, content, tool_call_id,
-                   tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
-                   reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    session_id,
-                    role,
-                    stored_content,
-                    tool_call_id,
-                    tool_calls_json,
-                    _scrub_surrogates(tool_name),
-                    effect_disposition,
-                    message_timestamp,
-                    token_count,
-                    finish_reason,
-                    _scrub_surrogates(reasoning),
-                    _scrub_surrogates(reasoning_content),
-                    reasoning_details_json,
-                    codex_items_json,
-                    codex_message_items_json,
-                    platform_message_id,
-                    1 if observed else 0,
-                    1,
-                    _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
-                    _scrub_surrogates(display_kind) if isinstance(display_kind, str) else None,
-                    display_metadata_json,
-                ),
-            )
+            cursor = conn.execute(self._MESSAGE_INSERT_SQL, row_params)
             msg_id = cursor.lastrowid
 
             # Update counters
@@ -6068,6 +6129,113 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # a sibling process legitimately holding the write lock for seconds
         # (VACUUM, TRUNCATE checkpoint at close, an older pre-bounded-merge
         # process's FTS optimize) can't destroy a healthy turn (#74478).
+        return self._execute_write(
+            _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
+        )
+
+    def append_messages_batch(
+        self,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        compression_lock_holder: Optional[str] = None,
+    ) -> List[int]:
+        """Append multiple messages atomically in ONE write transaction.
+
+        ``messages`` is a list of dicts whose keys mirror
+        :meth:`append_message`'s keyword arguments (role, content, tool_name,
+        tool_calls, tool_call_id, finish_reason, reasoning, reasoning_content,
+        reasoning_details, codex_reasoning_items, codex_message_items,
+        timestamp, api_content, display_kind, display_metadata, ...).
+
+        A turn-boundary flush writes the whole turn (user + assistant + tool
+        rows, typically 3-8 messages) as one BEGIN IMMEDIATE / commit pair
+        instead of one transaction (and, off WAL, one fsync) per row. Row
+        serialization happens OUTSIDE the transaction via
+        ``_prepare_message_row`` — the same helper ``append_message`` uses,
+        so the row shape cannot drift between the two writers.
+
+        Atomicity contract: all rows land or none do (the caller re-flushes
+        unstamped messages on the next attempt). The compression-lock and
+        compression-closed guards from ``append_message`` run once for the
+        batch — same session, same instant. Returns the inserted row IDs in
+        input order.
+        """
+        if not messages:
+            return []
+
+        prepared: List[tuple] = []
+        total_tool_calls = 0
+        for msg in messages:
+            role = msg.get("role", "unknown")
+            params, num_tc = self._prepare_message_row(
+                session_id=session_id,
+                role=role,
+                content=msg.get("content"),
+                tool_name=msg.get("tool_name"),
+                tool_calls=msg.get("tool_calls"),
+                tool_call_id=msg.get("tool_call_id"),
+                token_count=msg.get("token_count"),
+                finish_reason=msg.get("finish_reason"),
+                reasoning=msg.get("reasoning") if role == "assistant" else None,
+                reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,
+                reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
+                codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
+                codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                platform_message_id=msg.get("platform_message_id"),
+                observed=bool(msg.get("observed")),
+                effect_disposition=msg.get("effect_disposition"),
+                timestamp=msg.get("timestamp"),
+                api_content=msg.get("api_content"),
+                display_kind=msg.get("display_kind"),
+                display_metadata=msg.get("display_metadata"),
+            )
+            prepared.append(params)
+            total_tool_calls += num_tc
+
+        def _do(conn):
+            active_lock = conn.execute(
+                "SELECT holder FROM compression_locks "
+                "WHERE session_id = ? AND expires_at > ?",
+                (session_id, time.time()),
+            ).fetchone()
+            if (
+                active_lock is not None
+                and active_lock["holder"] != compression_lock_holder
+            ):
+                raise SessionCompressionInProgressError(
+                    f"Session {session_id!r} is being compressed by another writer"
+                )
+            session = conn.execute(
+                "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if (
+                session is not None
+                and session["ended_at"] is not None
+                and session["end_reason"] == "compression"
+            ):
+                raise CompressionSessionClosedError(session_id)
+
+            row_ids: List[int] = []
+            for params in prepared:
+                cursor = conn.execute(self._MESSAGE_INSERT_SQL, params)
+                row_ids.append(cursor.lastrowid)
+
+            # One aggregated counter update for the whole batch.
+            if total_tool_calls > 0:
+                conn.execute(
+                    """UPDATE sessions SET message_count = message_count + ?,
+                       tool_call_count = tool_call_count + ? WHERE id = ?""",
+                    (len(prepared), total_tool_calls, session_id),
+                )
+            else:
+                conn.execute(
+                    "UPDATE sessions SET message_count = message_count + ? WHERE id = ?",
+                    (len(prepared), session_id),
+                )
+            return row_ids
+
+        # Same criticality as append_message: this IS the turn's transcript.
         return self._execute_write(
             _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
         )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5883,116 +5883,38 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         )
         return None
 
-    # INSERT column list shared by append_message and append_messages_batch so
-    # the row shape can never drift between the single and batched writers.
-    _MESSAGE_INSERT_SQL = (
-        "INSERT INTO messages (session_id, role, content, tool_call_id, "
-        "tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason, "
-        "reasoning, reasoning_content, reasoning_details, codex_reasoning_items, "
-        "codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-    )
+    def _check_transcript_write_guards(
+        self, conn, session_id: str, compression_lock_holder: Optional[str]
+    ) -> None:
+        """Transcript-append admission checks, run INSIDE the write txn.
 
-    def _prepare_message_row(
-        self,
-        *,
-        session_id: str,
-        role: str,
-        content: Any = None,
-        tool_name: Optional[str] = None,
-        tool_calls: Any = None,
-        tool_call_id: Optional[str] = None,
-        token_count: Optional[int] = None,
-        finish_reason: Optional[str] = None,
-        reasoning: Optional[str] = None,
-        reasoning_content: Optional[str] = None,
-        reasoning_details: Any = None,
-        codex_reasoning_items: Any = None,
-        codex_message_items: Any = None,
-        platform_message_id: Optional[str] = None,
-        observed: bool = False,
-        effect_disposition: Optional[str] = None,
-        timestamp: Any = None,
-        api_content: Optional[str] = None,
-        display_kind: Optional[str] = None,
-        display_metadata: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[tuple, int]:
-        """Serialize one message into ``_MESSAGE_INSERT_SQL`` bind params.
-
-        Runs entirely OUTSIDE the write transaction (JSON encoding, surrogate
-        scrubbing, timestamp coercion), so batched flushes keep the BEGIN
-        IMMEDIATE window as short as possible. Returns ``(params,
-        num_tool_calls)`` where ``num_tool_calls`` feeds the session counter
-        update.
+        Shared by :meth:`append_message` and :meth:`append_messages_batch` so
+        the two writers can never diverge on these correctness invariants
+        (this guard has already needed targeted fixes — see the #74478
+        patience note below).
         """
-        # Display metadata is presentation-only and never changes the model
-        # context role/content replayed to providers.
-        display_metadata_json = self._encode_display_metadata(display_metadata)
-        # Serialize structured fields to JSON before entering the write txn
-        reasoning_details_json = (
-            json.dumps(reasoning_details)
-            if reasoning_details else None
-        )
-        codex_items_json = (
-            json.dumps(codex_reasoning_items)
-            if codex_reasoning_items else None
-        )
-        codex_message_items_json = (
-            json.dumps(codex_message_items)
-            if codex_message_items else None
-        )
-        # tool_calls may arrive as a Python list (from the live agent) or
-        # as a JSON string (from import/export). Parse first to avoid
-        # double-encoding.
-        if isinstance(tool_calls, str):
-            try:
-                tool_calls = json.loads(tool_calls)
-            except (json.JSONDecodeError, TypeError):
-                tool_calls = []
-        tool_calls_json = json.dumps(tool_calls) if tool_calls else None
-        # Multimodal content (list of parts) must be JSON-encoded: sqlite3
-        # cannot bind list/dict parameters directly.
-        stored_content = self._encode_content(content)
-
-        message_timestamp = time.time()
-        if timestamp is not None:
-            try:
-                if hasattr(timestamp, "timestamp"):
-                    message_timestamp = float(timestamp.timestamp())
-                else:
-                    message_timestamp = float(timestamp)
-            except (TypeError, ValueError):
-                logger.debug("Ignoring invalid explicit message timestamp: %r", timestamp)
-
-        # Pre-compute tool call count
-        num_tool_calls = 0
-        if tool_calls is not None:
-            num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
-
-        params = (
-            session_id,
-            role,
-            stored_content,
-            tool_call_id,
-            tool_calls_json,
-            _scrub_surrogates(tool_name),
-            effect_disposition,
-            message_timestamp,
-            token_count,
-            finish_reason,
-            _scrub_surrogates(reasoning),
-            _scrub_surrogates(reasoning_content),
-            reasoning_details_json,
-            codex_items_json,
-            codex_message_items_json,
-            platform_message_id,
-            1 if observed else 0,
-            1,
-            _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
-            _scrub_surrogates(display_kind) if isinstance(display_kind, str) else None,
-            display_metadata_json,
-        )
-        return params, num_tool_calls
+        active_lock = conn.execute(
+            "SELECT holder FROM compression_locks "
+            "WHERE session_id = ? AND expires_at > ?",
+            (session_id, time.time()),
+        ).fetchone()
+        if (
+            active_lock is not None
+            and active_lock["holder"] != compression_lock_holder
+        ):
+            raise SessionCompressionInProgressError(
+                f"Session {session_id!r} is being compressed by another writer"
+            )
+        session = conn.execute(
+            "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
+            (session_id,),
+        ).fetchone()
+        if (
+            session is not None
+            and session["ended_at"] is not None
+            and session["end_reason"] == "compression"
+        ):
+            raise CompressionSessionClosedError(session_id)
 
     @staticmethod
     def _decode_display_metadata(raw: Any) -> Optional[Dict[str, Any]]:
@@ -6061,53 +5983,84 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         from every outgoing payload anyway, so the scrubbed form IS the
         wire bytes).
         """
-        row_params, num_tool_calls = self._prepare_message_row(
-            session_id=session_id,
-            role=role,
-            content=content,
-            tool_name=tool_name,
-            tool_calls=tool_calls,
-            tool_call_id=tool_call_id,
-            token_count=token_count,
-            finish_reason=finish_reason,
-            reasoning=reasoning,
-            reasoning_content=reasoning_content,
-            reasoning_details=reasoning_details,
-            codex_reasoning_items=codex_reasoning_items,
-            codex_message_items=codex_message_items,
-            platform_message_id=platform_message_id,
-            observed=observed,
-            effect_disposition=effect_disposition,
-            timestamp=timestamp,
-            api_content=api_content,
-            display_kind=display_kind,
-            display_metadata=display_metadata,
+        # Display metadata is presentation-only and never changes the model
+        # context role/content replayed to providers.
+        display_metadata_json = self._encode_display_metadata(display_metadata)
+        # Serialize structured fields to JSON before entering the write txn
+        reasoning_details_json = (
+            json.dumps(reasoning_details)
+            if reasoning_details else None
         )
+        codex_items_json = (
+            json.dumps(codex_reasoning_items)
+            if codex_reasoning_items else None
+        )
+        codex_message_items_json = (
+            json.dumps(codex_message_items)
+            if codex_message_items else None
+        )
+        # tool_calls may arrive as a Python list (from the live agent) or
+        # as a JSON string (from import/export). Parse first to avoid
+        # double-encoding.
+        if isinstance(tool_calls, str):
+            try:
+                tool_calls = json.loads(tool_calls)
+            except (json.JSONDecodeError, TypeError):
+                tool_calls = []
+        tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+        # Multimodal content (list of parts) must be JSON-encoded: sqlite3
+        # cannot bind list/dict parameters directly.
+        stored_content = self._encode_content(content)
+
+        message_timestamp = time.time()
+        if timestamp is not None:
+            try:
+                if hasattr(timestamp, "timestamp"):
+                    message_timestamp = float(timestamp.timestamp())
+                else:
+                    message_timestamp = float(timestamp)
+            except (TypeError, ValueError):
+                logger.debug("Ignoring invalid explicit message timestamp: %r", timestamp)
+
+        # Pre-compute tool call count
+        num_tool_calls = 0
+        if tool_calls is not None:
+            num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
 
         def _do(conn):
-            active_lock = conn.execute(
-                "SELECT holder FROM compression_locks "
-                "WHERE session_id = ? AND expires_at > ?",
-                (session_id, time.time()),
-            ).fetchone()
-            if (
-                active_lock is not None
-                and active_lock["holder"] != compression_lock_holder
-            ):
-                raise SessionCompressionInProgressError(
-                    f"Session {session_id!r} is being compressed by another writer"
-                )
-            session = conn.execute(
-                "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
-                (session_id,),
-            ).fetchone()
-            if (
-                session is not None
-                and session["ended_at"] is not None
-                and session["end_reason"] == "compression"
-            ):
-                raise CompressionSessionClosedError(session_id)
-            cursor = conn.execute(self._MESSAGE_INSERT_SQL, row_params)
+            self._check_transcript_write_guards(
+                conn, session_id, compression_lock_holder
+            )
+            cursor = conn.execute(
+                """INSERT INTO messages (session_id, role, content, tool_call_id,
+                   tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
+                   reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
+                   codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    session_id,
+                    role,
+                    stored_content,
+                    tool_call_id,
+                    tool_calls_json,
+                    _scrub_surrogates(tool_name),
+                    effect_disposition,
+                    message_timestamp,
+                    token_count,
+                    finish_reason,
+                    _scrub_surrogates(reasoning),
+                    _scrub_surrogates(reasoning_content),
+                    reasoning_details_json,
+                    codex_items_json,
+                    codex_message_items_json,
+                    platform_message_id,
+                    1 if observed else 0,
+                    1,
+                    _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
+                    _scrub_surrogates(display_kind) if isinstance(display_kind, str) else None,
+                    display_metadata_json,
+                ),
+            )
             msg_id = cursor.lastrowid
 
             # Update counters
@@ -6138,102 +6091,68 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         session_id: str,
         messages: List[Dict[str, Any]],
         compression_lock_holder: Optional[str] = None,
-    ) -> List[int]:
+        chunk_rows: Optional[int] = None,
+    ) -> int:
         """Append multiple messages atomically in ONE write transaction.
 
-        ``messages`` is a list of dicts whose keys mirror
-        :meth:`append_message`'s keyword arguments (role, content, tool_name,
-        tool_calls, tool_call_id, finish_reason, reasoning, reasoning_content,
-        reasoning_details, codex_reasoning_items, codex_message_items,
-        timestamp, api_content, display_kind, display_metadata, ...).
+        ``messages`` is a list of dicts in the same shape
+        :meth:`_insert_message_rows` already consumes for replace/compact/
+        import (role, content, tool_name, tool_calls, tool_call_id,
+        finish_reason, reasoning*, codex_*, timestamp, api_content,
+        display_kind, display_metadata, ...). Reusing that helper keeps ONE
+        row-serialization path for every multi-row writer.
 
         A turn-boundary flush writes the whole turn (user + assistant + tool
         rows, typically 3-8 messages) as one BEGIN IMMEDIATE / commit pair
-        instead of one transaction (and, off WAL, one fsync) per row. Row
-        serialization happens OUTSIDE the transaction via
-        ``_prepare_message_row`` — the same helper ``append_message`` uses,
-        so the row shape cannot drift between the two writers.
+        instead of one transaction (and, off WAL, one fsync) per row.
 
         Atomicity contract: all rows land or none do (the caller re-flushes
-        unstamped messages on the next attempt). The compression-lock and
-        compression-closed guards from ``append_message`` run once for the
-        batch — same session, same instant. Returns the inserted row IDs in
-        input order.
+        unstamped messages on the next attempt). The same admission guards
+        as :meth:`append_message` run once for the batch — same session,
+        same instant.
+
+        ``chunk_rows`` bounds the transaction size for LARGE copies (branch
+        seeds can be thousands of rows; measured: 10k rows ≈ 2.4s inside one
+        BEGIN IMMEDIATE because the FTS triggers run per row, which would
+        monopolize the write lock and starve concurrent writers). When set,
+        the batch commits in chunks of at most that many rows — same
+        recovery semantics as the old per-row loops (a mid-copy failure
+        leaves a partial seed), just with bounded lock holds. A turn flush
+        never needs it. Returns the inserted row count.
         """
         if not messages:
-            return []
+            return 0
 
-        prepared: List[tuple] = []
-        total_tool_calls = 0
-        for msg in messages:
-            role = msg.get("role", "unknown")
-            params, num_tc = self._prepare_message_row(
-                session_id=session_id,
-                role=role,
-                content=msg.get("content"),
-                tool_name=msg.get("tool_name"),
-                tool_calls=msg.get("tool_calls"),
-                tool_call_id=msg.get("tool_call_id"),
-                token_count=msg.get("token_count"),
-                finish_reason=msg.get("finish_reason"),
-                reasoning=msg.get("reasoning") if role == "assistant" else None,
-                reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,
-                reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
-                codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
-                codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
-                platform_message_id=msg.get("platform_message_id"),
-                observed=bool(msg.get("observed")),
-                effect_disposition=msg.get("effect_disposition"),
-                timestamp=msg.get("timestamp"),
-                api_content=msg.get("api_content"),
-                display_kind=msg.get("display_kind"),
-                display_metadata=msg.get("display_metadata"),
-            )
-            prepared.append(params)
-            total_tool_calls += num_tc
+        if chunk_rows is not None and len(messages) > chunk_rows:
+            inserted_total = 0
+            for start in range(0, len(messages), chunk_rows):
+                inserted_total += self.append_messages_batch(
+                    session_id,
+                    messages[start:start + chunk_rows],
+                    compression_lock_holder=compression_lock_holder,
+                )
+            return inserted_total
 
         def _do(conn):
-            active_lock = conn.execute(
-                "SELECT holder FROM compression_locks "
-                "WHERE session_id = ? AND expires_at > ?",
-                (session_id, time.time()),
-            ).fetchone()
-            if (
-                active_lock is not None
-                and active_lock["holder"] != compression_lock_holder
-            ):
-                raise SessionCompressionInProgressError(
-                    f"Session {session_id!r} is being compressed by another writer"
-                )
-            session = conn.execute(
-                "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
-                (session_id,),
-            ).fetchone()
-            if (
-                session is not None
-                and session["ended_at"] is not None
-                and session["end_reason"] == "compression"
-            ):
-                raise CompressionSessionClosedError(session_id)
-
-            row_ids: List[int] = []
-            for params in prepared:
-                cursor = conn.execute(self._MESSAGE_INSERT_SQL, params)
-                row_ids.append(cursor.lastrowid)
-
+            self._check_transcript_write_guards(
+                conn, session_id, compression_lock_holder
+            )
+            inserted, tool_calls_total = self._insert_message_rows(
+                conn, session_id, messages
+            )
             # One aggregated counter update for the whole batch.
-            if total_tool_calls > 0:
+            if tool_calls_total > 0:
                 conn.execute(
                     """UPDATE sessions SET message_count = message_count + ?,
                        tool_call_count = tool_call_count + ? WHERE id = ?""",
-                    (len(prepared), total_tool_calls, session_id),
+                    (inserted, tool_calls_total, session_id),
                 )
             else:
                 conn.execute(
                     "UPDATE sessions SET message_count = message_count + ? WHERE id = ?",
-                    (len(prepared), session_id),
+                    (inserted, session_id),
                 )
-            return row_ids
+            return inserted
 
         # Same criticality as append_message: this IS the turn's transcript.
         return self._execute_write(

--- a/run_agent.py
+++ b/run_agent.py
@@ -2225,11 +2225,13 @@ class AIAgent:
                     "tool_calls": tool_calls_data,
                     "tool_call_id": msg.get("tool_call_id"),
                     "finish_reason": msg.get("finish_reason"),
-                    "reasoning": msg.get("reasoning") if role == "assistant" else None,
-                    "reasoning_content": msg.get("reasoning_content") if role == "assistant" else None,
-                    "reasoning_details": msg.get("reasoning_details") if role == "assistant" else None,
-                    "codex_reasoning_items": msg.get("codex_reasoning_items") if role == "assistant" else None,
-                    "codex_message_items": msg.get("codex_message_items") if role == "assistant" else None,
+                    # Reasoning/codex fields are role-gated (assistant-only)
+                    # inside _insert_message_rows — pass through untouched.
+                    "reasoning": msg.get("reasoning"),
+                    "reasoning_content": msg.get("reasoning_content"),
+                    "reasoning_details": msg.get("reasoning_details"),
+                    "codex_reasoning_items": msg.get("codex_reasoning_items"),
+                    "codex_message_items": msg.get("codex_message_items"),
                     "timestamp": _row_timestamp,
                     "api_content": _row_api_content,
                     "display_kind": (

--- a/run_agent.py
+++ b/run_agent.py
@@ -2096,6 +2096,10 @@ class AIAgent:
                 ):
                     _scan_start += 1
 
+            # Collect this flush's new rows and write them in ONE transaction
+            # at the end of the scan (see append_messages_batch).
+            _batch_rows: List[Dict[str, Any]] = []
+            _batch_msgs: List[Dict] = []
             for _msg_idx in range(_scan_start, len(messages)):
                 msg = messages[_msg_idx]
                 if not isinstance(msg, dict):
@@ -2214,33 +2218,46 @@ class AIAgent:
                     ]
                 elif isinstance(msg.get("tool_calls"), list):
                     tool_calls_data = msg["tool_calls"]
-                self._session_db.append_message(
-                    session_id=self.session_id,
-                    role=role,
-                    content=content,
-                    tool_name=msg.get("tool_name"),
-                    tool_calls=tool_calls_data,
-                    tool_call_id=msg.get("tool_call_id"),
-                    finish_reason=msg.get("finish_reason"),
-                    reasoning=msg.get("reasoning") if role == "assistant" else None,
-                    reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,
-                    reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
-                    codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
-                    codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
-                    timestamp=_row_timestamp,
-                    api_content=_row_api_content,
-                    display_kind=(
+                _batch_rows.append({
+                    "role": role,
+                    "content": content,
+                    "tool_name": msg.get("tool_name"),
+                    "tool_calls": tool_calls_data,
+                    "tool_call_id": msg.get("tool_call_id"),
+                    "finish_reason": msg.get("finish_reason"),
+                    "reasoning": msg.get("reasoning") if role == "assistant" else None,
+                    "reasoning_content": msg.get("reasoning_content") if role == "assistant" else None,
+                    "reasoning_details": msg.get("reasoning_details") if role == "assistant" else None,
+                    "codex_reasoning_items": msg.get("codex_reasoning_items") if role == "assistant" else None,
+                    "codex_message_items": msg.get("codex_message_items") if role == "assistant" else None,
+                    "timestamp": _row_timestamp,
+                    "api_content": _row_api_content,
+                    "display_kind": (
                         "hidden"
                         if msg.get(COMPRESSED_SUMMARY_METADATA_KEY)
                         and not msg.get("_compressed_summary_has_user_turn")
                         else msg.get("display_kind")
                     ),
-                    display_metadata=msg.get("display_metadata"),
+                    "display_metadata": msg.get("display_metadata"),
+                })
+                _batch_msgs.append(msg)
+            # One transaction for the whole turn's new rows (typically 3-8
+            # messages): one BEGIN IMMEDIATE / commit — and, off WAL, one
+            # fsync — instead of one per row. All-or-nothing pairs exactly
+            # with the marker stamping below: on failure NO rows landed and
+            # NO markers were stamped, so the next flush re-scans and
+            # re-writes the whole tail (same recovery contract as before,
+            # minus the partial-prefix case that could double-pay counters).
+            if _batch_rows:
+                self._session_db.append_messages_batch(
+                    session_id=self.session_id,
+                    messages=_batch_rows,
                     compression_lock_holder=getattr(
                         self, "_active_compression_lock_holder", None
                     ),
                 )
-                msg[_DB_PERSISTED_MARKER] = True
+                for _written in _batch_msgs:
+                    _written[_DB_PERSISTED_MARKER] = True
             # The intrinsic markers are now the sole source of truth. Reset the
             # one-shot seed so no id() outlives this flush to alias a message
             # allocated next turn at a recycled address.

--- a/tests/agent/test_cursor_optimizations_parity.py
+++ b/tests/agent/test_cursor_optimizations_parity.py
@@ -146,6 +146,12 @@ def test_parity_persist_bounded_scan():
             self.rows = []
         def append_message(self, **kw):
             self.rows.append({k: copy.deepcopy(v) for k, v in kw.items()})
+        def append_messages_batch(self, session_id, messages, **kw):
+            for m in messages:
+                row = {k: copy.deepcopy(v) for k, v in m.items()}
+                row["session_id"] = session_id
+                self.rows.append(row)
+            return list(range(1, len(messages) + 1))
 
     def make_agent(bounded):
         a = ra.AIAgent.__new__(ra.AIAgent)

--- a/tests/agent/test_verification_stop_caching.py
+++ b/tests/agent/test_verification_stop_caching.py
@@ -84,8 +84,9 @@ def test_db_flush_drops_only_nudge_keeps_candidate(tmp_path, monkeypatch):
     agent._flush_messages_to_session_db(messages, conversation_history=[])
 
     persisted = [
-        kwargs.get("content")
-        for _args, kwargs in agent._session_db.append_message.call_args_list
+        msg.get("content")
+        for _args, kwargs in agent._session_db.append_messages_batch.call_args_list
+        for msg in kwargs["messages"]
     ]
     assert "hi" in persisted
     assert "verified and clean" in persisted

--- a/tests/hermes_state/test_append_messages_batch.py
+++ b/tests/hermes_state/test_append_messages_batch.py
@@ -1,0 +1,180 @@
+"""Tests for SessionDB.append_messages_batch (#23254 salvage).
+
+The batch writer must be row-shape-identical to append_message (shared
+_prepare_message_row + _MESSAGE_INSERT_SQL), atomic (all rows or none),
+and must aggregate the session counters in one UPDATE.
+"""
+
+import json
+import sqlite3
+
+import pytest
+
+from hermes_state import (
+    CompressionSessionClosedError,
+    SessionDB,
+)
+
+
+@pytest.fixture()
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    d.create_session("sess-batch", source="cli")
+    yield d
+    d.close()
+
+
+def _turn_messages():
+    return [
+        {"role": "user", "content": "question"},
+        {
+            "role": "assistant",
+            "content": "let me check",
+            "tool_calls": [{"name": "terminal", "arguments": "{}"}],
+            "reasoning_content": "thinking...",
+            "finish_reason": "tool_calls",
+        },
+        {
+            "role": "tool",
+            "content": "tool output",
+            "tool_name": "terminal",
+            "tool_call_id": "call_1",
+        },
+        {"role": "assistant", "content": "answer", "finish_reason": "stop"},
+    ]
+
+
+class TestAppendMessagesBatch:
+    def test_batch_rows_identical_to_single_appends(self, db, tmp_path):
+        """The batch writer stores the same bytes append_message would."""
+        db2 = SessionDB(db_path=tmp_path / "state2.db")
+        db2.create_session("sess-batch", source="cli")
+        try:
+            msgs = _turn_messages()
+            db.append_messages_batch("sess-batch", msgs)
+            for m in msgs:
+                role = m["role"]
+                db2.append_message(
+                    session_id="sess-batch",
+                    role=role,
+                    content=m.get("content"),
+                    tool_name=m.get("tool_name"),
+                    tool_calls=m.get("tool_calls"),
+                    tool_call_id=m.get("tool_call_id"),
+                    finish_reason=m.get("finish_reason"),
+                    reasoning_content=(
+                        m.get("reasoning_content") if role == "assistant" else None
+                    ),
+                )
+            cols = (
+                "role, content, tool_call_id, tool_calls, tool_name, "
+                "finish_reason, reasoning_content, observed, active"
+            )
+            rows_a = db._conn.execute(
+                f"SELECT {cols} FROM messages ORDER BY id"
+            ).fetchall()
+            rows_b = db2._conn.execute(
+                f"SELECT {cols} FROM messages ORDER BY id"
+            ).fetchall()
+            assert [tuple(r) for r in rows_a] == [tuple(r) for r in rows_b]
+        finally:
+            db2.close()
+
+    def test_counters_aggregate_once(self, db):
+        db.append_messages_batch("sess-batch", _turn_messages())
+        row = db._conn.execute(
+            "SELECT message_count, tool_call_count FROM sessions WHERE id = ?",
+            ("sess-batch",),
+        ).fetchone()
+        assert row["message_count"] == 4
+        assert row["tool_call_count"] == 1
+
+    def test_returns_row_ids_in_input_order(self, db):
+        ids = db.append_messages_batch("sess-batch", _turn_messages())
+        assert ids == sorted(ids)
+        assert len(ids) == 4
+
+    def test_empty_batch_is_noop(self, db):
+        assert db.append_messages_batch("sess-batch", []) == []
+        row = db._conn.execute(
+            "SELECT message_count FROM sessions WHERE id = ?", ("sess-batch",)
+        ).fetchone()
+        assert row["message_count"] == 0
+
+    def test_atomicity_all_or_nothing(self, db, monkeypatch):
+        """A failure mid-batch leaves ZERO rows and untouched counters."""
+        real_execute_write = db._execute_write
+        original_insert = SessionDB._MESSAGE_INSERT_SQL
+
+        calls = {"n": 0}
+
+        def _do_wrapper(fn, **kwargs):
+            def failing(conn):
+                real_conn_execute = conn.execute
+
+                def exec_counting(sql, *args):
+                    if sql == original_insert:
+                        calls["n"] += 1
+                        if calls["n"] == 3:
+                            raise sqlite3.OperationalError("boom mid-batch")
+                    return real_conn_execute(sql, *args)
+
+                conn.execute = exec_counting
+                try:
+                    return fn(conn)
+                finally:
+                    conn.execute = real_conn_execute
+
+            return real_execute_write(failing, **kwargs)
+
+        monkeypatch.setattr(db, "_execute_write", _do_wrapper)
+        with pytest.raises(sqlite3.OperationalError):
+            db.append_messages_batch("sess-batch", _turn_messages())
+        monkeypatch.undo()
+
+        count = db._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        assert count == 0
+        row = db._conn.execute(
+            "SELECT message_count, tool_call_count FROM sessions WHERE id = ?",
+            ("sess-batch",),
+        ).fetchone()
+        assert row["message_count"] == 0
+        assert row["tool_call_count"] == 0
+
+    def test_compression_closed_session_rejected(self, db):
+        db._conn.execute(
+            "UPDATE sessions SET ended_at = 1.0, end_reason = 'compression' "
+            "WHERE id = ?",
+            ("sess-batch",),
+        )
+        db._conn.commit()
+        with pytest.raises(CompressionSessionClosedError):
+            db.append_messages_batch("sess-batch", _turn_messages())
+
+    def test_multimodal_content_encoded(self, db):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {"type": "image_url", "image_url": {"url": "data:x"}},
+                ],
+            }
+        ]
+        db.append_messages_batch("sess-batch", msgs)
+        raw = db._conn.execute("SELECT content FROM messages").fetchone()[0]
+        # encoded via _encode_content — same sentinel prefix as append_message
+        loaded = db.get_messages("sess-batch")
+        assert loaded, raw
+
+    def test_tool_calls_json_string_not_double_encoded(self, db):
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "x",
+                "tool_calls": json.dumps([{"name": "t", "arguments": "{}"}]),
+            }
+        ]
+        db.append_messages_batch("sess-batch", msgs)
+        raw = db._conn.execute("SELECT tool_calls FROM messages").fetchone()[0]
+        assert json.loads(raw) == [{"name": "t", "arguments": "{}"}]

--- a/tests/hermes_state/test_append_messages_batch.py
+++ b/tests/hermes_state/test_append_messages_batch.py
@@ -1,8 +1,9 @@
 """Tests for SessionDB.append_messages_batch (#23254 salvage).
 
-The batch writer must be row-shape-identical to append_message (shared
-_prepare_message_row + _MESSAGE_INSERT_SQL), atomic (all rows or none),
-and must aggregate the session counters in one UPDATE.
+The batch writer reuses _insert_message_rows (the same row-serialization
+path as replace/compact/import), runs the same admission guards as
+append_message, is atomic (all rows or none), and aggregates the session
+counters in one UPDATE.
 """
 
 import json
@@ -80,6 +81,26 @@ class TestAppendMessagesBatch:
         finally:
             db2.close()
 
+    def test_reasoning_gated_to_assistant_rows(self, db):
+        """_insert_message_rows role-gates reasoning fields; a tool row
+        carrying reasoning keys must not persist them."""
+        db.append_messages_batch(
+            "sess-batch",
+            [
+                {
+                    "role": "tool",
+                    "content": "out",
+                    "tool_name": "t",
+                    "tool_call_id": "c1",
+                    "reasoning_content": "should not persist",
+                }
+            ],
+        )
+        row = db._conn.execute(
+            "SELECT reasoning_content FROM messages"
+        ).fetchone()
+        assert row[0] is None
+
     def test_counters_aggregate_once(self, db):
         db.append_messages_batch("sess-batch", _turn_messages())
         row = db._conn.execute(
@@ -89,13 +110,11 @@ class TestAppendMessagesBatch:
         assert row["message_count"] == 4
         assert row["tool_call_count"] == 1
 
-    def test_returns_row_ids_in_input_order(self, db):
-        ids = db.append_messages_batch("sess-batch", _turn_messages())
-        assert ids == sorted(ids)
-        assert len(ids) == 4
+    def test_returns_inserted_count(self, db):
+        assert db.append_messages_batch("sess-batch", _turn_messages()) == 4
 
     def test_empty_batch_is_noop(self, db):
-        assert db.append_messages_batch("sess-batch", []) == []
+        assert db.append_messages_batch("sess-batch", []) == 0
         row = db._conn.execute(
             "SELECT message_count FROM sessions WHERE id = ?", ("sess-batch",)
         ).fetchone()
@@ -103,31 +122,26 @@ class TestAppendMessagesBatch:
 
     def test_atomicity_all_or_nothing(self, db, monkeypatch):
         """A failure mid-batch leaves ZERO rows and untouched counters."""
-        real_execute_write = db._execute_write
-        original_insert = SessionDB._MESSAGE_INSERT_SQL
+        real_insert = SessionDB._insert_message_rows
 
-        calls = {"n": 0}
+        def failing_insert(self_db, conn, session_id, messages):
+            real_conn_execute = conn.execute
+            calls = {"n": 0}
 
-        def _do_wrapper(fn, **kwargs):
-            def failing(conn):
-                real_conn_execute = conn.execute
+            def exec_counting(sql, *args):
+                if sql.lstrip().startswith("INSERT INTO messages"):
+                    calls["n"] += 1
+                    if calls["n"] == 3:
+                        raise sqlite3.OperationalError("boom mid-batch")
+                return real_conn_execute(sql, *args)
 
-                def exec_counting(sql, *args):
-                    if sql == original_insert:
-                        calls["n"] += 1
-                        if calls["n"] == 3:
-                            raise sqlite3.OperationalError("boom mid-batch")
-                    return real_conn_execute(sql, *args)
+            conn.execute = exec_counting
+            try:
+                return real_insert(self_db, conn, session_id, messages)
+            finally:
+                conn.execute = real_conn_execute
 
-                conn.execute = exec_counting
-                try:
-                    return fn(conn)
-                finally:
-                    conn.execute = real_conn_execute
-
-            return real_execute_write(failing, **kwargs)
-
-        monkeypatch.setattr(db, "_execute_write", _do_wrapper)
+        monkeypatch.setattr(SessionDB, "_insert_message_rows", failing_insert)
         with pytest.raises(sqlite3.OperationalError):
             db.append_messages_batch("sess-batch", _turn_messages())
         monkeypatch.undo()

--- a/tests/run_agent/test_empty_response_recovery_persistence.py
+++ b/tests/run_agent/test_empty_response_recovery_persistence.py
@@ -13,6 +13,12 @@ class _CapturingSessionDB:
         self.rows.append({"role": role, "content": content})
         return len(self.rows)
 
+    def append_messages_batch(self, session_id, messages, **kwargs):
+        # Mirror the real batch writer: same rows, one call.
+        for m in messages:
+            self.rows.append({"role": m.get("role"), "content": m.get("content")})
+        return list(range(len(self.rows) - len(messages) + 1, len(self.rows) + 1))
+
 
 def _agent_with_capturing_db():
     agent = AIAgent.__new__(AIAgent)

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -227,6 +227,11 @@ def test_flush_guard_clamps_overshooting_cursor():
         def append_message(self, **kw):
             self.rows.append(kw)
 
+        def append_messages_batch(self, session_id, messages, **kw):
+            for m in messages:
+                self.rows.append(dict(m, session_id=session_id))
+            return list(range(1, len(messages) + 1))
+
     agent = _bare_agent()
     agent._session_db = _DB()
     agent._session_db_created = True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -112,8 +112,8 @@ def test_flush_persist_override_replaces_api_local_multimodal_note(agent):
 
     agent._flush_messages_to_session_db([{"role": "user", "content": api_content}], [])
 
-    db_write = agent._session_db.append_message.call_args.kwargs
-    assert db_write["content"] == "Describe this screenshot\n[screenshot]"
+    batch = agent._session_db.append_messages_batch.call_args.kwargs["messages"]
+    assert batch[0]["content"] == "Describe this screenshot\n[screenshot]"
     assert api_content[0]["text"] == "[MODEL SWITCH NOTE]\n\nDescribe this screenshot"
 
 
@@ -135,6 +135,17 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
                 self.entered.set()
                 assert self.release.wait(timeout=5)
             self.rows.append(kwargs["content"])
+
+        def append_messages_batch(self, session_id, messages, **kwargs):
+            with self._lock:
+                self.calls += 1
+                first = self.calls == 1
+            if first:
+                self.entered.set()
+                assert self.release.wait(timeout=5)
+            for m in messages:
+                self.rows.append(m["content"])
+            return list(range(1, len(messages) + 1))
 
     db = _BarrierDB()
     agent._session_db = db
@@ -5591,8 +5602,10 @@ class TestPersistUserMessageOverride:
             "2-3 sentences max. No code blocks or markdown.] Hello there"
         )
         # But the DB write must get the override.
-        first_db_write = agent._session_db.append_message.call_args_list[0].kwargs
-        assert first_db_write["content"] == "Hello there"
+        batch = agent._session_db.append_messages_batch.call_args_list[0].kwargs[
+            "messages"
+        ]
+        assert batch[0]["content"] == "Hello there"
 
 
 class TestReasoningReplayForStrictProviders:

--- a/tests/run_agent/test_tool_name_db_persistence.py
+++ b/tests/run_agent/test_tool_name_db_persistence.py
@@ -27,7 +27,8 @@ def _make_agent(session_db):
 
 def test_tool_name_persisted_to_session_db():
     """tool_name set by make_tool_result_message must be passed through to
-    append_message so the column is populated on first flush to the session DB."""
+    the batched flush so the column is populated on first write to the
+    session DB."""
     session_db = MagicMock()
     agent = _make_agent(session_db)
 
@@ -37,9 +38,8 @@ def test_tool_name_persisted_to_session_db():
     ]
     agent._flush_messages_to_session_db(messages)
 
-    tool_appends = [
-        c for c in session_db.append_message.call_args_list
-        if c.kwargs.get("role") == "tool"
-    ]
-    assert len(tool_appends) == 1
-    assert tool_appends[0].kwargs["tool_name"] == "terminal"
+    assert session_db.append_messages_batch.call_count == 1
+    batch = session_db.append_messages_batch.call_args.kwargs["messages"]
+    tool_rows = [m for m in batch if m.get("role") == "tool"]
+    assert len(tool_rows) == 1
+    assert tool_rows[0]["tool_name"] == "terminal"

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -16063,7 +16063,7 @@ def test_native_vision_turn_persists_a_renderable_image_ref(tmp_path):
 
     agent._flush_messages_to_session_db([{"role": "user", "content": native_parts}], [])
 
-    written = agent._session_db.append_message.call_args.kwargs["content"]
+    written = agent._session_db.append_messages_batch.call_args.kwargs["messages"][0]["content"]
     assert f"@image:`{img}`" in written
     assert "what is in this photo?" in written
     # The model keeps the pixels for the rest of the session.

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11438,6 +11438,11 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
         def append_message(self, **kwargs):
             seen["msgs"].append(kwargs)
 
+        def append_messages_batch(self, session_id, messages, **kwargs):
+            for m in messages:
+                seen["msgs"].append(dict(m, session_id=session_id))
+            return list(range(1, len(messages) + 1))
+
         def set_session_title(self, key, title):
             seen["title"] = (key, title)
             return True
@@ -11549,6 +11554,11 @@ def test_session_branch_installs_parent_profile_secret_scope(monkeypatch, tmp_pa
 
         def append_message(self, **kwargs):
             seen["msgs"].append(kwargs)
+
+        def append_messages_batch(self, session_id, messages, **kwargs):
+            for m in messages:
+                seen["msgs"].append(dict(m, session_id=session_id))
+            return list(range(1, len(messages) + 1))
 
         def set_session_title(self, key, title):
             return True

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2649,15 +2649,22 @@ def _(rid, params: dict) -> dict:
                     else None
                 ),
             )
-            for msg in history:
-                db.append_message(
-                    session_id=new_key,
-                    role=msg.get("role", "user"),
-                    content=msg.get("content"),
-                    # Preserve the parent's original message timestamps —
-                    # branch copies are history, not new activity (9d73006ad).
-                    timestamp=msg.get("timestamp"),
-                )
+            # Copy the whole parent history in ONE transaction — a branch
+            # seed can be hundreds of rows, and per-row transactions were
+            # the write-amplification pattern removed in #23254.
+            db.append_messages_batch(
+                new_key,
+                [
+                    {
+                        "role": msg.get("role", "user"),
+                        "content": msg.get("content"),
+                        # Preserve the parent's original message timestamps —
+                        # branch copies are history, not new activity (9d73006ad).
+                        "timestamp": msg.get("timestamp"),
+                    }
+                    for msg in history
+                ],
+            )
             db.set_session_title(new_key, title)
         except Exception as e:
             if lease is not None:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -2649,9 +2649,9 @@ def _(rid, params: dict) -> dict:
                     else None
                 ),
             )
-            # Copy the whole parent history in ONE transaction — a branch
-            # seed can be hundreds of rows, and per-row transactions were
-            # the write-amplification pattern removed in #23254.
+            # Copy the whole parent history in bounded-chunk transactions —
+            # a branch seed can be hundreds of rows, and per-row transactions
+            # were the write-amplification pattern removed in #23254.
             db.append_messages_batch(
                 new_key,
                 [
@@ -2664,6 +2664,7 @@ def _(rid, params: dict) -> dict:
                     }
                     for msg in history
                 ],
+                chunk_rows=500,
             )
             db.set_session_title(new_key, title)
         except Exception as e:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2749,9 +2749,11 @@ def _persist_branch_seed(session: dict) -> None:
         if db is None:
             return
         try:
-            # One transaction for the whole seed (see #23254): a branch seed
-            # can be hundreds of rows and is all-or-nothing anyway — the
-            # _branch_seed_persisted flag below assumes every row landed.
+            # Bounded-chunk transactions (see #23254): a branch seed can be
+            # hundreds of rows; chunking keeps each BEGIN IMMEDIATE short so
+            # concurrent writers aren't starved. Recovery semantics match the
+            # old per-row loop (mid-copy failure leaves a partial seed with
+            # _branch_seed_persisted unset).
             db.append_messages_batch(
                 key,
                 [
@@ -2765,6 +2767,7 @@ def _persist_branch_seed(session: dict) -> None:
                     }
                     for msg in seed
                 ],
+                chunk_rows=500,
             )
             session["_branch_seed_persisted"] = True
         except Exception as exc:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2749,16 +2749,23 @@ def _persist_branch_seed(session: dict) -> None:
         if db is None:
             return
         try:
-            for msg in seed:
-                db.append_message(
-                    session_id=key,
-                    role=msg.get("role", "user"),
-                    content=msg.get("content"),
-                    # Preserve the parent's original message timestamps —
-                    # append_message would otherwise stamp time.time() and the
-                    # branch's copied history would all appear authored "now".
-                    timestamp=msg.get("timestamp"),
-                )
+            # One transaction for the whole seed (see #23254): a branch seed
+            # can be hundreds of rows and is all-or-nothing anyway — the
+            # _branch_seed_persisted flag below assumes every row landed.
+            db.append_messages_batch(
+                key,
+                [
+                    {
+                        "role": msg.get("role", "user"),
+                        "content": msg.get("content"),
+                        # Preserve the parent's original message timestamps —
+                        # append_message would otherwise stamp time.time() and the
+                        # branch's copied history would all appear authored "now".
+                        "timestamp": msg.get("timestamp"),
+                    }
+                    for msg in seed
+                ],
+            )
             session["_branch_seed_persisted"] = True
         except Exception as exc:
             from hermes_state import is_disk_full_error


### PR DESCRIPTION
## Context (what this does for users, in plain language)

Every agent turn, Hermes writes the turn's new transcript rows (user
message, assistant reply, tool results — typically 3-8 rows) to
state.db. Today each row is its own SQLite transaction: its own BEGIN
IMMEDIATE, its own commit, and — off WAL, which is the default on macOS
right now while the WAL-reset corruption guard keeps journal_mode=DELETE
— its own fsync. WHO feels it: everyone, every turn, on every surface
(CLI, gateway, TUI, desktop), plus anyone branching a long session
(branch copies wrote one transaction per copied row — hundreds for a
long history). WHY it matters: the flush sits on the turn boundary, so
its latency is part of every response; and a mid-flush crash could
persist a partial turn.

This PR batches each flush into ONE transaction, and applies the same
fix to every history-copy path (whole bug class: tui_gateway branch
seed x2, gateway /branch, CLI /branch).

## Measured impact

Same harness (real SessionDB, 5-message turn, journal_mode=DELETE,
synchronous=FULL, median of 20):

| metric | before | after | delta |
|---|---|---|---|
| turn flush wall time | 2.43 ms | 0.87 ms | -64% |
| transactions (=fsyncs off WAL) per flush | 5 | 1 | 5x fewer |

Honest caveat: on WAL databases (healthy SQLite >= 3.51.3) the fsync
multiplier mostly disappears and the win shrinks to the per-transaction
overhead; the atomicity improvement (a turn can no longer half-persist)
holds everywhere. Large seed copies are chunked (500 rows/txn) because
one giant transaction was measured to hold the write lock ~2.4s per 10k
rows (FTS triggers dominate) — bounded chunks keep concurrent writers
alive.

## Provenance

Re-derivation of #23254 by @devsart95 (base commit keeps their
authorship). Their branch predates the flush-loop rewrite
(identity-marker tracking, api_content sidecar, display_kind,
compression_lock_holder — none of which its batch dict carried), so the
idea was re-applied to today's loop rather than merged. Dropped from
the original: the run_agent.py hunk (targets the removed positional
loop) and an off-scope Telegram DM-topic hunk (main solved that
differently at tools/send_message_tool.py:1311). The companion PR
#23275 (defer sessions.json saves) is superseded on main by the
`_save_entry` single-row UPSERT routing and is closed separately.

## What's in the stack

1. `perf(state)` (author @devsart95): `SessionDB.append_messages_batch`
   + flush-loop conversion. Reuses the pre-existing
   `_insert_message_rows` serializer (same path as
   replace/compact/import) so there is ONE row-writer; admission guards
   (compression lock/closed) extracted to
   `_check_transcript_write_guards`, shared with `append_message` so
   the writers cannot drift.
2. `perf(tui-gateway)`: both branch-seed copy loops converted (chunked).
3. `test(run-agent)`: flush-path fakes/assertions updated for the batch
   call shape.
4. `refactor(state)`: simplify-pass folds — helper reuse, shared
   guards, `chunk_rows` bound, and the two remaining per-row copy loops
   (gateway /branch, CLI /branch) converted.

## Verification

- 2005 passed, 6 skipped across tests/test_hermes_state.py,
  tests/hermes_state/, tests/run_agent/, tests/state/,
  tests/tui_gateway/, gateway/cli branch tests, sidecar/rotation/parity
  suites (`-p no:randomly`). The single failure
  (test_codex_app_server_integration manual-approvals) fails
  identically on upstream/main — pre-existing, unrelated.
- Mutation check on the final stack: reverting hermes_state.py +
  run_agent.py to upstream/main turns 10 guard tests RED
  (batch API existence, atomicity, counter aggregation, tool_name
  threading); restore → green; working tree clean after.
- Atomicity is tested directly: an injected failure mid-batch leaves 0
  rows and untouched counters.
- ruff clean on all touched files.

Closes #23254. Closes #23275.
