### PR TITLE
fix(terminal): guard redact_terminal_output against exceptions

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3038,7 +3038,10 @@ def terminal_tool(
             # Real prefixes, auth headers, JWTs, private keys are masked in
             # both modes. See issue #43025.
             from agent.redact import redact_terminal_output
-            output = redact_terminal_output(output.strip(), command) if output else ""
+            try:
+                output = redact_terminal_output(output.strip(), command) if output else ""
+            except Exception:
+                logger.debug("redact_terminal_output failed", exc_info=True)
 
             # Interpret non-zero exit codes that aren't real errors
             # (e.g. grep=1 means "no matches", diff=1 means "files differ")


### PR DESCRIPTION
## Bug

The `redact_terminal_output` call on visible command output was not wrapped in a try/except. If it raised (regex failure on unusual input, resource error), the entire result pipeline would crash and return a raw traceback.

## Fix

Wrap in try/except with a debug log so the pipeline continues and the model still receives output (un-redacted is better than a traceback).