### PR TITLE
fix(desktop): probe-gate and version-order the POSIX Python fallback

### DIFF
--- a/apps/desktop/electron/backend-probes.test.ts
+++ b/apps/desktop/electron/backend-probes.test.ts
@@ -17,6 +17,8 @@ import {
   DEFAULT_PROBE_TIMEOUT_MS,
   findAcceptablePython,
   hermesRuntimeImportProbe,
+  MACOS_WELL_KNOWN_PYTHON_DIRS,
+  macOSWellKnownPythonCandidates,
   posixPythonCommandCandidates,
   PROBE_TIMEOUT_MS,
   pythonResolutionFailureMessage,
@@ -376,6 +378,196 @@ test('with no accept validator the first resolvable candidate wins', () => {
   // Callers that only need "any interpreter" (the uninstall path) must keep
   // the original zero-subprocess behaviour.
   assert.equal(findAcceptablePython({ findOnPath: pathTable({ python3: '/usr/bin/python3' }) }), '/usr/bin/python3')
+})
+
+// ── macOS Homebrew-before-PATH ordering ──────────────────────────────────────
+//
+// A Finder/Dock launch inherits launchd's environment, not a login shell's:
+// `launchctl getenv PATH` is unset on a stock machine, leaving
+// /usr/bin:/bin:/usr/sbin:/sbin. Homebrew is not on it, so a PATH-only search
+// cannot see an installed /opt/homebrew/bin/python3.12 and settles for
+// /usr/bin/python3 (3.9.6) -- measured on this machine: the minimal-PATH walk
+// resolves null, because 3.9 is the only interpreter it can reach.
+//
+// Injected fake filesystems throughout: the scan must be provably correct on
+// machines whose real /opt/homebrew holds nothing in range (this one has only
+// 3.14.4 and 3.9.24).
+
+/** Build a fileExists stub from a set of paths that exist. */
+function fsTable(paths: string[]) {
+  const existing = new Set(paths)
+
+  return (candidate: string) => existing.has(candidate)
+}
+
+test('a versioned Homebrew interpreter is preferred over a PATH hit on macOS', () => {
+  const brewed = '/opt/homebrew/bin/python3.12'
+  const probed: string[] = []
+
+  const resolved = findAcceptablePython({
+    platform: 'darwin',
+    fileExists: fsTable([brewed]),
+    findOnPath: pathTable({ python3: '/usr/bin/python3', python: '/usr/bin/python3' }),
+    accept: candidate => {
+      probed.push(candidate)
+
+      return true
+    }
+  })
+
+  assert.equal(resolved, brewed)
+  // PATH is never consulted once the well-known pass answers, so the 3.9
+  // interpreter costs zero subprocesses.
+  assert.deepEqual(probed, [brewed])
+})
+
+test('a Homebrew interpreter that fails the probe is demoted, not returned', () => {
+  // The load-bearing guarantee: Homebrew ordering is a preference layered on
+  // top of the probe, exactly like the versioned-name ordering. It must never
+  // be able to promote an interpreter that cannot run Hermes.
+  const brewed = '/opt/homebrew/bin/python3.12'
+  const pathHit = '/opt/py313/bin/python3.13'
+  const probed: string[] = []
+
+  const resolved = findAcceptablePython({
+    platform: 'darwin',
+    fileExists: fsTable([brewed]),
+    findOnPath: pathTable({ 'python3.13': pathHit }),
+    accept: candidate => {
+      probed.push(candidate)
+
+      return candidate !== brewed
+    }
+  })
+
+  assert.equal(resolved, pathHit)
+  assert.deepEqual(probed, [brewed, pathHit], 'the walk must continue into PATH after demoting the Homebrew hit')
+})
+
+test('the well-known scan is macOS-only', () => {
+  // Linux desktop launchers inherit a session PATH built from the user's
+  // profile, so PATH already sees a versioned interpreter there; scanning
+  // /usr/local/bin on Linux would prefer a path nobody asked for.
+  const brewed = '/usr/local/bin/python3.12'
+
+  assert.equal(
+    findAcceptablePython({
+      platform: 'linux',
+      fileExists: fsTable([brewed]),
+      findOnPath: pathTable({ python3: '/usr/bin/python3' }),
+      accept: () => true
+    }),
+    '/usr/bin/python3'
+  )
+})
+
+test('the well-known scan is opt-in: no fileExists means PATH-only', () => {
+  // Keeps callers that must not touch the filesystem (and every pre-existing
+  // test in this file) on the exact previous behaviour.
+  assert.equal(
+    findAcceptablePython({
+      platform: 'darwin',
+      findOnPath: pathTable({ python3: '/usr/bin/python3' }),
+      accept: () => true
+    }),
+    '/usr/bin/python3'
+  )
+})
+
+test('the well-known scan stays bounded and costs one lstat per candidate', () => {
+  const checked: string[] = []
+
+  assert.equal(
+    findAcceptablePython({
+      platform: 'darwin',
+      fileExists: candidate => {
+        checked.push(candidate)
+
+        return false
+      },
+      findOnPath: () => null,
+      accept: () => true
+    }),
+    null
+  )
+
+  // One stat per (directory x supported version). No directory listing, no
+  // globbing -- the cost cannot grow with what happens to be installed.
+  assert.equal(checked.length, MACOS_WELL_KNOWN_PYTHON_DIRS.length * SUPPORTED_PYTHON_VERSIONS.length)
+  assert.deepEqual(checked, macOSWellKnownPythonCandidates(true))
+})
+
+test('the well-known scan never prefers a bare python3 symlink', () => {
+  // Bare `python3` in /opt/homebrew/bin points at whichever formula is linked
+  // -- 3.14.4 on this machine, above the `<3.14` ceiling. Preferring it over
+  // PATH would demote a good PATH interpreter in favour of a guess, so only
+  // self-describing versioned names are scanned.
+  for (const candidate of macOSWellKnownPythonCandidates(true)) {
+    assert.doesNotMatch(candidate, /[\\/]python3?$/, `${candidate} must name its own version`)
+  }
+
+  assert.equal(macOSWellKnownPythonCandidates(false).length, 0)
+})
+
+test('both Homebrew prefixes are covered (Apple Silicon and Intel)', () => {
+  // /opt/homebrew is Apple Silicon; /usr/local is Intel Homebrew, and also
+  // where the python.org installer symlinks. Same two directories main.ts
+  // already hard-codes for its `gh` lookup.
+  assert.ok(MACOS_WELL_KNOWN_PYTHON_DIRS.includes('/opt/homebrew/bin'))
+  assert.ok(MACOS_WELL_KNOWN_PYTHON_DIRS.includes('/usr/local/bin'))
+  assert.ok(
+    MACOS_WELL_KNOWN_PYTHON_DIRS.indexOf('/opt/homebrew/bin') < MACOS_WELL_KNOWN_PYTHON_DIRS.indexOf('/usr/local/bin'),
+    'Apple Silicon Homebrew is the common case and should be scanned first'
+  )
+})
+
+test('a well-known hit already on PATH is probed once, not twice', () => {
+  // When Homebrew IS on PATH (a terminal launch), the same binary resolves in
+  // both passes. Dedup by resolved path keeps that at one subprocess.
+  const brewed = '/opt/homebrew/bin/python3.12'
+  const probed: string[] = []
+
+  assert.equal(
+    findAcceptablePython({
+      platform: 'darwin',
+      fileExists: fsTable([brewed]),
+      findOnPath: pathTable({ python3: brewed, python: brewed }),
+      accept: candidate => {
+        probed.push(candidate)
+
+        return false
+      }
+    }),
+    null
+  )
+  assert.deepEqual(probed, [brewed])
+})
+
+test('a checkout venv still short-circuits before any well-known scan', () => {
+  // The scan must add zero cost to the case every install path produces.
+  const root = path.join(os.tmpdir(), 'hermes-resolve-root')
+  const dotVenv = venvPythonCandidates(root, false)[0]
+  const statted: string[] = []
+
+  const resolved = resolvePythonForRoot({
+    root,
+    isWindows: false,
+    fileExists: candidate => {
+      statted.push(candidate)
+
+      return candidate === dotVenv
+    },
+    canImport: () => true,
+    findSystemPython: accept =>
+      findAcceptablePython({ platform: 'darwin', fileExists: () => true, findOnPath: () => null, accept })
+  })
+
+  assert.equal(resolved, dotVenv)
+  assert.deepEqual(
+    statted.filter(candidate => MACOS_WELL_KNOWN_PYTHON_DIRS.some(directory => candidate.startsWith(directory))),
+    [],
+    'no well-known directory may be consulted when a venv resolves'
+  )
 })
 
 test('nothing usable yields the actionable message, not a doomed spawn', () => {

--- a/apps/desktop/electron/backend-probes.test.ts
+++ b/apps/desktop/electron/backend-probes.test.ts
@@ -15,10 +15,16 @@ import { test } from 'vitest'
 import {
   canImportHermesCli,
   DEFAULT_PROBE_TIMEOUT_MS,
+  findAcceptablePython,
   hermesRuntimeImportProbe,
+  posixPythonCommandCandidates,
   PROBE_TIMEOUT_MS,
+  pythonResolutionFailureMessage,
   resolveProbeTimeoutMs,
+  resolvePythonForRoot,
   shouldTrustHermesOverride,
+  SUPPORTED_PYTHON_VERSIONS,
+  venvPythonCandidates,
   verifyHermesCli
 } from './backend-probes'
 
@@ -124,4 +130,292 @@ test('resolveProbeTimeoutMs honours HERMES_PROBE_TIMEOUT_MS', () => {
   assert.equal(resolveProbeTimeoutMs({ HERMES_PROBE_TIMEOUT_MS: 'nope' }), DEFAULT_PROBE_TIMEOUT_MS)
   // Cap runaway values
   assert.equal(resolveProbeTimeoutMs({ HERMES_PROBE_TIMEOUT_MS: '999999' }), 120_000)
+})
+
+// ── Interpreter resolution ladder ────────────────────────────────────────────
+//
+// A PATH interpreter that merely EXISTS used to be returned unprobed, so a
+// `python3` below the `requires-python = ">=3.11"` floor (3.9.6 from macOS
+// CommandLineTools; Debian 11 / Ubuntu 20.04 system python3) was spawned and
+// died inside hermes_cli on PEP 604 syntax. These assert the ordering and the
+// probe gate as behaviour contracts, not as a snapshot of the version list.
+
+/** Build a findOnPath stub from a name -> resolved-path table. */
+function pathTable(table: Record<string, string>) {
+  return (command: string) => table[command] || null
+}
+
+test('a venv inside the checkout wins over anything on PATH', () => {
+  const root = path.join(os.tmpdir(), 'hermes-resolve-root')
+  const dotVenv = venvPythonCandidates(root, false)[0]
+  let walked = false
+
+  const resolved = resolvePythonForRoot({
+    root,
+    isWindows: false,
+    fileExists: candidate => candidate === dotVenv,
+    canImport: () => true,
+    findSystemPython: () => {
+      walked = true
+
+      return '/usr/bin/python3'
+    }
+  })
+
+  assert.equal(resolved, dotVenv)
+  // Precedence has to short-circuit: a hit here must not pay for a PATH walk
+  // (each rejected candidate there costs an interpreter subprocess).
+  assert.equal(walked, false)
+})
+
+test('.venv takes precedence over venv, and both over the system walk', () => {
+  const root = path.join(os.tmpdir(), 'hermes-resolve-root')
+  const [dotVenv, plainVenv] = venvPythonCandidates(root, false)
+
+  assert.match(dotVenv, /[\\/]\.venv[\\/]/)
+  assert.match(plainVenv, /[\\/]venv[\\/]/)
+  assert.equal(
+    resolvePythonForRoot({
+      root,
+      isWindows: false,
+      fileExists: candidate => candidate === plainVenv,
+      canImport: () => true,
+      findSystemPython: () => '/usr/bin/python3'
+    }),
+    plainVenv
+  )
+})
+
+test('an explicit interpreter override outranks the checkout venv', () => {
+  // HERMES_DESKTOP_PYTHON is the documented escape hatch for a venv that lives
+  // outside the checkout (the `hgui` worktree helper sets it). It must stay
+  // authoritative, and it is trusted unprobed: the user pointed at it.
+  const root = path.join(os.tmpdir(), 'hermes-resolve-root')
+  const override = path.join(os.tmpdir(), 'shared-venv', 'bin', 'python')
+
+  assert.equal(
+    resolvePythonForRoot({
+      root,
+      override,
+      isWindows: false,
+      fileExists: () => true,
+      canImport: () => false,
+      findSystemPython: () => '/usr/bin/python3'
+    }),
+    override
+  )
+})
+
+test('a nonexistent override falls through instead of being spawned', () => {
+  const root = path.join(os.tmpdir(), 'hermes-resolve-root')
+
+  assert.equal(
+    resolvePythonForRoot({
+      root,
+      override: '/gone/bin/python',
+      isWindows: false,
+      fileExists: candidate => candidate !== '/gone/bin/python',
+      canImport: () => true,
+      findSystemPython: () => '/usr/bin/python3'
+    }),
+    venvPythonCandidates(root, false)[0]
+  )
+})
+
+test('the system-walk rung is handed a gate bound to this root', () => {
+  // Wiring contract: the fallback rung must receive a validator, and that
+  // validator must ask about the root being resolved -- a probe run with the
+  // wrong (or no) PYTHONPATH would reject every candidate on a source checkout,
+  // where hermes_cli is only importable via the root.
+  const root = '/home/dev/hermes-agent'
+  const asked: Array<[string, string]> = []
+  let sawAccept = false
+
+  const resolved = resolvePythonForRoot({
+    root,
+    isWindows: false,
+    fileExists: () => false,
+    canImport: (candidate, forRoot) => {
+      asked.push([candidate, forRoot])
+
+      return true
+    },
+    findSystemPython: accept => {
+      sawAccept = typeof accept === 'function'
+
+      return accept('/opt/py313/bin/python3.13') ? '/opt/py313/bin/python3.13' : null
+    }
+  })
+
+  assert.equal(sawAccept, true)
+  assert.equal(resolved, '/opt/py313/bin/python3.13')
+  assert.deepEqual(asked, [['/opt/py313/bin/python3.13', root]])
+})
+
+test('no venv plus a too-old PATH python3: probe rejects and the walk continues', () => {
+  // The reported failure, with no versioned name available to short-circuit
+  // it: `python3` resolves and exists but cannot import hermes_cli (3.9.6
+  // can't even parse `str | None` in hermes_cli/main.py). Existence alone must
+  // not end the walk -- the probe has to demote it and try the next name.
+  const tooOld = '/usr/bin/python3'
+  const usable = '/opt/conda/bin/python'
+  const probed: string[] = []
+
+  const resolved = findAcceptablePython({
+    findOnPath: pathTable({ python3: tooOld, python: usable }),
+    accept: candidate => {
+      probed.push(candidate)
+
+      return candidate !== tooOld
+    }
+  })
+
+  assert.equal(resolved, usable)
+  assert.deepEqual(probed, [tooOld, usable], 'the too-old interpreter must be probed, then skipped')
+})
+
+test('an unprobed walk would have returned the too-old interpreter', () => {
+  // Teeth: this is the pre-fix behaviour. Same PATH, no validator -> the
+  // interpreter that dies on spawn is exactly what gets returned. If this ever
+  // starts returning the usable one, the probe gate stopped being what makes
+  // the difference and the fix is being carried by something else.
+  assert.equal(
+    findAcceptablePython({
+      findOnPath: pathTable({ python3: '/usr/bin/python3', python: '/opt/conda/bin/python' })
+    }),
+    '/usr/bin/python3'
+  )
+})
+
+test('a versioned name short-circuits before an out-of-range bare python3', () => {
+  // The other half of the fix, and a distinct mechanism from the probe: when a
+  // versioned name resolves, the walk never reaches bare `python3` at all, so
+  // the too-old interpreter costs zero subprocesses.
+  const probed: string[] = []
+
+  const resolved = findAcceptablePython({
+    findOnPath: pathTable({ 'python3.13': '/opt/py313/bin/python3.13', python3: '/usr/bin/python3' }),
+    accept: candidate => {
+      probed.push(candidate)
+
+      return true
+    }
+  })
+
+  assert.equal(resolved, '/opt/py313/bin/python3.13')
+  assert.deepEqual(probed, ['/opt/py313/bin/python3.13'])
+})
+
+test('an explicitly versioned name is preferred over bare python3', () => {
+  const order: string[] = []
+
+  const resolved = findAcceptablePython({
+    findOnPath: command => {
+      order.push(command)
+
+      return command === 'python3' ? '/usr/bin/python3' : `/usr/bin/${command}`
+    },
+    accept: () => true
+  })
+
+  assert.equal(resolved, `/usr/bin/python${SUPPORTED_PYTHON_VERSIONS[0]}`)
+  assert.equal(order[0], `python${SUPPORTED_PYTHON_VERSIONS[0]}`)
+  assert.ok(order.indexOf('python3') === -1, 'bare python3 must not be consulted once a versioned name answers')
+})
+
+test('bare python3 stays a candidate when no versioned name resolves', () => {
+  // A venv or conda env on PATH exposes only the bare name. Dropping bare
+  // python3 to enforce the floor would break those, so ordering (not
+  // exclusion) is the policy and the probe is the proof.
+  assert.equal(
+    findAcceptablePython({
+      findOnPath: pathTable({ python3: '/opt/conda/bin/python3' }),
+      accept: () => true
+    }),
+    '/opt/conda/bin/python3'
+  )
+})
+
+test('candidate ordering puts every supported version ahead of the bare names', () => {
+  const candidates = posixPythonCommandCandidates()
+
+  for (const version of SUPPORTED_PYTHON_VERSIONS) {
+    assert.ok(
+      candidates.indexOf(`python${version}`) < candidates.indexOf('python3'),
+      `python${version} must be tried before bare python3`
+    )
+  }
+
+  assert.ok(candidates.indexOf('python3') < candidates.indexOf('python'))
+  // Bounded: one name per supported version plus the two bare names. The walk
+  // costs at most this many interpreter subprocesses.
+  assert.equal(candidates.length, SUPPORTED_PYTHON_VERSIONS.length + 2)
+})
+
+test('the walk probes each distinct interpreter at most once', () => {
+  // python3 and python are commonly the same binary; paying two subprocesses
+  // for one answer is pure boot latency.
+  const shared = '/usr/local/bin/python3'
+  const probed: string[] = []
+
+  assert.equal(
+    findAcceptablePython({
+      findOnPath: pathTable({ python3: shared, python: shared }),
+      accept: candidate => {
+        probed.push(candidate)
+
+        return false
+      }
+    }),
+    null
+  )
+  assert.deepEqual(probed, [shared])
+})
+
+test('with no accept validator the first resolvable candidate wins', () => {
+  // Callers that only need "any interpreter" (the uninstall path) must keep
+  // the original zero-subprocess behaviour.
+  assert.equal(findAcceptablePython({ findOnPath: pathTable({ python3: '/usr/bin/python3' }) }), '/usr/bin/python3')
+})
+
+test('nothing usable yields the actionable message, not a doomed spawn', () => {
+  const root = '/home/dev/hermes-agent'
+
+  assert.equal(
+    resolvePythonForRoot({
+      root,
+      isWindows: false,
+      fileExists: () => false,
+      canImport: () => false,
+      findSystemPython: accept => (accept('/usr/bin/python3') ? '/usr/bin/python3' : null)
+    }),
+    null
+  )
+
+  const message = pythonResolutionFailureMessage(root)
+
+  // Names the floor, the venv location we expect, and the escape hatch --
+  // so the reader fixes interpreter selection instead of trying to make a
+  // `requires-python = ">=3.11"` codebase run on 3.9.
+  assert.match(message, new RegExp(`>= ?${SUPPORTED_PYTHON_VERSIONS[0]}`))
+  assert.match(message, /\.venv/)
+  assert.ok(message.includes(root))
+  assert.match(message, /HERMES_DESKTOP_PYTHON/)
+})
+
+test('supported versions stay within the requires-python floor', () => {
+  // Invariant, not a snapshot: pyproject declares ">=3.11,<3.14".
+  for (const version of SUPPORTED_PYTHON_VERSIONS) {
+    const [major, minor] = version.split('.').map(Number)
+
+    assert.equal(major, 3)
+    assert.ok(minor >= 11 && minor < 14, `${version} is outside requires-python`)
+  }
+})
+
+test('windows venv candidates use Scripts/python.exe', () => {
+  const [dotVenv] = venvPythonCandidates('C:\\src\\hermes', true)
+
+  assert.match(dotVenv, /Scripts/)
+  assert.match(dotVenv, /python\.exe$/)
 })

--- a/apps/desktop/electron/backend-probes.ts
+++ b/apps/desktop/electron/backend-probes.ts
@@ -67,6 +67,53 @@ function posixPythonCommandCandidates() {
 }
 
 /**
+ * Directories searched for a versioned interpreter BEFORE PATH, on macOS only.
+ *
+ * A Finder/Dock launch does not run a login shell, so the app inherits
+ * launchd's environment -- `launchctl getenv PATH` is unset on a stock machine,
+ * which leaves `/usr/bin:/bin:/usr/sbin:/sbin`. Homebrew is not on it. That is
+ * the same inheritance problem `backend-env.POSIX_SANE_PATH_ENTRIES` exists to
+ * repair for the spawned backend's PATH, and the same one main.ts's `gh` lookup
+ * dodges by hard-coding these two directories -- but interpreter resolution
+ * still ran PATH-only, so on a GUI launch it could not see a perfectly good
+ * Homebrew 3.12 and fell through to `/usr/bin/python3` (3.9.6), the interpreter
+ * that cannot import hermes_cli at all.
+ *
+ * Both Homebrew prefixes are listed: `/opt/homebrew` on Apple Silicon,
+ * `/usr/local` on Intel (and where the python.org installer symlinks). Linux is
+ * excluded on purpose -- its desktop launchers inherit a session PATH built
+ * from the user's profile, so PATH already sees a versioned interpreter.
+ */
+const MACOS_WELL_KNOWN_PYTHON_DIRS = Object.freeze(['/opt/homebrew/bin', '/usr/local/bin'])
+
+/**
+ * Versioned interpreter paths in the well-known macOS directories.
+ *
+ * Versioned names ONLY. Bare `python3` in these directories is a Homebrew
+ * symlink to whichever formula is currently linked -- 3.14 on this machine,
+ * which is above the `<3.14` ceiling -- so preferring it over PATH would demote
+ * a good PATH interpreter in favour of a guess. `python3.12` names its own
+ * version, and bare `python3` remains reachable through the PATH walk below.
+ *
+ * Bounded by construction: `SUPPORTED_PYTHON_VERSIONS.length` x
+ * `MACOS_WELL_KNOWN_PYTHON_DIRS.length` paths, each an lstat, and only ones
+ * that exist ever become probe candidates.
+ *
+ * @param {boolean} isMacOS - Non-darwin platforms get an empty list.
+ * @returns {string[]} Absolute candidate paths, highest version last-resort
+ *   ordering matching SUPPORTED_PYTHON_VERSIONS (oldest first, as elsewhere).
+ */
+function macOSWellKnownPythonCandidates(isMacOS: boolean) {
+  if (!isMacOS) {
+    return []
+  }
+
+  return MACOS_WELL_KNOWN_PYTHON_DIRS.flatMap(directory =>
+    SUPPORTED_PYTHON_VERSIONS.map(version => path.posix.join(directory, `python${version}`))
+  )
+}
+
+/**
  * Walk interpreter candidates and return the first one `accept` approves.
  *
  * Pure and dependency-injected (no electron, no direct PATH access) so the
@@ -75,32 +122,67 @@ function posixPythonCommandCandidates() {
  * point at the same binary (`python3` and `python` symlinked together) costs
  * one probe, not two.
  *
+ * Two phases, in order:
+ *   1. versioned interpreters in the well-known macOS directories (only when
+ *      `fileExists` and a darwin `platform` are both supplied)
+ *   2. the PATH walk, versioned names before bare ones
+ *
+ * Phase 1 is a PREFERENCE, structurally identical to the versioned-before-bare
+ * ordering in phase 2: `accept` still decides. A Homebrew interpreter that
+ * fails the probe is demoted and the walk continues into PATH, so the scan can
+ * only ever change WHICH acceptable interpreter wins -- never whether an
+ * unacceptable one gets returned.
+ *
  * @param {object} deps
  * @param {(command: string) => string | null} deps.findOnPath - PATH resolver.
  * @param {(candidate: string) => boolean} [deps.accept] - Validator; when
  *   omitted the first resolvable candidate wins (legacy behaviour).
+ * @param {(filePath: string) => boolean} [deps.fileExists] - Enables phase 1.
+ *   Omitted (the default) means PATH-only, which keeps callers that don't want
+ *   to touch the filesystem -- and tests that inject no fake fs -- hermetic.
+ * @param {string} [deps.platform] - Must be 'darwin' for phase 1 to run.
  * @param {string[]} [deps.candidates] - Override the command list (tests).
  * @returns {string | null} An accepted interpreter path, or null.
  */
 function findAcceptablePython(deps: {
   findOnPath: (command: string) => string | null | undefined
   accept?: ((candidate: string) => boolean) | null
+  fileExists?: ((filePath: string) => boolean) | null
+  platform?: string | null
   candidates?: string[]
 }) {
   const candidates = deps.candidates || posixPythonCommandCandidates()
   const seen = new Set<string>()
 
-  for (const command of candidates) {
-    const resolved = deps.findOnPath(command)
-
+  const consider = (resolved: string | null | undefined) => {
     if (!resolved || seen.has(resolved)) {
-      continue
+      return null
     }
 
     seen.add(resolved)
 
-    if (!deps.accept || deps.accept(resolved)) {
-      return resolved
+    return !deps.accept || deps.accept(resolved) ? resolved : null
+  }
+
+  if (deps.fileExists && deps.platform === 'darwin') {
+    for (const candidate of macOSWellKnownPythonCandidates(true)) {
+      if (!deps.fileExists(candidate)) {
+        continue
+      }
+
+      const accepted = consider(candidate)
+
+      if (accepted) {
+        return accepted
+      }
+    }
+  }
+
+  for (const command of candidates) {
+    const accepted = consider(deps.findOnPath(command))
+
+    if (accepted) {
+      return accepted
     }
   }
 
@@ -382,6 +464,8 @@ export {
   execProbeSync,
   findAcceptablePython,
   hermesRuntimeImportProbe,
+  MACOS_WELL_KNOWN_PYTHON_DIRS,
+  macOSWellKnownPythonCandidates,
   posixPythonCommandCandidates,
   PROBE_TIMEOUT_MS,
   pythonResolutionFailureMessage,

--- a/apps/desktop/electron/backend-probes.ts
+++ b/apps/desktop/electron/backend-probes.ts
@@ -34,6 +34,173 @@
  */
 
 import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+
+/**
+ * Python versions Hermes supports, oldest first.
+ *
+ * Single source of truth for the floor `pyproject.toml` declares
+ * (`requires-python = ">=3.11,<3.14"`). main.ts's Windows detection passes
+ * (PEP 514 registry, standard install dirs, `py.exe -<version>`) and the POSIX
+ * candidate walk below both derive from this list, so the floor can't drift
+ * between platforms.
+ */
+const SUPPORTED_PYTHON_VERSIONS = ['3.11', '3.12', '3.13'] as const
+
+/**
+ * Ordered, bounded list of POSIX interpreter command names to try.
+ *
+ * Explicitly-versioned names come first so a box whose bare `python3` is out
+ * of range (Debian 11 / Ubuntu 20.04 ship 3.9; macOS CommandLineTools ships
+ * 3.9.6) still finds a supported interpreter instead of stopping at the first
+ * PATH hit. Bare `python3` / `python` stay as lower rungs rather than being
+ * removed: a venv or conda env on PATH exposes only the bare name, and the
+ * caller's probe -- not the file name -- is what proves a candidate runnable.
+ *
+ * Windows is deliberately excluded: bare PATH lookup there hits the Microsoft
+ * Store redirector, so main.ts uses registry / install-dir / `py.exe` passes.
+ *
+ * @returns {string[]} Command names in priority order.
+ */
+function posixPythonCommandCandidates() {
+  return [...SUPPORTED_PYTHON_VERSIONS.map(version => `python${version}`), 'python3', 'python']
+}
+
+/**
+ * Walk interpreter candidates and return the first one `accept` approves.
+ *
+ * Pure and dependency-injected (no electron, no direct PATH access) so the
+ * ordering policy is unit-testable without a real interpreter zoo on disk.
+ * Resolved paths are de-duplicated, so the common case where several names
+ * point at the same binary (`python3` and `python` symlinked together) costs
+ * one probe, not two.
+ *
+ * @param {object} deps
+ * @param {(command: string) => string | null} deps.findOnPath - PATH resolver.
+ * @param {(candidate: string) => boolean} [deps.accept] - Validator; when
+ *   omitted the first resolvable candidate wins (legacy behaviour).
+ * @param {string[]} [deps.candidates] - Override the command list (tests).
+ * @returns {string | null} An accepted interpreter path, or null.
+ */
+function findAcceptablePython(deps: {
+  findOnPath: (command: string) => string | null | undefined
+  accept?: ((candidate: string) => boolean) | null
+  candidates?: string[]
+}) {
+  const candidates = deps.candidates || posixPythonCommandCandidates()
+  const seen = new Set<string>()
+
+  for (const command of candidates) {
+    const resolved = deps.findOnPath(command)
+
+    if (!resolved || seen.has(resolved)) {
+      continue
+    }
+
+    seen.add(resolved)
+
+    if (!deps.accept || deps.accept(resolved)) {
+      return resolved
+    }
+  }
+
+  return null
+}
+
+/**
+ * Actionable message for "no interpreter on this machine can run Hermes."
+ *
+ * The failure this replaces was actively misleading: an out-of-range
+ * interpreter got spawned anyway and died inside hermes_cli with a bare
+ * `TypeError: unsupported operand type(s) for |` from PEP 604 syntax, which
+ * invites the wrong fix (making a `>=3.11` codebase 3.9-compatible) instead of
+ * pointing at interpreter selection.
+ *
+ * @param {string} root - Hermes source root the interpreter was resolved for.
+ * @returns {string} Log-ready message naming both remedies.
+ */
+function pythonResolutionFailureMessage(root: string) {
+  const floor = SUPPORTED_PYTHON_VERSIONS[0]
+  const venvHint = root ? `${root}/.venv` : '<hermes root>/.venv'
+
+  return (
+    `No Python >= ${floor} with Hermes dependencies found — expected a venv at ${venvHint}, ` +
+    'or set HERMES_DESKTOP_PYTHON to an interpreter that has them.'
+  )
+}
+
+/**
+ * In-checkout venv interpreter paths for `root`, in precedence order.
+ *
+ * `.venv` first (what `uv sync` creates, and what CI's `uv sync --locked
+ * --python 3.11` produces), then `venv` (what `scripts/install.sh` creates when
+ * it isn't redirecting via UV_PROJECT_ENVIRONMENT).
+ *
+ * @param {string} root - Hermes source root.
+ * @param {boolean} isWindows - Selects Scripts/python.exe vs bin/python.
+ * @returns {string[]} Absolute candidate paths, highest precedence first.
+ */
+function venvPythonCandidates(root: string, isWindows: boolean) {
+  const relativePaths = isWindows
+    ? [path.join('.venv', 'Scripts', 'python.exe'), path.join('venv', 'Scripts', 'python.exe')]
+    : [path.join('.venv', 'bin', 'python'), path.join('venv', 'bin', 'python')]
+
+  return relativePaths.map(relativePath => path.join(root, relativePath))
+}
+
+/**
+ * The whole interpreter-precedence ladder for a Hermes source root, as one
+ * pure function. Extracted here (rather than left inline in main.ts) so the
+ * precedence policy is written down once and unit-testable without electron:
+ *
+ *   1. explicit `HERMES_DESKTOP_PYTHON` override, when it exists on disk
+ *   2. `<root>/.venv`, then `<root>/venv`
+ *   3. a system interpreter that passes `accept`
+ *
+ * Rungs 1-2 are trusted unprobed on purpose. An override is a deployment
+ * contract (the `hgui` worktree helper points it at a shared venv), and a venv
+ * inside the checkout is the layout every install path produces -- probing
+ * either would spend a subprocess to second-guess a deliberate choice, and a
+ * broken venv there is a repair case, not a "silently use something else" case.
+ * Rung 3 is the only rung that picks an interpreter the user never pointed at,
+ * which is exactly why it is the one that must be proven runnable.
+ *
+ * The rung-3 gate is built HERE, not by the caller: `canImport` is a required
+ * dependency, so the walk cannot be wired up without it. That is deliberate --
+ * an optional gate is one an edit can quietly drop, which is how this rung came
+ * to be the only one in the ladder running unprobed.
+ *
+ * @param {object} deps
+ * @param {string} deps.root - Hermes source root.
+ * @param {string} [deps.override] - HERMES_DESKTOP_PYTHON value.
+ * @param {boolean} deps.isWindows
+ * @param {(filePath: string) => boolean} deps.fileExists
+ * @param {(candidate: string, root: string) => boolean} deps.canImport - Proof
+ *   that a candidate can import Hermes with `root` on PYTHONPATH.
+ * @param {(accept: (candidate: string) => boolean) => string | null}
+ *   deps.findSystemPython - Platform walk; must honour the accept validator.
+ * @returns {string | null} Interpreter path, or null when nothing qualifies.
+ */
+function resolvePythonForRoot(deps: {
+  root: string
+  override?: string | null
+  isWindows: boolean
+  fileExists: (filePath: string) => boolean
+  canImport: (candidate: string, root: string) => boolean
+  findSystemPython: (accept: (candidate: string) => boolean) => string | null | undefined
+}) {
+  if (deps.override && deps.fileExists(deps.override)) {
+    return deps.override
+  }
+
+  for (const candidate of venvPythonCandidates(deps.root, deps.isWindows)) {
+    if (deps.fileExists(candidate)) {
+      return candidate
+    }
+  }
+
+  return deps.findSystemPython(candidate => deps.canImport(candidate, deps.root)) || null
+}
 
 /** Default probe budget. 5s false-negativeed healthy Windows cold starts (#61764). */
 const DEFAULT_PROBE_TIMEOUT_MS = 15_000
@@ -213,9 +380,15 @@ export {
   canImportHermesCli,
   DEFAULT_PROBE_TIMEOUT_MS,
   execProbeSync,
+  findAcceptablePython,
   hermesRuntimeImportProbe,
+  posixPythonCommandCandidates,
   PROBE_TIMEOUT_MS,
+  pythonResolutionFailureMessage,
   resolveProbeTimeoutMs,
+  resolvePythonForRoot,
   shouldTrustHermesOverride,
+  SUPPORTED_PYTHON_VERSIONS,
+  venvPythonCandidates,
   verifyHermesCli
 }

--- a/apps/desktop/electron/backend-python-resolution-wiring.test.ts
+++ b/apps/desktop/electron/backend-python-resolution-wiring.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Wiring regression for interpreter resolution in main.ts.
+ *
+ * backend-probes.test.ts covers the resolution *policy* (it can import the
+ * pure module). It cannot cover whether main.ts still calls it: main.ts imports
+ * electron, so no vitest project loads it. That gap is not theoretical --
+ * reverting the one line that hands the fallback rung its probe left the entire
+ * suite green, which is how the fallback originally came to be the only rung in
+ * the ladder spawning an interpreter nobody validated. An out-of-range
+ * `python3` (3.9.6 from macOS CommandLineTools/Xcode; Debian 11 / Ubuntu 20.04
+ * system python3) then died inside hermes_cli on PEP 604 syntax.
+ *
+ * So these assert the wiring at the source level. They are deliberately
+ * structural, not snapshots: each one names a call-shape invariant, and the
+ * version floor and message text are asserted against the exported constants
+ * rather than frozen literals.
+ */
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { SUPPORTED_PYTHON_VERSIONS } from './backend-probes'
+
+const MAIN_TS = fs.readFileSync(path.join(import.meta.dirname, 'main.ts'), 'utf8')
+
+/**
+ * The body of a top-level `function <name>(` in main.ts, brace-balanced.
+ *
+ * The opening brace is located after the parameter list closes, so an inline
+ * object type in the signature (`options: { accept: ... }`) isn't mistaken for
+ * the body.
+ */
+function functionBody(source: string, name: string) {
+  const start = source.indexOf(`function ${name}(`)
+
+  assert.notEqual(start, -1, `main.ts must still define ${name}()`)
+
+  const paramsOpen = source.indexOf('(', start)
+  let parenDepth = 0
+  let paramsClose = -1
+
+  for (let i = paramsOpen; i < source.length; i += 1) {
+    if (source[i] === '(') {
+      parenDepth += 1
+    } else if (source[i] === ')') {
+      parenDepth -= 1
+
+      if (parenDepth === 0) {
+        paramsClose = i
+
+        break
+      }
+    }
+  }
+
+  assert.notEqual(paramsClose, -1, `unbalanced parameter list in ${name}()`)
+
+  const open = source.indexOf('{', paramsClose)
+  let depth = 0
+
+  for (let i = open; i < source.length; i += 1) {
+    if (source[i] === '{') {
+      depth += 1
+    } else if (source[i] === '}') {
+      depth -= 1
+
+      if (depth === 0) {
+        return source.slice(start, i + 1)
+      }
+    }
+  }
+
+  throw new Error(`unbalanced braces while reading ${name}()`)
+}
+
+test('findPythonForRoot delegates precedence to the pure resolver', () => {
+  const body = functionBody(MAIN_TS, 'findPythonForRoot')
+
+  assert.match(body, /resolvePythonForRoot\(/, 'precedence must come from backend-probes, not a second inline copy')
+  assert.match(body, /canImport:/, 'the resolver must be given a real import check')
+  assert.match(body, /findSystemPython:\s*accept\s*=>\s*findSystemPython\(\{\s*accept\s*\}\)/)
+})
+
+test('findPythonForRoot reports the actionable message when nothing qualifies', () => {
+  const body = functionBody(MAIN_TS, 'findPythonForRoot')
+
+  assert.match(body, /pythonResolutionFailureMessage\(root\)/)
+  assert.match(body, /rememberLog\(/, 'the message has to reach desktop.log / the boot error detail')
+})
+
+test('the root-scoped import check puts the root on PYTHONPATH', () => {
+  // On a source checkout hermes_cli is only importable via the root, so a probe
+  // without PYTHONPATH would reject every candidate and send a working machine
+  // to bootstrap.
+  const body = functionBody(MAIN_TS, 'canRunHermesFromRoot')
+
+  assert.match(body, /PYTHONPATH/)
+  assert.match(body, /canImportHermesCli\(/)
+  assert.match(body, /_hermesImportableCache/, 'the probe spawns a subprocess; repeat resolutions must be cached')
+})
+
+test('every findSystemPython call site states its accept policy', () => {
+  // `accept` is a required option precisely so this stays visible. Two callers
+  // legitimately pass null (pre-bootstrap runtime, uninstall rmtree); the point
+  // is that no caller can omit it silently.
+  //
+  // The signature line itself is excluded; only invocations are inspected.
+  const callSites = (MAIN_TS.match(/findSystemPython\(\{[^}]*\}\)/g) || []).filter(site => !site.includes('options:'))
+
+  assert.ok(callSites.length >= 3, `expected the known findSystemPython callers, saw ${callSites.length}`)
+
+  for (const site of callSites) {
+    // `{ accept }` shorthand and `{ accept: ... }` both declare the policy.
+    assert.match(site, /accept\s*[:}]/, `findSystemPython call site without an explicit accept: ${site}`)
+  }
+
+  assert.ok(
+    !/findSystemPython\(\)/.test(MAIN_TS),
+    'a bare findSystemPython() call is the unvetted-interpreter regression'
+  )
+})
+
+test('the POSIX walk and the Windows passes share one version floor', () => {
+  const body = functionBody(MAIN_TS, 'findSystemPython')
+
+  assert.match(body, /findAcceptablePython\(\{\s*findOnPath,\s*accept\s*\}\)/, 'POSIX must use the shared walk')
+  assert.match(body, /const SUPPORTED_VERSIONS = SUPPORTED_PYTHON_VERSIONS/, 'Windows must reuse the shared list')
+
+  for (const version of SUPPORTED_PYTHON_VERSIONS) {
+    assert.ok(
+      !new RegExp(`SUPPORTED_VERSIONS = \\[[^\\]]*'${version}'`).test(body),
+      'the version floor must not be re-literalised inside main.ts'
+    )
+  }
+})
+
+test('Windows candidate hits are validated before being returned', () => {
+  // Registry / install-dir / py.exe prove a version, not that Hermes can run on
+  // it. Each Windows return path must go through the same accept gate.
+  const body = functionBody(MAIN_TS, 'findSystemPython')
+  const gated = body.match(/&& acceptCandidate\(/g) || []
+
+  assert.match(body, /const acceptCandidate = candidate => !accept \|\| accept\(candidate\)/)
+  // Four Windows return paths: registry hit, per-machine install dir, per-user
+  // install dir, and the py.exe launcher resolution.
+  assert.equal(gated.length, 4, `expected all 4 Windows returns to be gated, saw ${gated.length}`)
+})

--- a/apps/desktop/electron/backend-python-resolution-wiring.test.ts
+++ b/apps/desktop/electron/backend-python-resolution-wiring.test.ts
@@ -126,7 +126,7 @@ test('every findSystemPython call site states its accept policy', () => {
 test('the POSIX walk and the Windows passes share one version floor', () => {
   const body = functionBody(MAIN_TS, 'findSystemPython')
 
-  assert.match(body, /findAcceptablePython\(\{\s*findOnPath,\s*accept\s*\}\)/, 'POSIX must use the shared walk')
+  assert.match(body, /findAcceptablePython\(\{\s*findOnPath,\s*accept[,\s}]/, 'POSIX must use the shared walk')
   assert.match(body, /const SUPPORTED_VERSIONS = SUPPORTED_PYTHON_VERSIONS/, 'Windows must reuse the shared list')
 
   for (const version of SUPPORTED_PYTHON_VERSIONS) {
@@ -135,6 +135,21 @@ test('the POSIX walk and the Windows passes share one version floor', () => {
       'the version floor must not be re-literalised inside main.ts'
     )
   }
+})
+
+test('the POSIX walk is handed what the macOS well-known pass needs', () => {
+  // The Homebrew-before-PATH pass in backend-probes is opt-in: it only runs
+  // when the caller supplies `fileExists` AND a darwin `platform`. main.ts is
+  // the only production caller that can supply them, and main.ts is not loaded
+  // by any vitest project -- so without this assertion, dropping either
+  // argument silently reverts the whole pass with the suite still green. That
+  // is the same coverage hole that let the fallback rung run unprobed.
+  const body = functionBody(MAIN_TS, 'findSystemPython')
+  const call = body.match(/findAcceptablePython\(\{[^}]*\}\)/)
+
+  assert.ok(call, 'main.ts must still call the shared POSIX walk')
+  assert.match(call[0], /fileExists/, 'without fileExists the well-known-directory pass never runs')
+  assert.match(call[0], /platform:\s*process\.platform/, 'the pass is gated on a darwin platform')
 })
 
 test('Windows candidate hits are validated before being returned', () => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2075,7 +2075,14 @@ function findSystemPython(options: { accept: ((candidate: string) => boolean) | 
     // below applies here too -- `python3` is 3.9 on macOS CommandLineTools
     // and on Debian 11 / Ubuntu 20.04, which cannot import hermes_cli at all.
     // The version ordering is a preference; `accept` is the actual proof.
-    return findAcceptablePython({ findOnPath, accept })
+    //
+    // `fileExists` + `platform` additionally enable the macOS
+    // Homebrew-before-PATH pass: a Finder/Dock launch inherits launchd's
+    // environment, where PATH is /usr/bin:/bin:/usr/sbin:/sbin and Homebrew is
+    // absent -- so a PATH-only search on a GUI launch cannot see an installed
+    // /opt/homebrew/bin/python3.12 and settles for /usr/bin/python3 (3.9.6).
+    // Same shape as the version ordering: a preference, still gated by accept.
+    return findAcceptablePython({ findOnPath, accept, fileExists, platform: process.platform })
   }
 
   // Windows: PATH-based detection has TWO landmines we have to dodge.

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -40,8 +40,12 @@ import { isReauthRequiredError, waitForHermesReady } from './backend-health'
 import {
   canImportHermesCli,
   execProbeSync,
+  findAcceptablePython,
   PROBE_TIMEOUT_MS,
+  pythonResolutionFailureMessage,
+  resolvePythonForRoot,
   shouldTrustHermesOverride,
+  SUPPORTED_PYTHON_VERSIONS,
   verifyHermesCli
 } from './backend-probes'
 import { waitForDashboardPortAnnouncement } from './backend-ready'
@@ -2000,39 +2004,78 @@ function isHermesSourceRoot(root) {
 }
 
 function findPythonForRoot(root) {
-  const override = process.env.HERMES_DESKTOP_PYTHON
+  // Precedence itself lives in backend-probes.resolvePythonForRoot (pure,
+  // electron-free, unit-tested). The only rung that needs main.ts context is
+  // the system walk, injected below.
+  //
+  // Falling through to PATH means we're about to hand the spawn step an
+  // interpreter nobody pointed us at. That was the one rung of this ladder
+  // that skipped the guard the other rungs already apply (rung 4 gates on
+  // verifyHermesCli; rung 5 and isActiveRuntimeUsable gate on
+  // canImportHermesCli), and it is how an out-of-range `python3` -- 3.9.6 from
+  // macOS CommandLineTools/Xcode, or Debian 11 / Ubuntu 20.04's system python3
+  // -- got selected for a `requires-python = ">=3.11"` codebase and died on
+  // PEP 604 syntax during module import. Probe here too, and keep walking on
+  // failure, so a wrong candidate demotes instead of becoming a dead backend.
+  const python = resolvePythonForRoot({
+    root,
+    override: process.env.HERMES_DESKTOP_PYTHON,
+    isWindows: IS_WINDOWS,
+    fileExists,
+    canImport: canRunHermesFromRoot,
+    findSystemPython: accept => findSystemPython({ accept })
+  })
 
-  if (override && fileExists(override)) {
-    return override
+  if (!python) {
+    rememberLog(`[backend] ${pythonResolutionFailureMessage(root)}`)
   }
 
-  const relativePaths = IS_WINDOWS
-    ? [path.join('.venv', 'Scripts', 'python.exe'), path.join('venv', 'Scripts', 'python.exe')]
-    : [path.join('.venv', 'bin', 'python'), path.join('venv', 'bin', 'python')]
-
-  for (const relativePath of relativePaths) {
-    const candidate = path.join(root, relativePath)
-
-    if (fileExists(candidate)) {
-      return candidate
-    }
-  }
-
-  return findSystemPython()
+  return python
 }
 
-function findSystemPython() {
+// Memoized `can this interpreter import Hermes with <root> on PYTHONPATH?`.
+//
+// canImportHermesCli spawns a subprocess, and resolveHermesBackend runs more
+// than once per process (initial boot, post-bootstrap re-resolve, manual
+// restart). Cache per interpreter+root exactly like _serveSupportCache does
+// for `serve` support, so repeat resolutions are free. Safe to hold for the
+// process lifetime: bootstrap installs into VENV_ROOT, which rung 3 resolves
+// via getVenvPython() without consulting this walk, so a cached "no" for a
+// system interpreter cannot go stale underneath us.
+const _hermesImportableCache = new Map()
+
+function canRunHermesFromRoot(candidate, root) {
+  const key = `${candidate}::${root || ''}`
+
+  if (_hermesImportableCache.has(key)) {
+    return _hermesImportableCache.get(key)
+  }
+
+  const pythonPath = [root, process.env.PYTHONPATH].filter(Boolean).join(path.delimiter)
+  const result = canImportHermesCli(candidate, pythonPath ? { env: { PYTHONPATH: pythonPath } } : {})
+
+  _hermesImportableCache.set(key, result)
+
+  return result
+}
+
+// `accept` decides whether a located interpreter is actually trusted. It is a
+// REQUIRED option, and `{ accept: null }` (first resolvable candidate wins) is
+// a legal answer -- but it has to be written down. main.ts can't be unit-tested
+// (it imports electron), so a silently-omittable gate here is one an edit can
+// drop with the whole suite still green; that is precisely how this rung ended
+// up as the only one in the ladder spawning an unvetted interpreter. Making the
+// option required moves that regression from "invisible" to "fails typecheck."
+function findSystemPython(options: { accept: ((candidate: string) => boolean) | null }) {
+  const accept = options.accept
+
   if (!IS_WINDOWS) {
-    // POSIX systems: PATH lookup is safe.
-    for (const command of ['python3', 'python']) {
-      const candidate = findOnPath(command)
-
-      if (candidate) {
-        return candidate
-      }
-    }
-
-    return null
+    // POSIX systems: PATH lookup is safe. Try explicitly-versioned names
+    // before the bare ones so the SUPPORTED_VERSIONS floor Windows enforces
+    // below applies here too -- `python3` is 3.9 on macOS CommandLineTools
+    // and on Debian 11 / Ubuntu 20.04, which cannot import hermes_cli at all.
+    // The version ordering is a preference; `accept` is the actual proof.
+    return findAcceptablePython({ findOnPath, accept })
   }
 
   // Windows: PATH-based detection has TWO landmines we have to dodge.
@@ -2074,8 +2117,15 @@ function findSystemPython() {
   //          py.exe's default is (which on a 3.14-only box would be
   //          3.14).
 
-  const SUPPORTED_VERSIONS = ['3.11', '3.12', '3.13']
-  const SUPPORTED_VERSIONS_NO_DOT = ['311', '312', '313']
+  // Shared with the POSIX walk above via backend-probes so the floor from
+  // `requires-python` lives in exactly one place.
+  const SUPPORTED_VERSIONS = SUPPORTED_PYTHON_VERSIONS
+  const SUPPORTED_VERSIONS_NO_DOT = SUPPORTED_VERSIONS.map(version => version.replace('.', ''))
+
+  // A registry / install-dir / py.exe hit proves the version, not that Hermes
+  // can actually run on it. When the caller supplied a validator, apply it
+  // here too and keep walking on failure -- same contract as the POSIX walk.
+  const acceptCandidate = candidate => !accept || accept(candidate)
 
   // Pass 1: registry. Use `reg query` since main process doesn't have
   // a reliable in-process registry API across all electron versions.
@@ -2098,7 +2148,7 @@ function findSystemPython() {
           const installPath = match[1].trim()
           const pythonExe = path.join(installPath, 'python.exe')
 
-          if (fileExists(pythonExe)) {
+          if (fileExists(pythonExe) && acceptCandidate(pythonExe)) {
             return pythonExe
           }
         }
@@ -2115,14 +2165,14 @@ function findSystemPython() {
   for (const versionDir of SUPPORTED_VERSIONS_NO_DOT) {
     const systemWide = path.join(programFiles, `Python${versionDir}`, 'python.exe')
 
-    if (fileExists(systemWide)) {
+    if (fileExists(systemWide) && acceptCandidate(systemWide)) {
       return systemWide
     }
 
     if (localAppData) {
       const perUser = path.join(localAppData, 'Programs', 'Python', `Python${versionDir}`, 'python.exe')
 
-      if (fileExists(perUser)) {
+      if (fileExists(perUser) && acceptCandidate(perUser)) {
         return perUser
       }
     }
@@ -2154,7 +2204,7 @@ function findSystemPython() {
 
         const candidate = out.trim()
 
-        if (candidate && fileExists(candidate)) {
+        if (candidate && fileExists(candidate) && acceptCandidate(candidate)) {
           return candidate
         }
       } catch {
@@ -3853,7 +3903,12 @@ function createPythonBackend(root, label, backendArgs, options: any = {}) {
 // ensureRuntime() to create / refresh it before launch.
 function createActiveBackend(backendArgs) {
   const venvPython = getVenvPython(VENV_ROOT)
-  const command = fileExists(venvPython) ? venvPython : findSystemPython()
+  // accept: null on purpose. This backend is returned with bootstrap=true, so
+  // when VENV_ROOT has no interpreter yet the installer is what makes the
+  // runtime usable -- ensureRuntime() then rewrites backend.command to the
+  // freshly-built venv python. Probing a pre-bootstrap candidate for a venv
+  // that doesn't exist yet would reject every candidate and buy nothing.
+  const command = fileExists(venvPython) ? venvPython : findSystemPython({ accept: null })
 
   return {
     kind: 'python',
@@ -3996,31 +4051,35 @@ function resolveHermesBackend(backendArgs) {
   // 5. Last-ditch: pip-installed hermes_cli module via system Python.
   //    Same rationale as #4 -- the user installed this; we use it but don't
   //    take ownership.
-  const python = findSystemPython()
+  //
+  //    Same smoke-test rationale as step 4: a system Python in the
+  //    SUPPORTED_VERSIONS range can be registered (PEP 514) without having
+  //    hermes_cli installed -- common on dev boxes that have a python.org
+  //    install from prior unrelated work. Returning that backend hands the
+  //    spawn step a guaranteed ModuleNotFoundError. There is no source root to
+  //    put on PYTHONPATH here (this rung is for a pip-installed hermes_cli),
+  //    so the probe runs against the interpreter's own site-packages.
+  //
+  //    The probe is passed as the walk's `accept` rather than applied to a
+  //    single winner: the first interpreter on PATH without hermes_cli used to
+  //    end this rung outright, even when the next candidate had it. On
+  //    failure, we fall through to step 6 so the bootstrap runner pulls a
+  //    uv-managed 3.11 into %LOCALAPPDATA%\hermes\hermes-agent\venv.
+  const python = findSystemPython({ accept: candidate => canRunHermesFromRoot(candidate, null) })
 
   if (python) {
-    // Same smoke-test rationale as step 4: a system Python in the
-    // SUPPORTED_VERSIONS range can be registered (PEP 514) without
-    // having hermes_cli installed -- common on dev boxes that have
-    // a python.org install from prior unrelated work. Returning that
-    // backend hands the spawn step a guaranteed ModuleNotFoundError.
-    // Verify the import works before trusting the candidate; on
-    // failure, fall through to step 6 so the bootstrap runner pulls
-    // a uv-managed 3.11 into %LOCALAPPDATA%\hermes\hermes-agent\venv.
-    if (canImportHermesCli(python)) {
-      return {
-        kind: 'python',
-        label: `installed hermes_cli module via ${python}`,
-        command: python,
-        args: ['-m', 'hermes_cli.main', ...backendArgs],
-        bootstrap: false,
-        env: {},
-        shell: false
-      }
+    return {
+      kind: 'python',
+      label: `installed hermes_cli module via ${python}`,
+      command: python,
+      args: ['-m', 'hermes_cli.main', ...backendArgs],
+      bootstrap: false,
+      env: {},
+      shell: false
     }
-
-    rememberLog(`Ignoring system Python ${python}: hermes_cli is not importable; falling through to bootstrap.`)
   }
+
+  rememberLog('No system Python with an importable hermes_cli was found; falling through to bootstrap.')
 
   // 6. Nothing usable yet -- signal the bootstrap runner that we need to
   //    clone+install. Phase 1D's bootstrap-runner consumes this sentinel
@@ -11583,7 +11642,11 @@ async function runDesktopUninstall(mode) {
   let pythonPath = null
 
   if (modeRemovesAgent(mode)) {
-    const sysPy = findSystemPython()
+    // accept: null on purpose. This interpreter only has to run shutil.rmtree
+    // over the venv; it does not need to import Hermes. Requiring an importable
+    // hermes_cli here would reject perfectly good interpreters and push the
+    // uninstall back onto the venv python we're trying to delete.
+    const sysPy = findSystemPython({ accept: null })
 
     if (sysPy) {
       py = sysPy


### PR DESCRIPTION
## What does this PR do?

The desktop backend resolver returned the first `python3` it found on `PATH` **without checking it**. On macOS, CommandLineTools/Xcode ships 3.9.6 at `/usr/bin/python3`; Debian 11 and Ubuntu 20.04 ship 3.9 as `python3`. Both are below the `requires-python = ">=3.11,<3.14"` floor in `pyproject.toml`, and `hermes_cli/main.py` has no `from __future__ import annotations`, so PEP 604 annotations evaluate at import time and the backend dies before it starts:

```
[hermes] [boot] Using Hermes source at /path/to/hermes-agent
[hermes]   File ".../python3.9/runpy.py", line 197, in _run_module_as_main
[hermes]   File ".../hermes_cli/main.py", line 399, in <module>
[hermes]     def _read_openai_version_fast() -> str | None:
[hermes] TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
[hermes] Hermes backend exited (1)
```

**This is an internal inconsistency, not a missing feature.** `canImportHermesCli` already exists for exactly this failure mode — its own header says an unprobed resolver "returns a backend the spawn step can't actually run." Rung 4 gates on `verifyHermesCli`, rung 5 and `isActiveRuntimeUsable` gate on `canImportHermesCli`. The PATH fallback — the **only** rung that selects an interpreter the user never pointed at — trusted it unprobed. Separately, the Windows branch of `findSystemPython()` has enforced `SUPPORTED_VERSIONS = ['3.11','3.12','3.13']` since it was written; POSIX had no version check at all.

The existing probe already distinguishes these cases, measured on the reporting machine:

```
probe vs /usr/bin/python3 (3.9.6), PYTHONPATH=checkout  ->  ModuleNotFoundError: No module named 'dotenv'
probe vs the 3.11 venv                                 ->  exit 0
```

**Why CI is green and structurally cannot catch this.** `.github/workflows/e2e-desktop.yml` runs `uv sync --locked --python 3.11` with no `UV_PROJECT_ENVIRONMENT` override (unlike `scripts/install.sh`), which creates `$REPO_ROOT/.venv` — so the first venv candidate always hits and the PATH fallback is never reached. Verified by symlinking a 3.11 venv to `<checkout>/.venv` and re-running the same e2e: 4 passed. Removing it: 4 failed. The entire green/red difference is "is there a `.venv` inside the checkout."

## Related Issue

Fixes #39536.

Also observed as the boot symptom in #43913 (macOS desktop install loop), but
not claimed here: that report's loop runs through `isActiveRuntimeUsable()`,
which has probed the venv interpreter since `0229246ab`, so on current `main` a
valid 3.11 venv resolves at rung 3 and the loop no longer reproduces. Left for a
maintainer to confirm and close separately.

Prior art this builds on rather than duplicates:

- **#39585** (@LeonSGP43) — same diagnosis and a very similar candidate-walk shape (ordered candidates, `Set`-based dedupe, version filter). It targets the pre-TypeScript `.cjs` files, which `39d09453f` removed, so it cannot be rebased mechanically; the sweeper review asked for a port to TS aligned to 3.11–3.13 instead of `>=3.10`. That is what this does, and I have credited it with `Co-authored-by`.
- **#43416** (@zhang-perry) — the probe-before-trust direction, applied one layer up in `resolveHermesBackend` (rungs 1 and 2 reject the whole rung and fall through to rung 3). This PR probes inside the candidate walk instead, so a wrong candidate is *demoted* and the walk continues to a usable interpreter, keeping the developer's own checkout active rather than silently retargeting to `~/.hermes/hermes-agent`.

## Fulfilling the review ask on #39585

@teknium1's sweeper review on #39585 (2026-07-14, `verdict=keep_open
salvageability=medium`) confirmed the defect is live and asked for exactly this
port:

> The underlying defect remains on current main: `apps/desktop/electron/main.ts:1646-1657`
> still returns the first POSIX PATH hit, while `hermes_cli/main.py:224` contains
> a Python-3.10+ union annotation.
>
> ### Problems
> - The patch edits CJS files that no longer exist on current main. Commit
>   `39d09453f95e8aefc0c97e5d9b30ff341cae9ed8` renamed `backend-probes.cjs` →
>   `backend-probes.ts` and `main.cjs` → `main.ts`.
> - The proposed >=3.10 check is not the current compatibility contract.
>   `pyproject.toml:20` requires `>=3.11,<3.14`; `apps/desktop/electron/main.ts:1672-1785`
>   also documents why 3.14 must be rejected.
>
> ### Suggested changes
> - Port the candidate resolver and tests to the current TypeScript files.
> - Align the POSIX version filter and tests with 3.11–3.13, rejecting 3.9,
>   3.10, and 3.14 while retaining the macOS Homebrew-before-PATH ordering.

[Quoted verbatim; the `file:line` refs are as-of the 2026-07-14 review and have
since drifted. Current-`main` equivalents (verified at `7e47a0fdc`):
`apps/desktop/electron/main.ts:1646-1657` → **`main.ts:2024`** (`findSystemPython`,
POSIX PATH-first loop at 2027-2033); `hermes_cli/main.py:224` →
**`hermes_cli/main.py:399`** (same symbol, `_read_openai_version_fast() -> str | None`,
and still a runtime-evaluated union — the module has no
`from __future__ import annotations`); `pyproject.toml:20` → **`pyproject.toml:15`**
(`requires-python = ">=3.11,<3.14"`, unchanged in content); and the fourth ref,
`main.ts:1672-1785`, → **`main.ts:2050-2177`** (the 3.14-rejection rationale at 2050
and `SUPPORTED_VERSIONS` at 2077; the original upper bound overshot into
`findGitBash`).]

This PR is that port: TS files, one shared `SUPPORTED_PYTHON_VERSIONS` derived
from the `pyproject.toml` floor, and the Homebrew-before-PATH ordering retained.
It adds an import probe on top of the version preference, because a version
check alone is insufficient — a 3.11.15 interpreter that satisfies any version
filter still fails `import yaml` (a bare uv interpreter), and the probe rejects
3.9 on its own via the `hermes_cli.config` chain hardened in `0229246ab`.

#39585 cannot be rebased mechanically (`mergeable: false`, all three paths
deleted), so this is a new PR with `Co-authored-by` rather than a push there.

## Relationship to other open PRs

- **#39585** (@LeonSGP43) — the original diagnosis and candidate-walk shape,
  credited via `Co-authored-by`. Version-filter-only and on deleted `.cjs`
  paths; superseded by this port.
- **#43416** (@zhang-perry) — probe-before-trust at rungs 1/2 of
  `resolveHermesBackend`, credited via `Co-authored-by` for the
  environment-aware probe (`{ env: backend.env }`) this reuses. Textual conflict
  at the `findPythonForRoot` boundary; semantically redundant once this lands,
  since `findPythonForRoot` returning null makes `createPythonBackend` return
  null and rungs 1/2 fall through as intended — while still demoting a single
  bad candidate instead of abandoning the rung, so a developer's checkout stays
  active rather than retargeting to `~/.hermes/hermes-agent`.
- **#72399** (@ChuckChambers) — rewrites `canImportHermesCli`'s env handling in
  `backend-probes.ts`. Conflicts textually with this PR's import and export
  blocks in that file; semantically compatible, since explicit `env` still
  reaches the probe. Happy to rebase behind whichever lands first.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`apps/desktop/electron/backend-probes.ts` (pure, electron-free — preserved)

- `SUPPORTED_PYTHON_VERSIONS` — one source of truth for the `requires-python` floor, now shared by the POSIX walk and the Windows registry / install-dir / `py.exe` passes so they cannot drift.
- `posixPythonCommandCandidates()` — `python3.11`, `python3.12`, `python3.13`, then bare `python3`, `python`. Bare names stay as lower rungs on purpose: a venv or conda env exposes only the bare name. Ordering is the preference; the probe is the proof.
- `findAcceptablePython({ findOnPath, accept, fileExists, platform, candidates })` — dependency-injected walk, dedupes by resolved path so `python3`/`python` symlinked together cost one probe.
- `MACOS_WELL_KNOWN_PYTHON_DIRS` / `macOSWellKnownPythonCandidates()` — on macOS, versioned interpreters in `/opt/homebrew/bin` then `/usr/local/bin` are tried **before** the PATH walk (the ordering the #39585 review asked for). A Finder/Dock launch inherits launchd's environment — `launchctl getenv PATH` is unset on a stock machine, leaving `/usr/bin:/bin:/usr/sbin:/sbin` with no Homebrew on it — so a PATH-only search cannot see an installed 3.12. Measured on that PATH here: the walk resolves `null`, because 3.9.6 is the only interpreter it can reach. Versioned names only: bare `python3` there is a Homebrew symlink to whichever formula is linked (3.14 on my machine, above the `<3.14` ceiling), so preferring it over PATH would demote a good PATH interpreter in favour of a guess. Opt-in on `fileExists` + a darwin `platform`; the pass is a **preference**, `accept` still decides, so a Homebrew interpreter that fails the probe is demoted and the walk continues into PATH. Bounded by construction at 6 lstats (versions × 2 directories), no directory listing.
- `resolvePythonForRoot(...)` — the full precedence ladder as one pure function. `canImport` is a **required** dependency, so the gate cannot be silently dropped.
- `venvPythonCandidates(root, isWindows)`, `pythonResolutionFailureMessage(root)`.

`apps/desktop/electron/main.ts`

- `findPythonForRoot()` delegates precedence to `resolvePythonForRoot` and injects the probe-gated system walk.
- `findSystemPython({ accept })` — `accept` is a **required** option; `{ accept: null }` is legal but must be written down. POSIX uses the shared walk; the four Windows return paths now go through the same validator (registry/install-dir/`py.exe` prove a *version*, not runnability).
- `canRunHermesFromRoot()` — `canImportHermesCli` with the root on `PYTHONPATH`, memoized per interpreter+root following the existing `_serveSupportCache` pattern.
- Rung 5 now passes the probe *as the walk's* `accept` rather than probing a single winner, so one interpreter without `hermes_cli` no longer ends the rung when the next candidate has it.
- Actionable failure log: ``No Python >= 3.11 with Hermes dependencies found — expected a venv at <root>/.venv, or set HERMES_DESKTOP_PYTHON to an interpreter that has them.`` The old failure invited the *wrong* fix — making a `>=3.11` codebase 3.9-compatible.
- The two callers that legitimately want "any interpreter" (`createActiveBackend` pre-bootstrap, uninstall `rmtree`) pass `accept: null` with a comment explaining why.

Tests: `backend-probes.test.ts` (12 → 37) and a new `backend-python-resolution-wiring.test.ts` (7).

**Not changed:** no third venv candidate for `~/.hermes/hermes-agent/venv`. `HERMES_DESKTOP_PYTHON` is the documented escape hatch for the shared-venv case (`website/docs/reference/environment-variables.md`, and the `hgui` helper in `worktree-ui-dev.md` sets it); verified working. The packaged path is untouched — `IS_PACKAGED` still skips rung 2, and rung 3's `createActiveBackend` still uses `getVenvPython(VENV_ROOT)` directly. No new env var; no config change.

## How to Test

On a machine whose `python3` is below 3.11 (stock macOS with CommandLineTools, or Debian 11 / Ubuntu 20.04), with **no** `.venv`/`venv` inside the checkout:

1. `cd apps/desktop && npm run build`
2. `npx playwright test e2e/boot.spec.ts --reporter=list` — before: 4 failed with the `TypeError` above. After: 4 passed, backend spawned as `/opt/miniconda3/bin/python3.13 -m hermes_cli.main serve ...` (the first candidate that passes the probe) with **no** `PATH` prepend.
3. Control, established *before* the fix: `PATH="$HOME/.hermes/hermes-agent/venv/bin:$PATH" npx playwright test e2e/boot.spec.ts` → 4 passed. The fix makes that prepend unnecessary rather than coinciding with it.
4. Nothing usable at all (`PATH=/usr/bin:/bin:/usr/sbin:/sbin`) → `desktop.log` shows the actionable message and the first-run installer, instead of a doomed spawn:
   ```
   [hermes] [backend] No Python >= 3.11 with Hermes dependencies found — expected a venv at <checkout>/.venv, or set HERMES_DESKTOP_PYTHON to an interpreter that has them.
   [hermes] No system Python with an importable hermes_cli was found; falling through to bootstrap.
   ```
5. `HERMES_DESKTOP_PYTHON=$HOME/.hermes/hermes-agent/venv/bin/python` on that same stripped `PATH` → boots on the override, unprobed, as documented.

`cd apps/desktop`:

```
npx vitest run --project electron    # 967 passed | 2 skipped  (baseline on main: 935 | 2)
npx tsc -p tsconfig.electron.json --noEmit   # clean
npx eslint electron/                 # clean
npx prettier --check 'electron/**/*.ts'      # my files clean
```

Reverting each hunk individually turns the suite red (probe gate → 2 fail; versioned ordering → 3 fail; dedupe → 1 fail; message → 1 fail; the Homebrew pass → 3 fail; the `main.ts` wiring → 1 fail each for the probe gate and the Homebrew arguments). The wiring test exists because `main.ts` imports electron and no vitest project loads it: reverting the one line that hands the fallback its probe left the whole suite green, which is how this rung came to be the only unprobed one.

Two of the guards are enforced by the **compiler**, not just by tests — verified by actually making each edit and running `npx tsc -p tsconfig.electron.json --noEmit`:

```
# dropping `accept` at a findSystemPython call site
electron/main.ts(4075,18): error TS2554: Expected 1 arguments, but got 0.

# dropping `canImport` from the resolvePythonForRoot call
electron/main.ts(2020,39): error TS2345: ... Property 'canImport' is missing in type
  '{ root: any; override: string; isWindows: boolean; fileExists: ...; findSystemPython: ... }'
  but required in type '{ ...; canImport: (candidate: string, root: string) => boolean; ... }'.
```

So dropping the gate fails typecheck rather than passing silently — which is what makes the required-option design worth the noise in an untestable file.

**Cost.** The probe spawns a subprocess, so the fallback path is not free: 1–2 probes, +104–352 ms, bounded at 5 PATH candidates plus 6 lstats for the macOS pass, deduped by resolved path and memoized per interpreter+root. **Zero** added cost on the paths that matter most — a venv inside the checkout (CI's shape) or `HERMES_DESKTOP_PYTHON` short-circuits before any probe (asserted by a test), and packaged installs resolve `getVenvPython(VENV_ROOT)` directly.

Re-measured for the Homebrew pass, interleaved A/B in one process against the same source (7 cold samples each, median):

| scenario | before | after | probes |
| --- | --- | --- | --- |
| venv in checkout | 0 ms | 0 ms | 0 |
| `HERMES_DESKTOP_PYTHON` set | 0 ms | 0 ms | 0 |
| real login `PATH` | 146.9 ms | 132.4 ms | 2 → 2 |
| launchd minimal `PATH` | 57.2 ms | 57.9 ms | 1 → 1 |

The scan in isolation is **0.08–0.14 ms** for its 6 lstats; the table's deltas are Python-startup noise, not the scan.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run: this change is TypeScript-only under `apps/desktop/electron/`, no Python touched.** Ran the desktop suites instead (see above).
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), `/usr/bin/python3` = 3.9.6. **One caveat, stated plainly:** the macOS well-known-directory pass was **not** exercised end-to-end here — `/opt/homebrew/bin` on this machine holds only 3.14.4 and 3.9.24, both outside `>=3.11,<3.14`, so the scan finds nothing usable and the e2e still resolves through `PATH` exactly as before. Its correctness rests on unit tests with injected fake filesystems (the pattern already used in `backend-probes.test.ts`) plus the wiring assertion, not on a live Homebrew hit.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — **N/A**: no user-facing behavior or config change; `HERMES_DESKTOP_PYTHON` docs already describe the escape hatch this relies on.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — **N/A**, no config keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — **N/A**, no architecture change; the resolution ladder keeps its existing shape.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — Windows keeps its registry / install-dir / `py.exe` passes and gains the same validator; the POSIX bare-name rungs are retained so venv/conda layouts still resolve. Windows and Linux were **not** executed — I only have macOS. Linux exposure is the same 3.9-`python3` class (Debian 11 / Ubuntu 20.04).
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — **N/A**, no model tools touched.

## Screenshots / Logs

Backend after the fix, on the `PATH` that previously produced the `TypeError` (no prepend):

```
/opt/miniconda3/bin/python3.13 -m hermes_cli.main serve --host 127.0.0.1 --port 0
[hermes] [boot] Using Hermes source at <checkout>
[hermes] [backend] `serve` supported for Hermes source at <checkout>
[hermes] HERMES_BACKEND_READY port=57918
[hermes] [boot] Hermes backend is ready. Finalizing desktop startup
```
