### PR TITLE
fix(mcp): fill missing items on array schema nodes (#77617)

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -352,6 +352,61 @@ class TestSchemaConversion:
         }
         assert schema["required"] == ["command"]
 
+    def test_array_nodes_missing_items_are_filled(self):
+        """Gemini rejects array parameters whose schema lacks an ``items`` key.
+
+        Regression: MCP servers can emit ``type: array`` parameters without an
+        ``items`` subschema (e.g. hound-mcp's ``mcp_smart_fetch`` ``actions``
+        param). Gemini via OpenRouter then fails every request with HTTP 400
+        ``INVALID_ARGUMENT: parameters.properties[actions].items: missing
+        field``. The normalizer must fill a generic placeholder so the schema
+        stays valid on OpenAI, Anthropic, Gemini, and Moonshot in one pass.
+        """
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "actions": {
+                    "type": "array",
+                    "description": "Actions to perform",
+                },
+                "nested": {
+                    "type": "object",
+                    "properties": {
+                        "tags": {"type": "array"},
+                    },
+                },
+            },
+            "required": ["actions"],
+        })
+
+        assert schema["properties"]["actions"]["items"] == {"type": "string"}
+        assert schema["properties"]["nested"]["properties"]["tags"]["items"] == {
+            "type": "string"
+        }
+
+    def test_array_nodes_with_items_are_unchanged(self):
+        """Schemas that already declare ``items`` must not be rewritten."""
+        from tools.mcp_tool import _normalize_mcp_input_schema
+
+        schema = _normalize_mcp_input_schema({
+            "type": "object",
+            "properties": {
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "counts": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                },
+            },
+        })
+
+        assert schema["properties"]["tags"]["items"] == {"type": "string"}
+        assert schema["properties"]["counts"]["items"] == {"type": "integer"}
+
     def test_hyphens_sanitized_to_underscores(self):
         """Hyphens in tool/server names are replaced with underscores for LLM compat."""
         from tools.mcp_tool import _convert_mcp_schema

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5372,6 +5372,10 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
     * ``required`` arrays are pruned to only names that exist in
       ``properties``; otherwise Google AI Studio / Gemini 400s with
       ``property is not defined``.  See PR #4651.
+    * An ``array`` node without an ``items`` subschema gets a generic
+      placeholder (``{"type": "string"}``); Gemini rejects array parameters
+      lacking ``items`` with HTTP 400 ``INVALID_ARGUMENT ... items: missing
+      field``.  See PR #77617.
     * MCP/Pydantic optional fields commonly arrive as
       ``anyOf: [{...}, {"type": "null"}], default: null``.  Anthropic rejects
       nullable branches in tool input schemas, so nullable unions are collapsed
@@ -5444,7 +5448,12 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
         return strip_nullable_unions(node, keep_nullable_hint=True)
 
     def _repair_object_shape(node):
-        """Recursively repair object-shaped nodes: fill type, prune required."""
+        """Recursively repair object/array-shaped nodes: fill type, prune required.
+
+        Also fills a generic ``items`` placeholder on ``array`` nodes that
+        lack one, since Gemini rejects array parameters without an ``items``
+        subschema (HTTP 400 ``INVALID_ARGUMENT ... items: missing field``).
+        """
         if isinstance(node, list):
             return [_repair_object_shape(item) for item in node]
         if not isinstance(node, dict):
@@ -5458,6 +5467,13 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
             "properties" in repaired or "required" in repaired
         ):
             repaired["type"] = "object"
+
+        if repaired.get("type") == "array" and (
+            "items" not in repaired or repaired.get("items") is None
+        ):
+            # Generic placeholder: keeps the schema valid on OpenAI, Anthropic,
+            # Gemini, and Moonshot in one pass. See PR #77617.
+            repaired["items"] = {"type": "string"}
 
         if repaired.get("type") == "object":
             # Ensure properties exists so required can reference it safely


### PR DESCRIPTION
## Summary

MCP servers sometimes emit `type: array` parameters without an `items` subschema (e.g. hound-mcp's `mcp_smart_fetch` `actions` param). Requests carrying such raw schemas to Gemini via OpenRouter fail on every attempt with:

```
HTTP 400 INVALID_ARGUMENT: parameters.properties[actions].items: missing field
```

`_normalize_mcp_input_schema` already documents that its repairs produce a schema "valid on OpenAI, Anthropic, Gemini, and Moonshot in one pass", but it never filled in missing `items` on array nodes. `sanitize_gemini_schema` does not fill it either, and it only runs on the native Gemini adapter — `chat-completions` requests load raw MCP schemas.

## Root Cause

`_repair_object_shape` in `tools/mcp_tool.py` coerces object shapes and prunes `required`, but array nodes lacking `items` passed through untouched, leaving schemas that Gemini rejects.

## Change

In `_normalize_mcp_input_schema` (`tools/mcp_tool.py`), extend the recursive `_repair_object_shape` walker so any `array` node missing an `items` subschema (or with a `null` one) gets a generic valid placeholder, `{"type": "string"}`. This is provider-agnostic, matches the existing cross-provider repair style, and leaves arrays that already declare `items` completely untouched.

## Verification

- Added regression tests in `tests/tools/test_mcp_tool.py`:
  - `test_array_nodes_missing_items_are_filled` — top-level and nested arrays without `items` get `{"type": "string"}` filled in.
  - `test_array_nodes_with_items_are_unchanged` — schemas that already declare `items` are not rewritten.
- `python3 -m pytest tests/tools/test_mcp_tool.py tests/agent/test_moonshot_schema.py -p no:xdist -q` → 129 passed.

Closes #77617
