### PR TITLE
feat(config): decouple default profile from global HERMES_HOME — phase A (#76584)

### DIFF
--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -321,7 +321,7 @@ TIPS = [
     "Long dangerous commands (>70 chars) get a 'view' option in the approval prompt to see the full text first.",
     "Audio level visualization shows ▁▂▃▄▅▆▇ bars during voice recording based on microphone RMS levels.",
     "Profile names cannot collide with existing PATH binaries — 'hermes profile create ls' would be rejected.",
-    "hermes profile create backup --clone-all copies everything (config, keys, SOUL.md, memories, skills, sessions).",
+    "hermes profile create backup --clone-all copies everything (config, keys, SOUL.md, memories, skills, cron, plugins) except per-profile session history.",
     "The voice record key is configurable via voice.record_key in config.yaml — not just Ctrl+B.",
     ".cursorrules and .cursor/rules/*.mdc files are auto-detected and loaded as project context.",
     "Context files support 10+ prompt injection patterns — invisible Unicode, 'ignore instructions', exfil attempts.",

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -255,6 +255,81 @@ Use `--yes` to skip confirmation: `hermes profile delete coder --yes`
 You cannot delete the default profile (`~/.hermes`). To remove everything, use `hermes uninstall`.
 :::
 
+## Retiring the default profile
+
+The default profile is not a real profile — it is `~/.hermes` itself (see [How it works](#how-it-works)). That single directory plays three roles at once:
+
+1. **The default agent's home** — `config.yaml`, `.env`, `auth.json`, skills, sessions, memories, logs.
+2. **The global shared layer** — plugins, pets, global cron, `channel_directory.json`.
+3. **The profiles root** — named profiles live inside it at `~/.hermes/profiles/<name>/`.
+
+Because `default` is hardwired to the root, it can never be renamed or deleted (`hermes profile rename` and `hermes profile delete` both refuse). If you run several profiles, you can still make the root a pure shared layer by moving the default agent's job to a named profile and retiring the root's agent-specific data.
+
+### Step 1 — clone the default agent into a named profile
+
+```bash
+hermes profile create main-agent --clone-all --clone-from default
+```
+
+`--clone-all` copies everything the default agent uses: `config.yaml`, `.env` (API keys and messaging bot tokens), `auth.json`, `SOUL.md`, memories, skills, cron jobs, plugins, pets, and logs. The new profile is a fresh workspace — session history is deliberately not copied (see the next step).
+
+### Step 2 — migrate session history (optional)
+
+`--clone-all` excludes per-profile history so the clone stays a fresh workspace and doesn't balloon by tens of GB: `state.db` (the SQLite session store), `sessions/` (transcripts), `backups/`, `state-snapshots/`, `checkpoints/`. Migrate them manually if you need them:
+
+- **Session transcripts and everything else** — use export/import *instead of* the `--clone-all` step above (import refuses an existing profile name). The export carries over `sessions/`, config, skills, cron, scripts, plugins, and memories — but **never** credentials or `state.db`:
+
+  ```bash
+  hermes profile export default
+  hermes profile import default.tar.gz --name main-agent
+  # Export skips credentials — copy them over explicitly:
+  cp ~/.hermes/.env ~/.hermes/auth.json ~/.hermes/profiles/main-agent/
+  chmod 600 ~/.hermes/profiles/main-agent/.env ~/.hermes/profiles/main-agent/auth.json
+  ```
+
+- **`state.db` (the SQLite session store)** — excluded from both `--clone-all` and export. Copy it only while the default gateway is stopped:
+
+  ```bash
+  hermes gateway stop
+  cp ~/.hermes/state.db ~/.hermes/profiles/main-agent/
+  # Also copy state.db-wal / state.db-shm if present
+  ```
+
+  Leave `backups/`, `state-snapshots/`, and `checkpoints/` in the root — they are the default agent's own restore points.
+
+### Step 3 — give the named profile its own gateway service
+
+The default gateway service (if you installed one) pins `HERMES_HOME` to the root. Install a per-profile service for the new profile instead (see [Persistent services](#persistent-services)):
+
+```bash
+hermes -p main-agent gateway install   # creates hermes-gateway-main-agent (systemd/launchd)
+hermes -p main-agent gateway start
+```
+
+Then disable the old default gateway service so the two don't run at the same time (e.g. `systemctl --user disable --now hermes-gateway` on systemd hosts, `launchctl unload` on macOS).
+
+### Step 4 — messaging pairing
+
+Bot tokens live in `.env`, which `--clone-all` copies — the new profile inherits your Telegram/Discord/Slack pairing. Because of the [token locks](#different-bot-tokens), two gateways cannot use the same bot token simultaneously: keep only one gateway running, or generate a fresh bot token for the new profile and update its `.env`.
+
+### Step 5 — switch over and trim the root
+
+```bash
+hermes profile use main-agent   # plain `hermes` now targets main-agent
+main-agent chat                 # smoke-test the clone
+```
+
+Once the new profile works, archive (don't delete) the default agent's data in the root so the shared layer stays intact:
+
+```bash
+mv ~/.hermes/config.yaml   ~/.hermes/.config.yaml.retired
+mv ~/.hermes/.env          ~/.hermes/.env.retired
+mv ~/.hermes/auth.json     ~/.hermes/.auth.json.retired
+mv ~/.hermes/sessions      ~/.hermes/.sessions.retired
+```
+
+Keep the genuinely shared infrastructure in place: `~/.hermes/plugins/`, `~/.hermes/pets/`, `~/.hermes/cron/`, `~/.hermes/profiles/`, and `channel_directory.json`. If a global fallback ever needs the default's config back, restore the `.retired` files.
+
 ## Tab completion
 
 ```bash


### PR DESCRIPTION
## Summary

Phase A of #76584 (decouple the default profile from the global root `HERMES_HOME`): document the "retire default" workflow so multi-profile users can turn `~/.hermes` into a pure shared layer. Phase A of the issue is user-side tooling + docs; the runtime code already deliberately excludes session history from `--clone-all` (tens of GB; resurrects the source profile's state), so this PR delivers the missing **documented manual migration path** rather than changing runtime behavior.

## Root Cause

The `default` profile is a hardcoded alias for the global root `~/.hermes`, which plays three roles at once: the default agent's home, the global shared layer (plugins, pets, global cron, `channel_directory.json`), and the profiles root. Phase B (a real `profiles/default/` layout) is a framework-side refactor that needs maintainer input (issue is `needs-decision`); Phase A is the user-side workflow that works today but is undocumented, leaving three gaps: session-history migration, profile-aware gateway services, and messaging pairing.

## Change

- **`website/docs/user-guide/profiles.md`** — new "Retiring the default profile" section:
  - Step 1: `hermes profile create <name> --clone-all --clone-from default` — what is copied and what is deliberately left behind
  - Step 2: manual session-history migration — export/import path for `sessions/` transcripts (with the credentials caveat: named-profile exports never include `.env`/`auth.json`), plus the `state.db` copy procedure with the default gateway stopped
  - Step 3: per-profile gateway service via `hermes -p <name> gateway install` and disabling the old default unit
  - Step 4: messaging pairing — bot tokens live in `.env` (copied by `--clone-all`) and the token-lock constraint on running two gateways with the same token
  - Step 5: switch over with `hermes profile use` and trim the root back to genuinely shared infrastructure
- **`hermes_cli/tips.py`** — fix a factual inaccuracy in the `--clone-all` tip: sessions are per-profile history and are NOT copied; the tip now states the exclusion.

## Verification

- `pytest tests/hermes_cli/test_tips.py` — 6 passed
- `pytest tests/hermes_cli/test_profiles.py` — 44 passed
- `pytest tests/hermes_cli/test_profiles_s6_hooks.py tests/hermes_cli/test_profile_distribution.py` — 52 passed
- No runtime behavior changed (one docs file + one tip string).

Closes #76584

(Phase B — real `profiles/default/` layout — is intentionally left out of this PR; it is a framework-side refactor awaiting the maintainer decision requested by the `needs-decision` label.)
