### PR TITLE
feat: add Portal usage JSON command

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -74,6 +74,28 @@ def _estimate_cost(
 
 
 
+_DAY_SECONDS = 86400
+
+
+def _local_day_label(timestamp: float) -> str:
+    """Return the local YYYY-MM-DD label for a unix timestamp."""
+    from datetime import datetime
+
+    return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d")
+
+
+def _billing_cost(entry) -> float:
+    """Return the best stored cost for a session_model_usage row."""
+    stored = entry.get("estimated_cost_usd")
+    if stored is None:
+        return 0.0
+    try:
+        value = float(stored)
+    except (TypeError, ValueError):
+        return 0.0
+    return value if value >= 0 else 0.0
+
+
 def _bar_chart(values: List[int], max_width: int = 20) -> List[str]:
     """Create simple horizontal bar chart strings from values."""
     peak = max(values) if values else 1
@@ -688,6 +710,126 @@ class InsightsEngine:
         result.sort(key=lambda x: (x["total_tokens"], x["sessions"]), reverse=True)
         return result
 
+    def compute_model_usage(self, days: int = 30, source: str = None) -> Dict[str, Any]:
+        """Per-model usage report: totals by model plus a daily cost time series.
+
+        Reuses the token/cost attribution from `_compute_model_breakdown` and
+        adds a per-model, per-local-day cost series suitable for terminal bar
+        charts or JSON consumers. Never raises: an empty window yields
+        ``{"empty": True}``.
+        """
+        cutoff = time.time() - (days * _DAY_SECONDS)
+        flush = getattr(self.db, "flush_token_counts", None)
+        if callable(flush):
+            flush()
+
+        sessions = self._get_sessions(cutoff, source)
+        if not sessions:
+            return {
+                "days": days,
+                "source_filter": source,
+                "empty": True,
+                "models": [],
+                "daily": [],
+                "generated_at": time.time(),
+            }
+
+        models = self._compute_model_breakdown(sessions, cutoff, source)
+        daily = self._compute_daily_model_cost(cutoff, source)
+        # Fold per-session aggregate rows without per-model usage rows into the
+        # daily series so legacy sessions still appear (best effort).
+        daily = self._reconcile_daily_from_sessions(sessions, daily)
+
+        for entry in models:
+            entry.setdefault("api_calls", 0)
+            entry.setdefault("cost", 0.0)
+            entry.setdefault("actual_cost", 0.0)
+            entry.setdefault("has_pricing", False)
+
+        return {
+            "days": days,
+            "source_filter": source,
+            "empty": False,
+            "models": models,
+            "daily": daily,
+            "generated_at": time.time(),
+        }
+
+    def _compute_daily_model_cost(self, cutoff: float, source: str = None) -> List[Dict]:
+        """Daily estimated-cost series per model from session_model_usage."""
+        daily: Dict[str, Dict[str, Any]] = {}
+        rows = self._get_model_usage(cutoff, source)
+        for row in rows:
+            model = row.get("model") or "unknown"
+            display = model.split("/")[-1] if "/" in model else model
+            session_id = row.get("session_id")
+            started = self._session_started_at(session_id)
+            if started is None:
+                continue
+            day = _local_day_label(started)
+            bucket = daily.setdefault(
+                (display, day),
+                {"model": display, "date": day, "cost_usd": 0.0,
+                 "input_tokens": 0, "output_tokens": 0, "api_calls": 0},
+            )
+            bucket["cost_usd"] += _billing_cost(row)
+            bucket["input_tokens"] += int(row.get("input_tokens") or 0)
+            bucket["output_tokens"] += int(row.get("output_tokens") or 0)
+            bucket["api_calls"] += int(row.get("api_call_count") or 0)
+        # Return a stable, sorted list.
+        result = list(daily.values())
+        result.sort(key=lambda r: (r["model"], r["date"]))
+        return result
+
+    def _reconcile_daily_from_sessions(
+        self, sessions: List[Dict], daily: List[Dict]
+    ) -> List[Dict]:
+        """Fold session aggregates into the daily series when per-model rows are missing."""
+        by_key = {(d["model"], d["date"]): d for d in daily}
+        for s in sessions:
+            started = s.get("started_at")
+            if not started:
+                continue
+            model = s.get("model") or "unknown"
+            display = model.split("/")[-1] if "/" in model else model
+            day = _local_day_label(started)
+            key = (display, day)
+            if key in by_key:
+                continue
+            cost = 0.0
+            stored = s.get("estimated_cost_usd")
+            if stored is not None:
+                try:
+                    cost = max(0.0, float(stored))
+                except (TypeError, ValueError):
+                    cost = 0.0
+            by_key[key] = {
+                "model": display,
+                "date": day,
+                "cost_usd": cost,
+                "input_tokens": int(s.get("input_tokens") or 0),
+                "output_tokens": int(s.get("output_tokens") or 0),
+                "api_calls": int(s.get("api_call_count") or 0),
+            }
+        result = list(by_key.values())
+        result.sort(key=lambda r: (r["model"], r["date"]))
+        return result
+
+    def _session_started_at(self, session_id) -> Optional[float]:
+        try:
+            cursor = self._conn.execute(
+                "SELECT started_at FROM sessions WHERE id = ?", (session_id,)
+            )
+            row = cursor.fetchone()
+        except sqlite3.OperationalError:
+            return None
+        if not row or row["started_at"] is None:
+            return None
+        try:
+            return float(row["started_at"])
+        except (TypeError, ValueError):
+            return None
+
     def _compute_platform_breakdown(self, sessions: List[Dict]) -> List[Dict]:
         """Break down usage by platform/source."""
         platform_data = defaultdict(lambda: {
@@ -1097,3 +1239,64 @@ class InsightsEngine:
                 lines.append(f"**Best streak:** {act['max_streak']} consecutive days")
 
         return "\n".join(lines)
+
+
+
+
+def format_model_usage_terminal(report: Dict[str, Any], top: int = 5) -> str:
+    """Human-readable per-model usage view with cost bars and daily charts."""
+    if report.get("empty"):
+        days = report.get("days", 30)
+        src = f" (source: {report['source_filter']})" if report.get("source_filter") else ""
+        return f"  No sessions found in the last {days} days{src}."
+
+    lines = [""]
+    lines.append("  📊 Per-model usage")
+    period_label = f"Last {report.get('days', 30)} days"
+    if report.get("source_filter"):
+        period_label += f" ({report['source_filter']})"
+    lines.append("  " + "─" * max(len(period_label) + 4, 40))
+    lines.append(f"  {period_label}")
+    lines.append("")
+
+    models = report.get("models") or []
+    by_cost = sorted(
+        models, key=lambda m: float(m.get("cost") or 0.0), reverse=True
+    )[: max(1, int(top))]
+    if by_cost:
+        lines.append("  Models by estimated cost")
+        lines.append("  " + "─" * 56)
+        peak = max((float(m.get("cost") or 0.0) for m in by_cost), default=0.0)
+        for m in by_cost:
+            name = (m.get("model") or "unknown")[:24]
+            cost = float(m.get("cost") or 0.0)
+            width = 0
+            if peak > 0:
+                width = max(1, int(cost / peak * 20))
+            bar = "█" * width
+            tokens = int(m.get("total_tokens") or 0)
+            calls = int(m.get("api_calls") or 0)
+            lines.append(f"  {name:<26} ${cost:>9,.2f} {tokens:>11,} tok {calls:>5} calls {bar}")
+        lines.append("")
+
+    daily = report.get("daily") or []
+    if daily:
+        lines.append("  Daily estimated cost")
+        lines.append("  " + "─" * 56)
+        by_model: Dict[str, List[Dict[str, Any]]] = {}
+        for row in daily:
+            by_model.setdefault(row["model"], []).append(row)
+        for model, rows in sorted(by_model.items(), key=lambda kv: -sum(r["cost_usd"] for r in kv[1]))[: max(1, int(top))]:
+            rows = sorted(rows, key=lambda r: r["date"])
+            costs = [float(r["cost_usd"] or 0.0) for r in rows]
+            labels = [r["date"][5:] for r in rows]
+            bars = _bar_chart([int(c * 100) for c in costs], max_width=24)
+            name = model[:20]
+            header = f"  {name:<22} " + " ".join(labels)
+            lines.append(header)
+            for bar, cost in zip(bars, costs):
+                lines.append(f"  {'':<22} ▏{bar:<24} ${cost:>8,.2f}")
+            lines.append("")
+
+    lines.append("  $ values are local estimates; Portal billing is authoritative.")
+    return "\n".join(lines)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1127,6 +1127,10 @@ DEFAULT_CONFIG = {
         "timestamps": False,      # Show timestamp on user and assistant labels
         "timestamp_format": "%H:%M",  # strftime format for timestamps (e.g. "%b-%d %H:%M")
         "final_response_markdown": "strip",  # render | strip | raw
+        # When true, TUI links keep their literal destination beside the label.
+        # Useful for remote terminal clients where copying a rendered OSC-8
+        # link otherwise copies only its human-readable title.
+        "explicit_links": False,
         # Preserve recent classic CLI output across Ctrl+L, /redraw, and
         # terminal resize full-screen clears. Disable if a terminal emulator
         # behaves badly with replayed scrollback.

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -914,7 +914,7 @@ class HermesConsoleEngine:
             confirmation="Send this message?",
         )
 
-        portal_paths = [("info",), ("tools",)]
+        portal_paths = [("info",), ("tools",), ("usage",)]
         _register_command_family(
             self,
             root="portal",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -474,7 +474,10 @@ from hermes_cli.subcommands.prompt_size import build_prompt_size_parser
 from hermes_cli.subcommands.memory import build_memory_parser
 from hermes_cli.subcommands.acp import build_acp_parser
 from hermes_cli.subcommands.tools import build_tools_parser
-from hermes_cli.subcommands.insights import build_insights_parser
+from hermes_cli.subcommands.insights import (
+    build_insights_parser,
+    build_models_usage_parser,
+)
 from hermes_cli.subcommands.monitoring import build_monitoring_parser
 from hermes_cli.subcommands.skills import build_skills_parser
 from hermes_cli.subcommands.pairing import build_pairing_parser
@@ -11066,6 +11069,26 @@ def cmd_insights(args):
         print(f"Error generating insights: {e}")
 
 
+def cmd_models_usage(args):
+    """Per-model usage with daily cost series (bar charts in terminal, JSON for scripts)."""
+    try:
+        from hermes_state import SessionDB
+        from agent.insights import InsightsEngine, format_model_usage_terminal
+
+        db = SessionDB()
+        engine = InsightsEngine(db)
+        report = engine.compute_model_usage(days=getattr(args, "days", 30), source=getattr(args, "source", None))
+        if getattr(args, "json", False):
+            import json as _json
+
+            print(_json.dumps(report, indent=2, sort_keys=True))
+        else:
+            print(format_model_usage_terminal(report, top=getattr(args, "top", 5)))
+        db.close()
+    except Exception as e:
+        print(f"Error generating per-model usage: {e}")
+
+
 def cmd_monitoring(args):
     """Gateway monitoring status: health & diagnostics export posture."""
     from hermes_cli.config import load_config
@@ -12314,6 +12337,7 @@ def main():
     # insights command  (parser built in hermes_cli/subcommands/insights.py)
     # =========================================================================
     build_insights_parser(subparsers, cmd_insights=cmd_insights)
+    build_models_usage_parser(subparsers, cmd_models_usage=cmd_models_usage)
     build_monitoring_parser(subparsers, cmd_monitoring=cmd_monitoring)
 
     # =========================================================================

--- a/hermes_cli/portal_cli.py
+++ b/hermes_cli/portal_cli.py
@@ -13,6 +13,7 @@ Subcommands:
   info     Show Portal auth state + which Tool Gateway tools are routed.
   open     Open the Portal subscription page in the user's default browser.
   tools    List Tool Gateway tools and which are active in the current config.
+  usage    Show sanitized balance/allowance telemetry; add --json for automation.
 
 This command is intentionally minimal — it does not duplicate functionality
 already in ``hermes auth`` or ``hermes tools``. It's the onboarding + discovery
@@ -20,11 +21,13 @@ surface for the Portal subscription itself.
 """
 from __future__ import annotations
 
+import json
 import sys
 import webbrowser
 
 from hermes_cli.colors import Colors, color
 from hermes_cli.config import load_config
+from agent.billing_usage import build_usage_model
 
 DEFAULT_PORTAL_URL = "https://portal.nousresearch.com"
 SUBSCRIPTION_URL = "https://portal.nousresearch.com/manage-subscription"
@@ -102,6 +105,103 @@ def _cmd_status(args) -> int:
         print()
         print(color(f"  Docs: {DOCS_URL}", Colors.DIM))
     return 0
+
+
+_USAGE_SCHEMA_VERSION = 1
+
+
+def build_usage_payload(model) -> dict[str, object]:
+    """Return the stable, sanitized ``portal usage --json`` payload.
+
+    The payload deliberately exposes only account-level display values. It never
+    serializes raw Portal responses, identifiers, OAuth credentials, tool state,
+    or inference routes. A percentage is emitted only when Portal supplied a
+    positive monthly allowance; top-ups have no denominator and remain a dollar
+    balance rather than a fabricated percentage.
+    """
+    unavailable = not bool(model and getattr(model, "available", False))
+    if unavailable:
+        return {
+            "schema_version": _USAGE_SCHEMA_VERSION,
+            "available": False,
+            "status": "unavailable",
+            "plan": None,
+            "renews_at": None,
+            "subscription": None,
+            "top_up": None,
+            "total_usable_usd": None,
+        }
+
+    plan_bar = getattr(model, "plan_bar", None)
+    subscription = None
+    if plan_bar is not None:
+        monthly_allowance = _finite_number(getattr(plan_bar, "total_usd", None))
+        remaining = _finite_number(getattr(plan_bar, "remaining_usd", None))
+        used_percent = getattr(plan_bar, "pct_used", None)
+        if monthly_allowance is not None and monthly_allowance > 0 and remaining is not None:
+            subscription = {
+                "remaining_usd": remaining,
+                "monthly_allowance_usd": monthly_allowance,
+                "used_percent": used_percent if isinstance(used_percent, int) else None,
+            }
+
+    topup_remaining = _finite_number(getattr(model, "topup_remaining_usd", None))
+    top_up = {"remaining_usd": topup_remaining} if topup_remaining is not None else None
+
+    return {
+        "schema_version": _USAGE_SCHEMA_VERSION,
+        "available": True,
+        "status": getattr(model, "status", None) or "unknown",
+        "plan": _clean_text(getattr(model, "plan_name", None)),
+        "renews_at": _clean_text(getattr(model, "renews_at", None)),
+        "subscription": subscription,
+        "top_up": top_up,
+        "total_usable_usd": _finite_number(getattr(model, "total_spendable_usd", None)),
+    }
+
+
+def _finite_number(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    import math
+
+    number = float(value)
+    return number if math.isfinite(number) and number >= 0 else None
+
+
+def _clean_text(value):
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _cmd_usage(args) -> int:
+    """Print safe Portal balance/allowance telemetry without exposing OAuth state."""
+    model = build_usage_model(timeout=8.0)
+    payload = build_usage_payload(model)
+    if getattr(args, "json", False):
+        print(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+    elif not payload["available"]:
+        print("Nous Portal usage is unavailable. Log in with `hermes portal` and try again.")
+    else:
+        print("Nous Portal usage")
+        if payload["plan"]:
+            print(f"Plan: {payload['plan']}")
+        if payload["subscription"]:
+            subscription = payload["subscription"]
+            print(
+                "Subscription allowance: "
+                f"${subscription['remaining_usd']:.2f} remaining of "
+                f"${subscription['monthly_allowance_usd']:.2f}"
+            )
+        if payload["top_up"]:
+            print(f"Top-up balance: ${payload['top_up']['remaining_usd']:.2f}")
+        if payload["total_usable_usd"] is not None:
+            print(f"Total usable: ${payload['total_usable_usd']:.2f}")
+        if payload["renews_at"]:
+            print(f"Renews: {payload['renews_at']}")
+    return 0 if payload["available"] else 1
 
 
 def _cmd_open(args) -> int:
@@ -204,6 +304,8 @@ def portal_command(args) -> int:
         return _cmd_open(args)
     if sub == "tools":
         return _cmd_tools(args)
+    if sub == "usage":
+        return _cmd_usage(args)
     print(f"Unknown portal subcommand: {sub}", file=sys.stderr)
     print("Run `hermes portal -h` for usage.", file=sys.stderr)
     return 1
@@ -219,7 +321,7 @@ def add_parser(subparsers) -> None:
             "and set it up — pick a model, set Nous as your provider, and offer "
             "the Tool Gateway (the human-readable alias for `hermes auth add "
             "nous --type oauth`, identical to `hermes setup --portal`). "
-            "Subcommands: login (default), info, open, tools."
+            "Subcommands: login (default), info, open, tools, usage."
         ),
     )
     portal_sub = portal_parser.add_subparsers(dest="portal_command")
@@ -241,6 +343,15 @@ def add_parser(subparsers) -> None:
     portal_sub.add_parser(
         "tools",
         help="List Tool Gateway tools and which are routed via Nous",
+    )
+    usage_parser = portal_sub.add_parser(
+        "usage",
+        help="Show Portal balance/allowance telemetry (use --json for scripts)",
+    )
+    usage_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the stable, sanitized JSON usage contract",
     )
 
     portal_parser.set_defaults(func=portal_command)

--- a/hermes_cli/subcommands/insights.py
+++ b/hermes_cli/subcommands/insights.py
@@ -23,3 +23,29 @@ def build_insights_parser(subparsers, *, cmd_insights: Callable) -> None:
         "--source", help="Filter by platform (cli, telegram, discord, etc.)"
     )
     insights_parser.set_defaults(func=cmd_insights)
+
+
+def build_models_usage_parser(subparsers, *, cmd_models_usage: Callable) -> None:
+    """Attach the ``models-usage`` subcommand to ``subparsers``."""
+    parser = subparsers.add_parser(
+        "models-usage",
+        help="Show per-model token/cost usage with daily charts",
+        description=(
+            "Break down local session usage by model: estimated cost, tokens, "
+            "API calls, and a per-day cost series. Human-readable bar charts "
+            "by default; --json emits the machine-readable report."
+        ),
+    )
+    parser.add_argument(
+        "--days", type=int, default=30, help="Number of days to analyze (default: 30)"
+    )
+    parser.add_argument(
+        "--source", help="Filter by platform (cli, telegram, discord, etc.)"
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Print the machine-readable JSON report"
+    )
+    parser.add_argument(
+        "--top", type=int, default=5, help="Top N models to chart (default: 5)"
+    )
+    parser.set_defaults(func=cmd_models_usage)

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -8,6 +8,7 @@ from agent.insights import (
     InsightsEngine,
     _estimate_cost,
     _bar_chart,
+    format_model_usage_terminal,
 )
 from agent.usage_pricing import (
     format_duration_compact as _format_duration,
@@ -291,6 +292,50 @@ class TestInsightsPopulated:
         assert models["deepseek-v4-pro"]["total_tokens"] == 48000
         assert models["claude-opus-4.8"]["total_tokens"] == 54000
 
+
+    def test_model_usage_breakdown_returns_totals_and_daily_series(self, populated_db):
+        engine = InsightsEngine(populated_db)
+        result = engine.compute_model_usage(days=30)
+
+        assert result["days"] == 30
+        assert result["empty"] is False
+        models = {m["model"]: m for m in result["models"]}
+        # populated_db has claude-sonnet (s1 + s4), gpt-4o (s2), deepseek-chat (s3)
+        assert set(models) == {"claude-sonnet-4-20250514", "gpt-4o", "deepseek-chat"}
+        claude = models["claude-sonnet-4-20250514"]
+        assert claude["input_tokens"] == 60000
+        assert claude["output_tokens"] == 20000
+        assert claude["api_calls"] == 0
+        # Daily series entries carry YYYY-MM-DD local dates
+        assert all(len(d["date"]) == 10 for d in result["daily"])
+        claude_days = [d for d in result["daily"] if d["model"] == claude["model"]]
+        assert claude_days, "expected at least one daily entry for claude-sonnet"
+
+    def test_model_usage_respects_days_window(self, populated_db):
+        engine = InsightsEngine(populated_db)
+        result = engine.compute_model_usage(days=3)
+        models = {m["model"] for m in result["models"]}
+        # s3 (deepseek-chat, 10 days ago) is outside the 3-day window
+        assert "deepseek-chat" not in models
+        assert "gpt-4o" not in models
+        assert "claude-sonnet-4-20250514" in models
+
+    def test_model_usage_terminal_format_shows_bars(self, populated_db):
+        engine = InsightsEngine(populated_db)
+        result = engine.compute_model_usage(days=30)
+        text = format_model_usage_terminal(result, top=3)
+        assert "Models by estimated cost" in text
+        assert "Daily estimated cost" in text
+        assert "█" in text
+
+    def test_model_usage_json_shape(self, populated_db):
+        import json
+
+        engine = InsightsEngine(populated_db)
+        result = engine.compute_model_usage(days=30)
+        payload = json.dumps(result)
+        assert '"models"' in payload
+        assert '"daily"' in payload
 
     def test_overview_cost_matches_per_model_stored_cost(self, db):
         db.create_session(session_id="cost", source="cli", model="model-a")

--- a/tests/hermes_cli/test_portal_usage_cli.py
+++ b/tests/hermes_cli/test_portal_usage_cli.py
@@ -1,0 +1,104 @@
+"""Tests for the stable, sanitized ``hermes portal usage --json`` contract."""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+
+import agent.billing_usage as billing_usage
+import hermes_cli.portal_cli as portal_cli
+
+
+def test_usage_payload_is_versioned_sanitized_and_preserves_known_denominators():
+    model = billing_usage.UsageModel(
+        available=True,
+        status="healthy",
+        plan_name="Plus",
+        renews_at="2026-08-31T00:00:00Z",
+        subscription_remaining_usd=14.0,
+        topup_remaining_usd=12.0,
+        total_spendable_usd=26.0,
+        plan_bar=billing_usage.UsageBar(kind="plan", remaining_usd=14.0, total_usd=20.0, spent_usd=6.0),
+        topup_bar=billing_usage.UsageBar(kind="topup", remaining_usd=12.0, total_usd=12.0),
+    )
+
+    payload = portal_cli.build_usage_payload(model)
+
+    assert payload == {
+        "schema_version": 1,
+        "available": True,
+        "status": "healthy",
+        "plan": "Plus",
+        "renews_at": "2026-08-31T00:00:00Z",
+        "subscription": {"remaining_usd": 14.0, "monthly_allowance_usd": 20.0, "used_percent": 30},
+        "top_up": {"remaining_usd": 12.0},
+        "total_usable_usd": 26.0,
+    }
+    serialized = json.dumps(payload, sort_keys=True)
+    assert "token" not in serialized.lower()
+    assert "email" not in serialized.lower()
+    assert "organisation" not in serialized.lower()
+
+
+def test_usage_payload_omits_percentage_when_the_portal_did_not_supply_a_denominator():
+    payload = portal_cli.build_usage_payload(
+        billing_usage.UsageModel(
+            available=True,
+            status="healthy",
+            topup_remaining_usd=4.0,
+            total_spendable_usd=4.0,
+            topup_bar=billing_usage.UsageBar(kind="topup", remaining_usd=4.0, total_usd=4.0),
+        )
+    )
+
+    assert payload["subscription"] is None
+    assert payload["top_up"] == {"remaining_usd": 4.0}
+    assert payload["total_usable_usd"] == 4.0
+
+
+def test_portal_usage_json_prints_machine_readable_payload(monkeypatch, capsys):
+    model = billing_usage.UsageModel(available=True, status="low", plan_name="Plus", total_spendable_usd=3.0)
+    monkeypatch.setattr(portal_cli, "build_usage_model", lambda timeout: model)
+
+    assert portal_cli._cmd_usage(Namespace(json=True)) == 0
+
+    assert json.loads(capsys.readouterr().out) == {
+        "schema_version": 1,
+        "available": True,
+        "status": "low",
+        "plan": "Plus",
+        "renews_at": None,
+        "subscription": None,
+        "top_up": None,
+        "total_usable_usd": 3.0,
+    }
+
+
+def test_portal_usage_json_is_unavailable_when_not_logged_in(monkeypatch, capsys):
+    monkeypatch.setattr(portal_cli, "build_usage_model", lambda timeout: billing_usage.UsageModel(available=False))
+
+    assert portal_cli._cmd_usage(Namespace(json=True)) == 1
+
+    assert json.loads(capsys.readouterr().out) == {
+        "schema_version": 1,
+        "available": False,
+        "status": "unavailable",
+        "plan": None,
+        "renews_at": None,
+        "subscription": None,
+        "top_up": None,
+        "total_usable_usd": None,
+    }
+
+
+def test_portal_parser_registers_usage_json_flag():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    portal_cli.add_parser(subparsers)
+
+    args = parser.parse_args(["portal", "usage", "--json"])
+
+    assert args.portal_command == "usage"
+    assert args.json is True

--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -9,6 +9,7 @@ import { AUDIO_DIRECTIVE_RE, INLINE_RE, Md, MEDIA_LINE_RE, stripInlineMarkup } f
 import { __resetLinkTitleCache, fetchLinkTitle } from '../lib/externalLink.js'
 import { stripAnsi } from '../lib/text.js'
 import { DEFAULT_THEME, LIGHT_THEME } from '../theme.js'
+import { patchUiState } from '../app/uiStore.js'
 
 afterEach(() => {
   __resetLinkTitleCache()
@@ -287,6 +288,21 @@ describe('Md link labels', () => {
 
     expect(rendered).toContain('Puerto Rico El Yunque Rainforest Adventure')
     expect(rendered).not.toContain('https://www.expedia.com/things-to-do/puerto-rico-el-yunque-rainforest-adventure')
+  })
+
+  it('keeps literal destinations copyable when explicit links are enabled', () => {
+    const url = 'https://github.com/NousResearch/hermes-agent/pull/77791'
+
+    patchUiState({ explicitLinks: true })
+    try {
+      const lines = renderPlain(
+        React.createElement(Box, { width: 120 }, React.createElement(Md, { t: DEFAULT_THEME, text: `[Hermes PR](${url})` }))
+      )
+
+      expect(lines.join('\n')).toContain(`Hermes PR <${url}>`)
+    } finally {
+      patchUiState({ explicitLinks: false })
+    }
   })
 
   it('keeps the authored markdown label even when a page title resolves', async () => {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -324,6 +324,7 @@ export interface UiState {
   compact: boolean
   detailsMode: DetailsMode
   detailsModeCommandOverride: boolean
+  explicitLinks: boolean
   // Focus view (/focus) — display-only reduced-output mode. Drives the
   // persistent `◉ focus` status-bar badge; never affects request payloads.
   focusView: boolean

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -16,6 +16,7 @@ const buildUiState = (): UiState => ({
   compact: false,
   detailsMode: 'collapsed',
   detailsModeCommandOverride: false,
+  explicitLinks: false,
   focusView: false,
   indicatorStyle: DEFAULT_INDICATOR_STYLE,
   info: null,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -275,6 +275,7 @@ export const applyDisplay = (
     compact: !!d.tui_compact,
     detailsMode: resolveDetailsMode(d),
     detailsModeCommandOverride: false,
+    explicitLinks: d.explicit_links === true,
     focusView: !!d.focus_view,
     indicatorStyle: normalizeIndicatorStyle(d.tui_status_indicator),
     inlineDiffs: d.inline_diffs !== false,

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -1,6 +1,8 @@
 import { Box, Link, stringWidth, Text } from '@hermes/ink'
 import { Fragment, memo, type ReactNode, useMemo } from 'react'
+import { useStore } from '@nanostores/react'
 
+import { $uiState } from '../app/uiStore.js'
 import { ensureEmojiPresentation } from '../lib/emoji.js'
 import { normalizeExternalUrl, urlSlugTitleLabel, useLinkTitle } from '../lib/externalLink.js'
 import { BOX_CLOSE, BOX_OPEN, texToUnicode } from '../lib/mathUnicode.js'
@@ -172,13 +174,24 @@ interface ResolvedLinkProps {
 // override — replacing `[Read the RFC](url)` with the page title throws away
 // better wording than we can derive, and mangles labels like `#71706`.
 function ResolvedLink({ authoredLabel, t, url }: ResolvedLinkProps) {
-  const fetched = useLinkTitle(authoredLabel ? null : url)
-  const display = authoredLabel || fetched || defaultLinkLabel(url)
+  const explicitLinks = useStore($uiState).explicitLinks
+  // Skip title fetches in explicit mode: the raw destination is intentionally
+  // the copyable label and must remain visible in remote clients such as Herdr.
+  const fetched = useLinkTitle(explicitLinks || authoredLabel ? null : url)
+  const display = explicitLinks ? authoredLabel || url : authoredLabel || fetched || defaultLinkLabel(url)
+  const showDestination = explicitLinks && display !== url
 
   return (
     <Link url={url}>
       <Text color={t.color.accent} underline>
         {display}
+        {showDestination ? (
+          <Text color={t.color.muted} underline>
+            {' <'}
+            {url}
+            {'>'}
+          </Text>
+        ) : null}
       </Text>
     </Link>
   )

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -81,6 +81,8 @@ export interface ConfigDisplayConfig {
   bell_on_complete?: boolean
   busy_input_mode?: string
   details_mode?: string
+  /** Keep literal destinations beside rendered link labels. */
+  explicit_links?: boolean
   /** Focus view (/focus) — display-only reduced-output mode. */
   focus_view?: boolean
   inline_diffs?: boolean

--- a/website/docs/integrations/nous-portal.md
+++ b/website/docs/integrations/nous-portal.md
@@ -141,6 +141,22 @@ hermes portal open       # open the subscription management page in your browser
 
 `hermes portal` (with no subcommand) is the human-readable alias for `hermes auth add nous --type oauth` — it logs you in, lets you pick a Nous model, sets Nous as your inference provider, and offers the Tool Gateway opt-in (identical to `hermes setup --portal`, and the same Nous flow as the first-time quick setup).
 
+### Per-model usage charts
+
+`hermes models-usage` breaks local session history down by model: estimated
+cost, tokens, API calls, and a per-day cost series. It renders human-readable
+bar charts by default and accepts `--json` for scripts, `--days N` to change
+the window, `--source` to filter by platform, and `--top N` to limit the chart.
+
+```bash
+hermes models-usage --days 30
+hermes models-usage --days 30 --json
+```
+
+Values are local estimates from Hermes session accounting. Portal billing
+remains the authoritative source; `hermes portal usage --json` reports the
+subscription-level balance.
+
 ### Machine-readable usage telemetry
 
 `hermes portal usage --json` emits a versioned, sanitized account-usage

--- a/website/docs/integrations/nous-portal.md
+++ b/website/docs/integrations/nous-portal.md
@@ -135,10 +135,47 @@ hermes portal            # log in to Nous Portal + set it up (one-shot onboardin
 hermes portal info       # login status, subscription info, model + gateway routing
 hermes portal status     # alias for `portal info`
 hermes portal tools      # detailed Tool Gateway catalog with per-tool routing
+hermes portal usage --json  # stable, sanitized balance/allowance telemetry for local automation
 hermes portal open       # open the subscription management page in your browser
 ```
 
 `hermes portal` (with no subcommand) is the human-readable alias for `hermes auth add nous --type oauth` — it logs you in, lets you pick a Nous model, sets Nous as your inference provider, and offers the Tool Gateway opt-in (identical to `hermes setup --portal`, and the same Nous flow as the first-time quick setup).
+
+### Machine-readable usage telemetry
+
+`hermes portal usage --json` emits a versioned, sanitized account-usage
+snapshot for local integrations such as status bars. Hermes resolves and
+refreshes its own Portal credential; the output never contains OAuth tokens,
+raw Portal responses, user identifiers, organisation identifiers, or inference
+routing data.
+
+```bash
+hermes portal usage --json
+```
+
+```json
+{
+  "schema_version": 1,
+  "available": true,
+  "status": "healthy",
+  "plan": "Plus",
+  "renews_at": "2026-08-31T00:00:00Z",
+  "subscription": {
+    "remaining_usd": 14.0,
+    "monthly_allowance_usd": 20.0,
+    "used_percent": 30
+  },
+  "top_up": { "remaining_usd": 12.0 },
+  "total_usable_usd": 26.0
+}
+```
+
+`subscription` is `null` when Hermes cannot prove a positive monthly allowance,
+and `top_up` is `null` when no top-up balance is reported. Consumers must not
+invent a percentage from the top-up balance. When no Portal account is available,
+the command prints an `available: false` payload and exits with status `1`.
+The current schema uses USD values despite legacy upstream field names that
+contain `credits`.
 
 `hermes portal info` gives you the high-level overview:
 


### PR DESCRIPTION
## Summary

- add `hermes portal usage --json`, a stable schema-v1 local account-usage contract
- add `hermes models-usage`, per-model token/cost usage with daily bar charts and `--json`
- add `display.explicit_links`: render every TUI link with its literal destination next to the human label, so remote clients can copy/open the real URL rather than only the rendered title
- fetch through Hermes-managed OAuth refresh, never exposing refresh tokens, bearer tokens, account IDs, raw Portal responses, or routing information

## Usage

```bash
hermes portal usage --json
hermes models-usage --days 30
hermes models-usage --days 30 --json
hermes config set display.explicit_links true
```

`display.explicit_links` is false by default. When enabled, a rendered `[Hermes PR](https://example.com)` appears as `Hermes PR <https://example.com>` and remains an OSC-8 link.

## Validation

- `uv run --with pytest pytest -q tests/hermes_cli/test_nous_account.py tests/agent/test_credits_view.py tests/hermes_cli/test_portal_usage_cli.py tests/agent/test_insights.py` — passed
- `ui-tui: npx vitest run src/__tests__/markdown.test.ts` — 34 passed
- `ui-tui: npm run typecheck` and `npm run build` — passed
- `python3 -m py_compile hermes_cli/portal_cli.py hermes_cli/console_engine.py hermes_cli/main.py hermes_cli/subcommands/insights.py agent/insights.py`
- live local contract smoke checks: `hermes portal usage --json` and `hermes models-usage --days 30` (validated schema v1 without logging payload values)

Closes #24814