### PR TITLE
fix(gateway): close insights database after failures

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5000,11 +5000,12 @@ class GatewaySlashCommandsMixin:
 
             def _run_insights():
                 db = SessionDB()
-                engine = InsightsEngine(db)
-                report = engine.generate(days=days, source=source)
-                result = engine.format_gateway(report)
-                db.close()
-                return result
+                try:
+                    engine = InsightsEngine(db)
+                    report = engine.generate(days=days, source=source)
+                    return engine.format_gateway(report)
+                finally:
+                    db.close()
 
             return await loop.run_in_executor(None, _run_insights)
         except Exception as e:

--- a/tests/gateway/test_insights_db_cleanup.py
+++ b/tests/gateway/test_insights_db_cleanup.py
@@ -1,0 +1,46 @@
+"""SessionDB lifecycle coverage for the gateway /insights command."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.slash_commands import GatewaySlashCommandsMixin
+
+
+class _InsightsEvent:
+    def get_command_args(self):
+        return ""
+
+
+def _install_insights(monkeypatch, db, engine):
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+    monkeypatch.setattr("agent.insights.InsightsEngine", lambda _db: engine)
+
+
+@pytest.mark.asyncio
+async def test_gateway_insights_closes_session_db_after_success(monkeypatch):
+    db = MagicMock()
+    engine = MagicMock()
+    engine.generate.return_value = {"summary": "ok"}
+    engine.format_gateway.return_value = "formatted"
+    _install_insights(monkeypatch, db, engine)
+    handler = object.__new__(GatewaySlashCommandsMixin)
+
+    result = await handler._handle_insights_command(_InsightsEvent())
+
+    assert result == "formatted"
+    db.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_gateway_insights_closes_session_db_after_failure(monkeypatch):
+    db = MagicMock()
+    engine = MagicMock()
+    engine.generate.side_effect = RuntimeError("analytics failed")
+    _install_insights(monkeypatch, db, engine)
+    handler = object.__new__(GatewaySlashCommandsMixin)
+
+    result = await handler._handle_insights_command(_InsightsEvent())
+
+    assert "analytics failed" in result
+    db.close.assert_called_once_with()


### PR DESCRIPTION
## What does this PR do?

The gateway `/insights` worker opened a fresh `SessionDB` and closed it only
after analytics generation and formatting both succeeded. If either operation
raised, the command returned its normal user-facing error but left connection
cleanup to garbage collection.

This moves the close into `finally`, preserving the existing executor
offloading, argument parsing, output, and error handling.

## Related Issue

No existing issue. This was found by auditing short-lived `SessionDB`
ownership on the current default branch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/slash_commands.py`: close the `/insights` worker's `SessionDB` in
  `finally`.
- `tests/gateway/test_insights_db_cleanup.py`: verify deterministic cleanup
  after both successful formatting and analytics failure.

## How to Test

1. Invoke the async gateway insights handler with a recording database fake.
2. Exercise a successful report and a failing analytics engine.
3. Confirm each executor path calls `close()` exactly once.

Automated validation:

- `scripts/run_tests.sh tests/gateway/test_insights_db_cleanup.py tests/gateway/test_insights_unicode_flags.py tests/gateway/test_command_bypass_active_session.py -q`
  - 45 passed
- `python -m ruff check gateway/slash_commands.py tests/gateway/test_insights_db_cleanup.py`
- `python -m py_compile gateway/slash_commands.py tests/gateway/test_insights_db_cleanup.py`
- `git diff --check`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (focused gateway suites passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; command behavior is unchanged
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A; no workflow changed
- [x] Cross-platform impact considered; this is platform-neutral SQLite cleanup
- [x] Tool descriptions/schemas are N/A; no tool surface changed

## Screenshots / Logs

Not applicable.
