### PR TITLE
fix(buzz): preserve configured agent handoffs

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1055,7 +1055,16 @@ platform_toolsets:
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
-
+#
+# Buzz exact routing for stable named handoffs:
+#
+# gateway:
+#   platforms:
+#     buzz:
+#       extra:
+#         outbound_mention_pubkeys:   # Exact routing for stable named handoffs
+#           CodexTerraM: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+#
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)
 #

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -808,13 +808,20 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--file", str(local),
                 "--content", "-",
             ]
+            send_content = caption or ""
+            configured_handoffs = set()
+            for name, pubkey in self.outbound_mention_pubkeys.values():
+                if _has_complete_mention(send_content, name):
+                    configured_handoffs.add(f"@{name}".casefold())
+                    args += ["--mention", pubkey]
             if reply_to:
                 args += ["--reply-to", str(reply_to)]
-            send_content = caption or ""
             code, out, err = await self._run_cli(args, input_text=send_content)
             for _ in range(_MENTION_FALLBACK_MAX_RETRIES):
                 fallback = (
-                    _unresolved_mention_fallback(send_content, err)
+                    _unresolved_mention_fallback(
+                        send_content, err, configured_handoffs
+                    )
                     if code != 0
                     else None
                 )

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -22,6 +22,7 @@ Configuration in config.yaml::
               - ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
             home_channel: ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
             poll_interval: 4           # seconds between poll sweeps
+            outbound_mention_pubkeys: {} # display name → exact agent npub/hex
             cli_path: ""               # path to the buzz binary (default: PATH, then ~/bin/buzz)
             credentials_file: ""       # JSON file holding the nsec (fallback for BUZZ_PRIVATE_KEY)
             allowed_users: []          # empty = allow all; entries are hex pubkeys or npubs
@@ -43,6 +44,7 @@ import os
 import re
 import shutil
 import time
+import unicodedata
 from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
@@ -238,19 +240,94 @@ _OUTBOUND_MENTION_RE = re.compile(r"(?<![\w@])@(?=[^\s@])")
 _MENTION_FALLBACK_MAX_RETRIES = 3
 
 
-def _unresolved_mention_fallback(content: str, error: str) -> Optional[str]:
+def _parse_outbound_mention_pubkeys(value: Any) -> Dict[str, Tuple[str, str]]:
+    """Validate configured display-name → exact-pubkey outbound routing."""
+    if value in (None, ""):
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError("Buzz outbound_mention_pubkeys must be a mapping")
+
+    parsed: Dict[str, Tuple[str, str]] = {}
+    for raw_name, raw_pubkey in value.items():
+        name = str(raw_name or "").strip().lstrip("@").strip()
+        pubkey = _normalize_user_ref(str(raw_pubkey or "").strip())
+        if not name or not pubkey:
+            raise ValueError(
+                "Buzz outbound_mention_pubkeys entries require a display name "
+                "and a valid hex or npub identity"
+            )
+        normalized_name = name.casefold()
+        if normalized_name in parsed:
+            raise ValueError(
+                "Buzz outbound_mention_pubkeys contains a duplicate display name"
+            )
+        parsed[normalized_name] = (name, pubkey)
+    return parsed
+
+
+def _is_mention_continuation(char: str) -> bool:
+    return bool(
+        char
+        and (
+            char.isalnum()
+            or char == "_"
+            or char in ".-"
+            or unicodedata.category(char).startswith("M")
+        )
+    )
+
+
+def _complete_mention_spans(content: str, mention: str) -> List[Tuple[int, int]]:
+    """Find complete mention tokens using one casefold normalization contract."""
+    target = mention if mention.startswith("@") else f"@{mention}"
+    normalized_target = target.casefold()
+    spans: List[Tuple[int, int]] = []
+    for start, char in enumerate(content or ""):
+        if char != "@":
+            continue
+        if start and (content[start - 1] == "@" or _is_mention_continuation(content[start - 1])):
+            continue
+        for end in range(start + 2, len(content) + 1):
+            normalized_candidate = content[start:end].casefold()
+            if len(normalized_candidate) > len(normalized_target):
+                break
+            if normalized_candidate != normalized_target:
+                continue
+            if end < len(content) and _is_mention_continuation(content[end]):
+                continue
+            spans.append((start, end))
+            break
+    return spans
+
+
+def _has_complete_mention(content: str, name: str) -> bool:
+    return bool(_complete_mention_spans(content, name))
+
+
+def _unresolved_mention_fallback(
+    content: str,
+    error: str,
+    protected_mentions: Optional[set[str]] = None,
+) -> Optional[str]:
     """Return readable text after a Buzz outbound mention-validation error."""
     error = error or ""
+    protected_mentions = protected_mentions or set()
     match = _MEMBER_MENTION_ERROR_RE.search(error)
     if match:
         mention = match.group(1)
-        fallback = re.sub(
-            rf"(?<![\w@]){re.escape(mention)}",
-            mention[1:],
-            content or "",
-            flags=re.IGNORECASE,
-        )
-    elif _MAX_MENTIONS_ERROR in error.lower():
+        if mention.casefold() in protected_mentions:
+            return None
+        spans = _complete_mention_spans(content or "", mention)
+        if not spans:
+            return None
+        pieces = []
+        cursor = 0
+        for start, end in spans:
+            pieces.extend((content[cursor:start], content[start + 1 : end]))
+            cursor = end
+        pieces.append(content[cursor:])
+        fallback = "".join(pieces)
+    elif _MAX_MENTIONS_ERROR in error.lower() and not protected_mentions:
         fallback = _OUTBOUND_MENTION_RE.sub("", content or "")
     else:
         return None
@@ -401,6 +478,10 @@ class BuzzAdapter(BasePlatformAdapter):
         self.channels: List[str] = [c.strip() for c in raw_channels if isinstance(c, str) and c.strip()]
 
         self.home_channel = (os.getenv("BUZZ_HOME_CHANNEL") or str(extra.get("home_channel", "") or "")).strip()
+
+        self.outbound_mention_pubkeys = _parse_outbound_mention_pubkeys(
+            extra.get("outbound_mention_pubkeys")
+        )
 
         try:
             interval = float(os.getenv("BUZZ_POLL_INTERVAL") or extra.get("poll_interval", _DEFAULT_POLL_INTERVAL))
@@ -636,6 +717,11 @@ class BuzzAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=False, error="Empty message")
         args = ["messages", "send", "--channel", str(chat_id), "--content", "-"]
+        configured_handoffs = set()
+        for name, pubkey in self.outbound_mention_pubkeys.values():
+            if _has_complete_mention(content, name):
+                configured_handoffs.add(f"@{name}".casefold())
+                args += ["--mention", pubkey]
         reply_target = reply_to or (metadata or {}).get("thread_id")
         if reply_target:
             args += ["--reply-to", str(reply_target)]
@@ -643,7 +729,9 @@ class BuzzAdapter(BasePlatformAdapter):
         code, out, err = await self._run_cli(args, input_text=send_content)
         for _ in range(_MENTION_FALLBACK_MAX_RETRIES):
             fallback = (
-                _unresolved_mention_fallback(send_content, err)
+                _unresolved_mention_fallback(
+                    send_content, err, configured_handoffs
+                )
                 if code != 0
                 else None
             )
@@ -1318,6 +1406,10 @@ def validate_config(config) -> bool:
     """Validate that the platform config has enough info to connect."""
     extra = getattr(config, "extra", {}) or {}
     relay = os.getenv("BUZZ_RELAY_URL") or extra.get("relay_url", "")
+    try:
+        _parse_outbound_mention_pubkeys(extra.get("outbound_mention_pubkeys"))
+    except ValueError:
+        return False
     return bool(relay and _resolve_private_key(extra))
 
 
@@ -1439,6 +1531,17 @@ async def _standalone_send(
         return {"error": "Buzz standalone send: no target channel (set BUZZ_HOME_CHANNEL)"}
 
     args = ["messages", "send", "--channel", target, "--content", "-"]
+    try:
+        outbound_mention_pubkeys = _parse_outbound_mention_pubkeys(
+            extra.get("outbound_mention_pubkeys")
+        )
+    except ValueError:
+        return {"error": "Buzz standalone send: invalid outbound_mention_pubkeys"}
+    configured_handoffs = set()
+    for name, pubkey in outbound_mention_pubkeys.values():
+        if _has_complete_mention(message, name):
+            configured_handoffs.add(f"@{name}".casefold())
+            args += ["--mention", pubkey]
     if thread_id:
         args += ["--reply-to", str(thread_id)]
     for path in media_files or []:
@@ -1454,7 +1557,9 @@ async def _standalone_send(
         )
         for _ in range(_MENTION_FALLBACK_MAX_RETRIES):
             fallback = (
-                _unresolved_mention_fallback(send_content, err)
+                _unresolved_mention_fallback(
+                    send_content, err, configured_handoffs
+                )
                 if code != 0
                 else None
             )

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -229,6 +229,33 @@ def _normalize_user_ref(ref: str) -> Optional[str]:
 # buzz-cli invocation helpers
 # ---------------------------------------------------------------------------
 
+_MEMBER_MENTION_ERROR_RE = re.compile(
+    r"mention '(@.+?)' (?:does not match a current channel member|is ambiguous)",
+    re.IGNORECASE,
+)
+_MAX_MENTIONS_ERROR = "too many unique message mentions"
+_OUTBOUND_MENTION_RE = re.compile(r"(?<![\w@])@(?=[^\s@])")
+_MENTION_FALLBACK_MAX_RETRIES = 3
+
+
+def _unresolved_mention_fallback(content: str, error: str) -> Optional[str]:
+    """Return readable text after a Buzz outbound mention-validation error."""
+    error = error or ""
+    match = _MEMBER_MENTION_ERROR_RE.search(error)
+    if match:
+        mention = match.group(1)
+        fallback = re.sub(
+            rf"(?<![\w@]){re.escape(mention)}",
+            mention[1:],
+            content or "",
+            flags=re.IGNORECASE,
+        )
+    elif _MAX_MENTIONS_ERROR in error.lower():
+        fallback = _OUTBOUND_MENTION_RE.sub("", content or "")
+    else:
+        return None
+    return fallback if fallback != content else None
+
 def _resolve_cli_path(configured: str = "") -> str:
     """Resolve the buzz CLI binary path portably.
 
@@ -612,7 +639,19 @@ class BuzzAdapter(BasePlatformAdapter):
         reply_target = reply_to or (metadata or {}).get("thread_id")
         if reply_target:
             args += ["--reply-to", str(reply_target)]
-        code, out, err = await self._run_cli(args, input_text=content)
+        send_content = content
+        code, out, err = await self._run_cli(args, input_text=send_content)
+        for _ in range(_MENTION_FALLBACK_MAX_RETRIES):
+            fallback = (
+                _unresolved_mention_fallback(send_content, err)
+                if code != 0
+                else None
+            )
+            if fallback is None:
+                break
+            logger.warning("Buzz: unresolved outbound mention; retrying as readable text")
+            send_content = fallback
+            code, out, err = await self._run_cli(args, input_text=send_content)
         if code != 0:
             return SendResult(
                 success=False,
@@ -683,7 +722,21 @@ class BuzzAdapter(BasePlatformAdapter):
             ]
             if reply_to:
                 args += ["--reply-to", str(reply_to)]
-            code, out, err = await self._run_cli(args, input_text=caption or "")
+            send_content = caption or ""
+            code, out, err = await self._run_cli(args, input_text=send_content)
+            for _ in range(_MENTION_FALLBACK_MAX_RETRIES):
+                fallback = (
+                    _unresolved_mention_fallback(send_content, err)
+                    if code != 0
+                    else None
+                )
+                if fallback is None:
+                    break
+                logger.warning(
+                    "Buzz: unresolved outbound caption mention; retrying as readable text"
+                )
+                send_content = fallback
+                code, out, err = await self._run_cli(args, input_text=send_content)
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
             try:
@@ -1391,9 +1444,33 @@ async def _standalone_send(
     for path in media_files or []:
         args += ["--file", str(path)]
     try:
+        send_content = message
         code, out, err = await _exec_buzz(
-            cli_path, args, relay_url=relay, private_key=private_key, input_text=message
+            cli_path,
+            args,
+            relay_url=relay,
+            private_key=private_key,
+            input_text=send_content,
         )
+        for _ in range(_MENTION_FALLBACK_MAX_RETRIES):
+            fallback = (
+                _unresolved_mention_fallback(send_content, err)
+                if code != 0
+                else None
+            )
+            if fallback is None:
+                break
+            logger.warning(
+                "Buzz: unresolved standalone mention; retrying as readable text"
+            )
+            send_content = fallback
+            code, out, err = await _exec_buzz(
+                cli_path,
+                args,
+                relay_url=relay,
+                private_key=private_key,
+                input_text=send_content,
+            )
     except asyncio.CancelledError:
         raise
     except OSError as e:

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -136,6 +136,39 @@ class TestBuzzAdapterInit:
         assert adapter.poll_interval == 2.0
         assert adapter.home_channel == "ccc"
 
+    def test_outbound_mention_pubkeys_reject_casefold_collisions(self):
+        from gateway.config import PlatformConfig
+
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={
+                "relay_url": "https://cfg.relay",
+                "outbound_mention_pubkeys": {
+                    "Agent": OTHER_PUBKEY,
+                    "agent": SELF_PUBKEY,
+                },
+            },
+        )
+
+        with pytest.raises(ValueError, match="duplicate display name"):
+            BuzzAdapter(cfg)
+
+    def test_validate_config_rejects_invalid_outbound_mention_mapping(
+        self, monkeypatch
+    ):
+        from gateway.config import PlatformConfig
+
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1test")
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={
+                "relay_url": "https://cfg.relay",
+                "outbound_mention_pubkeys": "not-a-mapping",
+            },
+        )
+
+        assert validate_config(cfg) is False
+
     def test_env_overrides_config(self, monkeypatch):
         monkeypatch.setenv("BUZZ_RELAY_URL", "https://env.relay")
         from gateway.config import PlatformConfig
@@ -408,6 +441,154 @@ class TestBuzzAdapterSend:
         # Our own event id is marked seen for echo suppression
         assert "evt123" in adapter._channel_state[CHANNEL]["seen"]
 
+
+    @pytest.mark.asyncio
+    async def test_send_configured_agent_handoff_uses_exact_pubkey(self):
+        adapter = _make_adapter(
+            {"outbound_mention_pubkeys": {"CodexTerraM": OTHER_PUBKEY}}
+        )
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt-agent-handoff", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "@CodexTerraM — review the clean rebuild.",
+            metadata={"thread_id": "thread-root"},
+        )
+
+        assert result.success is True
+        assert len(cli.calls) == 1
+        args, stdin_text = cli.calls[0]
+        assert args[args.index("--mention") + 1] == OTHER_PUBKEY
+        assert stdin_text == "@CodexTerraM — review the clean rebuild."
+
+    @pytest.mark.asyncio
+    async def test_send_uses_casefold_consistently_for_unicode_names(self):
+        adapter = _make_adapter(
+            {
+                "outbound_mention_pubkeys": {
+                    "i": OTHER_PUBKEY,
+                    "ı": SELF_PUBKEY,
+                }
+            }
+        )
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt-unicode-name", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "@ı — review this.")
+
+        assert result.success is True
+        args, stdin_text = cli.calls[0]
+        mention_values = [
+            args[index + 1]
+            for index, value in enumerate(args)
+            if value == "--mention"
+        ]
+        assert mention_values == [SELF_PUBKEY]
+        assert stdin_text == "@ı — review this."
+
+    @pytest.mark.asyncio
+    async def test_send_never_downgrades_configured_agent_handoff(self):
+        adapter = _make_adapter(
+            {"outbound_mention_pubkeys": {"CodexTerraM": OTHER_PUBKEY}}
+        )
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr=(
+                "mention '@CodexTerraM' does not match a current channel member"
+            ),
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "@CodexTerraM — review the clean rebuild.",
+        )
+
+        assert result.success is False
+        assert len(cli.calls) == 1
+        args, stdin_text = cli.calls[0]
+        assert args[args.index("--mention") + 1] == OTHER_PUBKEY
+        assert stdin_text == "@CodexTerraM — review the clean rebuild."
+
+    @pytest.mark.asyncio
+    async def test_send_configured_handoff_only_protects_its_own_marker(self):
+        adapter = _make_adapter(
+            {"outbound_mention_pubkeys": {"CodexTerraM": OTHER_PUBKEY}}
+        )
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="mention '@ghost' does not match a current channel member",
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt-mixed", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "@CodexTerraM — ask @ghost to review.",
+        )
+
+        assert result.success is True
+        assert len(cli.calls) == 2
+        first_args, first_text = cli.calls[0]
+        second_args, second_text = cli.calls[1]
+        assert first_args == second_args
+        assert first_args[first_args.index("--mention") + 1] == OTHER_PUBKEY
+        assert first_text == "@CodexTerraM — ask @ghost to review."
+        assert second_text == "@CodexTerraM — ask ghost to review."
+
+    @pytest.mark.asyncio
+    async def test_send_unconfigured_prefix_does_not_strip_configured_handoff(self):
+        adapter = _make_adapter(
+            {"outbound_mention_pubkeys": {"Ghostly": OTHER_PUBKEY}}
+        )
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="mention '@ghost' does not match a current channel member",
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt-prefix", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "@Ghostly — ask @ghost to review.",
+        )
+
+        assert result.success is True
+        assert [text for _args, text in cli.calls] == [
+            "@Ghostly — ask @ghost to review.",
+            "@Ghostly — ask ghost to review.",
+        ]
 
     @pytest.mark.asyncio
     async def test_send_retries_unresolved_mentions_as_readable_text(self):
@@ -793,6 +974,31 @@ class TestBuzzPluginRegistration:
 class TestStandaloneSend:
 
     @pytest.mark.asyncio
+    async def test_standalone_invalid_outbound_mapping_returns_error(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+
+        result = await _standalone_send(
+            PlatformConfig(
+                enabled=True,
+                extra={"outbound_mention_pubkeys": "not-a-mapping"},
+            ),
+            CHANNEL,
+            "hello",
+        )
+
+        assert result == {
+            "error": "Buzz standalone send: invalid outbound_mention_pubkeys"
+        }
+
+    @pytest.mark.asyncio
     async def test_standalone_send_success(self, monkeypatch, tmp_path):
         from gateway.config import PlatformConfig
 
@@ -816,6 +1022,45 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_configured_handoff_uses_exact_pubkey(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        calls = []
+
+        async def fake_exec(
+            cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0
+        ):
+            calls.append((list(args), input_text))
+            return 0, json.dumps(
+                {"accepted": True, "event_id": "evt-cron", "message": ""}
+            ), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        result = await _standalone_send(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "outbound_mention_pubkeys": {"CodexTerraM": OTHER_PUBKEY}
+                },
+            ),
+            CHANNEL,
+            "@CodexTerraM — review the scheduled result.",
+        )
+
+        assert result == {"success": True, "message_id": "evt-cron"}
+        args, stdin_text = calls[0]
+        assert args[args.index("--mention") + 1] == OTHER_PUBKEY
+        assert stdin_text == "@CodexTerraM — review the scheduled result."
 
     @pytest.mark.asyncio
     async def test_standalone_send_retries_unresolved_mention(self, monkeypatch, tmp_path):
@@ -847,4 +1092,46 @@ class TestStandaloneSend:
         assert [text for _args, text in calls] == ["Cron asks @ghost", "Cron asks ghost"]
         assert calls[1][0] == calls[0][0]
 
+    @pytest.mark.asyncio
+    async def test_standalone_configured_handoff_only_protects_its_own_marker(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.config import PlatformConfig
 
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        calls = []
+
+        async def fake_exec(
+            cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0
+        ):
+            calls.append((list(args), input_text))
+            if len(calls) == 1:
+                return 1, "", "mention '@ghost' does not match a current channel member"
+            return 0, json.dumps(
+                {"accepted": True, "event_id": "evt-cron", "message": ""}
+            ), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        result = await _standalone_send(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "outbound_mention_pubkeys": {"CodexTerraM": OTHER_PUBKEY}
+                },
+            ),
+            CHANNEL,
+            "@CodexTerraM asks @ghost to review",
+        )
+
+        assert result == {"success": True, "message_id": "evt-cron"}
+        assert [text for _args, text in calls] == [
+            "@CodexTerraM asks @ghost to review",
+            "@CodexTerraM asks ghost to review",
+        ]
+        assert calls[1][0] == calls[0][0]
+        assert calls[0][0][calls[0][0].index("--mention") + 1] == OTHER_PUBKEY

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -852,6 +852,114 @@ class TestBuzzAdapterSend:
         assert args[args.index("--file") + 1] == str(img)
 
     @pytest.mark.asyncio
+    async def test_send_image_configured_handoff_uses_exact_pubkey(self, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter(
+            {"outbound_mention_pubkeys": {"CodexTerraM": OTHER_PUBKEY}}
+        )
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt-image-handoff", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send_image(
+            CHANNEL,
+            str(img),
+            caption="@CodexTerraM — review this screenshot.",
+        )
+
+        assert result.success is True
+        args, stdin_text = cli.calls[0]
+        mention_values = [
+            args[index + 1]
+            for index, value in enumerate(args)
+            if value == "--mention"
+        ]
+        assert mention_values == [OTHER_PUBKEY]
+        assert stdin_text == "@CodexTerraM — review this screenshot."
+
+    @pytest.mark.asyncio
+    async def test_send_image_never_downgrades_configured_handoff(self, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter(
+            {"outbound_mention_pubkeys": {"CodexTerraM": OTHER_PUBKEY}}
+        )
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr=(
+                "mention '@CodexTerraM' does not match a current channel member"
+            ),
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send_image(
+            CHANNEL,
+            str(img),
+            caption="@CodexTerraM — review this screenshot.",
+        )
+
+        assert result.success is False
+        assert len(cli.calls) == 1
+        args, stdin_text = cli.calls[0]
+        assert args[args.index("--mention") + 1] == OTHER_PUBKEY
+        assert stdin_text == "@CodexTerraM — review this screenshot."
+
+    @pytest.mark.asyncio
+    async def test_send_image_configured_handoff_only_protects_its_marker(
+        self, tmp_path
+    ):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter(
+            {"outbound_mention_pubkeys": {"CodexTerraM": OTHER_PUBKEY}}
+        )
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="mention '@ghost' does not match a current channel member",
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt-image-mixed", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send_image(
+            CHANNEL,
+            str(img),
+            caption="@CodexTerraM — ask @ghost to review this screenshot.",
+        )
+
+        assert result.success is True
+        assert len(cli.calls) == 2
+        first_args, first_text = cli.calls[0]
+        second_args, second_text = cli.calls[1]
+        mention_values = [
+            first_args[index + 1]
+            for index, value in enumerate(first_args)
+            if value == "--mention"
+        ]
+        assert mention_values == [OTHER_PUBKEY]
+        assert second_args == first_args
+        assert first_text == (
+            "@CodexTerraM — ask @ghost to review this screenshot."
+        )
+        assert second_text == "@CodexTerraM — ask ghost to review this screenshot."
+
+    @pytest.mark.asyncio
     async def test_send_image_retries_unresolved_caption_mention(self, tmp_path):
         img = tmp_path / "shot.png"
         img.write_bytes(b"\x89PNG fake")

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -397,6 +397,7 @@ class TestBuzzAdapterSend:
         result = await adapter.send(CHANNEL, "hello **markdown**")
         assert result.success is True
         assert result.message_id == "evt123"
+        assert len(cli.calls) == 1
 
         args, stdin_text = cli.calls[0]
         assert args[:2] == ["messages", "send"]
@@ -407,6 +408,254 @@ class TestBuzzAdapterSend:
         # Our own event id is marked seen for echo suppression
         assert "evt123" in adapter._channel_state[CHANNEL]["seen"]
 
+
+    @pytest.mark.asyncio
+    async def test_send_retries_unresolved_mentions_as_readable_text(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr=(
+                "user_error: mention '@teknium1' does not match a current "
+                "channel member; retry with --mention <pubkey>"
+            ),
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt-fallback", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "Ask @teknium1 and notify @Codex, but keep bob@example.com intact.",
+            metadata={"thread_id": "thread-root"},
+        )
+
+        assert result.success is True
+        assert result.message_id == "evt-fallback"
+        assert len(cli.calls) == 2
+        first_args, first_text = cli.calls[0]
+        fallback_args, fallback_text = cli.calls[1]
+        assert first_text == "Ask @teknium1 and notify @Codex, but keep bob@example.com intact."
+        assert fallback_text == "Ask teknium1 and notify @Codex, but keep bob@example.com intact."
+        assert fallback_args == first_args
+        assert fallback_args[fallback_args.index("--reply-to") + 1] == "thread-root"
+
+    @pytest.mark.asyncio
+    async def test_send_retries_unicode_unresolved_mention(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="mention '@Иван' does not match a current channel member",
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt-unicode", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "Ask @Иван Петров to review")
+
+        assert result.success is True
+        assert [text for _args, text in cli.calls] == [
+            "Ask @Иван Петров to review",
+            "Ask Иван Петров to review",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_send_retries_apostrophe_name(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="mention '@O'Brien' does not match a current channel member",
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt-apostrophe", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "Ask @O'Brien to review")
+
+        assert result.success is True
+        assert [text for _args, text in cli.calls] == [
+            "Ask @O'Brien to review",
+            "Ask O'Brien to review",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_send_retries_each_new_unresolved_name_within_cap(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="mention '@Ghost One' does not match a current channel member",
+        )
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="mention '@Ghost Two' does not match a current channel member",
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt-multiple", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "ping @Ghost One and @Ghost Two")
+
+        assert result.success is True
+        assert [text for _args, text in cli.calls] == [
+            "ping @Ghost One and @Ghost Two",
+            "ping Ghost One and @Ghost Two",
+            "ping Ghost One and Ghost Two",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_send_caps_sequential_mention_fallback_retries(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        for name in ("One", "Two", "Three", "Four"):
+            cli.script(
+                "messages",
+                "send",
+                "",
+                code=1,
+                stderr=(
+                    f"mention '@Ghost {name}' does not match a current channel member"
+                ),
+            )
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "ping @Ghost One, @Ghost Two, @Ghost Three, and @Ghost Four",
+        )
+
+        assert result.success is False
+        assert result.error == (
+            "mention '@Ghost Four' does not match a current channel member"
+        )
+        assert len(cli.calls) == 4
+
+    @pytest.mark.asyncio
+    async def test_send_retries_ambiguous_mention_without_silencing_other_mentions(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr=(
+                "mention '@Twin' is ambiguous; candidates: npub1a, npub1b. "
+                "Retry with --mention <pubkey>"
+            ),
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt-ambiguous", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "Ask @Twin and notify @Codex")
+
+        assert result.success is True
+        assert cli.calls[1][1] == "Ask Twin and notify @Codex"
+
+    @pytest.mark.asyncio
+    async def test_send_retries_max_mentions_with_all_markers_neutralized(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="too many unique message mentions (max 2)",
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt-max", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(
+            CHANNEL,
+            "Ask @Иван, @李明, and @Codex; email bob@example.com",
+        )
+
+        assert result.success is True
+        assert cli.calls[1][1] == (
+            "Ask Иван, 李明, and Codex; email bob@example.com"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_does_not_retry_unrelated_failure(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="forbidden: sender is not authorized",
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "Ask @Codex")
+
+        assert result.success is False
+        assert len(cli.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_send_propagates_second_attempt_failure_without_third_attempt(self):
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="mention '@ghost' does not match a current channel member",
+        )
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="relay unavailable after fallback",
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send(CHANNEL, "Ask @ghost")
+
+        assert result.success is False
+        assert result.error == "relay unavailable after fallback"
+        assert len(cli.calls) == 2
 
     @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):
@@ -420,6 +669,37 @@ class TestBuzzAdapterSend:
         assert result.success is True
         args, _stdin = cli.calls[0]
         assert args[args.index("--file") + 1] == str(img)
+
+    @pytest.mark.asyncio
+    async def test_send_image_retries_unresolved_caption_mention(self, tmp_path):
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG fake")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "send",
+            "",
+            code=1,
+            stderr="mention '@ghost' does not match a current channel member",
+        )
+        cli.script(
+            "messages",
+            "send",
+            {"accepted": True, "event_id": "evt-image-fallback", "message": ""},
+        )
+        adapter._run_cli = cli
+
+        result = await adapter.send_image(
+            CHANNEL,
+            str(img),
+            caption="For @ghost",
+            reply_to="thread-root",
+        )
+
+        assert result.success is True
+        assert [text for _args, text in cli.calls] == ["For @ghost", "For ghost"]
+        assert cli.calls[1][0] == cli.calls[0][0]
 
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────
@@ -536,5 +816,35 @@ class TestStandaloneSend:
         assert captured["input_text"] == "cron says hi"
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_retries_unresolved_mention(self, monkeypatch, tmp_path):
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        calls = []
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0):
+            calls.append((list(args), input_text))
+            if len(calls) == 1:
+                return 1, "", "mention '@ghost' does not match a current channel member"
+            return 0, json.dumps({"accepted": True, "event_id": "evt-cron", "message": ""}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            CHANNEL,
+            "Cron asks @ghost",
+            thread_id="thread-root",
+        )
+
+        assert result == {"success": True, "message_id": "evt-cron"}
+        assert [text for _args, text in calls] == ["Cron asks @ghost", "Cron asks ghost"]
+        assert calls[1][0] == calls[0][0]
 
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -76,6 +76,8 @@ gateway:
           - ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
         home_channel: ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd
         poll_interval: 4                  # seconds between inbound poll sweeps (default 4 — balances latency vs. relay load)
+        outbound_mention_pubkeys:         # optional exact routing for named agent handoffs
+          CodexTerraM: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
         cli_path: ""                      # buzz binary (default: PATH, then ~/bin/buzz)
         credentials_file: ""              # JSON file with the nsec (BUZZ_PRIVATE_KEY fallback)
         allowed_users: []                 # empty = allow all if allow_all_users is true; otherwise restrict to listed npubs/hex pubkeys
@@ -98,7 +100,8 @@ gateway:
 ## Mentions, channels, and DMs
 
 - In shared channels the agent only responds when **addressed** — by `@name`, its npub, or its hex pubkey. Everything else is ignored.
-- If Buzz rejects an outbound message because an `@name` is unknown or ambiguous, Hermes removes only that offending mention marker and retries. If a retry identifies another invalid name, this repeats up to three fallback attempts in total. If the message exceeds Buzz's mention limit, all mention markers are removed for the retry. Readable text, email addresses, reply threads, attachments, and remaining content are preserved; neutralized names do not notify users.
+- `outbound_mention_pubkeys` maps stable display names to exact npub or 64-character hex identities. When outbound text contains a configured `@name`, Hermes preserves the literal marker and passes the exact identity to Buzz as structured mention metadata. Configured handoffs are never silently downgraded to plain text: if Buzz rejects one, delivery fails visibly.
+- For unconfigured names only, if Buzz rejects an outbound message because an `@name` is unknown or ambiguous, Hermes removes only that offending mention marker and retries. If a retry identifies another invalid name, this repeats up to three fallback attempts in total. If the message exceeds Buzz's mention limit, all mention markers are removed for the retry. Readable text, email addresses, reply threads, attachments, and remaining content are preserved; neutralized names do not notify users.
 - Direct messages always reach the agent, no mention needed.
 - The agent's own messages are never dispatched back to it (self-echo suppression by pubkey), and every event is de-duplicated by event id against a per-channel high-water mark.
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -98,6 +98,7 @@ gateway:
 ## Mentions, channels, and DMs
 
 - In shared channels the agent only responds when **addressed** — by `@name`, its npub, or its hex pubkey. Everything else is ignored.
+- If Buzz rejects an outbound message because an `@name` is unknown or ambiguous, Hermes removes only that offending mention marker and retries. If a retry identifies another invalid name, this repeats up to three fallback attempts in total. If the message exceeds Buzz's mention limit, all mention markers are removed for the retry. Readable text, email addresses, reply threads, attachments, and remaining content are preserved; neutralized names do not notify users.
 - Direct messages always reach the agent, no mention needed.
 - The agent's own messages are never dispatched back to it (self-echo suppression by pubkey), and every event is de-duplicated by event id against a per-channel high-water mark.
 


### PR DESCRIPTION
## What does this PR do?

Buzz supports structured identity mentions, but deliberate agent handoffs need a stable display-name-to-pubkey mapping. Dynamic channel-member lookup alone can resolve a configured name to the wrong identity, add duplicate notifications, or silently downgrade the handoff when Buzz rejects the intended identity.

This adds an optional `outbound_mention_pubkeys` map. When outbound text contains a complete configured `@display-name` marker, Hermes sends only the exact mapped npub or hex pubkey for that marker. Configured handoffs fail visibly if Buzz rejects the identity; they are never escaped, dynamically reassigned, or silently published as unstructured edits.

The guarantee applies to direct sends, local-image and attachment captions, standalone/cron sends, and streamed final replies. Matching uses Unicode NFKC plus casefold normalization, gives the longest configured name ownership of overlapping markers, and prevents dynamic lookup from reclaiming any configured span.

## Related Issue

No linked issue. This preserves the configured-handoff portion requested in [the maintainer review](https://github.com/NousResearch/hermes-agent/pull/77647#issuecomment-5482265009) while dropping the unresolved-mention fallback superseded by current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add optional `platforms.buzz.extra.outbound_mention_pubkeys` configuration for exact display-name-to-npub/hex identity mappings.
- Validate pubkeys and reject invalid mappings or Unicode-normalized display-name collisions.
- Normalize configured names and message content with NFKC plus casefold before complete-marker matching.
- Give the longest configured name ownership of overlapping markers while protecting every overlapping configured name from dynamic member resolution.
- Preserve exact configured identities across direct text sends, local-image and attachment captions, standalone/cron sends, and streamed final replies.
- Defer stream previews containing configured handoffs and route final content through a fresh structured send; reject configured markers on unstructured edit paths.
- Keep current `main`'s bounded recovery ladder for unconfigured presentation mentions and remove this PR's superseded broad unresolved-mention fallback.
- Document the configuration and add regressions for exact routing, invalid config, Unicode compatibility forms, overlapping names, dynamic collisions, retries, attachments, standalone delivery, and streaming.

## How to Test

1. Run `HERMES_PYTHON=<dev-python> scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_stream_consumer.py -q` and verify all **270** tests pass.
2. Run `HERMES_PYTHON=<dev-python> scripts/run_tests.sh tests/gateway -q`; in the recorded environment this produced **7,299 passed, 2 failed, 36 skipped**. The two WeCom callback failures reproduce on exact `upstream/main` because `defusedxml` is unavailable.
3. Run Ruff, Python compilation, and `git diff --check` on the changed Python files.
4. Configure a display name to a known pubkey, then verify direct, attachment, standalone, and streamed-final messages emit only that exact `--mention` identity.
5. Configure overlapping names such as `Ann` and `Ann Lee`, then verify `@Ann Lee` notifies only the longer exact identity while separate `@Ann` and `@Ann Lee` markers notify both intended identities.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04 with hosted Buzz

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — adapter logic is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool changed

## Screenshots / Logs

Exact candidate SHA: `d4d76f7430192e1b7431a4fc89b33a0b8bbdb216`.

Focused Buzz adapter and stream-consumer verification passed **270 tests**. The full Gateway suite produced **7,299 passed / 2 failed / 36 skipped**; both failures are the pre-existing WeCom callback environment failures described above. Ruff, Python compilation, `git diff --check`, and the added-line security scan passed.

Independent exact-head review exercised configured and dynamic identity collisions, NFKC-equivalent and overlapping names, distinct markers, stream success and failure paths, attachments, standalone delivery, config validation, retry behavior, and duplicate-notification risk, and returned **APPROVE** with no findings.