### PR TITLE
fix(config): persist JSON object/array values as structured YAML in config set (#40545)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4910,6 +4910,16 @@ def set_config_value(key: str, value: str, force: bool = False):
             coerced_value = int(value)
         elif value.replace('.', '', 1).isdigit():
             coerced_value = float(value)
+        elif value.lstrip()[:1] in ('{', '['):
+            # Persist JSON object/array literals as structured YAML rather than
+            # quoted scalars (#40545). Only dict/list results are applied, so a
+            # malformed value falls through and is kept verbatim below.
+            try:
+                _parsed = json.loads(value)
+            except (json.JSONDecodeError, ValueError):
+                _parsed = None
+            if isinstance(_parsed, (dict, list)):
+                coerced_value = _parsed
 
     value = coerced_value
     # Normalize a scalar ``model`` key before writing sub-keys so that

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -723,3 +723,69 @@ class TestMalformedYAMLConfigPreservation:
         assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
         raw = _read_config(_isolated_hermes_home)
         assert raw == self.BROKEN_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# JSON object/array values → structured YAML (#40545)
+# ---------------------------------------------------------------------------
+
+def _parse_config(tmp_path):
+    import yaml
+
+    config_path = tmp_path / "config.yaml"
+    if not config_path.exists():
+        return {}
+    text = config_path.read_text()
+    return yaml.safe_load(text) or {}
+
+
+class TestJsonValueCoercion:
+    """``hermes config set`` must persist JSON object/array values as structured
+    YAML, not as quoted scalars (#40545)."""
+
+    def test_object_value_persisted_as_mapping(self, _isolated_hermes_home):
+        set_config_value("foo.bar", '{"x": 1}')
+        parsed = _parse_config(_isolated_hermes_home)
+        assert parsed["foo"]["bar"] == {"x": 1}
+        # Must NOT be the literal string.
+        assert not isinstance(parsed["foo"]["bar"], str)
+
+    def test_array_value_persisted_as_list(self, _isolated_hermes_home):
+        set_config_value("foo.list", '[1, 2, 3]')
+        parsed = _parse_config(_isolated_hermes_home)
+        assert parsed["foo"]["list"] == [1, 2, 3]
+        assert not isinstance(parsed["foo"]["list"], str)
+
+    def test_nested_structure_preserved(self, _isolated_hermes_home):
+        set_config_value("foo.nested", '{"a": {"b": [1, 2]}}')
+        parsed = _parse_config(_isolated_hermes_home)
+        assert parsed["foo"]["nested"] == {"a": {"b": [1, 2]}}
+
+    def test_real_world_provider_mapping(self, _isolated_hermes_home):
+        set_config_value(
+            "providers.deepseek",
+            '{"base_url": "https://api.deepseek.com", '
+            '"key_env": "DEEPSEEK_API_KEY", "api_mode": "chat_completions"}',
+        )
+        parsed = _parse_config(_isolated_hermes_home)
+        assert parsed["providers"]["deepseek"] == {
+            "base_url": "https://api.deepseek.com",
+            "key_env": "DEEPSEEK_API_KEY",
+            "api_mode": "chat_completions",
+        }
+
+    def test_invalid_json_kept_as_string_literal(self, _isolated_hermes_home):
+        """A clearly malformed object literal must round-trip as the original string."""
+        set_config_value("foo.bad", '{not valid json')
+        parsed = _parse_config(_isolated_hermes_home)
+        # Must remain the literal string the user typed, not crash.
+        assert parsed["foo"]["bad"] == "{not valid json"
+
+    def test_string_typed_setting_not_json_parsed(self, _isolated_hermes_home):
+        """A setting whose schema default is a string (e.g. approvals.mode) must
+        keep a JSON-looking value as a literal string — enum/string settings are
+        never reinterpreted as structured data."""
+        set_config_value("approvals.mode", '{"x": 1}')
+        parsed = _parse_config(_isolated_hermes_home)
+        # approvals.mode default is a string ("off"), so no JSON coercion.
+        assert parsed["approvals"]["mode"] == '{"x": 1}'


### PR DESCRIPTION
## What

`hermes config set` now persists JSON object/array literals as structured YAML instead of quoted strings.

Before:
```yaml
foo:
  bar: '{"x":1}'     # string, not a mapping
```

After:
```yaml
foo:
  bar:
    x: 1             # structured mapping
```

## Why

`set_config_value()` in `hermes_cli/config.py` only coerced booleans / ints / floats before writing. JSON object/array literals (`{...}` / `[...]`) fell through all scalar checks and were serialized back into YAML as quoted scalars, so values like `providers.deepseek` set via `hermes config set` were stored as strings rather than structured mappings.

## How

Added a final `elif value.lstrip()[:1] in ('{', '['):` branch inside the existing string-gated coercion block. It attempts `json.loads()` on the value and applies the result only when it parses to a `dict` or `list`. Malformed JSON is caught and the original string is kept verbatim. The branch lives **inside** the `not isinstance(_default_value_for_key(key), str)` gate, so string-typed settings (e.g. `approvals.mode`) are never reinterpreted as structured data.

No new dependency — `json` was already imported.

## Tests

6 new regression tests in `tests/hermes_cli/test_set_config_value.py::TestJsonValueCoercion`:

- object value → mapping ✅
- array value → list ✅
- nested structure preserved ✅
- real-world provider mapping (`providers.deepseek`) ✅
- invalid JSON kept as string (no crash) ✅
- string-typed setting not parsed (`approvals.mode`) ✅

**Fail-without-fix proof:** 4 of 6 new tests fail on `upstream/main` (the two safety tests already pass because they assert existing behavior).

**Full suite:** 88 passed (82 existing + 6 new). `ruff check` clean. `git diff --check` clean.

Closes #40545.

---
*Auto-published by Moonsong via Path B automated pipeline.*