### PR TITLE
feat(context): automatic handoff boundary at ~100k tokens

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2001,6 +2001,24 @@ def init_agent(
                 compression_threshold_tokens = None
         except (TypeError, ValueError):
             compression_threshold_tokens = None
+    # Automatic handoff boundary. It runs before a model request and routes
+    # through the existing compression boundary without changing a live prompt.
+    compression_handoff_enabled = is_truthy_value(
+        _compression_cfg.get("handoff_enabled"), default=True
+    )
+    _raw_handoff_threshold = _compression_cfg.get("handoff_threshold_tokens", 100_000)
+    try:
+        if isinstance(_raw_handoff_threshold, bool):
+            raise ValueError
+        compression_handoff_threshold_tokens = int(_raw_handoff_threshold)
+        if isinstance(_raw_handoff_threshold, float) and (
+            _raw_handoff_threshold != compression_handoff_threshold_tokens
+        ):
+            raise ValueError
+        if compression_handoff_threshold_tokens <= 0:
+            compression_handoff_threshold_tokens = None
+    except (TypeError, ValueError):
+        compression_handoff_threshold_tokens = None
     # In-place compaction: when True, compress_context() rewrites the message
     # list + rebuilds the system prompt WITHOUT rotating the session id (no
     # parent_session_id chain, no `name #N` renumber). See #38763 and
@@ -2493,6 +2511,8 @@ def init_agent(
             pass
     agent.compression_enabled = compression_enabled
     agent.compression_in_place = compression_in_place
+    agent.compression_handoff_enabled = compression_handoff_enabled
+    agent.compression_handoff_threshold_tokens = compression_handoff_threshold_tokens
     # Apply micro-compaction settings to the compressor (feature is opt-in)
     _cc = getattr(agent, "context_compressor", None)
     if _cc is not None and hasattr(_cc, "_micro_compact_enabled"):

--- a/agent/context_handoff.py
+++ b/agent/context_handoff.py
@@ -1,0 +1,124 @@
+"""Cache-safe automatic context handoff artifacts.
+
+The artifact is deliberately metadata-only: the durable SessionDB remains the
+source of conversation truth, so this hook never rewrites messages, roles,
+tools, or the system prompt.  Compression/rotation is still performed by the
+existing pre-model compression path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+
+_MAX_HANDOFF_ARTIFACTS = 256
+
+
+def handoff_artifact_path(*, hermes_home: Path, session_id: str) -> Path:
+    """Return a collision-safe path while retaining the original id in JSON."""
+    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+    return Path(hermes_home) / "sessions" / "handoffs" / f"{digest}.json"
+
+
+def handoff_is_due(*, enabled: bool, estimated_tokens: int, threshold_tokens: Any) -> bool:
+    """Pure policy predicate used by the pre-model boundary."""
+    return bool(
+        enabled
+        and isinstance(threshold_tokens, int)
+        and not isinstance(threshold_tokens, bool)
+        and threshold_tokens > 0
+        and estimated_tokens >= threshold_tokens
+    )
+
+
+def write_handoff_artifact(
+    *,
+    hermes_home: Path,
+    session_id: Optional[str],
+    estimated_tokens: int,
+    threshold_tokens: int,
+    model: str = "",
+    reason: str = "context_threshold",
+) -> Optional[Path]:
+    """Atomically write a bounded resumable handoff marker.
+
+    No transcript is copied into this file.  This keeps artifact size bounded
+    and avoids creating a second, divergent conversation store.  A future
+    session can resume the durable session by id; the normal compression path
+    performs the actual context reduction before the next model request.
+    """
+    if (
+        not session_id
+        or isinstance(threshold_tokens, bool)
+        or not isinstance(threshold_tokens, int)
+        or threshold_tokens <= 0
+        or estimated_tokens < threshold_tokens
+    ):
+        return None
+    path = handoff_artifact_path(hermes_home=Path(hermes_home), session_id=session_id)
+    # One marker per session is sufficient. Avoid rewriting/fsyncing it on every
+    # qualifying turn; a new session id (rotation) gets a new marker naturally.
+    if path.is_file():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+            if (
+                existing.get("session_id") == session_id
+                and existing.get("threshold_tokens") == threshold_tokens
+            ):
+                _cleanup_handoff_artifacts(path.parent)
+                return path
+        except (OSError, ValueError, TypeError):
+            pass
+    payload = {
+        "version": 1,
+        "session_id": session_id,
+        "created_at": time.time(),
+        "estimated_tokens": int(estimated_tokens),
+        "threshold_tokens": int(threshold_tokens),
+        "model": str(model or ""),
+        "reason": reason,
+        "resumable": True,
+        "resume_command": f"hermes --resume {session_id}",
+        "conversation_source": "SessionDB",
+        "note": (
+            "Automatic handoff boundary reached. The durable session is the "
+            "source of truth; resume it or continue after pre-model compression."
+        ),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True, separators=(",", ":"))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, path)
+    finally:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+    _cleanup_handoff_artifacts(path.parent)
+    return path
+
+
+def _cleanup_handoff_artifacts(directory: Path) -> None:
+    """Keep a bounded recent marker set; SessionDB remains the transcript store."""
+    try:
+        artifacts = sorted(
+            directory.glob("*.json"), key=lambda item: item.stat().st_mtime, reverse=True
+        )
+        for stale in artifacts[_MAX_HANDOFF_ARTIFACTS:]:
+            try:
+                stale.unlink()
+            except OSError:
+                pass
+    except OSError:
+        pass

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -39,6 +39,7 @@ from agent.conversation_compression import (
     recover_rotated_compression_session,
 )
 from agent.context_engine import automatic_compaction_status_message
+from agent.context_handoff import handoff_is_due
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import build_memory_context_block
 from agent.memory_provider import is_trivial_prompt
@@ -737,17 +738,49 @@ def build_turn_context(
     _preflight_compression_blocked = False
     agent._turn_received_provider_response = False
     agent._turn_preflight_display_snapshot = None
+    _handoff_threshold = getattr(
+        agent, "compression_handoff_threshold_tokens", None
+    )
+    _handoff_threshold_int = (
+        _handoff_threshold
+        if isinstance(_handoff_threshold, int) and not isinstance(_handoff_threshold, bool)
+        else 0
+    )
+    _handoff_enabled = bool(
+        getattr(agent, "compression_handoff_enabled", False)
+    )
+    _handoff_due = False
+    _preflight_tokens = 0
+    _handoff_artifact_tokens = 0
+    _handoff_estimate_valid = _handoff_enabled and _handoff_threshold_int > 0
+    # Automatic handoff is an independent metadata boundary. Its decision must
+    # use the authoritative request estimate even when the cheap message-only
+    # compression gate says the transcript is small; system prompts and tool
+    # schemas are part of the request and can be the load-bearing tokens.
+    if _handoff_estimate_valid:
+        _preflight_tokens = estimate_request_tokens_rough(
+            messages,
+            system_prompt=active_system_prompt or "",
+            tools=agent.tools or None,
+        )
+        _handoff_artifact_tokens = _preflight_tokens
+        _handoff_due = handoff_is_due(
+            enabled=_handoff_enabled,
+            estimated_tokens=_preflight_tokens,
+            threshold_tokens=_handoff_threshold_int,
+        )
     if agent.compression_enabled and _should_run_preflight_estimate(
         messages,
         agent.context_compressor.protect_first_n,
         agent.context_compressor.protect_last_n,
         agent.context_compressor.threshold_tokens,
     ):
-        _preflight_tokens = estimate_request_tokens_rough(
-            messages,
-            system_prompt=active_system_prompt or "",
-            tools=agent.tools or None,
-        )
+        if not _handoff_estimate_valid:
+            _preflight_tokens = estimate_request_tokens_rough(
+                messages,
+                system_prompt=active_system_prompt or "",
+                tools=agent.tools or None,
+            )
         _compressor = agent.context_compressor
         # getattr guard: minimal compressor doubles (SimpleNamespace in the
         # engine-preflight tests) and plugin context engines lack this
@@ -1034,6 +1067,23 @@ def build_turn_context(
                     agent._last_content_with_tools = None
                     agent._last_content_tools_all_housekeeping = False
                     agent._mute_post_response = False
+
+    if _handoff_due:
+        # Write after compression/rotation, not before it: rotation changes
+        # agent.session_id and the marker must always name the active session.
+        try:
+            from agent.context_handoff import write_handoff_artifact
+            from hermes_constants import get_hermes_home
+
+            write_handoff_artifact(
+                hermes_home=get_hermes_home(),
+                session_id=agent.session_id,
+                estimated_tokens=_handoff_artifact_tokens,
+                threshold_tokens=_handoff_threshold_int,
+                model=getattr(agent, "model", ""),
+            )
+        except Exception:
+            logger.warning("Automatic context handoff artifact failed", exc_info=True)
 
     if _preflight_compressed:
         # Compression rebuilt the list (tail messages are fresh compaction

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -578,6 +578,10 @@ DEFAULT_CONFIG = {
                                       # triggers at the lower of the ratio-based
                                       # threshold and this token count. Clamped to
                                       # the model's context length at apply-time.
+        "handoff_enabled": True,      # create a bounded resume marker and use the
+                                      # existing pre-model compression boundary.
+        "handoff_threshold_tokens": 100000,  # set to 0 to disable; SessionDB is
+                                      # authoritative and the artifact is metadata-only.
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
         "min_tail_user_messages": 1,  # REAL (actionable) user messages guaranteed to

--- a/tests/agent/test_context_handoff.py
+++ b/tests/agent/test_context_handoff.py
@@ -1,0 +1,127 @@
+import json
+import os
+import pytest
+
+from agent.context_handoff import handoff_artifact_path, handoff_is_due, write_handoff_artifact
+
+
+def test_handoff_policy_is_threshold_and_config_driven():
+    assert handoff_is_due(enabled=True, estimated_tokens=100000, threshold_tokens=100000)
+    assert not handoff_is_due(enabled=True, estimated_tokens=99999, threshold_tokens=100000)
+    assert not handoff_is_due(enabled=False, estimated_tokens=200000, threshold_tokens=100000)
+    assert not handoff_is_due(enabled=True, estimated_tokens=200000, threshold_tokens=0)
+
+
+def test_handoff_artifact_is_bounded_atomic_and_resumable(tmp_path):
+    path = write_handoff_artifact(
+        hermes_home=tmp_path,
+        session_id="session/with spaces",
+        estimated_tokens=123456,
+        threshold_tokens=100000,
+        model="coding",
+    )
+
+    assert path == handoff_artifact_path(hermes_home=tmp_path, session_id="session/with spaces")
+    assert path is not None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["session_id"] == "session/with spaces"
+    assert payload["resumable"] is True
+    assert payload["resume_command"] == "hermes --resume session/with spaces"
+    assert payload["conversation_source"] == "SessionDB"
+    assert "messages" not in payload
+    assert path.stat().st_size < 4096
+    assert not list(path.parent.glob(".*.tmp"))
+
+    # Repeated crossings replace one marker instead of growing a directory.
+    write_handoff_artifact(
+        hermes_home=tmp_path,
+        session_id="session/with spaces",
+        estimated_tokens=200000,
+        threshold_tokens=100000,
+    )
+    assert len(list(path.parent.glob("*.json"))) == 1
+    assert json.loads(path.read_text())["estimated_tokens"] == 123456
+
+
+def test_session_ids_that_sanitize_alike_get_distinct_artifacts(tmp_path):
+    first = write_handoff_artifact(
+        hermes_home=tmp_path, session_id="a/b", estimated_tokens=100000, threshold_tokens=100000
+    )
+    second = write_handoff_artifact(
+        hermes_home=tmp_path, session_id="a_b", estimated_tokens=100000, threshold_tokens=100000
+    )
+    assert first != second
+    assert json.loads(first.read_text())["session_id"] == "a/b"
+    assert json.loads(second.read_text())["session_id"] == "a_b"
+
+
+def test_qualifying_repeat_is_deduplicated(tmp_path):
+    path = write_handoff_artifact(
+        hermes_home=tmp_path, session_id="sid", estimated_tokens=100000, threshold_tokens=100000
+    )
+    path.touch()
+    touched = path.stat().st_mtime_ns
+    assert write_handoff_artifact(
+        hermes_home=tmp_path, session_id="sid", estimated_tokens=200000, threshold_tokens=100000
+    ) == path
+    assert path.stat().st_mtime_ns == touched
+
+
+def test_qualifying_repeat_runs_retention_cleanup(tmp_path):
+    path = write_handoff_artifact(
+        hermes_home=tmp_path,
+        session_id="sid",
+        estimated_tokens=100000,
+        threshold_tokens=100000,
+    )
+    directory = path.parent
+    for index in range(256):
+        (directory / f"old-{index}.json").write_text("{}", encoding="utf-8")
+    # Keep the deduplicated marker newer than the synthetic backlog.
+    os.utime(path, None)
+
+    write_handoff_artifact(
+        hermes_home=tmp_path,
+        session_id="sid",
+        estimated_tokens=200000,
+        threshold_tokens=100000,
+    )
+
+    assert len(list(directory.glob("*.json"))) == 256
+    assert path.is_file()
+
+
+@pytest.mark.parametrize("value", [True, False, 1.5, "1.5"])
+def test_invalid_handoff_threshold_is_rejected(tmp_path, value):
+    assert not handoff_is_due(enabled=True, estimated_tokens=100000, threshold_tokens=value)
+    assert write_handoff_artifact(
+        hermes_home=tmp_path, session_id="sid", estimated_tokens=100000, threshold_tokens=value
+    ) is None
+
+
+def test_write_failure_does_not_leave_partial_artifact(tmp_path, monkeypatch):
+    def fail(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("agent.context_handoff.tempfile.mkstemp", fail)
+    with pytest.raises(OSError, match="disk full"):
+        write_handoff_artifact(
+            hermes_home=tmp_path, session_id="sid", estimated_tokens=100000, threshold_tokens=100000
+        )
+    assert not list(tmp_path.rglob("*.json"))
+
+
+def test_handoff_artifact_skips_invalid_boundary(tmp_path):
+    assert write_handoff_artifact(
+        hermes_home=tmp_path,
+        session_id="sid",
+        estimated_tokens=99999,
+        threshold_tokens=100000,
+    ) is None
+    assert not (tmp_path / "sessions").exists()
+    assert write_handoff_artifact(
+        hermes_home=tmp_path,
+        session_id=None,
+        estimated_tokens=100000,
+        threshold_tokens=100000,
+    ) is None

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -8,6 +8,7 @@ confirm the prologue produces the right ``TurnContext`` and applies the
 
 from __future__ import annotations
 
+import json
 import threading
 import types
 from unittest.mock import MagicMock, patch
@@ -195,6 +196,87 @@ def _build(agent, **overrides):
     )
     kwargs.update(overrides)
     return build_turn_context(**kwargs)
+
+
+def test_handoff_estimate_includes_system_prompt_and_tools_even_when_cheap_gate_skips():
+    agent = _FakeAgent()
+    agent.compression_handoff_enabled = True
+    agent.compression_handoff_threshold_tokens = 100
+    agent.tools = [{"type": "function", "function": {"name": "large_tool_schema"}}]
+    observed = {}
+
+    def _estimate(messages, *, system_prompt, tools):
+        observed.update(system_prompt=system_prompt, tools=tools, messages=messages)
+        return 101
+
+    with patch("agent.turn_context._should_run_preflight_estimate", return_value=False), \
+         patch("agent.turn_context.estimate_request_tokens_rough", side_effect=_estimate), \
+         patch("agent.context_handoff.write_handoff_artifact") as write_marker:
+        _build(agent)
+
+    assert observed["system_prompt"] == "SYSTEM"
+    assert observed["tools"] == agent.tools
+    write_marker.assert_called_once()
+    assert write_marker.call_args.kwargs["estimated_tokens"] == 101
+
+
+def test_handoff_estimate_does_not_force_compression_when_enabled():
+    agent = _FakeAgent()
+    agent.compression_enabled = True
+    agent.compression_handoff_enabled = True
+    agent.compression_handoff_threshold_tokens = 100
+    agent.context_compressor.threshold_tokens = 1000
+    agent.context_compressor.last_prompt_tokens = -1
+    agent.context_compressor.last_real_prompt_tokens = 0
+    agent.context_compressor.context_length = 10000
+    agent.context_compressor.should_defer_preflight_to_real_usage = lambda _tokens: False
+    agent.context_compressor.get_active_compression_failure_cooldown = lambda: None
+    agent._compress_context = MagicMock(side_effect=lambda messages, *_a, **_k: (messages, "SYSTEM"))
+
+    with patch("agent.turn_context._should_run_preflight_estimate", return_value=False), \
+         patch("agent.turn_context.estimate_request_tokens_rough", return_value=101), \
+         patch("agent.context_handoff.write_handoff_artifact"):
+        _build(agent)
+
+    agent._compress_context.assert_not_called()
+
+
+def test_handoff_marker_preserves_precompression_threshold_after_rotation(tmp_path):
+    agent = _FakeAgent()
+    agent.compression_enabled = True
+    agent.compression_handoff_enabled = True
+    agent.compression_handoff_threshold_tokens = 100
+    agent.context_compressor.threshold_tokens = 150
+    agent.context_compressor.last_prompt_tokens = -1
+    agent.context_compressor.last_real_prompt_tokens = 0
+    agent.context_compressor.context_length = 1000
+    agent.context_compressor.should_defer_preflight_to_real_usage = lambda _tokens: False
+    agent.context_compressor.should_compress = lambda tokens: tokens >= 150
+    compacted = [{"role": "user", "content": "[summary]"}]
+
+    def _compress(_messages, *_args, **_kwargs):
+        agent.session_id = "rotated-session"
+        return compacted, "SYSTEM"
+
+    agent._compress_context = MagicMock(side_effect=_compress)
+
+    with patch("agent.turn_context._should_run_preflight_estimate", return_value=True), \
+         patch(
+             "agent.turn_context.estimate_request_tokens_rough",
+             side_effect=[200, 50],
+         ), \
+         patch(
+             "agent.turn_context.conversation_history_after_compression",
+             return_value=compacted,
+         ), \
+         patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        _build(agent)
+
+    artifacts = list((tmp_path / "sessions" / "handoffs").glob("*.json"))
+    assert len(artifacts) == 1
+    payload = json.loads(artifacts[0].read_text(encoding="utf-8"))
+    assert payload["session_id"] == "rotated-session"
+    assert payload["estimated_tokens"] == 200
 
 
 def test_returns_turn_context_with_user_message_appended():


### PR DESCRIPTION
## What

Automatic runtime-enforced context handoff at ~100k tokens, before context compression or session reset.

## Why

Hermes had no native automatic handoff — only a self-regulated `/handoff` skill. A 7-day audit found 455 sessions with zero handoffs, 31 sessions ended by scheduled `session_reset`, and sessions growing to up to **1.49M input tokens** before being reset, losing context mid-work.

The `session_reset` sweep at 04:00 UTC (configurable via `session_reset.idle_minutes` / `at_hour`) killed sessions that had grown far past the policy handoff boundary. Without runtime enforcement, the 100k-token handoff point was advisory and regularly missed.

## What this adds

A config-driven automatic handoff that fires at the existing pre-model compression boundary:

- `compression.handoff_enabled` (default `true`)
- `compression.handoff_threshold_tokens` (default `100000`)

When the authoritative request estimate (messages + system prompt + tools) crosses the threshold, a bounded, atomic metadata marker is written after any compression/rotation. The marker records the **active post-rotation session id** and the **pre-compression token estimate**. The artifact is metadata-only — SessionDB remains the conversation source of truth.

No messages, roles, toolsets, or system prompt are mutated. Compression remains the only permitted cache-breaking boundary, exactly as before.

## Behavior by path

| Path | Handoff marker | Compression |
|---|---|---|
| Normal (compression enabled) | emitted when over threshold | unchanged |
| Compression disabled | emitted when over threshold | not forced |
| Cooldown active | emitted when over threshold | not forced |
| Native Codex compaction | emitted when over threshold | not forced |
| Rotation (session id changes) | emitted with post-rotation session id | unchanged |

## Safety

- **SHA-256 session-id artifact names** — collision-safe, original session id preserved in payload
- **Write deduplication** + **256-file retention invariant** (enforced on every write path, including dedup)
- **Threshold validation** — rejects `bool`, fractional, non-positive, and non-integer values
- **Pre-compression estimate preserved across rotation** — the marker records the estimate from before compression reduced the context, using the post-rotation session id
- **Failure to write is non-fatal** — logged, never blocks the turn

## Invariants preserved

- Prompt cache prefix stability (no mid-conversation context mutation)
- Strict message role alternation
- Byte-stable system prompt for the life of the conversation
- Existing compression, cooldown, native Codex, and rotation behavior unchanged

## Tests

Focused suite (in isolated venv with pinned deps):

- `tests/agent/test_context_handoff.py`
- `tests/agent/test_turn_context.py`
- `tests/run_agent/test_compression_boundary_hook.py`
- `tests/run_agent/test_codex_app_server_compaction.py`
- `tests/run_agent/test_compression_persistence.py`
- `tests/state/test_compression_lineage_guard.py`
- `tests/run_agent/test_preflight_compression_cap_e2e.py`
- `tests/agent/test_preflight_compression_gate.py`
- `tests/run_agent/test_per_model_compression_threshold.py`
- `tests/run_agent/test_compression_feasibility.py`

**114 passed, 0 failed** across handoff + compression lineage + turn context + Codex + preflight.

Regression coverage added:
- threshold crossing + system-prompt/tool-heavy estimate pushing real request over threshold
- compression-disabled emission
- post-rotation session lineage (marker uses rotated session id, pre-compression estimate)
- deduplication and 256-file retention invariant
- invalid threshold values (bool/fractional/non-positive)
- write failure handling

## Review history

This diff went through three independent adversarial review passes on this branch, each catching real issues that were fixed before the next pass:

1. **R1** (NO-GO) — handoff nested behind normal compression preflight gate; skipped when compression disabled; lossy session-id sanitization; rotation lineage gap; missing retention; invalid threshold parsing
2. **R2** (NO-GO) — system-prompt/tool-schema blind spot in the cheap estimate gate; dead state; retention edge case on dedup path
3. **R3** (GO) — pre-compression estimate preserved across rotation; post-rotation session lineage verified; all prior findings resolved

## Limitations / non-goals

- The artifact is a **resumable marker**, not a copied transcript. SessionDB remains authoritative.
- This does not itself rotate into a new session — it creates the marker and uses the existing compression boundary. Automatic fresh-session continuation on resume is a separate feature.
- Handoff depends on the preflight token-estimation path being reached (now fixed to use the authoritative full estimate including system prompt and tools).

## Related config

The companion runtime change (relaxing `session_reset.idle_minutes` from 1440 → 4320) is a separate local config change, not part of this PR.
