### PR TITLE
fix(credential_pool): unpack the tuple in next_available_at's gate

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -642,7 +642,8 @@ class CredentialPool:
         ``_available_entries`` caller (see the comment on ``has_available``).
         """
         with self._lock:
-            if self._available_entries():
+            available, _pending = self._available_entries()
+            if available:
                 return None
             candidates: List[float] = []
             for entry in self._entries:

--- a/tests/run_agent/test_reset_aware_primary_restore.py
+++ b/tests/run_agent/test_reset_aware_primary_restore.py
@@ -203,9 +203,23 @@ class TestNextAvailableAt:
         original = pool._available_entries
 
         def _probe(**kwargs):
-            held["locked"] = not pool._lock.acquire(blocking=False)
-            if not held["locked"]:
-                pool._lock.release()
+            # self._lock is an RLock (deferred-refresh mutations self-lock),
+            # so a same-thread non-blocking acquire always succeeds; probe
+            # ownership from a helper thread instead.
+            import threading as _t
+
+            blocked = _t.Event()
+
+            def _try():
+                if not pool._lock.acquire(blocking=False):
+                    blocked.set()
+                else:
+                    pool._lock.release()
+
+            worker = _t.Thread(target=_try)
+            worker.start()
+            worker.join(timeout=5)
+            held["locked"] = blocked.is_set()
             return original(**kwargs)
 
         pool._available_entries = _probe


### PR DESCRIPTION
Cross-PR interaction fix between two salvages that both landed today: #77714 (deferred single-use-token refresh, changes `_available_entries` to return a tuple) and #77631 (reset-aware primary restore, adds `next_available_at()` which truthiness-tests the bare return).

A non-empty tuple is ALWAYS truthy — even `([], [])` — so on current main `next_available_at()` returns None ('no wait information') for every exhausted pool, silently disabling the reset-aware gate #77631 shipped: the agent falls back to per-turn primary retries, i.e. exactly the pre-#77631 behavior (fail-open, no crash — but the feature is off).

This was the interaction the trio review predicted; the fix is the documented unpack (`available, _pending = ...`), matching `has_available()` one method up. Also adapts #77631's lock-probe test for #77714's RLock (a same-thread non-blocking acquire always succeeds on an RLock; the probe now checks ownership from a helper thread).

Verification: reset-aware suite + deferred-refresh suite + full pool suite = 76 passed on current main; the gate tests (stays-on-fallback / restores-once-elapsed) prove the feature is live again. ruff clean.