### PR TITLE
fix(gateway): suppress compaction completion notice when progress_notices=false

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -49,6 +49,7 @@ from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union,
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
 from agent.conversation_compression import (
     COMPACTION_STATUS,
+    COMPACTION_DONE_STATUS,
     COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE,
     COMPRESSION_RETRY_MESSAGES_STATUS_TEMPLATE,
     COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE,
@@ -94,6 +95,7 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|skipping\s+concurrent\s+compression"
     r"|compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
     r"|resumed\s+after\s+\d+s\s+idle\s+[—-]\s+compacting"
+    r"|context\s+compaction\s+complete\s+[—-]\s+continuing"
     r"|preflight\s+compression"
     r"|pre[- ]api\s+compression"
     # Buffered attempt/overflow retry chatter replayed through _emit_status
@@ -164,6 +166,7 @@ _COMPRESSION_PROGRESS_STATUS_RE = re.compile(
         _status_template_to_regex(_template)
         for _template in (
             COMPACTION_STATUS,
+            COMPACTION_DONE_STATUS,
             PRE_API_COMPRESSION_STATUS_TEMPLATE,
             PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,
             IDLE_COMPACTION_STATUS_TEMPLATE,

--- a/tests/gateway/test_compression_progress_notices.py
+++ b/tests/gateway/test_compression_progress_notices.py
@@ -76,21 +76,27 @@ def test_enabled_still_suppresses_non_compression_noise(
     assert _prepare_gateway_status_message(platform, "warn", message) is None
 
 
-@pytest.mark.parametrize("enabled", [True, False], ids=["enabled", "default"])
 @pytest.mark.parametrize("platform", CHAT_PLATFORMS)
-def test_compaction_completion_notice_reaches_chat(monkeypatch, platform, enabled):
-    """The #69546 'compacted' lifecycle edge is deliverable on chat surfaces.
+def test_compaction_completion_notice_suppressed_by_default(progress_notices_default, platform):
+    """With progress_notices off (default), the completion notice is suppressed.
 
-    COMPACTION_DONE_STATUS already flows through the status callback on
-    compaction completion and is not matched by the noise regex — the opt-in
-    gate must not change that in either mode, so users who enable
-    progress_notices see the completion stat notice paired with the start.
+    COMPACTION_DONE_STATUS is now matched by _TELEGRAM_NOISY_STATUS_RE so
+    it behaves symmetrically with the start notice — both are silent on chat
+    surfaces when progress_notices is not enabled.
     """
-    monkeypatch.setattr(
-        gateway_run,
-        "_load_gateway_config",
-        lambda: {"compression": {"progress_notices": enabled}},
+    assert (
+        _prepare_gateway_status_message(platform, "compacted", COMPACTION_DONE_STATUS)
+        is None
     )
+
+
+@pytest.mark.parametrize("platform", CHAT_PLATFORMS)
+def test_compaction_completion_notice_delivered_when_enabled(progress_notices_enabled, platform):
+    """With progress_notices on, the completion notice reaches chat surfaces.
+
+    This pairs with the start notice (compacting context) so users who opt
+    in see both edges of the compression lifecycle.
+    """
     assert (
         _prepare_gateway_status_message(platform, "compacted", COMPACTION_DONE_STATUS)
         == COMPACTION_DONE_STATUS


### PR DESCRIPTION
## Summary

The compaction completion message (`COMPACTION_DONE_STATUS`) was not matched by `_TELEGRAM_NOISY_STATUS_RE`, so it always passed through to chat surfaces regardless of the `compression.progress_notices` setting. This made the setting asymmetric: the start notice ("Compacting context — ...") was correctly suppressed by default, but the completion notice ("✓ Context compaction complete — continuing turn...") was always delivered.

Fix by adding `COMPACTION_DONE_STATUS` to `_TELEGRAM_NOISY_STATUS_RE` (caught as noise) and `_COMPRESSION_PROGRESS_STATUS_RE` (allowed through when the opt-in gate is enabled), matching the existing pattern for all other routine compression statuses.

## Changes

- **`gateway/run.py`**: Import `COMPACTION_DONE_STATUS`, add it to the noisy status regex and the compression progress regex
- **`tests/gateway/test_compression_progress_notices.py`**: Split the single parametrized test into two focused tests — one for suppressed-by-default, one for delivered-when-enabled

## Test results

- `test_compression_progress_notices.py`: 38/38 passed
- `test_telegram_noise_filter.py`: 133/133 passed

## Closes

Closes #77549