### PR TITLE
fix(prompt): anchor active-profile hint at HERMES_HOME, not a nested path

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -416,11 +416,21 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             "you to."
         )
     else:
+        # When a profile is active, HERMES_HOME is already profile-scoped, so
+        # the session's own data lives at get_hermes_home() itself — appending
+        # /profiles/<name>/ again fabricates a non-existent nested path. The
+        # default profile's data lives under the root, the parent of profiles/.
+        try:
+            from hermes_constants import get_default_hermes_root
+
+            default_home = get_default_hermes_root()
+        except Exception:
+            default_home = get_hermes_home()
         post_workspace_parts.append(
             f"Active Hermes profile: {active_profile}. This session reads "
-            f"and writes {get_hermes_home()}/profiles/{active_profile}/. The default "
-            f"profile's data lives at {get_hermes_home()}/skills/, {get_hermes_home()}/plugins/, "
-            f"{get_hermes_home()}/cron/, {get_hermes_home()}/memories/ — those belong to a "
+            f"and writes {get_hermes_home()}/. The default "
+            f"profile's data lives at {default_home}/skills/, {default_home}/plugins/, "
+            f"{default_home}/cron/, {default_home}/memories/ — those belong to a "
             f"different session run from a different shell. Do NOT modify "
             f"another profile's skills/plugins/cron/memories unless the user "
             f"explicitly directs you to. The cross-profile write guard will "

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -185,6 +185,60 @@ def test_coding_prompt_preserves_legacy_workspace_order(monkeypatch):
     assert agent._cached_system_prompt_static == "\n\n".join(expected.split("\n\n")[:4])
 
 
+def test_profile_prompt_no_nested_profiles_path(monkeypatch):
+    """Non-default profile sessions must not fabricate a nested profiles path.
+
+    When HERMES_HOME is already profile-scoped (e.g. /root/.hermes/profiles/foo),
+    the active-profile hint used to append /profiles/foo/ again, producing a
+    non-existent nested directory. The session's own data lives at HERMES_HOME
+    itself; the default profile's data lives under the root.
+    """
+    import agent.system_prompt as system_prompt
+
+    agent = _make_agent(
+        valid_tool_names=["read_file"],
+        _parallel_tool_call_guidance=False,
+    )
+    monkeypatch.setattr(system_prompt, "DEFAULT_AGENT_IDENTITY", "IDENTITY")
+    monkeypatch.setattr(system_prompt, "HERMES_AGENT_HELP_GUIDANCE", "HELP")
+    monkeypatch.setattr(system_prompt, "STEER_CHANNEL_NOTE", "STEER")
+    monkeypatch.setattr(
+        system_prompt, "get_hermes_home", lambda: Path("/root/.hermes/profiles/setup-radar-lab")
+    )
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root",
+        lambda: Path("/root/.hermes"),
+    )
+
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value="CONTEXT_FILES"),
+        patch(
+            "agent.coding_context.coding_system_prompt_parts",
+            return_value=(
+                ["CODING_STABLE"],
+                ["WORKSPACE"],
+                ["Operator instructions (from config):\nOPERATOR"],
+            ),
+        ),
+        patch(
+            "agent.file_safety._resolve_active_profile_name",
+            return_value="setup-radar-lab",
+        ),
+        patch("hermes_time.now", return_value=datetime(2026, 1, 2)),
+    ):
+        prompt = build_system_prompt(agent, system_message="SYSTEM_MESSAGE")
+
+    # The session's own data path is HERMES_HOME itself — no nested /profiles/<name>/.
+    assert "reads and writes /root/.hermes/profiles/setup-radar-lab/." in prompt
+    # The default profile's data is anchored at the root, not the profile dir.
+    assert "default profile's data lives at /root/.hermes/skills/" in prompt
+    # Regression: the fabricated nested path must never appear.
+    assert "/profiles/setup-radar-lab/profiles" not in prompt
+
+
 class TestTelegramRichMessagesHint:
     """Verify that TELEGRAM_RICH_MESSAGES_HINT is conditionally included."""
 


### PR DESCRIPTION
## Summary

When a named profile is active, `HERMES_HOME` is already profile-scoped (e.g. `~/.hermes/profiles/setup-radar-lab`), but `agent/system_prompt.py`'s active-profile hint appended `/profiles/<name>/` **again**, fabricating a non-existent nested path like:

```
~/.hermes/profiles/setup-radar-lab/profiles/setup-radar-lab/
```

Agents in profile-scoped desktop sessions were told their session reads/writes a phantom directory. The session's own data actually lives at `HERMES_HOME` itself; the default profile's data lives under the root (parent of `profiles/`).

## Change

- Active-profile hint now says the session reads/writes `HERMES_HOME` directly.
- The default profile's data is anchored at `get_default_hermes_root()` instead of being mis-derived from the profile-scoped home.
- Regression test `test_profile_prompt_no_nested_profiles_path` covers the non-default profile branch.

## Test plan

```bash
python -m pytest tests/agent/test_system_prompt.py -o 'addopts=' -q
# 11 passed (incl. new regression test)
```