### PR TITLE
fix(minimax-oauth): bound error-body reads to 16KB (salvage #56549)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -8161,6 +8161,68 @@ def _codex_device_code_login() -> Dict[str, Any]:
 
 # ==================== MiniMax Portal OAuth ====================
 
+_MINIMAX_OAUTH_ERROR_BODY_LIMIT = 16 * 1024
+
+
+def _minimax_response_error_text(
+    response: httpx.Response,
+    *,
+    limit: int = _MINIMAX_OAUTH_ERROR_BODY_LIMIT,
+) -> str:
+    """Return a bounded error body from a streamed MiniMax OAuth response."""
+    limit = max(0, int(limit))
+    chunks: list[bytes] = []
+    total = 0
+    truncated = False
+    try:
+        if getattr(response, "is_stream_consumed", False):
+            text = response.text
+            return text[:limit] + ("...[truncated]" if len(text) > limit else "")
+
+        for chunk in response.iter_bytes():
+            if not chunk:
+                continue
+            remaining = limit + 1 - total
+            if remaining <= 0:
+                truncated = True
+                break
+            if len(chunk) > remaining:
+                chunks.append(chunk[:remaining])
+                total += remaining
+                truncated = True
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+        raw = b"".join(chunks)
+        if len(raw) > limit:
+            raw = raw[:limit]
+            truncated = True
+        encoding = response.encoding or "utf-8"
+        text = raw.decode(encoding, errors="replace")
+        return text + ("...[truncated]" if truncated else "")
+    finally:
+        response.close()
+
+
+def _minimax_post_form(
+    client: httpx.Client,
+    url: str,
+    *,
+    data: Dict[str, Any],
+    headers: Dict[str, str],
+) -> httpx.Response:
+    """POST a MiniMax OAuth form without eagerly reading error bodies."""
+    request = client.build_request(
+        "POST",
+        url,
+        data=data,
+        headers=headers,
+    )
+    response = client.send(request, stream=True)
+    if response.status_code == 200:
+        response.read()
+    return response
+
 def _minimax_pkce_pair() -> tuple:
     """Generate (code_verifier, code_challenge_S256, state) for MiniMax OAuth."""
     import secrets
@@ -8176,7 +8238,8 @@ def _minimax_request_user_code(
     client: httpx.Client, *, portal_base_url: str, client_id: str,
     code_challenge: str, state: str,
 ) -> Dict[str, Any]:
-    response = client.post(
+    response = _minimax_post_form(
+        client,
         f"{portal_base_url}/oauth/code",
         data={
             "response_type": "code",
@@ -8193,8 +8256,9 @@ def _minimax_request_user_code(
         },
     )
     if response.status_code != 200:
+        body = _minimax_response_error_text(response)
         raise AuthError(
-            f"MiniMax OAuth authorization failed: {response.text or response.reason_phrase}",
+            f"MiniMax OAuth authorization failed: {body or response.reason_phrase}",
             provider="minimax-oauth", code="authorization_failed",
         )
     payload = response.json()
@@ -8242,7 +8306,8 @@ def _minimax_poll_token(
     interval = max(2.0, (interval_ms or 2000) / 1000.0)
 
     while _time.time() < deadline:
-        response = client.post(
+        response = _minimax_post_form(
+            client,
             f"{portal_base_url}/oauth/token",
             data={
                 "grant_type": MINIMAX_OAUTH_GRANT_TYPE,
@@ -8255,17 +8320,22 @@ def _minimax_poll_token(
                 "Accept": "application/json",
             },
         )
-        try:
-            payload = response.json() if response.text else {}
-        except Exception:
-            payload = {}
-
+        error_text = ""
         if response.status_code != 200:
-            msg = (payload.get("base_resp", {}) or {}).get("status_msg") or response.text
+            error_text = _minimax_response_error_text(response)
+            try:
+                payload = json.loads(error_text) if error_text else {}
+            except Exception:
+                payload = {}
+            msg = (payload.get("base_resp", {}) or {}).get("status_msg") or error_text
             raise AuthError(
                 f"MiniMax OAuth error: {msg or 'unknown'}",
                 provider="minimax-oauth", code="token_exchange_failed",
             )
+        try:
+            payload = response.json() if response.text else {}
+        except Exception:
+            payload = {}
 
         status = payload.get("status")
         if status == "error":
@@ -8401,7 +8471,8 @@ def _refresh_minimax_oauth_state(
     portal_base_url = state["portal_base_url"]
     with httpx.Client(timeout=httpx.Timeout(timeout_seconds),
                       follow_redirects=True) as client:
-        response = client.post(
+        response = _minimax_post_form(
+            client,
             f"{portal_base_url}/oauth/token",
             data={
                 "grant_type": "refresh_token",
@@ -8414,11 +8485,12 @@ def _refresh_minimax_oauth_state(
             },
         )
     if response.status_code != 200:
-        body = response.text.lower()
-        relogin = any(m in body for m in
+        body = _minimax_response_error_text(response)
+        body_lower = body.lower()
+        relogin = any(m in body_lower for m in
                       ("invalid_grant", "refresh_token_reused", "invalid_refresh_token"))
         raise AuthError(
-            f"MiniMax OAuth refresh failed: {response.text or response.reason_phrase}",
+            f"MiniMax OAuth refresh failed: {body or response.reason_phrase}",
             provider="minimax-oauth", code="refresh_failed",
             relogin_required=relogin,
         )

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -8484,16 +8484,20 @@ def _refresh_minimax_oauth_state(
                 "Accept": "application/json",
             },
         )
-    if response.status_code != 200:
-        body = _minimax_response_error_text(response)
-        body_lower = body.lower()
-        relogin = any(m in body_lower for m in
-                      ("invalid_grant", "refresh_token_reused", "invalid_refresh_token"))
-        raise AuthError(
-            f"MiniMax OAuth refresh failed: {body or response.reason_phrase}",
-            provider="minimax-oauth", code="refresh_failed",
-            relogin_required=relogin,
-        )
+        # The non-200 branch reads a STREAMED body, so it must run while
+        # the client is still open — iter_bytes() after the client context
+        # closes raises (StreamClosed).  The 200 path was already read by
+        # _minimax_post_form, so response.json() below is safe outside.
+        if response.status_code != 200:
+            body = _minimax_response_error_text(response)
+            body_lower = body.lower()
+            relogin = any(m in body_lower for m in
+                          ("invalid_grant", "refresh_token_reused", "invalid_refresh_token"))
+            raise AuthError(
+                f"MiniMax OAuth refresh failed: {body or response.reason_phrase}",
+                provider="minimax-oauth", code="refresh_failed",
+                relogin_required=relogin,
+            )
     payload = response.json()
     if payload.get("status") != "success":
         raise AuthError(

--- a/tests/test_minimax_oauth.py
+++ b/tests/test_minimax_oauth.py
@@ -42,7 +42,13 @@ from hermes_cli.auth import (
 # ---------------------------------------------------------------------------
 
 def _make_httpx_response(status_code: int, body: dict | None = None, text: str = ""):
-    """Return a minimal mock that quacks like httpx.Response."""
+    """Return a minimal mock that quacks like httpx.Response.
+
+    Includes the streamed-read surface used by ``_minimax_post_form`` /
+    ``_minimax_response_error_text``: ``is_stream_consumed`` is False and
+    ``iter_bytes()`` yields the body/text bytes, so non-200 paths exercise
+    the real bounded-read code instead of a truthy MagicMock attribute.
+    """
     resp = MagicMock()
     resp.status_code = status_code
     if body is not None:
@@ -52,6 +58,9 @@ def _make_httpx_response(status_code: int, body: dict | None = None, text: str =
         resp.json.side_effect = Exception("No body")
         resp.text = text
     resp.reason_phrase = "OK" if status_code == 200 else "Error"
+    resp.is_stream_consumed = False
+    resp.encoding = "utf-8"
+    resp.iter_bytes.return_value = iter([resp.text.encode("utf-8")] if resp.text else [])
     return resp
 
 
@@ -128,6 +137,7 @@ def test_request_user_code_state_mismatch_raises():
 
     client = MagicMock()
     client.post.return_value = mock_response
+    client.send.return_value = mock_response
 
     with pytest.raises(AuthError) as exc_info:
         _minimax_request_user_code(
@@ -387,6 +397,7 @@ def test_token_provider_refreshes_when_near_expiry():
         mock_instance.__enter__ = MagicMock(return_value=mock_instance)
         mock_instance.__exit__ = MagicMock(return_value=False)
         mock_instance.post.return_value = mock_resp
+        mock_instance.send.return_value = mock_resp
         mock_client_class.return_value = mock_instance
 
         token = provider()
@@ -441,6 +452,7 @@ def test_token_provider_quarantines_state_on_terminal_refresh():
         mock_instance.__enter__ = MagicMock(return_value=mock_instance)
         mock_instance.__exit__ = MagicMock(return_value=False)
         mock_instance.post.return_value = bad_resp
+        mock_instance.send.return_value = bad_resp
         mock_client_class.return_value = mock_instance
 
         with pytest.raises(AuthError) as exc_info:
@@ -475,3 +487,84 @@ def test_resolve_returns_callable_when_as_token_provider_true():
     assert creds["base_url"] == MINIMAX_OAUTH_GLOBAL_INFERENCE.rstrip("/")
 
 
+# ---------------------------------------------------------------------------
+# Bounded error-body reads (#56548 / PR #56549)
+# ---------------------------------------------------------------------------
+
+def test_refresh_error_body_bounded_and_readable_with_real_client():
+    """Refresh non-200 path over a REAL socket transport.
+
+    The error body is obtained via a streamed response; the bounded read
+    must happen while the client context is still open.  A real socket is
+    required to bind this contract: closing the client tears the connection
+    down, so a read after the ``with httpx.Client(...)`` block raises
+    ReadError/StreamClosed.  (MockTransport buffers in memory and would NOT
+    catch the regression.)
+    """
+    import http.server
+    import socketserver
+    import threading
+
+    import httpx
+
+    from hermes_cli.auth import _refresh_minimax_oauth_state
+
+    big_body = b"invalid_grant " + b"x" * (64 * 1024)  # 64KB error body
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(400)
+            self.send_header("Content-Length", str(len(big_body)))
+            self.end_headers()
+            self.wfile.write(big_body)
+
+        def log_message(self, *args):
+            pass
+
+    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as server:
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            state = {
+                "access_token": "expired",
+                "refresh_token": "burned-rt",
+                "portal_base_url": f"http://127.0.0.1:{port}",
+                "client_id": MINIMAX_OAUTH_CLIENT_ID,
+                "inference_base_url": MINIMAX_OAUTH_GLOBAL_INFERENCE,
+                "expires_at": _past_iso(100),
+            }
+            with pytest.raises(AuthError) as exc_info:
+                _refresh_minimax_oauth_state(state, force=True)
+        finally:
+            server.shutdown()
+
+    msg = str(exc_info.value)
+    assert "invalid_grant" in msg
+    assert exc_info.value.relogin_required is True
+    # Bounded: 16KB limit + truncation marker, never the full 64KB body.
+    assert len(msg) < 20 * 1024
+    assert "...[truncated]" in msg
+
+
+def test_minimax_response_error_text_truncates_above_limit():
+    """Bodies above the 16KB bound are cut and marked truncated."""
+    import httpx
+
+    from hermes_cli.auth import (
+        _MINIMAX_OAUTH_ERROR_BODY_LIMIT,
+        _minimax_response_error_text,
+    )
+
+    big = "e" * (_MINIMAX_OAUTH_ERROR_BODY_LIMIT * 4)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text=big)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        request = client.build_request("POST", "https://api.minimax.io/oauth/token")
+        response = client.send(request, stream=True)
+        text = _minimax_response_error_text(response)
+
+    assert text.endswith("...[truncated]")
+    assert len(text) <= _MINIMAX_OAUTH_ERROR_BODY_LIMIT + len("...[truncated]")


### PR DESCRIPTION
Salvage of #56549 by @luyifan (ooiuuii) — contributor commit cherry-picked (authorship preserved) + one review follow-up commit.

## What this does for users

MiniMax OAuth flows (`hermes auth login minimax` + background token refresh) eagerly materialized error response bodies via `response.text` on non-200 — an unbounded read: a misbehaving proxy or hijacked portal endpoint can stream an arbitrarily large body and balloon memory during auth (spec #56548). Now all three sites (authorize, token poll, refresh) send via `_minimax_post_form` (streamed; `read()` only on 200) and read error bodies through `_minimax_response_error_text` — bounded at 16KB with a `...[truncated]` marker, response closed in `finally`.

## Review follow-up (the sweeper's stream-lifetime bug — confirmed real and fixed)

The PR's refresh flow obtained the streamed response inside `with httpx.Client(...)` but ran the bounded read AFTER the context exited. Reading a streamed body after client close fails — proven with a real-socket repro (`ReadError: Bad file descriptor`; httpx.MockTransport buffers in memory and can NOT reproduce it, which is why the regression test spins up a real localhost server). The non-200 handling now runs inside the client context; the 200 path was already read by `_minimax_post_form`, so its `.json()` stays safe outside.

## Verification

- 14 tests green (`tests/test_minimax_oauth.py`), incl. the real-socket refresh-error regression + a truncation guard
- Mutation checks: (a) moving the non-200 handling back outside the context → real-socket test fails with the stream error; (b) unbounding the `is_stream_consumed` fallback → truncation test fails. (The two-layer chunk-loop bound absorbs single-layer mutations by design — the loop and the post-slice back-stop each other.)
- Whole-path leak audit: every non-200 consumer routes through `_minimax_response_error_text` (which closes); "pending" poll responses arrive as 200 + `{"status": "pending"}` and are read eagerly — no connection leak per poll tick
- Reuse note: `agent/bounded_response.read_streaming_error_body` covers the same class for provider streaming; not consolidated here because its contract differs (no truncation marker — asserted by the spec tests, no consumed-stream fallback, thread-based deadline that is redundant inside this 15s-timeout client). Unifying the two is a reasonable follow-up once the shared helper exposes truncation info.

Closes #56549. Closes #56548.
