### PR TITLE
fix(approval): render long commands fully in approval panel (#77764)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13257,6 +13257,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     smart_denied=smart_denied,
                 ),
                 "selected": 0,
+                # Full-command view viewport: scroll offset for commands too
+                # long to fit the panel; _cmd_overflow is set by the renderer
+                # when scrolling is active (#77764).
+                "_cmd_scroll": 0,
+                "_cmd_overflow": False,
                 "response_queue": response_queue,
             }
             self._approval_deadline = _time.monotonic() + timeout
@@ -13353,6 +13358,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         chosen = choices[selected]
         if chosen == "view":
             state["show_full"] = True
+            # Reset the full-command viewport; re-entering view always starts
+            # at the top of the command (#77764).
+            state["_cmd_scroll"] = 0
+            state["_cmd_overflow"] = False
             state["choices"] = [choice for choice in choices if choice != "view"]
             if state["selected"] >= len(state["choices"]):
                 state["selected"] = max(0, len(state["choices"]) - 1)
@@ -13482,15 +13491,40 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         chrome_rows = chrome_tight if use_compact_chrome else chrome_full
 
         # If the command itself is too long to leave room for choices (e.g. user
-        # hit "view" on a multi-hundred-character command), truncate it so the
-        # approve/deny buttons still render. Keep at least 1 row of command.
+        # hit "view" on a multi-hundred-character command), the approve/deny
+        # buttons must still render. Preview mode truncates; full-view mode
+        # scrolls the command viewport (↑/↓, PgUp/PgDn) so the complete command
+        # stays reviewable before approving (#77764).
         max_cmd_rows = max(1, available - chrome_rows - len(choice_wrapped))
-        if len(cmd_wrapped) > max_cmd_rows:
-            keep = max(1, max_cmd_rows - 1) if max_cmd_rows > 1 else 1
-            cmd_wrapped = cmd_wrapped[:keep] + _wrap_panel_text(
-                "… (command truncated — use /logs or /debug for full text)",
-                inner_text_width,
-            )
+        cmd_overflow = len(cmd_wrapped) > max_cmd_rows
+        if cmd_overflow:
+            if show_full:
+                # Scrollable full view: render the slice that fits and record
+                # the viewport metrics so the arrow-key bindings can scroll.
+                hint_rows = 1 if max_cmd_rows > 2 else 0
+                view_rows = max(1, max_cmd_rows - hint_rows)
+                total_lines = len(cmd_wrapped)
+                max_scroll = max(0, total_lines - view_rows)
+                scroll = max(0, min(state.get("_cmd_scroll", 0), max_scroll))
+                state["_cmd_scroll"] = scroll
+                state["_cmd_overflow"] = True
+                state["_cmd_total_lines"] = total_lines
+                state["_cmd_visible_lines"] = view_rows
+                cmd_wrapped = cmd_wrapped[scroll:scroll + view_rows]
+                if hint_rows:
+                    cmd_wrapped = cmd_wrapped + _wrap_panel_text(
+                        f"▲▼ {scroll + 1}–{scroll + view_rows}/{total_lines} (1–9 approve/deny)",
+                        inner_text_width,
+                    )
+            else:
+                state["_cmd_overflow"] = False
+                keep = max(1, max_cmd_rows - 1) if max_cmd_rows > 1 else 1
+                cmd_wrapped = cmd_wrapped[:keep] + _wrap_panel_text(
+                    "… (command truncated — use /logs or /debug for full text)",
+                    inner_text_width,
+                )
+        else:
+            state["_cmd_overflow"] = False
 
         # Allocate any remaining rows to description. The extra -1 in full mode
         # accounts for the blank separator between choices and description.
@@ -15712,16 +15746,55 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         @kb.add('up', filter=Condition(lambda: bool(self._approval_state)))
         def approval_up(event):
-            if self._approval_state:
-                self._approval_state["selected"] = max(0, self._approval_state["selected"] - 1)
+            state = self._approval_state
+            if not state:
+                return
+            if state.get("show_full") and state.get("_cmd_overflow"):
+                # Full-command view: ↑ scrolls the command; number keys decide.
+                state["_cmd_scroll"] = max(0, state.get("_cmd_scroll", 0) - 1)
                 event.app.invalidate()
+                return
+            state["selected"] = max(0, state["selected"] - 1)
+            event.app.invalidate()
 
         @kb.add('down', filter=Condition(lambda: bool(self._approval_state)))
         def approval_down(event):
-            if self._approval_state:
-                max_idx = len(self._approval_state["choices"]) - 1
-                self._approval_state["selected"] = min(max_idx, self._approval_state["selected"] + 1)
+            state = self._approval_state
+            if not state:
+                return
+            if state.get("show_full") and state.get("_cmd_overflow"):
+                # Full-command view: ↓ scrolls the command; number keys decide.
+                total = state.get("_cmd_total_lines", 0)
+                visible = state.get("_cmd_visible_lines", 1)
+                max_scroll = max(0, total - visible)
+                state["_cmd_scroll"] = min(max_scroll, state.get("_cmd_scroll", 0) + 1)
                 event.app.invalidate()
+                return
+            max_idx = len(state["choices"]) - 1
+            state["selected"] = min(max_idx, state["selected"] + 1)
+            event.app.invalidate()
+
+        @kb.add('pageup', filter=Condition(lambda: bool(self._approval_state)))
+        def approval_pageup(event):
+            state = self._approval_state
+            if not state or not (state.get("show_full") and state.get("_cmd_overflow")):
+                return
+            # Page-scroll the full-command view; number keys still decide.
+            step = max(1, state.get("_cmd_visible_lines", 1) - 1)
+            state["_cmd_scroll"] = max(0, state.get("_cmd_scroll", 0) - step)
+            event.app.invalidate()
+
+        @kb.add('pagedown', filter=Condition(lambda: bool(self._approval_state)))
+        def approval_pagedown(event):
+            state = self._approval_state
+            if not state or not (state.get("show_full") and state.get("_cmd_overflow")):
+                return
+            total = state.get("_cmd_total_lines", 0)
+            visible = state.get("_cmd_visible_lines", 1)
+            max_scroll = max(0, total - visible)
+            step = max(1, visible - 1)
+            state["_cmd_scroll"] = min(max_scroll, state.get("_cmd_scroll", 0) + step)
+            event.app.invalidate()
 
         # --- Slash-command confirmation: arrow-key navigation ---
         @kb.add('up', filter=Condition(lambda: bool(self._slash_confirm_state)))

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -147,11 +147,12 @@ class TestCliApprovalUi:
 
 
 
-    def test_approval_display_truncates_giant_command_in_view_mode(self):
+    def test_approval_display_scrolls_giant_command_in_view_mode(self):
         """If the user hits /view on a massive command, choices still render.
 
-        The command gets truncated with a marker; the description gets dropped
-        if there's no remaining row budget.
+        The command is no longer truncated with a marker: full-view mode
+        scrolls the command viewport (↑/↓, PgUp/PgDn) so the complete command
+        stays reviewable before approving (#77764).
         """
         cli = _make_cli_stub()
         # 50 lines of command when wrapped at ~64 chars.
@@ -178,8 +179,78 @@ class TestCliApprovalUi:
                       "Add to permanent allowlist", "Deny"):
             assert label in rendered, f"choice {label!r} missing"
 
-        # Command got truncated with a marker.
-        assert "(command truncated" in rendered
+        # The command is NOT truncated — the viewport scrolls instead, and the
+        # viewport metrics are recorded for the arrow-key bindings.
+        assert "(command truncated" not in rendered
+        assert "approve/deny" in rendered
+        assert cli._approval_state["_cmd_overflow"] is True
+        assert cli._approval_state["_cmd_scroll"] == 0
+        assert cli._approval_state["_cmd_total_lines"] > 1
+
+    def test_approval_display_scrolls_command_viewport_to_end(self):
+        """Scrolling the full-command viewport reveals the command tail.
+
+        The rendered slice tracks _cmd_scroll, the scroll hint reflects the
+        visible range, and out-of-range offsets clamp to the last line, so a
+        multi-hundred-character command is fully reviewable (#77764).
+        """
+        cli = _make_cli_stub()
+        giant_cmd = "bash -c 'echo " + ("x" * 3000) + "'"
+        cli._approval_state = {
+            "command": giant_cmd,
+            "description": "shell command via -c/-lc flag",
+            "choices": ["once", "session", "always", "deny"],
+            "selected": 0,
+            "show_full": True,
+            "response_queue": queue.Queue(),
+        }
+
+        import shutil as _shutil
+
+        term_size = _shutil.os.terminal_size((100, 24))
+        with patch("cli.shutil.get_terminal_size", return_value=term_size):
+            cli._get_approval_display_fragments()
+
+        total = cli._approval_state["_cmd_total_lines"]
+        visible = cli._approval_state["_cmd_visible_lines"]
+        assert total > visible
+
+        # Scroll to the end: the hint reports the last visible range and the
+        # command tail renders.
+        cli._approval_state["_cmd_scroll"] = total - visible
+        with patch("cli.shutil.get_terminal_size", return_value=term_size):
+            fragments = cli._get_approval_display_fragments()
+        rendered = "".join(text for _style, text in fragments)
+        expected_hint = f"▲▼ {total - visible + 1}–{total}/{total}"
+        assert expected_hint in rendered
+        # The command body (x-filled wrapped lines) renders in the tail slice.
+        assert "xxx" in rendered
+
+        # Overflowing scroll positions clamp to the last line.
+        cli._approval_state["_cmd_scroll"] = total + 100
+        with patch("cli.shutil.get_terminal_size", return_value=term_size):
+            cli._get_approval_display_fragments()
+        assert cli._approval_state["_cmd_scroll"] == total - visible
+
+    def test_approval_display_view_resets_scroll_on_entry(self):
+        """Selecting "view" resets the full-command viewport to the top."""
+        cli = _make_cli_stub()
+        cli._approval_state = {
+            "command": "sudo dd if=/tmp/in of=/usr/share/keyrings/githubcli-archive-keyring.gpg bs=4M status=progress",
+            "description": "disk copy",
+            "choices": ["once", "session", "always", "deny", "view"],
+            "selected": 4,
+            "response_queue": queue.Queue(),
+        }
+        cli._approval_state["_cmd_scroll"] = 7
+        cli._approval_state["_cmd_overflow"] = True
+
+        cli._handle_approval_selection()
+
+        assert cli._approval_state["show_full"] is True
+        assert cli._approval_state["_cmd_scroll"] == 0
+        assert cli._approval_state["_cmd_overflow"] is False
+        assert "view" not in cli._approval_state["choices"]
 
     def test_background_task_registers_thread_local_approval_callbacks(self):
         """Background /btw tasks must use the prompt_toolkit approval UI.


### PR DESCRIPTION
## Summary

Fixes #77764 — the dangerous-command approval panel truncated long commands in full-view mode, so outward-facing actions (e.g. `gh pr create --body` with multi-paragraph markdown, `curl -d '{...}'`) could not be fully reviewed before approving.

## Root Cause

`cli.py:_get_approval_display_fragments` wraps the command at `inner_text_width` and caps rendered command rows at `max_cmd_rows` (terminal height minus choices minus chrome). Even after the user selected **Show full command** (`show_full=True`), `max_cmd_rows` still applied, so very long commands were cut off with `… (command truncated — use /logs or /debug for full text)` — the exact case the `view` toggle was supposed to solve.

## Change

When the full command exceeds the panel's row budget, the approval panel now renders a **scrollable viewport** instead of truncating:

- **`cli.py` — `_get_approval_display_fragments`**: in full-view mode (`show_full=True`) an overflowing command is sliced to the visible rows and a scroll hint (`▲▼ 1–10/35 (1–9 approve/deny)`) is shown. Viewport metrics (`_cmd_scroll`, `_cmd_overflow`, `_cmd_total_lines`, `_cmd_visible_lines`) are recorded in the approval state so key bindings can drive it.
- **`cli.py` — key bindings**: while the full-command view is active and overflowing, **↑/↓** scroll the command (PgUp/PgDn page-scroll); number keys (1–9/0) still approve/deny directly, and Enter confirms the highlighted choice. When the command fits (or in preview mode), ↑/↓ navigate choices exactly as before.
- **`cli.py` — `_handle_approval_selection` / state init**: entering the full view resets the viewport to the top.
- Preview mode (before selecting "Show full command") keeps its existing compact truncation behavior.

## Verification

- Updated `tests/cli/test_cli_approval_ui.py` to assert the scroll behavior on a ~3000-char command: no truncation marker, scroll hint rendered, `_cmd_overflow` set, choices all visible.
- Added tests: viewport scrolls to the tail of the command (hint reflects the visible range), out-of-range scroll offsets clamp to the last line, and selecting "view" resets the viewport.
- `pytest tests/cli/test_cli_approval_ui.py` → 17 passed. Full `tests/cli/` suite → 927 passed (1 pre-existing flaky stdout-timing test, passes in isolation).

Closes #77764
