### PR TITLE
fix(tui): make tool rows respect display.tool_preview_length

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -474,6 +474,45 @@ def test_config_roundtrip(server, tmp_path):
     assert server._load_cfg()["model"] == "test/model"
 
 
+# ── display.tool_preview_length → _tool_ctx ──────────────────────────
+#
+# Exercises the real config path (config.yaml on disk → _load_cfg →
+# _load_tool_preview_len → _tool_ctx) rather than poking globals, so a
+# regression in any link of the chain fails these tests.
+
+_LONG_COMMAND = "echo " + " ".join(f"word{i}" for i in range(60))
+
+
+def test_tool_ctx_unset_keeps_legacy_80_cap(server, tmp_path):
+    server._hermes_home = tmp_path
+    server._save_cfg({"display": {}})
+    ctx = server._tool_ctx("terminal", {"command": _LONG_COMMAND})
+    assert len(ctx) == 80
+    assert ctx.endswith("...")
+
+
+def test_tool_ctx_honours_configured_preview_length(server, tmp_path):
+    server._hermes_home = tmp_path
+    server._save_cfg({"display": {"tool_preview_length": 40}})
+    ctx = server._tool_ctx("terminal", {"command": _LONG_COMMAND})
+    assert len(ctx) == 40
+    assert ctx.endswith("...")
+
+
+def test_tool_ctx_preview_length_zero_is_unlimited(server, tmp_path):
+    server._hermes_home = tmp_path
+    server._save_cfg({"display": {"tool_preview_length": 0}})
+    ctx = server._tool_ctx("terminal", {"command": _LONG_COMMAND})
+    assert ctx == _LONG_COMMAND
+
+
+def test_tool_ctx_invalid_preview_length_falls_back(server, tmp_path):
+    server._hermes_home = tmp_path
+    server._save_cfg({"display": {"tool_preview_length": "not-a-number"}})
+    ctx = server._tool_ctx("terminal", {"command": _LONG_COMMAND})
+    assert len(ctx) == 80
+
+
 # ── _cli_exec_blocked ────────────────────────────────────────────────
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4133,6 +4133,26 @@ def _load_tool_progress_mode() -> str:
     return mode if mode in {"off", "new", "all", "verbose"} else "all"
 
 
+def _load_tool_preview_len() -> int | None:
+    """Configured ``display.tool_preview_length``, or None when unset.
+
+    Read per call through the mtime-cached ``_load_cfg()`` rather than
+    mirrored into ``agent.display``'s process-global preview limit: the
+    gateway serves multiple sessions (and, via session.resume, multiple
+    profiles) from one process, so mutating the global on config loads
+    would race across sessions. A per-call read also covers every
+    transport (stdio entry, WebSocket, compute host) without each needing
+    its own startup initialisation.
+    """
+    raw = (_load_cfg().get("display") or {}).get("tool_preview_length")
+    if raw is None or isinstance(raw, bool):
+        return None
+    try:
+        return max(int(raw), 0)
+    except (TypeError, ValueError):
+        return None
+
+
 def _gui_surface_toolsets(platform: str) -> set[str]:
     """Toolsets that exist because of the CLIENT on the other end, not the host.
 
@@ -5255,7 +5275,14 @@ def _tool_ctx(name: str, args: dict) -> str:
     try:
         from agent.display import build_tool_preview
 
-        return build_tool_preview(name, args, max_len=80) or ""
+        # display.tool_preview_length governs this preview like it does the
+        # CLI spinner's (cli.py seeds agent.display's global from the same
+        # key; 0 = unlimited). Unset keeps the pre-config cap of 80 so the
+        # default row layout is unchanged.
+        limit = _load_tool_preview_len()
+        return build_tool_preview(
+            name, args, max_len=80 if limit is None else limit
+        ) or ""
     except Exception:
         return ""
 

--- a/ui-tui/src/__tests__/text.test.ts
+++ b/ui-tui/src/__tests__/text.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import {
   boundedLiveRenderText,
@@ -8,6 +8,7 @@ import {
   estimateRows,
   estimateTokensRough,
   fmtK,
+  formatToolCall,
   hasAnsi,
   isToolTrailResultLine,
   lastCotTrailIndex,
@@ -15,6 +16,7 @@ import {
   pasteTokenLabel,
   sameToolTrailGroup,
   sanitizeAnsiForRender,
+  setToolContextPreviewMax,
   splitToolDuration,
   stripAnsi,
   thinkingPreview
@@ -35,6 +37,34 @@ describe('buildToolTrailLine', () => {
     expect(line).toBe('Read File("x") (0.9s) ✓')
     expect(parseToolTrailResultLine(line)).toEqual({ call: 'Read File("x") (0.9s)', detail: '', mark: '✓' })
     expect(splitToolDuration('Read File("x") (0.9s)')).toEqual({ label: 'Read File("x")', duration: ' (0.9s)' })
+  })
+})
+
+describe('formatToolCall preview length', () => {
+  afterEach(() => setToolContextPreviewMax(null))
+
+  it('caps context at 64 chars when no length is configured', () => {
+    expect(formatToolCall('terminal', 'x'.repeat(100))).toBe(`Terminal("${'x'.repeat(63)}…")`)
+  })
+
+  it('honours a configured cap', () => {
+    setToolContextPreviewMax(80)
+
+    expect(formatToolCall('terminal', 'x'.repeat(100))).toBe(`Terminal("${'x'.repeat(79)}…")`)
+  })
+
+  it('treats 0 as unlimited, matching the CLI spinner semantics', () => {
+    setToolContextPreviewMax(0)
+    const cmd = 'x'.repeat(400)
+
+    expect(formatToolCall('terminal', cmd)).toBe(`Terminal("${cmd}")`)
+  })
+
+  it('restores the built-in cap on null', () => {
+    setToolContextPreviewMax(0)
+    setToolContextPreviewMax(null)
+
+    expect(formatToolCall('terminal', 'x'.repeat(100))).toBe(`Terminal("${'x'.repeat(63)}…")`)
   })
 })
 

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -11,10 +11,12 @@ import {
   normalizeStatusBar,
   syncMcpReload
 } from '../app/useConfigSync.js'
+import { formatToolCall, setToolContextPreviewMax } from '../lib/text.js'
 
 describe('applyDisplay', () => {
   beforeEach(() => {
     resetUiState()
+    setToolContextPreviewMax(null)
   })
 
   it('fans every display flag out to $uiState and the bell callback', () => {
@@ -141,6 +143,25 @@ describe('applyDisplay', () => {
     )
 
     expect($uiState.get().sections).toEqual({ activity: 'hidden' })
+  })
+
+  it('threads display.tool_preview_length through to tool trail previews', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: { tool_preview_length: 100 } } }, setBell)
+    expect(formatToolCall('terminal', 'x'.repeat(200))).toBe(`Terminal("${'x'.repeat(99)}…")`)
+
+    applyDisplay({ config: { display: { tool_preview_length: 0 } } }, setBell)
+    expect(formatToolCall('terminal', 'x'.repeat(200))).toBe(`Terminal("${'x'.repeat(200)}")`)
+
+    // A transient RPC failure (null cfg) must not clobber the configured
+    // value — same guard as the voice record key.
+    applyDisplay(null, setBell)
+    expect(formatToolCall('terminal', 'x'.repeat(200))).toBe(`Terminal("${'x'.repeat(200)}")`)
+
+    // Removing the key from config restores the built-in cap on next sync.
+    applyDisplay({ config: { display: {} } }, setBell)
+    expect(formatToolCall('terminal', 'x'.repeat(100))).toBe(`Terminal("${'x'.repeat(63)}…")`)
   })
 
   it('treats a null config like an empty display block', () => {

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -6,6 +6,7 @@ import type { GatewayClient } from '../gatewayClient.js'
 import type { ConfigFullResponse, ConfigMtimeResponse, ReloadMcpResponse } from '../gatewayTypes.js'
 import { DEFAULT_VOICE_RECORD_KEY, type ParsedVoiceRecordKey, parseVoiceRecordKey } from '../lib/platform.js'
 import { asRpcResult } from '../lib/rpc.js'
+import { setToolContextPreviewMax } from '../lib/text.js'
 
 import { applyConfiguredTuiTheme } from './createGatewayEventHandler.js'
 import {
@@ -207,6 +208,24 @@ const _pasteCollapseLinesFromConfig = (cfg: ConfigFullResponse | null): number =
   return 5
 }
 
+const _toolPreviewLengthFromConfig = (cfg: ConfigFullResponse | null): null | number => {
+  const raw = cfg?.config?.display?.tool_preview_length
+
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) {
+    return Math.round(raw)
+  }
+
+  if (typeof raw === 'string') {
+    const n = parseInt(raw, 10)
+
+    if (Number.isFinite(n) && n >= 0) {
+      return n
+    }
+  }
+
+  return null
+}
+
 const _pasteCollapseCharsFromConfig = (cfg: ConfigFullResponse | null): number => {
   if (!cfg?.config) {
     return 2000
@@ -267,6 +286,12 @@ export const applyDisplay = (
   // the last-good state and lets the next successful poll refresh it.
   if (setVoiceRecordKey && cfg) {
     setVoiceRecordKey(_voiceRecordKeyFromConfig(cfg))
+  }
+
+  // Same null-guard as the voice key above: a transient RPC failure must not
+  // reset a configured preview length back to the built-in cap.
+  if (cfg) {
+    setToolContextPreviewMax(_toolPreviewLengthFromConfig(cfg))
   }
 
   patchUiState({

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -91,6 +91,11 @@ export interface ConfigDisplayConfig {
   streaming?: boolean
   thinking_mode?: string
   /**
+   * Max chars for tool-call context previews in trail lines; 0 = unlimited.
+   * Same key the CLI spinner honours. Unset keeps the built-in cap.
+   */
+  tool_preview_length?: null | number | string
+  /**
    * Nudge the user toward the /agents spawn-tree dashboard the first time a
    * turn starts delegating, via a one-time transient activity hint.  Opens
    * nothing — just advertises the command.  Default true.

--- a/ui-tui/src/lib/text.ts
+++ b/ui-tui/src/lib/text.ts
@@ -77,7 +77,7 @@ const renderEstimateLine = (line: string) => {
 export const compactPreview = (s: string, max: number) => {
   const one = s.replace(WS_RE, ' ').trim()
 
-  return !one ? '' : one.length > max ? one.slice(0, max - 1) + '…' : one
+  return !one ? '' : max > 0 && one.length > max ? one.slice(0, max - 1) + '…' : one
 }
 
 export const estimateTokensRough = (text: string) => (!text ? 0 : (text.length + 3) >> 2)
@@ -204,9 +204,22 @@ export const toolTrailLabel = (name: string) =>
     .map(p => p[0]!.toUpperCase() + p.slice(1))
     .join(' ') || name
 
+// Cap for tool-call context previews when display.tool_preview_length is
+// unset (the pre-config-plumbing behaviour, so default rows look the same).
+const DEFAULT_TOOL_CONTEXT_CHARS = 64
+
+let toolContextChars = DEFAULT_TOOL_CONTEXT_CHARS
+
+// Synced from config by applyDisplay (useConfigSync) on hydrate and on every
+// config.yaml change; 0 means unlimited, matching the CLI spinner's handling
+// of the same key. null/undefined restores the built-in cap.
+export const setToolContextPreviewMax = (n: null | number | undefined) => {
+  toolContextChars = typeof n === 'number' && Number.isFinite(n) ? Math.max(0, Math.round(n)) : DEFAULT_TOOL_CONTEXT_CHARS
+}
+
 export const formatToolCall = (name: string, context = '') => {
   const label = toolTrailLabel(name)
-  const preview = compactPreview(context, 64)
+  const preview = compactPreview(context, toolContextChars)
 
   return preview ? `${label}("${preview}")` : label
 }

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -349,6 +349,8 @@ display:
 
 This is useful on narrow terminals or when tool arguments contain very long file paths.
 
+The key also applies to the tool rows in the full-screen TUI (`hermes --tui`). There the built-in preview cap is kept when the key is unset; set it explicitly (e.g. `tool_preview_length: 0`) to see full terminal commands in the transcript. Long previews wrap across lines instead of being clipped.
+
 ## Session Management
 
 ### Resuming Sessions

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -269,6 +269,22 @@ global `details_mode`. To reshape the layout:
 Anything set explicitly in `display.sections` wins over the defaults, so
 existing configs keep working unchanged.
 
+**Tool preview length**
+
+Tool rows show a one-line preview of the call's primary argument (the
+terminal command, file path, search pattern). By default the preview is
+capped, so long commands are elided. Set `display.tool_preview_length` to
+change this; `0` means no limit and long previews wrap across lines:
+
+```yaml
+display:
+  tool_preview_length: 0   # show full terminal commands in tool rows
+```
+
+The same key governs the classic CLI spinner's previews (where the default
+is already unlimited). Full command text is always available regardless via
+`/verbose` and in approval prompts.
+
 ## Sessions
 
 Sessions are shared between the TUI and the classic CLI — both write to the same `~/.hermes/state.db`. You can start a session in one, resume in the other. The session picker surfaces sessions from both sources, with a source tag.


### PR DESCRIPTION
## What does this PR do?

Makes `display.tool_preview_length` effective in the TUI. The key is
documented (user-guide/cli.md, "Tool Preview Length") as controlling
tool call preview lines, but only the classic CLI spinner honoured it.
The TUI clipped terminal commands twice, with no way to configure it:

- `tui_gateway/server.py::_tool_ctx` hard-coded `max_len=80`
- `ui-tui/src/lib/text.ts::formatToolCall` capped the context again at
  64 chars

So anything past 64 chars of a command was invisible in tool rows, and
setting the documented config key did nothing.

**Compatibility:** when the key is unset, rendering is byte-identical
to current behaviour (the 80/64 caps are preserved). Nothing changes
for existing users until they set the key explicitly. `0` means
unlimited, matching the CLI spinner and the documented semantics; long
previews wrap across rows instead of being clipped at the terminal
edge.

**Why this approach:**

- The gateway reads the key per call through the mtime-cached
  `_load_cfg()` rather than mutating `agent.display`'s process-global
  preview limit. One gateway process serves multiple sessions (and,
  via session.resume, multiple profiles), so a global mutated on
  config loads would race across sessions; that is the concern raised
  in review of #41852. A per-call read also covers every transport
  (stdio entry, WebSocket, compute host) without per-entry-point
  startup init, the gap flagged in review of #41854.
- The client syncs the key from `config.get full` in `applyDisplay`,
  both on hydrate and on every config.yaml mtime change, so config
  edits apply live.

Supersedes #41854 and #41852 (credit to their authors for identifying
the server-side gap); this PR additionally fixes the client-side 64
cap, which those PRs left in place. Without that, the server-side fix
alone has no visible effect. Related: #16636, #44888.

Out of scope, intentionally: the ACP adapter's separate 80-char title
truncation (#63949, open PR #67066) and the messaging gateway preview
pipeline (#46962, #71230).

## Related Issue

Related: #41854, #41852, #16636, #44888.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: new `_load_tool_preview_len()` (next to
  `_load_tool_progress_mode()`); `_tool_ctx()` passes it as `max_len`,
  keeping 80 when the key is unset
- `ui-tui/src/lib/text.ts`: `formatToolCall`'s cap becomes a module
  setting (`setToolContextPreviewMax`), default 64 unchanged;
  `compactPreview` treats a non-positive max as unlimited
- `ui-tui/src/app/useConfigSync.ts`: parse
  `display.tool_preview_length` in `applyDisplay` and sync it, with
  the same transient-failure null-guard as the voice record key
- `ui-tui/src/gatewayTypes.ts`: type the new display key
- `tests/tui_gateway/test_protocol.py`: 4 tests exercising the real
  config path (config.yaml on disk -> `_load_cfg` -> `_tool_ctx`):
  unset -> 80, explicit N, 0 -> full, invalid -> fallback
- `ui-tui/src/__tests__/text.test.ts`,
  `ui-tui/src/__tests__/useConfigSync.test.ts`: 5 tests for the
  client cap and the `applyDisplay` propagation chain
- `website/docs/user-guide/cli.md`, `website/docs/user-guide/tui.md`:
  document the TUI behaviour of the existing key

## How to Test

1. In `~/.hermes/config.yaml` set:
   ```yaml
   display:
     tool_preview_length: 0
   ```
2. Run `hermes --tui` and submit a prompt that triggers a long
   terminal command (e.g. ask for a recursive grep with several
   paths).
3. The tool row shows the full command, wrapping across lines, instead
   of `Terminal("…64 chars…")`. Remove the key (or set e.g. `80`) and
   the previous capped rendering returns.
4. Compound commands still summarise to `first + N commands`; that is
   the pre-existing `summarize_shell_command()` behaviour, identical
   to the CLI spinner with the same key, and untouched here.

This change has been tested on Linux.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh`
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered: config read + string caps
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Captured from a live `hermes --tui` session driving terminal tool
calls (same two commands in both runs).

Key unset (identical to current behaviour):

```
└─ ▾ Tool calls (2)
  ├─ ● Terminal("grep -rn 'def build_tool_preview' --include='*.py' /home/overbe…") (2.1s)
  └─ ● Terminal("git -C /home/user/code/python/hermes-agent status --short +…") (0.1s)
```

With `display.tool_preview_length: 0`:

```
└─ ▾ Tool calls (2)
  ├─ ● Terminal("grep -rn 'def build_tool_preview' --include='*.py'
      /home/overbeck/code/python/hermes-agent/agent /home/user/code/python/hermes-agent/tui_gateway
      --color=never --line-number") (2.5s)
  └─ ● Terminal("git -C /home/user/code/python/hermes-agent status --short + 1 command") (0.1s)
```
