### PR TITLE
chore: add contributor email mapping for ArcherQAQ

### DIFF
--- a/contributors/emails/314574126@qq.com
+++ b/contributors/emails/314574126@qq.com
@@ -1,0 +1,1 @@
+ArcherQAQ


### PR DESCRIPTION
Attribution mapping for @ArcherQAQ (314574126@qq.com), needed by the #26860 salvage.