### PR TITLE
fix(file_ops): enforce upper bound on search limit pagination

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -762,7 +762,7 @@ def normalize_search_pagination(offset: Any = DEFAULT_SEARCH_OFFSET,
                                 limit: Any = DEFAULT_SEARCH_LIMIT) -> tuple[int, int]:
     """Return safe search pagination bounds for shell head/tail pipelines."""
     normalized_offset = max(0, _coerce_int(offset, DEFAULT_SEARCH_OFFSET))
-    normalized_limit = max(1, _coerce_int(limit, DEFAULT_SEARCH_LIMIT))
+    normalized_limit = min(max(1, _coerce_int(limit, DEFAULT_SEARCH_LIMIT)), 5000)
     return normalized_offset, normalized_limit
 
 


### PR DESCRIPTION
## Bug

`normalize_search_pagination` clamped `offset` to ">=0" and `limit` to ">=1" but imposed no upper bound. A caller-controlled limit flowed directly into `head -n` in the rg/grep command builders, letting a single search request consume arbitrary resources.

## Fix

Cap `limit` at 5000, matching typical model context windows.