### PR TITLE
fix(registry): gate same-toolset tool replacement behind ownership check

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -583,3 +583,46 @@ class TestDeregisterAuthorization:
             evil_handler = eval("lambda *a, **k: 'hijacked'", {"__name__": "hermes_plugins.evil"})
             reg.register(name="protected", toolset="evil-ts", schema={}, handler=evil_handler, override=True)
         assert reg._tools["protected"].handler({}) == "built-in"
+
+
+def test_same_toolset_replacement_requires_operator_opt_in():
+    """A plugin cannot silently replace a tool in the same toolset without
+    operator opt-in.  Only cross-toolset shadows were gated before;
+    same-toolset re-registration silently overwrote the existing entry."""
+    reg = ToolRegistry()
+    reg._plugin_override_policy = {}
+    good_handler = eval("lambda *a, **k: 'good'", {"__name__": "hermes_plugins.a"})
+    evil_handler = eval("lambda *a, **k: 'evil'", {"__name__": "hermes_plugins.b"})
+
+    reg.register(name="shared", toolset="plugins", schema={}, handler=good_handler)
+    assert reg._tools["shared"].handler({}) == "good"
+
+    import pytest
+    with pytest.raises(PermissionError):
+        reg.register(name="shared", toolset="plugins", schema={}, handler=evil_handler)
+    # Original handler must survive.
+    assert reg._tools["shared"].handler({}) == "good"
+
+
+def test_same_toolset_replacement_allowed_with_opt_in():
+    """Operator opt-in allows a plugin to replace a tool in the same toolset."""
+    reg = ToolRegistry()
+    reg._plugin_override_policy = {"hermes_plugins.b": True}
+    good_handler = eval("lambda *a, **k: 'good'", {"__name__": "hermes_plugins.a"})
+    evil_handler = eval("lambda *a, **k: 'evil'", {"__name__": "hermes_plugins.b"})
+
+    reg.register(name="shared", toolset="plugins", schema={}, handler=good_handler)
+    reg.register(name="shared", toolset="plugins", schema={}, handler=evil_handler)
+    assert reg._tools["shared"].handler({}) == "evil"
+
+
+def test_mcp_same_toolset_replacement_not_gated():
+    """MCP toolset refresh must not be blocked by same-toolset ownership check."""
+    reg = ToolRegistry()
+    good_handler = eval("lambda *a, **k: 'good'", {"__name__": "hermes_plugins.a"})
+    other_handler = eval("lambda *a, **k: 'other'", {"__name__": "hermes_plugins.b"})
+
+    reg.register(name="mcp_x", toolset="mcp-srv", schema={}, handler=good_handler)
+    # MCP re-registration within the same mcp-* toolset must still be allowed.
+    reg.register(name="mcp_x", toolset="mcp-srv", schema={}, handler=other_handler)
+    assert reg._tools["mcp_x"].handler({}) == "other"

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -555,6 +555,34 @@ class ToolRegistry:
                         name, toolset, existing.toolset,
                     )
                     return
+            elif existing and not toolset.startswith("mcp-"):
+                # Same-toolset replacement — a plugin re-registering a tool
+                # under its own toolset silently overwrites the existing entry
+                # (line 558) without ever hitting the cross-toolset gate above.
+                # Apply the same ownership check that cross-toolset overrides
+                # require so a plugin cannot hijack another plugin's tool
+                # without operator opt-in.  MCP toolsets are exempt: dynamic
+                # discovery legitimately re-registers tools on every refresh.
+                _owner = self._plugin_owner_of(handler)
+                if _owner is not None and not self._plugin_override_policy.get(_owner, False):
+                    logger.error(
+                        "Tool registration REJECTED: plugin %r attempted to "
+                        "replace tool %r within the same toolset %r without "
+                        "operator opt-in. Set "
+                        "plugins.entries.<plugin_id>.allow_tool_override: true "
+                        "in config.yaml to allow it.",
+                        _owner, name, toolset,
+                    )
+                    raise PermissionError(
+                        f"Plugin module {_owner!r} cannot replace tool "
+                        f"{name!r} (toolset {toolset!r}) without operator "
+                        f"opt-in (allow_tool_override)."
+                    )
+                logger.info(
+                    "Tool '%s': same-toolset replacement in '%s' "
+                    "(override policy satisfied)",
+                    name, toolset,
+                )
             self._tools[name] = ToolEntry(
                 name=name,
                 toolset=toolset,


### PR DESCRIPTION
Cross-toolset re-registration was gated (PermissionError unless override=True + operator opt-in), but same-toolset re-registration silently overwrote the existing entry. A plugin could replace another plugin's tool in the same toolset without any authorization. Apply the same ownership check from the cross-toolset path. MCP toolsets (mcp-*) remain exempt.