### PR TITLE
fix(error_classifier): treat Z.AI 1305 overload as overloaded, not rate_limit

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4195,6 +4195,44 @@ def _recoverable_pool_provider(
     return None
 
 
+def _is_overloaded_error(exc: Exception) -> bool:
+    """Detect provider "temporarily overloaded" responses.
+
+    These reuse HTTP 429 (notably Z.AI / Zhipu error code 1305) but are
+    server-side capacity conditions, NOT per-credential rate limits: the key is
+    valid and the correct recovery is backoff / fallback, never marking the
+    credential exhausted. Shares the pattern and code tables with
+    ``error_classifier`` so both layers classify identically. (#14038)
+    """
+    try:
+        from agent.error_classifier import (
+            _OVERLOADED_PATTERNS,
+            _OVERLOAD_ERROR_CODES,
+        )
+    except Exception:
+        return False
+
+    text = str(exc).lower()
+    code = ""
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        err_obj = body.get("error")
+        msg = ""
+        if isinstance(err_obj, dict):
+            code = str(err_obj.get("code") or "").strip()
+            msg = str(err_obj.get("message") or "")
+        if not code:
+            code = str(body.get("code") or "").strip()
+        if not msg:
+            msg = str(body.get("message") or "")
+        if msg:
+            text = f"{text} {msg.lower()}"
+
+    if code and code in _OVERLOAD_ERROR_CODES:
+        return True
+    return any(p in text for p in _OVERLOADED_PATTERNS)
+
+
 def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str = "") -> bool:
     """Try same-provider credential-pool recovery for auxiliary calls.
 
@@ -4215,6 +4253,20 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
     status_code = getattr(exc, "status_code", None)
     error_context = _pool_error_context(exc)
     hint = failed_api_key or None
+
+    # A provider "temporarily overloaded" response (e.g. Z.AI / Zhipu HTTP 429
+    # code 1305) is not a credential failure -- the key is valid, the endpoint
+    # is merely busy. Marking it exhausted burns the pool while the endpoint is
+    # still overloaded and, for a single-key user, leaves nothing to rotate to
+    # (the exact failure #14038 describes). Leave the credential intact and let
+    # the caller retry / fall back.
+    if _is_overloaded_error(exc):
+        logger.info(
+            "Auxiliary client: %s reported a transient overload (not a "
+            "credential rate limit) -- leaving credential intact, no rotation",
+            normalized,
+        )
+        return False
 
     if _is_auth_error(exc):
         refreshed = pool.try_refresh_current()

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -192,7 +192,31 @@ _OVERLOADED_PATTERNS = [
     "currently overloaded",
     "at capacity",
     "over capacity",
+    # Localized (zh-CN) overload text. Z.AI / Zhipu return the code-1305
+    # overload message in Chinese depending on account locale, so none of the
+    # English patterns above match and a server-side overload still burned the
+    # credential pool -- the exact failure #14038 set out to fix.
+    # Deliberately EXCLUDES "请求过于频繁" (requests too frequent) and the
+    # generic "请稍后再试" (try again later), which also appear on genuine
+    # per-credential rate limits and must keep rotating. (#14038)
+    "访问量过大",          # "traffic volume too large" -- Z.AI 1305
+    "服务器繁忙",          # "server busy"
+    "系统繁忙",            # "system busy"
 ]
+
+# Provider error codes that mean "the server is temporarily overloaded", not
+# "this credential is rate-limited". Matching the numeric code is
+# locale-independent, so classification holds regardless of the account's
+# message language.
+#
+# Z.AI / Zhipu (all surfaced as HTTP 429):
+#   1305 -> "service may be temporarily overloaded"  => overload, retry same key
+#   1302 -> "rate limit reached for requests"        => genuine rate limit
+#   1313 -> fair-usage throttle                      => genuine rate limit
+#   1308 / 1310 / 1316-1321 -> usage & spend limits  => quota/billing
+# Only 1305 is a server-capacity condition; the rest must keep their existing
+# (rotating / billing) behavior. (#14038)
+_OVERLOAD_ERROR_CODES = {"1305"}
 
 # Usage-limit patterns that need disambiguation (could be billing OR rate_limit)
 _USAGE_LIMIT_PATTERNS = [
@@ -1089,6 +1113,17 @@ def _classify_by_status(
         # endpoint is still busy, and does nothing for a single-key user).
         # Disambiguate on the error body so an overload 429 takes the
         # transient-overload path instead of burning the pool. (#14038)
+        #
+        # Check the structured error code FIRST: it is locale-independent,
+        # whereas the message text is localized per account (Z.AI returns the
+        # 1305 overload message in Chinese for zh-CN accounts, which no
+        # English pattern matches -- leaving the original bug live for the
+        # very provider that motivated the fix).
+        if error_code.strip() in _OVERLOAD_ERROR_CODES:
+            return result_fn(
+                FailoverReason.overloaded,
+                retryable=True,
+            )
         if any(p in error_msg for p in _OVERLOADED_PATTERNS):
             return result_fn(
                 FailoverReason.overloaded,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1050,3 +1050,67 @@ class TestExpandedOverflowPatterns:
 
 
 
+
+
+class TestZaiLocalizedOverload:
+    """Z.AI returns HTTP 429 code 1305 for server-side overload, with the
+    message localized per account. The English-only _OVERLOADED_PATTERNS from
+    #53578 never matched the zh-CN text, so a transient provider overload was
+    still classified as rate_limit -- rotating and exhausting the pool, which
+    is fatal for a single-key user. (#14038)"""
+
+    def test_429_code_1305_chinese_message_is_overloaded(self):
+        """The real-world failure: code 1305 + Chinese body."""
+        e = MockAPIError(
+            "Error code: 429 - {'error': {'code': '1305', "
+            "'message': '该模型当前访问量过大，请您稍后再试'}}",
+            status_code=429,
+            body={"error": {"code": "1305",
+                            "message": "该模型当前访问量过大，请您稍后再试"}},
+        )
+        result = classify_api_error(e, provider="zai", model="glm-4.6v-flash")
+        assert result.reason == FailoverReason.overloaded
+        assert result.retryable is True
+        assert result.should_rotate_credential is False
+
+    def test_429_code_1305_classifies_by_code_even_without_known_text(self):
+        """Code-based match must hold even if the message is unrecognized."""
+        e = MockAPIError(
+            "Error code: 429",
+            status_code=429,
+            body={"error": {"code": "1305", "message": "\u2014"}},
+        )
+        result = classify_api_error(e, provider="zai")
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_rotate_credential is False
+
+    def test_429_chinese_overload_text_without_code_is_overloaded(self):
+        """Text net: localized overload phrasing with no structured code."""
+        e = MockAPIError(
+            "该模型当前访问量过大，请您稍后再试",
+            status_code=429,
+        )
+        result = classify_api_error(e, provider="zai")
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_rotate_credential is False
+
+    def test_429_code_1302_is_still_a_genuine_rate_limit(self):
+        """Guard: 1302 IS a real per-credential rate limit -- must still rotate."""
+        e = MockAPIError(
+            "Error code: 429 - {'error': {'code': '1302', "
+            "'message': 'Rate limit reached for requests'}}",
+            status_code=429,
+            body={"error": {"code": "1302",
+                            "message": "Rate limit reached for requests"}},
+        )
+        result = classify_api_error(e, provider="zai")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+
+    def test_429_chinese_too_frequent_is_rate_limit_not_overload(self):
+        """Guard: "请求过于频繁" (too many requests) is a genuine rate
+        limit and must NOT be swallowed by the localized overload patterns."""
+        e = MockAPIError("请求过于频繁，请稍后再试", status_code=429)
+        result = classify_api_error(e, provider="zai")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True


### PR DESCRIPTION
### Problem

#53578 added `_OVERLOADED_PATTERNS` so a 429 carrying overload language takes the transient-overload path instead of rotating the credential.

The pattern list is **English-only**, but Z.AI / Zhipu return the code-1305 overload message localized depending on account locale:

```
429 - {'error': {'code': '1305', 'message': '该模型当前访问量过大，请您稍后再试'}}
```

None of the English patterns match that text, so the provider that motivated #53578 still falls through to `rate_limit` and exhausts the pool after two errors — fatal for a single-key user, who has nothing to rotate to.

Per Z.AI's error reference, `1305` is *"the service may be temporarily overloaded, please try again later"* — a server-side capacity condition, not a per-credential rate limit.

### Production impact

A transient Z.AI overload on `glm-4.6v-flash` marked a barely-used `GLM_API_KEY` exhausted, collapsed the pool to `no available entries`, and fell back to a text-only model that rejects `image_url`:

```
credential pool: marking GLM_API_KEY exhausted (status=429), rotating
credential pool: no available entries (all exhausted or empty)
Auxiliary vision: rate limit on zai — falling back to main agent model (deepseek-v4-flash-free)
... 400 unknown variant `image_url`, expected `text`
```

The user-visible result was vision silently degrading to OCR, on a key that had barely been used.

### Fix

**1. `error_classifier` — classify on the structured error code first.**

The code is locale-independent, so classification no longer depends on the account's message language. Only `1305` is treated as overload; the other Z.AI 429 codes keep their existing behavior:

| Code | Meaning | Behavior |
|---|---|---|
| `1305` | service temporarily overloaded | **overload** — retry, keep credential |
| `1302`, `1313` | rate limit / fair-usage throttle | rate_limit — rotate (unchanged) |
| `1308`, `1310`, `1316`–`1321` | usage & spend limits | quota/billing (unchanged) |

The zh-CN overload phrasings are also added to `_OVERLOADED_PATTERNS` as a secondary net. This deliberately **excludes** `请求过于频繁` ("requests too frequent") and the generic `请稍后再试` ("try again later"), which also appear on genuine rate limits and must keep rotating.

**2. `auxiliary_client` — the auxiliary path never consulted the classifier.**

Vision / `web_extract` / compression / cron go through `_is_rate_limit_error()`, which returns `True` for any `openai` `RateLimitError` *before* inspecting the message:

```python
if type(exc).__name__ == "RateLimitError":
    return True
```

So a 1305 burned the pool there regardless of fix (1) — this is the path that actually broke vision in the report above. `_recover_provider_pool`, the single choke point for auxiliary pool marking, now leaves the credential intact on an overload and lets the caller retry / fall back. It shares the pattern and code tables with `error_classifier` so both layers classify identically.

### Tests

5 regression tests added covering:

- the localized 1305 body (the real-world failure)
- code-based classification when the message text is unrecognizable
- localized overload text with no structured code
- **guards**: `1302` and `请求过于频繁` must still classify as `rate_limit` and still rotate

```
tests/agent/test_error_classifier.py .......... 74 passed
```

`test_credential_pool_routing.py` reports 2 failures (`test_resolve_turn_includes_pool`, `test_unmatched_key_does_not_retry_only_pool_entry`) — these are **pre-existing on `main`** and unrelated to this change; verified identical with and without it by stashing.

The change is purely additive (+151 lines, no deletions, no behavior removed).

Refs #14038
