### PR TITLE
feat(gemini): forward cached_content from extra_body

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -994,8 +994,10 @@ class GeminiNativeClient:
         **_: Any,
     ) -> Any:
         thinking_config = None
+        cached_content = None
         if isinstance(extra_body, dict):
             thinking_config = extra_body.get("thinking_config") or extra_body.get("thinkingConfig")
+            cached_content = extra_body.get("cached_content") or extra_body.get("cachedContent")
 
         request = build_gemini_request(
             messages=messages or [],
@@ -1007,6 +1009,16 @@ class GeminiNativeClient:
             stop=stop,
             thinking_config=thinking_config,
         )
+
+        if cached_content:
+            # Explicit context caching: the named cachedContents resource
+            # already carries the system instruction, tool declarations, and
+            # any cached prefix turns. Google rejects the request if those are
+            # also sent inline alongside cachedContent.
+            request["cachedContent"] = str(cached_content)
+            request.pop("systemInstruction", None)
+            request.pop("tools", None)
+            request.pop("toolConfig", None)
 
         model = bare_gemini_model_id(model)
         if stream:

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -723,7 +723,7 @@ class ChatCompletionsTransport(ProviderTransport):
             if _native_gemini:
                 extra_body = {
                     k: v for k, v in extra_body.items()
-                    if k in ("thinking_config", "thinkingConfig")
+                    if k in ("thinking_config", "thinkingConfig", "cached_content", "cachedContent")
                 }
             if extra_body:
                 api_kwargs["extra_body"] = extra_body

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -259,3 +259,87 @@ def test_stream_event_translation_emits_tool_call_delta_with_stable_index():
 
 
 
+
+
+def _dummy_http_recording(recorded):
+    class DummyHTTP:
+        def post(self, url, json=None, headers=None, timeout=None):
+            recorded["url"] = url
+            recorded["json"] = json
+            recorded["headers"] = headers
+            return DummyResponse(
+                payload={
+                    "candidates": [
+                        {
+                            "content": {"parts": [{"text": "ok"}]},
+                            "finishReason": "STOP",
+                        }
+                    ],
+                    "usageMetadata": {
+                        "promptTokenCount": 1,
+                        "candidatesTokenCount": 1,
+                        "totalTokenCount": 2,
+                    },
+                }
+            )
+
+        def close(self):
+            return None
+
+    return DummyHTTP()
+
+
+def test_cached_content_forwarded_and_inline_duplicates_dropped(monkeypatch):
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    recorded = {}
+    monkeypatch.setattr(
+        "agent.gemini_native_adapter.httpx.Client",
+        lambda *a, **k: _dummy_http_recording(recorded),
+    )
+
+    client = GeminiNativeClient(api_key="AIza-test")
+    client.chat.completions.create(
+        model="gemini-2.5-flash",
+        messages=[
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ],
+        tools=[
+            {
+                "type": "function",
+                "function": {"name": "lookup", "parameters": {"type": "object"}},
+            }
+        ],
+        extra_body={"cached_content": "cachedContents/abc123"},
+    )
+
+    # The cache resource already carries systemInstruction/tools/toolConfig;
+    # sending them inline alongside cachedContent is a Google-side error.
+    assert recorded["json"]["cachedContent"] == "cachedContents/abc123"
+    assert "systemInstruction" not in recorded["json"]
+    assert "tools" not in recorded["json"]
+    assert "toolConfig" not in recorded["json"]
+
+
+def test_no_cached_content_key_leaves_request_unchanged(monkeypatch):
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    recorded = {}
+    monkeypatch.setattr(
+        "agent.gemini_native_adapter.httpx.Client",
+        lambda *a, **k: _dummy_http_recording(recorded),
+    )
+
+    client = GeminiNativeClient(api_key="AIza-test")
+    client.chat.completions.create(
+        model="gemini-2.5-flash",
+        messages=[
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ],
+        extra_body={"thinking_config": {"include_thoughts": True}},
+    )
+
+    assert "cachedContent" not in recorded["json"]
+    assert "systemInstruction" in recorded["json"]

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -731,3 +731,27 @@ class TestPromptCacheKeyCapability:
         assert first == second
         assert first != key("cron_job_2026-07-15T10:05:00Z", instructions="You are different.")
         assert first != key("cron_job_2026-07-15T10:05:00Z", tool_name="search")
+
+
+class TestNativeGeminiExtraBodyAllowlist:
+    def test_cached_content_survives_native_gemini_filter(self, transport):
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("gemini")
+        kw = transport.build_kwargs(
+            model="gemini-2.5-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            provider_profile=profile,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta",
+            request_overrides={
+                "extra_body": {
+                    "cached_content": "cachedContents/abc123",
+                    "tags": ["portal"],
+                }
+            },
+        )
+        # cached_content joins thinking_config on the allowlist; unknown
+        # OpenAI-style keys still get dropped (Gemini 400s on unknown fields).
+        assert kw["extra_body"]["cached_content"] == "cachedContents/abc123"
+        assert "tags" not in kw["extra_body"]


### PR DESCRIPTION
## Motivation

The native Gemini adapter already accounts for cache hits — it reads `cachedContentTokenCount` out of `usageMetadata` — but nothing in the request path can *produce* a `cachedContents` reference:

- `build_gemini_request()` assembles the wire payload from a fixed keyword-only signature with no passthrough.
- `_create_chat_completion()` reads exactly one thing out of `extra_body` (`thinking_config`/`thinkingConfig`); everything else lands in `**_`.
- The chat-completions transport's native-Gemini `extra_body` allowlist strips unknown keys (correctly — Gemini 400s on unknown fields).

So explicit context caching is unreachable, including from out-of-tree `llm_request` middleware — which is otherwise a clean seam for a caching plugin (create the `cachedContents` resource out-of-band, rewrite the request to reference it).

## Change

Minimal opt-in forwarding seam, no-op when absent:

- `extra_body.cached_content` (or `cachedContent`) → placed on the request as `cachedContent`; `systemInstruction`, `tools`, `toolConfig` dropped from the inline request (Google requires them to live in the cache resource, and rejects the request if sent alongside `cachedContent`).
- The native-Gemini `extra_body` allowlist admits the new key alongside `thinking_config`.

Caller contract: whoever sets `cached_content` is responsible for having removed the cached prefix turns from `messages` — the adapter cannot know how many turns the cache absorbed.

## Tests

- `tests/agent/test_gemini_native_adapter.py`: cachedContent forwarded onto the wire payload + inline duplicates dropped; absent key → request unchanged (systemInstruction retained).
- `tests/agent/transports/test_chat_completions.py`: allowlist admits `cached_content` on a native base_url while still dropping unknown OpenAI-style keys.

`scripts/run_tests.sh` on both files: 55 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)