### PR TITLE
feat(stt): add Gladia as a new STT provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -435,23 +435,27 @@ IMAGE_TOOLS_DEBUG=false
 # ElevenLabs API key (cloud STT/TTS — Scribe transcription)
 # ELEVENLABS_API_KEY=
 
+# Gladia API key (cloud STT — pre-recorded transcription via gladiaio-sdk)
+# GLADIA_API_KEY=
+
 # =============================================================================
 # STT PROVIDER SELECTION
 # =============================================================================
 # Default STT provider is "local" (faster-whisper) — runs on your machine, no API key needed.
 # Install with: pip install faster-whisper
 # Model downloads automatically on first use (~150 MB for "base").
-# To use cloud providers instead, set GROQ_API_KEY, VOICE_TOOLS_OPENAI_KEY, or ELEVENLABS_API_KEY above.
-# Provider priority: local > groq > openai > mistral > xai > elevenlabs
-# Configure in config.yaml: stt.provider: local | groq | openai | mistral | xai | elevenlabs
+# To use cloud providers instead, set GROQ_API_KEY, VOICE_TOOLS_OPENAI_KEY, ELEVENLABS_API_KEY, or GLADIA_API_KEY above.
+# Provider priority: local > groq > openai > mistral > xai > elevenlabs > gladia > deepinfra
+# Configure in config.yaml: stt.provider: local | groq | openai | mistral | xai | elevenlabs | gladia | deepinfra
 
 # =============================================================================
 # STT ADVANCED OVERRIDES (optional)
 # =============================================================================
-# Override default STT models per provider (normally set via stt.model in config.yaml)
+# Override default STT models per provider (normally set via stt.<provider>.model in config.yaml)
 # STT_GROQ_MODEL=whisper-large-v3-turbo
 # STT_OPENAI_MODEL=whisper-1
 # STT_ELEVENLABS_MODEL=scribe_v2
+# STT_GLADIA_MODEL=solaria-1
 
 # Override STT provider endpoints (for proxies or self-hosted instances)
 # GROQ_BASE_URL=https://api.groq.com/openai/v1

--- a/.env.example
+++ b/.env.example
@@ -443,23 +443,27 @@ IMAGE_TOOLS_DEBUG=false
 # ElevenLabs API key (cloud STT/TTS — Scribe transcription)
 # ELEVENLABS_API_KEY=
 
+# Gladia API key (cloud STT — pre-recorded transcription via gladiaio-sdk)
+# GLADIA_API_KEY=
+
 # =============================================================================
 # STT PROVIDER SELECTION
 # =============================================================================
 # Default STT provider is "local" (faster-whisper) — runs on your machine, no API key needed.
 # Install with: pip install faster-whisper
 # Model downloads automatically on first use (~150 MB for "base").
-# To use cloud providers instead, set GROQ_API_KEY, VOICE_TOOLS_OPENAI_KEY, or ELEVENLABS_API_KEY above.
-# Provider priority: local > groq > openai > mistral > xai > elevenlabs
-# Configure in config.yaml: stt.provider: local | groq | openai | mistral | xai | elevenlabs
+# To use cloud providers instead, set GROQ_API_KEY, VOICE_TOOLS_OPENAI_KEY, ELEVENLABS_API_KEY, or GLADIA_API_KEY above.
+# Provider priority: local > groq > openai > mistral > xai > elevenlabs > gladia > deepinfra
+# Configure in config.yaml: stt.provider: local | groq | openai | mistral | xai | elevenlabs | gladia | deepinfra
 
 # =============================================================================
 # STT ADVANCED OVERRIDES (optional)
 # =============================================================================
-# Override default STT models per provider (normally set via stt.model in config.yaml)
+# Override default STT models per provider (normally set via stt.<provider>.model in config.yaml)
 # STT_GROQ_MODEL=whisper-large-v3-turbo
 # STT_OPENAI_MODEL=whisper-1
 # STT_ELEVENLABS_MODEL=scribe_v2
+# STT_GLADIA_MODEL=solaria-1
 
 # Override STT provider endpoints (for proxies or self-hosted instances)
 # GROQ_BASE_URL=https://api.groq.com/openai/v1

--- a/agent/transcription_provider.py
+++ b/agent/transcription_provider.py
@@ -8,17 +8,18 @@ register instances via
 (selected via ``stt.provider`` in ``config.yaml``) services every
 :func:`tools.transcription_tools.transcribe_audio` call **when the
 configured name is neither a built-in (``local``, ``local_command``,
-``groq``, ``openai``, ``mistral``, ``xai``) nor disabled**.
+``groq``, ``openai``, ``mistral``, ``xai``, ``elevenlabs``, ``gladia``,
+``deepinfra``) nor disabled**.
 
 Two coexisting STT extension surfaces — in resolution order:
 
 1. **Built-in providers** (``BUILTIN_STT_PROVIDERS`` in
    :mod:`tools.transcription_tools`) — native Python implementations
-   for the 6 backends shipped today (faster-whisper, local_command,
-   Groq, OpenAI, Mistral, xAI). **Always win** — plugins cannot
-   shadow them. The single-env-var shell escape hatch
-   ``HERMES_LOCAL_STT_COMMAND`` is preserved via the built-in
-   ``local_command`` path.
+   for the backends shipped today (faster-whisper, local_command,
+   Groq, OpenAI, Mistral, xAI, ElevenLabs, Gladia, DeepInfra).
+   **Always win** — plugins cannot shadow them. The single-env-var
+   shell escape hatch ``HERMES_LOCAL_STT_COMMAND`` is preserved via
+   the built-in ``local_command`` path.
 2. **Plugin-registered providers** (this ABC). For new STT backends —
    OpenRouter, SenseAudio, Gemini-STT, custom proprietary engines —
    that need a Python implementation without modifying
@@ -74,7 +75,8 @@ class TranscriptionProvider(abc.ABC):
         Lowercase, no spaces. Examples: ``openrouter``, ``sensaudio``,
         ``gemini``, ``deepgram``. Names that collide with a built-in STT
         provider (``local``, ``local_command``, ``groq``, ``openai``,
-        ``mistral``, ``xai``) are rejected at registration time.
+        ``mistral``, ``xai``, ``elevenlabs``, ``gladia``, ``deepinfra``)
+        are rejected at registration time.
         """
 
     @property

--- a/agent/transcription_registry.py
+++ b/agent/transcription_registry.py
@@ -11,9 +11,10 @@ the configured ``stt.provider`` name is not a built-in.
 Built-ins-always-win
 --------------------
 Plugin names that collide with a built-in STT provider (``local``,
-``local_command``, ``groq``, ``openai``, ``mistral``, ``xai``) are
-rejected at registration with a warning. This invariant is also
-re-checked at dispatch time in
+``local_command``, ``groq``, ``openai``, ``mistral``, ``xai``,
+``elevenlabs``, ``gladia``, ``deepinfra``) are rejected at
+registration with a warning. This invariant is also re-checked at
+dispatch time in
 :func:`tools.transcription_tools._dispatch_to_plugin_provider`.
 """
 
@@ -45,6 +46,7 @@ _BUILTIN_NAMES = frozenset({
     "mistral",
     "xai",
     "elevenlabs",
+    "gladia",
     "deepinfra",
 })
 

--- a/agent/transcription_registry.py
+++ b/agent/transcription_registry.py
@@ -11,9 +11,10 @@ the configured ``stt.provider`` name is not a built-in.
 Built-ins-always-win
 --------------------
 Plugin names that collide with a built-in STT provider (``local``,
-``local_command``, ``groq``, ``openai``, ``mistral``, ``xai``) are
-rejected at registration with a warning. This invariant is also
-re-checked at dispatch time in
+``local_command``, ``groq``, ``openai``, ``mistral``, ``xai``,
+``elevenlabs``, ``gladia``, ``deepinfra``) are rejected at
+registration with a warning. This invariant is also re-checked at
+dispatch time in
 :func:`tools.transcription_tools._dispatch_to_plugin_provider`.
 """
 
@@ -46,6 +47,7 @@ _BUILTIN_NAMES = frozenset({
     "mistral",
     "xai",
     "elevenlabs",
+    "gladia",
     "deepinfra",
 })
 

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -259,10 +259,11 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   // modal/daytona/ssh). Remote backends need extra env (image, tokens, host).
   'terminal.backend': ['local', 'docker', 'singularity', 'modal', 'daytona', 'ssh'],
   'stt.elevenlabs.model_id': ['scribe_v2', 'scribe_v1'],
+  'stt.gladia.model': ['solaria-1', 'solaria-3'],
   'stt.local.model': ['tiny', 'base', 'small', 'medium', 'large-v3'],
   // Speech-to-text backends — kept in sync with the stt block in
-  // hermes_cli/config.py (local/groq/openai/mistral/elevenlabs).
-  'stt.provider': ['local', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs'],
+  // hermes_cli/config.py (local/groq/openai/mistral/elevenlabs/gladia).
+  'stt.provider': ['local', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs', 'gladia'],
   // OpenAI TTS voices — the union across models (per the OpenAI TTS API
   // docs). Model-specific narrowing happens in enumOptionsFor():
   // tts-1 / tts-1-hd support 9 voices; gpt-4o-mini-tts supports all 13.
@@ -626,6 +627,10 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
     echoTranscripts: 'Post the raw 🎙️ transcript of voice messages back to the chat.',
     elevenlabs: {
       languageCode: 'Optional ISO-639-3 language code. Blank lets ElevenLabs auto-detect.'
+    },
+    gladia: {
+      language: 'Optional ISO-639-1 language hint. Blank falls back to stt.language.',
+      diarization: 'Identify different speakers in the recording (pre-recorded only).'
     }
   },
   updates: {
@@ -746,6 +751,9 @@ export const SECTIONS: DesktopConfigSection[] = [
       'stt.elevenlabs.language_code',
       'stt.elevenlabs.tag_audio_events',
       'stt.elevenlabs.diarize',
+      'stt.gladia.model',
+      'stt.gladia.language',
+      'stt.gladia.diarization',
       'voice.record_key',
       'voice.max_recording_seconds'
     ]

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -247,10 +247,11 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   // modal/daytona/ssh). Remote backends need extra env (image, tokens, host).
   'terminal.backend': ['local', 'docker', 'singularity', 'modal', 'daytona', 'ssh'],
   'stt.elevenlabs.model_id': ['scribe_v2', 'scribe_v1'],
+  'stt.gladia.model': ['solaria-1', 'solaria-3'],
   'stt.local.model': ['tiny', 'base', 'small', 'medium', 'large-v3'],
   // Speech-to-text backends — kept in sync with the stt block in
-  // hermes_cli/config.py (local/groq/openai/mistral/elevenlabs).
-  'stt.provider': ['local', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs'],
+  // hermes_cli/config.py (local/groq/openai/mistral/elevenlabs/gladia).
+  'stt.provider': ['local', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs', 'gladia'],
   // OpenAI TTS voices — the union across models (per the OpenAI TTS API
   // docs). Model-specific narrowing happens in enumOptionsFor():
   // tts-1 / tts-1-hd support 9 voices; gpt-4o-mini-tts supports all 13.
@@ -619,6 +620,10 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
     echoTranscripts: 'Post the raw 🎙️ transcript of voice messages back to the chat.',
     elevenlabs: {
       languageCode: 'Optional ISO-639-3 language code. Blank lets ElevenLabs auto-detect.'
+    },
+    gladia: {
+      language: 'Optional ISO-639-1 language hint. Blank falls back to stt.language.',
+      diarization: 'Identify different speakers in the recording (pre-recorded only).'
     }
   },
   updates: {
@@ -743,6 +748,9 @@ export const SECTIONS: DesktopConfigSection[] = [
       'stt.elevenlabs.language_code',
       'stt.elevenlabs.tag_audio_events',
       'stt.elevenlabs.diarize',
+      'stt.gladia.model',
+      'stt.gladia.language',
+      'stt.gladia.diarization',
       'voice.record_key',
       'voice.max_recording_seconds',
       'voice.client_direct'

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -195,7 +195,7 @@ describe('settings helpers', () => {
 
     it('renders a dropdown for the STT provider including xAI (Grok)', () => {
       const opts = enumOptionsFor('stt.provider', 'local', config)
-      expect(opts).toEqual(['local', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs'])
+      expect(opts).toEqual(['local', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs', 'gladia'])
     })
 
     it('renders dropdowns for per-backend model/device sub-fields', () => {

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -196,7 +196,7 @@ describe('settings helpers', () => {
 
     it('renders a dropdown for the STT provider including xAI (Grok)', () => {
       const opts = enumOptionsFor('stt.provider', 'local', config)
-      expect(opts).toEqual(['local', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs'])
+      expect(opts).toEqual(['local', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs', 'gladia'])
     })
 
     it('renders dropdowns for per-backend model/device sub-fields', () => {

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -199,6 +199,7 @@ const BUILTIN_STT_PROVIDERS = new Set([
   'mistral',
   'xai',
   'elevenlabs',
+  'gladia',
   'deepinfra'
 ])
 

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -242,6 +242,7 @@ const BUILTIN_STT_PROVIDERS = new Set([
   'mistral',
   'xai',
   'elevenlabs',
+  'gladia',
   'deepinfra'
 ])
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1507,7 +1507,7 @@ DEFAULT_CONFIG = {
         # the raw transcript is also echoed back to the user as a 🎙️ message.
         # Set false to keep STT for the agent while suppressing that user-facing echo.
         "echo_transcripts": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe) | "deepinfra"
+        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe) | "gladia" | "deepinfra"
         # Global language hint applied to EVERY provider unless a per-provider
         # language overrides it. Defaults to "en" — Whisper auto-detection
         # frequently misidentifies short/accented clips, which reads as
@@ -1545,6 +1545,13 @@ DEFAULT_CONFIG = {
             "language_code": "",  # auto-detect by default; set to "eng", "spa", "fra", etc. to force
             "tag_audio_events": False,
             "diarize": False,
+        },
+        "gladia": {
+            "model": "solaria-1",  # solaria-1, solaria-3
+            "language": "",  # per-provider override of stt.language; blank = use global / auto
+            "diarization": False,
+            "code_switching": False,  # only when languages lists 3–5 expected codes
+            "languages": [],  # multi-lang / code-switch list; empty = use language / stt.language
         },
         "deepinfra": {
             "model": "",  # empty = first stt-tagged model from the live catalog
@@ -3709,6 +3716,14 @@ OPTIONAL_ENV_VARS = {
         "prompt": "ElevenLabs API key",
         "url": "https://elevenlabs.io/",
         "tools": ["elevenlabs_tts", "voice_transcription"],
+        "password": True,
+        "category": "tool",
+    },
+    "GLADIA_API_KEY": {
+        "description": "Gladia API key for pre-recorded speech-to-text transcription",
+        "prompt": "Gladia API key",
+        "url": "https://app.gladia.io/",
+        "tools": ["voice_transcription"],
         "password": True,
         "category": "tool",
     },

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1861,7 +1861,7 @@ DEFAULT_CONFIG = {
         # stored stt.provider as an explicit user pick; seeding "local" here
         # made a fresh install indistinguishable from a user choice. The
         # autodetect ladder covers unset. Valid values when set:
-        # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe) | "deepinfra"
+        # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe) | "gladia" | "deepinfra"
         # Global language hint applied to EVERY provider unless a per-provider
         # language overrides it. Defaults to "en" — Whisper auto-detection
         # frequently misidentifies short/accented clips, which reads as
@@ -1908,6 +1908,13 @@ DEFAULT_CONFIG = {
             "language_code": "",  # auto-detect by default; set to "eng", "spa", "fra", etc. to force
             "tag_audio_events": False,
             "diarize": False,
+        },
+        "gladia": {
+            "model": "solaria-1",  # solaria-1, solaria-3
+            "language": "",  # per-provider override of stt.language; blank = use global / auto
+            "diarization": False,
+            "code_switching": False,  # only when languages lists 3–5 expected codes
+            "languages": [],  # multi-lang / code-switch list; empty = use language / stt.language
         },
         "deepinfra": {
             "model": "",  # empty = first stt-tagged model from the live catalog
@@ -4517,6 +4524,14 @@ OPTIONAL_ENV_VARS = {
         "prompt": "ElevenLabs API key",
         "url": "https://elevenlabs.io/",
         "tools": ["elevenlabs_tts", "voice_transcription"],
+        "password": True,
+        "category": "tool",
+    },
+    "GLADIA_API_KEY": {
+        "description": "Gladia API key for pre-recorded speech-to-text transcription",
+        "prompt": "Gladia API key",
+        "url": "https://app.gladia.io/",
+        "tools": ["voice_transcription"],
         "password": True,
         "category": "tool",
     },

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -389,6 +389,7 @@ def run_dump(args):
         ("BROWSERBASE_API_KEY", "browserbase"),
         ("FAL_KEY", "fal"),
         ("ELEVENLABS_API_KEY", "elevenlabs"),
+        ("GLADIA_API_KEY", "gladia"),
         ("GITHUB_TOKEN", "github"),
     ]
 

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -391,6 +391,7 @@ def run_dump(args):
         ("BROWSERBASE_API_KEY", "browserbase"),
         ("FAL_KEY", "fal"),
         ("ELEVENLABS_API_KEY", "elevenlabs"),
+        ("GLADIA_API_KEY", "gladia"),
         ("GITHUB_TOKEN", "github"),
     ]
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -580,6 +580,8 @@ def _print_setup_summary(config: dict, hermes_home):
         tool_status.append(("Speech-to-Text (Groq Whisper)", True, None))
     elif stt_provider == "elevenlabs" and get_env_value("ELEVENLABS_API_KEY"):
         tool_status.append(("Speech-to-Text (ElevenLabs Scribe)", True, None))
+    elif stt_provider == "gladia" and get_env_value("GLADIA_API_KEY"):
+        tool_status.append(("Speech-to-Text (Gladia)", True, None))
     elif stt_provider == "xai":
         tool_status.append(("Speech-to-Text (xAI)", True, None))
     elif stt_provider == "deepinfra" and get_env_value("DEEPINFRA_API_KEY"):

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -658,6 +658,8 @@ def _print_setup_summary(config: dict, hermes_home):
         tool_status.append(("Speech-to-Text (Groq Whisper)", True, None))
     elif stt_provider == "elevenlabs" and get_env_value("ELEVENLABS_API_KEY"):
         tool_status.append(("Speech-to-Text (ElevenLabs Scribe)", True, None))
+    elif stt_provider == "gladia" and get_env_value("GLADIA_API_KEY"):
+        tool_status.append(("Speech-to-Text (Gladia)", True, None))
     elif stt_provider == "xai":
         tool_status.append(("Speech-to-Text (xAI)", True, None))
     elif stt_provider == "deepinfra" and get_env_value("DEEPINFRA_API_KEY"):

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -189,6 +189,7 @@ def show_status(args):
         "Browserbase": "BROWSERBASE_API_KEY",  # Optional — direct credentials only
         "FAL": "FAL_KEY",
         "ElevenLabs": "ELEVENLABS_API_KEY",
+        "Gladia": "GLADIA_API_KEY",
         "GitHub": "GITHUB_TOKEN",
     }
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -167,6 +167,7 @@ def show_status(args):
         "Browserbase": "BROWSERBASE_API_KEY",  # Optional — direct credentials only
         "FAL": "FAL_KEY",
         "ElevenLabs": "ELEVENLABS_API_KEY",
+        "Gladia": "GLADIA_API_KEY",
         "GitHub": "GITHUB_TOKEN",
     }
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -3994,6 +3994,7 @@ STT_MODEL_CATALOG = {
     "groq": ["whisper-large-v3-turbo", "whisper-large-v3", "distil-whisper-large-v3-en"],
     "openai": ["whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe", "gpt-transcribe"],
     "elevenlabs": ["scribe_v2", "scribe_v1"],
+    "gladia": ["solaria-1", "solaria-3"],
 }
 
 # ElevenLabs historically uses ``model_id`` instead of ``model``.
@@ -4005,6 +4006,7 @@ def _configure_stt_model(stt_provider: str, config: dict) -> None:
 
     Providers without a static catalog (xai, deepinfra) skip the prompt —
     xAI has a single model and DeepInfra resolves from its live catalog.
+    Gladia uses the static ``solaria-*`` catalog below.
     """
     catalog = STT_MODEL_CATALOG.get(stt_provider)
     if not catalog:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -467,6 +467,15 @@ TOOL_CATEGORIES = {
                 ],
                 "stt_provider": "elevenlabs",
             },
+            {
+                "name": "Gladia",
+                "badge": "paid",
+                "tag": "solaria — pre-recorded STT via gladiaio-sdk",
+                "env_vars": [
+                    {"key": "GLADIA_API_KEY", "prompt": "Gladia API key", "url": "https://app.gladia.io/"},
+                ],
+                "stt_provider": "gladia",
+            },
             # Mistral Voxtral STT intentionally omitted — mistralai PyPI
             # package quarantined (malicious 2.4.6 release, 2026-05-12).
             # Restore alongside the dashboard stt.provider option.

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -4588,6 +4588,7 @@ STT_MODEL_CATALOG = {
     "groq": ["whisper-large-v3-turbo", "whisper-large-v3", "distil-whisper-large-v3-en"],
     "openai": ["whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe", "gpt-transcribe"],
     "elevenlabs": ["scribe_v2", "scribe_v1"],
+    "gladia": ["solaria-1", "solaria-3"],
 }
 
 # ElevenLabs historically uses ``model_id`` instead of ``model``.
@@ -4599,6 +4600,7 @@ def _configure_stt_model(stt_provider: str, config: dict) -> None:
 
     Providers without a static catalog (xai, deepinfra) skip the prompt —
     xAI has a single model and DeepInfra resolves from its live catalog.
+    Gladia uses the static ``solaria-*`` catalog below.
     """
     catalog = STT_MODEL_CATALOG.get(stt_provider)
     if not catalog:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -469,6 +469,15 @@ TOOL_CATEGORIES = {
                 ],
                 "stt_provider": "elevenlabs",
             },
+            {
+                "name": "Gladia",
+                "badge": "paid",
+                "tag": "solaria — pre-recorded STT via gladiaio-sdk",
+                "env_vars": [
+                    {"key": "GLADIA_API_KEY", "prompt": "Gladia API key", "url": "https://app.gladia.io/"},
+                ],
+                "stt_provider": "gladia",
+            },
             # Mistral Voxtral STT intentionally omitted — mistralai PyPI
             # package quarantined (malicious 2.4.6 release, 2026-05-12).
             # Restore alongside the dashboard stt.provider option.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -888,7 +888,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Speech-to-text provider",
         # "mistral" temporarily removed — mistralai PyPI package quarantined
         # (malicious 2.4.6 release on 2026-05-12). Restore once available.
-        "options": ["local", "groq", "openai", "xai", "elevenlabs"],
+        "options": ["local", "groq", "openai", "xai", "elevenlabs", "gladia"],
     },
     "stt.local.model": {
         "type": "select",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -910,6 +910,11 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "ElevenLabs Scribe model",
         "options": ["scribe_v2", "scribe_v1"],
     },
+    "stt.gladia.model": {
+        "type": "select",
+        "description": "Gladia pre-recorded STT model",
+        "options": ["solaria-1", "solaria-3"],
+    },
     "display.skin": {
         "type": "select",
         "description": "CLI visual theme",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1253,7 +1253,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Speech-to-text provider",
         # "mistral" temporarily removed — mistralai PyPI package quarantined
         # (malicious 2.4.6 release on 2026-05-12). Restore once available.
-        "options": ["local", "groq", "openai", "xai", "elevenlabs"],
+        "options": ["local", "groq", "openai", "xai", "elevenlabs", "gladia"],
     },
     "stt.local.model": {
         "type": "select",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1275,6 +1275,11 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "ElevenLabs Scribe model",
         "options": ["scribe_v2", "scribe_v1"],
     },
+    "stt.gladia.model": {
+        "type": "select",
+        "description": "Gladia pre-recorded STT model",
+        "options": ["solaria-1", "solaria-3"],
+    },
     "display.skin": {
         "type": "select",
         "description": "CLI visual theme",

--- a/skills/autonomous-ai-agents/hermes-agent/references/configuration.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/configuration.md
@@ -13,7 +13,7 @@ Full reference: https://hermes-agent.nousresearch.com/docs/user-guide/configurat
 | `compression` | `enabled`, `threshold` (0.50), `target_ratio` (0.20) |
 | `display` | `skin`, `interface` (cli/tui), `language`, `show_reasoning`, `show_cost`, `pet` |
 | `approvals` | `mode` (smart/manual/off), `timeout`, `cron_mode` |
-| `stt` | `enabled`, `provider` (local/groq/openai/mistral/elevenlabs/deepinfra) |
+| `stt` | `enabled`, `provider` (local/groq/openai/mistral/elevenlabs/gladia/deepinfra) |
 | `tts` | `provider` (edge/elevenlabs/openai/minimax/mistral/neutts/gemini/piper/kittentts/deepinfra/xai) |
 | `memory` | `memory_enabled`, `user_profile_enabled`, `provider`, `write_approval` |
 | `security` | `redact_secrets`, `tirith_enabled`, `website_blocklist` |
@@ -67,12 +67,15 @@ Voice messages from messaging platforms are auto-transcribed.
 ```yaml
 stt:
   enabled: true
-  provider: local   # local (faster-whisper, free) | groq | openai | mistral | elevenlabs | deepinfra
+  provider: local   # local (faster-whisper, free) | groq | openai | mistral | elevenlabs | gladia | deepinfra
   local:
     model: base     # tiny, base, small, medium, large-v3
+  gladia:
+    model: solaria-1
+    diarization: false
 ```
 
-Auto-detect priority: local faster-whisper (`pip install faster-whisper`) → Groq (`GROQ_API_KEY`, free tier) → OpenAI (`VOICE_TOOLS_OPENAI_KEY`) → Mistral Voxtral (`MISTRAL_API_KEY`).
+Auto-detect priority: local faster-whisper (`pip install faster-whisper`) → Groq (`GROQ_API_KEY`, free tier) → OpenAI (`VOICE_TOOLS_OPENAI_KEY`) → Mistral Voxtral (`MISTRAL_API_KEY`) → … → Gladia (`GLADIA_API_KEY`).
 
 ### TTS (Text → Voice)
 

--- a/tests/agent/test_transcription_registry.py
+++ b/tests/agent/test_transcription_registry.py
@@ -85,6 +85,7 @@ class TestRegistration:
             "mistral",
             "xai",
             "elevenlabs",
+            "gladia",
             "deepinfra",
         ],
     )

--- a/tests/hermes_cli/test_stt_picker.py
+++ b/tests/hermes_cli/test_stt_picker.py
@@ -55,11 +55,11 @@ class TestSttCategory:
 
 
 class TestConfigWrites:
-    def test_write_provider_config_sets_stt_provider(self):
+    def test_write_provider_config_sets_gladia(self):
         config = {}
-        prov = _stt_provider_named("Groq")
+        prov = _stt_provider_named("Gladia")
         _write_provider_config(prov, config, managed_feature=None)
-        assert config["stt"]["provider"] == "groq"
+        assert config["stt"]["provider"] == "gladia"
         assert config["stt"]["use_gateway"] is False
 
 

--- a/tests/hermes_cli/test_stt_picker.py
+++ b/tests/hermes_cli/test_stt_picker.py
@@ -93,8 +93,20 @@ class TestModelPicker:
         assert set(STT_MODEL_CATALOG["openai"]) == OPENAI_MODELS
         assert set(STT_MODEL_CATALOG["groq"]) == GROQ_MODELS
 
+    def test_gladia_catalog_has_solaria_models(self):
+        assert "gladia" in STT_MODEL_CATALOG
+        assert "solaria-1" in STT_MODEL_CATALOG["gladia"]
+        assert "solaria-3" in STT_MODEL_CATALOG["gladia"]
 
-
+    def test_configure_stt_model_writes_gladia_model(self):
+        config = {"stt": {"gladia": {"model": "solaria-1"}}}
+        with patch(
+            "hermes_cli.tools_config._prompt_choice", return_value=1
+        ) as pc:
+            _configure_stt_model("gladia", config)
+        assert config["stt"]["gladia"]["model"] == "solaria-3"
+        args = pc.call_args[0]
+        assert args[2] == STT_MODEL_CATALOG["gladia"].index("solaria-1")
 
     def test_configure_stt_model_defaults_to_current(self):
         config = {"stt": {"openai": {"model": "gpt-transcribe"}}}

--- a/tests/hermes_cli/test_stt_picker.py
+++ b/tests/hermes_cli/test_stt_picker.py
@@ -101,8 +101,20 @@ class TestModelPicker:
         assert set(STT_MODEL_CATALOG["openai"]) == OPENAI_MODELS
         assert set(STT_MODEL_CATALOG["groq"]) == GROQ_MODELS
 
+    def test_gladia_catalog_has_solaria_models(self):
+        assert "gladia" in STT_MODEL_CATALOG
+        assert "solaria-1" in STT_MODEL_CATALOG["gladia"]
+        assert "solaria-3" in STT_MODEL_CATALOG["gladia"]
 
-
+    def test_configure_stt_model_writes_gladia_model(self):
+        config = {"stt": {"gladia": {"model": "solaria-1"}}}
+        with patch(
+            "hermes_cli.tools_config._prompt_choice", return_value=1
+        ) as pc:
+            _configure_stt_model("gladia", config)
+        assert config["stt"]["gladia"]["model"] == "solaria-3"
+        args = pc.call_args[0]
+        assert args[2] == STT_MODEL_CATALOG["gladia"].index("solaria-1")
 
     def test_configure_stt_model_defaults_to_current(self):
         config = {"stt": {"openai": {"model": "gpt-transcribe"}}}

--- a/tests/hermes_cli/test_stt_picker.py
+++ b/tests/hermes_cli/test_stt_picker.py
@@ -63,6 +63,13 @@ class TestConfigWrites:
         # Legacy key is popped so the read-time shim can't override the pick.
         assert "use_gateway" not in config["stt"]
 
+    def test_write_provider_config_sets_gladia(self):
+        config = {}
+        prov = _stt_provider_named("Gladia")
+        _write_provider_config(prov, config, managed_feature=None)
+        assert config["stt"]["provider"] == "gladia"
+        assert "use_gateway" not in config["stt"]
+
 
     def test_apply_provider_selection_stt(self):
         config = {}

--- a/tests/tools/test_transcription_gladia.py
+++ b/tests/tools/test_transcription_gladia.py
@@ -1,0 +1,179 @@
+"""Tests for the Gladia STT provider (pre-recorded via gladiaio-sdk)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def test_get_provider_gating_keys_on_gladia_api_key(monkeypatch):
+    """Explicit-provider gate: GLADIA_API_KEY presence flips ``gladia`` on/off."""
+    monkeypatch.delenv("GLADIA_API_KEY", raising=False)
+    from tools.transcription_tools import _get_provider
+
+    assert _get_provider({"provider": "gladia"}) == "none"
+    monkeypatch.setenv("GLADIA_API_KEY", "test-key")
+    assert _get_provider({"provider": "gladia"}) == "gladia"
+
+
+def test_build_gladia_options_maps_single_language(monkeypatch):
+    from tools.transcription_tools import _build_gladia_transcribe_options
+
+    options = _build_gladia_transcribe_options(
+        {"language": "en", "gladia": {"model": "solaria-1"}},
+        "solaria-1",
+    )
+    assert options["model"] == "solaria-1"
+    assert options["language_config"]["languages"] == ["en"]
+    assert "code_switching" not in options.get("language_config", {})
+
+
+def test_build_gladia_options_prefers_languages_list_and_diarization():
+    from tools.transcription_tools import _build_gladia_transcribe_options
+
+    options = _build_gladia_transcribe_options(
+        {
+            "language": "en",
+            "gladia": {
+                "languages": ["en", "fr", "es"],
+                "code_switching": True,
+                "diarization": True,
+            },
+        },
+        "solaria-3",
+    )
+    assert options["model"] == "solaria-3"
+    assert options["language_config"]["languages"] == ["en", "fr", "es"]
+    assert options["language_config"]["code_switching"] is True
+    assert options["diarization"] is True
+
+
+def test_build_gladia_options_ignores_code_switching_without_languages(caplog):
+    from tools.transcription_tools import _build_gladia_transcribe_options
+
+    with caplog.at_level("WARNING"):
+        options = _build_gladia_transcribe_options(
+            {"language": "", "gladia": {"language": "", "code_switching": True, "languages": []}},
+            "solaria-1",
+        )
+    assert "language_config" not in options or "code_switching" not in options.get(
+        "language_config", {}
+    )
+    assert "code_switching" in caplog.text
+
+
+def test_gladia_client_http_headers_include_hermes_version():
+    from hermes_cli import __version__
+    from tools.transcription_tools import _gladia_client_http_headers
+
+    headers = _gladia_client_http_headers()
+    assert headers == {"x-gladia-version": f"hermes-agent/{__version__}"}
+
+
+def test_transcribe_gladia_happy_path(monkeypatch, tmp_path):
+    monkeypatch.setenv("GLADIA_API_KEY", "test-key")
+    audio = tmp_path / "speech.wav"
+    audio.write_bytes(b"\x00" * 16)
+
+    captured: dict = {}
+
+    class _FakePrerecorded:
+        def transcribe(self, path, options):
+            captured["path"] = path
+            captured["options"] = options
+            return SimpleNamespace(
+                result=SimpleNamespace(
+                    transcription=SimpleNamespace(full_transcript="hello from gladia")
+                )
+            )
+
+    class _FakeClient:
+        def __init__(self, api_key=None, http_headers=None, **_kwargs):
+            captured["api_key"] = api_key
+            captured["http_headers"] = http_headers
+
+        def prerecorded(self):
+            return _FakePrerecorded()
+
+    fake_sdk = MagicMock()
+    fake_sdk.GladiaClient = _FakeClient
+
+    stt_config = {
+        "language": "en",
+        "gladia": {"model": "solaria-1", "diarization": False},
+    }
+
+    with patch.dict("sys.modules", {"gladiaio_sdk": fake_sdk}), patch(
+        "tools.transcription_tools._load_stt_config", return_value=stt_config
+    ), patch("tools.lazy_deps.ensure", return_value=True):
+        from hermes_cli import __version__
+        from tools.transcription_tools import _transcribe_gladia
+
+        result = _transcribe_gladia(str(audio), "solaria-1")
+
+    assert result["success"] is True
+    assert result["provider"] == "gladia"
+    assert result["transcript"] == "hello from gladia"
+    assert captured["api_key"] == "test-key"
+    assert captured["http_headers"] == {
+        "x-gladia-version": f"hermes-agent/{__version__}"
+    }
+    assert captured["options"]["language_config"]["languages"] == ["en"]
+
+
+def test_transcribe_gladia_missing_key(monkeypatch, tmp_path):
+    monkeypatch.delenv("GLADIA_API_KEY", raising=False)
+    audio = tmp_path / "speech.wav"
+    audio.write_bytes(b"\x00" * 16)
+
+    from tools.transcription_tools import _transcribe_gladia
+
+    result = _transcribe_gladia(str(audio), "solaria-1")
+    assert result["success"] is False
+    assert "GLADIA_API_KEY" in result["error"]
+
+
+def test_transcribe_gladia_sdk_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("GLADIA_API_KEY", "test-key")
+    audio = tmp_path / "speech.wav"
+    audio.write_bytes(b"\x00" * 16)
+
+    class _BoomClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        def prerecorded(self):
+            raise RuntimeError("boom")
+
+    fake_sdk = MagicMock()
+    fake_sdk.GladiaClient = _BoomClient
+
+    with patch.dict("sys.modules", {"gladiaio_sdk": fake_sdk}), patch(
+        "tools.transcription_tools._load_stt_config", return_value={"gladia": {}}
+    ), patch("tools.lazy_deps.ensure", return_value=True):
+        from tools.transcription_tools import _transcribe_gladia
+
+        result = _transcribe_gladia(str(audio), "solaria-1")
+
+    assert result["success"] is False
+    assert "Gladia STT transcription failed" in result["error"]
+
+
+def test_dispatch_routes_gladia_provider(monkeypatch, tmp_path):
+    monkeypatch.setenv("GLADIA_API_KEY", "test-key")
+    audio = tmp_path / "speech.wav"
+    audio.write_bytes(b"\x00" * 16)
+
+    with patch(
+        "tools.transcription_tools._transcribe_gladia",
+        return_value={"success": True, "transcript": "ok", "provider": "gladia"},
+    ) as mocked, patch(
+        "tools.transcription_tools._load_stt_config",
+        return_value={"enabled": True, "provider": "gladia", "gladia": {"model": "solaria-1"}},
+    ):
+        from tools.transcription_tools import _transcribe_prepared_audio
+
+        result = _transcribe_prepared_audio(str(audio))
+
+    assert result["provider"] == "gladia"
+    mocked.assert_called_once()

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -143,6 +143,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Speech-to-text providers ──────────────────────────────────────────
     "stt.mistral": ("mistralai==2.4.8",),
+    "stt.gladia": ("gladiaio-sdk==1.0.5",),
     "stt.faster_whisper": (
         "faster-whisper==1.2.1",
         "sounddevice==0.5.5",

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,7 +2,7 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with six providers:
+Provides speech-to-text transcription with multiple providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
@@ -12,6 +12,7 @@ Provides speech-to-text transcription with six providers:
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
   - **elevenlabs** — ElevenLabs Scribe API, requires ``ELEVENLABS_API_KEY``.
+  - **gladia** — Gladia pre-recorded STT API, requires ``GLADIA_API_KEY``.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -113,6 +114,7 @@ DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
 DEFAULT_ELEVENLABS_STT_MODEL = os.getenv("STT_ELEVENLABS_MODEL", "scribe_v2")
+DEFAULT_GLADIA_STT_MODEL = os.getenv("STT_GLADIA_MODEL", "solaria-1")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
@@ -346,6 +348,7 @@ BUILTIN_STT_PROVIDERS = frozenset({
     "mistral",
     "xai",
     "elevenlabs",
+    "gladia",
     "deepinfra",
 })
 
@@ -1049,6 +1052,14 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "gladia":
+            if _resolve_provider_key("GLADIA_API_KEY", "gladia"):
+                return "gladia"
+            logger.warning(
+                "STT provider 'gladia' configured but GLADIA_API_KEY not set"
+            )
+            return "none"
+
         if provider == "deepinfra":
             if _HAS_OPENAI and _resolve_provider_key("DEEPINFRA_API_KEY", "deepinfra"):
                 return "deepinfra"
@@ -1061,9 +1072,9 @@ def _get_provider(stt_config: dict) -> str:
         return provider  # Unknown — let it fail downstream
 
     # --- Auto-detect (no explicit provider):
-    #     local > groq > openai > mistral > xai > elevenlabs > deepinfra ---
+    #     local > groq > openai > mistral > xai > elevenlabs > gladia > deepinfra ---
     # DeepInfra is tried LAST so adding DEEPINFRA_API_KEY (commonly set for the
-    # chat surface) never silently displaces an existing xAI/ElevenLabs STT
+    # chat surface) never silently displaces an existing xAI/ElevenLabs/Gladia STT
     # auto-selection; a DeepInfra-only box still resolves to it. mistral is
     # intentionally skipped while `mistralai` is quarantined on PyPI (malicious
     # 2.4.6 release on 2026-05-12).
@@ -1098,6 +1109,9 @@ def _get_provider(stt_config: dict) -> str:
     if _resolve_provider_key("ELEVENLABS_API_KEY", "elevenlabs"):
         logger.info("No local STT available, using ElevenLabs Scribe STT API")
         return "elevenlabs"
+    if _resolve_provider_key("GLADIA_API_KEY", "gladia"):
+        logger.info("No local STT available, using Gladia STT API")
+        return "gladia"
     if _HAS_OPENAI and _resolve_provider_key("DEEPINFRA_API_KEY", "deepinfra"):
         logger.info("No local STT available, using DeepInfra Whisper API")
         return "deepinfra"
@@ -2294,6 +2308,152 @@ def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: Gladia (pre-recorded STT via gladiaio-sdk)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_gladia_languages(raw: Any) -> list[str]:
+    """Return a cleaned list of ISO language codes from config."""
+    if isinstance(raw, str) and raw.strip():
+        return [part.strip() for part in raw.split(",") if part.strip()]
+    if isinstance(raw, (list, tuple)):
+        out: list[str] = []
+        for item in raw:
+            if isinstance(item, str) and item.strip():
+                out.append(item.strip())
+        return out
+    return []
+
+
+def _build_gladia_transcribe_options(
+    stt_config: Dict[str, Any],
+    model_name: str,
+) -> Dict[str, Any]:
+    """Build Gladia ``prerecorded().transcribe`` options from Hermes STT config.
+
+    Language rules (Gladia):
+    - When a language is known, set ``language_config.languages`` explicitly.
+    - Never enable ``code_switching`` with an empty languages list.
+    - Multi-language / code-switch uses ``stt.gladia.languages`` when set.
+    """
+    gladia_config = stt_config.get("gladia") if isinstance(stt_config.get("gladia"), dict) else {}
+    options: Dict[str, Any] = {}
+
+    if isinstance(model_name, str) and model_name.strip():
+        options["model"] = model_name.strip()
+
+    languages = _normalize_gladia_languages(gladia_config.get("languages"))
+    if not languages:
+        single = _resolve_stt_language("gladia", stt_config)
+        if single:
+            languages = [single]
+
+    code_switching = is_truthy_value(gladia_config.get("code_switching", False))
+    if code_switching and not languages:
+        logger.warning(
+            "stt.gladia.code_switching is set but languages is empty; "
+            "ignoring code_switching (Gladia requires 3–5 expected languages)"
+        )
+        code_switching = False
+
+    if languages or code_switching:
+        language_config: Dict[str, Any] = {}
+        if languages:
+            language_config["languages"] = languages
+        if code_switching:
+            language_config["code_switching"] = True
+        options["language_config"] = language_config
+
+    if is_truthy_value(gladia_config.get("diarization", False)):
+        options["diarization"] = True
+
+    return options
+
+
+def _gladia_client_http_headers() -> Dict[str, str]:
+    """Headers passed to ``GladiaClient`` for Gladia request attribution.
+
+    Gladia's SDK appends its own ``SdkPython/...`` tag to ``x-gladia-version``,
+    so the wire value becomes ``hermes-agent/{version} SdkPython/{sdk}``.
+    """
+    try:
+        from hermes_cli import __version__ as _hermes_version
+    except Exception:
+        _hermes_version = "unknown"
+    return {"x-gladia-version": f"hermes-agent/{_hermes_version}"}
+
+
+def _extract_gladia_transcript(result: Any) -> str:
+    """Pull ``full_transcript`` from a Gladia SDK result (object or dict)."""
+    try:
+        transcription = getattr(getattr(result, "result", None), "transcription", None)
+        if transcription is not None:
+            text = getattr(transcription, "full_transcript", None)
+            if isinstance(text, str) and text.strip():
+                return text.strip()
+    except Exception:
+        pass
+
+    if isinstance(result, dict):
+        nested = result.get("result") or {}
+        if isinstance(nested, dict):
+            transcription = nested.get("transcription") or {}
+            if isinstance(transcription, dict):
+                text = transcription.get("full_transcript")
+                if isinstance(text, str) and text.strip():
+                    return text.strip()
+
+    return _extract_transcript_text(result)
+
+
+def _transcribe_gladia(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using Gladia pre-recorded STT via the official SDK."""
+    api_key = _resolve_provider_key("GLADIA_API_KEY", "gladia")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "GLADIA_API_KEY not set"}
+
+    stt_config = _load_stt_config()
+    options = _build_gladia_transcribe_options(stt_config, model_name)
+
+    try:
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
+            _lazy_ensure("stt.gladia", prompt=False)
+        except Exception:
+            pass
+        from gladiaio_sdk import GladiaClient
+
+        client = GladiaClient(
+            api_key=api_key,
+            http_headers=_gladia_client_http_headers(),
+        )
+
+        result = client.prerecorded().transcribe(file_path, options)
+        transcript_text = _extract_gladia_transcript(result)
+        if not transcript_text:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "Gladia STT returned empty transcript",
+                "no_speech": True,
+            }
+
+        logger.info(
+            "Transcribed %s via Gladia (%s, %d chars)",
+            Path(file_path).name,
+            model_name,
+            len(transcript_text),
+        )
+        return {"success": True, "transcript": transcript_text, "provider": "gladia"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("Gladia STT transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Gladia STT transcription failed: {e}"}
+
+
+# ---------------------------------------------------------------------------
 # Provider: DeepInfra (OpenAI-compatible /v1/audio/transcriptions)
 # ---------------------------------------------------------------------------
 
@@ -2449,6 +2609,11 @@ def _transcribe_prepared_audio(file_path: str, model: Optional[str] = None) -> D
         model_name = model or elevenlabs_cfg.get("model_id", DEFAULT_ELEVENLABS_STT_MODEL)
         return _transcribe_elevenlabs(file_path, model_name)
 
+    if provider == "gladia":
+        gladia_cfg = stt_config.get("gladia") if isinstance(stt_config.get("gladia"), dict) else {}
+        model_name = model or gladia_cfg.get("model") or DEFAULT_GLADIA_STT_MODEL
+        return _transcribe_gladia(file_path, model_name)
+
     if provider == "deepinfra":
         di_config = stt_config.get("deepinfra")  # may be None (YAML null)
         di_config = di_config if isinstance(di_config, dict) else {}
@@ -2515,8 +2680,8 @@ def _transcribe_prepared_audio(file_path: str, model: Optional[str] = None) -> D
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
             "Voxtral Transcribe, configure xAI OAuth or set XAI_API_KEY for xAI Grok STT, "
-            "set ELEVENLABS_API_KEY for ElevenLabs Scribe, or set VOICE_TOOLS_OPENAI_KEY "
-            "or OPENAI_API_KEY for the OpenAI Whisper API."
+            "set ELEVENLABS_API_KEY for ElevenLabs Scribe, set GLADIA_API_KEY for Gladia, "
+            "or set VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY for the OpenAI Whisper API."
         ),
     }
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,7 +2,7 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with six providers:
+Provides speech-to-text transcription with multiple providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
@@ -12,6 +12,7 @@ Provides speech-to-text transcription with six providers:
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
   - **elevenlabs** — ElevenLabs Scribe API, requires ``ELEVENLABS_API_KEY``.
+  - **gladia** — Gladia pre-recorded STT API, requires ``GLADIA_API_KEY``.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -113,6 +114,7 @@ DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
 DEFAULT_ELEVENLABS_STT_MODEL = os.getenv("STT_ELEVENLABS_MODEL", "scribe_v2")
+DEFAULT_GLADIA_STT_MODEL = os.getenv("STT_GLADIA_MODEL", "solaria-1")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
@@ -384,6 +386,7 @@ BUILTIN_STT_PROVIDERS = frozenset({
     "mistral",
     "xai",
     "elevenlabs",
+    "gladia",
     "deepinfra",
 })
 
@@ -1130,6 +1133,14 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "gladia":
+            if _resolve_provider_key("GLADIA_API_KEY", "gladia"):
+                return "gladia"
+            logger.warning(
+                "STT provider 'gladia' configured but GLADIA_API_KEY not set"
+            )
+            return "none"
+
         if provider == "deepinfra":
             if _HAS_OPENAI and _resolve_provider_key("DEEPINFRA_API_KEY", "deepinfra"):
                 return "deepinfra"
@@ -1142,9 +1153,9 @@ def _get_provider(stt_config: dict) -> str:
         return provider  # Unknown — let it fail downstream
 
     # --- Auto-detect (no explicit provider):
-    #     local > groq > openai > mistral > xai > elevenlabs > deepinfra ---
+    #     local > groq > openai > mistral > xai > elevenlabs > gladia > deepinfra ---
     # DeepInfra is tried LAST so adding DEEPINFRA_API_KEY (commonly set for the
-    # chat surface) never silently displaces an existing xAI/ElevenLabs STT
+    # chat surface) never silently displaces an existing xAI/ElevenLabs/Gladia STT
     # auto-selection; a DeepInfra-only box still resolves to it. mistral is
     # intentionally skipped while `mistralai` is quarantined on PyPI (malicious
     # 2.4.6 release on 2026-05-12).
@@ -1179,6 +1190,9 @@ def _get_provider(stt_config: dict) -> str:
     if _resolve_provider_key("ELEVENLABS_API_KEY", "elevenlabs"):
         logger.info("No local STT available, using ElevenLabs Scribe STT API")
         return "elevenlabs"
+    if _resolve_provider_key("GLADIA_API_KEY", "gladia"):
+        logger.info("No local STT available, using Gladia STT API")
+        return "gladia"
     if _HAS_OPENAI and _resolve_provider_key("DEEPINFRA_API_KEY", "deepinfra"):
         logger.info("No local STT available, using DeepInfra Whisper API")
         return "deepinfra"
@@ -2703,6 +2717,152 @@ def _transcribe_elevenlabs(
 
 
 # ---------------------------------------------------------------------------
+# Provider: Gladia (pre-recorded STT via gladiaio-sdk)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_gladia_languages(raw: Any) -> list[str]:
+    """Return a cleaned list of ISO language codes from config."""
+    if isinstance(raw, str) and raw.strip():
+        return [part.strip() for part in raw.split(",") if part.strip()]
+    if isinstance(raw, (list, tuple)):
+        out: list[str] = []
+        for item in raw:
+            if isinstance(item, str) and item.strip():
+                out.append(item.strip())
+        return out
+    return []
+
+
+def _build_gladia_transcribe_options(
+    stt_config: Dict[str, Any],
+    model_name: str,
+) -> Dict[str, Any]:
+    """Build Gladia ``prerecorded().transcribe`` options from Hermes STT config.
+
+    Language rules (Gladia):
+    - When a language is known, set ``language_config.languages`` explicitly.
+    - Never enable ``code_switching`` with an empty languages list.
+    - Multi-language / code-switch uses ``stt.gladia.languages`` when set.
+    """
+    gladia_config = stt_config.get("gladia") if isinstance(stt_config.get("gladia"), dict) else {}
+    options: Dict[str, Any] = {}
+
+    if isinstance(model_name, str) and model_name.strip():
+        options["model"] = model_name.strip()
+
+    languages = _normalize_gladia_languages(gladia_config.get("languages"))
+    if not languages:
+        single = _resolve_stt_language("gladia", stt_config)
+        if single:
+            languages = [single]
+
+    code_switching = is_truthy_value(gladia_config.get("code_switching", False))
+    if code_switching and not languages:
+        logger.warning(
+            "stt.gladia.code_switching is set but languages is empty; "
+            "ignoring code_switching (Gladia requires 3–5 expected languages)"
+        )
+        code_switching = False
+
+    if languages or code_switching:
+        language_config: Dict[str, Any] = {}
+        if languages:
+            language_config["languages"] = languages
+        if code_switching:
+            language_config["code_switching"] = True
+        options["language_config"] = language_config
+
+    if is_truthy_value(gladia_config.get("diarization", False)):
+        options["diarization"] = True
+
+    return options
+
+
+def _gladia_client_http_headers() -> Dict[str, str]:
+    """Headers passed to ``GladiaClient`` for Gladia request attribution.
+
+    Gladia's SDK appends its own ``SdkPython/...`` tag to ``x-gladia-version``,
+    so the wire value becomes ``hermes-agent/{version} SdkPython/{sdk}``.
+    """
+    try:
+        from hermes_cli import __version__ as _hermes_version
+    except Exception:
+        _hermes_version = "unknown"
+    return {"x-gladia-version": f"hermes-agent/{_hermes_version}"}
+
+
+def _extract_gladia_transcript(result: Any) -> str:
+    """Pull ``full_transcript`` from a Gladia SDK result (object or dict)."""
+    try:
+        transcription = getattr(getattr(result, "result", None), "transcription", None)
+        if transcription is not None:
+            text = getattr(transcription, "full_transcript", None)
+            if isinstance(text, str) and text.strip():
+                return text.strip()
+    except Exception:
+        pass
+
+    if isinstance(result, dict):
+        nested = result.get("result") or {}
+        if isinstance(nested, dict):
+            transcription = nested.get("transcription") or {}
+            if isinstance(transcription, dict):
+                text = transcription.get("full_transcript")
+                if isinstance(text, str) and text.strip():
+                    return text.strip()
+
+    return _extract_transcript_text(result)
+
+
+def _transcribe_gladia(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using Gladia pre-recorded STT via the official SDK."""
+    api_key = _resolve_provider_key("GLADIA_API_KEY", "gladia")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "GLADIA_API_KEY not set"}
+
+    stt_config = _load_stt_config()
+    options = _build_gladia_transcribe_options(stt_config, model_name)
+
+    try:
+        try:
+            from tools.lazy_deps import ensure as _lazy_ensure
+            _lazy_ensure("stt.gladia", prompt=False)
+        except Exception:
+            pass
+        from gladiaio_sdk import GladiaClient
+
+        client = GladiaClient(
+            api_key=api_key,
+            http_headers=_gladia_client_http_headers(),
+        )
+
+        result = client.prerecorded().transcribe(file_path, options)
+        transcript_text = _extract_gladia_transcript(result)
+        if not transcript_text:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "Gladia STT returned empty transcript",
+                "no_speech": True,
+            }
+
+        logger.info(
+            "Transcribed %s via Gladia (%s, %d chars)",
+            Path(file_path).name,
+            model_name,
+            len(transcript_text),
+        )
+        return {"success": True, "transcript": transcript_text, "provider": "gladia"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("Gladia STT transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Gladia STT transcription failed: {e}"}
+
+
+# ---------------------------------------------------------------------------
 # Provider: DeepInfra (OpenAI-compatible /v1/audio/transcriptions)
 # ---------------------------------------------------------------------------
 
@@ -3107,6 +3267,11 @@ def _dispatch_stt_provider(
             file_path, model_name, language=language, prompt=prompt,
         )
 
+    if provider == "gladia":
+        gladia_cfg = stt_config.get("gladia") if isinstance(stt_config.get("gladia"), dict) else {}
+        model_name = model or gladia_cfg.get("model") or DEFAULT_GLADIA_STT_MODEL
+        return _transcribe_gladia(file_path, model_name)
+
     if provider == "deepinfra":
         di_config = stt_config.get("deepinfra")  # may be None (YAML null)
         di_config = di_config if isinstance(di_config, dict) else {}
@@ -3188,8 +3353,8 @@ def _dispatch_stt_provider(
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
             "Voxtral Transcribe, configure xAI OAuth or set XAI_API_KEY for xAI Grok STT, "
-            "set ELEVENLABS_API_KEY for ElevenLabs Scribe, or set VOICE_TOOLS_OPENAI_KEY "
-            "or OPENAI_API_KEY for the OpenAI Whisper API."
+            "set ELEVENLABS_API_KEY for ElevenLabs Scribe, set GLADIA_API_KEY for Gladia, "
+            "or set VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY for the OpenAI Whisper API."
         ),
     }
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -162,11 +162,13 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `KREA_API_KEY` | Krea API key for Krea 2 image generation ([krea.ai](https://krea.ai/)) |
 | `GROQ_API_KEY` | Groq Whisper STT API key ([groq.com](https://groq.com/)) |
 | `ELEVENLABS_API_KEY` | ElevenLabs premium TTS voices ([elevenlabs.io](https://elevenlabs.io/)) |
+| `GLADIA_API_KEY` | Gladia pre-recorded speech-to-text ([app.gladia.io](https://app.gladia.io/)) |
 | `PORCUPINE_ACCESS_KEY` | Picovoice Porcupine wake-word engine ([console.picovoice.ai](https://console.picovoice.ai/)) — only for `wake_word.provider: porcupine`; the default openWakeWord and sherpa engines need no key |
 | `STT_GROQ_MODEL` | Override the Groq STT model (default: `whisper-large-v3-turbo`) |
 | `GROQ_BASE_URL` | Override the Groq OpenAI-compatible STT endpoint |
 | `STT_OPENAI_MODEL` | Override the OpenAI STT model (default: `whisper-1`) |
 | `STT_OPENAI_BASE_URL` | Override the OpenAI-compatible STT endpoint |
+| `STT_GLADIA_MODEL` | Override the Gladia STT model (default: `solaria-1`) |
 | `GITHUB_TOKEN` | GitHub token for Skills Hub (higher API rate limits, skill publish) |
 | `HONCHO_API_KEY` | Cross-session user modeling ([honcho.dev](https://honcho.dev/)) |
 | `HONCHO_BASE_URL` | Base URL for self-hosted Honcho instances (default: Honcho cloud). No API key required for local instances |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -160,11 +160,13 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `KREA_API_KEY` | Krea API key for Krea 2 image generation ([krea.ai](https://krea.ai/)) |
 | `GROQ_API_KEY` | Groq Whisper STT API key ([groq.com](https://groq.com/)) |
 | `ELEVENLABS_API_KEY` | ElevenLabs premium TTS voices ([elevenlabs.io](https://elevenlabs.io/)) |
+| `GLADIA_API_KEY` | Gladia pre-recorded speech-to-text ([app.gladia.io](https://app.gladia.io/)) |
 | `PORCUPINE_ACCESS_KEY` | Picovoice Porcupine wake-word engine ([console.picovoice.ai](https://console.picovoice.ai/)) — only for `wake_word.provider: porcupine`; the default openWakeWord and sherpa engines need no key |
 | `STT_GROQ_MODEL` | Override the Groq STT model (default: `whisper-large-v3-turbo`) |
 | `GROQ_BASE_URL` | Override the Groq OpenAI-compatible STT endpoint |
 | `STT_OPENAI_MODEL` | Override the OpenAI STT model (default: `whisper-1`) |
 | `STT_OPENAI_BASE_URL` | Override the OpenAI-compatible STT endpoint |
+| `STT_GLADIA_MODEL` | Override the Gladia STT model (default: `solaria-1`) |
 | `GITHUB_TOKEN` | GitHub token for Skills Hub (higher API rate limits, skill publish) |
 | `HONCHO_API_KEY` | Cross-session user modeling ([honcho.dev](https://honcho.dev/)) |
 | `HONCHO_BASE_URL` | Base URL for self-hosted Honcho instances (default: Honcho cloud). No API key required for local instances |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1807,7 +1807,7 @@ Hashes are deterministic — the same user always maps to the same hash, so the 
 stt:
   enabled: true                # Auto-transcribe inbound voice messages (default: true)
   echo_transcripts: true       # Post raw transcripts back to the chat as 🎙️ "..." (default: true)
-  provider: "local"            # "local" | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "deepinfra" | ...
+  provider: "local"            # "local" | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "gladia" | "deepinfra" | ...
   language: "en"               # GLOBAL language hint for every provider (per-provider language wins); set "" for auto-detect
   local:
     model: "base"              # tiny, base, small, medium, large-v3
@@ -1822,10 +1822,16 @@ stt:
   openai:
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe | gpt-transcribe
     language: ""               # per-provider override of stt.language
+  gladia:
+    model: "solaria-1"         # solaria-1 | solaria-3
+    language: ""               # per-provider override of stt.language
+    diarization: false
+    code_switching: false      # only with a non-empty languages list
+    languages: []              # multi-lang / code-switch list
   # model: "whisper-1"         # Legacy fallback key still respected
 ```
 
-Language resolution is the same for **every** STT provider (local, groq, openai, mistral, xai, elevenlabs, deepinfra, command providers, and plugins): `stt.<provider>.language` → `stt.language` → `HERMES_LOCAL_STT_LANGUAGE` env var → provider auto-detect. **The default is `stt.language: "en"`** — Whisper auto-detection frequently misidentifies short or accented clips, which shows up as voice notes transcribed in the wrong language. Non-English speakers should set `stt.language` to their language code once (e.g. `"es"`, `"zh"`, `"uk"`); set it to `""` to restore auto-detection for multilingual use.
+Language resolution is the same for **every** STT provider (local, groq, openai, mistral, xai, elevenlabs, gladia, deepinfra, command providers, and plugins): `stt.<provider>.language` → `stt.language` → `HERMES_LOCAL_STT_LANGUAGE` env var → provider auto-detect. **The default is `stt.language: "en"`** — Whisper auto-detection frequently misidentifies short or accented clips, which shows up as voice notes transcribed in the wrong language. Non-English speakers should set `stt.language` to their language code once (e.g. `"es"`, `"zh"`, `"uk"`); set it to `""` to restore auto-detection for multilingual use.
 
 Set `stt.echo_transcripts: false` when the gateway should transcribe voice notes for the agent but must not post the raw transcript back to the chat (for example, customer-facing WhatsApp bots).
 
@@ -1834,6 +1840,7 @@ Provider behavior:
 - `local` uses `faster-whisper` running on your machine. Install it separately with `pip install faster-whisper`. Silence-hallucination hardening is on by default: a Silero VAD filter keeps silence/noise from ever reaching Whisper, cross-window conditioning is disabled, and segments the model itself flags as probably-not-speech *and* low-confidence are dropped. Set `stt.local.vad: false` to transcribe non-speech audio (music, ambient) with the raw behavior.
 - `groq` uses Groq's Whisper-compatible endpoint and reads `GROQ_API_KEY`. Pass `stt.groq.language` (or the global `HERMES_LOCAL_STT_LANGUAGE` env var) to skip auto-detection and reduce latency.
 - `openai` uses the OpenAI speech API and reads `VOICE_TOOLS_OPENAI_KEY`.
+- `gladia` uses Gladia's pre-recorded STT API via the official `gladiaio-sdk` and reads `GLADIA_API_KEY`. Set language explicitly when known; enable `code_switching` only with a non-empty `languages` list.
 
 If the requested provider is unavailable, Hermes falls back automatically in this order: `local` → `groq` → `openai`.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2057,7 +2057,7 @@ Direct OpenAI API requests and custom proxy endpoints are unchanged.
 stt:
   enabled: true                # Auto-transcribe inbound voice messages (default: true)
   echo_transcripts: true       # Post raw transcripts back to the chat as 🎙️ "..." (default: true)
-  provider: "local"            # "local" | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "deepinfra" | ...
+  provider: "local"            # "local" | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "gladia" | "deepinfra" | ...
   language: "en"               # GLOBAL language hint for every provider (per-provider language wins); set "" for auto-detect
   cloud_trim_silence: true     # trim long pauses with ffmpeg before uploading to a cloud provider (default: true)
   cloud_trim_threshold_db: -40 # audio quieter than this counts as silence
@@ -2077,10 +2077,16 @@ stt:
   openai:
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe | gpt-transcribe
     language: ""               # per-provider override of stt.language
+  gladia:
+    model: "solaria-1"         # solaria-1 | solaria-3
+    language: ""               # per-provider override of stt.language
+    diarization: false
+    code_switching: false      # only with a non-empty languages list
+    languages: []              # multi-lang / code-switch list
   # model: "whisper-1"         # Legacy fallback key still respected
 ```
 
-Language resolution is the same for **every** STT provider (local, groq, openai, mistral, xai, elevenlabs, deepinfra, command providers, and plugins): `stt.<provider>.language` → `stt.language` → `HERMES_LOCAL_STT_LANGUAGE` env var → provider auto-detect. **The default is `stt.language: "en"`** — Whisper auto-detection frequently misidentifies short or accented clips, which shows up as voice notes transcribed in the wrong language. Non-English speakers should set `stt.language` to their language code once (e.g. `"es"`, `"zh"`, `"uk"`); set it to `""` to restore auto-detection for multilingual use.
+Language resolution is the same for **every** STT provider (local, groq, openai, mistral, xai, elevenlabs, gladia, deepinfra, command providers, and plugins): `stt.<provider>.language` → `stt.language` → `HERMES_LOCAL_STT_LANGUAGE` env var → provider auto-detect. **The default is `stt.language: "en"`** — Whisper auto-detection frequently misidentifies short or accented clips, which shows up as voice notes transcribed in the wrong language. Non-English speakers should set `stt.language` to their language code once (e.g. `"es"`, `"zh"`, `"uk"`); set it to `""` to restore auto-detection for multilingual use.
 
 Set `stt.echo_transcripts: false` when the gateway should transcribe voice notes for the agent but must not post the raw transcript back to the chat (for example, customer-facing WhatsApp bots).
 
@@ -2089,6 +2095,7 @@ Provider behavior:
 - `local` uses `faster-whisper` running on your machine. Install it separately with `pip install faster-whisper`. Silence-hallucination hardening is on by default: a Silero VAD filter keeps silence/noise from ever reaching Whisper, cross-window conditioning is disabled, and segments the model itself flags as probably-not-speech *and* low-confidence are dropped. Set `stt.local.vad: false` to transcribe non-speech audio (music, ambient) with the raw behavior. The model stays loaded in memory between voice messages for low-latency transcription; set `stt.local.unload_after_idle_seconds` (e.g. `300` for 5 minutes) to automatically release the model when idle. This frees GPU memory on CUDA hosts (the main win when a local LLM shares the GPU); on CPU the memory becomes reusable by the process, though the OS-visible footprint may not shrink until the process needs the space for something else. The next voice message reloads the model transparently.
 - `groq` uses Groq's Whisper-compatible endpoint and reads `GROQ_API_KEY`. Pass `stt.groq.language` (or the global `HERMES_LOCAL_STT_LANGUAGE` env var) to skip auto-detection and reduce latency.
 - `openai` uses the OpenAI speech API and reads `VOICE_TOOLS_OPENAI_KEY`.
+- `gladia` uses Gladia's pre-recorded STT API via the official `gladiaio-sdk` and reads `GLADIA_API_KEY`. Set language explicitly when known; enable `code_switching` only with a non-empty `languages` list.
 
 Cloud providers (groq, openai, mistral, xai, elevenlabs, deepinfra) get a **pre-upload silence trim** by default when `ffmpeg` is installed: long pauses in a voice note are collapsed client-side before the file uploads, keeping `cloud_trim_keep_ms` of each pause so natural pacing survives. Shorter audio means faster uploads, lower per-audio-minute billing, and fewer silence hallucinations from the remote model. Clips shorter than 12 seconds skip the trim entirely (savings can't matter there, and several providers bill a per-request minimum anyway). The trim is best-effort — if ffmpeg is missing, the trim fails, the clip is mostly silence, or trimming would save less than ~10%, the original file is uploaded untouched. Set `stt.cloud_trim_silence: false` to always upload the original (e.g. when transcribing music or ambient audio through a cloud provider). Command-type and plugin providers never get trimmed audio.
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -448,6 +448,7 @@ Voice messages sent on Telegram, Discord, WhatsApp, Slack, or Signal are automat
 |----------|---------|------|---------| 
 | **Local Whisper** (default) | Good | Free | None needed |
 | **Groq Whisper API** | Good–Best | Free tier | `GROQ_API_KEY` |
+| **Gladia** | Good–Best | Free tier | `GLADIA_API_KEY` |
 | **OpenAI Whisper API** | Good–Best | Paid | `VOICE_TOOLS_OPENAI_KEY` or `OPENAI_API_KEY` |
 
 :::info Zero Config
@@ -459,7 +460,7 @@ Local transcription works out of the box when `faster-whisper` is installed. If 
 ```yaml
 # In ~/.hermes/config.yaml
 stt:
-  provider: "local"           # "local" | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "deepinfra"
+  provider: "local"           # "local" | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "gladia" | "deepinfra"
   language: "en"              # Global language hint applied to every provider unless a per-provider language overrides it; set "" to restore auto-detect
   local:
     model: "base"             # tiny, base, small, medium, large-v3
@@ -473,6 +474,12 @@ stt:
   xai:
     model: "grok-stt"         # xAI Grok STT
     language: ""              # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else "en"
+  gladia:
+    model: "solaria-1"        # solaria-1, solaria-3
+    language: ""              # optional ISO-639-1 hint; blank = use stt.language
+    diarization: false        # speaker identification (pre-recorded)
+    code_switching: false     # only with a non-empty languages list (prefer 3–5 codes)
+    languages: []             # multi-lang / code-switch list; empty = use language / stt.language
 ```
 
 ### Provider Details
@@ -494,6 +501,8 @@ stt:
 **Mistral API (Voxtral Transcribe)** — Requires `MISTRAL_API_KEY`. Uses Mistral's [Voxtral Transcribe](https://docs.mistral.ai/capabilities/audio/speech_to_text/) models. Supports 13 languages, speaker diarization, and word-level timestamps. Install with `cd ~/.hermes/hermes-agent && uv pip install -e ".[mistral]"`.
 
 **xAI Grok STT** — Requires `XAI_API_KEY`. Posts to `https://api.x.ai/v1/stt` as multipart/form-data. Good choice if you're already using xAI for chat or TTS and want one API key for everything. Auto-detection order puts it after Groq — explicitly set `stt.provider: xai` to force it.
+
+**Gladia** — Requires `GLADIA_API_KEY` ([app.gladia.io](https://app.gladia.io/)). Uses the official [`gladiaio-sdk`](https://pypi.org/project/gladiaio-sdk/) pre-recorded API (`prerecorded().transcribe()`), which uploads and polls in one call. The SDK is lazy-installed on first use. Set `stt.gladia.language` (or global `stt.language`) so Gladia receives an explicit `language_config.languages` list when the language is known. Enable `stt.gladia.code_switching` only together with a non-empty `stt.gladia.languages` list of expected codes (prefer 3–5) — Gladia rejects empty-list code switching. Optional `stt.gladia.diarization` turns on speaker identification.
 
 **Custom local CLI fallback** — Set `HERMES_LOCAL_STT_COMMAND` if you want Hermes to call a local transcription command directly. The command template supports `{input_path}`, `{output_dir}`, `{language}`, and `{model}` placeholders. Hermes tokenizes the rendered template into an argument list and executes it without a shell, so operators such as `|`, `>`, `&&`, and `;` are passed as literal arguments. Your command must write a `.txt` transcript somewhere under `{output_dir}`.
 
@@ -610,7 +619,7 @@ The shell command runs under the same user as Hermes with full filesystem access
 
 ### Python plugin providers (STT)
 
-For STT engines that aren't built-in AND can't be expressed as a shell command (need a Python SDK, OAuth-refreshing auth, streaming chunks, etc.), register a Python plugin via `ctx.register_transcription_provider()`. The plugin **coexists with** the 8 built-in providers (`local`, `local_command`, `groq`, `openai`, `mistral`, `xai`, `elevenlabs`, `deepinfra`) and the `stt.providers.<name>: type: command` registry — built-ins keep their native implementations and always win on name collision; command providers win over plugins of the same name (config is more local than plugin install).
+For STT engines that aren't built-in AND can't be expressed as a shell command (need a Python SDK, OAuth-refreshing auth, streaming chunks, etc.), register a Python plugin via `ctx.register_transcription_provider()`. The plugin **coexists with** the 9 built-in providers (`local`, `local_command`, `groq`, `openai`, `mistral`, `xai`, `elevenlabs`, `gladia`, `deepinfra`) and the `stt.providers.<name>: type: command` registry — built-ins keep their native implementations and always win on name collision; command providers win over plugins of the same name (config is more local than plugin install).
 
 #### When to pick which (STT)
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -448,6 +448,7 @@ Voice messages sent on Telegram, Discord, WhatsApp, Slack, or Signal are automat
 |----------|---------|------|---------| 
 | **Local Whisper** (default) | Good | Free | None needed |
 | **Groq Whisper API** | Good–Best | Free tier | `GROQ_API_KEY` |
+| **Gladia** | Good–Best | Free tier | `GLADIA_API_KEY` |
 | **OpenAI Whisper API** | Good–Best | Paid | `VOICE_TOOLS_OPENAI_KEY` or `OPENAI_API_KEY` |
 
 :::info Zero Config
@@ -459,7 +460,7 @@ Local transcription works out of the box when `faster-whisper` is installed. If 
 ```yaml
 # In ~/.hermes/config.yaml
 stt:
-  provider: "local"           # "local" | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "deepinfra"
+  provider: "local"           # "local" | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "gladia" | "deepinfra"
   language: "en"              # Global language hint applied to every provider unless a per-provider language overrides it; set "" to restore auto-detect
   local:
     model: "base"             # tiny, base, small, medium, large-v3
@@ -473,6 +474,12 @@ stt:
   xai:
     model: "grok-stt"         # xAI Grok STT
     language: ""              # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else "en"
+  gladia:
+    model: "solaria-1"        # solaria-1, solaria-3
+    language: ""              # optional ISO-639-1 hint; blank = use stt.language
+    diarization: false        # speaker identification (pre-recorded)
+    code_switching: false     # only with a non-empty languages list (prefer 3–5 codes)
+    languages: []             # multi-lang / code-switch list; empty = use language / stt.language
 ```
 
 ### Provider Details
@@ -494,6 +501,8 @@ stt:
 **Mistral API (Voxtral Transcribe)** — Requires `MISTRAL_API_KEY`. Uses Mistral's [Voxtral Transcribe](https://docs.mistral.ai/capabilities/audio/speech_to_text/) models. Supports 13 languages, speaker diarization, and word-level timestamps. Install with `cd ~/.hermes/hermes-agent && uv pip install -e ".[mistral]"`.
 
 **xAI Grok STT** — Requires `XAI_API_KEY`. Posts to `https://api.x.ai/v1/stt` as multipart/form-data. Good choice if you're already using xAI for chat or TTS and want one API key for everything. Auto-detection order puts it after Groq — explicitly set `stt.provider: xai` to force it.
+
+**Gladia** — Requires `GLADIA_API_KEY` ([app.gladia.io](https://app.gladia.io/)). Uses the official [`gladiaio-sdk`](https://pypi.org/project/gladiaio-sdk/) pre-recorded API (`prerecorded().transcribe()`), which uploads and polls in one call. The SDK is lazy-installed on first use. Set `stt.gladia.language` (or global `stt.language`) so Gladia receives an explicit `language_config.languages` list when the language is known. Enable `stt.gladia.code_switching` only together with a non-empty `stt.gladia.languages` list of expected codes (prefer 3–5) — Gladia rejects empty-list code switching. Optional `stt.gladia.diarization` turns on speaker identification.
 
 **Custom local CLI fallback** — Set `HERMES_LOCAL_STT_COMMAND` if you want Hermes to call a local transcription command directly. The command template supports `{input_path}`, `{output_dir}`, `{language}`, and `{model}` placeholders. Hermes tokenizes the rendered template into an argument list and executes it without a shell, so operators such as `|`, `>`, `&&`, and `;` are passed as literal arguments. Your command must write a `.txt` transcript somewhere under `{output_dir}`.
 
@@ -612,7 +621,7 @@ The shell command runs under the same user as Hermes with full filesystem access
 
 ### Python plugin providers (STT)
 
-For STT engines that aren't built-in AND can't be expressed as a shell command (need a Python SDK, OAuth-refreshing auth, streaming chunks, etc.), register a Python plugin via `ctx.register_transcription_provider()`. The plugin **coexists with** the 8 built-in providers (`local`, `local_command`, `groq`, `openai`, `mistral`, `xai`, `elevenlabs`, `deepinfra`) and the `stt.providers.<name>: type: command` registry — built-ins keep their native implementations and always win on name collision; command providers win over plugins of the same name (config is more local than plugin install).
+For STT engines that aren't built-in AND can't be expressed as a shell command (need a Python SDK, OAuth-refreshing auth, streaming chunks, etc.), register a Python plugin via `ctx.register_transcription_provider()`. The plugin **coexists with** the 9 built-in providers (`local`, `local_command`, `groq`, `openai`, `mistral`, `xai`, `elevenlabs`, `gladia`, `deepinfra`) and the `stt.providers.<name>: type: command` registry — built-ins keep their native implementations and always win on name collision; command providers win over plugins of the same name (config is more local than plugin install).
 
 #### When to pick which (STT)
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -97,6 +97,7 @@ Add to `~/.hermes/.env`:
 # pip install faster-whisper          # Free, runs locally, recommended
 GROQ_API_KEY=your-key                 # Groq Whisper — fast, free tier (cloud)
 VOICE_TOOLS_OPENAI_KEY=your-key       # OpenAI Whisper — paid (cloud)
+GLADIA_API_KEY=your-key               # Gladia pre-recorded STT — paid (cloud)
 
 # Text-to-Speech (optional — Edge TTS and NeuTTS work without any key)
 ELEVENLABS_API_KEY=***           # ElevenLabs — premium quality
@@ -424,12 +425,16 @@ stt:
                                     # passes its path to the agent as part of the
                                     # inbound message, useful for custom pipelines
                                     # (diarization, alignment, archival, etc.)
-  provider: "local"                  # "local" (free) | "groq" | "openai" | "mistral" | "xai"
+  provider: "local"                  # "local" (free) | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "gladia" | "deepinfra"
   local:
     model: "base"                    # tiny, base, small, medium, large-v3
     language: ""                     # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else auto-detect
   groq:
     language: ""                     # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else auto-detect
+  gladia:
+    model: "solaria-1"               # solaria-1, solaria-3
+    language: ""                     # optional ISO-639-1 hint; blank = use stt.language
+    diarization: false
   # model: "whisper-1"              # Legacy: used when provider is not set
 
 # Text-to-Speech
@@ -463,10 +468,12 @@ tts:
 # pip install faster-whisper        # Free local STT — no API key needed
 GROQ_API_KEY=...                    # Groq Whisper (fast, free tier)
 VOICE_TOOLS_OPENAI_KEY=...         # OpenAI Whisper (paid)
+GLADIA_API_KEY=...                 # Gladia pre-recorded STT (free tier)
 
 # STT advanced overrides (optional)
 STT_GROQ_MODEL=whisper-large-v3-turbo    # Override default Groq STT model
 STT_OPENAI_MODEL=whisper-1               # Override default OpenAI STT model
+STT_GLADIA_MODEL=solaria-1               # Override default Gladia STT model
 GROQ_BASE_URL=https://api.groq.com/openai/v1     # Custom Groq endpoint
 STT_OPENAI_BASE_URL=https://api.openai.com/v1    # Custom OpenAI STT endpoint
 
@@ -493,8 +500,10 @@ DISCORD_ALLOWED_USERS=...
 | **OpenAI** | `gpt-transcribe` | Fast | Best | Paid ($0.0045/min) | Yes |
 | **Mistral** | `voxtral-mini-latest` | Fast | Good | Paid | Yes |
 | **xAI** | `grok-stt` | Fast | Good | Paid | Yes |
+| **Gladia** | `solaria-1` | Fast | Good–Best | free tier | Yes |
+| **Gladia** | `solaria-3` | Fast | Best | free tier | Yes |
 
-Provider priority (automatic fallback): **local** > **groq** > **openai**
+Provider priority (automatic fallback): **local** > **groq** > **openai** > **mistral** > **xai** > **elevenlabs** > **gladia** > **deepinfra**
 
 ### TTS Provider Comparison
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -97,6 +97,7 @@ Add to `~/.hermes/.env`:
 # pip install faster-whisper          # Free, runs locally, recommended
 GROQ_API_KEY=your-key                 # Groq Whisper — fast, free tier (cloud)
 VOICE_TOOLS_OPENAI_KEY=your-key       # OpenAI Whisper — paid (cloud)
+GLADIA_API_KEY=your-key               # Gladia pre-recorded STT — paid (cloud)
 
 # Text-to-Speech (optional — Edge TTS and NeuTTS work without any key)
 ELEVENLABS_API_KEY=***           # ElevenLabs — premium quality
@@ -442,12 +443,16 @@ stt:
                                     # passes its path to the agent as part of the
                                     # inbound message, useful for custom pipelines
                                     # (diarization, alignment, archival, etc.)
-  provider: "local"                  # "local" (free) | "groq" | "openai" | "mistral" | "xai"
+  provider: "local"                  # "local" (free) | "groq" | "openai" | "mistral" | "xai" | "elevenlabs" | "gladia" | "deepinfra"
   local:
     model: "base"                    # tiny, base, small, medium, large-v3
     language: ""                     # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else auto-detect
   groq:
     language: ""                     # optional ISO-639-1 hint; blank = use HERMES_LOCAL_STT_LANGUAGE if set, else auto-detect
+  gladia:
+    model: "solaria-1"               # solaria-1, solaria-3
+    language: ""                     # optional ISO-639-1 hint; blank = use stt.language
+    diarization: false
   # model: "whisper-1"              # Legacy: used when provider is not set
 
 # Text-to-Speech
@@ -481,10 +486,12 @@ tts:
 # pip install faster-whisper        # Free local STT — no API key needed
 GROQ_API_KEY=...                    # Groq Whisper (fast, free tier)
 VOICE_TOOLS_OPENAI_KEY=...         # OpenAI Whisper (paid)
+GLADIA_API_KEY=...                 # Gladia pre-recorded STT (free tier)
 
 # STT advanced overrides (optional)
 STT_GROQ_MODEL=whisper-large-v3-turbo    # Override default Groq STT model
 STT_OPENAI_MODEL=whisper-1               # Override default OpenAI STT model
+STT_GLADIA_MODEL=solaria-1               # Override default Gladia STT model
 GROQ_BASE_URL=https://api.groq.com/openai/v1     # Custom Groq endpoint
 STT_OPENAI_BASE_URL=https://api.openai.com/v1    # Custom OpenAI STT endpoint
 
@@ -511,8 +518,10 @@ DISCORD_ALLOWED_USERS=...
 | **OpenAI** | `gpt-transcribe` | Fast | Best | Paid ($0.0045/min) | Yes |
 | **Mistral** | `voxtral-mini-latest` | Fast | Good | Paid | Yes |
 | **xAI** | `grok-stt` | Fast | Good | Paid | Yes |
+| **Gladia** | `solaria-1` | Fast | Good–Best | free tier | Yes |
+| **Gladia** | `solaria-3` | Fast | Best | free tier | Yes |
 
-Provider priority (automatic fallback): **local** > **groq** > **openai**
+Provider priority (automatic fallback): **local** > **groq** > **openai** > **mistral** > **xai** > **elevenlabs** > **gladia** > **deepinfra**
 
 ### TTS Provider Comparison
 


### PR DESCRIPTION
## What does this PR do?

Adds Gladia as a built-in STT provider for voice-message transcription, using the official `gladiaio-sdk` (pre-recorded). Wired the same way as existing cloud STT backends: reserved built-in name, `GLADIA_API_KEY` gating, `stt.gladia` config, lazy SDK install, plus `hermes tools` / dashboard / desktop settings.

Auto-detect order: `local > groq > openai > mistral > xai > elevenlabs > gladia > deepinfra` (Gladia before DeepInfra so a chat-only DeepInfra key does not silently take STT).

## Related Issue

N/A — no existing Gladia STT issue/PR found on search.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Core: `tools/transcription_tools.py` (`_transcribe_gladia`, options mapping, provider gate)
- Reserve built-in name: `agent/transcription_registry.py`, `agent/transcription_provider.py`
- Config / secrets: `hermes_cli/config_defaults.py`, `.env.example` (`GLADIA_API_KEY`)
- Surfaces: `hermes_cli/tools_config.py`, `hermes_cli/web_server.py`, desktop settings
- Lazy dep: `tools/lazy_deps.py` (`gladiaio-sdk==1.0.5`)
- Docs + tests: voice/config/env docs; `tests/tools/test_transcription_gladia.py`

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_transcription_gladia.py -q
```

Optional live smoke: set `GLADIA_API_KEY` + `stt.provider: gladia`, then `transcribe_audio('/path/to/sample.wav')`.

## Checklist

### Code

- [x] Contributing Guide read
- [x] Conventional Commits (`feat(stt): …`)
- [x] Searched existing PRs/issues for Gladia STT (none found)
- [x] PR scoped to this feature only
- [x] Tests added (`tests/tools/test_transcription_gladia.py`)
- [ ] Full suite / platform smoke noted after review feedback if needed

### Documentation & Housekeeping

- [x] Docs updated (config, env vars, voice-mode, TTS)
- [x] N/A — `cli-config.yaml.example` (defaults in `config_defaults.py`)
- [x] N/A — no AGENTS.md / architecture change
- [x] Cross-platform: SDK path; no OS-specific shell
- [x] N/A — no new core tool schema