### PR TITLE
perf(state): LIMIT-based existence checks instead of COUNT(*) (salvage #56768)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2279,7 +2279,7 @@ class SessionStore:
         """
         if self._db:
             try:
-                return self._db.session_count() > 1
+                return self._db.session_count_ge(2)
             except Exception:
                 pass  # fall through to heuristic
         # Fallback: check if sessions.json was loaded with existing data.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7334,14 +7334,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return cursor.fetchone()[0]
 
     def session_count_ge(self, n: int = 1) -> bool:
-        """Check if at least N sessions exist.
+        """Check if at least N sessions exist (archived included).
 
-        Short-circuits via LIMIT — much cheaper than COUNT(*) when
-        you only need an existence check.  Use this instead of
-        ``session_count() >= n`` when the exact count is irrelevant.
+        Short-circuits via LIMIT — much cheaper than ``session_count()``,
+        which pays a full index scan for its default ``archived = 0``
+        filter (measured 543us vs 4us on a 20k-session DB). Archived
+        sessions count: every caller so far asks "has this install ever
+        had sessions", and an archived session is still a created one.
+        Use this instead of ``session_count() >= n`` when the exact count
+        is irrelevant.
         """
-        cursor = self._conn.execute("SELECT 1 FROM sessions LIMIT ?", (n,))
-        rows = cursor.fetchall()
+        with self._lock:
+            cursor = self._conn.execute("SELECT 1 FROM sessions LIMIT ?", (n,))
+            rows = cursor.fetchall()
         return len(rows) >= n
 
     def session_count_by_source(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7333,6 +7333,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             cursor = self._conn.execute(f"SELECT COUNT(*) FROM sessions s{where_sql}", params)
             return cursor.fetchone()[0]
 
+    def session_count_ge(self, n: int = 1) -> bool:
+        """Check if at least N sessions exist.
+
+        Short-circuits via LIMIT — much cheaper than COUNT(*) when
+        you only need an existence check.  Use this instead of
+        ``session_count() >= n`` when the exact count is irrelevant.
+        """
+        cursor = self._conn.execute("SELECT 1 FROM sessions LIMIT ?", (n,))
+        rows = cursor.fetchall()
+        return len(rows) >= n
+
     def session_count_by_source(
         self,
         *,
@@ -7558,9 +7569,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         def _do(conn):
             cursor = conn.execute(
-                "SELECT COUNT(*) FROM sessions WHERE id = ?", (session_id,)
+                "SELECT 1 FROM sessions WHERE id = ? LIMIT 1", (session_id,)
             )
-            if cursor.fetchone()[0] == 0:
+            if cursor.fetchone() is None:
                 return False
             if expected_ids is not None:
                 actual_ids = {

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1163,15 +1163,39 @@ class TestHasAnySessions:
         return s
 
     def test_uses_database_count_when_available(self, store_with_mock_db):
-        """has_any_sessions should use database session_count, not len(_entries)."""
+        """has_any_sessions should use database session_count_ge, not len(_entries)."""
         store = store_with_mock_db
         # Simulate single-platform user with only 1 entry in memory
         store._entries = {"telegram:12345": MagicMock()}
         # But database has 3 sessions (current + 2 previous resets)
-        store._db.session_count.return_value = 3
+        store._db.session_count_ge.return_value = True
 
         assert store.has_any_sessions() is True
-        store._db.session_count.assert_called_once()
+        store._db.session_count_ge.assert_called_once_with(2)
+
+    def test_first_session_ever_returns_false(self, store_with_mock_db):
+        """First session ever should return False (only current session in DB)."""
+        store = store_with_mock_db
+        store._entries = {"telegram:12345": MagicMock()}
+        # Database has exactly 1 session (the current one just created)
+        store._db.session_count_ge.return_value = False
+
+        assert store.has_any_sessions() is False
+
+    def test_fallback_without_database(self, tmp_path):
+        """Should fall back to len(_entries) when DB is not available."""
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._loaded = True
+        store._db = None
+        store._entries = {"key1": MagicMock(), "key2": MagicMock()}
+
+        # > 1 entries means has sessions
+        assert store.has_any_sessions() is True
+
+        store._entries = {"key1": MagicMock()}
+        assert store.has_any_sessions() is False
 
 
 class TestLastPromptTokens:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -816,6 +816,22 @@ class TestCounts:
 
 
 
+    def test_session_count_ge_empty(self, db):
+        """session_count_ge should return False for 0 sessions."""
+        assert db.session_count_ge(1) is False
+        assert db.session_count_ge(2) is False
+
+    def test_session_count_ge_at_threshold(self, db):
+        """session_count_ge should True when count >= n."""
+        db.create_session("s1", "cli")
+        assert db.session_count_ge(1) is True
+        assert db.session_count_ge(2) is False
+
+        db.create_session("s2", "telegram")
+        assert db.session_count_ge(1) is True
+        assert db.session_count_ge(2) is True
+        assert db.session_count_ge(3) is False
+
     def test_message_count_total(self, db):
         assert db.message_count() == 0
         db.create_session(session_id="s1", source="cli")


### PR DESCRIPTION
## Context

`SessionStore.has_any_sessions()` (gateway) answers "has this install ever created a session" — it gates first-run behavior. Today it calls `session_count() > 1`, which runs `SELECT COUNT(*) FROM sessions WHERE archived = 0`: a full index scan that counts every session ever, on every check, and silently gives the WRONG answer for a user whose old sessions are all archived (an archived session is still a created one). WHO benefits: every gateway install with a real session history — the check is paid where a two-row peek suffices.

## Measured impact

EXPLAIN/opcode + wall time on a 20k-session synthetic DB (median of 5 x 2000 reps):

| query | VM steps | wall |
|---|---|---|
| `COUNT(*) ... archived=0` (before) | 40,012 | 542.5 us |
| `SELECT 1 LIMIT 2` (after) | 15 | 4.3 us |

~126x fewer cycles per check. Honest caveat: this call is not per-turn hot — the win per invocation is microseconds; the semantic fix (archived sessions count toward "has ever had sessions") is the part users can actually observe.

The PR also converts the session-exists probe in `delete_session` from `COUNT(*) WHERE id=?` to `SELECT 1 ... LIMIT 1` (15 -> 14 VM steps; matches three pre-existing sibling sites).

## Provenance

Salvage of #56768 by @Skywind5487 (authorship preserved on the base commit). Follow-up commit folds two review findings: `session_count_ge` now takes `self._lock` like every sibling counter, and the deliberate archived-semantics divergence from `session_count()` is documented in the docstring.

## Verification

- 65 passed (tests/gateway/test_session.py + tests/test_hermes_state.py::TestCounts, `-p no:randomly`).
- Simplify pass (REUSE/QUALITY/EFFICIENCY): no material findings; all 13 remaining `session_count()` callers verified to need real counts (none missed by the bug-class sweep).
- ruff clean.

Closes #56768.
