### PR TITLE
fix(cron): preserve tied execution rows across pages

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -236,16 +236,27 @@ def recover_interrupted_executions() -> int:
 def list_executions(
     *, job_id: Optional[str] = None, limit: int = 50,
     before_claimed_at: Optional[str] = None,
+    before_id: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
-    """Return indexed, newest-first execution history with cursor pagination."""
+    """Return indexed, newest-first execution history with cursor pagination.
+
+    Pass both cursor fields from the last record of the previous page so rows
+    sharing one ``claimed_at`` value remain reachable.
+    """
     clauses: List[str] = []
     params: List[Any] = []
     if job_id is not None:
         clauses.append("job_id=?")
         params.append(str(job_id))
     if before_claimed_at is not None:
-        clauses.append("claimed_at < ?")
-        params.append(str(before_claimed_at))
+        if before_id is None:
+            clauses.append("claimed_at < ?")
+            params.append(str(before_claimed_at))
+        else:
+            clauses.append("(claimed_at, id) < (?, ?)")
+            params.extend((str(before_claimed_at), str(before_id)))
+    elif before_id is not None:
+        raise ValueError("before_id requires before_claimed_at")
     where = " WHERE " + " AND ".join(clauses) if clauses else ""
     params.append(max(1, min(int(limit), 500)))
     with _transaction() as conn:

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -39,6 +39,37 @@ def test_execution_transitions_are_durable(monkeypatch, tmp_path):
     assert persisted == [completed]
 
 
+def test_execution_history_composite_cursor_preserves_tied_timestamps(
+    monkeypatch, tmp_path
+):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    for _ in range(4):
+        executions.create_execution("cursor-job", source="builtin")
+    with executions._transaction() as conn:
+        conn.execute(
+            "UPDATE executions SET claimed_at=?",
+            ("2026-08-03T00:00:00+00:00",),
+        )
+
+    expected = executions.list_executions(job_id="cursor-job", limit=10)
+    first_page = executions.list_executions(job_id="cursor-job", limit=2)
+    cursor = first_page[-1]
+    second_page = executions.list_executions(
+        job_id="cursor-job",
+        limit=2,
+        before_claimed_at=cursor["claimed_at"],
+        before_id=cursor["id"],
+    )
+
+    assert [row["id"] for row in first_page + second_page] == [
+        row["id"] for row in expected
+    ]
+    with __import__("pytest").raises(
+        ValueError, match="before_id requires before_claimed_at"
+    ):
+        executions.list_executions(before_id=cursor["id"])
+
+
 def test_terminal_execution_cannot_be_rewritten(monkeypatch, tmp_path):
     executions = _point_ledger(monkeypatch, tmp_path)
     record = executions.create_execution("immutable", source="builtin")


### PR DESCRIPTION
## What does this PR do?

`list_executions()` orders rows by `claimed_at DESC, id DESC`, but its cursor
previously filtered only on `claimed_at < ?`. If two executions shared a
timestamp and a page ended between them, the remaining tied rows were skipped
permanently.

This adds an optional `before_id` cursor component and applies the same
`(claimed_at, id)` ordering tuple to the continuation predicate. Existing
timestamp-only callers retain their current exclusive timestamp behavior.

## Related Issue

No existing issue. This was found by auditing the execution-ledger pagination
contract on the current default branch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `cron/executions.py`: accept `before_id` and use a composite cursor when both
  cursor fields are supplied.
- `tests/cron/test_execution_ledger.py`: prove that two pages preserve all rows
  when every execution has the same timestamp, and reject an incomplete
  id-only cursor.

## How to Test

1. Create four execution records and force them to share one `claimed_at`.
2. Read two rows, then pass the last row's `claimed_at` and `id` as the cursor.
3. Confirm the second page contains the two remaining rows in ledger order.

Automated validation:

- `python -m pytest tests/cron/test_execution_ledger.py -q` - 19 passed
- `python -m pytest tests/cron/ -q` - 391 passed, 2 existing runtime warnings
- `python -m ruff check cron/executions.py tests/cron/test_execution_ledger.py`
- `python -m py_compile cron/executions.py tests/cron/test_execution_ledger.py`
- `git diff --check`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (focused ledger and full
  cron suites passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; the public function docstring documents
  the composite cursor
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A; no workflow changed
- [x] Cross-platform impact considered; the change uses SQLite row-value
  comparison supported by the project's SQLite baseline
- [x] Tool descriptions/schemas are N/A; no tool surface changed

## Screenshots / Logs

Not applicable.
