### PR TITLE
feat(delegate): per-call model override, gated for escalation only

### DIFF
--- a/tests/tools/test_delegate_per_call_model.py
+++ b/tests/tools/test_delegate_per_call_model.py
@@ -1,0 +1,278 @@
+"""Tests for per-call model/provider overrides in delegate_task.
+
+Covers the resolution precedence (per-task > top-level > delegation.model >
+parent inheritance), both accepted model forms (short alias and fully qualified
+id / inference URI), the operator allowlist, and the fail-fast contract: an
+invalid model must raise rather than silently fall back to the parent model.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tools.delegate_tool import _resolve_per_call_model
+
+
+class _FakeParent:
+    """Minimal stand-in for the parent agent's attribute surface."""
+
+    def __init__(self, provider="bedrock", model="parent-model"):
+        self.provider = provider
+        self.model = model
+
+
+def test_qualified_model_passes_through_verbatim():
+    """A Bedrock inference-profile ARN must not go through alias resolution."""
+    arn = (
+        "arn:aws:bedrock:eu-west-1:123456789012:inference-profile/"
+        "eu.anthropic.claude-opus-5"
+    )
+    creds = _resolve_per_call_model(arn, None, {}, _FakeParent())
+    assert creds["model"] == arn
+    assert creds["_requested_model"] == arn
+    assert creds["_alias_used"] is None
+
+
+def test_slash_qualified_model_passes_through_verbatim():
+    """An aggregator-style 'vendor/model' id is treated as qualified."""
+    creds = _resolve_per_call_model(
+        "anthropic/claude-opus-4", None, {}, _FakeParent()
+    )
+    assert creds["model"] == "anthropic/claude-opus-4"
+    assert creds["_alias_used"] is None
+
+
+def test_empty_model_raises():
+    with pytest.raises(ValueError, match="empty"):
+        _resolve_per_call_model("   ", None, {}, _FakeParent())
+
+
+def test_unknown_bare_word_raises_and_lists_aliases():
+    """Unknown model must fail loudly, never fall back to the parent model."""
+    with pytest.raises(ValueError) as exc:
+        _resolve_per_call_model("definitely-not-a-model", None, {}, _FakeParent())
+    msg = str(exc.value)
+    assert "unknown model" in msg.lower()
+    # The error is only actionable if it names valid options.
+    assert "alias" in msg.lower()
+
+
+def test_alias_resolution_uses_provider_catalog(monkeypatch):
+    """A known alias resolves against the effective provider's catalog."""
+    import hermes_cli.model_switch as ms
+
+    def _fake_resolve_alias(raw, provider):
+        assert raw == "opus"
+        assert provider == "bedrock"
+        return ("bedrock", "eu.anthropic.claude-opus-5", "opus")
+
+    monkeypatch.setattr(ms, "resolve_alias", _fake_resolve_alias)
+    creds = _resolve_per_call_model("opus", None, {}, _FakeParent())
+    assert creds["model"] == "eu.anthropic.claude-opus-5"
+    assert creds["_alias_used"] == "opus"
+
+
+def test_known_alias_unavailable_on_provider_raises(monkeypatch):
+    """A known alias with no catalog match must not degrade silently."""
+    import hermes_cli.model_switch as ms
+
+    monkeypatch.setattr(ms, "resolve_alias", lambda raw, provider: None)
+    with pytest.raises(ValueError) as exc:
+        _resolve_per_call_model("opus", None, {}, _FakeParent())
+    assert "no matching" in str(exc.value).lower()
+
+
+def test_explicit_provider_wins_over_config(monkeypatch):
+    """Per-call provider takes precedence for catalog lookup."""
+    import hermes_cli.model_switch as ms
+    import tools.delegate_tool as dt
+
+    seen = {}
+
+    def _fake_resolve_alias(raw, provider):
+        seen["provider"] = provider
+        return (provider, "some-model", raw)
+
+    monkeypatch.setattr(ms, "resolve_alias", _fake_resolve_alias)
+    # Stub the credential resolver: this test asserts which provider the alias
+    # catalog is searched against, not that real provider credentials exist.
+    monkeypatch.setattr(
+        dt,
+        "_resolve_delegation_credentials",
+        lambda cfg, parent: {"model": cfg.get("model"), "provider": cfg.get("provider")},
+    )
+    _resolve_per_call_model(
+        "opus", "openrouter", {"provider": "bedrock"}, _FakeParent()
+    )
+    assert seen["provider"] == "openrouter"
+
+
+def test_allowlist_permits_listed_model():
+    arn = "arn:aws:bedrock:eu-west-1:1:inference-profile/eu.anthropic.claude-opus-5"
+    cfg = {"allowed_models": [arn]}
+    creds = _resolve_per_call_model(arn, None, cfg, _FakeParent())
+    assert creds["model"] == arn
+
+
+def test_allowlist_rejects_unlisted_model():
+    cfg = {"allowed_models": ["anthropic/claude-sonnet-4"]}
+    with pytest.raises(ValueError) as exc:
+        _resolve_per_call_model(
+            "anthropic/claude-opus-4", None, cfg, _FakeParent()
+        )
+    msg = str(exc.value)
+    assert "not permitted" in msg
+    # Must tell the caller what IS allowed.
+    assert "anthropic/claude-sonnet-4" in msg
+
+
+def test_allowlist_accepts_string_scalar():
+    """A single string (not a list) is a valid allowlist form."""
+    cfg = {"allowed_models": "anthropic/claude-opus-4"}
+    creds = _resolve_per_call_model(
+        "anthropic/claude-opus-4", None, cfg, _FakeParent()
+    )
+    assert creds["model"] == "anthropic/claude-opus-4"
+
+
+def test_allowlist_matches_on_alias_name(monkeypatch):
+    """Allowlisting by alias works even though the resolved id differs."""
+    import hermes_cli.model_switch as ms
+
+    monkeypatch.setattr(
+        ms,
+        "resolve_alias",
+        lambda raw, provider: ("bedrock", "eu.anthropic.claude-opus-5", "opus"),
+    )
+    cfg = {"allowed_models": ["opus"]}
+    creds = _resolve_per_call_model("opus", None, cfg, _FakeParent())
+    assert creds["model"] == "eu.anthropic.claude-opus-5"
+
+
+def test_empty_allowlist_means_no_restriction():
+    """An unset/empty allowlist keeps existing configs working unchanged."""
+    for cfg in ({}, {"allowed_models": []}, {"allowed_models": None}):
+        creds = _resolve_per_call_model(
+            "anthropic/claude-opus-4", None, cfg, _FakeParent()
+        )
+        assert creds["model"] == "anthropic/claude-opus-4"
+
+
+def test_override_preserves_other_delegation_fields():
+    """Only model/provider are swapped; base_url and friends keep resolving."""
+    cfg = {"base_url": "https://example.invalid/v1", "api_key": "k-test"}
+    creds = _resolve_per_call_model(
+        "anthropic/claude-opus-4", None, cfg, _FakeParent()
+    )
+    assert creds["model"] == "anthropic/claude-opus-4"
+    assert creds["base_url"] == "https://example.invalid/v1"
+    assert creds["api_key"] == "k-test"
+
+
+def test_cfg_is_not_mutated():
+    """The shared delegation config dict must not be modified in place."""
+    cfg = {"model": "configured-model", "provider": "bedrock"}
+    snapshot = dict(cfg)
+    _resolve_per_call_model("anthropic/claude-opus-4", None, cfg, _FakeParent())
+    assert cfg == snapshot
+
+
+# --- Escalation gate: downgrade free, upgrade gated -------------------------
+
+
+_TIERS = {"model_tiers": ["haiku", "sonnet", "opus"]}
+
+
+def test_downgrade_is_always_permitted():
+    """sonnet -> haiku needs no permission: cannot blow a budget."""
+    cfg = dict(_TIERS, model="anthropic/claude-sonnet-4")
+    creds = _resolve_per_call_model(
+        "anthropic/claude-haiku-3", None, cfg, _FakeParent()
+    )
+    assert creds["model"] == "anthropic/claude-haiku-3"
+
+
+def test_upgrade_is_blocked_without_allow_escalation():
+    """sonnet -> opus must fail while allow_escalation is unset."""
+    cfg = dict(_TIERS, model="anthropic/claude-sonnet-4")
+    with pytest.raises(ValueError) as exc:
+        _resolve_per_call_model(
+            "anthropic/claude-opus-4", None, cfg, _FakeParent()
+        )
+    msg = str(exc.value)
+    assert "escalation" in msg.lower()
+    assert "sonnet -> opus" in msg
+    # The error must name the exact opt-in switch.
+    assert "allow_escalation" in msg
+
+
+def test_upgrade_permitted_when_allow_escalation_true():
+    cfg = dict(_TIERS, model="anthropic/claude-sonnet-4", allow_escalation=True)
+    creds = _resolve_per_call_model(
+        "anthropic/claude-opus-4", None, cfg, _FakeParent()
+    )
+    assert creds["model"] == "anthropic/claude-opus-4"
+
+
+def test_same_tier_is_not_an_escalation():
+    """Switching within a tier is neither up nor down."""
+    cfg = dict(_TIERS, model="anthropic/claude-sonnet-4")
+    creds = _resolve_per_call_model(
+        "anthropic/claude-sonnet-4-5", None, cfg, _FakeParent()
+    )
+    assert creds["model"] == "anthropic/claude-sonnet-4-5"
+
+
+def test_escalation_baseline_falls_back_to_parent_model():
+    """With no delegation.model, the parent's model is the baseline."""
+    cfg = dict(_TIERS)
+    parent = _FakeParent(model="anthropic/claude-sonnet-4")
+    with pytest.raises(ValueError, match="escalation"):
+        _resolve_per_call_model("anthropic/claude-opus-4", None, cfg, parent)
+
+
+def test_escalation_gate_matches_tier_inside_inference_uri():
+    """A Bedrock ARN must be ranked by the tier substring it contains."""
+    cfg = dict(_TIERS, model="anthropic/claude-sonnet-4")
+    arn = (
+        "arn:aws:bedrock:eu-west-1:1:inference-profile/"
+        "eu.anthropic.claude-opus-5"
+    )
+    with pytest.raises(ValueError, match="escalation"):
+        _resolve_per_call_model(arn, None, cfg, _FakeParent())
+
+
+def test_no_tiers_configured_means_no_gate():
+    """Without model_tiers there is no ladder — full backward compatibility."""
+    cfg = {"model": "anthropic/claude-sonnet-4"}
+    creds = _resolve_per_call_model(
+        "anthropic/claude-opus-4", None, cfg, _FakeParent()
+    )
+    assert creds["model"] == "anthropic/claude-opus-4"
+
+
+def test_unranked_model_is_not_gated():
+    """A model outside the ladder cannot be compared, so it passes."""
+    cfg = dict(_TIERS, model="anthropic/claude-sonnet-4")
+    creds = _resolve_per_call_model(
+        "mistral/mistral-large", None, cfg, _FakeParent()
+    )
+    assert creds["model"] == "mistral/mistral-large"
+
+
+def test_allowlist_and_escalation_gate_compose():
+    """Allowlist is checked first; escalation gate applies to what survives."""
+    cfg = dict(
+        _TIERS,
+        model="anthropic/claude-sonnet-4",
+        allowed_models=["anthropic/claude-opus-4"],
+    )
+    # Rejected by the allowlist, not the ladder.
+    with pytest.raises(ValueError, match="not permitted"):
+        _resolve_per_call_model(
+            "anthropic/claude-haiku-3", None, cfg, _FakeParent()
+        )
+    # Allowlisted but still an escalation.
+    with pytest.raises(ValueError, match="escalation"):
+        _resolve_per_call_model(
+            "anthropic/claude-opus-4", None, cfg, _FakeParent()
+        )

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2783,6 +2783,8 @@ def delegate_task(
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
     background: Optional[bool] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2862,6 +2864,21 @@ def delegate_task(
     except ValueError as exc:
         return tool_error(str(exc))
 
+    # Per-call model/provider override (top-level). A per-task override in
+    # tasks[] beats this; this beats delegation.model, which beats inheritance
+    # from the parent. Resolved eagerly so an invalid value fails before any
+    # child is built — never a silent fallback to the parent model.
+    if model:
+        try:
+            creds = _resolve_per_call_model(model, provider, cfg, parent_agent)
+        except ValueError as exc:
+            return tool_error(str(exc))
+    elif provider:
+        return tool_error(
+            "delegate_task: 'provider' requires 'model' on the same call — a "
+            "provider without a model cannot be resolved unambiguously."
+        )
+
     # Normalize to task list
     max_children = _get_max_concurrent_children()
     recovered_tasks, tasks_error = _recover_tasks_from_json_string(tasks)
@@ -2937,10 +2954,30 @@ def delegate_task(
     # toolset resolution never leaks into the parent (shared with the plugin
     # subagent-lifecycle API).
     children = []
+    child_creds: List[dict] = []
     for i, t in enumerate(task_list):
         # Per-task role beats top-level; normalise again so unknown
         # per-task values warn and degrade to leaf uniformly.
         effective_role = _normalize_role(t.get("role") or top_role)
+        # Per-task model/provider beats the top-level override, which beats
+        # delegation.model. Resolved inside the loop so a batch can mix models
+        # (e.g. mechanical extraction on a small model, adversarial review on a
+        # strong one) within a single call.
+        t_creds = creds
+        t_model = t.get("model")
+        if t_model:
+            try:
+                t_creds = _resolve_per_call_model(
+                    str(t_model), t.get("provider"), cfg, parent_agent
+                )
+            except ValueError as exc:
+                return tool_error(f"Task {i}: {exc}")
+        elif t.get("provider"):
+            return tool_error(
+                f"Task {i}: 'provider' requires 'model' on the same task — a "
+                f"provider without a model cannot be resolved unambiguously."
+            )
+        child_creds.append(t_creds)
         child = _build_child_preserving_parent_tools(
             task_index=i,
             goal=t["goal"],
@@ -2948,18 +2985,18 @@ def delegate_task(
             # Subagents always inherit the parent's toolsets; the model
             # cannot choose or narrow them (no model-facing toolsets arg).
             toolsets=None,
-            model=creds["model"],
+            model=t_creds["model"],
             max_iterations=effective_max_iter,
             task_count=n_tasks,
             parent_agent=parent_agent,
-            override_provider=creds["provider"],
-            override_base_url=creds["base_url"],
-            override_api_key=creds["api_key"],
-            override_api_mode=creds["api_mode"],
-            override_request_overrides=creds.get("request_overrides"),
-            override_max_tokens=creds.get("max_output_tokens"),
-            override_acp_command=creds.get("command"),
-            override_acp_args=creds.get("args"),
+            override_provider=t_creds["provider"],
+            override_base_url=t_creds["base_url"],
+            override_api_key=t_creds["api_key"],
+            override_api_mode=t_creds["api_mode"],
+            override_request_overrides=t_creds.get("request_overrides"),
+            override_max_tokens=t_creds.get("max_output_tokens"),
+            override_acp_command=t_creds.get("command"),
+            override_acp_args=t_creds.get("args"),
             role=effective_role,
         )
         # Tee the child's progress events into its live transcript log.
@@ -3315,6 +3352,20 @@ def delegate_task(
             return tuple(parts), in_tool
 
         _goals = [t["goal"] for t in task_list]
+        # Report the resolved model. When a batch mixes per-task models, a
+        # single value would be misleading, so summarise the distinct set — the
+        # completion block is the only place the caller learns what actually ran.
+        _distinct_models = []
+        for _c in child_creds:
+            _m = _c.get("model")
+            if _m and _m not in _distinct_models:
+                _distinct_models.append(_m)
+        if len(_distinct_models) == 1:
+            _batch_model = _distinct_models[0]
+        elif _distinct_models:
+            _batch_model = ", ".join(_distinct_models)
+        else:
+            _batch_model = creds["model"]
         dispatch = dispatch_async_delegation_batch(
             goals=_goals,
             context=context,
@@ -3322,7 +3373,7 @@ def delegate_task(
             # parent's toolsets (no model-facing toolsets arg).
             toolsets=None,
             role=top_role,
-            model=creds["model"],
+            model=_batch_model,
             session_key=_session_key,
             origin_ui_session_id=_origin_ui_session_id,
             origin_session_id=_wake_sid,
@@ -3474,6 +3525,199 @@ def _resolve_child_credential_pool(
             exc,
         )
     return None
+
+
+def _resolve_per_call_model(
+    raw_model: str,
+    raw_provider: Optional[str],
+    cfg: dict,
+    parent_agent,
+) -> dict:
+    """Resolve a per-call ``model`` (and optional ``provider``) override.
+
+    Accepts two forms for *raw_model*:
+
+    1. **Alias** — ``"sonnet"``, ``"opus"``, ``"gpt5"``, … resolved against the
+       effective provider's catalog via :func:`hermes_cli.model_switch.resolve_alias`.
+       Keeps calls portable: the same alias maps to whatever the operator's
+       provider actually offers.
+    2. **Fully qualified model id / inference URI** — passed through verbatim.
+       Required for Bedrock inference profiles
+       (``arn:aws:bedrock:<region>:<acct>:inference-profile/…``), which are
+       account- and region-specific and cannot be expressed as an alias.
+
+    The override is layered on top of ``delegation.*`` so every other credential
+    field (base_url, api_key, api_mode, request_overrides) keeps resolving
+    through the existing code path — this function only swaps model/provider
+    into a copy of *cfg* and re-runs the normal resolver.
+
+    Enforces the operator allowlist ``delegation.allowed_models`` when set, so
+    model choice stays under operator control even though the *call* selects it.
+
+    Raises ValueError with an actionable message; never silently falls back to
+    the parent model. A silent fallback is worse than an error here: the caller
+    would believe an expensive/strong model ran when it did not.
+    """
+    requested = str(raw_model or "").strip()
+    if not requested:
+        raise ValueError("delegate_task: 'model' was provided but empty.")
+
+    # Provider that the alias catalog should be searched against: explicit
+    # per-call provider > delegation.provider > parent's provider.
+    effective_provider = (
+        str(raw_provider or "").strip()
+        or str(cfg.get("provider") or "").strip()
+        or str(getattr(parent_agent, "provider", "") or "").strip()
+    )
+
+    resolved_model = requested
+    resolved_provider = str(raw_provider or "").strip() or None
+    alias_used: Optional[str] = None
+
+    # A value containing ':' or '/' is treated as an explicit id/URI, not an
+    # alias — this covers Bedrock ARNs, OpenRouter 'vendor/model' ids and
+    # LiteLLM-style prefixes. Bare words go through alias resolution.
+    looks_qualified = (":" in requested) or ("/" in requested)
+
+    if not looks_qualified:
+        try:
+            from hermes_cli.model_switch import MODEL_ALIASES, resolve_alias
+
+            hit = resolve_alias(requested, effective_provider) if effective_provider else None
+            if hit is not None:
+                alias_provider, alias_model, alias_name = hit
+                resolved_model = alias_model
+                alias_used = alias_name
+                # Only adopt the alias' provider when the caller did not pin one.
+                if resolved_provider is None and alias_provider:
+                    resolved_provider = alias_provider
+            elif requested.lower() in MODEL_ALIASES:
+                # Known alias, but the effective provider offers no match.
+                raise ValueError(
+                    f"delegate_task: model alias '{requested}' is known but no matching "
+                    f"model is available on provider '{effective_provider or '(unset)'}'. "
+                    f"Pass a fully qualified model id instead, or set 'provider' on the "
+                    f"same call."
+                )
+            else:
+                known = ", ".join(sorted(MODEL_ALIASES)[:12])
+                raise ValueError(
+                    f"delegate_task: unknown model '{requested}'. Pass a known alias "
+                    f"(e.g. {known}) or a fully qualified model id / inference URI "
+                    f"(containing '/' or ':')."
+                )
+        except ImportError:
+            # Alias machinery unavailable — treat the value as a literal id
+            # rather than failing the delegation outright.
+            logger.debug(
+                "delegate_task: model alias resolution unavailable; using %r verbatim",
+                requested,
+            )
+
+    # Operator allowlist. Empty/unset means "no restriction" so existing
+    # configs keep working unchanged.
+    allowed = cfg.get("allowed_models")
+    if allowed:
+        if isinstance(allowed, str):
+            allowed_list = [allowed]
+        else:
+            try:
+                allowed_list = [str(x) for x in allowed]
+            except TypeError:
+                allowed_list = []
+        norm = {a.strip().lower() for a in allowed_list if str(a).strip()}
+        candidates = {resolved_model.strip().lower(), requested.lower()}
+        if alias_used:
+            candidates.add(alias_used.lower())
+        if norm and not (candidates & norm):
+            raise ValueError(
+                f"delegate_task: model '{requested}' is not permitted. "
+                f"delegation.allowed_models restricts subagents to: "
+                f"{', '.join(sorted(norm))}."
+            )
+
+    # Escalation gate: downgrading is free, upgrading needs explicit permission.
+    #
+    # Rationale: the asymmetry is the whole point. Routing a mechanical subtask
+    # to a cheaper/weaker model can waste a little quality but cannot blow a
+    # budget or leak work to a stronger-but-costlier tier. Routing to a stronger
+    # model can do both, and the caller making that choice is a language model,
+    # not the operator. So: moving DOWN the ladder is always allowed; moving UP
+    # requires the operator to have opted in.
+    #
+    # Hermes cannot infer the ladder itself — there is no reliable cross-provider
+    # cost/tier metadata in-tree, and inferring rank from model names would be
+    # guesswork that breaks on every new release. The operator therefore declares
+    # it explicitly:
+    #
+    #     delegation:
+    #       model_tiers: [haiku, sonnet, opus]   # cheapest → strongest
+    #       allow_escalation: false              # default when tiers are set
+    #
+    # With no ``model_tiers`` configured there is no ladder, so no gate — fully
+    # backward compatible.
+    tiers_raw = cfg.get("model_tiers")
+    if tiers_raw and not is_truthy_value(cfg.get("allow_escalation")):
+        if isinstance(tiers_raw, str):
+            tiers = [tiers_raw]
+        else:
+            try:
+                tiers = [str(x) for x in tiers_raw]
+            except TypeError:
+                tiers = []
+        ladder = [t.strip().lower() for t in tiers if str(t).strip()]
+
+        def _rank(*names: Optional[str]) -> Optional[int]:
+            """Best (highest) ladder index matching any of *names*.
+
+            Matches an exact ladder entry or a ladder entry contained in the
+            model id, so ``opus`` ranks an ARN ending in
+            ``eu.anthropic.claude-opus-5``.
+            """
+            best: Optional[int] = None
+            for name in names:
+                if not name:
+                    continue
+                low = str(name).strip().lower()
+                for idx, tier in enumerate(ladder):
+                    if low == tier or tier in low:
+                        if best is None or idx > best:
+                            best = idx
+            return best
+
+        # Baseline the request is measured against: the configured delegation
+        # model if present, else the parent's model.
+        baseline_rank = _rank(
+            str(cfg.get("model") or "").strip() or None,
+            getattr(parent_agent, "model", None),
+        )
+        target_rank = _rank(resolved_model, requested, alias_used)
+
+        if (
+            baseline_rank is not None
+            and target_rank is not None
+            and target_rank > baseline_rank
+        ):
+            raise ValueError(
+                f"delegate_task: model '{requested}' is an escalation "
+                f"({ladder[baseline_rank]} -> {ladder[target_rank]}) and "
+                f"delegation.allow_escalation is not enabled. Downgrades are "
+                f"always permitted; to allow subagents to select a stronger "
+                f"model, set delegation.allow_escalation: true (optionally "
+                f"narrowing delegation.allowed_models)."
+            )
+
+    # Layer the override onto a copy of the delegation config and reuse the
+    # normal resolver so base_url/api_key/api_mode keep their semantics.
+    merged = dict(cfg)
+    merged["model"] = resolved_model
+    if resolved_provider:
+        merged["provider"] = resolved_provider
+
+    creds = _resolve_delegation_credentials(merged, parent_agent)
+    creds["_requested_model"] = requested
+    creds["_alias_used"] = alias_used
+    return creds
 
 
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
@@ -3819,6 +4063,29 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override. Beats the top-level 'model', "
+                                "which beats delegation.model in config.yaml. Accepts "
+                                "either a short alias ('sonnet', 'opus', 'haiku', "
+                                "'gpt5') resolved against the active provider's "
+                                "catalog, or a fully qualified model id / inference "
+                                "URI (anything containing '/' or ':', e.g. an AWS "
+                                "Bedrock inference-profile ARN). Lets one batch mix "
+                                "models: a cheap model for mechanical work, a strong "
+                                "one for reasoning-heavy work. Invalid values fail the "
+                                "call with an error instead of silently falling back."
+                            ),
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": (
+                                "Per-task provider override. Requires 'model' on the "
+                                "same task. Only needed to route a task to a different "
+                                "provider than delegation.provider."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -3842,6 +4109,32 @@ DELEGATE_TASK_SCHEMA = {
                     "the work finishes; just continue working in the meantime. "
                     "Setting this has no effect; the parameter remains only for "
                     "backward compatibility."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Model for the subagent(s) of THIS call. Overrides "
+                    "delegation.model from config.yaml; a per-task 'model' in "
+                    "tasks[] overrides this. Accepts either a short alias "
+                    "('sonnet', 'opus', 'haiku', 'gpt5') resolved against the "
+                    "active provider's catalog, or a fully qualified model id / "
+                    "inference URI (anything containing '/' or ':', e.g. an AWS "
+                    "Bedrock inference-profile ARN). Use a cheap model for "
+                    "mechanical, well-specified work and a strong one for "
+                    "reasoning-heavy work. Omit to inherit the configured or "
+                    "parent model. Invalid values fail the call with an error "
+                    "listing valid aliases — there is no silent fallback. The "
+                    "operator can restrict the permitted set via "
+                    "delegation.allowed_models."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Provider for the subagent(s) of THIS call. Requires 'model' "
+                    "on the same call. Only needed to route to a different "
+                    "provider than delegation.provider; omit otherwise."
                 ),
             },
         },
@@ -3904,6 +4197,8 @@ registry.register(
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
+        model=args.get("model"),
+        provider=args.get("provider"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## This proposes a feature that's been rejected repeatedly — read this first

Per-call model overrides for `delegate_task` have been proposed at least a
dozen times (#3172, #6771, #12715, #12794, #16163, #17756, #35033, #37966,
#50015, #63461, #64299, #64970, #64988, #65008, and the open feature request
#72394) and closed every time under a "standing `delegation-model-routing`
policy." @teknium1 gave the only substantive maintainer response I could find,
on #12794: "We do not want this." No elaboration followed in that thread, and
I couldn't find one anywhere else in the repo (Discussions are disabled).
Every other close cites that one sentence plus the removal commit
(`fb0f579b1`, restated in `a6f08ff0c`).

I'm not resubmitting the same thing hoping for a different outcome. Every
prior PR let the model route freely in both directions — cheaper or more
expensive, no distinction. I think that's exactly what earned the rejection,
and the reasoning is visible elsewhere in this codebase: `delegate_task` has
had two other model-facing parameters removed for letting the model set an
operational bound the operator didn't intend — `toolsets` (#56386: capability
scope is the operator's call, not the model's) and `max_iterations` (#14732:
a model guessed 40 and silently overrode a configured 250 mid-audit). Free
bidirectional model routing reproduces that same failure for cost/quality: a
model can dispatch a security-review subagent onto `haiku` and hand back a
summary indistinguishable from a real review, with the operator never in the
loop.

This PR removes exactly that failure mode while keeping the capability that's
actually missing today. `delegation.model` is one value for every subagent in
a session — a single batch with "list this directory" and "review this diff
for a security defect" has no way to put them on different models at all.
That's a real gap, and closing it doesn't require giving the model free rein:

- `delegation.model_tiers` — an explicit, operator-declared cheapest-to-
  strongest ladder (not inferred: there's no reliable cross-provider cost
  metadata in-tree, and ranking by model name breaks on every release).
- `delegation.allow_escalation` — off by default. A per-call `model` can
  select the parent's tier or cheaper without it; asking for something
  stronger raises with the tier list rather than clamping or silently
  falling back to the parent model.
- `delegation.allowed_models` — a hard allowlist, independent of tiers, for
  operators who want to cap the option set outright regardless of direction.

Downgrading can cost some quality but can't blow a budget. Upgrading can do
both, and the party asking here is a language model, not the operator. So the
model can make a task cheaper on its own judgment, and needs explicit
operator permission to make it more expensive. That's the same asymmetry
`max_iterations` enforces for iteration budgets, applied to model selection.

## Changes

- `tools/delegate_tool.py` (+315/-10): `model` / `provider` params on
  `delegate_task()`, top-level and per-task schema entries. New
  `_resolve_per_call_model()`: alias resolution via the existing
  `MODEL_ALIASES` catalog (`sonnet`/`opus`/`haiku`) vs. fully-qualified IDs —
  Bedrock inference-profile ARNs require the qualified form, so aliasing is
  skipped whenever the input already looks qualified. Tier/allowlist/
  escalation-gate enforcement. Batch completion reports the distinct set of
  resolved models instead of a single value.
- `tests/tools/test_delegate_per_call_model.py` (new, 278 lines): resolution
  precedence (per-task > top-level > `delegation.model` > parent
  inheritance), both accepted model forms, the allowlist, the escalation
  gate in both directions, and the fail-fast contract — an invalid or
  disallowed model raises with an actionable message, never a silent
  fallback to the parent model (a silent fallback would leave the caller
  believing a different model ran than actually did — the trust gap #72394
  raises independently of this PR).

## Backward compatibility

No new config keys set → no behavior change. `delegation.model` alone still
works exactly as before.

## Validation

- New tests: 23 passed (`tests/tools/test_delegate_per_call_model.py`).
- Full delegate regression: `tests/tools/test_delegate.py` +
  `test_async_delegation.py` — 82 passed, unmodified, no regressions.
  105/105 total across all three files.
- Live: exercised against a running Hermes/Bedrock session — per-call
  `model="haiku"` on one task and `model="opus"` on another in the same
  batch, with `delegation.model_tiers` set and `allow_escalation` unset;
  the escalation attempt raised with the tier list instead of running
  silently on the requested model.

## Prior art credited

The alias-vs-qualified-ID handling and the general resolution-chain shape
follow the pattern several closed PRs above converged on independently. The
tiered escalation gate is, as far as I found in the linked history, new to
this attempt — none of the prior PRs proposed asymmetric up/down permissions,
which is why I don't think this is the same PR getting resubmitted.
