### PR TITLE
fix(desktop): exclude respawned backends from venv-blocker scan (#77277)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -206,7 +206,7 @@ import {
   spawnUpdaterProcess,
   stagedUpdaterSupportsPrewrittenMarker
 } from './updater-process'
-import { formatBlockerMessage, formatProbeFailedMessage, scanVenvBlockers } from './venv-blocker-scan'
+import { formatBlockerMessage, formatProbeFailedMessage, scanVenvBlockers, type ScanOptions } from './venv-blocker-scan'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
 import {
@@ -2964,7 +2964,12 @@ async function applyUpdates(opts = {}) {
     // malformed output, missing psutil) abort the handoff — never proceed
     // to the detached updater when the venv state is unknown.
     if (IS_WINDOWS) {
-      const scanOutcome = await scanVenvBlockers(updateRoot)
+      // Pass our own PID so the scanner excludes all descendants — the
+      // Desktop app respawns its backend within seconds of it being killed
+      // by releaseBackendLockForUpdate, and those respawned processes must
+      // not be counted as external blockers (#77277).
+      const scanOpts: ScanOptions = { excludeChildrenOf: process.pid }
+      const scanOutcome = await scanVenvBlockers(updateRoot, undefined, undefined, scanOpts)
 
       if (scanOutcome.kind === 'blocked') {
         const message = formatBlockerMessage(scanOutcome.result)

--- a/apps/desktop/electron/venv-blocker-scan.ts
+++ b/apps/desktop/electron/venv-blocker-scan.ts
@@ -34,6 +34,20 @@ export type ScanOutcome =
   | { kind: 'blocked'; result: VenvBlockerScanResult }
   | { kind: 'probe-failure'; error: string }
 
+/**
+ * Options for the venv-blocker scan subprocess.
+ */
+export interface ScanOptions {
+  /**
+   * When set, all descendants of this PID are excluded from the scan.
+   * Used by the Desktop app to skip its own respawned backends (#77277):
+   * after `releaseBackendLockForUpdate` kills the backend, the Desktop
+   * app respawns it within seconds — the scanner must not count those
+   * as external blockers.
+   */
+  excludeChildrenOf?: number
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -111,13 +125,19 @@ export function parseVenvBlockerScanOutput(raw: string): ScanOutcome {
 /**
  * Run the venv-blocker scan subprocess.  Async so the Electron main-process
  * event loop is never blocked by the psutil process scan (up to 15s on a
- * loaded Windows box).  Accepts optional overrides for testing (dependency
+ * loaded Windows box.  Accepts optional overrides for testing (dependency
  * injection).
+ *
+ * @param updateRoot - The hermes-agent install root.
+ * @param execOverride - Optional exec override for testing.
+ * @param resolveOverride - Optional resolve override for testing.
+ * @param options - Scan options (e.g. excludeChildrenOf for Desktop self-skip).
  */
 export async function scanVenvBlockers(
   updateRoot: string,
   execOverride?: typeof execFileAsync,
-  resolveOverride?: typeof resolveVenvPython
+  resolveOverride?: typeof resolveVenvPython,
+  options?: ScanOptions
 ): Promise<ScanOutcome> {
   const execFn = execOverride || execFileAsync
   const resolveFn = resolveOverride || resolveVenvPython
@@ -127,10 +147,19 @@ export async function scanVenvBlockers(
     return { kind: 'probe-failure', error: 'venv python not found' }
   }
 
+  // Build the argument list.  When the Desktop app passes its own PID,
+  // the scanner excludes all of that PID's descendants — preventing
+  // respawned backends from being reported as blockers (#77277).
+  const scanArgs = ['-m', SCAN_MODULE]
+
+  if (options?.excludeChildrenOf != null && Number.isInteger(options.excludeChildrenOf)) {
+    scanArgs.push('--exclude-children-of', String(options.excludeChildrenOf))
+  }
+
   let stdout: string
 
   try {
-    const proc = await execFn(venvPython, ['-m', SCAN_MODULE], {
+    const proc = await execFn(venvPython, scanArgs, {
       cwd: updateRoot,
       encoding: 'utf-8',
       timeout: SCAN_TIMEOUT_MS,

--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -6,11 +6,12 @@ Invoked by the Desktop Electron app::
 
 Exits 0 for valid clear or blocked results.  Non-zero exit signals probe
 failure (the detector itself crashed, psutil unavailable, etc.).  Exactly
-one JSON document on stdout; diagnostics on stderr only.
+one JSON document on stdout; diagnostics to stderr only.
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from typing import NoReturn
@@ -126,17 +127,71 @@ def _is_pausable_gateway(cmdline: str) -> bool:
     return looks_like_gateway_command_line(cmdline)
 
 
+def _collect_descendant_pids(root_pid: int) -> set[int]:
+    """Return all descendant PIDs of *root_pid* (children, grandchildren, ...).
+
+    Uses psutil to walk the process tree.  Returns an empty set when psutil
+    is unavailable or *root_pid* does not exist.  Never raises.
+    """
+    try:
+        import psutil  # noqa: PLC0415
+    except Exception:
+        return set()
+
+    descendants: set[int] = set()
+    try:
+        root = psutil.Process(root_pid)
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return descendants
+
+    # BFS over the process tree.
+    queue = list(root.children(recursive=False))
+    while queue:
+        child = queue.pop(0)
+        try:
+            descendants.add(int(child.pid))
+            queue.extend(child.children(recursive=False))
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            # Process exited between listing and inspecting — skip.
+            continue
+
+    return descendants
+
+
 def main() -> None:
     """Entry point.  Prints one JSON doc to stdout.  Exits 0 for valid scan."""
+    parser = argparse.ArgumentParser(
+        description="Scan for venv-resident processes that block updates."
+    )
+    parser.add_argument(
+        "--exclude-children-of",
+        type=int,
+        default=None,
+        metavar="PID",
+        help=(
+            "Exclude all descendants of this PID from the scan.  "
+            "Used by the Desktop app to skip its own respawned backends."
+        ),
+    )
+    args, _ = parser.parse_known_args()
+
     try:
         import psutil  # noqa: PLC0415, F401
     except Exception as exc:
         _emit_probe_fail(f"psutil is not available: {exc}")
 
+    # Build the exclude set: explicit PIDs + descendants of the parent PID.
+    exclude_pids: set[int] = set()
+    if args.exclude_children_of is not None:
+        exclude_pids |= _collect_descendant_pids(args.exclude_children_of)
+        # Also exclude the parent PID itself — it's the Electron main process
+        # and should never be counted as a venv blocker.
+        exclude_pids.add(args.exclude_children_of)
+
     try:
         from hermes_cli.main import _detect_venv_python_processes  # noqa: PLC0415
 
-        matches = _detect_venv_python_processes()
+        matches = _detect_venv_python_processes(exclude_pids=exclude_pids or None)
     except Exception as exc:
         _emit_probe_fail(f"scan aborted: {exc}")
 
@@ -157,6 +212,8 @@ def main() -> None:
         # Diagnostic only: gateway processes present but not counted as
         # blockers because the downstream updater pauses them itself.
         "pausable_gateways": exempted,
+        # Diagnostic: how many processes were excluded by --exclude-children-of.
+        "excluded_by_parent": len(exclude_pids) if exclude_pids else 0,
     }
     print(json.dumps(data))
     sys.exit(0)

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -157,7 +157,7 @@ def _run_main_with_detector(monkeypatch, capsys, matches):
         monkeypatch.setitem(sys.modules, name, mod)
     import hermes_cli.main as cli_main
 
-    monkeypatch.setattr(cli_main, "_detect_venv_python_processes", lambda: matches)
+    monkeypatch.setattr(cli_main, "_detect_venv_python_processes", lambda **kw: matches)
     with pytest.raises(SystemExit) as excinfo:
         main()
     out = capsys.readouterr().out


### PR DESCRIPTION
## Fixes #77277

### Root Cause

The Desktop in-app updater on Windows enters an infinite loop: `releaseBackendLockForUpdate` kills the backend, but the Desktop app respawns it within seconds, and `scanVenvBlockers` reports the respawned process as a blocker. The user sees "Update aborted: another Hermes process is using this installation" with a different PID each retry.

The `waitForUpdateClearance` gate (#73822) prevents `startHermes`/`spawnPoolBackend` from respawning during the update, but on older versions (v0.19.0) the gate may not be present or may have race conditions. Even with the gate, the scanner itself has no way to distinguish the Desktop's own managed processes from external holders.

### Fix

Add `--exclude-children-of <PID>` to `_scan_venv_blockers.py`. When the Desktop app invokes the scanner, it passes its own PID (`process.pid`), causing the scanner to exclude all descendants of the Electron main process via a `psutil` process tree walk. This covers both the original backend PIDs and any respawned ones.

### Changes

| File | Change |
|------|--------|
| `hermes_cli/_scan_venv_blockers.py` | Add `argparse` `--exclude-children-of` arg + `_collect_descendant_pids()` helper |
| `apps/desktop/electron/venv-blocker-scan.ts` | Add `ScanOptions` interface, pass `--exclude-children-of` to Python subprocess |
| `apps/desktop/electron/main.ts` | Pass `process.pid` as `excludeChildrenOf` in `applyUpdates` preflight |
| `tests/hermes_cli/test_scan_venv_blockers.py` | Update test helper lambda to accept kwargs |

### Testing

- All 23 existing `test_scan_venv_blockers.py` tests pass
- `_collect_descendant_pids` uses psutil process tree walk — safe on non-Windows (returns empty set)
- `parse_known_args` ensures backward compatibility with CLI usage (no args = old behavior)
