### PR TITLE
fix(buzz): ingest protected inbound images

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -37,11 +37,13 @@ environment and is never logged.
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
 import re
 import shutil
+import tempfile
 import time
 from collections import OrderedDict
 from datetime import datetime
@@ -77,9 +79,11 @@ logger = logging.getLogger(__name__)
 
 from gateway.platforms.base import (
     BasePlatformAdapter,
-    SendResult,
     MessageEvent,
     MessageType,
+    SendResult,
+    cache_image_from_bytes,
+    validate_inbound_media_size,
 )
 from gateway.config import Platform
 
@@ -99,6 +103,21 @@ _DM_DISCOVERY_EVERY = 5
 _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
+
+_BUZZ_MARKDOWN_IMAGE_RE = re.compile(r"!\[[^\]\r\n]*\]\((https?://[^)\s]+)\)")
+_BUZZ_MEDIA_IMAGE_PATH_RE = re.compile(
+    r"/media/([0-9a-f]{64})\.(png|jpe?g|gif|webp|bmp)",
+    re.IGNORECASE,
+)
+_BUZZ_IMAGE_MIME = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+    "bmp": "image/bmp",
+}
+_MAX_BUZZ_IMAGES_PER_MESSAGE = 4
 
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
 # kind 44100 is Buzz's channel-membership event — used for live DM discovery.
@@ -1048,6 +1067,10 @@ class BuzzAdapter(BasePlatformAdapter):
         # strip applies to both chat types.
         dispatch_text = self._strip_mention(content)
 
+        dispatch_text, media_urls, media_types = await self._ingest_buzz_images(
+            dispatch_text
+        )
+
         await self._dispatch_message(
             text=dispatch_text,
             chat_id=channel_id,
@@ -1056,7 +1079,109 @@ class BuzzAdapter(BasePlatformAdapter):
             user_name=await self._resolve_user_name(pubkey),
             message_id=event_id,
             created_at=created_at,
+            message_type=MessageType.PHOTO if media_urls else MessageType.TEXT,
+            media_urls=media_urls,
+            media_types=media_types,
         )
+
+    def _buzz_image_metadata(self, url: str) -> Optional[Tuple[str, str, str]]:
+        """Return ``(sha256, extension, MIME)`` for this relay's image URL."""
+        relay = urlsplit(self.relay_url)
+        candidate = urlsplit(url)
+        if (
+            candidate.scheme.lower() != relay.scheme.lower()
+            or candidate.netloc.lower() != relay.netloc.lower()
+            or candidate.username is not None
+            or candidate.password is not None
+            or candidate.query
+            or candidate.fragment
+        ):
+            return None
+        match = _BUZZ_MEDIA_IMAGE_PATH_RE.fullmatch(candidate.path)
+        if match is None:
+            return None
+        digest, extension = match.groups()
+        extension = extension.lower()
+        return digest.lower(), f".{extension}", _BUZZ_IMAGE_MIME[extension]
+
+    @staticmethod
+    def _buzz_image_removal_span(
+        text: str, span: Tuple[int, int]
+    ) -> Tuple[int, int]:
+        """Expand standalone image markup to its line without touching neighbours."""
+        start, end = span
+        line_start = text.rfind("\n", 0, start) + 1
+        line_end = text.find("\n", end)
+        if line_end < 0:
+            line_end = len(text)
+        if text[line_start:start].strip() or text[end:line_end].strip():
+            return span
+        if line_end < len(text):
+            return line_start, line_end + 1
+        if line_start > 0:
+            return line_start - 1, line_end
+        return line_start, line_end
+
+    async def _ingest_buzz_images(self, text: str) -> Tuple[str, List[str], List[str]]:
+        """Authenticated-download protected Buzz Markdown images for vision."""
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        consumed_spans: List[Tuple[int, int]] = []
+        download_attempts = 0
+
+        for match in _BUZZ_MARKDOWN_IMAGE_RE.finditer(text):
+            url = match.group(1)
+            metadata = self._buzz_image_metadata(url)
+            if metadata is None:
+                continue
+            if download_attempts >= _MAX_BUZZ_IMAGES_PER_MESSAGE:
+                break
+            download_attempts += 1
+            expected_digest, extension, mime = metadata
+            fd, temporary_path = tempfile.mkstemp(
+                prefix="hermes_buzz_media_", suffix=extension
+            )
+            os.close(fd)
+            try:
+                code, _out, _err = await self._run_cli(
+                    ["media", "get", url, "--output", temporary_path]
+                )
+                if code != 0:
+                    logger.warning(
+                        "Buzz: authenticated inbound image download failed (exit %d)",
+                        code,
+                    )
+                    continue
+                path = Path(temporary_path)
+                validate_inbound_media_size(path.stat().st_size, media_type="image")
+                data = path.read_bytes()
+                if hashlib.sha256(data).hexdigest() != expected_digest:
+                    logger.warning("Buzz: inbound image hash did not match its media URL")
+                    continue
+                cached_path = cache_image_from_bytes(data, ext=extension)
+                os.chmod(cached_path, 0o600)
+                media_urls.append(cached_path)
+                media_types.append(mime)
+                consumed_spans.append(
+                    self._buzz_image_removal_span(text, match.span())
+                )
+            except (OSError, ValueError):
+                logger.warning("Buzz: could not cache authenticated inbound image", exc_info=True)
+            finally:
+                try:
+                    Path(temporary_path).unlink()
+                except OSError:
+                    pass
+
+        merged_spans: List[List[int]] = []
+        for start, end in sorted(consumed_spans):
+            if merged_spans and start <= merged_spans[-1][1]:
+                merged_spans[-1][1] = max(merged_spans[-1][1], end)
+            else:
+                merged_spans.append([start, end])
+        for start, end in reversed(merged_spans):
+            text = text[:start] + text[end:]
+        return text, media_urls, media_types
 
     # ── DM classification (issue #68871) ──────────────────────────────────
     #
@@ -1219,6 +1344,9 @@ class BuzzAdapter(BasePlatformAdapter):
         user_name: str,
         message_id: str,
         created_at: int,
+        message_type: MessageType = MessageType.TEXT,
+        media_urls: Optional[List[str]] = None,
+        media_types: Optional[List[str]] = None,
     ) -> None:
         """Build a MessageEvent and hand it to the base class handler."""
         if not self._message_handler:
@@ -1234,10 +1362,12 @@ class BuzzAdapter(BasePlatformAdapter):
 
         event = MessageEvent(
             text=text,
-            message_type=MessageType.TEXT,
+            message_type=message_type,
             source=source,
             message_id=message_id,
             timestamp=datetime.fromtimestamp(created_at) if created_at else datetime.now(),
+            media_urls=media_urls or [],
+            media_types=media_types or [],
         )
 
         await self.handle_message(event)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -118,6 +118,7 @@ _BUZZ_IMAGE_MIME = {
     "bmp": "image/bmp",
 }
 _MAX_BUZZ_IMAGES_PER_MESSAGE = 4
+_BUZZ_MEDIA_RETRY_DELAYS = (0.25, 0.75)
 
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
 # kind 44100 is Buzz's channel-membership event — used for live DM discovery.
@@ -350,6 +351,17 @@ def _cli_error_message(stderr: str, returncode: int) -> str:
     except ValueError:
         pass
     return text or f"buzz CLI failed with exit code {returncode}"
+
+
+def _cli_failure_is_retryable(stderr: str, returncode: int) -> bool:
+    """Honor the CLI error contract, with network/server exit-code fallback."""
+    try:
+        data = json.loads((stderr or "").strip())
+    except ValueError:
+        data = None
+    if isinstance(data, dict) and isinstance(data.get("retryable"), bool):
+        return data["retryable"]
+    return returncode in {2, 4}
 
 
 def _parse_json_list(stdout: str) -> List[dict]:
@@ -1143,12 +1155,23 @@ class BuzzAdapter(BasePlatformAdapter):
             )
             os.close(fd)
             try:
-                code, _out, _err = await self._run_cli(
-                    ["media", "get", url, "--output", temporary_path]
-                )
+                code = 4
+                _err = ""
+                attempts = 0
+                for delay in (0, *_BUZZ_MEDIA_RETRY_DELAYS):
+                    if delay:
+                        await asyncio.sleep(delay)
+                    attempts += 1
+                    code, _out, _err = await self._run_cli(
+                        ["media", "get", url, "--output", temporary_path]
+                    )
+                    if code == 0 or not _cli_failure_is_retryable(_err, code):
+                        break
                 if code != 0:
                     logger.warning(
-                        "Buzz: authenticated inbound image download failed (exit %d)",
+                        "Buzz: authenticated inbound image download failed "
+                        "after %d attempt(s) (exit %d)",
+                        attempts,
                         code,
                     )
                     continue

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -1,7 +1,11 @@
 """Tests for the Buzz platform adapter plugin."""
 
 import asyncio
+import hashlib
 import json
+from pathlib import Path
+import stat
+import sys
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
@@ -242,6 +246,148 @@ class TestMentionGating:
     async def test_name_mention_dispatched(self, adapter):
         await self._poll_with(adapter, _event("e1", content="hey @Chip can you help?", created_at=10))
         assert len(adapter._dispatched) == 1
+
+    @pytest.mark.asyncio
+    async def test_protected_buzz_markdown_image_is_downloaded_for_vision(
+        self, adapter, monkeypatch, tmp_path
+    ):
+        image_bytes = b"\x89PNG\r\n\x1a\nprotected-image"
+        image_hash = hashlib.sha256(image_bytes).hexdigest()
+        image_url = f"https://test.relay/media/{image_hash}.png"
+        event = _event(
+            "e1",
+            content=f"@Chip what does this show?\n![image]({image_url})",
+            created_at=10,
+        )
+        monkeypatch.setenv("IMAGE_CACHE_DIR", str(tmp_path / "images"))
+
+        cli = _ScriptedCli()
+        cli.script("messages", "get", [event])
+
+        async def run_cli(args, *, input_text=None):
+            cli.calls.append((list(args), input_text))
+            if args[:2] == ["media", "get"]:
+                output = Path(args[args.index("--output") + 1])
+                output.write_bytes(image_bytes)
+                return 0, "", ""
+            queue = cli.responses.get((args[0], args[1]), [])
+            return queue[0] if queue else (0, "[]", "")
+
+        adapter._run_cli = run_cli
+        await adapter._poll_channel(CHANNEL)
+
+        dispatched = adapter._dispatched[0]
+        assert dispatched["message_type"] is _buzz_mod.MessageType.PHOTO
+        assert dispatched["media_types"] == ["image/png"]
+        assert len(dispatched["media_urls"]) == 1
+        cached_image = Path(dispatched["media_urls"][0])
+        assert cached_image.read_bytes() == image_bytes
+        if not sys.platform.startswith("win"):
+            assert stat.S_IMODE(cached_image.stat().st_mode) == 0o600
+        assert dispatched["text"] == "what does this show?"
+        assert any(call[0][:3] == ["media", "get", image_url] for call in cli.calls)
+
+    @pytest.mark.asyncio
+    async def test_text_without_buzz_images_is_preserved_byte_for_byte(self, adapter):
+        original = (
+            "line one\n\n\n\nline two\n\n"
+            "```\ncode\n\n\n\nstill code\n```\n\ntrailing   \n"
+        )
+
+        text, media_urls, media_types = await adapter._ingest_buzz_images(original)
+
+        assert text == original
+        assert media_urls == []
+        assert media_types == []
+
+    @pytest.mark.asyncio
+    async def test_external_images_do_not_consume_buzz_download_cap(
+        self, adapter, monkeypatch, tmp_path
+    ):
+        image_bytes = b"\x89PNG\r\n\x1a\nprotected-after-external-links"
+        image_hash = hashlib.sha256(image_bytes).hexdigest()
+        buzz_url = f"https://test.relay/media/{image_hash}.png"
+        external = "\n".join(
+            f"![external](https://example.invalid/media/{index}.png)"
+            for index in range(_buzz_mod._MAX_BUZZ_IMAGES_PER_MESSAGE)
+        )
+        text = f"{external}\n![buzz]({buzz_url})"
+        monkeypatch.setenv("IMAGE_CACHE_DIR", str(tmp_path / "images"))
+
+        cli = _ScriptedCli()
+
+        async def run_cli(args, *, input_text=None):
+            cli.calls.append((list(args), input_text))
+            output = Path(args[args.index("--output") + 1])
+            output.write_bytes(image_bytes)
+            return 0, "", ""
+
+        adapter._run_cli = run_cli
+        result_text, media_urls, media_types = await adapter._ingest_buzz_images(text)
+
+        assert len(media_urls) == 1
+        assert media_types == ["image/png"]
+        assert buzz_url not in result_text
+        assert "https://example.invalid/media/0.png" in result_text
+        assert [call[0][:3] for call in cli.calls] == [["media", "get", buzz_url]]
+
+    @pytest.mark.asyncio
+    async def test_external_markdown_image_is_not_fetched_with_buzz_credentials(self, adapter):
+        external_url = "https://example.invalid/media/" + ("a" * 64) + ".png"
+        await self._poll_with(
+            adapter,
+            _event(
+                "e1",
+                content=f"@Chip inspect this\n![image]({external_url})",
+                created_at=10,
+            ),
+        )
+
+        dispatched = adapter._dispatched[0]
+        assert dispatched["media_urls"] == []
+        assert external_url in dispatched["text"]
+        assert all(call[0][:2] != ["media", "get"] for call in adapter._run_cli.calls)
+
+    @pytest.mark.asyncio
+    async def test_failed_authenticated_image_download_preserves_original_link(self, adapter):
+        image_url = "https://test.relay/media/" + ("a" * 64) + ".png"
+        cli = _ScriptedCli()
+        cli.script(
+            "messages",
+            "get",
+            [
+                _event(
+                    "e1",
+                    content=f"@Chip inspect this\n![image]({image_url})",
+                    created_at=10,
+                )
+            ],
+        )
+        cli.script("media", "get", "", code=3, stderr='{"error":"auth"}')
+        adapter._run_cli = cli
+
+        await adapter._poll_channel(CHANNEL)
+
+        dispatched = adapter._dispatched[0]
+        assert dispatched["media_urls"] == []
+        assert dispatched["message_type"] is _buzz_mod.MessageType.TEXT
+        assert image_url in dispatched["text"]
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_image_message_is_not_downloaded(self, adapter):
+        adapter._allowed_pubkeys = {"b" * 64}
+        image_url = "https://test.relay/media/" + ("a" * 64) + ".png"
+        await self._poll_with(
+            adapter,
+            _event(
+                "e1",
+                content=f"@Chip inspect this\n![image]({image_url})",
+                created_at=10,
+            ),
+        )
+
+        assert adapter._dispatched == []
+        assert all(call[0][:2] != ["media", "get"] for call in adapter._run_cli.calls)
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -288,6 +288,44 @@ class TestMentionGating:
         assert any(call[0][:3] == ["media", "get", image_url] for call in cli.calls)
 
     @pytest.mark.asyncio
+    async def test_retryable_media_failure_is_retried_before_preserving_link(
+        self, adapter, monkeypatch, tmp_path
+    ):
+        image_bytes = b"\x89PNG\r\n\x1a\nprotected-image-after-retry"
+        image_hash = hashlib.sha256(image_bytes).hexdigest()
+        image_url = f"https://test.relay/media/{image_hash}.png"
+        monkeypatch.setenv("IMAGE_CACHE_DIR", str(tmp_path / "images"))
+        monkeypatch.setattr(
+            _buzz_mod, "_BUZZ_MEDIA_RETRY_DELAYS", (0,), raising=False
+        )
+        attempts = 0
+
+        async def run_cli(args, *, input_text=None):
+            nonlocal attempts
+            assert args[:3] == ["media", "get", image_url]
+            attempts += 1
+            if attempts == 1:
+                return (
+                    4,
+                    "",
+                    '{"error":"server_error","message":"media unavailable",'
+                    '"retryable":true}',
+                )
+            output = Path(args[args.index("--output") + 1])
+            output.write_bytes(image_bytes)
+            return 0, "", ""
+
+        adapter._run_cli = run_cli
+        text = f"inspect this\n![image]({image_url})"
+        result_text, media_urls, media_types = await adapter._ingest_buzz_images(text)
+
+        assert attempts == 2
+        assert image_url not in result_text
+        assert len(media_urls) == 1
+        assert Path(media_urls[0]).read_bytes() == image_bytes
+        assert media_types == ["image/png"]
+
+    @pytest.mark.asyncio
     async def test_text_without_buzz_images_is_preserved_byte_for_byte(self, adapter):
         original = (
             "line one\n\n\n\nline two\n\n"
@@ -372,6 +410,7 @@ class TestMentionGating:
         assert dispatched["media_urls"] == []
         assert dispatched["message_type"] is _buzz_mod.MessageType.TEXT
         assert image_url in dispatched["text"]
+        assert sum(call[0][:2] == ["media", "get"] for call in cli.calls) == 1
 
     @pytest.mark.asyncio
     async def test_unauthorized_image_message_is_not_downloaded(self, adapter):

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -2,7 +2,7 @@
 
 The Buzz adapter connects Hermes to a [Buzz](https://github.com/block/buzz) community — Block's open-source human+agent collaboration platform built on the Nostr protocol — and relays messages between Buzz channels (or DMs) and the agent. Outbound traffic shells out to the `buzz` CLI binary ("JSON in, JSON out"); inbound uses a native Nostr WebSocket subscription (via the already-bundled `websockets` package) with CLI polling as fallback. **No extra Python packages are required** — just the `buzz` binary.
 
-Buzz renders markdown, so agent replies keep their formatting. Images are delivered as uploads (local files) or links (URLs). Replies can thread onto an existing message via its event id.
+Buzz renders markdown, so agent replies keep their formatting. Outbound images are delivered as uploads (local files) or links (URLs). For inbound messages, same-relay Markdown images under Buzz's content-addressed `/media/` path are downloaded with the agent identity's existing Buzz authentication, integrity-checked against the URL hash, cached locally with owner-only permissions, and passed through Hermes' normal image pipeline. External image URLs remain links. Replies can thread onto an existing message via its event id.
 
 Inbound messages arrive over a persistent NIP-42-authenticated Nostr WebSocket subscription by default (near-instant delivery), with automatic fallback to CLI polling when the WebSocket can't be established. Outbound messages always go through the `buzz` CLI. Control it with `transport` / `BUZZ_TRANSPORT`: `auto` (default), `websocket` (require WS, fail otherwise), or `poll`. If your relay membership uses NIP-OA owner attestation, set `BUZZ_AUTH_TAG` to the four-string auth tag JSON.
 
@@ -120,4 +120,5 @@ Check status with `hermes gateway status` — Buzz connection state is reported 
 - **Inbound is polled, not streamed.** The `buzz` CLI is request/response, so the adapter polls `buzz messages get` per watched channel every `poll_interval` seconds (default 4). Expect up to one interval of latency on inbound messages. A future optimization is a websocket transport (the Buzz repo ships `buzz-ws-client` for true streaming).
 - On (re)connect the adapter seeds its high-water mark from the newest events, so channel history is never replayed into the agent.
 - New DM conversations are discovered automatically (every few poll sweeps).
+- Protected inbound Buzz images require a recent `buzz` CLI with `buzz media get` support. If authenticated download or integrity validation fails, Hermes preserves the original Markdown link in the message instead of silently dropping it.
 - The private key is passed to the CLI via the subprocess environment — it never appears in argv or logs.


### PR DESCRIPTION
## What does this PR do?

Buzz Desktop can display protected hosted media because it uses the authenticated Buzz identity, but Hermes previously received only the Markdown image URL. Anonymous retrieval of that URL returns `401 Unauthorized`, so the image never reached the existing Gateway vision path.

This PR moves protected inbound-image retrieval to the Buzz adapter boundary. For image URLs on the configured relay that exactly match `/media/<sha256>.<supported-image-extension>`, the adapter uses its existing authenticated Buzz CLI/profile, verifies the downloaded bytes against the URL digest, validates the image through the existing Gateway media cache, and dispatches the resulting local image through normal `MessageEvent` media semantics.

The boundary is intentionally narrow:

- foreign-host URLs are never sent to authenticated Buzz retrieval and do not consume the four-attempt budget;
- URLs with user info, query strings, fragments, unexpected paths, or unsupported extensions are rejected;
- failed retrieval, validation, or caching leaves the original Markdown unchanged;
- messages with no successfully consumed image remain byte-for-byte unchanged;
- only successfully consumed image spans are removed from the prompt;
- temporary downloads are cleaned up and cached private media is restricted to owner-only permissions on POSIX systems.

This does not change Buzz authorization policy or generic Gateway vision behavior. The CLI download completes before the adapter can apply the Gateway size limit, and the cache helper is followed by `chmod(0600)` rather than creating the final cache entry atomically; same-relay validation, bounded attempts, digest verification, and cleanup limit those existing trade-offs.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/buzz/adapter.py`
  - recognize only exact same-relay protected image URLs;
  - retrieve eligible images with authenticated `buzz media get`;
  - enforce a maximum of four eligible authenticated attempts per message;
  - verify SHA-256, size, image content, and cache permissions;
  - clean temporary downloads and preserve original Markdown on failure;
  - route successful downloads through existing `MessageEvent` image fields.
- `tests/gateway/test_buzz_adapter.py`
  - cover protected retrieval, digest and permission handling, unchanged-message behavior, removal layouts, failure preservation, foreign-host isolation, and attempt-cap accounting;
  - keep the POSIX mode assertion conditional on non-Windows platforms.
- `website/docs/user-guide/messaging/buzz.md`
  - document authenticated protected-image ingestion and the required Buzz CLI support.

## How to Test

1. Configure Buzz with a recent CLI that supports `buzz media get`, then send Hermes a protected hosted image attachment. Verify the adapter dispatches a local image and the vision path can inspect it.
2. Send messages without images, with failed protected-image downloads, and with foreign-host Markdown images. Verify their text remains unchanged and foreign URLs never receive Buzz-authenticated retrieval.
3. Run the focused regression group:

   `PYTHONPATH=. python -m pytest -q tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py tests/gateway/test_image_input_routing_runtime.py tests/gateway/test_mixed_attachment_routing.py tests/gateway/test_native_image_buffer_isolation.py tests/gateway/test_queued_native_image_session_key.py`

   Result on the final rebased candidate: `41 passed`.

Additional verification:

- Ruff, `py_compile`, `git diff --check`, and `scripts/check-windows-footguns.py` pass.
- Independent candidate-versus-parent full Gateway runs produced the same 16 baseline failures on both sides; the candidate added six passing regressions and introduced no candidate-only failures.
- A live hosted-Buzz acceptance test delivered a newly uploaded protected JPEG as a local owner-only image and successfully passed it through Hermes vision.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04 LTS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture or workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tool schema changed)

## Screenshots / Logs

Focused verification on the final rebased candidate:

```text
.........................................                                [100%]
41 passed
```

The hosted-Buzz acceptance test confirmed protected media arrived as a local image with owner-only permissions and was readable by Hermes vision. No private relay URL, identity, credential, or attachment is included here.