### PR TITLE
fix: hashlib.sha1 FIPS crash in tui_gateway/server.py and optional-skills/dossier.py

### DIFF
--- a/optional-skills/security/unbroker/scripts/dossier.py
+++ b/optional-skills/security/unbroker/scripts/dossier.py
@@ -22,7 +22,7 @@ def now() -> str:
 def new_subject_id(full_name: str = "") -> str:
     # Opaque id: derives NOTHING from the name, so PII never leaks into directory names,
     # case ids, drafts, or the audit log. full_name kept only for call compatibility.
-    return "sub_" + hashlib.sha1(os.urandom(8)).hexdigest()[:10]
+    return "sub_" + hashlib.sha1(os.urandom(8), usedforsecurity=False).hexdigest()[:10]
 
 
 def create(identity: dict, consent: dict, residency: str = "US", prefs: dict | None = None) -> dict:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11674,7 +11674,7 @@ def _compute_mcp_rev() -> str:
             sort_keys=True,
             default=str,
         )
-        return hashlib.sha1(rev_src.encode()).hexdigest()[:12]
+        return hashlib.sha1(rev_src.encode(), usedforsecurity=False).hexdigest()[:12]
     except Exception:
         return ""
 


### PR DESCRIPTION
## Summary

Add `usedforsecurity=False` to two remaining `hashlib.sha1()` calls that crash on FIPS-enabled systems (RHEL 8/9).

## Changes

- `tui_gateway/server.py:11677` — revision hash for MCP config change detection
- `optional-skills/security/unbroker/scripts/dossier.py:25` — opaque subject ID generation

Both calls use SHA-1 for non-security purposes (content hashing, unique ID generation). On FIPS-enabled systems, `hashlib.sha1()` without `usedforsecurity=False` raises `ValueError: EVP_DigestInit_ex disabled for FIPS`.

## Background

This is the same pattern fixed in prior PRs for other files:
- #56715 (context_compressor.md5)
- #56716 (codex_responses_adapter.sha1)
- #56719 (gateway/platforms + skills_hub)
- #62654 (skills_sync, skills_hub, web_server)
- #64062 (qqbot, wecom, yuanbao_media)
- #66857 (weixin.md5)

These two call sites were missed in those earlier batches. SHA-256 is FIPS-approved and does not need this parameter.
