### PR TITLE
fix(web): clamp dashboard pagination and analytics-days params (#39200 + #74778 salvage)

### DIFF
--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -56,7 +56,10 @@ _write_profile_model = late("_write_profile_model")
 
 @sessions_router.get("/api/profiles/sessions")
 def get_profiles_sessions(
-    limit: int = Query(20, ge=0),
+    # ``le=100`` caps the per-request page size (idea from #39200) — this
+    # endpoint fans the query out across EVERY profile's state.db, so an
+    # unbounded limit multiplies the damage.
+    limit: int = Query(20, ge=0, le=100),
     offset: int = Query(0, ge=0),
     min_messages: int = 0,
     archived: str = "exclude",

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -56,10 +56,13 @@ _write_profile_model = late("_write_profile_model")
 
 @sessions_router.get("/api/profiles/sessions")
 def get_profiles_sessions(
-    # ``le=100`` caps the per-request page size (idea from #39200) — this
+    # ``le=500`` caps the per-request page size (idea from #39200) — this
     # endpoint fans the query out across EVERY profile's state.db, so an
-    # unbounded limit multiplies the damage.
-    limit: int = Query(20, ge=0, le=100),
+    # unbounded limit multiplies the damage. 500 (not 100) because real
+    # desktop callers use limit=200 (sessions-settings ARCHIVED_FETCH_LIMIT,
+    # command palette) and the electron remote-merge over-fetches
+    # ``limit + offset``.
+    limit: int = Query(20, ge=0, le=500),
     offset: int = Query(0, ge=0),
     min_messages: int = 0,
     archived: str = "exclude",

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -49,7 +49,10 @@ _strip_session_list_rows = late("_strip_session_list_rows")
 
 @list_router.get("/api/sessions")
 def get_sessions(
-    limit: int = Query(20, ge=0),
+    # ``le=100`` caps the page size (idea from #39200): an unbounded limit
+    # lets one request drag every session row (plus correlated-subquery
+    # preview work) out of SQLite in a single hit.
+    limit: int = Query(20, ge=0, le=100),
     offset: int = Query(0, ge=0),
     min_messages: int = 0,
     archived: str = "exclude",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -102,7 +102,7 @@ from utils import env_var_enabled
 
 try:
     from fastapi import (
-        FastAPI, File, Form, HTTPException, Request, UploadFile,
+        FastAPI, File, Form, HTTPException, Query, Request, UploadFile,
         WebSocket, WebSocketDisconnect,
     )
     from fastapi.middleware.cors import CORSMiddleware
@@ -118,7 +118,7 @@ except ImportError:
         from tools.lazy_deps import ensure as _lazy_ensure
         _lazy_ensure("tool.dashboard", prompt=False)
         from fastapi import (
-            FastAPI, File, Form, HTTPException, Request, UploadFile,
+            FastAPI, File, Form, HTTPException, Query, Request, UploadFile,
             WebSocket, WebSocketDisconnect,
         )
         from fastapi.middleware.cors import CORSMiddleware
@@ -14099,7 +14099,14 @@ def _get_usage_analytics(days: int = 30, profile: Optional[str] = None):
 
 
 @app.get("/api/analytics/usage")
-async def get_usage_analytics(days: int = 30, profile: Optional[str] = None):
+async def get_usage_analytics(
+    days: int = Query(30, ge=1, le=365),
+    profile: Optional[str] = None,
+):
+    """``days`` is clamped to 1-365 (idea from #74778): huge or non-positive
+    values would force expensive full-history SQL and InsightsEngine work, or
+    produce empty/inverted time windows. The UI only offers 7/30/90-day
+    presets."""
     return await asyncio.to_thread(_get_usage_analytics, days, profile)
 
 
@@ -14280,7 +14287,11 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
 
 
 @app.get("/api/analytics/models")
-async def get_models_analytics(days: int = 30, profile: Optional[str] = None):
+async def get_models_analytics(
+    days: int = Query(30, ge=1, le=365),
+    profile: Optional[str] = None,
+):
+    # ``days`` clamped to 1-365 (idea from #74778) — see get_usage_analytics.
     """Return model analytics without blocking the serving event loop."""
     return await asyncio.to_thread(_get_models_analytics, days, profile)
 

--- a/tests/hermes_cli/test_dashboard_param_clamps.py
+++ b/tests/hermes_cli/test_dashboard_param_clamps.py
@@ -1,0 +1,55 @@
+"""Dashboard query-param clamps (#39200 + #74778 salvage).
+
+FastAPI Query bounds reject out-of-range values at the validation layer
+(422) instead of letting them reach SQL/insights code: an unbounded
+``limit`` drags every session row out of SQLite in one hit (multiplied
+across every profile's state.db on the fan-out endpoint), and an
+unbounded/inverted ``days`` forces full-history InsightsEngine work.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "clamp-test-token")
+    from hermes_cli import web_server
+
+    with TestClient(web_server.app, raise_server_exceptions=False) as c:
+        c.headers["Authorization"] = "Bearer clamp-test-token"
+        yield c
+
+
+class TestSessionPaginationClamps:
+    def test_oversized_limit_rejected(self, client):
+        r = client.get("/api/sessions", params={"limit": 10_000})
+        assert r.status_code == 422
+
+    def test_negative_limit_rejected(self, client):
+        r = client.get("/api/sessions", params={"limit": -1})
+        assert r.status_code == 422
+
+    def test_profile_fanout_limit_clamped(self, client):
+        r = client.get("/api/profiles/sessions", params={"limit": 10_000})
+        assert r.status_code == 422
+
+    def test_in_range_limit_accepted(self, client):
+        r = client.get("/api/sessions", params={"limit": 50})
+        assert r.status_code == 200
+
+
+class TestAnalyticsDaysClamps:
+    @pytest.mark.parametrize("days", [0, -5, 100_000])
+    def test_out_of_range_days_rejected(self, client, days):
+        r = client.get("/api/analytics/usage", params={"days": days})
+        assert r.status_code == 422
+
+    def test_in_range_days_accepted(self, client):
+        r = client.get("/api/analytics/usage", params={"days": 30})
+        assert r.status_code == 200

--- a/tests/hermes_cli/test_dashboard_param_clamps.py
+++ b/tests/hermes_cli/test_dashboard_param_clamps.py
@@ -39,6 +39,13 @@ class TestSessionPaginationClamps:
         r = client.get("/api/profiles/sessions", params={"limit": 10_000})
         assert r.status_code == 422
 
+    def test_profile_fanout_accepts_real_desktop_maximum(self, client):
+        # Desktop callers use limit=200 (ARCHIVED_FETCH_LIMIT, command
+        # palette) and electron over-fetches limit+offset — the clamp must
+        # sit ABOVE real client maxima, not break them.
+        r = client.get("/api/profiles/sessions", params={"limit": 200, "offset": 120})
+        assert r.status_code == 200
+
     def test_in_range_limit_accepted(self, client):
         r = client.get("/api/sessions", params={"limit": 50})
         assert r.status_code == 200


### PR DESCRIPTION
Salvage of #39200 + #74778 by @aydnOktay — the twin param-clamp PRs, re-derived onto current main as one commit under their authorship (the session endpoints moved into web_routers/ and the analytics endpoints gained asyncio.to_thread wrappers since the originals), plus one simplify follow-up.

## Context — what this changes for users

- limit clamps on /api/sessions, /api/sessions/search, /api/profiles/sessions: one unbounded request could drag every session row (plus correlated-subquery preview work) out of SQLite — multiplied across every profile's state.db on the fan-out endpoint.
- days ge=1 le=365 on /api/analytics/usage + /api/analytics/models: huge or non-positive values force full-history InsightsEngine work or inverted windows. UI presets are 7/30/90.

FastAPI Query bounds reject at the validation layer (422) before any SQL runs.

## Simplify follow-up folded (regression catch)

The initial fan-out clamp (le=100) would have 422'd REAL desktop callers: sessions-settings fetches archived at limit=200, the command palette lists at 200, and the electron remote-merge over-fetches limit+offset. Raised to le=500 with a test pinning the real client maximum (200 w/ offset).

## Verification

9 tests green; both clamp classes mutation-checked (clamp removed → its tests fail; verified with snapshot-restore). ruff clean.

Closes #39200. Closes #74778.