### PR TITLE
fix(auth): fence stale xAI refresh writers against shared token revocation (#77553)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4416,6 +4416,10 @@ def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
         "last_refresh": state.get("last_refresh"),
         "discovery": state.get("discovery") or {},
         "redirect_uri": state.get("redirect_uri"),
+        # #77553: surface the lineage fencing stamps so callers (and the
+        # stale-writer fence) can tell a superseded copy from the current head.
+        "lineage_generation": int(state.get("lineage_generation") or 0),
+        "lineage_write_contract": str(state.get("lineage_write_contract") or ""),
     }
 
 
@@ -4509,6 +4513,15 @@ def _save_xai_oauth_tokens(
         )
         if state is None:
             state = {}
+        # #77553: stamp the persisted lineage so every writer can fence
+        # superseded tokens. lineage_generation is a monotonic per-store
+        # counter — a writer holding an older generation knows a newer writer
+        # already rotated the shared grant. lineage_write_contract records
+        # that the state was last persisted by a write-through-correct
+        # runtime, so mixed-version fleets can be detected (and warned about)
+        # before a stale process spends the shared refresh token.
+        state["lineage_generation"] = int(state.get("lineage_generation") or 0) + 1
+        state["lineage_write_contract"] = XAI_OAUTH_LINEAGE_CONTRACT
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
         state["auth_mode"] = auth_mode
@@ -4832,6 +4845,123 @@ def refresh_xai_oauth_pure(
     return updated
 
 
+# ---------------------------------------------------------------------------
+# Stale-writer fence for the shared xAI OAuth lineage (#77553)
+# ---------------------------------------------------------------------------
+
+# Runtime compatibility marker stamped on every xai-oauth state persisted by
+# a write-through-correct runtime (post #74339 / #43589). A shared lineage
+# whose state lacks this marker was last touched by an older runtime and may
+# hold a consumed ancestor; writers warn before spending it.
+XAI_OAUTH_LINEAGE_CONTRACT = "xai-oauth-write-through-v2"
+
+
+def _xai_oauth_pool_refresh_tokens(auth_store):
+    """Refresh tokens currently persisted in the xai-oauth credential pool."""
+    credential_pool = auth_store.get("credential_pool")
+    entries = (
+        credential_pool.get("xai-oauth")
+        if isinstance(credential_pool, dict)
+        else None
+    )
+    if not isinstance(entries, list):
+        return []
+    return [
+        str(entry.get("refresh_token", "") or "").strip()
+        for entry in entries
+        if isinstance(entry, dict)
+    ]
+
+
+def _fence_xai_oauth_refresh_spend(tokens: Dict[str, Any]) -> None:
+    """Fail-closed fence: never spend a refresh token that is no longer the
+    current head of its persisted xAI OAuth lineage.
+
+    xAI rotates refresh tokens on every refresh, and replaying a consumed
+    refresh token revokes the *entire* token family. After the source-path
+    write-through fixes (#74339) writers running the new code propagate the
+    successor correctly — but a stale writer can still hold a superseded
+    token (a gateway that cached credentials before another writer rotated
+    the shared grant, or a profile shadow key left behind by a pre-fix
+    runtime). If such a writer spends the old token, xAI revokes the shared
+    lineage for every profile plus the external refresh coordinator
+    (fleet-wide ``invalid_grant``) — issue #77553.
+
+    This guard runs under the auth-store lock, immediately before the token
+    endpoint is called, and compares the token about to be spent against the
+    current persisted head of the lineage (provider state first, credential
+    pool fallback, both source-path aware). On any mismatch it raises
+    WITHOUT touching the network: no token is burned, so the fence can never
+    trigger the family-wide revocation it exists to prevent.
+    """
+    spend_refresh = str(tokens.get("refresh_token", "") or "").strip()
+    if not spend_refresh:
+        raise AuthError(
+            "Refusing to spend an xAI OAuth refresh token: none present.",
+            provider="xai-oauth",
+            code="xai_stale_refresh_fenced",
+        )
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        state, source_path = _load_provider_state_with_source(
+            auth_store, "xai-oauth"
+        )
+        persisted_head = ""
+        contract = ""
+        if isinstance(state, dict):
+            persisted_head = str(
+                (state.get("tokens") or {}).get("refresh_token", "") or ""
+            ).strip()
+            contract = str(state.get("lineage_write_contract") or "")
+        if persisted_head:
+            if persisted_head != spend_refresh:
+                raise AuthError(
+                    "xAI OAuth lineage already rotated by another writer: the "
+                    "refresh token this process holds was superseded before it "
+                    "could be spent. Refusing to replay a consumed token "
+                    "(fail-closed, #77553). Re-resolve credentials to pick up "
+                    "the current lineage head.",
+                    provider="xai-oauth",
+                    code="xai_stale_refresh_fenced",
+                )
+        else:
+            # No provider state — the grant may live in the credential pool.
+            pool_heads = set(_xai_oauth_pool_refresh_tokens(auth_store))
+            global_store = _load_global_auth_store()
+            if global_store:
+                pool_heads.update(_xai_oauth_pool_refresh_tokens(global_store))
+            if spend_refresh not in pool_heads:
+                raise AuthError(
+                    "xAI OAuth refresh token is not the current head of any "
+                    "persisted lineage (provider state or credential pool). "
+                    "Refusing to spend an unverified token (fail-closed, "
+                    "#77553). Re-authenticate with `hermes model`.",
+                    provider="xai-oauth",
+                    code="xai_unverified_lineage",
+                    relogin_required=True,
+                )
+        # Mixed-version safety: a shared (global-root) lineage last persisted
+        # by a runtime without the write-through contract may hold a consumed
+        # ancestor. Warn loudly before participating in rotation so operators
+        # can finish rolling the fleet or re-authenticate first.
+        global_root = _global_auth_file_path()
+        shared_lineage = bool(
+            source_path is not None
+            and global_root is not None
+            and _same_path(source_path, global_root)
+        )
+        if shared_lineage and contract != XAI_OAUTH_LINEAGE_CONTRACT:
+            logger.warning(
+                "xAI OAuth: shared lineage at %s was last persisted by a "
+                "runtime without the write-through contract (%r). Rotating "
+                "the shared token now may revoke other holders if any gateway "
+                "still runs a stale build. Ensure the whole fleet runs the "
+                "write-through-correct runtime, or re-authenticate (#77553).",
+                source_path,
+                contract or "<legacy/no-contract>",
+            )
+
+
 def _refresh_xai_oauth_tokens(
     tokens: Dict[str, Any],
     *,
@@ -4847,6 +4977,10 @@ def _refresh_xai_oauth_tokens(
         auth_mode = str(state.get("auth_mode") or "oauth_device_code")
     except Exception:
         auth_mode = "oauth_device_code"
+    # #77553: fail-closed stale-writer fence — never spend a refresh token
+    # that is no longer the current head of its persisted lineage. Must run
+    # before the token endpoint is hit; re-resolve instead of replaying.
+    _fence_xai_oauth_refresh_spend(tokens)
     refreshed = refresh_xai_oauth_pure(
         str(tokens.get("access_token", "") or ""),
         str(tokens.get("refresh_token", "") or ""),

--- a/tests/hermes_cli/test_xai_oauth_stale_writer_fence.py
+++ b/tests/hermes_cli/test_xai_oauth_stale_writer_fence.py
@@ -1,0 +1,200 @@
+"""Regression tests for the stale-writer fence on the shared xAI OAuth lineage.
+
+Issue #77553: xAI rotates refresh tokens on every refresh, and replaying a
+consumed refresh token revokes the *entire* token family. A stale writer —
+a gateway that cached credentials before another writer rotated the shared
+grant, or a profile shadow key left behind by a pre-fix runtime — can spend
+a superseded refresh token and revoke the shared lineage for every profile
+plus the external refresh coordinator (fleet-wide ``invalid_grant``).
+
+The fence (``_fence_xai_oauth_refresh_spend``) runs at the single spend
+choke point (``_refresh_xai_oauth_tokens``) under the auth-store lock and
+fails CLOSED: if the token about to be spent is no longer the current head
+of the persisted lineage, it raises without ever calling the token endpoint,
+so no token is burned and no family-wide revocation can be triggered.
+
+These tests drive the real ``_refresh_xai_oauth_tokens`` / ``_save_xai_oauth_tokens``
+against real on-disk auth stores (profile + root under ``tmp_path``) and spy
+on the token endpoint so we can assert it is never called on a fenced spend.
+"""
+
+import json
+
+import pytest
+
+from hermes_cli import auth
+
+
+def _write_store(path, store):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(store), encoding="utf-8")
+
+
+def _read_store(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def profile_and_root(tmp_path, monkeypatch):
+    """Wire a profile auth store + a distinct global-root auth store on disk.
+
+    Returns (profile_path, root_path). HOME is pointed away from the tmp
+    root so the pytest seat belt in
+    ``_write_through_xai_oauth_to_global_root`` does not trip (mirrors
+    ``test_xai_oauth_writethrough.py``).
+    """
+    profile_path = tmp_path / "profiles" / "work" / "auth.json"
+    root_path = tmp_path / "root" / "auth.json"
+
+    monkeypatch.setattr(auth, "_auth_file_path", lambda: profile_path)
+    monkeypatch.setattr(auth, "_global_auth_file_path", lambda: root_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    return profile_path, root_path
+
+
+def _refresh_spy(spent, result=None):
+    """Token-endpoint spy: records every refresh token it is asked to spend."""
+    def _fake_pure(access_token, refresh_token, **kwargs):
+        spent.append(refresh_token)
+        if result is not None:
+            return result
+        return {
+            "access_token": "a-rotated",
+            "refresh_token": "r-rotated",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+            "last_refresh": "2026-08-03T00:00:00Z",
+        }
+    return _fake_pure
+
+
+def test_stale_writer_is_fenced_before_spending_shared_token(profile_and_root, monkeypatch):
+    """#77553: a writer holding a superseded refresh token fails closed and
+    the token endpoint is NEVER called (nothing is burned)."""
+    profile_path, root_path = profile_and_root
+    # Root already holds the rotated head (gen 2) written by another writer.
+    _write_store(root_path, {"version": 1, "providers": {"xai-oauth": {
+        "tokens": {"access_token": "a-new", "refresh_token": "r-new"},
+        "lineage_generation": 2,
+        "lineage_write_contract": auth.XAI_OAUTH_LINEAGE_CONTRACT,
+    }}})
+    _write_store(profile_path, {"version": 1, "providers": {}})
+
+    spent = []
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", _refresh_spy(spent))
+
+    with pytest.raises(auth.AuthError) as excinfo:
+        auth._refresh_xai_oauth_tokens(
+            {"access_token": "a-old", "refresh_token": "r-old"},
+            token_endpoint="https://token.x.ai/oauth2/token",
+            timeout_seconds=5.0,
+        )
+    assert excinfo.value.code == "xai_stale_refresh_fenced"
+    assert spent == []  # token endpoint never called -> no token burned
+    # Stores untouched by the fenced spend.
+    assert _read_store(root_path)["providers"]["xai-oauth"]["tokens"]["refresh_token"] == "r-new"
+    assert "providers" not in _read_store(profile_path) or "xai-oauth" not in _read_store(profile_path)["providers"]
+
+
+def test_current_head_writer_passes_fence_and_bumps_generation(profile_and_root, monkeypatch):
+    """A writer spending the CURRENT head passes the fence, rotates, and the
+    write-through lands back in root with the generation bumped and the
+    write-through contract stamped — without shadowing the profile store."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {"xai-oauth": {
+        "tokens": {"access_token": "a-new", "refresh_token": "r-new"},
+        "lineage_generation": 2,
+        "lineage_write_contract": auth.XAI_OAUTH_LINEAGE_CONTRACT,
+    }}})
+    _write_store(profile_path, {"version": 1, "providers": {}})
+
+    spent = []
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", _refresh_spy(spent))
+
+    rotated = auth._refresh_xai_oauth_tokens(
+        {"access_token": "a-new", "refresh_token": "r-new"},
+        token_endpoint="https://token.x.ai/oauth2/token",
+        timeout_seconds=5.0,
+    )
+    assert spent == ["r-new"]  # the head was spent exactly once
+    assert rotated["refresh_token"] == "r-rotated"
+
+    root = _read_store(root_path)
+    state = root["providers"]["xai-oauth"]
+    assert state["tokens"]["refresh_token"] == "r-rotated"
+    assert state["lineage_generation"] == 3
+    assert state["lineage_write_contract"] == auth.XAI_OAUTH_LINEAGE_CONTRACT
+    # Source-path write-through (#74339): no shadowing key in the profile.
+    assert "xai-oauth" not in _read_store(profile_path).get("providers", {})
+
+
+def test_detached_pool_writer_is_fenced(profile_and_root, monkeypatch):
+    """A writer spending a refresh token that matches NO persisted lineage
+    head (provider state or credential pool) fails closed."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {}})
+    _write_store(profile_path, {"version": 1, "providers": {}, "credential_pool": {
+        "xai-oauth": [{"access_token": "a-new", "refresh_token": "r-new"}]
+    }})
+
+    spent = []
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", _refresh_spy(spent))
+
+    with pytest.raises(auth.AuthError) as excinfo:
+        auth._refresh_xai_oauth_tokens(
+            {"access_token": "a-old", "refresh_token": "r-detached"},
+            token_endpoint="https://token.x.ai/oauth2/token",
+            timeout_seconds=5.0,
+        )
+    assert excinfo.value.code == "xai_unverified_lineage"
+    assert excinfo.value.relogin_required is True
+    assert spent == []
+
+
+def test_pool_head_writer_passes_fence(profile_and_root, monkeypatch):
+    """A writer spending the current credential-pool head passes the fence."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, {"version": 1, "providers": {}})
+    _write_store(profile_path, {"version": 1, "providers": {}, "credential_pool": {
+        "xai-oauth": [{"access_token": "a-new", "refresh_token": "r-new"}]
+    }})
+
+    spent = []
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", _refresh_spy(spent))
+
+    auth._refresh_xai_oauth_tokens(
+        {"access_token": "a-new", "refresh_token": "r-new"},
+        token_endpoint="https://token.x.ai/oauth2/token",
+        timeout_seconds=5.0,
+    )
+    assert spent == ["r-new"]
+
+
+def test_legacy_shared_lineage_still_spends_head_and_gets_stamped(profile_and_root, monkeypatch, caplog):
+    """A legacy (pre-fix, uncontracted) shared lineage is NOT bricked: the
+    writer spending the current head proceeds, emits the mixed-version
+    compatibility warning, and the save stamps the write-through contract."""
+    profile_path, root_path = profile_and_root
+    # Pre-fix root state: no lineage_write_contract, no lineage_generation.
+    _write_store(root_path, {"version": 1, "providers": {"xai-oauth": {
+        "tokens": {"access_token": "a-legacy", "refresh_token": "r-legacy"},
+    }}})
+    _write_store(profile_path, {"version": 1, "providers": {}})
+
+    spent = []
+    monkeypatch.setattr(auth, "refresh_xai_oauth_pure", _refresh_spy(spent))
+
+    with caplog.at_level("WARNING", logger="hermes_cli.auth"):
+        auth._refresh_xai_oauth_tokens(
+            {"access_token": "a-legacy", "refresh_token": "r-legacy"},
+            token_endpoint="https://token.x.ai/oauth2/token",
+            timeout_seconds=5.0,
+        )
+    assert spent == ["r-legacy"]
+    assert any("write-through contract" in rec.message for rec in caplog.records)
+
+    root = _read_store(root_path)
+    state = root["providers"]["xai-oauth"]
+    assert state["tokens"]["refresh_token"] == "r-rotated"
+    assert state["lineage_generation"] == 1
+    assert state["lineage_write_contract"] == auth.XAI_OAUTH_LINEAGE_CONTRACT


### PR DESCRIPTION
## Summary

Adds a **fail-closed stale-writer fence** to the shared xAI OAuth refresh path so a stale writer can no longer spend a superseded single-use refresh token and revoke the entire shared lineage (fleet-wide `invalid_grant`).

## Root Cause

xAI rotates refresh tokens on every refresh, and replaying a consumed refresh token revokes the **whole token family**. The source-path write-through fixes (#74339) make writers that run the new code propagate successors correctly, but a stale writer — a gateway that cached credentials before another writer rotated the shared grant, or a profile shadow key left behind by a pre-fix runtime — can still spend an already-rotated refresh token. There was **no signal on the persisted lineage** letting fixed writers detect supersession before spending, so one stale process turned a partial rollout into a fleet-wide revocation for every fixed profile plus the external refresh coordinator.

## Change

- **Lineage fencing stamp**: `_save_xai_oauth_tokens` now stamps every persisted `xai-oauth` state (profile and global-root write-through paths alike) with:
  - `lineage_generation` — monotonic per-store counter (a writer holding an older generation knows a newer writer already rotated the shared grant);
  - `lineage_write_contract` — runtime compatibility marker proving the state was last persisted by a write-through-correct runtime (post-#74339).
- **Spend-time CAS fence**: `_fence_xai_oauth_refresh_spend()` runs at the single spend choke point (`_refresh_xai_oauth_tokens`, immediately before the token endpoint) under the auth-store lock. It compares the token about to be spent against the current persisted head of the lineage (provider state first, credential-pool fallback, source-path aware). On any mismatch it raises (`xai_stale_refresh_fenced` / `xai_unverified_lineage`) **without touching the network** — no token is burned, so the fence can never trigger the revocation it exists to prevent.
- **Mixed-version compatibility warning**: when a *shared* (global-root) lineage was last persisted without the write-through contract, the writer logs an explicit warning before rotating, so operators can finish rolling the fleet or re-authenticate first. Legacy installs are not bricked: spending the current head proceeds and the save stamps the contract.

## Verification

New deterministic regression suite `tests/hermes_cli/test_xai_oauth_stale_writer_fence.py` (drives the real save/refresh paths against on-disk profile+root stores with a token-endpoint spy):

- stale writer holding a superseded token → `xai_stale_refresh_fenced`, endpoint **never** called, stores untouched;
- current-head writer → fence passes, single spend, write-through lands in root with generation bumped + contract stamped, no profile shadow key (#74339 preserved);
- detached pool-sourced token → `xai_unverified_lineage`, endpoint never called;
- current pool head → passes;
- legacy uncontracted shared lineage → spends current head, emits the compatibility warning, stamps the contract.

Full xAI OAuth suites pass: `test_xai_oauth_stale_writer_fence`, `test_xai_oauth_writethrough`, `test_auth_xai_oauth_provider`, `test_xai_oauth_refresh`, `test_xai_oauth_profile_auth`, `test_setup_tts_xai_oauth`, plus the run_agent/agent xAI recovery tests (67 tests, 0 failures).

Closes #77553
