### PR TITLE
fix(agent): key same_tool_failure_halt streak by error fingerprint to stop false-positive halts

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -10,11 +10,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from utils import safe_json_loads
 from agent.tool_result_classification import file_mutation_result_landed
+
+_DIGITS_RE = re.compile(r"\d+")
 
 
 IDEMPOTENT_TOOL_NAMES = frozenset(
@@ -280,6 +283,12 @@ class ToolCallGuardrailController:
     def reset_for_turn(self) -> None:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
+        # tool_name -> (failure_fingerprint, consecutive_count). The halt
+        # streak only accumulates while consecutive failures share the same
+        # error fingerprint; a failure with a *different* error resets the
+        # streak, because exploring different paths that fail for different
+        # reasons is not a retry loop.
+        self._same_tool_failure_streaks: dict[str, tuple[str, int]] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
         # Per-turn runaway-loop cap counters. Reset every turn (this method
@@ -368,16 +377,26 @@ class ToolCallGuardrailController:
             same_count = self._same_tool_failure_counts.get(tool_name, 0) + 1
             self._same_tool_failure_counts[tool_name] = same_count
 
-            if self.config.hard_stop_enabled and same_count >= self.config.same_tool_failure_halt_after:
+            fingerprint = _failure_signature(tool_name, result)
+            previous_streak = self._same_tool_failure_streaks.get(tool_name)
+            if previous_streak is not None and previous_streak[0] == fingerprint:
+                streak = previous_streak[1] + 1
+            else:
+                streak = 1
+            self._same_tool_failure_streaks[tool_name] = (fingerprint, streak)
+
+            if self.config.hard_stop_enabled and streak >= self.config.same_tool_failure_halt_after:
                 decision = ToolGuardrailDecision(
                     action="halt",
                     code="same_tool_failure_halt",
                     message=(
-                        f"Stopped {tool_name}: it failed {same_count} times this turn. "
-                        "Stop retrying the same failing tool path and choose a different approach."
+                        f"Stopped {tool_name}: it failed {streak} times in a row "
+                        f"with the same underlying error ({same_count} failures "
+                        "total this turn). Stop retrying this failing path and "
+                        "choose a different approach."
                     ),
                     tool_name=tool_name,
-                    count=same_count,
+                    count=streak,
                     signature=signature,
                 )
                 self._halt_decision = decision
@@ -411,6 +430,7 @@ class ToolCallGuardrailController:
 
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
+        self._same_tool_failure_streaks.pop(tool_name, None)
 
         if not self._is_idempotent(tool_name):
             self._no_progress.pop(signature, None)
@@ -552,6 +572,51 @@ def _tool_failure_recovery_hint(tool_name: str, count: int) -> str:
 
 def _coerce_args(args: Mapping[str, Any] | None) -> Mapping[str, Any]:
     return args if isinstance(args, Mapping) else {}
+
+
+def _failure_signature(tool_name: str, result: str | None) -> str:
+    """Stable fingerprint of *why* a tool call failed.
+
+    Keys the same-tool failure streak so three exploratory calls that fail
+    for three different reasons don't read as a retry loop, while retries
+    that keep hitting the same wall (even with tweaked arguments) still
+    accumulate toward the halt threshold.
+
+    Digit runs and path-like tokens are normalized away so cosmetic
+    differences (line numbers, tmp dirs, changing filenames) don't fragment
+    an otherwise identical error.
+    """
+    if result is None:
+        return "none"
+    data = safe_json_loads(result)
+    text = ""
+    if isinstance(data, dict):
+        if tool_name == "terminal":
+            output = str(data.get("output") or "")
+            tail = ""
+            for line in reversed(output.splitlines()):
+                if line.strip():
+                    tail = line.strip()
+                    break
+            text = f"terminal:{data.get('exit_code')}:{tail}"
+        else:
+            error = data.get("error")
+            if isinstance(error, str) and error:
+                text = f"error:{error}"
+    if not text:
+        text = f"raw:{result or ''}"
+    return _sha256(_normalize_error_text(text))
+
+
+def _normalize_error_text(text: str) -> str:
+    tokens = []
+    for token in text.lower().split():
+        if "/" in token or "\\" in token:
+            tokens.append("<path>")
+            continue
+        token = _DIGITS_RE.sub("#", token)
+        tokens.append(token)
+    return " ".join(tokens)[:300]
 
 
 def _result_hash(result: str | None) -> str:

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -131,6 +131,105 @@ def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_succes
         assert controller.after_call("custom_tool", {"x": 1}, "ok", failed=False).action == "allow"
 
 
+# ── same_tool_failure_halt keyed by error fingerprint ──────────────────────
+
+
+def _halt_config(halt_after: int = 3) -> ToolCallGuardrailConfig:
+    return ToolCallGuardrailConfig(
+        warnings_enabled=False,
+        hard_stop_enabled=True,
+        exact_failure_block_after=99,
+        same_tool_failure_halt_after=halt_after,
+        no_progress_block_after=99,
+    )
+
+
+def test_same_tool_distinct_errors_do_not_halt():
+    """Exploratory calls that fail for different reasons are not a retry loop."""
+    controller = ToolCallGuardrailController(_halt_config(halt_after=3))
+
+    errors = [
+        '{"exit_code": 1, "output": "bash: foo: command not found"}',
+        '{"exit_code": 2, "output": "ls: /missing: No such file or directory"}',
+        '{"exit_code": 126, "output": "bash: ./run.sh: Permission denied"}',
+        '{"exit_code": 1, "output": "curl: (6) Could not resolve host: x"}',
+    ]
+    decisions = [
+        controller.after_call("terminal", {"command": f"cmd{i}"}, err, failed=True)
+        for i, err in enumerate(errors)
+    ]
+
+    assert all(d.action == "allow" for d in decisions)
+    assert controller.halt_decision is None
+
+
+def test_same_tool_same_error_different_args_still_halts():
+    """Retrying with tweaked args but hitting the same wall IS a loop."""
+    controller = ToolCallGuardrailController(_halt_config(halt_after=3))
+
+    result = '{"exit_code": 1, "output": "curl: (6) Could not resolve host: internal.api"}'
+    decisions = [
+        controller.after_call("terminal", {"command": f"curl attempt{i}"}, result, failed=True)
+        for i in range(3)
+    ]
+
+    assert decisions[0].action == "allow"
+    assert decisions[1].action == "allow"
+    assert decisions[2].action == "halt"
+    assert decisions[2].code == "same_tool_failure_halt"
+    assert decisions[2].count == 3
+    assert "same underlying error" in decisions[2].message
+    assert "4 failures total" not in decisions[2].message
+    assert controller.halt_decision is not None
+
+
+def test_error_change_mid_sequence_resets_halt_streak():
+    controller = ToolCallGuardrailController(_halt_config(halt_after=3))
+
+    err_a = '{"error": "File not found: /a"}'
+    err_b = '{"error": "Permission denied"}'
+
+    assert controller.after_call("read_file", {"path": "/a"}, err_a, failed=True).action == "allow"
+    assert controller.after_call("read_file", {"path": "/a"}, err_a, failed=True).action == "allow"
+    # Error changes -> streak resets instead of reaching 3.
+    assert controller.after_call("read_file", {"path": "/a"}, err_b, failed=True).action == "allow"
+    assert controller.after_call("read_file", {"path": "/a"}, err_b, failed=True).action == "allow"
+    assert controller.halt_decision is None
+    # Third consecutive same-error failure now halts.
+    decision = controller.after_call("read_file", {"path": "/a"}, err_b, failed=True)
+    assert decision.action == "halt"
+    assert decision.code == "same_tool_failure_halt"
+
+
+def test_error_fingerprint_normalizes_paths_and_numbers():
+    """Same error class with different paths/line numbers shares a fingerprint."""
+    controller = ToolCallGuardrailController(_halt_config(halt_after=3))
+
+    variants = [
+        '{"exit_code": 1, "output": "Error at line 12 in /tmp/work/a.py: boom"}',
+        '{"exit_code": 1, "output": "Error at line 98 in /tmp/other/b.py: boom"}',
+        '{"exit_code": 1, "output": "Error at line 3 in /var/tmp/c.py: boom"}',
+    ]
+    decisions = [
+        controller.after_call("terminal", {"command": f"run{i}"}, v, failed=True)
+        for i, v in enumerate(variants)
+    ]
+
+    assert decisions[2].action == "halt"
+    assert decisions[2].code == "same_tool_failure_halt"
+
+
+def test_success_between_failures_resets_halt_streak():
+    controller = ToolCallGuardrailController(_halt_config(halt_after=2))
+
+    err = '{"error": "boom"}'
+    assert controller.after_call("memory", {"action": "add"}, err, failed=True).action == "allow"
+    assert controller.after_call("memory", {"action": "add"}, "ok", failed=False).action == "allow"
+    assert controller.after_call("memory", {"action": "add"}, err, failed=True).action == "allow"
+    assert controller.halt_decision is None
+    assert controller.after_call("memory", {"action": "add"}, err, failed=True).action == "halt"
+
+
 
 
 


### PR DESCRIPTION
## Problem

`same_tool_failure_halt` fires on **any** N failures of the same tool within a turn, regardless of whether the calls were retries or distinct attempts. The streak counter is keyed by `tool_name` only:

```python
same_count = self._same_tool_failure_counts.get(tool_name, 0) + 1
```

So these all trip the same circuit breaker (with `hard_stop_after.same_tool_failure: 3`):

- 3 identical retries of a broken command (the case the guardrail exists for) ✅
- 3 **parallel exploratory calls** with different args that each fail for a different reason (e.g. diagnosing with `ps` + `grep` + `ls`, or reading 3 files that happen to be missing) ❌
- 3 sequential attempts with different args hitting *different* errors (command-not-found → no-such-file → permission-denied) ❌

The false-positive cases are the dominant trigger in practice — see #53959 for a catalog of real sessions (10+ occurrences over 3 months across `terminal`, `read_file`, `memory`, `process`, `patch`, `execute_code`). Each halt truncates the turn with a canned response, and in headless/cron runs there is no user to un-stick the task (related: #64322).

## Fix

Key the halt streak by **error fingerprint** instead of tool name alone:

- `_failure_signature()` extracts *why* the call failed — for `terminal`, the exit code + last non-empty output line; for JSON results, the `error` field; otherwise the raw result head — then normalizes digit runs and path-like tokens so cosmetic differences (line numbers, tmp dirs, changing filenames) don't fragment an otherwise identical error.
- The controller tracks `tool_name -> (fingerprint, consecutive_count)`. A failure whose fingerprint matches the previous one extends the streak; a failure with a **different error resets it**, because exploring different paths that fail for different reasons is not a retry loop.
- Retries that tweak arguments but keep hitting the same wall still share a fingerprint and still halt.
- The broad per-tool failure count (`_same_tool_failure_counts`) is unchanged and still drives the soft `same_tool_failure_warning`, preserving the "this tool keeps failing, consider switching" nudge.
- The halt message now reports both the streak and the turn total: *"failed 3 times in a row with the same underlying error (4 failures total this turn)"*.

Behavior matrix (threshold 3):

| Sequence | Before | After |
|---|---|---|
| same call, same error ×3 | halt | halt |
| different args, same error ×3 | halt | halt |
| different args, different errors ×3 | **halt (false positive)** | allow |
| err A ×2 → err B ×2 | halt | allow (streak resets on error change) |
| fail → success → fail ×2 | allow | allow |

## Tests

5 new tests in `tests/agent/test_tool_guardrails.py`:

- `test_same_tool_distinct_errors_do_not_halt` — the false-positive regression test
- `test_same_tool_same_error_different_args_still_halts` — the loop the guardrail exists for still halts
- `test_error_change_mid_sequence_resets_halt_streak`
- `test_error_fingerprint_normalizes_paths_and_numbers`
- `test_success_between_failures_resets_halt_streak`

```
tests/agent/test_tool_guardrails.py ............ 12 passed
tests/run_agent/test_tool_call_guardrail_runtime.py .......... 10 passed
```

## Notes / non-goals

- This PR deliberately does **not** add config knobs or change thresholds — it only fixes the streak attribution. The configurability ask in #53959 (per-profile threshold / mode) is orthogonal and can ride on top.
- The fingerprint is a SHA-256 of normalized error text; no raw argument or result content is exposed in decision metadata (same privacy posture as the existing `args_hash`).

Refs #53959
Related: #64322
