### PR TITLE
fix(terminal): detect bind mounts in Docker --mount syntax

### DIFF
--- a/tests/tools/test_modal_sandbox_fixes.py
+++ b/tests/tools/test_modal_sandbox_fixes.py
@@ -437,3 +437,57 @@ class TestDockerHostBindApproval:
         res = A.check_execute_code_guard("import os", "vercel_sandbox",
                                          has_host_access=True)
         assert res["approved"] is True
+
+    def test_docker_extra_args_bind_mount_detection(self):
+        """_docker_has_host_access detects bind mounts in docker_extra_args.
+
+        docker_extra_args appends directly to ``docker run`` and supports
+        the same mount syntaxes as docker_volumes, but in argv form.
+        The classifier must inspect every flag form so a host bind cannot
+        be treated as isolated.
+        """
+        # Separated --mount with bind spec
+        assert _tt_mod._docker_has_host_access({
+            "env_type": "docker",
+            "docker_extra_args": [
+                "--mount", "type=bind,source=/host,target=/container"
+            ],
+        }) is True
+
+        # Equals form --mount=...
+        assert _tt_mod._docker_has_host_access({
+            "env_type": "docker",
+            "docker_extra_args": [
+                "--mount=type=bind,source=/host,target=/container"
+            ],
+        }) is True
+
+        # -v short form (separated)
+        assert _tt_mod._docker_has_host_access({
+            "env_type": "docker",
+            "docker_extra_args": ["-v", "/host:/container"],
+        }) is True
+
+        # --volume (separated)
+        assert _tt_mod._docker_has_host_access({
+            "env_type": "docker",
+            "docker_extra_args": ["--volume", "/tmp:/workspace"],
+        }) is True
+
+        # Non-bind flags do not trigger host access
+        assert _tt_mod._docker_has_host_access({
+            "env_type": "docker",
+            "docker_extra_args": ["--gpus=all", "--shm-size=16g"],
+        }) is False
+
+        # docker_extra_args with no binds
+        assert _tt_mod._docker_has_host_access({
+            "env_type": "docker",
+            "docker_extra_args": [],
+        }) is False
+
+        # Non-docker env_type ignores extra_args
+        assert _tt_mod._docker_has_host_access({
+            "env_type": "local",
+            "docker_extra_args": ["-v", "/:/host"],
+        }) is False

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -357,10 +357,23 @@ def _docker_volume_uses_host_path(volume_spec: str) -> bool:
         return False
 
     vol = volume_spec.strip()
-    return bool(vol) and (
-        vol.startswith(("/", "~", "./", "../")) or
-        (len(vol) >= 3 and vol[1] == ":" and vol[2] in ("/", "\\"))
-    )
+    if not vol:
+        return False
+    # Short-form bind mount: /host:/container, ~/data:/data, ./src:/app
+    if vol.startswith(("/", "~", "./", "../")) or (
+        len(vol) >= 3 and vol[1] == ":" and vol[2] in ("/", "\\")
+    ):
+        return True
+    # --mount syntax: type=bind,source=/host,target=/container
+    lower = vol.lower()
+    if lower.startswith("type=bind") or ",type=bind" in lower:
+        import re
+        m = re.search(r"(?:^|,)source=([^,]+)", vol)
+        if m:
+            src = m.group(1).strip()
+            if src.startswith(("/", "~", "./", "../")):
+                return True
+    return False
 
 
 def _docker_has_host_access(config: Dict[str, Any]) -> bool:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -362,7 +362,88 @@ def _docker_has_host_access(config: Dict[str, Any]) -> bool:
         return False
     if config.get("host_cwd") and config.get("docker_mount_cwd_to_workspace"):
         return True
-    return any(_docker_volume_uses_host_path(vol) for vol in config.get("docker_volumes", []))
+    if any(_docker_volume_uses_host_path(vol) for vol in config.get("docker_volumes", [])):
+        return True
+    # Also check docker_extra_args for bind mounts specified via --mount or -v/--volume
+    return _docker_extra_args_have_host_bind(config.get("docker_extra_args", []))
+
+
+def _docker_extra_args_have_host_bind(extra_args: list) -> bool:
+    """Parse docker_extra_args for host bind mounts.
+    
+    Docker supports multiple forms:
+      --mount type=bind,source=/host,target=/container
+      --mount type=bind,src=/host,dst=/container
+      --mount=... (equals form)
+      -v /host:/container
+      -v=/host:/container (equals form)
+      --volume /host:/container
+      --volume=/host:/container (equals form)
+    """
+    if not extra_args:
+        return False
+    
+    args = list(extra_args)
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        # --mount=... form
+        if arg.startswith("--mount="):
+            mount_spec = arg[len("--mount="):]
+            if _is_host_bind_mount(mount_spec):
+                return True
+        # --mount value form (next arg)
+        elif arg == "--mount" and i + 1 < len(args):
+            if _is_host_bind_mount(args[i + 1]):
+                return True
+            i += 1
+        # -v=/host:/container or --volume=/host:/container
+        elif arg.startswith("-v=") or arg.startswith("--volume="):
+            mount_spec = arg.split("=", 1)[1]
+            if _is_host_bind_volume(mount_spec):
+                return True
+        # -v /host:/container or --volume /host:/container (next arg)
+        elif arg in ("-v", "--volume") and i + 1 < len(args):
+            if _is_host_bind_volume(args[i + 1]):
+                return True
+            i += 1
+        i += 1
+    return False
+
+
+def _is_host_bind_mount(mount_spec: str) -> bool:
+    """Check if a --mount spec is a bind mount with a host path source."""
+    params = {}
+    for part in mount_spec.split(","):
+        if "=" in part:
+            key, value = part.split("=", 1)
+            params[key.strip()] = value.strip()
+    # type must be bind (or omitted, default is bind)
+    mount_type = params.get("type", "bind")
+    if mount_type != "bind":
+        return False
+    # source/src can be host path
+    source = params.get("source") or params.get("src", "")
+    return _docker_volume_uses_host_path(source)
+
+
+def _is_host_bind_volume(volume_spec: str) -> bool:
+    """Check if a -v/--volume spec bind-mounts a host path.
+    
+    Formats:
+      /host:/container
+      /host:/container:ro
+      named_volume:/container
+    """
+    if not volume_spec:
+        return False
+    parts = volume_spec.split(":")
+    if len(parts) >= 2:
+        source = parts[0]
+        # Named volumes are not host paths
+        if "/" in source or source.startswith(".") or source == "~":
+            return True
+    return False
 
 
 def _check_all_guards(command: str, env_type: str,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -376,13 +376,67 @@ def _docker_volume_uses_host_path(volume_spec: str) -> bool:
     return False
 
 
+def _docker_extra_args_has_host_path(extra_args: list) -> bool:
+    """Return True when docker_extra_args contains a host-path bind mount.
+    
+    docker_extra_args appends directly to ``docker run`` and supports
+    the same mount syntaxes as docker_volumes, but in argv form:
+    
+        --mount type=bind,source=/host,target=/container  (separated)
+        --mount=type=bind,source=/host,target=/container  (equals form)
+        -v /host:/container                                 (short form)
+    
+    Pairs each flag with the next arg when the value is separated,
+    then delegates to ``_docker_volume_uses_host_path`` for the
+    actual parsing.
+    """
+    if not isinstance(extra_args, list):
+        return False
+    
+    i = 0
+    while i < len(extra_args):
+        arg = str(extra_args[i]) if extra_args[i] is not None else ""
+        
+        # Separated form: --mount value (next arg is the spec)
+        if arg == "--mount" and i + 1 < len(extra_args):
+            spec = str(extra_args[i + 1]) if extra_args[i + 1] is not None else ""
+            if _docker_volume_uses_host_path(spec):
+                return True
+            i += 2
+            continue
+        
+        # Equals form: --mount=type=bind,source=...
+        if arg.startswith("--mount=") and len(arg) > 8:
+            spec = arg[8:]
+            if _docker_volume_uses_host_path(spec):
+                return True
+            i += 1
+            continue
+        
+        # -v /host:/container (separated)
+        if arg in ("-v", "--volume") and i + 1 < len(extra_args):
+            spec = str(extra_args[i + 1]) if extra_args[i + 1] is not None else ""
+            if _docker_volume_uses_host_path(spec):
+                return True
+            i += 2
+            continue
+        
+        i += 1
+    
+    return False
+
+
 def _docker_has_host_access(config: Dict[str, Any]) -> bool:
     """Return True when a Docker sandbox exposes host paths through bind mounts."""
     if config.get("env_type") != "docker":
         return False
     if config.get("host_cwd") and config.get("docker_mount_cwd_to_workspace"):
         return True
-    return any(_docker_volume_uses_host_path(vol) for vol in config.get("docker_volumes", []))
+    if any(_docker_volume_uses_host_path(vol) for vol in config.get("docker_volumes", [])):
+        return True
+    if _docker_extra_args_has_host_path(config.get("docker_extra_args", [])):
+        return True
+    return False
 
 
 def _check_all_guards(command: str, env_type: str,


### PR DESCRIPTION
_docker_volume_uses_host_path only flags short-form bind mounts (/host:/container, ./src:/app). Docker --mount syntax (type=bind,source=/host,target=/container) was never detected, so a sandbox declared with long-form syntax silently gained host access. Added --mount parsing that extracts the source= field and checks whether it starts with a host-path prefix.