### PR TITLE
fix(cron): do not report empty delivery as delivered (#77763)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1731,6 +1731,26 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 opened_thread_id = new_thread_id
 
         if live_adapter_ready:
+            # Nothing to deliver: content was emptied by MEDIA extraction (e.g.
+            # a response that is ONLY a ``MEDIA:`` tag whose path failed
+            # validation) and no media survived filtering. Sending an empty
+            # payload would be a no-op; logging "delivered" here would be a lie
+            # (#77763). Fall through to the standalone path (which also guards
+            # empty content) so the job is not reported as successfully
+            # delivered.
+            if not cleaned_delivery_content.strip() and not media_files:
+                logger.warning(
+                    "Job '%s': nothing to deliver to %s:%s (content empty after "
+                    "MEDIA extraction and no media files)",
+                    job["id"], platform_name, chat_id,
+                )
+                err_msg = (
+                    f"empty delivery content for {platform_name}:{chat_id} "
+                    "(nothing to send after MEDIA extraction)"
+                )
+                target_errors.append(err_msg)
+                delivery_errors.append(err_msg)
+                continue
             # Telegram topic routing (#22773, regression fixed #52060): a
             # ``telegram:<positive_chat_id>:<numeric_thread_id>`` cron target is
             # ambiguous — a forum-style topic in a private chat and a genuine
@@ -1794,6 +1814,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
                 timed_out = False
+                # Track whether anything was actually dispatched. A cron result
+                # whose delivered content is empty after MEDIA extraction (e.g. a
+                # response that is ONLY a ``MEDIA:`` tag whose path fails
+                # validation) must NOT be reported as "delivered" — otherwise the
+                # job logs success while the target never receives anything
+                # (#77763).
+                anything_dispatched = False
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
 
@@ -1866,6 +1893,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                     "to avoid duplicate)",
                                     job["id"], platform_name, chat_id,
                                 )
+                                # The send is in flight on the wire — it was
+                                # dispatched, so it counts toward "delivered"
+                                # (#38922) and must not be reported as an
+                                # empty no-op (#77763).
+                                anything_dispatched = True
                         except Exception as ex:
                             # A real send error (not a slow confirmation) — fall
                             # through to the standalone path so the message is
@@ -1918,7 +1950,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                                     )
                                 target_errors.append(msg)
                                 adapter_ok = False  # fall through to standalone path
-                            elif (
+                            else:
+                                # Text was confirmed sent by the live adapter.
+                                anything_dispatched = True
+                            if (
                                 send_raw_response
                                 and thread_id
                                 and send_raw_response.get("thread_fallback")
@@ -1941,6 +1976,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # skipped attachments so the drop is visible rather than silently
                 # lost.
                 if adapter_ok and not timed_out and media_files:
+                    anything_dispatched = True
                     routed_media_metadata = dict(media_metadata or {})
                     if transport is not None and transport.is_relay:
                         routed_media_metadata["_relay_logical_platform"] = platform.value
@@ -1967,7 +2003,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     logger.warning("Job '%s': %s", job["id"], msg)
                     delivery_errors.append(msg)
 
-                if adapter_ok:
+                if adapter_ok and anything_dispatched:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                     delivered = True
                     # Seed the thread session only now that delivery into it

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -418,6 +418,54 @@ class TestDeliverResultWrapping:
         voice_call = adapter.send_voice.call_args
         assert voice_call[1]["audio_path"] == str(media_path)
 
+    def test_empty_content_after_media_extraction_is_not_reported_delivered(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression for #77763: a cron result whose delivered content is ONLY
+        a ``MEDIA:`` tag whose path fails validation (so both text and media
+        are empty) must NOT be logged as "delivered" — the job reports failure
+        instead of a silent no-op."""
+        from gateway.config import Platform
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+        adapter.send_document = AsyncMock(return_value=MagicMock(success=True))
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        job = {
+            "id": "empty-content-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+
+        # The invalid MEDIA path is filtered out by extract_media/filter, so
+        # both text_to_send and media_files end up empty.
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})):
+            result = _deliver_result(
+                job,
+                "MEDIA:/nonexistent/cron-journal.md",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        # Nothing was sent through the live adapter...
+        adapter.send.assert_not_called()
+        adapter.send_document.assert_not_called()
+        # ... and the job is NOT reported as delivered — an error string is
+        # returned so the failure is visible instead of a silent no-op.
+        assert result is not None
+        assert "nothing to deliver" in result or "empty delivery" in result
+        assert adapter.send.await_count == 0
+
 
 class TestDeliverResultErrorReturns:
     """Verify _deliver_result returns error strings on failure, None on success."""


### PR DESCRIPTION
## Summary

Fixes #77763 — a cron agent job could log "delivered to <chat> via live adapter" while **nothing was actually sent** to the target platform (Telegram). The job reported success with zero sends.

## Root Cause

In `cron/scheduler.py::_deliver_result`, when a cron result's delivered content is **only** a `MEDIA:` tag whose path fails validation (e.g. `/nonexistent/journal.md`), the MEDIA extraction + path filtering empties both the text (`cleaned_delivery_content.strip()` == "") and the media list. The `if text_to_send:` send block is skipped entirely, yet `adapter_ok` was already set to `True` **before** that block — so the scheduler logged "delivered via live adapter" and set `delivered = True` without dispatching anything. The standalone fallback was never reached because the live-adapter branch claimed success.

## Change

- **Early guard**: when `cleaned_delivery_content.strip()` and `media_files` are both empty, the live-adapter branch now logs a warning, records a `delivery_errors` entry ("nothing to send after MEDIA extraction"), and skips the target — the job is reported as failed (visible) instead of silently "delivered".
- **`anything_dispatched` tracking**: the "delivered via live adapter" log and `delivered = True` now require that at least one real dispatch happened — confirmed text send, in-flight timeout (already on the wire, per #38922), or media attachments — closing the empty-payload false-positive path.

## Verification

- Repro (MEDIA-only invalid path): before → "delivered" with zero `adapter.send`/`send_document` calls; after → "nothing to deliver" warning + error return.
- New regression test `test_empty_content_after_media_extraction_is_not_reported_delivered` asserts no sends and a non-None (error) result.
- `pytest tests/cron/test_scheduler.py` → 64 passed (media-attachment test preserved).
