### PR TITLE
perf(tui): memoize useSessionLifecycle return (#38491 salvage)

### DIFF
--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -2,7 +2,7 @@ import { writeFileSync } from 'node:fs'
 
 import type { ScrollBoxHandle } from '@hermes/ink'
 import { evictInkCaches } from '@hermes/ink'
-import { type RefObject, useCallback, useEffect, useRef } from 'react'
+import { type RefObject, useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { buildSetupRequiredSections, SETUP_REQUIRED_TITLE } from '../content/setup.js'
 import { introMsg, toTranscriptMessages } from '../domain/messages.js'
@@ -423,15 +423,28 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
     [sys]
   )
 
-  return {
-    activateLiveSession,
-    closeSession,
-    guardBusySessionSwitch,
-    newLiveSession,
-    newSession,
-    resetSession,
-    resetVisibleHistory,
-    resumeById,
-    trimLastExchange: trimTail
-  }
+  return useMemo(
+    () => ({
+      activateLiveSession,
+      closeSession,
+      guardBusySessionSwitch,
+      newLiveSession,
+      newSession,
+      resetSession,
+      resetVisibleHistory,
+      resumeById,
+      trimLastExchange: trimTail
+    }),
+    [
+      activateLiveSession,
+      closeSession,
+      guardBusySessionSwitch,
+      newLiveSession,
+      newSession,
+      resetSession,
+      resetVisibleHistory,
+      resumeById,
+      trimTail
+    ]
+  )
 }


### PR DESCRIPTION
Re-derivation of #38491 by @stremtec onto current main (original 10,119 commits behind; the hook moved into ui-tui/src/app/). Author credit preserved via the PR commit's email.

## Context — what this changes for users

useSessionLifecycle returned a fresh object literal every render, defeating memoization in useMainApp's consumers during streaming (every token render rebuilt downstream deps). useMemo over the nine useCallback-stable handles makes the return referentially stable.

## Review verification

- Dep array covers ALL nine returned handles including trimTail — the initial re-derivation omitted it (stale-closure class), caught on harvest and fixed before commit.
- All nine deps verified useCallback-stable end-to-end (simplify pass) — no per-render dep defeats the memo; placement matches ui-tui conventions.
- tsc clean; full ui-tui suite: 1515 passed, 12 failures verified PRE-EXISTING (identical with the change stashed).

Attribution mapping for stremtec landed in #77760.

Closes #38491.