### PR TITLE
fix(desktop): create connection.json owner-only

### DIFF
--- a/apps/desktop/e2e/at-rest-connection-token.spec.ts
+++ b/apps/desktop/e2e/at-rest-connection-token.spec.ts
@@ -1,0 +1,720 @@
+/**
+ * E2E at-rest contract for the remote-gateway session token (issue #77486).
+ *
+ * The reported bug: configuring a remote gateway persisted the dashboard
+ * session token as PLAINTEXT into `connection.json` under the app's userData
+ * dir (macOS `~/Library/Application Support/Hermes/connection.json`, Windows
+ * `AppData\Roaming\Hermes\connection.json`). Anything that can read the file
+ * — a backup, a sync client, another local process, a support bundle — got a
+ * live gateway credential.
+ *
+ * The contract these tests encode is deliberately stated WITHOUT naming a
+ * storage strategy:
+ *
+ *   1. ABSENT FROM DISK. After the app has been configured with a remote
+ *      gateway token, the token's plaintext value must not appear anywhere in
+ *      `connection.json`, in any sibling file the app writes under userData,
+ *      or in HERMES_HOME (logs included).
+ *   2. STILL FUNCTIONAL. After a restart, the app must still be able to USE
+ *      that credential — it decrypts the stored blob and puts the exact
+ *      original token on the wire.
+ *
+ * Both halves matter and neither is sufficient alone. (1) alone is trivially
+ * satisfied by a "fix" that drops the token on the floor; (2) alone is
+ * satisfied by the bug itself. So (2) is verified through the app's own
+ * connection test against a fake gateway that records the
+ * `X-Hermes-Session-Token` header it receives — a dropped or mangled token
+ * cannot produce that header.
+ *
+ * We deliberately do NOT assert `encoding === 'safeStorage'` or any other
+ * shape of the stored blob. That would be a change-detector: a fix that moved
+ * to the OS keychain proper, to an async safeStorage provider, or to a
+ * separate credential file would break the test while being *more* correct.
+ * The load-bearing assertion is the raw-bytes absence of the secret.
+ *
+ * Two at-rest paths, hence two tests — one enforced, one a documented gap:
+ *
+ *   1. A NEWLY configured token (ACTIVE). The app's own write path routes
+ *      through the strict `encryptDesktopSecret`; this test holds it there
+ *      against regression.
+ *   2. An EXISTING plaintext `connection.json` (`test.fixme`). Legacy payloads
+ *      are deliberately NOT migrated yet. The test is kept, disabled, with a
+ *      precise reason — see the block comment above it.
+ *
+ * ── Correcting the record on (2) ────────────────────────────────────────
+ *
+ * An earlier revision of this file asserted that migration and justified it by
+ * claiming the first implementation (`d3d177283`) fell back to
+ * `{ encoding: 'plain', value }` when `isEncryptionAvailable()` was false.
+ * That citation is FALSE for this codebase. What is actually true:
+ *
+ *   git merge-base --is-ancestor d3d1772837a7b0552940b55455ae734c72e0a8f1 HEAD  -> 1 (NOT an ancestor)
+ *   git merge-base --is-ancestor 51c68d4ab1a9e3c62fb1048fccb84144c409f0e7 HEAD  -> 0 (IS an ancestor)
+ *   git log -S 'Fall through to plaintext' upstream/main -- apps/desktop        -> (no commits)
+ *
+ * `d3d177283` exists only on `upstream/bb/gui-mainmerge-tmp`,
+ * `brooklyn/gui-installer-prereqs`, and the `desktop-pr20059-installers`
+ * pre-release tag. Mainline NEVER shipped a code path that wrote a plaintext
+ * gateway token: `51c68d4ab` ("Add Hermes desktop app (#20059)"), the commit
+ * that brought the desktop app to mainline, already contained the strict
+ * throw ("Secure token storage is unavailable, …") in `hardening.cjs`.
+ *
+ * One `{ encoding: 'plain', value }` literal does remain on mainline
+ * (`electron/main.ts`, in `coerceDesktopConnectionConfig`), but it is
+ * unreachable as an at-rest write: it is gated on `persistToken === false`,
+ * whose only caller is the connection-TEST handler, which never calls
+ * `writeDesktopConnectionConfig`. That token stays in memory for the duration
+ * of one probe.
+ *
+ * So the affected population is not "anyone who configured a gateway before
+ * the fix". It is narrow and non-mainline: pre-release `bb/gui` installs
+ * (including the `desktop-pr20059-installers` build) plus hand-edited or
+ * hand-migrated `connection.json` files. Those files DO still work, because
+ * `decryptDesktopSecret` returns any non-safeStorage `value` verbatim on read
+ * — the read path is intentionally unchanged, so nobody is signed out. That
+ * read-path acceptance, not a mainline writer, is what makes the fixme'd
+ * fixture realistic.
+ *
+ * Migration is DEFERRED, not forgotten. An adversarial review of the
+ * migration that briefly lived here returned DO NOT SHIP, having reproduced
+ * two token-loss scenarios: it silently reverts and then destroys the opt-in
+ * plaintext choice that open upstream PR #62319 deliberately adds; and it
+ * converts a portable credential into a keychain-bound one with no consent,
+ * destroying the only recoverable copy while not actually remediating the
+ * exposure (the plaintext is already in backups, so the real remedy is
+ * ROTATION). The prerequisites are enumerated above test 2.
+ *
+ * Environment limits are encoded rather than papered over. Electron's
+ * safeStorage is unavailable on Linux with no keyring, which is the shape of
+ * this suite's CI runner (ubuntu-latest, see .github/workflows/e2e-desktop.yml).
+ * The absence assertion is unconditional there — it is the security
+ * requirement, and it must hold in every environment. Only the *other* half is
+ * conditional: with secure storage the save must succeed, and without it the
+ * save must fail loudly (which is what the current strict `encryptDesktopSecret`
+ * does) instead of quietly writing plaintext. See the branch comments in each
+ * test for the reasoning, including the one case this spec refuses to invent a
+ * policy for.
+ *
+ * Prerequisite: `npm run build` must have been run so dist/ exists.
+ */
+
+import * as fs from 'node:fs'
+import * as http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import * as path from 'node:path'
+
+import { buildAppEnv, createSandbox, launchDesktop, type Sandbox } from './fixtures'
+import { allowErrorBanners, type ElectronApplication, expect, type Page, test } from './test'
+
+/**
+ * The secret under test. Long, random-looking, and unique to this spec so a
+ * raw-bytes scan cannot produce a false negative by colliding with ordinary
+ * config content. Kept to `[A-Za-z0-9-]` on purpose: encodeURIComponent() is
+ * the identity function over this alphabet, so the raw-bytes needle also
+ * covers the URL-encoded form the WS dialer builds (`?token=…`).
+ */
+const SENTINEL_TOKEN = 'hermes-e2e-at-rest-sentinel-Zq7Z4hV9nX2pL8sK3tB6wR1yM5jD0fG'
+
+/** Skip absurdly large files during the leak scan (Chromium caches). */
+const MAX_SCAN_BYTES = 16 * 1024 * 1024
+
+/**
+ * One fixed Electron app name for this spec, instead of the timestamped one
+ * `buildAppEnv` generates. On macOS the safeStorage keychain item is derived
+ * from the app name, so a per-launch name would (a) make the post-restart
+ * decrypt fail for the wrong reason and (b) leave a fresh keychain entry on
+ * the developer's login keychain on every run. Safe because the suite runs
+ * one worker at a time and both launches here are sequential; the
+ * single-instance lock keys off userData, which is per-sandbox.
+ */
+const STABLE_APP_NAME = 'HermesE2EAtRestStorage'
+
+// ─── Fake gateway ───────────────────────────────────────────────────────
+
+interface FakeGateway {
+  url: string
+  /** Every `X-Hermes-Session-Token` value the app has sent us. */
+  sessionTokens: string[]
+  close: () => Promise<void>
+}
+
+/**
+ * A minimal stand-in for a remote Hermes gateway. It serves the public
+ * `/api/status` probe (which the desktop connection test hits first, with the
+ * session token in a header) and refuses the WebSocket upgrade immediately so
+ * the second leg of the connection test fails fast instead of burning the
+ * probe's 10s connect timeout. We only care about the header it captured.
+ *
+ * The e2e mock-server is an OpenAI-compatible *inference* mock, not a gateway,
+ * so it cannot answer /api/status — hence this small local server.
+ */
+async function startFakeGateway(): Promise<FakeGateway> {
+  const sessionTokens: string[] = []
+
+  const server = http.createServer((req, res) => {
+    const token = req.headers['x-hermes-session-token']
+
+    if (typeof token === 'string' && token) {
+      sessionTokens.push(token)
+    }
+
+    if (req.url?.startsWith('/api/status')) {
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ auth_required: false, ok: true, version: '0.0.0-e2e-fake' }))
+
+      return
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ detail: 'not found' }))
+  })
+
+  // Refuse the WS leg at once: the connection test's WS probe should return a
+  // fast failure rather than hang. The status header is already captured.
+  server.on('upgrade', (req, socket) => {
+    const token = new URL(req.url ?? '/', 'http://127.0.0.1').searchParams.get('token')
+
+    if (token) {
+      sessionTokens.push(token)
+    }
+
+    socket.destroy()
+  })
+
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+
+  const { port } = server.address() as AddressInfo
+
+  return {
+    close: () =>
+      new Promise<void>(resolve => {
+        server.closeAllConnections?.()
+        server.close(() => resolve())
+      }),
+    sessionTokens,
+    url: `http://127.0.0.1:${port}`,
+  }
+}
+
+// ─── On-disk leak scanning ──────────────────────────────────────────────
+
+interface Needle {
+  bytes: Buffer
+  label: string
+}
+
+/**
+ * The forms a leak could take. Raw bytes, not JSON.parse + field inspection:
+ * the point is that the secret is nowhere in the file — including inside a
+ * nested field, a cached WS URL, or a field name nobody thought to check.
+ *
+ * The base64 needle catches the cheapest wrong "fix": base64 is an encoding,
+ * not encryption, so a token that is merely base64'd is still plaintext at
+ * rest. A real ciphertext will contain neither needle.
+ */
+function secretNeedles(secret: string): Needle[] {
+  return [
+    { bytes: Buffer.from(secret, 'utf8'), label: 'plaintext' },
+    { bytes: Buffer.from(Buffer.from(secret, 'utf8').toString('base64'), 'utf8'), label: 'base64' },
+  ]
+}
+
+/** Relative paths of every file under `root` whose bytes contain a needle. */
+function scanTreeForSecret(root: string, needles: Needle[]): string[] {
+  const hits: string[] = []
+
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[]
+
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name)
+
+      if (entry.isDirectory()) {
+        walk(full)
+
+        continue
+      }
+
+      if (!entry.isFile()) {
+        continue
+      }
+
+      try {
+        if (fs.statSync(full).size > MAX_SCAN_BYTES) {
+          continue
+        }
+      } catch {
+        continue
+      }
+
+      let buf: Buffer
+
+      try {
+        buf = fs.readFileSync(full)
+      } catch {
+        continue
+      }
+
+      for (const needle of needles) {
+        if (buf.includes(needle.bytes)) {
+          hits.push(`${path.relative(root, full)} [${needle.label}]`)
+        }
+      }
+    }
+  }
+
+  walk(root)
+
+  return hits
+}
+
+/**
+ * Read a file's bytes, or an empty buffer when it does not exist. A correct
+ * fix is allowed to delete/replace `connection.json` rather than rewrite it,
+ * and the refusal path may never create it at all — neither should crash the
+ * scan before its assertion runs.
+ */
+function readIfExists(filePath: string): Buffer {
+  try {
+    return fs.readFileSync(filePath)
+  } catch {
+    return Buffer.alloc(0)
+  }
+}
+
+/**
+ * The stored token's `encoding` tag, for diagnostics only — never its value.
+ * Reported on failure so a red run says *why* (e.g. still `plain`) instead of
+ * only that a scan matched. Deliberately NOT an assertion: which encoding a
+ * correct fix chooses is its own business.
+ */
+function storedTokenEncoding(connectionFile: string): string {
+  try {
+    const parsed = JSON.parse(readIfExists(connectionFile).toString('utf8'))
+
+    return String(parsed?.remote?.token?.encoding ?? '<none>')
+  } catch {
+    return '<unparsable>'
+  }
+}
+
+// ─── App helpers ────────────────────────────────────────────────────────
+
+/**
+ * Launch the desktop app against `sandbox` with a fake boot failure injected.
+ *
+ * The credential path we are testing is entirely main-process (IPC handler →
+ * coerce → safeStorage → userData write) and does not need a live agent
+ * backend, so we skip spawning `hermes serve` (no Python needed, ~3s launch,
+ * hermetic). This is also a real user situation rather than an artificial one:
+ * the boot-failure overlay's own recovery affordance is "Connection settings",
+ * i.e. pointing the app at a remote gateway is exactly what a user does from
+ * this state. BOOT_FAKE_ERROR short-circuits startHermes() *before* remote
+ * resolution, so no launch ever dials the fake gateway on its own.
+ */
+async function launchAgainst(sandbox: Sandbox): Promise<{ app: ElectronApplication; page: Page }> {
+  const env = buildAppEnv(sandbox, {
+    HERMES_DESKTOP_APP_NAME: STABLE_APP_NAME,
+    HERMES_DESKTOP_BOOT_FAKE_ERROR: 'E2E at-rest storage spec: local backend intentionally not started',
+  })
+
+  const { app, page } = await launchDesktop(env)
+
+  // The capability bridge is what we drive; it lands with the preload, well
+  // before the app would be "ready" in the boot sense.
+  await page.waitForFunction(
+    () => Boolean((window as unknown as { hermesDesktop?: Record<string, unknown> }).hermesDesktop?.saveConnectionConfig),
+    undefined,
+    { timeout: 60_000 },
+  )
+
+  return { app, page }
+}
+
+/**
+ * Ask the running app where userData actually is, the same way the app does
+ * (`app.getPath('userData')`). The fixtures point userData at a temp sandbox,
+ * so a home-relative hardcoded path would test the wrong file — or no file.
+ */
+async function resolveUserDataDir(app: ElectronApplication): Promise<string> {
+  return app.evaluate(({ app: electronApp }) => electronApp.getPath('userData'))
+}
+
+interface SafeStorageCapability {
+  available: boolean
+  backend: string
+}
+
+/**
+ * What secure storage is actually capable of on THIS host, asked after ready
+ * (on Linux the answer is meaningless before then).
+ *
+ * `backend` matters for the honest reading of a green run: on Linux with no
+ * keyring, Electron can still report encryption as available while selecting
+ * the `basic_text` backend, which encrypts with a hardcoded password — the
+ * bytes on disk are not the plaintext, but they are not meaningfully
+ * protected either. We record it rather than assert on it, because which
+ * posture Hermes should take there (refuse to save vs. accept basic_text) is
+ * a product decision, not something this test should silently ratify.
+ */
+async function readSafeStorageCapability(app: ElectronApplication): Promise<SafeStorageCapability> {
+  return app.evaluate(async ({ app: electronApp, safeStorage }) => {
+    await electronApp.whenReady()
+
+    let available = false
+    let backend = 'unavailable'
+
+    try {
+      available = safeStorage.isEncryptionAvailable()
+    } catch {
+      available = false
+    }
+
+    try {
+      // Linux-oriented API; other platforms may not implement it.
+      backend = safeStorage.getSelectedStorageBackend?.() ?? 'n/a'
+    } catch {
+      backend = 'n/a'
+    }
+
+    return { available, backend }
+  })
+}
+
+interface SaveOutcome {
+  config: { remoteTokenPreview?: null | string; remoteTokenSet?: boolean; remoteUrl?: string } | null
+  error: null | string
+}
+
+/**
+ * Drive the app's REAL save surface: the same `saveConnectionConfig` payload
+ * Settings → Gateway sends (see src/app/settings/gateway-settings.tsx). We use
+ * save rather than apply so the app persists the credential without trying to
+ * re-home onto the fake gateway.
+ */
+async function saveRemoteToken(page: Page, remoteUrl: string, remoteToken?: string): Promise<SaveOutcome> {
+  return page.evaluate(
+    async ([url, token]) => {
+      const desktop = (window as unknown as { hermesDesktop: any }).hermesDesktop
+
+      try {
+        const config = await desktop.saveConnectionConfig({
+          mode: 'remote',
+          remoteAuthMode: 'token',
+          ...(token ? { remoteToken: token } : {}),
+          remoteUrl: url,
+        })
+
+        return { config, error: null }
+      } catch (error) {
+        return { config: null, error: error instanceof Error ? error.message : String(error) }
+      }
+    },
+    [remoteUrl, remoteToken ?? ''] as const,
+  )
+}
+
+/**
+ * Make the app USE the stored credential. No token in the payload, so the main
+ * process must read `connection.json`, decrypt what it stored, and put the
+ * plaintext on the wire itself. `buildRemoteBlock` throws "Remote gateway
+ * session token is required." when the stored blob no longer decrypts, so a
+ * fix that dropped the token fails here instead of quietly passing the
+ * absence assertion.
+ */
+async function exerciseStoredToken(page: Page, remoteUrl: string): Promise<{ error: null | string }> {
+  return page.evaluate(async url => {
+    const desktop = (window as unknown as { hermesDesktop: any }).hermesDesktop
+
+    try {
+      await desktop.testConnectionConfig({ mode: 'remote', remoteUrl: url })
+
+      return { error: null }
+    } catch (error) {
+      // A failing WS leg is expected (the fake gateway refuses the upgrade).
+      // The assertion is on what the gateway received, not on this result.
+      return { error: error instanceof Error ? error.message : String(error) }
+    }
+  }, remoteUrl)
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+let gateway: FakeGateway | null = null
+let sandbox: Sandbox | null = null
+let app: ElectronApplication | null = null
+
+test.beforeAll(async () => {
+  gateway = await startFakeGateway()
+})
+
+test.afterAll(async () => {
+  await gateway?.close()
+  gateway = null
+})
+
+test.beforeEach(() => {
+  // Boot is intentionally failed in this spec (see launchAgainst), so the
+  // boot-failure overlay's error banner is expected, not a failure.
+  allowErrorBanners()
+})
+
+test.afterEach(async () => {
+  await app?.close().catch(() => undefined)
+  app = null
+  sandbox?.cleanup()
+  sandbox = null
+})
+
+test.describe('remote gateway session token at rest', () => {
+  test('a newly configured token is never written to userData in plaintext, and still works after restart', async () => {
+    const fake = gateway!
+    sandbox = createSandbox('at-rest-fresh')
+
+    const first = await launchAgainst(sandbox)
+    app = first.app
+
+    const capability = await readSafeStorageCapability(app)
+    const userDataDir = await resolveUserDataDir(app)
+    const connectionFile = path.join(userDataDir, 'connection.json')
+
+    test.info().annotations.push({
+      description: `isEncryptionAvailable=${capability.available} backend=${capability.backend}`,
+      type: 'safeStorage',
+    })
+
+    const saved = await saveRemoteToken(first.page, fake.url, SENTINEL_TOKEN)
+
+    // Defined degradation, not a silent plaintext write. Where secure storage
+    // works, the save must succeed. Where it genuinely does not (headless
+    // Linux with no keyring, per Electron's safeStorage docs), refusing the
+    // save with a loud error is an acceptable outcome — what is NEVER
+    // acceptable is reporting success while leaving the secret readable on
+    // disk. The absence assertion below runs in both branches.
+    if (capability.available) {
+      expect(
+        saved.error,
+        'secure storage is available on this host, so saving a remote gateway token must succeed',
+      ).toBeNull()
+      expect(saved.config?.remoteTokenSet).toBe(true)
+    } else {
+      expect(
+        saved.error,
+        'secure storage is unavailable, so the save must fail loudly rather than persist a plaintext token',
+      ).not.toBeNull()
+    }
+
+    // Guard against a vacuous pass: when the save succeeded, the artifact must
+    // exist and must be the file the app really wrote for THIS connection.
+    // Without this, "no plaintext on disk" would also be true if nothing had
+    // been saved at all. Only asserted on the success branch — a refused save
+    // legitimately leaves no file behind.
+    const rawConnection = readIfExists(connectionFile)
+
+    if (capability.available) {
+      expect(fs.existsSync(connectionFile), `expected the app to write ${connectionFile}`).toBe(true)
+      expect(
+        rawConnection.includes(Buffer.from(fake.url, 'utf8')),
+        'connection.json should record the configured gateway URL (proves this is the real artifact)',
+      ).toBe(true)
+    }
+
+    // ── The load-bearing assertion ─────────────────────────────────────
+    const needles = secretNeedles(SENTINEL_TOKEN)
+
+    const connectionHits = needles.filter(needle => rawConnection.includes(needle.bytes)).map(needle => needle.label)
+    expect(
+      connectionHits,
+      `the gateway session token must not be recoverable from ${connectionFile} ` +
+        `(stored token encoding is "${storedTokenEncoding(connectionFile)}")`,
+    ).toEqual([])
+
+    // …and not in any sibling file the app writes alongside it, nor in
+    // HERMES_HOME (desktop.log lives there).
+    expect(
+      scanTreeForSecret(userDataDir, needles),
+      'the gateway session token leaked into a userData file',
+    ).toEqual([])
+    expect(
+      scanTreeForSecret(sandbox.hermesHome, needles),
+      'the gateway session token leaked into a HERMES_HOME file (logs included)',
+    ).toEqual([])
+
+    if (!capability.available) {
+      // Nothing was stored, so there is no round trip to verify. The refusal
+      // itself was already asserted above.
+      return
+    }
+
+    // ── Secondary: the credential must still be USABLE ─────────────────
+    // Restart against the same userData so the token comes off disk, not out
+    // of a live process's memory.
+    await app.close().catch(() => undefined)
+    app = null
+
+    const second = await launchAgainst(sandbox)
+    app = second.app
+
+    expect(
+      await resolveUserDataDir(app),
+      'the restarted app must resolve the same userData dir, or this is not a round trip',
+    ).toBe(userDataDir)
+
+    const reread = await second.page.evaluate(async () => {
+      const desktop = (window as unknown as { hermesDesktop: any }).hermesDesktop
+
+      return desktop.getConnectionConfig()
+    })
+
+    expect(reread.remoteTokenSet, 'the stored token must survive a restart').toBe(true)
+    expect(reread.remoteUrl).toBe(fake.url)
+
+    const before = fake.sessionTokens.length
+    await exerciseStoredToken(second.page, fake.url)
+
+    // The gateway is the witness: the app decrypted its stored blob and put
+    // the original secret on the wire. A dropped, truncated, or re-encoded
+    // token cannot produce this.
+    expect(
+      fake.sessionTokens.slice(before),
+      'the app must send the exact stored token to the gateway after a restart',
+    ).toContain(SENTINEL_TOKEN)
+  })
+
+  /**
+   * DEFERRED GAP — legacy plaintext payloads are not migrated.
+   *
+   * Held as `fixme` rather than deleted: the fixture below is the correct
+   * fixture for the population that a migration must eventually cover, and
+   * the harness (seed → boot-poll → authoritative re-save → raw-bytes scan →
+   * wire check) is the harness such a migration needs. Keeping it typechecked
+   * and listed makes the gap visible in `--list` and in every report; deleting
+   * it would make the gap invisible and cost the next implementer this setup.
+   *
+   * It is NOT enabled because the migration it asserted was reviewed
+   * DO NOT SHIP. Before this can be un-fixme'd, three prerequisites (see the
+   * header, and the matching note in electron/main.ts readDesktopConnectionConfig):
+   *
+   *   1. Sequence with #62319's opt-in plaintext marker, so a user who
+   *      deliberately chose plaintext is not silently overridden. This
+   *      fixture has NO marker, so it stays in scope for migration — but the
+   *      implementation must be able to tell the two apart.
+   *   2. Write through the config sanitizer, not around it.
+   *   3. Surface ROTATION guidance. Re-encrypting cannot un-expose a secret
+   *      that is already in a backup; it only prevents future exposure.
+   *
+   * Un-fixme'ing this without (1) risks destroying a deliberate user choice,
+   * and without (3) it reports a remediation it did not actually perform.
+   */
+  test('an existing plaintext connection.json is migrated off plaintext and keeps working', async () => {
+    test.fixme(
+      true,
+      'Deferred: legacy plaintext connection.json is intentionally NOT migrated. ' +
+        'Affected population is pre-release bb/gui installs (incl. the desktop-pr20059-installers build) ' +
+        'plus hand-edited configs — mainline never wrote a plaintext gateway token. ' +
+        'Blocked on: (1) #62319 opt-in-marker coordination, (2) writing through the config sanitizer, ' +
+        '(3) surfacing token-rotation guidance. Re-encrypting alone does not remediate an already-backed-up secret.',
+    )
+
+    const fake = gateway!
+    sandbox = createSandbox('at-rest-migrate')
+
+    // Seed the file an affected user has on disk. This is live, usable
+    // plaintext rather than a strawman, because `decryptDesktopSecret` returns
+    // `value` verbatim for any non-safeStorage encoding — the READ path
+    // accepts it. Note what does NOT justify this fixture: mainline never
+    // WROTE this shape to disk. `coerceDesktopConnectionConfig` does build it,
+    // but only under `persistToken: false`, whose sole caller is the
+    // connection-test handler, which never persists. The writers were
+    // non-mainline pre-release builds and hand edits. There is deliberately no
+    // opt-in marker here, so this payload is in scope for a future migration.
+    fs.writeFileSync(
+      path.join(sandbox.userDataDir, 'connection.json'),
+      JSON.stringify(
+        {
+          mode: 'remote',
+          profiles: {},
+          remote: {
+            authMode: 'token',
+            token: { encoding: 'plain', value: SENTINEL_TOKEN },
+            url: fake.url,
+          },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    )
+
+    const launched = await launchAgainst(sandbox)
+    app = launched.app
+
+    const capability = await readSafeStorageCapability(app)
+
+    test.info().annotations.push({
+      description: `isEncryptionAvailable=${capability.available} backend=${capability.backend}`,
+      type: 'safeStorage',
+    })
+
+    if (!capability.available) {
+      // With no secure storage there is nowhere to migrate the secret TO, and
+      // scrubbing it would silently sign the user out of a working gateway.
+      // Asserting either outcome here would be inventing policy.
+      test.skip(
+        true,
+        'secure storage unavailable on this host — the correct migration policy for an existing plaintext file is undecided',
+      )
+
+      return
+    }
+
+    const userDataDir = await resolveUserDataDir(app)
+    const connectionFile = path.join(userDataDir, 'connection.json')
+    const needles = secretNeedles(SENTINEL_TOKEN)
+
+    // Two chances, so the test does not depend on WHERE the fix hooks the
+    // migration: (a) on read at boot, (b) on the next authoritative write.
+    // Poll for (a) first.
+    const deadline = Date.now() + 15_000
+    let stillPlaintext = true
+
+    while (Date.now() < deadline) {
+      stillPlaintext = readIfExists(connectionFile).includes(needles[0].bytes)
+
+      if (!stillPlaintext) {
+        break
+      }
+
+      await launched.page.waitForTimeout(500)
+    }
+
+    if (stillPlaintext) {
+      // (b) A real save through the app's own surface, carrying no new token —
+      // the stored blob is inherited. Re-persisting an inherited secret is the
+      // other place plaintext must not survive.
+      const resaved = await saveRemoteToken(launched.page, fake.url)
+      expect(resaved.error, 'a re-save that inherits the stored token must not fail').toBeNull()
+    }
+
+    expect(
+      scanTreeForSecret(userDataDir, needles),
+      'an existing plaintext gateway token must not remain readable under userData after the app has run ' +
+        `(stored token encoding is still "${storedTokenEncoding(connectionFile)}")`,
+    ).toEqual([])
+
+    // And the migration must not have cost the user their credential.
+    const before = fake.sessionTokens.length
+    await exerciseStoredToken(launched.page, fake.url)
+
+    expect(
+      fake.sessionTokens.slice(before),
+      'the migrated token must still reach the gateway unchanged',
+    ).toContain(SENTINEL_TOKEN)
+  })
+})

--- a/apps/desktop/e2e/at-rest-connection-token.spec.ts
+++ b/apps/desktop/e2e/at-rest-connection-token.spec.ts
@@ -18,13 +18,23 @@
  *   2. STILL FUNCTIONAL. After a restart, the app must still be able to USE
  *      that credential — it decrypts the stored blob and puts the exact
  *      original token on the wire.
+ *   3. UNREADABLE BY OTHER LOCAL ACCOUNTS. `connection.json` must not be
+ *      group/other-accessible, whether the app just wrote it or inherited it
+ *      from an older install.
  *
- * Both halves matter and neither is sufficient alone. (1) alone is trivially
+ * All three matter and none is sufficient alone. (1) alone is trivially
  * satisfied by a "fix" that drops the token on the floor; (2) alone is
  * satisfied by the bug itself. So (2) is verified through the app's own
  * connection test against a fake gateway that records the
  * `X-Hermes-Session-Token` header it receives — a dropped or mangled token
  * cannot produce that header.
+ *
+ * (3) is orthogonal to (1) and invisible to it: safeStorage keeps the token
+ * opaque no matter what the file's mode is, so a 0644 `connection.json` passes
+ * the raw-bytes scan every time while still exposing the ciphertext blob, the
+ * gateway URL and the SSH host/user/keyPath to any other local account. It is
+ * asserted explicitly (see `expectOwnerOnlyMode`) because no amount of
+ * encryption evidence implies it.
  *
  * We deliberately do NOT assert `encoding === 'safeStorage'` or any other
  * shape of the stored blob. That would be a change-detector: a fix that moved
@@ -32,16 +42,23 @@
  * separate credential file would break the test while being *more* correct.
  * The load-bearing assertion is the raw-bytes absence of the secret.
  *
- * Two at-rest paths, hence two tests — one enforced, one a documented gap:
+ * Four at-rest paths, hence four tests — three enforced, one a documented gap:
  *
  *   1. A NEWLY configured token (ACTIVE). The app's own write path routes
  *      through the strict `encryptDesktopSecret`; this test holds it there
- *      against regression.
- *   2. An EXISTING plaintext `connection.json` (`test.fixme`). Legacy payloads
+ *      against regression, and pins the mode of the file it actually wrote.
+ *   2. An EXISTING `connection.json` at the old 0644 (ACTIVE). Covers the
+ *      read-side tighten, and ONLY the mode — its token is already ciphertext,
+ *      which is what keeps it independent of the migration test 4 defers.
+ *   3. A CORRUPT `connection.json` at 0644 (ACTIVE). The tighten must not be
+ *      gated on the parse succeeding: a truncated file still holds the token
+ *      bytes, and the parse failure is swallowed, so nothing would ever come
+ *      back for it.
+ *   4. An EXISTING plaintext `connection.json` (`test.fixme`). Legacy payloads
  *      are deliberately NOT migrated yet. The test is kept, disabled, with a
  *      precise reason — see the block comment above it.
  *
- * ── Correcting the record on (2) ────────────────────────────────────────
+ * ── Correcting the record on test 4 ─────────────────────────────────────
  *
  * An earlier revision of this file asserted that migration and justified it by
  * claiming the first implementation (`d3d177283`) fell back to
@@ -304,6 +321,39 @@ function storedTokenEncoding(connectionFile: string): string {
   }
 }
 
+/**
+ * Assert a credential file is not readable or writable by group/other.
+ *
+ * This is the one contract the raw-bytes scan above structurally cannot see:
+ * safeStorage keeps the token opaque regardless of the file's mode, so a
+ * world-readable `connection.json` passes every absence assertion in this file
+ * while still handing the URL, the SSH host/user/keyPath, and the ciphertext
+ * blob to any other local account. Encryption and permissions are independent
+ * halves of "at rest", and only one of them was covered here.
+ *
+ * Asserted as `mode & 0o077 === 0` rather than `=== 0o600`: the requirement is
+ * that nobody else can reach the file, and pinning the exact bits would make
+ * this a change-detector against a future 0400 or a setgid-dir umask.
+ *
+ * POSIX only. `tightenSecretFileMode` no-ops on Windows deliberately (Node maps
+ * chmod to the read-only bit there, and userData is already ACL'd to the user
+ * profile — see the docstring in electron/hardening.ts, and PR #77527 for the
+ * one place ACLs are being handled). Mode bits are advisory on Windows, so
+ * asserting them would go red for behaviour the fix never claimed. The suite
+ * runs ubuntu-latest today (.github/workflows/e2e-desktop.yml); nothing else in
+ * this spec is platform-specific, and this assertion should not be what
+ * changes that.
+ */
+function expectOwnerOnlyMode(filePath: string, why: string): void {
+  if (process.platform === 'win32') {
+    return
+  }
+
+  const mode = fs.statSync(filePath).mode & 0o777
+
+  expect(mode & 0o077, `${why} (mode ${mode.toString(8)})`).toBe(0)
+}
+
 // ─── App helpers ────────────────────────────────────────────────────────
 
 /**
@@ -523,6 +573,17 @@ test.describe('remote gateway session token at rest', () => {
         rawConnection.includes(Buffer.from(fake.url, 'utf8')),
         'connection.json should record the configured gateway URL (proves this is the real artifact)',
       ).toBe(true)
+
+      // The write path's OTHER half of at-rest: opaque bytes AND owner-only
+      // permissions. Deliberately here, on the file this test just proved the
+      // app really wrote, rather than in a unit test — nothing in the repo
+      // imports electron/main.ts (it imports electron), so this is the only
+      // place that can witness the app's own write actually going out at 0600
+      // instead of the 0644 umask default.
+      expectOwnerOnlyMode(
+        connectionFile,
+        'connection.json is group/other-accessible, so the encrypted token blob, gateway URL and SSH fields are readable by other local accounts',
+      )
     }
 
     // ── The load-bearing assertion ─────────────────────────────────────
@@ -585,6 +646,158 @@ test.describe('remote gateway session token at rest', () => {
       fake.sessionTokens.slice(before),
       'the app must send the exact stored token to the gateway after a restart',
     ).toContain(SENTINEL_TOKEN)
+  })
+
+  /**
+   * The read side of the same contract: an install written BEFORE the file was
+   * owner-only keeps its 0644 bits until something chmods it, and the write
+   * path cannot fix it — `fs.writeFileSync(path, data, { mode })` applies
+   * `mode` only when it CREATES the file. Waiting for the user's next Settings
+   * save would leave the file group/other-readable indefinitely, which is why
+   * `readDesktopConnectionConfig` tightens on a cache miss.
+   *
+   * Scoped to the MODE, and deliberately independent of the deferred migration
+   * below. The fixture's token is already safeStorage ciphertext (the app wrote
+   * it), so nothing here re-encrypts anything, touches the #62319 opt-in
+   * plaintext marker, or needs rotation guidance — the three prerequisites that
+   * keep the next test fixme'd. Tightening a permission bit neither performs a
+   * migration nor claims to, so it can be covered now while migration stays
+   * deferred.
+   *
+   * The fixture is produced by the app itself rather than hand-written, so the
+   * only difference from a real pre-fix install is the one bit under test.
+   */
+  test('an install whose connection.json predates owner-only mode is tightened on read', async () => {
+    const fake = gateway!
+    sandbox = createSandbox('at-rest-tighten')
+
+    const first = await launchAgainst(sandbox)
+    app = first.app
+
+    const capability = await readSafeStorageCapability(app)
+
+    test.info().annotations.push({
+      description: `isEncryptionAvailable=${capability.available} backend=${capability.backend}`,
+      type: 'safeStorage',
+    })
+
+    if (!capability.available) {
+      // Without secure storage the save is refused by design, so there is no
+      // app-written artifact to loosen and re-read. The refusal itself is
+      // already asserted in the first test.
+      test.skip(true, 'secure storage unavailable on this host — no app-written connection.json to tighten')
+
+      return
+    }
+
+    const userDataDir = await resolveUserDataDir(app)
+    const connectionFile = path.join(userDataDir, 'connection.json')
+
+    const saved = await saveRemoteToken(first.page, fake.url, SENTINEL_TOKEN)
+    expect(saved.error, 'the fixture write must succeed, or there is nothing to tighten').toBeNull()
+
+    await app.close().catch(() => undefined)
+    app = null
+
+    // Regress the file to what a pre-fix install has on disk. Everything else
+    // about it — including the encrypted token — is exactly what the app wrote.
+    fs.chmodSync(connectionFile, 0o644)
+    expect(fs.statSync(connectionFile).mode & 0o077, 'the fixture must start group/other-accessible').not.toBe(0)
+
+    const seededMtimeMs = fs.statSync(connectionFile).mtimeMs
+
+    // A fresh process starts with an empty config cache, so the first read is a
+    // miss and the tighten runs. `getConnectionConfig()` forces that read
+    // through the app's own IPC surface.
+    const second = await launchAgainst(sandbox)
+    app = second.app
+
+    const reread = await second.page.evaluate(async () => {
+      const desktop = (window as unknown as { hermesDesktop: any }).hermesDesktop
+
+      return desktop.getConnectionConfig()
+    })
+
+    expectOwnerOnlyMode(
+      connectionFile,
+      'a pre-existing world-readable connection.json was not tightened when the app read it',
+    )
+
+    // The tighten must be a chmod, not a rewrite. It sits INSIDE the function
+    // whose cache keys on mtimeMs, so if it ever moved mtime it would
+    // invalidate that cache on every read and re-tighten forever. chmod moves
+    // ctime only, which is what makes the placement safe — this pins it.
+    expect(
+      Math.abs(fs.statSync(connectionFile).mtimeMs - seededMtimeMs),
+      'tightening must not rewrite the file: mtime is the config cache key, so moving it would invalidate the cache the tighten sits inside',
+    ).toBeLessThan(1)
+
+    // And tightening must not have cost the user their credential — the whole
+    // reason this happens on read instead of by deleting the file.
+    expect(reread.remoteTokenSet, 'the stored token must survive being tightened').toBe(true)
+    expect(reread.remoteUrl).toBe(fake.url)
+  })
+
+  /**
+   * The tighten must not be gated on the file being valid JSON.
+   *
+   * A truncated `connection.json` — an interrupted write on an older build, a
+   * half-finished hand edit, a partially restored backup — still contains the
+   * token bytes, and `JSON.parse` throws straight into the `catch` that falls
+   * back to local mode. That fallback is never written back, so nothing
+   * re-tightens the file later. With the chmod sequenced AFTER the parse,
+   * exactly the file that is both corrupt AND world-readable would be the one
+   * file never tightened, permanently.
+   *
+   * This is the only test that can tell the two orderings apart: every other
+   * test here uses a parseable file, where either ordering tightens. Asserting
+   * `mode === 'local'` is what makes it load-bearing — it proves the parse
+   * really threw, so a green mode assertion cannot be explained by anything
+   * downstream of the parse.
+   *
+   * Needs no secure storage: it is a chmod on a file that is never decrypted,
+   * so it holds on the keyring-less CI runner too.
+   */
+  test('a corrupt connection.json is tightened even though it never parses', async () => {
+    sandbox = createSandbox('at-rest-tighten-corrupt')
+
+    const connectionFile = path.join(sandbox.userDataDir, 'connection.json')
+
+    // Truncated mid-token: unparseable, yet the secret bytes are right there.
+    fs.writeFileSync(
+      connectionFile,
+      `{"mode":"remote","remote":{"authMode":"token","token":{"encoding":"plain","value":"${SENTINEL_TOKEN}`,
+      { encoding: 'utf8', mode: 0o644 },
+    )
+    fs.chmodSync(connectionFile, 0o644)
+    expect(fs.statSync(connectionFile).mode & 0o077, 'the fixture must start group/other-accessible').not.toBe(0)
+
+    const seededMtimeMs = fs.statSync(connectionFile).mtimeMs
+
+    const launched = await launchAgainst(sandbox)
+    app = launched.app
+
+    const reread = await launched.page.evaluate(async () => {
+      const desktop = (window as unknown as { hermesDesktop: any }).hermesDesktop
+
+      return desktop.getConnectionConfig()
+    })
+
+    expect(
+      reread.mode,
+      'the fixture must be unparseable, so the app falls back to local — otherwise this test proves nothing about ordering',
+    ).toBe('local')
+
+    expectOwnerOnlyMode(
+      connectionFile,
+      'a corrupt world-readable connection.json still holding token bytes was left group/other-accessible',
+    )
+
+    // Same cache invariant as above: chmod, not rewrite.
+    expect(
+      Math.abs(fs.statSync(connectionFile).mtimeMs - seededMtimeMs),
+      'tightening must not rewrite the file: mtime is the config cache key',
+    ).toBeLessThan(1)
   })
 
   /**

--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -18,8 +18,53 @@ import {
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
-  sensitiveFileBlockReason
+  SAFE_STORAGE_ENCODING,
+  SECRET_FILE_MODE,
+  sensitiveFileBlockReason,
+  tightenSecretFileMode,
+  writeSecretFileAtomic
 } from './hardening'
+
+/**
+ * Real temp dir per test: the property under test IS the on-disk mode after a
+ * temp-file-then-rename, which a mocked fs would assert into existence rather
+ * than verify. `platform` is still injected so the Windows branch is coverable
+ * from a POSIX run.
+ */
+function withTempDir(run: (dir: string) => void) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-secret-file-'))
+
+  try {
+    run(dir)
+  } finally {
+    fs.rmSync(dir, { force: true, recursive: true })
+  }
+}
+
+function modeOf(filePath: string) {
+  return fs.statSync(filePath).mode & 0o777
+}
+
+/**
+ * No file other than the target may survive a write, and nothing left in the
+ * directory may contain the payload. Asserts the CONTRACT (no readable debris)
+ * instead of a literal directory listing, so adding a lock file or renaming the
+ * staging file does not break the test.
+ */
+function assertNoSecretDebris(dir: string, targetName: string, secret: string) {
+  for (const name of fs.readdirSync(dir)) {
+    if (name === targetName) {
+      continue
+    }
+
+    // Substring, not RegExp: a real token can contain regex metacharacters.
+    assert.equal(
+      fs.readFileSync(path.join(dir, name), 'utf8').includes(secret),
+      false,
+      `leftover file ${name} still contains the secret`
+    )
+  }
+}
 
 async function rejectsWithCode(promise, code: string) {
   await assert.rejects(promise, (error: any) => {
@@ -97,10 +142,307 @@ test('encryptDesktopSecret stores safeStorage base64 payload', () => {
     encryptString: value => Buffer.from(`enc:${value}`, 'utf8')
   })
 
-  assert.deepEqual(secret, {
-    encoding: 'safeStorage',
-    value: Buffer.from('enc:token-123', 'utf8').toString('base64')
+  // Contract: the payload is tagged with the SAME constant main's
+  // decryptDesktopSecret dispatches on, and `value` is the keychain ciphertext
+  // base64'd — not the token itself.
+  assert.equal(secret?.encoding, SAFE_STORAGE_ENCODING)
+  assert.equal(Buffer.from(String(secret?.value), 'base64').toString('utf8'), 'enc:token-123')
+  assert.doesNotMatch(String(secret?.value), /token-123/, 'the plaintext is not recoverable from the payload')
+})
+
+// ─── Owner-only credential files (connection.json) ─────────────────────────
+
+test('writeSecretFileAtomic creates the file owner-only, not at the 0644 umask default', () => {
+  withTempDir(dir => {
+    const target = path.join(dir, 'connection.json')
+    const payload = JSON.stringify({ remote: { token: { encoding: SAFE_STORAGE_ENCODING, value: 'BLOB' } } })
+
+    writeSecretFileAtomic(target, payload)
+
+    assert.equal(modeOf(target), SECRET_FILE_MODE)
+    assert.equal(modeOf(target) & 0o077, 0, 'no group/other bits')
+    assert.equal(fs.readFileSync(target, 'utf8'), payload, 'content round-trips')
+    assertNoSecretDebris(dir, 'connection.json', 'BLOB')
   })
+})
+
+test('writeSecretFileAtomic does not inherit loose bits from a stale temp file', () => {
+  // renameSync keeps the TEMP file's permissions, and writeFileSync's `mode`
+  // is ignored when the path already exists — so a temp left by a crashed
+  // earlier write would otherwise hand 0644 straight to the target.
+  withTempDir(dir => {
+    const target = path.join(dir, 'connection.json')
+    fs.writeFileSync(`${target}.tmp`, 'stale', { mode: 0o666 })
+    assert.notEqual(modeOf(`${target}.tmp`), SECRET_FILE_MODE)
+
+    writeSecretFileAtomic(target, 'fresh')
+
+    assert.equal(modeOf(target), SECRET_FILE_MODE)
+    assert.equal(fs.readFileSync(target, 'utf8'), 'fresh')
+  })
+})
+
+/**
+ * Owner-only is carried by two independent mechanisms — the create-time `mode`
+ * and the chmod before the rename — because each covers a case the other
+ * cannot. The next two tests knock out one mechanism at a time (with the REAL
+ * fs doing the actual write, so the assertion is still the on-disk mode) and
+ * require the survivor to hold the line on its own. Without them, either
+ * mechanism could be deleted with every test still green.
+ */
+function fsWith(overrides: Record<string, unknown>) {
+  return { ...fs, ...overrides } as any
+}
+
+test('the written file is owner-only even where chmod does nothing', () => {
+  // Windows, and any mount that refuses chmod. The create-time `mode` is what
+  // covers this — there is no second chance to tighten.
+  withTempDir(dir => {
+    const target = path.join(dir, 'connection.json')
+    // Pin a permissive umask so a mode-less create WOULD land
+    // group/other-readable — otherwise a restrictive-umask host could pass this
+    // for free. Synchronous and restored in `finally`, and the electron project
+    // runs one process per file, so no other test observes it.
+    const previousUmask = process.umask(0o022)
+
+    try {
+      const witness = path.join(dir, 'witness.json')
+      fs.writeFileSync(witness, 'x')
+      assert.notEqual(modeOf(witness), SECRET_FILE_MODE, 'the ambient default is NOT already owner-only')
+
+      writeSecretFileAtomic(target, 'tok', { fs: fsWith({ chmodSync: () => void 0 }) })
+    } finally {
+      process.umask(previousUmask)
+    }
+
+    assert.equal(modeOf(target), SECRET_FILE_MODE, 'created owner-only, not tightened after the fact')
+  })
+})
+
+test('the written file is owner-only even when a stale temp cannot be removed', () => {
+  // The unlink is best-effort; if the stale temp survives, writeFileSync's
+  // `mode` is ignored on an existing path and only the chmod before the rename
+  // can still fix the bits.
+  withTempDir(dir => {
+    const target = path.join(dir, 'connection.json')
+    fs.writeFileSync(`${target}.tmp`, 'stale', { mode: 0o666 })
+
+    writeSecretFileAtomic(target, 'tok', { fs: fsWith({ rmSync: () => void 0 }) })
+
+    assert.equal(modeOf(target), SECRET_FILE_MODE, 'tightened before the rename handed the bits over')
+    assert.equal(fs.readFileSync(target, 'utf8'), 'tok')
+  })
+})
+
+test('writeSecretFileAtomic cannot be redirected through a symlink planted at the temp path', () => {
+  // A stale temp path is attacker-controllable in a shared temp/userData dir.
+  // Following it would write the token into the victim file AND then rename the
+  // link over connection.json, so every later write leaks too.
+  withTempDir(dir => {
+    const target = path.join(dir, 'connection.json')
+    const victim = path.join(dir, 'victim.txt')
+    fs.writeFileSync(victim, 'original', { mode: 0o644 })
+
+    try {
+      fs.symlinkSync(victim, `${target}.tmp`, 'file')
+    } catch (error: any) {
+      if (error?.code === 'EPERM' || error?.code === 'EACCES') {
+        return
+      }
+
+      throw error
+    }
+
+    writeSecretFileAtomic(target, 'tok-live-42')
+
+    assert.equal(fs.readFileSync(victim, 'utf8'), 'original', 'the symlink target was not written through')
+    assert.equal(modeOf(victim), 0o644, 'the victim file was not chmodded either')
+    assert.equal(fs.readFileSync(target, 'utf8'), 'tok-live-42')
+    assert.equal(fs.lstatSync(target).isSymbolicLink(), false, 'the target is a real file, not the planted link')
+    assert.equal(modeOf(target), SECRET_FILE_MODE)
+  })
+})
+
+test('tightenSecretFileMode tightens a pre-existing world-readable config in place', () => {
+  // The upgrade path: a connection.json written by an older build sits at 0644
+  // with a real (encrypted) token in it. Tightening must change the mode and
+  // nothing else — the token has to stay readable or the user loses their
+  // configured gateway.
+  withTempDir(dir => {
+    const target = path.join(dir, 'connection.json')
+
+    const legacy = JSON.stringify({
+      mode: 'remote',
+      remote: {
+        url: 'https://gw.example.com',
+        authMode: 'token',
+        token: { encoding: SAFE_STORAGE_ENCODING, value: 'BLOB' }
+      }
+    })
+
+    fs.writeFileSync(target, legacy, { mode: 0o644 })
+    assert.equal(modeOf(target), 0o644)
+
+    assert.equal(tightenSecretFileMode(target), true)
+
+    assert.equal(modeOf(target), SECRET_FILE_MODE)
+    assert.deepEqual(JSON.parse(fs.readFileSync(target, 'utf8')), JSON.parse(legacy), 'contents untouched')
+  })
+})
+
+test('tightenSecretFileMode leaves a non-safeStorage token payload readable', () => {
+  // A hand-edited config (or one from a pre-release build) can hold a
+  // non-safeStorage token payload, which decryptDesktopSecret still reads
+  // verbatim on purpose. Tightening the mode must not disturb that fallback —
+  // it only narrows who can open the file.
+  withTempDir(dir => {
+    const target = path.join(dir, 'connection.json')
+
+    const legacyPlain = JSON.stringify({
+      mode: 'remote',
+      remote: { url: 'https://gw.example.com', authMode: 'token', token: { encoding: 'plain', value: 'tok-live-42' } }
+    })
+
+    fs.writeFileSync(target, legacyPlain, { mode: 0o644 })
+
+    tightenSecretFileMode(target)
+
+    assert.equal(modeOf(target), SECRET_FILE_MODE)
+    assert.equal(JSON.parse(fs.readFileSync(target, 'utf8')).remote.token.value, 'tok-live-42')
+  })
+})
+
+test('tightenSecretFileMode is idempotent and never throws on an unusable path', () => {
+  withTempDir(dir => {
+    const target = path.join(dir, 'connection.json')
+    writeSecretFileAtomic(target, '{}')
+
+    assert.equal(tightenSecretFileMode(target), true)
+    assert.equal(tightenSecretFileMode(target), true)
+    assert.equal(modeOf(target), SECRET_FILE_MODE)
+
+    // Missing file (fresh install, nothing saved yet) reports failure quietly
+    // instead of breaking the read path it is called from.
+    assert.equal(tightenSecretFileMode(path.join(dir, 'absent.json')), false)
+  })
+})
+
+test('tightenSecretFileMode refuses to chmod a symlink instead of following it to its target', () => {
+  // Matches readInstallationId in desktop-installation.ts. Without the lstat
+  // guard a link planted at the config path sends the chmod to whatever it
+  // resolves to — someone else's file gets its mode rewritten.
+  withTempDir(dir => {
+    const target = path.join(dir, 'connection.json')
+    const victim = path.join(dir, 'victim.txt')
+    fs.writeFileSync(victim, 'not mine', { mode: 0o644 })
+
+    try {
+      fs.symlinkSync(victim, target, 'file')
+    } catch (error: any) {
+      if (error?.code === 'EPERM' || error?.code === 'EACCES') {
+        return
+      }
+
+      throw error
+    }
+
+    assert.equal(tightenSecretFileMode(target), false, 'reports "not tightened" rather than acting on the link')
+    assert.equal(modeOf(victim), 0o644, 'the symlink target keeps its own mode')
+  })
+})
+
+test('tightenSecretFileMode only touches a regular file the current user owns', () => {
+  // Directories, sockets, fifos and files owned by another account are all
+  // "not ours to chmod". Injected lstat so the foreign-owner branch is
+  // reachable without a second OS account.
+  const chmodded: string[] = []
+
+  const fakeFs = (stat: Record<string, unknown>) =>
+    ({
+      chmodSync: (filePath: string) => void chmodded.push(filePath),
+      lstatSync: () => ({ isFile: () => true, isSymbolicLink: () => false, mode: 0o644, uid: 0, ...stat }),
+      renameSync: () => void 0,
+      rmSync: () => void 0,
+      writeFileSync: () => void 0
+    }) as any
+
+  const uid = typeof process.getuid === 'function' ? process.getuid() : 0
+
+  assert.equal(
+    tightenSecretFileMode('/x/connection.json', { fs: fakeFs({ isFile: () => false }), platform: 'linux' }),
+    false
+  )
+  assert.equal(
+    tightenSecretFileMode('/x/connection.json', { fs: fakeFs({ uid: uid + 1 }), platform: 'linux' }),
+    false,
+    'a file owned by another user is left alone'
+  )
+  assert.deepEqual(chmodded, [], 'nothing was chmodded on the rejected paths')
+
+  // The same fs shape, but ours and loose: now it tightens.
+  assert.equal(tightenSecretFileMode('/x/connection.json', { fs: fakeFs({ uid }), platform: 'linux' }), true)
+  assert.deepEqual(chmodded, ['/x/connection.json'])
+})
+
+test('tightenSecretFileMode leaves Windows alone rather than flipping the read-only bit', () => {
+  const chmods: string[] = []
+
+  const fakeFs = {
+    chmodSync: (filePath: string) => void chmods.push(filePath),
+    lstatSync: () => ({
+      isFile: () => true,
+      isSymbolicLink: () => false,
+      mode: 0o644,
+      uid: typeof process.getuid === 'function' ? process.getuid() : 0
+    }),
+    renameSync: () => void 0,
+    rmSync: () => void 0,
+    writeFileSync: () => void 0
+  } as any
+
+  assert.equal(tightenSecretFileMode('C:\\Users\\me\\connection.json', { fs: fakeFs, platform: 'win32' }), true)
+  assert.deepEqual(chmods, [], 'no chmod on win32')
+
+  // Same fs, POSIX: the chmod does happen, proving the platform gate is what
+  // suppressed it above.
+  assert.equal(tightenSecretFileMode('/home/me/connection.json', { fs: fakeFs, platform: 'linux' }), true)
+  assert.ok(chmods.includes('/home/me/connection.json'), 'the POSIX path was tightened')
+})
+
+test('a token is never persisted in plaintext when safeStorage is unavailable', () => {
+  // The defined degradation for `isEncryptionAvailable() === false` (Linux with
+  // no keyring): encryptDesktopSecret throws with an actionable message, so the
+  // save aborts before any write. It must never fall back to a plaintext
+  // payload — the file mode is defense in depth, not a substitute for the
+  // keychain.
+  const unavailable = {
+    isEncryptionAvailable: () => false,
+    encryptString: () => Buffer.from('unused', 'utf8')
+  }
+
+  assert.throws(
+    () => encryptDesktopSecret('tok-live-42', unavailable),
+    (error: unknown) => {
+      assert.ok(error instanceof Error, 'aborts instead of returning a payload')
+      assert.match(String((error as Error).message), /Secure token storage is unavailable/)
+      assert.doesNotMatch(String((error as Error).message), /tok-live-42/, 'the secret is not echoed in the error')
+
+      return true
+    }
+  )
+
+  // And a throwing keychain (available, but encryptString fails) is the same
+  // contract — no silent plaintext.
+  assert.throws(
+    () =>
+      encryptDesktopSecret('tok-live-42', {
+        isEncryptionAvailable: () => true,
+        encryptString: () => {
+          throw new Error('keyring locked')
+        }
+      }),
+    /Failed to encrypt the remote gateway token/
+  )
 })
 
 test('sensitiveFileBlockReason blocks obvious secret file patterns', () => {

--- a/apps/desktop/electron/hardening.ts
+++ b/apps/desktop/electron/hardening.ts
@@ -35,6 +35,119 @@ function dataUrlReadMaxBytesFromMb(maxMb) {
 const SAFE_ENV_SUFFIXES = new Set(['dist', 'example', 'sample', 'template'])
 const SENSITIVE_EXTENSIONS = new Set(['.kdbx', '.p12', '.pem', '.pfx'])
 
+// Owner-only mode for userData files that carry credentials (the encrypted
+// gateway token in connection.json, and the URL/SSH fields alongside it).
+// connection.json was the odd one out: its two credential-bearing neighbours
+// under userData are already 0600 — desktop-installation.json
+// (desktop-installation.ts) and native-oauth-tokens.json (main.ts
+// `_nativeTokenStoreIo`) — while connection.json was written with no mode at
+// all and landed at the 0644 umask default. This makes the three consistent.
+const SECRET_FILE_MODE = 0o600
+
+// The encoding tag that marks a payload as OS-encrypted. One constant because
+// the writer (encryptDesktopSecret, here) and the reader
+// (decryptDesktopSecret, in main.ts) have to agree on the exact string across
+// a file boundary, and the native-token store round-trips the same shape.
+const SAFE_STORAGE_ENCODING = 'safeStorage'
+
+interface SecretFileFs {
+  chmodSync: typeof fs.chmodSync
+  lstatSync: typeof fs.lstatSync
+  renameSync: typeof fs.renameSync
+  rmSync: typeof fs.rmSync
+  writeFileSync: typeof fs.writeFileSync
+}
+
+interface SecretFileOptions {
+  encoding?: BufferEncoding
+  fs?: SecretFileFs
+  platform?: string
+}
+
+/**
+ * Tighten an existing credential file to owner-only (0600), returning whether
+ * the file now has that mode.
+ *
+ * Exists because `fs.writeFileSync(path, data, { mode })` only applies `mode`
+ * when it CREATES the file — rewriting an existing path silently keeps the old
+ * bits. So a file already on disk at 0644 (every connection.json written
+ * before this change, since that write passed no mode at all) needs an explicit
+ * chmod; a fresh `mode:` alone would never tighten it.
+ *
+ * Guards match `readInstallationId` in desktop-installation.ts, which does the
+ * same job for the sibling userData credential file: only ever chmod a regular
+ * file we own, never a symlink and never another user's file. Without them a
+ * symlink planted at the path would send the chmod to whatever it resolves to.
+ *
+ * POSIX only. Windows has no meaningful chmod (Node maps it to the read-only
+ * bit), and userData there is already ACL'd to the user profile, so we report
+ * success without touching the file rather than flipping it read-only and
+ * breaking the next write.
+ *
+ * Never throws: a chmod can legitimately fail (read-only mount, file owned by
+ * another user), and failing to tighten a file is not a reason to lose the
+ * user's configured gateway.
+ */
+function tightenSecretFileMode(filePath, options: SecretFileOptions = {}) {
+  const fsImpl = options.fs || fs
+  const platform = options.platform || process.platform
+
+  if (platform === 'win32') {
+    return true
+  }
+
+  try {
+    const stat = fsImpl.lstatSync(filePath)
+
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      return false
+    }
+
+    if (typeof process.getuid === 'function' && stat.uid !== process.getuid()) {
+      return false
+    }
+
+    if ((stat.mode & 0o777) === SECRET_FILE_MODE) {
+      return true
+    }
+
+    fsImpl.chmodSync(filePath, SECRET_FILE_MODE)
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Atomically write a credential file, owner-only wherever the OS expresses
+ * permissions as mode bits.
+ *
+ * On POSIX the file is owner-only from the moment it exists. On Windows this
+ * only gets the atomic rename: `tightenSecretFileMode` no-ops there (Node maps
+ * chmod to the read-only bit), so the file inherits the userData directory's
+ * ACL rather than an explicit owner-only one. Tightening Windows ACLs is being
+ * handled once, for the Python `_secure_file`, in PR #77527 — the desktop
+ * should follow that rather than start a second ACL story here.
+ *
+ * The temp-then-rename dance is what makes the mode subtle: `renameSync` keeps
+ * the TEMP file's permissions, so writing the temp at the default umask (0644)
+ * hands those bits to the target — and a crashed earlier write can leave a
+ * stale temp file whose existing loose bits `mode:` will not correct. Hence the
+ * unlink of any stale temp (which also drops a planted symlink, so the write
+ * cannot be redirected), the create-time `mode`, and the chmod before the
+ * rename.
+ */
+function writeSecretFileAtomic(targetPath, data, options: SecretFileOptions = {}) {
+  const fsImpl = options.fs || fs
+  const tmp = targetPath + '.tmp'
+
+  fsImpl.rmSync(tmp, { force: true })
+  fsImpl.writeFileSync(tmp, data, { encoding: options.encoding, mode: SECRET_FILE_MODE })
+  tightenSecretFileMode(tmp, options)
+  fsImpl.renameSync(tmp, targetPath)
+}
+
 function resolveTimeoutMs(timeoutMs, fallbackMs = DEFAULT_FETCH_TIMEOUT_MS) {
   const fallback =
     Number.isFinite(fallbackMs) && Number(fallbackMs) > 0 ? Math.round(Number(fallbackMs)) : DEFAULT_FETCH_TIMEOUT_MS
@@ -72,7 +185,7 @@ function encryptDesktopSecret(value, safeStorageApi) {
 
   try {
     return {
-      encoding: 'safeStorage',
+      encoding: SAFE_STORAGE_ENCODING,
       value: safeStorageApi.encryptString(raw).toString('base64')
     }
   } catch (error) {
@@ -361,6 +474,10 @@ export {
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
+  SAFE_STORAGE_ENCODING,
+  SECRET_FILE_MODE,
   sensitiveFileBlockReason,
-  TEXT_PREVIEW_SOURCE_MAX_BYTES
+  TEXT_PREVIEW_SOURCE_MAX_BYTES,
+  tightenSecretFileMode,
+  writeSecretFileAtomic
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -132,7 +132,10 @@ import {
   resolveReadableFileForIpc,
   resolveRequestedPathForIpc,
   resolveTimeoutMs,
-  TEXT_PREVIEW_SOURCE_MAX_BYTES
+  SAFE_STORAGE_ENCODING,
+  TEXT_PREVIEW_SOURCE_MAX_BYTES,
+  tightenSecretFileMode,
+  writeSecretFileAtomic
 } from './hardening'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { ensureMainWindow } from './main-window-lifecycle'
@@ -6785,7 +6788,7 @@ function decryptDesktopSecret(secret) {
     return ''
   }
 
-  if (secret.encoding === 'safeStorage') {
+  if (secret.encoding === SAFE_STORAGE_ENCODING) {
     try {
       return safeStorage.decryptString(Buffer.from(value, 'base64'))
     } catch {
@@ -6793,6 +6796,10 @@ function decryptDesktopSecret(secret) {
     }
   }
 
+  // Any other encoding (a hand-edited config, or one written by a pre-release
+  // build) is returned verbatim on purpose: this fallback is what lets such a
+  // config connect at all. Not a plaintext-writing path — nothing in this file
+  // persists a token this way.
   return value
 }
 
@@ -6898,6 +6905,22 @@ function readDesktopConnectionConfig() {
     const raw = fs.readFileSync(DESKTOP_CONNECTION_CONFIG_PATH, 'utf8')
     const parsed = JSON.parse(raw)
 
+    // Tighten an install written before this file was owner-only. Every write
+    // now goes out at 0600, but a file already on disk keeps its old 0644 bits
+    // until something chmods it, and waiting for the user's next Settings save
+    // would leave it group/other-readable indefinitely. Runs on a cache miss
+    // only (once per launch, plus after an external edit); chmod moves ctime,
+    // not mtime, so it cannot invalidate the cache it sits inside.
+    tightenSecretFileMode(DESKTOP_CONNECTION_CONFIG_PATH)
+
+    // NOT done here: migrating a legacy non-safeStorage token payload to
+    // ciphertext at rest. Deferred deliberately — it has to honor the opt-in
+    // plaintext choice PR #62319 adds (re-encrypting it converts a portable
+    // credential into a keychain-bound one and can lose the token), write
+    // through sanitizeConnectionProfiles below rather than persisting raw
+    // `parsed`, and tell the user to ROTATE, since every existing backup copy
+    // still holds the old secret. Do not add it without those three.
+
     if (parsed && typeof parsed === 'object') {
       const remote = parsed.remote && typeof parsed.remote === 'object' ? parsed.remote : {}
       // authMode lives on the remote sub-object: 'oauth' (cookie + ws-ticket)
@@ -6925,7 +6948,14 @@ function readDesktopConnectionConfig() {
 
 function writeDesktopConnectionConfig(config) {
   fs.mkdirSync(path.dirname(DESKTOP_CONNECTION_CONFIG_PATH), { recursive: true })
-  writeFileAtomic(DESKTOP_CONNECTION_CONFIG_PATH, JSON.stringify(config, null, 2))
+  // Owner-only, not writeFileAtomic: this is the single choke point for every
+  // connection.json write (the IPC save/apply handlers and
+  // persistSshConnectionToken all land here), and the file carries the
+  // safeStorage-encrypted gateway token plus its URL and SSH host/user/keyPath.
+  // safeStorage keeps the token opaque; 0600 keeps the whole record — and the
+  // fields that are NOT encrypted — off other local accounts, matching
+  // native-oauth-tokens.json and desktop-installation.json.
+  writeSecretFileAtomic(DESKTOP_CONNECTION_CONFIG_PATH, JSON.stringify(config, null, 2))
   connectionConfigCache = config
   connectionConfigCacheMtime = fs.statSync(DESKTOP_CONNECTION_CONFIG_PATH).mtimeMs
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6903,15 +6903,23 @@ function readDesktopConnectionConfig() {
 
   try {
     const raw = fs.readFileSync(DESKTOP_CONNECTION_CONFIG_PATH, 'utf8')
-    const parsed = JSON.parse(raw)
-
     // Tighten an install written before this file was owner-only. Every write
     // now goes out at 0600, but a file already on disk keeps its old 0644 bits
     // until something chmods it, and waiting for the user's next Settings save
     // would leave it group/other-readable indefinitely. Runs on a cache miss
     // only (once per launch, plus after an external edit); chmod moves ctime,
     // not mtime, so it cannot invalidate the cache it sits inside.
+    //
+    // Deliberately BEFORE JSON.parse, not after: a truncated or hand-mangled
+    // connection.json still contains the token bytes, and parse throws into the
+    // catch below, which swallows the error and falls back to local mode. With
+    // the tighten after the parse, exactly the file that is both corrupt AND
+    // world-readable would be the one file never tightened — and nothing would
+    // ever retry it, because the fallback config is not written back. The chmod
+    // needs only the path, so it has no reason to wait for valid JSON.
     tightenSecretFileMode(DESKTOP_CONNECTION_CONFIG_PATH)
+
+    const parsed = JSON.parse(raw)
 
     // NOT done here: migrating a legacy non-safeStorage token payload to
     // ciphertext at rest. Deferred deliberately — it has to honor the opt-in


### PR DESCRIPTION
## What does this PR do?

`connection.json` under the desktop app's Electron `userData` was written with **no file mode**, so it landed at the `0644` umask default — while its two credential-bearing neighbours in the same directory were already `0600`: `desktop-installation.json` ([desktop-installation.ts:106](https://github.com/NousResearch/hermes-agent/blob/main/apps/desktop/electron/desktop-installation.ts#L106)) and `native-oauth-tokens.json` ([main.ts:6304](https://github.com/NousResearch/hermes-agent/blob/main/apps/desktop/electron/main.ts#L6304)). That file holds the safeStorage-encrypted gateway token **plus fields that are not encrypted**: the gateway URL and the SSH host, user, and key path. This makes the three consistent.

Three mechanisms, all on the single write choke point (`writeDesktopConnectionConfig`, which every IPC save/apply and `persistSshConnectionToken` funnels through):

1. **Owner-only atomic create** — `writeSecretFileAtomic` creates the file `0600` from the moment it exists.
2. **Tighten-on-read** — an install that already has a `0644` file gets chmod'ed once per launch on the read path, so it does not stay group/other-readable until the user's next Settings save. Runs on a cache miss only; chmod moves ctime, not mtime, so it cannot invalidate the cache it sits inside.

   Sequenced **before** `JSON.parse`, not after. A truncated or hand-mangled `connection.json` still contains the token bytes, and the parse throws into the `catch` that falls back to local mode — a fallback that is never written back, so nothing would ever come back for that file. With the chmod after the parse, exactly the file that is both corrupt **and** world-readable would be the one file never tightened, permanently. The chmod needs only the path, so it has no reason to wait for valid JSON.

3. **Refuse to act on a symlink or a path not owned by the current user** — matching the guards `desktop-installation.ts` already applies to its sibling ([desktop-installation.ts:19-30](https://github.com/NousResearch/hermes-agent/blob/main/apps/desktop/electron/desktop-installation.ts#L19-L30)).

### The symlink finding (why the guard alone was not enough)

`writeSecretFileAtomic` tightens its **temp** path, so a symlink planted at `connection.json.tmp` meant `writeFileSync` followed it, the lstat guard correctly bailed, and `renameSync` then moved the **link** onto `connection.json` permanently. Measured:

```
guards only            token leaked: true    config is a symlink: true   755
guards + temp unlink   token leaked: false   config is a symlink: false  600
```

Hence the temp path is unlinked before the write.

### At-rest migration is deliberately NOT included

An earlier revision of this branch implemented migration of legacy non-safeStorage payloads to ciphertext. It was **removed after review reproduced two token-loss paths**:

- It force-converts the opt-in plaintext choice that open PR #62319 (*"fix(desktop): allow remote gateway token storage on keyring-less Linux"*) deliberately adds — silently reverting the user's decision, then destroying the token on the next launch without the `--password-store=basic` flag that PR adds. It also makes that PR's *"Token stored in plain text"* banner lie.
- It converts a portable credential into a keychain-bound one with no consent, destroying the only recoverable copy — while **not** remediating the real exposure, since every existing backup/sync copy still holds the plaintext. The true remedy is **rotation**.
- It persisted raw `parsed`, bypassing `sanitizeConnectionProfiles` (reproduced: profile names violating `PROFILE_NAME_RE`, bogus `authMode`, and arbitrary junk re-persisted by the app's own hand).

A comment at the read path records the three preconditions any future attempt needs. `decryptDesktopSecret`'s non-safeStorage read fallback is untouched — it is what lets a pre-release or hand-edited config work at all.

### Windows

Mode bits are advisory there, so `connection.json` still inherits the userData directory ACL. `tightenSecretFileMode` no-ops on `win32` rather than flipping Node's read-only bit and breaking the next write. Deferred to open PR #77527 (*"fix(security): enforce owner-only ACLs on Windows in `_secure_file`"*) rather than growing a second ACL implementation here.

## Related Issue

Context: #77486 — **not** `Fixes`, because that issue bundles three claims and this addresses one, with a corrected premise.

**Correcting the premise.** The issue's headline claim is that a dashboard session token is persisted in plaintext. That does not hold against `main`. The token has been safeStorage-encrypted since the desktop app reached mainline in `51c68d4ab`, and `encryptDesktopSecret` aborts with an actionable message rather than degrading to plaintext when safeStorage is unavailable. Verified:

| Check | Result |
|---|---|
| `git merge-base --is-ancestor d3d177283 upstream/main` | **not** an ancestor (exit 1) |
| `git merge-base --is-ancestor d208f2c2c upstream/main` | **not** an ancestor (exit 1) |
| `git merge-base --is-ancestor 51c68d4ab upstream/main` | **is** an ancestor (exit 0) |
| `git log -S 'Fall through to plaintext' upstream/main -- apps/desktop` | empty (0 commits) |

To be precise, because the loose version of this claim is false: the `{ encoding: 'plain', value }` literal **does** exist on `main` at `main.ts:7084`, but only on the `persistToken: false` branch. Its sole caller is `testDesktopConnectionConfig` (`main.ts:7750`, reached only via `ipcMain.handle('hermes:connection-config:test')` at `main.ts:9839`), and that function body contains no write call of any kind. So the accurate statement is **no mainline path *writes* a plaintext token** — not that the literal is absent.

The other two parts of #77486 are handled by sibling PRs, both open: **#77579** (*"fix(security): create browser-profile and media-cache artifacts owner-only"*) and **#77584** (*"fix(desktop): bound in-flight turn journal retention and purge it on delete"*). That second one **inverts** the issue's proposed remedy: the issue asks for *journal redaction*, and #77584 instead bounds retention and purges on delete — redacting the turn tail would defeat the journal's purpose, since it exists to restore an interrupted turn and a redacted entry cannot do that.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `apps/desktop/electron/hardening.ts` — new `tightenSecretFileMode` and `writeSecretFileAtomic` helpers, `SECRET_FILE_MODE = 0o600`, and `SAFE_STORAGE_ENCODING` extracted so the writer here and the reader in `main.ts` cannot drift across the file boundary.
- `apps/desktop/electron/main.ts` — `writeDesktopConnectionConfig` routes through `writeSecretFileAtomic`; `readDesktopConnectionConfig` calls `tightenSecretFileMode` on a cache miss; `decryptDesktopSecret` uses the shared encoding constant and gains a comment stating the non-safeStorage fallback is a read path, not a write path.
- `apps/desktop/electron/hardening.test.ts` — 15 → 27 tests.
- `apps/desktop/e2e/at-rest-connection-token.spec.ts` — new, implementation-independent at-rest contract: encryption, usability after restart, **and** owner-only mode on all three paths that can produce the file (fresh write, pre-existing `0644`, corrupt `0644`).

`native-oauth-tokens.json` was deliberately **not** routed through the new helper: its introducing commit already wrote `{ mode: 0o600 }`, so unlike `connection.json` there is no loose-mode population in the field, and changing it would mix concerns.

## How to Test

1. From `apps/desktop`: `npx vitest run --project electron electron/hardening.test.ts` → **27 passed**.
2. `npx vitest run --project electron` → **947 passed | 2 skipped**. Measured baseline on the parent commit (`b45d88690`, current `upstream/main`) in a separate worktree: **935 passed | 2 skipped**. So this is **+12 tests, no coverage loss**; `hardening.test.ts` alone goes 15 → 27.
3. `npm run build && npx playwright test e2e/at-rest-connection-token.spec.ts --reporter=list` → **3 passed, 1 skipped** (the skip is a deliberate `test.fixme` for the migration case, naming its three blockers).
4. Manual: with an existing `0644` `connection.json`, launch the app and `stat` the file — it becomes `600` on first read, and the configured gateway still connects.

The vitest count is unchanged by the mode coverage below — the three new tests are Playwright, not vitest. `main.ts` cannot be unit-tested (it imports `electron`; `grep -rln "from './main'"` returns zero hits repo-wide), which is why the wiring is covered end to end instead.

The e2e spec asserts the contract implementation-independently: the token's plaintext value **and** its base64 form must not appear in a raw-bytes scan of any file under `userData` or `HERMES_HOME`, **and** the app must still put the exact original token on the wire after a restart — so a "fix" that simply drops the token cannot pass. Proven non-vacuous by mutation: writing `{ encoding: 'plain', value }` still fails the scan while the file-exists and gateway-URL guards pass.

### Mutation testing (each mechanism reverted individually)

Two of the five new tests exist because reverting either owner-only mechanism **alone initially scored zero failures** — they were masking each other, so either could have been deleted green. That was a real anti-pattern, caught and fixed:

| Reverted mechanism | Failures | Test that catches it |
|---|---|---|
| create-time `mode` | 1 | owner-only even where chmod does nothing |
| chmod-before-rename | 1 | owner-only even when a stale temp cannot be removed |
| stale-temp unlink | 1 | cannot be redirected through a symlink planted at the temp path |
| tighten-on-read chmod | 5 | the `tightenSecretFileMode` group |
| lstat guards → bare `statSync` | 3 | symlink / ownership / Windows guards |

All five were restored byte-identically afterwards (`hardening.ts` sha256 `603a7f4d…`, `main.ts` `16f075ed…`) and the suite is green again.

### The wiring is now covered end to end

The mutation table above covers the **helpers**. It did not cover the **wiring**, and that turned out to matter: with both call sites and both imports in `main.ts` reverted — `writeDesktopConnectionConfig` back to plain `writeFileAtomic`, no tighten-on-read — the entire suite stayed green (**947 passed / 2 skipped**, `tsc` exit 0, eslint clean, e2e 1 passed 1 skipped) while `connection.json` went back to `0644`. Bundle proof: `writeSecretFileAtomic(` and `tightenSecretFileMode(` both dropped to **0 occurrences** in `dist/electron-main.mjs`. So the user-visible fix in this PR's title was, until now, untested.

The e2e spec could not have caught it by construction. It asserted the **encryption** contract with a raw-bytes scan, and safeStorage keeps the token opaque regardless of the file's mode, so a `0644` file passes that scan every time. There was no mode assertion anywhere in `e2e/`.

The spec now asserts a third contract — *unreadable by other local accounts* — on all three paths that can produce the file:

| Test | Path covered | Fixture |
|---|---|---|
| a newly configured token … still works after restart | the write choke point | the app's own save |
| an install whose `connection.json` predates owner-only mode is tightened on read | tighten-on-read, valid file | the app's own encrypted file, chmod'ed back to `0644` |
| a corrupt `connection.json` is tightened even though it never parses | tighten-on-read, parse fails | truncated JSON at `0644` still holding token bytes |

Each is mutation-proven, individually:

| Mutation | e2e failures | Which tests |
|---|---|---|
| revert **all** `main.ts` wiring (both call sites + both imports) | 3 | all three, each reporting `mode 644` |
| revert **only** `writeDesktopConnectionConfig` → `writeFileAtomic` | 1 | write test only; both read tests correctly stay green |
| delete **only** the tighten-on-read call | 2 | both read tests only; write test correctly stays green |
| move the tighten **below** `JSON.parse` | 1 | corrupt test only — the only test that can distinguish the ordering |
| make the tighten a **rewrite** instead of a chmod | 2 | both `mtime` assertions |

`main.ts` was restored byte-identically after each (sha256 `0431244d…`), and the rebuilt bundle returned to sha256 `96ed89fc…` with `writeSecretFileAtomic(` back at 2 and `tightenSecretFileMode(` back at 3 occurrences. Every mutation was verified present in `dist/electron-main.mjs` **before** its run, since a stale `dist/` would silently produce a false green.

Two design notes on the new assertions:

- Asserted as `mode & 0o077 === 0`, not `=== 0o600`. The requirement is that nobody else can reach the file; pinning exact bits would be a change-detector against a future `0400` or a setgid-directory umask.
- The mode assertion is skipped on `win32` (mode bits are advisory there and `tightenSecretFileMode` no-ops by design — see the Windows section), so it cannot go red on a Windows runner for behaviour this PR never claimed. The encryption half stays unconditional.

The two read tests also pin the invariant the tighten-on-read placement depends on: the tighten must be a **chmod, not a rewrite**, because it sits inside the function whose cache keys on `mtimeMs`. Measured directly on macOS: mode `644 → 600`, `mtimeMs` unchanged, `ctimeMs` moved.

**Follow-up, not done here:** `readDesktopConnectionConfig` / `writeDesktopConnectionConfig` both hardcode the module-level `DESKTOP_CONNECTION_CONFIG_PATH`, which is why no unit test can reach them. Making the path injectable — as `desktop-installation.ts` already does, precisely so [desktop-installation.test.ts:41](https://github.com/NousResearch/hermes-agent/blob/main/apps/desktop/electron/desktop-installation.test.ts#L41) can assert the mode of the file its orchestrating function wrote — is the durable fix and would make this unit-testable without Electron. It is a refactor of a ~12k-line file's call sites, so it does not belong in a bug fix; the e2e assertions above cover the same behaviour today, and with better fidelity (they witness the real `app.getPath('userData')` file, not an injected temp path).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(desktop):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (4 files, one logical change)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run, and not applicable**: this change is TypeScript-only under `apps/desktop/` and touches no Python. I ran the JS/TS equivalents instead (vitest electron project, `tsc` on `tsconfig.electron.json` and `tsconfig.e2e.json`, eslint, Playwright) — all listed above. I did not run the full `scripts/run_tests.sh` Python suite.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (arm64), Node 22

Lint/typecheck, run in this branch's worktree: `npx eslint electron/` → clean (exit 0). `npx eslint e2e/at-rest-connection-token.spec.ts` → clean (exit 0). `npx tsc -p tsconfig.electron.json --noEmit` and `npx tsc -p tsconfig.e2e.json --noEmit` → both clean. To be clear, `npx eslint e2e/` as a whole is **not** clean — it exits 1 with 244 pre-existing problems (103 errors, 141 warnings) unrelated to this change; I linted only my own file.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing surface, no new config keys; the reasoning lives in code comments at both the write and read paths)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — POSIX gets owner-only mode; Windows no-ops by design (see Windows section) and is deferred to #77527
- [x] I've updated tool descriptions/schemas — N/A

## Relationship to prior art

Searched `gh search prs/issues` for `connection.json` (19 PRs / 12 issues), `safeStorage` (11 PRs / 5 issues), and `desktop userData mode` (0 results). Two open PRs touch `hardening.ts`:

- **#62319** — orthogonal now the migration is gone: it changes *encryption policy* (`encryptDesktopSecret`, a new `resolvePersistedRemoteToken` seam, an opt-in plaintext path), this changes *file modes* at the write/read choke point. It does not touch `writeDesktopConnectionConfig`, `writeFileAtomic`, or either new helper (verified by grep over its diff). Both PRs do append to the same `export {}` block, so I tested that specific hazard with `git merge-file` against the common base: **exit 0, zero conflict markers**, and all six symbols coexist in the merged output. No textual conflict.
- **#41236** (*"feat(desktop): auto-detect Linux keychain backend for secure token storage"*) — touches `bootstrap-platform.ts` and `main.ts`, not `hardening.ts` or this choke point.

### On #74897 (the apparent counter-signal)

**#74897** moved `write_file` new files from 0600 to umask-derived 0644, which superficially points the other way. It does not generalize here, and its own body says why: `_atomic_write`'s chmod branch only ran when the target already existed (`if [ -e "$t" ]`), so new files silently kept `mktemp`'s 0600 — *"invisible in single-user setups, but breaks any cross-process/cross-user reader (Obsidian LiveSync, Docker volumes, NAS mounts)."* That 0600 was an **accident of a skipped branch, not a policy**, and #74897 restored umask-derived permissions for a path the **user** names, under a documented interop contract. `connection.json` is an app-private credential file inside Electron's `userData` that the user never names and no second process is expected to read, and its two immediate neighbours are already 0600. Different contract, opposite default.

