### PR TITLE
fix(cron): don't attribute no_agent script failures to a provider

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -102,8 +102,30 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     text = (error or "unknown error").strip()
     lower = text.lower()
 
+    # A no_agent job IS its script — run_job short-circuits it before any model
+    # is reached ("no LLM involvement", see the no_agent branch in run_job). So
+    # provider timeouts, rate limits, auth errors and fallback chains are not
+    # merely unlikely for these jobs, they are structurally impossible. Classify
+    # on the job's MODE before pattern-matching its prose.
+    #
+    # Without this gate the branches below classify by substring, so a script's
+    # own wording decides which subsystem gets blamed. _run_job_script reports a
+    # timeout as "Script timed out after {n}s: {path}" — that contains "timed
+    # out", so it matched the provider branch and the operator was told
+    # "provider timeout. Fallback chain was exhausted or unavailable." for a job
+    # that never opened a socket. "429" or "authentication" appearing anywhere
+    # in a script's output misfires the same way.
+    #
+    # A delivery line that names the wrong subsystem is worse than no line at
+    # all: it does not merely fail to inform, it sends the reader to the wrong
+    # place.
+    #
+    # Falling through leaves the generic cleaner below to report what actually
+    # happened, naming the script. No new message text is needed.
+    provider_reachable = not job.get("no_agent")
+
     # Provider/API failures are the common noisy path. Keep these short.
-    if "429" in text or "rate limit" in lower or "usage limit" in lower:
+    if provider_reachable and ("429" in text or "rate limit" in lower or "usage limit" in lower):
         reason = "rate limit"
         if "weekly usage limit" in lower:
             reason = "weekly usage limit"
@@ -115,7 +137,9 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
             "Full details saved in cron output."
         )
 
-    if "readtimeout" in lower or "timed out" in lower or "timeout" in lower:
+    if provider_reachable and (
+        "readtimeout" in lower or "timed out" in lower or "timeout" in lower
+    ):
         return (
             f"⚠️ Cron '{job_name}' failed: provider timeout. "
             "Fallback chain was exhausted or unavailable. "
@@ -125,7 +149,9 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     # Match authentication/authorization wording at a word boundary and the
     # 401/403 status codes as whole tokens, so "oauth", "4015" and similar do
     # not trip a misleading auth message.
-    if re.search(r"authenticat|authoriz", lower) or re.search(r"\b(401|403)\b", text):
+    if provider_reachable and (
+        re.search(r"authenticat|authoriz", lower) or re.search(r"\b(401|403)\b", text)
+    ):
         return (
             f"⚠️ Cron '{job_name}' failed: provider authentication error. "
             "Full details saved in cron output."

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -118,3 +118,59 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     ok, output = _run_job_script("/etc/passwd")
     assert ok is False
     assert "Blocked" in output or "outside" in output
+
+
+# ---------------------------------------------------------------------------
+# _summarize_cron_failure_for_delivery: mode-aware failure attribution
+# ---------------------------------------------------------------------------
+#
+# The summarizer classified failures by substring-matching the error prose and
+# mapped any hit onto a provider-shaped explanation. For a no_agent job that is
+# structurally impossible — run_job short-circuits before any model is reached —
+# so a script whose own text happened to contain "timed out", "429" or
+# "authentication" had its failure attributed to a provider it never called.
+#
+# Observed in practice: _run_job_script reports a timeout as "Script timed out
+# after {n}s: {path}", which was delivered to chat as "provider timeout. Fallback
+# chain was exhausted or unavailable." for a job that never opened a socket.
+#
+# The summarizer had no direct test coverage — the only test referencing it
+# mocks it out and asserts on its arguments — which is why this shipped.
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        "Script timed out after 900s: /home/u/.hermes/scripts/nightly.sh",
+        "Script failed: curl returned 429 from api.example.com",
+        "Script failed: gpg authentication failed for key",
+        "Script failed: ReadTimeout contacting localhost",
+    ],
+)
+def test_no_agent_failure_never_blamed_on_a_provider(error):
+    """A script job's failure must never be reported as a provider/fallback failure."""
+    from cron.scheduler import _summarize_cron_failure_for_delivery
+
+    job = {"name": "nightly-job", "no_agent": True, "script": "nightly.sh"}
+    msg = _summarize_cron_failure_for_delivery(job, error)
+
+    assert "provider" not in msg.lower()
+    assert "fallback chain" not in msg.lower()
+    # The operator must be pointed at what actually failed.
+    assert "Script" in msg
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        ("ReadTimeout: provider did not respond", "provider timeout"),
+        ("HTTP 429 rate limit exceeded", "provider rate limit"),
+        ("HTTP 401 authentication failed", "provider authentication error"),
+    ],
+)
+def test_agent_job_provider_classification_unchanged(error, expected):
+    """Regression guard: agent-mode jobs keep the provider-shaped summaries."""
+    from cron.scheduler import _summarize_cron_failure_for_delivery
+
+    job = {"name": "daily-digest", "no_agent": False}
+    assert expected in _summarize_cron_failure_for_delivery(job, error)


### PR DESCRIPTION
## Problem

`_summarize_cron_failure_for_delivery` in `cron/scheduler.py` classifies a failed cron job by substring-matching the error **prose** — `"timed out"`, `"429"`, `authenticat|authoriz` — and maps any hit onto a provider-shaped explanation. It never consults the job's execution mode, which is present in the same `job` dict it is passed.

A `no_agent` job **is** its script: `run_job` short-circuits it before any model is reached ("no LLM involvement"). Provider timeouts, rate limits, auth errors and fallback chains are therefore *structurally impossible* for such a job — yet those branches are tested first.

## Reproduction

`_run_job_script` reports a timeout as `f"Script timed out after {script_timeout}s: {path}"`. That string contains `"timed out"`, so a shell script exceeding its timeout is delivered to chat as:

```
⚠️ Cron 'x' failed: provider timeout. Fallback chain was exhausted or unavailable.
```

for a job that never opened a socket. The operator is sent to inspect model routing and fallback configuration while the actual fault is a shell script. `"429"` or `"authentication"` appearing anywhere in a script's output misfires the same way.

```python
from cron.scheduler import _summarize_cron_failure_for_delivery as f
job = {"name": "nightly-job", "no_agent": True, "script": "nightly.sh"}
f(job, "Script timed out after 900s: /home/u/.hermes/scripts/nightly.sh")
# -> "⚠️ Cron 'nightly-job' failed: provider timeout. Fallback chain was
#     exhausted or unavailable. Full details saved in cron output."
```

## Fix

Gate the three provider branches on `not job.get("no_agent")` and let script jobs fall through to the existing generic cleaner, which already reports the real error and names the script. **No new message text** — the correct output already existed on the fall-through path:

```
⚠️ Cron 'nightly-job' failed: Script timed out after 900s: /home/u/.hermes/scripts/nightly.sh
```

Agent-mode jobs are unaffected.

The auth branch already carries a word-boundary guard so `"oauth"` and `"4015"` do not trip it, which addresses one substring false-positive; gating on mode removes the remaining class for script jobs.

## Tests

The summarizer had no direct coverage — the only test referencing it (`tests/cron/test_shutdown_interrupt.py`) patches it out and asserts on its call arguments, so the classification logic itself was never exercised.

Adds parametrized cases to `tests/cron/test_cron_no_agent.py` pinning both directions:

- script jobs are never blamed on a provider, including when their own output contains `"429"`, `"authentication"` or `"ReadTimeout"`
- agent-mode jobs keep the existing `provider timeout` / `provider rate limit` / `provider authentication error` summaries unchanged

## Notes

No change to what data reaches the delivery channel beyond routing these errors to the existing generic path: script stdout/stderr already passes through `redact_sensitive_text`, and the timeout error is a fixed string plus the script path.