### PR TITLE
fix(gateway): make queued follow-up flush media-aware

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1595,6 +1595,96 @@ def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
                         break
     return paths
 
+
+async def _deliver_media_attachments(
+    chat_id: str,
+    platform: Any,
+    response: str,
+    thread_meta: Optional[Dict[str, Any]],
+    adapter,
+) -> None:
+    """Extract explicit MEDIA: tags from ``response`` and upload them natively.
+
+    Shared core behind ``GatewayRunner._deliver_media_from_response`` (the
+    post-stream rescan, run after the text was already streamed) and the
+    queued-follow-up first-response flush (``GatewayRunner._run_agent_inner``,
+    run when the first response was never streamed at all). Both need the
+    same explicit-``MEDIA:``-tag extraction and per-type dispatch so an
+    attachment is uploaded exactly once no matter how the surrounding text
+    reached the user.
+    """
+    from pathlib import Path
+    from urllib.parse import quote as _quote
+
+    try:
+        # Capture [[as_document]] before extract_media strips it, so the
+        # dispatch partition below can route image-extension files through
+        # send_document (preserving bytes) instead of send_multiple_images
+        # (Telegram sendPhoto recompresses to ~1280px).
+        force_document_attachments = "[[as_document]]" in response
+
+        from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
+
+        media_files, cleaned = adapter.extract_media(response)
+        media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+        # Do NOT deduplicate explicit MEDIA tags against prior turns here
+        # (#73771): an explicit MEDIA: directive is the model deliberately
+        # attaching a file, including a user-requested resend.
+        adapter.extract_images(cleaned)
+
+        _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
+        _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
+
+        image_paths: list = []
+        non_image_media: list = []
+        for media_path, is_voice in media_files:
+            ext = Path(media_path).suffix.lower()
+            if (ext in _IMAGE_EXTS
+                    and not is_voice
+                    and not force_document_attachments):
+                image_paths.append(media_path)
+            else:
+                non_image_media.append((media_path, is_voice))
+
+        if image_paths:
+            try:
+                images = [(f"file://{_quote(p)}", "") for p in image_paths]
+                await adapter.send_multiple_images(
+                    chat_id=chat_id,
+                    images=images,
+                    metadata=thread_meta,
+                )
+            except Exception as e:
+                logger.warning("[%s] Media attachment image batch delivery failed: %s", adapter.name, e)
+
+        for media_path, is_voice in non_image_media:
+            try:
+                ext = Path(media_path).suffix.lower()
+                if should_send_media_as_audio(platform, ext, is_voice=is_voice):
+                    await adapter.send_voice(
+                        chat_id=chat_id,
+                        audio_path=media_path,
+                        metadata=thread_meta,
+                    )
+                elif ext in _VIDEO_EXTS:
+                    await adapter.send_video(
+                        chat_id=chat_id,
+                        video_path=media_path,
+                        metadata=thread_meta,
+                    )
+                else:
+                    await adapter.send_document(
+                        chat_id=chat_id,
+                        file_path=media_path,
+                        metadata=thread_meta,
+                    )
+            except Exception as e:
+                logger.warning("[%s] Media attachment delivery failed: %s", adapter.name, e)
+
+    except Exception as e:
+        logger.warning("Media attachment extraction failed: %s", e)
+
+
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
 # Must run BEFORE any HTTP library (discord, aiohttp, etc.) is imported.
@@ -19091,92 +19181,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         asked to deliver (#20834). Only ``MEDIA:`` directives — the explicit
         attachment contract — trigger post-stream uploads.
         """
-        from pathlib import Path
-        from urllib.parse import quote as _quote
-
-        try:
-            # Capture [[as_document]] before extract_media strips it, so the
-            # dispatch partition below can route image-extension files
-            # through send_document (preserving bytes) instead of
-            # send_multiple_images (Telegram sendPhoto recompresses to ~1280px).
-            force_document_attachments = "[[as_document]]" in response
-
-            from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
-
-            media_files, cleaned = adapter.extract_media(response)
-            media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
-            # Do NOT deduplicate explicit MEDIA tags against prior turns here
-            # (#73771). This rescan is already EXPLICIT-ONLY (see docstring):
-            # a MEDIA: directive in the final streamed reply is the model
-            # deliberately attaching a file — including a user-requested
-            # resend. Stale auto-appended tags are deduped upstream in
-            # _collect_auto_append_media_tags with history_media_paths.
-            # Mirrors the same filter removal on the non-streaming path in
-            # gateway/platforms/base.py.
-            # Strip image URLs from the cleaned text for parity with the
-            # non-streaming chain, but do NOT run extract_local_files here:
-            # post-stream delivery is explicit-only (#20834). Bare local paths
-            # in an already-streamed reply are text the user has seen (or
-            # stale inspected content), not an attachment request.
-            adapter.extract_images(cleaned)
-
-            _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
-
-            _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
-            _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
-
-            # Partition out images so they can be sent as a single batch
-            # (e.g. Signal's multi-attachment RPC). When [[as_document]] was
-            # set, image-extension files skip the photo path and route to
-            # send_document below — preserving original bytes.
-            image_paths: list = []
-            non_image_media: list = []
-            for media_path, is_voice in media_files:
-                ext = Path(media_path).suffix.lower()
-                if (ext in _IMAGE_EXTS
-                        and not is_voice
-                        and not force_document_attachments):
-                    image_paths.append(media_path)
-                else:
-                    non_image_media.append((media_path, is_voice))
-
-            if image_paths:
-                try:
-                    images = [(f"file://{_quote(p)}", "") for p in image_paths]
-                    await adapter.send_multiple_images(
-                        chat_id=event.source.chat_id,
-                        images=images,
-                        metadata=_thread_meta,
-                    )
-                except Exception as e:
-                    logger.warning("[%s] Post-stream image batch delivery failed: %s", adapter.name, e)
-
-            for media_path, is_voice in non_image_media:
-                try:
-                    ext = Path(media_path).suffix.lower()
-                    if should_send_media_as_audio(event.source.platform, ext, is_voice=is_voice):
-                        await adapter.send_voice(
-                            chat_id=event.source.chat_id,
-                            audio_path=media_path,
-                            metadata=_thread_meta,
-                        )
-                    elif ext in _VIDEO_EXTS:
-                        await adapter.send_video(
-                            chat_id=event.source.chat_id,
-                            video_path=media_path,
-                            metadata=_thread_meta,
-                        )
-                    else:
-                        await adapter.send_document(
-                            chat_id=event.source.chat_id,
-                            file_path=media_path,
-                            metadata=_thread_meta,
-                        )
-                except Exception as e:
-                    logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
-
-        except Exception as e:
-            logger.warning("Post-stream media extraction failed: %s", e)
+        await _deliver_media_attachments(
+            chat_id=event.source.chat_id,
+            platform=event.source.platform,
+            response=response,
+            thread_meta=self._thread_metadata_for_source(
+                event.source, self._reply_anchor_for_event(event)
+            ),
+            adapter=adapter,
+        )
 
 
 
@@ -25325,10 +25338,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",
                                 session_key or "?",
                             )
-                            await adapter.send(
-                                source.chat_id,
-                                first_response,
-                                metadata=_status_thread_metadata,
+                            # Route through the same explicit-MEDIA extraction
+                            # the normal completed-turn path uses, instead of
+                            # sending the raw response: a literal MEDIA:<path>
+                            # tag must never reach the user as text, and the
+                            # file it names must still be uploaded natively.
+                            _, _first_response_text = adapter.extract_media(first_response)
+                            _first_response_text = _first_response_text.strip()
+                            if _first_response_text:
+                                await adapter.send(
+                                    source.chat_id,
+                                    _first_response_text,
+                                    metadata=_status_thread_metadata,
+                                )
+                            await _deliver_media_attachments(
+                                chat_id=source.chat_id,
+                                platform=source.platform,
+                                response=first_response,
+                                thread_meta=_status_thread_metadata,
+                                adapter=adapter,
                             )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
@@ -25337,6 +25365,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Queued follow-up for session %s: skipping resend because final streamed delivery was confirmed.",
                             session_key or "?",
                         )
+                        # Streaming only delivers text — any MEDIA:<path> tag
+                        # in the streamed reply still needs the explicit
+                        # post-stream upload pass (mirrors the terminal-turn
+                        # handling in _handle_message_with_agent).
+                        try:
+                            await _deliver_media_attachments(
+                                chat_id=source.chat_id,
+                                platform=source.platform,
+                                response=first_response,
+                                thread_meta=_status_thread_metadata,
+                                adapter=adapter,
+                            )
+                        except Exception as e:
+                            logger.warning("Failed to deliver streamed first response's media attachments: %s", e)
                     # Release deferred bg-review notifications now that the
                     # first response has been delivered.  Pop from the
                     # adapter's callback dict (prevents double-fire in

--- a/tests/gateway/test_queued_followup_media_delivery.py
+++ b/tests/gateway/test_queued_followup_media_delivery.py
@@ -1,0 +1,197 @@
+"""Queued-follow-up first-response delivery must stay media-aware.
+
+When a message is queued (``/queue`` or an interrupt follow-up) behind a
+turn that is still running, ``GatewayRunner._run_agent_inner`` flushes the
+just-finished turn's response directly via ``adapter.send()`` before
+recursing into the queued turn — bypassing the extraction/upload stage that
+every other delivery path (streaming post-processing, the non-streaming
+``_process_message_background`` pipeline) runs on a response before it
+reaches the user. A response containing an explicit ``MEDIA:<path>``
+directive therefore leaked the raw tag as chat text instead of stripping it
+and uploading the attachment.
+
+The fix routes this flush through the same ``_deliver_media_attachments``
+helper used by the post-stream rescan (``GatewayRunner._deliver_media_from_response``,
+covered by ``test_post_stream_media_delivery.py`` /
+``test_73771_media_resend_dedup.py`` / ``test_tts_media_routing.py``), so the
+"already streamed" queued-flush branch — text reached the user via
+streaming, but streaming never uploads attachments on its own — is fixed by
+the same change and exercised by that existing shared-helper coverage.
+"""
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource
+
+
+class CaptureAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self.sent = []
+        self.images_sent = []
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append({"chat_id": chat_id, "content": content, "metadata": metadata})
+        return SendResult(success=True, message_id=f"sent-{len(self.sent)}")
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def stop_typing(self, chat_id) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    async def send_multiple_images(self, chat_id, images, metadata=None, human_delay=0.0):
+        self.images_sent.append({"chat_id": chat_id, "images": images, "metadata": metadata})
+        return SendResult(success=True, message_id="imgs")
+
+
+class CaptureQueuedFollowupAgent:
+    """Fake AIAgent: first call returns a MEDIA-tagged reply, second is plain."""
+
+    calls = []
+    first_response = ""
+
+    def __init__(self, **kwargs):
+        self.tools = []
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).calls.append(message)
+        if len(type(self).calls) == 1:
+            return {
+                "final_response": type(self).first_response,
+                "messages": [],
+                "api_calls": 1,
+            }
+        return {
+            "final_response": "second turn done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+def _make_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    runner._decide_image_input_mode = lambda **_kw: "native"
+    return runner
+
+
+def _allowed_media_path(tmp_path, monkeypatch, name):
+    root = tmp_path / "media-cache"
+    media_file = root / name
+    media_file.parent.mkdir(parents=True, exist_ok=True)
+    media_file.write_bytes(b"media")
+    monkeypatch.setattr(
+        "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+        (root,),
+    )
+    return media_file.resolve()
+
+
+@pytest.mark.asyncio
+async def test_queued_followup_first_response_media_not_leaked_and_uploaded(monkeypatch, tmp_path):
+    """Reproduces the reported bug: MEDIA:<path> in a queued first response
+    used to reach the user as literal text, with no upload attempted."""
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "chart.png")
+    first_response = f"Here is the chart.\nMEDIA:{media_file}"
+
+    CaptureQueuedFollowupAgent.calls = []
+    CaptureQueuedFollowupAgent.first_response = first_response
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = CaptureQueuedFollowupAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    adapter = CaptureAdapter()
+    runner = _make_runner(adapter)
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        chat_type="group",
+        thread_id="topic-42",
+    )
+    session_key = "agent:main:telegram:group:chat-1"
+
+    # A message queued (e.g. via /queue) behind the still-running turn that
+    # will produce ``first_response`` above.
+    adapter._pending_messages[session_key] = MessageEvent(
+        text="what's next",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="queued-1",
+    )
+
+    result = await runner._run_agent(
+        message="generate the chart",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-queued-media",
+        session_key=session_key,
+    )
+
+    # The queued follow-up still ran as the second turn.
+    assert len(CaptureQueuedFollowupAgent.calls) == 2
+    assert result["final_response"] == "second turn done"
+
+    # Text must be sent exactly once, and must never carry the raw
+    # directive — the model's internal attachment contract is not
+    # user-facing text.
+    texts = [entry["content"] for entry in adapter.sent]
+    assert not any("MEDIA:" in text for text in texts)
+    assert texts.count("Here is the chart.") == 1
+
+    # The file must actually be uploaded natively, not silently dropped.
+    assert len(adapter.images_sent) == 1
+    delivery = adapter.images_sent[0]
+    assert delivery["chat_id"] == "chat-1"
+    assert str(media_file) in delivery["images"][0][0]
+
+    # Both lanes must carry the same intended thread routing.
+    text_send = next(e for e in adapter.sent if e["content"] == "Here is the chart.")
+    assert text_send["metadata"] == delivery["metadata"]
+    assert delivery["metadata"].get("thread_id") == "topic-42"


### PR DESCRIPTION
## Bug

When a message is queued (`/queue`, or an interrupt follow-up) behind a turn
that is still running, `GatewayRunner._run_agent_inner` flushes the
just-finished turn's response before recursing into the queued message. That
flush went straight through a raw `adapter.send(source.chat_id, first_response, ...)`
call — completely bypassing the extraction/upload stage that every other
delivery path in the gateway runs on a response before it reaches the user
(the streaming post-processing rescan and the non-streaming
`_process_message_background` pipeline both extract `MEDIA:<path>` tags and
upload the referenced file instead of sending the tag as text).

Trigger → direct branch → skipped stage → user-visible result:
- Trigger: a message arrives while the agent is still finishing the current
  turn, and that turn's final response contains an explicit `MEDIA:<path>`
  directive (e.g. from a tool that generates an attachment).
- Direct branch: `_run_agent_inner`'s queued-follow-up handling sends that
  response directly via `adapter.send()` so the user isn't left without a
  reply while the queued message is processed next.
- Skipped stage: the direct send never runs `extract_media`/`extract_images`
  or the per-type dispatch (`send_document`/`send_multiple_images`/etc.), so
  the response text and the upload step are never separated.
- User-visible result: the user sees the literal `MEDIA:/path/to/file...`
  string as chat text, and the file itself is never delivered as a native
  attachment. A later, ordinary (non-queued) turn that references the same
  artifact uploads it correctly, which is what made the missing-upload half
  of the bug visible only intermittently.

There are two sibling branches in this same queued-flush code, and both were
affected in slightly different ways:
- "final stream delivery not confirmed" → text was never sent at all → text
  leaked the raw directive.
- "already streamed" → text reached the user via the stream consumer, but
  streaming never uploads attachments on its own, and this branch had no
  post-stream upload pass — so the attachment was silently dropped even
  though the text looked fine.

## Fix

Extracted the explicit-`MEDIA:`-tag extraction + per-type dispatch core out
of `GatewayRunner._deliver_media_from_response` (previously only reachable
after streaming had already sent the visible text) into a module-level
`_deliver_media_attachments(chat_id, platform, response, thread_meta, adapter)`
helper. `_deliver_media_from_response` keeps its exact existing signature and
behavior — it's now a thin wrapper that computes `chat_id`/`thread_meta` from
the `MessageEvent` it already receives and delegates to the shared helper.

Both queued-flush branches in `_run_agent_inner` now route through the same
helper:
- The "not confirmed" branch extracts the response's text/media first, sends
  the cleaned text (once, and only if non-empty), then delivers the
  attachment(s) with the same thread metadata that was already computed for
  this delivery (`_status_thread_metadata`) — no separate recomputation, so
  the text and attachment lanes can't diverge in routing.
- The "already streamed" branch now also calls the shared helper (media
  only, since the text already reached the user via streaming) — closing
  the second, previously-silent half of this bug class.

## Tests

Added `tests/gateway/test_queued_followup_media_delivery.py`: drives a real
`GatewayRunner._run_agent()` call (minimal runner + fake `AIAgent`, same
harness pattern as `test_queued_native_image_session_key.py`) through a
queued-follow-up scenario where the first turn's response contains a
`MEDIA:<path>` tag pointing at a synthetic temp file. Asserts the text is
sent exactly once and never contains the raw directive, the file is
delivered natively via `send_multiple_images`, and both the text and
attachment sends carry the same thread metadata.

Confirmed red against the pre-fix code (reproduces the leak exactly:
`MEDIA:` string present in sent text, zero attachment uploads) and green
after the fix. Ran `scripts/run_tests.sh` on the new test plus the existing
shared-helper coverage (`test_post_stream_media_delivery.py`,
`test_73771_media_resend_dedup.py`, `test_tts_media_routing.py`,
`test_queued_native_image_session_key.py`) and the broader `tests/gateway/`
suite (pre-existing, unrelated failures only — missing optional
dependencies / sandbox limitations, confirmed identical with and without
this change via `git stash`).

```
scripts/run_tests.sh tests/gateway/test_queued_followup_media_delivery.py \
  tests/gateway/test_post_stream_media_delivery.py \
  tests/gateway/test_73771_media_resend_dedup.py \
  tests/gateway/test_tts_media_routing.py \
  tests/gateway/test_queued_native_image_session_key.py -q
# => 5 files, 13 tests passed, 0 failed
```

## Scope

No behavior change to `_deliver_media_from_response`'s public contract, no
config/env additions, no unrelated cleanup. All example paths/content in the
new test are synthetic (a temp file under a monkeypatched safe root).