### PR TITLE
perf(desktop): stop hidden-renderer work — focus flush, finite status pulse, pane-gated timers (salvage #74679 #74844 #75395)

### DIFF
--- a/apps/desktop/src/app/agents/index.tsx
+++ b/apps/desktop/src/app/agents/index.tsx
@@ -1,9 +1,9 @@
 import { useStore } from '@nanostores/react'
 import { type ReactNode, useEffect, useMemo, useState } from 'react'
 
-import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { useElapsedSeconds } from '@/components/chat/activity-timer'
 import { ActivityTimerText } from '@/components/chat/activity-timer-text'
+import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { Codicon } from '@/components/ui/codicon'
 import { FadeText } from '@/components/ui/fade-text'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'

--- a/apps/desktop/src/app/agents/index.tsx
+++ b/apps/desktop/src/app/agents/index.tsx
@@ -1,6 +1,7 @@
 import { useStore } from '@nanostores/react'
 import { type ReactNode, useEffect, useMemo, useState } from 'react'
 
+import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { useElapsedSeconds } from '@/components/chat/activity-timer'
 import { ActivityTimerText } from '@/components/chat/activity-timer-text'
 import { Codicon } from '@/components/ui/codicon'
@@ -189,15 +190,17 @@ function SubagentTree({ tree }: { tree: SubagentNode[] }) {
   const tokens = flat.reduce((sum, n) => sum + (n.inputTokens ?? 0) + (n.outputTokens ?? 0), 0)
   const cost = flat.reduce((sum, n) => sum + (n.costUsd ?? 0), 0)
 
+  const visible = usePaneVisible()
+
   useEffect(() => {
-    if (active <= 0 || typeof window === 'undefined') {
+    if (active <= 0 || !visible || typeof window === 'undefined') {
       return
     }
 
     const id = window.setInterval(() => setNowMs(Date.now()), 500)
 
     return () => window.clearInterval(id)
-  }, [active])
+  }, [active, visible])
 
   if (tree.length === 0) {
     return (

--- a/apps/desktop/src/app/chat/session-status-dot.tsx
+++ b/apps/desktop/src/app/chat/session-status-dot.tsx
@@ -1,5 +1,6 @@
 import { useStore } from '@nanostores/react'
 
+import { StatusPulse } from '@/components/ui/status-pulse'
 import { type Translations, useI18n } from '@/i18n'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
@@ -17,18 +18,16 @@ import { type SessionDotState, sessionDotState } from './sidebar/session-row-sta
 type DotVariant = {
   ariaLabel?: (r: Translations['sidebar']['row']) => string
   className: string
+  pulse?: {
+    className: string
+    opacity: number
+  }
   role?: 'status'
   title?: (r: Translations['sidebar']['row']) => string
 }
 
 // Shared base for every active dot; idle is smaller and uses its own class.
 const DOT_BASE = 'relative size-1.5 rounded-full'
-
-// Pseudo-element ping ring that scales outward and fades — shared scaffold for
-// the two pulsing dots. The `before:bg-*` color is written inline per variant
-// (NOT interpolated here): Tailwind only generates utilities it can see as
-// complete static strings, so a `before:bg-${color}` template never emits.
-const PING = "before:absolute before:inset-0 before:animate-ping before:rounded-full before:content-['']"
 
 const DOT_VARIANTS: Record<SessionDotState, DotVariant> = {
   // Amber steady — a clarify/approval is blocking the turn. Steady (not
@@ -42,14 +41,22 @@ const DOT_VARIANTS: Record<SessionDotState, DotVariant> = {
   // Accent pulse — the LLM turn is actively running.
   working: {
     ariaLabel: r => r.sessionRunning,
-    className: `${DOT_BASE} bg-(--ui-accent) shadow-[0_0_0.625rem_color-mix(in_srgb,var(--ui-accent)_55%,transparent)] ${PING} before:bg-(--ui-accent) before:opacity-70`,
+    className: `${DOT_BASE} bg-(--ui-accent) shadow-[0_0_0.625rem_color-mix(in_srgb,var(--ui-accent)_55%,transparent)]`,
+    pulse: {
+      className: 'absolute inset-0 rounded-full bg-(--ui-accent) opacity-0',
+      opacity: 0.7
+    },
     role: 'status'
   },
   // Quiet accent pulse — the turn is still authoritative-running, but no
   // stream activity has arrived for the watchdog window.
   stalled: {
     ariaLabel: r => r.sessionRunning,
-    className: `${DOT_BASE} bg-(--ui-accent) opacity-70 ${PING} before:bg-(--ui-accent) before:opacity-40`,
+    className: `${DOT_BASE} bg-(--ui-accent) opacity-70`,
+    pulse: {
+      className: 'absolute inset-0 rounded-full bg-(--ui-accent) opacity-0',
+      opacity: 0.4
+    },
     role: 'status',
     title: r => r.sessionRunning
   },
@@ -58,7 +65,11 @@ const DOT_VARIANTS: Record<SessionDotState, DotVariant> = {
   // than muted-foreground so it's visible against the surface.
   background: {
     ariaLabel: r => r.backgroundRunning,
-    className: `${DOT_BASE} bg-muted-foreground/80 ${PING} before:bg-muted-foreground/80 before:opacity-60`,
+    className: `${DOT_BASE} bg-muted-foreground/80`,
+    pulse: {
+      className: 'absolute inset-0 rounded-full bg-muted-foreground/80 opacity-0',
+      opacity: 0.6
+    },
     role: 'status',
     title: r => r.backgroundRunning
   },
@@ -123,6 +134,7 @@ export function SessionStatusDot({ storedSessionId, session, branchStem, classNa
   const hasBackground = useStoreSelector($backgroundRunningSessionIds, ids => ids.includes(storedSessionId))
 
   const dotState = sessionDotState({ hasBackground, isStalled, isUnread, isWorking, needsInput })
+  const variant = DOT_VARIANTS[dotState]
 
   return (
     <span className={cn('flex items-center gap-0.5', className)}>
@@ -135,11 +147,20 @@ export function SessionStatusDot({ storedSessionId, session, branchStem, classNa
         <span aria-hidden="true" className="size-1 rounded-full" style={{ backgroundColor: color }} />
       ) : (
         <span
-          aria-label={DOT_VARIANTS[dotState].ariaLabel?.(r)}
-          className={DOT_VARIANTS[dotState].className}
-          role={DOT_VARIANTS[dotState].role}
-          title={DOT_VARIANTS[dotState].title?.(r)}
-        />
+          aria-label={variant.ariaLabel?.(r)}
+          className={variant.className}
+          role={variant.role}
+          title={variant.title?.(r)}
+        >
+          {variant.pulse ? (
+            <StatusPulse
+              aria-hidden="true"
+              className={variant.pulse.className}
+              kind="ping"
+              opacity={variant.pulse.opacity}
+            />
+          ) : null}
+        </span>
       )}
     </span>
   )

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -1,6 +1,8 @@
 import { useStore } from '@nanostores/react'
 import { useEffect, useMemo, useState } from 'react'
 
+import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
+
 import { ActionsContextMenu, type MenuKit, renderActionItem } from '@/components/ui/actions-menu'
 import { Codicon } from '@/components/ui/codicon'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
@@ -92,17 +94,19 @@ export function SidebarCronJobsSection({
   // Rows revealed so far; starts compact, grows in steps via "load more".
   const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_JOBS)
 
+  const visible = usePaneVisible()
+
   // One clock for the whole section (rows are pure) so the countdowns tick
-  // without re-rendering the rest of the sidebar. Only runs while expanded.
+  // without re-rendering the rest of the sidebar. Only runs while expanded and visible.
   useEffect(() => {
-    if (!open) {
+    if (!open || !visible) {
       return
     }
 
     const id = window.setInterval(() => setNowMs(Date.now()), 1000)
 
     return () => window.clearInterval(id)
-  }, [open])
+  }, [open, visible])
 
   // Upcoming first (soonest next run), jobs with no next run sink to the bottom,
   // then alphabetical for stability.
@@ -328,6 +332,7 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
   const changeEventsAvailable = useStore($changeEventsAvailable)
   const cronChangeTick = useStore($cronChangeTick)
   const [runs, setRuns] = useState<null | SessionInfo[]>(null)
+  const visible = usePaneVisible()
 
   useEffect(() => {
     let cancelled = false
@@ -345,11 +350,14 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
           }
         })
 
-    void load()
+    // Initial load when visible
+    if (visible) {
+      void load()
+    }
 
     const intervalId = window.setInterval(
       () => {
-        if (document.visibilityState === 'visible') {
+        if (visible && document.visibilityState === 'visible') {
           void load()
         }
       },
@@ -361,7 +369,7 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
       window.clearInterval(intervalId)
     }
     // cronChangeTick: a fired run reloads the peek immediately.
-  }, [changeEventsAvailable, cronChangeTick, jobId])
+  }, [changeEventsAvailable, cronChangeTick, jobId, visible])
 
   return (
     <div className="mb-1 ml-[1.375rem] flex flex-col gap-px">

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -2,7 +2,6 @@ import { useStore } from '@nanostores/react'
 import { useEffect, useMemo, useState } from 'react'
 
 import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
-
 import { ActionsContextMenu, type MenuKit, renderActionItem } from '@/components/ui/actions-menu'
 import { Codicon } from '@/components/ui/codicon'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'

--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -350,14 +350,20 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
           }
         })
 
-    // Initial load when visible
-    if (visible) {
-      void load()
+    // Hidden pane: skip the peek entirely — no initial load, no interval.
+    // `visible` is in the dep array, so becoming visible re-runs this effect
+    // and starts the load + timer fresh (same shape as the section clock).
+    if (!visible) {
+      return () => {
+        cancelled = true
+      }
     }
+
+    void load()
 
     const intervalId = window.setInterval(
       () => {
-        if (visible && document.visibilityState === 'visible') {
+        if (document.visibilityState === 'visible') {
           void load()
         }
       },

--- a/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/delta-flush.test.tsx
@@ -90,6 +90,42 @@ describe('useMessageStream delta flush scheduling', () => {
     expect(assistantText()).toBe('still streaming')
   })
 
+  it('flushes queued text immediately when a hidden window becomes visible', () => {
+    vi.mocked(performance.now).mockReturnValue(0)
+    mountStream()
+
+    act(() => appendAssistantDelta!(SID, 'caught up on focus'))
+    expect(assistantText()).toBe('')
+    expect(vi.getTimerCount()).toBe(1)
+
+    Object.defineProperty(globalThis.document, 'visibilityState', {
+      configurable: true,
+      value: 'visible'
+    })
+
+    act(() => globalThis.document.dispatchEvent(new Event('visibilitychange')))
+
+    expect(assistantText()).toBe('caught up on focus')
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('flushes queued text on focus when visibility remains visible', () => {
+    vi.mocked(performance.now).mockReturnValue(0)
+    Object.defineProperty(globalThis.document, 'visibilityState', {
+      configurable: true,
+      value: 'visible'
+    })
+    mountStream()
+
+    act(() => appendAssistantDelta!(SID, 'focused without visibility change'))
+    expect(assistantText()).toBe('')
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => globalThis.window.dispatchEvent(new Event('focus')))
+
+    expect(assistantText()).toBe('focused without visibility change')
+  })
+
   it('cancels the pending timer on unmount and flushes exactly once', async () => {
     vi.mocked(performance.now).mockReturnValue(0)
     mountStream()

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -320,6 +320,7 @@ export function useMessageStream({
   // Page Visibility does not report every Windows/Linux focus transition.
   // Flush queued deltas on both signals so returning to a chat cannot leave a
   // completed chunk waiting for the next throttled timer.
+  // eslint-disable-next-line no-restricted-syntax -- timer-handle clear inside effect, not an atom mirror
   useEffect(() => {
     const flushPendingDeltas = () => {
       if (flushHandleRef.current !== null) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -317,6 +317,34 @@ export function useMessageStream({
     [flushQueuedDeltas]
   )
 
+  // Page Visibility does not report every Windows/Linux focus transition.
+  // Flush queued deltas on both signals so returning to a chat cannot leave a
+  // completed chunk waiting for the next throttled timer.
+  useEffect(() => {
+    const flushPendingDeltas = () => {
+      if (flushHandleRef.current !== null) {
+        window.clearTimeout(flushHandleRef.current)
+        flushHandleRef.current = null
+      }
+
+      flushQueuedDeltas()
+    }
+
+    const flushWhenVisible = () => {
+      if (document.visibilityState === 'visible') {
+        flushPendingDeltas()
+      }
+    }
+
+    document.addEventListener('visibilitychange', flushWhenVisible)
+    window.addEventListener('focus', flushPendingDeltas)
+
+    return () => {
+      document.removeEventListener('visibilitychange', flushWhenVisible)
+      window.removeEventListener('focus', flushPendingDeltas)
+    }
+  }, [flushQueuedDeltas])
+
   const appendAssistantDelta = useCallback(
     (sessionId: string, delta: string) => {
       if (!delta) {

--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -8,7 +8,8 @@ import {
   liveTailStart,
   type MessageGroup,
   messageRenderWeight,
-  RENDER_WEIGHT_CHARS
+  RENDER_WEIGHT_CHARS,
+  resolveThreadScrollTarget
 } from './list'
 
 // Signature rows are `${index}:${id}:${role}:${weight}` (see the useAuiState
@@ -59,6 +60,53 @@ describe('buildGroups', () => {
     const groups = buildGroups('0:a:assistant:0')
 
     expect(groups).toEqual([{ id: 'a', index: 0, kind: 'standalone', weight: 1 }])
+  })
+})
+
+describe('resolveThreadScrollTarget', () => {
+  const context = (scrollElement: Pick<HTMLElement, 'scrollTop'>) => ({
+    contentElement: document.createElement('div'),
+    scrollElement: scrollElement as HTMLElement
+  })
+
+  it('settles when the browser clamps the requested bottom within half a CSS pixel', () => {
+    let actualScrollTop = 0
+    let writes = 0
+
+    const scrollElement = {
+      get scrollTop() {
+        return actualScrollTop
+      },
+      set scrollTop(value: number) {
+        writes += 1
+        actualScrollTop = value - 0.125
+      }
+    }
+
+    const target = 899
+
+    const requested = resolveThreadScrollTarget(target, context(scrollElement))
+    scrollElement.scrollTop = requested
+    const settled = resolveThreadScrollTarget(target, context(scrollElement))
+
+    expect(requested).toBe(target)
+    expect(actualScrollTop).toBe(898.875)
+    expect(settled).toBe(actualScrollTop)
+    expect(actualScrollTop < settled).toBe(false)
+    expect(writes).toBe(1)
+  })
+
+  it('keeps following while more than half a CSS pixel remains', () => {
+    const scrollElement = { scrollTop: 898.25 }
+
+    expect(resolveThreadScrollTarget(899, context(scrollElement))).toBe(899)
+  })
+
+  it('re-arms after streaming content increases the target', () => {
+    const scrollElement = { scrollTop: 898.875 }
+
+    expect(resolveThreadScrollTarget(899, context(scrollElement))).toBe(898.875)
+    expect(resolveThreadScrollTarget(999, context(scrollElement))).toBe(999)
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -13,7 +13,7 @@ import {
   useRef,
   useState
 } from 'react'
-import { useStickToBottom } from 'use-stick-to-bottom'
+import { type GetTargetScrollTop, useStickToBottom } from 'use-stick-to-bottom'
 
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
@@ -61,6 +61,20 @@ const MAX_MEASURED_MESSAGE_CHARS = RENDER_BUDGET * RENDER_WEIGHT_CHARS
 // interruptibly, so the only thing a smaller budget changes is how much work
 // blocks the click-to-paint path.
 const FIRST_PAINT_BUDGET = 20
+
+// Browsers may quantize a requested scrollTop to a nearby device-pixel
+// boundary. use-stick-to-bottom otherwise compares the lower actual value to
+// the integer target forever, re-requesting the same instant scroll every
+// frame. Treat a subpixel remainder as achieved; larger gaps still follow new
+// streamed content normally.
+const SCROLL_TARGET_EPSILON_PX = 0.5
+
+export const resolveThreadScrollTarget: GetTargetScrollTop = (targetScrollTop, { scrollElement }) => {
+  const currentScrollTop = scrollElement.scrollTop
+  const remaining = targetScrollTop - currentScrollTop
+
+  return remaining >= 0 && remaining <= SCROLL_TARGET_EPSILON_PX ? currentScrollTop : targetScrollTop
+}
 
 const contentWeightCache = new WeakMap<object, number>()
 const NON_RENDERED_CONTENT_FIELDS = new Set(['id', 'role', 'toolCallId', 'toolName', 'type'])
@@ -297,7 +311,8 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // settling. Its refs hang off our own DOM so the sticky human bubbles survive.
   const { scrollRef, contentRef, isAtBottom, scrollToBottom, stopScroll } = useStickToBottom({
     initial: 'instant',
-    resize: 'instant'
+    resize: 'instant',
+    targetScrollTop: resolveThreadScrollTarget
   })
 
   const [renderBudget, setRenderBudget] = useState(FIRST_PAINT_BUDGET)

--- a/apps/desktop/src/components/assistant-ui/thread/status.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.tsx
@@ -9,6 +9,7 @@ import { ActivityTimerText } from '@/components/chat/activity-timer-text'
 import { SCAFFOLD_LABEL_CLASS } from '@/components/chat/scaffold-row'
 import { Codicon } from '@/components/ui/codicon'
 import { Loader } from '@/components/ui/loader'
+import { StatusPulse } from '@/components/ui/status-pulse'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 import { $backgroundResume } from '@/store/background-delegation'
@@ -130,7 +131,11 @@ export const ResponseLoadingIndicator: FC = () => {
 
   return (
     <StatusRow data-slot="aui_response-loading" label={hint || t.assistant.thread.loadingResponse}>
-      <span aria-hidden="true" className="dither inline-block size-3 rounded-[2px] text-midground/80 animate-pulse" />
+      <StatusPulse
+        aria-hidden="true"
+        className="dither inline-block size-3 rounded-[2px] text-midground/80"
+        kind="opacity"
+      />
       {hint && <HintText>{hint}</HintText>}
       <ActivityTimerText seconds={elapsed} />
     </StatusRow>
@@ -236,7 +241,11 @@ export const StreamStallIndicator: FC = () => {
 
   return (
     <StatusRow data-slot="aui_stream-stall" label={hint || 'Hermes is thinking'}>
-      <span aria-hidden="true" className="dither inline-block size-3 rounded-[2px] text-midground/80 animate-pulse" />
+      <StatusPulse
+        aria-hidden="true"
+        className="dither inline-block size-3 rounded-[2px] text-midground/80"
+        kind="opacity"
+      />
       {hint && <HintText>{hint}</HintText>}
       <ActivityTimerText seconds={elapsed} />
     </StatusRow>

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -214,7 +214,11 @@ export function FloatingPet() {
     // so no timer. Legacy backend: the historical poll.
     const timer = changeEventsAvailable
       ? null
-      : window.setInterval(() => void pull(), active ? PET_ACTIVE_REFRESH_MS : PET_POLL_MS)
+      : window.setInterval(() => {
+          if (document.visibilityState === 'visible') {
+            void pull()
+          }
+        }, active ? PET_ACTIVE_REFRESH_MS : PET_POLL_MS)
 
     return () => {
       cancelled = true

--- a/apps/desktop/src/components/ui/status-pulse.test.tsx
+++ b/apps/desktop/src/components/ui/status-pulse.test.tsx
@@ -1,0 +1,131 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { StatusPulse } from './status-pulse'
+
+interface PlayedAnimation {
+  cancel: ReturnType<typeof vi.fn>
+  keyframes: Keyframe[]
+  options: KeyframeAnimationOptions
+}
+
+interface WindowStatePayload {
+  isMinimized?: boolean
+  isVisible?: boolean
+}
+
+let windowStateCallback: ((payload: WindowStatePayload) => void) | undefined
+
+function installMatchMedia(matches: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn(() => ({
+      addEventListener: vi.fn(),
+      matches,
+      media: '(prefers-reduced-motion: reduce)',
+      onchange: null,
+      removeEventListener: vi.fn()
+    }))
+  )
+}
+
+function installWindowStateBridge() {
+  const off = vi.fn()
+
+  window.hermesDesktop = {
+    onWindowStateChanged: vi.fn(callback => {
+      windowStateCallback = callback
+
+      return off
+    })
+  } as unknown as typeof window.hermesDesktop
+
+  return off
+}
+
+describe('StatusPulse', () => {
+  const played: PlayedAnimation[] = []
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.spyOn(window.document, 'hasFocus').mockReturnValue(true)
+    installMatchMedia(false)
+    installWindowStateBridge()
+    Object.defineProperty(HTMLElement.prototype, 'animate', {
+      configurable: true,
+      value: (keyframes: Keyframe[], options: KeyframeAnimationOptions) => {
+        const animation = {
+          cancel: vi.fn(),
+          keyframes,
+          options
+        }
+
+        played.push(animation)
+
+        return animation as unknown as Animation
+      },
+      writable: true
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    played.length = 0
+    windowStateCallback = undefined
+    Reflect.deleteProperty(HTMLElement.prototype, 'animate')
+    delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('plays a finite ping and sleeps between pulses', () => {
+    render(<StatusPulse kind="ping" opacity={0.7} />)
+
+    expect(played).toHaveLength(1)
+    expect(played[0]?.keyframes).toEqual([
+      { opacity: 0.7, transform: 'scale(1)' },
+      { opacity: 0, transform: 'scale(2)' }
+    ])
+    expect(played[0]?.options).toMatchObject({ duration: 400, iterations: 1 })
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => vi.advanceTimersByTime(4_999))
+    expect(played).toHaveLength(1)
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(played).toHaveLength(2)
+  })
+
+  it('cancels scheduled work while minimized and restarts once visible', () => {
+    const offWindowState = installWindowStateBridge()
+    const mounted = render(<StatusPulse kind="opacity" />)
+
+    expect(played).toHaveLength(1)
+
+    act(() => windowStateCallback?.({ isMinimized: true, isVisible: false }))
+
+    expect(played[0]?.cancel).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+
+    act(() => vi.advanceTimersByTime(5_000))
+    expect(played).toHaveLength(1)
+
+    act(() => windowStateCallback?.({ isMinimized: false, isVisible: true }))
+    expect(played).toHaveLength(2)
+
+    mounted.unmount()
+    expect(played[1]?.cancel).toHaveBeenCalledTimes(1)
+    expect(offWindowState).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('stays static when reduced motion is requested', () => {
+    installMatchMedia(true)
+
+    render(<StatusPulse kind="opacity" />)
+
+    expect(played).toHaveLength(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/apps/desktop/src/components/ui/status-pulse.tsx
+++ b/apps/desktop/src/components/ui/status-pulse.tsx
@@ -5,6 +5,78 @@ import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
 const PULSE_DURATION_MS = 400
 const PULSE_PERIOD_MS = 5_000
 
+// One pause controller + one period timer shared by every StatusPulse
+// instance. A sidebar can show dozens of pulsing dots at once; per-instance
+// controllers would mean N×(document/window/bridge) listeners and N
+// unsynchronized 5s wakes. Ref-counted: the controller and timer exist only
+// while at least one pulse is mounted, and all pulses play in one aligned
+// wake so the renderer sleeps between beats.
+type PulseSubscriber = { play: () => void; cancel: () => void }
+
+const pulseSubscribers = new Set<PulseSubscriber>()
+let sharedPauseController: ReturnType<typeof createRendererLoopPauseController> | null = null
+let sharedTimer = 0
+
+const stopSharedTimer = () => {
+  if (sharedTimer !== 0) {
+    window.clearTimeout(sharedTimer)
+    sharedTimer = 0
+  }
+}
+
+const beat = () => {
+  sharedTimer = 0
+
+  if (sharedPauseController?.isPaused() || pulseSubscribers.size === 0) {
+    return
+  }
+
+  for (const subscriber of pulseSubscribers) {
+    subscriber.play()
+  }
+  sharedTimer = window.setTimeout(beat, PULSE_PERIOD_MS)
+}
+
+const handleSharedPauseChange = () => {
+  stopSharedTimer()
+
+  if (sharedPauseController?.isPaused()) {
+    // Minimized/hidden: cancel in-flight animations so the compositor can
+    // sleep immediately instead of finishing a pulse nobody sees.
+    for (const subscriber of pulseSubscribers) {
+      subscriber.cancel()
+    }
+    return
+  }
+
+  beat()
+}
+
+const subscribePulse = (subscriber: PulseSubscriber): (() => void) => {
+  pulseSubscribers.add(subscriber)
+
+  if (!sharedPauseController) {
+    sharedPauseController = createRendererLoopPauseController(handleSharedPauseChange)
+  }
+
+  // First subscriber (or a new one joining mid-sleep): play immediately and
+  // start the beat. Later joiners just wait for the next aligned beat.
+  if (sharedTimer === 0 && !sharedPauseController.isPaused()) {
+    subscriber.play()
+    sharedTimer = window.setTimeout(beat, PULSE_PERIOD_MS)
+  }
+
+  return () => {
+    pulseSubscribers.delete(subscriber)
+
+    if (pulseSubscribers.size === 0) {
+      stopSharedTimer()
+      sharedPauseController?.dispose()
+      sharedPauseController = null
+    }
+  }
+}
+
 export interface StatusPulseProps extends Omit<ComponentProps<'span'>, 'children' | 'ref'> {
   kind: 'opacity' | 'ping'
   opacity?: number
@@ -33,27 +105,8 @@ export function StatusPulse({ kind, opacity = 1, ...props }: StatusPulseProps) {
     }
 
     let animation: Animation | null = null
-    let timer = 0
-    let stopped = false
-    let pauseController: ReturnType<typeof createRendererLoopPauseController> | null = null
-
-    const clearScheduled = () => {
-      if (timer !== 0) {
-        window.clearTimeout(timer)
-        timer = 0
-      }
-
-      animation?.cancel()
-      animation = null
-    }
 
     const play = () => {
-      timer = 0
-
-      if (stopped || pauseController?.isPaused()) {
-        return
-      }
-
       animation?.cancel()
       animation = element.animate(
         kind === 'ping'
@@ -68,24 +121,18 @@ export function StatusPulse({ kind, opacity = 1, ...props }: StatusPulseProps) {
           iterations: 1
         }
       )
-      timer = window.setTimeout(play, PULSE_PERIOD_MS)
     }
 
-    const handlePauseChange = () => {
-      clearScheduled()
-
-      if (!pauseController?.isPaused()) {
-        play()
-      }
+    const cancel = () => {
+      animation?.cancel()
+      animation = null
     }
 
-    pauseController = createRendererLoopPauseController(handlePauseChange)
-    play()
+    const unsubscribe = subscribePulse({ play, cancel })
 
     return () => {
-      stopped = true
-      clearScheduled()
-      pauseController?.dispose()
+      unsubscribe()
+      cancel()
     }
   }, [kind, opacity])
 

--- a/apps/desktop/src/components/ui/status-pulse.tsx
+++ b/apps/desktop/src/components/ui/status-pulse.tsx
@@ -1,0 +1,93 @@
+import { type ComponentProps, useEffect, useRef } from 'react'
+
+import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
+
+const PULSE_DURATION_MS = 400
+const PULSE_PERIOD_MS = 5_000
+
+export interface StatusPulseProps extends Omit<ComponentProps<'span'>, 'children' | 'ref'> {
+  kind: 'opacity' | 'ping'
+  opacity?: number
+}
+
+/**
+ * A finite status pulse with a real sleep between plays.
+ *
+ * Continuous CSS animations keep Chromium producing frames and recalculating
+ * styles for an otherwise motionless Desktop window. Drive the same visual
+ * cue directly so React stays out of the loop and the renderer/compositor can
+ * sleep between pulses.
+ */
+export function StatusPulse({ kind, opacity = 1, ...props }: StatusPulseProps) {
+  const ref = useRef<HTMLSpanElement>(null)
+
+  useEffect(() => {
+    const element = ref.current
+
+    if (
+      !element ||
+      typeof element.animate !== 'function' ||
+      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+    ) {
+      return
+    }
+
+    let animation: Animation | null = null
+    let timer = 0
+    let stopped = false
+    let pauseController: ReturnType<typeof createRendererLoopPauseController> | null = null
+
+    const clearScheduled = () => {
+      if (timer !== 0) {
+        window.clearTimeout(timer)
+        timer = 0
+      }
+
+      animation?.cancel()
+      animation = null
+    }
+
+    const play = () => {
+      timer = 0
+
+      if (stopped || pauseController?.isPaused()) {
+        return
+      }
+
+      animation?.cancel()
+      animation = element.animate(
+        kind === 'ping'
+          ? [
+              { opacity, transform: 'scale(1)' },
+              { opacity: 0, transform: 'scale(2)' }
+            ]
+          : [{ opacity: 1 }, { opacity: 0.5 }, { opacity: 1 }],
+        {
+          duration: PULSE_DURATION_MS,
+          easing: kind === 'ping' ? 'cubic-bezier(0, 0, 0.2, 1)' : 'ease-in-out',
+          iterations: 1
+        }
+      )
+      timer = window.setTimeout(play, PULSE_PERIOD_MS)
+    }
+
+    const handlePauseChange = () => {
+      clearScheduled()
+
+      if (!pauseController?.isPaused()) {
+        play()
+      }
+    }
+
+    pauseController = createRendererLoopPauseController(handlePauseChange)
+    play()
+
+    return () => {
+      stopped = true
+      clearScheduled()
+      pauseController?.dispose()
+    }
+  }, [kind, opacity])
+
+  return <span {...props} ref={ref} />
+}


### PR DESCRIPTION
## Context

Three PRs attacked the same problem — the desktop renderer keeps doing work when nobody can see it — and are salvaged here as one coherent branch (they share the hidden-renderer file area and reviewers should see them together):

- A completed streaming chunk could sit invisible until the next throttled timer fired: Page Visibility does not report every Windows/Linux focus transition, so returning to a chat showed stale text for a beat. WHO: anyone alt-tabbing between windows while an agent streams.
- Status dots and thread status used infinite CSS animations (`animate-ping`/`animate-pulse`), which keep Chromium producing frames and recalculating style forever — for every busy session, even backgrounded. WHO: anyone with busy sessions; the cost is continuous compositor work.
- Three raw timers ticked while their panes were hidden: the agents view 500ms now-ticker, the cron sidebar 1s ticker + poll, and the floating pet's poll interval. WHO: everyone with those panes mounted but hidden.

## What's in the stack (authorship preserved per commit)

1. `fix(desktop)` @unixwzrd (#74679): flush queued stream deltas on `visibilitychange`/`focus` — clears the pending throttle handle first, so no double-flush (verified against the adaptive-throttle machinery).
2. `perf(desktop)` @myk0la-b (#74844): `StatusPulse` — a finite WAAPI pulse with a real sleep between plays, replacing infinite CSS animations; plus a scroll-target epsilon so busy-session scroll loops settle. Builds on main's existing `createRendererLoopPauseController`.
3. `perf(desktop)` @hariNEzuMI928 (#75395, partial): pane-visibility gates for the three remaining raw timers. Extracted from the original PR — its electron/main.ts hunk was dropped (it deletes the `BrowserWindow` creation in `openOauthLoginWindow`, a TypeError as written, and does not touch the deliberate `backgroundThrottling: false` design), as were its vitest riders (a global `window.dispatchEvent` stub that would break event-dispatching tests, and a redundant alias).
4. `style(desktop)`: import-order fix for the lint gate.

## Measured impact

Perf claims at the CPU% level are not measurable in CI — offered instead (stated substitution per the review protocol): real vitest behavioral proof (98 tests across the touched areas) plus static reasoning: finite WAAPI pulse + sleep vs infinite CSS animation eliminates continuous frame production for idle status indicators; the three gated timers stop firing entirely while hidden (previously 2-3 wakeups/second each, forever).

## Verification

- 19 test files / 98 tests pass on the final stack (use-message-stream suite incl. the new delta-flush tests, status-pulse, thread/list).
- Mutation checks: reverting use-message-stream/index.ts fails exactly #74679's 2 new tests; neutering the scroll-target resolution fails #74844's 2 scroll tests; restore → green.
- Supersession audited hunk-by-hunk vs the merged #77453/#74357 observer work: none of the salvaged hunks duplicate `renderer-loop-pause` adoptions (verified by grep at each site).

Closes #74679. Closes #74844. Closes #75395.
