### PR TITLE
chore: contributor email mapping for BKStock

### DIFF
--- a/contributors/emails/bot@bkstock.dev
+++ b/contributors/emails/bot@bkstock.dev
@@ -1,0 +1,1 @@
+BKStock


### PR DESCRIPTION
Maps bot@bkstock.dev -> BKStock for release attribution. Needed by the #72448 salvage.