### PR TITLE
chore: contributor email mapping for stremtec

### DIFF
--- a/contributors/emails/copii.list@gmail.com
+++ b/contributors/emails/copii.list@gmail.com
@@ -1,0 +1,1 @@
+stremtec


### PR DESCRIPTION
Maps copii.list@gmail.com -> stremtec for release attribution. Needed by the #38491 re-derivation.