### PR TITLE
fix(state): route session-resume reads through the WAL read-only connection (salvage #73539)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6837,9 +6837,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             session_ids = self._session_lineage_root_to_tip(session_id)
 
         active_clause = "" if include_inactive else " AND active = 1"
-        with self._lock:
+        with self._read_ctx() as conn:
             placeholders = ",".join("?" for _ in session_ids)
-            rows = self._conn.execute(
+            rows = conn.execute(
                 f"SELECT {self._CONVERSATION_ROW_COLUMNS} "
                 f"FROM messages WHERE session_id IN ({placeholders})"
                 # Order by AUTOINCREMENT id (true insertion order), NOT timestamp:
@@ -7018,9 +7018,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         output (see test_get_resume_conversations_matches_separate_reads).
         """
         session_ids = self._session_lineage_root_to_tip(session_id)
-        with self._lock:
+        with self._read_ctx() as conn:
             placeholders = ",".join("?" for _ in session_ids)
-            rows = self._conn.execute(
+            rows = conn.execute(
                 f"SELECT session_id, {self._CONVERSATION_ROW_COLUMNS} "
                 f"FROM messages WHERE session_id IN ({placeholders}) AND active = 1 "
                 # ORDER BY id (insertion order) — see get_messages_as_conversation
@@ -7072,9 +7072,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         session_ids = self._session_lineage_root_to_tip(session_id)
         if len(session_ids) <= 1:
             return []
-        with self._lock:
+        with self._read_ctx() as conn:
             placeholders = ",".join("?" for _ in session_ids)
-            rows = self._conn.execute(
+            rows = conn.execute(
                 f"SELECT session_id, {self._CONVERSATION_ROW_COLUMNS} "
                 f"FROM messages WHERE session_id IN ({placeholders}) AND active = 1 "
                 "ORDER BY id",
@@ -7111,13 +7111,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         chain = []
         current = session_id
         seen = set()
-        with self._lock:
+        with self._read_ctx() as conn:
             for _ in range(100):
                 if not current or current in seen:
                     break
                 seen.add(current)
                 chain.append(current)
-                row = self._conn.execute(
+                row = conn.execute(
                     "SELECT parent_session_id FROM sessions WHERE id = ?",
                     (current,),
                 ).fetchone()

--- a/tests/test_session_db_read_path_split.py
+++ b/tests/test_session_db_read_path_split.py
@@ -129,3 +129,41 @@ def test_anchored_view_and_around_use_read_path(db):
         assert done["view"]["window"]
     finally:
         db._lock.release()
+
+
+@pytest.mark.requires_wal
+def test_session_resume_reads_do_not_take_writer_lock(db):
+    """session.resume's three read paths must not convoy behind writer flushes.
+
+    get_messages_as_conversation / get_resume_conversations /
+    get_ancestor_display_prefix are the hottest reads in the file — every
+    resume across the gateway, CLI, and ACP adapter goes through one of
+    them — so they must use the same per-thread read-only connection as
+    get_messages, not the legacy self._lock path.
+    """
+    db.create_session(session_id="parent1", source="cli", model="m")
+    db.append_message("parent1", role="user", content="parent turn")
+    db.append_message("parent1", role="assistant", content="parent reply")
+    db.create_session(session_id="child1", source="cli", model="m", parent_session_id="parent1")
+    db.append_message("child1", role="user", content="child turn")
+    db.append_message("child1", role="assistant", content="child reply")
+
+    acquired = db._lock.acquire()
+    try:
+        done = {}
+
+        def reader():
+            done["conversation"] = db.get_messages_as_conversation("s1")
+            done["resume"] = db.get_resume_conversations("child1")
+            done["ancestor_prefix"] = db.get_ancestor_display_prefix("child1")
+
+        t = threading.Thread(target=reader)
+        t.start(); t.join(timeout=5.0)
+        assert not t.is_alive(), "session resume reads blocked on writer lock"
+        assert len(done["conversation"]) == 2
+        model_history, display_history = done["resume"]
+        assert len(model_history) == 2
+        assert len(display_history) == 4
+        assert len(done["ancestor_prefix"]) == 2
+    finally:
+        db._lock.release()


### PR DESCRIPTION
Salvages #73539 by @pierrenode — commit cherry-picked to preserve authorship; one conflict resolved (main centralized the resume SELECT's column list into `_CONVERSATION_ROW_COLUMNS` after the PR's base — kept main's constant, the PR's connection routing).

## Context — what this fixes, for whom

Anyone resuming sessions while the writer is busy: `session.resume`'s read paths (`get_resume_conversations`, lineage walk, ancestor resolution) still ran on the writer connection under `self._lock`, so a resume convoyed behind writer flushes/checkpoints. Main already has the per-thread WAL read-connection infrastructure (`_read_ctx()`, added for dashboard polling in this campaign's #76895 line of work) — this PR routes the four resume-path read sites through it. In DELETE-journal mode `_read_ctx()` falls back to the locked writer path, so non-WAL runtimes are unchanged.

## Absorption check (why this is NOT mooted by #76895)

#76895 routed dashboard/read-polling paths; the resume sites at hermes_state.py ~7003/7057/7096 still used `self._lock` + `self._conn` on current main (verified pre-pick). This PR is the complementary half for the resume path.

## Verification (with one honest caveat)

- `tests/test_hermes_state.py`: 178 passed on the merged tree
- `tests/test_session_db_read_path_split.py`: 3 passed, 5 skipped LOCALLY — the 5 skips (including the PR's new `test_session_resume_reads_do_not_take_writer_lock`) are `requires_wal` tests, and this machine's SQLite 3.46.0 has the WAL-reset bug so Hermes runs journal_mode=DELETE. They exercise on any runtime with WAL active (the PR author built the skip guard correctly). The mutation check is therefore vacuous for the new test locally; the non-WAL fallback path (`test_non_wal_uses_locked_path`) does run and passes.
- ruff clean

Closes #73539 (superseded by this salvage — original author credited via cherry-pick authorship).
