### PR TITLE
fix(reactions): close session database after tool calls

### DIFF
--- a/tests/tools/test_react_to_message_tool.py
+++ b/tests/tools/test_react_to_message_tool.py
@@ -1,0 +1,48 @@
+"""Resource-lifecycle tests for the desktop reaction tool."""
+
+import json
+from unittest.mock import MagicMock
+
+from tools import react_to_message_tool as reaction_tool
+
+
+def _install_db(monkeypatch, db):
+    monkeypatch.setattr(reaction_tool, "get_session_env", lambda *_args: "session-1")
+    monkeypatch.setattr(reaction_tool, "_open_session_db", lambda: db)
+    monkeypatch.setattr(reaction_tool.desktop_ui, "emit", MagicMock())
+
+
+def test_reaction_closes_session_db_after_success(monkeypatch):
+    db = MagicMock()
+    db.latest_message_row_id.return_value = 42
+    db.set_message_reaction.return_value = [{"emoji": "👍", "author": "agent"}]
+    _install_db(monkeypatch, db)
+
+    result = json.loads(reaction_tool.react_to_message_tool("👍"))
+
+    assert result["success"] is True
+    assert result["row_id"] == 42
+    db.close.assert_called_once_with()
+
+
+def test_reaction_closes_session_db_when_target_is_missing(monkeypatch):
+    db = MagicMock()
+    db.latest_message_row_id.return_value = None
+    _install_db(monkeypatch, db)
+
+    result = json.loads(reaction_tool.react_to_message_tool("👍"))
+
+    assert "No user message" in result["error"]
+    db.close.assert_called_once_with()
+
+
+def test_reaction_closes_session_db_after_write_failure(monkeypatch):
+    db = MagicMock()
+    db.latest_message_row_id.return_value = 42
+    db.set_message_reaction.side_effect = RuntimeError("write failed")
+    _install_db(monkeypatch, db)
+
+    result = json.loads(reaction_tool.react_to_message_tool("👍"))
+
+    assert "write failed" in result["error"]
+    db.close.assert_called_once_with()

--- a/tools/react_to_message_tool.py
+++ b/tools/react_to_message_tool.py
@@ -45,48 +45,54 @@ def react_to_message_tool(emoji: str, message_row_id=None, messages_back=None) -
     if db is None:
         return tool_error("Session storage is unavailable.")
 
-    row_id = message_row_id
-    target_role = "user"
-    if row_id is None:
-        # Default target: the latest user message. `messages_back` steps to
-        # earlier user turns (1 = the one before, etc.) for retroactive
-        # reactions — quoting text would be ambiguous, ids aren't visible to
-        # the model, but "two messages ago" is how a person thinks about it.
-        back = max(0, int(messages_back or 0))
-        row_id = db.latest_message_row_id(session_key, role="user", offset=back)
+    try:
+        row_id = message_row_id
+        target_role = "user"
         if row_id is None:
-            return tool_error(
-                f"No user message found {back} back." if back else "No user message to react to yet."
+            # Default target: the latest user message. `messages_back` steps to
+            # earlier user turns (1 = the one before, etc.) for retroactive
+            # reactions — quoting text would be ambiguous, ids aren't visible
+            # to the model, but "two messages ago" is how a person thinks.
+            back = max(0, int(messages_back or 0))
+            row_id = db.latest_message_row_id(session_key, role="user", offset=back)
+            if row_id is None:
+                return tool_error(
+                    f"No user message found {back} back."
+                    if back
+                    else "No user message to react to yet."
+                )
+        else:
+            row = db.get_message_role(session_key, int(row_id))
+            target_role = row or "user"
+
+        try:
+            reactions = db.set_message_reaction(
+                session_key, int(row_id), emoji or None, author="agent"
             )
-    else:
-        row = db.get_message_role(session_key, int(row_id))
-        target_role = row or "user"
+        except Exception as exc:
+            return tool_error(f"Failed to set the reaction: {exc}")
 
-    try:
-        reactions = db.set_message_reaction(
-            session_key, int(row_id), emoji or None, author="agent"
+        if reactions is None:
+            return tool_error(f"Message {row_id} is not part of this conversation.")
+
+        # Paint it live. A missing bridge (non-desktop surface) is not an error
+        # — the reaction is persisted either way and shows on the next load.
+        # `role` lets the renderer match a live message that doesn't know its
+        # durable row id yet (it only learns rowId on resume).
+        try:
+            desktop_ui.emit(
+                "message.reaction",
+                {"row_id": int(row_id), "reactions": reactions, "role": target_role},
+            )
+        except Exception:
+            pass
+
+        return json.dumps(
+            {"success": True, "row_id": int(row_id), "reactions": reactions},
+            ensure_ascii=False,
         )
-    except Exception as exc:
-        return tool_error(f"Failed to set the reaction: {exc}")
-
-    if reactions is None:
-        return tool_error(f"Message {row_id} is not part of this conversation.")
-
-    # Paint it live. A missing bridge (non-desktop surface) is not an error —
-    # the reaction is persisted either way and shows on the next load.
-    # `role` lets the renderer match a live message that doesn't know its
-    # durable row id yet (it only learns rowId on resume).
-    try:
-        desktop_ui.emit(
-            "message.reaction",
-            {"row_id": int(row_id), "reactions": reactions, "role": target_role},
-        )
-    except Exception:
-        pass
-
-    return json.dumps(
-        {"success": True, "row_id": int(row_id), "reactions": reactions}, ensure_ascii=False
-    )
+    finally:
+        db.close()
 
 
 def check_react_requirements() -> bool:


### PR DESCRIPTION
## What does this PR do?

`react_to_message_tool()` opened a fresh `SessionDB` for each desktop
reaction but never closed it. The leak occurred after successful reactions and
on early error returns such as a missing target message or failed write.

This wraps all database-backed reaction work in `try/finally` so the
function-owned connection is closed deterministically without changing
reaction selection, persistence, or live UI events.

## Related Issue

No existing issue. This was found by auditing short-lived `SessionDB`
ownership on the current default branch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/react_to_message_tool.py`: close the reaction tool's `SessionDB` in
  `finally` across every database-backed return path.
- `tests/tools/test_react_to_message_tool.py`: cover successful reactions,
  missing target messages, and failed writes.

## How to Test

1. Invoke the reaction tool with a recording database fake.
2. Exercise success, missing-target, and write-failure paths.
3. Confirm each path calls `close()` exactly once.

Automated validation:

- `scripts/run_tests.sh tests/tools/test_react_to_message_tool.py tests/test_message_reactions.py -q`
  - 16 passed
- `python -m ruff check tools/react_to_message_tool.py tests/tools/test_react_to_message_tool.py`
- `python -m py_compile tools/react_to_message_tool.py tests/tools/test_react_to_message_tool.py`
- `git diff --check`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (focused reaction suites passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; the public behavior is unchanged
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A; no workflow changed
- [x] Cross-platform impact considered; this is platform-neutral SQLite cleanup
- [x] Tool descriptions/schemas are N/A; no tool surface changed

## Screenshots / Logs

Not applicable.
