### PR TITLE
fix(update): refuse immutable release checkouts

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -80,6 +80,90 @@ import sys
 _bootstrap_root = os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir))
 if _bootstrap_root not in sys.path:
     sys.path.insert(0, _bootstrap_root)
+
+_RELEASE_MANIFEST_FILENAME = ".hermes-release-manifest.json"
+
+
+_UPDATE_PREFIX_VALUE_OPTIONS = frozenset(
+    {
+        "-z",
+        "--oneshot",
+        "--usage-file",
+        "-m",
+        "--model",
+        "--provider",
+        "--reasoning",
+        "-t",
+        "--toolsets",
+        "--resume",
+        "-r",
+        "--continue",
+        "-c",
+        "--skills",
+        "-s",
+        "-p",
+        "--profile",
+    }
+)
+_UPDATE_PREFIX_BOOLEAN_OPTIONS = frozenset(
+    {
+        "--no-restore-cwd",
+        "--worktree",
+        "-w",
+        "--accept-hooks",
+        "--yolo",
+        "--pass-session-id",
+        "--ignore-user-config",
+        "--ignore-rules",
+        "--safe-mode",
+        "--tui",
+        "--cli",
+        "--dev",
+    }
+)
+
+
+def _top_level_update_requested(argv: list[str]) -> bool:
+    """Recognize the update subcommand after supported global options."""
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if token == "update":
+            return True
+        if token in _UPDATE_PREFIX_BOOLEAN_OPTIONS:
+            index += 1
+            continue
+        if token in _UPDATE_PREFIX_VALUE_OPTIONS:
+            index += 2
+            continue
+        if any(token.startswith(f"{option}=") for option in _UPDATE_PREFIX_VALUE_OPTIONS):
+            index += 1
+            continue
+        return False
+    return False
+
+
+def _early_release_managed_update_requested() -> bool:
+    """Refuse top-level release-managed updates before recovery/config imports."""
+    argv = sys.argv[1:]
+    if not _top_level_update_requested(argv):
+        return False
+    marker = os.path.join(_bootstrap_root, _RELEASE_MANIFEST_FILENAME)
+    try:
+        os.lstat(marker)
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return True
+    return True
+
+
+if _early_release_managed_update_requested():
+    print("✗ This checkout is managed as an immutable Hermes release.")
+    print("  Use the external release manager to promote or roll back a slot.")
+    raise SystemExit(1)
+
+
 from hermes_cli import _startup_fast  # noqa: E402
 
 # Early venv self-heal — MUST run before any third-party import below.  When
@@ -9061,6 +9145,20 @@ def _size_delta_label(saved_mb: float) -> str:
     return f"grew by {-saved_mb:.1f} MB"
 
 
+def _release_managed_checkout(root: Path) -> bool:
+    """Detect the reserved immutable-release marker without following links."""
+    marker = root / _RELEASE_MANIFEST_FILENAME
+    try:
+        marker.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError:
+        # An updater must not proceed when it cannot safely classify the
+        # reserved policy path.
+        return True
+    return True
+
+
 def cmd_update(args):
     """Update Hermes Agent to the latest version.
 
@@ -9068,6 +9166,11 @@ def cmd_update(args):
     runs the update, then restores stdio on the way out (even on
     ``sys.exit`` or unhandled exceptions).
     """
+    if _release_managed_checkout(PROJECT_ROOT):
+        print("✗ This checkout is managed as an immutable Hermes release.")
+        print("  Use the external release manager to promote or roll back a slot.")
+        sys.exit(1)
+
     from hermes_cli.config import (
         detect_install_method,
         format_docker_update_message,

--- a/tests/hermes_cli/test_release_managed_update.py
+++ b/tests/hermes_cli/test_release_managed_update.py
@@ -1,0 +1,119 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_cli.main as main
+
+
+def test_early_release_marker_guard_precedes_recovery_and_config_imports():
+    source = Path(main.__file__).read_text(encoding="utf-8")
+
+    guard = source.index("if _early_release_managed_update_requested():")
+    recovery = source.index("from hermes_cli import _early_recovery")
+    config = source.index("from hermes_cli.config import get_hermes_home")
+
+    assert guard < recovery < config
+
+
+def test_early_release_marker_detection_is_fail_closed(tmp_path, monkeypatch):
+    monkeypatch.setattr(main, "_bootstrap_root", str(tmp_path))
+    monkeypatch.setattr(main.sys, "argv", ["hermes", "update", "--check"])
+
+    marker = tmp_path / ".hermes-release-manifest.json"
+    marker.symlink_to(tmp_path / "missing-manifest")
+
+    assert main._early_release_managed_update_requested() is True
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["hermes", "plugins", "update", "web"],
+        ["hermes", "profile", "update", "work"],
+        ["hermes", "-z", "update"],
+    ],
+)
+def test_early_release_marker_does_not_capture_nested_or_prompt_values(
+    tmp_path, monkeypatch, argv
+):
+    monkeypatch.setattr(main, "_bootstrap_root", str(tmp_path))
+    monkeypatch.setattr(main.sys, "argv", argv)
+    (tmp_path / ".hermes-release-manifest.json").write_text("{}")
+
+    assert main._early_release_managed_update_requested() is False
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["hermes", "update"],
+        ["hermes", "-p", "work", "update"],
+        ["hermes", "--profile", "work", "update"],
+        ["hermes", "--profile=work", "update"],
+        ["hermes", "--ignore-rules", "update"],
+        ["hermes", "-p", "work", "--safe-mode", "update"],
+    ],
+)
+def test_early_release_marker_captures_profile_scoped_top_level_update(
+    tmp_path, monkeypatch, argv
+):
+    monkeypatch.setattr(main, "_bootstrap_root", str(tmp_path))
+    monkeypatch.setattr(main.sys, "argv", argv)
+    (tmp_path / ".hermes-release-manifest.json").write_text("{}")
+
+    assert main._early_release_managed_update_requested() is True
+
+
+@pytest.mark.parametrize("check", [False, True])
+def test_release_managed_checkout_refuses_before_update_side_effects(
+    tmp_path, monkeypatch, check
+):
+    marker = tmp_path / ".hermes-release-manifest.json"
+    marker.write_text("{}")
+    monkeypatch.setattr(main, "PROJECT_ROOT", tmp_path)
+
+    touched = []
+    monkeypatch.setattr(
+        main,
+        "_install_hangup_protection",
+        lambda **kwargs: touched.append("logging"),
+    )
+    monkeypatch.setattr(
+        main,
+        "_cmd_update_check",
+        lambda **kwargs: touched.append("check"),
+    )
+    monkeypatch.setattr(
+        main,
+        "_cmd_update_impl",
+        lambda *args, **kwargs: touched.append("apply"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main.cmd_update(SimpleNamespace(check=check, branch=None, gateway=False))
+
+    assert exc_info.value.code == 1
+    assert touched == []
+
+
+def test_release_managed_checkout_refuses_dangling_symlink_marker(
+    tmp_path, monkeypatch
+):
+    (tmp_path / ".hermes-release-manifest.json").symlink_to(
+        tmp_path / "missing-manifest"
+    )
+    monkeypatch.setattr(main, "PROJECT_ROOT", tmp_path)
+
+    touched = []
+    monkeypatch.setattr(
+        main,
+        "_install_hangup_protection",
+        lambda **kwargs: touched.append("logging"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main.cmd_update(SimpleNamespace(check=False, branch=None, gateway=False))
+
+    assert exc_info.value.code == 1
+    assert touched == []


### PR DESCRIPTION
## Summary

- reserve `.hermes-release-manifest.json` as the immutable-release marker
- refuse top-level `hermes update` before startup recovery, config loading, update logging, lock acquisition, fetches, or other updater side effects
- preserve nested commands and one-shot prompts containing the word `update`
- fail closed on marker inspection errors and refuse `--check` as well as apply mode

## Why

Release-managed installations are assembled and promoted atomically outside Git. In-place updates can split source, Python, Node, and Desktop components or mutate an immutable slot. A reserved marker needs to stop every updater mode before any updater-owned mutation.

## Verification

```text
47 passed across:
- tests/hermes_cli/test_release_managed_update.py
- tests/hermes_cli/test_cmd_update.py
- tests/gateway/test_update_command.py

ruff: passed
```

Tests ran in a macOS sandbox that denies writes beneath the live Hermes home.
