### PR TITLE
fix(media): release generated resources on every exit path

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -291,51 +291,54 @@ def save_url_image(
     import requests
 
     response = requests.get(url, timeout=timeout, stream=True)
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
 
-    # Infer extension from the response content-type, falling back to the
-    # URL suffix when xAI / OpenAI omit a precise type (some CDNs return
-    # ``application/octet-stream``).  Defaults to ``png``.
-    content_type = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip().lower()
-    extension = _URL_IMAGE_CONTENT_TYPES.get(content_type)
-    if extension is None:
-        url_path = url.split("?", 1)[0].lower()
-        for ext in ("png", "jpg", "jpeg", "webp", "gif"):
-            if url_path.endswith(f".{ext}"):
-                extension = "jpg" if ext == "jpeg" else ext
-                break
-    if extension is None:
-        extension = "png"
+        # Infer extension from the response content-type, falling back to the
+        # URL suffix when xAI / OpenAI omit a precise type (some CDNs return
+        # ``application/octet-stream``).  Defaults to ``png``.
+        content_type = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip().lower()
+        extension = _URL_IMAGE_CONTENT_TYPES.get(content_type)
+        if extension is None:
+            url_path = url.split("?", 1)[0].lower()
+            for ext in ("png", "jpg", "jpeg", "webp", "gif"):
+                if url_path.endswith(f".{ext}"):
+                    extension = "jpg" if ext == "jpeg" else ext
+                    break
+        if extension is None:
+            extension = "png"
 
-    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-    short = uuid.uuid4().hex[:8]
-    path = _images_cache_dir() / f"{prefix}_{ts}_{short}.{extension}"
+        ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        short = uuid.uuid4().hex[:8]
+        path = _images_cache_dir() / f"{prefix}_{ts}_{short}.{extension}"
 
-    bytes_written = 0
-    with path.open("wb") as fh:
-        for chunk in response.iter_content(chunk_size=64 * 1024):
-            if not chunk:
-                continue
-            bytes_written += len(chunk)
-            if bytes_written > max_bytes:
-                fh.close()
-                try:
-                    path.unlink()
-                except OSError:
-                    pass
-                raise ValueError(
-                    f"Image at {url} exceeds {max_bytes // (1024 * 1024)}MB cap; refusing to cache."
-                )
-            fh.write(chunk)
+        bytes_written = 0
+        with path.open("wb") as fh:
+            for chunk in response.iter_content(chunk_size=64 * 1024):
+                if not chunk:
+                    continue
+                bytes_written += len(chunk)
+                if bytes_written > max_bytes:
+                    fh.close()
+                    try:
+                        path.unlink()
+                    except OSError:
+                        pass
+                    raise ValueError(
+                        f"Image at {url} exceeds {max_bytes // (1024 * 1024)}MB cap; refusing to cache."
+                    )
+                fh.write(chunk)
 
-    if bytes_written == 0:
-        try:
-            path.unlink()
-        except OSError:
-            pass
-        raise ValueError(f"Image at {url} returned 0 bytes; refusing to cache.")
+        if bytes_written == 0:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            raise ValueError(f"Image at {url} returned 0 bytes; refusing to cache.")
 
-    return path
+        return path
+    finally:
+        response.close()
 
 
 def success_response(

--- a/agent/video_gen_provider.py
+++ b/agent/video_gen_provider.py
@@ -272,48 +272,51 @@ def save_url_video(
     import requests
 
     response = requests.get(url, timeout=timeout, stream=True)
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
 
-    content_type = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip().lower()
-    extension = _URL_VIDEO_CONTENT_TYPES.get(content_type)
-    if extension is None:
-        url_path = url.split("?", 1)[0].lower()
-        for ext in ("mp4", "webm", "mov", "mkv"):
-            if url_path.endswith(f".{ext}"):
-                extension = ext
-                break
-    if extension is None:
-        extension = "mp4"
+        content_type = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip().lower()
+        extension = _URL_VIDEO_CONTENT_TYPES.get(content_type)
+        if extension is None:
+            url_path = url.split("?", 1)[0].lower()
+            for ext in ("mp4", "webm", "mov", "mkv"):
+                if url_path.endswith(f".{ext}"):
+                    extension = ext
+                    break
+        if extension is None:
+            extension = "mp4"
 
-    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-    short = uuid.uuid4().hex[:8]
-    path = _videos_cache_dir() / f"{prefix}_{ts}_{short}.{extension}"
+        ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        short = uuid.uuid4().hex[:8]
+        path = _videos_cache_dir() / f"{prefix}_{ts}_{short}.{extension}"
 
-    bytes_written = 0
-    with path.open("wb") as fh:
-        for chunk in response.iter_content(chunk_size=256 * 1024):
-            if not chunk:
-                continue
-            bytes_written += len(chunk)
-            if bytes_written > max_bytes:
-                fh.close()
-                try:
-                    path.unlink()
-                except OSError:
-                    pass
-                raise ValueError(
-                    f"Video at {url} exceeds {max_bytes // (1024 * 1024)}MB cap; refusing to cache."
-                )
-            fh.write(chunk)
+        bytes_written = 0
+        with path.open("wb") as fh:
+            for chunk in response.iter_content(chunk_size=256 * 1024):
+                if not chunk:
+                    continue
+                bytes_written += len(chunk)
+                if bytes_written > max_bytes:
+                    fh.close()
+                    try:
+                        path.unlink()
+                    except OSError:
+                        pass
+                    raise ValueError(
+                        f"Video at {url} exceeds {max_bytes // (1024 * 1024)}MB cap; refusing to cache."
+                    )
+                fh.write(chunk)
 
-    if bytes_written == 0:
-        try:
-            path.unlink()
-        except OSError:
-            pass
-        raise ValueError(f"Video at {url} was empty (0 bytes).")
+        if bytes_written == 0:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            raise ValueError(f"Video at {url} was empty (0 bytes).")
 
-    return path
+        return path
+    finally:
+        response.close()
 
 
 def success_response(

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -947,23 +947,42 @@ class SimplexAdapter(BasePlatformAdapter):
             from PIL import Image
 
             img = Image.open(file_path)
-            if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
-                png_path = str(p.with_suffix(".png"))
-                img.save(png_path, "PNG")
-            thumb = img.copy()
-            thumb.thumbnail((128, 128))
-            import io
-
-            buf = io.BytesIO()
-            thumb.save(buf, "JPEG", quality=70)
-            thumb_uri = (
-                "data:image/jpg;base64,"
-                + base64.b64encode(buf.getvalue()).decode()
-            )
-        except ImportError:
+            generated_png = False
             try:
                 if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
-                    png_path = str(p.with_suffix(".png"))
+                    with tempfile.NamedTemporaryFile(
+                        suffix=".png", prefix="simplex_image_", delete=False
+                    ) as converted:
+                        png_path = converted.name
+                    generated_png = True
+                    img.save(png_path, "PNG")
+                thumb = img.copy()
+                thumb.thumbnail((128, 128))
+                import io
+
+                buf = io.BytesIO()
+                thumb.save(buf, "JPEG", quality=70)
+                thumb_uri = (
+                    "data:image/jpg;base64,"
+                    + base64.b64encode(buf.getvalue()).decode()
+                )
+            except Exception:
+                if generated_png:
+                    try:
+                        os.remove(png_path)
+                    except OSError:
+                        pass
+                raise
+        except ImportError:
+            tmp_path = None
+            generated_png = False
+            try:
+                if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
+                    with tempfile.NamedTemporaryFile(
+                        suffix=".png", prefix="simplex_image_", delete=False
+                    ) as converted:
+                        png_path = converted.name
+                    generated_png = True
                     subprocess.run(
                         ["convert", file_path, png_path],
                         check=True,
@@ -990,9 +1009,20 @@ class SimplexAdapter(BasePlatformAdapter):
                     thumb_uri = (
                         "data:image/jpg;base64," + base64.b64encode(f.read()).decode()
                     )
-                os.remove(tmp_path)
             except (FileNotFoundError, subprocess.SubprocessError) as exc:
                 logger.warning("SimpleX: image conversion unavailable: %s", exc)
+                if generated_png:
+                    try:
+                        os.remove(png_path)
+                    except OSError:
+                        pass
+                    png_path = file_path
+            finally:
+                if tmp_path:
+                    try:
+                        os.remove(tmp_path)
+                    except OSError:
+                        pass
 
         return png_path, thumb_uri
 
@@ -1021,32 +1051,39 @@ class SimplexAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Image file not found")
 
         png_path, thumb_uri = self._prepare_image(file_path)
+        generated_png = os.path.abspath(png_path) != os.path.abspath(file_path)
+        try:
+            # /_send addresses by numeric ID; /f only accepts display names
+            # which breaks for group IDs.
+            composed = json.dumps(
+                [
+                    {
+                        "filePath": png_path,
+                        "msgContent": {
+                            "type": "image",
+                            "image": thumb_uri,
+                            "text": caption or "",
+                        },
+                    }
+                ]
+            )
 
-        # /_send addresses by numeric ID; /f only accepts display names which
-        # breaks for group IDs.
-        composed = json.dumps(
-            [
-                {
-                    "filePath": png_path,
-                    "msgContent": {
-                        "type": "image",
-                        "image": thumb_uri,
-                        "text": caption or "",
-                    },
-                }
-            ]
-        )
+            if chat_id.startswith("group:"):
+                group_id = chat_id[6:]
+                command = f"/_send #{group_id} json {composed}"
+            else:
+                command = f"/_send @{chat_id} json {composed}"
 
-        if chat_id.startswith("group:"):
-            group_id = chat_id[6:]
-            command = f"/_send #{group_id} json {composed}"
-        else:
-            command = f"/_send @{chat_id} json {composed}"
-
-        result = await self._send_command(command)
-        if result is not None:
-            return SendResult(success=True)
-        return SendResult(success=False, error="Failed to send image")
+            result = await self._send_command(command)
+            if result is not None:
+                return SendResult(success=True)
+            return SendResult(success=False, error="Failed to send image")
+        finally:
+            if generated_png:
+                try:
+                    os.remove(png_path)
+                except OSError:
+                    pass
 
     async def send_image_file(
         self,

--- a/tests/agent/test_generated_media_response_cleanup.py
+++ b/tests/agent/test_generated_media_response_cleanup.py
@@ -1,0 +1,92 @@
+import requests
+import pytest
+
+from agent import image_gen_provider, video_gen_provider
+
+
+class _RecordingResponse:
+    def __init__(self, chunks, *, content_type, http_error=False):
+        self.chunks = chunks
+        self.close_calls = 0
+        self.headers = {"Content-Type": content_type}
+        self.http_error = http_error
+
+    def raise_for_status(self):
+        if self.http_error:
+            raise RuntimeError("HTTP 500")
+
+    def iter_content(self, *, chunk_size):
+        del chunk_size
+        yield from self.chunks
+
+    def close(self):
+        self.close_calls += 1
+
+
+@pytest.fixture(
+    params=[
+        (
+            image_gen_provider,
+            "save_url_image",
+            "_images_cache_dir",
+            "image/png",
+        ),
+        (
+            video_gen_provider,
+            "save_url_video",
+            "_videos_cache_dir",
+            "video/mp4",
+        ),
+    ],
+    ids=["image", "video"],
+)
+def media_saver(request, monkeypatch, tmp_path):
+    module, helper_name, cache_name, content_type = request.param
+    monkeypatch.setattr(module, cache_name, lambda: tmp_path)
+    return getattr(module, helper_name), content_type
+
+
+def test_generated_media_download_closes_successful_response(
+    media_saver,
+    monkeypatch,
+):
+    save, content_type = media_saver
+    response = _RecordingResponse([b"asset-bytes"], content_type=content_type)
+    monkeypatch.setattr(requests, "get", lambda *_args, **_kwargs: response)
+
+    path = save("https://example.test/asset", max_bytes=100)
+
+    assert path.read_bytes() == b"asset-bytes"
+    assert response.close_calls == 1
+
+
+def test_generated_media_download_closes_oversized_response(
+    media_saver,
+    monkeypatch,
+):
+    save, content_type = media_saver
+    response = _RecordingResponse([b"oversized"], content_type=content_type)
+    monkeypatch.setattr(requests, "get", lambda *_args, **_kwargs: response)
+
+    with pytest.raises(ValueError, match="exceeds"):
+        save("https://example.test/asset", max_bytes=4)
+
+    assert response.close_calls == 1
+
+
+def test_generated_media_download_closes_http_error(
+    media_saver,
+    monkeypatch,
+):
+    save, content_type = media_saver
+    response = _RecordingResponse(
+        [],
+        content_type=content_type,
+        http_error=True,
+    )
+    monkeypatch.setattr(requests, "get", lambda *_args, **_kwargs: response)
+
+    with pytest.raises(RuntimeError, match="HTTP 500"):
+        save("https://example.test/asset")
+
+    assert response.close_calls == 1

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
+import tempfile
+import types
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -161,6 +165,82 @@ async def test_send_group():
     assert result.success is True
 
 
+def test_prepare_image_uses_unique_temp_png(monkeypatch, tmp_path):
+    class _FakeImage:
+        def save(self, target, _format, quality=None):
+            if hasattr(target, "write"):
+                target.write(b"jpeg")
+            else:
+                Path(target).write_bytes(b"png")
+
+        def copy(self):
+            return self
+
+        def thumbnail(self, _size):
+            return None
+
+    pil = types.ModuleType("PIL")
+    pil.Image = types.SimpleNamespace(open=lambda _path: _FakeImage())
+    monkeypatch.setitem(sys.modules, "PIL", pil)
+    source = tmp_path / "source.webp"
+    source.write_bytes(b"webp")
+
+    png_path, thumb_uri = SimplexAdapter._prepare_image(str(source))
+
+    try:
+        assert Path(png_path).is_file()
+        assert Path(png_path) != source.with_suffix(".png")
+        assert not source.with_suffix(".png").exists()
+        assert thumb_uri.startswith("data:image/jpg;base64,")
+    finally:
+        Path(png_path).unlink(missing_ok=True)
+
+
+def test_prepare_image_cleans_temp_png_when_thumbnail_fails(monkeypatch, tmp_path):
+    class _FakeImage:
+        def save(self, target, _format, quality=None):
+            Path(target).write_bytes(b"png")
+
+        def copy(self):
+            raise RuntimeError("thumbnail failed")
+
+    pil = types.ModuleType("PIL")
+    pil.Image = types.SimpleNamespace(open=lambda _path: _FakeImage())
+    monkeypatch.setitem(sys.modules, "PIL", pil)
+    source = tmp_path / "source.webp"
+    source.write_bytes(b"webp")
+    named_tempfile = tempfile.NamedTemporaryFile
+    monkeypatch.setattr(
+        tempfile,
+        "NamedTemporaryFile",
+        lambda **kwargs: named_tempfile(dir=tmp_path, **kwargs),
+    )
+
+    with pytest.raises(RuntimeError, match="thumbnail failed"):
+        SimplexAdapter._prepare_image(str(source))
+
+    assert list(tmp_path.glob("simplex_image_*.png")) == []
+
+
+@pytest.mark.asyncio
+async def test_send_image_cleans_generated_png(monkeypatch, tmp_path):
+    adapter = _adapter_with_ws()
+    source = tmp_path / "source.webp"
+    source.write_bytes(b"webp")
+    generated = tmp_path / "generated.png"
+    generated.write_bytes(b"png")
+    monkeypatch.setattr(
+        adapter, "_prepare_image", lambda _path: (str(generated), "data:image/jpg;base64,eA==")
+    )
+    adapter._send_command = AsyncMock(return_value={"ok": True})
+
+    result = await adapter.send_image_file("alice", str(source))
+
+    assert result.success is True
+    assert source.exists()
+    assert not generated.exists()
+
+
 # ---------------------------------------------------------------------------
 # 7b. Channel directory enumeration (list_channels)
 # ---------------------------------------------------------------------------
@@ -299,5 +379,3 @@ def _make_file_chat_item(file_path: str, file_name: str) -> dict:
             },
         },
     }
-
-


### PR DESCRIPTION
## What does this PR do?

Makes generated-media resources deterministic across download, conversion, and
send boundaries:

- generated image URL responses
- generated video URL responses
- SimpleX non-PNG image conversion
- SimpleX generated-file cleanup after send success or failure

Current `main` leaves streamed HTTP responses to garbage collection on HTTP
errors, iterator failures, and size-cap exits. SimpleX also converts a source
such as `image.webp` into the collision-prone sibling `image.png` and leaves
generated PNG/JPEG scratch files behind.

The fix gives every generated response or file one explicit owner:

- response objects close in `finally`
- conversion uses collision-free temporary paths
- generated send artifacts are removed on every exit path
- original user files and existing PNG/JPEG inputs are never removed

This consolidates the SimpleX lifecycle fix from #77766 into one complete
generated-media ownership change.

## Current-main reproduction

Verified against current `main` at `5c6aff143`:

```text
scripts/run_tests.sh \
  tests/agent/test_generated_media_response_cleanup.py \
  tests/gateway/test_simplex_plugin.py \
  -k 'generated_media_download_closes_http_error or prepare_image_uses_unique_temp_png or send_image_cleans_generated_png' -q

# current main production code: 4 failed
# - image HTTP error response close_calls == 0
# - video HTTP error response close_calls == 0
# - SimpleX writes to the source sibling .png path
# - generated SimpleX PNG remains after send
```

All four pass on this PR.

## Verification

```text
scripts/run_tests.sh \
  tests/agent/test_generated_media_response_cleanup.py \
  tests/agent/test_save_url_image.py \
  tests/gateway/test_simplex_plugin.py -q
# 24 passed

uv run ruff check <all changed Python files>
# All checks passed

.venv/bin/python scripts/check-windows-footguns.py --diff origin/main
# No Windows footguns found

git diff --check
# passed
```

## Scope

- No URL, redirect, SSRF, MIME, or size-cap policy changes.
- No public media-send behavior changes.
- No deletion of caller-owned source files.
- Relay inbound cache ownership remains separate in #77757.
