### PR TITLE
fix(trace-upload): close session database after transcript load

### DIFF
--- a/agent/trace_upload.py
+++ b/agent/trace_upload.py
@@ -336,10 +336,13 @@ def load_session_messages(
     """
     from hermes_state import SessionDB
     db = SessionDB(db_path=db_path) if db_path else SessionDB()
-    resolved = db.resolve_session_id(session_id) or session_id
-    meta = db.get_session(resolved) or {}
-    messages = db.get_messages_as_conversation(resolved)
-    return messages, meta
+    try:
+        resolved = db.resolve_session_id(session_id) or session_id
+        meta = db.get_session(resolved) or {}
+        messages = db.get_messages_as_conversation(resolved)
+        return messages, meta
+    finally:
+        db.close()
 
 
 def upload_session_trace(

--- a/tests/agent/test_trace_upload.py
+++ b/tests/agent/test_trace_upload.py
@@ -118,9 +118,29 @@ def test_converter_keeps_secrets_when_redact_disabled():
 # ---------------------------------------------------------------------------
 
 
+def test_load_session_messages_closes_session_db(monkeypatch):
+    fake_db = MagicMock()
+    fake_db.resolve_session_id.return_value = "resolved"
+    fake_db.get_session.return_value = {"id": "resolved"}
+    fake_db.get_messages_as_conversation.return_value = _sample_messages()
+    monkeypatch.setattr("hermes_state.SessionDB", MagicMock(return_value=fake_db))
+
+    messages, meta = trace_upload.load_session_messages("prefix")
+
+    assert messages == _sample_messages()
+    assert meta == {"id": "resolved"}
+    fake_db.close.assert_called_once_with()
 
 
+def test_load_session_messages_closes_session_db_after_read_failure(monkeypatch):
+    fake_db = MagicMock()
+    fake_db.resolve_session_id.side_effect = RuntimeError("read failed")
+    monkeypatch.setattr("hermes_state.SessionDB", MagicMock(return_value=fake_db))
 
+    with pytest.raises(RuntimeError, match="read failed"):
+        trace_upload.load_session_messages("prefix")
+
+    fake_db.close.assert_called_once_with()
 
 
 def test_upload_happy_path_mocked(monkeypatch):
@@ -159,9 +179,6 @@ def test_upload_happy_path_mocked(monkeypatch):
     first = json.loads(body.strip().split("\n")[0])
     assert first["type"] in ("user", "assistant")
     assert first["sessionId"] == "20260531_abc"
-
-
-
 
 
 


### PR DESCRIPTION
## What does this PR do?

`load_session_messages()` opened a fresh `SessionDB` for every trace upload but
returned without closing it. Repeated `/upload-trace` or `hermes trace upload`
calls therefore left connection cleanup to garbage collection, including when
a transcript read raised.

This closes the function-owned database in `finally`, preserving the existing
return values and exception behavior.

## Related Issue

No existing issue. This was found by auditing short-lived `SessionDB`
ownership on the current default branch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/trace_upload.py`: close the transcript loader's `SessionDB` in a
  `finally` block.
- `tests/agent/test_trace_upload.py`: verify deterministic close behavior after
  both a successful read and a propagated read failure.

## How to Test

1. Replace `SessionDB` with a recording fake.
2. Load a transcript successfully and confirm `close()` is called once.
3. Raise during session resolution and confirm `close()` is still called once.

Automated validation:

- `python -m pytest tests/agent/test_trace_upload.py -q` - 7 passed, 1 skipped
  because `huggingface_hub` is an optional local dependency
- `HERMES_PYTHON=... scripts/run_tests.sh tests/agent/test_trace_upload.py -q`
  - 7 passed, 0 failed with the repository's hermetic runner
- `python -m ruff check agent/trace_upload.py tests/agent/test_trace_upload.py`
- `python -m py_compile agent/trace_upload.py tests/agent/test_trace_upload.py`
- `git diff --check`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (focused trace-upload tests
  passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; behavior and public API are unchanged
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A; no workflow changed
- [x] Cross-platform impact considered; this is platform-neutral SQLite
  resource cleanup
- [x] Tool descriptions/schemas are N/A; no tool surface changed

## Screenshots / Logs

Not applicable.
