### PR TITLE
fix(guard): catch ValueError from os.open on NUL-containing paths (#77780)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,10 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # OSError: unreadable/long paths.  ValueError: embedded NUL byte
+        # in the path from binary content tokenized as a script path —
+        # a guarded path must never crash the guard (#76762, #77780).
         return None, False
     try:
         metadata = os.fstat(descriptor)


### PR DESCRIPTION
## Fixes #77780

`_read_referenced_script()` in `cron/lifecycle_guard.py` calls `os.open(path, flags)` but only catches `OSError`. When the path contains an embedded NUL byte (from binary content tokenized as a script path), `os.open()` raises `ValueError: embedded null byte` which propagates uncaught through `contains_gateway_lifecycle_command_or_referenced_script` → `terminal_tool`, blocking all subsequent terminal commands.

The caller at line 318 already handles `ValueError` for `script_path.resolve()`, but the `os.open()` call at line 260 was missed.

### Fix

Add `ValueError` to the `except` clause at `lifecycle_guard.py:261`, matching the existing pattern at line 318.
