### PR TITLE
fix(relay): avoid managed-execution wrap for tools with persistent event loops (#77244)

### DIFF
--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -121,7 +121,12 @@ async def execute_async(
 ) -> Any:
     """Run one asynchronous physical provider attempt through Relay."""
     runtime, session, parent = relay_runtime.resolve_execution_context(session_id)
-    if runtime is None or session is None or not runtime.managed_execution_enabled():
+    if (
+        runtime is None
+        or session is None
+        or not runtime.managed_execution_enabled()
+        or not runtime.managed_execution_safe_on_thread()
+    ):
         return await callback(request)
     logical = _logical_parent(runtime, session, parent, metadata)
     parent = logical[1] if logical is not None else parent

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -71,6 +71,20 @@ class RelayRuntime:
         with self._execution_consumers_lock:
             return bool(self._execution_consumers)
 
+    def managed_execution_safe_on_thread(self) -> bool:
+        """Return whether managed execution is safe on the current thread.
+
+        Async tools bridge sync->async via ``model_tools._run_async``, which
+        runs the coroutine on a per-thread persistent loop (worker threads).
+        NeMo Relay's native ``llm.execute`` / ``tools.execute`` return a
+        Future bound to a loop captured at scope-push time on the main thread
+        — that loop never runs on a worker thread, so awaiting the Future
+        there raises "attached to a different loop" (#77244). Managed
+        execution is therefore only safe on the main thread; worker-thread
+        tool calls bypass the Relay wrapping and run the callback directly.
+        """
+        return threading.current_thread() is threading.main_thread()
+
     def ensure_session(
         self,
         event: dict[str, Any],

--- a/agent/relay_tools.py
+++ b/agent/relay_tools.py
@@ -25,7 +25,12 @@ def execute(
 ) -> tuple[Any, dict[str, Any]]:
     """Run one tool call through Relay and return its final arguments."""
     runtime, session, parent = relay_runtime.resolve_execution_context(session_id)
-    if runtime is None or session is None or not runtime.managed_execution_enabled():
+    if (
+        runtime is None
+        or session is None
+        or not runtime.managed_execution_enabled()
+        or not runtime.managed_execution_safe_on_thread()
+    ):
         return callback(args), args
 
     observed_args = args

--- a/tests/agent/test_relay_tools.py
+++ b/tests/agent/test_relay_tools.py
@@ -64,6 +64,55 @@ def test_tool_adapter_bypasses_relay_without_an_active_consumer(
     assert final_args is args
 
 
+def test_worker_thread_bypasses_managed_execution_for_async_tools(
+    relay_turn, monkeypatch
+):
+    """Async tools running on worker threads must bypass the managed Relay
+    wrapping (#77244).
+
+    NeMo Relay's native ``tools.execute`` returns a Future bound to a loop
+    captured at scope-push time on the main thread. When an async tool bridges
+    sync->async via ``model_tools._run_async`` (per-thread persistent loop),
+    awaiting that foreign-loop Future raises
+    "attached to a different loop" — so managed execution must be skipped on
+    worker threads and the callback run directly.
+    """
+    relay = relay_turn
+    runtime = relay_runtime.get_runtime()
+    assert runtime is not None
+    assert runtime.managed_execution_enabled()
+
+    # Simulate a worker-thread tool call: the Relay wrapper must NOT run.
+    def _worker_thread_call(_args):
+        from concurrent.futures import ThreadPoolExecutor
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(_call_relay_tools_from_worker, relay, _args).result()
+
+    monkeypatch.setattr(
+        relay.tools,
+        "execute",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("worker-thread tool call must bypass managed Relay")
+        ),
+    )
+
+    args = {"image_url": "http://x/img.png", "user_prompt": "describe"}
+    result, final_args = _worker_thread_call(args)
+    assert result is args
+    assert final_args is args
+
+
+def _call_relay_tools_from_worker(relay, args):
+    return relay_tools.execute(
+        "vision_analyze",
+        args,
+        lambda value: value,
+        session_id="session-1",
+        metadata={"tool_call_id": "call-1"},
+    )
+
+
 
 
 def test_request_rewrite_reaches_authorized_callback_once(relay_turn):


### PR DESCRIPTION
## Summary

Fixes #77244 — NeMo Relay's `retain_managed_execution()` (activated unconditionally by `relay_shared_metrics`) breaks async tools like `vision_analyze` that have their own persistent event loop. The tool fails with `RuntimeError: Task ... got Future attached to a different loop`.

## Root Cause

When managed execution is active, `relay_tools.execute` / `relay_llm.execute_async` wrap every call through `run_in_session_async`, which awaits the native `nemo_relay.llm.execute` / `tools.execute` Future. That native Future is bound to a loop captured at scope-push time on the main thread. Async tools bridge sync→async via `model_tools._run_async`, which runs the coroutine on a **per-thread persistent loop** (worker thread). Awaiting a foreign-loop Future on that worker loop raises the cross-loop error — the Future's own loop never runs, so no bridge (`wrap_future`, polling) can complete it.

## Change

- `agent/relay_runtime.py` — new `managed_execution_safe_on_thread()`: managed execution is only safe on the main thread (where the Relay scope loop lives); worker-thread tool calls must run the callback directly.
- `agent/relay_tools.py` / `agent/relay_llm.py` — the managed-execution gate now also requires `managed_execution_safe_on_thread()`. Worker-thread async tool calls bypass the Relay wrapping and execute the callback directly, preserving the tool result and avoiding the cross-loop Future entirely.
- `tests/agent/test_relay_tools.py` — regression: worker-thread tool call with managed execution active asserts the Relay wrapper is NOT invoked and the callback runs directly.

## Verification

- Repro script from the issue (managed `relay_tools.execute` → `_run_async` → `relay_llm.execute_async`): before the fix raises `RuntimeError: Future attached to a different loop`; after, returns the provider result.
- `pytest tests/agent/test_relay_tools.py tests/agent/test_relay_llm.py` → 22 passed.
