### PR TITLE
fix(mcp): point mcp add at /reload-mcp instead of misleading 'start a new session' (#76954)

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -614,7 +614,16 @@ def cmd_mcp_add(args):
     if _save_mcp_server(name, server_config):
         print()
         _success(f"Saved '{name}' to {display_hermes_home()}/config.yaml ({tool_count}/{total} tools enabled)")
-        _info("Start a new session to use these tools.")
+        # #76954: "start a new session" was misleading in the desktop app,
+        # where a new chat session does NOT re-read the MCP config — the
+        # tool registry is built once at backend process start. /reload-mcp
+        # is the honest, immediate path (TUI/CLI); a desktop user must
+        # restart the app or gateway until #58414 lands.
+        _info(
+            "Run /reload-mcp to use these tools in the current session, "
+            "or restart the desktop app / gateway (a new chat session alone "
+            "does not pick up newly added MCP servers)."
+        )
 
 
 # ─── hermes mcp remove ───────────────────────────────────────────────────────
@@ -1065,7 +1074,13 @@ def cmd_mcp_configure(args):
 
     new_count = len(chosen)
     _success(f"Updated config: {new_count}/{total} tools enabled")
-    _info("Start a new session for changes to take effect.")
+    # Same truthfulness fix as mcp add (#76954): /reload-mcp is the honest
+    # immediate path; a new desktop chat session alone does not pick up the
+    # change (the tool registry is built once at backend start).
+    _info(
+        "Run /reload-mcp to apply changes in the current session, "
+        "or restart the desktop app / gateway."
+    )
 
 
 # ─── Dispatcher ───────────────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -207,6 +207,30 @@ class TestMcpAdd:
         assert config["mcp_servers"]["ink"]["url"] == "https://mcp.ml.ink/mcp"
 
 
+    def test_add_hints_reload_mcp_instead_of_new_session(self, tmp_path, capsys, monkeypatch):
+        """#76954: the success message must point at /reload-mcp, not
+        "start a new session" — a new desktop chat session does not re-read
+        the MCP config (tool registry is built once at backend process
+        start), so the old hint was misleading there.
+        """
+        def mock_probe(name, config, **kw):
+            return [("search", "Search repos")]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        inputs = iter(["n", ""])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(name="ink", url="https://mcp.ml.ink/mcp"))
+        out = capsys.readouterr().out
+        assert "/reload-mcp" in out
+        assert "Start a new session to use these tools." not in out
+        assert "restart the desktop app / gateway" in out
+
+
     def test_add_stdio_server_with_env(self, tmp_path, capsys, monkeypatch):
         """Stdio servers can persist explicit environment variables."""
         fake_tools = [FakeTool("search", "Search repos")]


### PR DESCRIPTION
## What

`hermes mcp add` printed `Start a new session to use these tools.` — misleading in the **desktop app**, where a new chat session does **not** re-read the MCP config: the tool registry is built once at backend process start, so servers added after launch stayed invisible until a full app restart (while `hermes mcp test` in a fresh CLI process confirmed the config was fine).

## Fix

The success messages (both the `mcp add` flow and the tool-selection flow) now point at `/reload-mcp` — the honest, immediate path in TUI/CLI — and state that a desktop app / gateway restart is required until #58414 (desktop MCP/skill reload controls) lands. A new regression test asserts the message contains `/reload-mcp` and no longer contains the misleading `Start a new session to use these tools.`.

## How to test

```
pytest tests/hermes_cli/test_mcp_config.py -o 'addopts=' -q
```

New test: `test_add_hints_reload_mcp_instead_of_new_session`. Related MCP CLI suites also pass (26 tests).

## Platforms tested

- macOS (local). `tests/hermes_cli/test_mcp_config.py` (31 passed), MCP CLI/watch suites (26 passed).

Closes #76954
