### PR TITLE
fix(agent): keep context_length pin for named custom providers

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -209,7 +209,18 @@ def _context_route_mismatch(
 
     if active_route:
         configured_routes = _provider_default_routes(configured_provider)
-        return not configured_routes or active_route not in configured_routes
+        if configured_routes:
+            return active_route not in configured_routes
+        # Named/custom providers have no catalog default routes. An empty
+        # configured URL with a matching provider identity is still the same
+        # route — agent_init fills base_url from custom_providers before this
+        # check, but gateway display/hygiene paths historically compared the
+        # raw empty model.base_url and falsely dropped model.context_length,
+        # falling through to family defaults (e.g. qwen → 131072) on Discord
+        # session-reset banners while /status still showed the config pin.
+        if active_provider and configured_provider == active_provider:
+            return False
+        return True
     return bool(
         configured_provider
         and active_provider

--- a/tests/agent/test_context_route_mismatch.py
+++ b/tests/agent/test_context_route_mismatch.py
@@ -1,0 +1,56 @@
+"""Tests for agent_init._context_route_mismatch context-pin scoping."""
+
+from agent.agent_init import _context_route_mismatch
+
+
+class TestContextRouteMismatchNamedCustomProvider:
+    """Named custom providers store the URL under custom_providers, not model.base_url.
+
+    Gateway session-reset banners used to treat empty model.base_url + a runtime
+    custom URL as a route mismatch, drop model.context_length, and fall back to
+    the Qwen family default (131072) even though /status still showed the pin.
+    """
+
+    def test_same_named_custom_provider_keeps_pin_without_configured_url(self):
+        assert (
+            _context_route_mismatch(
+                None,
+                "http://127.0.0.1:8080/v1",
+                "custom-local-agentw",
+                "custom-local-agentw",
+            )
+            is False
+        )
+
+    def test_different_provider_still_clears_pin(self):
+        assert (
+            _context_route_mismatch(
+                None,
+                "http://127.0.0.1:8080/v1",
+                "custom-local-agentw",
+                "openrouter",
+            )
+            is True
+        )
+
+    def test_explicit_base_url_mismatch_still_clears_pin(self):
+        assert (
+            _context_route_mismatch(
+                "http://127.0.0.1:8080/v1",
+                "http://10.0.0.2:8080/v1",
+                "custom-local-agentw",
+                "custom-local-agentw",
+            )
+            is True
+        )
+
+    def test_catalog_provider_rejects_non_default_runtime_url(self):
+        assert (
+            _context_route_mismatch(
+                None,
+                "http://127.0.0.1:8080/v1",
+                "openrouter",
+                "openrouter",
+            )
+            is True
+        )

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -64,6 +64,58 @@ class TestFormatSessionInfo:
         assert "localhost:11434" in info
         assert "8K" in info
 
+    def test_named_custom_provider_keeps_context_pin_without_model_base_url(
+        self, runner, tmp_path
+    ):
+        """Session-reset banner must honor model.context_length for named custom providers.
+
+        Repro: /status shows 262144 from config while the reset banner said
+        ``131K tokens (detected)`` because empty model.base_url + runtime URL
+        falsely cleared the pin and fell through to the Qwen family default.
+        """
+        model = "custom-local-agentw/Qwen-AgentWorld-35B-A3B-Q5_K_XL"
+        config_yaml = (
+            "model:\n"
+            f"  default: {model}\n"
+            "  provider: custom-local-agentw\n"
+            "  context_length: 262144\n"
+            "custom_providers:\n"
+            "  - name: custom-local-agentw\n"
+            "    base_url: http://127.0.0.1:8080/v1\n"
+            "    models: {}\n"
+        )
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            config_yaml,
+            model,
+            {
+                "provider": "custom-local-agentw",
+                "base_url": "http://127.0.0.1:8080/v1",
+                "api_key": "",
+            },
+        )
+        with p1, p2, p3, patch(
+            "hermes_cli.config.get_compatible_custom_providers",
+            return_value=[
+                {
+                    "name": "custom-local-agentw",
+                    "base_url": "http://127.0.0.1:8080/v1",
+                    "models": {},
+                }
+            ],
+        ), patch(
+            "agent.model_metadata.get_model_context_length",
+            side_effect=lambda *args, **kwargs: (
+                kwargs.get("config_context_length")
+                if kwargs.get("config_context_length")
+                else 131072
+            ),
+        ):
+            info = runner._format_session_info()
+        assert "262K" in info
+        assert "config" in info
+        assert "131K" not in info
+
 
 class TestResetNoticeSessionInfo:
     """#59003: the auto-reset banner must report the serving profile's config,


### PR DESCRIPTION
## Summary
- Named custom providers often leave `model.base_url` empty and resolve the URL at runtime. That empty configured URL was treated as a route mismatch, so gateway session-reset banners dropped `model.context_length` and fell back to the Qwen family default (`131072` / 131K).
- `/status` still showed the configured pin (e.g. 262144), so Discord looked inconsistent: status said 262K, session start said 131K detected.
- Keep the pin when the configured and active provider identities match and there is no catalog default-route set to compare against.

## Test plan
- [x] `scripts/run_tests.sh tests/agent/test_context_route_mismatch.py tests/gateway/test_session_info.py -q`
- [ ] Discord: set `model.context_length: 262144` on a named custom Qwen local provider with no `model.base_url`, restart gateway, `/new` or session reset — banner should show `262K tokens (config)`, not `131K tokens (detected)`
- [ ] `/status` and session-reset banner agree on context length