### PR TITLE
fix(file_ops): surface oversized file warning in read_file result

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1163,9 +1163,13 @@ class ShellFileOperations(FileOperations):
             file_size = 0
         
         # Check if file is too large
+        size_warning = None
         if file_size > MAX_FILE_SIZE:
-            # Still try to read, but warn
-            pass
+            size_warning = (
+                f"File is {file_size:,} bytes (limit is {MAX_FILE_SIZE:,}). "
+                "Consider using offset and limit to read a smaller portion, "
+                "or search_files to locate specific content."
+            )
         
         # Images are never inlined — redirect to the vision tool
         if self._is_image(path):
@@ -1225,7 +1229,8 @@ class ShellFileOperations(FileOperations):
             total_lines=total_lines,
             file_size=file_size,
             truncated=truncated,
-            hint=hint
+            hint=hint,
+            warning=size_warning,
         )
     
     def _suggest_similar_files(self, path: str) -> ReadResult:


### PR DESCRIPTION
## Bug

`MAX_FILE_SIZE` (50KB) is defined but the guard at `read_file` line 1166 was an empty `pass` block — it never warned the model, refused the read, or truncated. The model had no signal that the file exceeded the recommended limit and would receive a potentially huge payload.

## Fix

Emit a `warning` on the `ReadResult` when the file exceeds `MAX_FILE_SIZE`, nudging the model toward `offset`/`limit` or `search_files` instead.