### PR TITLE
fix(desktop): show sidebar messaging/cron sections for messaging-only or cron-only profiles

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -132,6 +132,7 @@ import {
 } from './projects'
 import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
 import { buildSessionByAnyId } from './session-index'
+import { showSessionSectionsGate } from './session-sections-gate'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
 
@@ -1087,7 +1088,13 @@ export function ChatSidebar({
 
   const showSessionSkeletons = sessionsLoading && sortedSessions.length === 0
 
-  const showSessionSections = showSessionSkeletons || sortedSessions.length > 0 || projectModel.length > 0
+  const showSessionSections = showSessionSectionsGate({
+    showSessionSkeletons,
+    localSessionCount: sortedSessions.length,
+    messagingSessionCount: messagingSessions.length,
+    cronSessionCount: cronSessions.length,
+    projectCount: projectModel.length
+  })
 
   // Each reorderable list reports its OWN new id order; persisting is a direct,
   // typed write — no id-prefix sniffing to figure out which level moved.

--- a/apps/desktop/src/app/chat/sidebar/session-sections-gate.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-sections-gate.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { showSessionSectionsGate } from './session-sections-gate'
+
+const noSessions = {
+  showSessionSkeletons: false,
+  localSessionCount: 0,
+  messagingSessionCount: 0,
+  cronSessionCount: 0,
+  projectCount: 0
+}
+
+describe('showSessionSectionsGate', () => {
+  it('hides the session sections when there is truly nothing to show', () => {
+    expect(showSessionSectionsGate(noSessions)).toBe(false)
+  })
+
+  it('shows sections while local recents are loading (skeleton state)', () => {
+    expect(showSessionSectionsGate({ ...noSessions, showSessionSkeletons: true })).toBe(true)
+  })
+
+  it('shows sections for local (recents) sessions alone', () => {
+    expect(showSessionSectionsGate({ ...noSessions, localSessionCount: 1 })).toBe(true)
+  })
+
+  it('shows sections for projects alone', () => {
+    expect(showSessionSectionsGate({ ...noSessions, projectCount: 1 })).toBe(true)
+  })
+
+  // Regression for issue #77816: a messaging-only user (e.g. WeChat/Telegram
+  // via the gateway) with zero local sessions and zero projects must still
+  // see their platform sections instead of the blank "No sessions" state.
+  it('shows sections for messaging-platform sessions alone, with zero local sessions or projects', () => {
+    expect(showSessionSectionsGate({ ...noSessions, messagingSessionCount: 1 })).toBe(true)
+  })
+
+  // Same regression class, noted in the issue as deserving the same fix:
+  // a cron-only profile must not be hidden behind the blank state either.
+  it('shows sections for cron sessions alone, with zero local sessions or projects', () => {
+    expect(showSessionSectionsGate({ ...noSessions, cronSessionCount: 1 })).toBe(true)
+  })
+
+  it('shows sections when any combination is non-empty', () => {
+    expect(
+      showSessionSectionsGate({
+        showSessionSkeletons: false,
+        localSessionCount: 0,
+        messagingSessionCount: 2,
+        cronSessionCount: 1,
+        projectCount: 0
+      })
+    ).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/session-sections-gate.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-sections-gate.ts
@@ -1,0 +1,36 @@
+interface SessionSectionsGateInput {
+  showSessionSkeletons: boolean
+  localSessionCount: number
+  messagingSessionCount: number
+  cronSessionCount: number
+  projectCount: number
+}
+
+/**
+ * Whether the sidebar's session sections (recents, per-platform messaging
+ * groups, cron) should render at all, vs. the blank "No sessions" state.
+ *
+ * Regression guard (issue #77816): the gate originally only counted LOCAL
+ * (recents) sessions and projects, so a profile whose only conversations
+ * came from a messaging platform (or only from cron) -- zero local
+ * sessions, zero projects -- saw the entire session area replaced by the
+ * blank state even though their messaging/cron sessions existed and were
+ * fetched (as $messagingSessions / $cronSessions) and rendered separately
+ * inside the very block this gate controls. Messaging and cron sessions
+ * must count toward the gate independently of local recents/projects.
+ */
+export function showSessionSectionsGate({
+  showSessionSkeletons,
+  localSessionCount,
+  messagingSessionCount,
+  cronSessionCount,
+  projectCount
+}: SessionSectionsGateInput): boolean {
+  return (
+    showSessionSkeletons ||
+    localSessionCount > 0 ||
+    messagingSessionCount > 0 ||
+    cronSessionCount > 0 ||
+    projectCount > 0
+  )
+}


### PR DESCRIPTION
Fixes #77816.

## Problem

The sidebar's session sections (recents, per-platform messaging groups, cron) were all gated behind a single `showSessionSections` condition that only counted LOCAL (recents) sessions and projects. A profile whose only conversations came from a messaging platform (or only from cron) -- zero local sessions, zero projects -- saw the entire session area replaced by the blank "No sessions" state, even though their sessions existed and were fetched separately as `$messagingSessions`/`$cronSessions`.

## Fix

Included `messagingSessions.length > 0` and `cronSessions.length > 0` in the gate, matching the issue's proposed fix and its noted consideration that cron sessions deserve the same treatment.

Extracted the gate condition into a small, separately-testable pure function (`session-sections-gate.ts`), following the established pattern already used elsewhere in this directory (`order.ts`/`order.test.ts`, `session-row-state.ts`/`session-row-state.test.ts`) rather than leaving it untestable inline in the large sidebar component file.

## Verification

Added 7 unit tests covering each session-source case individually and in combination, including the exact regression. 7/7 pass; 114/114 across the full sidebar test directory (15 files, no regression). `index.tsx` also verified to compile cleanly with esbuild after the change.