### PR TITLE
refactor(desktop): hoist the reference-line matcher, drop dead textWithoutImageRefs (follow-up #77653)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -557,7 +557,7 @@ describe('preserveLocalPendingTurnMessages', () => {
   // `attachmentRefs`. A naive text compare (chatMessageText a === b) therefore
   // always mismatched whenever an image was attached and re-appended the
   // optimistic row as a distinct, duplicate user bubble. Both sides must now
-  // reduce to the same visible text via textWithoutImageRefs.
+  // reduce to the same visible text via textWithoutReferenceLines.
   it('does not duplicate the optimistic image turn when the persisted turn carries @image refs', () => {
     const previous = [
       msg('1-user', 'user', 'first'),

--- a/apps/desktop/src/components/assistant-ui/reference-kinds.ts
+++ b/apps/desktop/src/components/assistant-ui/reference-kinds.ts
@@ -159,18 +159,15 @@ export function referenceRe(): RegExp {
 }
 
 /** Remove reference-only lines when comparing visible message text. */
-export function textWithoutReferenceLines(text: string): string {
-  const matcher = referenceRe()
+// Anchored + non-global: no shared `lastIndex` state (the hazard referenceRe()
+// exists to avoid), and hoisting skips a RegExp construction per call — this
+// runs on both sides of every message comparison in the reconcile loops.
+const REFERENCE_LINE_RE = new RegExp(`^(?:${REFERENCE_PATTERN.source})$`)
 
+export function textWithoutReferenceLines(text: string): string {
   return text
     .split('\n')
-    .filter(line => {
-      const candidate = line.trimEnd()
-      matcher.lastIndex = 0
-      const match = matcher.exec(candidate)
-
-      return !match || match.index !== 0 || match[0] !== candidate
-    })
+    .filter(line => !REFERENCE_LINE_RE.test(line.trimEnd()))
     .join('\n')
     .trim()
 }

--- a/apps/desktop/src/lib/embedded-images.test.ts
+++ b/apps/desktop/src/lib/embedded-images.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { extractEmbeddedImages, extractImageRefs, textWithoutImageRefs } from './embedded-images'
+import { extractEmbeddedImages, extractImageRefs } from './embedded-images'
 
 const SAMPLE_PNG_DATA_URL = 'data:image/png;base64,' + 'A'.repeat(120)
 
@@ -40,28 +40,6 @@ describe('extractEmbeddedImages', () => {
     expect(result.cleanedText).toBe('describe this  thanks')
     expect(result.images).toHaveLength(1)
     expect(result.images[0]).toHaveLength(hugeDataUrl.length)
-  })
-})
-
-describe('textWithoutImageRefs', () => {
-  it('leaves plain text untouched', () => {
-    expect(textWithoutImageRefs('just a question')).toBe('just a question')
-  })
-
-  it('strips a single leading @image directive line', () => {
-    expect(textWithoutImageRefs('@image:/tmp/cat.png\nwhat is this?')).toBe('what is this?')
-  })
-
-  it('strips multiple @image directive lines and trims', () => {
-    const input = '@image:/tmp/a.png\n@image:/tmp/b.png\n  describe both  '
-
-    expect(textWithoutImageRefs(input)).toBe('describe both')
-  })
-
-  it('does not treat an inline @image mention as a directive line', () => {
-    // Only full-line leading directives are stripped, matching the gateway's
-    // persist-time rewrite. A bare mention mid-prose is preserved.
-    expect(textWithoutImageRefs('see @image:/tmp/cat.png here')).toBe('see @image:/tmp/cat.png here')
   })
 })
 

--- a/apps/desktop/src/lib/embedded-images.ts
+++ b/apps/desktop/src/lib/embedded-images.ts
@@ -165,20 +165,15 @@ export function textWithoutEmbeddedImages(text: string): string {
 // (see tui_gateway/server.py's persist-time rewrite), prepended before the
 // user's own text. The composer's own optimistic/local turn never carries
 // this prefix — it keeps the attachment as separate `attachmentRefs`
-// metadata, not inline text. Comparing raw chatMessageText between the
-// optimistic turn and the authoritative (persisted) turn therefore always
-// mismatches whenever an image was attached, which defeats the "is this the
-// same turn" checks in preserveLocalPendingTurnMessages / appendLiveSessionProjection
-// and re-appends the optimistic row as if it were a distinct, unconfirmed
-// turn — a duplicated user bubble. Strip the directive line(s) before any
-// such equality comparison so both sides reduce to the same visible text.
+// metadata, not inline text. The turn-equality comparisons in
+// preserveLocalPendingTurnMessages / appendLiveSessionProjection strip ALL
+// reference-directive lines (not just images) via
+// `textWithoutReferenceLines` in components/assistant-ui/reference-kinds.ts;
+// IMAGE_REF_LINE_RE remains here for extractImageRefs below, which moves the
+// image directives into attachmentRefs metadata.
 const IMAGE_REF_LINE_RE = /^@image:[^\n]*\n?/gm
 
-export function textWithoutImageRefs(text: string): string {
-  return text.replace(IMAGE_REF_LINE_RE, '').trim()
-}
-
-// Same directive lines as textWithoutImageRefs, but keeps them instead of
+// Same directive lines as IMAGE_REF_LINE_RE, but keeps them instead of
 // discarding — used when converting persisted server messages into
 // ChatMessage/ThreadMessageLike shape, where `@image:<path>` refs need to
 // move from inline text into the `attachmentRefs` metadata field (mirroring


### PR DESCRIPTION
Simplify-pass findings on #77653's final diff, which auto-merged before the folds landed: (1) textWithoutReferenceLines built a fresh /g RegExp per call inside the reconcile comparison loops — an anchored non-global regex has no lastIndex hazard and is hoisted to module scope, removing the per-call construction and the composite match check; (2) #77653 removed the last production consumer of textWithoutImageRefs — the function and its tests are deleted (IMAGE_REF_LINE_RE stays for extractImageRefs) and the stale comment above it now points at textWithoutReferenceLines. 66 tests green across both touched areas.