### PR TITLE
fix(terminal): log warning when unredacted spill file cannot be removed

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3101,7 +3101,11 @@ def terminal_tool(
                     try:
                         Path(spill_file_path).unlink()
                     except OSError:
-                        pass
+                        logger.warning(
+                            "Failed to remove unredacted spill file %s — "
+                            "raw output may persist on disk",
+                            spill_file_path,
+                        )
             try:
                 from agent.verification_evidence import record_terminal_result
 


### PR DESCRIPTION
When redaction of the overflow spill file fails, the code tries to unlink() the spill file but silently passes on OSError. If the deletion fails because the file is in use or permissions are denied, the unredacted spill file remains on disk with no visibility. Changed the silent pass to a logger.warning so the operator can investigate.