### PR TITLE
fix(mcp): bound HTTP reconnect loop after keepalive failure (#77765)

### DIFF
--- a/tests/tools/test_mcp_parked_probe_bounded.py
+++ b/tests/tools/test_mcp_parked_probe_bounded.py
@@ -1,0 +1,195 @@
+"""Tests for the bounded parked self-probe loop (#77765).
+
+After a keepalive failure on an HTTP+OAuth MCP server, the long-lived
+gateway process can wedge its OAuth/auth flow: every parked self-probe
+burns the full ``connect_timeout`` per attempt (default 60s × 3 attempts
+≈ 3 minutes) and then parks again — forever, even though the server,
+token, and network are healthy (a fresh process connects in ~0.3s).
+
+The fix bounds that loop:
+
+- revival probes run on a short connect budget
+  (``_PARKED_PROBE_CONNECT_TIMEOUT``) so a wedged auth flow gives up in
+  seconds instead of minutes;
+- after ``_MAX_PARKED_PROBE_FAILURES`` consecutive failed probes the timed
+  self-probe is abandoned — the server waits only for an explicit
+  reconnect request or shutdown.
+"""
+
+import asyncio
+
+import pytest
+
+
+def _patch_fast_sleep(monkeypatch):
+    """Make ``asyncio.sleep`` a no-op (except for real-time polling).
+
+    Returns the real ``asyncio.sleep`` so the test can still wait on wall
+    clock while the run task's backoff/park sleeps are instant.
+    """
+    real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_delay, *a, **kw):
+        await real_sleep(0)
+
+    monkeypatch.setattr("tools.mcp_tool.asyncio.sleep", _fast_sleep)
+    return real_sleep
+
+
+@pytest.mark.no_isolate
+def test_parked_probe_runs_on_short_connect_budget(monkeypatch, tmp_path):
+    """Revival probes must use the short connect budget, not the full one."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    monkeypatch.setattr(mcp_tool, "_PARKED_RETRY_INTERVAL", 0.05)
+    real_sleep = _patch_fast_sleep(monkeypatch)
+
+    seen = []
+
+    class _Task(MCPServerTask):
+        def _deregister_tools(self):
+            self._registered_tool_names = []
+
+        async def _run_http(self, config):
+            seen.append(self._effective_connect_timeout(config))
+            raise asyncio.TimeoutError()
+
+    async def _scenario():
+        task = _Task("srv")
+        task._registered_tool_names = ["srv__tool"]
+        run_task = asyncio.ensure_future(
+            task.run(
+                {
+                    "url": "https://example.test/mcp",
+                    "connect_timeout": 60.0,
+                    "auth": "oauth",
+                }
+            )
+        )
+        # Exhaust the initial ladder (3 full-budget attempts) and park.
+        for _ in range(5000):
+            await real_sleep(0.005)
+            if task._was_parked:
+                break
+        assert task._was_parked, "server never parked"
+
+        # First connect used the full budget; the probe must be capped.
+        for _ in range(5000):
+            await real_sleep(0.005)
+            if seen and seen[-1] <= mcp_tool._PARKED_PROBE_CONNECT_TIMEOUT:
+                break
+        assert seen, "no connect attempts recorded"
+        assert seen[0] == 60.0, f"first connect should use the full budget: {seen}"
+        assert any(
+            t <= mcp_tool._PARKED_PROBE_CONNECT_TIMEOUT for t in seen
+        ), f"revival probe did not use the short budget: {seen}"
+
+        task._shutdown_event.set()
+        task._reconnect_event.set()
+        try:
+            await asyncio.wait_for(run_task, timeout=15)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            run_task.cancel()
+
+    asyncio.run(_scenario())
+
+
+@pytest.mark.no_isolate
+def test_parked_self_probe_gives_up_after_max_failures(monkeypatch, tmp_path):
+    """After the failure threshold the timed self-probe stops; an explicit
+    reconnect request still revives the server."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    monkeypatch.setattr(mcp_tool, "_PARKED_RETRY_INTERVAL", 0.05)
+    monkeypatch.setattr(mcp_tool, "_MAX_PARKED_PROBE_FAILURES", 3)
+    real_sleep = _patch_fast_sleep(monkeypatch)
+
+    attempts = []
+
+    class _Task(MCPServerTask):
+        def _deregister_tools(self):
+            self._registered_tool_names = []
+
+        async def _run_http(self, config):
+            attempts.append(1)
+            raise asyncio.TimeoutError()
+
+    async def _scenario():
+        task = _Task("srv")
+        task._registered_tool_names = ["srv__tool"]
+        run_task = asyncio.ensure_future(
+            task.run({"url": "https://example.test/mcp", "auth": "oauth"})
+        )
+        # Reach the give-up threshold (3 failed probe cycles).
+        for _ in range(10000):
+            await real_sleep(0.005)
+            if task._parked_probe_failures >= 3:
+                break
+        assert task._parked_probe_failures >= 3, "give-up threshold not reached"
+        count_at_giveup = len(attempts)
+
+        # Give-up: no new probe attempts fire while parked.
+        for _ in range(500):
+            await real_sleep(0.005)
+            assert len(attempts) == count_at_giveup, (
+                f"self-probe kept firing after give-up: {len(attempts)} "
+                f"attempts (was {count_at_giveup})"
+            )
+
+        # An explicit reconnect request still wakes the parked server.
+        task._reconnect_event.set()
+        for _ in range(5000):
+            await real_sleep(0.005)
+            if len(attempts) > count_at_giveup:
+                break
+        assert len(attempts) > count_at_giveup, (
+            "explicit reconnect did not revive the parked server"
+        )
+
+        task._shutdown_event.set()
+        task._reconnect_event.set()
+        try:
+            await asyncio.wait_for(run_task, timeout=15)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
+            run_task.cancel()
+
+    asyncio.run(_scenario())
+
+
+def test_mark_session_proven_resets_parked_probe_failures(monkeypatch, tmp_path):
+    """A session that proves healthy restarts the probe-failure counter."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_tool import MCPServerTask
+
+    task = MCPServerTask("srv")
+    task._session_proven = False
+    task._was_parked = True
+    task._reconnect_retries = 4
+    task._parked_probe_failures = 3
+    task._mark_session_proven()
+    assert task._session_proven is True
+    assert task._was_parked is False
+    assert task._reconnect_retries == 0
+    assert task._parked_probe_failures == 0
+
+
+def test_effective_connect_timeout_caps_only_probe_attempts(monkeypatch, tmp_path):
+    """The short budget applies only while a revival probe is armed."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+
+    task = MCPServerTask("srv")
+    task._probe_connect_timeout = mcp_tool._PARKED_PROBE_CONNECT_TIMEOUT
+    assert (
+        task._effective_connect_timeout({"connect_timeout": 60.0})
+        == mcp_tool._PARKED_PROBE_CONNECT_TIMEOUT
+    )
+    # The cap never *raises* a configured timeout.
+    assert task._effective_connect_timeout({"connect_timeout": 5.0}) == 5.0
+    task._probe_connect_timeout = None
+    assert task._effective_connect_timeout({"connect_timeout": 60.0}) == 60.0

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -340,6 +340,19 @@ _MAX_BACKOFF_SECONDS = 60
 # server is unrevivable: its tools are out of the registry, so no tool call
 # can ever reach the circuit-breaker half-open probe or _signal_reconnect.
 _PARKED_RETRY_INTERVAL = 300     # seconds between parked self-probes
+# Revival probes from the parked state run on a short connect budget
+# (#77765): for an HTTP+OAuth server whose OAuth/auth flow hangs inside the
+# long-lived gateway process, every self-probe used to burn the full
+# connect_timeout (default 60s × 3 attempts ≈ 3 minutes) and then park
+# again — forever. Capping the probe budget keeps each wake cheap so the
+# give-up threshold below is reached in minutes, not hours.
+_PARKED_PROBE_CONNECT_TIMEOUT = 10.0
+# After this many consecutive failed revival probes the timed self-probe is
+# abandoned entirely: the server stays parked until an explicit reconnect
+# is requested (manual /mcp refresh, OAuth recovery) or the process
+# restarts. Without this bound the park loop times out forever in the
+# background even though the server/token/network are healthy (#77765).
+_MAX_PARKED_PROBE_FAILURES = 6
 _RECYCLED_RECONNECT_TIMEOUT = 15.0
 # Jitter applied to reconnect backoff sleeps. Without it, every server that
 # lost the same backend retries in lockstep (thundering herd) and log lines
@@ -1840,6 +1853,7 @@ class MCPServerTask:
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported",
         "_reconnect_retries", "_session_proven", "_was_parked",
+        "_parked_probe_failures", "_probe_connect_timeout",
     )
 
     def __init__(self, name: str):
@@ -1874,6 +1888,14 @@ class MCPServerTask:
         # until the session proves healthy again — used to log the
         # parked→revived transition exactly once.
         self._was_parked: bool = False
+        # Consecutive failed revival probes while parked (#77765). Reset by
+        # _mark_session_proven once the session proves healthy again.
+        self._parked_probe_failures: int = 0
+        # When set, the next HTTP connect attempt(s) run on a short budget
+        # (_PARKED_PROBE_CONNECT_TIMEOUT) instead of the full
+        # connect_timeout. Armed on every park wake; cleared once a session
+        # establishes so later (non-probe) reconnects use the full budget.
+        self._probe_connect_timeout: Optional[float] = None
         self._auth_type: str = ""
         self._refresh_lock = asyncio.Lock()
         # MCP stdio sessions are a single JSON-RPC stream. Some servers emit
@@ -1916,6 +1938,20 @@ class MCPServerTask:
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
         return "url" in self._config
+
+    def _effective_connect_timeout(self, config: dict) -> float:
+        """Return the connect timeout for the next transport attempt.
+
+        Revival probes from the parked state run on a short budget
+        (:data:`_PARKED_PROBE_CONNECT_TIMEOUT`) so a wedged OAuth/auth flow
+        gives up in seconds instead of burning the full ``connect_timeout``
+        on every self-probe wake (#77765). Non-probe attempts keep the
+        configured timeout.
+        """
+        connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+        if self._probe_connect_timeout is not None:
+            connect_timeout = min(connect_timeout, self._probe_connect_timeout)
+        return connect_timeout
 
     def _advertises_tools(self) -> bool:
         """Whether the server advertises the ``tools`` capability.
@@ -2218,6 +2254,10 @@ class MCPServerTask:
         if not self._session_proven:
             self._session_proven = True
             self._reconnect_retries = 0
+            # A healthy session proves the revival succeeded — restart the
+            # consecutive-probe-failure counter so a later outage gets a
+            # fresh self-probe budget (#77765).
+            self._parked_probe_failures = 0
             if self._was_parked:
                 self._was_parked = False
                 logger.warning(
@@ -2330,6 +2370,58 @@ class MCPServerTask:
             return "shutdown"
         self._reconnect_event.clear()
         return "reconnect"
+
+    async def _park_for_revival(self, park_reason: str) -> str:
+        """Park this server and wait for revival, bounding the self-probe loop.
+
+        Parking deregisters the server's tools, so no tool call can reach the
+        circuit-breaker half-open probe or ``_signal_reconnect`` — the park
+        must therefore wake periodically and attempt one revival probe itself
+        (#57129). That wake cadence is what #77765 turned into an eternal
+        loop: for an HTTP+OAuth server whose OAuth/auth flow hangs inside the
+        long-lived gateway process, every self-probe burns the full
+        ``connect_timeout`` per attempt (default 60s × 3 attempts ≈ 3 minutes)
+        and then parks again — forever, even though the server, token, and
+        network are all healthy (a fresh process connects in ~0.3s).
+
+        This bounds that loop in two ways:
+
+        * Every revival wake arms a short connect budget
+          (:data:`_PARKED_PROBE_CONNECT_TIMEOUT`) for the next transport
+          attempt(s), so a wedged auth flow gives up in seconds.
+        * After :data:`_MAX_PARKED_PROBE_FAILURES` consecutive failed probes
+          the timed self-probe is abandoned: the server stops waking and
+          waits only for an explicit reconnect request (manual ``/mcp``
+          refresh, OAuth recovery) or shutdown. The loop desists instead of
+          timing out forever in the background.
+
+        ``park_reason`` is a short human-readable label for the give-up log.
+
+        Returns ``"shutdown"`` or ``"reconnect"`` (see
+        :meth:`_wait_for_reconnect_or_shutdown`).
+        """
+        if self._was_parked:
+            # A previous revival probe failed and we are parking again: charge
+            # the consecutive-failure counter so the self-probe loop is bounded.
+            self._parked_probe_failures += 1
+        self._was_parked = True
+        self._deregister_tools()
+        self._reconnect_event.clear()
+        if self._parked_probe_failures >= _MAX_PARKED_PROBE_FAILURES:
+            logger.warning(
+                "MCP server '%s': %d consecutive revival probes failed (%s); "
+                "giving up the timed self-probe loop — the server stays "
+                "parked until an explicit reconnect is requested (e.g. "
+                "/reload-mcp) or the gateway is restarted",
+                self.name, self._parked_probe_failures, park_reason,
+            )
+            timeout: Optional[float] = None
+        else:
+            timeout = _PARKED_RETRY_INTERVAL
+        parked = await self._wait_for_reconnect_or_shutdown(timeout=timeout)
+        # Revival wake: arm the short connect budget for the probe attempt(s).
+        self._probe_connect_timeout = _PARKED_PROBE_CONNECT_TIMEOUT
+        return parked
 
     async def _wait_for_reconnect_or_shutdown(
         self, timeout: Optional[float] = None
@@ -2766,7 +2858,7 @@ class MCPServerTask:
         # case-insensitive so conventional casing is preserved.
         if not any(key.lower() == "mcp-protocol-version" for key in headers):
             headers["mcp-protocol-version"] = LATEST_PROTOCOL_VERSION
-        connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+        connect_timeout = self._effective_connect_timeout(config)
         ssl_verify = config.get("ssl_verify", True)
         client_cert = _resolve_client_cert(self.name, config)
 
@@ -3003,6 +3095,10 @@ class MCPServerTask:
         # Clears any latch from a prior connection in case the server gained
         # ping support across the reconnect.
         self._ping_unsupported = False
+        # The transport just established: if a revival probe budget was armed
+        # by _park_for_revival, it has served its purpose — drop the cap so
+        # later (non-probe) reconnects use the full connect_timeout (#77765).
+        self._probe_connect_timeout = None
         if self.session is None:
             return
         if not self._advertises_tools():
@@ -3190,11 +3286,8 @@ class MCPServerTask:
                             self.name, _MAX_RECONNECT_RETRIES,
                             _PARKED_RETRY_INTERVAL,
                         )
-                        self._was_parked = True
-                        self._deregister_tools()
-                        self._reconnect_event.clear()
-                        parked = await self._wait_for_reconnect_or_shutdown(
-                            timeout=_PARKED_RETRY_INTERVAL
+                        parked = await self._park_for_revival(
+                            "rapid-drop budget exhausted"
                         )
                         if parked == "shutdown":
                             break
@@ -3273,11 +3366,8 @@ class MCPServerTask:
                         )
                         self._error = exc
                         self._ready.set()
-                        self._was_parked = True
-                        self._deregister_tools()
-                        self._reconnect_event.clear()
-                        parked = await self._wait_for_reconnect_or_shutdown(
-                            timeout=_PARKED_RETRY_INTERVAL
+                        parked = await self._park_for_revival(
+                            "permanent initial failure"
                         )
                         if parked == "shutdown":
                             return
@@ -3305,11 +3395,8 @@ class MCPServerTask:
                         )
                         self._error = exc
                         self._ready.set()
-                        self._was_parked = True
-                        self._deregister_tools()
-                        self._reconnect_event.clear()
-                        parked = await self._wait_for_reconnect_or_shutdown(
-                            timeout=_PARKED_RETRY_INTERVAL
+                        parked = await self._park_for_revival(
+                            "initial connection failures"
                         )
                         if parked == "shutdown":
                             return
@@ -3363,11 +3450,8 @@ class MCPServerTask:
                         self.name, _PARKED_RETRY_INTERVAL,
                         type(root).__name__, root,
                     )
-                    self._was_parked = True
-                    self._deregister_tools()
-                    self._reconnect_event.clear()
-                    parked = await self._wait_for_reconnect_or_shutdown(
-                        timeout=_PARKED_RETRY_INTERVAL
+                    parked = await self._park_for_revival(
+                        "permanent error"
                     )
                     if parked == "shutdown":
                         return
@@ -3399,14 +3483,13 @@ class MCPServerTask:
                     # deregisters the tools, no tool call can reach the
                     # circuit-breaker half-open probe or _signal_reconnect —
                     # so the park is a TIMED wait: every _PARKED_RETRY_INTERVAL
-                    # we wake and attempt one reconnect ourselves (#57129).
+                    # we wake and attempt one reconnect ourselves (#57129),
+                    # bounded by _park_for_revival (short probe budget +
+                    # give-up after _MAX_PARKED_PROBE_FAILURES, #77765).
                     # An explicit _reconnect_event.set() (OAuth recovery,
                     # manual /mcp refresh) still wakes us immediately.
-                    self._was_parked = True
-                    self._deregister_tools()
-                    self._reconnect_event.clear()
-                    parked = await self._wait_for_reconnect_or_shutdown(
-                        timeout=_PARKED_RETRY_INTERVAL
+                    parked = await self._park_for_revival(
+                        "reconnect budget exhausted"
                     )
                     if parked == "shutdown":
                         return


### PR DESCRIPTION
## Summary

Fixes #77765 — after a keepalive failure on an HTTP+OAuth MCP server, the long-lived gateway process can get permanently stuck in reconnect timeouts: every parked self-probe burns the full `connect_timeout` (default 60s × 3 attempts ≈ 3 minutes) and then parks again — forever, even though the server, token, and network are all healthy (a fresh process connects in ~0.3s). Only a gateway restart recovered it.

## Root Cause

The parked self-probe loop (introduced for #57129) wakes every `_PARKED_RETRY_INTERVAL` (300s) and rebuilds the transport to attempt revival. For an HTTP+OAuth server whose OAuth/auth flow hangs inside the long-lived process, each revival attempt times out at the full `connect_timeout` (60s) per attempt — 3 attempts per probe cycle — and the cycle repeats indefinitely. The loop is *bounded per cycle* but never *desists*: there is no give-up path, so a wedged auth flow makes the server time out in the background forever.

## Change

All five park sites in `MCPServerTask.run()` now route through a single `_park_for_revival()` helper that bounds the loop in two ways:

1. **Short probe connect budget** — every revival wake arms `_PARKED_PROBE_CONNECT_TIMEOUT` (10s) for the next HTTP connect attempt(s) via the new `_effective_connect_timeout()` (used by `_run_http`), so a wedged OAuth/auth flow gives up in seconds instead of minutes. The cap is dropped as soon as a session establishes (`_discover_tools`), so non-probe reconnects keep the configured timeout.
2. **Give-up after consecutive failures** — after `_MAX_PARKED_PROBE_FAILURES` (6) consecutive failed revival probes, the timed self-probe is abandoned: the server parks with an indefinite wait and a WARNING, staying revivable only via an explicit reconnect request (manual `/reload-mcp`, OAuth recovery) or shutdown. The loop desists instead of timing out forever.

`_mark_session_proven()` resets the consecutive-failure counter once a session proves healthy, so a genuine recovery restores the full self-probe budget.

## Verification

- New tests in `tests/tools/test_mcp_parked_probe_bounded.py`:
  - revival probes use the short connect budget (first connect keeps the full budget);
  - after the failure threshold the timed self-probe stops, and an explicit reconnect request still revives the server;
  - `_mark_session_proven` resets the counter;
  - `_effective_connect_timeout` caps only probe attempts.
- `tests/tools/test_mcp_parked_probe_bounded.py`: 4 passed.
- Regression: `test_mcp_parked_self_probe.py`, `test_mcp_stability.py`, `test_mcp_rapid_drop_budget.py`, `test_mcp_transport_group_reconnect.py`, `test_mcp_reconnect_log_hygiene.py`, `test_mcp_initial_connect_shutdown.py`, `test_mcp_circuit_breaker.py`, `test_mcp_failure_classification.py` — 57 passed.
- Full `tests/tools`: 5437 passed; the 32 failures are pre-existing/environmental (daytona/approval/tts/web_tools_config, verified identical on the base tree) and none are MCP-related.
- `ruff check` clean on both changed files.

Closes #77765