### PR TITLE
refactor(gateway): extract interrupt helpers from run.py (slice 19 of #54962)

### DIFF
--- a/gateway/interrupt_helpers.py
+++ b/gateway/interrupt_helpers.py
@@ -1,0 +1,32 @@
+"""Interrupt-marker helpers extracted from the ``gateway.run`` god-file.
+
+``_stamp_hygiene_compression_provenance`` records a best-effort activity
+provenance stamp for hygiene compression transitions (timeout / cooldown).
+It was extracted as part of the god-file campaign (#54962) and is
+re-exported from ``gateway.run`` via a module-attribute import so
+``gateway.run._stamp_hygiene_compression_provenance`` keeps resolving.
+
+``_is_fresh_gateway_interruption`` intentionally STAYS in ``gateway.run``:
+it depends on ``_coerce_gateway_timestamp``, which is claimed by open PR
+#77433 (display helpers extraction) and may not be moved here.  Once that
+PR lands, the freshness check (and its exclusive constant
+``_AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT``) can follow into this module.
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger("gateway.run")
+
+
+def _stamp_hygiene_compression_provenance(
+    agent: Any,
+    desc: str,
+    provenance: "ActivityProvenance",
+    debug_label: str,
+) -> None:
+    """Best-effort activity provenance stamp for hygiene compression transitions."""
+    try:
+        agent._touch_activity(desc, provenance=provenance)
+    except Exception:
+        logger.debug(debug_label, exc_info=True)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -893,19 +893,6 @@ def _float_env(name: str, default: float) -> float:
         return float(default)
 
 
-def _stamp_hygiene_compression_provenance(
-    agent: Any,
-    desc: str,
-    provenance: "ActivityProvenance",
-    debug_label: str,
-) -> None:
-    """Best-effort activity provenance stamp for hygiene compression transitions."""
-    try:
-        agent._touch_activity(desc, provenance=provenance)
-    except Exception:
-        logger.debug(debug_label, exc_info=True)
-
-
 def _is_fresh_gateway_interruption(
     value: Any,
     *,
@@ -2292,6 +2279,7 @@ from gateway.whatsapp_identity import (
     expand_whatsapp_aliases as _expand_whatsapp_auth_aliases,
     normalize_whatsapp_identifier as _normalize_whatsapp_identifier,
 )
+from gateway.interrupt_helpers import _stamp_hygiene_compression_provenance
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION

<!-- native-links:v1 -->
Related #54962 #55138 #77433
## What / Why

Slice 19 of the god-file extraction campaign (#54962): pulls the interrupt-marker helpers out of the 26,823-line `gateway/run.py` god file into a focused `gateway/interrupt_helpers.py` module.

Moved (pure move, byte-verbatim, zero behavior change):

- `_stamp_hygiene_compression_provenance` — best-effort activity provenance stamp for hygiene compression transitions (timeout / cooldown).

Kept in `gateway/run.py` (documented, not moved):

- `_is_fresh_gateway_interruption` — depends on `_coerce_gateway_timestamp`, which is claimed by open PR #77433 (display helpers extraction) and may not be moved by this slice. Once #77433 lands, the freshness check and its exclusive constant `_AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT` can follow into this module.
- `_AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT` — only consumer is `_is_fresh_gateway_interruption`, which stays.

`gateway/run.py` re-exports the moved function via a module-attribute import, so `gateway.run._stamp_hygiene_compression_provenance` keeps resolving with identical object identity (log records also keep the `gateway.run` logger name).

## How to test

```bash
python -c "import gateway.run"
python -m pytest tests/gateway/test_restart_resume_pending.py -q --no-header -p no:cacheprovider
```

Verified in this PR:

- `import gateway.run` succeeds from the worktree; `gateway.run._stamp_hygiene_compression_provenance is gateway.interrupt_helpers._stamp_hygiene_compression_provenance` (identity asserted).
- `tests/gateway/test_restart_resume_pending.py`: **31 passed** (the only test file referencing the interrupt cluster).
- `git diff --check`: clean. `scripts/check-windows-footguns.py`: no footguns found.
- Moved function is byte-verbatim identical to `HEAD:gateway/run.py` (diff-checked).

## Shrink

`gateway/run.py`: 26,823 → 26,811 lines (−12). New module: `gateway/interrupt_helpers.py` (+27). Net line movement is the smallest clean extraction: one function + its private imports; the dependent member stays with its claimed dependency rather than forcing the cluster.

## Platforms tested

- Windows 11 (git-bash), CPython via project venv — import + targeted pytest run.
- Pure Python module move; no platform-specific code touched.

Part of #54962

Part of #55138

Part of #78647
