### PR TITLE
fix(desktop): track one unscoped stream pin per session

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -214,7 +214,9 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
     upsertToolCall
   } = deps
 
-  const unscopedStreamSessionIdRef = useRef<string | null>(null)
+  // One pin per concurrent unscoped stream, not a single shared slot: two chats
+  // streaming at once used to clobber each other's pin (#46194 / #62823).
+  const unscopedStreamSessionIdsRef = useRef<readonly string[]>([])
 
   // session.info arrives in bursts (agent build ready + turn end + title /
   // MCP / compress edges within the same second). Each used to fire its own
@@ -260,10 +262,10 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         activeSessionId: activeSessionIdRef.current,
         eventType: event.type,
         explicitSessionId: explicitSid,
-        unscopedStreamSessionId: unscopedStreamSessionIdRef.current
+        unscopedStreamSessionIds: unscopedStreamSessionIdsRef.current
       })
 
-      unscopedStreamSessionIdRef.current = route.nextUnscopedStreamSessionId
+      unscopedStreamSessionIdsRef.current = route.nextUnscopedStreamSessionIds
 
       if (route.drop) {
         return

--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -31,12 +31,12 @@ describe('gateway event routing', () => {
       activeSessionId: 'session-a',
       eventType: 'message.start',
       explicitSessionId: '',
-      unscopedStreamSessionId: null
+      unscopedStreamSessionIds: []
     })
 
     expect(started).toEqual({
       drop: false,
-      nextUnscopedStreamSessionId: 'session-a',
+      nextUnscopedStreamSessionIds: ['session-a'],
       sessionId: 'session-a'
     })
 
@@ -44,12 +44,12 @@ describe('gateway event routing', () => {
       activeSessionId: 'session-b',
       eventType: 'message.delta',
       explicitSessionId: '',
-      unscopedStreamSessionId: started.nextUnscopedStreamSessionId
+      unscopedStreamSessionIds: started.nextUnscopedStreamSessionIds
     })
 
     expect(delta).toEqual({
       drop: false,
-      nextUnscopedStreamSessionId: 'session-a',
+      nextUnscopedStreamSessionIds: ['session-a'],
       sessionId: 'session-a'
     })
 
@@ -57,12 +57,12 @@ describe('gateway event routing', () => {
       activeSessionId: 'session-b',
       eventType: 'message.complete',
       explicitSessionId: '',
-      unscopedStreamSessionId: delta.nextUnscopedStreamSessionId
+      unscopedStreamSessionIds: delta.nextUnscopedStreamSessionIds
     })
 
     expect(completed).toEqual({
       drop: false,
-      nextUnscopedStreamSessionId: null,
+      nextUnscopedStreamSessionIds: [],
       sessionId: 'session-a'
     })
   })
@@ -72,12 +72,14 @@ describe('gateway event routing', () => {
       activeSessionId: 'session-b',
       eventType: 'message.start',
       explicitSessionId: '',
-      unscopedStreamSessionId: 'session-a'
+      unscopedStreamSessionIds: ['session-a']
     })
 
+    // Session B owns its own start, but A's stream is still running and keeps
+    // its pin — the second start adds, it does not take over.
     expect(routed).toEqual({
       drop: false,
-      nextUnscopedStreamSessionId: 'session-b',
+      nextUnscopedStreamSessionIds: ['session-a', 'session-b'],
       sessionId: 'session-b'
     })
   })
@@ -87,13 +89,151 @@ describe('gateway event routing', () => {
       activeSessionId: 'session-b',
       eventType: 'message.complete',
       explicitSessionId: 'session-a',
-      unscopedStreamSessionId: 'session-a'
+      unscopedStreamSessionIds: ['session-a']
     })
 
     expect(routed).toEqual({
       drop: false,
-      nextUnscopedStreamSessionId: null,
+      nextUnscopedStreamSessionIds: [],
       sessionId: 'session-a'
+    })
+  })
+
+  it('retires only the completing stream when several run concurrently', () => {
+    const routed = resolveGatewayEventSessionId({
+      activeSessionId: 'session-b',
+      eventType: 'message.complete',
+      explicitSessionId: 'session-a',
+      unscopedStreamSessionIds: ['session-a', 'session-b']
+    })
+
+    expect(routed).toEqual({
+      drop: false,
+      nextUnscopedStreamSessionIds: ['session-b'],
+      sessionId: 'session-a'
+    })
+  })
+
+  it("does not let a second chat's stream steal the first chat's unscoped events", () => {
+    // The #46194 / #62823 race. A single shared pin was overwritten by B's
+    // message.start, so every later unscoped event from A resolved to B and
+    // painted A's output onto B's transcript.
+    const aStarted = resolveGatewayEventSessionId({
+      activeSessionId: 'session-a',
+      eventType: 'message.start',
+      explicitSessionId: '',
+      unscopedStreamSessionIds: []
+    })
+
+    const bStarted = resolveGatewayEventSessionId({
+      activeSessionId: 'session-b',
+      eventType: 'message.start',
+      explicitSessionId: '',
+      unscopedStreamSessionIds: aStarted.nextUnscopedStreamSessionIds
+    })
+
+    expect(bStarted.nextUnscopedStreamSessionIds).toEqual(['session-a', 'session-b'])
+
+    // A's stream completes while B is focused and still streaming. Before the
+    // per-stream pins this resolved to 'session-b'.
+    const aCompleted = resolveGatewayEventSessionId({
+      activeSessionId: 'session-b',
+      eventType: 'message.complete',
+      explicitSessionId: 'session-a',
+      unscopedStreamSessionIds: bStarted.nextUnscopedStreamSessionIds
+    })
+
+    expect(aCompleted.sessionId).toBe('session-a')
+    expect(aCompleted.nextUnscopedStreamSessionIds).toEqual(['session-b'])
+
+    // B's own unscoped delta still lands on B, unambiguously.
+    const bDelta = resolveGatewayEventSessionId({
+      activeSessionId: 'session-b',
+      eventType: 'message.delta',
+      explicitSessionId: '',
+      unscopedStreamSessionIds: aCompleted.nextUnscopedStreamSessionIds
+    })
+
+    expect(bDelta).toEqual({
+      drop: false,
+      nextUnscopedStreamSessionIds: ['session-b'],
+      sessionId: 'session-b'
+    })
+  })
+
+  it('attributes an ambiguous unscoped delta to the focused chat when it is streaming', () => {
+    const routed = resolveGatewayEventSessionId({
+      activeSessionId: 'session-b',
+      eventType: 'message.delta',
+      explicitSessionId: '',
+      unscopedStreamSessionIds: ['session-a', 'session-b']
+    })
+
+    expect(routed).toEqual({
+      drop: false,
+      nextUnscopedStreamSessionIds: ['session-a', 'session-b'],
+      sessionId: 'session-b'
+    })
+  })
+
+  it('drops an unscoped delta it cannot attribute to any of several live streams', () => {
+    // Two background streams, focused chat idle: nothing in the event says
+    // which stream it came from, and guessing is what grafts A's output onto B.
+    const routed = resolveGatewayEventSessionId({
+      activeSessionId: 'session-c',
+      eventType: 'message.delta',
+      explicitSessionId: '',
+      unscopedStreamSessionIds: ['session-a', 'session-b']
+    })
+
+    expect(routed).toEqual({
+      drop: true,
+      nextUnscopedStreamSessionIds: ['session-a', 'session-b'],
+      sessionId: null
+    })
+  })
+
+  it('leaves single-stream and no-stream routing unchanged', () => {
+    // #70376 owns tightening the no-pin fallback; this change must not move it.
+    const lateDelta = resolveGatewayEventSessionId({
+      activeSessionId: 'session-b',
+      eventType: 'message.delta',
+      explicitSessionId: '',
+      unscopedStreamSessionIds: []
+    })
+
+    expect(lateDelta).toEqual({
+      drop: false,
+      nextUnscopedStreamSessionIds: [],
+      sessionId: 'session-b'
+    })
+
+    const nonStreamEvent = resolveGatewayEventSessionId({
+      activeSessionId: 'session-b',
+      eventType: 'session.info',
+      explicitSessionId: '',
+      unscopedStreamSessionIds: ['session-a']
+    })
+
+    expect(nonStreamEvent).toEqual({
+      drop: false,
+      nextUnscopedStreamSessionIds: ['session-a'],
+      sessionId: 'session-b'
+    })
+  })
+
+  it('still drops unscoped subagent events without disturbing live pins', () => {
+    const routed = resolveGatewayEventSessionId({
+      activeSessionId: 'session-b',
+      eventType: 'subagent.progress',
+      explicitSessionId: '',
+      unscopedStreamSessionIds: ['session-a']
+    })
+
+    expect(routed).toEqual({
+      drop: true,
+      nextUnscopedStreamSessionIds: ['session-a'],
+      sessionId: null
     })
   })
 })

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -60,13 +60,55 @@ export interface GatewayEventSessionRouteInput {
   activeSessionId: null | string
   eventType: string | undefined
   explicitSessionId: string
-  unscopedStreamSessionId: null | string
+  /**
+   * Sessions with an unscoped stream in flight, in ``message.start`` order.
+   *
+   * One pin per concurrent stream. A single shared pin could not represent two
+   * chats streaming at once: the second ``message.start`` overwrote the first,
+   * and every later unscoped event from the first stream then resolved to the
+   * second chat (#46194 / #62823).
+   */
+  unscopedStreamSessionIds: readonly string[]
 }
 
 export interface GatewayEventSessionRoute {
   drop: boolean
-  nextUnscopedStreamSessionId: null | string
+  nextUnscopedStreamSessionIds: readonly string[]
   sessionId: null | string
+}
+
+const withStreamPin = (pins: readonly string[], sessionId: string): readonly string[] =>
+  pins.includes(sessionId) ? pins : [...pins, sessionId]
+
+const withoutStreamPin = (pins: readonly string[], sessionId: string): readonly string[] =>
+  pins.includes(sessionId) ? pins.filter(pin => pin !== sessionId) : pins
+
+/**
+ * Which in-flight stream owns an unscoped stream event.
+ *
+ * Returns `null` when ownership is genuinely ambiguous, so the caller drops the
+ * event instead of grafting one chat's output onto another.
+ */
+function resolveUnscopedStreamOwner(pins: readonly string[], activeSessionId: null | string): null | string {
+  // No concurrent streams: preserve the established single-stream behaviour —
+  // the lone pin owns it, and with no pin at all the focused chat does. The
+  // late-event case for that second branch is #70376's subject, not this one.
+  if (pins.length <= 1) {
+    return pins[0] ?? activeSessionId
+  }
+
+  // Two or more streams are live. The gateway stamps background sessions'
+  // events with their own id, so an unscoped one is the focused turn's output —
+  // but only when the focused chat is itself mid-stream.
+  if (activeSessionId && pins.includes(activeSessionId)) {
+    return activeSessionId
+  }
+
+  // The focused chat is idle, so this belongs to one of several background
+  // streams and nothing in the event says which. Guessing is what painted A's
+  // deltas onto B; drop instead. The store keeps the correct rows, so the
+  // transcript recovers on refetch.
+  return null
 }
 
 /**
@@ -80,17 +122,18 @@ export function resolveGatewayEventSessionId({
   activeSessionId,
   eventType,
   explicitSessionId,
-  unscopedStreamSessionId
+  unscopedStreamSessionIds
 }: GatewayEventSessionRouteInput): GatewayEventSessionRoute {
-  if (explicitSessionId) {
-    const nextUnscopedStreamSessionId =
-      eventType && UNSCOPED_STREAM_END_EVENT_TYPES.has(eventType) && explicitSessionId === unscopedStreamSessionId
-        ? null
-        : unscopedStreamSessionId
+  const streamEnd = eventType ? UNSCOPED_STREAM_END_EVENT_TYPES.has(eventType) : false
 
+  if (explicitSessionId) {
     return {
       drop: false,
-      nextUnscopedStreamSessionId,
+      // Retire only the pin this event names. Streams still running in other
+      // chats keep theirs.
+      nextUnscopedStreamSessionIds: streamEnd
+        ? withoutStreamPin(unscopedStreamSessionIds, explicitSessionId)
+        : unscopedStreamSessionIds,
       sessionId: explicitSessionId
     }
   }
@@ -98,32 +141,47 @@ export function resolveGatewayEventSessionId({
   if (gatewayEventRequiresSessionId(eventType)) {
     return {
       drop: true,
-      nextUnscopedStreamSessionId: unscopedStreamSessionId,
+      nextUnscopedStreamSessionIds: unscopedStreamSessionIds,
       sessionId: null
     }
   }
 
-  const streamEvent = eventType ? UNSCOPED_STREAM_EVENT_TYPES.has(eventType) : false
+  if (eventType === 'message.start') {
+    return {
+      drop: false,
+      // Add a pin rather than replace one, so a second chat starting a turn
+      // cannot take ownership of a stream that is already running elsewhere.
+      nextUnscopedStreamSessionIds: activeSessionId
+        ? withStreamPin(unscopedStreamSessionIds, activeSessionId)
+        : unscopedStreamSessionIds,
+      sessionId: activeSessionId
+    }
+  }
 
-  const sessionId =
-    eventType === 'message.start'
-      ? activeSessionId
-      : streamEvent
-        ? unscopedStreamSessionId || activeSessionId
-        : activeSessionId
+  if (!(eventType && UNSCOPED_STREAM_EVENT_TYPES.has(eventType))) {
+    return {
+      drop: false,
+      nextUnscopedStreamSessionIds: unscopedStreamSessionIds,
+      sessionId: activeSessionId
+    }
+  }
 
-  let nextUnscopedStreamSessionId = unscopedStreamSessionId
+  const owner = resolveUnscopedStreamOwner(unscopedStreamSessionIds, activeSessionId)
 
-  if (eventType === 'message.start' && activeSessionId) {
-    nextUnscopedStreamSessionId = activeSessionId
-  } else if (eventType && UNSCOPED_STREAM_END_EVENT_TYPES.has(eventType)) {
-    nextUnscopedStreamSessionId = null
+  if (!owner) {
+    return {
+      drop: true,
+      nextUnscopedStreamSessionIds: unscopedStreamSessionIds,
+      sessionId: null
+    }
   }
 
   return {
     drop: false,
-    nextUnscopedStreamSessionId,
-    sessionId
+    nextUnscopedStreamSessionIds: streamEnd
+      ? withoutStreamPin(unscopedStreamSessionIds, owner)
+      : unscopedStreamSessionIds,
+    sessionId: owner
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

`unscopedStreamSessionId` is a **single shared slot** shared by every concurrent stream flowing through `handleGatewayEvent`. When a second chat starts a turn while the first is still streaming, its `message.start` overwrites the pin, and every later unscoped event from the first stream resolves to the second chat — grafting one conversation's deltas, tool events and reasoning onto another's transcript.

I verified the race against unmodified `main` by running the sequence through the current resolver:

```
A message.start    → nextUnscopedStreamSessionId = 'session-a'
B message.start    → nextUnscopedStreamSessionId = 'session-b'   ← A's pin is clobbered
A's unscoped delta → sessionId = 'session-b'                     ← A's output lands on B
```

The existing test `routes a new unscoped stream start to the currently active session` encodes that overwrite as expected behaviour, which is why the race has stayed latent.

This replaces the single slot with **one pin per concurrent stream**. `message.start` adds a pin instead of replacing one; a stream end retires only its own pin, so chats still streaming keep theirs.

When several streams are live, an unscoped event carries no field naming its owner. It is attributed to the focused chat when that chat is itself mid-stream, and **dropped** otherwise. Dropping is the deliberately conservative half: the store keeps the correct rows (a transcript recovers on refetch), whereas guessing is precisely what paints one chat's output onto another.

**Credit:** the diagnosis is entirely @johncrash64's — the root-cause analysis in [#62823](https://github.com/NousResearch/hermes-agent/issues/62823#issuecomment-5016513106) identified the shared ref, the mechanism, and the per-session map as the fix. This PR implements that proposal with regression coverage.

### Relationship to #70376

Deliberately orthogonal, **not** a competing duplicate. #70376 tightens the *pin-cleared* path (no pin → don't fall back to the focused chat). This PR fixes the *pin-overwritten* path, which #70376 does not reach: once B has clobbered the pin to `session-b`, the value is truthy, no drop fires, and A's delta still lands on B.

Single-stream and no-stream routing are intentionally left exactly as they are today, so the two changes compose rather than conflict.

## Related Issue

Refs #46194
Refs #62823

Not marked `Fixes` — both issues track several distinct symptoms. This closes the concrete renderer misattribution race, not the whole complex.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/gateway-events.ts` — `unscopedStreamSessionId: null | string` → `unscopedStreamSessionIds: readonly string[]` on both the route input and result. Added `withStreamPin` / `withoutStreamPin` helpers and `resolveUnscopedStreamOwner`, which returns `null` when ownership is genuinely ambiguous so the caller drops rather than guesses.
- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts` — the backing ref becomes `useRef<readonly string[]>([])`. Single call site; no other consumer of the resolver exists.
- `apps/desktop/src/lib/gateway-events.test.ts` — six new cases, including the A→B overwrite regression, ambiguous-attribution both ways, and an explicit guard that single-stream / no-stream routing is unchanged.

### One existing assertion changed

`routes a new unscoped stream start to the currently active session` previously asserted `nextUnscopedStreamSessionId: 'session-b'` — the clobber. It now asserts `['session-a', 'session-b']`. The test's intent (a new start routes to the active session) is preserved; only the pin bookkeeping changed. Flagging it explicitly since rewriting an existing assertion deserves scrutiny.

## How to Test

```bash
npm install --workspace apps/desktop
cd apps/desktop && npx vitest run --project ui
```

To see the bug on unmodified `main`:

1. `git show main:apps/desktop/src/lib/gateway-events.ts` into a scratch module.
2. Feed it `message.start`(A) → `message.start`(B) → `message.delta` with `explicitSessionId: ''`, threading `nextUnscopedStreamSessionId` between calls.
3. The delta resolves to `session-b`. On this branch the equivalent sequence keeps both pins and routes A's events to A.

In the app: run two chats with long prompts streaming concurrently, switch between them, and force an unscoped event (reconnect the gateway mid-stream, or trigger a global error). Before this change, deltas from one chat briefly paint onto the other's transcript.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #70376 is the closest and is addressed above; #74581 (merged) fixed the composer-queue path, which is a different mechanism
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **N/A, and not run.** This change is TypeScript-only under `apps/desktop`. I ran the desktop suite instead: **387 files / 3366 tests pass**, plus `tsc --noEmit`, `eslint`, and `prettier --check` all clean.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0), Node 22.23.1 — **unit/integration suite only.** I have not exercised the fix in a running Electron build with two live concurrent streams; the race is reproduced and locked at the resolver level. Independent confirmation in the app would be welcome.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — behaviour is documented in the JSDoc on `GatewayEventSessionRouteInput` and `resolveUnscopedStreamOwner`
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — pure renderer logic, no platform-specific paths or APIs
- [x] N/A — no tool descriptions/schemas changed

## Screenshots / Logs

```
$ npx vitest run --project ui
 Test Files  387 passed (387)
      Tests  3366 passed (3366)

$ tsc -p . --noEmit          → exit 0
$ eslint <3 changed files>   → exit 0
$ prettier --check           → All matched files use Prettier code style!
```
