### PR TITLE
feat(telegram): expose handler registration extension point

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3643,6 +3643,34 @@ class TelegramAdapter(BasePlatformAdapter):
             if self._post_connect_task is asyncio.current_task():
                 self._post_connect_task = None
 
+    def _register_handlers(self, application: Application) -> None:
+        """Register Telegram update handlers on a newly-built application.
+
+        Subclasses may extend Telegram with additional update types by
+        overriding this method, calling ``super()``, and registering their own
+        handlers.  Keeping registration in one overridable method also ensures
+        custom handlers are restored whenever ``connect()`` rebuilds the PTB
+        application after a failed initialization attempt.
+        """
+        application.add_handler(TelegramMessageHandler(
+            filters.TEXT & ~filters.COMMAND,
+            self._handle_text_message
+        ))
+        application.add_handler(TelegramMessageHandler(
+            filters.COMMAND,
+            self._handle_command
+        ))
+        application.add_handler(TelegramMessageHandler(
+            filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
+            self._handle_location_message
+        ))
+        application.add_handler(TelegramMessageHandler(
+            filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
+            self._handle_media_message
+        ))
+        # Handle inline keyboard button callbacks (update prompts)
+        application.add_handler(CallbackQueryHandler(self._handle_callback_query))
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to Telegram via polling or webhook.
 
@@ -3855,25 +3883,7 @@ class TelegramAdapter(BasePlatformAdapter):
             self._app = builder.build()
             self._bot = self._app.bot
             
-            # Register handlers
-            self._app.add_handler(TelegramMessageHandler(
-                filters.TEXT & ~filters.COMMAND,
-                self._handle_text_message
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.COMMAND,
-                self._handle_command
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
-                self._handle_location_message
-            ))
-            self._app.add_handler(TelegramMessageHandler(
-                filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
-                self._handle_media_message
-            ))
-            # Handle inline keyboard button callbacks (update prompts)
-            self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+            self._register_handlers(self._app)
             
             # Start polling — retry initialize() for transient TLS resets.
             # Each attempt is capped by _init_timeout so a single unreachable
@@ -3987,24 +3997,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         old_app = self._app
                         self._app = builder.build()
                         self._bot = self._app.bot
-                        # Re-register handlers on the new app
-                        self._app.add_handler(TelegramMessageHandler(
-                            filters.TEXT & ~filters.COMMAND,
-                            self._handle_text_message
-                        ))
-                        self._app.add_handler(TelegramMessageHandler(
-                            filters.COMMAND,
-                            self._handle_command
-                        ))
-                        self._app.add_handler(TelegramMessageHandler(
-                            filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
-                            self._handle_location_message
-                        ))
-                        self._app.add_handler(TelegramMessageHandler(
-                            filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
-                            self._handle_media_message
-                        ))
-                        self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+                        self._register_handlers(self._app)
                         # Best-effort discard the old app's resources
                         try:
                             await _shutdown_abandoned_app(old_app)

--- a/tests/gateway/test_telegram_handler_extension.py
+++ b/tests/gateway/test_telegram_handler_extension.py
@@ -1,0 +1,85 @@
+"""Tests for the Telegram adapter's handler-registration extension point."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram import adapter as telegram_module
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def test_subclass_can_extend_telegram_handler_registration():
+    custom_handler = object()
+
+    class ExtendedTelegramAdapter(TelegramAdapter):
+        def _register_handlers(self, application):
+            super()._register_handlers(application)
+            application.add_handler(custom_handler)
+
+    application = MagicMock()
+    adapter = ExtendedTelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    adapter._register_handlers(application)
+
+    assert application.add_handler.call_count >= 2
+    assert application.add_handler.call_args_list[-1].args == (custom_handler,)
+
+
+@pytest.mark.asyncio
+async def test_connect_restores_overridden_handlers_after_application_rebuild(
+    monkeypatch,
+):
+    class ExtendedTelegramAdapter(TelegramAdapter):
+        def __init__(self, config):
+            super().__init__(config)
+            self.handler_applications = []
+
+        def _register_handlers(self, application):
+            self.handler_applications.append(application)
+
+    adapter = ExtendedTelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    first_app = SimpleNamespace(
+        bot=SimpleNamespace(username="test_bot"),
+        initialize=AsyncMock(side_effect=OSError("temporary reset")),
+        shutdown=AsyncMock(),
+    )
+    rebuilt_app = SimpleNamespace(
+        bot=SimpleNamespace(username="test_bot"),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.side_effect = [first_app, rebuilt_app]
+
+    monkeypatch.setattr(
+        telegram_module,
+        "Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+    monkeypatch.setattr(telegram_module, "HTTPXRequest", MagicMock)
+    monkeypatch.setattr(
+        telegram_module, "discover_fallback_ips", AsyncMock(return_value=[])
+    )
+    monkeypatch.setattr(telegram_module.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock", lambda scope, identity: None
+    )
+    monkeypatch.setattr(adapter, "_delete_webhook_best_effort", AsyncMock())
+    monkeypatch.setattr(
+        adapter, "_start_polling_resilient", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(adapter, "_polling_heartbeat_loop", AsyncMock())
+    monkeypatch.setattr(adapter, "_start_post_connect_housekeeping", MagicMock())
+
+    assert await adapter.connect() is True
+    assert adapter.handler_applications == [first_app, rebuilt_app]

--- a/website/docs/developer-guide/adding-platform-adapters.md
+++ b/website/docs/developer-guide/adding-platform-adapters.md
@@ -198,6 +198,34 @@ When you call `ctx.register_platform()`, the following integration points are ha
 | Token lock (multi-profile) | Use `acquire_scoped_lock()` in your `connect()` |
 | Orphaned config warning | Descriptive log when plugin is missing |
 
+### Extending or replacing Telegram handlers
+
+A plugin that needs Telegram update types not handled by Hermes — for example, `InlineQueryHandler` — can subclass the bundled `TelegramAdapter` and override `_register_handlers(application)`. Hermes calls this method for the initial `python-telegram-bot` `Application` and again whenever connection recovery rebuilds the application.
+
+Call `super()` to preserve the built-in text, command, location, media, and callback-query handlers and add your own:
+
+```python
+from telegram.ext import InlineQueryHandler
+
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+class InlineTelegramAdapter(TelegramAdapter):
+    def _register_handlers(self, application):
+        super()._register_handlers(application)
+        application.add_handler(InlineQueryHandler(self._handle_inline_query))
+```
+
+Omit `super()` when the plugin intentionally replaces the complete handler set:
+
+```python
+class ReplacementTelegramAdapter(TelegramAdapter):
+    def _register_handlers(self, application):
+        application.add_handler(MyReplacementHandler(...))
+```
+
+A plugin providing either subclass should register it under the concrete platform name `telegram` with `ctx.register_platform(..., adapter_factory=...)`. That concrete plugin registration takes precedence over the bundled lazy adapter. Replacing all handlers also replaces Hermes' normal message and command intake, so use that form only when the plugin owns the complete Telegram update flow.
+
 ## Env-Driven Auto-Configuration
 
 Most users set up a platform by dropping env vars into `~/.hermes/.env` rather than editing `config.yaml`. The `env_enablement_fn` hook lets your plugin pick those env vars up **before** the adapter is constructed, so `hermes gateway status`, `get_connected_platforms()`, and cron delivery see the correct state without instantiating the platform SDK.


### PR DESCRIPTION
## Summary

- extract Telegram's built-in PTB handler registration into an overridable `_register_handlers()` method
- use the same extension point for both initial application creation and initialization-retry rebuilds
- document how calling `super()` extends the built-in handlers while omitting it replaces the complete handler set
- add coverage proving subclasses can register custom update handlers and retain them after a rebuild

This enables standalone platform plugins to subclass `TelegramAdapter` and add handlers such as `InlineQueryHandler` without copying the adapter's `connect()` implementation, while still allowing plugins that intentionally own the complete Telegram update flow.

## Testing

- `scripts/run_tests.sh -j 4 tests/gateway/test_telegram_handler_extension.py tests/gateway/test_telegram_connect.py tests/gateway/test_telegram_conflict.py tests/test_telegram_polling_progress_ptb.py -q` — 17 passed
- `ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_handler_extension.py`
- `npm run docusaurus build -- --locale en`

## Platform

- Linux
