### PR TITLE
perf(insights): partial index for assistant tool-call scans + read-only fallback (salvage #67350)

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -99,6 +99,29 @@ class InsightsEngine:
         """
         self.db = db
         self._conn = db._conn
+        # INDEXED BY is a hard dependency (SQLite errors on a missing index).
+        # A read-only open of a state.db written by an older version skips
+        # schema init and lacks the partial index — probe once and fall back
+        # to the unpinned variants (identical rows, optimizer-chosen plan).
+        try:
+            self._has_assistant_calls_index = bool(
+                self._conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?",
+                    (self._MESSAGES_ASSISTANT_CALLS_INDEX,),
+                ).fetchone()
+            )
+        except sqlite3.Error:
+            self._has_assistant_calls_index = False
+        if not self._has_assistant_calls_index:
+            _strip = f" INDEXED BY {self._MESSAGES_ASSISTANT_CALLS_INDEX}"
+            self._GET_TOOL_CALLS_WITH_SOURCE = (
+                self._GET_TOOL_CALLS_WITH_SOURCE.replace(_strip, "")
+            )
+            self._GET_TOOL_CALLS_ALL = self._GET_TOOL_CALLS_ALL.replace(_strip, "")
+            self._GET_SKILL_CALLS_WITH_SOURCE = (
+                self._GET_SKILL_CALLS_WITH_SOURCE.replace(_strip, "")
+            )
+            self._GET_SKILL_CALLS_ALL = self._GET_SKILL_CALLS_ALL.replace(_strip, "")
 
     def generate(self, days: int = 30, source: str = None) -> Dict[str, Any]:
         """
@@ -200,11 +223,14 @@ class InsightsEngine:
     # is deterministic on a freshly initialized state.db (before ANALYZE has
     # run) for BOTH the unfiltered and source-filtered branches — without the
     # hint the optimizer falls back to ``idx_messages_session_active`` for the
-    # source-filtered probe and scans each session's non-tool-call rows.  Safe
-    # because the index is declared in ``SCHEMA_SQL`` (created by every
-    # read-write ``SessionDB._init_schema``); every ``InsightsEngine`` caller
-    # opens a read-write ``SessionDB`` — read-only attachments (which skip
-    # schema init) are never used for insights.
+    # source-filtered probe and scans each session's non-tool-call rows.
+    #
+    # The pin is a HARD dependency: SQLite raises ``no such index`` when the
+    # named index is absent. That happens in practice — the web dashboard's
+    # usage analytics open the DB ``read_only=True`` (skipping
+    # ``_init_schema``), so a state.db created by an older writer has no
+    # partial index yet. ``__init__`` probes for the index once and falls
+    # back to the unpinned (still-correct, just optimizer-chosen) variants.
     _MESSAGES_ASSISTANT_CALLS_INDEX = "idx_messages_assistant_calls_by_session"
     _GET_TOOL_CALLS_WITH_SOURCE = (
         "SELECT m.tool_calls"

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -114,14 +114,16 @@ class InsightsEngine:
             self._has_assistant_calls_index = False
         if not self._has_assistant_calls_index:
             _strip = f" INDEXED BY {self._MESSAGES_ASSISTANT_CALLS_INDEX}"
-            self._GET_TOOL_CALLS_WITH_SOURCE = (
-                self._GET_TOOL_CALLS_WITH_SOURCE.replace(_strip, "")
-            )
-            self._GET_TOOL_CALLS_ALL = self._GET_TOOL_CALLS_ALL.replace(_strip, "")
-            self._GET_SKILL_CALLS_WITH_SOURCE = (
-                self._GET_SKILL_CALLS_WITH_SOURCE.replace(_strip, "")
-            )
-            self._GET_SKILL_CALLS_ALL = self._GET_SKILL_CALLS_ALL.replace(_strip, "")
+            # Loop over every pinned statement so adding a new one can't
+            # forget its strip line (which would be a hard `no such index`
+            # crash on read-only DBs — the exact bug this fallback prevents).
+            for _attr in (
+                "_GET_TOOL_CALLS_WITH_SOURCE",
+                "_GET_TOOL_CALLS_ALL",
+                "_GET_SKILL_CALLS_WITH_SOURCE",
+                "_GET_SKILL_CALLS_ALL",
+            ):
+                setattr(self, _attr, getattr(self, _attr).replace(_strip, ""))
 
     def generate(self, days: int = 30, source: str = None) -> Dict[str, Any]:
         """

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -195,6 +195,46 @@ class InsightsEngine:
         " ORDER BY started_at DESC"
     )
 
+    # Assistant ``tool_calls`` scan for tool/skill usage.  ``INDEXED BY`` pins
+    # the partial index ``idx_messages_assistant_calls_by_session`` so the plan
+    # is deterministic on a freshly initialized state.db (before ANALYZE has
+    # run) for BOTH the unfiltered and source-filtered branches — without the
+    # hint the optimizer falls back to ``idx_messages_session_active`` for the
+    # source-filtered probe and scans each session's non-tool-call rows.  Safe
+    # because the index is declared in ``SCHEMA_SQL`` (created by every
+    # read-write ``SessionDB._init_schema``); every ``InsightsEngine`` caller
+    # opens a read-write ``SessionDB`` — read-only attachments (which skip
+    # schema init) are never used for insights.
+    _MESSAGES_ASSISTANT_CALLS_INDEX = "idx_messages_assistant_calls_by_session"
+    _GET_TOOL_CALLS_WITH_SOURCE = (
+        "SELECT m.tool_calls"
+        f" FROM messages m INDEXED BY {_MESSAGES_ASSISTANT_CALLS_INDEX}"
+        " JOIN sessions s ON s.id = m.session_id"
+        " WHERE s.started_at >= ? AND s.source = ?"
+        " AND m.role = 'assistant' AND m.tool_calls IS NOT NULL"
+    )
+    _GET_TOOL_CALLS_ALL = (
+        "SELECT m.tool_calls"
+        f" FROM messages m INDEXED BY {_MESSAGES_ASSISTANT_CALLS_INDEX}"
+        " JOIN sessions s ON s.id = m.session_id"
+        " WHERE s.started_at >= ?"
+        " AND m.role = 'assistant' AND m.tool_calls IS NOT NULL"
+    )
+    _GET_SKILL_CALLS_WITH_SOURCE = (
+        "SELECT m.tool_calls, m.timestamp"
+        f" FROM messages m INDEXED BY {_MESSAGES_ASSISTANT_CALLS_INDEX}"
+        " JOIN sessions s ON s.id = m.session_id"
+        " WHERE s.started_at >= ? AND s.source = ?"
+        " AND m.role = 'assistant' AND m.tool_calls IS NOT NULL"
+    )
+    _GET_SKILL_CALLS_ALL = (
+        "SELECT m.tool_calls, m.timestamp"
+        f" FROM messages m INDEXED BY {_MESSAGES_ASSISTANT_CALLS_INDEX}"
+        " JOIN sessions s ON s.id = m.session_id"
+        " WHERE s.started_at >= ?"
+        " AND m.role = 'assistant' AND m.tool_calls IS NOT NULL"
+    )
+
     def _get_sessions(self, cutoff: float, source: str = None) -> List[Dict]:
         """Fetch sessions within the time window."""
         if source:
@@ -243,22 +283,10 @@ class InsightsEngine:
         # (covers CLI sessions where tool_name is NULL on tool responses)
         if source:
             cursor2 = self._conn.execute(
-                """SELECT m.tool_calls
-                   FROM messages m
-                   JOIN sessions s ON s.id = m.session_id
-                   WHERE s.started_at >= ? AND s.source = ?
-                     AND m.role = 'assistant' AND m.tool_calls IS NOT NULL""",
-                (cutoff, source),
+                self._GET_TOOL_CALLS_WITH_SOURCE, (cutoff, source)
             )
         else:
-            cursor2 = self._conn.execute(
-                """SELECT m.tool_calls
-                   FROM messages m
-                   JOIN sessions s ON s.id = m.session_id
-                   WHERE s.started_at >= ?
-                     AND m.role = 'assistant' AND m.tool_calls IS NOT NULL""",
-                (cutoff,),
-            )
+            cursor2 = self._conn.execute(self._GET_TOOL_CALLS_ALL, (cutoff,))
 
         tool_calls_counts = Counter()
         for row in cursor2.fetchall():
@@ -301,22 +329,10 @@ class InsightsEngine:
 
         if source:
             cursor = self._conn.execute(
-                """SELECT m.tool_calls, m.timestamp
-                   FROM messages m
-                   JOIN sessions s ON s.id = m.session_id
-                   WHERE s.started_at >= ? AND s.source = ?
-                     AND m.role = 'assistant' AND m.tool_calls IS NOT NULL""",
-                (cutoff, source),
+                self._GET_SKILL_CALLS_WITH_SOURCE, (cutoff, source)
             )
         else:
-            cursor = self._conn.execute(
-                """SELECT m.tool_calls, m.timestamp
-                   FROM messages m
-                   JOIN sessions s ON s.id = m.session_id
-                   WHERE s.started_at >= ?
-                     AND m.role = 'assistant' AND m.tool_calls IS NOT NULL""",
-                (cutoff,),
-            )
+            cursor = self._conn.execute(self._GET_SKILL_CALLS_ALL, (cutoff,))
 
         for row in cursor.fetchall():
             try:

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -337,6 +337,14 @@ CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
 CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id, id);
+-- Partial index for the Insights assistant tool-call scan
+-- (agent/insights.py _get_tool_usage / _get_skill_usage): those queries filter
+-- messages by role='assistant' AND tool_calls IS NOT NULL, a small fraction of
+-- rows on a large state.db. role and tool_calls are base columns, so this can
+-- live in SCHEMA_SQL rather than DEFERRED_INDEX_SQL.
+CREATE INDEX IF NOT EXISTS idx_messages_assistant_calls_by_session
+    ON messages(session_id)
+    WHERE role = 'assistant' AND tool_calls IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usage(session_id);
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -1,5 +1,6 @@
 """Tests for agent/insights.py — InsightsEngine analytics and reporting."""
 
+import sqlite3
 import time
 import pytest
 
@@ -368,30 +369,99 @@ class TestInsightsPopulated:
 
 
 
-    def test_tool_and_skill_usage_invariant_to_partial_index(self, populated_db):
-        """The assistant tool-call partial index is a pure optimization: tool
-        and skill usage must be byte-for-byte identical with and without it."""
-        engine = InsightsEngine(populated_db)
-        cutoff = 0.0
-        index = "idx_messages_assistant_calls_by_session"
+    # The Insights assistant tool-call queries pin
+    # idx_messages_assistant_calls_by_session via INDEXED BY.  These tests prove
+    # (a) the planner uses that index for BOTH the unfiltered and source-filtered
+    # branches on a fresh DB *without* ANALYZE, and (b) the index is a pure
+    # optimization — output is identical whether or not it is selected.
+    _INDEX = "idx_messages_assistant_calls_by_session"
+    _PINNED_QUERIES = (
+        ("_GET_TOOL_CALLS_ALL", (0.0,)),
+        ("_GET_TOOL_CALLS_WITH_SOURCE", (0.0, "cli")),
+        ("_GET_SKILL_CALLS_ALL", (0.0,)),
+        ("_GET_SKILL_CALLS_WITH_SOURCE", (0.0, "cli")),
+    )
 
-        with_index_tools = engine._get_tool_usage(cutoff)
-        with_index_skills = engine._get_skill_usage(cutoff)
-        # The index must exist by default (it lives in SCHEMA_SQL).
+    def test_assistant_call_queries_use_partial_index_without_analyze(
+        self, populated_db
+    ):
+        """Every fixed-predicate branch selects the partial index on a fresh DB.
+
+        No ANALYZE is run, so this covers the default-statistics case a freshly
+        initialized state.db is actually in. Both the unfiltered and the
+        source-filtered (``s.source = ?``) branches are checked.
+        """
+        # Guard against the fresh-DB planner regression the reviewers found:
+        # without INDEXED BY the source-filtered branch fell back to
+        # idx_messages_session_active.
+        assert "ANALYZE" not in "".join(
+            r["sql"] or ""
+            for r in populated_db._conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type = 'index'"
+            )
+        )
+        for attr, params in self._PINNED_QUERIES:
+            sql = getattr(InsightsEngine, attr)
+            plan = "\n".join(
+                row["detail"]
+                for row in populated_db._conn.execute(
+                    "EXPLAIN QUERY PLAN " + sql, params
+                ).fetchall()
+            )
+            assert self._INDEX in plan, f"{attr} did not use the index:\n{plan}"
+
+    def test_assistant_call_rows_invariant_to_index_selection(self, populated_db):
+        """The pinned index only changes the plan, never the result set.
+
+        For every branch, the index-pinned query and the un-pinned form (whose
+        plan the optimizer chooses freely) must return identical rows — proving
+        the index is a pure optimization — for both the unfiltered and
+        source-filtered scopes.
+        """
         assert populated_db._conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
-            (index,),
+            (self._INDEX,),
         ).fetchone() is not None
 
-        populated_db._conn.execute(f"DROP INDEX IF EXISTS {index}")
-        populated_db._conn.commit()
-        without_index_tools = engine._get_tool_usage(cutoff)
-        without_index_skills = engine._get_skill_usage(cutoff)
+        for attr, params in self._PINNED_QUERIES:
+            pinned_sql = getattr(InsightsEngine, attr)
+            unpinned_sql = pinned_sql.replace(f" INDEXED BY {self._INDEX}", "")
+            pinned = [
+                tuple(r) for r in
+                populated_db._conn.execute(pinned_sql, params).fetchall()
+            ]
+            unpinned = [
+                tuple(r) for r in
+                populated_db._conn.execute(unpinned_sql, params).fetchall()
+            ]
+            assert sorted(pinned) == sorted(unpinned), attr
 
-        assert with_index_tools == without_index_tools
-        assert with_index_skills == without_index_skills
-        # Sanity: the fixture actually exercises the assistant tool_calls path.
-        assert any(t["tool_name"] == "search_files" for t in with_index_tools)
+    def test_tool_and_skill_usage_invariant_to_partial_index(self, populated_db):
+        """The public tool/skill usage output is stable and exercises the
+        assistant tool_calls path for both scopes."""
+        engine = InsightsEngine(populated_db)
+        cutoff = 0.0
+
+        tools = engine._get_tool_usage(cutoff)
+        tools_cli = engine._get_tool_usage(cutoff, source="cli")
+        skills = engine._get_skill_usage(cutoff)
+        skills_cli = engine._get_skill_usage(cutoff, source="cli")
+
+        # Sanity: the fixture actually drives the assistant tool_calls path.
+        assert any(t["tool_name"] == "search_files" for t in tools)
+        assert any(t["tool_name"] == "search_files" for t in tools_cli)
+        assert isinstance(skills, list) and isinstance(skills_cli, list)
+
+    def test_indexed_by_requires_the_index_to_exist(self, populated_db):
+        """INDEXED BY is a hard dependency: if the index were ever missing the
+        query fails loudly rather than silently degrading. This documents why
+        every InsightsEngine caller must open a read-write SessionDB."""
+        populated_db._conn.execute(f"DROP INDEX IF EXISTS {self._INDEX}")
+        populated_db._conn.commit()
+        with pytest.raises(sqlite3.OperationalError, match="no such index"):
+            populated_db._conn.execute(
+                InsightsEngine._GET_TOOL_CALLS_ALL, (0.0,)
+            ).fetchall()
 
 
 # =========================================================================

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -452,16 +452,26 @@ class TestInsightsPopulated:
         assert any(t["tool_name"] == "search_files" for t in tools_cli)
         assert isinstance(skills, list) and isinstance(skills_cli, list)
 
-    def test_indexed_by_requires_the_index_to_exist(self, populated_db):
-        """INDEXED BY is a hard dependency: if the index were ever missing the
-        query fails loudly rather than silently degrading. This documents why
-        every InsightsEngine caller must open a read-write SessionDB."""
+    def test_missing_index_falls_back_to_unpinned_queries(self, populated_db):
+        """INDEXED BY would be a hard error if the index is missing — which
+        happens on read-only opens of a state.db written by an older version
+        (web dashboard analytics). The engine must probe and fall back to the
+        unpinned variants instead of crashing, returning identical rows."""
+        engine_pinned = InsightsEngine(populated_db)
+        tools_before = engine_pinned._get_tool_usage(0.0)
+
         populated_db._conn.execute(f"DROP INDEX IF EXISTS {self._INDEX}")
         populated_db._conn.commit()
-        with pytest.raises(sqlite3.OperationalError, match="no such index"):
-            populated_db._conn.execute(
-                InsightsEngine._GET_TOOL_CALLS_ALL, (0.0,)
-            ).fetchall()
+
+        engine = InsightsEngine(populated_db)
+        assert engine._has_assistant_calls_index is False
+        assert "INDEXED BY" not in engine._GET_TOOL_CALLS_ALL
+        tools_after = engine._get_tool_usage(0.0)
+        assert sorted(t["tool_name"] for t in tools_after) == sorted(
+            t["tool_name"] for t in tools_before
+        )
+        # And with the index present, the pin stays.
+        assert "INDEXED BY" in InsightsEngine._GET_TOOL_CALLS_ALL
 
 
 # =========================================================================

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -368,6 +368,31 @@ class TestInsightsPopulated:
 
 
 
+    def test_tool_and_skill_usage_invariant_to_partial_index(self, populated_db):
+        """The assistant tool-call partial index is a pure optimization: tool
+        and skill usage must be byte-for-byte identical with and without it."""
+        engine = InsightsEngine(populated_db)
+        cutoff = 0.0
+        index = "idx_messages_assistant_calls_by_session"
+
+        with_index_tools = engine._get_tool_usage(cutoff)
+        with_index_skills = engine._get_skill_usage(cutoff)
+        # The index must exist by default (it lives in SCHEMA_SQL).
+        assert populated_db._conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?",
+            (index,),
+        ).fetchone() is not None
+
+        populated_db._conn.execute(f"DROP INDEX IF EXISTS {index}")
+        populated_db._conn.commit()
+        without_index_tools = engine._get_tool_usage(cutoff)
+        without_index_skills = engine._get_skill_usage(cutoff)
+
+        assert with_index_tools == without_index_tools
+        assert with_index_skills == without_index_skills
+        # Sanity: the fixture actually exercises the assistant tool_calls path.
+        assert any(t["tool_name"] == "search_files" for t in with_index_tools)
+
 
 # =========================================================================
 # Formatting

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3641,3 +3641,79 @@ class TestApplyDatabasePragmas:
             assert conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0] == before
         finally:
             conn.close()
+class TestInsightsToolCallIndex:
+    """The Insights assistant tool-call scan has a predicate-aligned index.
+
+    ``InsightsEngine._get_tool_usage`` / ``_get_skill_usage`` filter messages by
+    ``role = 'assistant' AND tool_calls IS NOT NULL``.  A partial index over that
+    predicate keeps the scan off the full ``messages`` table on a large state.db.
+    """
+
+    _INDEX = "idx_messages_assistant_calls_by_session"
+
+    def _index_defn(self, conn):
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?",
+            (self._INDEX,),
+        ).fetchone()
+        return row["sql"] if row else None
+
+    def test_index_created_on_fresh_db(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "fresh.db")
+        try:
+            sql = self._index_defn(db._conn)
+            assert sql is not None, "partial index missing on a fresh database"
+            # Partial predicate must match the queried rows exactly.
+            assert "role = 'assistant'" in sql
+            assert "tool_calls IS NOT NULL" in sql
+        finally:
+            db.close()
+
+    def test_index_created_on_existing_db(self, tmp_path):
+        """Reopening a DB that predates the index must create it (SCHEMA_SQL is
+        re-run on every open; role/tool_calls are original base columns)."""
+        db_path = tmp_path / "legacy.db"
+        db = SessionDB(db_path=db_path)
+        # Simulate a database created before the index shipped.
+        db._conn.execute(f"DROP INDEX IF EXISTS {self._INDEX}")
+        db._conn.commit()
+        assert self._index_defn(db._conn) is None
+        db.close()
+
+        db2 = SessionDB(db_path=db_path)
+        try:
+            assert self._index_defn(db2._conn) is not None, (
+                "index not recreated when reopening an existing database"
+            )
+        finally:
+            db2.close()
+
+    def test_index_serves_assistant_tool_call_scan(self, db):
+        """The planner uses the partial index for the exact Insights predicate.
+
+        Seed enough rows that the optimizer prefers the partial index over a
+        full table scan, then assert the plan names it.
+        """
+        db.create_session(session_id="s1", source="cli")
+        for i in range(200):
+            if i % 5 == 0:
+                db.append_message(
+                    "s1", role="assistant", content=f"m{i}",
+                    tool_calls=[{"function": {"name": "search_files"}}],
+                )
+            else:
+                db.append_message("s1", role="user", content=f"m{i}")
+        db._conn.execute("ANALYZE")
+        db._conn.commit()
+
+        plan = "\n".join(
+            row["detail"]
+            for row in db._conn.execute(
+                "EXPLAIN QUERY PLAN "
+                "SELECT m.tool_calls FROM messages m "
+                "JOIN sessions s ON s.id = m.session_id "
+                "WHERE s.started_at >= 0 "
+                "AND m.role = 'assistant' AND m.tool_calls IS NOT NULL"
+            ).fetchall()
+        )
+        assert self._INDEX in plan, plan

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3688,32 +3688,15 @@ class TestInsightsToolCallIndex:
         finally:
             db2.close()
 
-    def test_index_serves_assistant_tool_call_scan(self, db):
-        """The planner uses the partial index for the exact Insights predicate.
+    def test_index_predicate_is_partial(self, db):
+        """The index covers only the assistant tool-call rows Insights reads.
 
-        Seed enough rows that the optimizer prefers the partial index over a
-        full table scan, then assert the plan names it.
+        Query-plan coverage (that the Insights queries actually select this
+        index, for both scopes, without ANALYZE) lives with the queries in
+        tests/agent/test_insights.py.
         """
-        db.create_session(session_id="s1", source="cli")
-        for i in range(200):
-            if i % 5 == 0:
-                db.append_message(
-                    "s1", role="assistant", content=f"m{i}",
-                    tool_calls=[{"function": {"name": "search_files"}}],
-                )
-            else:
-                db.append_message("s1", role="user", content=f"m{i}")
-        db._conn.execute("ANALYZE")
-        db._conn.commit()
-
-        plan = "\n".join(
-            row["detail"]
-            for row in db._conn.execute(
-                "EXPLAIN QUERY PLAN "
-                "SELECT m.tool_calls FROM messages m "
-                "JOIN sessions s ON s.id = m.session_id "
-                "WHERE s.started_at >= 0 "
-                "AND m.role = 'assistant' AND m.tool_calls IS NOT NULL"
-            ).fetchall()
-        )
-        assert self._INDEX in plan, plan
+        sql = self._index_defn(db._conn)
+        assert sql is not None
+        assert "WHERE" in sql
+        assert "role = 'assistant'" in sql
+        assert "tool_calls IS NOT NULL" in sql


### PR DESCRIPTION
## Context

`hermes insights` (CLI), the gateway `/insights` command, and the web dashboard's usage analytics all scan `messages` for assistant rows carrying `tool_calls` — on a big state.db that's a full-table scan of mostly-irrelevant rows, twice per report (tool usage + skill usage). WHO benefits: anyone running insights/analytics on a mature install (hundreds of thousands of message rows).

## Measured impact

Synthetic DB, 5k sessions / 200k messages / 10% assistant-with-tool-calls, `_get_tool_usage`-shaped queries, median of 5:

| state | source-filtered | unfiltered |
|---|---|---|
| no index (before) | 35.2-66.2 ms, `SCAN m` | 36.0-69.7 ms, `SCAN m` |
| partial index, pre-ANALYZE | 13.8 ms | 22.8 ms |
| partial index, post-ANALYZE | 5.6 ms | 16.0 ms |

2.4x immediately, up to ~11x once ANALYZE has run. The `INDEXED BY` pin makes the plan deterministic pre-ANALYZE (without it the source-filtered branch falls back to `idx_messages_session_active` and re-scans non-tool-call rows per session).

## Provenance

Salvage of #67350 by @PRATHAMESH75 (both commits authorship-preserved). Follow-up commits fold a review finding and a simplify finding:

- CRITICAL fold: `INDEXED BY` is a hard dependency — SQLite raises `no such index` when it's absent, and that happens in production: the web dashboard's usage analytics open state.db `read_only=True` (skipping `_init_schema`), so a DB last written by a pre-index version crashes every insights call. Reproduced E2E; fixed with a one-time `sqlite_master` probe in `__init__` that strips the pins when the index is missing (identical rows, optimizer-chosen plan). The original change-detector test that froze the crash as intended behavior is replaced with a fallback-equivalence test.
- Simplify fold: the four pin-strip statements became an attribute loop so a future fifth pinned query can't forget its strip line (which would resurrect the crash).

Index placement follows the schema rules: partial index on base columns only, so it lives in `SCHEMA_SQL` (not `DEFERRED_INDEX_SQL`); read-only opens simply don't have it and fall back.

## Verification

- 31 passed (tests/agent/test_insights.py, `-p no:randomly`), including plan-pinning invariance tests and the read-only fallback equivalence test.
- E2E repro: main-created DB opened read-only by this branch — `generate()` succeeds (crashed with OperationalError before the fold).
- Simplify pass: 1 medium finding folded (attribute loop); REUSE/EFFICIENCY clean (probe is a µs-scale point lookup; all four `InsightsEngine` construction sites traced — human-rate bounded, never per-turn).

Closes #67350.
