### PR TITLE
fix(install): require npm alongside node; report npm install failures honestly (#77003)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -829,8 +829,16 @@ check_node() {
     # enough for the desktop build AND an npm that can read our .npmrc. A
     # bad-band npm (see npm_supports_npmrc) fails `npm ci` outright, and the
     # managed Node we install instead bundles one that works.
-    if command -v node &> /dev/null && node_satisfies_build "$(node --version)"; then
-        if ! command -v npm &> /dev/null || npm_supports_npmrc "$(npm --version 2>/dev/null)"; then
+    #
+    # npm must actually be reachable, not just node: a stray `node` symlink
+    # without a sibling npm (leftover from a node version manager) makes
+    # `command -v node` succeed while every later `npm install` silently
+    # fails and the desktop build dies with an opaque "Node.js / npm
+    # unavailable" (#77003). Node only counts as found when npm resolves on
+    # the same PATH.
+    if command -v node &> /dev/null && command -v npm &> /dev/null \
+        && node_satisfies_build "$(node --version)"; then
+        if npm_supports_npmrc "$(npm --version 2>/dev/null)"; then
             log_success "Node.js $(node --version) found"
             HAS_NODE=true
             return 0
@@ -842,14 +850,17 @@ check_node() {
     fi
 
     # Prefer a Hermes-managed Node from a previous run over a too-old system one.
-    if [ -x "$HERMES_HOME/node/bin/node" ] && node_satisfies_build "$("$HERMES_HOME/node/bin/node" --version)"; then
+    if [ -x "$HERMES_HOME/node/bin/node" ] && [ -x "$HERMES_HOME/node/bin/npm" ] \
+        && node_satisfies_build "$("$HERMES_HOME/node/bin/node" --version)"; then
         export PATH="$HERMES_HOME/node/bin:$PATH"
         log_success "Node.js $("$HERMES_HOME/node/bin/node" --version) found (Hermes-managed)"
         HAS_NODE=true
         return 0
     fi
 
-    if command -v node &> /dev/null; then
+    if command -v node &> /dev/null && ! command -v npm &> /dev/null; then
+        log_warn "node found but npm is not on PATH (stray node symlink?) — installing Hermes-managed Node $NODE_VERSION LTS..."
+    elif command -v node &> /dev/null; then
         log_warn "Node.js $(node --version) is too old (Hermes requires Node >=26) — installing Hermes-managed Node $NODE_VERSION..."
     elif [ "$DISTRO" = "termux" ]; then
         log_info "Node.js not found — installing Node.js via pkg..."
@@ -2288,10 +2299,14 @@ install_node_deps() {
         cd "$INSTALL_DIR"
         # Time-boxed: a stalled registry fetch would otherwise hang here with no
         # progress (same #39219 stall class as the desktop build below).
-        run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent || {
+        # Success is only reported when the install actually succeeded — a
+        # failed npm install used to still print "✓ Node.js dependencies
+        # installed", hiding the degradation from the user (#77003).
+        if run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent; then
+            log_success "Node.js dependencies installed"
+        else
             log_warn "npm install failed or timed out (browser tools may not work)"
-        }
-        log_success "Node.js dependencies installed"
+        fi
 
         # Install Playwright browser + system dependencies.
         # Playwright's --with-deps only supports apt-based systems natively.
@@ -2390,10 +2405,12 @@ install_node_deps() {
         log_info "Installing TUI dependencies..."
         cd "$INSTALL_DIR/ui-tui"
         # Time-boxed: a stalled registry fetch would otherwise hang here (#39219).
-        run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent || {
+        # Report success only on actual success, same as node-deps above (#77003).
+        if run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent; then
+            log_success "TUI dependencies installed"
+        else
             log_warn "TUI npm install failed or timed out (hermes --tui may not work)"
-        }
-        log_success "TUI dependencies installed"
+        fi
     fi
 
     # Keep the checkout clean so `hermes update` doesn't autostash every run.

--- a/tests/test_install_sh_node_npm_check.py
+++ b/tests/test_install_sh_node_npm_check.py
@@ -1,0 +1,74 @@
+"""Regression tests for install.sh Node/npm checks (#77003).
+
+A stray `node` symlink without a sibling `npm` (leftover from a node
+version manager) made the installer report "✓ Node.js found" and then fail
+opaquely at the desktop stage. Node must only count as found when npm
+resolves on the same PATH, and npm install stages must not report success
+when the install actually failed.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def test_check_node_requires_npm_alongside_node() -> None:
+    """check_node must not report success when only `node` resolves.
+
+    Before the fix, `command -v node` succeeding was enough — a stray node
+    symlink (no sibling npm) passed the check, every later `npm install`
+    failed silently, and the desktop build died with an opaque
+    "Node.js / npm unavailable" (#77003).
+    """
+    text = INSTALL_SH.read_text()
+
+    # The system-toolchain branch now gates on BOTH node and npm.
+    assert (
+        "if command -v node &> /dev/null && command -v npm &> /dev/null \\" in text
+    )
+    # The "node found but npm missing" case has its own explicit branch that
+    # falls through to installing the Hermes-managed Node (which bundles npm).
+    assert "node found but npm is not on PATH (stray node symlink?)" in text
+
+
+def test_check_node_managed_requires_npm() -> None:
+    """The Hermes-managed Node fallback also requires its npm to exist."""
+    text = INSTALL_SH.read_text()
+    assert (
+        '[ -x "$HERMES_HOME/node/bin/node" ] && [ -x "$HERMES_HOME/node/bin/npm" ] \\'
+        in text
+    )
+
+
+def test_node_deps_success_log_is_conditional() -> None:
+    """install_node_deps must not print ✓ when the npm install failed.
+
+    Before the fix, `log_success "Node.js dependencies installed"` ran
+    unconditionally after a `||` warn, so a failed npm install still read as
+    success — hiding the browser-tool degradation from the user (#77003).
+    """
+    text = INSTALL_SH.read_text()
+
+    # The success log now sits inside the `if run_with_timeout ...; then`
+    # branch, so it cannot fire when the install failed.
+    node_deps_block = text.split("Installing Node.js dependencies (browser tools)...", 1)[1]
+    node_deps_block = node_deps_block.split("Installing browser engine", 1)[0]
+    assert 'if run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent; then' in node_deps_block
+    assert 'log_success "Node.js dependencies installed"' in node_deps_block
+    assert 'log_warn "npm install failed or timed out (browser tools may not work)"' in node_deps_block
+    # Success and failure are mutually exclusive branches.
+    success_pos = node_deps_block.find('log_success "Node.js dependencies installed"')
+    warn_pos = node_deps_block.find('log_warn "npm install failed or timed out')
+    assert success_pos != -1 and warn_pos != -1
+    assert 'else' in node_deps_block[success_pos:warn_pos] or 'else' in node_deps_block[:warn_pos]
+
+
+def test_tui_deps_success_log_is_conditional() -> None:
+    """The TUI npm install follows the same success-only-on-success rule."""
+    text = INSTALL_SH.read_text()
+    tui_block = text.split("Installing TUI dependencies...", 1)[1]
+    tui_block = tui_block.split("restore_dirty_lockfiles", 1)[0]
+    assert 'if run_with_timeout "$NODE_DEPS_TIMEOUT" npm install --silent; then' in tui_block
+    assert 'log_success "TUI dependencies installed"' in tui_block
+    assert 'log_warn "TUI npm install failed or timed out (hermes --tui may not work)"' in tui_block


### PR DESCRIPTION
## What

The installer's Node check was a **false positive**: `check_node` reported `✓ Node.js found` based on `node` alone, but a stray `node` symlink without a sibling `npm` (leftover from a node version manager — reported with `n`) made every later `npm install` fail silently, and the desktop build then died with an opaque `Cannot build desktop app: Node.js / npm unavailable`.

Additionally, `install_node_deps` and the TUI deps block printed `✓ Node.js dependencies installed` **unconditionally** after a `||` warn — so a failed npm install still read as success, hiding the browser-tool degradation.

## Fix

1. **`check_node`** — the system toolchain only counts as found when **both** `node` and `npm` resolve on PATH (`command -v npm` was previously allowed to be absent, and the new explicit branch "node found but npm is not on PATH (stray node symlink?)" falls through to installing the Hermes-managed Node, which bundles a working npm). The Hermes-managed fallback now requires its `npm` binary too.
2. **`install_node_deps`** — `log_success "Node.js dependencies installed"` now sits inside the success branch of the time-boxed npm install; failure prints only the warning.
3. **TUI deps block** — same success-only-on-success rule.

## How to test

```
pytest tests/test_install_sh_node_npm_check.py tests/test_install_sh_browser_install.py -o 'addopts=' -q
```

4 new regression tests assert:
- `check_node` gates on `command -v npm` alongside `command -v node`
- the stray-symlink branch message exists
- the managed-Node fallback requires `npm`
- node-deps and TUI success logs are conditional (not unconditional)

Also: `bash -n scripts/install.sh` passes; the full install-sh test set passes.

## Platforms tested

- macOS (local). `test_install_sh_node_npm_check.py` + `test_install_sh_browser_install.py` (11 passed), install-sh suite (9 passed).

Closes #77003
