### PR TITLE
chore(contributors): map two B3 salvage author emails

### DIFF
--- a/contributors/emails/abdulsalamalotaibi86@gmail.com
+++ b/contributors/emails/abdulsalamalotaibi86@gmail.com
@@ -1,0 +1,1 @@
+carbongotfound

--- a/contributors/emails/soundbrokaz@kakao.com
+++ b/contributors/emails/soundbrokaz@kakao.com
@@ -1,0 +1,1 @@
+JeremyDev87


### PR DESCRIPTION
Attribution mappings for the B3 prompt/skills salvages: carbongotfound (#74025), JeremyDev87 (#72813).