### PR TITLE
fix(sessions): close transient databases on every exit path

### DIFF
--- a/agent/trace_upload.py
+++ b/agent/trace_upload.py
@@ -336,10 +336,13 @@ def load_session_messages(
     """
     from hermes_state import SessionDB
     db = SessionDB(db_path=db_path) if db_path else SessionDB()
-    resolved = db.resolve_session_id(session_id) or session_id
-    meta = db.get_session(resolved) or {}
-    messages = db.get_messages_as_conversation(resolved)
-    return messages, meta
+    try:
+        resolved = db.resolve_session_id(session_id) or session_id
+        meta = db.get_session(resolved) or {}
+        messages = db.get_messages_as_conversation(resolved)
+        return messages, meta
+    finally:
+        db.close()
 
 
 def upload_session_trace(

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5177,11 +5177,12 @@ class GatewaySlashCommandsMixin:
 
             def _run_insights():
                 db = SessionDB()
-                engine = InsightsEngine(db)
-                report = engine.generate(days=days, source=source)
-                result = engine.format_gateway(report)
-                db.close()
-                return result
+                try:
+                    engine = InsightsEngine(db)
+                    report = engine.generate(days=days, source=source)
+                    return engine.format_gateway(report)
+                finally:
+                    db.close()
 
             return await loop.run_in_executor(None, _run_insights)
         except Exception as e:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11102,6 +11102,7 @@ def cmd_tools(args):
 
 
 def cmd_insights(args):
+    db = None
     try:
         from hermes_state import SessionDB
         from agent.insights import InsightsEngine
@@ -11110,9 +11111,14 @@ def cmd_insights(args):
         engine = InsightsEngine(db)
         report = engine.generate(days=args.days, source=args.source)
         print(engine.format_terminal(report))
-        db.close()
     except Exception as e:
         print(f"Error generating insights: {e}")
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
 
 
 def cmd_monitoring(args):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1496,6 +1496,7 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
       from an exit summary printed before the bug fix, or from notes) get
       resumed at the live tip instead of a stale parent with no messages.
     """
+    db = None
     try:
         from hermes_state import SessionDB
 
@@ -1518,10 +1519,15 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
             except Exception:
                 pass
 
-        db.close()
         return resolved_id
     except Exception:
         pass
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
     return None
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1531,6 +1531,24 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
     return None
 
 
+def _resume_session_cwd(session_id: str) -> str:
+    """Return a resumed session's cwd without abandoning the owned database."""
+    db = None
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        return ((db.get_session(session_id) or {}).get("cwd") or "").strip()
+    except Exception:
+        return ""
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+
 def _read_tui_active_session_file(path: Optional[str]) -> Optional[str]:
     if not path:
         return None
@@ -2583,9 +2601,7 @@ def cmd_chat(args):
         and not getattr(args, "worktree", False)
     ):
         try:
-            from hermes_state import SessionDB
-
-            _saved_cwd = ((SessionDB().get_session(args.resume) or {}).get("cwd") or "").strip()
+            _saved_cwd = _resume_session_cwd(args.resume)
             if _saved_cwd and not os.path.isdir(_saved_cwd):
                 print(f"⚠ session's recorded dir is gone ({_saved_cwd}); staying in {os.getcwd()}")
             elif _saved_cwd and os.path.realpath(_saved_cwd) != os.path.realpath(os.getcwd()):

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -90,15 +90,23 @@ def cmd_sessions(args, sessions_parser=None):
             if report.get("backup_path"):
                 print(f"  backup: {report['backup_path']}")
             print(f"  strategy: {report.get('strategy')}")
+            db = None
             try:
                 from hermes_state import SessionDB
 
-                n = SessionDB()._conn.execute(
+                db = SessionDB()
+                n = db._conn.execute(
                     "SELECT COUNT(*) FROM sessions"
                 ).fetchone()[0]
                 print(f"✓ Repaired — {n} sessions recovered.")
             except Exception:
                 print("✓ Repaired.")
+            finally:
+                if db is not None:
+                    try:
+                        db.close()
+                    except Exception:
+                        pass
         else:
             print(f"✗ Repair failed: {report.get('error')}")
             if report.get("backup_path"):

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -43,6 +43,7 @@ import urllib.request
 from collections import deque
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FuturesTimeout
+from contextlib import closing
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Dict, Optional
 
@@ -807,13 +808,12 @@ class A2AAdapter(BasePlatformAdapter):
         if not db or not os.path.exists(db):
             return ""
         try:
-            con = sqlite3.connect(db, timeout=5)
-            row = con.execute(
-                "SELECT id FROM sessions WHERE title = ? ORDER BY started_at DESC LIMIT 1",
-                (title,),
-            ).fetchone()
-            con.close()
-            return str(row[0]) if row else ""
+            with closing(sqlite3.connect(db, timeout=5)) as con:
+                row = con.execute(
+                    "SELECT id FROM sessions WHERE title = ? ORDER BY started_at DESC LIMIT 1",
+                    (title,),
+                ).fetchone()
+                return str(row[0]) if row else ""
         except Exception:
             logger.debug("A2A: could not lookup forwarded session", exc_info=True)
             return ""
@@ -823,13 +823,12 @@ class A2AAdapter(BasePlatformAdapter):
         if not db or not os.path.exists(db):
             return ""
         try:
-            con = sqlite3.connect(db, timeout=5)
-            row = con.execute(
-                "SELECT id FROM sessions WHERE source = 'a2a' AND started_at >= ? ORDER BY started_at DESC LIMIT 1",
-                (started_after - 2.0,),
-            ).fetchone()
-            con.close()
-            return str(row[0]) if row else ""
+            with closing(sqlite3.connect(db, timeout=5)) as con:
+                row = con.execute(
+                    "SELECT id FROM sessions WHERE source = 'a2a' AND started_at >= ? ORDER BY started_at DESC LIMIT 1",
+                    (started_after - 2.0,),
+                ).fetchone()
+                return str(row[0]) if row else ""
         except Exception:
             logger.debug("A2A: could not find latest forwarded session", exc_info=True)
             return ""
@@ -839,10 +838,9 @@ class A2AAdapter(BasePlatformAdapter):
         if not db or not os.path.exists(db) or not session_id:
             return
         try:
-            con = sqlite3.connect(db, timeout=5)
-            con.execute("UPDATE sessions SET title = ? WHERE id = ?", (title, session_id))
-            con.commit()
-            con.close()
+            with closing(sqlite3.connect(db, timeout=5)) as con:
+                con.execute("UPDATE sessions SET title = ? WHERE id = ?", (title, session_id))
+                con.commit()
         except Exception:
             logger.debug("A2A: could not title forwarded session", exc_info=True)
 

--- a/tests/agent/test_trace_upload.py
+++ b/tests/agent/test_trace_upload.py
@@ -118,9 +118,29 @@ def test_converter_keeps_secrets_when_redact_disabled():
 # ---------------------------------------------------------------------------
 
 
+def test_load_session_messages_closes_session_db(monkeypatch):
+    fake_db = MagicMock()
+    fake_db.resolve_session_id.return_value = "resolved"
+    fake_db.get_session.return_value = {"id": "resolved"}
+    fake_db.get_messages_as_conversation.return_value = _sample_messages()
+    monkeypatch.setattr("hermes_state.SessionDB", MagicMock(return_value=fake_db))
+
+    messages, meta = trace_upload.load_session_messages("prefix")
+
+    assert messages == _sample_messages()
+    assert meta == {"id": "resolved"}
+    fake_db.close.assert_called_once_with()
 
 
+def test_load_session_messages_closes_session_db_after_read_failure(monkeypatch):
+    fake_db = MagicMock()
+    fake_db.resolve_session_id.side_effect = RuntimeError("read failed")
+    monkeypatch.setattr("hermes_state.SessionDB", MagicMock(return_value=fake_db))
 
+    with pytest.raises(RuntimeError, match="read failed"):
+        trace_upload.load_session_messages("prefix")
+
+    fake_db.close.assert_called_once_with()
 
 
 def test_upload_happy_path_mocked(monkeypatch):
@@ -159,9 +179,6 @@ def test_upload_happy_path_mocked(monkeypatch):
     first = json.loads(body.strip().split("\n")[0])
     assert first["type"] in ("user", "assistant")
     assert first["sessionId"] == "20260531_abc"
-
-
-
 
 
 

--- a/tests/gateway/test_insights_db_cleanup.py
+++ b/tests/gateway/test_insights_db_cleanup.py
@@ -1,0 +1,46 @@
+"""SessionDB lifecycle coverage for the gateway /insights command."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.slash_commands import GatewaySlashCommandsMixin
+
+
+class _InsightsEvent:
+    def get_command_args(self):
+        return ""
+
+
+def _install_insights(monkeypatch, db, engine):
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+    monkeypatch.setattr("agent.insights.InsightsEngine", lambda _db: engine)
+
+
+@pytest.mark.asyncio
+async def test_gateway_insights_closes_session_db_after_success(monkeypatch):
+    db = MagicMock()
+    engine = MagicMock()
+    engine.generate.return_value = {"summary": "ok"}
+    engine.format_gateway.return_value = "formatted"
+    _install_insights(monkeypatch, db, engine)
+    handler = object.__new__(GatewaySlashCommandsMixin)
+
+    result = await handler._handle_insights_command(_InsightsEvent())
+
+    assert result == "formatted"
+    db.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_gateway_insights_closes_session_db_after_failure(monkeypatch):
+    db = MagicMock()
+    engine = MagicMock()
+    engine.generate.side_effect = RuntimeError("analytics failed")
+    _install_insights(monkeypatch, db, engine)
+    handler = object.__new__(GatewaySlashCommandsMixin)
+
+    result = await handler._handle_insights_command(_InsightsEvent())
+
+    assert "analytics failed" in result
+    db.close.assert_called_once_with()

--- a/tests/hermes_cli/test_cmd_insights_cleanup.py
+++ b/tests/hermes_cli/test_cmd_insights_cleanup.py
@@ -1,0 +1,37 @@
+"""SessionDB lifecycle coverage for the CLI insights command."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from hermes_cli.main import cmd_insights
+
+
+def _args():
+    return SimpleNamespace(days=30, source=None)
+
+
+def test_cmd_insights_closes_database_after_success(monkeypatch, capsys):
+    db = MagicMock()
+    engine = MagicMock()
+    engine.generate.return_value = {"summary": "ok"}
+    engine.format_terminal.return_value = "formatted"
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+    monkeypatch.setattr("agent.insights.InsightsEngine", lambda _db: engine)
+
+    cmd_insights(_args())
+
+    assert capsys.readouterr().out.strip() == "formatted"
+    db.close.assert_called_once_with()
+
+
+def test_cmd_insights_closes_database_after_failure(monkeypatch, capsys):
+    db = MagicMock()
+    engine = MagicMock()
+    engine.generate.side_effect = RuntimeError("analytics failed")
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+    monkeypatch.setattr("agent.insights.InsightsEngine", lambda _db: engine)
+
+    cmd_insights(_args())
+
+    assert "analytics failed" in capsys.readouterr().out
+    db.close.assert_called_once_with()

--- a/tests/hermes_cli/test_session_resolver_cleanup.py
+++ b/tests/hermes_cli/test_session_resolver_cleanup.py
@@ -1,0 +1,41 @@
+"""SessionDB lifecycle tests for CLI session-name resolution."""
+
+from unittest.mock import MagicMock
+
+from hermes_cli.main import _resolve_session_by_name_or_id
+
+
+def test_session_resolver_closes_database_after_success(monkeypatch):
+    db = MagicMock()
+    db.get_session.return_value = {"id": "session-root"}
+    db.get_compression_tip.return_value = "session-tip"
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+
+    result = _resolve_session_by_name_or_id("session-root")
+
+    assert result == "session-tip"
+    db.close.assert_called_once_with()
+
+
+def test_session_resolver_closes_database_after_query_failure(monkeypatch):
+    db = MagicMock()
+    db.get_session.side_effect = RuntimeError("read failed")
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+
+    result = _resolve_session_by_name_or_id("session-root")
+
+    assert result is None
+    db.close.assert_called_once_with()
+
+
+def test_session_resolver_keeps_result_when_close_fails(monkeypatch):
+    db = MagicMock()
+    db.get_session.return_value = {"id": "session-root"}
+    db.get_compression_tip.return_value = "session-tip"
+    db.close.side_effect = RuntimeError("close failed")
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+
+    result = _resolve_session_by_name_or_id("session-root")
+
+    assert result == "session-tip"
+    db.close.assert_called_once_with()

--- a/tests/hermes_cli/test_session_resolver_cleanup.py
+++ b/tests/hermes_cli/test_session_resolver_cleanup.py
@@ -1,8 +1,11 @@
 """SessionDB lifecycle tests for CLI session-name resolution."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from hermes_cli.main import _resolve_session_by_name_or_id
+import pytest
+
+from hermes_cli import main as main_mod
 
 
 def test_session_resolver_closes_database_after_success(monkeypatch):
@@ -11,7 +14,7 @@ def test_session_resolver_closes_database_after_success(monkeypatch):
     db.get_compression_tip.return_value = "session-tip"
     monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
 
-    result = _resolve_session_by_name_or_id("session-root")
+    result = main_mod._resolve_session_by_name_or_id("session-root")
 
     assert result == "session-tip"
     db.close.assert_called_once_with()
@@ -22,7 +25,7 @@ def test_session_resolver_closes_database_after_query_failure(monkeypatch):
     db.get_session.side_effect = RuntimeError("read failed")
     monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
 
-    result = _resolve_session_by_name_or_id("session-root")
+    result = main_mod._resolve_session_by_name_or_id("session-root")
 
     assert result is None
     db.close.assert_called_once_with()
@@ -35,7 +38,60 @@ def test_session_resolver_keeps_result_when_close_fails(monkeypatch):
     db.close.side_effect = RuntimeError("close failed")
     monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
 
-    result = _resolve_session_by_name_or_id("session-root")
+    result = main_mod._resolve_session_by_name_or_id("session-root")
 
     assert result == "session-tip"
+    db.close.assert_called_once_with()
+
+
+def test_resume_session_cwd_closes_database_after_success(monkeypatch):
+    db = MagicMock()
+    db.get_session.return_value = {"cwd": " /tmp/project "}
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+
+    result = main_mod._resume_session_cwd("session-root")
+
+    assert result == "/tmp/project"
+    db.close.assert_called_once_with()
+
+
+def test_resume_session_cwd_closes_database_after_query_failure(monkeypatch):
+    db = MagicMock()
+    db.get_session.side_effect = RuntimeError("read failed")
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+
+    result = main_mod._resume_session_cwd("session-root")
+
+    assert result == ""
+    db.close.assert_called_once_with()
+
+
+def test_cmd_chat_resume_cwd_restore_closes_database(monkeypatch, tmp_path):
+    class StopAfterCwdRestore(Exception):
+        pass
+
+    db = MagicMock()
+    db.get_session.return_value = {"cwd": str(tmp_path)}
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+    monkeypatch.setattr("hermes_cli.main._resolve_use_tui", lambda _args: False)
+    monkeypatch.setattr("hermes_cli.main._apply_safe_mode", lambda _args: None)
+    monkeypatch.setattr(
+        "hermes_cli.main._resolve_session_by_name_or_id",
+        lambda session_id: session_id,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.main._has_any_provider_configured",
+        MagicMock(side_effect=StopAfterCwdRestore),
+    )
+    monkeypatch.setattr("hermes_cli.main.os.chdir", MagicMock())
+    args = SimpleNamespace(
+        continue_last=None,
+        resume="session-root",
+        no_restore_cwd=False,
+        worktree=False,
+    )
+
+    with pytest.raises(StopAfterCwdRestore):
+        main_mod.cmd_chat(args)
+
     db.close.assert_called_once_with()

--- a/tests/hermes_cli/test_sessions_repair_cleanup.py
+++ b/tests/hermes_cli/test_sessions_repair_cleanup.py
@@ -1,0 +1,87 @@
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_state
+from hermes_cli.sessions_cmd import cmd_sessions
+
+
+class _CountConnection:
+    def __init__(self, *, query_error: bool = False):
+        self.query_error = query_error
+
+    def execute(self, _sql):
+        if self.query_error:
+            raise RuntimeError("count failed")
+        return self
+
+    def fetchone(self):
+        return (3,)
+
+
+class _RecordingSessionDB:
+    def __init__(self, *, query_error: bool = False, close_error: bool = False):
+        self._conn = _CountConnection(query_error=query_error)
+        self.close_calls = 0
+        self.close_error = close_error
+
+    def close(self):
+        self.close_calls += 1
+        if self.close_error:
+            raise RuntimeError("close failed")
+
+
+def _run_repair(monkeypatch, tmp_path, db):
+    db_path = tmp_path / "state.db"
+    db_path.write_bytes(b"broken")
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", db_path)
+    monkeypatch.setattr(hermes_state, "_db_opens_cleanly", lambda _path: "malformed")
+    monkeypatch.setattr(
+        hermes_state,
+        "repair_state_db_schema",
+        lambda _path, *, backup: {
+            "repaired": True,
+            "backup_path": None,
+            "strategy": "test",
+        },
+    )
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: db)
+
+    cmd_sessions(
+        SimpleNamespace(
+            sessions_action="repair",
+            check_only=False,
+            no_backup=False,
+        )
+    )
+
+
+def test_repair_closes_count_database(monkeypatch, tmp_path, capsys):
+    db = _RecordingSessionDB()
+
+    _run_repair(monkeypatch, tmp_path, db)
+
+    assert db.close_calls == 1
+    assert "3 sessions recovered" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("query_error", "close_error"),
+    [(True, False), (False, True)],
+)
+def test_repair_cleanup_failures_remain_best_effort(
+    monkeypatch,
+    tmp_path,
+    capsys,
+    query_error,
+    close_error,
+):
+    db = _RecordingSessionDB(
+        query_error=query_error,
+        close_error=close_error,
+    )
+
+    _run_repair(monkeypatch, tmp_path, db)
+
+    assert db.close_calls == 1
+    assert "✓ Repaired" in capsys.readouterr().out

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -201,7 +201,7 @@ class TestAudit:
         security.audit("inbound", "peer-y", "task-1", "hello world")
         audit_file = tmp_path / "a2a_audit.jsonl"
         assert audit_file.exists()
-        rec = json.loads(audit_file.read_text().strip().splitlines()[-1])
+        rec = json.loads(audit_file.read_text(encoding="utf-8").strip().splitlines()[-1])
         assert rec["direction"] == "inbound"
         assert rec["peer"] == "peer-y"
         assert rec["task_id"] == "task-1"
@@ -1569,6 +1569,49 @@ class TestV1SpecRegressionFixes:
         assert "bad" not in adapter._agents
         assert "one" in adapter._agents
         assert "two" not in adapter._agents
+
+    @pytest.mark.parametrize(
+        ("helper_name", "helper_args"),
+        [
+            ("_lookup_forward_session", ("dev", "session-title")),
+            ("_latest_a2a_session", ("dev", 0.0)),
+            ("_title_forward_session", ("dev", "session-id", "session-title")),
+        ],
+    )
+    def test_profile_session_helpers_close_connection_on_query_error(
+        self,
+        helper_name,
+        helper_args,
+        monkeypatch,
+        tmp_path,
+    ):
+        from plugins.platforms.a2a import adapter as adapter_module
+        from gateway.config import PlatformConfig
+
+        class FailingConnection:
+            closed = False
+
+            def execute(self, *_args, **_kwargs):
+                raise RuntimeError("query failed")
+
+            def close(self):
+                self.closed = True
+
+        db_path = tmp_path / "state.db"
+        db_path.touch()
+        connection = FailingConnection()
+        monkeypatch.setattr(
+            adapter_module.sqlite3,
+            "connect",
+            lambda *_args, **_kwargs: connection,
+        )
+
+        adapter = adapter_module.A2AAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_profile_state_db", lambda _profile: str(db_path))
+
+        getattr(adapter, helper_name)(*helper_args)
+
+        assert connection.closed is True
 
     def test_forward_to_profile_first_contact_creates_then_resumes_fake_hermes(self, monkeypatch, tmp_path):
         from plugins.platforms.a2a.adapter import A2AAdapter

--- a/tests/tools/test_react_to_message_tool.py
+++ b/tests/tools/test_react_to_message_tool.py
@@ -1,0 +1,48 @@
+"""Resource-lifecycle tests for the desktop reaction tool."""
+
+import json
+from unittest.mock import MagicMock
+
+from tools import react_to_message_tool as reaction_tool
+
+
+def _install_db(monkeypatch, db):
+    monkeypatch.setattr(reaction_tool, "get_session_env", lambda *_args: "session-1")
+    monkeypatch.setattr(reaction_tool, "_open_session_db", lambda: db)
+    monkeypatch.setattr(reaction_tool.desktop_ui, "emit", MagicMock())
+
+
+def test_reaction_closes_session_db_after_success(monkeypatch):
+    db = MagicMock()
+    db.latest_message_row_id.return_value = 42
+    db.set_message_reaction.return_value = [{"emoji": "👍", "author": "agent"}]
+    _install_db(monkeypatch, db)
+
+    result = json.loads(reaction_tool.react_to_message_tool("👍"))
+
+    assert result["success"] is True
+    assert result["row_id"] == 42
+    db.close.assert_called_once_with()
+
+
+def test_reaction_closes_session_db_when_target_is_missing(monkeypatch):
+    db = MagicMock()
+    db.latest_message_row_id.return_value = None
+    _install_db(monkeypatch, db)
+
+    result = json.loads(reaction_tool.react_to_message_tool("👍"))
+
+    assert "No user message" in result["error"]
+    db.close.assert_called_once_with()
+
+
+def test_reaction_closes_session_db_after_write_failure(monkeypatch):
+    db = MagicMock()
+    db.latest_message_row_id.return_value = 42
+    db.set_message_reaction.side_effect = RuntimeError("write failed")
+    _install_db(monkeypatch, db)
+
+    result = json.loads(reaction_tool.react_to_message_tool("👍"))
+
+    assert "write failed" in result["error"]
+    db.close.assert_called_once_with()

--- a/tools/react_to_message_tool.py
+++ b/tools/react_to_message_tool.py
@@ -45,48 +45,54 @@ def react_to_message_tool(emoji: str, message_row_id=None, messages_back=None) -
     if db is None:
         return tool_error("Session storage is unavailable.")
 
-    row_id = message_row_id
-    target_role = "user"
-    if row_id is None:
-        # Default target: the latest user message. `messages_back` steps to
-        # earlier user turns (1 = the one before, etc.) for retroactive
-        # reactions — quoting text would be ambiguous, ids aren't visible to
-        # the model, but "two messages ago" is how a person thinks about it.
-        back = max(0, int(messages_back or 0))
-        row_id = db.latest_message_row_id(session_key, role="user", offset=back)
+    try:
+        row_id = message_row_id
+        target_role = "user"
         if row_id is None:
-            return tool_error(
-                f"No user message found {back} back." if back else "No user message to react to yet."
+            # Default target: the latest user message. `messages_back` steps to
+            # earlier user turns (1 = the one before, etc.) for retroactive
+            # reactions — quoting text would be ambiguous, ids aren't visible
+            # to the model, but "two messages ago" is how a person thinks.
+            back = max(0, int(messages_back or 0))
+            row_id = db.latest_message_row_id(session_key, role="user", offset=back)
+            if row_id is None:
+                return tool_error(
+                    f"No user message found {back} back."
+                    if back
+                    else "No user message to react to yet."
+                )
+        else:
+            row = db.get_message_role(session_key, int(row_id))
+            target_role = row or "user"
+
+        try:
+            reactions = db.set_message_reaction(
+                session_key, int(row_id), emoji or None, author="agent"
             )
-    else:
-        row = db.get_message_role(session_key, int(row_id))
-        target_role = row or "user"
+        except Exception as exc:
+            return tool_error(f"Failed to set the reaction: {exc}")
 
-    try:
-        reactions = db.set_message_reaction(
-            session_key, int(row_id), emoji or None, author="agent"
+        if reactions is None:
+            return tool_error(f"Message {row_id} is not part of this conversation.")
+
+        # Paint it live. A missing bridge (non-desktop surface) is not an error
+        # — the reaction is persisted either way and shows on the next load.
+        # `role` lets the renderer match a live message that doesn't know its
+        # durable row id yet (it only learns rowId on resume).
+        try:
+            desktop_ui.emit(
+                "message.reaction",
+                {"row_id": int(row_id), "reactions": reactions, "role": target_role},
+            )
+        except Exception:
+            pass
+
+        return json.dumps(
+            {"success": True, "row_id": int(row_id), "reactions": reactions},
+            ensure_ascii=False,
         )
-    except Exception as exc:
-        return tool_error(f"Failed to set the reaction: {exc}")
-
-    if reactions is None:
-        return tool_error(f"Message {row_id} is not part of this conversation.")
-
-    # Paint it live. A missing bridge (non-desktop surface) is not an error —
-    # the reaction is persisted either way and shows on the next load.
-    # `role` lets the renderer match a live message that doesn't know its
-    # durable row id yet (it only learns rowId on resume).
-    try:
-        desktop_ui.emit(
-            "message.reaction",
-            {"row_id": int(row_id), "reactions": reactions, "role": target_role},
-        )
-    except Exception:
-        pass
-
-    return json.dumps(
-        {"success": True, "row_id": int(row_id), "reactions": reactions}, ensure_ascii=False
-    )
+    finally:
+        db.close()
 
 
 def check_react_requirements() -> bool:


### PR DESCRIPTION
## What does this PR do?

Makes short-lived session-database ownership exception-safe across seven
independent user-facing paths:

- post-repair verification in `hermes sessions repair`
- CLI session-name / session-id resolution
- `hermes insights`
- Gateway `/insights`
- desktop `react_to_message` tool calls
- trace-upload transcript loading
- A2A forwarded-session lookup, discovery, and title helpers

Each function constructs and exclusively owns a `SessionDB` or raw SQLite
connection, but current `main` closes it only on the happy path or not at all.
Exceptions and early returns therefore leave connections and file descriptors
to garbage collection.

The fix uses guarded `finally` cleanup at each ownership boundary while
preserving the existing return values, error handling, and best-effort
behavior.

This consolidates the sibling lifecycle fixes from #78125, #77770, #77762,
#77742, and #77701 into one complete session-database ownership change.

## Current-main reproduction

Verified against current `main` at `5c6aff143` using one failure or early-return
case from each production path:

```text
scripts/run_tests.sh \
  tests/hermes_cli/test_sessions_repair_cleanup.py \
  tests/hermes_cli/test_session_resolver_cleanup.py \
  tests/hermes_cli/test_cmd_insights_cleanup.py \
  tests/gateway/test_insights_db_cleanup.py \
  tests/tools/test_react_to_message_tool.py \
  tests/agent/test_trace_upload.py \
  -k 'repair_closes_count_database or session_resolver_closes_database_after_query_failure or cmd_insights_closes_database_after_failure or gateway_insights_closes_session_db_after_failure or reaction_closes_session_db_when_target_is_missing or load_session_messages_closes_session_db_after_read_failure' -q

# current main production code: 6 failed
# each failure reports close() called 0 times
```

All six pass on this PR. The same negative-control procedure for the three A2A
helpers fails 3/3 on current `main`, with each raw SQLite connection remaining
open after a query error.

## Verification

```text
scripts/run_tests.sh \
  tests/hermes_cli/test_sessions_repair_cleanup.py \
  tests/hermes_cli/test_sessions_size_delta_label.py \
  tests/hermes_cli/test_session_resolver_cleanup.py \
  tests/hermes_cli/test_cmd_insights_cleanup.py \
  tests/cli/test_cli_resume_command.py \
  tests/cli/test_resume_display.py \
  tests/cli/test_cli_insights_command.py \
  tests/hermes_cli/test_resolve_last_session.py \
  tests/tools/test_react_to_message_tool.py \
  tests/test_message_reactions.py \
  tests/agent/test_trace_upload.py \
  tests/agent/test_insights.py \
  tests/gateway/test_insights_db_cleanup.py \
  tests/gateway/test_insights_unicode_flags.py \
  tests/plugins/test_a2a_plugin.py \
  tests/plugins/test_a2a_phase23.py -q
# 263 passed

uv run ruff check <all changed Python files>
# All checks passed

.venv/bin/python scripts/check-windows-footguns.py --diff origin/main
# No Windows footguns found

git diff --check
# passed
```

## Scope

- No database schema or transaction behavior changes.
- No CLI, Gateway, tool, reaction, Insights, or trace-upload output changes.
- No shared/global database ownership changes; only function-owned connections
  are closed.
- Close failures remain non-fatal only where the existing caller is explicitly
  best-effort.
