### PR TITLE
perf(agent): cache per-turn display-flag config reads

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3413,12 +3413,21 @@ class AIAgent:
         ``HERMES_FILE_MUTATION_VERIFIER`` env var overrides config.  Exposed
         as a method so tests can patch a single seam without reaching into
         the private ``_turn_failed_file_mutations`` state dict.
+
+        The config lookup is read once per agent and cached (mirroring
+        ``_credits_notices_enabled``) — the footer gate runs at the end of
+        every turn, and a config flip applying on the next session is fine.
+        The env-var override stays authoritative on every call and is never
+        cached, so tests and operators can still flip it at runtime.
         """
         try:
             import os as _os
             env = _os.environ.get("HERMES_FILE_MUTATION_VERIFIER")
             if env is not None:
                 return env.strip().lower() not in {"0", "false", "no", "off"}
+            cached = getattr(self, "_file_mutation_verifier_enabled_cache", None)
+            if cached is not None:
+                return cached
             # Read from the persisted config.yaml so gateway and CLI share
             # the same setting.  Import lazily to avoid a startup-time cycle.
             try:
@@ -3428,7 +3437,11 @@ class AIAgent:
                 _cfg = {}
             _display = _cfg.get("display") if isinstance(_cfg, dict) else None
             if isinstance(_display, dict) and "file_mutation_verifier" in _display:
-                return bool(_display.get("file_mutation_verifier"))
+                enabled = bool(_display.get("file_mutation_verifier"))
+            else:
+                enabled = True  # safe default: verifier on
+            self._file_mutation_verifier_enabled_cache = enabled
+            return enabled
         except Exception:
             pass
         return True  # safe default: verifier on
@@ -3510,12 +3523,21 @@ class AIAgent:
         True).  ``HERMES_TURN_COMPLETION_EXPLAINER`` env var overrides
         config.  Exposed as a method so tests can patch a single seam,
         mirroring ``_file_mutation_verifier_enabled``.
+
+        The config lookup is read once per agent and cached (mirroring
+        ``_credits_notices_enabled``) — the gate runs at the end of every
+        turn, and a config flip applying on the next session is fine.
+        The env-var override stays authoritative on every call and is never
+        cached, so tests and operators can still flip it at runtime.
         """
         try:
             import os as _os
             env = _os.environ.get("HERMES_TURN_COMPLETION_EXPLAINER")
             if env is not None:
                 return env.strip().lower() not in {"0", "false", "no", "off"}
+            cached = getattr(self, "_turn_completion_explainer_enabled_cache", None)
+            if cached is not None:
+                return cached
             # Read from the persisted config.yaml so gateway and CLI share
             # the same setting.  Import lazily to avoid a startup-time cycle.
             try:
@@ -3525,7 +3547,11 @@ class AIAgent:
                 _cfg = {}
             _display = _cfg.get("display") if isinstance(_cfg, dict) else None
             if isinstance(_display, dict) and "turn_completion_explainer" in _display:
-                return bool(_display.get("turn_completion_explainer"))
+                enabled = bool(_display.get("turn_completion_explainer"))
+            else:
+                enabled = True  # safe default: explainer on
+            self._turn_completion_explainer_enabled_cache = enabled
+            return enabled
         except Exception:
             pass
         return True  # safe default: explainer on

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -317,10 +317,11 @@ class TestVerifierEnabled:
         """Measured-work pin: the config lookup happens once per agent.
 
         The footer gate runs at the end of every turn, so a fresh
-        ``load_config()`` per call is wasted work (~1 ms deepcopy per turn,
-        see #74211 for the sibling per-turn-config kill).  The config read
-        must be cached after the first call; the env-var override must still
-        win on every call, cached or not.
+        ``load_config()`` per call is wasted work (measured ~0.9 ms/call on
+        a warm mtime-cache on this host; the sibling per-turn-config kill in
+        #74211 removed exactly this class of read).  The config read must be
+        cached after the first call; the env-var override must still win on
+        every call, cached or not.
         """
         monkeypatch.delenv("HERMES_FILE_MUTATION_VERIFIER", raising=False)
         agent = _bare_agent()

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -313,6 +313,56 @@ class TestVerifierEnabled:
         agent = _bare_agent()
         assert agent._file_mutation_verifier_enabled() is False
 
+    def test_config_read_once_then_cached(self, monkeypatch):
+        """Measured-work pin: the config lookup happens once per agent.
+
+        The footer gate runs at the end of every turn, so a fresh
+        ``load_config()`` per call is wasted work (~1 ms deepcopy per turn,
+        see #74211 for the sibling per-turn-config kill).  The config read
+        must be cached after the first call; the env-var override must still
+        win on every call, cached or not.
+        """
+        monkeypatch.delenv("HERMES_FILE_MUTATION_VERIFIER", raising=False)
+        agent = _bare_agent()
+        calls = {"n": 0}
+
+        import hermes_cli.config as _cfg_mod
+
+        def counting_load():
+            calls["n"] += 1
+            return {"display": {"file_mutation_verifier": True}}
+
+        monkeypatch.setattr(_cfg_mod, "load_config", counting_load)
+
+        # First call reads config and caches the result.
+        assert agent._file_mutation_verifier_enabled() is True
+        assert calls["n"] == 1
+        # Subsequent calls must not re-read config.
+        assert agent._file_mutation_verifier_enabled() is True
+        assert agent._file_mutation_verifier_enabled() is True
+        assert calls["n"] == 1
+        # Env override stays authoritative even after the cache is warm.
+        monkeypatch.setenv("HERMES_FILE_MUTATION_VERIFIER", "0")
+        assert agent._file_mutation_verifier_enabled() is False
+        assert calls["n"] == 1  # env path never touches config
+
+    def test_cache_respects_config_value(self, monkeypatch):
+        """A disabled config value is cached as False, not re-read."""
+        monkeypatch.delenv("HERMES_FILE_MUTATION_VERIFIER", raising=False)
+        agent = _bare_agent()
+
+        import hermes_cli.config as _cfg_mod
+        monkeypatch.setattr(
+            _cfg_mod, "load_config", lambda: {"display": {"file_mutation_verifier": False}}
+        )
+        assert agent._file_mutation_verifier_enabled() is False
+        # Warm cache: flip the underlying config; the agent still reports the
+        # cached value (same next-session semantics as _credits_notices_enabled).
+        monkeypatch.setattr(
+            _cfg_mod, "load_config", lambda: {"display": {"file_mutation_verifier": True}}
+        )
+        assert agent._file_mutation_verifier_enabled() is False
+
 
 
 

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -116,8 +116,9 @@ def test_explainer_config_read_once_then_cached():
     """Measured-work pin: the config lookup happens once per agent.
 
     The explainer gate runs at the end of every turn, so a fresh
-    ``load_config()`` per call is wasted work (per-turn config reads were
-    killed repo-wide in #74211; this seam was missed).  The config read must
+    ``load_config()`` per call is wasted work (measured ~0.9 ms/call on a
+    warm mtime-cache on this host; per-turn config reads were killed
+    repo-wide in #74211, and this seam was missed).  The config read must
     be cached after the first call; the env-var override must still win on
     every call, cached or not.
     """

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -112,6 +112,40 @@ def test_explainer_disabled_via_env():
         assert agent._turn_completion_explainer_enabled() is False
 
 
+def test_explainer_config_read_once_then_cached():
+    """Measured-work pin: the config lookup happens once per agent.
+
+    The explainer gate runs at the end of every turn, so a fresh
+    ``load_config()`` per call is wasted work (per-turn config reads were
+    killed repo-wide in #74211; this seam was missed).  The config read must
+    be cached after the first call; the env-var override must still win on
+    every call, cached or not.
+    """
+    agent = _make_agent()
+    calls = {"n": 0}
+
+    def counting_load():
+        calls["n"] += 1
+        return {"display": {"turn_completion_explainer": True}}
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("HERMES_TURN_COMPLETION_EXPLAINER", None)
+        with patch("hermes_cli.config.load_config", counting_load):
+            # First call reads config and caches the result.
+            assert agent._turn_completion_explainer_enabled() is True
+            assert calls["n"] == 1
+            # Subsequent calls must not re-read config.
+            assert agent._turn_completion_explainer_enabled() is True
+            assert agent._turn_completion_explainer_enabled() is True
+            assert calls["n"] == 1
+            # Env override stays authoritative even after the cache is warm.
+            with patch.dict(
+                os.environ, {"HERMES_TURN_COMPLETION_EXPLAINER": "0"}, clear=False
+            ):
+                assert agent._turn_completion_explainer_enabled() is False
+            assert calls["n"] == 1  # env path never touches config
+
+
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Cache the two per-turn display-flag config reads on the agent instance, mirroring `_credits_notices_enabled`. `_file_mutation_verifier_enabled` and `_turn_completion_explainer_enabled` re-read `config.yaml` via `load_config()` on every call; `finalize_turn` runs them at the end of every turn, so each turn paid two redundant config deepcopies (~0.9 ms/call measured on a warm mtime-cache on this host). Per-turn config reads were already killed repo-wide in #74211; these two seams were missed.

Env-var overrides (`HERMES_FILE_MUTATION_VERIFIER`, `HERMES_TURN_COMPLETION_EXPLAINER`) stay authoritative and uncached on every call, so runtime flips still work. Config flips now apply on the next session, matching the documented `_credits_notices_enabled` semantics.

## Changes Made

- `run_agent.py` — add `self._file_mutation_verifier_enabled_cache` / `self._turn_completion_explainer_enabled_cache`, populated after the first config read, read before it on subsequent calls.
- `tests/run_agent/test_file_mutation_verifier.py` — measured-work pins: `load_config` call count stays 1 across repeated invocations; env override bypasses the cache; a disabled config value is cached as False.
- `tests/run_agent/test_turn_completion_explainer.py` — same measured-work pin for the explainer seam.

## How to Test

Validation:

1. Sabotage (revert-verify, both test files): pre-fix code fails the new pins (2 failed / 1 failed), with the fix all pass (27 passed / 8 passed, 0 failed).
2. Full repo-wide suite: branch 25203 passed, 8 failed vs baseline 25201 passed, 7 failed. The 2 branch-only failures were triaged:
   - `tests/honcho_plugin/test_pin_peer_name.py::test_cache_busting_signature_reflects_pin_peer_name` — fails identically on a clean `origin/main` worktree (pre-existing; unrelated to display-flag caching).
   - `tests/test_minimax_oauth.py::test_refresh_error_body_bounded_and_readable_with_real_client` — `httpcore.ReadError [Errno 104]` connection reset against the live OAuth endpoint; passed 2x on standalone re-run (network flake).
   - No code path from this change reaches honcho or minimax OAuth.
3. Duplicate check: 65 potential matches reviewed — none covers this change.
4. GitHub CI remains the final confirmation environment.

## Logs

Sabotage verification output:

```
# base leg (pre-fix code + branch tests):
#   tests: 7 passed, 1 failed
# head leg (with fix):
#   tests: 8 passed, 0 failed
```
