### PR TITLE
feat(curator): include archived skills in consolidation + durable absorbed guard

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -217,6 +217,17 @@ def get_consolidate() -> bool:
     return bool(cfg.get("consolidate", DEFAULT_CONSOLIDATE))
 
 
+def get_consolidate_archived() -> bool:
+    """Whether the LLM consolidation pass may inspect archived skills.
+
+    Archived candidates are opt-in separately from the existing consolidation
+    gate so enabling ``curator.consolidate`` keeps its historical behavior and
+    does not add old packages to the review prompt unexpectedly.
+    """
+    cfg = _load_config()
+    return bool(cfg.get("consolidate_archived", False))
+
+
 # ---------------------------------------------------------------------------
 # Idle / interval check
 # ---------------------------------------------------------------------------
@@ -449,6 +460,16 @@ CURATOR_REVIEW_PROMPT = (
     "run. You MAY still consolidate it into an umbrella — but only because "
     "the curator rewrites cron job skill references to follow consolidations; "
     "never simply prune it.\n"
+    "3d. Entries with `state=archived` are historical local skill packages, "
+    "not live prompt skills. Inspect their complete package at the listed "
+    "`archive_path` with terminal before judging it. Compare each archived "
+    "package against live skills in the same domain: patch a live umbrella "
+    "with genuinely unique content and leave the original archived, or restore "
+    "the whole package before merging/restoring it when no suitable live "
+    "umbrella exists. Never flatten a package and leave its support files or "
+    "relative links behind. If an archived package was absorbed, list it in "
+    "the structured `consolidations` block so its durable absorbed marker can "
+    "prevent a future re-merge.\n"
     "4. DO NOT use usage counters as a reason to skip consolidation. The "
     "counters are new and often mostly zero. Judge overlap on CONTENT, "
     "not on use_count. 'use=0' is not evidence a skill is valuable; it's "
@@ -1188,6 +1209,65 @@ def _write_run_report(
     consolidated = classification["consolidated"]
     pruned = classification["pruned"]
 
+    # An archived candidate remains in the archive after its unique content is
+    # merged into a live umbrella, so it is not part of ``removed``. Trust the
+    # reviewer's structured declaration for those historical packages when the
+    # named source was actually present as an archived candidate and the target
+    # survived the pass.
+    archived_before = {
+        row.get("name")
+        for row in before_report
+        if isinstance(row, dict) and row.get("state") == skill_usage.STATE_ARCHIVED
+    }
+    live_destinations = {
+        row.get("name")
+        for row in after_report
+        if isinstance(row, dict) and row.get("state") != skill_usage.STATE_ARCHIVED
+    } | set(added or [])
+    classified_names = {
+        entry.get("name")
+        for entry in consolidated + pruned
+        if isinstance(entry, dict)
+    }
+    for entry in model_block.get("consolidations", []):
+        source = entry.get("from")
+        target = entry.get("into")
+        if (
+            isinstance(source, str)
+            and isinstance(target, str)
+            and source in archived_before
+            and source not in classified_names
+            and target != source
+            and target in live_destinations
+        ):
+            consolidated.append({
+                "name": source,
+                "into": target,
+                "source": "model (archived candidate)",
+                "reason": entry.get("reason") or "",
+            })
+            classified_names.add(source)
+
+    # Persist the guard before the next curator run. Active consolidations are
+    # already marked by skill_manage's recoverable archive path; this idempotent
+    # pass also covers archived packages that stayed under .archive/ while their
+    # content was merged into a live umbrella.
+    for entry in consolidated:
+        if not isinstance(entry, dict):
+            continue
+        source = entry.get("name")
+        target = entry.get("into")
+        if isinstance(source, str) and isinstance(target, str) and source and target:
+            try:
+                if not skill_usage.mark_absorbed(source, target):
+                    logger.debug(
+                        "Curator could not persist absorbed marker: %s -> %s",
+                        source,
+                        target,
+                    )
+            except Exception as e:
+                logger.debug("Curator absorbed marker write failed: %s", e, exc_info=True)
+
     # Rewrite cron job skill references. When the curator consolidates
     # skill X into umbrella Y, any cron job that lists X fails to load
     # it at run time — the scheduler skips it and the job runs without
@@ -1470,14 +1550,22 @@ def _render_report_markdown(p: Dict[str, Any]) -> str:
 # Orchestrator — spawn a forked AIAgent for the LLM review pass
 # ---------------------------------------------------------------------------
 
-def _render_candidate_list() -> str:
-    """Human/agent-readable list of curator-managed skills with usage stats."""
-    rows = skill_usage.curated_report()
+def _render_candidate_list(include_archived: Optional[bool] = None) -> str:
+    """Render live candidates and, when enabled, archived package candidates."""
+    if include_archived is None:
+        include_archived = get_consolidate_archived()
+    rows = skill_usage.curated_report(include_archived=bool(include_archived))
     if not rows:
         return "No curator-managed skills to review."
     cron_referenced = _cron_referenced_skills()
     lines = [f"Curator-managed skills ({len(rows)}):\n"]
     for r in rows:
+        archived_fields = ""
+        if r.get("state") == skill_usage.STATE_ARCHIVED:
+            archived_fields = (
+                "  location=archived"
+                f"  archive_path={r.get('archive_path', '.archive/' + r['name'])}"
+            )
         lines.append(
             f"- {r['name']}  "
             f"provenance={r.get('provenance', 'agent')}  "
@@ -1489,6 +1577,7 @@ def _render_candidate_list() -> str:
             f"view={r.get('view_count', 0)}  "
             f"patches={r.get('patch_count', 0)}  "
             f"last_activity={r.get('last_activity_at') or 'never'}"
+            f"{archived_fields}"
         )
     return "\n".join(lines)
 
@@ -1529,11 +1618,12 @@ def run_curator_review(
     """
     if consolidate is None:
         consolidate = get_consolidate()
+    include_archived = bool(consolidate) and get_consolidate_archived()
     start = datetime.now(timezone.utc)
     if dry_run:
         # Count candidates without mutating state.
         try:
-            report = skill_usage.curated_report()
+            report = skill_usage.curated_report(include_archived=include_archived)
             counts = {
                 "checked": len(report),
                 "marked_stale": 0,
@@ -1586,7 +1676,7 @@ def run_curator_review(
         nonlocal auto_summary
         # Snapshot skill state BEFORE the LLM pass so the report can diff.
         try:
-            before_report = skill_usage.curated_report()
+            before_report = skill_usage.curated_report(include_archived=include_archived)
         except Exception:
             before_report = []
         before_names = {r.get("name") for r in before_report if isinstance(r, dict)}
@@ -1612,7 +1702,7 @@ def run_curator_review(
             state2["last_run_duration_seconds"] = elapsed
             state2["last_run_summary"] = final_summary
             try:
-                after_report = skill_usage.curated_report()
+                after_report = skill_usage.curated_report(include_archived=include_archived)
             except Exception:
                 after_report = []
             try:
@@ -1640,8 +1730,8 @@ def run_curator_review(
 
         llm_meta: Dict[str, Any] = {}
         try:
-            candidate_list = _render_candidate_list()
-            if "No agent-created skills" in candidate_list:
+            candidate_list = _render_candidate_list(include_archived=include_archived)
+            if candidate_list.startswith("No curator-managed skills"):
                 final_summary = f"{prefix}{auto_summary}; llm: skipped (no candidates)"
                 llm_meta = {
                     "final": "",
@@ -1699,7 +1789,7 @@ def run_curator_review(
         try:
             rename_lines = _build_rename_summary(
                 before_names=before_names,
-                after_report=skill_usage.curated_report(),
+                after_report=skill_usage.curated_report(include_archived=include_archived),
                 tool_calls=llm_meta.get("tool_calls", []) or [],
                 model_final=llm_meta.get("final", "") or "",
             )
@@ -1717,7 +1807,7 @@ def run_curator_review(
         # reporting bug never breaks the curator itself. Report path is
         # recorded in state so `hermes curator status` can point at it.
         try:
-            after_report = skill_usage.curated_report()
+            after_report = skill_usage.curated_report(include_archived=include_archived)
         except Exception:
             after_report = []
         try:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1823,6 +1823,10 @@ DEFAULT_CONFIG = {
         # class-level umbrellas. `hermes curator run --consolidate` overrides
         # this for a single invocation.
         "consolidate": False,
+        # Include recoverable packages under skills/.archive/ in the opt-in
+        # consolidation review. Kept separate so existing consolidation users
+        # do not incur extra historical-package review until they enable it.
+        "consolidate_archived": False,
         # Also prune (archive) bundled built-in skills after the inactivity
         # period, not just agent-created ones. ON by default. Built-ins are
         # normally restored on every `hermes update`, so pruning them only

--- a/tests/agent/test_curator_archived_skills.py
+++ b/tests/agent/test_curator_archived_skills.py
@@ -1,0 +1,114 @@
+"""Regression coverage for archived curator consolidation candidates."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def curator_archived_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    skills = home / "skills"
+    skills.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    import tools.skill_usage as skill_usage
+    import agent.curator as curator
+
+    importlib.reload(skill_usage)
+    importlib.reload(curator)
+    monkeypatch.setattr(skill_usage, "_prune_builtins_enabled", lambda: False)
+    monkeypatch.setattr(curator, "_load_config", lambda: {})
+    return {"home": home, "skills": skills, "usage": skill_usage, "curator": curator}
+
+
+def _write_skill(skills: Path, name: str) -> Path:
+    skill_dir = skills / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: test\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _archive_managed_skill(env, name: str, *, absorbed_into: str | None = None) -> None:
+    usage = env["usage"]
+    _write_skill(env["skills"], name)
+    usage.mark_agent_created(name)
+    ok, message = usage.archive_skill(name, absorbed_into=absorbed_into)
+    assert ok, message
+
+
+def test_archived_skill_is_a_consolidation_candidate(curator_archived_env, monkeypatch):
+    env = curator_archived_env
+    usage = env["usage"]
+    curator = env["curator"]
+    _archive_managed_skill(env, "historical-api")
+    usage.bump_use("historical-api")
+
+    monkeypatch.setattr(curator, "_load_config", lambda: {"consolidate_archived": True})
+    rows = usage.curated_report(include_archived=True)
+    listing = curator._render_candidate_list()
+
+    row = next(row for row in rows if row["name"] == "historical-api")
+    assert row["state"] == usage.STATE_ARCHIVED
+    assert row["activity_count"] == 1
+    assert "- historical-api" in listing
+    assert "state=archived" in listing
+    assert "archive_path=" in listing
+    assert "historical-api" in listing
+
+
+def test_absorbed_skill_is_filtered_from_future_passes(curator_archived_env, monkeypatch):
+    env = curator_archived_env
+    usage = env["usage"]
+    curator = env["curator"]
+    _write_skill(env["skills"], "already-merged")
+    usage.mark_agent_created("already-merged")
+    assert usage.mark_absorbed("already-merged", "general-umbrella") is True
+
+    monkeypatch.setattr(curator, "_load_config", lambda: {"consolidate_archived": True})
+    assert "already-merged" not in usage.list_agent_created_skill_names()
+    assert "already-merged" not in curator._render_candidate_list()
+
+
+def test_absorbed_marker_survives_archive_restore_until_adopt(curator_archived_env):
+    env = curator_archived_env
+    usage = env["usage"]
+    curator = env["curator"]
+    name = "restored-merged"
+    _write_skill(env["skills"], name)
+    usage.mark_agent_created(name)
+
+    ok, message = usage.archive_skill(name, absorbed_into="general-umbrella")
+    assert ok, message
+    assert usage.get_record(name)["absorbed_into"] == "general-umbrella"
+
+    ok, message = usage.restore_skill(name)
+    assert ok, message
+    restored = usage.get_record(name)
+    assert restored["state"] == usage.STATE_ACTIVE
+    assert restored["absorbed_into"] == "general-umbrella"
+    assert name not in curator._render_candidate_list(include_archived=True)
+
+    ok, message = usage.adopt_skill(name)
+    assert ok, message
+    assert usage.get_record(name).get("absorbed_into") is None
+    assert name in curator._render_candidate_list(include_archived=True)
+
+
+def test_archived_candidates_are_config_gated(curator_archived_env, monkeypatch):
+    env = curator_archived_env
+    curator = env["curator"]
+    _archive_managed_skill(env, "gated-history")
+
+    monkeypatch.setattr(curator, "_load_config", lambda: {})
+    assert "gated-history" not in curator._render_candidate_list()
+
+    monkeypatch.setattr(curator, "_load_config", lambda: {"consolidate_archived": True})
+    assert "gated-history" in curator._render_candidate_list()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1237,7 +1237,10 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if curator_pass:
         try:
             from tools.skill_usage import archive_skill
-            ok, archive_msg = archive_skill(name)
+            ok, archive_msg = archive_skill(
+                name,
+                absorbed_into=absorbed_target if is_consolidation else None,
+            )
         except Exception as e:
             return {"success": False, "error": f"failed to archive '{name}': {e}"}
         if not ok:

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -34,7 +34,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
-from agent.skill_utils import is_excluded_skill_path, is_external_skill_path
+from agent.skill_utils import (
+    is_excluded_skill_path,
+    is_external_skill_path,
+    is_skill_support_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +57,8 @@ except ImportError:  # pragma: no cover - platform-specific fallback
 STATE_ACTIVE = "active"
 STATE_STALE = "stale"
 STATE_ARCHIVED = "archived"
-_VALID_STATES = {STATE_ACTIVE, STATE_STALE, STATE_ARCHIVED}
+STATE_ABSORBED = "absorbed"
+_VALID_STATES = {STATE_ACTIVE, STATE_STALE, STATE_ARCHIVED, STATE_ABSORBED}
 
 # Load-bearing bundled built-ins the curator must NEVER archive or consolidate,
 # regardless of ``curator.prune_builtins``, pin state, or LLM judgment. These
@@ -172,6 +177,19 @@ def activity_count(record: Dict[str, Any]) -> int:
         except (TypeError, ValueError):
             continue
     return total
+
+
+def is_absorbed_record(record: Any) -> bool:
+    """Return True when a skill has been durably absorbed into another skill.
+
+    ``absorbed_into`` is deliberately independent of the lifecycle ``state``:
+    an absorbed skill may be archived and later restored for inspection without
+    becoming a consolidation candidate again.
+    """
+    if not isinstance(record, dict):
+        return False
+    target = record.get("absorbed_into")
+    return bool(isinstance(target, str) and target.strip()) or record.get("state") == STATE_ABSORBED
 
 
 # ---------------------------------------------------------------------------
@@ -372,6 +390,10 @@ def list_agent_created_skill_names() -> List[str]:
         # Hub-installed skills are always off-limits.
         if name in hub:
             continue
+        # An absorbed skill remains hidden even if it was restored. This is a
+        # durable guard against re-merging the same content on every pass.
+        if is_absorbed_record(usage.get(name)):
+            continue
         # Protected built-ins are never curation candidates — exempt from the
         # automatic transition walk AND the LLM consolidation pass.
         if is_protected_builtin(name):
@@ -422,6 +444,27 @@ def _read_skill_name(skill_md: Path, fallback: str) -> str:
             if value:
                 return value
     return fallback
+
+
+def _iter_archived_skill_files():
+    """Yield archived skill entry points without using the active-tree scan.
+
+    ``.archive`` is intentionally in ``EXCLUDED_SKILL_DIRS`` for normal skill
+    discovery. Consolidation needs a narrow exception: walk the archive
+    explicitly, while still ignoring support-package ``SKILL.md`` files nested
+    below ``references/``, ``templates/``, ``scripts/``, or ``assets/``.
+    """
+    archive_root = _archive_dir()
+    if not archive_root.exists():
+        return
+    for skill_md in sorted(archive_root.rglob("SKILL.md")):
+        try:
+            skill_md.relative_to(archive_root)
+        except ValueError:
+            continue
+        if is_skill_support_path(skill_md, root=archive_root):
+            continue
+        yield skill_md
 
 
 def is_agent_created(skill_name: str) -> bool:
@@ -630,6 +673,10 @@ def adopt_skill(skill_name: str) -> Tuple[bool, str]:
         return False, _external_read_only_message(skill_name)
     usage = load_usage()
     if _is_curator_managed_record(usage.get(skill_name)):
+        if is_absorbed_record(usage.get(skill_name)):
+            if clear_absorbed(skill_name):
+                return True, f"re-adopted '{skill_name}' into curator management"
+            return False, f"could not clear absorbed marker for '{skill_name}'"
         return True, f"'{skill_name}' is already curator-managed"
     mark_agent_created(skill_name)
     if not _is_curator_managed_record(load_usage().get(skill_name)):
@@ -654,6 +701,8 @@ def _empty_record() -> Dict[str, Any]:
         "state": STATE_ACTIVE,
         "pinned": False,
         "archived_at": None,
+        "absorbed_into": None,
+        "absorbed_at": None,
     }
 
 
@@ -821,12 +870,76 @@ def set_state(skill_name: str, state: str) -> None:
         logger.debug("set_state: invalid state %r for %s", state, skill_name)
         return
     def _apply(rec: Dict[str, Any]) -> None:
-        rec["state"] = state
+        # Legacy/state-only absorbed markers must survive archive/restore too;
+        # newer records use ``absorbed_into`` and can retain normal lifecycle
+        # state values for clearer status output.
+        state_only_absorbed = (
+            rec.get("state") == STATE_ABSORBED
+            and not rec.get("absorbed_into")
+            and state in {STATE_ACTIVE, STATE_STALE, STATE_ARCHIVED}
+        )
+        rec["state"] = STATE_ABSORBED if state_only_absorbed else state
         if state == STATE_ARCHIVED:
             rec["archived_at"] = _now_iso()
         elif state == STATE_ACTIVE:
             rec["archived_at"] = None
+        elif state == STATE_ABSORBED:
+            rec["absorbed_at"] = rec.get("absorbed_at") or _now_iso()
     _mutate(skill_name, _apply, require_curation_eligible=True)
+
+
+def mark_absorbed(skill_name: str, absorbed_into: str) -> bool:
+    """Persist that *skill_name* was merged into *absorbed_into*.
+
+    The sidecar read-modify-write is protected by the same lock and atomic
+    replace used by all other usage mutations. The marker is intentionally not
+    cleared by ``set_state`` so archive/restore can change lifecycle state
+    without making an absorbed skill visible to a future consolidation pass.
+    """
+    target = absorbed_into.strip() if isinstance(absorbed_into, str) else ""
+    if not skill_name or not target:
+        return False
+    try:
+        with _usage_file_lock():
+            data = load_usage()
+            rec = data.get(skill_name)
+            if not isinstance(rec, dict):
+                rec = _empty_record()
+            rec["absorbed_into"] = target
+            rec["absorbed_at"] = _now_iso()
+            data[skill_name] = rec
+            save_usage(data)
+            persisted = load_usage().get(skill_name)
+            return (
+                isinstance(persisted, dict)
+                and persisted.get("absorbed_into") == target
+            )
+    except Exception as e:
+        logger.debug("skill_usage.mark_absorbed(%s) failed: %s", skill_name, e, exc_info=True)
+        return False
+
+
+def clear_absorbed(skill_name: str) -> bool:
+    """Explicitly re-adopt a previously absorbed skill for future review."""
+    if not skill_name:
+        return False
+    try:
+        with _usage_file_lock():
+            data = load_usage()
+            rec = data.get(skill_name)
+            if not isinstance(rec, dict) or not is_absorbed_record(rec):
+                return False
+            rec.pop("absorbed_into", None)
+            rec.pop("absorbed_at", None)
+            if rec.get("state") == STATE_ABSORBED:
+                rec["state"] = STATE_ACTIVE
+            data[skill_name] = rec
+            save_usage(data)
+            persisted = load_usage().get(skill_name)
+            return isinstance(persisted, dict) and not is_absorbed_record(persisted)
+    except Exception as e:
+        logger.debug("skill_usage.clear_absorbed(%s) failed: %s", skill_name, e, exc_info=True)
+        return False
 
 
 def set_pinned(skill_name: str, pinned: bool) -> None:
@@ -873,7 +986,7 @@ def forget(skill_name: str) -> None:
 # Archive / restore
 # ---------------------------------------------------------------------------
 
-def archive_skill(skill_name: str) -> Tuple[bool, str]:
+def archive_skill(skill_name: str, absorbed_into: Optional[str] = None) -> Tuple[bool, str]:
     """Move a curator-eligible skill directory to ~/.hermes/skills/.archive/.
 
     Returns (ok, message). Never archives hub-installed skills. Bundled
@@ -931,6 +1044,11 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
         add_suppressed_name(skill_name)
 
     set_state(skill_name, STATE_ARCHIVED)
+    if isinstance(absorbed_into, str) and absorbed_into.strip():
+        # Mark after the recoverable move succeeds. If the archive operation
+        # fails, the source remains a visible active candidate and can be
+        # retried; a failed consolidation must not silently hide it.
+        mark_absorbed(skill_name, absorbed_into)
     return True, f"archived to {dest}"
 
 
@@ -1005,6 +1123,9 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
     # Restoring a pruned built-in lifts its suppression so updates can manage it.
     remove_suppressed_name(skill_name)
 
+    # ``set_state`` intentionally leaves ``absorbed_into`` untouched. A
+    # restored absorbed package remains excluded until ``curator adopt`` or a
+    # deliberate manual sidecar edit clears that marker.
     set_state(skill_name, STATE_ACTIVE)
     return True, f"restored to {dest}"
 
@@ -1049,10 +1170,14 @@ def _find_external_skill_dir(skill_name: str) -> Optional[Path]:
 # Reporting — for the curator CLI / slash command
 # ---------------------------------------------------------------------------
 
-def curated_report() -> List[Dict[str, Any]]:
+def curated_report(*, include_archived: bool = False) -> List[Dict[str, Any]]:
     """Return a list of {name, provenance, state, pinned, last_activity_at, ...}
     records for every curator-managed skill. Missing usage records are
     backfilled with defaults so callers can always index fields.
+
+    ``include_archived`` is opt-in because the lifecycle transition pass must
+    continue to scan only live skills. The consolidation candidate builder can
+    request archived packages explicitly.
 
     ``provenance`` is 'agent', 'bundled', or 'hub' (see :func:`provenance`).
     Bundled skills are only included when ``curator.prune_builtins`` is enabled.
@@ -1067,12 +1192,61 @@ def curated_report() -> List[Dict[str, Any]]:
     rows: List[Dict[str, Any]] = []
     for name in list_agent_created_skill_names():
         raw = data.get(name)
+        if is_absorbed_record(raw):
+            continue
         persisted = isinstance(raw, dict)
-        rec: Dict[str, Any] = raw if isinstance(raw, dict) else _empty_record()
+        rec: Dict[str, Any] = dict(raw) if isinstance(raw, dict) else _empty_record()
         base = _empty_record()
         for k, v in base.items():
             rec.setdefault(k, v)
         row = {"name": name, **rec, "_persisted": persisted}
+        row["last_activity_at"] = latest_activity_at(row)
+        row["activity_count"] = activity_count(row)
+        row["provenance"] = provenance(name)
+        rows.append(row)
+    if include_archived:
+        active_names = {row["name"] for row in rows}
+        for row in archived_report():
+            if row["name"] not in active_names:
+                rows.append(row)
+    return rows
+
+
+def archived_report() -> List[Dict[str, Any]]:
+    """Return curator-managed archived skills with their last-known stats.
+
+    This is deliberately a separate filesystem scan from active discovery:
+    ``.archive`` is excluded from ``agent.skill_utils``' normal ``rglob``
+    traversal. Archived rows are marked ``state=archived`` for the reviewer,
+    even if an older sidecar record still says ``active``.
+    """
+    data = load_usage()
+    hub = _read_hub_installed_names()
+    bundled = _read_bundled_manifest_names()
+    prune_builtins = _prune_builtins_enabled()
+    rows: List[Dict[str, Any]] = []
+    seen: Set[str] = set()
+
+    for skill_md in _iter_archived_skill_files():
+        name = _read_skill_name(skill_md, fallback=skill_md.parent.name)
+        if not name or name in seen or name in hub or is_protected_builtin(name):
+            continue
+        raw = data.get(name)
+        if is_absorbed_record(raw):
+            continue
+        if name in bundled:
+            if not prune_builtins:
+                continue
+        elif not _is_curator_managed_record(raw):
+            continue
+
+        seen.add(name)
+        rec: Dict[str, Any] = dict(raw) if isinstance(raw, dict) else _empty_record()
+        for key, value in _empty_record().items():
+            rec.setdefault(key, value)
+        row = {"name": name, **rec, "_persisted": isinstance(raw, dict)}
+        row["state"] = STATE_ARCHIVED
+        row["archive_path"] = str(skill_md.relative_to(_skills_dir()))
         row["last_activity_at"] = latest_activity_at(row)
         row["activity_count"] = activity_count(row)
         row["provenance"] = provenance(name)

--- a/website/docs/user-guide/features/curator.md
+++ b/website/docs/user-guide/features/curator.md
@@ -54,10 +54,11 @@ curator:
   stale_after_days: 30
   archive_after_days: 90
   consolidate: false           # LLM umbrella-building pass — opt-in (prune-only by default)
+  consolidate_archived: false  # also review recoverable packages in .archive/
   prune_builtins: true         # archive unused bundled built-in skills too (hub skills always exempt)
 ```
 
-To disable entirely, set `curator.enabled: false`. To keep the always-on pruning but opt into LLM consolidation, set `curator.consolidate: true`.
+To disable entirely, set `curator.enabled: false`. To keep the always-on pruning but opt into LLM consolidation, set `curator.consolidate: true`. Archived packages are included only when `curator.consolidate_archived: true`; absorbed packages retain a durable sidecar marker so they are not merged repeatedly.
 
 ### Running the review on a cheaper aux model
 


### PR DESCRIPTION
## Curator: archived skills enter consolidation + durable absorbed guard

Closes #77264 — both phases.

### Phase 1: archived skills are consolidation candidates

`curated_report(include_archived=True)` now scans `.archive/` alongside the active tree. Archived skills appear in the candidate list marked `state=archived`, with their last-known usage stats, so the LLM consolidation pass can merge dormant knowledge into live umbrellas instead of letting it rot (or worse, letting the agent re-create a near-identical skill from scratch — the #67582 duplicate problem).

Gated by `curator.consolidate_archived: true` (default **false**, so existing consolidate behavior is unchanged when off).

### Phase 2: durable `absorbed` guard (prevents infinite re-merging)

Today `absorbed_into=<umbrella>` was only a transient argument at delete time — an absorbed skill could be re-scanned on every run and merged into yet another umbrella (duplicated content, wasted LLM calls, drift).

This adds:
- `STATE_ABSORBED` / `absorbed_into` persisted durably in the skill usage store, written atomically at consolidation time.
- The candidate list builder **filters out any absorbed skill** regardless of active/archived/restored state.
- The marker survives archive/restore cycles — a restored absorbed skill stays hidden until `curator adopt` (or manual unmark) clears it.

### Other
- Cron references rewritten the same way the existing consolidate pass handles them (#26326).
- Config default + docs updated (`consolidate_archived`, sidecar marker behavior).

### Verification
- **39 curator tests pass** (`test_curator.py`, `test_curator_activity.py`, `test_curator_classification.py`, `test_curator_archived_skills.py`).
- 4 new tests cover: archived candidate appears, absorbed filtered from future passes, marker survives archive/restore until adopt, config gating.
- Windows-path assertion made separator-agnostic (`.archive/` vs `.archive\`).

Default behavior unchanged (`curator.consolidate: false` / `consolidate_archived: false` → prune-only, exactly as before).
