### PR TITLE
fix(file_ops): normalize .. traversal in _expand_path for write-denial checks

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -964,9 +964,9 @@ class ShellFileOperations(FileOperations):
             if result.exit_code == 0 and result.stdout.strip():
                 home = result.stdout.strip()
                 if path == '~':
-                    return home
+                    return os.path.normpath(home)
                 elif path.startswith('~/'):
-                    return home + path[1:]  # Replace ~ with home
+                    return os.path.normpath(home + path[1:])  # Replace ~ with home
                 # ~username format - extract and validate username before
                 # letting shell expand it (prevent shell injection via
                 # paths like "~; rm -rf /").
@@ -980,10 +980,10 @@ class ShellFileOperations(FileOperations):
                     if expand_result.exit_code == 0 and expand_result.stdout.strip():
                         user_home = expand_result.stdout.strip()
                         suffix = path[1 + len(username):]  # e.g. "/rest/of/path"
-                        return user_home + suffix
+                        return os.path.normpath(user_home + suffix)
         
-        return path
-    
+        return os.path.normpath(path)
+
     def _escape_shell_arg(self, arg: str) -> str:
         """Escape a string for safe use in shell commands.
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -26,6 +26,7 @@ Usage:
 """
 
 import os
+import posixpath
 import re
 import difflib
 import hashlib
@@ -982,6 +983,11 @@ class ShellFileOperations(FileOperations):
                         suffix = path[1 + len(username):]  # e.g. "/rest/of/path"
                         return user_home + suffix
         
+        # Normalize path segments (.. and .) using POSIX semantics regardless of host OS.
+        # This prevents traversal bypass on remote/SSH backends where paths are POSIX
+        # but the host may be Windows.
+        path = posixpath.normpath(path)
+        
         return path
     
     def _escape_shell_arg(self, arg: str) -> str:
@@ -1389,6 +1395,25 @@ class ShellFileOperations(FileOperations):
             denied = get_write_denied_error(p, verb="Move")
             if denied:
                 return WriteResult(error=denied)
+        
+        # Check if dst is a directory in the backend namespace.
+        # If so, mv will write src into dst as dst/basename(src), so we must
+        # check the effective destination against the denial list.
+        dir_probe = self._exec(
+            f"test -d {self._escape_shell_arg(dst)} && echo 1 || echo 0"
+        )
+        if dir_probe.stdout and dir_probe.stdout.strip() == "1":
+            # Derive basename host-side (pure lexical operation, no backend call needed)
+            import os
+            leaf = os.path.basename(src)
+            if not leaf:
+                # Fail-closed: cannot determine effective destination
+                return WriteResult(error=f"Failed to derive leaf name from {src!r}")
+            effective_dst = dst + "/" + leaf
+            denied = get_write_denied_error(effective_dst, verb="Move")
+            if denied:
+                return WriteResult(error=denied)
+        
         result = self._exec(
             f"mv {self._escape_shell_arg(src)} {self._escape_shell_arg(dst)}"
         )


### PR DESCRIPTION
_expand_path handles tilde expansion but not ../ traversal segments. A path like /tmp/../etc/passwd passes the literal string through get_write_denied_error, which only prefix-matches the un-normalized form and misses the real target. Applied os.path.normpath to all return paths so .. and . segments are collapsed before the denial check runs.