### PR TITLE
fix(desktop): un-break .btn-arc — '*/' inside a CSS comment ended it early (extract #59352)

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1076,8 +1076,9 @@ code {
 }
 
 /* Arc-style multicolor action surface (static, not animated). Reusable on any
-   Button via className. Unlayered so it beats Tailwind's bg-*/
-text-* variant utilities. */ .btn-arc {
+   Button via className. Unlayered so it beats Tailwind's bg- and text- variant
+   utilities. */
+.btn-arc {
   background-image: linear-gradient(110deg, #5b6cff 0%, #8b5cf6 28%, #d946ef 58%, #fb7185 82%, #fb923c 100%);
   color: #fff;
   border-color: transparent;


### PR DESCRIPTION
Extract-salvage of the one alive piece of #59352 (author @rerdi92, authorship preserved): the comment above .btn-arc contains 'bg-*/' whose */ terminates the comment early, leaving an invalid prelude that can drop the whole rule. Rewords the comment. The PR's other pieces (month-stale full-file icons.ts rewrite that would drop 10+ live icons; chunkSizeWarningLimit bump that masks rather than fixes) were not salvaged. Closes #59352.