### PR TITLE
refactor(gateway): extract media/event helpers from run.py (slice 7 of #54962)

### DIFF
--- a/gateway/media_helpers.py
+++ b/gateway/media_helpers.py
@@ -1,0 +1,170 @@
+"""Media/event-handling helpers extracted from ``gateway/run.py``.
+
+Pure helpers that classify message attachments (image/audio/video/STT),
+build media placeholders and document context notes, and probe audio
+durations.  Part of the god-file shrink of ``gateway/run.py`` (#54962).
+
+Moved verbatim from ``gateway/run.py`` — zero behavior change.  ``gateway/run``
+re-exports these names so existing ``gateway.run.<name>`` references and
+test monkeypatches keep working.
+"""
+
+import asyncio
+import os
+from typing import Optional
+
+from gateway.platforms.base import MessageType
+
+
+def _event_media_type_at(event, index: int) -> str:
+    """Return the per-attachment MIME for the attachment at *index*.
+
+    Empty string when the platform didn't populate a per-file MIME for
+    that slot (some adapters only set a message-level type).
+    """
+    media_types = getattr(event, "media_types", None) or []
+    return media_types[index] if index < len(media_types) else ""
+
+
+def _event_media_is_image(event, index: int) -> bool:
+    """True if the attachment at *index* is an image.
+
+    Trust the per-attachment MIME when present. Only fall back to the
+    message-level ``PHOTO`` type when this attachment's MIME is unknown --
+    otherwise a document (or any non-image) uploaded alongside an image in
+    the same message gets mis-routed as an image, base64'd into a vision
+    content part, and the provider 400s ("Could not process image").
+    """
+    mtype = _event_media_type_at(event, index)
+    if mtype:
+        return mtype.startswith("image/")
+    return getattr(event, "message_type", None) == MessageType.PHOTO
+
+
+def _event_media_is_audio(event, index: int) -> bool:
+    """True if the attachment at *index* is audio (per-attachment MIME first)."""
+    mtype = _event_media_type_at(event, index)
+    if mtype:
+        return mtype.startswith("audio/")
+    return getattr(event, "message_type", None) in {MessageType.VOICE, MessageType.AUDIO}
+
+
+def _event_media_is_stt_input(event, index: int) -> bool:
+    """True when an audio attachment should enter the automatic STT pipeline."""
+    message_type = getattr(event, "message_type", None)
+    if message_type in {MessageType.AUDIO, MessageType.DOCUMENT}:
+        return False
+    return (
+        message_type == MessageType.VOICE
+        or _event_media_type_at(event, index).startswith("audio/")
+    )
+
+
+def _event_media_is_video(event, index: int) -> bool:
+    """True if the attachment at *index* is video (per-attachment MIME first)."""
+    mtype = _event_media_type_at(event, index)
+    if mtype:
+        return mtype.startswith("video/")
+    return getattr(event, "message_type", None) == MessageType.VIDEO
+
+
+def _build_media_placeholder(event) -> str:
+    """Build a text placeholder for media-only events so they aren't dropped.
+
+    When a photo/document is queued during active processing and later
+    dequeued, only .text is extracted.  If the event has no caption,
+    the media would be silently lost.  This builds a placeholder that
+    the vision enrichment pipeline will replace with a real description.
+    """
+    parts = []
+    media_urls = getattr(event, "media_urls", None) or []
+    for i, url in enumerate(media_urls):
+        if _event_media_is_image(event, i):
+            parts.append(f"[User sent an image: {url}]")
+        elif _event_media_is_audio(event, i):
+            parts.append(f"[User sent audio: {url}]")
+        elif _event_media_is_video(event, i):
+            parts.append(f"[User sent a video: {url}]")
+        else:
+            parts.append(f"[User sent a file: {url}]")
+    return "\n".join(parts)
+
+
+def _build_document_context_note(display_name: str, agent_path: str, mtype: str) -> str:
+    """Context note prepended to a user turn when they attach a document.
+
+    Text documents (``text/*``) have their content inlined upstream by the
+    platform adapter, so the note just confirms that and records the path.
+
+    Binary documents (PDF, DOCX, XLSX, …) cannot be inlined as text. The note
+    must tell the agent to *extract* the text itself before answering — earlier
+    wording ("Ask the user what they'd like you to do with it") steered the
+    model into punting back to the user, which is why attached PDFs/DOCX looked
+    "unreadable" to the agent even though it has the tools to read them.
+    """
+    if mtype.startswith("text/"):
+        return (
+            f"[The user sent a text document: '{display_name}'. "
+            f"Its content has been included below. "
+            f"The file is also saved at: {agent_path}]"
+        )
+    return (
+        f"[The user sent a document: '{display_name}'. It is saved at: {agent_path}. "
+        f"Its text is not inlined here (it's a binary format such as PDF or DOCX). "
+        f"To read it, extract the document's text yourself — for example with the "
+        f"terminal tool or the ocr-and-documents skill — before answering, instead "
+        f"of asking the user to paste the contents.]"
+    )
+
+
+def _format_duration(seconds: float) -> str:
+    total = int(round(seconds))
+    if total < 0:
+        total = 0
+    hours, rem = divmod(total, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{secs:02d}"
+    return f"{minutes}:{secs:02d}"
+
+
+async def _probe_audio_duration(path: str) -> Optional[str]:
+    """Best-effort duration probe. Returns formatted MM:SS / HH:MM:SS, or None on failure."""
+    ext = os.path.splitext(path)[1].lower()
+
+    if ext == ".wav":
+        try:
+            def _wav_duration() -> float:
+                import wave
+                with wave.open(path, "rb") as wf:
+                    frames = wf.getnframes()
+                    rate = wf.getframerate() or 1
+                    return frames / float(rate)
+            secs = await asyncio.to_thread(_wav_duration)
+            return _format_duration(secs)
+        except Exception:
+            pass
+
+    if ext in (".ogg", ".opus", ".oga"):
+        try:
+            def _ogg_duration() -> float:
+                from mutagen.oggopus import OggOpus
+                return float(OggOpus(path).info.length)
+            secs = await asyncio.to_thread(_ogg_duration)
+            return _format_duration(secs)
+        except Exception:
+            pass
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "ffprobe", "-v", "error", "-show_entries", "format=duration",
+            "-of", "default=noprint_wrappers=1:nokey=1", path,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5.0)
+        if proc.returncode == 0:
+            return _format_duration(float(stdout.decode().strip()))
+    except Exception:
+        pass
+
+    return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2256,6 +2256,17 @@ from gateway.session_state import (
 )
 from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
+from gateway.media_helpers import (
+    _build_document_context_note,
+    _build_media_placeholder,
+    _event_media_is_audio,
+    _event_media_is_image,
+    _event_media_is_stt_input,
+    _event_media_is_video,
+    _event_media_type_at,
+    _format_duration,
+    _probe_audio_duration,
+)
 from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.turn_context import TurnContext
 from gateway.platforms.base import (
@@ -2546,159 +2557,6 @@ def _try_resolve_fallback_provider() -> dict | None:
         pass
     return None
 
-
-def _event_media_type_at(event, index: int) -> str:
-    """Return the per-attachment MIME for the attachment at *index*.
-
-    Empty string when the platform didn't populate a per-file MIME for
-    that slot (some adapters only set a message-level type).
-    """
-    media_types = getattr(event, "media_types", None) or []
-    return media_types[index] if index < len(media_types) else ""
-
-
-def _event_media_is_image(event, index: int) -> bool:
-    """True if the attachment at *index* is an image.
-
-    Trust the per-attachment MIME when present. Only fall back to the
-    message-level ``PHOTO`` type when this attachment's MIME is unknown --
-    otherwise a document (or any non-image) uploaded alongside an image in
-    the same message gets mis-routed as an image, base64'd into a vision
-    content part, and the provider 400s ("Could not process image").
-    """
-    mtype = _event_media_type_at(event, index)
-    if mtype:
-        return mtype.startswith("image/")
-    return getattr(event, "message_type", None) == MessageType.PHOTO
-
-
-def _event_media_is_audio(event, index: int) -> bool:
-    """True if the attachment at *index* is audio (per-attachment MIME first)."""
-    mtype = _event_media_type_at(event, index)
-    if mtype:
-        return mtype.startswith("audio/")
-    return getattr(event, "message_type", None) in {MessageType.VOICE, MessageType.AUDIO}
-
-
-def _event_media_is_stt_input(event, index: int) -> bool:
-    """True when an audio attachment should enter the automatic STT pipeline."""
-    message_type = getattr(event, "message_type", None)
-    if message_type in {MessageType.AUDIO, MessageType.DOCUMENT}:
-        return False
-    return (
-        message_type == MessageType.VOICE
-        or _event_media_type_at(event, index).startswith("audio/")
-    )
-
-
-def _event_media_is_video(event, index: int) -> bool:
-    """True if the attachment at *index* is video (per-attachment MIME first)."""
-    mtype = _event_media_type_at(event, index)
-    if mtype:
-        return mtype.startswith("video/")
-    return getattr(event, "message_type", None) == MessageType.VIDEO
-
-
-def _build_media_placeholder(event) -> str:
-    """Build a text placeholder for media-only events so they aren't dropped.
-
-    When a photo/document is queued during active processing and later
-    dequeued, only .text is extracted.  If the event has no caption,
-    the media would be silently lost.  This builds a placeholder that
-    the vision enrichment pipeline will replace with a real description.
-    """
-    parts = []
-    media_urls = getattr(event, "media_urls", None) or []
-    for i, url in enumerate(media_urls):
-        if _event_media_is_image(event, i):
-            parts.append(f"[User sent an image: {url}]")
-        elif _event_media_is_audio(event, i):
-            parts.append(f"[User sent audio: {url}]")
-        elif _event_media_is_video(event, i):
-            parts.append(f"[User sent a video: {url}]")
-        else:
-            parts.append(f"[User sent a file: {url}]")
-    return "\n".join(parts)
-
-
-def _build_document_context_note(display_name: str, agent_path: str, mtype: str) -> str:
-    """Context note prepended to a user turn when they attach a document.
-
-    Text documents (``text/*``) have their content inlined upstream by the
-    platform adapter, so the note just confirms that and records the path.
-
-    Binary documents (PDF, DOCX, XLSX, …) cannot be inlined as text. The note
-    must tell the agent to *extract* the text itself before answering — earlier
-    wording ("Ask the user what they'd like you to do with it") steered the
-    model into punting back to the user, which is why attached PDFs/DOCX looked
-    "unreadable" to the agent even though it has the tools to read them.
-    """
-    if mtype.startswith("text/"):
-        return (
-            f"[The user sent a text document: '{display_name}'. "
-            f"Its content has been included below. "
-            f"The file is also saved at: {agent_path}]"
-        )
-    return (
-        f"[The user sent a document: '{display_name}'. It is saved at: {agent_path}. "
-        f"Its text is not inlined here (it's a binary format such as PDF or DOCX). "
-        f"To read it, extract the document's text yourself — for example with the "
-        f"terminal tool or the ocr-and-documents skill — before answering, instead "
-        f"of asking the user to paste the contents.]"
-    )
-
-
-def _format_duration(seconds: float) -> str:
-    total = int(round(seconds))
-    if total < 0:
-        total = 0
-    hours, rem = divmod(total, 3600)
-    minutes, secs = divmod(rem, 60)
-    if hours:
-        return f"{hours}:{minutes:02d}:{secs:02d}"
-    return f"{minutes}:{secs:02d}"
-
-
-async def _probe_audio_duration(path: str) -> Optional[str]:
-    """Best-effort duration probe. Returns formatted MM:SS / HH:MM:SS, or None on failure."""
-    ext = os.path.splitext(path)[1].lower()
-
-    if ext == ".wav":
-        try:
-            def _wav_duration() -> float:
-                import wave
-                with wave.open(path, "rb") as wf:
-                    frames = wf.getnframes()
-                    rate = wf.getframerate() or 1
-                    return frames / float(rate)
-            secs = await asyncio.to_thread(_wav_duration)
-            return _format_duration(secs)
-        except Exception:
-            pass
-
-    if ext in (".ogg", ".opus", ".oga"):
-        try:
-            def _ogg_duration() -> float:
-                from mutagen.oggopus import OggOpus
-                return float(OggOpus(path).info.length)
-            secs = await asyncio.to_thread(_ogg_duration)
-            return _format_duration(secs)
-        except Exception:
-            pass
-
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "ffprobe", "-v", "error", "-show_entries", "format=duration",
-            "-of", "default=noprint_wrappers=1:nokey=1", path,
-            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5.0)
-        if proc.returncode == 0:
-            return _format_duration(float(stdout.decode().strip()))
-    except Exception:
-        pass
-
-    return None
 
 
 def _dequeue_pending_event(adapter, session_key: str) -> MessageEvent | None:


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #54962 #55138
## What

Extracts the media/event-handling cluster (9 pure helpers) out of the 26,823-line `gateway/run.py` god file into a new self-contained `gateway/media_helpers.py` module.

Moved functions (verbatim — zero behavior change, docstrings/comments preserved):

- `_event_media_type_at`
- `_event_media_is_image`
- `_event_media_is_audio`
- `_event_media_is_stt_input`
- `_event_media_is_video`
- `_build_media_placeholder`
- `_build_document_context_note`
- `_format_duration`
- `_probe_audio_duration` (async)

The cluster is CLEAN: it only depends on `MessageType` (from `gateway.platforms.base`), `asyncio`, `os`, and `typing.Optional` — no module-level state, no move-with constants. `gateway/run.py` now re-exports the names via a module-attribute import, so `gateway.run.<name>` references (call sites in `GatewayRunner` methods and any external lazy importers) keep resolving unchanged.

## Why

Part of the god-file shrink campaign (#54962): `gateway/run.py` is 26,823 lines, and this is one of several pure-cluster extractions into focused `gateway/*_helpers.py` modules. Pure moves only — no behavior change, no refactor of the moved bodies.

## How to test

```bash
# Import smoke test — must print "import OK"
python -c "import gateway.run; import gateway.media_helpers as mh; print('import OK', gateway.run._event_media_type_at is mh._event_media_type_at)"

# Targeted suites — 131 passed, 1 failed
python -m pytest tests/gateway/test_document_context_note.py \
  tests/gateway/test_mixed_attachment_routing.py \
  tests/gateway/test_video_context_note.py \
  tests/gateway/test_voice_command.py \
  tests/agent/test_insights.py \
  tests/gateway/test_media_extraction.py \
  tests/gateway/test_73771_media_resend_dedup.py \
  -q --no-header -p no:cacheprovider
```

Expected: `import OK` and all targeted tests green. The single failure (`test_73771_media_resend_dedup.py::test_streamed_explicit_media_resend_is_delivered`) is a pre-existing Windows path/URL-encoding environment issue — stash-proven to fail identically on pristine `main` (it asserts a raw `C:\...` path against a `file://C%3A...` URL-encoded form). Not related to this move.

## Platforms tested

- Windows native: parse + `import gateway.run` + `import gateway.media_helpers` + targeted test suites above
- `git diff --check` clean
- `scripts/check-windows-footguns.py gateway/run.py gateway/media_helpers.py` — ✓ No Windows footguns

## Shrink

`gateway/run.py`: 26,823 → 26,681 lines (net −142; 153 lines moved out, 11-line re-export import added). New module: `gateway/media_helpers.py` (169 lines).

Part of #54962

Part of #55138

Part of #78647
