### PR TITLE
perf(plugins): seed plugin routes from sessionStorage for instant render (#19805 salvage)

### DIFF
--- a/web/src/plugins/usePlugins.test.ts
+++ b/web/src/plugins/usePlugins.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  getCachedManifests,
+  cacheManifests,
+  MANIFEST_CACHE_KEY,
+} from "./usePlugins";
+import type { PluginManifest } from "./types";
+
+function makeStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    clear() {
+      store.clear();
+    },
+    get length() {
+      return store.size;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+  } as Storage;
+}
+
+const exampleManifest: PluginManifest = {
+  name: "test",
+  label: "Test",
+  description: "A test plugin",
+  icon: "Puzzle",
+  version: "1.0.0",
+  tab: { path: "/test" },
+  entry: "index.js",
+  has_api: false,
+  source: "local",
+};
+
+describe("plugin manifest cache helpers", () => {
+  let storage: Storage;
+
+  beforeEach(() => {
+    storage = makeStorage();
+    vi.stubGlobal("sessionStorage", storage);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("getCachedManifests returns null when nothing is cached", () => {
+    expect(getCachedManifests()).toBeNull();
+  });
+
+  it("getCachedManifests returns null for invalid JSON", () => {
+    storage.setItem(MANIFEST_CACHE_KEY, "not-json");
+    expect(getCachedManifests()).toBeNull();
+  });
+
+  it("getCachedManifests returns null for non-array JSON", () => {
+    storage.setItem(MANIFEST_CACHE_KEY, JSON.stringify({ foo: "bar" }));
+    expect(getCachedManifests()).toBeNull();
+  });
+
+  it("getCachedManifests returns null for scalar JSON", () => {
+    storage.setItem(MANIFEST_CACHE_KEY, JSON.stringify(42));
+    expect(getCachedManifests()).toBeNull();
+  });
+
+  it("getCachedManifests returns a valid manifest array", () => {
+    const list: PluginManifest[] = [exampleManifest];
+    cacheManifests(list);
+    expect(getCachedManifests()).toEqual(list);
+  });
+
+  it("cacheManifests overwrites a previous cache on refresh", () => {
+    const first: PluginManifest[] = [exampleManifest];
+    cacheManifests(first);
+    expect(getCachedManifests()).toEqual(first);
+
+    const second: PluginManifest[] = [
+      { ...exampleManifest, name: "updated", label: "Updated" },
+    ];
+    cacheManifests(second);
+    expect(getCachedManifests()).toEqual(second);
+  });
+
+  it("cacheManifests swallows storage errors", () => {
+    const badStorage = makeStorage();
+    badStorage.setItem = () => {
+      throw new Error("QuotaExceededError");
+    };
+    vi.stubGlobal("sessionStorage", badStorage);
+    expect(() => cacheManifests([exampleManifest])).not.toThrow();
+  });
+});

--- a/web/src/plugins/usePlugins.test.ts
+++ b/web/src/plugins/usePlugins.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   getCachedManifests,
   cacheManifests,
+  canSeedLoadedFromCache,
   MANIFEST_CACHE_KEY,
 } from "./usePlugins";
 import type { PluginManifest } from "./types";
@@ -98,5 +99,46 @@ describe("plugin manifest cache helpers", () => {
     };
     vi.stubGlobal("sessionStorage", badStorage);
     expect(() => cacheManifests([exampleManifest])).not.toThrow();
+  });
+});
+
+describe("canSeedLoadedFromCache (loading seed gate)", () => {
+  it("returns false when there is no cache (first visit keeps loading=true)", () => {
+    expect(canSeedLoadedFromCache(null)).toBe(false);
+  });
+
+  it("returns true for an empty cached list", () => {
+    expect(canSeedLoadedFromCache([])).toBe(true);
+  });
+
+  it("returns true when no cached manifest overrides /chat", () => {
+    const list: PluginManifest[] = [
+      exampleManifest,
+      {
+        ...exampleManifest,
+        name: "other",
+        tab: { path: "/other", override: "/skills" },
+      },
+    ];
+    expect(canSeedLoadedFromCache(list)).toBe(true);
+  });
+
+  it("returns false when a cached manifest overrides /chat — loading must stay true so App.tsx's pluginsLoading gate keeps the persistent chat host unmounted", () => {
+    const list: PluginManifest[] = [
+      exampleManifest,
+      {
+        ...exampleManifest,
+        name: "chat-replacer",
+        tab: { path: "/chat-alt", override: "/chat" },
+      },
+    ];
+    expect(canSeedLoadedFromCache(list)).toBe(false);
+  });
+
+  it("tolerates malformed cached entries missing a tab object", () => {
+    const malformed = [
+      { ...exampleManifest, tab: undefined },
+    ] as unknown as PluginManifest[];
+    expect(canSeedLoadedFromCache(malformed)).toBe(true);
   });
 });

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -17,17 +17,51 @@ import {
   setPluginLoadError,
 } from "./registry";
 
+const MANIFEST_CACHE_KEY = "hermes:plugin-manifests";
+
+function getCachedManifests(): PluginManifest[] | null {
+  try {
+    const raw = sessionStorage.getItem(MANIFEST_CACHE_KEY);
+    return raw ? (JSON.parse(raw) as PluginManifest[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function cacheManifests(manifests: PluginManifest[]): void {
+  try {
+    sessionStorage.setItem(MANIFEST_CACHE_KEY, JSON.stringify(manifests));
+  } catch {
+    // sessionStorage unavailable (private browsing, storage full, etc.)
+  }
+}
+
 export function usePlugins() {
-  const [manifests, setManifests] = useState<PluginManifest[]>([]);
+  // Lazy initialisers run once at mount — safe to read sessionStorage here.
+  // This avoids the "cannot access ref during render" lint error that would
+  // occur if we stored the cached value in a useRef and read .current in the
+  // useState initial value expression.
+  const [manifests, setManifests] = useState<PluginManifest[]>(
+    () => getCachedManifests() ?? [],
+  );
   const [plugins, setPlugins] = useState<RegisteredPlugin[]>([]);
-  const [loading, setLoading] = useState(true);
+  // Start loading=false when the cache has manifests so plugin routes are
+  // registered synchronously on the first render after a refresh.
+  // The catch-all in App.tsx is only a safety net for the very first visit
+  // (no cache yet). On subsequent visits this flag starts false immediately.
+  const [loading, setLoading] = useState<boolean>(
+    () => getCachedManifests() === null,
+  );
   const loadedScripts = useRef<Set<string>>(new Set());
 
-  // Fetch manifests on mount.
+  // Always re-fetch in the background to keep the cache fresh.
+  // This handles: new plugins added, plugins removed, manifest changes.
+  // setManifests(list) will update routes if the server list differs from cache.
   useEffect(() => {
     api
       .getPlugins()
       .then((list) => {
+        cacheManifests(list);
         setManifests(list);
         if (list.length === 0) setLoading(false);
       })

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -22,7 +22,9 @@ const MANIFEST_CACHE_KEY = "hermes:plugin-manifests";
 function getCachedManifests(): PluginManifest[] | null {
   try {
     const raw = sessionStorage.getItem(MANIFEST_CACHE_KEY);
-    return raw ? (JSON.parse(raw) as PluginManifest[]) : null;
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as PluginManifest[]) : null;
   } catch {
     return null;
   }

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -17,9 +17,9 @@ import {
   setPluginLoadError,
 } from "./registry";
 
-const MANIFEST_CACHE_KEY = "hermes:plugin-manifests";
+export const MANIFEST_CACHE_KEY = "hermes:plugin-manifests";
 
-function getCachedManifests(): PluginManifest[] | null {
+export function getCachedManifests(): PluginManifest[] | null {
   try {
     const raw = sessionStorage.getItem(MANIFEST_CACHE_KEY);
     if (!raw) return null;
@@ -30,7 +30,7 @@ function getCachedManifests(): PluginManifest[] | null {
   }
 }
 
-function cacheManifests(manifests: PluginManifest[]): void {
+export function cacheManifests(manifests: PluginManifest[]): void {
   try {
     sessionStorage.setItem(MANIFEST_CACHE_KEY, JSON.stringify(manifests));
   } catch {

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -38,6 +38,25 @@ export function cacheManifests(manifests: PluginManifest[]): void {
   }
 }
 
+/**
+ * Whether it is safe to skip the initial plugin-loading gate for a set of
+ * cached manifests.
+ *
+ * App.tsx waits on `pluginsLoading` before mounting the persistent ChatPage
+ * host: if a plugin overrides /chat (`tab.override === "/chat"`), mounting
+ * the built-in chat first would spawn a PTY and then yank it out from under
+ * the user when the plugin resolves. That gate is load-bearing — so we may
+ * only seed `loading = false` from the cache when no cached manifest
+ * declares a /chat override. Manifests are still seeded either way; only
+ * the loading flag stays conservative.
+ */
+export function canSeedLoadedFromCache(
+  cached: PluginManifest[] | null,
+): boolean {
+  if (cached === null) return false;
+  return !cached.some((m) => m.tab?.override === "/chat");
+}
+
 export function usePlugins() {
   // Lazy initialisers run once at mount — safe to read sessionStorage here.
   // This avoids the "cannot access ref during render" lint error that would
@@ -51,8 +70,12 @@ export function usePlugins() {
   // registered synchronously on the first render after a refresh.
   // The catch-all in App.tsx is only a safety net for the very first visit
   // (no cache yet). On subsequent visits this flag starts false immediately.
+  //
+  // Exception: if any cached manifest overrides /chat we must keep
+  // loading=true — App.tsx's pluginsLoading gate around the persistent
+  // ChatPage host is load-bearing (see canSeedLoadedFromCache).
   const [loading, setLoading] = useState<boolean>(
-    () => getCachedManifests() === null,
+    () => !canSeedLoadedFromCache(getCachedManifests()),
   );
   const loadedScripts = useRef<Set<string>>(new Set());
 


### PR DESCRIPTION
Salvage of #19805 by @AllardQuek — both commits cherry-picked to preserve authorship (rebased clean), plus one review follow-up commit.

## Context — what this changes for users

Dashboard plugin routes/nav rendered only after a network round-trip on every load. This seeds manifests from a per-tab sessionStorage cache for instant first paint, with stale-while-revalidate semantics (background refetch always runs and overwrites the cache). Array-validation guards reject corrupt cache entries.

## Review follow-up folded

Seeding loading=false from a stale cache silently weakened a documented invariant: App.tsx's pluginsLoading gate is load-bearing (the persistent chat host must not mount and then get yanked when a /chat-override plugin resolves from the fresh fetch). Folded canSeedLoadedFromCache(): the loading gate seeds open only when the cached manifests contain NO /chat tab.override — manifests still seed either way.

## Verification

12/12 vitest (7 original + 5 new incl. the /chat-override gate case); mutation-verified (prod reverted → 7 fail); tsc clean. Known bounded wart (documented, accepted): a disabled plugin's seeded route can flash an error pane for ~1 RTT until the background fetch prunes it — the server-side asset gate (#46435) holds, so it's UX-only.

Closes #19805.