### PR TITLE
fix(state): tolerate vanishing SQLite sidecars

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1077,7 +1077,12 @@ def preflight_db_writability(
         except (OSError, ValueError):
             return False
 
-    def _ensure_writable(p: Path, *, is_dir: bool = False) -> None:
+    def _ensure_writable(
+        p: Path,
+        *,
+        is_dir: bool = False,
+        allow_missing: bool = False,
+    ) -> None:
         import stat as _stat
 
         if os.access(p, os.R_OK | os.W_OK):
@@ -1086,6 +1091,13 @@ def preflight_db_writability(
             try:
                 add = _stat.S_IRUSR | _stat.S_IWUSR | (_stat.S_IXUSR if is_dir else 0)
                 os.chmod(p, p.stat().st_mode | add)
+            except FileNotFoundError:
+                # WAL/SHM sidecars are ephemeral. SQLite can unlink either
+                # after the is_file() preflight probe but before chmod/access
+                # below when the last connection closes. Their disappearance
+                # is healthy and must not be reported as permission drift.
+                if allow_missing:
+                    return
             except OSError:
                 pass
             if os.access(p, os.R_OK | os.W_OK):
@@ -1096,6 +1108,8 @@ def preflight_db_writability(
                     "x" if is_dir else "",
                 )
                 return
+        if allow_missing and not p.exists():
+            return
         kind = "directory" if is_dir else "file"
         wal_note = (
             " Do NOT delete the -wal file — it contains committed data that "
@@ -1119,7 +1133,7 @@ def preflight_db_writability(
     for suffix in ("", "-wal", "-shm"):
         p = db_path.with_name(db_path.name + suffix) if suffix else db_path
         if p.is_file():
-            _ensure_writable(p)
+            _ensure_writable(p, allow_missing=bool(suffix))
 
 
 def _db_opens_cleanly(db_path: Path) -> Optional[str]:

--- a/tests/test_hermes_state_readonly_preflight.py
+++ b/tests/test_hermes_state_readonly_preflight.py
@@ -144,6 +144,31 @@ class TestRefusalOutsideScope:
             os.chmod(wal, 0o644)
 
 
+class TestEphemeralSidecars:
+    @pytest.mark.parametrize("suffix", ["-wal", "-shm"])
+    def test_sidecar_vanishing_after_is_file_probe_is_ignored(
+        self, hermes_home, monkeypatch, suffix
+    ):
+        db = hermes_home / "state.db"
+        _make_db(db)
+        sidecar = db.with_name(db.name + suffix)
+        sidecar.touch()
+        real_is_file = Path.is_file
+
+        def is_file_then_unlink(path):
+            result = real_is_file(path)
+            if path == sidecar and result:
+                path.unlink()
+            return result
+
+        monkeypatch.setattr(Path, "is_file", is_file_then_unlink)
+
+        # SQLite legitimately removes WAL/SHM files when the last connection
+        # closes. A vanished sidecar is not a read-only file and must not make
+        # startup fail with a misleading chmod instruction.
+        preflight_db_writability(db, db_label="state.db")
+
+
 class TestSkips:
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a time-of-check/time-of-use race in the shared SQLite writability preflight. SQLite may legitimately remove an ephemeral `-wal` or `-shm` sidecar after `Path.is_file()` observes it but before the permission check runs. The old code then treated the missing path as an existing read-only file and aborted database startup with a misleading chmod instruction.

The fix permits only WAL/SHM sidecars to disappear during preflight. Existing read-only sidecars, the primary database, and the parent directory keep the current strict repair/error behavior.

## Related Issue

Fixes #77775

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`: allow ephemeral WAL/SHM sidecars to vanish between the existence and permission checks without weakening checks for paths that still exist.
- `tests/test_hermes_state_readonly_preflight.py`: add deterministic regression coverage for both `-wal` and `-shm` disappearance.

## How to Test

1. Run `scripts/run_tests.sh tests/test_hermes_state_readonly_preflight.py -q`.
2. Confirm both parametrized sidecar-race cases pass and existing permission-repair/refusal tests remain green.
3. Optionally exercise concurrent Kanban CLI reads; startup should no longer emit false read-only errors for vanished sidecars.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open/closed issues and open/merged PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] Full canonical suite: attempted, but the checkout reported unrelated failures outside the touched paths before completion. The focused canonical test file passes: 10 tests passed; CI remains the full-suite source of truth.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on Ubuntu 24.04 with Python 3.11.15

### Documentation & Housekeeping

- [x] Relevant documentation update — N/A; behavior and rationale are documented in code and regression tests
- [x] `cli-config.yaml.example` update — N/A; no configuration changes
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no architecture or workflow changes
- [x] Cross-platform impact considered; the production change uses platform-neutral `pathlib`/`OSError` behavior and does not introduce POSIX-specific logic
- [x] Tool descriptions/schemas update — N/A; no tool schema changes

## For New Skills

N/A — this PR does not add or modify a skill.

## Screenshots / Logs

Not applicable; deterministic regression coverage is included in the test suite.

Verification completed before opening the PR:

- focused canonical suite: 10 passed
- 80 concurrent local Kanban CLI reads: 80 succeeded with zero stderr
- the issue reproduction uses an isolated temporary `HERMES_HOME`
