### PR TITLE
fix(gateway): stop revoking managed-mode group access on the flush dir

### DIFF
--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -36,14 +36,90 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 
+def _managed_install() -> bool:
+    """True when a package manager (NixOS) owns this install's directory modes.
+
+    Read at each creation so the *creation* mode honours the same carve-out
+    ``hermes_cli.config._secure_dir`` already applies to reconciliation. The
+    import is local and a failure means "not managed": an unimportable config
+    module is the single-user source-install case, where owner-only is right.
+    """
+    try:
+        from hermes_cli.config import is_managed
+
+        return bool(is_managed())
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
+def _reconcile_flush_dir_mode(flush_dir: Path) -> None:
+    """Apply the shared HERMES_HOME directory policy to an existing flush dir.
+
+    Delegates to ``hermes_cli.config._secure_dir`` — the single place that
+    implements this policy for HERMES_HOME *and every subdirectory*
+    ``ensure_hermes_home`` creates (``cron``, ``sessions``, ``logs``,
+    ``memories``, ...). The hand-rolled ``os.chmod(flush_dir, 0o700)`` this
+    replaces diverged from that shared policy on three axes:
+
+    * it ran in managed mode, where the policy is to stand down;
+    * it ignored ``HERMES_HOME_MODE``, which every sibling dir honours;
+    * it was unguarded, and ``chmod`` by a non-owner raises ``EPERM`` — so on
+      a shared-state install it raised straight out of ``_get_flush_dir()``,
+      and because every caller wraps this module in ``except Exception:
+      pass`` the shutdown flush degraded to a silent no-op, losing the very
+      messages it exists to save.
+
+    Best-effort by design: this runs on the shutdown path, so a failure to
+    reconcile permissions must never cost us the flush itself.
+    """
+    if os.name != "posix":
+        # POSIX mode bits are advisory on Windows, where at-rest protection is
+        # ACL-based; preserves this function's original non-POSIX behaviour.
+        return
+    try:
+        from hermes_cli.config import _secure_dir
+
+        _secure_dir(flush_dir)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Could not reconcile pending-message dir mode: %s", exc)
+
+
 def _get_flush_dir():
-    """Return the pending-messages flush directory under the active HERMES_HOME."""
+    """Return the pending-messages flush directory under the active HERMES_HOME.
+
+    Created owner-only (0700) so the verbatim user messages parked here for
+    crash recovery are not world-readable, with the mode passed to ``mkdir``
+    rather than chmod'd afterwards so the directory never exists at umask
+    permissions.
+
+    **Managed installs are carved out at creation, not just at
+    reconciliation.** ``pending_messages`` is not among the directories
+    ``nix/nixosModules.nix`` pre-creates via ``systemd.tmpfiles`` (only
+    stateDir, .hermes, cron, sessions, logs, memories, plugins), so on a
+    managed host it is always made lazily at runtime and these lines are the
+    only thing setting its mode. That module pins those dirs to ``2770``
+    (setgid, group-rwx), runs the gateway with ``UMask = "0007"`` precisely so
+    "files created by the gateway should be group-writable so interactive
+    users in the hermes group can read/write them", and deliberately avoids
+    ``chown -R`` to keep the setgid bit alive "for group access by hostUsers".
+    ``container.hostUsers`` get a ``~/.hermes`` symlink to that same stateDir,
+    so the gateway service and an interactive CLI share one ``$HERMES_HOME``
+    at two different uids. Forcing 0700 there locks whichever side ran second
+    out of the recovery directory — including the operator who has to salvage
+    an agent-history snapshot by hand. Omitting the explicit mode lets the
+    inherited setgid + umask land 2770, matching ``ensure_hermes_home``'s
+    managed branch and its ``logs/curator`` lazy-mkdir precedent.
+    """
     from hermes_constants import get_hermes_home
 
     flush_dir = get_hermes_home() / "pending_messages"
+    if _managed_install():
+        # Let the NixOS-configured setgid + umask decide, and skip the
+        # reconciler (which stands down under is_managed() anyway).
+        flush_dir.mkdir(parents=True, exist_ok=True)
+        return flush_dir
     flush_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-    if os.name == "posix":
-        os.chmod(flush_dir, 0o700)
+    _reconcile_flush_dir_mode(flush_dir)
     return flush_dir
 
 

--- a/tests/gateway/test_shutdown_flush.py
+++ b/tests/gateway/test_shutdown_flush.py
@@ -132,3 +132,296 @@ def test_get_flush_dir_uses_get_hermes_home(tmp_path, monkeypatch):
     assert result == tmp_path / "pending_messages"
 
 
+# ---------------------------------------------------------------------------
+# At-rest permissions for the recovery directory (#72680 follow-up)
+#
+# ``pending_messages/`` holds *verbatim undelivered user messages*, and the
+# agent-history payloads written here are documented as operator-salvaged by
+# hand ("so an operator can salvage the conversation after repairing
+# state.db"). So the directory is read by a human, not only by the gateway.
+#
+# Two mechanisms set its mode and they mask each other under a plain
+# "is it 0700?" assertion: the ``mode=`` on ``mkdir`` and the ``_secure_dir``
+# reconciliation. Each class below isolates one of them.
+# ---------------------------------------------------------------------------
+
+posix_only = pytest.mark.skipif(
+    os.name != "posix",
+    reason="POSIX mode bits; Windows at-rest protection is ACL-based (#77527)",
+)
+
+GROUP_OTHER_BITS = (
+    stat.S_IRGRP
+    | stat.S_IWGRP
+    | stat.S_IXGRP
+    | stat.S_IROTH
+    | stat.S_IWOTH
+    | stat.S_IXOTH
+)
+
+
+def _mode(path) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+@pytest.fixture
+def permissive_umask():
+    """Force a world-readable-by-default umask for the duration of a test."""
+    previous = os.umask(0o022)
+    try:
+        yield
+    finally:
+        os.umask(previous)
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """A real HERMES_HOME with ``pending_messages`` deliberately absent."""
+    home = tmp_path / "hermes-home"
+    home.mkdir(mode=0o700)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # Never let the ambient environment silently disable the hardening.
+    monkeypatch.delenv("HERMES_CONTAINER", raising=False)
+    monkeypatch.delenv("HERMES_SKIP_CHMOD", raising=False)
+    monkeypatch.delenv("HERMES_HOME_MODE", raising=False)
+    monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    return home
+
+
+@pytest.fixture
+def neutralized_secure_dir(monkeypatch):
+    """Make the post-creation reconciliation step a recording no-op.
+
+    ``_get_flush_dir`` hardens twice over: ``mode=`` on ``mkdir``, then
+    ``hermes_cli.config._secure_dir`` to reconcile policy. Either mechanism
+    alone satisfies a plain "is it 0700?" assertion, so the two mask each
+    other and such a test cannot tell which one did the work — deleting
+    ``mode=`` keeps it green.
+
+    Stubbing the reconciler out isolates the creation mode as the *only*
+    thing that can produce the observed bits. ``_secure_dir`` is patched on
+    ``hermes_cli.config`` (not on the caller) because the production code
+    imports it lazily inside the function, so the attribute is resolved at
+    call time.
+    """
+    import hermes_cli.config as hermes_config
+
+    calls = []
+
+    def _recording_noop(path):
+        calls.append(str(path))
+
+    monkeypatch.setattr(hermes_config, "_secure_dir", _recording_noop)
+    return calls
+
+
+@pytest.fixture
+def managed_nixos_home(hermes_home, monkeypatch):
+    """Simulate a managed NixOS install that shares state via the hermes group.
+
+    Reproduces the two conditions ``nix/nixosModules.nix`` actually creates:
+
+    * ``systemd.tmpfiles`` pins ``stateDir/.hermes`` to ``2770`` — setgid,
+      group-rwx — so the gateway and interactive ``hostUsers`` share it;
+    * the service runs with ``UMask = "0007"``, commented "files created by
+      the gateway should be group-writable so interactive users in the hermes
+      group can read/write them".
+
+    ``pending_messages`` is *not* in those tmpfiles rules, so it is created
+    lazily at runtime under exactly this umask — which is why the creation
+    mode, not just the reconciliation, has to honour the carve-out. Setting
+    ``HERMES_MANAGED`` without the umask and the 2770 parent would pass for
+    the wrong reason.
+    """
+    monkeypatch.setenv("HERMES_MANAGED", "nixos")
+    os.chmod(hermes_home, 0o2770)
+    previous = os.umask(0o007)
+    try:
+        yield hermes_home
+    finally:
+        os.umask(previous)
+
+
+@posix_only
+class TestFlushDirUnmanagedPermissions:
+    """Unmanaged installs keep the recovery dir owner-only."""
+
+    def test_fresh_dir_has_no_group_or_other_access(
+        self, hermes_home, permissive_umask
+    ):
+        """The real path must not leave undelivered messages world-readable."""
+        from gateway.shutdown_flush import _get_flush_dir
+
+        flush_dir = _get_flush_dir()
+
+        assert flush_dir == hermes_home / "pending_messages"
+        mode = _mode(flush_dir)
+        assert not (mode & GROUP_OTHER_BITS), (
+            f"recovery dir {flush_dir} is group/other-accessible: {oct(mode)}"
+        )
+
+    def test_mode_is_not_umask_derived(self, hermes_home, permissive_umask):
+        """Owner keeps full access; the mode comes from code, not the umask."""
+        from gateway.shutdown_flush import _get_flush_dir
+
+        assert _mode(_get_flush_dir()) == 0o700
+
+    def test_creation_mode_alone_is_owner_only(
+        self, hermes_home, permissive_umask, neutralized_secure_dir
+    ):
+        """Teeth for ``mode=`` on mkdir, with the reconciler stubbed out.
+
+        The mkdir->chmod window is what ``mode=`` closes; the race itself is
+        not assertable, but "correct with no chmod at all" is the equivalent
+        deterministic property.
+        """
+        from gateway.shutdown_flush import _get_flush_dir
+
+        flush_dir = _get_flush_dir()
+
+        mode = _mode(flush_dir)
+        assert mode == 0o700, (
+            "creation mode must be owner-only on its own — the mkdir mode is "
+            f"what closes the TOCTOU window, got {oct(mode)}"
+        )
+        assert neutralized_secure_dir == [str(flush_dir)], (
+            "unmanaged installs must still reconcile via the shared "
+            "hermes_cli.config._secure_dir policy"
+        )
+
+    def test_flush_payload_is_owner_only(self, hermes_home, permissive_umask):
+        """The payload file itself carries the verbatim message text."""
+        from gateway.shutdown_flush import _get_flush_dir, flush_pending_to_file
+
+        assert flush_pending_to_file(
+            {"agent:main:telegram:dm:1": "verbatim user text"},
+            reason="shutdown",
+        ) == 1
+
+        payloads = list(_get_flush_dir().glob("pending-*.json"))
+        assert len(payloads) == 1
+        mode = _mode(payloads[0])
+        assert not (mode & GROUP_OTHER_BITS), (
+            f"recovery payload {payloads[0]} is group/other-readable: {oct(mode)}"
+        )
+
+    def test_home_mode_hatch_is_honoured(
+        self, hermes_home, permissive_umask, monkeypatch
+    ):
+        """Delegating to ``_secure_dir`` picks up the documented hatch.
+
+        Every other HERMES_HOME subdirectory ``ensure_hermes_home`` creates
+        honours ``HERMES_HOME_MODE``; this one now does too rather than
+        hard-coding a mode the operator overrode.
+        """
+        from gateway.shutdown_flush import _get_flush_dir
+
+        monkeypatch.setenv("HERMES_HOME_MODE", "0701")
+
+        assert _mode(_get_flush_dir()) == 0o701
+
+
+@posix_only
+class TestFlushDirManagedPermissions:
+    """Managed (NixOS) installs must not have group access revoked."""
+
+    def test_fresh_dir_keeps_group_access(self, managed_nixos_home):
+        """The case at issue: dir absent, created lazily under UMask=0007.
+
+        The gateway service and an interactive hermes-group CLI share one
+        ``$HERMES_HOME`` at two uids, so a 0700 dir created by whichever ran
+        first locks the other out of the recovery directory with EACCES.
+        """
+        from gateway.shutdown_flush import _get_flush_dir
+
+        flush_dir = _get_flush_dir()
+
+        assert flush_dir.is_dir()
+        mode = _mode(flush_dir)
+        assert mode & stat.S_IRWXG == stat.S_IRWXG, (
+            "managed installs deliberately share this dir with the hermes "
+            f"group (UMask=0007, parent 2770); got {oct(mode)}"
+        )
+
+    def test_fresh_dir_creation_does_not_hardcode_a_mode(
+        self, managed_nixos_home, neutralized_secure_dir
+    ):
+        """Teeth for the managed branch at the *creation* site.
+
+        With the reconciler stubbed out, the only thing that can produce the
+        observed bits is the ``mkdir`` call — so an unconditional
+        ``mode=0o700`` fails here even though ``_secure_dir`` would have
+        stood down anyway.
+        """
+        from gateway.shutdown_flush import _get_flush_dir
+
+        mode = _mode(_get_flush_dir())
+
+        assert mode & stat.S_IRWXG == stat.S_IRWXG, (
+            "creation must not hardcode a mode in managed mode: the inherited "
+            f"setgid + umask should land group-rwx, got {oct(mode)}"
+        )
+
+    def test_reconciler_is_not_invoked_in_managed_mode(
+        self, managed_nixos_home, neutralized_secure_dir
+    ):
+        """Managed mode returns before reconciliation, not merely into a no-op."""
+        from gateway.shutdown_flush import _get_flush_dir
+
+        _get_flush_dir()
+
+        assert neutralized_secure_dir == [], (
+            "managed mode should short-circuit before the reconciler"
+        )
+
+    def test_preexisting_dir_mode_is_left_alone(self, managed_nixos_home):
+        """A dir the activation script already placed keeps its mode."""
+        from gateway.shutdown_flush import _get_flush_dir
+
+        preexisting = managed_nixos_home / "pending_messages"
+        preexisting.mkdir()
+        os.chmod(preexisting, 0o750)
+
+        assert _mode(_get_flush_dir()) == 0o750
+
+    def test_flush_still_writes_under_managed_mode(self, managed_nixos_home):
+        """The carve-out must not cost us the flush itself."""
+        from gateway.shutdown_flush import _get_flush_dir, flush_pending_to_file
+
+        assert flush_pending_to_file(
+            {"agent:main:telegram:dm:1": "verbatim user text"},
+            reason="shutdown",
+        ) == 1
+        assert len(list(_get_flush_dir().glob("pending-*.json"))) == 1
+
+
+@posix_only
+class TestFlushDirIsResilient:
+    """Permission reconciliation must never cost us the messages."""
+
+    def test_flush_survives_a_failing_reconciler(
+        self, hermes_home, permissive_umask, monkeypatch
+    ):
+        """``chmod`` by a non-owner is EPERM on a shared-state install.
+
+        Unguarded, that raised out of ``_get_flush_dir()``, and because every
+        caller wraps this module in ``except Exception: pass`` the shutdown
+        flush degraded to a silent no-op — losing the very messages it exists
+        to save.
+        """
+        import hermes_cli.config as hermes_config
+
+        def _boom(path):
+            raise PermissionError(13, "Operation not permitted")
+
+        monkeypatch.setattr(hermes_config, "_secure_dir", _boom)
+
+        from gateway.shutdown_flush import flush_pending_to_file
+
+        assert flush_pending_to_file(
+            {"agent:main:telegram:dm:1": "verbatim user text"},
+            reason="shutdown",
+        ) == 1
+        payloads = list((hermes_home / "pending_messages").glob("pending-*.json"))
+        assert len(payloads) == 1, "a chmod EPERM must not lose the flush"
+


### PR DESCRIPTION
## What does this PR do?

`gateway/shutdown_flush.py::_get_flush_dir()` creates `$HERMES_HOME/pending_messages` with an unconditional `mode=0o700` **and** chmods it `0700` again:

```python
flush_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
if os.name == "posix":
    os.chmod(flush_dir, 0o700)
```

On a managed (NixOS) install, both mechanisms override group permissions the module deliberately configures. This is pre-existing upstream code, not a regression from a recent PR.

**The NixOS evidence** (`nix/nixosModules.nix` on current `main`):

- Lines 711-719 pre-create only `stateDir`, `.hermes`, `cron`, `sessions`, `logs`, `memories`, `plugins` at `2770` (setgid, group-rwx) via `systemd.tmpfiles`, mirrored by the activation loop at 740-743. **`pending_messages` is absent from both lists** — so on a managed host it is always created lazily at runtime, and these two lines are the only thing setting its mode.
- Line 907 sets `UMask = "0007"`, commented *"files created by the gateway should be group-writable so interactive users in the hermes group can read/write them."*
- Lines 135-136 avoid `chown -R` specifically because it strips setgid, *"destroying the 2770 permissions … for group access by hostUsers."*
- `container.hostUsers` get a `~/.hermes` symlink to that same `stateDir`, so the gateway service and an interactive CLI share one `$HERMES_HOME` at two different uids.

**Measured** under real managed conditions (2770 parent, `umask 0007`, dir absent):

| | dir | payload |
|---|---|---|
| before | `0o700` (no group) | `0o600` |
| after | `0o770` (group-rwx) | `0o600` |

The payload files stay `0o600` either way — only the directory widens, which is the part that gates the *second* process. Measured consequence: `mkdir(exist_ok=True)` on a dir owned by the other uid **succeeds silently**, then the `mkstemp` inside it fails `EACCES`. So the flush is *lost*, not merely unreadable, and because every caller wraps this module in `except Exception: pass` it fails silently.

### Blast radius, stated honestly

The automatic reader `recover_pending_to_db()` is called from exactly one place, `gateway/run.py:26505` — gateway-only. In the common case writer and reader are the same service, so this is narrower than a user-facing directory.

What makes it more than cosmetic: `flush_agent_history_to_file` payloads are *deliberately skipped* by automatic recovery (`if payload.get("reason") == "shutdown-with-unpersisted-agent-history": continue`) and documented as left for a human — *"so an operator can salvage the conversation after repairing state.db."* A `0700` dir owned by the service uid locks that operator out of their own transcript. Plus, on managed hosts the two uids sharing `$HERMES_HOME` are both gateway processes, so the `EACCES` write-loss path is reachable without any CLI involvement.

## Related Issue

Refs #77472 — the `pending_messages/` item in cluster R-DUMP ("flush files raw unredacted; 0600 skipped on Windows"). This PR addresses the **directory-mode** half of that item on managed installs; the payload files were already `0600` on `main` and stay `0600` here. The sibling file-mode items in that cluster are #77520 (trajectories / MoA traces / `/save`) and #77655 (a2a logs, batch trajectories, `sessions/saved`); its unbounded-growth item is #78395 and its redactor-correctness item is #78379.

Note on that issue's framing: the report characterises this path as an at-rest exposure. It is not one on POSIX — the payloads are already `0o600` and the directory `0o700` on `main`. The real defect runs the opposite direction, which is what this PR fixes: `0o700` is forced *even on a managed install*, revoking the group access `nix/nixosModules.nix` deliberately configures (`UMask = "0007"` at `nixosModules.nix:907`, `~/.hermes` at `0o2770` setgid).

No dedicated issue for this specific defect. Related context: #72680 (the incident that introduced this module), and #14181 tracks the same managed/shared-runtime permission class for `SKILL.md`. Sibling PR #77579 (head `4195f1e98`) is precedent for the fix **shape**, not a parent — the two touch disjoint files and can land in either order.

- **#75536** (`fix(gateway): resolve session_key in shutdown-flush recovery`, open, head `b1db79117`) — shares two files with this PR. The production hunks are disjoint: #75536 edits `recover_pending_to_db` (from line 168) while this edits `_get_flush_dir` (lines 36-46), so `gateway/shutdown_flush.py` should merge cleanly. `tests/gateway/test_shutdown_flush.py` **will** conflict textually — both changes are pure appends at the same anchor (line 132 of a 134-line file), #75536 adding 110 lines and this one 293. Semantically compatible; the conflict is positional only. Happy to rebase behind whichever lands first.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/shutdown_flush.py`
  - `_get_flush_dir()` branches on `is_managed()` **at the creation site**, mirroring `ensure_hermes_home` (`hermes_cli/config.py:896`) and its `logs/curator` bare-mkdir precedent. Managed installs get `mkdir(parents=True, exist_ok=True)` so the inherited setgid + `UMask=0007` lands `2770`.
  - New `_managed_install()` helper — local import, failure means "not managed" (an unimportable config module is the single-user source install, where owner-only is right).
  - The hand-rolled `os.chmod(flush_dir, 0o700)` is replaced by `_reconcile_flush_dir_mode()`, which delegates to `hermes_cli.config._secure_dir` — the single owner of this policy for HERMES_HOME and every subdir `ensure_hermes_home` creates.
- `tests/gateway/test_shutdown_flush.py` — 5 → 16 tests, three new classes. (Baseline measured at merge base `cb11a7e25`: 5 test functions, no `parametrize`; current `upstream/main` also has 5.)

### Why delegate the chmod rather than guard it inline

The hand-rolled chmod diverged from the shared policy on three axes, each independently a defect:

1. it ran in managed mode, where the policy is to stand down;
2. it ignored `HERMES_HOME_MODE`, which every sibling dir honours;
3. it was **unguarded** — `chmod` by a non-owner raises `EPERM`, which propagated straight out of `_get_flush_dir()` into callers that all swallow exceptions, silently degrading the flush to a no-op.

17 `gateway/` modules already import from `hermes_cli.config` (counted on `upstream/main`), so the dependency direction is established, not new.

**Not** using #77655's `secure_mkdir`: it does not exist on `main` (#77655 is separately open), so importing it would couple two open PRs. Following that author's own precedent, this branch stands alone.

**`HERMES_HOME_MODE` now applies** (`0o701` instead of `0o700`) as a deliberate consequence of delegating. #77655 argued the hatch exists for traversal to a *served* subdir and nothing is served here. I went the other way for this site: `pending_messages` is a peer of `sessions/` and `logs/`, which all honour it, the payload files stay `0600`, and `uuid4().hex` filenames aren't guessable from an execute-only directory. Happy to gate it if a maintainer prefers consistency with #77655 instead.

### Relationship to #74897

#74897 moved `write_file` new files from `0600` to umask-derived `0644`. Reading it, the real story is that `_atomic_write`'s chmod branch only ran when the target already existed, so new files silently kept `mktemp`'s `0600` — an accident, not a policy — and #74897 restored umask-derived permissions for a path the *user* named with a documented interop contract (#70856: Obsidian LiveSync, Docker volumes, NAS mounts). This change moves in the **same direction** for managed mode: removing a hardcoded mode in favour of the configured umask.

## How to Test

1. Managed-mode fresh creation (the case at issue):
   ```bash
   ./scripts/run_tests.sh tests/gateway/test_shutdown_flush.py -q
   ```
   16 passed. `TestFlushDirManagedPermissions` reproduces all three real conditions — `HERMES_MANAGED=nixos`, parent chmod'd `2770`, `umask 0007`, dir absent.
2. Teeth, per mechanism (each reverted individually, restored byte-identically, sha256 re-confirmed):

   | reverted mechanism | result |
   |---|---|
   | managed-branch `mkdir(..., mode=0o700)` restored | 2 failures |
   | unmanaged mkdir `mode=` stripped | 1 failure (isolation test only) |
   | managed early-return deleted | 3 failures |
   | reconciler `try/except` removed | 1 failure |

   **The mkdir mode and the chmod do mask each other**, as suspected. Stripping `mode=` from the unmanaged mkdir left both plain "is it 0700?" tests green, because `_secure_dir` alone produced `0700`. Only `test_creation_mode_alone_is_owner_only`, which stubs the reconciler to a recording no-op, caught it. That's why the isolation fixture exists rather than a second final-mode assertion.
3. Full octal matrix, dir and payload, before/after, measured under a temp `HERMES_HOME`:

   | scenario | dir before | dir after | file before | file after |
   |---|---|---|---|---|
   | unmanaged, `umask 022` | `0o700` | `0o700` | `0o600` | `0o600` |
   | unmanaged, `umask 077` | `0o700` | `0o700` | `0o600` | `0o600` |
   | **managed, `umask 0007`, parent `2770`, dir absent** | `0o700` | **`0o770`** | `0o600` | `0o600` |
   | managed, dir pre-existing `0750` | `0o700` | **`0o750`** | `0o600` | `0o600` |
   | `HERMES_HOME_MODE=0701`, `umask 022` | `0o700` | **`0o701`** | `0o600` | `0o600` |

### On `atomic_json_write(..., mode=0o600)` in `_write_payload` — left untouched

Measured, so it doesn't get "fixed" needlessly: a **fresh** file is `0o600` with or without the argument under umask `022`/`077`/`007`, because `mkstemp` creates at `0600` and `_restore_file_mode` no-ops with no prior mode. The argument only changes the **overwrite** path, which `uuid4().hex` filenames make unreachable. It does close a real fchmod-before-rename window for the overwrite case, so removing it would be churn. No change made.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run.** I ran the canonical `./scripts/run_tests.sh` on the changed file (16/16) plus the 77-file regression set matching `shutdown_flush|pending_messages`: **558 passed, 1 failed**. The one failure is `test_telegram_thread_fallback.py::test_send_image_upload_fallback_blocks_connect_time_rebind`, a pre-existing SSRF-guard baseline failure — confirmed baseline by reproducing it with `gateway/shutdown_flush.py` reverted to `upstream/main`. `test_shutdown_forensics.py` (Linux-only) is likewise baseline-failing in this worktree, verified the same way.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 27.0 (Darwin 27.0.0, arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on both new helpers and `_get_flush_dir`)
- [x] N/A — no config keys added or changed. Behavior follows existing `HERMES_MANAGED` / `HERMES_HOME_MODE`; **no new `HERMES_*` env var**
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: the reconciler keeps its original non-POSIX early return, and the new tests are POSIX-gated (`os.name != "posix"`). Windows ACL enforcement is deliberately left to #77527 rather than duplicated here. macOS verified directly; setgid inheritance confirmed on Darwin (`2770` parent → `0770` child under `umask 0007`)
- [x] N/A — no tool schema change

## Screenshots / Logs

```
=== Summary: 1 files, 16 tests passed, 0 failed (100% complete) in 3.5s

ruff 0.16.1 — All checks passed!
scripts/check-windows-footguns.py --diff upstream/main — ✓ No Windows footguns found
scripts/check_subprocess_stdin.py — ✅ All TUI-context subprocess calls have explicit stdin=
```

