### PR TITLE
fix(secrets): fail closed on mixed Bitwarden auth errors

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -586,7 +586,7 @@ def fetch_bitwarden_secrets(
         #   honor that on the fallback path too.  `ttl_seconds=inf` on the
         #   read bypasses freshness (we explicitly want a stale hit); the
         #   caller's real TTL gates whether we even attempt the read.
-        kind = _classify_bws_error(str(exc))
+        kind = _classify_bws_exception(exc)
         if use_cache and kind in (ErrorKind.NETWORK, ErrorKind.TIMEOUT):
             if encrypted_cache_enabled:
                 stale = _read_encrypted_disk_cache(
@@ -664,6 +664,14 @@ def _summarize_bws_stderr(raw: str) -> str:
     return "; ".join(causes) if causes else text
 
 
+class _BwsCommandError(RuntimeError):
+    """A bounded user-facing bws error carrying its precomputed kind."""
+
+    def __init__(self, message: str, *, error_kind: ErrorKind) -> None:
+        super().__init__(message)
+        self.error_kind = error_kind
+
+
 def _run_bws_list(
     bws: Path, access_token: str, project_id: str, server_url: str = ""
 ) -> Tuple[Dict[str, str], List[str]]:
@@ -710,8 +718,9 @@ def _run_bws_list(
         # "Location:" / "Backtrace omitted" noise.  Strip ANSI and boil it
         # down to the meaningful cause line(s) before surfacing.
         err = _summarize_bws_stderr(proc.stderr or proc.stdout or "")
-        raise RuntimeError(
-            f"bws exited {proc.returncode}: {err[:200]}"
+        raise _BwsCommandError(
+            f"bws exited {proc.returncode}: {err[:200]}",
+            error_kind=_classify_bws_error(err),
         )
 
     raw = proc.stdout.strip()
@@ -969,7 +978,7 @@ class BitwardenSource(SecretSource):
             )
         except RuntimeError as exc:
             result.error = str(exc)
-            result.error_kind = _classify_bws_error(str(exc))
+            result.error_kind = _classify_bws_exception(exc)
             if result.error_kind == ErrorKind.AUTH_FAILED:
                 # Translate the raw OAuth reject into what it actually means
                 # for the user before the mechanics.
@@ -998,12 +1007,10 @@ class BitwardenSource(SecretSource):
 def _classify_bws_error(message: str) -> ErrorKind:
     """Best-effort mapping of bws failure text onto the shared taxonomy."""
     lowered = message.lower()
-    if "timed out" in lowered:
-        return ErrorKind.TIMEOUT
     if "binary not available" in lowered or "failed to invoke" in lowered:
         return ErrorKind.BINARY_MISSING
     if any(tok in lowered for tok in ("unauthorized", "invalid token",
-                                      "access token", "401", "403",
+                                      "401", "403",
                                       # The BSM identity endpoint rejects a
                                       # revoked/expired/deleted machine-account
                                       # token with an OAuth-style
@@ -1011,10 +1018,21 @@ def _classify_bws_error(message: str) -> ErrorKind:
                                       "invalid_client", "invalid_grant",
                                       "400 bad request")):
         return ErrorKind.AUTH_FAILED
+    if "timed out" in lowered:
+        return ErrorKind.TIMEOUT
+    if "access token" in lowered:
+        return ErrorKind.AUTH_FAILED
     if any(tok in lowered for tok in ("network", "connection", "resolve",
                                       "download", "dns")):
         return ErrorKind.NETWORK
     return ErrorKind.INTERNAL
+
+
+def _classify_bws_exception(exc: RuntimeError) -> ErrorKind:
+    """Use a precomputed kind when the displayed bws error was truncated."""
+    if isinstance(exc, _BwsCommandError):
+        return exc.error_kind
+    return _classify_bws_error(str(exc))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/secret_sources/test_error_remediation.py
+++ b/tests/secret_sources/test_error_remediation.py
@@ -85,6 +85,31 @@ def test_fetch_auth_failure_gets_friendly_error(monkeypatch, tmp_path):
     assert "invalid_client" in result.error  # mechanics preserved
 
 
+def test_fetch_keeps_auth_kind_when_marker_is_beyond_display_limit(
+    monkeypatch, tmp_path,
+):
+    src = BitwardenSource()
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.dead")
+    monkeypatch.setattr(
+        bw, "find_bws", lambda install_if_missing=True: tmp_path / "bws"
+    )
+    stderr = "Error:\n  0: network timed out " + ("x" * 220) + " invalid_client"
+    monkeypatch.setattr(
+        bw.subprocess,
+        "run",
+        lambda *a, **kw: mock.Mock(returncode=1, stdout="", stderr=stderr),
+    )
+
+    result = src.fetch(
+        {"enabled": True, "project_id": "p", "cache_ttl_seconds": 0},
+        tmp_path,
+    )
+
+    assert result.error_kind == ErrorKind.AUTH_FAILED
+    assert "rejected the machine-account access token" in result.error
+    assert "invalid_client" not in result.error
+
+
 # ---------------------------------------------------------------------------
 # remediation() hook
 # ---------------------------------------------------------------------------

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -457,7 +457,16 @@ def _seed_stale_disk_cache(home, *, secrets, age_seconds, project_id="proj-1",
     }))
 
 
-def test_stale_disk_cache_returned_when_bws_fails(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    ("stderr", "expected_detail"),
+    [
+        ("Error: dns resolution failed", "dns resolution failed"),
+        ("Error: request timed out fetching access token", "timed out"),
+    ],
+)
+def test_stale_disk_cache_returned_when_bws_fails(
+    monkeypatch, tmp_path, stderr, expected_detail,
+):
     """When bws fails and the disk cache is stale, return the stale secrets
     with a warning rather than raising."""
     home = tmp_path / ".hermes"
@@ -470,10 +479,9 @@ def test_stale_disk_cache_returned_when_bws_fails(monkeypatch, tmp_path):
     _seed_stale_disk_cache(home, secrets={"OPENAI_API_KEY": "sk-old"},
                            age_seconds=3600)
 
-    # Now simulate a BWS network failure
+    # Now simulate a transient BWS transport failure.
     def fail_run(*a, **kw):
-        return mock.Mock(returncode=1, stdout="",
-                         stderr="Error: dns resolution failed")
+        return mock.Mock(returncode=1, stdout="", stderr=stderr)
     monkeypatch.setattr(bw.subprocess, "run", fail_run)
 
     secrets, warnings = bw.fetch_bitwarden_secrets(
@@ -483,7 +491,7 @@ def test_stale_disk_cache_returned_when_bws_fails(monkeypatch, tmp_path):
     assert secrets == {"OPENAI_API_KEY": "sk-old"}
     assert len(warnings) == 1
     assert "stale disk cache" in warnings[0]
-    assert "dns resolution failed" in warnings[0]
+    assert expected_detail in warnings[0]
 
 
 
@@ -517,6 +525,70 @@ def test_stale_fallback_skipped_on_auth_failure(monkeypatch, tmp_path):
             access_token="0.t", project_id="proj-1", binary=fake_binary,
             cache_ttl_seconds=300, home_path=home,
         )
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "Error:\n  0: request timed out\n  1: invalid_client",
+        "Error:\n  0: invalid_client\n  1: request timed out",
+    ],
+)
+def test_auth_failure_outranks_timeout_for_stale_fallback(
+    monkeypatch, tmp_path, stderr,
+):
+    """Mixed diagnostics must fail closed when they contain an auth reject."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("")
+    bw._reset_cache_for_tests(home)
+
+    _seed_stale_disk_cache(home, secrets={"K1": "v1"}, age_seconds=3600)
+
+    monkeypatch.setattr(
+        bw.subprocess, "run",
+        lambda *a, **kw: mock.Mock(
+            returncode=1,
+            stdout="",
+            stderr=stderr,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="invalid_client"):
+        bw.fetch_bitwarden_secrets(
+            access_token="0.t", project_id="proj-1", binary=fake_binary,
+            cache_ttl_seconds=300, home_path=home,
+        )
+
+
+def test_auth_marker_after_display_limit_blocks_stale_fallback(
+    monkeypatch, tmp_path,
+):
+    """Classification uses full stderr while the surfaced error stays bounded."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("")
+    bw._reset_cache_for_tests(home)
+
+    _seed_stale_disk_cache(home, secrets={"K1": "v1"}, age_seconds=3600)
+    stderr = "Error:\n  0: network timed out " + ("x" * 220) + " invalid_client"
+    monkeypatch.setattr(
+        bw.subprocess, "run",
+        lambda *a, **kw: mock.Mock(returncode=1, stdout="", stderr=stderr),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        bw.fetch_bitwarden_secrets(
+            access_token="0.t", project_id="proj-1", binary=fake_binary,
+            cache_ttl_seconds=300, home_path=home,
+        )
+
+    detail = str(exc_info.value).partition(": ")[2]
+    assert len(detail) == 200
+    assert "invalid_client" not in detail
+    assert bw._classify_bws_exception(exc_info.value) == bw.ErrorKind.AUTH_FAILED
 
 
 


### PR DESCRIPTION
## Summary

- classify explicit Bitwarden authentication rejects before timeout and network failures
- classify the full summarized bws diagnostic before bounding the user-visible error to 200 characters
- carry the precomputed `ErrorKind` through both stale-cache fallback and `BitwardenSource.fetch()`
- preserve timeout fallback for ambiguous messages such as "timed out fetching access token"

## Root cause

The stale-cache path intentionally only permits `NETWORK` and `TIMEOUT` failures. However, `_classify_bws_error()` checked `"timed out"` before explicit auth markers, so mixed diagnostics could be treated as transient. Separately, `_run_bws_list()` truncated stderr before callers classified it, hiding auth markers after character 200.

## Impact

Bitwarden credential rejects now fail closed instead of returning last-known secrets. The surfaced error remains bounded, and genuine transport timeouts continue to use the existing stale-cache behavior.

## Checks

- `scripts/run_tests.sh tests/test_bitwarden_secrets.py tests/secret_sources/test_error_remediation.py -q -k 'not install_bws_happy_path and not encrypted_cache_writes_without_plaintext'` — 26 passed
- `python -m ruff check agent/secret_sources/bitwarden.py tests/test_bitwarden_secrets.py tests/secret_sources/test_error_remediation.py` — passed
- `git diff upstream/main...HEAD --check` — passed

The two excluded Bitwarden tests are unrelated Windows-only baseline failures: the install fixture archives `bws` while Windows looks for `bws.exe`, and NTFS reports `0666` rather than the asserted POSIX `0600` mode.

Fixes #77477