### PR TITLE
perf(state): narrow FTS UPDATE triggers with AFTER UPDATE OF (salvage #73639)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1489,7 +1489,8 @@ BEGIN
     VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
 END;
 
-CREATE TRIGGER IF NOT EXISTS messages_fts_cjk_update AFTER UPDATE ON messages
+CREATE TRIGGER IF NOT EXISTS messages_fts_cjk_update
+AFTER UPDATE OF content, tool_name, tool_calls, role ON messages
 WHEN (old.content IS NOT new.content
     OR old.tool_name IS NOT new.tool_name
     OR old.tool_calls IS NOT new.tool_calls

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -419,7 +419,11 @@ BEGIN
     VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
 END;
 
-CREATE TRIGGER IF NOT EXISTS messages_fts_update AFTER UPDATE ON messages
+-- UPDATE OF skips the trigger entirely for non-content column writes
+-- (status/compacted/observed/etc.), which is stronger than the WHEN gate
+-- alone and avoids FTS I/O saturation on large state.db (#68858 / #73639).
+CREATE TRIGGER IF NOT EXISTS messages_fts_update
+AFTER UPDATE OF content, tool_name, tool_calls ON messages
 WHEN (old.content IS NOT new.content
     OR old.tool_name IS NOT new.tool_name
     OR old.tool_calls IS NOT new.tool_calls)
@@ -487,7 +491,8 @@ BEGIN
     VALUES ('delete', old.id, old.content, old.tool_name, old.tool_calls);
 END;
 
-CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update AFTER UPDATE ON messages
+CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update
+AFTER UPDATE OF content, tool_name, tool_calls, role ON messages
 WHEN (old.content IS NOT new.content
     OR old.tool_name IS NOT new.tool_name
     OR old.tool_calls IS NOT new.tool_calls
@@ -548,7 +553,8 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_delete AFTER DELETE ON messages BEGIN
     DELETE FROM messages_fts WHERE rowid = old.id;
 END;
 
-CREATE TRIGGER IF NOT EXISTS messages_fts_update AFTER UPDATE ON messages BEGIN
+CREATE TRIGGER IF NOT EXISTS messages_fts_update
+AFTER UPDATE OF content, tool_name, tool_calls ON messages BEGIN
     DELETE FROM messages_fts WHERE rowid = old.id;
     INSERT INTO messages_fts(rowid, content) VALUES (
         new.id,
@@ -575,7 +581,8 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_delete AFTER DELETE ON message
     DELETE FROM messages_fts_trigram WHERE rowid = old.id;
 END;
 
-CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update AFTER UPDATE ON messages BEGIN
+CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update
+AFTER UPDATE OF content, tool_name, tool_calls ON messages BEGIN
     DELETE FROM messages_fts_trigram WHERE rowid = old.id;
     INSERT INTO messages_fts_trigram(rowid, content) VALUES (
         new.id,

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -85,8 +85,6 @@ class SessionSchemaMixin:
 
         Returns the number of triggers dropped (0 when already converged).
         """
-        import re as _re
-
         # CJK is a v23-only surface.  Decide the layout before selecting
         # destructive candidates so the legacy branch never drops a trigger
         # it does not recreate.
@@ -113,9 +111,8 @@ class SessionSchemaMixin:
             return 0
 
         for name in to_drop:
-            # Trigger names are from our fixed allowlist, not user input.
-            if not _re.fullmatch(r"[A-Za-z0-9_]+", name):
-                continue
+            # Names are drawn from the update_names literal allowlist above —
+            # never user input — so the identifier is interpolation-safe.
             cursor.execute(f"DROP TRIGGER IF EXISTS {name}")
 
         # Re-apply current DDL so CREATE TRIGGER installs the OF variants.

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -16,6 +16,7 @@ from typing import Dict, Optional
 from hermes_constants import get_hermes_home
 from hermes_state_common import (
     DEFERRED_INDEX_SQL,
+    FTS_CJK_STALE_KEY,
     FTS_SQL,
     FTS_STORAGE_VERSION,
     FTS_TRIGRAM_SQL,
@@ -86,14 +87,20 @@ class SessionSchemaMixin:
         """
         import re as _re
 
+        # CJK is a v23-only surface.  Decide the layout before selecting
+        # destructive candidates so the legacy branch never drops a trigger
+        # it does not recreate.
+        legacy_layout = self._db_has_legacy_inline_fts(cursor)
         update_names = (
             "messages_fts_update",
             "messages_fts_trigram_update",
-            "messages_fts_cjk_update",
         )
+        if not legacy_layout and hasattr(self, "_ensure_fts_cjk_schema"):
+            update_names += ("messages_fts_cjk_update",)
+        placeholders = ", ".join("?" for _ in update_names)
         rows = cursor.execute(
             "SELECT name, sql FROM sqlite_master "
-            "WHERE type = 'trigger' AND name IN (?, ?, ?)",
+            f"WHERE type = 'trigger' AND name IN ({placeholders})",
             update_names,
         ).fetchall()
         to_drop = []
@@ -113,7 +120,7 @@ class SessionSchemaMixin:
 
         # Re-apply current DDL so CREATE TRIGGER installs the OF variants.
         # Choose legacy vs v23 the same way _init_schema does.
-        if self._db_has_legacy_inline_fts(cursor):
+        if legacy_layout:
             self._ensure_fts_schema(cursor, "messages_fts", LEGACY_FTS_SQL)
             self._ensure_fts_schema(
                 cursor, "messages_fts_trigram", LEGACY_FTS_TRIGRAM_SQL
@@ -123,15 +130,27 @@ class SessionSchemaMixin:
             self._ensure_fts_schema(
                 cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
             )
-            # CJK triggers live on the host SessionDB; only recreate if present.
-            if hasattr(self, "_ensure_fts_cjk_schema"):
+            # CJK triggers live on the host SessionDB; only recreate one that
+            # this migration actually dropped.  Unexpected ensure failures
+            # must not leave the host advertising a now-triggerless index.
+            if (
+                "messages_fts_cjk_update" in to_drop
+            ):
                 try:
                     self._ensure_fts_cjk_schema(cursor)
                 except Exception:
-                    logger.debug(
-                        "CJK FTS re-ensure after UPDATE OF migration skipped",
-                        exc_info=True,
+                    self._fts_cjk_available = False
+                    try:
+                        self.set_meta(FTS_CJK_STALE_KEY, "1", cursor=cursor)
+                    except Exception:
+                        logger.debug(
+                            "Could not persist CJK FTS stale breadcrumb",
+                            exc_info=True,
+                        )
+                    logger.exception(
+                        "CJK FTS re-ensure after UPDATE OF migration failed"
                     )
+                    raise
 
         logger.info(
             "Migrated %d broad FTS UPDATE trigger(s) to AFTER UPDATE OF "

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -56,6 +56,91 @@ class SessionSchemaMixin:
         ).fetchone()
         return int(row[0] if not isinstance(row, sqlite3.Row) else row[0])
 
+
+    @staticmethod
+    def _fts_update_trigger_needs_narrowing(sql: Optional[str]) -> bool:
+        """True when trigger SQL is missing AFTER UPDATE OF (still broad)."""
+        if not sql:
+            return False
+        # Collapse whitespace so multi-line DDL still matches.
+        compact = " ".join(sql.split()).upper()
+        # Already narrowed.
+        if "AFTER UPDATE OF " in compact:
+            return False
+        # Broad UPDATE trigger that we still need to replace.
+        return "AFTER UPDATE ON " in compact
+
+    def _migrate_broad_fts_update_triggers(self, cursor: sqlite3.Cursor) -> int:
+        """Replace broad AFTER UPDATE FTS triggers with AFTER UPDATE OF variants.
+
+        ``CREATE TRIGGER IF NOT EXISTS`` will not replace an existing broad
+        trigger, so installs that already created ``AFTER UPDATE ON messages``
+        would keep firing on every messages row touch (status/compaction
+        writes included). Inspect ``sqlite_master``, drop any still-broad
+        UPDATE triggers, and re-apply the current DDL constants.
+
+        No FTS rebuild: content correctness was already gated by WHEN clauses
+        on modern installs; OF only skips unnecessary trigger evaluation.
+
+        Returns the number of triggers dropped (0 when already converged).
+        """
+        import re as _re
+
+        update_names = (
+            "messages_fts_update",
+            "messages_fts_trigram_update",
+            "messages_fts_cjk_update",
+        )
+        rows = cursor.execute(
+            "SELECT name, sql FROM sqlite_master "
+            "WHERE type = 'trigger' AND name IN (?, ?, ?)",
+            update_names,
+        ).fetchall()
+        to_drop = []
+        for row in rows:
+            name = row[0] if not isinstance(row, sqlite3.Row) else row["name"]
+            sql = row[1] if not isinstance(row, sqlite3.Row) else row["sql"]
+            if self._fts_update_trigger_needs_narrowing(sql):
+                to_drop.append(name)
+        if not to_drop:
+            return 0
+
+        for name in to_drop:
+            # Trigger names are from our fixed allowlist, not user input.
+            if not _re.fullmatch(r"[A-Za-z0-9_]+", name):
+                continue
+            cursor.execute(f"DROP TRIGGER IF EXISTS {name}")
+
+        # Re-apply current DDL so CREATE TRIGGER installs the OF variants.
+        # Choose legacy vs v23 the same way _init_schema does.
+        if self._db_has_legacy_inline_fts(cursor):
+            self._ensure_fts_schema(cursor, "messages_fts", LEGACY_FTS_SQL)
+            self._ensure_fts_schema(
+                cursor, "messages_fts_trigram", LEGACY_FTS_TRIGRAM_SQL
+            )
+        else:
+            self._ensure_fts_schema(cursor, "messages_fts", FTS_SQL)
+            self._ensure_fts_schema(
+                cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
+            )
+            # CJK triggers live on the host SessionDB; only recreate if present.
+            if hasattr(self, "_ensure_fts_cjk_schema"):
+                try:
+                    self._ensure_fts_cjk_schema(cursor)
+                except Exception:
+                    logger.debug(
+                        "CJK FTS re-ensure after UPDATE OF migration skipped",
+                        exc_info=True,
+                    )
+
+        logger.info(
+            "Migrated %d broad FTS UPDATE trigger(s) to AFTER UPDATE OF "
+            "(no rebuild required)",
+            len(to_drop),
+        )
+        return len(to_drop)
+
+
     @staticmethod
     def _rebuild_fts_indexes(
         cursor: sqlite3.Cursor,
@@ -854,6 +939,11 @@ class SessionSchemaMixin:
                     # CJK-bigram index (cjk_unicode61). Strictly additive to
                     # the surfaces above and gated on the loadable tokenizer:
                     self._ensure_fts_cjk_schema(cursor)
+
+            # Replace any pre-existing broad AFTER UPDATE triggers with
+            # AFTER UPDATE OF variants. IF NOT EXISTS cannot rewrite them.
+            if getattr(self, "_fts_enabled", False):
+                self._migrate_broad_fts_update_triggers(cursor)
 
         self._conn.commit()
 

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -131,26 +131,26 @@ class SessionSchemaMixin:
                 cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
             )
             # CJK triggers live on the host SessionDB; only recreate one that
-            # this migration actually dropped.  Unexpected ensure failures
-            # must not leave the host advertising a now-triggerless index.
-            if (
-                "messages_fts_cjk_update" in to_drop
-            ):
+            # this migration actually dropped. ``_ensure_fts_cjk_schema`` is
+            # documented never-raises and soft-fails OperationalError by
+            # clearing availability — raise-path handling alone is not
+            # enough. After ensure, require a narrowed CJK UPDATE trigger or
+            # durable quarantine (stale breadcrumb + unavailable).
+            if "messages_fts_cjk_update" in to_drop:
                 try:
                     self._ensure_fts_cjk_schema(cursor)
                 except Exception:
-                    self._fts_cjk_available = False
-                    try:
-                        self.set_meta(FTS_CJK_STALE_KEY, "1", cursor=cursor)
-                    except Exception:
-                        logger.debug(
-                            "Could not persist CJK FTS stale breadcrumb",
-                            exc_info=True,
-                        )
+                    self._quarantine_cjk_after_update_of_migration(cursor)
                     logger.exception(
                         "CJK FTS re-ensure after UPDATE OF migration failed"
                     )
                     raise
+                if not self._cjk_update_trigger_is_narrowed(cursor):
+                    self._quarantine_cjk_after_update_of_migration(cursor)
+                    logger.warning(
+                        "CJK FTS UPDATE trigger missing or still broad after "
+                        "UPDATE OF migration; marked stale and unavailable"
+                    )
 
         logger.info(
             "Migrated %d broad FTS UPDATE trigger(s) to AFTER UPDATE OF "
@@ -158,6 +158,43 @@ class SessionSchemaMixin:
             len(to_drop),
         )
         return len(to_drop)
+
+    def _cjk_update_trigger_is_narrowed(self, cursor: sqlite3.Cursor) -> bool:
+        """True when messages_fts_cjk_update exists with AFTER UPDATE OF."""
+        row = cursor.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'trigger' AND name = ?",
+            ("messages_fts_cjk_update",),
+        ).fetchone()
+        if not row:
+            return False
+        sql = row[0] if not isinstance(row, sqlite3.Row) else row["sql"]
+        return not self._fts_update_trigger_needs_narrowing(sql)
+
+    def _quarantine_cjk_after_update_of_migration(
+        self, cursor: sqlite3.Cursor
+    ) -> None:
+        """Fail-closed after dropping CJK UPDATE during OF migration.
+
+        Clears availability, persists ``fts_cjk_stale``, and drops any
+        residual broad/partial CJK UPDATE trigger so a later open cannot
+        ``CREATE TRIGGER IF NOT EXISTS`` a gap without rebuild.
+        """
+        self._fts_cjk_available = False
+        try:
+            self.set_meta(FTS_CJK_STALE_KEY, "1", cursor=cursor)
+        except Exception:
+            logger.debug(
+                "Could not persist CJK FTS stale breadcrumb",
+                exc_info=True,
+            )
+        try:
+            cursor.execute("DROP TRIGGER IF EXISTS messages_fts_cjk_update")
+        except Exception:
+            logger.debug(
+                "Could not drop residual CJK UPDATE trigger after quarantine",
+                exc_info=True,
+            )
 
 
     @staticmethod

--- a/tests/test_fts_update_of_narrowing.py
+++ b/tests/test_fts_update_of_narrowing.py
@@ -1,0 +1,96 @@
+"""FTS UPDATE OF narrowing + migration (#73639 retargeted onto split SessionDB)."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_state_schema import SessionSchemaMixin
+
+
+def _trigger_sql(conn: sqlite3.Connection, name: str) -> str | None:
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='trigger' AND name=?",
+        (name,),
+    ).fetchone()
+    return row[0] if row else None
+
+
+def test_fresh_db_installs_update_of_triggers(tmp_path: Path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        sql = _trigger_sql(db._conn, "messages_fts_update")
+        assert sql is not None
+        compact = " ".join(sql.split()).upper()
+        assert "AFTER UPDATE OF " in compact
+        assert "CONTENT" in compact
+        assert "TOOL_NAME" in compact
+        assert "TOOL_CALLS" in compact
+
+        tri = _trigger_sql(db._conn, "messages_fts_trigram_update")
+        if tri:  # trigram may be unavailable on some builds
+            tcompact = " ".join(tri.split()).upper()
+            assert "AFTER UPDATE OF " in tcompact
+    finally:
+        db.close()
+
+
+def test_migrate_replaces_broad_update_trigger(tmp_path: Path):
+    path = tmp_path / "state.db"
+    db = SessionDB(db_path=path)
+    try:
+        # Force a broad trigger the way older installs had it.
+        db._conn.execute("DROP TRIGGER IF EXISTS messages_fts_update")
+        db._conn.execute(
+            """
+            CREATE TRIGGER messages_fts_update AFTER UPDATE ON messages
+            BEGIN
+                SELECT 1;
+            END
+            """
+        )
+        db._conn.commit()
+        before = _trigger_sql(db._conn, "messages_fts_update")
+        assert "AFTER UPDATE OF" not in " ".join(before.split()).upper()
+
+        dropped = db._migrate_broad_fts_update_triggers(db._conn)
+        db._conn.commit()
+        assert dropped >= 1
+
+        after = _trigger_sql(db._conn, "messages_fts_update")
+        assert after is not None
+        compact = " ".join(after.split()).upper()
+        assert "AFTER UPDATE OF " in compact
+    finally:
+        db.close()
+
+
+def test_needs_narrowing_helper():
+    assert SessionSchemaMixin._fts_update_trigger_needs_narrowing(
+        "CREATE TRIGGER t AFTER UPDATE ON messages BEGIN SELECT 1; END"
+    )
+    assert not SessionSchemaMixin._fts_update_trigger_needs_narrowing(
+        "CREATE TRIGGER t AFTER UPDATE OF content ON messages BEGIN SELECT 1; END"
+    )
+    assert not SessionSchemaMixin._fts_update_trigger_needs_narrowing(None)
+
+
+def test_status_only_update_does_not_require_content_change(tmp_path: Path):
+    """Smoke: DB opens and accepts message updates under narrowed triggers."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        sid = "s1"
+        db.create_session(sid, source="test")
+        mid = db.append_message(sid, role="user", content="hello searchable")
+        db._conn.execute(
+            "UPDATE messages SET content = content WHERE id = ?",
+            (mid,),
+        )
+        db._conn.commit()
+        assert _trigger_sql(db._conn, "messages_fts_update")
+    finally:
+        db.close()

--- a/tests/test_fts_update_of_narrowing.py
+++ b/tests/test_fts_update_of_narrowing.py
@@ -200,6 +200,43 @@ def test_cjk_ensure_failure_marks_unavailable_and_propagates(
         db.close()
 
 
+def test_cjk_soft_fail_ensure_without_raise_marks_stale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Production ensure swallows OperationalError — still must quarantine."""
+    path = tmp_path / "state.db"
+    db = SessionDB(db_path=path)
+    try:
+        db._conn.execute("DROP TRIGGER IF EXISTS messages_fts_cjk_update")
+        db._conn.execute(
+            "CREATE TRIGGER messages_fts_cjk_update "
+            "AFTER UPDATE ON messages BEGIN SELECT 1; END"
+        )
+        db._fts_cjk_available = True
+
+        def _soft_fail_cjk_ensure(_cursor):
+            # Mirrors real _ensure_fts_cjk_schema OperationalError path:
+            # clear availability, do not raise, do not recreate triggers.
+            db._fts_cjk_available = False
+
+        monkeypatch.setattr(db, "_ensure_fts_cjk_schema", _soft_fail_cjk_ensure)
+
+        dropped = db._migrate_broad_fts_update_triggers(db._conn)
+        assert dropped >= 1
+        assert db._fts_cjk_available is False
+        assert _trigger_sql(db._conn, "messages_fts_cjk_update") is None
+
+        with sqlite3.connect(path) as observer:
+            stale = observer.execute(
+                "SELECT value FROM state_meta WHERE key = ?",
+                (FTS_CJK_STALE_KEY,),
+            ).fetchone()
+            assert stale == ("1",)
+            assert _trigger_sql(observer, "messages_fts_cjk_update") is None
+    finally:
+        db.close()
+
+
 def test_cjk_broad_trigger_is_restored_as_update_of(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/test_fts_update_of_narrowing.py
+++ b/tests/test_fts_update_of_narrowing.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from hermes_state import SessionDB
+from hermes_state_common import FTS_CJK_STALE_KEY
 from hermes_state_schema import SessionSchemaMixin
 
 
@@ -18,6 +19,59 @@ def _trigger_sql(conn: sqlite3.Connection, name: str) -> str | None:
         (name,),
     ).fetchone()
     return row[0] if row else None
+
+
+def _assert_nonindexed_updates_bypass_missing_fts_target(
+    db: SessionDB, message_id: int
+) -> None:
+    """Prove the UPDATE OF gate, not the trigger's content-change WHEN."""
+    db._conn.execute("DROP TABLE messages_fts")
+    assert _trigger_sql(db._conn, "messages_fts_update") is not None
+
+    db._conn.execute(
+        "UPDATE messages SET active = 0, compacted = 1, observed = 1 "
+        "WHERE id = ?",
+        (message_id,),
+    )
+    with pytest.raises(sqlite3.OperationalError, match=r"no such table.*messages_fts"):
+        db._conn.execute(
+            "UPDATE messages SET content = 'changed' WHERE id = ?",
+            (message_id,),
+        )
+
+
+def _install_legacy_inline_base_fts(db: SessionDB) -> None:
+    """Replace v23 FTS with the broad inline shape shipped by v11..v22."""
+    db._drop_fts_triggers(db._conn)
+    db._conn.executescript(
+        """
+        DROP TABLE IF EXISTS messages_fts;
+        DROP TABLE IF EXISTS messages_fts_trigram;
+        DROP VIEW IF EXISTS messages_fts_trigram_src;
+
+        CREATE VIRTUAL TABLE messages_fts USING fts5(content);
+        CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN
+            INSERT INTO messages_fts(rowid, content) VALUES (
+                new.id,
+                COALESCE(new.content, '') || ' ' ||
+                COALESCE(new.tool_name, '') || ' ' ||
+                COALESCE(new.tool_calls, '')
+            );
+        END;
+        CREATE TRIGGER messages_fts_delete AFTER DELETE ON messages BEGIN
+            DELETE FROM messages_fts WHERE rowid = old.id;
+        END;
+        CREATE TRIGGER messages_fts_update AFTER UPDATE ON messages BEGIN
+            DELETE FROM messages_fts WHERE rowid = old.id;
+            INSERT INTO messages_fts(rowid, content) VALUES (
+                new.id,
+                COALESCE(new.content, '') || ' ' ||
+                COALESCE(new.tool_name, '') || ' ' ||
+                COALESCE(new.tool_calls, '')
+            );
+        END;
+        """
+    )
 
 
 def test_fresh_db_installs_update_of_triggers(tmp_path: Path):
@@ -79,18 +133,114 @@ def test_needs_narrowing_helper():
     assert not SessionSchemaMixin._fts_update_trigger_needs_narrowing(None)
 
 
-def test_status_only_update_does_not_require_content_change(tmp_path: Path):
-    """Smoke: DB opens and accepts message updates under narrowed triggers."""
+def test_v23_status_only_update_bypasses_fts_trigger_body(tmp_path: Path):
     db = SessionDB(db_path=tmp_path / "state.db")
     try:
         sid = "s1"
         db.create_session(sid, source="test")
         mid = db.append_message(sid, role="user", content="hello searchable")
+        _assert_nonindexed_updates_bypass_missing_fts_target(db, mid)
+    finally:
+        db.close()
+
+
+def test_legacy_status_only_update_bypasses_migrated_fts_trigger(tmp_path: Path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        sid = "s1"
+        db.create_session(sid, source="test")
+        mid = db.append_message(sid, role="user", content="legacy searchable")
+        _install_legacy_inline_base_fts(db)
+
+        assert db._db_has_legacy_inline_fts(db._conn)
+        assert db._migrate_broad_fts_update_triggers(db._conn) >= 1
+        assert "AFTER UPDATE OF" in " ".join(
+            _trigger_sql(db._conn, "messages_fts_update").split()
+        ).upper()
+
+        _assert_nonindexed_updates_bypass_missing_fts_target(db, mid)
+    finally:
+        db.close()
+
+
+def test_cjk_ensure_failure_marks_unavailable_and_propagates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    path = tmp_path / "state.db"
+    db = SessionDB(db_path=path)
+    try:
+        db._conn.execute("DROP TRIGGER IF EXISTS messages_fts_cjk_update")
         db._conn.execute(
-            "UPDATE messages SET content = content WHERE id = ?",
-            (mid,),
+            "CREATE TRIGGER messages_fts_cjk_update "
+            "AFTER UPDATE ON messages BEGIN SELECT 1; END"
         )
-        db._conn.commit()
-        assert _trigger_sql(db._conn, "messages_fts_update")
+        db._fts_cjk_available = True
+
+        def _fail_cjk_ensure(_cursor):
+            raise sqlite3.DatabaseError("injected CJK ensure failure")
+
+        monkeypatch.setattr(db, "_ensure_fts_cjk_schema", _fail_cjk_ensure)
+
+        with pytest.raises(sqlite3.DatabaseError, match="injected CJK ensure failure"):
+            db._migrate_broad_fts_update_triggers(db._conn)
+        assert db._fts_cjk_available is False
+        assert _trigger_sql(db._conn, "messages_fts_cjk_update") is None
+
+        # The DROP is autocommitted.  Fail-closed therefore needs a durable
+        # breadcrumb that other processes can observe, not just an instance
+        # flag on the SessionDB whose initialization is aborting.
+        with sqlite3.connect(path) as observer:
+            stale = observer.execute(
+                "SELECT value FROM state_meta WHERE key = ?",
+                (FTS_CJK_STALE_KEY,),
+            ).fetchone()
+            assert stale == ("1",)
+            assert _trigger_sql(observer, "messages_fts_cjk_update") is None
+    finally:
+        db.close()
+
+
+def test_cjk_broad_trigger_is_restored_as_update_of(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db._conn.execute("DROP TRIGGER IF EXISTS messages_fts_cjk_update")
+        db._conn.execute(
+            "CREATE TRIGGER messages_fts_cjk_update "
+            "AFTER UPDATE ON messages BEGIN SELECT 1; END"
+        )
+
+        def _restore_cjk_update_trigger(cursor):
+            cursor.execute(
+                "CREATE TRIGGER messages_fts_cjk_update "
+                "AFTER UPDATE OF content, tool_name, tool_calls ON messages "
+                "BEGIN SELECT 1; END"
+            )
+
+        monkeypatch.setattr(db, "_ensure_fts_cjk_schema", _restore_cjk_update_trigger)
+
+        assert db._migrate_broad_fts_update_triggers(db._conn) == 1
+        cjk_sql = _trigger_sql(db._conn, "messages_fts_cjk_update")
+        assert cjk_sql is not None
+        assert "AFTER UPDATE OF" in " ".join(cjk_sql.split()).upper()
+    finally:
+        db.close()
+
+
+def test_legacy_migration_does_not_drop_cjk_trigger(tmp_path: Path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        _install_legacy_inline_base_fts(db)
+        db._conn.execute("DROP TRIGGER IF EXISTS messages_fts_cjk_update")
+        db._conn.execute(
+            "CREATE TRIGGER messages_fts_cjk_update "
+            "AFTER UPDATE ON messages BEGIN SELECT 1; END"
+        )
+
+        assert db._migrate_broad_fts_update_triggers(db._conn) >= 1
+        cjk_sql = _trigger_sql(db._conn, "messages_fts_cjk_update")
+        assert cjk_sql is not None
+        assert "AFTER UPDATE OF" not in " ".join(cjk_sql.split()).upper()
     finally:
         db.close()


### PR DESCRIPTION
## Context

Every `UPDATE messages SET ...` fires the FTS sync triggers today, because they are broad `AFTER UPDATE ON messages`. Status-only writes — marking rows inactive/compacted/observed during compaction, recovery, and housekeeping — pay trigger WHEN-clause evaluation for every row touched even though no indexed column changed, which on large state.dbs saturates I/O (#68858). WHO benefits: anyone with a large session DB, during compaction/optimize passes and bulk status updates.

## Measured impact

10,000 status-only UPDATEs on a synthetic FTS-enabled DB (sqlite trace-counted):

| metric | before (broad) | after (OF) | delta |
|---|---|---|---|
| trigger WHEN evaluations | 10,000 | 0 | eliminated |
| wall time | 20.9 ms | 8.6 ms | 59% faster |
| content-update reindex | works | works (WHEN-evals=1, fts row updated) | unchanged |

Honest caveat: the win applies to status-only UPDATE statements; content/tool_name/tool_calls updates still (correctly) fire the triggers. Every `UPDATE messages SET` site on main was enumerated — none can change indexed columns without listing them in SET, so `AFTER UPDATE OF` is semantically safe.

## Provenance

Salvage of #73639 by @smfworks (3 commits, authorship preserved, incl. the co-contributed fail-closed CJK migration handling). Migration audited: `_migrate_broad_fts_update_triggers` is idempotent (second open drops 0), costs two µs-scale sqlite_master point reads per writer open in steady state, and the legacy-layout branch recreates everything it drops. The CJK quarantine path uses the existing in-transaction `set_meta(..., cursor=)` variant — no nested-transaction hazard. Simplify-pass fold: removed an unreachable regex allowlist guard whose `continue` would have miscounted a skipped trigger (names come from a literal allowlist via IN binding).

## Verification

- 9 passed (tests/test_fts_update_of_narrowing.py) + 21 passed (FTS suite in tests/test_hermes_state.py), `-p no:randomly`.
- Mutation check: reverting the three production files turns all 9 new tests RED; restore -> green.
- OF-column audit: role is included in the OF lists where the WHEN clause inspects it (trigram/cjk `role <> 'tool'`).
- Simplify pass: 1 low finding folded (dead guard); REUSE verified (`_drop_fts_triggers` is a false consolidation target — it drops insert/delete triggers too).

Closes #73639.
