### PR TITLE
fix(desktop): make LogsPane text selectable and add autoscroll (#77794)

### DIFF
--- a/apps/desktop/src/app/contrib/panes.tsx
+++ b/apps/desktop/src/app/contrib/panes.tsx
@@ -52,17 +52,25 @@ export function LogsPane() {
   // Stick-to-bottom: auto-scroll when the user is already near the bottom.
   useEffect(() => {
     const el = preRef.current
-    if (!el || !shouldStickRef.current) return
+
+    if (!el || !shouldStickRef.current) {
+      return
+    }
 
     const raf = requestAnimationFrame(() => {
       el.scrollTo({ top: el.scrollHeight })
     })
+
     return () => cancelAnimationFrame(raf)
   }, [data])
 
   function handleScroll() {
     const el = preRef.current
-    if (!el) return
+
+    if (!el) {
+      return
+    }
+
     shouldStickRef.current =
       el.scrollHeight - el.scrollTop - el.clientHeight <= LOGS_BOTTOM_THRESHOLD
   }
@@ -83,10 +91,10 @@ export function LogsPane() {
   // pane's only label. Just the tail.
   return (
     <pre
-      ref={preRef}
+      className="h-full min-h-0 overflow-auto whitespace-pre-wrap break-words p-2.5 font-mono text-[0.66rem] leading-relaxed text-(--ui-text-secondary)"
       data-selectable-text="true"
       onScroll={handleScroll}
-      className="h-full min-h-0 overflow-auto whitespace-pre-wrap break-words p-2.5 font-mono text-[0.66rem] leading-relaxed text-(--ui-text-secondary)"
+      ref={preRef}
     >
       {data.lines.join('\n')}
     </pre>

--- a/apps/desktop/src/app/contrib/panes.tsx
+++ b/apps/desktop/src/app/contrib/panes.tsx
@@ -11,6 +11,7 @@
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 import { atom } from 'nanostores'
+import { useEffect, useRef } from 'react'
 import type { CSSProperties } from 'react'
 
 import { ChatPreviewRail } from '@/app/chat/right-rail/preview'
@@ -36,12 +37,35 @@ import { $currentCwd } from '@/store/session'
 // the controller) — never in a default layout, never a standing tab.
 // ---------------------------------------------------------------------------
 
+const LOGS_BOTTOM_THRESHOLD = 48
+
 export function LogsPane() {
   const { data, error } = useQuery({
     queryKey: ['contrib-logs-tail'],
     queryFn: () => getLogs({ lines: 300 }),
     refetchInterval: 5000
   })
+
+  const preRef = useRef<HTMLPreElement>(null)
+  const shouldStickRef = useRef(true)
+
+  // Stick-to-bottom: auto-scroll when the user is already near the bottom.
+  useEffect(() => {
+    const el = preRef.current
+    if (!el || !shouldStickRef.current) return
+
+    const raf = requestAnimationFrame(() => {
+      el.scrollTo({ top: el.scrollHeight })
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [data])
+
+  function handleScroll() {
+    const el = preRef.current
+    if (!el) return
+    shouldStickRef.current =
+      el.scrollHeight - el.scrollTop - el.clientHeight <= LOGS_BOTTOM_THRESHOLD
+  }
 
   if (error) {
     return <div className="p-3 text-xs text-(--ui-text-quaternary)">log unavailable: {String(error)}</div>
@@ -58,7 +82,12 @@ export function LogsPane() {
   // No chrome of its own — the zone header (when the user summons it) is the
   // pane's only label. Just the tail.
   return (
-    <pre className="h-full min-h-0 overflow-auto whitespace-pre-wrap break-words p-2.5 font-mono text-[0.66rem] leading-relaxed text-(--ui-text-secondary)">
+    <pre
+      ref={preRef}
+      data-selectable-text="true"
+      onScroll={handleScroll}
+      className="h-full min-h-0 overflow-auto whitespace-pre-wrap break-words p-2.5 font-mono text-[0.66rem] leading-relaxed text-(--ui-text-secondary)"
+    >
       {data.lines.join('\n')}
     </pre>
   )


### PR DESCRIPTION
## Summary

The Logs pane rendered a plain `<pre>` without `data-selectable-text`, so the app global `body { user-select: none }` prevented text selection. It also had no scroll management, so new log lines landed below the fold on every 5-second refetch.

## Changes

- Add `data-selectable-text="true"` to the `<pre>` element so log text can be selected and copied
- Add stick-to-bottom auto-scroll logic using `useRef` + `useEffect` + `requestAnimationFrame` (same pattern as `preview-console.tsx`)
- Track scroll position via `onScroll` handler so auto-scroll only activates when user is near the bottom

## Test Plan

- [ ] Open Logs pane via Ctrl+K
- [ ] Verify log text can be selected and copied
- [ ] Scroll to bottom, wait for refetch - view sticks to newest lines
- [ ] Scroll up to read older logs - view does not jump back down

Fixes #77794