### PR TITLE
perf(state): config-gated SQLite PRAGMA tuning for large DBs (salvage #71755)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -855,16 +855,23 @@ def apply_database_pragmas(
     *,
     db_label: str = "state.db",
 ) -> None:
-    """Apply optional WAL-sizing PRAGMAs from ``config.yaml``.
+    """Apply optional performance and WAL-sizing PRAGMAs from ``config.yaml``.
 
-    Reads the ``database:`` section and applies ``wal_autocheckpoint``
-    and ``journal_size_limit`` when set to integer values.  The journal
-    mode itself is NOT handled here — ``database.journal_mode`` is owned
-    by :func:`resolve_journal_mode` inside :func:`apply_wal_with_fallback`,
-    which layers the operator setting under all the safety guards
-    (never live-downgrading an on-disk WAL DB, filesystem fallback,
-    WAL-reset-bug gating).  Keeping a single owner prevents a second,
-    unguarded journal-mode switch path.
+    Reads the ``database:`` section and applies configurable PRAGMAs when set
+    to integer values.  The journal mode itself is NOT handled here —
+    ``database.journal_mode`` is owned by :func:`resolve_journal_mode` inside
+    :func:`apply_wal_with_fallback`, which layers the operator setting under
+    all the safety guards (never live-downgrading an on-disk WAL DB,
+    filesystem fallback, WAL-reset-bug gating).
+
+    Supported keys under ``database:`` in config.yaml:
+
+    * ``cache_size`` — negative value = KiB, positive = pages
+      (e.g. ``-262144`` = 256 MB page cache)
+    * ``mmap_size`` — max bytes for memory-mapped I/O (0 = disabled)
+    * ``temp_store`` — 0=DEFAULT(file), 1=FILE, 2=MEMORY, 3=ALWAYS
+    * ``wal_autocheckpoint`` — WAL auto-checkpoint threshold in pages
+    * ``journal_size_limit`` — max journal/WAL size in bytes
 
     Best-effort: config load or pragma failures are ignored so DB init
     never breaks on a malformed ``database:`` section.
@@ -877,7 +884,15 @@ def apply_database_pragmas(
     except Exception:
         return
 
-    for pragma_name in ("wal_autocheckpoint", "journal_size_limit"):
+    # Performance PRAGMAs (applied to ALL connection types: writer, read_only,
+    # and WAL per-thread readers).
+    for pragma_name in (
+        "cache_size",
+        "mmap_size",
+        "temp_store",
+        "wal_autocheckpoint",
+        "journal_size_limit",
+    ):
         raw_value = cfg_get(cfg, "database", pragma_name, default=None)
         if raw_value is None:
             continue
@@ -1919,6 +1934,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
+                apply_database_pragmas(self._conn, db_label="state.db")
                 # FTS capability flags normally come from writable schema
                 # initialisation. Probe existing virtual tables with SELECTs
                 # only so read-only search keeps its FTS and trigram paths.
@@ -2006,6 +2022,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     apply_wal_with_fallback(self._conn, db_label="state.db") == "wal"
                 )
                 apply_database_pragmas(self._conn, db_label="state.db")
+                self._conn.execute("PRAGMA cache_size=-8000")
+                self._conn.execute("PRAGMA journal_mode=WAL")
+                self._conn.execute("PRAGMA synchronous=NORMAL")
                 self._conn.execute("PRAGMA foreign_keys=ON")
                 self._fts_cjk_loaded = load_fts5_cjk_extension(self._conn)
                 self._init_schema()
@@ -2128,6 +2147,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 isolation_level=None,
             )
             conn.row_factory = sqlite3.Row
+            apply_database_pragmas(conn, db_label="state.db")
             # Load the CJK tokenizer extension on this connection so
             # messages_fts_cjk queries work on the read path. The .so
             # registers the tokenizer in the connection's in-memory

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1934,7 +1934,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     isolation_level=None,
                 )
                 self._conn.row_factory = sqlite3.Row
-                apply_database_pragmas(self._conn, db_label="state.db")
                 # FTS capability flags normally come from writable schema
                 # initialisation. Probe existing virtual tables with SELECTs
                 # only so read-only search keeps its FTS and trigram paths.
@@ -1945,6 +1944,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # raw-copy for the rest of the process — the writable heal
                 # that follows would then repair WITHOUT its forensic backup.
                 try:
+                    apply_database_pragmas(self._conn, db_label="state.db")
                     cursor = self._conn.cursor()
                     self._fts_enabled = (
                         self._fts_table_probe(cursor, "messages_fts") is True
@@ -2022,9 +2022,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     apply_wal_with_fallback(self._conn, db_label="state.db") == "wal"
                 )
                 apply_database_pragmas(self._conn, db_label="state.db")
-                self._conn.execute("PRAGMA cache_size=-8000")
-                self._conn.execute("PRAGMA journal_mode=WAL")
-                self._conn.execute("PRAGMA synchronous=NORMAL")
                 self._conn.execute("PRAGMA foreign_keys=ON")
                 self._fts_cjk_loaded = load_fts5_cjk_extension(self._conn)
                 self._init_schema()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3835,6 +3835,38 @@ class TestApplyDatabasePragmas:
             assert conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0] == before
         finally:
             conn.close()
+
+    def test_ignores_non_integer_performance_values(self, tmp_path, monkeypatch):
+        """Garbage cache_size/mmap_size/temp_store values must be rejected."""
+        import sqlite3
+        from hermes_state import apply_database_pragmas
+
+        conn = sqlite3.connect(str(tmp_path / "pragmas.db"))
+        try:
+            before = {
+                name: conn.execute(f"PRAGMA {name}").fetchone()[0]
+                for name in ("cache_size", "mmap_size", "temp_store")
+            }
+            self._patch_cfg(
+                monkeypatch,
+                {
+                    "database": {
+                        "cache_size": "big",
+                        "mmap_size": [256],
+                        "temp_store": "ram please",
+                    }
+                },
+            )
+            apply_database_pragmas(conn, db_label="test.db")
+            after = {
+                name: conn.execute(f"PRAGMA {name}").fetchone()[0]
+                for name in ("cache_size", "mmap_size", "temp_store")
+            }
+            assert after == before
+        finally:
+            conn.close()
+
+
 class TestInsightsToolCallIndex:
     """The Insights assistant tool-call scan has a predicate-aligned index.
 
@@ -4017,3 +4049,113 @@ class TestFtsRebuildFinishWithoutTrigram:
             assert db.search_messages("zebra")
         finally:
             db.close()
+
+
+
+class TestPerformancePragmasEndToEnd:
+    """E2E guard for PR #71755: config-gated cache_size / mmap_size /
+    temp_store must reach EVERY connection type (writer, read-only
+    cross-profile attach, WAL per-thread reader) — and default installs
+    (no ``database:`` keys) must see byte-identical SQLite defaults.
+
+    NOTE: SQLite's compiled-in default for ``cache_size`` is already
+    ``-2000``, so the configured value here is ``-16000`` — a value the
+    test can actually discriminate from the default (a reverted prod
+    change must FAIL this test, not accidentally pass it).
+    """
+
+    PRAGMAS = ("cache_size", "mmap_size", "temp_store")
+    CONFIGURED = {"cache_size": -16000, "mmap_size": 1048576, "temp_store": 2}
+
+    @staticmethod
+    def _read(conn):
+        return {
+            name: conn.execute(f"PRAGMA {name}").fetchone()[0]
+            for name in ("cache_size", "mmap_size", "temp_store")
+        }
+
+    @staticmethod
+    def _sqlite_defaults(tmp_path):
+        import sqlite3
+
+        conn = sqlite3.connect(str(tmp_path / "baseline.db"))
+        try:
+            return {
+                name: conn.execute(f"PRAGMA {name}").fetchone()[0]
+                for name in ("cache_size", "mmap_size", "temp_store")
+            }
+        finally:
+            conn.close()
+
+    def _fresh_home(self, tmp_path, monkeypatch, config_text=None):
+        import hermes_state
+
+        # Local venvs may bundle a WAL-reset-vulnerable SQLite (e.g. 3.46.0),
+        # which would silently disable WAL and skip the per-thread reader
+        # path. Force WAL eligibility so _get_read_conn is truly exercised
+        # (established pattern used by the WAL tests above).
+        monkeypatch.setattr(
+            hermes_state,
+            "is_sqlite_wal_reset_vulnerable",
+            lambda version_info=None: False,
+        )
+        home = tmp_path / "hermes_home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        if config_text is not None:
+            (home / "config.yaml").write_text(config_text)
+        return home
+
+    def test_configured_pragmas_reach_all_connection_types(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_state import SessionDB
+
+        home = self._fresh_home(
+            tmp_path,
+            monkeypatch,
+            "database:\n"
+            "  cache_size: -16000\n"
+            "  temp_store: 2\n"
+            "  mmap_size: 1048576\n",
+        )
+        db_path = home / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            # Writer connection.
+            assert self._read(db._conn) == self.CONFIGURED
+            # WAL per-thread reader.
+            rconn = db._get_read_conn()
+            assert rconn is not None, "WAL reader expected on local filesystem"
+            assert self._read(rconn) == self.CONFIGURED
+        finally:
+            db.close()
+
+        # Read-only cross-profile attach.
+        ro = SessionDB(db_path=db_path, read_only=True)
+        try:
+            assert self._read(ro._conn) == self.CONFIGURED
+        finally:
+            ro.close()
+
+    def test_defaults_unchanged_without_config(self, tmp_path, monkeypatch):
+        """No database: keys in config.yaml → SQLite defaults untouched."""
+        from hermes_state import SessionDB
+
+        defaults = self._sqlite_defaults(tmp_path)
+        home = self._fresh_home(tmp_path, monkeypatch, config_text=None)
+        db_path = home / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            assert self._read(db._conn) == defaults
+            rconn = db._get_read_conn()
+            if rconn is not None:
+                assert self._read(rconn) == defaults
+        finally:
+            db.close()
+
+        ro = SessionDB(db_path=db_path, read_only=True)
+        try:
+            assert self._read(ro._conn) == defaults
+        finally:
+            ro.close()


### PR DESCRIPTION
## Context

Users with large state.dbs (hundreds of MB — heavy browser/tool sessions) can only tune SQLite via `wal_autocheckpoint`/`journal_size_limit` today. This adds three config-gated, non-durability pragmas — `database.cache_size`, `database.mmap_size`, `database.temp_store` — and applies the pragma pass to the read-only connection and the per-thread WAL readers (cache_size/mmap_size are per-connection, so readers never benefited before). WHO benefits: opt-in only — users who set these keys in config.yaml, i.e. large-DB power users; a default install is byte-for-byte unchanged.

## Measured impact

211 MB synthetic DB (360k rows), heavy read scan, default page cache vs `cache_size=-262144` + 256 MB mmap, median of 5:

| scenario | before | after | delta |
|---|---|---|---|
| cold-ish full scan | 0.484 s | 0.468 s | +3.3% |
| warm re-scan | 0.211 s | 0.163 s | +22.9% |

Honest caveat: config-gated and default-off; the win only exists for users who opt in on a large DB, and is workload-dependent (warm repeated reads benefit most; cold I/O-bound scans barely move).

## Safety audit (the #64091 lesson)

No durability pragmas: the allowlisted tuple gains only `cache_size`, `mmap_size`, `temp_store` — no `synchronous`, `journal_mode`, `locking_mode`, or `fullfsync`. Values apply ONLY when present in config.yaml; integer coercion warns-and-skips garbage; `apply_database_pragmas` remains best-effort try/except so a failing pragma cannot break open. The docstring's journal-mode-ownership warning stays accurate. Per-reader cost is bounded: the reader connection is thread-local, so the pragma pass runs once per thread lifetime, and the config read is the mtime-cached fast path.

## Provenance

Salvage of #71755 by @crayfish-ai (both commits authorship-preserved). Follow-up commit adds the missing guard test: config-set pragmas must reach the writer, read-only, and per-thread reader connections (with a discriminating `-16000` vs SQLite's `-2000` default so a revert can't accidentally pass), and a no-config run must leave defaults untouched. Mutation-checked: reverting the pragma wiring turns the test RED.

## Verification

- 165 passed (tests/test_hermes_state.py, `-p no:randomly`) + the new end-to-end pragma test.
- Simplify pass: no material findings (coercion loop reused, not duplicated; per-thread cost traced to once-per-thread-lifetime).

Closes #71755.
