### PR TITLE
fix(transport): replay api content sidecars

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -17,6 +17,7 @@ from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
+from agent.turn_context import substitute_api_content
 
 
 def _static_prompt_instructions(messages: list[dict[str, Any]]) -> str:
@@ -239,6 +240,9 @@ class ChatCompletionsTransport(ProviderTransport):
           ``Extra inputs are not permitted, field: 'messages[N].tool_name'``.
           Permissive providers (OpenRouter, MiniMax) silently ignore the
           field, which masked the bug for months.
+        - ``api_content`` — substitute this persist-what-you-send sidecar into
+          user/assistant content before removing the internal field, preserving
+          the exact historical bytes at this final API boundary.
         - Hermes-internal scaffolding markers — any top-level message key
           starting with ``_`` (e.g. ``_empty_recovery_synthetic``,
           ``_empty_terminal_sentinel``, ``_thinking_prefill``). These are
@@ -314,7 +318,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 out_msg.pop("tool_name", None)
                 out_msg.pop("effect_disposition", None)
                 out_msg.pop("timestamp", None)  # #47868 — leak into strict providers
-                out_msg.pop("api_content", None)  # persist-what-you-send sidecar
+                substitute_api_content(out_msg)
 
 
             # Drop all Hermes-internal scaffolding markers (``_``-prefixed).

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -84,6 +84,38 @@ class TestChatCompletionsBasic:
         msgs = [{"role": "user", "content": "hi"}]
         assert transport.convert_messages(msgs) is msgs
 
+    @pytest.mark.parametrize("role", ["user", "assistant"])
+    def test_convert_messages_replays_api_content_sidecar(self, transport, role):
+        msgs = [
+            {
+                "role": role,
+                "content": "clean transcript content",
+                "api_content": "exact bytes previously sent",
+            }
+        ]
+
+        result = transport.convert_messages(msgs)
+
+        assert result[0]["content"] == "exact bytes previously sent"
+        assert "api_content" not in result[0]
+        assert result[0] is not msgs[0]
+        assert msgs[0]["content"] == "clean transcript content"
+        assert msgs[0]["api_content"] == "exact bytes previously sent"
+
+    def test_convert_messages_does_not_substitute_tool_api_content(self, transport):
+        msgs = [
+            {
+                "role": "tool",
+                "content": "tool result",
+                "api_content": "invalid sidecar",
+            }
+        ]
+
+        result = transport.convert_messages(msgs)
+
+        assert result[0]["content"] == "tool result"
+        assert "api_content" not in result[0]
+
     def test_convert_messages_strips_internal_scaffolding_markers(self, transport):
         """Hermes-internal ``_``-prefixed markers must never reach the wire.
 


### PR DESCRIPTION
## What does this PR do?

Makes `ChatCompletionsTransport.convert_messages()` honor the `api_content` persist-what-you-send contract at the final OpenAI-compatible API boundary.

`api_content` stores the exact bytes previously sent when the clean transcript differs from the wire representation. The shared `substitute_api_content()` helper and its docstring require every API-bound message builder to restore that value before removing the internal field. The main conversation loop and max-iterations summary already do this, but the chat-completions transport only popped the sidecar, so any direct transport/build-kwargs caller silently fell back to clean content and could break byte-stable historical replay.

This was found during a default-branch test/contract audit. It relates to the replay invariant discussed in #77320, but does not close that issue: the main-loop historical replay described there is already present on current `main`.

## Related Issue

No standalone issue. Refs #77320 for the same `api_content` replay invariant.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/transports/chat_completions.py`
  - Call the shared `substitute_api_content()` helper during copy-on-write sanitization.
  - Restore sidecars only for user/assistant roles, then remove the internal field before the request leaves Hermes.
- `tests/agent/transports/test_chat_completions.py`
  - Cover user and assistant replay.
  - Assert tool messages do not accept an invalid sidecar.
  - Assert the original message objects remain unchanged.

The change preserves the transport's no-copy fast path for clean histories and does not alter prompt-cache-key capability handling added on current `main`.

## How to Test

1. Pass a user or assistant message with clean `content` and a different `api_content` value to `ChatCompletionsTransport.convert_messages()`.
2. Confirm the returned wire message uses `api_content` as `content`, omits the sidecar field, and leaves the input object untouched.
3. Run:

```text
python -m pytest \
  tests/agent/transports/test_chat_completions.py \
  tests/agent/test_api_content_sidecar.py -q
# 74 passed

python -m pytest \
  tests/agent/test_model_metadata.py \
  tests/agent/test_compressed_summary_metadata.py \
  tests/run_agent/test_session_meta_filtering.py -q
# 78 passed

python -m ruff check \
  agent/transports/chat_completions.py \
  tests/agent/transports/test_chat_completions.py
# passed

python -m py_compile \
  agent/transports/chat_completions.py \
  tests/agent/transports/test_chat_completions.py
# passed
```

The new user/assistant tests were also run before the production change: both failed with clean transcript content on the wire, then passed after the helper was connected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs by issue text, `api_content`, `substitute_api_content`, and changed files
- [x] My PR contains **only** changes related to this fix
- [x] The relevant Python test suites pass
- [x] I've added regression tests for the changed behavior
- [x] I've tested on my platform: macOS, Apple Silicon, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the transport contract docstring is updated; no user-facing docs are affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure Python message conversion with no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A; this is a request-construction invariant with automated regression coverage.
