### PR TITLE
fix(terminal): skip binary content on the referenced-script remote-read fallback (#77703)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,12 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # OSError: unreadable / missing / over-long paths. ValueError: an
+        # embedded NUL byte in *path* itself — a binary's decoded bytes
+        # tokenized into a bogus script path by the recursion (#77703). A
+        # guarded read must never crash the guard, so treat either as
+        # "nothing to scan" (mirrors the resolve() ValueError guard below).
         return None, False
     try:
         metadata = os.fstat(descriptor)

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -145,7 +145,7 @@ class TestCronCreateLifecycleBlock:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
         scripts_dir = tmp_path / ".hermes" / "scripts"
         scripts_dir.mkdir(parents=True)
-        (scripts_dir / "restart.sh").write_text("#!/bin/bash\nhermes gateway restart\n")
+        (scripts_dir / "restart.sh").write_text("#!/bin/bash\nhermes gateway restart\n", encoding="utf-8")
         args = Namespace(
             cron_command="create",
             schedule="1h",
@@ -302,7 +302,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         import tools.terminal_tool as tt
 
         script = tmp_path / "delayed-ops.sh"
-        script.write_text("#!/bin/bash\nsleep 45\nhermes gateway restart\n")
+        script.write_text("#!/bin/bash\nsleep 45\nhermes gateway restart\n", encoding="utf-8")
         self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
 
         result = json.loads(tt.terminal_tool(command=f"/bin/bash {script}"))
@@ -314,7 +314,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         import tools.terminal_tool as tt
 
         script = tmp_path / "health-check.sh"
-        script.write_text("#!/bin/bash\nprintf 'healthy\\n'\n")
+        script.write_text("#!/bin/bash\nprintf 'healthy\\n'\n", encoding="utf-8")
         self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
 
         result = json.loads(tt.terminal_tool(
@@ -392,7 +392,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         import tools.terminal_tool as tt
 
         script = tmp_path / "relative.sh"
-        script.write_text("#!/bin/bash\nhermes gateway restart\n")
+        script.write_text("#!/bin/bash\nhermes gateway restart\n", encoding="utf-8")
 
         class _FakeEnv:
             env = {}
@@ -411,7 +411,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         import tools.terminal_tool as tt
 
         script = tmp_path / "delayed.sh"
-        script.write_text("#!/bin/bash\nhermes gateway stop\n")
+        script.write_text("#!/bin/bash\nhermes gateway stop\n", encoding="utf-8")
         script.chmod(0o700)
         self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
 
@@ -434,7 +434,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         import tools.terminal_tool as tt
 
         script = tmp_path / "options.sh"
-        script.write_text("#!/bin/bash\nhermes gateway restart\n")
+        script.write_text("#!/bin/bash\nhermes gateway restart\n", encoding="utf-8")
         self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
 
         result = json.loads(tt.terminal_tool(
@@ -447,7 +447,7 @@ class TestTerminalToolGatewayLifecycleGuard:
         import tools.terminal_tool as tt
 
         script = tmp_path / "nested.sh"
-        script.write_text("#!/bin/bash\nlaunchctl submit -l ai.hermes.loop -- /bin/true\n")
+        script.write_text("#!/bin/bash\nlaunchctl submit -l ai.hermes.loop -- /bin/true\n", encoding="utf-8")
 
         class _FakeEnv:
             env = {}
@@ -467,9 +467,9 @@ class TestTerminalToolGatewayLifecycleGuard:
         import tools.terminal_tool as tt
 
         inner = tmp_path / "inner.sh"
-        inner.write_text("#!/bin/bash\nhermes gateway restart\n")
+        inner.write_text("#!/bin/bash\nhermes gateway restart\n", encoding="utf-8")
         outer = tmp_path / "outer.sh"
-        outer.write_text("#!/bin/bash\n/bin/bash inner.sh\n")
+        outer.write_text("#!/bin/bash\n/bin/bash inner.sh\n", encoding="utf-8")
 
         class _FakeEnv:
             env = {}
@@ -521,7 +521,7 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         calls = []
         script = tmp_path / "health-check.sh"
-        script.write_text("#!/bin/bash\nprintf 'healthy\\n'\n")
+        script.write_text("#!/bin/bash\nprintf 'healthy\\n'\n", encoding="utf-8")
 
         class _FakeEnv:
             env = {}
@@ -582,7 +582,7 @@ class TestLifecycleGuardModule:
     def test_script_with_command_raises(self, tmp_path, monkeypatch):
         from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
         script = tmp_path / "restart.sh"
-        script.write_text("#!/bin/bash\nhermes gateway restart\n")
+        script.write_text("#!/bin/bash\nhermes gateway restart\n", encoding="utf-8")
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("clean prompt", str(script))
 
@@ -606,7 +606,7 @@ class TestLifecycleGuardModule:
     ):
         from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
         script = tmp_path / "persistent.sh"
-        script.write_text(f"#!/bin/bash\n{line}\n")
+        script.write_text(f"#!/bin/bash\n{line}\n", encoding="utf-8")
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("clean prompt", str(script))
 
@@ -615,7 +615,7 @@ class TestLifecycleGuardModule:
         script to slip through."""
         from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
         script = tmp_path / "ops.sh"
-        script.write_text("hermes gateway stop\n")
+        script.write_text("hermes gateway stop\n", encoding="utf-8")
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("daily ops job", str(script))
 
@@ -672,7 +672,7 @@ class TestLifecycleGuardModule:
         by the direct regex scan."""
         from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
         script = tmp_path / "evil.py"
-        script.write_text('import os\nos.system("hermes gateway restart")\n')
+        script.write_text('import os\nos.system("hermes gateway restart")\n', encoding="utf-8")
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("clean prompt", str(script))
 
@@ -695,13 +695,54 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_read_referenced_script_tolerates_nul_in_path(self):
+        """#77703: _read_referenced_script opens by path. A path with an
+        embedded NUL byte (a binary's bytes mis-tokenized into a bogus path by
+        the recursion) makes os.open raise ValueError — not OSError — which used
+        to escape the OSError-only guard and crash the whole terminal tool. It
+        is now caught and reported as nothing-to-scan."""
+        from pathlib import Path
+
+        from cron.lifecycle_guard import _read_referenced_script
+
+        text, unsafe = _read_referenced_script(Path("/tmp/hermes\x00binary"))
+        assert text is None
+        assert unsafe is False
+
+    def test_remote_read_fallback_binary_does_not_crash_guard(self):
+        """#77703: in the gateway the referenced-script walk carries a
+        ``read_remote_script`` fallback (SSH/Modal/Daytona backends read the
+        script over the wire). When the referenced path is an ELF binary, that
+        fallback returned the binary's decoded bytes; the scanner then
+        tokenized machine code into bogus NUL-bearing paths and crashed with
+        ``ValueError: embedded null byte`` (the tool errored out, the command
+        never ran). The guard must tolerate binary content from the fallback
+        and return False without raising."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        # Simulates the pre-fix _read_script_in_env handing back an ELF's
+        # decoded bytes (NUL preserved through errors="replace"). The newline
+        # puts a NUL-bearing absolute path in command position, exactly how the
+        # recursion re-tokenized machine code into a bogus script reference.
+        binary_blob = "\x7fELF\x01\x01\n/opt/bin/tool\x00\x01 --run\n"
+
+        def _remote_read(_path: str):
+            return binary_blob
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "/home/zedi/venv/bin/python --version",
+            read_remote_script=_remote_read,
+        )
+        assert result is False
+
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:
         a .sh script that itself invokes a lifecycle command is caught."""
         from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
         script = tmp_path / "wrapper.sh"
-        script.write_text("#!/bin/bash\n./deploy.sh\n")
-        (tmp_path / "deploy.sh").write_text("#!/bin/bash\nhermes gateway stop\n")
+        script.write_text("#!/bin/bash\n./deploy.sh\n", encoding="utf-8")
+        (tmp_path / "deploy.sh").write_text("#!/bin/bash\nhermes gateway stop\n", encoding="utf-8")
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("daily ops", str(script))
 
@@ -837,8 +878,8 @@ class TestCronCreateLifecycleBlockExtra:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
         scripts_dir = tmp_path / ".hermes" / "scripts"
         scripts_dir.mkdir(parents=True)
-        (scripts_dir / "inner.sh").write_text("#!/bin/bash\nhermes gateway restart\n")
-        (scripts_dir / "outer.sh").write_text("#!/bin/bash\n/bin/bash inner.sh\n")
+        (scripts_dir / "inner.sh").write_text("#!/bin/bash\nhermes gateway restart\n", encoding="utf-8")
+        (scripts_dir / "outer.sh").write_text("#!/bin/bash\n/bin/bash inner.sh\n", encoding="utf-8")
         args = Namespace(
             cron_command="create",
             schedule="1h",

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2545,6 +2545,14 @@ def terminal_tool(
                         if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= 1024 * 1024:
                             data = local_path.read_bytes()
                             if len(data) <= 1024 * 1024:
+                                if b"\x00" in data:
+                                    # Binary (ELF/Mach-O/PE), not a shell script:
+                                    # feeding its decoded bytes back into the guard
+                                    # tokenizes machine code into bogus NUL-bearing
+                                    # paths and crashes the scanner (#77703). Mirror
+                                    # lifecycle_guard._read_referenced_script and
+                                    # treat it as nothing to scan.
+                                    return None
                                 return data.decode("utf-8", errors="replace")
                 except Exception:
                     pass
@@ -2552,7 +2560,12 @@ def terminal_tool(
                 try:
                     result = env.execute(f"cat {shlex.quote(script_path)}")
                     if result.get("returncode", -1) == 0:
-                        return result.get("output", "")
+                        output = result.get("output", "")
+                        if output and "\x00" in output:
+                            # Binary content from a remote `cat`: skip for the
+                            # same reason as the local branch above (#77703).
+                            return None
+                        return output
                 except Exception:
                     pass
                 return None


### PR DESCRIPTION
## Problem

The gateway terminal guard **crashes** (the tool errors out, `exit_code: -1`, the command never runs) with `ValueError: embedded null byte` when a command invokes an ELF binary by full path, e.g. `/home/zedi/venv/bin/python --version`. Reproduced on `main` in the desktop gateway (Ubuntu 24.04). Fixes #77703.

```
File ".../cron/lifecycle_guard.py", line 260, in _read_referenced_script
    descriptor = os.open(path, flags)
ValueError: embedded null byte
```

## Root cause

`_read_referenced_script()` correctly rejects the ELF locally — it sees a NUL byte in the first chunk and returns `(None, False)` (the #76762 fix). But the referenced-script walk then falls back to `read_remote_script` (`terminal_tool._read_script_in_env`, used for SSH/Modal/Daytona backends). That fallback **re-reads the same file's bytes without any NUL guard**, decodes them, and hands the binary content back to the scanner. The recursion re-tokenizes machine code into a bogus NUL-bearing "script path", and `os.open` on that path raises `ValueError` — which the `except OSError` at the top of `_read_referenced_script` doesn't catch.

The #76762 fix only closed the **local** read path; the gateway's **remote-read fallback** path was still exposed.

## Fix

- **`tools/terminal_tool.py` — `_read_script_in_env`**: skip content containing a NUL byte on both the local-read and remote-`cat` branches, mirroring `_read_referenced_script` (a binary is *nothing to scan*). This is the root cause — binary never re-enters the guard, and it fixes the inconsistency where the fallback re-read a file the local guard had already rejected.
- **`cron/lifecycle_guard.py` — `_read_referenced_script`**: tolerate `ValueError` from `os.open` alongside the existing `OSError` guard, so the guard can never crash the terminal tool regardless of what reaches it (defense at the chokepoint, matching the existing `resolve()` `ValueError` guard just below).

## Tests

`tests/hermes_cli/test_gateway_restart_loop.py`:
- `test_read_referenced_script_tolerates_nul_in_path` — a NUL-in-path makes `os.open` raise `ValueError`; now caught, returns `(None, False)`.
- `test_remote_read_fallback_binary_does_not_crash_guard` — reproduces the exact #77703 scenario (a `read_remote_script` fallback returning binary content) and asserts the guard returns `False` without raising.

Both fail on `main` and pass with this change. Full `test_gateway_restart_loop.py` + `test_terminal_tool.py` suites pass. (The bare-`write_text` `encoding="utf-8"` additions in the touched test file are the required windows-footgun gate fixes for pre-existing lines.)
