### PR TITLE
fix: honor ACP profile runtime settings

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -239,6 +239,15 @@ def main(argv: list[str] | None = None) -> None:
     logger = logging.getLogger(__name__)
     logger.info("Starting hermes-agent ACP adapter")
 
+    # Plugin tools and toolsets must be registered before the first AIAgent
+    # snapshots the tool registry.
+    try:
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
+    except Exception:
+        logger.warning("Plugin discovery failed at ACP startup", exc_info=True)
+
     # Ensure the project root is on sys.path so ``from run_agent import AIAgent`` works
     project_root = str(Path(__file__).resolve().parent.parent)
     if project_root not in sys.path:

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -601,7 +601,7 @@ class SessionManager:
             return self._agent_factory()
 
         from run_agent import AIAgent
-        from hermes_cli.config import load_config
+        from hermes_cli.config import load_config, read_raw_config_readonly
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
         config = load_config()
@@ -619,18 +619,31 @@ class SessionManager:
             for name, cfg in (config.get("mcp_servers") or {}).items()
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
+        agent_cfg = config.get("agent") or {}
+        configured_toolsets = config.get("toolsets")
+        if not isinstance(configured_toolsets, list) or "toolsets" not in read_raw_config_readonly():
+            configured_toolsets = ["hermes-acp"]
+        try:
+            max_iterations = int(agent_cfg.get("max_turns"))
+        except (TypeError, ValueError):
+            max_iterations = None
+        if max_iterations is not None and max_iterations <= 0:
+            max_iterations = None
 
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
+                configured_toolsets,
                 mcp_server_names=configured_mcp_servers,
             ),
+            "disabled_toolsets": agent_cfg.get("disabled_toolsets") or None,
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),
             "model": model or default_model,
         }
+        if max_iterations is not None:
+            kwargs["max_iterations"] = max_iterations
 
         try:
             runtime = resolve_runtime_provider(requested=requested_provider or config_provider)

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -16,11 +16,16 @@ def test_main_enables_unstable_protocol(monkeypatch):
 
     monkeypatch.setattr(entry, "_setup_logging", lambda: None)
     monkeypatch.setattr(entry, "_load_env", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.discover_plugins",
+        lambda: calls.setdefault("plugins_discovered", True),
+    )
     monkeypatch.setattr(acp, "run_agent", fake_run_agent)
 
     entry.main([])
 
     assert calls["kwargs"]["use_unstable_protocol"] is True
+    assert calls["plugins_discovered"] is True
 
 
 def test_main_skips_configured_mcp_discovery_when_requested(monkeypatch):

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -95,6 +95,7 @@ class TestCreateSession:
                 "mcp_servers": {},
             },
         )
+        monkeypatch.setattr("hermes_cli.config.read_raw_config_readonly", lambda: {})
         monkeypatch.setattr(
             "hermes_cli.runtime_provider.resolve_runtime_provider",
             lambda requested=None: {
@@ -109,6 +110,62 @@ class TestCreateSession:
         state = SessionManager(db=None).create_session(cwd="/tmp/project")
 
         assert state.agent.session_cwd == "/tmp/project"
+        assert state.agent.kwargs["enabled_toolsets"] == ["hermes-acp"]
+
+    def test_make_agent_honors_profile_tools_and_turn_budget(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            model = "fake-model"
+
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {"default": "fake-model", "provider": "fake-provider"},
+                "toolsets": ["all"],
+                "agent": {"max_turns": 300, "disabled_toolsets": ["browser"]},
+                "mcp_servers": {},
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config_readonly",
+            lambda: {"toolsets": ["all"]},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {
+                "provider": requested,
+                "api_mode": "chat_completions",
+                "base_url": "https://example.invalid",
+                "api_key": "test-key",
+            },
+        )
+        monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda task_id, cwd: None)
+
+        SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        assert captured["enabled_toolsets"] == ["all"]
+        assert captured["disabled_toolsets"] == ["browser"]
+        assert captured["max_iterations"] == 300
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {"default": "fake-model", "provider": "fake-provider"},
+                "toolsets": ["hermes-cli"],
+                "agent": {"max_turns": None},
+                "mcp_servers": {},
+            },
+        )
+        captured.clear()
+        SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        assert captured["enabled_toolsets"] == ["hermes-cli"]
+        assert "max_iterations" not in captured
 
 
 

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -93,7 +93,11 @@ def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "hermes_cli.config",
-        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m", "provider": "p"}}),
+        mod(
+            "hermes_cli.config",
+            load_config=lambda: {"model": {"default": "m", "provider": "p"}},
+            read_raw_config_readonly=lambda: {},
+        ),
     )
     monkeypatch.setitem(
         sys.modules,


### PR DESCRIPTION
## Summary
- initialize plugins before ACP constructs its first agent
- honor explicit profile toolsets and disabled toolsets while preserving ACP's restricted default when the profile omits `toolsets`
- propagate and validate `agent.max_turns` as the ACP agent iteration budget

## Verification
- `/home/duurrrr/.hermes/hermes-agent/venv/bin/python -m pytest tests/acp tests/acp_adapter -o 'addopts=' -q` — 141 passed
- `git diff --check`
- live Buzz ACP construction exposed `agency_agents_route_plan` and logged the routed call; direct construction reported `max_iterations=300`
