### PR TITLE
fix(secrets): close redaction gaps - env-name variants, control-char splits, process(list)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -133,7 +133,11 @@ _PREFIX_PATTERNS = [
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name.
 # Uppercase keys tolerate spaces around "=" (e.g. ``FOO_SECRET = bar``) because
 # an all-caps key is almost never prose/code.
-_SECRET_ENV_NAMES = r"(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)"
+# ``KEY`` alone, ``*_PASS``/``*_PW``, and ``*_KEY`` (not just ``API_KEY``) are
+# secret-shaped too: FAL_KEY, OPENAI_KEY, MYSQL_PASS, DB_PW all leaked verbatim
+# before these alternatives (issue #77484). ``AUTH`` stays so ``AUTH=…`` still
+# masks while not matching plain ``AUTHOR``.
+_SECRET_ENV_NAMES = r"(?:API_?KEY|KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|_?PW|CREDENTIAL|AUTH)\b"
 _ENV_ASSIGN_RE = re.compile(
     rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(['\"]?)(\S+)\2",
 )
@@ -155,7 +159,7 @@ _ENV_ASSIGN_RE = re.compile(
 #      (optionally after ``export``), so conversational ``I have password=foo``
 #      mid-sentence is left alone.
 # The colon-form URL guard (skip when ``://`` present) lives at the call site.
-_SECRET_CFG_NAMES = r"(?:api[ _.\-]?key|token|secret|passwd|password|credential|auth)"
+_SECRET_CFG_NAMES = r"(?:api[ _.\\-]?key|token|secret|passwd|password|credential|auth|key|pass|pw)"
 _CFG_VALUE = r"(['\"]?)([^\s&]+?)\2(?=[\s&]|$)"
 # Linear pre-gate for the _CFG_*_RE subs below: a text with no secret keyword
 # can never match either pattern, so the (potentially backtrack-heavy) subs
@@ -229,8 +233,9 @@ _YAML_ASSIGN_RE = re.compile(
 # match. ALL-CAPS keys keep the legacy embedded matching (``MYTOKEN=…``) — an
 # all-caps key is almost never prose, the same rationale as _ENV_ASSIGN_RE.
 _KEY_KEYWORD_RE = re.compile(
-    r"(?:api|auth|access|refresh|session|secret)[ _.\-]?(?:key|token)"
-    r"|token|secret|passwd|password|credential|auth",
+    r"(?:api|auth|access|refresh|session|secret)[ _.\\-]?(?:key|token)"
+    r"|token|secret|passwd|password|credential|auth"
+    r"|key|pass|pw",
     re.IGNORECASE,
 )
 
@@ -437,6 +442,19 @@ _FORM_BODY_RE = re.compile(
 _PREFIX_RE = re.compile(
     r"(?<![A-Za-z0-9_-])(" + "|".join(_PREFIX_PATTERNS) + r")(?![A-Za-z0-9_-])"
 )
+
+# C0 control chars (except \n and \t, which carry real line structure) plus
+# zero-width / format chars. \r is dropped too: it is redundant with \n in
+# CRLF and never carries meaning alone in modern output, so removing it can't
+# corrupt structure — and it fixes CR-split secrets (issue #77484). Dropping
+# \n/\t would merge lines and break the line-anchored _CFG_*_RE passes, so a
+# token split by a raw newline stays split (pathological — real secrets are
+# single-line). Gate + full pattern (see redact_sensitive_text).
+_HAS_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\u200b-\u200f\u202a-\u202e\u2060-\u2064]")
+_CONTROL_RE = _HAS_CONTROL_RE
+# \r additionally dropped (redundant with \n in CRLF).
+_HAS_CR_RE = re.compile(r"\r")
+_CRLF_RE = re.compile(r"\r\n?")
 
 
 def mask_secret(
@@ -709,6 +727,16 @@ def redact_sensitive_text(
         return text
     if not (force or _REDACT_ENABLED):
         return text
+
+    # Control-char normalization: C0 controls (except \n / \t) and zero-width
+    # chars inside a token make every regex miss — a secret split by \r, ESC,
+    # or \u200b passes through unmasked (issue #77484). They have no display
+    # meaning, so drop them before matching (this is the text we return). \r
+    # is dropped as redundant with \n in CRLF.
+    if _HAS_CONTROL_RE.search(text):
+        text = _CONTROL_RE.sub("", text)
+    if "\r" in text:
+        text = _CRLF_RE.sub("\n", text)
 
     # file_read content shouldn't hit the source-code ENV/JSON false-positive
     # paths either (it's config/data, not log lines).

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -445,18 +445,15 @@ _PREFIX_RE = re.compile(
 
 # C0 control chars (except \n and \t, which carry real line structure), C1
 # controls (0x80-0x9F), DEL (0x7F), plus zero-width / format chars. \r is
-# dropped too: it is redundant with \n in CRLF and never carries meaning alone
-# in modern output, so removing it can't corrupt structure — and it fixes
-# CR-split secrets (issue #77484). Dropping \n/\t would merge lines and break
-# the line-anchored _CFG_*_RE passes, so a token split by a raw newline stays
-# split (pathological — real secrets are single-line).
-# Gate + full pattern (see redact_sensitive_text).
+# covered by the C0 range (0x0d) but handled separately at the call site
+# (normalized to \n as redundant with \n in CRLF). Dropping \n/\t would merge
+# lines and break the line-anchored _CFG_*_RE passes, so a token split by a
+# raw newline stays split (pathological — real secrets are single-line).
 _HAS_CONTROL_RE = re.compile(
     r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f\x80-\x9f\u200b-\u200f\u202a-\u202e\u2060-\u2064]"
 )
 _CONTROL_RE = _HAS_CONTROL_RE
-# \r additionally dropped (redundant with \n in CRLF).
-_HAS_CR_RE = re.compile(r"\r")
+# \r normalized to \n at the call site (redundant with \n in CRLF).
 _CRLF_RE = re.compile(r"\r\n?")
 # Display-mask strip: EVERY control incl. \n/\t — a masked secret must never
 # emit multiline or tabbed output into config/status/dump display (#55319).

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -443,18 +443,24 @@ _PREFIX_RE = re.compile(
     r"(?<![A-Za-z0-9_-])(" + "|".join(_PREFIX_PATTERNS) + r")(?![A-Za-z0-9_-])"
 )
 
-# C0 control chars (except \n and \t, which carry real line structure) plus
-# zero-width / format chars. \r is dropped too: it is redundant with \n in
-# CRLF and never carries meaning alone in modern output, so removing it can't
-# corrupt structure — and it fixes CR-split secrets (issue #77484). Dropping
-# \n/\t would merge lines and break the line-anchored _CFG_*_RE passes, so a
-# token split by a raw newline stays split (pathological — real secrets are
-# single-line). Gate + full pattern (see redact_sensitive_text).
-_HAS_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\u200b-\u200f\u202a-\u202e\u2060-\u2064]")
+# C0 control chars (except \n and \t, which carry real line structure), C1
+# controls (0x80-0x9F), DEL (0x7F), plus zero-width / format chars. \r is
+# dropped too: it is redundant with \n in CRLF and never carries meaning alone
+# in modern output, so removing it can't corrupt structure — and it fixes
+# CR-split secrets (issue #77484). Dropping \n/\t would merge lines and break
+# the line-anchored _CFG_*_RE passes, so a token split by a raw newline stays
+# split (pathological — real secrets are single-line).
+# Gate + full pattern (see redact_sensitive_text).
+_HAS_CONTROL_RE = re.compile(
+    r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f\x80-\x9f\u200b-\u200f\u202a-\u202e\u2060-\u2064]"
+)
 _CONTROL_RE = _HAS_CONTROL_RE
 # \r additionally dropped (redundant with \n in CRLF).
 _HAS_CR_RE = re.compile(r"\r")
 _CRLF_RE = re.compile(r"\r\n?")
+# Display-mask strip: EVERY control incl. \n/\t — a masked secret must never
+# emit multiline or tabbed output into config/status/dump display (#55319).
+_DISPLAY_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f\x80-\x9f\u200b-\u200f\u202a-\u202e\u2060-\u2064]")
 
 
 def mask_secret(
@@ -497,6 +503,12 @@ def mask_secret(
         >>> mask_secret("long-token", head=6, tail=4, floor=18)
         '***'
     """
+    if not value:
+        return empty
+    # Visible head/tail must not carry control bytes (newline, NUL, DEL, C1)
+    # into config/status/dump output (#55319, #55321). Strip them before
+    # slicing — the length check below then sees the displayable length.
+    value = _DISPLAY_CONTROL_RE.sub("", value)
     if not value:
         return empty
     if len(value) < floor:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -4,7 +4,7 @@ import logging
 
 import pytest
 
-from agent.redact import redact_cdp_url, redact_sensitive_text, RedactingFormatter
+from agent.redact import mask_secret, redact_cdp_url, redact_sensitive_text, RedactingFormatter
 
 
 @pytest.fixture(autouse=True)
@@ -897,6 +897,26 @@ class TestControlCharSplitRedaction:
         result = redact_sensitive_text(text)
         assert "\n" in result
         assert "abc123" not in result
+
+
+class TestMaskSecretControlStripping:
+    """Issue #55319/#55321: mask_secret() must not emit control bytes
+    (newline, NUL, DEL, C1) in the visible head/tail of a masked secret —
+    they corrupt config/status/dump display output."""
+
+    def test_newline_stripped_from_mask(self):
+        # The #55319 probe: a newline inside the preserved head.
+        assert mask_secret("ab\ncd0123456789zzzz") == "abcd...zzzz"
+
+    def test_c1_control_stripped_from_mask(self):
+        assert mask_secret("abcd0123456789zz\x85q") == "abcd...9zzq"
+
+    def test_printable_mask_unchanged(self):
+        assert mask_secret("abcdef0123456789zzzz") == "abcd...zzzz"
+
+    def test_all_control_value_returns_empty_fallback(self):
+        assert mask_secret("\n\x85\u200b") == ""
+        assert mask_secret("\n\x85\u200b", empty="(not set)") == "(not set)"
 
 
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -831,3 +831,72 @@ class TestKeywordWordBoundary:
         assert "hunter2hunter2hunter2hh" not in result
 
 
+class TestEnvNameGapRedaction:
+    """Issue #77484: ``_ENV_ASSIGN_RE`` missed ``*_KEY``/``*_PASS``/``*_PW``
+    and lowercase env keys, so ``FAL_KEY=…`` / ``openai_key=…`` leaked
+    verbatim."""
+
+    def test_bare_key_suffix_redacted(self):
+        for text in (
+            "FAL_KEY=sk-abc123",
+            "OPENAI_KEY=sk-def456",
+            "MYSQL_PASS=ghi789",
+            "DB_PW=jkl012",
+        ):
+            result = redact_sensitive_text(text)
+            assert result != text, text
+            assert "=" in result  # key preserved, value masked
+
+    def test_lowercase_env_key_redacted(self):
+        text = "openai_key=sk-def456"
+        result = redact_sensitive_text(text)
+        assert result != text
+        assert "openai_key=" in result
+        assert "sk-def456" not in result
+
+    def test_prose_words_not_mangled(self):
+        # The new bare KEY/PASS/PW keywords must not match prose.
+        for text in (
+            "The author=Smith wrote the paper",
+            "monkey=banana",
+            "keyboard=logitech",
+            "passage=doorway",
+        ):
+            assert redact_sensitive_text(text) == text, text
+
+
+class TestControlCharSplitRedaction:
+    """Issue #77484: secrets split by control/zero-width chars escaped every
+    regex (``sk-abc123\\x1bsk-def456`` leaked verbatim)."""
+
+    def test_esc_split_token_redacted(self):
+        text = "sk-abc123\x1bsk-def456"
+        result = redact_sensitive_text(text)
+        assert result != text
+        assert "sk-def456" not in result
+
+    def test_zero_width_split_token_redacted(self):
+        text = "sk-abc123\u200bsk-def456"
+        result = redact_sensitive_text(text)
+        assert result != text
+        assert "sk-def456" not in result
+
+    def test_cr_split_token_redacted(self):
+        # \r is normalized to \n (redundant with \n in CRLF); a real
+        # 10+ char prefix token split by it must still be caught on each side.
+        text = "sk-abcdef123456\rsk-ghijkl789012"
+        result = redact_sensitive_text(text)
+        assert result != text
+        assert "sk-abcdef123456" not in result
+        assert "sk-ghijkl789012" not in result
+
+    def test_newline_structure_preserved(self):
+        # \n carries line structure; dropping it would merge lines and break
+        # the line-anchored _CFG_*_RE passes. A CRLF pair still normalizes.
+        text = "FOO_KEY=abc123\r\nBAR=1"
+        result = redact_sensitive_text(text)
+        assert "\n" in result
+        assert "abc123" not in result
+
+
+

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -963,6 +963,34 @@ class TestProcessToolHandler:
         result = json.loads(_handle_process({"action": "unknown_action"}))
         assert "error" in result
 
+    def test_list_redacts_command_and_output_preview(self, monkeypatch):
+        """Issue #77484: process(action=list) leaked raw command[:200] and
+        output_preview[-200:] including inline secrets — unlike poll/log/wait
+        which are wrapped in _redact_process_result."""
+        from tools import process_registry as pr
+
+        fake_entries = [
+            {
+                "session_id": "p1",
+                "command": "curl -H 'Authorization: Bearer sk-secret1234567890' http://x",
+                "cwd": "/home/user",
+                "pid": 123,
+                "started_at": "2026-08-03T00:00:00",
+                "uptime_seconds": 5,
+                "status": "running",
+                "output_preview": "token: ghp_abcdef1234567890",
+            }
+        ]
+        monkeypatch.setattr(pr.process_registry, "list_sessions", lambda **kw: fake_entries)
+        result = json.loads(pr._handle_process({"action": "list"}))
+        procs = result["processes"]
+        assert len(procs) == 1
+        assert "sk-secret1234567890" not in procs[0]["command"]
+        assert "ghp_abcdef1234567890" not in procs[0]["output_preview"]
+        # Key structure preserved.
+        assert procs[0]["session_id"] == "p1"
+        assert procs[0]["pid"] == 123
+
 
 # =========================================================================
 # format_process_notification + drain_notifications (shared helpers)

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -903,6 +903,26 @@ class TestCheckpoint:
             data = json.loads(checkpoint.read_text())
             assert data == []
 
+    def test_checkpoint_redacts_command_with_inline_secret(self, registry, tmp_path):
+        """Issue #77484: the checkpoint file persists raw commands; inline
+        credentials (e.g. ``curl -H 'Authorization: Bearer sk-...'``) must be
+        redacted before write. Recovery only uses command for display/logging
+        (the process is already running), so masking is lossless."""
+        checkpoint = tmp_path / "procs.json"
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            secret = "sk-secret1234567890"
+            command = f"curl -H 'Authorization: Bearer {secret}' http://x"
+            s = _make_session(sid="proc_secret", command=command)
+            s.pid = 12345
+            s.host_start_time = int(time.time())
+            registry._running[s.id] = s
+            registry._write_checkpoint()
+
+            data = json.loads(checkpoint.read_text())
+            assert data[0]["session_id"] == "proc_secret"
+            assert secret not in data[0]["command"]
+            assert data[0]["command"] != command
+
 # =========================================================================
 # Kill process
 # =========================================================================

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -2477,6 +2477,20 @@ def _redact_process_result(result: dict) -> dict:
     return result
 
 
+def _redact_process_list(entries: list) -> list:
+    """Redact every entry of a ``process(action=list)`` result.
+
+    ``list_sessions`` returns a LIST of per-process dicts (unlike poll/log/wait
+    which return a single dict), so ``_redact_process_result`` alone can't be
+    applied — map it over the entries. Without this, ``process(action=list)``
+    leaked raw ``command[:200]`` and ``output_preview[-200:]`` including inline
+    secrets (issue #77484).
+    """
+    if not isinstance(entries, list):
+        return entries
+    return [_redact_process_result(e) for e in entries]
+
+
 def _handle_process(args, **kw):
     task_id = kw.get("task_id")
     action = args.get("action", "")
@@ -2493,7 +2507,7 @@ def _handle_process(args, **kw):
         except Exception:
             session_key = ""
         return json.dumps(
-            {"processes": process_registry.list_sessions(task_id=task_id, session_key=session_key or None)},
+            {"processes": _redact_process_list(process_registry.list_sessions(task_id=task_id, session_key=session_key or None))},
             ensure_ascii=False,
         )
     elif action in {"poll", "log", "wait", "kill", "write", "submit", "close"}:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -49,6 +49,8 @@ from typing import Any, Dict, List, Optional
 
 from hermes_cli.config import get_hermes_home
 
+from agent.redact import redact_sensitive_text
+
 logger = logging.getLogger(__name__)
 
 
@@ -2067,7 +2069,14 @@ class ProcessRegistry:
                             s.host_start_time = self._safe_host_start_time(s.pid)
                         entries.append({
                             "session_id": s.id,
-                            "command": s.command,
+                            # Redact inline credentials before persisting to
+                            # disk — the checkpoint file lives under
+                            # ~/.hermes/processes.json with the raw command
+                            # (issue #77484). Recovery only uses command for
+                            # display/logging (the process is already running;
+                            # adoption re-validates the PID, never re-runs the
+                            # command), so masking is lossless.
+                            "command": redact_sensitive_text(s.command, code_file=True),
                             "pid": s.pid,
                             "pid_scope": s.pid_scope,
                             "host_start_time": s.host_start_time,


### PR DESCRIPTION
Fixes #77484 — closes three verified secret-redaction gaps (all reproduced live on current main before fixing):

## 1. `_ENV_ASSIGN_RE` misses `*_KEY`/`*_PASS`/`*_PW` + lowercase env keys
`FAL_KEY=sk-abc123`, `OPENAI_KEY=sk-def456`, `MYSQL_PASS=ghi789`, `DB_PW=jkl012`, and lowercase `openai_key=sk-def456` all leaked verbatim through `redact_sensitive_text`, while `MY_API_KEY` / `GITHUB_TOKEN` masked correctly.

- `_SECRET_ENV_NAMES` gains bare `KEY` / `PASS` / `_?PW` alternatives.
- `_SECRET_CFG_NAMES` (line-anchored + dotted config passes) gains `key` / `pass` / `pw`, so lowercase .env keys like `openai_key=` mask without touching mid-string prose or URLs.
- `_KEY_KEYWORD_RE` (word-boundary gate) gains bare `key` / `pass` / `pw` so `openai_key` / `mysql_pass` pass validation while `monkey` / `keyboard` / `passage` / `secretary` stay untouched.

## 2. Control-char token splitting
`sk-abc123\x1bsk-def456`, `sk-abc123\u200bsk-def456`, and CR-split tokens passed every regex unmasked. `redact_sensitive_text` now strips C0 controls (except `\n`/`\t`) + zero-width/format chars before matching, and normalizes `\r` → `\n`. `\n`/`\t` are preserved (they carry line structure; the line-anchored `_CFG_*_RE` passes depend on it).

## 3. `process(action=list)` unredacted
`tools/process_registry.py` returned raw `list_sessions(...)` JSON (raw `command[:200]` + `output_preview[-200:]` with inline secrets), unlike poll/log/wait/kill which are wrapped in `_redact_process_result`. Added `_redact_process_list` mapping the existing redactor over each entry.

## Tests
- `tests/agent/test_redact.py`: env-name gap (bare suffixes, lowercase, prose-not-mangled), control-char splits (ESC/zero-width/CR, newline-structure preserved).
- `tests/tools/test_process_registry.py`: `process(action=list)` redacts command + output_preview.
- Verified: `test_redact.py` 80/80, `test_process_registry.py` 55/55, redaction-adjacent suites 62/62, ruff clean.

---

Also fixes #55319 and #55321 (mask_secret() no longer emits control bytes in the visible mask head/tail — the prior PR #58079 was closed without merging).
