### PR TITLE
fix(cli): close session database after resolver failures

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1490,6 +1490,7 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
       from an exit summary printed before the bug fix, or from notes) get
       resumed at the live tip instead of a stale parent with no messages.
     """
+    db = None
     try:
         from hermes_state import SessionDB
 
@@ -1512,10 +1513,15 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
             except Exception:
                 pass
 
-        db.close()
         return resolved_id
     except Exception:
         pass
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
     return None
 
 

--- a/tests/hermes_cli/test_session_resolver_cleanup.py
+++ b/tests/hermes_cli/test_session_resolver_cleanup.py
@@ -1,0 +1,41 @@
+"""SessionDB lifecycle tests for CLI session-name resolution."""
+
+from unittest.mock import MagicMock
+
+from hermes_cli.main import _resolve_session_by_name_or_id
+
+
+def test_session_resolver_closes_database_after_success(monkeypatch):
+    db = MagicMock()
+    db.get_session.return_value = {"id": "session-root"}
+    db.get_compression_tip.return_value = "session-tip"
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+
+    result = _resolve_session_by_name_or_id("session-root")
+
+    assert result == "session-tip"
+    db.close.assert_called_once_with()
+
+
+def test_session_resolver_closes_database_after_query_failure(monkeypatch):
+    db = MagicMock()
+    db.get_session.side_effect = RuntimeError("read failed")
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+
+    result = _resolve_session_by_name_or_id("session-root")
+
+    assert result is None
+    db.close.assert_called_once_with()
+
+
+def test_session_resolver_keeps_result_when_close_fails(monkeypatch):
+    db = MagicMock()
+    db.get_session.return_value = {"id": "session-root"}
+    db.get_compression_tip.return_value = "session-tip"
+    db.close.side_effect = RuntimeError("close failed")
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+
+    result = _resolve_session_by_name_or_id("session-root")
+
+    assert result == "session-tip"
+    db.close.assert_called_once_with()


### PR DESCRIPTION
## What does this PR do?

`_resolve_session_by_name_or_id()` opened a fresh `SessionDB` while resolving
CLI `--resume` / continue targets, but only closed it on the successful tail of
the function. Any lookup exception was intentionally swallowed for best-effort
resolution while also skipping connection cleanup.

This moves cleanup into a guarded `finally`, preserving the resolver's existing
best-effort behavior even if either the lookup or `close()` itself fails.

## Related Issue

No existing issue. This was found by auditing transient `SessionDB` ownership
on the current default branch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: close the session resolver's database in `finally`.
- `tests/hermes_cli/test_session_resolver_cleanup.py`: cover successful
  resolution, lookup failure, and non-fatal close failure.

## How to Test

1. Resolve a session id through a recording `SessionDB` fake.
2. Repeat with `get_session()` raising.
3. Confirm both paths close once, while a close error does not discard a valid
   resolved id.

Automated validation:

- `scripts/run_tests.sh tests/hermes_cli/test_session_resolver_cleanup.py tests/cli/test_cli_resume_command.py tests/cli/test_resume_display.py tests/hermes_cli/test_resolve_last_session.py -q`
  - 29 passed
- `python -m ruff check hermes_cli/main.py tests/hermes_cli/test_session_resolver_cleanup.py`
- `python -m py_compile hermes_cli/main.py tests/hermes_cli/test_session_resolver_cleanup.py`
- `git diff --check`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (focused CLI/resume suites passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; resolver behavior is unchanged
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A; no workflow changed
- [x] Cross-platform impact considered; this is platform-neutral SQLite cleanup
- [x] Tool descriptions/schemas are N/A; no tool surface changed

## Screenshots / Logs

Not applicable.
