### PR TITLE
perf(dashboard): hoist per-entry config loads + negative-cache failed installs (#56636 salvage)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8216,10 +8216,21 @@ def _messaging_env_info(key: str) -> dict[str, Any]:
     }
 
 
-def _gateway_platform_config(platform_id: str):
+# Sentinel: "no pre-loaded gateway config was provided — load on demand".
+# Distinct from None, which means "the caller's per-request load failed".
+_GATEWAY_CONFIG_UNSET = object()
+
+
+def _gateway_platform_config(platform_id: str, config: Any = _GATEWAY_CONFIG_UNSET):
     from gateway.config import Platform, load_gateway_config
 
-    config = load_gateway_config()
+    if config is _GATEWAY_CONFIG_UNSET:
+        config = load_gateway_config()
+    if config is None:
+        # The caller pre-loaded the config for the whole request and that load
+        # failed; surface it so each payload takes its env-var fallback path
+        # (same behavior as a per-entry load failure — never a 500).
+        raise RuntimeError("gateway config unavailable for this request")
     platform = Platform(platform_id)
     platform_config = config.platforms.get(platform)
     return config, platform, platform_config
@@ -8231,6 +8242,7 @@ def _messaging_platform_payload(
     runtime: dict | None,
     scoped: bool = False,
     profile_home: Optional[Path] = None,
+    gateway_config: Any = _GATEWAY_CONFIG_UNSET,
 ) -> dict[str, Any]:
     platform_id = entry["id"]
     runtime_platforms = runtime.get("platforms") if runtime else {}
@@ -8300,13 +8312,13 @@ def _messaging_platform_payload(
         configured = all(env_on_disk.get(key) for key in entry["required_env"])
     else:
         try:
-            gateway_config, platform, platform_config = _gateway_platform_config(
-                platform_id
+            gw_config, platform, platform_config = _gateway_platform_config(
+                platform_id, gateway_config
             )
             enabled = bool(platform_config and platform_config.enabled)
             configured = bool(
                 platform_config
-                and gateway_config._is_platform_connected(platform, platform_config)
+                and gw_config._is_platform_connected(platform, platform_config)
             )
             home_channel = (
                 platform_config.home_channel.to_dict()
@@ -9273,6 +9285,24 @@ async def get_messaging_platforms(profile: Optional[str] = None):
             if scoped_dir is not None
             else read_runtime_status()
         )
+        # Snapshot the catalog BEFORE loading the gateway config: loading can
+        # re-run plugin discovery, which mutates the registry the catalog is
+        # built from (credit: PR #56636).
+        catalog = list(_messaging_platform_catalog())
+        # Hoist the config load out of the per-entry loop: the config is
+        # identical for every catalog entry (~30), and load_gateway_config()
+        # is a full reload including plugin requirement checks (~360ms), so
+        # per-entry loads added ~10s per request (credit: PR #56636). Scoped
+        # requests never consume it — don't pay for it. None signals a failed
+        # load so each payload takes its env-var fallback (never a 500).
+        gateway_config = _GATEWAY_CONFIG_UNSET
+        if scoped_dir is None:
+            from gateway.config import load_gateway_config
+
+            try:
+                gateway_config = load_gateway_config()
+            except Exception:
+                gateway_config = None
         return {
             "env_path": str(get_env_path()),
             "gateway_start_command": _gateway_display_command(profile, "start"),
@@ -9283,8 +9313,9 @@ async def get_messaging_platforms(profile: Optional[str] = None):
                     runtime,
                     scoped=scoped_dir is not None,
                     profile_home=scoped_dir,
+                    gateway_config=gateway_config,
                 )
-                for entry in _messaging_platform_catalog()
+                for entry in catalog
             ]
         }
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -509,6 +509,47 @@ class TestWebServerEndpoints:
         assert seen["status_path"] == worker_home / "gateway_state.json"
         assert seen["expected_home"] == worker_home
 
+    def test_messaging_platforms_loads_gateway_config_once(self, monkeypatch):
+        """The unscoped listing must load the gateway config exactly ONCE.
+
+        load_gateway_config() is a full reload — plugin discovery plus
+        per-platform requirement checks (~360ms). The per-entry
+        _gateway_platform_config() path re-ran it for every catalog entry
+        (~30), so one dashboard request stacked ~10s of identical reloads.
+        The handler now hoists a single load before the loop and passes it
+        down to every payload (credit: PR #56636).
+        """
+        import gateway.config as gateway_config_mod
+
+        calls = {"n": 0}
+
+        class _FakeGatewayConfig:
+            platforms: dict = {}
+
+            def _is_platform_connected(self, platform, platform_config):
+                return False
+
+        def _counting_load(*args, **kwargs):
+            calls["n"] += 1
+            return _FakeGatewayConfig()
+
+        monkeypatch.setattr(
+            gateway_config_mod, "load_gateway_config", _counting_load
+        )
+
+        resp = self.client.get("/api/messaging/platforms")
+
+        assert resp.status_code == 200
+        platforms = resp.json()["platforms"]
+        # The invariant only means something when the catalog fans out to
+        # many entries — the whole point of the hoist.
+        assert len(platforms) > 1
+        assert calls["n"] == 1, (
+            f"load_gateway_config() ran {calls['n']}x for "
+            f"{len(platforms)} catalog entries; the hoist in "
+            "get_messaging_platforms must load it exactly once per request"
+        )
+
 
 
 

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -12,10 +12,25 @@ call is mocked — we never actually shell out during unit tests.
 
 from __future__ import annotations
 
+import time
 
 import pytest
 
 import tools.lazy_deps as ld
+
+
+@pytest.fixture(autouse=True)
+def _reset_install_failure_cache():
+    """Keep the module-level negative install cache from leaking across tests.
+
+    ``_install_failures`` is a per-process dict; subprocess isolation gives
+    each test a fresh copy in CI, but under ``--no-isolate`` (and a plain
+    ``pytest`` invocation) it would otherwise carry a recorded failure from
+    one test into the next — several tests reuse the ``test.feat`` key.
+    """
+    ld._install_failures.clear()
+    yield
+    ld._install_failures.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +156,100 @@ class TestEnsure:
         )
         with pytest.raises(ld.FeatureUnavailable, match="still not importable"):
             ld.ensure("test.cache", prompt=False)
+
+
+# ---------------------------------------------------------------------------
+# Negative cache — failed install attempts short-circuit within a cooldown
+#
+# Without this, a missing-and-uninstallable backend (offline, sandboxed venv,
+# PyPI 404) re-runs the full uv/pip subprocess ladder on every ensure() call.
+# The discord requirements check runs on every load_gateway_config(), which the
+# dashboard's /api/messaging/platforms endpoint fanned out ~30x per request —
+# turning one bad install into ~10s of stacked, doomed pip invocations.
+# ---------------------------------------------------------------------------
+
+
+class TestNegativeCache:
+    def test_failed_install_not_retried_within_cooldown(self, monkeypatch):
+        monkeypatch.setitem(ld.LAZY_DEPS, "test.neg", ("zzzfake>=1",))
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+
+        calls = {"n": 0}
+
+        def fake_install(specs, **kw):
+            calls["n"] += 1
+            return ld._InstallResult(False, "", "ERROR: offline")
+
+        monkeypatch.setattr(ld, "_venv_pip_install", fake_install)
+
+        # First call actually attempts the install and fails.
+        with pytest.raises(ld.FeatureUnavailable, match="pip install failed"):
+            ld.ensure("test.neg", prompt=False)
+        # Second call short-circuits via the negative cache — pip is NOT rerun.
+        with pytest.raises(ld.FeatureUnavailable, match="not retrying yet"):
+            ld.ensure("test.neg", prompt=False)
+
+        assert calls["n"] == 1, "pip must run once, not on the cached retry"
+
+    def test_install_reported_success_but_missing_is_cached(self, monkeypatch):
+        # pip claims success but packages stay unimportable → treated as a
+        # failed attempt so the next call short-circuits too.
+        monkeypatch.setitem(ld.LAZY_DEPS, "test.ghost", ("zzzfake>=1",))
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+
+        calls = {"n": 0}
+
+        def fake_install(specs, **kw):
+            calls["n"] += 1
+            return ld._InstallResult(True, "ok", "")
+
+        monkeypatch.setattr(ld, "_venv_pip_install", fake_install)
+
+        with pytest.raises(ld.FeatureUnavailable, match="still not importable"):
+            ld.ensure("test.ghost", prompt=False)
+        with pytest.raises(ld.FeatureUnavailable, match="not retrying yet"):
+            ld.ensure("test.ghost", prompt=False)
+
+        assert calls["n"] == 1
+
+    def test_cache_cleared_when_feature_becomes_available(self, monkeypatch):
+        # A cached failure must not permanently block a feature whose packages
+        # later appear by other means (user ran `hermes tools`, etc.).
+        monkeypatch.setitem(ld.LAZY_DEPS, "test.recover", ("zzzfake>=1",))
+        ld._record_install_failure("test.recover")
+        assert ld._recent_install_failure("test.recover") is True
+
+        # feature_missing() now returns empty → ensure() returns and clears.
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: True)
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip should not be called"),
+        )
+        ld.ensure("test.recover", prompt=False)  # no raise
+        assert ld._recent_install_failure("test.recover") is False
+
+    def test_successful_install_clears_cache(self, monkeypatch):
+        monkeypatch.setitem(ld.LAZY_DEPS, "test.win", ("zzzfake>=1",))
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        # Missing pre-install, present post-install.
+        states = iter([False, True])
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: next(states))
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda specs, **kw: ld._InstallResult(True, "ok", ""),
+        )
+        ld.ensure("test.win", prompt=False)
+        assert "test.win" not in ld._install_failures
+
+    def test_cooldown_expiry_allows_retry(self, monkeypatch):
+        # A failure older than the cooldown must not block a retry.
+        monkeypatch.setattr(ld, "_INSTALL_FAILURE_COOLDOWN_S", 300.0)
+        ld._install_failures["test.expired"] = time.monotonic() - 301.0
+        assert ld._recent_install_failure("test.expired") is False
+        # Expired entry is pruned on read.
+        assert "test.expired" not in ld._install_failures
 
 
 # ---------------------------------------------------------------------------

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -75,6 +75,8 @@ import site
 import subprocess
 import sys
 import sysconfig
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -82,6 +84,59 @@ from typing import Any, Callable, Optional
 from hermes_cli._subprocess_compat import windows_hide_flags
 
 logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Per-process negative cache for failed install attempts.
+#
+# When a feature's packages are missing AND the install fails (offline,
+# sandboxed venv with no network, PyPI 404/quarantine), nothing used to
+# remember the failure — so every caller re-ran the full uv/pip subprocess
+# ladder. Discord's requirements check runs on every load_gateway_config(),
+# which the dashboard's /api/messaging/platforms endpoint fanned out per
+# platform; each doomed pip install cost hundreds of ms and stacked into a
+# ~10s, UX-timing-out request.
+#
+# The cache records the monotonic time of the last failed attempt per feature
+# and short-circuits subsequent ensure() calls within a cooldown window,
+# raising FeatureUnavailable immediately instead of shelling out again. It is
+# intentionally per-process and forgetful: the cheap feature_missing() check
+# still runs first (so packages that appeared by other means succeed and clear
+# the entry), a successful install clears the entry, and the cooldown expiry
+# lets a user who fixed their network retry without restarting the process.
+# =============================================================================
+
+_INSTALL_FAILURE_COOLDOWN_S = 300.0
+_install_failures: dict[str, float] = {}
+_install_failures_lock = threading.Lock()
+
+
+def _recent_install_failure(feature: str) -> bool:
+    """Return True if ``feature`` failed to install within the cooldown window.
+
+    Expired entries are pruned on read so a stale failure doesn't linger past
+    its cooldown.
+    """
+    with _install_failures_lock:
+        ts = _install_failures.get(feature)
+        if ts is None:
+            return False
+        if (time.monotonic() - ts) >= _INSTALL_FAILURE_COOLDOWN_S:
+            del _install_failures[feature]
+            return False
+        return True
+
+
+def _record_install_failure(feature: str) -> None:
+    """Remember that a lazy install for ``feature`` just failed."""
+    with _install_failures_lock:
+        _install_failures[feature] = time.monotonic()
+
+
+def _clear_install_failure(feature: str) -> None:
+    """Forget any recorded failure for ``feature`` (install succeeded / deps present)."""
+    with _install_failures_lock:
+        _install_failures.pop(feature, None)
 
 
 # =============================================================================
@@ -841,6 +896,9 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
 
     missing = feature_missing(feature)
     if not missing:
+        # Deps are present (installed by us earlier, by `hermes tools`, or by
+        # the user directly). Drop any stale negative-cache entry and succeed.
+        _clear_install_failure(feature)
         return
 
     unsupported = _unsupported_feature_reason(feature)
@@ -875,6 +933,17 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
                 f"them at runtime. Add the dependencies for {feature!r} via "
                 f"{managed_by} (or run a pip/uv install of Hermes instead)."
             )
+
+    # Negative cache: a recent install attempt for this feature already failed.
+    # Don't pay for another doomed uv/pip subprocess within the cooldown. The
+    # feature_missing() check above runs first, so packages that became
+    # available by other means still succeed and clear the cache above.
+    if _recent_install_failure(feature):
+        raise FeatureUnavailable(
+            feature, missing,
+            "recent install attempt failed; not retrying yet "
+            f"(cooldown {int(_INSTALL_FAILURE_COOLDOWN_S)}s)",
+        )
 
     # Validate every spec against the allowlist + safety regex. Belt and
     # braces — the keys-in-LAZY_DEPS check above already constrains this.
@@ -924,6 +993,9 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
     logger.info("Lazy-installing %s for feature %r", " ".join(missing), feature)
     result = _venv_pip_install(missing)
     if not result.success:
+        # Remember the failure so the next call within the cooldown short-
+        # circuits instead of re-running pip (the whole point of the cache).
+        _record_install_failure(feature)
         # Surface the actual pip error so the user can debug PyPI-side
         # issues (404 quarantine, network down, etc.).
         snippet = (result.stderr or result.stdout or "").strip()
@@ -946,12 +1018,17 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
 
     still_missing = feature_missing(feature)
     if still_missing:
+        # pip claimed success but the packages aren't importable (wrong venv,
+        # metadata cache, needs a restart). Treat it as a failed attempt so we
+        # don't keep re-running the install that can't take effect this process.
+        _record_install_failure(feature)
         raise FeatureUnavailable(
             feature, still_missing,
             "install reported success but packages still not importable "
             "(may require Python restart)"
         )
 
+    _clear_install_failure(feature)
     logger.info("Lazy install complete for feature %r", feature)
 
 


### PR DESCRIPTION
Extract-salvage of #56636 by @junhohong — the PR's two still-novel groups; the negative-cache commit under their authorship, the hoist re-implemented (kshitij) against main's rewritten handler.

## Context — what this changes for users

- G1 (re-implemented): /api/messaging/platforms called load_gateway_config() once PER CATALOG ENTRY (~30x per request, uncached full parse). Now loaded once before the loop; failed load falls back to env-var resolution per entry (never 500s); catalog snapshotted before the load (plugin-discovery mutation guard); scoped requests don't pay.
- G2 (ported, junhohong's commit): tools/lazy_deps.py per-process negative cache (300s cooldown) for failed installs — stops check_fn re-running doomed pip installs.

## Scope honesty

The PR's third group (gateway_running hoist) was dropped as superseded: main's _messaging_platform_payload now uses resolve_gateway_liveness + get_running_pid_cached (gateway/status.py:2206). The original's "~10s request" claim is partially stale (main gates check_fn to enabled platforms); the surviving claim is the ~30x uncached config parse, verified live on main at web_server.py:8149-8152.

## Verification

Hoist test pins exactly 1 load_gateway_config call for a multi-platform listing (mutation: per-entry loads restored → fails); negative-cache tests from the PR adapted (mutation: cooldown removed → fails); 123-test web_server file + 69 messaging/lazy_deps tests green; ruff clean. Simplify pass: sentinel + cooldown-constant idioms verified against house precedent.

Closes #56636.