### PR TITLE
fix(credential_pool): defer single-use-token refresh outside the pool lock (salvage #71775)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1334,7 +1334,7 @@ def _resolve_anthropic_pool_token() -> Optional[str]:
         # to auth.json or trigger a network refresh from a bare resolve. select()
         # is deliberately NOT used — it runs clear_expired=True, refresh=True,
         # which would violate this read-only contract.
-        entries = pool._available_entries(clear_expired=False, refresh=False)
+        entries, _pending = pool._available_entries(clear_expired=False, refresh=False)
     except Exception:
         logger.debug("Failed to read Anthropic credential_pool", exc_info=True)
         return None

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -588,7 +588,12 @@ class CredentialPool:
         self._entries = sorted(entries, key=lambda entry: entry.priority)
         self._current_id: Optional[str] = None
         self._strategy = get_pool_strategy(provider)
-        self._lock = threading.Lock()
+        # RLock: the mutation primitives below (_replace_entry/_persist)
+        # self-acquire this lock so the DEFERRED single-use-token refresh
+        # path (which runs network I/O outside the lock by design) still
+        # serializes its pool mutations. In-lock callers re-acquire
+        # reentrantly at negligible cost.
+        self._lock = threading.RLock()
         self._active_leases: Dict[str, int] = {}
         self._max_concurrent = DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL
         # Monotonic timestamp of the last "no available entries" log, used to
@@ -657,18 +662,27 @@ class CredentialPool:
             return matches[0].id if len(matches) == 1 else None
 
     def _replace_entry(self, old: PooledCredential, new: PooledCredential) -> None:
-        """Swap an entry in-place by id, preserving sort order."""
-        for idx, entry in enumerate(self._entries):
-            if entry.id == old.id:
-                self._entries[idx] = new
-                return
+        """Swap an entry in-place by id, preserving sort order.
+
+        Self-locking (RLock) so the deferred refresh path — which
+        deliberately runs outside the pool lock — cannot tear
+        ``self._entries`` against a concurrent select()/rotation.
+        """
+        with self._lock:
+            for idx, entry in enumerate(self._entries):
+                if entry.id == old.id:
+                    self._entries[idx] = new
+                    return
 
     def _persist(self, *, removed_ids: Optional[List[str]] = None) -> None:
-        write_credential_pool(
-            self.provider,
-            [entry.to_dict() for entry in self._entries],
-            removed_ids=removed_ids,
-        )
+        # Self-locking (RLock): snapshotting self._entries must not race a
+        # concurrent rotation when called from the deferred refresh path.
+        with self._lock:
+            write_credential_pool(
+                self.provider,
+                [entry.to_dict() for entry in self._entries],
+                removed_ids=removed_ids,
+            )
 
     def _is_terminal_auth_failure(
         self,
@@ -1674,10 +1688,10 @@ class CredentialPool:
         On failure the entry is silently skipped.
         """
         for entry, sync_fn in pending:
-            refreshed = self._refresh_entry(entry, force=False)
-            if refreshed is not None:
-                with self._lock:
-                    self._replace_entry(entry, refreshed)
+            # _refresh_entry already merges the refreshed entry into the
+            # pool internally (its mutation primitives are self-locking),
+            # so no second _replace_entry is needed here.
+            self._refresh_entry(entry, force=False)
 
     def _available_entries(
         self, *, clear_expired: bool = False, refresh: bool = False,

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -618,7 +618,8 @@ class CredentialPool:
         # otherwise a status probe here can race a concurrent ``select`` /
         # rotation and tear ``self._entries`` or double-write auth.json.
         with self._lock:
-            return bool(self._available_entries())
+            available, _pending = self._available_entries()
+            return bool(available)
 
     def entries(self) -> List[PooledCredential]:
         with self._lock:
@@ -1646,26 +1647,61 @@ class CredentialPool:
         return False
 
     def select(self) -> Optional[PooledCredential]:
-        with self._lock:
-            entry = self._select_unlocked()
-            if entry is not None:
-                # A normal (non-recovery) selection starts a fresh episode —
-                # don't let a leftover unmatched-rotation streak from an old
-                # failure trip the #70401 bound early next time.
-                self._unmatched_rotation_streak = 0
+        entry, pending_refresh = self._select_under_lock()
+        if pending_refresh:
+            self._refresh_pending_entries(pending_refresh)
+        if entry is not None:
+            self._unmatched_rotation_streak = 0
             return entry
+        # If no entry was available but we just refreshed some, re-select
+        # now that the refreshed entries are back in the pool.
+        if pending_refresh:
+            entry, _ = self._select_under_lock()
+            if entry is not None:
+                self._unmatched_rotation_streak = 0
+        return entry
 
-    def _available_entries(self, *, clear_expired: bool = False, refresh: bool = False) -> List[PooledCredential]:
-        """Return entries not currently in exhaustion cooldown.
+    def _select_under_lock(self) -> Tuple[Optional[PooledCredential], List[tuple]]:
+        """Run selection under the lock, returning entry + pending refreshes."""
+        with self._lock:
+            return self._select_unlocked()
+
+    def _refresh_pending_entries(self, pending: List[tuple]) -> None:
+        """Refresh deferred single-use-token entries outside the lock.
+
+        Each entry is refreshed under the cross-process ``_auth_store_lock``
+        (which can block for 20+ seconds) and then merged into the pool.
+        On failure the entry is silently skipped.
+        """
+        for entry, sync_fn in pending:
+            refreshed = self._refresh_entry(entry, force=False)
+            if refreshed is not None:
+                with self._lock:
+                    self._replace_entry(entry, refreshed)
+
+    def _available_entries(
+        self, *, clear_expired: bool = False, refresh: bool = False,
+    ) -> Tuple[List[PooledCredential], List[tuple]]:
+        """Return (available, pending_refresh) for entries not in cooldown.
 
         When *clear_expired* is True, entries whose cooldown has elapsed are
         reset to STATUS_OK and persisted.  When *refresh* is True, entries
         that need a token refresh are refreshed (skipped on failure).
+
+        Single-use-token refreshes (openai-codex, xai-oauth) are returned as
+        *pending_refresh* tuples so the caller can execute them outside the
+        lock, avoiding stalling all pool consumers during cross-process flock
+        acquisition + OAuth network I/O.
         """
         now = time.time()
         cleared_any = False
         entries_to_prune: List[str] = []
         available: List[PooledCredential] = []
+        # Entries that need an OAuth refresh via a single-use token provider
+        # (openai-codex, xai-oauth).  These require a cross-process file lock
+        # that can block for 20+ seconds.  We collect them under self._lock
+        # and refresh outside the lock to avoid stalling all pool consumers.
+        pending_refresh: List[tuple] = []  # (entry, sync_entry_fn)
         for entry in self._entries:
             # Borrowed credentials persist as metadata-only references and are
             # hydrated from their live source on load.  A stale duplicate row
@@ -1774,6 +1810,16 @@ class CredentialPool:
                     entry = cleared
                     cleared_any = True
             if refresh and self._entry_needs_refresh(entry):
+                if self.provider in ("openai-codex", "xai-oauth"):
+                    # Defer single-use-token refresh to avoid holding the
+                    # threading lock during cross-process flock + network I/O.
+                    sync_fn = (
+                        self._sync_codex_entry_from_auth_store
+                        if self.provider == "openai-codex"
+                        else self._sync_xai_oauth_entry_from_pool_store
+                    )
+                    pending_refresh.append((entry, sync_fn))
+                    continue
                 refreshed = self._refresh_entry(entry, force=False)
                 if refreshed is None:
                     continue
@@ -1784,7 +1830,7 @@ class CredentialPool:
             self._entries = [e for e in self._entries if e.id not in pruned_ids]
         if cleared_any:
             self._persist(removed_ids=entries_to_prune)
-        return available
+        return available, pending_refresh
 
     def _log_no_available_entries(self) -> None:
         """Emit the empty-pool INFO line at most once per throttle window.
@@ -1800,12 +1846,17 @@ class CredentialPool:
         self._last_no_entries_log_at = now
         logger.info("credential pool: no available entries (all exhausted or empty)")
 
-    def _select_unlocked(self, *, refresh: bool = True) -> Optional[PooledCredential]:
-        available = self._available_entries(clear_expired=True, refresh=refresh)
+    def _select_unlocked(self, *, refresh: bool = True) -> Tuple[Optional[PooledCredential], List[tuple]]:
+        """Select the best available credential entry.
+
+        Returns ``(entry, pending_refresh)`` where *pending_refresh* contains
+        single-use-token entries that must be refreshed outside the lock.
+        """
+        available, pending_refresh = self._available_entries(clear_expired=True, refresh=refresh)
         if not available:
             self._current_id = None
             self._log_no_available_entries()
-            return None
+            return None, pending_refresh
 
         # A successful selection means the pool recovered; re-arm the throttle
         # so a later re-exhaustion logs immediately rather than being silenced
@@ -1815,7 +1866,7 @@ class CredentialPool:
         if self._strategy == STRATEGY_RANDOM:
             entry = random.choice(available)
             self._current_id = entry.id
-            return entry
+            return entry, pending_refresh
 
         if self._strategy == STRATEGY_LEAST_USED and len(available) > 1:
             entry = min(available, key=lambda e: e.request_count)
@@ -1823,7 +1874,7 @@ class CredentialPool:
             updated = replace(entry, request_count=entry.request_count + 1)
             self._replace_entry(entry, updated)
             self._current_id = entry.id
-            return updated
+            return updated, pending_refresh
 
         if self._strategy == STRATEGY_ROUND_ROBIN and len(available) > 1:
             entry = available[0]
@@ -1832,11 +1883,11 @@ class CredentialPool:
             self._entries = [replace(candidate, priority=idx) for idx, candidate in enumerate(rotated)]
             self._persist()
             self._current_id = entry.id
-            return self._current_unlocked() or entry
+            return self._current_unlocked() or entry, pending_refresh
 
         entry = available[0]
         self._current_id = entry.id
-        return entry
+        return entry, pending_refresh
 
     def peek(self) -> Optional[PooledCredential]:
         # Single lock acquisition for the whole read; call the unlocked
@@ -1845,7 +1896,7 @@ class CredentialPool:
             current = self._current_unlocked()
             if current is not None:
                 return current
-            available = self._available_entries()
+            available, _pending = self._available_entries()
             return available[0] if available else None
 
     def mark_exhausted_and_rotate(
@@ -1894,7 +1945,8 @@ class CredentialPool:
                 # guessing and surface the error (no cooldown is written for
                 # anybody — healthy keys stay available for the next turn).
                 self._unmatched_rotation_streak += 1
-                available_count = len(self._available_entries())
+                available_count, _ = self._available_entries()
+                available_count = len(available_count)
                 if self._unmatched_rotation_streak > max(available_count, 1):
                     logger.warning(
                         "credential pool: failed credential identity matched no "
@@ -1913,8 +1965,9 @@ class CredentialPool:
                     self.provider,
                 )
                 self._current_id = None
-                next_entry = self._select_unlocked()
-                if next_entry is not None and len(self._available_entries()) == 1:
+                next_entry, _pending = self._select_unlocked(refresh=False)
+                avail, _ = self._available_entries()
+                if next_entry is not None and len(avail) == 1:
                     # A single-entry pool cannot rotate. Returning its only
                     # entry reports a successful recovery without changing
                     # the credential, so the caller retries the same 401
@@ -1927,7 +1980,7 @@ class CredentialPool:
             # streak is stale (this mark WILL advance pool state).
             self._unmatched_rotation_streak = 0
             if entry is None:
-                entry = self._current_unlocked() or self._select_unlocked()
+                entry = self._current_unlocked() or self._select_unlocked(refresh=False)[0]
             if entry is None:
                 return None
             _label = entry.label or entry.id[:8]
@@ -1972,7 +2025,7 @@ class CredentialPool:
                     _label, status_code,
                 )
             self._current_id = None
-            next_entry = self._select_unlocked()
+            next_entry, _pending = self._select_unlocked(refresh=False)
             if next_entry:
                 _next_label = next_entry.label or next_entry.id[:8]
                 logger.info("credential pool: rotated to %s", _next_label)
@@ -1986,15 +2039,24 @@ class CredentialPool:
         a stable tie-breaker. When every credential is already at the soft cap,
         still return the least-leased one instead of blocking.
         """
+        chosen_id, pending_refresh = self._acquire_lease_under_lock(credential_id)
+        if pending_refresh:
+            self._refresh_pending_entries(pending_refresh)
+        return chosen_id
+
+    def _acquire_lease_under_lock(
+        self, credential_id: Optional[str],
+    ) -> Tuple[Optional[str], List[tuple]]:
+        """Run lease acquisition under the lock, returning id + pending refreshes."""
         with self._lock:
             if credential_id:
                 self._active_leases[credential_id] = self._active_leases.get(credential_id, 0) + 1
                 self._current_id = credential_id
-                return credential_id
+                return credential_id, []
 
-            available = self._available_entries(clear_expired=True, refresh=True)
+            available, pending_refresh = self._available_entries(clear_expired=True, refresh=True)
             if not available:
-                return None
+                return None, pending_refresh
 
             below_cap = [
                 entry for entry in available
@@ -2007,7 +2069,7 @@ class CredentialPool:
             )
             self._active_leases[chosen.id] = self._active_leases.get(chosen.id, 0) + 1
             self._current_id = chosen.id
-            return chosen.id
+            return chosen.id, pending_refresh
 
     def release_lease(self, credential_id: str) -> None:
         """Release a previously acquired credential lease."""
@@ -2059,7 +2121,7 @@ class CredentialPool:
                 else:
                     entry = self._current_unlocked() or self._select_unlocked(
                         refresh=False
-                    )
+                    )[0]
             if entry is None:
                 return None
             self._current_id = entry.id

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -239,7 +239,7 @@ class TestResolveAnthropicToken:
             access_token="pool-oauth-token",
         )
         pool = SimpleNamespace(
-            _available_entries=lambda **_kwargs: [pool_entry],
+            _available_entries=lambda **_kwargs: ([pool_entry], []),
         )
         monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
 
@@ -260,7 +260,7 @@ class TestResolveAnthropicToken:
             access_token="pool-oauth-token",
         )
         pool = SimpleNamespace(
-            _available_entries=lambda **_kwargs: [pool_entry],
+            _available_entries=lambda **_kwargs: ([pool_entry], []),
         )
         monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
 
@@ -279,7 +279,7 @@ class TestResolveAnthropicToken:
 
         broken_entry = SimpleNamespace(auth_type="oauth", access_token=None)
         pool = SimpleNamespace(
-            _available_entries=lambda **_kwargs: [broken_entry],
+            _available_entries=lambda **_kwargs: ([broken_entry], []),
         )
         monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
 
@@ -299,7 +299,7 @@ class TestResolveAnthropicToken:
 
         api_key_entry = SimpleNamespace(auth_type="api_key", access_token="sk-pool-apikey")
         pool = SimpleNamespace(
-            _available_entries=lambda **_kwargs: [api_key_entry],
+            _available_entries=lambda **_kwargs: ([api_key_entry], []),
         )
         monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
 
@@ -322,7 +322,7 @@ class TestResolveAnthropicToken:
 
         def _available_entries(**kwargs):
             captured.update(kwargs)
-            return [pool_entry]
+            return ([pool_entry], [])
 
         pool = SimpleNamespace(_available_entries=_available_entries)
         monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)

--- a/tests/agent/test_credential_pool_deferred_refresh.py
+++ b/tests/agent/test_credential_pool_deferred_refresh.py
@@ -1,0 +1,93 @@
+"""Thread-safety of the deferred single-use-token refresh path (#71775).
+
+The deferred path deliberately runs OAuth network I/O outside the pool
+lock. These tests pin the two invariants that make that safe:
+
+1. `select()` does NOT hold the pool lock while the deferred refresh's
+   network call runs (the whole point of the PR).
+2. The pool mutations that follow the network call (`_replace_entry`,
+   `_persist`) DO re-serialize under the pool lock, so a concurrent
+   `select()`/rotation cannot tear `self._entries` or double-write
+   auth.json.
+"""
+
+import threading
+from dataclasses import replace
+
+from agent.credential_pool import (
+    AUTH_TYPE_OAUTH,
+    CredentialPool,
+    PooledCredential,
+)
+
+
+def _codex_entry(entry_id: str = "codex-1") -> PooledCredential:
+    return PooledCredential(
+        provider="openai-codex",
+        id=entry_id,
+        label="test codex",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source="device_code",
+        access_token="at-stale",
+        refresh_token="rt-stale",
+        expires_at_ms=1,  # long expired -> needs refresh
+    )
+
+
+def test_select_does_not_hold_pool_lock_during_deferred_refresh(monkeypatch):
+    pool = CredentialPool("openai-codex", [_codex_entry()])
+    lock_free_during_refresh = {}
+
+    def _fake_refresh(entry, *, force):
+        # If select() still held the pool lock here, this non-blocking
+        # acquire would fail — the regression this PR exists to fix.
+        acquired = pool._lock.acquire(blocking=False)
+        lock_free_during_refresh["value"] = acquired
+        if acquired:
+            pool._lock.release()
+        refreshed = replace(entry, access_token="at-fresh", expires_at_ms=2**53)
+        pool._replace_entry(entry, refreshed)
+        return refreshed
+
+    monkeypatch.setattr(
+        pool, "_entry_needs_refresh", lambda e: e.access_token == "at-stale"
+    )
+    monkeypatch.setattr(pool, "_refresh_entry", _fake_refresh)
+    monkeypatch.setattr(pool, "_persist", lambda **kw: None)
+
+    selected = pool.select()
+
+    assert lock_free_during_refresh.get("value") is True, (
+        "select() held the pool lock during the deferred refresh network window"
+    )
+    assert selected is not None
+    assert selected.access_token == "at-fresh"
+
+
+def test_deferred_mutations_serialize_against_concurrent_rotation(monkeypatch):
+    """_replace_entry/_persist from the deferred path must contend on the
+    pool lock: with the lock held by another thread, the deferred mutation
+    must block rather than mutate concurrently."""
+    pool = CredentialPool("openai-codex", [_codex_entry()])
+    monkeypatch.setattr(pool, "_persist", lambda **kw: None)
+
+    entry = pool._entries[0]
+    refreshed = replace(entry, access_token="at-fresh")
+
+    mutated = threading.Event()
+
+    def _deferred_mutation():
+        pool._replace_entry(entry, refreshed)  # self-locking
+        mutated.set()
+
+    with pool._lock:
+        t = threading.Thread(target=_deferred_mutation)
+        t.start()
+        # While we hold the lock, the deferred mutation must NOT complete.
+        assert not mutated.wait(timeout=0.3), (
+            "_replace_entry mutated the pool while another thread held the lock"
+        )
+    t.join(timeout=5)
+    assert mutated.is_set()
+    assert pool._entries[0].access_token == "at-fresh"


### PR DESCRIPTION
Salvages #71775 by @dsad — commit cherry-picked to preserve authorship, plus one review-fold commit closing the thread-safety gap the deferred path opened.

## Context — what this fixes, for whom

Anyone running codex/xai OAuth credential pools across multiple Hermes processes: `_available_entries()` held the pool's threading lock while refreshing single-use-token entries — a cross-process flock (20+ second timeout) plus an OAuth network POST. Every other pool consumer (`select()`, `has_available()`, status probes, concurrent sessions) stalled behind that lock for the full refresh. The PR's structure — collect pending refreshes under the lock, execute them outside — is the right shape and is kept intact, including the `_available_entries` List→Tuple return change propagated across all callers.

## Review folds (the salvage's additions, dossier findings 1 + 2)

1. **Unlocked mutations (High)**: `_refresh_entry_impl` internally calls `_replace_entry` + `_persist`; from the deferred path those ran with NO lock, racing concurrent select/rotation (exactly what `has_available`'s comment warns about — torn `self._entries`, double-written auth.json). Fix: `self._lock` becomes an `RLock` and the two mutation primitives are now self-locking, so the network I/O stays outside the lock (the PR's whole point) while every pool mutation re-serializes. In-lock callers re-acquire reentrantly at negligible cost.
2. **Redundant re-replace (Medium)**: `_refresh_pending_entries` did a second `_replace_entry` after `_refresh_entry` had already merged internally — dropped.

New `tests/agent/test_credential_pool_deferred_refresh.py` pins both invariants: select() must NOT hold the lock during the refresh window, and post-refresh mutations MUST contend on the lock (blocking-thread probe).

## Verification

- `tests/agent/test_credential_pool.py`: 58 passed; codex quota probe + xai oauth: 28 passed; anthropic adapter (tuple-return caller): 92 passed; new deferred tests: 2 passed
- Full trio stack (this + #77561 + #77631's branches) was assembled and run during review: 55 pool tests green, `has_available`/`next_available_at` tuple-unpack verified correct
- Trio note: last of the credential_pool sequence (#76341→#67642→#71775); the rebase onto main after #77631 merges adapts `next_available_at`'s `_available_entries()` call to unpack the tuple.
- ruff clean

Closes #71775 (superseded by this salvage — original author credited via cherry-pick authorship).
