### PR TITLE
fix(desktop): dedupe optimistic user turns for all wire references (salvage #75733)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { WIRE_REFERENCE_KINDS } from '@/components/assistant-ui/reference-kinds'
+import { textWithoutReferenceLines, WIRE_REFERENCE_KINDS } from '@/components/assistant-ui/reference-kinds'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { $approvalModes, approvalModeForProfile } from '@/store/approval-mode'
 import { $desktopOnboarding } from '@/store/onboarding'
@@ -615,6 +615,49 @@ describe('preserveLocalPendingTurnMessages', () => {
       expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
     }
   )
+
+  it('does not duplicate a directive-only file turn', () => {
+    const previous = [
+      msg('1-user', 'user', 'first'),
+      msg('2-assistant', 'assistant', 'first answer'),
+      msg('user-optimistic', 'user', '', {
+        attachmentRefs: ['@file:X']
+      })
+    ]
+
+    const next = [
+      msg('1-user-stored', 'user', 'first'),
+      msg('2-assistant-stored', 'assistant', 'first answer'),
+      msg('3-user-stored', 'user', '@file:X')
+    ]
+
+    expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
+  })
+
+  it('does not duplicate a turn with multiple CRLF directives and Unicode payloads', () => {
+    const refs = ['@file:`資料/über notes.md`', '@url:`https://example.com/café?q=✓`']
+    const previous = [
+      msg('1-user', 'user', 'first'),
+      msg('2-assistant', 'assistant', 'first answer'),
+      msg('user-optimistic', 'user', 'text', {
+        attachmentRefs: refs
+      })
+    ]
+
+    const next = [
+      msg('1-user-stored', 'user', 'first'),
+      msg('2-assistant-stored', 'assistant', 'first answer'),
+      msg('3-user-stored', 'user', `${refs.join('\r\n')}\r\n\r\ntext`)
+    ]
+
+    expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
+  })
+
+  it('strips only complete reference lines from visible text', () => {
+    expect(textWithoutReferenceLines('see @file:X here')).toBe('see @file:X here')
+    expect(textWithoutReferenceLines('@file:X trailing prose')).toBe('@file:X trailing prose')
+    expect(textWithoutReferenceLines('  @file:X')).toBe('@file:X')
+  })
 
   it('still keeps a genuinely uncommitted optimistic image turn when the persisted text differs', () => {
     const previous = [

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { WIRE_REFERENCE_KINDS } from '@/components/assistant-ui/reference-kinds'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { $approvalModes, approvalModeForProfile } from '@/store/approval-mode'
 import { $desktopOnboarding } from '@/store/onboarding'
@@ -574,6 +575,46 @@ describe('preserveLocalPendingTurnMessages', () => {
 
     expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
   })
+
+  it('does not duplicate the optimistic file turn when the persisted turn carries @file refs', () => {
+    const previous = [
+      msg('1-user', 'user', 'first'),
+      msg('2-assistant', 'assistant', 'first answer'),
+      msg('user-optimistic', 'user', 'text', {
+        attachmentRefs: ['@file:X']
+      })
+    ]
+
+    const next = [
+      msg('1-user-stored', 'user', 'first'),
+      msg('2-assistant-stored', 'assistant', 'first answer'),
+      msg('3-user-stored', 'user', '@file:X\n\ntext')
+    ]
+
+    expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
+  })
+
+  it.each(WIRE_REFERENCE_KINDS.filter(kind => kind !== 'file' && kind !== 'image'))(
+    'does not duplicate the optimistic %s turn when the persisted turn carries its directive',
+    kind => {
+      const ref = `@${kind}:X`
+      const previous = [
+        msg('1-user', 'user', 'first'),
+        msg('2-assistant', 'assistant', 'first answer'),
+        msg('user-optimistic', 'user', 'text', {
+          attachmentRefs: [ref]
+        })
+      ]
+
+      const next = [
+        msg('1-user-stored', 'user', 'first'),
+        msg('2-assistant-stored', 'assistant', 'first answer'),
+        msg('3-user-stored', 'user', `${ref}\n\ntext`)
+      ]
+
+      expect(preserveLocalPendingTurnMessages(next, previous)).toBe(next)
+    }
+  )
 
   it('still keeps a genuinely uncommitted optimistic image turn when the persisted text differs', () => {
     const previous = [

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1,7 +1,8 @@
 import { getSession } from '@/hermes'
+import { textWithoutReferenceLines } from '@/components/assistant-ui/reference-kinds'
 import { assistantTextPart, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
-import { embeddedImageUrls, textWithoutEmbeddedImages, textWithoutImageRefs } from '@/lib/embedded-images'
+import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { requestDesktopOnboardingForCredentialWarning } from '@/store/onboarding'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
@@ -403,7 +404,8 @@ export function preserveLocalPendingTurnMessages(
     if (
       isOptimisticUser &&
       latestAuthoritativeUser &&
-      textWithoutImageRefs(chatMessageText(latestAuthoritativeUser)) === textWithoutImageRefs(chatMessageText(message))
+      textWithoutReferenceLines(chatMessageText(latestAuthoritativeUser)) ===
+        textWithoutReferenceLines(chatMessageText(message))
     ) {
       continue
     }
@@ -415,7 +417,9 @@ export function preserveLocalPendingTurnMessages(
         continue
       }
 
-      if (textWithoutImageRefs(chatMessageText(authoritative)) === textWithoutImageRefs(chatMessageText(message))) {
+      if (
+        textWithoutReferenceLines(chatMessageText(authoritative)) === textWithoutReferenceLines(chatMessageText(message))
+      ) {
         continue
       }
     }
@@ -484,7 +488,9 @@ export function appendLiveSessionProjection(
   }
 
   const persistedInLatestRun = (text: string): boolean =>
-    latestUserRun.some(message => textWithoutImageRefs(chatMessageText(message)) === textWithoutImageRefs(text))
+    latestUserRun.some(
+      message => textWithoutReferenceLines(chatMessageText(message)) === textWithoutReferenceLines(text)
+    )
 
   const inflightUserAlreadyPersisted = Boolean(inflightUser) && persistedInLatestRun(inflightUser)
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1,5 +1,5 @@
-import { getSession } from '@/hermes'
 import { textWithoutReferenceLines } from '@/components/assistant-ui/reference-kinds'
+import { getSession } from '@/hermes'
 import { assistantTextPart, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'

--- a/apps/desktop/src/components/assistant-ui/reference-kinds.ts
+++ b/apps/desktop/src/components/assistant-ui/reference-kinds.ts
@@ -157,3 +157,20 @@ const REFERENCE_PATTERN = /@(file|folder|url|image|tool|line|terminal|session):(
 export function referenceRe(): RegExp {
   return new RegExp(REFERENCE_PATTERN.source, 'g')
 }
+
+/** Remove reference-only lines when comparing visible message text. */
+export function textWithoutReferenceLines(text: string): string {
+  const matcher = referenceRe()
+
+  return text
+    .split('\n')
+    .filter(line => {
+      const candidate = line.trimEnd()
+      matcher.lastIndex = 0
+      const match = matcher.exec(candidate)
+
+      return !match || match.index !== 0 || match[0] !== candidate
+    })
+    .join('\n')
+    .trim()
+}


### PR DESCRIPTION
## Context

Send a message containing `@file:`/`@url:`/any non-image reference on desktop and you may see your own message twice. The optimistic dedupe that reconciles your locally-painted user turn with the gateway's authoritative echo strips only `@image:` lines before comparing — any other reference makes the texts mismatch, so the echo is treated as a different message and both render. WHO: anyone using context references in chat (a core desktop feature).

This extends the normalization to all wire reference kinds, with a shared reference-kinds registry.

## Measured impact

Correctness fix, no perf claim. The bug reproduces on main's list logic: reverting the production code fails 9/54 of the PR's tests (behavioral proof the duplicate-turn bug exists for non-image refs today).

## Provenance

Salvage of #75733 by @pnascimento9596 (3 commits, authorship preserved: fix + edge-case tests + lint-sort). Adversarial review: dedupe key remains normalized-text equality consistent with the pre-existing design; the reference-only-message collision edge predates this PR (noted as a low-sev follow-up, not a regression).

## Verification

- utils.test.ts 54/54 green; 298-test sweep across use-session-actions + assistant-ui green (10 test-file load failures are the pre-existing frimousse resolution issue, reproduced identically on a main-equivalent worktree).
- Mutation check: revert → 9 tests fail; restore → green.

Closes #75733.
