### PR TITLE
fix(desktop): clarify/document macOS 12+ minimum requirement (#77618)

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -50,7 +50,13 @@ hermes update
 
 ## Requirements
 
-The installer handles everything for you (Python 3.11+, a portable Git, ripgrep).
+The desktop app runs on:
+
+- **macOS** 12 (Monterey) or later
+- **Windows** 10 or later
+- **Linux** — any modern distribution with a graphical session (X11 or Wayland)
+
+The installer handles everything else for you (Python 3.11+, a portable Git, ripgrep).
 
 ---
 
@@ -186,6 +192,9 @@ rm "$HOME/.hermes/hermes-agent/.hermes-bootstrap-complete"
 rm -rf "$HOME/.hermes/hermes-agent/venv"
 # Reset a stuck macOS microphone prompt (macOS only)
 tccutil reset Microphone com.nousresearch.hermes
+# macOS only — after a drag-and-drop install, Gatekeeper may block launch with
+# "can't be opened" / "is damaged"; clear the quarantine flag:
+xattr -cr "/Applications/Hermes.app"
 ```
 
 **Windows (PowerShell):**


### PR DESCRIPTION
## Summary

The desktop app's README `Requirements` section documented only the runtime pieces the installer handles (Python 3.11+, portable Git, ripgrep) — it never stated the supported OS minimums, even though the official site (hermes-agent.nousresearch.com) lists **macOS 12+**, **Windows 10/11**, **Linux (any distro)**. This PR makes the repo's README consistent with the documented requirement and adds a troubleshooting entry for the most common macOS launch failure.

## Change

- `apps/desktop/README.md` — `Requirements` section now lists supported OS minimums:
  - **macOS** 12 (Monterey) or later
  - **Windows** 10 or later
  - **Linux** — any modern distribution with a graphical session (X11 or Wayland)
- `apps/desktop/README.md` — macOS troubleshooting block gains the Gatekeeper quarantine fix (`xattr -cr`) for drag-and-drop installs that fail with "can't be opened" / "is damaged" — the exact scenario in #77618 (macOS 15, drag-and-drop install, app won't run).

Docs-only change; no runtime behavior affected. Since the reporter's macOS 15 satisfies the macOS 12+ floor, the likely cause is Gatekeeper quarantine rather than an OS-version gate, and the issue remains needs-repro for anything deeper.

## Verification

- `git diff` reviewed — 10 insertions, 1 deletion in a single markdown file.
- Markdown renders correctly; no code, config, or build files touched.

Closes #77618