### PR TITLE
feat(kanban): collapse completed child tasks under parents

### DIFF
--- a/apps/desktop/src/plugins/kanban/board-filter.test.ts
+++ b/apps/desktop/src/plugins/kanban/board-filter.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest'
+
+import { filterKanbanBoard, type KanbanBoardFilters, pruneTaskSelection } from './board-filter'
+import type { KanbanBoard, KanbanTask } from './types'
+
+const task = (
+  id: string,
+  status: string,
+  collapseParentIds: string[] = [],
+  extra: Partial<KanbanTask> = {}
+): KanbanTask => ({
+  collapse_parent_ids: collapseParentIds,
+  id,
+  link_counts: { children: 0, parents: collapseParentIds.length },
+  status,
+  title: id,
+  ...extra
+})
+
+const board = (tasks: KanbanTask[]): KanbanBoard => ({
+  assignees: ['builder', 'reviewer'],
+  columns: [
+    { name: 'ready', tasks: tasks.filter(candidate => candidate.status === 'ready') },
+    { name: 'done', tasks: tasks.filter(candidate => candidate.status === 'done') },
+    { name: 'archived', tasks: tasks.filter(candidate => candidate.status === 'archived') }
+  ],
+  latest_event_id: 1,
+  now: 1,
+  tenants: ['product']
+})
+
+const defaults: KanbanBoardFilters = {
+  assignee: '',
+  search: '',
+  showCompletedChildren: false,
+  tenant: ''
+}
+
+const ids = (filtered: KanbanBoard) => filtered.columns.flatMap(column => column.tasks.map(candidate => candidate.id))
+
+describe('completed-child board filtering', () => {
+  it('hides only done child cards with a visible parent', () => {
+    const source = board([
+      task('workflow-root', 'done', [], {
+        link_counts: { children: 2, parents: 0 },
+        progress: { done: 1, total: 2 }
+      }),
+      task('finished-step', 'done', ['workflow-root']),
+      task('next-step', 'ready', ['workflow-root']),
+      task('standalone-result', 'done'),
+      task('archived-step', 'archived', ['workflow-root'])
+    ])
+
+    const result = filterKanbanBoard(source, defaults)
+
+    expect(ids(result.board)).toEqual(['next-step', 'workflow-root', 'standalone-result', 'archived-step'])
+    expect(result.completedChildren).toBe(1)
+
+    const root = result.board.columns
+      .flatMap(column => column.tasks)
+      .find(candidate => candidate.id === 'workflow-root')
+
+    expect(root?.progress).toEqual({ done: 1, total: 2 })
+  })
+
+  it('reveals completed child tasks when the user enables the history toggle', () => {
+    const source = board([task('workflow-root', 'done'), task('finished-step', 'done', ['workflow-root'])])
+    const result = filterKanbanBoard(source, { ...defaults, showCompletedChildren: true })
+
+    expect(ids(result.board)).toEqual(['workflow-root', 'finished-step'])
+    expect(result.completedChildren).toBe(1)
+  })
+
+  it('lets an explicit search find matching completed child tasks without another toggle', () => {
+    const source = board([
+      task('workflow-root', 'done'),
+      task('hidden-step', 'done', ['workflow-root'], { body: 'render the final proposal' }),
+      task('other-step', 'done', ['workflow-root'])
+    ])
+
+    const result = filterKanbanBoard(source, { ...defaults, search: 'final proposal' })
+
+    expect(ids(result.board)).toEqual(['hidden-step'])
+    expect(result.completedChildren).toBe(0)
+  })
+
+  it('keeps a completed child visible when its parent is filtered out', () => {
+    const source = board([
+      task('workflow-root', 'done', [], { assignee: 'builder' }),
+      task('review-result', 'done', ['workflow-root'], { assignee: 'reviewer' })
+    ])
+
+    const result = filterKanbanBoard(source, { ...defaults, assignee: 'reviewer' })
+
+    expect(ids(result.board)).toEqual(['review-result'])
+    expect(result.completedChildren).toBe(0)
+  })
+
+  it('keeps a completed child visible when its parent is omitted from the board', () => {
+    const source = board([task('orphaned-result', 'done', ['archived-parent'])])
+    const result = filterKanbanBoard(source, defaults)
+
+    expect(ids(result.board)).toEqual(['orphaned-result'])
+    expect(result.completedChildren).toBe(0)
+  })
+
+  it('collapses under any visible parent in a multi-parent graph', () => {
+    const source = board([
+      task('visible-parent', 'done', [], { tenant: 'product' }),
+      task('filtered-parent', 'done', [], { tenant: 'ops' }),
+      task('joined-result', 'done', ['visible-parent', 'filtered-parent'], { tenant: 'product' })
+    ])
+
+    const result = filterKanbanBoard(source, { ...defaults, tenant: 'product' })
+
+    expect(ids(result.board)).toEqual(['visible-parent'])
+    expect(result.completedChildren).toBe(1)
+  })
+
+  it('collapses a completed dependency chain to its visible root', () => {
+    const source = board([
+      task('workflow-root', 'done'),
+      task('middle-step', 'done', ['workflow-root']),
+      task('final-step', 'done', ['middle-step'])
+    ])
+
+    const result = filterKanbanBoard(source, defaults)
+
+    expect(ids(result.board)).toEqual(['workflow-root'])
+    expect(result.completedChildren).toBe(2)
+  })
+
+  it('keeps reopened child work visible', () => {
+    const source = board([task('workflow-root', 'done'), task('reopened-step', 'ready', ['workflow-root'])])
+    const result = filterKanbanBoard(source, defaults)
+
+    expect(ids(result.board)).toEqual(['reopened-step', 'workflow-root'])
+    expect(result.completedChildren).toBe(0)
+  })
+
+  it('counts only collapsible children inside the active assignee and tenant filters', () => {
+    const source = board([
+      task('matching-parent', 'done', [], { assignee: 'reviewer', tenant: 'product' }),
+      task('matching-step', 'done', ['matching-parent'], { assignee: 'reviewer', tenant: 'product' }),
+      task('other-profile', 'done', ['matching-parent'], { assignee: 'builder', tenant: 'product' }),
+      task('other-tenant', 'done', ['matching-parent'], { assignee: 'reviewer', tenant: 'ops' })
+    ])
+
+    const result = filterKanbanBoard(source, { ...defaults, assignee: 'reviewer', tenant: 'product' })
+
+    expect(ids(result.board)).toEqual(['matching-parent'])
+    expect(result.completedChildren).toBe(1)
+  })
+
+  it('removes hidden cards from bulk selection without churning unchanged state', () => {
+    const source = board([task('workflow-root', 'done'), task('finished-step', 'done', ['workflow-root'])])
+    const filtered = filterKanbanBoard(source, defaults).board
+    const selected = new Set(['workflow-root', 'finished-step'])
+    const pruned = pruneTaskSelection(selected, filtered)
+
+    expect([...pruned]).toEqual(['workflow-root'])
+    expect(pruneTaskSelection(pruned, filtered)).toBe(pruned)
+  })
+})

--- a/apps/desktop/src/plugins/kanban/board-filter.ts
+++ b/apps/desktop/src/plugins/kanban/board-filter.ts
@@ -1,0 +1,65 @@
+import type { KanbanBoard, KanbanTask } from './types'
+
+export interface KanbanBoardFilters {
+  assignee: string
+  search: string
+  showCompletedChildren: boolean
+  tenant: string
+}
+
+export interface FilteredKanbanBoard {
+  board: KanbanBoard
+  /** Completed child cards collapsible under a currently visible parent. */
+  completedChildren: number
+}
+
+const matchesOrdinaryFilters = (task: KanbanTask, filters: KanbanBoardFilters, query: string) =>
+  (!query || `${task.title} ${task.body ?? ''} ${task.id}`.toLowerCase().includes(query)) &&
+  (!filters.tenant || task.tenant === filters.tenant) &&
+  (!filters.assignee || task.assignee === filters.assignee)
+
+/**
+ * Keep workflow history without letting each completed step occupy the Done
+ * lane forever. Parent/root cards stay visible and retain the backend's N/M
+ * rollup; completed children remain discoverable through search, the parent
+ * drawer, or the explicit filter-menu toggle.
+ */
+export function filterKanbanBoard(board: KanbanBoard, filters: KanbanBoardFilters): FilteredKanbanBoard {
+  const query = filters.search.trim().toLowerCase()
+  let completedChildren = 0
+
+  const candidates = board.columns.map(column => ({
+    ...column,
+    tasks: column.tasks.filter(task => matchesOrdinaryFilters(task, filters, query))
+  }))
+
+  const visibleParentIds = new Set(candidates.flatMap(column => column.tasks.map(task => task.id)))
+
+  const columns = candidates.map(column => {
+    const tasks = column.tasks.filter(task => {
+      const hasVisibleParent = task.collapse_parent_ids?.some(parentId => visibleParentIds.has(parentId)) ?? false
+
+      if (task.status !== 'done' || !hasVisibleParent) {
+        return true
+      }
+
+      completedChildren += 1
+
+      // An explicit search is already a request to find matching history, so
+      // never make the user toggle a second control to open the result.
+      return filters.showCompletedChildren || Boolean(query)
+    })
+
+    return { ...column, tasks }
+  })
+
+  return { board: { ...board, columns }, completedChildren }
+}
+
+/** Drop hidden cards from bulk selection so the action count stays truthful. */
+export function pruneTaskSelection(selected: ReadonlySet<string>, board: KanbanBoard): ReadonlySet<string> {
+  const visible = new Set(board.columns.flatMap(column => column.tasks.map(task => task.id)))
+  const kept = [...selected].filter(id => visible.has(id))
+
+  return kept.length === selected.size ? selected : new Set(kept)
+}

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -25,6 +25,7 @@ import {
   DialogHeader,
   DialogTitle,
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
@@ -76,6 +77,7 @@ import {
   patchTask,
   PROFILES_KEY
 } from './api'
+import { filterKanbanBoard, pruneTaskSelection } from './board-filter'
 import { BoardSwitcher } from './board-switcher'
 import { TaskDrawer } from './drawer'
 import { EMPTY_OVERRIDE, ModelOverrideField, overrideCreateFields, type TaskModelOverride } from './model-override'
@@ -871,7 +873,10 @@ function FilterMenu({
   board,
   onArchived,
   onAssignee,
+  onShowCompletedChildren,
   onTenant,
+  completedChildren,
+  showCompletedChildren,
   tenant
 }: {
   archived: boolean
@@ -879,11 +884,14 @@ function FilterMenu({
   board: KanbanBoard
   onArchived: (v: boolean) => void
   onAssignee: (v: string) => void
+  onShowCompletedChildren: (v: boolean) => void
   onTenant: (v: string) => void
+  completedChildren: number
+  showCompletedChildren: boolean
   tenant: string
 }) {
   const k = useKanban()
-  const active = Boolean(assignee || tenant || archived)
+  const active = Boolean(assignee || tenant || archived || showCompletedChildren)
   const lanesByProfile = useValue($lanesByProfile)
 
   const check = (on: boolean) => (on ? <Codicon className="ml-auto" name="check" size="0.8rem" /> : null)
@@ -932,6 +940,9 @@ function FilterMenu({
           {k.showArchived}
           {check(archived)}
         </DropdownMenuItem>
+        <DropdownMenuCheckboxItem checked={showCompletedChildren} onCheckedChange={onShowCompletedChildren}>
+          {k.completedChildren(completedChildren)}
+        </DropdownMenuCheckboxItem>
         <DropdownMenuItem onSelect={() => $lanesByProfile.set(!lanesByProfile)}>
           {k.groupRunning}
           {check(lanesByProfile)}
@@ -1098,6 +1109,7 @@ export function KanbanBoardPage() {
   const [search, setSearch] = useState('')
   const [tenant, setTenant] = useState('')
   const [assignee, setAssignee] = useState('')
+  const [showCompletedChildren, setShowCompletedChildren] = useState(false)
   const [selected, setSelected] = useState<ReadonlySet<string>>(new Set())
 
   // A new-task request raised from outside the page (⌘⌥N, the palette row).
@@ -1167,20 +1179,27 @@ export function KanbanBoardPage() {
   )
 
   // Client-side filters, mirroring the dashboard (search over title/body/id).
-  const filtered = useMemo(() => {
+  // Completed child cards collapse by default while root/standalone results
+  // remain visible; the parent drawer and menu toggle preserve full history.
+  const filteredResult = useMemo(() => {
     if (!board) {
       return null
     }
 
-    const q = search.trim().toLowerCase()
+    return filterKanbanBoard(board, { assignee, search, showCompletedChildren, tenant })
+  }, [board, search, tenant, assignee, showCompletedChildren])
 
-    const keep = (task: KanbanTask) =>
-      (!q || `${task.title} ${task.body ?? ''} ${task.id}`.toLowerCase().includes(q)) &&
-      (!tenant || task.tenant === tenant) &&
-      (!assignee || task.assignee === assignee)
+  const filtered = filteredResult?.board ?? null
+  const completedChildren = filteredResult?.completedChildren ?? 0
 
-    return { ...board, columns: board.columns.map(col => ({ ...col, tasks: col.tasks.filter(keep) })) }
-  }, [board, search, tenant, assignee])
+  // Hidden cards must not remain bulk-actionable through stale selection.
+  useEffect(() => {
+    if (!filtered) {
+      return
+    }
+
+    setSelected(prev => pruneTaskSelection(prev, filtered))
+  }, [filtered])
 
   const total = filtered?.columns.reduce((sum, col) => sum + col.tasks.length, 0) ?? 0
 
@@ -1336,9 +1355,12 @@ export function KanbanBoardPage() {
             archived={archived}
             assignee={assignee}
             board={board}
+            completedChildren={completedChildren}
             onArchived={setArchived}
             onAssignee={setAssignee}
+            onShowCompletedChildren={setShowCompletedChildren}
             onTenant={setTenant}
+            showCompletedChildren={showCompletedChildren}
             tenant={tenant}
           />
         )}

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -49,6 +49,7 @@ type KanbanMessages = {
   allProfiles: string
   allTenants: string
   showArchived: string
+  completedChildren: (n: number) => string
   groupRunning: string
   nSelected: (n: number) => string
   moveToShort: string
@@ -238,6 +239,7 @@ const en: KanbanMessages = {
   allProfiles: 'All profiles',
   allTenants: 'All tenants',
   showArchived: 'Show archived',
+  completedChildren: n => `Show completed child tasks · ${n}`,
   groupRunning: 'Group Running by profile',
   nSelected: n => `${n} selected`,
   moveToShort: 'Move to',
@@ -430,6 +432,7 @@ const ja: KanbanMessages = {
   allProfiles: 'すべてのプロフィール',
   allTenants: 'すべてのテナント',
   showArchived: 'アーカイブを表示',
+  completedChildren: n => `完了した子タスクを表示・${n}`,
   groupRunning: '実行中をプロフィールでグループ化',
   nSelected: n => `${n} 件選択中`,
   moveToShort: '移動',
@@ -620,6 +623,7 @@ const zh: KanbanMessages = {
   allProfiles: '所有配置档',
   allTenants: '所有租户',
   showArchived: '显示已归档',
+  completedChildren: n => `显示已完成的子任务・${n}`,
   groupRunning: '按配置档分组运行中',
   nSelected: n => `已选择 ${n} 个`,
   moveToShort: '移动到',
@@ -808,6 +812,7 @@ const zhHant: KanbanMessages = {
   allProfiles: '所有設定檔',
   allTenants: '所有租戶',
   showArchived: '顯示已封存',
+  completedChildren: n => `顯示已完成的子任務・${n}`,
   groupRunning: '依設定檔分組執行中',
   nSelected: n => `已選取 ${n} 個`,
   moveToShort: '移至',

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -15,6 +15,8 @@ export interface KanbanTask {
   latest_summary?: null | string
   comment_count?: number
   link_counts?: { parents: number; children: number }
+  /** Display owners used to collapse completed workflow children. */
+  collapse_parent_ids?: string[]
   /** N-of-M child completion, or null when the task has no children. */
   progress?: null | { done: number; total: number }
   /** Compact diagnostics rollup — present only when a card has warnings. */

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -169,6 +169,7 @@ export {
 } from '@/components/ui/dialog'
 export {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -406,10 +406,11 @@ def get_board(
             workflow_template_id=workflow_template_id,
             current_step_key=current_step_key,
         )
-        # Pre-fetch link counts per task (cheap: one query).
+        # Pre-fetch link counts and dependency-parent identities (one query).
         link_counts: dict[str, dict[str, int]] = {}
+        dependency_parent_ids: dict[str, list[str]] = {}
         for row in conn.execute(
-            "SELECT parent_id, child_id FROM task_links"
+            "SELECT parent_id, child_id FROM task_links ORDER BY parent_id, child_id"
         ).fetchall():
             link_counts.setdefault(row["parent_id"], {"parents": 0, "children": 0})[
                 "children"
@@ -417,6 +418,55 @@ def get_board(
             link_counts.setdefault(row["child_id"], {"parents": 0, "children": 0})[
                 "parents"
             ] += 1
+            dependency_parent_ids.setdefault(row["child_id"], []).append(row["parent_id"])
+
+        # Auto-decomposition deliberately links generated tasks *into* the
+        # workflow root so the root waits for all generated work. That edge
+        # direction is the opposite of the visual owner/child relationship.
+        # The generated task's durable creation event records the owner
+        # explicitly, so derive a presentation-only projection instead of
+        # asking the renderer to guess from dependency direction.
+        decomposition_owner: dict[str, str] = {}
+        generated_children: dict[str, set[str]] = {}
+        board_task_ids = [task.id for task in tasks]
+        provenance_task_ids = set(board_task_ids)
+        for task_id in board_task_ids:
+            # A decomposed root's generated prerequisites can be excluded by
+            # tenant/archived filters while their dependency edges remain.
+            # Include those direct IDs so the root projection can still remove
+            # inverted prerequisite edges without scanning unrelated history.
+            provenance_task_ids.update(dependency_parent_ids.get(task_id, []))
+        canonical_creation_payload: dict[str, tuple[int, Optional[str]]] = {}
+        # Bound lookup work to returned tasks and their direct prerequisites.
+        # idx_events_task(task_id, created_at) services each IN lookup; chunks
+        # stay below SQLite builds with conservative host-parameter limits.
+        ordered_provenance_ids = sorted(provenance_task_ids)
+        for start in range(0, len(ordered_provenance_ids), 400):
+            task_id_chunk = ordered_provenance_ids[start : start + 400]
+            placeholders = ",".join("?" for _ in task_id_chunk)
+            rows = conn.execute(
+                f"SELECT id, task_id, payload FROM task_events "
+                f"WHERE task_id IN ({placeholders}) AND kind = 'created'",
+                task_id_chunk,
+            ).fetchall()
+            for row in rows:
+                current = canonical_creation_payload.get(row["task_id"])
+                if current is None or row["id"] < current[0]:
+                    canonical_creation_payload[row["task_id"]] = (row["id"], row["payload"])
+
+        # The earliest creation event is canonical. Ignore accidental
+        # duplicate/replayed creation events instead of letting the latest
+        # event silently change a task's display owner.
+        for task_id, (_, raw_payload) in canonical_creation_payload.items():
+            try:
+                payload = json.loads(raw_payload) if raw_payload else {}
+            except (TypeError, ValueError):
+                continue
+            owner_id = payload.get("from_decompose_of") if isinstance(payload, dict) else None
+            if not isinstance(owner_id, str) or not owner_id:
+                continue
+            decomposition_owner[task_id] = owner_id
+            generated_children.setdefault(owner_id, set()).add(task_id)
 
         # Comment + event counts (both cheap aggregates).
         comment_counts: dict[str, int] = {
@@ -466,6 +516,21 @@ def get_board(
             )
             d = _task_dict(t, latest_summary=preview)
             d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
+            owner_id = decomposition_owner.get(t.id)
+            if owner_id:
+                # Every generated task collapses under its workflow owner,
+                # regardless of sibling dependency topology.
+                d["collapse_parent_ids"] = [owner_id]
+            else:
+                # For ordinary dependency graphs, direct parents remain the
+                # visual owners. Exclude generated tasks linked into a
+                # decomposed root; those are prerequisites, not its owners.
+                generated = generated_children.get(t.id, set())
+                d["collapse_parent_ids"] = [
+                    parent_id
+                    for parent_id in dependency_parent_ids.get(t.id, [])
+                    if parent_id not in generated
+                ]
             d["comment_count"] = comment_counts.get(t.id, 0)
             d["progress"] = progress.get(t.id)  # None when the task has no children
             diags = diagnostics_per_task.get(t.id)

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -115,6 +115,109 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_board_includes_collapse_parents_even_when_parents_are_filtered_out(client):
+    """The renderer needs edge identity, not only counts, to avoid orphaning cards."""
+    parent_a = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "parent a", "tenant": "parents"},
+    ).json()["task"]
+    parent_b = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "parent b", "tenant": "parents"},
+    ).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "child",
+            "tenant": "children",
+            "parents": [parent_b["id"], parent_a["id"]],
+        },
+    ).json()["task"]
+
+    response = client.get("/api/plugins/kanban/board?tenant=children")
+
+    assert response.status_code == 200
+    tasks = {
+        task["id"]: task
+        for column in response.json()["columns"]
+        for task in column["tasks"]
+    }
+    assert list(tasks) == [child["id"]]
+    assert tasks[child["id"]]["collapse_parent_ids"] == sorted(
+        [parent_a["id"], parent_b["id"]]
+    )
+    assert tasks[child["id"]]["link_counts"]["parents"] == 2
+
+
+def test_board_projects_decomposed_children_under_workflow_root(client):
+    """Auto-decompose dependency edges must not invert the visual workflow owner."""
+    conn = kb.connect()
+    try:
+        root_id = kb.create_task(conn, title="workflow root", triage=True)
+        child_ids = kb.decompose_triage_task(
+            conn,
+            root_id,
+            root_assignee=None,
+            children=[
+                {"title": "research", "parents": []},
+                {"title": "build", "parents": [0]},
+            ],
+            author="test",
+        )
+        assert child_ids is not None
+        other_owner_id = kb.create_task(conn, title="other workflow")
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn,
+                child_ids[0],
+                "created",
+                {"from_decompose_of": other_owner_id},
+            )
+    finally:
+        conn.close()
+
+    response = client.get("/api/plugins/kanban/board")
+    assert response.status_code == 200
+    tasks = {
+        task["id"]: task
+        for column in response.json()["columns"]
+        for task in column["tasks"]
+    }
+
+    # The DB links both generated tasks as dependency parents of the root so
+    # the root waits. The board projection keeps the root visible and groups
+    # each generated card beneath it instead.
+    assert tasks[root_id]["link_counts"]["parents"] == 2
+    assert tasks[root_id]["collapse_parent_ids"] == []
+    assert tasks[child_ids[0]]["collapse_parent_ids"] == [root_id]
+    assert tasks[child_ids[1]]["collapse_parent_ids"] == [root_id]
+
+    # Provenance for direct prerequisites remains available even when one is
+    # removed by a tenant filter and another is omitted as archived. Neither
+    # inverted edge may leak back into the visible root's projection.
+    conn = kb.connect()
+    try:
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET tenant = 'visible' WHERE id = ?", (root_id,))
+            conn.execute("UPDATE tasks SET tenant = 'hidden' WHERE id = ?", (child_ids[0],))
+            conn.execute(
+                "UPDATE tasks SET tenant = 'visible', status = 'archived' WHERE id = ?",
+                (child_ids[1],),
+            )
+    finally:
+        conn.close()
+
+    filtered_response = client.get("/api/plugins/kanban/board?tenant=visible")
+    assert filtered_response.status_code == 200
+    filtered_tasks = {
+        task["id"]: task
+        for column in filtered_response.json()["columns"]
+        for task in column["tasks"]
+    }
+    assert list(filtered_tasks) == [root_id]
+    assert filtered_tasks[root_id]["collapse_parent_ids"] == []
+
+
 def test_patch_board_sets_project_directory(client, tmp_path):
     """Board-level default_workdir must be editable after creation."""
     kb.create_board("late-config")


### PR DESCRIPTION
## Summary

- collapse `done` workflow-child cards when their display owner remains visible on the board
- preserve auto-decomposed workflow roots even though their dependency edges run generated prerequisite → root
- keep root and standalone completed cards visible, preserve parent `N/M` rollups, and leave every non-`done` child visible
- reveal matching completed children during search and through an accessible checked **Completed children** visibility item
- prune hidden cards from bulk-selection state

## Relationship projection

The task-link table is a dependency graph rather than a dedicated subtask model. For ordinary graphs, the board projection uses direct dependency parents as display owners. Auto-decomposition records its workflow owner durably as `from_decompose_of`, while linking generated prerequisites into the root so the root waits for them. The API therefore exposes purpose-specific `collapse_parent_ids`: generated tasks point to that workflow owner, and the inverted prerequisite edges are removed from the root's display-owner set. Creation metadata is fetched only for task IDs already returned on the board and their direct prerequisite IDs, in bounded chunks through the existing `idx_events_task` index; this preserves correct root projection when generated prerequisites are filtered or archived without scanning unrelated history. The earliest creation event remains canonical if duplicate events exist.

This remains presentation-only: no task status, dependency, archival, retention, or execution semantics change.

## Behavior

- a completed child collapses only when at least one projected owner survives the active tenant/assignee filters
- auto-decomposed roots remain visible; their generated children collapse beneath them regardless of fan-out/chain dependency topology
- search results reveal matching completed children automatically
- the checkbox visibility item communicates and controls the reveal state
- archived, reopened, blocked, ready, running, and other actionable children remain visible

## Verification

- `npm run typecheck`
- focused ESLint over changed Desktop files
- `npm run test:ui -- src/plugins/kanban/board-filter.test.ts src/plugins/kanban/model-override.test.tsx` — 19 passed
- full `npm test` — 4,305 passed, 2 skipped
- `npm run lint` — 0 errors (existing warnings only)
- `npm run build` including packaged-output assertion
- `pytest tests/plugins/test_kanban_dashboard_plugin.py -q` — 22 passed
- SQLite query-plan probe — indexed `task_id` lookup; no full `task_events` scan or temporary sort
- broader plugin sweep — 1,248 passed; one pre-existing order-dependent A2A failure reproduced on clean `main`
- `git diff --check`
