### PR TITLE
fix(gateway): accept command menu ellipsis

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2141,6 +2141,12 @@ class MessageEvent:
         raw = parts[0][1:].lower() if parts else None
         if raw and "@" in raw:
             raw = raw.split("@", 1)[0]
+        # Some platform command pickers render argument-taking commands with a
+        # trailing Unicode ellipsis and submit that display token verbatim
+        # (for example ``/steer… message``).  The ellipsis is UI affordance,
+        # not part of the registered command name.
+        if raw:
+            raw = raw.removesuffix("\u2026") or None
         # Reject file paths: valid command names never contain /
         if raw and "/" in raw:
             return None

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -107,6 +107,11 @@ class TestMessageEventGetCommand:
         event = MessageEvent(text="/reset session")
         assert event.get_command() == "reset"
 
+    def test_command_menu_ellipsis_is_not_part_of_command_name(self):
+        event = MessageEvent(text="/steer… inspect the review routing")
+        assert event.get_command() == "steer"
+        assert event.get_command_args() == "inspect the review routing"
+
     def test_not_a_command(self):
         event = MessageEvent(text="hello")
         assert event.get_command() is None

--- a/tests/gateway/test_steer_command.py
+++ b/tests/gateway/test_steer_command.py
@@ -117,6 +117,25 @@ async def test_steer_calls_agent_steer_and_does_not_interrupt():
 
 
 @pytest.mark.asyncio
+async def test_steer_menu_ellipsis_reaches_running_agent():
+    runner, _adapter = _make_runner(_session_entry())
+    sk = build_session_key(_make_source())
+    running_agent = MagicMock()
+    running_agent.steer.return_value = True
+    runner._running_agents[sk] = running_agent
+
+    result = await runner._handle_message(
+        _make_event("/steer… use ClaudeCode for the independent review")
+    )
+
+    assert result is not None
+    running_agent.steer.assert_called_once_with(
+        "use ClaudeCode for the independent review"
+    )
+    running_agent.interrupt.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_steer_agent_without_steer_method_falls_back():
     """If the running agent somehow lacks the steer() method (older build,
     test stub), the handler must not explode — fall back to /queue."""

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -13,6 +13,8 @@ Hermes has two slash-command surfaces, both driven by a central `COMMAND_REGISTR
 
 Installed skills are also exposed as dynamic slash commands on both surfaces. That includes bundled skills like `/plan`, which opens plan mode and saves markdown plans under `.hermes/plans/` relative to the active workspace/backend working directory.
 
+Some messaging command menus display argument-taking commands with a trailing ellipsis, such as `/steer…`. If the client submits that display token verbatim, Hermes treats the Unicode ellipsis as a UI hint rather than part of the command name.
+
 ## Permissions and admin/user split
 
 Every messaging platform that supports a per-user allowlist (Telegram, Discord, Slack, Matrix, Mattermost, Signal, …) also supports a two-tier slash command split: **admins** get every registered command, **regular users** only get the names you list in `user_allowed_commands` (plus the always-allowed floor `/help` and `/whoami`). Configure `allow_admin_from` and `user_allowed_commands` (and the per-group equivalents `group_allow_admin_from` / `group_user_allowed_commands`) inside the platform's `extra:` block in `~/.hermes/gateway-config.yaml`.


### PR DESCRIPTION
## What does this PR do?

Some messaging command pickers display argument-taking slash commands with a trailing Unicode ellipsis and submit that display text verbatim. For example, `/steer… prompt` was parsed as command name `steer…`, which is not in the command registry, so Hermes returned “unknown command.”

This normalizes one trailing U+2026 ellipsis from the parsed command token after optional bot-suffix handling and before command validation. Command arguments remain unchanged. Ordinary command tokens, bot suffixes, and file-path rejection behavior remain intact.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Normalize one trailing Unicode command-picker ellipsis in `MessageEvent.get_command()`.
- Add parser coverage proving `/steer… inspect logs` resolves to command `steer` while preserving `inspect logs` as its arguments.
- Add gateway-level coverage proving the exact ellipsis form reaches an active agent through `/steer` dispatch.
- Document command-picker ellipsis normalization in the slash-command reference.

## How to Test

1. Run `HERMES_PYTHON=<dev-python> scripts/run_tests.sh tests/gateway/test_platform_base.py tests/gateway/test_steer_command.py tests/gateway/test_command_bypass_active_session.py tests/gateway/test_slash_access_dispatch.py` and verify all 122 tests pass.
2. Run Ruff, Python compilation, and `git diff --check` on the changed Python files.
3. While a Gateway agent is active, submit `/steer… reply with STEER_OK` through a command picker and verify the prompt is injected after the next tool call instead of returning “unknown command.”

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04 with hosted Buzz

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses Python string normalization only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool changed

## Screenshots / Logs

Post-rebase focused result: 122 passed, 0 failed. Ruff, Python compilation, and `git diff --check` pass. At exact SHA `64e8d450e`, full `tests/gateway` produced 4758 passed / 17 failed versus base `219bb35c` at 4756 passed / 17 failed; the failure lists are identical in both directions, and the +2 passing tests are this PR's regressions. The exact `/steer…` form was also verified end-to-end through hosted Buzz after restarting the Gateway.