### PR TITLE
fix(image): fail closed on prompt integrity mismatches

### DIFF
--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -246,12 +246,17 @@ class TestRegistryIntegration:
 
     def test_schema_exposes_expected_agent_params(self, image_tool):
         """The agent-facing schema exposes the unified text+image surface:
-        prompt (required), aspect_ratio, and the image-to-image inputs
-        image_url + reference_image_urls. Model selection stays a user-level
-        config choice, never an agent-level arg."""
+        prompt (required), aspect ratio, image-to-image inputs, and the optional
+        paired frozen-prompt integrity contract. Model selection stays a
+        user-level config choice, never an agent-level arg."""
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
         assert set(props.keys()) == {
-            "prompt", "aspect_ratio", "image_url", "reference_image_urls",
+            "prompt",
+            "frozen_prompt_length_chars",
+            "frozen_prompt_sha256",
+            "aspect_ratio",
+            "image_url",
+            "reference_image_urls",
         }
         assert image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["required"] == ["prompt"]
 

--- a/tests/tools/test_image_generation_prompt_integrity.py
+++ b/tests/tools/test_image_generation_prompt_integrity.py
@@ -1,0 +1,440 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+
+def _synthetic_frozen_prompt(length: int = 1544) -> str:
+    seed = "Synthetic frozen image prompt for an isolated no-provider regression. "
+    return (seed * ((length // len(seed)) + 1))[:length]
+
+
+def _literal_truncate(prompt: str, length: int = 221) -> str:
+    marker = "...[truncated]"
+    return prompt[: length - len(marker)] + marker
+
+
+def _sha256(prompt: str) -> str:
+    return hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+
+def _install_fake_provider(monkeypatch, image_tool, payload):
+    calls = []
+
+    def fake_dispatch(prompt, aspect_ratio, **kwargs):
+        calls.append((prompt, aspect_ratio, kwargs))
+        return json.dumps(payload)
+
+    def fail_unexpected_route(*args, **kwargs):
+        pytest.fail("image generation escaped the isolated fake provider route")
+
+    monkeypatch.setattr(image_tool, "_dispatch_to_plugin_provider", fake_dispatch)
+    monkeypatch.setattr(image_tool, "_maybe_route_managed_krea", fail_unexpected_route)
+    monkeypatch.setattr(image_tool, "image_generate_tool", fail_unexpected_route)
+    return calls
+
+
+def test_literal_truncation_is_rejected_before_provider_dispatch(monkeypatch):
+    from tools import image_generation_tool as image_tool
+
+    frozen_prompt = _synthetic_frozen_prompt()
+    actual_prompt = _literal_truncate(frozen_prompt)
+    calls = _install_fake_provider(
+        monkeypatch,
+        image_tool,
+        {"success": True, "image": "/tmp/must-not-be-admitted.png"},
+    )
+
+    result = json.loads(
+        image_tool._handle_image_generate(
+            {
+                "prompt": actual_prompt,
+                "aspect_ratio": "landscape",
+                "frozen_prompt_length_chars": len(frozen_prompt),
+                "frozen_prompt_sha256": _sha256(frozen_prompt),
+            }
+        )
+    )
+
+    assert len(frozen_prompt) == 1544
+    assert len(actual_prompt) == 221
+    assert actual_prompt.endswith("...[truncated]")
+    assert calls == []
+    assert result["success"] is False
+    assert result["image"] is None
+    assert result["error_type"] == "prompt_integrity"
+    assert result["reason_code"] == "PROMPT_ARGUMENT_LITERAL_TRUNCATION"
+    assert result["prompt_integrity"] == {
+        "verified": False,
+        "output_admitted": False,
+        "frozen_prompt_length_chars": 1544,
+        "actual_prompt_length_chars": 221,
+        "frozen_prompt_sha256": _sha256(frozen_prompt),
+        "actual_prompt_sha256": _sha256(actual_prompt),
+        "utf8_encoding_valid": True,
+        "literal_truncation_marker_present": True,
+        "length_matches": False,
+        "sha256_matches": False,
+    }
+
+
+def test_registry_execution_boundary_rejects_persisted_actual_arguments(monkeypatch):
+    from model_tools import handle_function_call
+    from tools import image_generation_tool as image_tool
+
+    frozen_prompt = _synthetic_frozen_prompt()
+    actual_prompt = _literal_truncate(frozen_prompt)
+    persisted_actual_arguments = {
+        "prompt": actual_prompt,
+        "aspect_ratio": "landscape",
+        "frozen_prompt_length_chars": len(frozen_prompt),
+        "frozen_prompt_sha256": _sha256(frozen_prompt),
+    }
+    calls = _install_fake_provider(
+        monkeypatch,
+        image_tool,
+        {"success": True, "image": "/tmp/must-not-be-admitted.png"},
+    )
+
+    result = json.loads(
+        handle_function_call(
+            "image_generate",
+            persisted_actual_arguments,
+            task_id="prompt-integrity-regression",
+        )
+    )
+
+    assert calls == []
+    assert persisted_actual_arguments["prompt"] == actual_prompt
+    assert result["reason_code"] == "PROMPT_ARGUMENT_LITERAL_TRUNCATION"
+    assert result["prompt_integrity"]["actual_prompt_length_chars"] == 221
+    assert result["prompt_integrity"]["actual_prompt_sha256"] == _sha256(actual_prompt)
+    assert result["prompt_integrity"]["output_admitted"] is False
+
+
+def test_handler_verifies_the_same_prompt_snapshot_used_for_dispatch(monkeypatch):
+    from tools import image_generation_tool as image_tool
+
+    frozen_prompt = "frozen prompt"
+
+    class MutatingPromptArgs(dict):
+        prompt_reads = 0
+
+        def get(self, key, default=None):
+            if key == "prompt":
+                self.prompt_reads += 1
+                return "Frozen prompt" if self.prompt_reads == 1 else frozen_prompt
+            return super().get(key, default)
+
+    args = MutatingPromptArgs(
+        frozen_prompt_length_chars=len(frozen_prompt),
+        frozen_prompt_sha256=_sha256(frozen_prompt),
+    )
+    calls = _install_fake_provider(
+        monkeypatch,
+        image_tool,
+        {"success": True, "image": "/tmp/must-not-be-admitted.png"},
+    )
+
+    result = json.loads(image_tool._handle_image_generate(args))
+
+    assert args.prompt_reads == 1
+    assert calls == []
+    assert result["reason_code"] == "PROMPT_ARGUMENT_SHA256_MISMATCH"
+    assert result["prompt_integrity"]["actual_prompt_sha256"] == _sha256(
+        "Frozen prompt"
+    )
+    assert result["prompt_integrity"]["output_admitted"] is False
+
+
+def test_literal_truncation_is_fail_closed_without_frozen_contract(monkeypatch):
+    from tools import image_generation_tool as image_tool
+
+    calls = _install_fake_provider(
+        monkeypatch,
+        image_tool,
+        {"success": True, "image": "/tmp/must-not-be-admitted.png"},
+    )
+
+    result = json.loads(
+        image_tool._handle_image_generate(
+            {"prompt": "ordinary prompt...[truncated]", "aspect_ratio": "square"}
+        )
+    )
+
+    assert calls == []
+    assert result["reason_code"] == "PROMPT_ARGUMENT_LITERAL_TRUNCATION"
+    assert result["prompt_integrity"]["output_admitted"] is False
+
+
+@pytest.mark.parametrize(
+    ("actual_prompt", "expected_reason"),
+    [
+        ("frozen prompt!", "PROMPT_ARGUMENT_LENGTH_MISMATCH"),
+        ("Frozen prompt", "PROMPT_ARGUMENT_SHA256_MISMATCH"),
+    ],
+)
+def test_length_and_sha256_mismatches_are_rejected_before_dispatch(
+    monkeypatch, actual_prompt, expected_reason
+):
+    from tools import image_generation_tool as image_tool
+
+    frozen_prompt = "frozen prompt"
+    calls = _install_fake_provider(
+        monkeypatch,
+        image_tool,
+        {"success": True, "image": "/tmp/must-not-be-admitted.png"},
+    )
+
+    result = json.loads(
+        image_tool._handle_image_generate(
+            {
+                "prompt": actual_prompt,
+                "frozen_prompt_length_chars": len(frozen_prompt),
+                "frozen_prompt_sha256": _sha256(frozen_prompt),
+            }
+        )
+    )
+
+    assert calls == []
+    assert result["success"] is False
+    assert result["reason_code"] == expected_reason
+    assert result["prompt_integrity"]["output_admitted"] is False
+
+
+@pytest.mark.parametrize(
+    "contract",
+    [
+        {"frozen_prompt_length_chars": None},
+        {"frozen_prompt_sha256": None},
+        {
+            "frozen_prompt_length_chars": None,
+            "frozen_prompt_sha256": None,
+        },
+        {"frozen_prompt_length_chars": 13},
+        {"frozen_prompt_sha256": "0" * 64},
+        {
+            "frozen_prompt_length_chars": True,
+            "frozen_prompt_sha256": "0" * 64,
+        },
+        {
+            "frozen_prompt_length_chars": 13,
+            "frozen_prompt_sha256": "A" * 64,
+        },
+        {
+            "frozen_prompt_length_chars": 13,
+            "frozen_prompt_sha256": "é" * 64,
+        },
+    ],
+)
+def test_incomplete_or_malformed_contract_is_fail_closed(monkeypatch, contract):
+    from tools import image_generation_tool as image_tool
+
+    calls = _install_fake_provider(
+        monkeypatch,
+        image_tool,
+        {"success": True, "image": "/tmp/must-not-be-admitted.png"},
+    )
+
+    result = json.loads(
+        image_tool._handle_image_generate({"prompt": "frozen prompt", **contract})
+    )
+
+    assert calls == []
+    assert result["reason_code"] == "PROMPT_INTEGRITY_CONTRACT_INVALID"
+    assert result["prompt_integrity"]["output_admitted"] is False
+
+
+def test_empty_actual_prompt_with_contract_returns_integrity_evidence(monkeypatch):
+    from tools import image_generation_tool as image_tool
+
+    frozen_prompt = "frozen prompt"
+    calls = _install_fake_provider(
+        monkeypatch,
+        image_tool,
+        {"success": True, "image": "/tmp/must-not-be-admitted.png"},
+    )
+
+    result = json.loads(
+        image_tool._handle_image_generate(
+            {
+                "prompt": "",
+                "frozen_prompt_length_chars": len(frozen_prompt),
+                "frozen_prompt_sha256": _sha256(frozen_prompt),
+            }
+        )
+    )
+
+    assert calls == []
+    assert result["reason_code"] == "PROMPT_ARGUMENT_LENGTH_MISMATCH"
+    assert result["prompt_integrity"]["actual_prompt_length_chars"] == 0
+    assert result["prompt_integrity"]["output_admitted"] is False
+
+
+def test_unpaired_surrogate_with_contract_is_rejected_before_dispatch(monkeypatch):
+    from tools import image_generation_tool as image_tool
+
+    frozen_prompt = "frozen prompt"
+    calls = _install_fake_provider(
+        monkeypatch,
+        image_tool,
+        {"success": True, "image": "/tmp/must-not-be-admitted.png"},
+    )
+
+    result = json.loads(
+        image_tool._handle_image_generate(
+            {
+                "prompt": "\ud800",
+                "frozen_prompt_length_chars": len(frozen_prompt),
+                "frozen_prompt_sha256": _sha256(frozen_prompt),
+            }
+        )
+    )
+
+    assert calls == []
+    assert result["reason_code"] == "PROMPT_ARGUMENT_UTF8_ENCODING_INVALID"
+    assert result["prompt_integrity"]["actual_prompt_sha256"] is None
+    assert result["prompt_integrity"]["utf8_encoding_valid"] is False
+    assert result["prompt_integrity"]["output_admitted"] is False
+
+
+def test_exact_unicode_prompt_is_dispatched_and_admission_is_bound(monkeypatch):
+    from tools import image_generation_tool as image_tool
+
+    frozen_prompt = "ภาพสินค้า 🪽 exact\nsecond line"
+    calls = _install_fake_provider(
+        monkeypatch,
+        image_tool,
+        {"success": True, "image": "/tmp/admitted.png"},
+    )
+
+    result = json.loads(
+        image_tool._handle_image_generate(
+            {
+                "prompt": frozen_prompt,
+                "aspect_ratio": "portrait",
+                "frozen_prompt_length_chars": len(frozen_prompt),
+                "frozen_prompt_sha256": _sha256(frozen_prompt),
+            }
+        )
+    )
+
+    assert calls == [
+        (
+            frozen_prompt,
+            "portrait",
+            {"image_url": None, "reference_image_urls": None},
+        )
+    ]
+    assert result["success"] is True
+    assert result["image"] == "/tmp/admitted.png"
+    assert result["prompt_integrity"] == {
+        "verified": True,
+        "output_admitted": True,
+        "frozen_prompt_length_chars": len(frozen_prompt),
+        "actual_prompt_length_chars": len(frozen_prompt),
+        "frozen_prompt_sha256": _sha256(frozen_prompt),
+        "actual_prompt_sha256": _sha256(frozen_prompt),
+        "utf8_encoding_valid": True,
+        "literal_truncation_marker_present": False,
+        "length_matches": True,
+        "sha256_matches": True,
+    }
+
+
+def test_verified_prompt_does_not_admit_a_provider_failure(monkeypatch):
+    from tools import image_generation_tool as image_tool
+
+    frozen_prompt = "exact prompt"
+    calls = _install_fake_provider(
+        monkeypatch,
+        image_tool,
+        {"success": False, "image": None, "error": "synthetic provider failure"},
+    )
+
+    result = json.loads(
+        image_tool._handle_image_generate(
+            {
+                "prompt": frozen_prompt,
+                "frozen_prompt_length_chars": len(frozen_prompt),
+                "frozen_prompt_sha256": _sha256(frozen_prompt),
+            }
+        )
+    )
+
+    assert len(calls) == 1
+    assert result["success"] is False
+    assert result["prompt_integrity"]["verified"] is True
+    assert result["prompt_integrity"]["output_admitted"] is False
+
+
+def test_non_boolean_provider_success_is_not_marked_admitted(monkeypatch):
+    from tools import image_generation_tool as image_tool
+
+    frozen_prompt = "exact prompt"
+    _install_fake_provider(
+        monkeypatch,
+        image_tool,
+        {"success": "false", "image": "/tmp/malformed-provider-result.png"},
+    )
+
+    result = json.loads(
+        image_tool._handle_image_generate(
+            {
+                "prompt": frozen_prompt,
+                "frozen_prompt_length_chars": len(frozen_prompt),
+                "frozen_prompt_sha256": _sha256(frozen_prompt),
+            }
+        )
+    )
+
+    assert result["prompt_integrity"]["verified"] is True
+    assert result["prompt_integrity"]["output_admitted"] is False
+
+
+def test_call_without_integrity_contract_remains_backward_compatible(monkeypatch):
+    from tools import image_generation_tool as image_tool
+
+    calls = _install_fake_provider(
+        monkeypatch,
+        image_tool,
+        {"success": True, "image": "/tmp/legacy.png"},
+    )
+
+    result = json.loads(
+        image_tool._handle_image_generate(
+            {"prompt": "ordinary complete prompt", "aspect_ratio": "landscape"}
+        )
+    )
+
+    assert len(calls) == 1
+    assert result == {"success": True, "image": "/tmp/legacy.png"}
+
+
+def test_legacy_unpaired_surrogate_is_not_prehashed(monkeypatch):
+    from tools import image_generation_tool as image_tool
+
+    prompt = "legacy \ud800 prompt"
+    calls = _install_fake_provider(
+        monkeypatch,
+        image_tool,
+        {"success": True, "image": "/tmp/legacy.png"},
+    )
+
+    result = json.loads(image_tool._handle_image_generate({"prompt": prompt}))
+
+    assert calls[0][0] == prompt
+    assert result == {"success": True, "image": "/tmp/legacy.png"}
+
+
+def test_schema_exposes_the_frozen_prompt_contract():
+    from tools.image_generation_tool import IMAGE_GENERATE_SCHEMA
+
+    properties = IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
+
+    assert properties["frozen_prompt_length_chars"]["type"] == "integer"
+    assert properties["frozen_prompt_length_chars"]["minimum"] == 1
+    assert properties["frozen_prompt_sha256"]["type"] == "string"
+    assert properties["frozen_prompt_sha256"]["pattern"] == "^[0-9a-f]{64}$"

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -20,6 +20,8 @@ Pricing shown in UI strings is as-of the initial commit; we accept drift and
 update when it's noticed.
 """
 
+import hashlib
+import hmac
 import json
 import logging
 import os
@@ -835,6 +837,160 @@ def _postprocess_image_generate_result(raw: str, task_id: str | None = None) -> 
     return json.dumps(payload, ensure_ascii=False)
 
 
+_LITERAL_TRUNCATION_SUFFIX = "...[truncated]"
+_PROMPT_INTEGRITY_FIELD_ABSENT = object()
+
+
+def _is_lower_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(char in "0123456789abcdef" for char in value)
+    )
+
+
+def _prompt_integrity_details(
+    prompt: Any, frozen_length: Any, frozen_sha256: Any
+) -> dict:
+    actual_length = len(prompt) if isinstance(prompt, str) else None
+    actual_sha256 = None
+    utf8_encoding_valid = None
+    if isinstance(prompt, str):
+        try:
+            actual_sha256 = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+            utf8_encoding_valid = True
+        except UnicodeEncodeError:
+            utf8_encoding_valid = False
+    return {
+        "verified": False,
+        "output_admitted": False,
+        "frozen_prompt_length_chars": frozen_length,
+        "actual_prompt_length_chars": actual_length,
+        "frozen_prompt_sha256": frozen_sha256,
+        "actual_prompt_sha256": actual_sha256,
+        "utf8_encoding_valid": utf8_encoding_valid,
+        "literal_truncation_marker_present": bool(
+            isinstance(prompt, str)
+            and prompt.rstrip().endswith(_LITERAL_TRUNCATION_SUFFIX)
+        ),
+        "length_matches": (
+            actual_length == frozen_length
+            if actual_length is not None and type(frozen_length) is int
+            else None
+        ),
+        "sha256_matches": (
+            hmac.compare_digest(actual_sha256, frozen_sha256)
+            if isinstance(actual_sha256, str) and _is_lower_sha256(frozen_sha256)
+            else None
+        ),
+    }
+
+
+def _prompt_integrity_failure(reason_code: str, error: str, details: dict) -> str:
+    return tool_error(
+        error,
+        success=False,
+        image=None,
+        error_type="prompt_integrity",
+        reason_code=reason_code,
+        prompt_integrity=details,
+    )
+
+
+def _verify_frozen_prompt_integrity(
+    prompt: Any, frozen_length: Any, frozen_sha256: Any
+) -> tuple[Optional[dict], Optional[str]]:
+    """Verify the exact persisted prompt before any provider can run.
+
+    Hashing uses the UTF-8 encoding of the string exactly as received, without
+    stripping or normalization. The literal truncation suffix is always denied.
+    A frozen length or digest activates the paired, fail-closed contract.
+    """
+    literal_truncation = bool(
+        isinstance(prompt, str)
+        and prompt.rstrip().endswith(_LITERAL_TRUNCATION_SUFFIX)
+    )
+    length_present = frozen_length is not _PROMPT_INTEGRITY_FIELD_ABSENT
+    sha256_present = frozen_sha256 is not _PROMPT_INTEGRITY_FIELD_ABSENT
+    contract_requested = length_present or sha256_present
+    if not literal_truncation and not contract_requested:
+        return None, None
+
+    details = _prompt_integrity_details(
+        prompt,
+        frozen_length if length_present else None,
+        frozen_sha256 if sha256_present else None,
+    )
+    if details["literal_truncation_marker_present"]:
+        return None, _prompt_integrity_failure(
+            "PROMPT_ARGUMENT_LITERAL_TRUNCATION",
+            "Prompt ends with the literal truncation marker; provider dispatch refused.",
+            details,
+        )
+
+    valid_contract = (
+        length_present
+        and sha256_present
+        and type(frozen_length) is int
+        and frozen_length > 0
+        and _is_lower_sha256(frozen_sha256)
+    )
+    if not valid_contract:
+        return None, _prompt_integrity_failure(
+            "PROMPT_INTEGRITY_CONTRACT_INVALID",
+            "Frozen prompt integrity requires both a positive character length "
+            "and a lowercase 64-character SHA-256 digest.",
+            details,
+        )
+    if not isinstance(prompt, str):
+        return None, _prompt_integrity_failure(
+            "PROMPT_ARGUMENT_TYPE_INVALID",
+            "Prompt must be a string when frozen prompt integrity is requested.",
+            details,
+        )
+    if details["utf8_encoding_valid"] is not True:
+        return None, _prompt_integrity_failure(
+            "PROMPT_ARGUMENT_UTF8_ENCODING_INVALID",
+            "Prompt cannot be encoded as UTF-8 for frozen SHA-256 verification.",
+            details,
+        )
+    if details["length_matches"] is not True:
+        return None, _prompt_integrity_failure(
+            "PROMPT_ARGUMENT_LENGTH_MISMATCH",
+            "Prompt character length does not match the frozen prompt contract.",
+            details,
+        )
+    if details["sha256_matches"] is not True:
+        return None, _prompt_integrity_failure(
+            "PROMPT_ARGUMENT_SHA256_MISMATCH",
+            "Prompt SHA-256 does not match the frozen prompt contract.",
+            details,
+        )
+
+    details["verified"] = True
+    return details, None
+
+
+def _attach_prompt_integrity_proof(raw: str, proof: Optional[dict]) -> str:
+    if proof is None:
+        return raw
+    try:
+        payload = json.loads(raw) if isinstance(raw, str) else raw
+    except Exception:
+        return raw
+    if not isinstance(payload, dict):
+        return raw
+
+    bound_proof = dict(proof)
+    bound_proof["output_admitted"] = bool(
+        payload.get("success") is True
+        and isinstance(payload.get("image"), str)
+        and payload["image"].strip()
+    )
+    payload["prompt_integrity"] = bound_proof
+    return json.dumps(payload, ensure_ascii=False)
+
+
 def image_generate_tool(
     prompt: str,
     aspect_ratio: str = DEFAULT_ASPECT_RATIO,
@@ -1183,7 +1339,27 @@ IMAGE_GENERATE_SCHEMA = {
                 "description": (
                     "The text prompt describing the desired image (text-to-"
                     "image) or the edit to apply (image-to-image). Be detailed "
-                    "and descriptive."
+                    "and descriptive. A literal suffix of `...[truncated]` is "
+                    "rejected before provider dispatch."
+                ),
+            },
+            "frozen_prompt_length_chars": {
+                "type": "integer",
+                "minimum": 1,
+                "description": (
+                    "Optional fail-closed prompt-integrity contract. Exact "
+                    "character length of the frozen prompt. Supply together "
+                    "with `frozen_prompt_sha256`; both must match the exact "
+                    "persisted `prompt` argument before any provider call."
+                ),
+            },
+            "frozen_prompt_sha256": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$",
+                "description": (
+                    "Optional fail-closed prompt-integrity contract. Lowercase "
+                    "SHA-256 of the exact frozen prompt encoded as UTF-8. Supply "
+                    "together with `frozen_prompt_length_chars`."
                 ),
             },
             "aspect_ratio": {
@@ -1500,6 +1676,17 @@ def _maybe_route_managed_krea(
 
 def _handle_image_generate(args, **kw):
     prompt = args.get("prompt", "")
+    frozen_length = args.get(
+        "frozen_prompt_length_chars", _PROMPT_INTEGRITY_FIELD_ABSENT
+    )
+    frozen_sha256 = args.get(
+        "frozen_prompt_sha256", _PROMPT_INTEGRITY_FIELD_ABSENT
+    )
+    prompt_integrity, integrity_error = _verify_frozen_prompt_integrity(
+        prompt, frozen_length, frozen_sha256
+    )
+    if integrity_error is not None:
+        return integrity_error
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
@@ -1516,7 +1703,8 @@ def _handle_image_generate(args, **kw):
         reference_image_urls=reference_image_urls,
     )
     if dispatched is not None:
-        return _postprocess_image_generate_result(dispatched, task_id=task_id)
+        bound = _attach_prompt_integrity_proof(dispatched, prompt_integrity)
+        return _postprocess_image_generate_result(bound, task_id=task_id)
 
     # Managed-mode Krea routing: when no explicit plugin provider is configured
     # but the selected model is a native ``krea-2-*`` id, a portal user routes to
@@ -1529,7 +1717,8 @@ def _handle_image_generate(args, **kw):
         reference_image_urls=reference_image_urls,
     )
     if krea_routed is not None:
-        return _postprocess_image_generate_result(krea_routed, task_id=task_id)
+        bound = _attach_prompt_integrity_proof(krea_routed, prompt_integrity)
+        return _postprocess_image_generate_result(bound, task_id=task_id)
 
     raw = image_generate_tool(
         prompt=prompt,
@@ -1537,7 +1726,8 @@ def _handle_image_generate(args, **kw):
         image_url=image_url,
         reference_image_urls=reference_image_urls,
     )
-    return _postprocess_image_generate_result(raw, task_id=task_id)
+    bound = _attach_prompt_integrity_proof(raw, prompt_integrity)
+    return _postprocess_image_generate_result(bound, task_id=task_id)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Hardens the existing `image_generate` registry execution boundary against prompt truncation and prompt drift.

When a caller supplies a frozen prompt contract, the exact persisted `prompt` argument must match both its character length and lowercase SHA-256 before any provider route can run. A literal prompt ending in `...[truncated]` is rejected even without a contract. Calls that omit both frozen fields keep the existing behavior.

## Related Issue

No public issue. The regression is reproduced with a synthetic, provider-free test in this PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Add optional `frozen_prompt_length_chars` and `frozen_prompt_sha256` fields to the existing `image_generate` schema.
- Validate the pair before plugin, managed-Krea, or built-in provider dispatch.
- Fail closed on partial/malformed contracts, length or digest mismatch, literal truncation, malformed digest Unicode, and unpaired-surrogate prompts.
- Attach structured prompt-integrity proof to successful tool results; admit output only after verified integrity plus a successful non-empty provider result.
- Add isolated regression coverage with every provider route replaced by a fake.

Changed surface remains three files:

- `tools/image_generation_tool.py`
- `tests/tools/test_image_generation.py`
- `tests/tools/test_image_generation_prompt_integrity.py`

## Reproduction / How to Test

On unpatched `main`, a registry call whose `prompt` ends in literal `...[truncated]` can reach provider dispatch. The added regression test records provider calls and requires zero dispatch.

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
  tests/tools/test_image_generation.py \
  tests/tools/test_image_generation_plugin_dispatch.py \
  tests/tools/test_image_generation_prompt_integrity.py -q
```

Expected: `58 passed, 0 failed`.

For the explicit mismatch path, run:

```bash
python -m pytest \
  tests/tools/test_image_generation_prompt_integrity.py::test_registry_bound_persisted_args_block_provider_on_mismatch -q
```

Expected: structured `PROMPT_INTEGRITY_MISMATCH`, `output_admitted: false`, and zero provider calls.

## Verification

- Final fresh-base focused suite: **58/58 passed**.
- Broader image-tool owner-boundary suite: **76/76 passed** across seven files.
- `ruff 0.15.10 check .`: passed.
- Windows footgun scan: passed across 934 files.
- `compileall` on touched files: passed.
- `git diff --check`: passed.
- Rebase range-diff: exact patch-equivalent (`=`) after rebasing onto current `main`.
- Isolated Codex review: two P2 edge cases were fixed (non-ASCII digest and unpaired surrogate); final verdict **patch is correct (0.94)** with no actionable findings. The final rebase preserved the exact reviewed patch.
- No real image provider, network generation, or paid path was invoked.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows Conventional Commits
- [x] I searched open and closed PRs/issues for duplicates
- [x] This PR contains only changes related to this fix
- [ ] Full repository suite — delegated to GitHub CI; focused and owner-boundary suites pass locally
- [x] I've added regression tests for the change
- [x] Tested on macOS 26.5.2 with Python 3.11.14

### Documentation & Housekeeping

- [x] README/docs update: N/A — behavior is described in the tool schema and structured result
- [x] `cli-config.yaml.example`: N/A — no config key added
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no architecture or workflow change
- [x] Cross-platform impact considered; implementation uses Python stdlib only and the repository Windows guard passes
- [x] Tool descriptions/schema updated with the new optional contract fields
