### PR TITLE
fix(updater): preserve gateway command lines for classification

### DIFF
--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -26,6 +26,7 @@ _SENSITIVE_LONG_FLAGS: list[str] = [
     "--private-key",
     "--session-key",
 ]
+_DIAGNOSTIC_CMDLINE_LIMIT = 120
 
 
 def _probe_fail_json() -> str:
@@ -92,6 +93,14 @@ def _redact_sensitive_cmdline(cmdline: str) -> str:
     return cmdline
 
 
+def _format_diagnostic_cmdline(cmdline: str) -> str:
+    """Redact and bound a command line intended for diagnostic output."""
+    diagnostic = _redact_sensitive_cmdline(cmdline)
+    if len(diagnostic) > _DIAGNOSTIC_CMDLINE_LIMIT:
+        return diagnostic[: _DIAGNOSTIC_CMDLINE_LIMIT - 3] + "..."
+    return diagnostic
+
+
 def _is_pausable_gateway(cmdline: str) -> bool:
     """Return True when *cmdline* is a gateway process the updater can pause.
 
@@ -144,7 +153,7 @@ def main() -> None:
         {
             "pid": pid,
             "name": name,
-            "cmdline": _redact_sensitive_cmdline(cmdline),
+            "cmdline": _format_diagnostic_cmdline(cmdline),
         }
         for pid, name, cmdline in matches
         if not _is_pausable_gateway(cmdline)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2911,7 +2911,9 @@ def _detect_venv_python_processes(
         if not is_holder:
             continue
         name = info.get("name") or Path(exe).name
-        matches.append((int(pid), str(name), cmdline_raw[:120]))
+        # Preserve the live argv for gateway classification. Long install
+        # paths can place ``gateway run`` beyond a diagnostic prefix.
+        matches.append((int(pid), str(name), cmdline_raw))
     return matches
 
 def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> str:
@@ -2926,7 +2928,16 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
             hint = "  ← Hermes Desktop backend (close the desktop app)"
         elif "gateway" in low:
             hint = "  ← gateway"
-        lines.append(f"  PID {pid}  {name}  {cmdline}{hint}")
+        diagnostic = cmdline
+        try:
+            from hermes_cli._scan_venv_blockers import _format_diagnostic_cmdline
+
+            diagnostic = _format_diagnostic_cmdline(diagnostic)
+        except Exception:
+            # Never expose a raw process command line when the authoritative
+            # formatter is unavailable or fails closed.
+            diagnostic = "<redacted>"
+        lines.append(f"  PID {pid}  {name}  {diagnostic}{hint}")
     if len(matches) > 6:
         lines.append(f"  ... and {len(matches) - 6} more")
     lines.append("")
@@ -3026,9 +3037,8 @@ def _leftover_pausable_gateway_pids(
     to exempt them (``_is_pausable_gateway``), so the preflight's exemption
     and this guard's tolerance cannot drift apart — matcher drift between
     two views of the same process table is what produced the launcher/worker
-    dead-end fixed above. The scan captures only a 120-char cmdline prefix,
-    so the live argv is re-read where psutil allows; an unreadable argv
-    falls back to the captured prefix.
+    dead-end fixed above. The scan preserves the full cmdline for reliable
+    gateway classification; diagnostics are bounded separately when displayed.
 
     Returns ``None`` when any holder is not a pausable gateway — an operator
     REPL, a stray script, or the Desktop backend has no pause machinery

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -17,6 +17,7 @@ import pytest
 
 import agent.redact as redact_module
 from hermes_cli._scan_venv_blockers import (
+    _format_diagnostic_cmdline,
     _is_pausable_gateway,
     _redact_sensitive_cmdline,
     main,
@@ -96,6 +97,14 @@ def test_redact_short_flags_not_redacted() -> None:
     assert result == raw  # short flags pass through unchanged
 
 
+def test_diagnostic_cmdline_is_bounded_after_redaction() -> None:
+    raw = "python.exe " + ("--arg value " * 40) + "--token secret"
+    result = _format_diagnostic_cmdline(raw)
+    assert len(result) == 120
+    assert result.endswith("...")
+    assert "secret" not in result
+
+
 # ---------------------------------------------------------------------------
 # _is_pausable_gateway — the gateway exemption
 #
@@ -129,6 +138,13 @@ def test_redact_short_flags_not_redacted() -> None:
     ],
 )
 def test_is_pausable_gateway_accepts_gateway_run_chains(cmdline: str) -> None:
+    assert _is_pausable_gateway(cmdline) is True
+
+
+def test_is_pausable_gateway_accepts_long_runtime_path() -> None:
+    runtime = "C:\\Users\\u\\AppData\\Roaming\\uv\\python\\" + ("deep-" * 28)
+    cmdline = f'"{runtime}python.exe" -m hermes_cli.main gateway run --replace'
+    assert len(cmdline) > 120
     assert _is_pausable_gateway(cmdline) is True
 
 
@@ -212,3 +228,21 @@ def test_main_desktop_serve_backend_still_blocks(monkeypatch, capsys):
     assert data["blocked"] is True
     assert [p["pid"] for p in data["processes"]] == [78]
     assert data["pausable_gateways"] == 0
+
+
+def test_main_exempts_long_managed_runtime_gateway(monkeypatch, capsys):
+    """Classification uses the full argv, even when the runtime path is long."""
+    runtime = "C:\\Users\\u\\AppData\\Roaming\\uv\\python\\" + ("deep-" * 28)
+    gateway = (
+        90,
+        "python.exe",
+        f'"{runtime}python.exe" -m hermes_cli.main gateway run --replace',
+    )
+    assert len(gateway[2]) > 120
+
+    code, data = _run_main_with_detector(monkeypatch, capsys, [gateway])
+
+    assert code == 0
+    assert data["blocked"] is False
+    assert data["processes"] == []
+    assert data["pausable_gateways"] == 1

--- a/tests/hermes_cli/test_update_venv_health.py
+++ b/tests/hermes_cli/test_update_venv_health.py
@@ -86,6 +86,54 @@ def test_detect_venv_python_excludes_self_and_ancestors(_winp, tmp_path):
         assert cli_main._detect_venv_python_processes() == []
 
 
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_venv_python_preserves_long_gateway_cmdline(_winp, tmp_path):
+    """Gateway classification must see argv beyond the diagnostic prefix."""
+    venv_py = str(tmp_path / "venv" / "Scripts" / "python.exe")
+    long_runtime = "C:\\Users\\u\\AppData\\Roaming\\uv\\python\\" + ("deep-" * 28)
+    cmdline = f'"{long_runtime}python.exe" -m hermes_cli.main gateway run --replace'
+    assert len(cmdline) > 120
+    me = MagicMock()
+    me.parents.return_value = []
+    fake_psutil = types.SimpleNamespace(
+        process_iter=lambda attrs: iter([_proc(701, venv_py, "python.exe", cmdline.split())]),
+        Process=lambda *a, **k: me,
+    )
+    with patch.object(cli_main, "PROJECT_ROOT", tmp_path), patch.dict(
+        sys.modules, {"psutil": fake_psutil}
+    ):
+        matches = cli_main._detect_venv_python_processes()
+
+    assert matches == [(701, "python.exe", cmdline)]
+
+
+def test_format_venv_python_holders_bounds_diagnostic_cmdline():
+    cmdline = "python.exe " + ("--arg value " * 40)
+    rendered = cli_main._format_venv_python_holders_message(
+        [(701, "python.exe", cmdline)]
+    )
+    detail = next(line for line in rendered.splitlines() if "PID 701" in line)
+    assert len(detail.split("  ", 3)[-1]) <= 123
+    assert detail.endswith("...")
+
+
+def test_format_venv_python_holders_fails_closed_on_redactor_error(monkeypatch):
+    import hermes_cli._scan_venv_blockers as scanner
+
+    def _fail_redaction(_cmdline):
+        raise RuntimeError("redactor unavailable")
+
+    monkeypatch.setattr(
+        scanner, "_redact_sensitive_cmdline", _fail_redaction
+    )
+    raw = "python.exe --token secret-value"
+    rendered = cli_main._format_venv_python_holders_message(
+        [(701, "python.exe", raw)]
+    )
+    assert "secret-value" not in rendered
+    assert "<redacted>" in rendered
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a deterministic Windows Desktop updater false positive when Hermes is installed under a long managed-runtime path.

The venv-holder detector previously truncated each process command line to 120 characters before returning it. The Desktop preflight later used that already-truncated value to decide whether a venv process was a pausable Hermes gateway. When `gateway run` appeared after character 120, the real gateway was misclassified as an unrelated blocker and the update aborted before the CLI updater could pause it.

This change preserves the full command line for internal classification and applies redaction plus the 120-character display limit only when producing diagnostics. Diagnostic formatting fails closed to `<redacted>` if sanitization cannot be loaded or executed.

Related to #74267 and #74326.

This is complementary to, not a duplicate of, #74599 (process-scan performance and updater lock handoff) and #74831 (retrying transient post-shutdown scans). This PR fixes deterministic classification caused by the old command-line prefix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Preserve complete process argv values in `hermes_cli/update_cmd.py` for gateway classification.
- Centralize redacted, bounded diagnostic formatting in `hermes_cli/_scan_venv_blockers.py`.
- Fail closed to `<redacted>` if diagnostic sanitization fails.
- Add regression tests for long managed-runtime paths, gateway classification, bounded diagnostics, and the Desktop preflight result.

## How to Test

1. Start a Windows Hermes gateway whose managed Python/runtime prefix pushes `gateway run` beyond character 120.
2. Run the Desktop venv-blocker preflight; confirm the gateway is reported as pausable rather than a fatal blocker.
3. Run the focused regression suites:
   `python scripts/run_tests_parallel.py tests/hermes_cli/test_scan_venv_blockers.py tests/hermes_cli/test_update_venv_health.py tests/hermes_cli/test_update_concurrent_quarantine.py -q`

Validation completed on Windows 11:

- 45 focused updater/process tests passed.
- Ruff passed on every changed file.
- `scripts/check-windows-footguns.py --diff origin/main` passed.
- Live preflight changed from `blocked: true` to `blocked: false` for the same managed gateway process pair.
- Two real Desktop-initiated updates then paused and restarted the gateway successfully.
- An independent read-only Grok audit and a separate reviewer both found no publication blockers. Their two low-severity polish suggestions (shared diagnostic formatting and a main-level long-path test) are included here.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing issues and PRs and confirmed this is not a duplicate.
- [x] This PR contains only changes related to this fix.
- [ ] I've run the entire `pytest tests/ -q` suite. (The 45 affected and adjacent tests pass; CI will run the complete matrix.)
- [x] I've added regression tests for the fix.
- [x] I've tested on Windows 11.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing configuration or workflow changed.
- [x] `cli-config.yaml.example`: N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or contributor workflow changed.
- [x] Cross-platform impact considered; the behavioral path remains Windows-gated and diagnostics remain platform-neutral.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

Before:

```text
Update aborted: another Hermes process is using this installation.
...python.exe -m hermes_cli.main gateway run --replace
```

After:

```text
Stopping Windows gateway process(es)...
Paused gateway profile(s): default
Update complete
Starting Windows gateway after update
```
