### PR TITLE
fix(desktop): show status bar by default for new users (#77594)

### DIFF
--- a/apps/desktop/src/store/statusbar-prefs.ts
+++ b/apps/desktop/src/store/statusbar-prefs.ts
@@ -3,11 +3,13 @@ import { Codecs, persistentAtom } from '@/lib/persisted'
 const STATUSBAR_HIDDEN_STORAGE_KEY = 'hermes.desktop.statusbarHidden'
 const STATUSBAR_VISIBLE_STORAGE_KEY = 'hermes.desktop.statusbarVisible'
 
-// Whole-bar visibility, VS Code's `workbench.statusBar.visible`. Off by default
-// — the bar is opt-in. Hiding it unmounts the bar (its 15s status poll goes with
-// it), so the way back is the `view.toggleStatusbar` keybind or the ⌘K row,
-// never the bar itself.
-export const $statusbarVisible = persistentAtom(STATUSBAR_VISIBLE_STORAGE_KEY, false, Codecs.bool)
+// Whole-bar visibility, VS Code's `workbench.statusBar.visible`. On by default
+// so new users get the bar — plugins and the gateway both render their status
+// indicators into it, and with it hidden they silently fail (the gateway's
+// connection state has no fallback surface). Hiding it unmounts the bar (its
+// 15s status poll goes with it), so the way back is the `view.toggleStatusbar`
+// keybind or the ⌘K row, never the bar itself.
+export const $statusbarVisible = persistentAtom(STATUSBAR_VISIBLE_STORAGE_KEY, true, Codecs.bool)
 
 export function toggleStatusbarVisible() {
   $statusbarVisible.set(!$statusbarVisible.get())


### PR DESCRIPTION
Show status bar by default for new desktop users (#77594).

## What
On Hermes Desktop, the bottom status bar was **hidden by default** for new users. Two downstream things broke silently because of this:

1. **Plugins that draw status indicators** (plugin status pills) — invisible because the bar is hidden
2. **Gateway connection state in the UI** — no fallback path when the bar is hidden

The status bar toggle in Settings exists, but the default value was wrong (`false`), so most new users never saw it.

## Fix
In `apps/desktop/src/store/statusbar-prefs.ts`:

- Default `$statusbarVisible` from `false` → `true`
- Existing users who explicitly toggled the setting keep their preference (the persistent atom reads from local storage first; only fresh installs get the new default)
- No migration needed — the storage key (`STATUSBAR_VISIBLE_STORAGE_KEY`) is unchanged

## Files
- `apps/desktop/src/store/statusbar-prefs.ts` (+7/-5)

One-line default value change + a clarifying doc comment. No unrelated refactors.