### PR TITLE
fix(terminal): guard config bridge one-shot with a lock

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1398,6 +1398,7 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
 # succeeded — merged config always carries terminal.backend) or the import
 # failed and retrying every call would be wasted work.
 _terminal_config_bridge_attempted = False
+_terminal_config_bridge_lock = threading.Lock()
 
 
 def _ensure_terminal_env_bridged() -> None:
@@ -1420,9 +1421,10 @@ def _ensure_terminal_env_bridged() -> None:
     keep working unchanged.
     """
     global _terminal_config_bridge_attempted
-    if _terminal_config_bridge_attempted:
-        return
-    _terminal_config_bridge_attempted = True
+    with _terminal_config_bridge_lock:
+        if _terminal_config_bridge_attempted:
+            return
+        _terminal_config_bridge_attempted = True
     try:
         from hermes_cli.config import apply_terminal_config_to_env, read_raw_config
 


### PR DESCRIPTION
## Bug

`_ensure_terminal_env_bridged` used a bare boolean flag to ensure the bridge runs once. Two concurrent callers could both observe False, both enter the critical section, and both call `apply_terminal_config_to_env`.

## Fix

Wrap the check-and-set in a `threading.Lock` with a double-check after acquiring.