### PR TITLE
fix: allow native worker executables in gateway

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -105,6 +105,16 @@ _SHELL_OPTIONS_WITH_VALUES = frozenset({"-O", "+O", "-o", "+o"})
 _MAX_REFERENCED_SCRIPT_BYTES = 1024 * 1024
 _MAX_REFERENCED_SCRIPT_DEPTH = 8
 _CONTROL_CHARS = frozenset(";&|()")
+_NATIVE_EXECUTABLE_MAGICS = (
+    b"\x7fELF",  # Linux and other ELF platforms
+    b"MZ",  # Windows PE/COFF
+    b"\xfe\xed\xfa\xce",  # Mach-O 32-bit
+    b"\xfe\xed\xfa\xcf",  # Mach-O 64-bit
+    b"\xce\xfa\xed\xfe",  # Mach-O 32-bit, reverse byte order
+    b"\xcf\xfa\xed\xfe",  # Mach-O 64-bit, reverse byte order
+    b"\xca\xfe\xba\xbe",  # Mach-O universal binary
+    b"\xbe\xba\xfe\xca",  # Mach-O universal binary, reverse byte order
+)
 
 
 
@@ -272,14 +282,14 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         return None, False
     finally:
         os.close(descriptor)
-    # A NUL byte in the first chunk means this is a binary (ELF/Mach-O/
-    # PE), not a shell script — scanning its decoded contents would
-    # tokenize machine code and feed junk paths into the recursion
-    # (including a `ValueError: embedded null byte` from Path.resolve,
-    # #76762). Treat it as "nothing to scan" rather than unsafe: a binary
-    # executed by the user is not a referenced *shell script*.
-    if b"\x00" in data:
-        return None, False
+    # Native executables are commands, not referenced shell scripts. Return
+    # an empty string rather than None so callers know the local read was
+    # definitive and do not retry it through a remote ``cat`` callback. That
+    # retry decoded the Python interpreter as text and reintroduced the exact
+    # false positive this check is meant to avoid (spawn_claude_code launches
+    # its tracked worker through an absolute interpreter path).
+    if any(data.startswith(magic) for magic in _NATIVE_EXECUTABLE_MAGICS):
+        return "", False
     if len(data) > _MAX_REFERENCED_SCRIPT_BYTES:
         return None, True
     return data.decode("utf-8", errors="replace"), False

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -8,6 +8,8 @@ Covers:
 
 import json
 import os
+import shlex
+import sys
 from argparse import Namespace
 
 import pytest
@@ -309,6 +311,45 @@ class TestTerminalToolGatewayLifecycleGuard:
 
         assert result["exit_code"] == 1
         assert "referenced script" in result["error"]
+
+    def test_nul_byte_cannot_hide_lifecycle_command_in_shell_script(
+        self, monkeypatch, tmp_path
+    ):
+        import tools.terminal_tool as tt
+
+        script = tmp_path / "nul-delayed-ops.sh"
+        script.write_bytes(
+            b"#!/bin/bash\n# attacker-controlled NUL: \x00\nhermes gateway restart\n"
+        )
+        self._patch_env(monkeypatch, self._make_fake_env(), inside_gateway=True)
+
+        result = json.loads(tt.terminal_tool(command=f"/bin/bash {script}"))
+
+        assert result["exit_code"] == 1
+        assert "referenced script" in result["error"]
+
+    def test_allows_absolute_python_interpreter_inside_gateway(self, monkeypatch):
+        import tools.terminal_tool as tt
+
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "Python worker started", "returncode": 0}
+
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True}
+        )
+        command = f"{shlex.quote(sys.executable)} --version"
+
+        result = json.loads(tt.terminal_tool(command=command))
+
+        assert result["exit_code"] == 0
+        assert calls == [command]
 
     def test_blocks_launchctl_submit_inside_gateway(self, monkeypatch, tmp_path):
         import tools.terminal_tool as tt


### PR DESCRIPTION
## Summary

- distinguish native executables by platform magic instead of treating every NUL-containing file as an unscannable binary
- return a definitive empty scan result for native executables so `terminal_tool` does not retry them through the remote-script callback
- keep scanning NUL-containing shell scripts so a NUL byte cannot hide a gateway lifecycle command
- add gateway-level regressions for absolute Python worker executables and NUL-bearing shell scripts

## Root cause

`spawn_claude_code` dispatches its tracked worker through an absolute Python interpreter path. The lifecycle guard correctly recognized the interpreter as binary, but returned `None`, which also means "local file unavailable." `terminal_tool` therefore retried the interpreter through its remote `cat` callback, decoded the executable as text, and could classify the safe worker launch as an unsafe referenced script.

Returning `""` for recognized ELF, PE, and Mach-O executables preserves the distinction: the local read was definitive, there is nothing to scan, and no remote fallback is needed.

The previous generic NUL heuristic also allowed a NUL-bearing shell script to skip scanning. Restricting the skip to native executable magics closes that bypass.

## Verification

- `scripts/run_tests.sh tests/tools/test_terminal_tool.py tests/hermes_cli/test_gateway_restart_loop.py` — 94 passed
- end-to-end `spawn_claude_code` integration using the active Claude Code plugin plus this branch's `terminal_tool` — tracked terminal launch completed with `status=ok`, `subtype=success`, and exit code 0
- `git diff --check origin/main...HEAD` — clean

The full suite was also attempted, but the local shared test environment lacks `pytest-asyncio`; unrelated async-marked tests failed and the run timed out after 600 seconds at 23.8%.
