### PR TITLE
fix(gateway): make API-server wake retries idempotent

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -656,6 +656,13 @@ class GatewayKanbanWatchersMixin:
                                     adapter,
                                     text=_synth,
                                     session_id=_session_key,
+                                    producer_identity=(
+                                        "kanban",
+                                        board_slug or _kb.DEFAULT_BOARD,
+                                        sub["task_id"],
+                                        d.get("old_cursor", 0),
+                                        d["cursor"],
+                                    ),
                                 )
                                 logger.info(
                                     "kanban notifier: woke agent for %s on %s/%s profile=%s events=%s",

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1176,7 +1176,9 @@ class _IdempotencyCache:
         while len(self._store) > self._max:
             self._store.popitem(last=False)
 
-    async def get_or_set(self, key: str, fingerprint: str, compute_coro):
+    async def get_or_set(
+        self, key: str, fingerprint: str, compute_coro, *, should_cache=None
+    ):
         self._purge()
         item = self._store.get(key)
         if item and item["fp"] == fingerprint:
@@ -1187,9 +1189,10 @@ class _IdempotencyCache:
         if task is None:
             async def _compute_and_store():
                 resp = await compute_coro()
-                import time as _t
-                self._store[key] = {"resp": resp, "fp": fingerprint, "ts": _t.time()}
-                self._purge()
+                if should_cache is None or should_cache(resp):
+                    import time as _t
+                    self._store[key] = {"resp": resp, "fp": fingerprint, "ts": _t.time()}
+                    self._purge()
                 return resp
 
             task = asyncio.create_task(_compute_and_store())
@@ -4095,8 +4098,23 @@ class APIServerAdapter(BasePlatformAdapter):
                 body,
                 keys=["model", "provider", "model_options", "messages", "tools", "tool_choice", "stream"],
             )
+
+            def _should_cache_completion(response) -> bool:
+                response_result, _response_usage = response
+                response_text = _resolve_media_to_data_urls(
+                    response_result.get("final_response") or ""
+                )
+                return bool(response_text) or not (
+                    response_result.get("failed") or response_result.get("partial")
+                )
+
             try:
-                result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
+                result, usage = await _idem_cache.get_or_set(
+                    idempotency_key,
+                    fp,
+                    _compute_completion,
+                    should_cache=_should_cache_completion,
+                )
             except Exception as e:
                 logger.error("Error running agent for chat completions: %s", e, exc_info=True)
                 return web.json_response(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21667,7 +21667,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "session %s via self-post",
                             raw_sid,
                         )
-                        await deliver_wake(adapter, text=synth_text, session_id=raw_sid)
+                        await deliver_wake(
+                            adapter,
+                            text=synth_text,
+                            session_id=raw_sid,
+                            producer_identity=self._completion_delivery_identity(evt),
+                        )
                         return True
                     except Exception as e:
                         logger.warning(
@@ -21710,7 +21715,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "%s via self-post",
                     raw_sid,
                 )
-                await deliver_wake(adapter, text=synth_text, session_id=raw_sid)
+                await deliver_wake(
+                    adapter,
+                    text=synth_text,
+                    session_id=raw_sid,
+                    producer_identity=self._completion_delivery_identity(evt),
+                )
                 return True
             except Exception as e:
                 logger.warning(

--- a/gateway/wake.py
+++ b/gateway/wake.py
@@ -26,8 +26,11 @@ rewind cursors / retry instead of silently losing the event.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import logging
-from typing import Any, Optional
+import secrets
+from typing import Any, Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +62,7 @@ async def deliver_wake(
     text: str,
     session_id: str = "",
     source: Any = None,
+    producer_identity: Optional[Sequence[Any]] = None,
 ) -> None:
     """Deliver a wake turn to the session behind ``adapter``.
 
@@ -91,11 +95,27 @@ async def deliver_wake(
             "deliver_wake: non-push adapter (supports_async_delivery=False) "
             "requires the raw session id to self-post the wake turn"
         )
-    await _self_post_chat_completion(adapter, text=text, session_id=session_id)
+    if producer_identity is None:
+        await _self_post_chat_completion(
+            adapter,
+            text=text,
+            session_id=session_id,
+        )
+    else:
+        await _self_post_chat_completion(
+            adapter,
+            text=text,
+            session_id=session_id,
+            producer_identity=producer_identity,
+        )
 
 
 async def _self_post_chat_completion(
-    adapter: Any, *, text: str, session_id: str
+    adapter: Any,
+    *,
+    text: str,
+    session_id: str,
+    producer_identity: Optional[Sequence[Any]] = None,
 ) -> None:
     """POST the wake text to the in-pod API server as a normal session turn.
 
@@ -123,8 +143,25 @@ async def _self_post_chat_completion(
     if ":" in host and not host.startswith("["):
         host = f"[{host}]"  # bare IPv6 literal
     url = f"http://{host}:{port}/v1/chat/completions"
+    if producer_identity is None:
+        producer_identity = ("nonce", secrets.token_hex(32))
+    canonical_identity = json.dumps(
+        {
+            "producer": list(producer_identity),
+            "session_id": session_id,
+            "version": 1,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    idempotency_key = (
+        "wake-v1:"
+        + hashlib.sha256(canonical_identity.encode("utf-8")).hexdigest()
+    )
     headers = {
         "Authorization": f"Bearer {api_key}",
+        "Idempotency-Key": idempotency_key,
         "X-Hermes-Session-Id": session_id,
     }
     payload = {

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -261,6 +261,7 @@ def _persist_pending_completion(event):
         "delegation_id": event["delegation_id"],
         "session_key": event["session_key"],
         "origin_ui_session_id": "",
+        "origin_session_id": event.get("origin_session_id", ""),
         "parent_session_id": event.get("parent_session_id"),
         "dispatched_at": event["dispatched_at"],
     })
@@ -268,6 +269,126 @@ def _persist_pending_completion(event):
         "status": "completed",
         "summary": event["summary"],
     })
+
+
+def test_apiserver_durable_completion_recomputes_after_failed_agent_result(
+    monkeypatch,
+):
+    """An outer durable replay must not inherit a cached failed agent run."""
+    from aiohttp import web
+
+    import gateway.platforms.api_server as api_server_mod
+    import gateway.wake as wake_mod
+    from tools import async_delegation
+
+    monkeypatch.setattr(wake_mod, "_RETRY_DELAYS_SECONDS", ())
+    monkeypatch.setattr(
+        api_server_mod,
+        "_idem_cache",
+        api_server_mod._IdempotencyCache(),
+    )
+
+    event = {
+        **_async_event("deleg_apiserver_retry"),
+        "session_key": "raw-api-retry-session",
+        "origin_session_id": "raw-api-retry-session",
+    }
+    _persist_pending_completion(event)
+
+    response_statuses = []
+    request_keys = []
+    run_agent_calls = 0
+
+    @web.middleware
+    async def observe_status(request, handler):
+        request_keys.append(request.headers.get("Idempotency-Key"))
+        response = await handler(request)
+        response_statuses.append(response.status)
+        return response
+
+    async def run_agent(**_kwargs):
+        nonlocal run_agent_calls
+        run_agent_calls += 1
+        usage = {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+        if run_agent_calls == 1:
+            return (
+                {
+                    "final_response": "",
+                    "messages": [],
+                    "api_calls": 1,
+                    "completed": False,
+                    "failed": True,
+                    "error": "transient agent failure",
+                },
+                usage,
+            )
+        return (
+            {
+                "final_response": "completion accepted",
+                "messages": [],
+                "api_calls": 1,
+                "completed": True,
+            },
+            usage,
+        )
+
+    async def exercise():
+        adapter = api_server_mod.APIServerAdapter(
+            api_server_mod.PlatformConfig(
+                enabled=True,
+                extra={"key": "test-key"},
+            )
+        )
+        monkeypatch.setattr(
+            adapter,
+            "_ensure_session_db_async",
+            AsyncMock(return_value=None),
+        )
+        monkeypatch.setattr(adapter, "_run_agent", run_agent)
+
+        app = web.Application(middlewares=[observe_status])
+        app.router.add_post(
+            "/v1/chat/completions",
+            adapter._handle_chat_completions,
+        )
+        web_runner = web.AppRunner(app)
+        await web_runner.setup()
+        site = web.TCPSite(web_runner, "127.0.0.1", 0)
+        await site.start()
+        adapter._host = "127.0.0.1"
+        adapter._port = site._server.sockets[0].getsockname()[1]
+
+        delivery_runner = _runner(adapter)
+        delivery_runner.adapters = {Platform.API_SERVER: adapter}
+        try:
+            first = await delivery_runner._deliver_completion_notification(
+                "delegation complete",
+                dict(event),
+            )
+            first_state = async_delegation.get_durable_delegation(
+                event["delegation_id"]
+            )
+            second = await delivery_runner._deliver_completion_notification(
+                "delegation complete",
+                dict(event),
+            )
+            return first, first_state, second
+        finally:
+            await web_runner.cleanup()
+
+    first, first_state, second = asyncio.run(exercise())
+
+    assert first is False
+    assert first_state["delivery_state"] == "pending"
+    assert response_statuses[0] >= 500
+    assert second is True
+    assert response_statuses == [502, 200]
+    assert request_keys[0]
+    assert request_keys[0] == request_keys[1]
+    assert run_agent_calls == 2
+    final_state = async_delegation.get_durable_delegation(event["delegation_id"])
+    assert final_state["delivery_state"] == "delivered"
+    assert final_state["delivery_attempts"] == 2
 
 
 def test_explicit_kill_returns_output_before_consuming_notification(monkeypatch):

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -186,6 +186,74 @@ def test_failed_async_injection_is_retried_and_only_success_is_acked(
     assert acknowledgements == ["deleg_duplicate"]
 
 
+@pytest.mark.parametrize(
+    ("event", "expected_identity"),
+    [
+        (
+            {
+                **_async_event("deleg_api_stable"),
+                "session_key": "raw-api-target",
+                "origin_session_id": "raw-api-target",
+            },
+            ("async_delegation", "deleg_api_stable", ""),
+        ),
+        (
+            {
+                **_completion_event(
+                    started_at=1234.5,
+                    session_id="proc_api_stable",
+                ),
+                "session_key": "raw-api-target",
+                "origin_session_id": "raw-api-target",
+                "platform": "",
+                "chat_id": "",
+            },
+            ("completion", "proc_api_stable", 1234.5),
+        ),
+    ],
+)
+def test_apiserver_durable_completion_passes_stable_producer_identity(
+    monkeypatch, event, expected_identity,
+):
+    """Replayable delegation/process events retain identity at self-post."""
+    adapter = SimpleNamespace(supports_async_delivery=False)
+    runner = _runner(adapter)
+    runner.adapters = {Platform.API_SERVER: adapter}
+    deliveries = []
+
+    async def fake_deliver_wake(
+        _adapter,
+        *,
+        text,
+        session_id,
+        producer_identity=None,
+    ):
+        deliveries.append({
+            "text": text,
+            "session_id": session_id,
+            "producer_identity": producer_identity,
+        })
+
+    import gateway.wake as wake_mod
+
+    monkeypatch.setattr(wake_mod, "deliver_wake", fake_deliver_wake)
+
+    async def exercise():
+        assert await runner._inject_watch_notification("done", dict(event)) is True
+        assert await runner._inject_watch_notification("done", dict(event)) is True
+
+    asyncio.run(exercise())
+
+    assert [d["session_id"] for d in deliveries] == [
+        "raw-api-target",
+        "raw-api-target",
+    ]
+    assert [d["producer_identity"] for d in deliveries] == [
+        expected_identity,
+        expected_identity,
+    ]
+
+
 def _persist_pending_completion(event):
     from tools import async_delegation
 

--- a/tests/gateway/test_kanban_notifier_apiserver_wake.py
+++ b/tests/gateway/test_kanban_notifier_apiserver_wake.py
@@ -51,13 +51,17 @@ class ApiServerLikeAdapter:
         self.handle_message_calls.append(event)
 
 
-async def _run_one_notifier_tick(monkeypatch, runner):
+async def _run_notifier_ticks(monkeypatch, runner, *, ticks=1):
     real_sleep = asyncio.sleep
+    completed_ticks = 0
 
     async def fake_sleep(delay):
+        nonlocal completed_ticks
         if delay == 5:
             return None
-        runner._running = False
+        completed_ticks += 1
+        if completed_ticks >= ticks:
+            runner._running = False
         await real_sleep(0)
 
     monkeypatch.setattr(asyncio, "sleep", fake_sleep)
@@ -114,25 +118,70 @@ def test_apiserver_sub_wakes_real_session_via_self_post(tmp_path, monkeypatch):
 
     posts = []
 
-    async def fake_self_post(adapter, *, text, session_id):
-        posts.append({"text": text, "session_id": session_id})
+    async def fake_deliver_wake(
+        adapter, *, text, session_id, source=None, producer_identity=None,
+    ):
+        assert source is None
+        posts.append({
+            "text": text,
+            "session_id": session_id,
+            "producer_identity": producer_identity,
+        })
 
     import gateway.wake as wake_mod
 
-    monkeypatch.setattr(wake_mod, "_self_post_chat_completion", fake_self_post)
+    monkeypatch.setattr(wake_mod, "deliver_wake", fake_deliver_wake)
 
     adapter = ApiServerLikeAdapter()
     runner = _make_runner({Platform.API_SERVER: adapter})
-    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    asyncio.run(_run_notifier_ticks(monkeypatch, runner))
 
     assert adapter.handle_message_calls == [], (
         "api_server wake must not go through handle_message (wrong-session bug)"
     )
     assert len(posts) == 1
     assert posts[0]["session_id"] == "raw-sid-123"
+    assert posts[0]["producer_identity"]
     assert tid in posts[0]["text"]
     # The wake self-post IS the delivery on this path (no separate text-ping
     # fallback is attempted for stateless api_server subs) — cursor advances
     # once the wake succeeds.
     assert _unseen_terminal_events(tid, "api_server", "raw-sid-123") == []
 
+
+def test_apiserver_rewind_replay_reuses_kanban_producer_identity(
+    tmp_path, monkeypatch,
+):
+    """A failed wake is replayed with the same producer identity."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "apiserver-replay.db"))
+    kb.init_db()
+    tid = _create_completed_subscription(
+        "api_server",
+        "raw-sid-replay",
+        session_id="raw-sid-replay",
+    )
+    producer_identities = []
+
+    async def flaky_deliver_wake(
+        adapter, *, text, session_id, source=None, producer_identity=None,
+    ):
+        assert session_id == "raw-sid-replay"
+        assert source is None
+        producer_identities.append(producer_identity)
+        if len(producer_identities) == 1:
+            raise asyncio.TimeoutError("ambiguous first delivery")
+
+    import gateway.wake as wake_mod
+
+    monkeypatch.setattr(wake_mod, "deliver_wake", flaky_deliver_wake)
+
+    adapter = ApiServerLikeAdapter()
+    runner = _make_runner({Platform.API_SERVER: adapter})
+    asyncio.run(_run_notifier_ticks(monkeypatch, runner, ticks=2))
+
+    assert len(producer_identities) == 2
+    assert producer_identities[0]
+    assert producer_identities[0] == producer_identities[1]
+    assert adapter.handle_message_calls == []
+    assert adapter.send_calls == 0
+    assert _unseen_terminal_events(tid, "api_server", "raw-sid-replay") == []

--- a/tests/gateway/test_wake_delivery.py
+++ b/tests/gateway/test_wake_delivery.py
@@ -9,6 +9,8 @@ Two strategies:
 """
 
 import asyncio
+import re
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -53,12 +55,39 @@ def test_adapter_supports_push_default_true():
     assert adapter_supports_push(ApiServerLikeAdapter()) is False
 
 
+def test_deliver_wake_push_path_ignores_idempotency_identity():
+    """Adding retry identity must not change the synthetic push contract."""
+    adapter = PushAdapter()
+    source = _source()
+
+    asyncio.run(deliver_wake(
+        adapter,
+        text="push wake",
+        session_id="push-session",
+        source=source,
+        producer_identity=("delegation", "deleg-push-1"),
+    ))
+
+    assert len(adapter.handled) == 1
+    event = adapter.handled[0]
+    assert event.text == "push wake"
+    assert event.source is source
+    assert event.internal is True
+
+
 async def _serve(handler):
     """Spin an in-process aiohttp server on an ephemeral loopback port."""
     from aiohttp import web
 
     app = web.Application()
     app.router.add_post("/v1/chat/completions", handler)
+    return await _serve_app(app)
+
+
+async def _serve_app(app):
+    """Spin an aiohttp application on an ephemeral loopback port."""
+    from aiohttp import web
+
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, "127.0.0.1", 0)
@@ -125,3 +154,187 @@ def test_deliver_wake_retries_429_then_succeeds(monkeypatch):
     assert calls["n"] == 2
 
 
+def test_deliver_wake_timeout_retry_reuses_nonempty_idempotency_key(monkeypatch):
+    """A transport-ambiguous retry represents the same logical wake."""
+    from aiohttp import web
+
+    import gateway.wake as wake_mod
+
+    monkeypatch.setattr(wake_mod, "WAKE_TURN_TIMEOUT_SECONDS", 0.03)
+    monkeypatch.setattr(wake_mod, "_RETRY_DELAYS_SECONDS", (0,))
+    attempt_keys = []
+    release_first = asyncio.Event()
+
+    async def handler(request):
+        attempt_keys.append(request.headers.get("Idempotency-Key"))
+        if len(attempt_keys) == 1:
+            await release_first.wait()
+        return web.json_response({"choices": []})
+
+    async def run():
+        runner, port = await _serve(handler)
+        try:
+            adapter = ApiServerLikeAdapter(port=port)
+            await deliver_wake(adapter, text="retry me", session_id="sid-timeout")
+        finally:
+            release_first.set()
+            await runner.cleanup()
+
+    asyncio.run(run())
+
+    assert len(attempt_keys) == 2
+    assert attempt_keys[0]
+    assert attempt_keys[0] == attempt_keys[1]
+
+
+def test_wake_idempotency_keys_are_scoped_opaque_and_bounded():
+    """Target and producer scope the key without leaking their raw values."""
+    from aiohttp import web
+
+    seen_keys = []
+    session_a = "raw-session-alpha-secret"
+    session_b = "raw-session-beta-secret"
+    producer_a = (
+        "async_delegation",
+        "delegation-secret-123",
+        "process-secret-456",
+        "board-secret-789",
+        "task-secret-abc",
+    )
+    producer_b = ("async_delegation", "delegation-secret-other")
+
+    async def handler(request):
+        seen_keys.append(request.headers.get("Idempotency-Key"))
+        return web.json_response({"choices": []})
+
+    async def run():
+        runner, port = await _serve(handler)
+        try:
+            adapter = ApiServerLikeAdapter(port=port)
+            await deliver_wake(
+                adapter,
+                text="same payload",
+                session_id=session_a,
+                producer_identity=producer_a,
+            )
+            await deliver_wake(
+                adapter,
+                text="same payload",
+                session_id=session_b,
+                producer_identity=producer_a,
+            )
+            await deliver_wake(
+                adapter,
+                text="same payload",
+                session_id=session_a,
+                producer_identity=producer_b,
+            )
+        finally:
+            await runner.cleanup()
+
+    asyncio.run(run())
+
+    assert all(seen_keys)
+    assert seen_keys[0] != seen_keys[1], "target session must scope wake identity"
+    assert seen_keys[0] != seen_keys[2], "producer must scope wake identity"
+    for key in seen_keys:
+        assert len(key) <= 128
+        assert re.fullmatch(r"(?:[a-z][a-z0-9_-]*:)*[0-9a-f]{32,64}", key)
+        for raw_component in (
+            session_a,
+            session_b,
+            "delegation-secret-123",
+            "delegation-secret-other",
+            "process-secret-456",
+            "board-secret-789",
+            "task-secret-abc",
+        ):
+            assert raw_component not in key
+
+
+def test_wake_retry_joins_real_chat_completion_handler_inflight_work(
+    monkeypatch, tmp_path,
+):
+    """A timed-out self-post retry joins the handler's shielded agent task."""
+    from aiohttp import web
+
+    import gateway.platforms.api_server as api_server_mod
+    import gateway.wake as wake_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(wake_mod, "WAKE_TURN_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(wake_mod, "_RETRY_DELAYS_SECONDS", (0,))
+    monkeypatch.setattr(
+        api_server_mod,
+        "_idem_cache",
+        api_server_mod._IdempotencyCache(),
+    )
+
+    attempt_keys = []
+    agent_started = asyncio.Event()
+    second_attempt = asyncio.Event()
+    release_agent = asyncio.Event()
+    run_agent_calls = 0
+
+    @web.middleware
+    async def observe_attempts(request, handler):
+        attempt_keys.append(request.headers.get("Idempotency-Key"))
+        if len(attempt_keys) >= 2:
+            second_attempt.set()
+        return await handler(request)
+
+    async def run_agent(**_kwargs):
+        nonlocal run_agent_calls
+        run_agent_calls += 1
+        agent_started.set()
+        await release_agent.wait()
+        return (
+            {"final_response": "delivered", "messages": [], "api_calls": 1},
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+
+    async def run():
+        adapter = api_server_mod.APIServerAdapter(
+            api_server_mod.PlatformConfig(
+                enabled=True,
+                extra={"key": "test-key"},
+            )
+        )
+        monkeypatch.setattr(
+            adapter,
+            "_ensure_session_db_async",
+            AsyncMock(return_value=None),
+        )
+        monkeypatch.setattr(adapter, "_run_agent", run_agent)
+
+        app = web.Application(middlewares=[observe_attempts])
+        app.router.add_post(
+            "/v1/chat/completions",
+            adapter._handle_chat_completions,
+        )
+        runner, port = await _serve_app(app)
+        adapter._host = "127.0.0.1"
+        adapter._port = port
+        delivery = asyncio.create_task(deliver_wake(
+            adapter,
+            text="durable completion",
+            session_id="raw-integration-session",
+        ))
+        try:
+            await asyncio.wait_for(agent_started.wait(), timeout=1)
+            await asyncio.wait_for(second_attempt.wait(), timeout=1)
+            release_agent.set()
+            await asyncio.wait_for(delivery, timeout=1)
+        finally:
+            release_agent.set()
+            if not delivery.done():
+                delivery.cancel()
+            await asyncio.gather(delivery, return_exceptions=True)
+            await runner.cleanup()
+
+    asyncio.run(run())
+
+    assert len(attempt_keys) >= 2
+    assert all(attempt_keys)
+    assert len(set(attempt_keys)) == 1
+    assert run_agent_calls == 1


### PR DESCRIPTION
## Summary

- add an opaque, producer-stable `Idempotency-Key` to API-server wake self-posts;
- reuse one key across timeout, connection, and 429 retries for the same outcome-unknown delivery;
- propagate durable completion identity and stable Kanban cursor identity so replayed producer events retain the same key;
- keep identical in-flight API requests coalesced while admitting only successful/soft chat results to the durable idempotency cache;
- allow a later durable replay to recompute after a confirmed hard-failure/HTTP 502 instead of replaying that failure until the producer exhausts its retry budget.

## Problem

API-server wake delivery can time out after the server has accepted `/v1/chat/completions`. Retrying without an idempotency key can start overlapping agent runs for one logical delivery.

The first idempotency implementation also exposed a second failure mode: the API cache stored the agent result before the chat handler mapped an empty failed/partial result to HTTP 502. A durable producer replayed the same stable key and could receive the cached 502 repeatedly without rerunning the agent.

## Implementation

- `gateway/wake.py`
  - derives bounded opaque `hermes-wake-v1` SHA-256 keys from the target session and structured producer identity;
  - generates one request identity when a producer identity is unavailable;
  - reuses the key across retries for one delivery.
- `gateway/run.py`
  - passes the durable completion identity into wake delivery.
- `gateway/kanban_watchers.py`
  - passes board/task/cursor identity into wake delivery.
- `gateway/platforms/api_server.py`
  - adds optional producer-side cache admission;
  - preserves one shielded in-flight task for matching `(key, fingerprint)` requests;
  - returns a failed producer result to current joiners but does not store results that the chat handler maps to HTTP 502;
  - retains successful and soft-result replay;
  - keeps task-identity cleanup so an old completion callback cannot delete a newer replacement task.

## Tests

Added regression coverage for:

- key stability across timeout, connection, and 429 retries;
- separation between sessions and producer events without exposing raw identifiers;
- real `/v1/chat/completions` in-flight coalescing;
- durable completion and Kanban replay identity;
- first hard failure returning 502, followed by replay with the same key rerunning the agent, succeeding, and allowing durable acknowledgement/advance.

Verified on an isolated x86_64 checkout of exact commit `4bdd056706f6acfd69333e47a4c641081a4a04d7` (tree `d7acd328a9133969efb775106347a85fe03d5e8b`):

- intended tests-only RED reproduced on `6e0a1d0446df3e2c17b81780f1e0b52303e17058`;
- named GREEN regression: `1 passed`;
- affected wake/completion/Kanban/API surface: `118 passed`;
- Ruff: passed;
- explicit-path Windows footgun scan: passed;
- canonical full suite: `24,938 passed / 27 failed` across `2,581` files in `490.5s`;
- the historical base accounts for 24 failures, and the remaining three exact test IDs reproduced identically on both candidate and original base `d1afa16053a3777849c2b5465d59a0147b2172f9`; candidate-only failure delta is empty;
- full-scope independent read-only review: PASS with no blocking findings.

Full-suite log SHA-256: `3de12677131f7c5b17461b6d8ce1b8338f5484275bdfa38792cec1645902b28c`.

## Scope and risk

- non-streaming API-server wake path only;
- no change to authentication or request fingerprint conflict handling;
- streaming requests remain outside the idempotency cache;

## Follow-up hardening (non-blocking)

Add a dedicated concurrent interleaving test in which old waiters from a failed producer overlap a newly created replacement task. The implementation's producer-side admission and task-identity cleanup were reviewed as race-safe, but the current new regression exercises sequential replay rather than that exact overlap.

Closes #77797
