### PR TITLE
fix(models): alibaba-coding-plan no longer silently drops reasoning_effort

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -10,6 +10,7 @@ reasoning configuration, temperature handling, and extra_body assembly.
 """
 
 import json
+import logging
 from typing import Any, Dict
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
@@ -17,6 +18,18 @@ from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
+
+logger = logging.getLogger(__name__)
+
+# Field names existing provider profiles use to forward reasoning/thinking
+# control (custom/deepseek/zai/kimi-coding/openrouter etc.) -- used by the
+# systemic silent-drop warning in _build_kwargs_from_profile() below.
+_REASONING_FIELD_NAMES = frozenset(
+    {"reasoning_effort", "reasoning", "think", "thinking"}
+)
+# Profiles already warned about a silent reasoning_config drop this process
+# lifetime -- warn once per profile, not per request (hot path).
+_reasoning_drop_warned: set = set()
 
 
 def _static_prompt_instructions(messages: list[dict[str, Any]]) -> str:
@@ -670,6 +683,34 @@ class ChatCompletionsTransport(ProviderTransport):
             )
         )
         api_kwargs.update(top_level_from_profile)
+
+        # Fail loud on the same class of silent drop reported in #77818: a
+        # thin-shell provider profile that doesn't override
+        # build_api_kwargs_extras() inherits the base class's no-op default
+        # (({}, {})), so a configured reasoning_config is discarded without
+        # any error or warning -- the setting parses correctly and /reasoning
+        # echoes the change, but the value never reaches the wire. Warn once
+        # per profile (not per request) to avoid log spam on a hot path.
+        if (
+            reasoning_config
+            and isinstance(reasoning_config, dict)
+            and not _REASONING_FIELD_NAMES.intersection(top_level_from_profile)
+            and not _REASONING_FIELD_NAMES.intersection(extra_body_from_profile or {})
+        ):
+            _profile_name = getattr(profile, "name", type(profile).__name__)
+            if _profile_name not in _reasoning_drop_warned:
+                _reasoning_drop_warned.add(_profile_name)
+                logger.warning(
+                    "Provider profile %r has a configured reasoning_config "
+                    "but build_api_kwargs_extras() returned no reasoning-"
+                    "related field -- the setting will silently have no "
+                    "effect on the outgoing request. If this profile "
+                    "supports reasoning/thinking control, override "
+                    "build_api_kwargs_extras() to forward it (see the "
+                    "custom/deepseek/zai/kimi-coding profiles for the "
+                    "precedent).",
+                    _profile_name,
+                )
 
         # extra_body assembly
         extra_body: dict[str, Any] = {}

--- a/plugins/model-providers/alibaba-coding-plan/__init__.py
+++ b/plugins/model-providers/alibaba-coding-plan/__init__.py
@@ -4,10 +4,52 @@ Separate from the standard `alibaba` profile because it hits a different
 endpoint (coding-intl.dashscope.aliyuncs.com) with a dedicated API key tier.
 """
 
+from typing import Any
+
 from providers import register_provider
 from providers.base import ProviderProfile
 
-alibaba_coding_plan = ProviderProfile(
+
+class AlibabaCodingPlanProfile(ProviderProfile):
+    """Alibaba Cloud Coding Plan — forwards reasoning_effort to the wire.
+
+    The dashscope Qwen3 thinking models this endpoint serves (e.g.
+    qwen3.8-max-preview) always have thinking ON and accept
+    reasoning_effort: xhigh / medium / low (server default: xhigh) --
+    they cannot disable thinking outright. Without this override, the
+    base ProviderProfile.build_api_kwargs_extras() default (({}, {}))
+    silently discarded the user's configured reasoning_effort with no
+    error or warning (issue #77818): the setting parsed correctly and
+    /reasoning echoed the change, but the value never reached the API
+    request.
+    """
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        **ctx: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        top_level: dict[str, Any] = {}
+        if reasoning_config and isinstance(reasoning_config, dict):
+            effort = (reasoning_config.get("effort") or "").strip().lower()
+            enabled = reasoning_config.get("enabled", True)
+            if not enabled or effort == "none":
+                # These models cannot disable thinking (always on) -- map
+                # a disabled/none request to the lowest available level
+                # instead of forwarding "none" or omitting the field,
+                # which the endpoint would reject (same failure mode as
+                # #65233 for CustomProfile's own none-handling).
+                top_level["reasoning_effort"] = "low"
+            elif effort:
+                top_level["reasoning_effort"] = effort
+            # effort unset (and enabled) -> omit the field; the server's
+            # own default (xhigh) applies, matching the "don't force a
+            # level the user didn't pick" precedent from CustomProfile.
+        return {}, top_level
+
+
+alibaba_coding_plan = AlibabaCodingPlanProfile(
     name="alibaba-coding-plan",
     aliases=("alibaba_coding", "alibaba-coding", "dashscope-coding"),
     display_name="Alibaba Cloud (Coding Plan)",

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -731,3 +731,104 @@ class TestPromptCacheKeyCapability:
         assert first == second
         assert first != key("cron_job_2026-07-15T10:05:00Z", instructions="You are different.")
         assert first != key("cron_job_2026-07-15T10:05:00Z", tool_name="search")
+
+
+class TestChatCompletionsSilentReasoningDropWarning:
+    """Regression tests for the systemic warning requested in issue #77818:
+    a thin-shell ProviderProfile that doesn't override
+    build_api_kwargs_extras() inherits the base class's no-op default
+    (({}, {})), so a configured reasoning_config used to be silently
+    discarded with no error or warning anywhere in the pipeline. This is
+    a general-purpose safety net for ANY such profile, not specific to
+    the alibaba-coding-plan profile that #77818 itself fixed.
+    """
+
+    @staticmethod
+    def _thin_shell_profile(name: str):
+        """A plain ProviderProfile instance with no
+        build_api_kwargs_extras() override -- exactly the shape
+        alibaba-coding-plan had before issue #77818's fix, and the shape
+        any FUTURE thin-shell profile would have if it forgot to
+        implement reasoning support."""
+        from providers.base import ProviderProfile
+
+        return ProviderProfile(
+            name=name,
+            aliases=(),
+            display_name=name,
+            description="test-only thin-shell profile",
+            signup_url="",
+            env_vars=(),
+            base_url="https://example.test/v1",
+            auth_type="api_key",
+        )
+
+    def test_warns_once_when_profile_silently_drops_reasoning_config(
+        self, transport, caplog
+    ):
+        import logging
+
+        profile = self._thin_shell_profile("test-thin-shell-warns-once")
+        msgs = [{"role": "user", "content": "Hi"}]
+
+        with caplog.at_level(logging.WARNING, logger="agent.transports.chat_completions"):
+            transport.build_kwargs(
+                model="test-model", messages=msgs,
+                provider_profile=profile,
+                reasoning_config={"enabled": True, "effort": "low"},
+            )
+            transport.build_kwargs(
+                model="test-model", messages=msgs,
+                provider_profile=profile,
+                reasoning_config={"enabled": True, "effort": "low"},
+            )
+
+        drop_warnings = [
+            r for r in caplog.records
+            if "reasoning_config" in r.message and "no reasoning-related field" in r.message
+        ]
+        assert len(drop_warnings) == 1, (
+            "must warn exactly once per profile, not once per request "
+            f"(hot path, would spam logs): {[r.message for r in caplog.records]}"
+        )
+        assert "test-thin-shell-warns-once" in drop_warnings[0].message
+
+    def test_no_warning_when_no_reasoning_config_passed(self, transport, caplog):
+        import logging
+
+        profile = self._thin_shell_profile("test-thin-shell-no-config")
+        msgs = [{"role": "user", "content": "Hi"}]
+
+        with caplog.at_level(logging.WARNING, logger="agent.transports.chat_completions"):
+            transport.build_kwargs(
+                model="test-model", messages=msgs,
+                provider_profile=profile,
+                reasoning_config=None,
+            )
+
+        assert not any(
+            "no reasoning-related field" in r.message for r in caplog.records
+        )
+
+    def test_no_warning_when_profile_correctly_forwards_reasoning(self, transport, caplog):
+        """Sanity: a profile that DOES override build_api_kwargs_extras()
+        and correctly forwards the setting must never trigger this
+        warning -- e.g. the now-fixed alibaba-coding-plan profile itself."""
+        import logging
+
+        import model_tools  # noqa: F401
+        import providers
+
+        profile = providers.get_provider_profile("alibaba-coding-plan")
+        msgs = [{"role": "user", "content": "Hi"}]
+
+        with caplog.at_level(logging.WARNING, logger="agent.transports.chat_completions"):
+            transport.build_kwargs(
+                model="qwen3.8-max-preview", messages=msgs,
+                provider_profile=profile,
+                reasoning_config={"enabled": True, "effort": "low"},
+            )
+
+        assert not any(
+            "no reasoning-related field" in r.message for r in caplog.records
+        )

--- a/tests/plugins/model_providers/test_alibaba_coding_plan_profile.py
+++ b/tests/plugins/model_providers/test_alibaba_coding_plan_profile.py
@@ -1,0 +1,102 @@
+"""Unit tests for the Alibaba Cloud Coding Plan provider profile's
+reasoning_effort wiring (issue #77818).
+
+Before this fix, alibaba-coding-plan was a thin-shell ProviderProfile
+instance with no build_api_kwargs_extras() override, so it inherited the
+base class's no-op default (({}, {})) -- a configured reasoning_effort was
+silently discarded and never reached the outgoing API request, with no
+error or warning anywhere in the pipeline.
+
+The dashscope Qwen3 thinking models this endpoint serves always have
+thinking ON (cannot be disabled) and accept reasoning_effort:
+xhigh/medium/low (server default: xhigh).
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def alibaba_coding_plan_profile():
+    """Resolve the registered profile via the provider registry.
+
+    Going through get_provider_profile() (not importing the module's
+    instance directly) keeps the test honest: if the registered class is
+    ever swapped back for a plain ProviderProfile, the assertions below
+    collapse rather than silently testing a stale reference.
+    """
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("alibaba-coding-plan")
+    assert profile is not None, "alibaba-coding-plan provider profile must be registered"
+    return profile
+
+
+class TestAlibabaCodingPlanReasoningWiring:
+    def test_no_reasoning_config_emits_nothing(self, alibaba_coding_plan_profile):
+        """No configured reasoning_config: omit the field entirely so the
+        endpoint's own server-side default (xhigh) applies -- don't force
+        a level the user didn't pick."""
+        extra_body, top_level = alibaba_coding_plan_profile.build_api_kwargs_extras(
+            reasoning_config=None,
+        )
+        assert "reasoning_effort" not in top_level
+        assert "reasoning_effort" not in extra_body
+
+    def test_enabled_with_effort_forwards_top_level_reasoning_effort(
+        self, alibaba_coding_plan_profile
+    ):
+        """The exact regression from #77818: a configured effort level
+        must reach the wire as a top-level reasoning_effort field."""
+        extra_body, top_level = alibaba_coding_plan_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "low"},
+        )
+        assert top_level.get("reasoning_effort") == "low"
+
+    def test_enabled_without_effort_omits_field(self, alibaba_coding_plan_profile):
+        """Enabled but no specific effort chosen: omit the field, letting
+        the server's own default (xhigh) apply."""
+        extra_body, top_level = alibaba_coding_plan_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": ""},
+        )
+        assert "reasoning_effort" not in top_level
+
+    def test_disabled_remaps_to_lowest_level_not_forwarded_as_none(
+        self, alibaba_coding_plan_profile
+    ):
+        """These Qwen3 thinking models cannot disable thinking outright --
+        the server always has it on. A disabled reasoning_config must be
+        remapped to the lowest available level ("low"), not forwarded
+        verbatim as reasoning_effort="none" (which the endpoint would
+        reject) and not silently omitted either (issue #65233 established
+        this same remap pattern for CustomProfile's own none-handling)."""
+        extra_body, top_level = alibaba_coding_plan_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": ""},
+        )
+        assert top_level.get("reasoning_effort") == "low"
+
+    def test_effort_none_string_remaps_to_lowest_level(self, alibaba_coding_plan_profile):
+        """Same remap must apply when effort is explicitly the string
+        "none" (however enabled is set), not just when enabled=False."""
+        extra_body, top_level = alibaba_coding_plan_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "none"},
+        )
+        assert top_level.get("reasoning_effort") == "low"
+
+    def test_medium_and_xhigh_pass_through_unchanged(self, alibaba_coding_plan_profile):
+        for level in ("medium", "xhigh"):
+            _, top_level = alibaba_coding_plan_profile.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": level},
+            )
+            assert top_level.get("reasoning_effort") == level
+
+    def test_no_thinking_related_extra_body_emitted(self, alibaba_coding_plan_profile):
+        """This profile forwards reasoning purely as a top-level field --
+        it must not also emit an extra_body.think/thinking entry (that's
+        the Ollama-style flag other profiles use, not applicable here)."""
+        extra_body, _ = alibaba_coding_plan_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "low"},
+        )
+        assert "think" not in extra_body
+        assert "thinking" not in extra_body


### PR DESCRIPTION
Fixes #77818.

## Problem

`alibaba-coding-plan` was a thin-shell `ProviderProfile` instance with no `build_api_kwargs_extras()` override, so it inherited the base class's no-op default (`({}, {})`) -- a configured `reasoning_effort` was silently discarded and never reached the outgoing API request. The config value parsed correctly and `/reasoning` echoed the change, but it died silently at the transport layer with no error or warning.

## Fix

Converted the profile to a subclass with a `build_api_kwargs_extras()` override, following the `custom`/`deepseek`/`zai`/`kimi-coding` precedent:
- enabled + effort set -> top-level `reasoning_effort`
- enabled + no effort -> omit the field, server default (xhigh) applies
- disabled, or effort == `'none'` -> remapped to `reasoning_effort='low'`, since these Qwen3 thinking models always have thinking ON and would reject a literal `'none'` value (same remap pattern established for `CustomProfile` in issue #65233)

Also implemented the optional systemic warning proposed in the issue: `_build_kwargs_from_profile()` now logs a one-time-per-profile WARNING when a configured `reasoning_config` produces no reasoning-related field from the profile -- catching this exact class of bug for any future thin-shell profile.

## Verification

7 tests for the profile's own reasoning wiring, 3 for the systemic warning. Verified as genuine regressions by reverting the primary fix and confirming 5 tests fail -- including the systemic warning correctly catching the exact silent-drop scenario by profile name.

54/54 pass across the two directly affected test files; 190/190 across the full provider-profile test suite (no regression).