### PR TITLE
fix(security): create the remaining plaintext transcript artifacts owner-only

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -47,6 +47,7 @@ logger = logging.getLogger(__name__)
 import fire
 
 from run_agent import AIAgent
+from utils import open_private_append
 from toolset_distributions import (
     list_distributions, 
     sample_toolsets_from_distribution,
@@ -483,7 +484,13 @@ def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
             }
             
             # Append to batch output file
-            with open(batch_output_file, 'a', encoding='utf-8') as f:
+            # Same artifact class as agent/trajectory.py: a full trajectory
+            # (tool results and tool-call arguments verbatim) appended under
+            # the CWD, not the 0o700 HERMES_HOME. A bare append open would
+            # create it 0o644 at a default umask. New files start owner-only;
+            # an existing file the operator widened to feed a training
+            # pipeline is left alone (see open_private_append).
+            with open_private_append(batch_output_file) as f:
                 f.write(json.dumps(trajectory_entry, ensure_ascii=False) + "\n")
                 f.flush()
                 os.fsync(f.fileno())

--- a/cli.py
+++ b/cli.py
@@ -8375,7 +8375,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         saved_dir = get_hermes_home() / "sessions" / "saved"
         try:
-            saved_dir.mkdir(parents=True, exist_ok=True)
+            # Every file in here is a full plaintext transcript, so the
+            # directory listing is sensitive too: a bare mkdir creates it 0o755
+            # at a default umask, which under the documented HERMES_HOME_MODE
+            # traversal hatch (e.g. 0o701 so nginx can reach a served subdir)
+            # leaves the snapshot filenames world-readable. secure_mkdir sets
+            # the mode at creation and skips managed mode, where the NixOS
+            # module deliberately group-shares sessions/ (2770).
+            from hermes_cli.config import secure_mkdir
+
+            secure_mkdir(saved_dir)
         except Exception as e:
             print(f"(x_x) Failed to create save directory {saved_dir}: {e}")
             return

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -794,6 +794,50 @@ def _secure_dir(path):
     _chown_to_hermes_uid(path)
 
 
+def secure_mkdir(path) -> None:
+    """Create an artifact subdirectory of HERMES_HOME owner-only, at creation.
+
+    For directories that hold verbatim transcript content the agent names
+    itself (``sessions/saved``, ``a2a_conversations``). A bare
+    ``mkdir(parents=True, exist_ok=True)`` derives the mode from the process
+    umask — 0o755 on a default install — so the listing of a conversation-log
+    directory is world-readable even though each file inside is 0o600.
+
+    The mode is passed to ``mkdir`` rather than chmod'd afterwards, so there
+    is no window in which the directory exists at umask permissions. An
+    already-existing directory keeps its mode (``exist_ok=True`` does not
+    re-apply it), matching ``_secure_dir``'s "never fight the user" stance and
+    ``open_private_append``'s create-only contract.
+
+    Skipped in managed mode, exactly like ``_secure_dir``: the NixOS module
+    creates HERMES_HOME's subdirs setgid group-writable (2770) with
+    ``UMask=0007`` on the service, so interactive users in the hermes group can
+    share state with the gateway. Forcing 0o700 here would silently revoke
+    that group access, and unlike ``_secure_dir``'s chmod a mode passed at
+    creation is not re-reconciled by a later activation pass. Note
+    ``_is_container()`` is deliberately *not* consulted — it gates
+    ``_secure_file`` only, and this module has no container carve-out for
+    directories.
+
+    ``HERMES_HOME_MODE`` is deliberately not honoured either. That hatch
+    exists so a web server can *traverse* HERMES_HOME to reach a served
+    subdirectory (e.g. 0o701); nothing is served out of these artifact dirs,
+    and a 0o755 child under a 0o701 home is exactly the case where the listing
+    becomes genuinely world-readable.
+
+    Only the leaf gets the mode — ``parents=True`` creates intermediate dirs at
+    umask, as ``mkdir -p`` does. Both call sites sit under a HERMES_HOME that
+    ``ensure_hermes_home()`` has already secured.
+
+    POSIX bits are advisory on Windows, where at-rest protection is ACL-based.
+    """
+    path = Path(path)
+    if is_managed():
+        path.mkdir(parents=True, exist_ok=True)
+        return
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+
 def _is_container() -> bool:
     """Detect if we're running inside a Docker/Podman/LXC container.
 

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -804,10 +804,18 @@ def _safe_name(context_id: str) -> str:
 def persist_message(context_id: str, role: str, text: str, task_id: str = "") -> None:
     """Append one message to the context's on-disk conversation log."""
     try:
+        # These records are verbatim peer conversation turns — the same text
+        # the model saw, unredacted. A bare mkdir + append open derives both
+        # modes from the umask (0o755 dir / 0o644 file on a default install),
+        # so every local account can read another agent's conversation log.
+        # Create both owner-only, at creation, with no chmod-after window.
+        from hermes_cli.config import secure_mkdir
+        from utils import open_private_append
+
         d = _conv_dir()
-        d.mkdir(parents=True, exist_ok=True)
+        secure_mkdir(d)
         rec = {"ts": time.time(), "role": role, "text": text, "task_id": task_id}
-        with (d / f"{_safe_name(context_id)}.jsonl").open("a", encoding="utf-8") as fh:
+        with open_private_append(d / f"{_safe_name(context_id)}.jsonl") as fh:
             fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
     except Exception:
         pass

--- a/plugins/platforms/a2a/security.py
+++ b/plugins/platforms/a2a/security.py
@@ -365,8 +365,15 @@ def audit(direction: str, peer: str, task_id: str, summary: str) -> None:
             "summary": (summary or "")[:500],
         }
         path = _audit_path()
+        # Each record embeds a 500-char summary of the peer exchange, so the
+        # log is partial transcript content and must not be born 0o644.
+        # Only the file gets a mode here: path.parent is HERMES_HOME itself,
+        # whose mode belongs to ensure_hermes_home()/_secure_dir (and is
+        # user-overridable via HERMES_HOME_MODE) — not to this call site.
+        from utils import open_private_append
+
         path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("a", encoding="utf-8") as fh:
+        with open_private_append(path) as fh:
             fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
     except Exception:
         logger.debug("A2A: audit write failed", exc_info=True)

--- a/tests/test_transcript_artifact_file_modes_remaining.py
+++ b/tests/test_transcript_artifact_file_modes_remaining.py
@@ -1,0 +1,355 @@
+"""The remaining plaintext transcript artifacts must be created owner-only.
+
+Follow-up to the four paths hardened in #77520 (``/save`` snapshots, agent
+trajectories, MoA traces). The sites covered here were deliberately scoped out
+of that PR to keep it narrow, and are the same defect at sibling call paths:
+
+* ``plugins/platforms/a2a/protocol.py:persist_message`` — verbatim peer
+  conversation turns, ``mkdir`` and append open both at umask (0o755 / 0o644).
+* ``plugins/platforms/a2a/security.py:audit`` — 500-char summaries of each
+  peer exchange, append open at umask (0o644).
+* ``batch_runner.py:_process_batch_worker`` — full trajectories appended under
+  the CWD's ``data/<run>/``, append open at umask (0o644). Closest sibling to
+  ``agent/trajectory.py``, which #77520 fixed.
+* ``cli.py:save_conversation`` — the ``sessions/saved`` *directory* (0o755).
+  #77520 fixed the snapshot file inside it and left the directory as an
+  explicit follow-up.
+
+These assert the *contract* — no group/other bits on a freshly created
+artifact — rather than freezing an octal, exercise the real write paths under a
+deliberately permissive ``umask 022``, and are POSIX-only because Windows
+at-rest protection is ACL-based (PR #77527's territory).
+
+Content is intentionally NOT asserted to be redacted, and two tests assert the
+opposite: these artifacts are replayed/audited full-fidelity, and masking a
+credential in a replayed path poisons the replay (#43083, guarded by
+``tests/agent/test_tool_call_arg_no_redaction.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+# batch_runner / cli are root-level modules, not an installed package.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+posix_only = pytest.mark.skipif(
+    os.name != "posix",
+    reason="POSIX permission bits; Windows at-rest protection is ACL-based",
+)
+
+
+@pytest.fixture
+def permissive_umask():
+    """Force a umask that would yield group/world-readable artifacts."""
+    previous = os.umask(0o022)
+    try:
+        yield
+    finally:
+        os.umask(previous)
+
+
+@pytest.fixture
+def temp_hermes_home(tmp_path, monkeypatch):
+    """A real HERMES_HOME the artifact writers resolve at call time."""
+    home = tmp_path / ".hermes"
+    home.mkdir(mode=0o700)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def _assert_owner_only(path: Path) -> None:
+    mode = _mode(path)
+    assert not mode & (stat.S_IRWXG | stat.S_IRWXO), (
+        f"{path.name} is group/other-accessible ({oct(mode)}); a plaintext "
+        "transcript artifact must be created owner-only"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A2A conversation logs (plugins/platforms/a2a/protocol.py)
+# ---------------------------------------------------------------------------
+
+@posix_only
+def test_a2a_conversation_log_and_dir_owner_only(
+    temp_hermes_home, permissive_umask
+):
+    """persist_message stores verbatim peer turns — dir and file owner-only."""
+    from plugins.platforms.a2a import protocol
+
+    protocol.persist_message("ctx-abc", "user", "deploy with PGPASSWORD=hunter2", "task-1")
+
+    conv_dir = temp_hermes_home / "a2a_conversations"
+    written = conv_dir / "ctx-abc.jsonl"
+    assert written.is_file(), list(conv_dir.iterdir())
+    _assert_owner_only(written)
+    _assert_owner_only(conv_dir)
+
+
+@posix_only
+def test_a2a_conversation_log_appends_verbatim(temp_hermes_home, permissive_umask):
+    """Hardening the mode must not change append semantics or content."""
+    from plugins.platforms.a2a import protocol
+
+    protocol.persist_message("ctx-abc", "user", "first PGPASSWORD=hunter2", "t1")
+    protocol.persist_message("ctx-abc", "agent", "second", "t1")
+
+    # Read back through the module's own loader: the log must stay replayable.
+    loaded = protocol.load_conversation("ctx-abc")
+    assert [r["role"] for r in loaded] == ["user", "agent"]
+    assert loaded[0]["text"] == "first PGPASSWORD=hunter2", (
+        "conversation logs are replayed into the model on context resume; "
+        "masking a credential here poisons the replay (#43083)"
+    )
+
+
+@posix_only
+def test_a2a_conversation_existing_relaxed_file_is_not_retightened(
+    temp_hermes_home, permissive_umask
+):
+    """A file the operator deliberately widened keeps its mode."""
+    from plugins.platforms.a2a import protocol
+
+    conv_dir = temp_hermes_home / "a2a_conversations"
+    conv_dir.mkdir(mode=0o700)
+    target = conv_dir / "ctx-abc.jsonl"
+    target.write_text("", encoding="utf-8")
+    os.chmod(target, 0o644)
+
+    protocol.persist_message("ctx-abc", "user", "hi", "t1")
+
+    assert _mode(target) == 0o644, (
+        "only the creating open applies the private mode; an existing file's "
+        "permissions must be left as the operator set them"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A2A audit log (plugins/platforms/a2a/security.py)
+# ---------------------------------------------------------------------------
+
+@posix_only
+def test_a2a_audit_log_owner_only(temp_hermes_home, permissive_umask):
+    """audit() records a summary of each peer exchange — partial transcript."""
+    from plugins.platforms.a2a import security
+
+    security.audit("inbound", "peer.example", "task-1", "ran psql PGPASSWORD=hunter2")
+
+    written = temp_hermes_home / "a2a_audit.jsonl"
+    assert written.is_file(), list(temp_hermes_home.iterdir())
+    _assert_owner_only(written)
+
+    record = json.loads(written.read_text(encoding="utf-8").strip())
+    assert record["summary"] == "ran psql PGPASSWORD=hunter2", (
+        "the audit log is an audit trail; redacting it would defeat its purpose"
+    )
+
+
+@posix_only
+def test_a2a_audit_log_appends(temp_hermes_home, permissive_umask):
+    """Second record appends rather than truncating."""
+    from plugins.platforms.a2a import security
+
+    security.audit("inbound", "peer.example", "t1", "first")
+    security.audit("outbound", "peer.example", "t2", "second")
+
+    lines = (
+        (temp_hermes_home / "a2a_audit.jsonl").read_text(encoding="utf-8").strip().splitlines()
+    )
+    assert [json.loads(line)["summary"] for line in lines] == ["first", "second"]
+
+
+# ---------------------------------------------------------------------------
+# batch_runner trajectories (batch_runner.py)
+# ---------------------------------------------------------------------------
+
+def _batch_prompt_result() -> dict:
+    return {
+        "success": True,
+        "trajectory": [
+            {"role": "assistant", "content": "ran it"},
+            {"role": "tool", "content": "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI"},
+        ],
+        "reasoning_stats": {"has_any_reasoning": True},
+        "tool_stats": {},
+        "metadata": {},
+        "completed": True,
+        "api_calls": 1,
+        "toolsets_used": [],
+    }
+
+
+@posix_only
+def test_batch_trajectory_jsonl_owner_only(tmp_path, monkeypatch, permissive_umask):
+    """batch_N.jsonl carries full trajectories under the CWD, not HERMES_HOME."""
+    from batch_runner import _process_batch_worker
+
+    monkeypatch.setattr(
+        "batch_runner._process_single_prompt", lambda *a, **kw: _batch_prompt_result()
+    )
+
+    out_dir = tmp_path / "data" / "myrun"
+    out_dir.mkdir(parents=True)
+    _process_batch_worker((0, [(0, {"prompt": "hi"})], out_dir, set(), {"verbose": False}))
+
+    written = out_dir / "batch_0.jsonl"
+    assert written.is_file(), list(out_dir.iterdir())
+    _assert_owner_only(written)
+
+    # Trajectories are training data — they must stay full-fidelity.
+    entry = json.loads(written.read_text(encoding="utf-8").strip())
+    assert entry["conversations"][1]["content"] == "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI"
+
+
+@posix_only
+def test_batch_trajectory_appends_across_prompts(tmp_path, monkeypatch, permissive_umask):
+    """Two prompts in one batch append two lines to the same file."""
+    from batch_runner import _process_batch_worker
+
+    monkeypatch.setattr(
+        "batch_runner._process_single_prompt", lambda *a, **kw: _batch_prompt_result()
+    )
+
+    out_dir = tmp_path / "data" / "myrun"
+    out_dir.mkdir(parents=True)
+    _process_batch_worker(
+        (0, [(0, {"prompt": "a"}), (1, {"prompt": "b"})], out_dir, set(), {"verbose": False})
+    )
+
+    lines = (out_dir / "batch_0.jsonl").read_text(encoding="utf-8").strip().splitlines()
+    assert [json.loads(line)["prompt_index"] for line in lines] == [0, 1]
+
+
+@posix_only
+def test_batch_trajectory_existing_relaxed_file_is_not_retightened(
+    tmp_path, monkeypatch, permissive_umask
+):
+    """A resumed run must not re-tighten a file the operator widened."""
+    from batch_runner import _process_batch_worker
+
+    monkeypatch.setattr(
+        "batch_runner._process_single_prompt", lambda *a, **kw: _batch_prompt_result()
+    )
+
+    out_dir = tmp_path / "data" / "myrun"
+    out_dir.mkdir(parents=True)
+    target = out_dir / "batch_0.jsonl"
+    target.write_text("", encoding="utf-8")
+    os.chmod(target, 0o644)
+
+    _process_batch_worker((0, [(0, {"prompt": "hi"})], out_dir, set(), {"verbose": False}))
+
+    assert _mode(target) == 0o644
+
+
+# ---------------------------------------------------------------------------
+# /save snapshot directory (cli.py) + the shared secure_mkdir helper
+# ---------------------------------------------------------------------------
+
+@posix_only
+def test_save_conversation_dir_owner_only(temp_hermes_home, permissive_umask):
+    """Every file in sessions/saved is a transcript, so the listing is too."""
+    import cli
+
+    stub = SimpleNamespace(
+        conversation_history=[{"role": "user", "content": "deploy with PGPASSWORD=hunter2"}],
+        model="test-model",
+        session_id="20260101_120000_abc123",
+        session_start=datetime(2026, 1, 1, 12, 0, 0),
+    )
+    cli.HermesCLI.save_conversation(stub)
+
+    saved_dir = temp_hermes_home / "sessions" / "saved"
+    assert saved_dir.is_dir()
+    _assert_owner_only(saved_dir)
+    assert list(saved_dir.glob("hermes_conversation_*.json")), list(saved_dir.iterdir())
+
+
+@posix_only
+def test_secure_mkdir_creates_owner_only_and_preserves_existing(
+    tmp_path, permissive_umask
+):
+    """Mode is applied at creation; an existing directory keeps its own."""
+    from hermes_cli.config import secure_mkdir
+
+    fresh = tmp_path / "fresh"
+    secure_mkdir(fresh)
+    _assert_owner_only(fresh)
+
+    relaxed = tmp_path / "relaxed"
+    relaxed.mkdir(mode=0o755)
+    secure_mkdir(relaxed)
+    assert _mode(relaxed) == 0o755, (
+        "an existing directory's permissions must be left alone, matching "
+        "_secure_dir's and open_private_append's create-only stance"
+    )
+
+
+@posix_only
+def test_secure_mkdir_defers_to_managed_group_sharing(
+    tmp_path, monkeypatch, permissive_umask
+):
+    """Managed (NixOS) mode deliberately group-shares HERMES_HOME's subdirs.
+
+    The module creates them setgid group-writable (2770) and runs the service
+    with ``UMask=0007`` so interactive users in the hermes group can share
+    state with the gateway. Forcing 0o700 at creation would silently revoke
+    that, and unlike ``_secure_dir``'s chmod it could not be reconciled by a
+    later activation pass — so ``secure_mkdir`` skips managed mode exactly the
+    way ``_secure_dir`` does.
+    """
+    from hermes_cli.config import secure_mkdir
+
+    monkeypatch.setenv("HERMES_MANAGED", "1")
+    parent = tmp_path / "sessions"
+    parent.mkdir()
+    os.chmod(parent, 0o2770)
+
+    previous = os.umask(0o007)
+    try:
+        target = parent / "saved"
+        secure_mkdir(target)
+    finally:
+        os.umask(previous)
+
+    assert _mode(target) & stat.S_IRWXG, (
+        "managed mode must keep hermes-group access on HERMES_HOME subdirs"
+    )
+
+
+# ---------------------------------------------------------------------------
+# request_dump_*.json — already correct, pinned so it stays that way
+# ---------------------------------------------------------------------------
+
+@posix_only
+def test_request_dump_fresh_file_is_owner_only_without_explicit_mode(
+    tmp_path, permissive_umask
+):
+    """``agent/agent_runtime_helpers.py`` calls ``atomic_json_write`` with no
+    ``mode=``, and that is *already* correct for this artifact: the temp file
+    comes from ``tempfile.mkstemp`` (0o600) and ``_restore_file_mode`` is a
+    no-op when there was no pre-existing file, so a fresh dump lands 0o600.
+
+    No production change is made there. This test pins the invariant the
+    absent argument silently depends on, so a future refactor of
+    ``atomic_json_write``'s temp-file creation cannot regress request dumps to
+    umask permissions unnoticed.
+    """
+    from utils import atomic_json_write
+
+    dump = tmp_path / "request_dump_sess_20260101_000000_000000.json"
+    atomic_json_write(dump, {"body": {"messages": [{"role": "user", "content": "hi"}]}}, default=str)
+
+    _assert_owner_only(dump)

--- a/utils.py
+++ b/utils.py
@@ -171,6 +171,37 @@ def atomic_write_text(
         raise
 
 
+def open_private_append(
+    path: Union[str, Path],
+    *,
+    encoding: str = "utf-8",
+    mode: int = 0o600,
+):
+    """Open *path* for appending, creating it owner-only when it's new.
+
+    Append-mode transcript artifacts (agent trajectories, MoA traces) are
+    created by a bare ``open(..., "a")`` in most codebases, which derives
+    permissions from the process umask — typically 0o644, i.e. readable by
+    every local account. These files carry full tool output and message
+    content, so a fresh one should start owner-only.
+
+    Only the *creating* open applies ``mode``: an existing file keeps whatever
+    permissions it has. That is deliberate. These artifacts are explicit
+    opt-in exports (``save_trajectories``, ``moa.save_traces``) that users
+    legitimately relax to share or to feed a training pipeline, and silently
+    re-tightening a file the user widened on purpose would fight that.
+
+    ``mode`` is advisory on Windows, where ``os.open`` honours only the
+    read-only bit; at-rest protection there comes from ACLs, not POSIX bits.
+    """
+    path = Path(path)
+
+    def _opener(target: str, flags: int) -> int:
+        return os.open(target, flags, mode)
+
+    return open(path, "a", encoding=encoding, opener=_opener)
+
+
 def atomic_json_write(
     path: Union[str, Path],
     data: Any,


### PR DESCRIPTION
## What does this PR do?

Follow-up to **#77520**, which hardened four plaintext transcript-artifact write paths. The sites below are the same defect at sibling call paths; they were **deliberately scoped out of that PR to keep it narrow**, and are called out there as explicit follow-ups.

Measured on `upstream/main` under `umask 022`, before -> after:

| site | artifact | before | after |
|---|---|---|---|
| `plugins/platforms/a2a/protocol.py` `persist_message` | `a2a_conversations/` dir | `0o755` | `0o700` |
| " | `<ctx>.jsonl` - verbatim peer turns | `0o644` | `0o600` |
| `plugins/platforms/a2a/security.py` `audit` | `a2a_audit.jsonl` - 500-char exchange summaries | `0o644` | `0o600` |
| `batch_runner.py` `_process_batch_worker` | `data/<run>/batch_N.jsonl` - full trajectories, in the **CWD** | `0o644` | `0o600` |
| `cli.py` `save_conversation` | `sessions/saved/` dir | `0o755` | `0o700` |

**Scoped to file modes only.** No redaction is added anywhere - these artifacts are replayed and audited full-fidelity, and masking a credential in a replayed path poisons the replay (#43083, guarded by `tests/agent/test_tool_call_arg_no_redaction.py`). Two tests here assert content stays verbatim, so this can't drift.

### Severity, stated accurately

The two a2a sites are **materially lower severity than #77520's trajectories** and I don't want to oversell them: the plugin is opt-in (only when that platform is enabled), and both paths write under `HERMES_HOME`, which is `0o700` by default - so on a stock install the parent already blocks the traversal.

The concrete exposure is the **documented `HERMES_HOME_MODE` hatch**: `_secure_dir`'s docstring supports e.g. `HERMES_HOME_MODE=0701` so a web server can traverse `HERMES_HOME` to reach a served subdir. Under that config a `0o755` child is genuinely world-readable - the execute-only bit on the parent is specifically chosen to allow cd-through, and a `0o755` `a2a_conversations/` then lists every peer conversation to any local account.

`batch_runner`'s `data/<run>/batch_N.jsonl` needs no such precondition. Like `save_trajectory()` it appends **to the CWD**, not under `HERMES_HOME`, so a datagen run in a checkout drops world-readable full trajectories with no protective parent at all. That one is the direct sibling of the file #77520 fixed.

### Why this is one PR

One logical change: *finish the owner-only-at-creation mode class for plaintext transcript artifacts.* It is one mechanism (`open_private_append` / mode-at-`mkdir`) applied at the sibling call paths of an already-open fix, which is what `AGENTS.md` asks for - "fix the whole bug class ... sibling call paths included." Splitting by directory would produce two PRs reviewed against the identical rationale and the same helper, and would leave the class half-finished in the interim. No refactor, no feature, no behavior change beyond permission bits.

### One site I did NOT change, deliberately

`agent/agent_runtime_helpers.py` calls `atomic_json_write(dump_file, ...)` for `request_dump_*.json` **without** `mode=`. That looks like the same bug and isn't - measured, not assumed:

```
atomic_json_write, fresh file, no mode=      -> 0o600
atomic_json_write, existing 0o644, no mode=  -> 0o644  (preserved)
```

`tempfile.mkstemp` creates the temp file `0o600`, and `_restore_file_mode` is a no-op when there was no pre-existing file, so a fresh dump **already lands `0o600`**. The only case an explicit `mode=0o600` would change is overwriting an existing relaxed file - and request-dump filenames carry a microsecond timestamp, so that path is unreachable in practice; forcing it would also re-tighten a file the user widened, which is exactly what #77520's create-only contract avoids. Adding the argument would be a no-op. Instead I pinned the invariant the absent argument silently depends on, so a future refactor of `atomic_json_write`'s temp-file creation can't regress request dumps unnoticed.

Also verified and **excluded** as a weaker class: `hermes_cli/session_export_md.py` and `tools/delegation_live_log.py`. `delegation_live_log` redacts unconditionally with `force=True` at a single choke point (`event()`), so its content exposure is bounded. `session_export_md`'s line 277 is `manifest.jsonl`, which holds only `session_id` / path / sha256 / counts - no transcript content - and its export path is a directory the *user* names with `--output`, which puts it on #74897's side of the line.

### Managed / NixOS disclosure

`sessions/saved` and `a2a_conversations` are both under `HERMES_HOME`, so the new `secure_mkdir()` **skips managed mode**, exactly as `_secure_dir` does. This is deliberate and worth flagging because an unconditional `mode=` at creation *would* change managed behavior: `nix/nixosModules.nix` creates `HERMES_HOME`'s subdirs setgid group-writable (`2770`, lines 711-719 and 743) and runs the service with `UMask = "0007"` (line 907) so interactive users in the hermes group can share state with the gateway. Measured:

```
unmanaged, umask 022      : sessions/saved -> 0o700
managed, umask 007,
  parent sessions/ = 2770 : sessions/saved -> 0o770   (group access + setgid preserved)
  if forced mode=0o700    : sessions/saved -> 0o700   (would revoke hermes-group access)
```

Unlike `_secure_dir`'s chmod, a mode passed at creation is not re-reconciled by a later activation pass, so getting this wrong would be silent. `_is_container()` is **not** consulted: it gates `_secure_file` only, and this module has no container carve-out for directories. `HERMES_HOME_MODE` is also not honoured - that hatch is for *traversal to a served subdir*, and nothing is served out of these two artifact dirs.

## Related Issue

Follow-up to #77520 (no separate issue). Refs #77472 - the remaining file-mode items; the "exact-value redaction on every persistence path" ask there remains deliberately not implemented, per #43083.

## Type of Change

- [x] Security fix

## Changes Made

- `utils.py` - `open_private_append()`. **Identical to the helper in #77520**; carried here so this branch stands alone on `main`. If #77520 lands first, the hunk is byte-identical and drops out on rebase.
- `hermes_cli/config.py` - new `secure_mkdir()`, the directory analogue of `_secure_dir`: mode at `mkdir` (no chmod-after TOCTOU window), never re-applied to an existing dir, skipped in managed mode. Docstring records the `_is_container` / `HERMES_HOME_MODE` reasoning above.
- `plugins/platforms/a2a/protocol.py` - `persist_message()` uses `secure_mkdir` + `open_private_append`.
- `plugins/platforms/a2a/security.py` - `audit()` uses `open_private_append`. **File only**: `path.parent` is `HERMES_HOME` itself, whose mode belongs to `ensure_hermes_home()` / `_secure_dir` and is user-overridable - not to this call site.
- `batch_runner.py` - `_process_batch_worker()` uses `open_private_append`. File only; `data/<run>/` is a workspace directory the user names via `--run_name`, and #77520 set the same precedent for `agent/trajectory.py` (harden the artifact, not the CWD).
- `tests/test_transcript_artifact_file_modes_remaining.py` - new, 12 tests.

## How to Test

1. `scripts/run_tests.sh tests/test_transcript_artifact_file_modes_remaining.py -q` - **12 passed**. They assert the *contract* (no group/other bits on a freshly created artifact) rather than a frozen octal, exercise the real write paths against a temp `HERMES_HOME` / temp CWD under a deliberately permissive `umask 022`, and are `skipif(os.name != "posix")`.

2. **Teeth check, per mechanism.** Each hunk reverted individually, suite re-run, then restored. All eight turn something red - none of these is load-bearing only in aggregate:

   | reverted mechanism | result |
   |---|---|
   | a2a dir mode (`secure_mkdir` -> bare `mkdir`) | 11p / **1f** |
   | a2a log file mode | 11p / **1f** |
   | a2a audit file mode | 11p / **1f** |
   | `batch_runner` file mode | 11p / **1f** |
   | `cli` `sessions/saved` dir mode | 11p / **1f** |
   | `secure_mkdir` managed carve-out (-> unconditional `0o700`) | 11p / **1f** |
   | `secure_mkdir` create-only (-> chmod-after) | 11p / **1f** |
   | `open_private_append` create-only (-> chmod-after) | 10p / **2f** |

   The harness asserted each revert string matched exactly once before editing, so no "revert" was a silent no-op.

3. Regression, direct blast radius - every test file mentioning a touched module (`rg -l 'batch_runner|a2a|save_conversation|atomic_json_write|open_private_append|secure_mkdir' tests`): **20 files, 321 passed, 0 failed.**

4. Regression, `hermes_cli/config.py` blast radius (it is imported nearly everywhere): `rg -l 'hermes_cli.config|_secure_dir|ensure_hermes_home' tests` -> **300 files, 5579 passed, 7 failed.** The same 7 failures reproduce on a clean `upstream/main` worktree - macOS-environmental: `test_voice_mode` (3, sounddevice/WSL2), `test_wake_word`, `test_web_providers`, `test_approval`, and the known load-flaky `test_api_server::test_health_detailed_returns_ok`. **I did not run the full suite**; the two sets above are what I ran.

5. Lint on changed files: `uvx ruff check` (**ruff 0.16.1**) - all checks passed. `scripts/check-windows-footguns.py --diff upstream/main` - 0 findings (it caught 6 bare `read_text()` / `write_text()` calls in my test file on the first pass; fixed with `encoding="utf-8"`). `scripts/check_subprocess_stdin.py` - passed.

6. Manual, real write paths, temp `HERMES_HOME`, `umask 022`:

   ```
   SITE1 dir  a2a_conversations: 0o700   (was 0o755)
   SITE1 file ctx-abc.jsonl    : 0o600   (was 0o644)
   SITE1 content preserved     : PGPASSWORD='hunter2' psql -h db
   SITE2 file a2a_audit.jsonl  : 0o600   (was 0o644)
   SITE2 content preserved     : summary sk-proj-secretvalue
   SITE4 file batch_0.jsonl    : 0o600   (was 0o644)
   SITE4 dir  data/myrun       : 0o755   (unchanged, deliberate)
   SITE5 dir  sessions/saved   : 0o700   (was 0o755)
   ```

## Precedent for this exact pattern

Verified on `upstream/main`, not from memory - `gateway/shutdown_flush.py` already writes a verbatim-content artifact with both primitives:

- line 44: `flush_dir.mkdir(parents=True, exist_ok=True, mode=0o700)`
- lines 67-70: `atomic_json_write(final_path, payload, mode=0o600, default=str)`

Same modes, same reasoning: pending gateway messages are verbatim user content, so the directory is born `0o700` and each payload `0o600`. `atomic_json_write`'s `mode=` docstring names the motivation ("avoiding chmod-after-write TOCTOU exposure for secret-bearing files"). #77520 added `open_private_append` for the append-mode cases `atomic_json_write` can't cover; this PR applies both to the paths that were left.

## Why this isn't a reversal of #74897

#74897 moved `write_file`'s **new** files off `0600` onto umask-derived `0644`, so the direction looks opposite. It isn't the same class of file, and the detail matters: `_atomic_write`'s chmod branch only ran `if [ -e "$t" ]`, so new files silently kept `mktemp`'s `0600`. That `0600` was an **accident of the temp-file mechanism, not a policy** - which is why restoring umask-derived permissions was a fix and not a loosening.

What #74897 protected was a path the **user** named, with a documented interop contract: cross-process readers by design (#70856 - Obsidian LiveSync, Docker volumes, NAS mounts). Nothing in it generalizes to artifacts the **agent** names and the user never types: `a2a_conversations/<ctx>.jsonl`, `a2a_audit.jsonl`, `data/<run>/batch_N.jsonl`, `sessions/saved/`. No cross-process reader is implied by any of them, and there is no interop contract to break.

Both changes also agree on the invariant #74897 actually defended - **never override permissions the user set.** Its regression guard is "overwrite 0755 file -> preserved." Everything here applies its mode only at *creation*, asserted directly by three tests (`..._existing_relaxed_file_is_not_retightened` for the a2a log and the batch file, plus `secure_mkdir` preserving an existing `0o755` dir). An operator who widens a batch trajectory to feed a training pipeline keeps that.

## Prior art searched

`gh search prs` for `a2a`, `owner-only`, `0600`, `batch_runner`, `mkdir mode`; `gh search issues` for `a2a permissions`, `a2a_conversations`, `world-readable transcript`, `file permissions 0644 umask`. Nothing overlaps. The a2a plugin landed recently (`837003b1e`, "closes #514") and the only other open a2a PR is #77526 (`feat(a2a): inject conversation history on context resume`), which touches `persist_message`'s *module* but not its `mkdir` / open - it adds a reader alongside. Adjacent owner-only work in flight is on disjoint files: #77520 (parent), #77579 (browser profile / media cache), #77622 (desktop `connection.json`), #77527 (Windows ACLs in `_secure_file`).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass - **not the full suite.** I ran the two regression sets in "How to Test" (20 files / 321 passed, and 300 files / 5579 passed with 7 failures confirmed baseline on clean `upstream/main`).
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 27.0 (Darwin 27.0.0, arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] Docs - docstrings on `secure_mkdir` carry the managed-mode / `HERMES_HOME_MODE` / `_is_container` reasoning. No user-facing behavior change, so no `docs/` edit.
- [x] `cli-config.yaml.example` - N/A, no config keys added.
- [x] `CONTRIBUTING.md` / `AGENTS.md` - N/A.
- [x] Cross-platform: POSIX mode bits are advisory on Windows (`os.open` honours only the read-only bit; `mkdir(mode=)` is ignored), so every mode test is `skipif(os.name != "posix")` and the docstrings say so. Windows at-rest protection is ACL-based and belongs to #77527 - not duplicated here.
- [x] Tool descriptions / schemas - N/A, no tool surface touched.

