### PR TITLE
fix(desktop): stop the inflight dump sandwiching structured mid-turn rows

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/resume-structural-parts.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/resume-structural-parts.test.ts
@@ -73,4 +73,70 @@ describe('reconcileResumeMessages — structural parts on a mid-turn switch', ()
 
     expect(assistant.parts.filter(p => p.type === 'tool-call')).toHaveLength(1)
   })
+
+  it('keeps live-tail structure when the flat dump is not a strict text extension', () => {
+    // Mid-turn sandwich path: cache holds reasoning/tools; resume returns a
+    // longer non-extending dump. Structure source must be live-tail.
+    const cached: ChatMessage[] = [
+      {
+        id: 'assistant-stream-1',
+        pending: true,
+        parts: [
+          { type: 'reasoning', text: 'thinking about tools' },
+          { type: 'tool-call', toolCallId: 'c1', toolName: 'terminal', args: {} },
+          { type: 'text', text: 'partial' }
+        ],
+        role: 'assistant'
+      }
+    ]
+
+    const authoritative: ChatMessage[] = [
+      {
+        id: 'assistant-stream-1',
+        pending: true,
+        parts: [{ type: 'text', text: 'thinking about tools\nRan terminal\npartial and more dump' }],
+        role: 'assistant'
+      }
+    ]
+
+    const [assistant] = reconcileResumeMessages(authoritative, cached)
+
+    expect(assistant.parts.some(part => part.type === 'reasoning')).toBe(true)
+    expect(assistant.parts.some(part => part.type === 'tool-call')).toBe(true)
+    expect(assistant.parts.filter(part => part.type === 'text').map(part => ('text' in part ? part.text : ''))).toEqual([
+      'partial'
+    ])
+  })
+
+  it('does not graft historical structure onto a live text-only row after compression rewrote ordinals', () => {
+    // Previous cache still has a completed structured assistant at ordinal 0.
+    // Resume after compression returns a new live text-only assistant at the
+    // same role ordinal for an unrelated turn — must not inherit foreign parts.
+    const cached: ChatMessage[] = [
+      {
+        id: 'old-assistant',
+        parts: [
+          { type: 'reasoning', text: 'old thinking' },
+          { type: 'tool-call', toolCallId: 'old-call', toolName: 'terminal', args: {} },
+          { type: 'text', text: 'old answer' }
+        ],
+        role: 'assistant'
+      }
+    ]
+
+    const authoritative: ChatMessage[] = [
+      {
+        id: 'assistant-stream-runtime-1',
+        pending: true,
+        parts: [{ type: 'text', text: 'brand new partial' }],
+        role: 'assistant'
+      }
+    ]
+
+    const [assistant] = reconcileResumeMessages(authoritative, cached)
+
+    expect(assistant.parts.some(part => part.type === 'reasoning')).toBe(false)
+    expect(assistant.parts.some(part => part.type === 'tool-call')).toBe(false)
+    expect(assistant.parts).toEqual([{ type: 'text', text: 'brand new partial' }])
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1157,4 +1157,36 @@ describe('appendLiveSessionProjection', () => {
       'partial'
     ])
   })
+
+  it('still projects inflight when only a completed historical tool reply has structure', () => {
+    // Older completed assistants keep reasoning/tool parts in the full
+    // transcript; they must not suppress a new turn's text projection.
+    const stored: ChatMessage[] = [
+      msg('old-user', 'user', 'previous task'),
+      {
+        id: 'old-assistant',
+        role: 'assistant',
+        parts: [
+          { type: 'tool-call', toolCallId: 'old', toolName: 'terminal', args: {} },
+          { type: 'text', text: 'done earlier' }
+        ]
+      },
+      msg('new-user', 'user', 'new task')
+    ]
+
+    const restored = appendLiveSessionProjection(stored, {
+      session_id: 'runtime-1',
+      inflight: {
+        user: 'new task',
+        assistant: 'working on it',
+        streaming: true
+      }
+    })
+
+    expect(restored.map(message => message.id)).toContain('assistant-stream-runtime-1')
+    expect(restored.at(-1)).toMatchObject({
+      id: 'assistant-stream-runtime-1',
+      pending: true
+    })
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -1120,4 +1120,41 @@ describe('appendLiveSessionProjection', () => {
 
     expect(appendLiveSessionProjection(stored, { session_id: 'runtime-1' })).toBe(stored)
   })
+
+  it('does not sandwich a structured mid-turn row with the inflight flat dump (#76444)', () => {
+    const stored: ChatMessage[] = [
+      msg('stored-user', 'user', 'do the work'),
+      {
+        id: 'live-assistant',
+        role: 'assistant',
+        pending: true,
+        parts: [
+          { type: 'reasoning', text: 'thinking about tools' },
+          { type: 'tool-call', toolCallId: 'c1', toolName: 'terminal', args: {} },
+          { type: 'text', text: 'partial' }
+        ]
+      }
+    ]
+
+    const restored = appendLiveSessionProjection(stored, {
+      session_id: 'runtime-1',
+      inflight: {
+        user: 'do the work',
+        // Flat dump includes thinking chatter + tool narration — longer than
+        // the answer text alone, which is how the sandwich used to grow.
+        assistant: 'thinking about tools\nRan terminal\npartial and more dump',
+        streaming: true
+      }
+    })
+
+    const assistants = restored.filter(message => message.role === 'assistant')
+    expect(assistants).toHaveLength(1)
+    expect(assistants[0].id).toBe('live-assistant')
+    expect(assistants[0].parts.some(part => part.type === 'reasoning')).toBe(true)
+    expect(assistants[0].parts.some(part => part.type === 'tool-call')).toBe(true)
+    // Answer text stays the structured row's text, not the dump.
+    expect(assistants[0].parts.filter(part => part.type === 'text').map(part => ('text' in part ? part.text : ''))).toEqual([
+      'partial'
+    ])
+  })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -53,6 +53,20 @@ function hasStructuralParts(message: ChatMessage): boolean {
 }
 
 /**
+ * A live-turn row — the gateway's text-only `inflight` projection, a
+ * still-streaming local bubble, or an interim row sealed inside the running
+ * turn — as opposed to a committed transcript row.
+ */
+function isLiveTailRow(message: ChatMessage): boolean {
+  return (
+    message.pending === true ||
+    message.id.startsWith('assistant-stream-') ||
+    message.id.startsWith('inflight-assistant-') ||
+    message.interim === true
+  )
+}
+
+/**
  * True when `next` is a pure forward extension of the previous *answer* text.
  * Empty previous answer never accepts a dump as an extension — that is how the
  * mid-turn inflight flat dump used to sandwich structured rows (#76444).
@@ -301,11 +315,6 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
     // live is not enough — after compression a new live assistant can share a
     // role ordinal with an unrelated historical structured row and must not
     // inherit its reasoning/tool parts (#76444 review / salvage).
-    const isLiveTailRow = (row: ChatMessage): boolean =>
-      Boolean(row.pending) ||
-      row.id.startsWith('assistant-stream-') ||
-      Boolean(row.interim)
-
     const sameTurn =
       sameText ||
       (nextText.length > 0 && previousTrimmed.length > 0 && isStrictAnswerTextExtension(nextText, previousTrimmed)) ||
@@ -394,19 +403,12 @@ const isGatewaySystemMarker = (message: ChatMessage): boolean =>
   message.role === 'user' && chatMessageText(message).trimStart().startsWith('[System:')
 
 /**
- * Does the local pending row carry anything a viewer would miss — streamed
- * text, reasoning, or tool calls? An empty inflight shell carries none of it.
+ * Does the row carry anything a viewer would miss — streamed answer text, or
+ * the reasoning / tool-call structure the gateway's flat dump cannot express?
+ * An empty inflight shell carries none of it.
  */
 const hasStreamedContent = (message: ChatMessage): boolean =>
-  chatMessageText(message).trim().length > 0 ||
-  message.parts.some(part => part.type === 'tool-call' || part.type === 'reasoning')
-
-/**
- * A live-turn projection row — the gateway's text-only `inflight` snapshot or a
- * still-streaming local bubble — as opposed to a committed transcript row.
- */
-const isLiveProjectionRow = (message: ChatMessage): boolean =>
-  message.pending === true || message.id.startsWith('assistant-stream-') || message.id.startsWith('inflight-assistant-')
+  chatMessageText(message).trim().length > 0 || hasStructuralParts(message)
 
 /**
  * May the cached local row stand in for this authoritative assistant?
@@ -419,11 +421,11 @@ const isLiveProjectionRow = (message: ChatMessage): boolean =>
  * from the local partial would hide the error and mark the turn healthy again.
  */
 const localPendingSupersedes = (local: ChatMessage, authoritative: ChatMessage): boolean => {
-  if (local.role !== 'assistant' || !isLiveProjectionRow(local)) {
+  if (local.role !== 'assistant' || !isLiveTailRow(local)) {
     return false
   }
 
-  if (!isLiveProjectionRow(authoritative) || authoritative.error) {
+  if (!isLiveTailRow(authoritative) || authoritative.error) {
     return false
   }
 
@@ -435,7 +437,7 @@ const localPendingSupersedes = (local: ChatMessage, authoritative: ChatMessage):
 
   const localText = chatMessageText(local).trim()
 
-  return localText.length > authoritativeText.length && localText.startsWith(authoritativeText)
+  return localText.length > authoritativeText.length && isStrictAnswerTextExtension(localText, authoritativeText)
 }
 
 /**
@@ -705,28 +707,32 @@ export function appendLiveSessionProjection(
   // Only inspect the live tail after the latest user run — never a completed
   // historical tool-bearing reply earlier in the transcript (review feedback).
   const liveStreamId = `assistant-stream-${sessionId}`
-  const liveAssistantOfCurrentTurn = (() => {
+
+  const liveAssistantOfCurrentTurn = ((): ChatMessage | null => {
     const byStreamId = messages.find(message => message.id === liveStreamId)
+
     if (byStreamId) {
       return byStreamId
     }
+
     // Assistants after the latest user row belong to this turn's tail.
     if (latestUserIndex < 0) {
       return null
     }
+
     for (let index = messages.length - 1; index > latestUserIndex; index -= 1) {
       if (messages[index].role === 'assistant') {
         return messages[index]
       }
     }
+
     return null
   })()
+
   const turnAlreadyStructured = Boolean(
     liveAssistantOfCurrentTurn &&
-      hasStructuralParts(liveAssistantOfCurrentTurn) &&
-      (liveAssistantOfCurrentTurn.pending ||
-        liveAssistantOfCurrentTurn.id === liveStreamId ||
-        liveAssistantOfCurrentTurn.interim)
+    hasStructuralParts(liveAssistantOfCurrentTurn) &&
+    isLiveTailRow(liveAssistantOfCurrentTurn)
   )
 
   if (inflightAssistant || inflightStreaming || inflightError || (inflightUser && queuedUser)) {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -295,10 +295,12 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
     // the strict equality path — they reconcile a SETTLED row, and a growing
     // row is by definition not settled.
     //
-    // Live-tail identity: only treat structure as same-turn evidence when the
-    // cached row is still the in-flight stream (pending / stream id), not a
-    // historical completed assistant that merely shares a role ordinal after
-    // compression rewrote history (#76444 review).
+    // Live-tail identity: structure-only same-turn carry is allowed only when
+    // the *structure-bearing cached row* is still the in-flight stream
+    // (pending / stream id / interim). Marking only the text-only next row
+    // live is not enough — after compression a new live assistant can share a
+    // role ordinal with an unrelated historical structured row and must not
+    // inherit its reasoning/tool parts (#76444 review / salvage).
     const isLiveTailRow = (row: ChatMessage): boolean =>
       Boolean(row.pending) ||
       row.id.startsWith('assistant-stream-') ||
@@ -311,7 +313,7 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
         previous.role === 'assistant' &&
         hasStructuralParts(previous) &&
         !hasStructuralParts(message) &&
-        (isLiveTailRow(previous) || isLiveTailRow(message)))
+        isLiveTailRow(previous))
 
     if (sameTurn) {
       preserved = preserveStructuralParts(preserved, previous)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -47,6 +47,27 @@ function withAppendedText(message: ChatMessage, suffix: string): ChatMessage {
   return appended ? { ...message, parts } : message
 }
 
+/** Reasoning / tool-call parts that the gateway inflight dump cannot express. */
+function hasStructuralParts(message: ChatMessage): boolean {
+  return message.parts.some(part => part.type === 'reasoning' || part.type === 'tool-call')
+}
+
+/**
+ * True when `next` is a pure forward extension of the previous *answer* text.
+ * Empty previous answer never accepts a dump as an extension — that is how the
+ * mid-turn inflight flat dump used to sandwich structured rows (#76444).
+ */
+export function isStrictAnswerTextExtension(next: string, previous: string): boolean {
+  const n = next.trim()
+  const p = previous.trim()
+
+  if (!p || !n) {
+    return false
+  }
+
+  return n.startsWith(p)
+}
+
 /**
  * Carry structural parts an authoritative row cannot express.
  *
@@ -273,11 +294,33 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
     // for structural carry-over. Attachment refs and image re-appending stay on
     // the strict equality path — they reconcile a SETTLED row, and a growing
     // row is by definition not settled.
+    //
+    // Structured local assistant + text-only live projection (gateway inflight
+    // dump) at the same ordinal is still the same turn even when answer text is
+    // still empty — without this the dump would drop structure and reappear as
+    // a plain-text sandwich (#76444).
     const sameTurn =
-      sameText || (nextText.length > 0 && previousTrimmed.length > 0 && nextText.startsWith(previousTrimmed))
+      sameText ||
+      (nextText.length > 0 && previousTrimmed.length > 0 && isStrictAnswerTextExtension(nextText, previousTrimmed)) ||
+      (message.role === 'assistant' &&
+        previous.role === 'assistant' &&
+        hasStructuralParts(previous) &&
+        !hasStructuralParts(message))
 
     if (sameTurn) {
       preserved = preserveStructuralParts(preserved, previous)
+
+      // Never replace structured answer text with a non-extending flat dump.
+      if (
+        message.role === 'assistant' &&
+        hasStructuralParts(previous) &&
+        !hasStructuralParts(message) &&
+        !isStrictAnswerTextExtension(nextText, previousVisibleText)
+      ) {
+        const nonText = preserved.parts.filter(part => part.type !== 'text')
+        const priorAnswer = previous.parts.filter(part => part.type === 'text')
+        preserved = { ...preserved, parts: [...nonText, ...priorAnswer] }
+      }
     }
 
     if (
@@ -646,14 +689,27 @@ export function appendLiveSessionProjection(
 
   // Keep a pending assistant boundary even before the first delta when a
   // queued user turn follows it. This preserves the two distinct turns.
+  //
+  // When the transcript already holds a structured mid-turn assistant row
+  // (reasoning / tool-call parts from the live stream or journal), do NOT
+  // append a pure-text projection of `inflight.assistant` — that flat dump
+  // re-renders thinking as answer text and sandwiches the structured parts
+  // (#76444). Errors still force a projection so the failure is visible.
+  const lastAssistant = [...messages].reverse().find(message => message.role === 'assistant')
+  const turnAlreadyStructured = Boolean(lastAssistant && hasStructuralParts(lastAssistant))
+
   if (inflightAssistant || inflightStreaming || inflightError || (inflightUser && queuedUser)) {
-    projected.push({
-      id: `assistant-stream-${sessionId}`,
-      role: 'assistant',
-      parts: inflightAssistant ? [assistantTextPart(inflightAssistant)] : [],
-      pending: inflightStreaming,
-      ...(inflightError ? { error: inflightError } : {})
-    })
+    if (turnAlreadyStructured && !inflightError) {
+      // Structure is authoritative; skip the text-only dump row.
+    } else {
+      projected.push({
+        id: `assistant-stream-${sessionId}`,
+        role: 'assistant',
+        parts: inflightAssistant ? [assistantTextPart(inflightAssistant)] : [],
+        pending: inflightStreaming,
+        ...(inflightError ? { error: inflightError } : {})
+      })
+    }
   }
 
   if (queuedUser) {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -295,17 +295,23 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
     // the strict equality path — they reconcile a SETTLED row, and a growing
     // row is by definition not settled.
     //
-    // Structured local assistant + text-only live projection (gateway inflight
-    // dump) at the same ordinal is still the same turn even when answer text is
-    // still empty — without this the dump would drop structure and reappear as
-    // a plain-text sandwich (#76444).
+    // Live-tail identity: only treat structure as same-turn evidence when the
+    // cached row is still the in-flight stream (pending / stream id), not a
+    // historical completed assistant that merely shares a role ordinal after
+    // compression rewrote history (#76444 review).
+    const isLiveTailRow = (row: ChatMessage): boolean =>
+      Boolean(row.pending) ||
+      row.id.startsWith('assistant-stream-') ||
+      Boolean(row.interim)
+
     const sameTurn =
       sameText ||
       (nextText.length > 0 && previousTrimmed.length > 0 && isStrictAnswerTextExtension(nextText, previousTrimmed)) ||
       (message.role === 'assistant' &&
         previous.role === 'assistant' &&
         hasStructuralParts(previous) &&
-        !hasStructuralParts(message))
+        !hasStructuralParts(message) &&
+        (isLiveTailRow(previous) || isLiveTailRow(message)))
 
     if (sameTurn) {
       preserved = preserveStructuralParts(preserved, previous)
@@ -690,20 +696,43 @@ export function appendLiveSessionProjection(
   // Keep a pending assistant boundary even before the first delta when a
   // queued user turn follows it. This preserves the two distinct turns.
   //
-  // When the transcript already holds a structured mid-turn assistant row
-  // (reasoning / tool-call parts from the live stream or journal), do NOT
-  // append a pure-text projection of `inflight.assistant` — that flat dump
-  // re-renders thinking as answer text and sandwiches the structured parts
-  // (#76444). Errors still force a projection so the failure is visible.
-  const lastAssistant = [...messages].reverse().find(message => message.role === 'assistant')
-  const turnAlreadyStructured = Boolean(lastAssistant && hasStructuralParts(lastAssistant))
+  // When the *current live turn* already holds a structured mid-turn assistant
+  // row (reasoning / tool-call from the live stream or journal), do NOT append
+  // a pure-text projection of `inflight.assistant` — that flat dump re-renders
+  // thinking as answer text and sandwiches the structured parts (#76444).
+  // Only inspect the live tail after the latest user run — never a completed
+  // historical tool-bearing reply earlier in the transcript (review feedback).
+  const liveStreamId = `assistant-stream-${sessionId}`
+  const liveAssistantOfCurrentTurn = (() => {
+    const byStreamId = messages.find(message => message.id === liveStreamId)
+    if (byStreamId) {
+      return byStreamId
+    }
+    // Assistants after the latest user row belong to this turn's tail.
+    if (latestUserIndex < 0) {
+      return null
+    }
+    for (let index = messages.length - 1; index > latestUserIndex; index -= 1) {
+      if (messages[index].role === 'assistant') {
+        return messages[index]
+      }
+    }
+    return null
+  })()
+  const turnAlreadyStructured = Boolean(
+    liveAssistantOfCurrentTurn &&
+      hasStructuralParts(liveAssistantOfCurrentTurn) &&
+      (liveAssistantOfCurrentTurn.pending ||
+        liveAssistantOfCurrentTurn.id === liveStreamId ||
+        liveAssistantOfCurrentTurn.interim)
+  )
 
   if (inflightAssistant || inflightStreaming || inflightError || (inflightUser && queuedUser)) {
     if (turnAlreadyStructured && !inflightError) {
       // Structure is authoritative; skip the text-only dump row.
     } else {
       projected.push({
-        id: `assistant-stream-${sessionId}`,
+        id: liveStreamId,
         role: 'assistant',
         parts: inflightAssistant ? [assistantTextPart(inflightAssistant)] : [],
         pending: inflightStreaming,

--- a/apps/desktop/src/lib/inflight-turn-journal.test.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.test.ts
@@ -179,7 +179,9 @@ describe('recoverInFlightTurnJournal', () => {
   it('overlays the backend text-only projection instead of dropping local tool progress', () => {
     // Sweeper regression on #44339: a backend `inflight` assistant snapshot
     // (text only) used to mark the richer local tail "caught up" and delete
-    // locally recorded tool calls.
+    // locally recorded tool calls. After #76444, longer text wins only when it
+    // is a strict extension of the journal answer (flat thinking dumps must
+    // not replace structured answer text).
     journalEntry([
       user('u1', 'do the thing'),
       assistantWithTool('assistant-stream-old', 'local part', { pending: true })
@@ -187,7 +189,7 @@ describe('recoverInFlightTurnJournal', () => {
 
     const base = [
       user('db-u1', 'do the thing'),
-      assistant('assistant-stream-rt9', 'longer partial text from the backend snapshot', { pending: true })
+      assistant('assistant-stream-rt9', 'local part and more from the backend snapshot', { pending: true })
     ]
 
     const result = recoverInFlightTurnJournal('stored-1', base, { keepPending: true })
@@ -200,11 +202,33 @@ describe('recoverInFlightTurnJournal', () => {
     // Keeps the BASE projection row id so live deltas keep landing on it.
     expect(merged.id).toBe('assistant-stream-rt9')
     expect(result.streamId).toBe('assistant-stream-rt9')
-    // Journal structure survives; the longer backend text wins.
+    // Journal structure survives; strict-extension backend text wins.
     expect(merged.parts[0]).toMatchObject({ type: 'tool-call', toolName: 'terminal' })
-    expect(merged.parts[1]).toMatchObject({ type: 'text', text: 'longer partial text from the backend snapshot' })
+    expect(merged.parts[1]).toMatchObject({ type: 'text', text: 'local part and more from the backend snapshot' })
     // Still in flight — the journal must NOT be cleared.
     expect(readInFlightTurnJournal('stored-1')).not.toBeNull()
+  })
+
+  it('keeps journal answer text when a longer flat dump is not a strict extension (#76444)', () => {
+    journalEntry([
+      user('u1', 'do the thing'),
+      assistantWithTool('assistant-stream-old', 'partial', { pending: true })
+    ])
+
+    const base = [
+      user('db-u1', 'do the thing'),
+      assistant(
+        'assistant-stream-rt9',
+        'thinking chatter\nRan terminal\npartial and unrelated dump longer than answer',
+        { pending: true }
+      )
+    ]
+
+    const result = recoverInFlightTurnJournal('stored-1', base, { keepPending: true })
+    const merged = result.messages.at(-1)!
+
+    expect(merged.parts[0]).toMatchObject({ type: 'tool-call', toolName: 'terminal' })
+    expect(merged.parts[1]).toMatchObject({ type: 'text', text: 'partial' })
   })
 
   it('keeps the journal text when it is longer than the projection text', () => {

--- a/apps/desktop/src/lib/inflight-turn-journal.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.ts
@@ -254,6 +254,10 @@ function assistantTextLength(message: ChatMessage): number {
  * BASE row's id so live deltas keep appending to the row the stream handler
  * already targets.
  */
+function hasStructuralParts(message: ChatMessage): boolean {
+  return message.parts.some(part => part.type === 'reasoning' || part.type === 'tool-call')
+}
+
 function overlayProjectionRow(projection: ChatMessage, journalRow: ChatMessage): ChatMessage {
   // A projected error (retained failed turn) must survive the overlay.
   const error = journalRow.error ?? projection.error
@@ -271,7 +275,20 @@ function overlayProjectionRow(projection: ChatMessage, journalRow: ChatMessage):
 
   // Backend text is newer than the journal's last throttled write — swap it
   // into the journal's first text part, keeping tool calls and reasoning.
+  // When the journal already carries structure, only accept a *strict*
+  // extension of the answer text. A longer flat dump that starts with
+  // thinking chatter must not overwrite / insert as answer text (#76444).
   const projectionText = chatMessageText(projection)
+  const journalText = chatMessageText(journalRow).trim()
+
+  if (hasStructuralParts(journalRow)) {
+    const next = projectionText.trim()
+
+    if (!journalText || !next.startsWith(journalText)) {
+      return merged
+    }
+  }
+
   const parts: ChatMessagePart[] = []
   let textReplaced = false
 


### PR DESCRIPTION
Stacked on #77644 — review that first; the base retargets to `main` automatically once it merges.

## What does this PR do?

Salvages #76744 into the same reconcile surface #77644 touches, and gives both fixes one shared vocabulary.

`inflight.assistant` is a flat string of mid-turn prose (thinking chatter + tool narration + partial answer). On resume that dump was projected as *answer text* next to structured reasoning/tool-call parts, so a plain-text slab appeared between the tools and the final answer — thickening on every switch.

Supersedes #76744

## Related Issue

Fixes #76444

## Why it belongs on top of #77644

Both changes edit the same `sameTurn` statement in `reconcileResumeMessages`, from opposite directions — #77644 asks "is the cached row richer, prefer it"; this asks "is the authoritative row a flat dump, refuse it as answer text." Landing them independently meant whichever merged second silently reshaped the other's guard. They also arrived at near-duplicate helpers: `isLiveProjectionRow`/`isLiveTailRow` and `hasStreamedContent`/`hasStructuralParts`.

## Changes Made

- `appendLiveSessionProjection`: skip the text-only dump row when the live turn tail already holds structure, scoped to assistants after the latest user run so a completed historical tool-bearing reply can't suppress it
- `reconcileResumeMessages`: structured local + text-only projection counts as the same turn even at empty answer text; a non-extending dump never replaces structured answer text
- `overlayProjectionRow` (journal): accept backend text only as a strict extension when the journal row carries structure
- **Consolidation:** one module-level `isLiveTailRow` + `hasStreamedContent`/`hasStructuralParts` pair serving both guards, both text checks routed through `isStrictAnswerTextExtension`. Side effect worth noting: the #77644 reply guard now also treats a sealed `interim` row as live tail rather than committed history
- Hoisted the live-tail lookup out of an inline IIFE; clears the 6 lint warnings that shipped with it

## How to Test

```
cd apps/desktop
../../node_modules/.bin/vitest run --project ui \
  src/app/session/hooks/use-session-actions/ src/lib/inflight-turn-journal.test.ts
```

Expected: **101 passed**

Manual: start a turn with several reasoning segments and a tool call; switch sessions (or blur/focus) mid-turn and return. Structure stays the source of truth — no plain-text thinking slab between the tools and the final answer, and no second copy of the mid-turn path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Original commits cherry-picked, authorship preserved for @686f6c61
- [ ] I've run `pytest tests/ -q` — N/A: Desktop-only TypeScript change
- [x] I've added tests for my changes — @686f6c61's regressions carried over intact
- [x] Desktop `ui` suite green (386 files / 3356 tests), `tsc --noEmit` clean, eslint + prettier clean

### Documentation & Housekeeping

- [x] Docs / config / AGENTS — N/A (no user-facing API or config change)
- [x] Cross-platform: renderer reconciliation only
