### PR TITLE
fix(terminal): check collapsed container id in idle reaper process check

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1767,6 +1767,14 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
         for task_id in list(_last_activity.keys()):
             if process_registry.has_active_processes(task_id):
                 _last_activity[task_id] = current_time  # Keep sandbox alive
+                continue
+            # Background processes spawned with a collapsed container id
+            # (e.g. "default") are invisible to a probe keyed on the raw
+            # task id — check both so a sandbox shared across sessions
+            # is not torn down while a background command still runs.
+            alt = _resolve_container_task_id(task_id)
+            if alt != task_id and process_registry.has_active_processes(alt):
+                _last_activity[task_id] = current_time
     except ImportError:
         pass
 


### PR DESCRIPTION
_cleanup_inactive_envs calls has_active_processes(task_id) with the raw key from _last_activity, but background processes are registered under the collapsed effective_task_id. When raw and collapsed keys differ, a sandbox is torn down while a background command still runs. Now checks both keys.