### PR TITLE
fix(langfuse): close root-observation CMs on shutdown to prevent TypeError

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import atexit
 import re
 import threading
 import time
@@ -64,6 +65,7 @@ _TRACE_STATE: Dict[str, TraceState] = {}
 # to bound the leak from non-finalizing turns, not to limit concurrency.
 _MAX_TRACE_STATE = 256
 _LANGFUSE_CLIENT = None
+_SHUTDOWN_REGISTERED = False
 _READ_FILE_LINE_RE = re.compile(r"^\s*(\d+)\|(.*)$")
 _READ_FILE_HEAD_LINES = 25
 _READ_FILE_TAIL_LINES = 15
@@ -710,6 +712,27 @@ def _merge_trace_output(output: Any, state: TraceState) -> Any:
     return merged
 
 
+def _exit_root_context(state: TraceState) -> None:
+    """Best-effort close the suspended root-observation context manager.
+
+    ``_start_root_trace`` enters ``root_ctx`` manually (``__enter__``) to keep
+    the trace open across multiple LLM/tool hooks. The matching ``__exit__``
+    must run before the Langfuse client shuts down; if it never does, the
+    generator is left suspended at ``yield`` and gets GC'd during interpreter
+    teardown, after ``opentelemetry.trace.Span`` has been nulled out — which
+    surfaces as ``TypeError: isinstance() arg 2 must be a type`` from
+    ``use_span.__exit__`` on shutdown. Ending the span alone is not enough;
+    the generator's ``finally`` block is what detaches the OTel context token.
+    """
+    ctx = getattr(state, "root_ctx", None)
+    if ctx is None:
+        return
+    try:
+        ctx.__exit__(None, None, None)
+    except Exception as exc:  # pragma: no cover - fail-open
+        _debug(f"exit root context failed: {exc}")
+
+
 def _evict_stale_locked() -> None:
     """Drop least-recently-updated trace state to make room for a new entry.
 
@@ -731,7 +754,8 @@ def _evict_stale_locked() -> None:
         try:
             state.root_span.end()
         except Exception as exc:  # pragma: no cover - fail-open
-            _debug(f"evict stale trace failed: {exc}")
+            _debug(f"evict stale trace end failed: {exc}")
+        _exit_root_context(state)
 
 
 def _finish_trace(task_key: str, *, output: Any = None) -> None:
@@ -760,6 +784,7 @@ def _finish_trace(task_key: str, *, output: Any = None) -> None:
     except Exception as exc:  # pragma: no cover - fail-open
         _debug(f"finish trace failed: {exc}")
     finally:
+        _exit_root_context(state)
         try:
             client.flush()
         except Exception:
@@ -1125,6 +1150,29 @@ def on_post_tool_call(*, tool_name: str = "", args: Any = None, result: Any = No
     )
 
 
+def _drain_all_traces() -> None:
+    """Finalize any live traces on process exit.
+
+    Turns whose final assistant message had content + no tool calls are already
+    finished via ``_finish_trace``. This drains the rest — interrupted turns,
+    tool-only final steps, empty final content — so their suspended root context
+    managers are closed cleanly *before* interpreter teardown nukes the
+    ``opentelemetry.trace.Span`` symbol (the source of the
+    ``TypeError: isinstance() arg 2 must be a type`` traceback on exit).
+    """
+    client = _get_langfuse()
+    if client is None:
+        return
+    with _STATE_LOCK:
+        keys = list(_TRACE_STATE.keys())
+    for key in keys:
+        _finish_trace(key)
+    try:
+        client.flush()
+    except Exception:
+        pass
+
+
 def register(ctx) -> None:
     # Register for both hook name variants so the plugin works across
     # Hermes versions.  pre_api_request / post_api_request fire per API
@@ -1135,3 +1183,8 @@ def register(ctx) -> None:
     ctx.register_hook("post_llm_call", on_post_llm_call)
     ctx.register_hook("pre_tool_call", on_pre_tool_call)
     ctx.register_hook("post_tool_call", on_post_tool_call)
+
+    global _SHUTDOWN_REGISTERED
+    if not _SHUTDOWN_REGISTERED:
+        _SHUTDOWN_REGISTERED = True
+        atexit.register(_drain_all_traces)

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -779,3 +779,192 @@ class TestUsageFromSanitizedResponse:
 
         assert seen["resp"] is resp
         assert captured["usage_details"] == {"input": 7, "output": 3}
+
+
+# ---------------------------------------------------------------------------
+# Shutdown drain (#shutdown-typeerror).
+#
+# Regression: the root observation context manager was entered via
+# ``__enter__`` but only ``span.end()`` was ever called — the matching
+# ``__exit__`` never ran. The suspended generator was left at ``yield``
+# until interpreter teardown GC'd it, by which point
+# ``opentelemetry.trace.Span`` had been nulled out during module
+# finalization, surfacing as
+# ``TypeError: isinstance() arg 2 must be a type`` from
+# ``opentelemetry.trace.use_span.__exit__`` on every CLI exit.
+#
+# The fix: ``_exit_root_context`` calls ``__exit__`` on the stored CM,
+# ``_finish_trace`` and ``_evict_stale_locked`` invoke it, and an
+# ``atexit``-registered ``_drain_all_traces`` finalizes any live traces
+# before teardown. These tests pin all three paths.
+# ---------------------------------------------------------------------------
+
+
+class TestShutdownDrain:
+    def _fresh_plugin(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    @staticmethod
+    def _tracking_client():
+        """Langfuse stand-in that records root-CM __exit__ calls."""
+
+        exited: list[str] = []
+
+        class _Span:
+            def update(self, **kw):
+                pass
+
+            def end(self, **kw):
+                pass
+
+            def set_trace_io(self, **kw):
+                pass
+
+            def start_observation(self, **kw):
+                return _Span()
+
+        class _RootCM:
+            def __init__(self, trace_id):
+                self._trace_id = trace_id
+
+            def __enter__(self):
+                return _Span()
+
+            def __exit__(self, *exc):
+                exited.append(self._trace_id)
+                return False
+
+        class _Client:
+            def create_trace_id(self, seed=None):
+                return f"trace::{seed}"
+
+            def start_as_current_observation(self, **kw):
+                return _RootCM(kw.get("trace_context", {}).get("trace_id"))
+
+            def flush(self):
+                pass
+
+        return _Client(), exited
+
+    def test_finish_trace_exits_root_context_manager(self, monkeypatch):
+        """_finish_trace must call __exit__ on the root CM, not just span.end()."""
+        mod = self._fresh_plugin()
+        client, exited = self._tracking_client()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
+        mod._TRACE_STATE.clear()
+
+        # Start a root trace by firing the pre-LLM request hook.
+        mod.on_pre_llm_request(
+            task_id="task-fin",
+            session_id="sess-fin",
+            model="m",
+            provider="p",
+            api_mode="chat",
+            api_call_count=1,
+            request_messages=[{"role": "user", "content": "hi"}],
+            turn_id="sess-fin:task-fin:turn1",
+            api_request_id="sess-fin:task-fin:turn1:api:1",
+        )
+        assert not exited, "root CM should still be suspended mid-turn"
+
+        # Finalize the turn — this pops state and must close the CM.
+        mod.on_post_llm_call(
+            task_id="task-fin",
+            session_id="sess-fin",
+            model="m",
+            provider="p",
+            api_mode="chat",
+            api_call_count=1,
+            assistant_content_chars=5,
+            assistant_tool_call_count=0,
+            usage={"input_tokens": 1, "output_tokens": 1},
+            turn_id="sess-fin:task-fin:turn1",
+            api_request_id="sess-fin:task-fin:turn1:api:1",
+        )
+
+        assert len(exited) == 1
+        assert mod._TRACE_STATE == {}
+
+    def test_drain_all_traces_finalizes_live_traces(self, monkeypatch):
+        """_drain_all_traces (atexit handler) closes CMs for non-finalizing turns."""
+        mod = self._fresh_plugin()
+        client, exited = self._tracking_client()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
+        mod._TRACE_STATE.clear()
+
+        # Two turns that never finalize (tool-only final step).
+        for n in (1, 2):
+            mod.on_pre_llm_request(
+                task_id=f"task-{n}",
+                session_id="sess-drain",
+                model="m",
+                provider="p",
+                api_mode="chat",
+                api_call_count=1,
+                request_messages=[{"role": "user", "content": "hi"}],
+                turn_id=f"sess-drain:task-{n}:turn{n}",
+                api_request_id=f"sess-drain:task-{n}:turn{n}:api:1",
+            )
+            mod.on_post_llm_call(
+                task_id=f"task-{n}",
+                session_id="sess-drain",
+                model="m",
+                provider="p",
+                api_mode="chat",
+                api_call_count=1,
+                assistant_content_chars=0,
+                assistant_tool_call_count=1,
+                usage={"input_tokens": 1, "output_tokens": 1},
+                turn_id=f"sess-drain:task-{n}:turn{n}",
+                api_request_id=f"sess-drain:task-{n}:turn{n}:api:1",
+            )
+
+        assert len(mod._TRACE_STATE) == 2
+        assert exited == []
+
+        # The atexit drain must finalize both.
+        mod._drain_all_traces()
+
+        assert len(exited) == 2
+        assert mod._TRACE_STATE == {}
+
+    def test_evict_stale_exits_root_context_manager(self, monkeypatch):
+        """LRU eviction must also close the CM, not just end the span."""
+        mod = self._fresh_plugin()
+        client, exited = self._tracking_client()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
+        monkeypatch.setattr(mod, "_MAX_TRACE_STATE", 4)
+        mod._TRACE_STATE.clear()
+
+        # Overflow the cap so the oldest entry gets evicted.
+        for n in range(6):
+            mod.on_pre_llm_request(
+                task_id=f"task-ev-{n}",
+                session_id="sess-ev",
+                model="m",
+                provider="p",
+                api_mode="chat",
+                api_call_count=1,
+                request_messages=[{"role": "user", "content": "hi"}],
+                turn_id=f"sess-ev:task-ev-{n}:turn{n}",
+                api_request_id=f"sess-ev:task-ev-{n}:turn{n}:api:1",
+            )
+
+        # At least the evicted entries had their CMs closed.
+        assert len(exited) >= 2
+        assert len(mod._TRACE_STATE) <= 4
+
+    def test_drain_is_idempotent(self, monkeypatch):
+        """Calling _drain_all_traces twice must not raise (atexit + explicit)."""
+        mod = self._fresh_plugin()
+        client, _ = self._tracking_client()
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+        monkeypatch.setattr(mod, "_end_observation", lambda *a, **k: None)
+        mod._TRACE_STATE.clear()
+
+        mod._drain_all_traces()  # empty — no-op
+        mod._drain_all_traces()  # still no-op


### PR DESCRIPTION
## Problem

The langfuse plugin entered each root observation context manager via `__enter__` but only called `span.end()` — never `__exit__`. The suspended generator stayed at `yield` until interpreter teardown GC'd it, by which point `opentelemetry.trace.Span` had been nulled out during module finalization. `use_span.__exit__`'s `isinstance(span, Span)` then raised:

```
TypeError: isinstance() arg 2 must be a type
```

…on every CLI exit when langfuse tracing was enabled.

## Root cause

`_finish_trace` ended the span but didn't exit the root observation's context manager. The generator suspended at `yield` in `use_span` was never resumed until GC collected it — after OTel module finalization had already set `Span` to `None`.

## Fix

Three changes in `plugins/observability/langfuse/__init__.py`:

1. **`_exit_root_context(state)`** — calls `__exit__` on the stored root CM. The generator's `finally` block detaches the OTel context token; ending the span alone does not.
2. **`_finish_trace` and `_evict_stale_locked`** — now call `_exit_root_context` so finalized/evicted traces close their CMs immediately, not at GC time.
3. **`_drain_all_traces()`** — registered via `atexit` in `register()`. Finalizes any live traces (interrupted turns, tool-only final steps) before interpreter teardown nukes `otel.Span`.

## Tests

Adds 4 regression tests:
- `test_finish_trace_exits_root_context_manager`
- `test_drain_all_traces_finalizes_live_traces`
- `test_evict_stale_exits_context_manager`
- `test_drain_all_traces_idempotent`

## Test plan

- [ ] `scripts/run_tests.sh tests/plugins/test_langfuse_plugin.py` passes
- [ ] No `TypeError` on CLI exit with langfuse enabled