### PR TITLE
chore: add contributor email mapping for WojtekMR3

### DIFF
--- a/contributors/emails/WojtekMR3@users.noreply.github.com
+++ b/contributors/emails/WojtekMR3@users.noreply.github.com
@@ -1,0 +1,1 @@
+WojtekMR3


### PR DESCRIPTION
Attribution mapping for @WojtekMR3 (bare-login noreply form, not auto-resolvable), needed by the #67642 salvage.