### PR TITLE
fix(relay): cache inbound media under managed storage

### DIFF
--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -449,7 +449,7 @@ class RelayAdapter(BasePlatformAdapter):
             logger.debug("slack session-thread stamp failed", exc_info=True)
 
     async def _localize_inbound_media(self, event) -> None:
-        """Download connector re-hosted attachments to local temp paths.
+        """Download connector re-hosted attachments to managed cache paths.
 
         The wire's ``media_urls`` name connector re-hosts
         (``{connector}/relay/media/{id}``, per-gateway-bearer-authenticated) or
@@ -457,7 +457,7 @@ class RelayAdapter(BasePlatformAdapter):
         presents inbound media to the agent as LOCAL FILE PATHS (the vision /
         file tools consume paths, and an authenticated URL would be useless in
         the agent's context anyway) — so mirror that here: fetch each URL and
-        swap the list entries for temp paths. Best-effort per entry: a failed
+        swap the list entries for managed-cache paths. Best-effort per entry: a failed
         download drops that entry (never the message); no client ⇒ only
         re-host URLs are dropped (they'd 401 for every consumer downstream),
         public URLs stay.

--- a/gateway/relay/media.py
+++ b/gateway/relay/media.py
@@ -6,9 +6,9 @@ event's ``media_urls`` name connector re-hosted attachments
 ``source_url`` the connector resolves back to bytes. This module is the
 gateway-side HTTP client for that plane:
 
-  - ``download(url)``  → GET a re-hosted attachment to a local temp file (the
-    agent's vision/file tools consume LOCAL paths, matching every native
-    adapter's inbound media behaviour).
+  - ``download(url)``  → GET a re-hosted attachment to the managed profile
+    cache (the agent's vision/file tools consume LOCAL paths, matching every
+    native adapter's inbound media behaviour).
   - ``upload(path)``   → POST local file bytes to ``/relay/media``; returns the
     ``/relay/media/{id}`` reference for a subsequent ``send_media`` op. This is
     how a locally-generated artifact (image_generate output, TTS voice note,
@@ -33,8 +33,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import mimetypes
-import os
-import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -152,7 +150,7 @@ class RelayMediaClient:
         return await asyncio.get_running_loop().run_in_executor(None, _post)
 
     async def download(self, url: str, *, suggested_name: Optional[str] = None) -> Optional[str]:
-        """GET a re-hosted attachment to a local temp file; return its path.
+        """GET a re-hosted attachment to the managed media cache; return its path.
 
         Presents the per-gateway bearer for connector re-host URLs; plain
         public URLs (e.g. a Discord CDN pass-through) are fetched without it.
@@ -187,14 +185,30 @@ class RelayMediaClient:
                         cd = resp.headers.get("Content-Disposition") or ""
                         if "filename=" in cd:
                             name = cd.split("filename=", 1)[1].strip().strip('"')
-                    ext = Path(name).suffix if name else ""
-                    if not ext:
-                        mime = (resp.headers.get("Content-Type") or "").split(";")[0]
-                        ext = mimetypes.guess_extension(mime) or ".bin"
-                    fd, tmp_path = tempfile.mkstemp(prefix="relay_media_", suffix=ext)
-                    with os.fdopen(fd, "wb") as fh:
-                        fh.write(data)
-                    return tmp_path
+                    mime = (resp.headers.get("Content-Type") or "").split(";")[0]
+                    if not mime and name:
+                        mime = mimetypes.guess_type(name)[0] or ""
+                    from gateway.platforms.media_cache import cache_media_bytes
+
+                    resolved_mime = mime or "application/octet-stream"
+                    try:
+                        return cache_media_bytes(
+                            data,
+                            resolved_mime,
+                            filename_hint=name,
+                        )
+                    except ValueError:
+                        if not resolved_mime.lower().startswith("image/"):
+                            raise
+                        # Some valid image formats are intentionally outside
+                        # the image cache's magic-byte allowlist. Preserve the
+                        # attachment as an opaque document instead of dropping it.
+                        return cache_media_bytes(
+                            data,
+                            resolved_mime,
+                            filename_hint=name,
+                            kind_hint="document",
+                        )
             except (urllib.error.URLError, ValueError, OSError) as exc:
                 logger.warning("relay media download failed for %s: %s", url, exc)
                 return None

--- a/tests/gateway/relay/test_relay_media.py
+++ b/tests/gateway/relay/test_relay_media.py
@@ -168,6 +168,85 @@ async def test_inbound_without_client_keeps_public_drops_rehost():
 
 
 @pytest.mark.asyncio
+async def test_client_download_routes_bytes_to_managed_cache(monkeypatch):
+    data = b"\x89PNG\r\n\x1a\npayload"
+    captured = {}
+
+    class _Response:
+        headers = {
+            "Content-Length": str(len(data)),
+            "Content-Type": "image/png; charset=binary",
+            "Content-Disposition": 'attachment; filename="relay-shot.png"',
+        }
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, _limit):
+            return data
+
+    def fake_urlopen(request, *, timeout):
+        captured["authorization"] = request.headers.get("Authorization")
+        captured["timeout"] = timeout
+        return _Response()
+
+    def fake_cache(payload, mime, *, filename_hint):
+        captured.update(payload=payload, mime=mime, filename_hint=filename_hint)
+        return "/managed/cache/relay-shot.png"
+
+    monkeypatch.setattr("gateway.relay.media.urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        "gateway.platforms.media_cache.cache_media_bytes", fake_cache
+    )
+    client = RelayMediaClient("https://conn.example", "gw1", "secret")
+
+    result = await client.download("https://conn.example/relay/media/aa11")
+
+    assert result == "/managed/cache/relay-shot.png"
+    assert captured["payload"] == data
+    assert captured["mime"] == "image/png"
+    assert captured["filename_hint"] == "relay-shot.png"
+    assert captured["authorization"].startswith("Bearer ")
+
+
+@pytest.mark.asyncio
+async def test_client_download_preserves_unrecognized_image_as_document(monkeypatch):
+    data = b'<svg xmlns="http://www.w3.org/2000/svg"><rect /></svg>'
+
+    class _Response:
+        headers = {
+            "Content-Length": str(len(data)),
+            "Content-Type": "image/svg+xml",
+            "Content-Disposition": 'attachment; filename="diagram.svg"',
+        }
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, _limit):
+            return data
+
+    monkeypatch.setattr(
+        "gateway.relay.media.urllib.request.urlopen",
+        lambda _request, *, timeout: _Response(),
+    )
+    client = RelayMediaClient("https://conn.example", "gw1", "secret")
+
+    result = await client.download("https://conn.example/relay/media/aa11")
+
+    assert result is not None
+    cached = Path(result)
+    assert cached.name.endswith("_diagram.svg")
+    assert cached.read_bytes() == data
+
+
+@pytest.mark.asyncio
 async def test_client_upload_rejects_oversize_and_missing(tmp_path: Path):
     c = RelayMediaClient("https://c.example", "gw1", "sec")
     # Missing file → None (no network attempted).


### PR DESCRIPTION
## What does this PR do?

Relay inbound attachments were downloaded with `tempfile.mkstemp()` into the
system temporary directory. Those `relay_media_*` files sit outside Hermes'
image/audio/document caches, so the gateway's periodic 24-hour media cleanup
never sees them and a long-running Relay gateway accumulates files indefinitely.

This routes downloaded bytes through the shared media-cache dispatcher. The
agent still receives a local path, while MIME classification, profile scoping,
file validation, and existing housekeeping now match native adapters.

## Related Issue

No existing issue. This was found by auditing temporary-file ownership on the
current default branch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/relay/media.py`: dispatch downloaded bytes to
  `cache_media_bytes()` using response MIME and filename metadata.
- `gateway/relay/media.py`: fall back to document caching when a valid
  `image/*` format is outside the image cache magic-byte allowlist.
- `gateway/relay/adapter.py`: document that localized inbound paths now live in
  the managed cache.
- `tests/gateway/relay/test_relay_media.py`: verify bearer-authenticated
  downloads preserve bytes, MIME, and filename, including SVG document fallback.

## How to Test

1. Download a connector-hosted image through `RelayMediaClient`.
2. Confirm the authenticated response bytes are passed to the shared cache.
3. Confirm the returned path is the cache path rather than `relay_media_*`.

Automated validation:

- `scripts/run_tests.sh tests/gateway/relay/test_relay_media.py tests/gateway/test_media_cache.py -q`
  - 44 passed
- `python -m ruff check gateway/relay/media.py gateway/relay/adapter.py tests/gateway/relay/test_relay_media.py`
- `python -m py_compile gateway/relay/media.py gateway/relay/adapter.py tests/gateway/relay/test_relay_media.py`
- `git diff --check`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (focused Relay/media suites passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Relevant inline documentation was updated
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A; no workflow changed
- [x] Cross-platform impact considered; shared cache paths are platform-neutral
- [x] Tool descriptions/schemas are N/A; no tool surface changed

## Screenshots / Logs

Not applicable.