### PR TITLE
fix: replace assert with runtime guards in buzz adapter and session recovery

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -1238,7 +1238,8 @@ def recover_session_database(
         output_path=output_path,
         work_dir=work_dir,
     )
-    assert output is not None
+    if output is None:
+        raise SessionRecoverySafetyError("output_path is required for recovery")
     disk_space = _disk_space_preflight(source, work_root, output.parent)
 
     temp_dir, snapshot_source, inspection = _snapshot_and_inspect(source, work_root)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -128,7 +128,11 @@ def _load_nostr_auth():
 
         path = Path(__file__).with_name("nostr_auth.py")
         spec = importlib.util.spec_from_file_location("plugin_adapter_buzz_nostr_auth", path)
-        assert spec is not None and spec.loader is not None
+        if spec is None or spec.loader is None:
+            raise ImportError(
+                f"Cannot load nostr_auth from {path}: "
+                "spec_from_file_location returned None"
+            )
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         return module


### PR DESCRIPTION
## Summary

Replace two `assert` statements in production code with explicit runtime guards. `assert` is stripped by `python -O`, silently removing invariant checks.

## Changes

### 1. `plugins/platforms/buzz/adapter.py:131`

`assert spec is not None and spec.loader is not None` after `importlib.util.spec_from_file_location()`.

**Problem**: If `nostr_auth.py` is missing or corrupt, `spec` is `None`. With the assert, the error is an unhelpful `AssertionError`. With `python -O`, the assert is removed entirely and `spec.loader.exec_module()` raises `AttributeError` on `None`.

**Fix**: Replace with explicit `ImportError` that includes the file path for debugging.

### 2. `hermes_cli/session_recovery.py:1241`

`assert output is not None` after `_validate_paths()`.

**Problem**: While `output_path` is required by the function signature making this assert logically unreachable, `assert` is stripped by `python -O`. Replace with `SessionRecoverySafetyError` for consistent error handling.

## Test Plan

- [x] `python3 -c "import ast; ast.parse(open(f).read())"` passes for both files
- [ ] `pytest tests/` passes
