### PR TITLE
feat(mcp): allow pinning OAuth endpoints per server (#77684)

### DIFF
--- a/tests/tools/test_mcp_oauth_pinned_endpoints.py
+++ b/tests/tools/test_mcp_oauth_pinned_endpoints.py
@@ -1,0 +1,356 @@
+"""Tests for pinning MCP OAuth endpoints per server (skip discovery).
+
+GH#77684: allow overriding the OAuth endpoints for an MCP server in config
+(``oauth.authorization_endpoint`` / ``token_endpoint`` /
+``registration_endpoint`` / ``issuer``) instead of relying on RFC 8414
+well-known discovery. This is the escape hatch for providers whose
+discovery endpoints are rate-limited or broken (e.g. IBKR's hosted MCP 403s
+the well-known endpoints under load, which previously left
+``oauth_metadata=None`` and fell back to wrong ``{origin}/authorize`` /
+``{origin}/token`` URLs).
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("mcp.client.auth.oauth2", reason="MCP SDK 1.26.0+ required")
+
+
+def _set_interactive_stdin(monkeypatch, *, is_tty: bool = True) -> None:
+    mock_stdin = MagicMock()
+    mock_stdin.isatty.return_value = is_tty
+    monkeypatch.setattr("tools.mcp_oauth.sys.stdin", mock_stdin)
+
+
+# ---------------------------------------------------------------------------
+# build_pinned_oauth_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_metadata_none_when_not_pinned():
+    """No pin keys -> None (normal discovery path)."""
+    from tools.mcp_oauth import build_pinned_oauth_metadata
+
+    assert (
+        build_pinned_oauth_metadata({}, server_url="https://mcp.example/mcp")
+        is None
+    )
+    assert (
+        build_pinned_oauth_metadata(
+            {"client_id": "abc", "redirect_port": 0},
+            server_url="https://mcp.example/mcp",
+        )
+        is None
+    )
+
+
+def test_pinned_metadata_builds_full_object():
+    """Both required endpoints + optional registration/issuer are honored."""
+    from tools.mcp_oauth import build_pinned_oauth_metadata
+
+    meta = build_pinned_oauth_metadata(
+        {
+            "issuer": "https://auth.example.com",
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+            "registration_endpoint": "https://auth.example.com/register",
+        },
+        server_url="https://mcp.example/mcp",
+    )
+    assert meta is not None
+    # AnyHttpUrl normalizes to a trailing slash for bare origins.
+    assert str(meta.issuer).rstrip("/") == "https://auth.example.com"
+    assert str(meta.authorization_endpoint) == "https://auth.example.com/authorize"
+    assert str(meta.token_endpoint) == "https://auth.example.com/token"
+    assert str(meta.registration_endpoint) == "https://auth.example.com/register"
+
+
+def test_pinned_metadata_issuer_defaults_to_server_origin():
+    """issuer is optional and defaults to the server URL origin."""
+    from tools.mcp_oauth import build_pinned_oauth_metadata
+
+    meta = build_pinned_oauth_metadata(
+        {
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        },
+        server_url="https://mcp.example.com/mcp",
+    )
+    assert meta is not None
+    assert str(meta.issuer).rstrip("/") == "https://mcp.example.com"
+    assert meta.registration_endpoint is None
+
+
+@pytest.mark.parametrize(
+    "cfg",
+    [
+        {"authorization_endpoint": "https://auth.example.com/authorize"},
+        {"token_endpoint": "https://auth.example.com/token"},
+        {"issuer": "https://auth.example.com"},
+    ],
+)
+def test_pinned_metadata_partial_pin_raises(cfg):
+    """Pinning without BOTH authorization_endpoint and token_endpoint fails fast."""
+    from tools.mcp_oauth import build_pinned_oauth_metadata
+
+    with pytest.raises(ValueError, match="authorization_endpoint"):
+        build_pinned_oauth_metadata(cfg, server_url="https://mcp.example/mcp")
+
+
+def test_pinned_metadata_requires_issuer_source():
+    """No issuer and no server_url -> clear error."""
+    from tools.mcp_oauth import build_pinned_oauth_metadata
+
+    with pytest.raises(ValueError, match="issuer"):
+        build_pinned_oauth_metadata(
+            {
+                "authorization_endpoint": "https://auth.example.com/authorize",
+                "token_endpoint": "https://auth.example.com/token",
+            },
+            server_url=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Provider wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_initializes_with_pinned_metadata(tmp_path, monkeypatch):
+    """get_or_build_provider + _initialize pre-populates context.oauth_metadata
+    from the pinned config and skips pre-flight discovery."""
+    from tools.mcp_oauth_manager import MCPOAuthManager, reset_manager_for_tests
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    reset_manager_for_tests()
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider(
+        "srv",
+        "https://mcp.example.com/mcp",
+        {
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        },
+    )
+    assert provider is not None
+    assert provider._hermes_pinned_metadata is not None
+
+    await provider._initialize()
+
+    assert provider.context.oauth_metadata is not None
+    assert (
+        str(provider.context.oauth_metadata.token_endpoint)
+        == "https://auth.example.com/token"
+    )
+    assert (
+        str(provider.context.oauth_metadata.authorization_endpoint)
+        == "https://auth.example.com/authorize"
+    )
+
+
+@pytest.mark.asyncio
+async def test_manager_partial_pin_raises(tmp_path, monkeypatch):
+    """A partial pin surfaces as a clear ValueError through the manager."""
+    from tools.mcp_oauth_manager import MCPOAuthManager, reset_manager_for_tests
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _set_interactive_stdin(monkeypatch)
+    reset_manager_for_tests()
+
+    mgr = MCPOAuthManager()
+    with pytest.raises(ValueError, match="authorization_endpoint"):
+        mgr.get_or_build_provider(
+            "srv",
+            "https://mcp.example.com/mcp",
+            {"token_endpoint": "https://auth.example.com/token"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Discovery is skipped on the 401 branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pinned_flow_skips_well_known_discovery(tmp_path, monkeypatch):
+    """On a 401, the flow must NOT yield well-known discovery requests to the
+    caller — they are intercepted and answered with synthetic 404s, so the
+    pinned metadata survives and the flow proceeds straight to the token
+    exchange against the pinned token_endpoint."""
+    import httpx
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="old_access",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="old_refresh",
+        )
+    )
+    # Seed client_info so the SDK skips dynamic client registration and goes
+    # straight from discovery to authorization.
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+
+    metadata = OAuthClientMetadata(
+        redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+        client_name="Hermes Agent",
+    )
+
+    from tools.mcp_oauth import build_pinned_oauth_metadata
+
+    pinned = build_pinned_oauth_metadata(
+        {
+            "authorization_endpoint": "https://auth.example.com/authorize",
+            "token_endpoint": "https://auth.example.com/token",
+        },
+        server_url="https://mcp.example.com/mcp",
+    )
+    assert pinned is not None
+
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://mcp.example.com/mcp",
+        client_metadata=metadata,
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+        oauth_metadata=pinned,
+    )
+
+    # The authorization step would build a browser URL and wait for a
+    # callback; replace it so the flow yields the token-exchange request
+    # we can observe.
+    async def fake_perform_authorization() -> httpx.Request:
+        return httpx.Request("POST", "https://auth.example.com/token")
+
+    provider._perform_authorization = fake_perform_authorization  # type: ignore[method-assign]
+
+    req = httpx.Request("POST", "https://mcp.example.com/mcp")
+    flow = provider.async_auth_flow(req)
+
+    # First yield: the outbound MCP request itself.
+    outbound = await flow.__anext__()
+    assert outbound.url.host == "mcp.example.com"
+
+    # Reply with a 401 (no WWW-Authenticate resource_metadata, so the SDK
+    # falls back to the well-known discovery URLs).
+    fake_401 = httpx.Response(401, request=outbound)
+
+    # The next yielded request must be the token exchange against the
+    # PINNED token endpoint — never a well-known discovery GET.
+    next_request = await flow.asend(fake_401)
+    assert isinstance(next_request, httpx.Request)
+    assert str(next_request.url) == "https://auth.example.com/token", (
+        "flow should skip well-known discovery and go straight to the pinned "
+        f"token endpoint, got {next_request.url}"
+    )
+    assert ".well-known" not in str(next_request.url)
+
+    # Pinned metadata survived the 401 branch untouched.
+    assert provider.context.oauth_metadata is not None
+    assert (
+        str(provider.context.oauth_metadata.token_endpoint)
+        == "https://auth.example.com/token"
+    )
+
+    await flow.aclose()
+
+
+@pytest.mark.asyncio
+async def test_unpinned_flow_still_yields_discovery(tmp_path, monkeypatch):
+    """Without a pin, the 401 branch must still yield the well-known discovery
+    request to the caller — pinning must not change default behaviour."""
+    import httpx
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="old_access",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="old_refresh",
+        )
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+
+    metadata = OAuthClientMetadata(
+        redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+        client_name="Hermes Agent",
+    )
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://mcp.example.com/mcp",
+        client_metadata=metadata,
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+    assert provider._hermes_pinned_metadata is None
+
+    req = httpx.Request("POST", "https://mcp.example.com/mcp")
+    flow = provider.async_auth_flow(req)
+
+    outbound = await flow.__anext__()
+    fake_401 = httpx.Response(401, request=outbound)
+
+    # Without a pin, the SDK's 401 branch yields the PRM well-known GET.
+    next_request = await flow.asend(fake_401)
+    assert isinstance(next_request, httpx.Request)
+    assert ".well-known/oauth-protected-resource" in str(next_request.url)
+
+    await flow.aclose()
+
+
+async def _noop_redirect(_url: str) -> None:
+    """Redirect handler that does nothing (won't be invoked in these tests)."""
+    return None
+
+
+async def _noop_callback() -> tuple[str, str | None]:
+    """Callback handler that won't be invoked in these tests."""
+    raise AssertionError(
+        "callback handler should not be invoked in bidirectional-generator tests"
+    )

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -32,6 +32,15 @@ Configuration in config.yaml::
           redirect_uri: "https://proxy/callback"  # default: loopback callback
           redirect_host: "localhost"            # loopback hostname (WAF-safe)
           client_name: "My Custom Client"       # default: "Hermes Agent"
+          # Pinned endpoints — set ANY of these to pre-populate the RFC 8414
+          # provider metadata and SKIP well-known discovery (#77684):
+          #   authorization_endpoint: "https://auth.example.com/authorize"
+          #   token_endpoint: "https://auth.example.com/token"
+          #   registration_endpoint: "https://auth.example.com/register"
+          #   issuer: "https://auth.example.com"   # default: server origin
+          # authorization_endpoint + token_endpoint are both required when
+          # pinning; discovery is skipped entirely for rate-limited or
+          # broken well-known endpoints (e.g. IBKR's hosted MCP).
 """
 
 import asyncio
@@ -1182,6 +1191,85 @@ def apply_oauth_provider_defaults(
         if not cfg.get("token_endpoint_auth_method"):
             cfg["token_endpoint_auth_method"] = "client_secret_post"
     return cfg
+
+
+# Keys under ``mcp_servers.<name>.oauth`` that pin RFC 8414 metadata.
+# Presence of ANY of them switches the provider to pinned mode (skip
+# well-known discovery). See :func:`build_pinned_oauth_metadata`.
+_PINNED_OAUTH_METADATA_KEYS = (
+    "issuer",
+    "authorization_endpoint",
+    "token_endpoint",
+    "registration_endpoint",
+)
+
+
+def _server_origin(url: str) -> str | None:
+    """Return ``scheme://netloc`` for *url*, or None when unparseable."""
+    from urllib.parse import urlsplit
+
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return None
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def build_pinned_oauth_metadata(
+    cfg: dict,
+    *,
+    server_url: str | None = None,
+) -> "OAuthMetadata | None":
+    """Build ``OAuthMetadata`` from pinned ``oauth`` config endpoints.
+
+    When a server's ``oauth`` block pins any of ``issuer`` /
+    ``authorization_endpoint`` / ``token_endpoint`` /
+    ``registration_endpoint``, pre-populate an RFC 8414 metadata object so
+    the MCP SDK skips well-known discovery and uses the pinned URLs for the
+    authorize redirect, token exchange, and refresh. This is the escape
+    hatch for providers whose discovery endpoints are unavailable or
+    rate-limited (e.g. IBKR's hosted MCP 403s the well-known endpoints
+    under load, which previously left ``oauth_metadata=None`` and fell back
+    to wrong ``{origin}/authorize`` / ``{origin}/token`` URLs).
+
+    ``authorization_endpoint`` and ``token_endpoint`` are both required —
+    they drive the authorize URL and the token exchange / refresh URL in
+    the SDK. ``registration_endpoint`` and ``issuer`` are optional;
+    ``issuer`` defaults to the server URL origin when omitted.
+
+    Returns None when no pin keys are present (normal discovery).
+    Raises ValueError when only one of ``authorization_endpoint`` /
+    ``token_endpoint`` is pinned.
+    """
+    pinned = {k: cfg.get(k) for k in _PINNED_OAUTH_METADATA_KEYS if cfg.get(k)}
+    if not pinned:
+        return None
+    if OAuthMetadata is None:
+        _ensure_sdk_loaded()
+    missing = [
+        k for k in ("authorization_endpoint", "token_endpoint") if not pinned.get(k)
+    ]
+    if missing:
+        raise ValueError(
+            "oauth block pins OAuth endpoints but is missing required "
+            f"key(s): {', '.join(missing)}. Pin both authorization_endpoint "
+            "and token_endpoint (registration_endpoint and issuer are "
+            "optional)."
+        )
+    issuer = pinned.get("issuer") or _server_origin(server_url or "")
+    if not issuer:
+        raise ValueError(
+            "oauth.issuer is required when pinning OAuth endpoints without "
+            "a server URL to derive it from."
+        )
+    return OAuthMetadata(
+        issuer=issuer,
+        authorization_endpoint=pinned["authorization_endpoint"],
+        token_endpoint=pinned["token_endpoint"],
+        registration_endpoint=pinned.get("registration_endpoint"),
+    )
 
 
 def _build_client_metadata(cfg: dict) -> "OAuthClientMetadata":

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -70,6 +70,22 @@ def _same_endpoint(a: str, b: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _synthetic_metadata_response(outgoing: Any) -> Any:
+    """Build a synthetic 404 for a discovery request that must not go out.
+
+    Used when a server pins its OAuth endpoints: well-known discovery
+    requests are intercepted in :meth:`HermesMCPOAuthProvider.async_auth_flow`
+    and answered locally with a 404 so the SDK's discovery loops exhaust
+    without any network I/O. ``handle_protected_resource_response`` maps a
+    non-200 to None (try next URL) and ``handle_auth_metadata_response``
+    maps a 4XX to ``(True, None)`` (keep going), so a 404 terminates both
+    loops with the pinned ``oauth_metadata`` intact.
+    """
+    import httpx  # local import: httpx is an MCP SDK dependency
+
+    return httpx.Response(404, request=outgoing)
+
+
 @dataclass
 class _ProviderEntry:
     """Per-server OAuth state tracked by the manager.
@@ -129,11 +145,16 @@ def _make_hermes_provider_class() -> Optional[type]:
         (``src/utils/auth.ts:1320``, CC-1096 / GH#24317).
         """
 
+        # Class-level default: instances constructed via ``__new__`` (tests
+        # that bypass ``__init__``) behave as unpinned.
+        _hermes_pinned_metadata: Optional[Any] = None
+
         def __init__(
             self,
             *args: Any,
             server_name: str = "",
             preregistered: bool = False,
+            oauth_metadata: Optional[Any] = None,
             **kwargs: Any,
         ):
             super().__init__(*args, **kwargs)
@@ -145,6 +166,12 @@ def _make_hermes_provider_class() -> Optional[type]:
             # registration can't help. Only auto-heal dynamically-registered
             # clients. See _maybe_flag_poisoned_client.
             self._hermes_preregistered = preregistered
+            # Pinned RFC 8414 metadata (oauth.authorization_endpoint /
+            # token_endpoint / registration_endpoint / issuer). When set,
+            # well-known discovery is skipped and these endpoints are
+            # authoritative for the authorize redirect, token exchange, and
+            # refresh (GH#77684).
+            self._hermes_pinned_metadata = oauth_metadata
 
         async def _initialize(self) -> None:
             """Load stored tokens + client info AND seed token_expiry_time.
@@ -182,6 +209,15 @@ def _make_hermes_provider_class() -> Optional[type]:
             tokens = self.context.current_tokens
             if tokens is not None and tokens.expires_in is not None:
                 self.context.update_token_expiry(tokens)
+
+            # Pinned endpoints from config are authoritative: pre-populate
+            # the SDK's metadata so the authorize redirect, token exchange,
+            # and refresh use the pinned URLs, and RFC 8414 well-known
+            # discovery is skipped entirely. The cold-load disk restore and
+            # pre-flight discovery below are both guarded by
+            # ``oauth_metadata is None``, so they are skipped automatically.
+            if self._hermes_pinned_metadata is not None:
+                self.context.oauth_metadata = self._hermes_pinned_metadata
 
             # Cold-load: restore OAuth server metadata from disk before any
             # refresh attempt. Without this, a restarted process with cached
@@ -304,7 +340,12 @@ def _make_hermes_provider_class() -> Optional[type]:
             Called after the SDK's normal 401-branch auth flow completes so
             metadata discovered via the lazy path (not pre-flight) is also
             saved. No-op when nothing to persist or metadata hasn't changed.
+            Pinned metadata is never persisted — config is the source of
+            truth and must stay authoritative even if the user edits or
+            removes the pin later.
             """
+            if self._hermes_pinned_metadata is not None:
+                return
             meta = self.context.oauth_metadata
             if meta is None:
                 return
@@ -420,7 +461,18 @@ def _make_hermes_provider_class() -> Optional[type]:
             try:
                 outgoing = await inner.__anext__()
                 while True:
-                    incoming = yield outgoing
+                    # Pinned endpoints: never let RFC 8414 / RFC 9728
+                    # well-known discovery requests hit the network — the
+                    # whole point of pinning is skipping discovery for
+                    # providers whose well-known endpoints are rate-limited
+                    # or broken (GH#77684). Feed back a synthetic 404 so the
+                    # SDK's discovery loops exhaust and the pinned metadata
+                    # survives untouched; registration, token exchange, and
+                    # refresh requests pass through normally.
+                    if self._should_skip_discovery(outgoing):
+                        incoming = _synthetic_metadata_response(outgoing)
+                    else:
+                        incoming = yield outgoing
                     # Sniff the response for a dead-client-registration signal
                     # before handing it back to the SDK (best-effort, GH#36767).
                     await self._maybe_flag_poisoned_client(incoming)
@@ -430,6 +482,27 @@ def _make_hermes_provider_class() -> Optional[type]:
                 # 401 branch so a subsequent cold-load skips discovery.
                 self._persist_oauth_metadata_if_changed()
                 return
+
+        def _should_skip_discovery(self, outgoing: Any) -> bool:
+            """True when *outgoing* is a well-known discovery request and the
+            server pins its OAuth endpoints (skip discovery).
+
+            Matches the RFC 8414 / RFC 9728 well-known paths the SDK's URL
+            builders generate:
+            ``/.well-known/oauth-protected-resource`` (PRM) and
+            ``/.well-known/oauth-authorization-server`` (ASM). A
+            ``resource_metadata`` URL from a WWW-Authenticate header is not
+            matched — if a provider serves a valid PRM there, discovery
+            succeeds and the pinned ASM still wins (the ASM loop is
+            intercepted, so ``oauth_metadata`` is never overwritten).
+            """
+            if self._hermes_pinned_metadata is None:
+                return False
+            url = str(getattr(outgoing, "url", ""))
+            return (
+                "/.well-known/oauth-protected-resource" in url
+                or "/.well-known/oauth-authorization-server" in url
+            )
 
     return HermesMCPOAuthProvider
 
@@ -546,10 +619,21 @@ class MCPOAuthManager:
             return None
 
         cfg = dict(entry.oauth_config or {})
-        from tools.mcp_oauth import apply_oauth_provider_defaults
+        from tools.mcp_oauth import (
+            apply_oauth_provider_defaults,
+            build_pinned_oauth_metadata,
+        )
 
         apply_oauth_provider_defaults(
             cfg, server_name=server_name, server_url=entry.server_url
+        )
+        # Pinned endpoints (oauth.authorization_endpoint / token_endpoint /
+        # registration_endpoint / issuer) pre-populate the provider metadata
+        # so the SDK skips well-known discovery (GH#77684). May raise
+        # ValueError for a partial pin (e.g. authorization_endpoint without
+        # token_endpoint) — callers surface it as a clear config error.
+        pinned_metadata = build_pinned_oauth_metadata(
+            cfg, server_url=entry.server_url
         )
         storage = HermesTokenStorage(server_name)
 
@@ -579,6 +663,7 @@ class MCPOAuthManager:
         return _HERMES_PROVIDER_CLS(
             server_name=server_name,
             preregistered=bool(cfg.get("client_id")),
+            oauth_metadata=pinned_metadata,
             server_url=entry.server_url,
             client_metadata=client_metadata,
             storage=storage,

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -271,6 +271,22 @@ mcp_servers:
 
 Then run `hermes mcp login googledrive` — with the pre-registered client, Hermes skips registration and runs the normal browser authorization flow.
 
+**Pinning OAuth endpoints (skip discovery).** Some providers' RFC 8414 well-known discovery endpoints are unreliable or rate-limited (e.g. IBKR's hosted MCP 403s them under any load). When discovery fails the SDK is left with no metadata and falls back to wrong `{origin}/authorize` / `{origin}/token` URLs — the browser login builds a broken authorize URL and headless refresh 404s. Pin the endpoints explicitly to pre-populate the provider metadata and skip discovery entirely:
+
+```yaml
+mcp_servers:
+  ibkr:
+    url: "https://mcp.example.com/mcp"
+    auth: oauth
+    oauth:
+      authorization_endpoint: "https://auth.example.com/authorize"
+      token_endpoint: "https://auth.example.com/token"
+      registration_endpoint: "https://auth.example.com/register"  # optional
+      issuer: "https://auth.example.com"                          # optional, defaults to the server origin
+```
+
+`authorization_endpoint` and `token_endpoint` are both required when pinning (they drive the authorize redirect and the token exchange/refresh URLs); `registration_endpoint` and `issuer` are optional. Setting any of these keys switches the server to pinned mode — Hermes skips the well-known discovery requests entirely and uses the pinned endpoints for login, token exchange, and headless refresh.
+
 **Pitfall — config auto-reload race.** When you edit `~/.hermes/config.yaml` from inside a running Hermes session, the CLI auto-reloads MCP connections with a 30s timeout. That's not enough for an interactive OAuth flow. Add the entry, then run `hermes mcp login <server>` from a fresh terminal — it waits the full 5 minutes for you to complete auth.
 
 ## mTLS / client certificates


### PR DESCRIPTION
## Summary

Allow pinning the OAuth endpoints per MCP server in config (`oauth.authorization_endpoint` / `token_endpoint` / `registration_endpoint` / `issuer`) so the provider metadata is pre-populated and RFC 8414 well-known discovery is skipped entirely.

This is the escape hatch for providers whose discovery endpoints are rate-limited or broken — e.g. IBKR's hosted MCP 403s the well-known endpoints under any load, which previously left `oauth_metadata=None` and made the SDK fall back to wrong `{origin}/authorize` / `{origin}/token` URLs (broken authorize URL on login, 404 on headless refresh).

## Change

- **`tools/mcp_oauth.py`** — new `build_pinned_oauth_metadata()`: builds an `OAuthMetadata` from pinned config keys. `authorization_endpoint` + `token_endpoint` are both required when pinning (clear `ValueError` on partial pins); `registration_endpoint` and `issuer` are optional, and `issuer` defaults to the server URL origin.
- **`tools/mcp_oauth_manager.py`** — `HermesMCPOAuthProvider` accepts the pinned metadata and pre-populates `context.oauth_metadata` in `_initialize()`, which automatically skips the cold-load disk restore and pre-flight discovery. The `async_auth_flow` bridge intercepts well-known discovery requests (`/.well-known/oauth-protected-resource`, `/.well-known/oauth-authorization-server`) when pinned and answers them with synthetic 404s, so no discovery request ever hits the network and the pinned metadata survives the SDK's 401 branch untouched. Pinned metadata is never persisted to the state dir — config stays the source of truth.
- **`website/docs/user-guide/features/mcp.md`** — new "Pinning OAuth endpoints (skip discovery)" section with a config example.
- **`tests/tools/test_mcp_oauth_pinned_endpoints.py`** — unit tests for metadata building/validation/issuer default, manager wiring, a generator-level test proving the 401 branch skips discovery and goes straight to the pinned token endpoint, and a regression test that unpinned flows still discover.

## Verification

- New tests: `tests/tools/test_mcp_oauth_pinned_endpoints.py` — 11 passed
- Related OAuth suites: `test_mcp_oauth_manager.py`, `test_mcp_oauth_bidirectional.py`, `test_mcp_oauth_metadata.py`, `test_mcp_oauth_cold_load_expiry.py`, `test_mcp_oauth.py`, `test_mcp_oauth_integration.py`, `test_mcp_tool_401_handling.py`, `test_mcp_dashboard_oauth.py`, `test_mcp_config.py`, `test_mcp_discovery_timing.py` — all pass
- `ruff check` clean on modified files

Closes #77684
