### PR TITLE
fix(file_ops): check resolved dst path in move_file for directories

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1389,6 +1389,15 @@ class ShellFileOperations(FileOperations):
             denied = get_write_denied_error(p, verb="Move")
             if denied:
                 return WriteResult(error=denied)
+        # When dst is an existing directory, mv writes into it as
+        # dst/basename(src) — check that resolved path too so a
+        # move into a denied directory is caught.
+        dst_path = Path(dst)
+        if dst_path.is_dir():
+            resolved_dst = str(dst_path / Path(src).name)
+            denied = get_write_denied_error(resolved_dst, verb="Move")
+            if denied:
+                return WriteResult(error=denied)
         result = self._exec(
             f"mv {self._escape_shell_arg(src)} {self._escape_shell_arg(dst)}"
         )

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1389,6 +1389,25 @@ class ShellFileOperations(FileOperations):
             denied = get_write_denied_error(p, verb="Move")
             if denied:
                 return WriteResult(error=denied)
+        
+        # Check if dst is a directory in the backend namespace.
+        # If so, mv will write src into dst as dst/basename(src), so we must
+        # check the effective destination against the denial list.
+        dir_probe = self._exec(
+            f"test -d {self._escape_shell_arg(dst)} && echo 1 || echo 0"
+        )
+        if dir_probe.stdout and dir_probe.stdout.strip() == "1":
+            # Derive basename host-side (pure lexical operation, no backend call needed)
+            import os
+            leaf = os.path.basename(src)
+            if not leaf:
+                # Fail-closed: cannot determine effective destination
+                return WriteResult(error=f"Failed to derive leaf name from {src!r}")
+            effective_dst = dst + "/" + leaf
+            denied = get_write_denied_error(effective_dst, verb="Move")
+            if denied:
+                return WriteResult(error=denied)
+        
         result = self._exec(
             f"mv {self._escape_shell_arg(src)} {self._escape_shell_arg(dst)}"
         )


### PR DESCRIPTION
move_file checks src and dst against the write-denial list, but when dst is an existing directory, mv writes the source inside it as dst/basename(src). Only the literal dst string was checked, so a move into a denied directory with a different basename would bypass the guard. Added a check for the resolved dst/basename(src) path when dst is a directory.