### PR TITLE
fix(insights): close databases after failures

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5171,11 +5171,12 @@ class GatewaySlashCommandsMixin:
 
             def _run_insights():
                 db = SessionDB()
-                engine = InsightsEngine(db)
-                report = engine.generate(days=days, source=source)
-                result = engine.format_gateway(report)
-                db.close()
-                return result
+                try:
+                    engine = InsightsEngine(db)
+                    report = engine.generate(days=days, source=source)
+                    return engine.format_gateway(report)
+                finally:
+                    db.close()
 
             return await loop.run_in_executor(None, _run_insights)
         except Exception as e:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11085,6 +11085,7 @@ def cmd_tools(args):
 
 
 def cmd_insights(args):
+    db = None
     try:
         from hermes_state import SessionDB
         from agent.insights import InsightsEngine
@@ -11093,9 +11094,14 @@ def cmd_insights(args):
         engine = InsightsEngine(db)
         report = engine.generate(days=args.days, source=args.source)
         print(engine.format_terminal(report))
-        db.close()
     except Exception as e:
         print(f"Error generating insights: {e}")
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
 
 
 def cmd_monitoring(args):

--- a/tests/gateway/test_insights_db_cleanup.py
+++ b/tests/gateway/test_insights_db_cleanup.py
@@ -1,0 +1,46 @@
+"""SessionDB lifecycle coverage for the gateway /insights command."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.slash_commands import GatewaySlashCommandsMixin
+
+
+class _InsightsEvent:
+    def get_command_args(self):
+        return ""
+
+
+def _install_insights(monkeypatch, db, engine):
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+    monkeypatch.setattr("agent.insights.InsightsEngine", lambda _db: engine)
+
+
+@pytest.mark.asyncio
+async def test_gateway_insights_closes_session_db_after_success(monkeypatch):
+    db = MagicMock()
+    engine = MagicMock()
+    engine.generate.return_value = {"summary": "ok"}
+    engine.format_gateway.return_value = "formatted"
+    _install_insights(monkeypatch, db, engine)
+    handler = object.__new__(GatewaySlashCommandsMixin)
+
+    result = await handler._handle_insights_command(_InsightsEvent())
+
+    assert result == "formatted"
+    db.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_gateway_insights_closes_session_db_after_failure(monkeypatch):
+    db = MagicMock()
+    engine = MagicMock()
+    engine.generate.side_effect = RuntimeError("analytics failed")
+    _install_insights(monkeypatch, db, engine)
+    handler = object.__new__(GatewaySlashCommandsMixin)
+
+    result = await handler._handle_insights_command(_InsightsEvent())
+
+    assert "analytics failed" in result
+    db.close.assert_called_once_with()

--- a/tests/hermes_cli/test_cmd_insights_cleanup.py
+++ b/tests/hermes_cli/test_cmd_insights_cleanup.py
@@ -1,0 +1,37 @@
+"""SessionDB lifecycle coverage for the CLI insights command."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from hermes_cli.main import cmd_insights
+
+
+def _args():
+    return SimpleNamespace(days=30, source=None)
+
+
+def test_cmd_insights_closes_database_after_success(monkeypatch, capsys):
+    db = MagicMock()
+    engine = MagicMock()
+    engine.generate.return_value = {"summary": "ok"}
+    engine.format_terminal.return_value = "formatted"
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+    monkeypatch.setattr("agent.insights.InsightsEngine", lambda _db: engine)
+
+    cmd_insights(_args())
+
+    assert capsys.readouterr().out.strip() == "formatted"
+    db.close.assert_called_once_with()
+
+
+def test_cmd_insights_closes_database_after_failure(monkeypatch, capsys):
+    db = MagicMock()
+    engine = MagicMock()
+    engine.generate.side_effect = RuntimeError("analytics failed")
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+    monkeypatch.setattr("agent.insights.InsightsEngine", lambda _db: engine)
+
+    cmd_insights(_args())
+
+    assert "analytics failed" in capsys.readouterr().out
+    db.close.assert_called_once_with()


### PR DESCRIPTION
## What does this PR do?

Closes `SessionDB` reliably for both user-facing Insights entry points:

- `hermes insights`
- Gateway `/insights`

Both paths previously closed the database only after successful generation and
formatting. Any exception after construction leaked the SQLite connection for
the lifetime of the process.

The CLI now closes in `finally` while preserving its existing error output.
The Gateway worker does the same while preserving the existing slash-command
error response.

This consolidates the sibling Gateway fix from #77750 into one complete
Insights lifecycle change.

## Current-main reproduction

The same two failure-path tests were run against production code from current
`main` at `e5e96e8bb`:

```text
scripts/run_tests.sh \
  tests/hermes_cli/test_cmd_insights_cleanup.py \
  tests/gateway/test_insights_db_cleanup.py \
  -k after_failure -q

# 2 failed: db.close() called 0 times in both CLI and Gateway
```

Both pass with this PR.

## Verification

```text
scripts/run_tests.sh \
  tests/agent/test_insights.py \
  tests/cli/test_cli_insights_command.py \
  tests/gateway/test_insights_db_cleanup.py \
  tests/gateway/test_insights_unicode_flags.py \
  tests/hermes_cli/test_cmd_insights_cleanup.py -q
# 51 passed

uv run ruff check \
  hermes_cli/main.py gateway/slash_commands.py \
  tests/hermes_cli/test_cmd_insights_cleanup.py \
  tests/gateway/test_insights_db_cleanup.py
# All checks passed

.venv/bin/python scripts/check-windows-footguns.py --diff origin/main
# No Windows footguns found

git diff --check
# passed
```

## Scope

No Insights generation, formatting, argument parsing, or error-message
behavior changes. The diff only makes database ownership exception-safe and
adds lifecycle coverage for both public entry points.
