### PR TITLE
fix(simplex): clean generated image files after sends

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -948,8 +948,15 @@ class SimplexAdapter(BasePlatformAdapter):
 
             img = Image.open(file_path)
             if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
-                png_path = str(p.with_suffix(".png"))
-                img.save(png_path, "PNG")
+                with tempfile.NamedTemporaryFile(
+                    suffix=".png", prefix="simplex_image_", delete=False
+                ) as converted:
+                    png_path = converted.name
+                try:
+                    img.save(png_path, "PNG")
+                except Exception:
+                    os.remove(png_path)
+                    raise
             thumb = img.copy()
             thumb.thumbnail((128, 128))
             import io
@@ -961,9 +968,15 @@ class SimplexAdapter(BasePlatformAdapter):
                 + base64.b64encode(buf.getvalue()).decode()
             )
         except ImportError:
+            tmp_path = None
+            generated_png = False
             try:
                 if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
-                    png_path = str(p.with_suffix(".png"))
+                    with tempfile.NamedTemporaryFile(
+                        suffix=".png", prefix="simplex_image_", delete=False
+                    ) as converted:
+                        png_path = converted.name
+                    generated_png = True
                     subprocess.run(
                         ["convert", file_path, png_path],
                         check=True,
@@ -990,9 +1003,20 @@ class SimplexAdapter(BasePlatformAdapter):
                     thumb_uri = (
                         "data:image/jpg;base64," + base64.b64encode(f.read()).decode()
                     )
-                os.remove(tmp_path)
             except (FileNotFoundError, subprocess.SubprocessError) as exc:
                 logger.warning("SimpleX: image conversion unavailable: %s", exc)
+                if generated_png:
+                    try:
+                        os.remove(png_path)
+                    except OSError:
+                        pass
+                    png_path = file_path
+            finally:
+                if tmp_path:
+                    try:
+                        os.remove(tmp_path)
+                    except OSError:
+                        pass
 
         return png_path, thumb_uri
 
@@ -1021,32 +1045,39 @@ class SimplexAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Image file not found")
 
         png_path, thumb_uri = self._prepare_image(file_path)
+        generated_png = os.path.abspath(png_path) != os.path.abspath(file_path)
+        try:
+            # /_send addresses by numeric ID; /f only accepts display names
+            # which breaks for group IDs.
+            composed = json.dumps(
+                [
+                    {
+                        "filePath": png_path,
+                        "msgContent": {
+                            "type": "image",
+                            "image": thumb_uri,
+                            "text": caption or "",
+                        },
+                    }
+                ]
+            )
 
-        # /_send addresses by numeric ID; /f only accepts display names which
-        # breaks for group IDs.
-        composed = json.dumps(
-            [
-                {
-                    "filePath": png_path,
-                    "msgContent": {
-                        "type": "image",
-                        "image": thumb_uri,
-                        "text": caption or "",
-                    },
-                }
-            ]
-        )
+            if chat_id.startswith("group:"):
+                group_id = chat_id[6:]
+                command = f"/_send #{group_id} json {composed}"
+            else:
+                command = f"/_send @{chat_id} json {composed}"
 
-        if chat_id.startswith("group:"):
-            group_id = chat_id[6:]
-            command = f"/_send #{group_id} json {composed}"
-        else:
-            command = f"/_send @{chat_id} json {composed}"
-
-        result = await self._send_command(command)
-        if result is not None:
-            return SendResult(success=True)
-        return SendResult(success=False, error="Failed to send image")
+            result = await self._send_command(command)
+            if result is not None:
+                return SendResult(success=True)
+            return SendResult(success=False, error="Failed to send image")
+        finally:
+            if generated_png:
+                try:
+                    os.remove(png_path)
+                except OSError:
+                    pass
 
     async def send_image_file(
         self,

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
+import types
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -161,6 +164,56 @@ async def test_send_group():
     assert result.success is True
 
 
+def test_prepare_image_uses_unique_temp_png(monkeypatch, tmp_path):
+    class _FakeImage:
+        def save(self, target, _format, quality=None):
+            if hasattr(target, "write"):
+                target.write(b"jpeg")
+            else:
+                Path(target).write_bytes(b"png")
+
+        def copy(self):
+            return self
+
+        def thumbnail(self, _size):
+            return None
+
+    pil = types.ModuleType("PIL")
+    pil.Image = types.SimpleNamespace(open=lambda _path: _FakeImage())
+    monkeypatch.setitem(sys.modules, "PIL", pil)
+    source = tmp_path / "source.webp"
+    source.write_bytes(b"webp")
+
+    png_path, thumb_uri = SimplexAdapter._prepare_image(str(source))
+
+    try:
+        assert Path(png_path).is_file()
+        assert Path(png_path) != source.with_suffix(".png")
+        assert not source.with_suffix(".png").exists()
+        assert thumb_uri.startswith("data:image/jpg;base64,")
+    finally:
+        Path(png_path).unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_send_image_cleans_generated_png(monkeypatch, tmp_path):
+    adapter = _adapter_with_ws()
+    source = tmp_path / "source.webp"
+    source.write_bytes(b"webp")
+    generated = tmp_path / "generated.png"
+    generated.write_bytes(b"png")
+    monkeypatch.setattr(
+        adapter, "_prepare_image", lambda _path: (str(generated), "data:image/jpg;base64,eA==")
+    )
+    adapter._send_command = AsyncMock(return_value={"ok": True})
+
+    result = await adapter.send_image_file("alice", str(source))
+
+    assert result.success is True
+    assert source.exists()
+    assert not generated.exists()
+
+
 # ---------------------------------------------------------------------------
 # 7b. Channel directory enumeration (list_channels)
 # ---------------------------------------------------------------------------
@@ -299,5 +352,4 @@ def _make_file_chat_item(file_path: str, file_name: str) -> dict:
             },
         },
     }
-
 


### PR DESCRIPTION
## What does this PR do?

SimpleX image sending converted non-PNG/JPEG inputs to
`source.with_suffix(".png")`. That could overwrite an existing sibling file and
left generated PNGs behind after every send. The ImageMagick thumbnail fallback
also left its `delete=False` JPEG behind when conversion failed.

This uses unique temporary PNGs, deletes generated send artifacts on every
success/failure path, and always cleans the thumbnail scratch file. Original
user images and existing PNG/JPEG inputs are never removed.

## Related Issue

No existing issue. This was found by auditing temporary-file ownership on the
current default branch.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `plugins/platforms/simplex/adapter.py`: generate collision-free temporary
  PNGs and clean converted/thumbnail files deterministically.
- `tests/gateway/test_simplex_plugin.py`: prove conversion avoids sibling-path
  writes and generated PNGs are removed after send.

## How to Test

1. Prepare a non-PNG image and convert it for SimpleX.
2. Confirm conversion uses a unique temporary path, not `<source>.png`.
3. Send the image and confirm the generated path is removed while the source
   remains.

Automated validation:

- `scripts/run_tests.sh tests/gateway/test_simplex_plugin.py -q` - 15 passed
- `python -m ruff check plugins/platforms/simplex/adapter.py tests/gateway/test_simplex_plugin.py`
- `python -m py_compile plugins/platforms/simplex/adapter.py tests/gateway/test_simplex_plugin.py`
- `git diff --check`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (focused SimpleX suite passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; outbound behavior is unchanged
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` are N/A; no workflow changed
- [x] Cross-platform impact considered; `NamedTemporaryFile` is portable
- [x] Tool descriptions/schemas are N/A; no tool surface changed

## Screenshots / Logs

Not applicable.
