### PR TITLE
feat(stt): transcribe voice messages with Codex OAuth

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -111,6 +111,7 @@ class _OpenAIProxy:
 
 OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
+from agent.codex_headers import codex_cloudflare_headers as _codex_cloudflare_headers
 from agent.credential_pool import load_pool
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH, get_model_context_length
 from hermes_cli.config import get_hermes_home
@@ -963,45 +964,6 @@ _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 # they want explicitly (from config.yaml model.model, auxiliary.<task>.model,
 # or the user's active Codex model selection).
 _CODEX_AUX_BASE_URL = "https://chatgpt.com/backend-api/codex"
-
-
-def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
-    """Headers required to avoid Cloudflare 403s on chatgpt.com/backend-api/codex.
-
-    The Cloudflare layer in front of the Codex endpoint whitelists a small set of
-    first-party originators (``codex_cli_rs``, ``codex_vscode``, ``codex_sdk_ts``,
-    anything starting with ``Codex``). Requests from non-residential IPs (VPS,
-    server-hosted agents) that don't advertise an allowed originator are served
-    a 403 with ``cf-mitigated: challenge`` regardless of auth correctness.
-
-    We pin ``originator: codex_cli_rs`` to match the upstream codex-rs CLI, set
-    ``User-Agent`` to a codex_cli_rs-shaped string (beats SDK fingerprinting),
-    and extract ``ChatGPT-Account-ID`` (canonical casing, from codex-rs
-    ``auth.rs``) out of the OAuth JWT's ``chatgpt_account_id`` claim.
-
-    Malformed tokens are tolerated — we drop the account-ID header rather than
-    raise, so a bad token still surfaces as an auth error (401) instead of a
-    crash at client construction.
-    """
-    headers = {
-        "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
-        "originator": "codex_cli_rs",
-    }
-    if not isinstance(access_token, str) or not access_token.strip():
-        return headers
-    try:
-        import base64
-        parts = access_token.split(".")
-        if len(parts) < 2:
-            return headers
-        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
-        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
-        acct_id = claims.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
-        if isinstance(acct_id, str) and acct_id:
-            headers["ChatGPT-Account-ID"] = acct_id
-    except Exception:
-        pass
-    return headers
 
 
 def _to_openai_base_url(base_url: str) -> str:

--- a/agent/codex_headers.py
+++ b/agent/codex_headers.py
@@ -1,0 +1,38 @@
+"""Shared request fingerprint for ChatGPT's private Codex backends."""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Dict
+
+
+def codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
+    """Return the first-party-shaped headers expected by ChatGPT's edge.
+
+    The Cloudflare layer in front of ChatGPT's private Codex routes accepts a
+    small set of first-party originators.  Match the upstream codex-rs client
+    and include the account ID carried by the OAuth JWT when available.
+    Malformed tokens intentionally omit the account header so the backend can
+    return the authoritative authentication error.
+    """
+    headers = {
+        "User-Agent": "codex_cli_rs/0.0.0 (Hermes Agent)",
+        "originator": "codex_cli_rs",
+    }
+    if not isinstance(access_token, str) or not access_token.strip():
+        return headers
+
+    try:
+        parts = access_token.split(".")
+        if len(parts) < 2:
+            return headers
+        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
+        account_id = claims.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
+        if isinstance(account_id, str) and account_id:
+            headers["ChatGPT-Account-ID"] = account_id
+    except Exception:
+        pass
+
+    return headers

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1703,6 +1703,42 @@ class CredentialPool:
                 self._unmatched_rotation_streak = 0
         return entry
 
+    def select_excluding(
+        self,
+        *,
+        credential_id: Optional[str] = None,
+        api_key_hint: Optional[str] = None,
+    ) -> Optional[PooledCredential]:
+        """Select an available alternative without exhausting or reprioritizing entries."""
+        with self._lock:
+            available, pending_refresh = self._available_entries(
+                clear_expired=True, refresh=True
+            )
+            alternatives = [
+                entry
+                for entry in available
+                if (not credential_id or entry.id != credential_id)
+                and (not api_key_hint or entry.runtime_api_key != api_key_hint)
+            ]
+            entry = alternatives[0] if alternatives else None
+        if pending_refresh:
+            self._refresh_pending_entries(pending_refresh)
+        if entry is not None:
+            return entry
+        if pending_refresh:
+            with self._lock:
+                available, _ = self._available_entries(
+                    clear_expired=True, refresh=False
+                )
+                alternatives = [
+                    candidate
+                    for candidate in available
+                    if (not credential_id or candidate.id != credential_id)
+                    and (not api_key_hint or candidate.runtime_api_key != api_key_hint)
+                ]
+                return alternatives[0] if alternatives else None
+        return None
+
     def _select_under_lock(self) -> Tuple[Optional[PooledCredential], List[tuple]]:
         """Run selection under the lock, returning entry + pending refreshes."""
         with self._lock:

--- a/agent/transcription_registry.py
+++ b/agent/transcription_registry.py
@@ -10,10 +10,9 @@ the configured ``stt.provider`` name is not a built-in.
 
 Built-ins-always-win
 --------------------
-Plugin names that collide with a built-in STT provider (``local``,
-``local_command``, ``groq``, ``openai``, ``mistral``, ``xai``) are
-rejected at registration with a warning. This invariant is also
-re-checked at dispatch time in
+Plugin names that collide with the native provider names reserved in
+:const:`_BUILTIN_NAMES` are rejected at registration with a warning. This
+invariant is also re-checked at dispatch time in
 :func:`tools.transcription_tools._dispatch_to_plugin_provider`.
 """
 
@@ -42,6 +41,7 @@ _BUILTIN_NAMES = frozenset({
     "local_command",
     "groq",
     "openai",
+    "openai-codex",
     "mistral",
     "xai",
     "elevenlabs",

--- a/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from 'react-router'
 import type * as ReactRouterDom from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ToolsetConfig } from '@/types/hermes'
+import type { OAuthPollResponse, OAuthStartResponse, ToolsetConfig } from '@/types/hermes'
 
 // EnvVarField navigates to Settings → Keys via useNavigate, so every render
 // needs a router context. The navigate spy asserts the deep-link target.
@@ -39,6 +39,8 @@ const runToolsetPostSetup = vi.fn()
 const getActionStatus = vi.fn()
 const startOAuthLogin = vi.fn()
 const pollOAuthSession = vi.fn()
+const cancelOAuthSession = vi.fn()
+const getApiRequestProfile = vi.fn<() => null | string>(() => null)
 const getHermesConfigRecord = vi.fn()
 const getHermesConfigSchema = vi.fn()
 const saveHermesConfig = vi.fn()
@@ -57,18 +59,27 @@ vi.mock('@/hermes', () => ({
   revealEnvVar: (key: string) => revealEnvVar(key),
   runToolsetPostSetup: (name: string, key: string) => runToolsetPostSetup(name, key),
   getActionStatus: (name: string, lines?: number) => getActionStatus(name, lines),
-  startOAuthLogin: (providerId: string) => startOAuthLogin(providerId),
-  pollOAuthSession: (providerId: string, sessionId: string) => pollOAuthSession(providerId, sessionId),
+  getApiRequestProfile: () => getApiRequestProfile(),
+  startOAuthLogin: (providerId: string, activateProvider?: boolean, profile?: null | string) =>
+    startOAuthLogin(providerId, activateProvider, profile),
+  pollOAuthSession: (providerId: string, sessionId: string, profile?: null | string) =>
+    pollOAuthSession(providerId, sessionId, profile),
+  cancelOAuthSession: (sessionId: string, profile?: null | string) => cancelOAuthSession(sessionId, profile),
   getHermesConfigRecord: () => getHermesConfigRecord(),
   getHermesConfigSchema: () => getHermesConfigSchema(),
   saveHermesConfig: (config: unknown) => saveHermesConfig(config),
   getElevenLabsVoices: () => getElevenLabsVoices()
 }))
 
-vi.mock('@/store/notifications', () => ({
-  notify: vi.fn(),
-  notifyError: vi.fn()
-}))
+vi.mock('@/store/notifications', () => {
+  let nextNotificationId = 0
+
+  return {
+    notify: vi.fn(() => `notification-${++nextNotificationId}`),
+    dismissNotification: vi.fn(),
+    notifyError: vi.fn()
+  }
+})
 
 vi.mock('@/store/activity', () => ({
   upsertDesktopActionTask: vi.fn()
@@ -106,6 +117,7 @@ function config(overrides: Partial<ToolsetConfig> = {}): ToolsetConfig {
 }
 
 beforeEach(() => {
+  getApiRequestProfile.mockReturnValue(null)
   // Radix menus/selects call these on open; jsdom implements neither, so the
   // dropdown never opens without the stubs (mirrors model-settings.test.tsx).
   Element.prototype.scrollIntoView = vi.fn()
@@ -145,6 +157,7 @@ beforeEach(() => {
   getHermesConfigSchema.mockResolvedValue({ fields: {}, category_order: [] })
   saveHermesConfig.mockResolvedValue({ ok: true })
   getElevenLabsVoices.mockResolvedValue({ available: false, voices: [] })
+  cancelOAuthSession.mockResolvedValue({ ok: true })
 })
 
 afterEach(() => {
@@ -889,14 +902,14 @@ describe('ToolsetConfigPanel', () => {
         getToolsetConfig.mockClear()
         warning!.action!.onClick()
 
-        await waitFor(() => expect(startOAuthLogin).toHaveBeenCalledWith('nous'))
+        await waitFor(() => expect(startOAuthLogin).toHaveBeenCalledWith('nous', true, null))
         expect(openSpy).toHaveBeenCalledWith(
           'https://portal.nousresearch.com/device?user_code=NOUS-1234',
           '_blank',
           'noopener,noreferrer'
         )
         // Approved poll → the panel refetches the config so status flips.
-        await waitFor(() => expect(pollOAuthSession).toHaveBeenCalledWith('nous', 'sess-1'), { timeout: 8000 })
+        await waitFor(() => expect(pollOAuthSession).toHaveBeenCalledWith('nous', 'sess-1', null), { timeout: 8000 })
         await waitFor(() => expect(getToolsetConfig).toHaveBeenCalled(), { timeout: 8000 })
       } finally {
         openSpy.mockRestore()
@@ -921,6 +934,390 @@ describe('ToolsetConfigPanel', () => {
 
       await waitFor(() => expect(notify).toHaveBeenCalledWith(expect.objectContaining({ kind: 'success' })))
       expect(startOAuthLogin).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Codex STT OAuth activation', () => {
+    it('authenticates before persisting the STT provider selection', async () => {
+      const { dismissNotification, notify } = await import('@/store/notifications')
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText }
+      })
+
+      getToolsetConfig.mockResolvedValue(
+        config({
+          name: 'stt',
+          active_provider: null,
+          providers: [
+            {
+              name: 'OpenAI Codex OAuth',
+              badge: 'subscription',
+              tag: 'ChatGPT/Codex dictation',
+              env_vars: [],
+              post_setup: null,
+              auth_provider: 'openai-codex',
+              requires_nous_auth: false,
+              is_active: false,
+              status: 'needs_auth'
+            }
+          ]
+        })
+      )
+      startOAuthLogin.mockResolvedValue({
+        flow: 'device_code',
+        session_id: 'codex-session',
+        user_code: 'CODEX-1234',
+        verification_url: 'https://auth.openai.com/device',
+        poll_interval: 5,
+        expires_in: 600
+      })
+      pollOAuthSession.mockResolvedValue({
+        session_id: 'codex-session',
+        status: 'approved'
+      })
+      selectToolsetProvider.mockResolvedValue({
+        ok: true,
+        name: 'stt',
+        provider: 'OpenAI Codex OAuth'
+      })
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+      try {
+        const { ToolsetConfigPanel } = await import('./toolset-config-panel')
+        render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="stt" />)
+
+        await screen.findByRole('button', { name: /OpenAI Codex OAuth/ })
+        fireEvent.click(await screen.findByRole('button', { name: /Use this backend/ }))
+
+        await waitFor(() => expect(startOAuthLogin).toHaveBeenCalledWith('openai-codex', false, null))
+        await waitFor(() =>
+          expect(notify).toHaveBeenCalledWith(
+            expect.objectContaining({
+              title: 'OpenAI Codex authorization code',
+              message: 'CODEX-1234',
+              action: expect.objectContaining({ label: 'Copy code' })
+            })
+          )
+        )
+
+        const codeNotice = vi
+          .mocked(notify)
+          .mock.calls.map(call => call[0])
+          .find(call => call.title === 'OpenAI Codex authorization code')
+
+        codeNotice?.action?.onClick()
+        expect(writeText).toHaveBeenCalledWith('CODEX-1234')
+        expect(selectToolsetProvider).not.toHaveBeenCalled()
+        await waitFor(() => expect(pollOAuthSession).toHaveBeenCalledWith('openai-codex', 'codex-session', null), {
+          timeout: 8000
+        })
+        await waitFor(() => expect(selectToolsetProvider).toHaveBeenCalledWith('stt', 'OpenAI Codex OAuth'), {
+          timeout: 8000
+        })
+        expect(dismissNotification).toHaveBeenCalledWith(expect.stringMatching(/^notification-/))
+      } finally {
+        openSpy.mockRestore()
+      }
+    }, 20000)
+
+    it('cancels an unfinished OAuth session when the panel unmounts', async () => {
+      const { dismissNotification } = await import('@/store/notifications')
+
+      getToolsetConfig.mockResolvedValue(
+        config({
+          name: 'stt',
+          active_provider: null,
+          providers: [
+            {
+              name: 'OpenAI Codex OAuth',
+              badge: 'subscription',
+              tag: 'ChatGPT/Codex dictation',
+              env_vars: [],
+              post_setup: null,
+              auth_provider: 'openai-codex',
+              requires_nous_auth: false,
+              is_active: false,
+              status: 'needs_auth'
+            }
+          ]
+        })
+      )
+      startOAuthLogin.mockResolvedValue({
+        flow: 'device_code',
+        session_id: 'abandoned-codex-session',
+        user_code: 'CODEX-5678',
+        verification_url: 'https://auth.openai.com/device',
+        poll_interval: 5,
+        expires_in: 900
+      })
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+      try {
+        const { ToolsetConfigPanel } = await import('./toolset-config-panel')
+        const rendered = render(<ToolsetConfigPanel toolset="stt" />)
+
+        fireEvent.click(await screen.findByRole('button', { name: /Use this backend/ }))
+        await waitFor(() => expect(startOAuthLogin).toHaveBeenCalled())
+        rendered.unmount()
+
+        await waitFor(() => expect(cancelOAuthSession).toHaveBeenCalledWith('abandoned-codex-session', null))
+        expect(dismissNotification).toHaveBeenCalledWith(expect.stringMatching(/^notification-/))
+        expect(selectToolsetProvider).not.toHaveBeenCalled()
+      } finally {
+        openSpy.mockRestore()
+      }
+    })
+
+    it('cancels when an in-flight OAuth start resolves after unmount', async () => {
+      getToolsetConfig.mockResolvedValue(
+        config({
+          name: 'stt',
+          active_provider: null,
+          providers: [
+            {
+              name: 'OpenAI Codex OAuth',
+              badge: 'subscription',
+              tag: 'ChatGPT/Codex dictation',
+              env_vars: [],
+              post_setup: null,
+              auth_provider: 'openai-codex',
+              requires_nous_auth: false,
+              is_active: false,
+              status: 'needs_auth'
+            }
+          ]
+        })
+      )
+      let resolveStart: ((value: OAuthStartResponse) => void) | undefined
+
+      startOAuthLogin.mockReturnValue(
+        new Promise<OAuthStartResponse>(resolve => {
+          resolveStart = resolve
+        })
+      )
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+      try {
+        const { ToolsetConfigPanel } = await import('./toolset-config-panel')
+        const rendered = render(<ToolsetConfigPanel toolset="stt" />)
+
+        fireEvent.click(await screen.findByRole('button', { name: /Use this backend/ }))
+        await waitFor(() => expect(startOAuthLogin).toHaveBeenCalled())
+        rendered.unmount()
+        resolveStart?.({
+          flow: 'device_code',
+          session_id: 'late-start-session',
+          user_code: 'LATE-1234',
+          verification_url: 'https://auth.openai.com/device',
+          poll_interval: 5,
+          expires_in: 900
+        })
+
+        await waitFor(() => expect(cancelOAuthSession).toHaveBeenCalledWith('late-start-session', null))
+        expect(openSpy).not.toHaveBeenCalled()
+        expect(selectToolsetProvider).not.toHaveBeenCalled()
+      } finally {
+        openSpy.mockRestore()
+      }
+    })
+
+    it('does not open a browser fallback when bridge failure resolves after unmount', async () => {
+      getToolsetConfig.mockResolvedValue(
+        config({
+          name: 'stt',
+          active_provider: null,
+          providers: [
+            {
+              name: 'OpenAI Codex OAuth',
+              badge: 'subscription',
+              tag: 'ChatGPT/Codex dictation',
+              env_vars: [],
+              post_setup: null,
+              auth_provider: 'openai-codex',
+              requires_nous_auth: false,
+              is_active: false,
+              status: 'needs_auth'
+            }
+          ]
+        })
+      )
+      startOAuthLogin.mockResolvedValue({
+        flow: 'device_code',
+        session_id: 'bridge-race-settings-session',
+        user_code: 'BRIDGE-5678',
+        verification_url: 'https://auth.openai.com/device',
+        poll_interval: 5,
+        expires_in: 900
+      })
+      let rejectOpen: ((reason?: unknown) => void) | undefined
+
+      const openExternal = vi.fn(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectOpen = reject
+          })
+      )
+
+      const originalDesktop = Object.getOwnPropertyDescriptor(window, 'hermesDesktop')
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+      try {
+        Object.defineProperty(window, 'hermesDesktop', {
+          configurable: true,
+          value: { ...window.hermesDesktop, openExternal }
+        })
+        const { ToolsetConfigPanel } = await import('./toolset-config-panel')
+        const rendered = render(<ToolsetConfigPanel toolset="stt" />)
+
+        fireEvent.click(await screen.findByRole('button', { name: /Use this backend/ }))
+        await waitFor(() => expect(openExternal).toHaveBeenCalled())
+        rendered.unmount()
+        rejectOpen?.(new Error('bridge unavailable'))
+
+        await waitFor(() => expect(cancelOAuthSession).toHaveBeenCalledWith('bridge-race-settings-session', null))
+        expect(openSpy).not.toHaveBeenCalled()
+        expect(selectToolsetProvider).not.toHaveBeenCalled()
+      } finally {
+        openSpy.mockRestore()
+
+        if (originalDesktop) {
+          Object.defineProperty(window, 'hermesDesktop', originalDesktop)
+        } else {
+          Reflect.deleteProperty(window, 'hermesDesktop')
+        }
+      }
+    })
+
+    it('does not select a provider when an in-flight poll approves after unmount', async () => {
+      getToolsetConfig.mockResolvedValue(
+        config({
+          name: 'stt',
+          active_provider: null,
+          providers: [
+            {
+              name: 'OpenAI Codex OAuth',
+              badge: 'subscription',
+              tag: 'ChatGPT/Codex dictation',
+              env_vars: [],
+              post_setup: null,
+              auth_provider: 'openai-codex',
+              requires_nous_auth: false,
+              is_active: false,
+              status: 'needs_auth'
+            }
+          ]
+        })
+      )
+      startOAuthLogin.mockResolvedValue({
+        flow: 'device_code',
+        session_id: 'late-poll-session',
+        user_code: 'POLL-1234',
+        verification_url: 'https://auth.openai.com/device',
+        poll_interval: 1,
+        expires_in: 900
+      })
+      let resolvePoll: ((value: OAuthPollResponse) => void) | undefined
+
+      pollOAuthSession.mockReturnValue(
+        new Promise<OAuthPollResponse>(resolve => {
+          resolvePoll = resolve
+        })
+      )
+      let timerSpy: ReturnType<typeof vi.spyOn> | undefined
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+      try {
+        const { ToolsetConfigPanel } = await import('./toolset-config-panel')
+        const rendered = render(<ToolsetConfigPanel toolset="stt" />)
+        const selectButton = await screen.findByRole('button', { name: /Use this backend/ })
+
+        timerSpy = vi.spyOn(window, 'setTimeout').mockImplementation(handler => {
+          if (typeof handler === 'function') {
+            window.queueMicrotask(handler)
+          }
+
+          return 1 as never
+        })
+        fireEvent.click(selectButton)
+
+        for (let attempt = 0; attempt < 10 && !pollOAuthSession.mock.calls.length; attempt += 1) {
+          await Promise.resolve()
+        }
+
+        expect(pollOAuthSession).toHaveBeenCalled()
+        rendered.unmount()
+        resolvePoll?.({ status: 'approved', session_id: 'late-poll-session' })
+
+        await waitFor(() => expect(cancelOAuthSession).toHaveBeenCalledWith('late-poll-session', null))
+        expect(selectToolsetProvider).not.toHaveBeenCalled()
+      } finally {
+        timerSpy?.mockRestore()
+        openSpy.mockRestore()
+      }
+    })
+
+    it('pins OAuth polling to its initiating profile and rejects a stale approval after profile switch', async () => {
+      const { dismissNotification } = await import('@/store/notifications')
+
+      getApiRequestProfile.mockReturnValue('coder')
+      getToolsetConfig.mockResolvedValue(
+        config({
+          name: 'stt',
+          active_provider: null,
+          providers: [
+            {
+              name: 'OpenAI Codex OAuth',
+              badge: 'subscription',
+              tag: 'ChatGPT/Codex dictation',
+              env_vars: [],
+              post_setup: null,
+              auth_provider: 'openai-codex',
+              requires_nous_auth: false,
+              is_active: false,
+              status: 'needs_auth'
+            }
+          ]
+        })
+      )
+      startOAuthLogin.mockResolvedValue({
+        flow: 'device_code',
+        session_id: 'profile-owned-session',
+        user_code: 'PROFILE-1234',
+        verification_url: 'https://auth.openai.com/device',
+        poll_interval: 1,
+        expires_in: 900
+      })
+      let resolvePoll: ((value: OAuthPollResponse) => void) | undefined
+
+      pollOAuthSession.mockReturnValue(
+        new Promise<OAuthPollResponse>(resolve => {
+          resolvePoll = resolve
+        })
+      )
+
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue({} as Window)
+
+      try {
+        const { ToolsetConfigPanel } = await import('./toolset-config-panel')
+
+        render(<ToolsetConfigPanel toolset="stt" />)
+        fireEvent.click(await screen.findByRole('button', { name: /Use this backend/ }))
+
+        await waitFor(
+          () => expect(pollOAuthSession).toHaveBeenCalledWith('openai-codex', 'profile-owned-session', 'coder'),
+          { timeout: 3000 }
+        )
+        getApiRequestProfile.mockReturnValue('other')
+        resolvePoll?.({ status: 'approved', session_id: 'profile-owned-session' })
+
+        await waitFor(() => expect(cancelOAuthSession).toHaveBeenCalledWith('profile-owned-session', 'coder'))
+        expect(dismissNotification).toHaveBeenCalledWith(expect.stringMatching(/^notification-/))
+        expect(selectToolsetProvider).not.toHaveBeenCalled()
+      } finally {
+        openSpy.mockRestore()
+      }
     })
   })
 

--- a/apps/desktop/src/app/settings/toolset-config-panel.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.tsx
@@ -5,8 +5,10 @@ import { SETTINGS_ROUTE } from '@/app/routes'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
+  cancelOAuthSession,
   deleteEnvVar,
   getActionStatus,
+  getApiRequestProfile,
   getToolsetConfig,
   getToolsetModels,
   pollOAuthSession,
@@ -21,7 +23,7 @@ import { useI18n } from '@/i18n'
 import { Check, Loader2, Save, Terminal } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
-import { notify, notifyError } from '@/store/notifications'
+import { dismissNotification, notify, notifyError } from '@/store/notifications'
 import type {
   ActionStatusResponse,
   ToolEnvVar,
@@ -500,8 +502,18 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
   // Default-provider selection and a user click race just after config arrives:
   // a stale initialization effect must never replace an explicit choice.
   const providerChoiceClaimedRef = useRef(false)
-  // Guard the Nous Portal sign-in poll loop against unmount/state updates.
+  // Guard the OAuth sign-in poll loop against unmount/state updates.
   const mountedRef = useRef(true)
+  const oauthOperationGenerationRef = useRef(0)
+
+  const activeOAuthSessionRef = useRef<{
+    generation: number
+    profile: null | string
+    sessionId: string
+  } | null>(null)
+
+  const popupRecoveryNotificationRef = useRef<{ generation: number; id: string } | null>(null)
+  const authorizationCodeNotificationRef = useRef<{ generation: number; id: string } | null>(null)
 
   // eslint-disable-next-line no-restricted-syntax -- mount flag guarding an async poll loop, not an atom mirror
   useEffect(() => {
@@ -509,6 +521,23 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
 
     return () => {
       mountedRef.current = false
+      oauthOperationGenerationRef.current += 1
+      const session = activeOAuthSessionRef.current
+      const notifications = [popupRecoveryNotificationRef.current, authorizationCodeNotificationRef.current]
+
+      activeOAuthSessionRef.current = null
+      popupRecoveryNotificationRef.current = null
+      authorizationCodeNotificationRef.current = null
+
+      for (const notification of notifications) {
+        if (notification) {
+          dismissNotification(notification.id)
+        }
+      }
+
+      if (session) {
+        void cancelOAuthSession(session.sessionId, session.profile)
+      }
     }
   }, [])
 
@@ -574,6 +603,18 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
     setSelecting(provider.name)
 
     try {
+      if (provider.auth_provider && providerStatus(provider, envState) === 'needs_auth') {
+        const authenticated = await signInToOAuthProvider(provider.auth_provider)
+
+        if (!authenticated) {
+          return
+        }
+      }
+
+      if (!mountedRef.current) {
+        return
+      }
+
       const result = await selectToolsetProvider(toolset, provider.name)
       // Mirror the backend write locally so dependent UI (model catalog
       // enablement) tracks the new active backend without a refetch.
@@ -596,7 +637,7 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
           kind: 'warning',
           title: copy.nousAuthNeededTitle,
           message: copy.nousAuthNeededMessage(provider.name),
-          action: { label: copy.nousAuthSignIn, onClick: () => void signInToNousPortal() }
+          action: { label: copy.nousAuthSignIn, onClick: () => void signInToOAuthProvider('nous') }
         })
 
         return
@@ -614,57 +655,229 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange }: ToolsetConfi
   // Drive the existing Nous Portal OAuth device-code flow (the same session
   // machinery onboarding uses: start → open verification URL → poll), then
   // refetch the toolset config so is_active / status flip once entitled.
-  async function signInToNousPortal() {
+  async function signInToOAuthProvider(providerId: string): Promise<boolean> {
+    const generation = ++oauthOperationGenerationRef.current
+    const profile = getApiRequestProfile()
+    const previousSession = activeOAuthSessionRef.current
+
+    activeOAuthSessionRef.current = null
+
+    if (previousSession) {
+      void cancelOAuthSession(previousSession.sessionId, previousSession.profile).catch(() => undefined)
+    }
+
+    for (const ref of [popupRecoveryNotificationRef, authorizationCodeNotificationRef]) {
+      const notification = ref.current
+
+      ref.current = null
+
+      if (notification) {
+        dismissNotification(notification.id)
+      }
+    }
+
+    let sessionId: string | null = null
+
+    const operationIsCurrent = () =>
+      mountedRef.current && oauthOperationGenerationRef.current === generation && getApiRequestProfile() === profile
+
+    const sessionIsCurrent = () => {
+      const active = activeOAuthSessionRef.current
+
+      return (
+        operationIsCurrent() &&
+        active?.generation === generation &&
+        active.sessionId === sessionId &&
+        active.profile === profile
+      )
+    }
+
+    const dismissOperationNotifications = () => {
+      for (const ref of [popupRecoveryNotificationRef, authorizationCodeNotificationRef]) {
+        const notification = ref.current
+
+        if (notification?.generation === generation) {
+          ref.current = null
+          dismissNotification(notification.id)
+        }
+      }
+    }
+
+    const releaseSession = () => {
+      const active = activeOAuthSessionRef.current
+
+      if (active?.generation === generation && active.sessionId === sessionId && active.profile === profile) {
+        activeOAuthSessionRef.current = null
+      }
+
+      dismissOperationNotifications()
+    }
+
     try {
-      const start = await startOAuthLogin('nous')
+      const start = await startOAuthLogin(providerId, providerId !== 'openai-codex', profile)
+
+      sessionId = start.session_id
+
+      if (!operationIsCurrent()) {
+        await cancelOAuthSession(start.session_id, profile).catch(() => undefined)
+
+        return false
+      }
 
       if (start.flow !== 'device_code') {
-        notifyError(new Error(`unexpected flow: ${start.flow}`), copy.nousAuthFailed)
+        await cancelOAuthSession(start.session_id, profile).catch(() => undefined)
+        notifyError(new Error(`unexpected flow: ${start.flow}`), copy.failedSelect(providerId))
 
-        return
+        return false
+      }
+
+      activeOAuthSessionRef.current = { generation, profile, sessionId: start.session_id }
+
+      if (providerId === 'openai-codex' && start.user_code) {
+        const authorizationCode = start.user_code
+        let notificationId = ''
+
+        notificationId = notify({
+          kind: 'warning',
+          title: 'OpenAI Codex authorization code',
+          message: authorizationCode,
+          action: {
+            label: 'Copy code',
+            onClick: () => {
+              if (sessionIsCurrent()) {
+                void navigator.clipboard?.writeText(authorizationCode)
+              }
+
+              const current = authorizationCodeNotificationRef.current
+
+              if (current?.generation === generation && current.id === notificationId) {
+                authorizationCodeNotificationRef.current = null
+              }
+
+              dismissNotification(notificationId)
+            }
+          }
+        })
+        authorizationCodeNotificationRef.current = { generation, id: notificationId }
       }
 
       const url = start.verification_url
+      let opened = false
 
       if (window.hermesDesktop?.openExternal) {
         try {
           await window.hermesDesktop.openExternal(url)
+          opened = true
         } catch {
-          window.open(url, '_blank', 'noopener,noreferrer')
+          if (sessionIsCurrent()) {
+            opened = window.open(url, '_blank', 'noopener,noreferrer') !== null
+          }
         }
-      } else {
-        window.open(url, '_blank', 'noopener,noreferrer')
+      } else if (sessionIsCurrent()) {
+        opened = window.open(url, '_blank', 'noopener,noreferrer') !== null
       }
 
-      // Poll until the device-code session resolves (~5s cadence, bounded).
-      for (let attempt = 0; attempt < 120 && mountedRef.current; attempt += 1) {
-        await new Promise(resolve => window.setTimeout(resolve, 5000))
+      if (!sessionIsCurrent()) {
+        releaseSession()
+        await cancelOAuthSession(start.session_id, profile).catch(() => undefined)
 
-        if (!mountedRef.current) {
-          return
+        return false
+      }
+
+      if (!opened) {
+        let notificationId = ''
+
+        notificationId = notify({
+          kind: 'warning',
+          title: 'Sign-in window was blocked',
+          message: 'Allow pop-ups, then open the authorization page to continue.',
+          action: {
+            label: 'Open sign-in page',
+            onClick: () => {
+              if (sessionIsCurrent()) {
+                window.open(url, '_blank', 'noopener,noreferrer')
+              }
+
+              const current = popupRecoveryNotificationRef.current
+
+              if (current?.generation === generation && current.id === notificationId) {
+                popupRecoveryNotificationRef.current = null
+              }
+
+              dismissNotification(notificationId)
+            }
+          }
+        })
+        popupRecoveryNotificationRef.current = { generation, id: notificationId }
+      }
+
+      const pollIntervalMs = Math.max(1000, start.poll_interval * 1000)
+      const deadline = Date.now() + start.expires_in * 1000
+
+      while (sessionIsCurrent() && Date.now() < deadline) {
+        await new Promise(resolve => window.setTimeout(resolve, pollIntervalMs))
+
+        if (!sessionIsCurrent()) {
+          releaseSession()
+          await cancelOAuthSession(start.session_id, profile).catch(() => undefined)
+
+          return false
         }
 
-        const polled = await pollOAuthSession('nous', start.session_id)
+        const polled = await pollOAuthSession(providerId, start.session_id, profile)
+
+        if (!sessionIsCurrent()) {
+          releaseSession()
+          await cancelOAuthSession(start.session_id, profile).catch(() => undefined)
+
+          return false
+        }
 
         if (polled.status === 'approved') {
-          notify({ kind: 'success', title: copy.nousAuthDoneTitle, message: copy.nousAuthDoneMessage })
+          releaseSession()
+
+          if (providerId === 'nous') {
+            notify({ kind: 'success', title: copy.nousAuthDoneTitle, message: copy.nousAuthDoneMessage })
+          }
+
           await refresh()
+
+          if (!operationIsCurrent()) {
+            return false
+          }
+
           onConfiguredChange?.()
 
-          return
+          return true
         }
 
         if (polled.status !== 'pending') {
-          notifyError(new Error(polled.error_message || `Sign-in ${polled.status}`), copy.nousAuthFailed)
+          releaseSession()
+          notifyError(new Error(polled.error_message || `Sign-in ${polled.status}`), copy.failedSelect(providerId))
 
-          return
+          return false
         }
       }
+
+      if (sessionIsCurrent()) {
+        releaseSession()
+        await cancelOAuthSession(start.session_id, profile)
+      }
     } catch (err) {
-      if (mountedRef.current) {
-        notifyError(err, copy.nousAuthFailed)
+      const shouldNotify = operationIsCurrent()
+
+      releaseSession()
+
+      if (sessionId) {
+        await cancelOAuthSession(sessionId, profile).catch(() => undefined)
+      }
+
+      if (shouldNotify) {
+        notifyError(err, copy.failedSelect(providerId))
       }
     }
+
+    return false
   }
 
   function patchEnv(key: string, isSet: boolean) {

--- a/apps/desktop/src/components/onboarding/flow.tsx
+++ b/apps/desktop/src/components/onboarding/flow.tsx
@@ -40,7 +40,16 @@ export function FlowPanel({
   const title = 'provider' in flow && flow.provider ? providerTitle(flow.provider) : ''
 
   if (flow.status === 'starting') {
-    return <Status>{t.onboarding.startingSignIn(title)}</Status>
+    return (
+      <div className="grid gap-3">
+        <Status>{t.onboarding.startingSignIn(title)}</Status>
+        <div className="flex justify-end">
+          <Button onClick={cancelOnboardingFlow} variant="outline">
+            {t.onboarding.pickDifferentProvider}
+          </Button>
+        </div>
+      </div>
+    )
   }
 
   if (flow.status === 'submitting') {

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -7,6 +7,8 @@ import {
   AUDIO_TRANSCRIBE_MIN_REQUEST_TIMEOUT_MS,
   audioSpeakRequestTimeoutMs,
   audioTranscribeRequestTimeoutMs,
+  cancelOAuthSession,
+  CODEX_OAUTH_START_TIMEOUT_MS,
   getCronJobs,
   getGlobalModelInfo,
   getGlobalModelOptions,
@@ -18,9 +20,11 @@ import {
   listAllProfileSessions,
   listSessions,
   listSidebarSessions,
+  pollOAuthSession,
   resetSidebarBatchCapability,
   setApiRequestProfile,
   speakText,
+  startOAuthLogin,
   transcribeAudio
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
@@ -58,6 +62,37 @@ describe('Hermes REST helpers', () => {
         path: '/api/sessions?limit=50&offset=0&min_messages=1&archived=exclude&order=recent',
         timeoutMs: 60_000
       })
+    )
+  })
+
+  it('allows Codex OAuth start to outlive the backend retry window', async () => {
+    await startOAuthLogin('openai-codex', false)
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/providers/oauth/openai-codex/start?activate_provider=false',
+        timeoutMs: CODEX_OAUTH_START_TIMEOUT_MS
+      })
+    )
+    expect(CODEX_OAUTH_START_TIMEOUT_MS).toBeGreaterThan(245_000)
+  })
+
+  it('pins OAuth lifecycle requests to an explicit initiating profile', async () => {
+    await startOAuthLogin('openai-codex', false, 'coder')
+    await pollOAuthSession('openai-codex', 'session-1', 'coder')
+    await cancelOAuthSession('session-1', 'coder')
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/providers/oauth/openai-codex/start?activate_provider=false',
+        profile: 'coder'
+      })
+    )
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/api/providers/oauth/openai-codex/poll/session-1', profile: 'coder' })
+    )
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/api/providers/oauth/sessions/session-1', profile: 'coder' })
     )
   })
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -867,34 +867,52 @@ export function disconnectOAuthProvider(providerId: string): Promise<{ ok: boole
   })
 }
 
-export function startOAuthLogin(providerId: string): Promise<OAuthStartResponse> {
+// The backend permits four 15s device-code requests plus three 60s capped
+// Retry-After delays (245s total with margin). Keep transport timeout above it.
+export const CODEX_OAUTH_START_TIMEOUT_MS = 255_000
+
+export function startOAuthLogin(
+  providerId: string,
+  activateProvider = true,
+  profile?: null | string
+): Promise<OAuthStartResponse> {
   return window.hermesDesktop.api<OAuthStartResponse>({
-    ...profileScoped(),
-    path: `/api/providers/oauth/${encodeURIComponent(providerId)}/start`,
+    ...profileScoped(profile),
+    path: `/api/providers/oauth/${encodeURIComponent(providerId)}/start?activate_provider=${activateProvider}`,
     method: 'POST',
-    body: {}
+    body: {},
+    ...(providerId === 'openai-codex' ? { timeoutMs: CODEX_OAUTH_START_TIMEOUT_MS } : {})
   })
 }
 
-export function submitOAuthCode(providerId: string, sessionId: string, code: string): Promise<OAuthSubmitResponse> {
+export function submitOAuthCode(
+  providerId: string,
+  sessionId: string,
+  code: string,
+  profile?: null | string
+): Promise<OAuthSubmitResponse> {
   return window.hermesDesktop.api<OAuthSubmitResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/providers/oauth/${encodeURIComponent(providerId)}/submit`,
     method: 'POST',
     body: { session_id: sessionId, code }
   })
 }
 
-export function pollOAuthSession(providerId: string, sessionId: string): Promise<OAuthPollResponse> {
+export function pollOAuthSession(
+  providerId: string,
+  sessionId: string,
+  profile?: null | string
+): Promise<OAuthPollResponse> {
   return window.hermesDesktop.api<OAuthPollResponse>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/providers/oauth/${encodeURIComponent(providerId)}/poll/${encodeURIComponent(sessionId)}`
   })
 }
 
-export function cancelOAuthSession(sessionId: string): Promise<{ ok: boolean }> {
+export function cancelOAuthSession(sessionId: string, profile?: null | string): Promise<{ ok: boolean }> {
   return window.hermesDesktop.api<{ ok: boolean }>({
-    ...profileScoped(),
+    ...profileScoped(profile),
     path: `/api/providers/oauth/sessions/${encodeURIComponent(sessionId)}`,
     method: 'DELETE'
   })

--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -1,15 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { setApiRequestProfile } from '@/hermes'
 import * as notifications from '@/store/notifications'
-import type { OAuthProvider } from '@/types/hermes'
+import type { OAuthPollResponse, OAuthProvider, OAuthStartResponse } from '@/types/hermes'
 
 import {
   $desktopOnboarding,
+  cancelOnboardingFlow,
+  closeManualOnboarding,
   type DesktopOnboardingState,
   type OnboardingContext,
   refreshOnboarding,
   requestDesktopOnboarding,
   saveOnboardingLocalEndpoint,
+  startProviderOAuth,
   submitOnboardingCode
 } from './onboarding'
 
@@ -91,13 +95,308 @@ function fallbackTimeoutGateway(): OnboardingContext['requestGateway'] {
 describe('refreshOnboarding', () => {
   beforeEach(() => {
     window.localStorage.clear()
+    setApiRequestProfile(null)
     $desktopOnboarding.set(baseState())
   })
 
   afterEach(() => {
     window.localStorage.clear()
+    setApiRequestProfile(null)
     $desktopOnboarding.set(baseState())
     vi.restoreAllMocks()
+  })
+
+  it('cancels a stale OAuth start that resolves after onboarding is dismissed', async () => {
+    let resolveStart: ((value: OAuthStartResponse) => void) | undefined
+
+    const startPromise = new Promise<OAuthStartResponse>(resolve => {
+      resolveStart = resolve
+    })
+
+    const api = vi.fn(({ path }: { path: string }) => {
+      if (path.includes('/start')) {
+        return startPromise
+      }
+
+      if (path.includes('/sessions/stale-onboarding-session')) {
+        return Promise.resolve({ ok: true })
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+    installApiMock(api)
+    const operation = startProviderOAuth(provider('openai-codex'), onboardingContext(emptyOpenRouterGateway()))
+
+    expect($desktopOnboarding.get().flow.status).toBe('starting')
+    cancelOnboardingFlow()
+    resolveStart?.({
+      flow: 'device_code',
+      session_id: 'stale-onboarding-session',
+      user_code: 'STALE-1234',
+      verification_url: 'https://auth.openai.com/device',
+      expires_in: 900,
+      poll_interval: 5
+    })
+    await operation
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/providers/oauth/sessions/stale-onboarding-session',
+        method: 'DELETE'
+      })
+    )
+    expect(openSpy).not.toHaveBeenCalled()
+    expect($desktopOnboarding.get().flow.status).toBe('idle')
+  })
+
+  it('cancels and isolates the previous session when OAuth is replaced', async () => {
+    let startCount = 0
+
+    const api = vi.fn(({ path }: { path: string }) => {
+      if (path.includes('/start')) {
+        startCount += 1
+
+        return Promise.resolve({
+          flow: 'device_code',
+          session_id: `replacement-session-${startCount}`,
+          user_code: `REPLACE-${startCount}`,
+          verification_url: 'https://auth.openai.com/device',
+          expires_in: 900,
+          poll_interval: 5
+        })
+      }
+
+      if (path.includes('/sessions/')) {
+        return Promise.resolve({ ok: true })
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+    try {
+      notifications.clearNotifications()
+      installApiMock(api)
+      await startProviderOAuth(provider('openai-codex'), onboardingContext(emptyOpenRouterGateway()))
+      const staleRecovery = notifications.$notifications.get().find(item => item.title === 'Sign-in window was blocked')
+
+      await startProviderOAuth(provider('openai-codex'), onboardingContext(emptyOpenRouterGateway()))
+
+      expect(api).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/api/providers/oauth/sessions/replacement-session-1',
+          method: 'DELETE'
+        })
+      )
+      expect($desktopOnboarding.get().flow.status).toBe('polling')
+
+      staleRecovery?.action?.onClick()
+
+      expect(openSpy).toHaveBeenCalledTimes(2)
+      expect(notifications.$notifications.get().some(item => item.title === 'Sign-in window was blocked')).toBe(true)
+    } finally {
+      cancelOnboardingFlow()
+      notifications.clearNotifications()
+      openSpy.mockRestore()
+    }
+  })
+
+  it('clears a failed OAuth start after its initiating profile changes', async () => {
+    let rejectStart: ((reason?: unknown) => void) | undefined
+
+    const api = vi.fn(
+      ({ path }: { path: string }) =>
+        new Promise<unknown>((_resolve, reject) => {
+          if (!path.includes('/start')) {
+            throw new Error(`unexpected api path: ${path}`)
+          }
+
+          rejectStart = reject
+        })
+    )
+
+    installApiMock(api)
+    setApiRequestProfile('coder')
+    const operation = startProviderOAuth(provider('openai-codex'), onboardingContext(emptyOpenRouterGateway()))
+    await vi.waitFor(() => expect($desktopOnboarding.get().flow.status).toBe('starting'))
+
+    setApiRequestProfile('other')
+    rejectStart?.(new Error('old profile failed'))
+    await operation
+
+    expect($desktopOnboarding.get().flow.status).toBe('idle')
+  })
+
+  it('does not open a browser fallback when bridge failure resolves after cancellation', async () => {
+    let rejectOpen: ((reason?: unknown) => void) | undefined
+
+    const openExternal = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectOpen = reject
+        })
+    )
+
+    const originalDesktop = Object.getOwnPropertyDescriptor(window, 'hermesDesktop')
+
+    const api = vi.fn(({ path }: { path: string }) => {
+      if (path.includes('/start')) {
+        return Promise.resolve({
+          flow: 'device_code',
+          session_id: 'bridge-race-session',
+          user_code: 'BRIDGE-1234',
+          verification_url: 'https://auth.openai.com/device',
+          expires_in: 900,
+          poll_interval: 5
+        })
+      }
+
+      if (path.includes('/sessions/bridge-race-session')) {
+        return Promise.resolve({ ok: true })
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+    try {
+      installApiMock(api)
+      Object.defineProperty(window, 'hermesDesktop', {
+        configurable: true,
+        value: { ...window.hermesDesktop, openExternal }
+      })
+      const operation = startProviderOAuth(provider('openai-codex'), onboardingContext(emptyOpenRouterGateway()))
+
+      await vi.waitFor(() => expect(openExternal).toHaveBeenCalled())
+      cancelOnboardingFlow()
+      rejectOpen?.(new Error('bridge unavailable'))
+      await operation
+
+      expect(openSpy).not.toHaveBeenCalled()
+      expect($desktopOnboarding.get().flow.status).toBe('idle')
+      expect(api).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/api/providers/oauth/sessions/bridge-race-session',
+          method: 'DELETE'
+        })
+      )
+    } finally {
+      openSpy.mockRestore()
+
+      if (originalDesktop) {
+        Object.defineProperty(window, 'hermesDesktop', originalDesktop)
+      } else {
+        Reflect.deleteProperty(window, 'hermesDesktop')
+      }
+    }
+  })
+
+  it('dismisses popup recovery and prevents its stale action after cancellation', async () => {
+    const api = vi.fn(({ path }: { path: string }) => {
+      if (path.includes('/start')) {
+        return Promise.resolve({
+          flow: 'device_code',
+          session_id: 'popup-recovery-session',
+          user_code: 'POPUP-1234',
+          verification_url: 'https://auth.openai.com/device',
+          expires_in: 900,
+          poll_interval: 5
+        })
+      }
+
+      if (path.includes('/sessions/popup-recovery-session')) {
+        return Promise.resolve({ ok: true })
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+
+    try {
+      notifications.clearNotifications()
+      installApiMock(api)
+      await startProviderOAuth(provider('openai-codex'), onboardingContext(emptyOpenRouterGateway()))
+
+      const recovery = notifications.$notifications.get().find(item => item.title === 'Sign-in window was blocked')
+
+      expect(recovery?.action).toBeTruthy()
+      cancelOnboardingFlow()
+      recovery?.action?.onClick()
+
+      expect(openSpy).toHaveBeenCalledTimes(1)
+      expect(notifications.$notifications.get().some(item => item.id === recovery?.id)).toBe(false)
+    } finally {
+      openSpy.mockRestore()
+      notifications.clearNotifications()
+    }
+  })
+
+  it('ignores an in-flight poll that approves after manual onboarding closes', async () => {
+    vi.useFakeTimers()
+    let resolvePoll: ((value: OAuthPollResponse) => void) | undefined
+
+    const pollPromise = new Promise<OAuthPollResponse>(resolve => {
+      resolvePoll = resolve
+    })
+
+    const api = vi.fn(({ path }: { path: string }) => {
+      if (path.includes('/start')) {
+        return Promise.resolve({
+          flow: 'device_code',
+          session_id: 'manual-poll-session',
+          user_code: 'MANUAL-1234',
+          verification_url: 'https://auth.openai.com/device',
+          expires_in: 900,
+          poll_interval: 5
+        })
+      }
+
+      if (path.includes('/poll/manual-poll-session')) {
+        return pollPromise
+      }
+
+      if (path.includes('/sessions/manual-poll-session')) {
+        return Promise.resolve({ ok: true })
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const requestGateway = vi.fn()
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue({} as Window)
+
+    try {
+      installApiMock(api)
+      $desktopOnboarding.set(baseState({ manual: true, requested: true }))
+      await startProviderOAuth(provider('openai-codex'), onboardingContext(requestGateway))
+      await vi.advanceTimersByTimeAsync(2000)
+      expect(api).toHaveBeenCalledWith(
+        expect.objectContaining({ path: '/api/providers/oauth/openai-codex/poll/manual-poll-session' })
+      )
+
+      closeManualOnboarding()
+      resolvePoll?.({ status: 'approved', session_id: 'manual-poll-session' })
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect($desktopOnboarding.get().flow.status).toBe('idle')
+      expect(requestGateway).not.toHaveBeenCalled()
+      expect(api).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/api/providers/oauth/sessions/manual-poll-session',
+          method: 'DELETE'
+        })
+      )
+    } finally {
+      openSpy.mockRestore()
+      vi.useRealTimers()
+    }
   })
 
   it('refreshes OAuth providers again when onboarding was explicitly requested', async () => {

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -2,6 +2,7 @@ import { atom } from 'nanostores'
 
 import {
   cancelOAuthSession,
+  getApiRequestProfile,
   getGlobalModelOptions,
   getRecommendedDefaultModel,
   listOAuthProviders,
@@ -14,7 +15,7 @@ import {
 } from '@/hermes'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { evaluateRuntimeReadiness, type RuntimeReadinessResult } from '@/lib/runtime-readiness'
-import { notify, notifyError } from '@/store/notifications'
+import { dismissNotification, notify, notifyError } from '@/store/notifications'
 import type { ModelOptionProvider, OAuthProvider, OAuthStartResponse } from '@/types/hermes'
 
 type PkceStart = Extract<OAuthStartResponse, { flow: 'pkce' }>
@@ -160,6 +161,11 @@ export const $desktopOnboarding = atom<DesktopOnboardingState>(INITIAL)
 
 let pollTimer: number | null = null
 let providersRefreshPromise: null | Promise<void> = null
+let oauthOperationGeneration = 0
+let pollRequestGeneration: number | null = null
+let activeOAuthSessionId: string | null = null
+let activeOAuthProfile: null | string = null
+const OAUTH_POPUP_RECOVERY_NOTIFICATION_ID = 'onboarding-oauth-popup-recovery'
 
 const errMessage = (e: unknown) => (e instanceof Error ? e.message : String(e))
 
@@ -174,6 +180,36 @@ function clearPoll() {
   if (pollTimer !== null) {
     window.clearInterval(pollTimer)
     pollTimer = null
+  }
+}
+
+function oauthOperationIsCurrent(generation: number, sessionId: string, profile: null | string): boolean {
+  if (generation !== oauthOperationGeneration) {
+    return false
+  }
+
+  return activeOAuthSessionId === sessionId && activeOAuthProfile === profile && getApiRequestProfile() === profile
+}
+
+function clearFlowAfterProfileChange(generation: number, profile: null | string) {
+  if (generation === oauthOperationGeneration && getApiRequestProfile() !== profile) {
+    dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
+    setFlow({ status: 'idle' })
+  }
+}
+
+function invalidateCurrentOAuthFlow() {
+  oauthOperationGeneration += 1
+  clearPoll()
+  const sessionId = activeOAuthSessionId ?? sessionIdFor($desktopOnboarding.get().flow)
+  const profile = activeOAuthProfile
+
+  activeOAuthSessionId = null
+  activeOAuthProfile = null
+  dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
+
+  if (sessionId) {
+    cancelOAuthSession(sessionId, profile).catch(() => undefined)
   }
 }
 
@@ -307,22 +343,39 @@ async function completeWithModelConfirm(
   // When true, a failing runtime check no longer blocks progression — the
   // user is allowed through onboarding regardless. Used by the API-key path,
   // where we intentionally don't validate the key (it blocked too many users).
-  ignoreRuntimeGate = false
+  ignoreRuntimeGate = false,
+  isCurrent: () => boolean = () => true
 ) {
   await ctx.requestGateway('reload.env').catch(() => undefined)
 
+  if (!isCurrent()) {
+    return
+  }
+
   const defaults = await fetchProviderDefaultModel(preferredSlugs)
+
+  if (!isCurrent()) {
+    return
+  }
 
   if (defaults) {
     // Persist the chosen provider/model before the runtime gate so a stale
     // config provider (e.g. anthropic from a prior failed setup) cannot make
     // setup.runtime_check validate the wrong backend after a fresh OAuth login.
     try {
+      if (!isCurrent()) {
+        return
+      }
+
       const res = await setModelAssignment({
         scope: 'main',
         provider: defaults.providerSlug,
         model: defaults.defaultModel
       })
+
+      if (!isCurrent()) {
+        return
+      }
 
       notifyGatewayTools(res.gateway_tools)
     } catch {
@@ -332,6 +385,10 @@ async function completeWithModelConfirm(
   }
 
   const runtime = await checkRuntime(ctx, preferredSlugs[0])
+
+  if (!isCurrent()) {
+    return
+  }
 
   if (!runtime.ready && !ignoreRuntimeGate) {
     onFail(runtime.reason)
@@ -406,6 +463,7 @@ export function requestDesktopOnboardingForCredentialWarning(reason: null | stri
 // duplicating provider UI. Sets manual=true so the overlay shows the picker
 // even though configured===true, and refreshes the provider list.
 export function startManualOnboarding(reason: null | string = DEFAULT_MANUAL_ONBOARDING_REASON) {
+  invalidateCurrentOAuthFlow()
   patch({
     manual: true,
     requested: true,
@@ -425,6 +483,7 @@ export function startManualOnboarding(reason: null | string = DEFAULT_MANUAL_ONB
 // (`custom` is not an OAuth provider, so the generic manual flow would just
 // re-show the picker — the original "booted back to the first screen" loop).
 export function startManualLocalEndpoint(reason: null | string = null) {
+  invalidateCurrentOAuthFlow()
   pendingProviderOAuthId = null
   patch({
     manual: true,
@@ -465,13 +524,17 @@ export function clearPendingProviderOAuth() {
 // (working) configuration. Only valid in the manual path — the unconfigured
 // first-run flow has no close affordance because the app can't run yet.
 export function closeManualOnboarding() {
+  invalidateCurrentOAuthFlow()
   pendingProviderOAuthId = null
 
   patch({ manual: false, requested: false, localEndpoint: false, flow: { status: 'idle' } })
 }
 
 export function completeDesktopOnboarding() {
+  oauthOperationGeneration += 1
   clearPoll()
+  activeOAuthSessionId = null
+  dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
   writeCachedConfigured(true)
   // A real provider is now connected, so any earlier "choose later" skip is
   // moot — clear it so the flag never lingers in a configured install.
@@ -496,7 +559,7 @@ export function completeDesktopOnboarding() {
 // stops forcing the choice up front. Distinct from completeDesktopOnboarding,
 // which marks the app actually configured.
 export function dismissFirstRunOnboarding() {
-  clearPoll()
+  invalidateCurrentOAuthFlow()
   writeCachedSkipped(true)
   patch({ firstRunSkipped: true, requested: false, manual: false, localEndpoint: false, flow: { status: 'idle' } })
 }
@@ -561,12 +624,12 @@ export async function refreshOnboarding(ctx: OnboardingContext) {
 // when the bridge isn't present (e.g. the web dashboard / dev preview) so
 // the flow never silently stalls in a waiting state. Mirrors the pattern in
 // apps/desktop/src/app/artifacts/index.tsx.
-async function openSignInUrl(url: string) {
+async function openSignInUrl(url: string, isCurrent: () => boolean) {
   if (window.hermesDesktop?.openExternal) {
     try {
       await window.hermesDesktop.openExternal(url)
 
-      return
+      return true
     } catch {
       // Bridge present but failed (no OS handler, user denied, etc.). Fall
       // through to window.open so the sign-in URL still opens and the flow
@@ -574,11 +637,33 @@ async function openSignInUrl(url: string) {
     }
   }
 
-  window.open(url, '_blank', 'noopener,noreferrer')
+  if (!isCurrent()) {
+    return false
+  }
+
+  return window.open(url, '_blank', 'noopener,noreferrer') !== null
 }
 
 export async function startProviderOAuth(provider: OAuthProvider, ctx: OnboardingContext) {
+  const previousSessionId = activeOAuthSessionId
+  const previousProfile = activeOAuthProfile
+
   clearPoll()
+  const operationGeneration = ++oauthOperationGeneration
+  const operationProfile = getApiRequestProfile()
+  activeOAuthSessionId = null
+  activeOAuthProfile = null
+  dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
+
+  if (previousSessionId) {
+    await cancelOAuthSession(previousSessionId, previousProfile).catch(() => undefined)
+  }
+
+  if (operationGeneration !== oauthOperationGeneration || getApiRequestProfile() !== operationProfile) {
+    clearFlowAfterProfileChange(operationGeneration, operationProfile)
+
+    return
+  }
 
   if (provider.flow === 'external') {
     setFlow({ status: 'external_pending', provider, copied: false })
@@ -589,9 +674,50 @@ export async function startProviderOAuth(provider: OAuthProvider, ctx: Onboardin
   setFlow({ status: 'starting', provider })
 
   try {
-    const start = await startOAuthLogin(provider.id)
+    const start = await startOAuthLogin(provider.id, true, operationProfile)
+
+    if (operationGeneration !== oauthOperationGeneration || getApiRequestProfile() !== operationProfile) {
+      await cancelOAuthSession(start.session_id, operationProfile).catch(() => undefined)
+      clearFlowAfterProfileChange(operationGeneration, operationProfile)
+
+      return
+    }
+
+    activeOAuthSessionId = start.session_id
+    activeOAuthProfile = operationProfile
+
     const browserUrl = start.flow === 'device_code' ? start.verification_url : start.auth_url
-    await openSignInUrl(browserUrl)
+    const isCurrent = () => oauthOperationIsCurrent(operationGeneration, start.session_id, operationProfile)
+    const opened = await openSignInUrl(browserUrl, isCurrent)
+
+    if (!isCurrent()) {
+      await cancelOAuthSession(start.session_id, operationProfile).catch(() => undefined)
+      clearFlowAfterProfileChange(operationGeneration, operationProfile)
+
+      return
+    }
+
+    if (!opened) {
+      notify({
+        id: OAUTH_POPUP_RECOVERY_NOTIFICATION_ID,
+        kind: 'warning',
+        title: 'Sign-in window was blocked',
+        message: 'Allow pop-ups, then open the authorization page to continue.',
+        action: {
+          label: 'Open sign-in page',
+          onClick: () => {
+            if (!isCurrent()) {
+              return
+            }
+
+            window.open(browserUrl, '_blank', 'noopener,noreferrer')
+            dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
+          }
+        }
+      })
+    } else {
+      dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
+    }
 
     if (start.flow === 'pkce') {
       setFlow({ status: 'awaiting_user', provider, start, code: '' })
@@ -600,33 +726,93 @@ export async function startProviderOAuth(provider: OAuthProvider, ctx: Onboardin
     }
 
     setFlow({ status: 'polling', provider, start, copied: false })
-    pollTimer = window.setInterval(() => void pollSession(provider, start, ctx), POLL_MS)
+    pollTimer = window.setInterval(() => {
+      if (pollRequestGeneration === operationGeneration) {
+        return
+      }
+
+      pollRequestGeneration = operationGeneration
+      void pollSession(provider, start, ctx, operationGeneration, operationProfile).finally(() => {
+        if (pollRequestGeneration === operationGeneration) {
+          pollRequestGeneration = null
+        }
+      })
+    }, POLL_MS)
   } catch (error) {
+    if (operationGeneration !== oauthOperationGeneration || getApiRequestProfile() !== operationProfile) {
+      clearFlowAfterProfileChange(operationGeneration, operationProfile)
+
+      return
+    }
+
+    dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
     setFlow({ status: 'error', provider, message: `Could not start sign-in: ${errMessage(error)}` })
   }
 }
 
 // Poll a session-backed device-code flow until it resolves.
-async function pollSession(provider: OAuthProvider, start: DeviceStart, ctx: OnboardingContext) {
+async function pollSession(
+  provider: OAuthProvider,
+  start: DeviceStart,
+  ctx: OnboardingContext,
+  operationGeneration: number,
+  operationProfile: null | string
+) {
+  if (!oauthOperationIsCurrent(operationGeneration, start.session_id, operationProfile)) {
+    clearPoll()
+    dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
+    await cancelOAuthSession(start.session_id, operationProfile).catch(() => undefined)
+    clearFlowAfterProfileChange(operationGeneration, operationProfile)
+
+    return
+  }
+
   try {
-    const { error_message, status } = await pollOAuthSession(provider.id, start.session_id)
+    const { error_message, status } = await pollOAuthSession(provider.id, start.session_id, operationProfile)
+
+    if (!oauthOperationIsCurrent(operationGeneration, start.session_id, operationProfile)) {
+      clearPoll()
+      dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
+      await cancelOAuthSession(start.session_id, operationProfile).catch(() => undefined)
+      clearFlowAfterProfileChange(operationGeneration, operationProfile)
+
+      return
+    }
 
     if (status === 'approved') {
       clearPoll()
+      dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
       setFlow({ status: 'success', provider })
-      await completeWithModelConfirm(ctx, provider.name, [provider.id], reason =>
-        setFlow({
-          status: 'error',
-          provider,
-          message: providerResolutionFailure(reason)
-        })
+      await completeWithModelConfirm(
+        ctx,
+        provider.name,
+        [provider.id],
+        reason => {
+          if (oauthOperationIsCurrent(operationGeneration, start.session_id, operationProfile)) {
+            setFlow({
+              status: 'error',
+              provider,
+              message: providerResolutionFailure(reason)
+            })
+          }
+        },
+        false,
+        () => oauthOperationIsCurrent(operationGeneration, start.session_id, operationProfile)
       )
     } else if (status !== 'pending') {
       clearPoll()
+      dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
       setFlow({ status: 'error', provider, start, message: error_message || `Sign-in ${status}.` })
     }
   } catch (error) {
+    if (!oauthOperationIsCurrent(operationGeneration, start.session_id, operationProfile)) {
+      clearFlowAfterProfileChange(operationGeneration, operationProfile)
+
+      return
+    }
+
     clearPoll()
+    dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
     setFlow({ status: 'error', provider, start, message: `Polling failed: ${errMessage(error)}` })
   }
 }
@@ -647,35 +833,64 @@ export async function submitOnboardingCode(ctx: OnboardingContext) {
   }
 
   const { provider, start, code } = flow
+  const operationGeneration = oauthOperationGeneration
+  const operationProfile = activeOAuthProfile
+
+  if (getApiRequestProfile() !== operationProfile) {
+    invalidateCurrentOAuthFlow()
+    setFlow({ status: 'idle' })
+
+    return
+  }
+
+  activeOAuthSessionId = start.session_id
   setFlow({ status: 'submitting', provider, start })
 
   try {
-    const resp = await submitOAuthCode(provider.id, start.session_id, code.trim())
+    const resp = await submitOAuthCode(provider.id, start.session_id, code.trim(), operationProfile)
+
+    if (!oauthOperationIsCurrent(operationGeneration, start.session_id, operationProfile)) {
+      dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
+      await cancelOAuthSession(start.session_id, operationProfile).catch(() => undefined)
+
+      return
+    }
 
     if (resp.ok && resp.status === 'approved') {
+      dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
       setFlow({ status: 'success', provider })
-      await completeWithModelConfirm(ctx, provider.name, [provider.id], reason =>
-        setFlow({
-          status: 'error',
-          provider,
-          message: providerResolutionFailure(reason)
-        })
+      await completeWithModelConfirm(
+        ctx,
+        provider.name,
+        [provider.id],
+        reason => {
+          if (oauthOperationIsCurrent(operationGeneration, start.session_id, operationProfile)) {
+            setFlow({
+              status: 'error',
+              provider,
+              message: providerResolutionFailure(reason)
+            })
+          }
+        },
+        false,
+        () => oauthOperationIsCurrent(operationGeneration, start.session_id, operationProfile)
       )
     } else {
+      dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
       setFlow({ status: 'error', provider, start, message: resp.message || 'Token exchange failed.' })
     }
   } catch (error) {
+    if (!oauthOperationIsCurrent(operationGeneration, start.session_id, operationProfile)) {
+      return
+    }
+
+    dismissNotification(OAUTH_POPUP_RECOVERY_NOTIFICATION_ID)
     setFlow({ status: 'error', provider, start, message: errMessage(error) })
   }
 }
 
 export function cancelOnboardingFlow() {
-  clearPoll()
-  const sessionId = sessionIdFor($desktopOnboarding.get().flow)
-
-  if (sessionId) {
-    cancelOAuthSession(sessionId).catch(() => undefined)
-  }
+  invalidateCurrentOAuthFlow()
 
   setFlow({ status: 'idle' })
 }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -947,6 +947,8 @@ export interface ToolProvider {
   tag: string
   env_vars: ToolEnvVar[]
   post_setup: string | null
+  /** OAuth provider to authenticate before this backend can be selected. */
+  auth_provider?: string | null
   requires_nous_auth: boolean
   /** True when this is the provider currently written to config (mirrors the
    *  CLI `hermes tools` active-provider detection). */

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -826,6 +826,9 @@ def _normalize_lmstudio_runtime_base_url(base_url: str) -> str:
 # Such failures are transient and re-authenticating cannot resolve them, so
 # they must be kept distinct from missing/expired-credential errors.
 CODEX_RATE_LIMITED_CODE = "codex_rate_limited"
+# Four 15-second request attempts plus three capped 60-second Retry-After
+# delays, with a small scheduling margin for the dashboard worker.
+CODEX_DEVICE_CODE_START_MAX_WAIT_SECONDS = 245
 
 
 class AuthError(RuntimeError):
@@ -3671,7 +3674,13 @@ def _sync_codex_pool_entries(
         entry["last_error_reset_at"] = None
 
 
-def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: str = None) -> None:
+def _save_codex_tokens(
+    tokens: Dict[str, str],
+    last_refresh: Optional[str] = None,
+    label: Optional[str] = None,
+    *,
+    set_active: bool = True,
+) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -3689,7 +3698,9 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
         state["auth_mode"] = "chatgpt"
         if label and str(label).strip():
             state["label"] = str(label).strip()
-        _save_provider_state(auth_store, "openai-codex", state)
+        _store_provider_state(
+            auth_store, "openai-codex", state, set_active=set_active
+        )
         _sync_codex_pool_entries(
             auth_store,
             tokens,
@@ -3925,6 +3936,18 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
         return dict(tokens)
     except Exception:
         return None
+
+
+def codex_account_id_from_access_token(access_token: str) -> Optional[str]:
+    """Return the ChatGPT account id embedded in a Codex access token."""
+    claims = _decode_jwt_claims(access_token)
+    auth_claims = claims.get("https://api.openai.com/auth")
+    if not isinstance(auth_claims, dict):
+        return None
+    account_id = auth_claims.get("chatgpt_account_id")
+    if isinstance(account_id, str) and account_id.strip():
+        return account_id.strip()
+    return None
 
 
 def resolve_codex_runtime_credentials(
@@ -4368,6 +4391,21 @@ def _pool_codex_access_token() -> str:
     except Exception:
         logger.debug("Codex pool fallback lookup failed", exc_info=True)
     return ""
+
+
+def has_codex_runtime_credentials() -> bool:
+    """Return whether Hermes has a usable singleton or pooled Codex token.
+
+    This is a local auth-store probe only: it never refreshes tokens or calls
+    the network, so status and picker UIs can use it safely.
+    """
+    try:
+        from agent.credential_pool import load_pool
+
+        return load_pool("openai-codex").has_available()
+    except Exception:
+        logger.debug("Codex credential availability probe failed", exc_info=True)
+        return False
 
 
 # =============================================================================
@@ -7685,6 +7723,31 @@ def login_command(args) -> None:
     raise SystemExit(0)
 
 
+def login_openai_codex_credentials_only() -> bool:
+    """Ensure Codex OAuth credentials without changing the inference provider."""
+    if has_codex_runtime_credentials():
+        return True
+
+    creds = _codex_device_code_login()
+    _save_codex_device_login_tokens(
+        creds["tokens"],
+        creds.get("last_refresh"),
+        set_active=False,
+    )
+    return has_codex_runtime_credentials()
+
+
+def _save_codex_device_login_tokens(
+    tokens: Dict[str, Any],
+    last_refresh: Optional[str] = None,
+    *,
+    set_active: bool = True,
+) -> None:
+    """Persist an explicitly authorized device login and restore its source."""
+    unsuppress_credential_source("openai-codex", "device_code")
+    _save_codex_tokens(tokens, last_refresh, set_active=set_active)
+
+
 def _login_openai_codex(
     args,
     pconfig: ProviderConfig,
@@ -7732,7 +7795,7 @@ def _login_openai_codex(
             except (EOFError, KeyboardInterrupt):
                 do_import = "n"
             if do_import in {"y", "yes"}:
-                _save_codex_tokens(cli_tokens)
+                _save_codex_device_login_tokens(cli_tokens)
                 base_url = os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/") or DEFAULT_CODEX_BASE_URL
                 config_path = _update_config_for_provider("openai-codex", base_url)
                 print()
@@ -7750,7 +7813,7 @@ def _login_openai_codex(
     creds = _codex_device_code_login()
 
     # Save tokens to Hermes auth store
-    _save_codex_tokens(creds["tokens"], creds.get("last_refresh"))
+    _save_codex_device_login_tokens(creds["tokens"], creds.get("last_refresh"))
     config_path = _update_config_for_provider("openai-codex", creds.get("base_url", DEFAULT_CODEX_BASE_URL))
     print()
     print("Login successful!")
@@ -8012,52 +8075,50 @@ def _xai_oauth_device_code_login(
     }
 
 
-def _codex_device_code_login() -> Dict[str, Any]:
-    """Run the OpenAI device code login flow and return credentials dict."""
-    import time as _time
-
+def _request_codex_device_code(
+    *,
+    retry_notice: Optional[Callable[[int], None]] = None,
+    error_formatter: Optional[Callable[[Any], str]] = None,
+) -> Dict[str, Any]:
+    """Request a Codex device code with shared bounded 429 handling."""
     issuer = "https://auth.openai.com"
-    client_id = CODEX_OAUTH_CLIENT_ID
-
-    # Step 1: Request device code. OpenAI's auth endpoint rate-limits this
-    # request (HTTP 429) when login is attempted too often from the same
-    # IP/account — retry with capped backoff (honoring ``Retry-After``)
-    # before surfacing a clear, actionable message instead of a bare status.
-    resp = None
+    response = None
     max_attempts = 4
     for attempt in range(1, max_attempts + 1):
         try:
             with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
-                resp = client.post(
+                response = client.post(
                     f"{issuer}/api/accounts/deviceauth/usercode",
-                    json={"client_id": client_id},
+                    json={"client_id": CODEX_OAUTH_CLIENT_ID},
                     headers={"Content-Type": "application/json"},
                 )
         except Exception as exc:
             raise AuthError(
                 f"Failed to request device code: {exc}",
-                provider="openai-codex", code="device_code_request_failed",
-            )
-
-        if resp.status_code != 429:
+                provider="openai-codex",
+                code="device_code_request_failed",
+            ) from exc
+        if response.status_code != 429:
             break
-
         if attempt < max_attempts:
             retry_after = _parse_retry_after_seconds(
-                getattr(resp, "headers", None)
+                getattr(response, "headers", None)
             )
-            # Exponential backoff (2s, 4s, 8s) capped, preferring the
-            # server-provided Retry-After when present.
-            delay = retry_after if retry_after is not None else 2 ** attempt
-            delay = max(1, min(int(delay), 60))
-            print(
-                "OpenAI is rate-limiting login requests "
-                f"(429); retrying in {delay}s..."
+            delay = max(
+                1,
+                min(
+                    int(retry_after if retry_after is not None else 2**attempt),
+                    60,
+                ),
             )
-            _time.sleep(delay)
+            if retry_notice:
+                retry_notice(delay)
+            time.sleep(delay)
 
-    if resp is not None and resp.status_code == 429:
-        retry_after = _parse_retry_after_seconds(getattr(resp, "headers", None))
+    if response is not None and response.status_code == 429:
+        retry_after = _parse_retry_after_seconds(
+            getattr(response, "headers", None)
+        )
         wait_hint = (
             f" Try again in about {retry_after}s."
             if retry_after is not None
@@ -8067,17 +8128,88 @@ def _codex_device_code_login() -> Dict[str, Any]:
             "OpenAI is rate-limiting Codex login requests (HTTP 429). "
             "This is a temporary throttle on OpenAI's side, not a credential "
             f"problem.{wait_hint}",
-            provider="openai-codex", code=CODEX_RATE_LIMITED_CODE,
+            provider="openai-codex",
+            code=CODEX_RATE_LIMITED_CODE,
         )
-
-    if resp is None or resp.status_code != 200:
-        status = resp.status_code if resp is not None else "unknown"
+    if response is None or response.status_code != 200:
+        status = response.status_code if response is not None else "unknown"
+        message = (
+            error_formatter(response)
+            if error_formatter is not None and response is not None
+            else f"Device code request returned status {status}."
+        )
         raise AuthError(
-            f"Device code request returned status {status}.",
-            provider="openai-codex", code="device_code_request_error",
+            message,
+            provider="openai-codex",
+            code="device_code_request_error",
         )
+    return response.json()
 
-    device_data = resp.json()
+
+def _exchange_codex_device_tokens(
+    authorization_code: str, code_verifier: str
+) -> Dict[str, Any]:
+    """Exchange a Codex device authorization code with shared 429 classification."""
+    issuer = "https://auth.openai.com"
+    try:
+        with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
+            response = client.post(
+                CODEX_OAUTH_TOKEN_URL,
+                data={
+                    "grant_type": "authorization_code",
+                    "code": authorization_code,
+                    "redirect_uri": f"{issuer}/deviceauth/callback",
+                    "client_id": CODEX_OAUTH_CLIENT_ID,
+                    "code_verifier": code_verifier,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+    except Exception as exc:
+        raise AuthError(
+            f"Token exchange failed: {exc}",
+            provider="openai-codex",
+            code="token_exchange_failed",
+        ) from exc
+
+    if response.status_code == 429:
+        retry_after = _parse_retry_after_seconds(getattr(response, "headers", None))
+        wait_hint = (
+            f" Try again in about {retry_after}s."
+            if retry_after is not None
+            else " Wait a minute and run the login again."
+        )
+        raise AuthError(
+            "OpenAI is rate-limiting Codex login requests (HTTP 429) during "
+            "token exchange. This is a temporary throttle on OpenAI's side, "
+            f"not a credential problem.{wait_hint}",
+            provider="openai-codex",
+            code=CODEX_RATE_LIMITED_CODE,
+        )
+    if response.status_code != 200:
+        raise AuthError(
+            f"Token exchange returned status {response.status_code}.",
+            provider="openai-codex",
+            code="token_exchange_error",
+        )
+    return response.json()
+
+
+def _codex_device_code_login() -> Dict[str, Any]:
+    """Run the OpenAI device code login flow and return credentials dict."""
+    import time as _time
+
+    issuer = "https://auth.openai.com"
+
+    # Step 1: Request device code. OpenAI's auth endpoint rate-limits this
+    # request (HTTP 429) when login is attempted too often from the same
+    # IP/account — retry with capped backoff (honoring ``Retry-After``)
+    # before surfacing a clear, actionable message instead of a bare status.
+    device_data = _request_codex_device_code(
+        retry_notice=lambda delay: print(
+            "OpenAI is rate-limiting login requests "
+            f"(429); retrying in {delay}s..."
+        )
+    )
     user_code = device_data.get("user_code", "")
     device_auth_id = device_data.get("device_auth_id", "")
     poll_interval = max(3, int(device_data.get("interval", "5")))
@@ -8134,7 +8266,6 @@ def _codex_device_code_login() -> Dict[str, Any]:
     # Step 4: Exchange authorization code for tokens
     authorization_code = code_resp.get("authorization_code", "")
     code_verifier = code_resp.get("code_verifier", "")
-    redirect_uri = f"{issuer}/deviceauth/callback"
 
     if not authorization_code or not code_verifier:
         raise AuthError(
@@ -8142,48 +8273,7 @@ def _codex_device_code_login() -> Dict[str, Any]:
             provider="openai-codex", code="device_code_incomplete_exchange",
         )
 
-    try:
-        with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
-            token_resp = client.post(
-                CODEX_OAUTH_TOKEN_URL,
-                data={
-                    "grant_type": "authorization_code",
-                    "code": authorization_code,
-                    "redirect_uri": redirect_uri,
-                    "client_id": client_id,
-                    "code_verifier": code_verifier,
-                },
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-            )
-    except Exception as exc:
-        raise AuthError(
-            f"Token exchange failed: {exc}",
-            provider="openai-codex", code="token_exchange_failed",
-        )
-
-    if token_resp.status_code == 429:
-        retry_after = _parse_retry_after_seconds(
-            getattr(token_resp, "headers", None)
-        )
-        wait_hint = (
-            f" Try again in about {retry_after}s."
-            if retry_after is not None
-            else " Wait a minute and run the login again."
-        )
-        raise AuthError(
-            "OpenAI is rate-limiting Codex login requests (HTTP 429) during "
-            "token exchange. This is a temporary throttle on OpenAI's side, "
-            f"not a credential problem.{wait_hint}",
-            provider="openai-codex", code=CODEX_RATE_LIMITED_CODE,
-        )
-
-    if token_resp.status_code != 200:
-        raise AuthError(
-            f"Token exchange returned status {token_resp.status_code}.",
-            provider="openai-codex", code="token_exchange_error",
-        )
-
-    tokens = token_resp.json()
+    tokens = _exchange_codex_device_tokens(authorization_code, code_verifier)
     access_token = tokens.get("access_token", "")
     refresh_token = tokens.get("refresh_token", "")
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1507,7 +1507,8 @@ DEFAULT_CONFIG = {
         # the raw transcript is also echoed back to the user as a 🎙️ message.
         # Set false to keep STT for the agent while suppressing that user-facing echo.
         "echo_transcripts": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe) | "deepinfra"
+        # Built-in and plugin provider names are documented in the voice-mode guide.
+        "provider": "local",
         # Global language hint applied to EVERY provider unless a per-provider
         # language overrides it. Defaults to "en" — Whisper auto-detection
         # frequently misidentifies short/accented clips, which reads as
@@ -1532,6 +1533,9 @@ DEFAULT_CONFIG = {
         "openai": {
             "model": "whisper-1",  # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe, gpt-transcribe
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
+        },
+        "openai_codex": {
+            "timeout": 120,
         },
         "mistral": {
             "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -243,6 +243,7 @@ def _tts_label(current_provider: str) -> str:
 def _stt_label(current_provider: str) -> str:
     mapping = {
         "openai": "OpenAI Whisper",
+        "openai-codex": "OpenAI Codex OAuth",
         "groq": "Groq Whisper",
         "mistral": "Mistral Voxtral Transcribe",
         "local": "Local faster-whisper",
@@ -264,6 +265,16 @@ def _local_stt_backend_available() -> bool:
         from tools.transcription_tools import _HAS_FASTER_WHISPER
 
         return bool(_HAS_FASTER_WHISPER)
+    except Exception:
+        return False
+
+
+def _codex_stt_backend_available() -> bool:
+    """Return whether Hermes has locally stored Codex OAuth credentials."""
+    try:
+        from hermes_cli.auth import has_codex_runtime_credentials
+
+        return has_codex_runtime_credentials()
     except Exception:
         return False
 
@@ -443,6 +454,9 @@ def get_nous_subscription_features(
     # signal is whether faster-whisper is importable; we lazy-import so
     # this module stays cheap on the happy path.
     direct_openai_stt = bool(resolve_openai_audio_api_key())
+    direct_codex_stt = bool(
+        stt_provider == "openai-codex" and _codex_stt_backend_available()
+    )
     direct_groq_stt = bool(get_env_value("GROQ_API_KEY"))
     direct_mistral_stt = bool(get_env_value("MISTRAL_API_KEY"))
     try:
@@ -468,6 +482,7 @@ def get_nous_subscription_features(
         direct_elevenlabs = False
     if stt_use_gateway:
         direct_openai_stt = False
+        direct_codex_stt = False
         direct_groq_stt = False
         direct_mistral_stt = False
         local_stt_available = False
@@ -583,6 +598,7 @@ def get_nous_subscription_features(
     )
     stt_available = bool(
         (stt_current_provider == "local" and local_stt_available)
+        or (stt_current_provider == "openai-codex" and direct_codex_stt)
         or (stt_current_provider == "openai" and (managed_stt_available or direct_openai_stt))
         or (stt_current_provider == "groq" and direct_groq_stt)
         or (stt_current_provider == "mistral" and direct_mistral_stt)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -915,7 +915,7 @@ class PluginContext:
 
         1. ``provider.name`` is NOT a built-in STT provider name
            (``local``, ``local_command``, ``groq``, ``openai``,
-           ``mistral``, ``xai``). Built-ins always win — the registry
+           ``openai-codex``, ``mistral``, ``xai``). Built-ins always win — the registry
            rejects shadowing names with a warning.
         2. There is NO ``stt.providers.<name>: type: command`` entry
            with the same name. Command-providers win on name
@@ -923,7 +923,7 @@ class PluginContext:
            — same precedence rule as TTS.
 
         Coexists with the in-tree dispatcher and the STT
-        command-provider registry rather than replacing them. The 6
+        command-provider registry rather than replacing them. The
         built-in STT backends keep their native implementations in
         ``tools/transcription_tools.py``; this hook is for *new* Python
         engines (OpenRouter, SenseAudio, Gemini-STT, custom proprietary

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -576,6 +576,20 @@ def _print_setup_summary(config: dict, hermes_home):
         get_env_value("VOICE_TOOLS_OPENAI_KEY") or get_env_value("OPENAI_API_KEY")
     ):
         tool_status.append(("Speech-to-Text (OpenAI)", True, None))
+    elif stt_provider == "openai-codex":
+        try:
+            from hermes_cli.auth import has_codex_runtime_credentials
+
+            codex_ready = has_codex_runtime_credentials()
+        except Exception:
+            codex_ready = False
+        tool_status.append(
+            (
+                "Speech-to-Text (OpenAI Codex OAuth)",
+                codex_ready,
+                None if codex_ready else "run 'hermes auth add openai-codex'",
+            )
+        )
     elif stt_provider == "groq" and get_env_value("GROQ_API_KEY"):
         tool_status.append(("Speech-to-Text (Groq Whisper)", True, None))
     elif stt_provider == "elevenlabs" and get_env_value("ELEVENLABS_API_KEY"):

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -434,6 +434,14 @@ TOOL_CATEGORIES = {
                 "override_env_vars": ["VOICE_TOOLS_OPENAI_KEY", "OPENAI_API_KEY"],
             },
             {
+                "name": "OpenAI Codex OAuth",
+                "badge": "subscription",
+                "tag": "ChatGPT/Codex dictation via your existing OAuth login",
+                "env_vars": [],
+                "auth_provider": "openai-codex",
+                "stt_provider": "openai-codex",
+            },
+            {
                 "name": "OpenAI",
                 "badge": "paid",
                 "tag": "whisper-1, gpt-4o-transcribe, gpt-transcribe",
@@ -1939,6 +1947,34 @@ def _run_post_setup(post_setup_key: str):
         _print_info("    Restart Hermes for tracing to take effect.")
         _print_info("    Verify: hermes plugins list")
 
+    elif post_setup_key == "openai_codex":
+        try:
+            from hermes_cli.auth import (
+                has_codex_runtime_credentials,
+                login_openai_codex_credentials_only,
+            )
+        except Exception as exc:
+            _print_warning(f"    Could not load OpenAI Codex auth helpers: {exc}")
+            _print_info("    Run later: hermes auth add openai-codex")
+            return False
+
+        if has_codex_runtime_credentials():
+            _print_success("    OpenAI Codex OAuth credentials are already configured")
+            return True
+
+        _print_info("    OpenAI Codex OAuth login is required for transcription.")
+        try:
+            if login_openai_codex_credentials_only():
+                _print_success("    OpenAI Codex OAuth credentials saved")
+                return True
+        except (Exception, SystemExit) as exc:
+            logger.debug("OpenAI Codex credential-only login failed: %s", exc)
+        _print_warning(
+            "    OpenAI Codex login did not complete. "
+            "Run later: hermes auth add openai-codex"
+        )
+        return False
+
     elif post_setup_key == "xai_grok":
         # Shared credential bootstrap for any picker entry that talks to xAI
         # (TTS, Video Gen, future Image Gen, etc.). Accepts either a
@@ -2061,9 +2097,12 @@ def run_post_setup_command(args) -> int:
         return 2
     _print_info(f"Running post-setup hook: {key}")
     try:
-        _run_post_setup(key)
+        result = _run_post_setup(key)
     except Exception as exc:  # pragma: no cover — defensive
         _print_error(f"Post-setup failed: {exc}")
+        return 1
+    if result is False:
+        _print_error(f"Post-setup '{key}' did not complete")
         return 1
     _print_success(f"Post-setup '{key}' complete")
     return 0
@@ -3344,6 +3383,15 @@ def provider_readiness_status(
         # carry a local install hook (e.g. the managed browser row needs
         # the agent-browser CLI on this machine).
 
+    auth_provider = provider.get("auth_provider")
+    if auth_provider == "openai-codex":
+        try:
+            from hermes_cli.auth import has_codex_runtime_credentials
+
+            return "ready" if has_codex_runtime_credentials() else "needs_auth"
+        except Exception:
+            return "needs_auth"
+
     post_setup = provider.get("post_setup")
     if post_setup:
         if post_setup == "xai_grok":
@@ -4187,6 +4235,17 @@ def _configure_provider(
             )
             return
 
+    if provider.get("auth_provider") == "openai-codex":
+        from hermes_cli.auth import has_codex_runtime_credentials
+
+        if not has_codex_runtime_credentials():
+            _run_post_setup("openai_codex")
+        if not has_codex_runtime_credentials():
+            _print_warning(
+                "  Not enabled — OpenAI Codex OAuth login is required for transcription."
+            )
+            return
+
     # Set TTS provider in config if applicable
     if provider.get("tts_provider"):
         tts_cfg = config.setdefault("tts", {})
@@ -4693,6 +4752,17 @@ def _reconfigure_provider(
             )
             _print_warning(
                 f"  {message or 'Nous Subscription is only available after logging into Nous Portal.'}"
+            )
+            return
+
+    if provider.get("auth_provider") == "openai-codex":
+        from hermes_cli.auth import has_codex_runtime_credentials
+
+        if not has_codex_runtime_credentials():
+            _run_post_setup("openai_codex")
+        if not has_codex_runtime_credentials():
+            _print_warning(
+                "  Not enabled — OpenAI Codex OAuth login is required for transcription."
             )
             return
 

--- a/hermes_cli/web_routers/tools.py
+++ b/hermes_cli/web_routers/tools.py
@@ -235,6 +235,7 @@ async def get_toolset_config(name: str, profile: Optional[str] = None):
                     "tag": prov.get("tag", ""),
                     "env_vars": env_vars,
                     "post_setup": prov.get("post_setup"),
+                    "auth_provider": prov.get("auth_provider"),
                     "requires_nous_auth": bool(prov.get("requires_nous_auth")),
                     "is_active": is_active,
                     # Honest server-side readiness. The GUI's old client-side
@@ -425,6 +426,7 @@ async def select_toolset_provider(
     from hermes_cli.tools_config import (
         TOOL_CATEGORIES,
         apply_provider_selection,
+        provider_readiness_status,
         web_provider_capabilities,
         _get_effective_configurable_toolsets,
         _visible_providers,
@@ -482,6 +484,27 @@ async def select_toolset_provider(
                 config["web"] = web_cfg
             web_cfg[f"{body.capability}_backend"] = backend
         else:
+            cat = TOOL_CATEGORIES.get(name)
+            row = None
+            if cat:
+                row = next(
+                    (
+                        p
+                        for p in _visible_providers(cat, config, force_fresh=True)
+                        if p.get("name") == body.provider
+                    ),
+                    None,
+                )
+            if row and row.get("auth_provider"):
+                status = provider_readiness_status(row, config)
+                if status == "needs_auth":
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            f"Authenticate {row['auth_provider']} before selecting "
+                            f"{body.provider}"
+                        ),
+                    )
             try:
                 apply_provider_selection(name, body.provider, config)
             except KeyError as exc:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10118,7 +10118,16 @@ def _oauth_session_profile(
     with _oauth_sessions_lock:
         sess = _oauth_sessions.get(session_id)
         profile = sess.get("profile") if sess else None
-    return profile or _oauth_profile_name(fallback)
+    # A registered session always owns the profile captured at creation.  In
+    # particular, ``None`` means the default profile and must not fall through
+    # to a later request's currently-selected profile.
+    return profile if sess is not None else _oauth_profile_name(fallback)
+
+
+def _require_oauth_session_profile(sess: Dict[str, Any], profile: Optional[str]) -> None:
+    """Reject cross-profile access to a profile-owned OAuth session."""
+    if sess.get("profile") != _oauth_profile_name(profile):
+        raise HTTPException(status_code=409, detail="Profile mismatch for OAuth session")
 
 
 def _save_anthropic_oauth_creds(access_token: str, refresh_token: str, expires_at_ms: int) -> None:
@@ -10215,6 +10224,7 @@ def _submit_anthropic_pkce(
         sess = _oauth_sessions.get(session_id)
     if not sess or sess["provider"] != "anthropic" or sess["flow"] != "pkce":
         raise HTTPException(status_code=404, detail="Unknown or expired session")
+    _require_oauth_session_profile(sess, profile)
     if sess["status"] != "pending":
         return {"ok": False, "status": sess["status"], "message": sess.get("error_message")}
 
@@ -10288,6 +10298,8 @@ def _submit_anthropic_pkce(
 async def _start_device_code_flow(
     provider_id: str,
     profile: Optional[str] = None,
+    *,
+    activate_provider: bool = True,
 ) -> Dict[str, Any]:
     """Initiate a device-code flow (Nous, OpenAI Codex, MiniMax, or xAI).
 
@@ -10348,8 +10360,11 @@ async def _start_device_code_flow(
         }
 
     if provider_id == "openai-codex":
+        from hermes_cli.auth import CODEX_DEVICE_CODE_START_MAX_WAIT_SECONDS
+
         # Codex uses fixed OpenAI device-auth endpoints; reuse the helper.
-        sid, _ = _new_oauth_session("openai-codex", "device_code", profile=profile)
+        sid, sess = _new_oauth_session("openai-codex", "device_code", profile=profile)
+        sess["activate_provider"] = activate_provider
         # Use the helper but in a thread because it polls inline.
         # We can't extract just the start step without refactoring auth.py,
         # so we run the full helper in a worker and proxy the user_code +
@@ -10359,8 +10374,11 @@ async def _start_device_code_flow(
             target=_codex_full_login_worker, args=(sid,), daemon=True,
             name=f"oauth-codex-{sid[:6]}",
         ).start()
-        # Block briefly until the worker has populated the user_code, OR error.
-        deadline = time.monotonic() + 10
+        # Wait through the bounded device-code request/retry window until the
+        # worker has populated the user_code, or surfaced an error.
+        deadline = (
+            time.monotonic() + CODEX_DEVICE_CODE_START_MAX_WAIT_SECONDS
+        )
         while time.monotonic() < deadline:
             with _oauth_sessions_lock:
                 s = _oauth_sessions.get(sid)
@@ -10372,6 +10390,8 @@ async def _start_device_code_flow(
         if s.get("status") == "error":
             raise HTTPException(status_code=500, detail=s.get("error_message") or "device-auth failed")
         if not s.get("user_code"):
+            with _oauth_sessions_lock:
+                _oauth_sessions.pop(sid, None)
             raise HTTPException(status_code=504, detail="device-auth timed out before returning a user code")
         return {
             "session_id": sid,
@@ -10782,21 +10802,15 @@ def _codex_full_login_worker(session_id: str) -> None:
     try:
         import httpx
         from hermes_cli.auth import (
-            CODEX_OAUTH_CLIENT_ID,
-            CODEX_OAUTH_TOKEN_URL,
+            _exchange_codex_device_tokens,
+            _request_codex_device_code,
         )
         issuer = "https://auth.openai.com"
 
         # Step 1: request device code
-        with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
-            resp = client.post(
-                f"{issuer}/api/accounts/deviceauth/usercode",
-                json={"client_id": CODEX_OAUTH_CLIENT_ID},
-                headers={"Content-Type": "application/json"},
-            )
-        if resp.status_code != 200:
-            raise RuntimeError(_codex_device_code_start_error(resp))
-        device_data = resp.json()
+        device_data = _request_codex_device_code(
+            error_formatter=_codex_device_code_start_error
+        )
         user_code = device_data.get("user_code", "")
         device_auth_id = device_data.get("device_auth_id", "")
         poll_interval = max(3, int(device_data.get("interval", "5")))
@@ -10827,9 +10841,10 @@ def _codex_full_login_worker(session_id: str) -> None:
                     _log.info("oauth/device: openai-codex login cancelled (session=%s)", session_id)
                     return
                 time.sleep(poll_interval)
-                if sess.get("cancelled"):
-                    _log.info("oauth/device: openai-codex login cancelled (session=%s)", session_id)
-                    return
+                with _oauth_sessions_lock:
+                    current = _oauth_sessions.get(session_id)
+                    if current is not sess or current.get("cancelled"):
+                        return
                 poll = client.post(
                     f"{issuer}/api/accounts/deviceauth/token",
                     json={"device_auth_id": device_auth_id, "user_code": user_code},
@@ -10844,8 +10859,10 @@ def _codex_full_login_worker(session_id: str) -> None:
 
         if code_resp is None:
             with _oauth_sessions_lock:
-                sess["status"] = "expired"
-                sess["error_message"] = "Device code expired before approval"
+                current = _oauth_sessions.get(session_id)
+                if current:
+                    current["status"] = "expired"
+                    current["error_message"] = "Device code expired before approval"
             return
 
         if sess.get("cancelled"):
@@ -10857,46 +10874,29 @@ def _codex_full_login_worker(session_id: str) -> None:
         code_verifier = code_resp.get("code_verifier", "")
         if not authorization_code or not code_verifier:
             raise RuntimeError("device-auth response missing authorization_code/code_verifier")
-        with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
-            token_resp = client.post(
-                CODEX_OAUTH_TOKEN_URL,
-                data={
-                    "grant_type": "authorization_code",
-                    "code": authorization_code,
-                    "redirect_uri": f"{issuer}/deviceauth/callback",
-                    "client_id": CODEX_OAUTH_CLIENT_ID,
-                    "code_verifier": code_verifier,
-                },
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-            )
-        if token_resp.status_code != 200:
-            raise RuntimeError(f"token exchange returned {token_resp.status_code}")
-        tokens = token_resp.json()
+        tokens = _exchange_codex_device_tokens(authorization_code, code_verifier)
         access_token = tokens.get("access_token", "")
         refresh_token = tokens.get("refresh_token", "")
         if not access_token:
             raise RuntimeError("token exchange did not return access_token")
 
-        from hermes_cli.auth import _save_codex_tokens
+        from hermes_cli.auth import _save_codex_device_login_tokens
 
-        # The cancellation check and the save must be one atomic critical
-        # section under the same lock cancel_oauth_session() uses. Checking
-        # "cancelled" and then saving as two separate steps left a window
-        # where DELETE could flip the flag between them and the worker would
-        # still persist tokens after the user believed the login was
-        # aborted. Holding the lock across both closes that window: DELETE
-        # either lands before this section (worker observes cancelled and
-        # returns) or blocks until this section (and the save) is done.
         with _oauth_sessions_lock:
-            if sess.get("cancelled"):
-                _log.info("oauth/device: openai-codex login cancelled before token save (session=%s)", session_id)
+            current = _oauth_sessions.get(session_id)
+            if current is not sess or current.get("cancelled"):
                 return
-            with _profile_scope(session_profile):
-                _save_codex_tokens({
-                    "access_token": access_token,
-                    "refresh_token": refresh_token,
-                })
-            sess["status"] = "approved"
+            # Keep cancellation and persistence atomic: cancellation acquires
+            # this same lock before removing the session.
+            with _profile_scope(current.get("profile")):
+                _save_codex_device_login_tokens(
+                    {
+                        "access_token": access_token,
+                        "refresh_token": refresh_token,
+                    },
+                    set_active=bool(current.get("activate_provider", True)),
+                )
+            current["status"] = "approved"
         _log.info("oauth/device: openai-codex login completed (session=%s)", session_id)
     except Exception as e:
         _log.warning("codex device-code worker failed (session=%s): %s", session_id, e)
@@ -10912,6 +10912,7 @@ async def start_oauth_login(
     provider_id: str,
     request: Request,
     profile: Optional[str] = None,
+    activate_provider: bool = True,
 ):
     """Initiate an OAuth login flow. Token-protected."""
     _require_token(request)
@@ -10936,7 +10937,11 @@ async def start_oauth_login(
         if catalog_entry["flow"] == "pkce" and provider_id == "anthropic":
             return _start_anthropic_pkce(profile=profile)
         if catalog_entry["flow"] == "device_code":
-            return await _start_device_code_flow(provider_id, profile=profile)
+            return await _start_device_code_flow(
+                provider_id,
+                profile=profile,
+                activate_provider=activate_provider,
+            )
     except HTTPException:
         raise
     except Exception as e:
@@ -10979,6 +10984,7 @@ async def poll_oauth_session(
         raise HTTPException(status_code=404, detail="Session not found or expired")
     if sess["provider"] != provider_id:
         raise HTTPException(status_code=400, detail="Provider mismatch for session")
+    _require_oauth_session_profile(sess, profile)
     return {
         "session_id": session_id,
         "status": sess["status"],
@@ -11005,6 +11011,7 @@ async def cancel_oauth_session(
     with _oauth_sessions_lock:
         sess = _oauth_sessions.get(session_id)
         if sess is not None:
+            _require_oauth_session_profile(sess, profile)
             sess["cancelled"] = True
         _oauth_sessions.pop(session_id, None)
     if sess is None:

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -580,6 +580,43 @@ def test_is_rate_limited_auth_error_distinguishes_credential_errors():
     assert is_rate_limited_auth_error(ValueError("nope")) is False
 
 
+def test_login_openai_codex_force_new_login_skips_existing_reuse_prompt(monkeypatch):
+    called = {"device_login": 0}
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        lambda: {"base_url": DEFAULT_CODEX_BASE_URL},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._import_codex_cli_tokens",
+        lambda: {"access_token": "cli-at", "refresh_token": "cli-rt"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_device_code_login",
+        lambda: {
+            "tokens": {"access_token": "fresh-at", "refresh_token": "fresh-rt"},
+            "last_refresh": "2026-04-01T00:00:00Z",
+            "base_url": DEFAULT_CODEX_BASE_URL,
+        },
+    )
+
+    def _fake_save(tokens, last_refresh=None, *, set_active=True):
+        called["device_login"] += 1
+        called["tokens"] = dict(tokens)
+        called["last_refresh"] = last_refresh
+        called["set_active"] = set_active
+
+    monkeypatch.setattr("hermes_cli.auth._save_codex_device_login_tokens", _fake_save)
+    monkeypatch.setattr("hermes_cli.auth._update_config_for_provider", lambda *args, **kwargs: "/tmp/config.yaml")
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda prompt="": (_ for _ in ()).throw(AssertionError("force_new_login should not prompt for reuse/import")),
+    )
+
+    _login_openai_codex(SimpleNamespace(), PROVIDER_REGISTRY["openai-codex"], force_new_login=True)
+
+    assert called["device_login"] == 1
+    assert called["tokens"]["access_token"] == "fresh-at"
 
 
 class _FakeResp:

--- a/tests/hermes_cli/test_codex_stt_auth_helpers.py
+++ b/tests/hermes_cli/test_codex_stt_auth_helpers.py
@@ -1,0 +1,120 @@
+"""Tests for public Codex auth helpers used by speech-to-text UIs."""
+
+import base64
+import json
+import time
+from unittest.mock import Mock, patch
+
+from hermes_cli.auth import (
+    codex_account_id_from_access_token,
+    has_codex_runtime_credentials,
+    login_openai_codex_credentials_only,
+)
+
+
+def _jwt(claims: dict) -> str:
+    def _part(payload: dict) -> str:
+        raw = json.dumps(payload, separators=(",", ":")).encode()
+        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+    return f"{_part({'alg': 'none'})}.{_part(claims)}.sig"
+
+
+def test_codex_account_id_is_read_from_access_token_claims():
+    token = _jwt(
+        {
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": " account-123 "
+            }
+        }
+    )
+
+    assert codex_account_id_from_access_token(token) == "account-123"
+
+
+def test_codex_credential_probe_uses_read_only_pool_availability():
+    pool = Mock()
+    pool.has_available.return_value = True
+    with patch("agent.credential_pool.load_pool", return_value=pool):
+        assert has_codex_runtime_credentials() is True
+
+    pool.has_available.assert_called_once_with()
+    pool.select.assert_not_called()
+
+
+def test_codex_credential_probe_reports_exhausted_pool_unavailable():
+    pool = Mock()
+    pool.has_available.return_value = False
+    with patch("agent.credential_pool.load_pool", return_value=pool):
+        assert has_codex_runtime_credentials() is False
+
+
+def test_codex_credentials_only_login_does_not_activate_model_provider():
+    credentials = {
+        "tokens": {
+            "access_token": "new-token",
+            "refresh_token": "refresh-token",
+        },
+        "last_refresh": "now",
+    }
+    with (
+        patch(
+            "hermes_cli.auth.has_codex_runtime_credentials",
+            side_effect=[False, True],
+        ),
+        patch(
+            "hermes_cli.auth._codex_device_code_login",
+            return_value=credentials,
+        ),
+        patch("hermes_cli.auth._save_codex_device_login_tokens") as save_tokens,
+        patch("hermes_cli.auth._update_config_for_provider") as update_model,
+    ):
+        assert login_openai_codex_credentials_only() is True
+
+    save_tokens.assert_called_once_with(
+        credentials["tokens"], "now", set_active=False
+    )
+    update_model.assert_not_called()
+
+
+def test_codex_credentials_only_relogin_restores_suppressed_device_source(
+    tmp_path, monkeypatch
+):
+    token = _jwt(
+        {
+            "exp": int(time.time()) + 3600,
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "account-123"
+            },
+        }
+    )
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "active_provider": "anthropic",
+                "providers": {"anthropic": {"api_key": "anthropic-key"}},
+                "suppressed_sources": {"openai-codex": ["device_code"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("model:\n  provider: anthropic\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_device_code_login",
+        lambda: {
+            "tokens": {"access_token": token, "refresh_token": "refresh-token"},
+            "last_refresh": "now",
+        },
+    )
+
+    assert login_openai_codex_credentials_only() is True
+
+    saved = json.loads(auth_path.read_text(encoding="utf-8"))
+    assert saved["active_provider"] == "anthropic"
+    assert "device_code" not in saved.get("suppressed_sources", {}).get(
+        "openai-codex", []
+    )
+    assert config_path.read_text(encoding="utf-8") == "model:\n  provider: anthropic\n"

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -2,6 +2,7 @@
 
 from hermes_cli.nous_account import NousPortalAccountInfo, NousToolAccessInfo
 from hermes_cli import nous_subscription as ns
+from hermes_cli import auth
 
 
 _POOL_COVERAGE = {
@@ -182,6 +183,41 @@ def test_apply_nous_managed_defaults_writes_video_gen_config(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def test_stt_codex_oauth_provider_uses_hermes_auth_store(monkeypatch):
+    monkeypatch.setattr(ns, "get_env_value", lambda name: "")
+    monkeypatch.setattr(
+        ns,
+        "get_nous_portal_account_info",
+        lambda **kw: _account(logged_in=False),
+    )
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: False)
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "_codex_stt_backend_available", lambda: True)
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+    monkeypatch.setattr(ns, "is_managed_tool_gateway_ready", lambda vendor: False)
+
+    features = ns.get_nous_subscription_features(
+        {"stt": {"provider": "openai-codex"}}
+    )
+
+    assert features.stt.available is True
+    assert features.stt.active is True
+    assert features.stt.managed_by_nous is False
+    assert features.stt.current_provider == "OpenAI Codex OAuth"
+    assert features.stt.explicit_configured is True
+
+
+def test_codex_stt_backend_uses_local_credential_probe(monkeypatch):
+    monkeypatch.setattr(auth, "has_codex_runtime_credentials", lambda: True)
+
+    assert ns._codex_stt_backend_available() is True
+
+
+def test_codex_stt_backend_is_unavailable_without_credentials(monkeypatch):
+    monkeypatch.setattr(auth, "has_codex_runtime_credentials", lambda: False)
+
+    assert ns._codex_stt_backend_available() is False
 
 
 

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -129,6 +129,40 @@ def test_setup_copilot_acp_skips_same_provider_pool_step(tmp_path, monkeypatch):
     assert config.get("credential_pool_strategies", {}) == {}
 
 
+def test_setup_summary_reports_codex_stt_ready(tmp_path, monkeypatch, capsys):
+    from hermes_cli import auth
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(auth, "has_codex_runtime_credentials", lambda: True)
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
+    config = load_config()
+    config["stt"]["provider"] = "openai-codex"
+
+    _print_setup_summary(config, tmp_path)
+    output = capsys.readouterr().out
+
+    assert "Speech-to-Text (OpenAI Codex OAuth)" in output
+    assert "hermes auth add openai-codex" not in output
+
+
+def test_setup_summary_reports_missing_codex_stt_auth(tmp_path, monkeypatch, capsys):
+    from hermes_cli import auth
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setattr(auth, "has_codex_runtime_credentials", lambda: False)
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
+    config = load_config()
+    config["stt"]["provider"] = "openai-codex"
+
+    _print_setup_summary(config, tmp_path)
+    output = capsys.readouterr().out
+
+    assert "Speech-to-Text (OpenAI Codex OAuth)" in output
+    assert "hermes auth add openai-codex" in output
+
+
 def test_setup_summary_local_browser_unavailable_without_chromium(
     tmp_path, monkeypatch, capsys
 ):

--- a/tests/hermes_cli/test_stt_picker.py
+++ b/tests/hermes_cli/test_stt_picker.py
@@ -20,10 +20,13 @@ from hermes_cli.tools_config import (  # noqa: E402
     STT_MODEL_CATALOG,
     TOOL_CATEGORIES,
     _checklist_toolset_keys,
+    _configure_provider,
     _configure_stt_model,
     _is_provider_active,
+    _reconfigure_provider,
     _write_provider_config,
     apply_provider_selection,
+    provider_readiness_status,
 )
 
 
@@ -122,3 +125,68 @@ class TestPostSetup:
         from hermes_cli.tools_config import _POST_SETUP_READY
 
         assert "faster_whisper" in _POST_SETUP_READY
+
+    def test_codex_row_declares_oauth_provider(self):
+        provider = _stt_provider_named("OpenAI Codex OAuth")
+        assert provider["auth_provider"] == "openai-codex"
+        assert "post_setup" not in provider
+
+    @pytest.mark.parametrize(
+        ("credentials_present", "expected"),
+        [(False, "needs_auth"), (True, "ready")],
+    )
+    def test_codex_readiness_tracks_oauth_credentials(
+        self, monkeypatch, credentials_present, expected
+    ):
+        from hermes_cli import auth
+
+        monkeypatch.setattr(
+            auth,
+            "has_codex_runtime_credentials",
+            lambda: credentials_present,
+        )
+        assert (
+            provider_readiness_status(
+                _stt_provider_named("OpenAI Codex OAuth"), {}
+            )
+            == expected
+        )
+
+    def test_failed_codex_login_does_not_select_provider(self, monkeypatch):
+        from hermes_cli import auth
+
+        monkeypatch.setattr(auth, "has_codex_runtime_credentials", lambda: False)
+        config = {}
+        with patch("hermes_cli.tools_config._run_post_setup") as post_setup:
+            _configure_provider(
+                _stt_provider_named("OpenAI Codex OAuth"), config
+            )
+
+        post_setup.assert_called_once_with("openai_codex")
+        assert config == {}
+
+    def test_authenticated_codex_selection_writes_provider(self, monkeypatch):
+        from hermes_cli import auth
+
+        monkeypatch.setattr(auth, "has_codex_runtime_credentials", lambda: True)
+        config = {}
+        with patch("hermes_cli.tools_config._run_post_setup") as post_setup:
+            _configure_provider(
+                _stt_provider_named("OpenAI Codex OAuth"), config
+            )
+
+        assert config["stt"]["provider"] == "openai-codex"
+        post_setup.assert_not_called()
+
+    def test_failed_codex_login_does_not_reconfigure_provider(self, monkeypatch):
+        from hermes_cli import auth
+
+        monkeypatch.setattr(auth, "has_codex_runtime_credentials", lambda: False)
+        config = {"stt": {"provider": "local"}}
+        with patch("hermes_cli.tools_config._run_post_setup") as post_setup:
+            _reconfigure_provider(
+                _stt_provider_named("OpenAI Codex OAuth"), config
+            )
+
+        post_setup.assert_called_once_with("openai_codex")
+        assert config["stt"]["provider"] == "local"

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -23,7 +23,8 @@ import asyncio
 import json
 import time
 from datetime import datetime, timezone
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import httpx
 import pytest
@@ -171,6 +172,352 @@ def test_oauth_start_stores_profile_for_background_completion(tmp_path, monkeypa
         ws._oauth_sessions.pop(session_id, None)
 
 
+def test_oauth_poll_and_cancel_reject_cross_profile_session_access(monkeypatch):
+    from hermes_cli import web_server as ws
+
+    monkeypatch.setattr(ws, "_oauth_profile_name", lambda profile: profile)
+    session_id, _ = ws._new_oauth_session(
+        "openai-codex", "device_code", profile="coder"
+    )
+    try:
+        wrong_poll = client.get(
+            f"/api/providers/oauth/openai-codex/poll/{session_id}?profile=other",
+            headers=HEADERS,
+        )
+        wrong_cancel = client.delete(
+            f"/api/providers/oauth/sessions/{session_id}?profile=other",
+            headers=HEADERS,
+        )
+        omitted_poll = client.get(
+            f"/api/providers/oauth/openai-codex/poll/{session_id}",
+            headers=HEADERS,
+        )
+        omitted_cancel = client.delete(
+            f"/api/providers/oauth/sessions/{session_id}",
+            headers=HEADERS,
+        )
+
+        assert wrong_poll.status_code == 409
+        assert wrong_cancel.status_code == 409
+        assert omitted_poll.status_code == 409
+        assert omitted_cancel.status_code == 409
+        assert session_id in ws._oauth_sessions
+
+        right_poll = client.get(
+            f"/api/providers/oauth/openai-codex/poll/{session_id}?profile=coder",
+            headers=HEADERS,
+        )
+        right_cancel = client.delete(
+            f"/api/providers/oauth/sessions/{session_id}?profile=coder",
+            headers=HEADERS,
+        )
+
+        assert right_poll.status_code == 200
+        assert right_cancel.status_code == 200
+        assert session_id not in ws._oauth_sessions
+    finally:
+        ws._oauth_sessions.pop(session_id, None)
+
+
+def test_oauth_session_profile_preserves_explicit_default_owner(monkeypatch):
+    from hermes_cli import web_server as ws
+
+    monkeypatch.setattr(ws, "_oauth_profile_name", lambda profile: profile)
+    session_id, _ = ws._new_oauth_session("anthropic", "pkce", profile=None)
+    try:
+        assert ws._oauth_session_profile(session_id, "coder") is None
+    finally:
+        ws._oauth_sessions.pop(session_id, None)
+
+
+def test_pkce_submit_rejects_omitted_profile_for_named_session(monkeypatch):
+    from hermes_cli import web_server as ws
+
+    monkeypatch.setattr(ws, "_oauth_profile_name", lambda profile: profile)
+    session_id, _ = ws._new_oauth_session("anthropic", "pkce", profile="coder")
+    try:
+        with pytest.raises(ws.HTTPException) as exc_info:
+            ws._submit_anthropic_pkce(session_id, "code#state", profile=None)
+
+        assert exc_info.value.status_code == 409
+    finally:
+        ws._oauth_sessions.pop(session_id, None)
+
+
+def test_codex_dashboard_worker_credential_only_preserves_active_provider(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import web_server as ws
+    from hermes_cli.auth import get_active_provider
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    access_token = "h.eyJleH...OTl9.s"
+
+    class _Resp:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def post(self, url, **kwargs):
+            if url.endswith("/deviceauth/usercode"):
+                return _Resp(200, {
+                    "device_auth_id": "device-auth-id",
+                    "interval": 3,
+                    "user_code": "CODEX-1234",
+                })
+            if url.endswith("/deviceauth/token"):
+                return _Resp(200, {
+                    "authorization_code": "authorization-code",
+                    "code_verifier": "code-verifier",
+                })
+            return _Resp(200, {
+                "access_token": access_token,
+                "refresh_token": "codex-refresh",
+            })
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "auth.json").write_text(
+        json.dumps(
+            {
+                "active_provider": "anthropic",
+                "providers": {"anthropic": {"api_key": "anthropic-key"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("model:\n  provider: anthropic\n", encoding="utf-8")
+    monkeypatch.setattr(httpx, "Client", _Client)
+    monkeypatch.setattr(ws.time, "sleep", lambda _: None)
+
+    sid, sess = ws._new_oauth_session("openai-codex", "device_code")
+    sess["activate_provider"] = False
+    try:
+        ws._codex_full_login_worker(sid)
+
+        assert ws._oauth_sessions[sid]["status"] == "approved"
+        assert get_active_provider() == "anthropic"
+        assert config_path.read_text(encoding="utf-8") == "model:\n  provider: anthropic\n"
+
+        runtime = resolve_runtime_provider(requested="openai-codex")
+        assert runtime["provider"] == "openai-codex"
+        assert runtime["api_key"] == access_token
+        assert runtime["api_mode"] == "codex_responses"
+    finally:
+        ws._oauth_sessions.pop(sid, None)
+
+
+def test_codex_dashboard_worker_does_not_save_after_session_cancelled(monkeypatch):
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import web_server as ws
+
+    session = {}
+
+    class _Resp:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def post(self, url, **kwargs):
+            if url.endswith("/deviceauth/usercode"):
+                return _Resp(
+                    200,
+                    {
+                        "device_auth_id": "device-auth-id",
+                        "interval": 3,
+                        "user_code": "CODEX-1234",
+                    },
+                )
+            if url.endswith("/deviceauth/token"):
+                return _Resp(
+                    200,
+                    {
+                        "authorization_code": "authorization-code",
+                        "code_verifier": "code-verifier",
+                    },
+                )
+            with ws._oauth_sessions_lock:
+                ws._oauth_sessions.pop(session["id"], None)
+            return _Resp(
+                200,
+                {
+                    "access_token": "codex-access",
+                    "refresh_token": "codex-refresh",
+                },
+            )
+
+    save_tokens = Mock()
+    monkeypatch.setattr(httpx, "Client", _Client)
+    monkeypatch.setattr(ws.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        auth_mod, "_save_codex_device_login_tokens", save_tokens
+    )
+
+    sid, _ = ws._new_oauth_session("openai-codex", "device_code")
+    session["id"] = sid
+    ws._codex_full_login_worker(sid)
+
+    assert sid not in ws._oauth_sessions
+    save_tokens.assert_not_called()
+
+
+def test_codex_dashboard_worker_persists_inside_session_profile(tmp_path, monkeypatch):
+    from hermes_cli import auth as auth_mod
+    from hermes_cli import web_server as ws
+    from hermes_constants import get_hermes_home
+
+    profile_home = _make_profile_home(tmp_path, monkeypatch)
+
+    class _Resp:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def post(self, url, **kwargs):
+            if url.endswith("/deviceauth/usercode"):
+                return _Resp(200, {
+                    "device_auth_id": "device-auth-id",
+                    "interval": 3,
+                    "user_code": "CODEX-1234",
+                })
+            if url.endswith("/deviceauth/token"):
+                return _Resp(200, {
+                    "authorization_code": "authorization-code",
+                    "code_verifier": "code-verifier",
+                })
+            return _Resp(200, {
+                "access_token": "codex-access",
+                "refresh_token": "codex-refresh",
+            })
+
+    saved_homes = []
+    monkeypatch.setattr(httpx, "Client", _Client)
+    monkeypatch.setattr(ws.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        auth_mod,
+        "_save_codex_device_login_tokens",
+        lambda tokens, *args, **kwargs: saved_homes.append(get_hermes_home()),
+    )
+
+    sid, _ = ws._new_oauth_session(
+        "openai-codex",
+        "device_code",
+        profile="coder",
+    )
+    try:
+        ws._codex_full_login_worker(sid)
+
+        assert ws._oauth_sessions[sid]["status"] == "approved"
+        assert saved_homes == [profile_home]
+    finally:
+        ws._oauth_sessions.pop(sid, None)
+
+
+def test_codex_dashboard_start_forwards_credential_only_intent(monkeypatch):
+    from hermes_cli import web_server as ws
+
+    captured = {}
+
+    async def fake_start(provider_id, profile=None, *, activate_provider=True):
+        captured.update(
+            provider_id=provider_id,
+            profile=profile,
+            activate_provider=activate_provider,
+        )
+        return {"session_id": "sid", "flow": "device_code"}
+
+    monkeypatch.setattr(ws, "_start_device_code_flow", fake_start)
+    resp = client.post(
+        "/api/providers/oauth/openai-codex/start?activate_provider=false",
+        headers=HEADERS,
+    )
+
+    assert resp.status_code == 200
+    assert captured == {
+        "provider_id": "openai-codex",
+        "profile": None,
+        "activate_provider": False,
+    }
+
+
+def test_codex_dashboard_start_waits_through_shared_retry_window(monkeypatch):
+    from hermes_cli import web_server as ws
+
+    class _Thread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            return None
+
+    clock = iter((0.0, 11.0, 11.0))
+
+    async def fake_sleep(_seconds):
+        with ws._oauth_sessions_lock:
+            session = next(
+                value
+                for value in ws._oauth_sessions.values()
+                if value.get("provider") == "openai-codex"
+            )
+            session.update(
+                user_code="LATE-429",
+                verification_url="https://auth.openai.com/codex/device",
+                expires_in=900,
+                interval=5,
+            )
+
+    monkeypatch.setattr(ws.threading, "Thread", _Thread)
+    monkeypatch.setattr(
+        ws,
+        "time",
+        SimpleNamespace(time=time.time, monotonic=lambda: next(clock)),
+    )
+    monkeypatch.setattr(ws.asyncio, "sleep", fake_sleep)
+
+    result = asyncio.run(ws._start_device_code_flow("openai-codex"))
+    try:
+        assert result["user_code"] == "LATE-429"
+    finally:
+        ws._oauth_sessions.pop(result["session_id"], None)
 
 
 def test_codex_dashboard_start_rewords_device_authorization_error(monkeypatch):
@@ -273,14 +620,18 @@ def test_codex_dashboard_worker_stops_polling_after_cancel(tmp_path, monkeypatch
     saved = []
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setattr(httpx, "Client", _Client)
-    monkeypatch.setattr(auth_mod, "_save_codex_tokens", lambda tokens: saved.append(tokens))
+    monkeypatch.setattr(
+        auth_mod,
+        "_save_codex_tokens",
+        lambda tokens, last_refresh=None, **kwargs: saved.append(tokens),
+    )
 
     sid, _ = ws._new_oauth_session("openai-codex", "device_code", profile="coder")
 
     def fake_sleep(_interval):
         # Simulate a real concurrent DELETE /api/providers/oauth/sessions/{sid}
         # firing while the worker is asleep between polls.
-        resp = client.delete(f"/api/providers/oauth/sessions/{sid}", headers=HEADERS)
+        resp = client.delete(f"/api/providers/oauth/sessions/{sid}?profile=coder", headers=HEADERS)
         assert resp.status_code == 200, resp.text
 
     monkeypatch.setattr(ws.time, "sleep", fake_sleep)
@@ -354,7 +705,7 @@ def test_codex_worker_final_save_is_atomic_with_cancel_delete(tmp_path, monkeypa
     delete_started = threading.Event()
     delete_finished = threading.Event()
 
-    def fake_save(tokens):
+    def fake_save(tokens, last_refresh=None, **kwargs):
         # We are inside the worker's critical section right now (holding
         # _oauth_sessions_lock). Fire a real DELETE from another thread and
         # prove it cannot complete until this section releases the lock.
@@ -369,7 +720,7 @@ def test_codex_worker_final_save_is_atomic_with_cancel_delete(tmp_path, monkeypa
 
     def _fire_delete():
         delete_started.set()
-        client.delete(f"/api/providers/oauth/sessions/{sid}", headers=HEADERS)
+        client.delete(f"/api/providers/oauth/sessions/{sid}?profile=coder", headers=HEADERS)
         delete_finished.set()
 
     monkeypatch.setattr(auth_mod, "_save_codex_tokens", fake_save)
@@ -418,7 +769,7 @@ def test_cancel_oauth_session_marks_dict_cancelled_before_popping():
     worker_ref = ws._oauth_sessions[session_id]
 
     resp = client.delete(
-        f"/api/providers/oauth/sessions/{session_id}",
+        f"/api/providers/oauth/sessions/{session_id}?profile=coder",
         headers=HEADERS,
     )
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2130,6 +2130,38 @@ class TestNewEndpoints:
 
 
 
+    def test_codex_stt_row_exposes_oauth_metadata(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.auth.has_codex_runtime_credentials", lambda: False
+        )
+
+        resp = self.client.get("/api/tools/toolsets/stt/config")
+
+        assert resp.status_code == 200
+        by_name = {p["name"]: p for p in resp.json()["providers"]}
+        codex = by_name["OpenAI Codex OAuth"]
+        assert codex["auth_provider"] == "openai-codex"
+        assert codex["post_setup"] is None
+        assert codex["status"] == "needs_auth"
+
+    def test_codex_stt_selection_requires_oauth_before_config_write(
+        self, monkeypatch
+    ):
+        from hermes_cli.config import load_config
+
+        monkeypatch.setattr(
+            "hermes_cli.auth.has_codex_runtime_credentials", lambda: False
+        )
+        before = load_config()["stt"]["provider"]
+
+        resp = self.client.put(
+            "/api/tools/toolsets/stt/provider",
+            json={"provider": "OpenAI Codex OAuth"},
+        )
+
+        assert resp.status_code == 409
+        assert load_config()["stt"]["provider"] == before
+
     def test_select_managed_nous_provider_reports_needs_nous_auth(self, monkeypatch):
         """Selecting a managed Nous row while logged out flags needs_nous_auth.
 

--- a/tests/tools/test_transcription_openai_codex.py
+++ b/tests/tools/test_transcription_openai_codex.py
@@ -1,0 +1,559 @@
+"""Behavior tests for ChatGPT/Codex OAuth speech-to-text."""
+
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+class _Response:
+    def __init__(self, status_code=200, payload=None, text="", headers=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+        self.headers = headers or {"content-type": "application/json"}
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import requests
+
+            error = requests.HTTPError(f"{self.status_code} response")
+            error.response = self
+            raise error
+
+
+def test_explicit_openai_codex_provider_uses_existing_oauth_login():
+    from tools.transcription_tools import _get_provider
+
+    resolver = Mock()
+    with (
+        patch(
+            "hermes_cli.auth.has_codex_runtime_credentials",
+            return_value=True,
+        ),
+        patch(
+            "tools.transcription_tools._resolve_codex_stt_credentials",
+            resolver,
+        ),
+    ):
+        assert _get_provider({"provider": "openai-codex"}) == "openai-codex"
+
+    resolver.assert_not_called()
+
+
+def test_codex_credentials_include_optional_chatgpt_account_id():
+    from tools.transcription_tools import _resolve_codex_stt_credentials
+
+    entry = SimpleNamespace(runtime_api_key="oauth-token", id="cred-1")
+    pool = Mock()
+    pool.select.return_value = entry
+    with (
+        patch("agent.credential_pool.load_pool", return_value=pool),
+        patch(
+            "hermes_cli.auth.codex_account_id_from_access_token",
+            return_value="account-123",
+        ) as account_id,
+    ):
+        credentials = _resolve_codex_stt_credentials()
+
+    assert credentials["account_id"] == "account-123"
+    assert credentials["credential_id"] == "cred-1"
+    account_id.assert_called_once_with("oauth-token")
+
+
+def test_openai_codex_transcription_uses_subscription_endpoint(tmp_path):
+    from tools.transcription_tools import _transcribe_openai_codex
+
+    audio = tmp_path / "voice.webm"
+    audio.write_bytes(b"audio")
+    response = _Response(payload={"text": "Merhaba Codex"})
+
+    with (
+        patch(
+            "tools.transcription_tools._resolve_codex_stt_credentials",
+            return_value={"api_key": "oauth-token", "account_id": "account-123"},
+        ),
+        patch("requests.post", return_value=response) as post,
+    ):
+        result = _transcribe_openai_codex(str(audio), language="tr")
+
+    assert result == {
+        "success": True,
+        "transcript": "Merhaba Codex",
+        "provider": "openai-codex",
+    }
+    kwargs = post.call_args.kwargs
+    assert post.call_args.args[0] == "https://chatgpt.com/backend-api/transcribe"
+    assert kwargs["headers"]["Authorization"] == "Bearer oauth-token"
+    assert kwargs["headers"]["ChatGPT-Account-ID"] == "account-123"
+    assert kwargs["headers"]["User-Agent"].startswith("codex_cli_rs/")
+    assert kwargs["headers"]["originator"] == "codex_cli_rs"
+    assert kwargs["data"] == {"language": "tr"}
+    assert kwargs["allow_redirects"] is False
+    filename, handle, mime = kwargs["files"]["file"]
+    assert filename == "voice.webm"
+    assert mime == "audio/webm"
+    assert handle.closed
+
+
+def test_openai_codex_transcription_refreshes_once_after_unauthorized(tmp_path):
+    from tools.transcription_tools import _transcribe_openai_codex
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"audio")
+    resolver = Mock(return_value={"api_key": "old-token", "credential_id": "old"})
+    retry = Mock(return_value={"api_key": "new-token", "credential_id": "new"})
+
+    with (
+        patch(
+            "tools.transcription_tools._resolve_codex_stt_credentials", resolver
+        ),
+        patch("tools.transcription_tools._retry_codex_stt_credentials", retry),
+        patch(
+            "requests.post",
+            side_effect=[
+                _Response(status_code=401, text="expired"),
+                _Response(payload={"text": "yenilendi"}),
+            ],
+        ) as post,
+    ):
+        assert _transcribe_openai_codex(str(audio)) == {
+            "success": True,
+            "transcript": "yenilendi",
+            "provider": "openai-codex",
+        }
+
+    assert resolver.call_args_list[0].kwargs == {}
+    retry.assert_called_once_with(
+        {"api_key": "old-token", "credential_id": "old"}, 401
+    )
+    assert post.call_args_list[1].kwargs["headers"]["Authorization"] == "Bearer new-token"
+
+
+def test_codex_retry_refreshes_matching_pool_credential():
+    from tools.transcription_tools import _retry_codex_stt_credentials
+
+    refreshed = SimpleNamespace(runtime_api_key="new-token", id="cred-1")
+    pool = Mock()
+    pool.try_refresh_matching.return_value = refreshed
+    with (
+        patch("agent.credential_pool.load_pool", return_value=pool),
+        patch(
+            "hermes_cli.auth.codex_account_id_from_access_token",
+            return_value=None,
+        ),
+    ):
+        credentials = _retry_codex_stt_credentials(
+            {"api_key": "old-token", "credential_id": "cred-1"}, 401
+        )
+
+    assert credentials is not None
+    assert credentials["api_key"] == "new-token"
+    pool.try_refresh_matching.assert_called_once_with(
+        api_key_hint="old-token", credential_id="cred-1"
+    )
+    pool.mark_exhausted_and_rotate.assert_not_called()
+
+
+def test_codex_retry_rotates_pool_credential_after_rate_limit():
+    from tools.transcription_tools import _retry_codex_stt_credentials
+
+    next_entry = SimpleNamespace(runtime_api_key="next-token", id="cred-2")
+    pool = Mock()
+    pool.select_excluding.return_value = next_entry
+    with (
+        patch("agent.credential_pool.load_pool", return_value=pool),
+        patch(
+            "hermes_cli.auth.codex_account_id_from_access_token",
+            return_value=None,
+        ),
+    ):
+        credentials = _retry_codex_stt_credentials(
+            {"api_key": "limited-token", "credential_id": "cred-1"}, 429
+        )
+
+    assert credentials is not None
+    assert credentials["api_key"] == "next-token"
+    pool.select_excluding.assert_called_once_with(
+        credential_id="cred-1", api_key_hint="limited-token"
+    )
+    pool.mark_exhausted_and_rotate.assert_not_called()
+
+
+def test_codex_rate_limit_uses_real_fill_first_pool_alternative():
+    from agent.credential_pool import CredentialPool, PooledCredential
+    from tools.transcription_tools import _retry_codex_stt_credentials
+
+    pool = CredentialPool(
+        "openai-codex",
+        [
+            PooledCredential(
+                provider="openai-codex",
+                id="a",
+                label="first",
+                auth_type="api_key",
+                priority=0,
+                source="manual:first",
+                access_token="token-a",
+            ),
+            PooledCredential(
+                provider="openai-codex",
+                id="b",
+                label="second",
+                auth_type="api_key",
+                priority=1,
+                source="manual:second",
+                access_token="token-b",
+            ),
+        ],
+    )
+    first = pool.select()
+    assert first is not None
+    assert first.id == "a"
+
+    with (
+        patch("agent.credential_pool.load_pool", return_value=pool),
+        patch(
+            "hermes_cli.auth.codex_account_id_from_access_token",
+            return_value=None,
+        ),
+    ):
+        retry = _retry_codex_stt_credentials(
+            {"api_key": "token-a", "credential_id": "a"}, 429
+        )
+
+    assert retry is not None
+    assert retry["credential_id"] == "b"
+    assert retry["api_key"] == "token-b"
+    assert [(entry.id, entry.last_status) for entry in pool.entries()] == [
+        ("a", None),
+        ("b", None),
+    ]
+
+
+def test_openai_codex_transcription_rotates_once_after_rate_limit(tmp_path):
+    from tools.transcription_tools import _transcribe_openai_codex
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"audio")
+    retry = Mock(return_value={"api_key": "next-token", "credential_id": "next"})
+
+    with (
+        patch(
+            "tools.transcription_tools._resolve_codex_stt_credentials",
+            return_value={"api_key": "limited-token", "credential_id": "limited"},
+        ),
+        patch("tools.transcription_tools._retry_codex_stt_credentials", retry),
+        patch(
+            "requests.post",
+            side_effect=[
+                _Response(status_code=429, text="limited"),
+                _Response(payload={"text": "diğer hesap"}),
+            ],
+        ) as post,
+    ):
+        result = _transcribe_openai_codex(str(audio))
+
+    assert result["transcript"] == "diğer hesap"
+    retry.assert_called_once()
+    assert len(post.call_args_list) == 2
+
+
+def test_openai_codex_second_unauthorized_is_terminal(tmp_path):
+    from tools.transcription_tools import _transcribe_openai_codex
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"audio")
+    with (
+        patch(
+            "tools.transcription_tools._resolve_codex_stt_credentials",
+            return_value={"api_key": "old-token", "credential_id": "old"},
+        ),
+        patch(
+            "tools.transcription_tools._retry_codex_stt_credentials",
+            return_value={"api_key": "new-token", "credential_id": "new"},
+        ),
+        patch(
+            "tools.transcription_tools._mark_codex_stt_credentials_failed"
+        ) as mark_failed,
+        patch(
+            "requests.post",
+            side_effect=[_Response(status_code=401), _Response(status_code=401)],
+        ) as post,
+    ):
+        result = _transcribe_openai_codex(str(audio))
+
+    assert result["error"].endswith("HTTP 401.")
+    assert len(post.call_args_list) == 2
+    mark_failed.assert_called_once_with(
+        {"api_key": "new-token", "credential_id": "new"}, 401
+    )
+
+
+def test_openai_codex_second_rate_limit_does_not_exhaust_shared_pool(tmp_path):
+    from tools.transcription_tools import _transcribe_openai_codex
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"audio")
+    with (
+        patch(
+            "tools.transcription_tools._resolve_codex_stt_credentials",
+            return_value={"api_key": "old-token", "credential_id": "old"},
+        ),
+        patch(
+            "tools.transcription_tools._retry_codex_stt_credentials",
+            return_value={"api_key": "new-token", "credential_id": "new"},
+        ),
+        patch(
+            "tools.transcription_tools._mark_codex_stt_credentials_failed"
+        ) as mark_failed,
+        patch(
+            "requests.post",
+            side_effect=[_Response(status_code=429), _Response(status_code=429)],
+        ) as post,
+    ):
+        result = _transcribe_openai_codex(str(audio))
+
+    assert result["error"].endswith("HTTP 429.")
+    assert len(post.call_args_list) == 2
+    mark_failed.assert_not_called()
+
+
+def test_openai_codex_missing_credentials_returns_safe_error(tmp_path):
+    from tools.transcription_tools import _transcribe_openai_codex
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"audio")
+    with patch(
+        "tools.transcription_tools._resolve_codex_stt_credentials",
+        side_effect=ValueError("OpenAI Codex OAuth credentials are unavailable."),
+    ):
+        result = _transcribe_openai_codex(str(audio))
+
+    assert result["error"] == "OpenAI Codex OAuth credentials are unavailable."
+
+
+def test_openai_codex_refuses_redirects_without_replaying_audio(tmp_path):
+    from tools.transcription_tools import _transcribe_openai_codex
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"audio")
+    response = _Response(
+        status_code=307,
+        payload={"text": "must not be accepted"},
+        headers={"location": "https://attacker.invalid/upload"},
+    )
+    with (
+        patch(
+            "tools.transcription_tools._resolve_codex_stt_credentials",
+            return_value={"api_key": "secret-token", "account_id": "account-1"},
+        ),
+        patch("requests.post", return_value=response) as post,
+    ):
+        result = _transcribe_openai_codex(str(audio))
+
+    assert result["error"].endswith("refused an unexpected redirect.")
+    assert post.call_args.kwargs["allow_redirects"] is False
+    assert len(post.call_args_list) == 1
+
+
+def test_openai_codex_cloudflare_challenge_has_specific_error(tmp_path):
+    from tools.transcription_tools import _transcribe_openai_codex
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"audio")
+    response = _Response(
+        status_code=403,
+        text="secret response body",
+        headers={"cf-mitigated": "challenge"},
+    )
+    with (
+        patch(
+            "tools.transcription_tools._resolve_codex_stt_credentials",
+            return_value={"api_key": "secret-token"},
+        ),
+        patch("requests.post", return_value=response),
+    ):
+        result = _transcribe_openai_codex(str(audio))
+
+    assert "blocked" in result["error"]
+    assert "secret" not in result["error"]
+
+
+def test_openai_codex_ordinary_forbidden_returns_safe_http_error(tmp_path):
+    from tools.transcription_tools import _transcribe_openai_codex
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"audio")
+    with (
+        patch(
+            "tools.transcription_tools._resolve_codex_stt_credentials",
+            return_value={"api_key": "secret-token"},
+        ),
+        patch(
+            "requests.post",
+            return_value=_Response(status_code=403, text="secret response body"),
+        ),
+    ):
+        result = _transcribe_openai_codex(str(audio))
+
+    assert result["error"].endswith("HTTP 403.")
+    assert "secret" not in result["error"]
+
+
+def test_openai_codex_timeout_returns_specific_error(tmp_path):
+    import requests
+
+    from tools.transcription_tools import _transcribe_openai_codex
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"audio")
+    with (
+        patch(
+            "tools.transcription_tools._resolve_codex_stt_credentials",
+            return_value={"api_key": "secret-token"},
+        ),
+        patch("requests.post", side_effect=requests.Timeout),
+    ):
+        result = _transcribe_openai_codex(str(audio))
+
+    assert result["error"].endswith("request timed out.")
+    assert "secret-token" not in result["error"]
+
+
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        (["not", "an", "object"], "invalid response"),
+        ({}, "returned no text"),
+        ({"text": ["not", "a", "string"]}, "returned no text"),
+    ],
+)
+def test_openai_codex_rejects_malformed_success_payload(tmp_path, payload, error):
+    from tools.transcription_tools import _transcribe_openai_codex
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"audio")
+    with (
+        patch(
+            "tools.transcription_tools._resolve_codex_stt_credentials",
+            return_value={"api_key": "token"},
+        ),
+        patch("requests.post", return_value=_Response(payload=payload)),
+    ):
+        result = _transcribe_openai_codex(str(audio))
+
+    assert error in result["error"]
+
+
+def test_openai_codex_rejects_non_json_success(tmp_path):
+    from tools.transcription_tools import _transcribe_openai_codex
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"audio")
+    response = _Response()
+    response.json = Mock(side_effect=ValueError("not json"))
+    with (
+        patch(
+            "tools.transcription_tools._resolve_codex_stt_credentials",
+            return_value={"api_key": "token"},
+        ),
+        patch("requests.post", return_value=response),
+    ):
+        result = _transcribe_openai_codex(str(audio))
+
+    assert result["error"].endswith("invalid JSON.")
+
+
+def test_dispatch_routes_openai_codex_provider(tmp_path):
+    from tools.transcription_tools import _transcribe_prepared_audio
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    audio = tmp_path / "voice.webm"
+    audio.write_bytes(b"audio")
+    config = deepcopy(DEFAULT_CONFIG["stt"])
+    config.update(provider="openai-codex", language="tr")
+    config["openai_codex"]["timeout"] = 45
+
+    with (
+        patch("tools.transcription_tools._load_stt_config", return_value=config),
+        patch("tools.transcription_tools._get_provider", return_value="openai-codex"),
+        patch(
+            "tools.transcription_tools._transcribe_openai_codex",
+            return_value={
+                "success": True,
+                "transcript": "uçtan uca",
+                "provider": "openai-codex",
+            },
+        ) as transcribe,
+    ):
+        assert _transcribe_prepared_audio(str(audio)) == {
+            "success": True,
+            "transcript": "uçtan uca",
+            "provider": "openai-codex",
+        }
+
+    transcribe.assert_called_once_with(str(audio), language="tr", timeout=45)
+
+
+def test_dispatch_prefers_nonempty_codex_language_override(tmp_path):
+    from tools.transcription_tools import _transcribe_prepared_audio
+
+    audio = tmp_path / "voice.webm"
+    audio.write_bytes(b"audio")
+    config = {
+        "enabled": True,
+        "provider": "openai-codex",
+        "language": "tr",
+        "openai_codex": {"language": "de", "timeout": 120},
+    }
+    with (
+        patch("tools.transcription_tools._load_stt_config", return_value=config),
+        patch("tools.transcription_tools._get_provider", return_value="openai-codex"),
+        patch(
+            "tools.transcription_tools._transcribe_openai_codex",
+            return_value={
+                "success": True,
+                "transcript": "Deutsch",
+                "provider": "openai-codex",
+            },
+        ) as transcribe,
+    ):
+        _transcribe_prepared_audio(str(audio))
+
+    transcribe.assert_called_once_with(str(audio), language="de", timeout=120)
+
+
+def test_dispatch_preserves_explicit_empty_codex_language_for_auto_detect(tmp_path):
+    from tools.transcription_tools import _transcribe_prepared_audio
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"audio")
+    config = {
+        "enabled": True,
+        "provider": "openai-codex",
+        "language": "en",
+        "openai_codex": {"language": "", "timeout": 120},
+    }
+
+    with (
+        patch("tools.transcription_tools._load_stt_config", return_value=config),
+        patch("tools.transcription_tools._get_provider", return_value="openai-codex"),
+        patch(
+            "tools.transcription_tools._transcribe_openai_codex",
+            return_value={
+                "success": True,
+                "transcript": "Türkçe",
+                "provider": "openai-codex",
+            },
+        ) as transcribe,
+    ):
+        result = _transcribe_prepared_audio(str(audio))
+
+    assert result["success"] is True
+    transcribe.assert_called_once_with(str(audio), language="", timeout=120)

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,12 +2,13 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with six providers:
+Provides speech-to-text transcription with multiple providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
+  - **openai-codex** — ChatGPT/Codex subscription dictation via OAuth.
   - **mistral** — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
@@ -28,6 +29,7 @@ Usage::
 """
 
 import logging
+import mimetypes
 import os
 import platform
 import queue
@@ -42,6 +44,7 @@ from pathlib import Path
 from typing import Optional, Dict, Any
 from urllib.parse import urljoin
 
+from agent.codex_headers import codex_cloudflare_headers
 from hermes_cli._subprocess_compat import windows_hide_flags
 from utils import is_truthy_value
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
@@ -119,6 +122,7 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
+OPENAI_CODEX_TRANSCRIBE_URL = "https://chatgpt.com/backend-api/transcribe"
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
 ELEVENLABS_STT_BASE_URL = os.getenv("ELEVENLABS_STT_BASE_URL", "https://api.elevenlabs.io/v1")
 # DeepInfra STT base URL now resolved via hermes_cli.models.deepinfra_base_url (shared).
@@ -201,6 +205,88 @@ def _has_openai_audio_backend() -> bool:
         return True
     except ValueError:
         return False
+
+
+def _codex_stt_credentials_from_pool_entry(entry: Any) -> Dict[str, Any]:
+    """Convert a selected Codex credential-pool entry to request credentials."""
+    from hermes_cli.auth import codex_account_id_from_access_token
+
+    token = str(entry.runtime_api_key or "").strip()
+    if not token:
+        raise ValueError("OpenAI Codex OAuth credentials are unavailable.")
+    return {
+        "provider": "openai-codex",
+        "api_key": token,
+        "source": "credential_pool",
+        "credential_id": entry.id,
+        "account_id": codex_account_id_from_access_token(token),
+    }
+
+
+def _resolve_codex_stt_credentials() -> Dict[str, Any]:
+    """Select and proactively refresh a Codex OAuth pool credential."""
+    from agent.credential_pool import load_pool
+
+    entry = load_pool("openai-codex").select()
+    if entry is None:
+        raise ValueError("OpenAI Codex OAuth credentials are unavailable.")
+    return _codex_stt_credentials_from_pool_entry(entry)
+
+
+def _retry_codex_stt_credentials(
+    credentials: Dict[str, Any], status_code: int
+) -> Optional[Dict[str, Any]]:
+    """Refresh/rotate once without globally exhausting STT-only throttles."""
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    credential_id = str(credentials.get("credential_id") or "").strip() or None
+    failed_token = str(credentials.get("api_key") or "").strip()
+
+    if status_code == 401:
+        refreshed = pool.try_refresh_matching(
+            api_key_hint=failed_token or None,
+            credential_id=credential_id,
+        )
+        if refreshed is not None and refreshed.runtime_api_key != failed_token:
+            return _codex_stt_credentials_from_pool_entry(refreshed)
+        next_entry = pool.mark_exhausted_and_rotate(
+            status_code=status_code,
+            api_key_hint=failed_token or None,
+            credential_id=credential_id,
+        )
+    else:
+        # A transcribe-endpoint 429 may be feature-local rather than an
+        # account-wide Codex quota. Rotate for this bounded request only; do
+        # not persist shared inference-pool exhaustion.
+        next_entry = pool.select_excluding(
+            credential_id=credential_id,
+            api_key_hint=failed_token or None,
+        )
+    if next_entry is None or next_entry.runtime_api_key == failed_token:
+        return None
+    return _codex_stt_credentials_from_pool_entry(next_entry)
+
+
+def _mark_codex_stt_credentials_failed(
+    credentials: Dict[str, Any], status_code: int
+) -> None:
+    """Persist a terminal retry failure without issuing another request."""
+    from agent.credential_pool import load_pool
+
+    failed_token = str(credentials.get("api_key") or "").strip()
+    credential_id = str(credentials.get("credential_id") or "").strip() or None
+    load_pool("openai-codex").mark_exhausted_and_rotate(
+        status_code=status_code,
+        api_key_hint=failed_token or None,
+        credential_id=credential_id,
+    )
+
+
+def _has_codex_stt_backend() -> bool:
+    from hermes_cli.auth import has_codex_runtime_credentials
+
+    return has_codex_runtime_credentials()
 
 
 def _find_binary(binary_name: str) -> Optional[str]:
@@ -343,6 +429,7 @@ BUILTIN_STT_PROVIDERS = frozenset({
     "local_command",
     "groq",
     "openai",
+    "openai-codex",
     "mistral",
     "xai",
     "elevenlabs",
@@ -1019,6 +1106,14 @@ def _get_provider(stt_config: dict) -> str:
                 return "openai"
             logger.warning(
                 "STT provider 'openai' configured but no API key available"
+            )
+            return "none"
+
+        if provider == "openai-codex":
+            if _has_codex_stt_backend():
+                return "openai-codex"
+            logger.warning(
+                "STT provider 'openai-codex' configured but no ChatGPT/Codex OAuth login is available"
             )
             return "none"
 
@@ -1999,6 +2094,171 @@ def _transcribe_openai(
         return {"success": False, "transcript": "", "error": f"Transcription failed: {e}"}
 
 # ---------------------------------------------------------------------------
+# Provider: openai-codex (ChatGPT/Codex subscription OAuth)
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_openai_codex(
+    file_path: str,
+    *,
+    language: str = "",
+    timeout: int = 120,
+) -> Dict[str, Any]:
+    """Transcribe through Codex's subscription-backed dictation endpoint.
+
+    This is the same private ChatGPT backend used by first-party Codex
+    dictation, not the separately billed OpenAI Platform audio API. The
+    ``codex-cli`` user agent is required: ChatGPT's edge otherwise presents a
+    browser challenge to non-browser clients before OAuth is evaluated.
+    """
+    import requests
+
+    def _request(creds: Dict[str, Any]):
+        token = str(creds.get("api_key") or "").strip()
+        if not token:
+            raise ValueError("ChatGPT/Codex OAuth login is missing")
+
+        suffix = Path(file_path).suffix.lower()
+        mime_type = (
+            {
+                ".webm": "audio/webm",
+                ".ogg": "audio/ogg",
+                ".oga": "audio/ogg",
+                ".opus": "audio/ogg",
+                ".m4a": "audio/mp4",
+                ".mp4": "audio/mp4",
+            }.get(suffix)
+            or mimetypes.guess_type(file_path)[0]
+            or "application/octet-stream"
+        )
+        form_data = {"language": language} if language else {}
+        headers = codex_cloudflare_headers(token)
+        headers.update(
+            {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+            }
+        )
+        account_id = str(creds.get("account_id") or "").strip()
+        if account_id:
+            headers["ChatGPT-Account-ID"] = account_id
+        with open(file_path, "rb") as audio_file:
+            return requests.post(
+                OPENAI_CODEX_TRANSCRIBE_URL,
+                headers=headers,
+                files={"file": (Path(file_path).name, audio_file, mime_type)},
+                data=form_data,
+                timeout=timeout,
+                allow_redirects=False,
+            )
+
+    try:
+        credentials = _resolve_codex_stt_credentials()
+        response = _request(credentials)
+
+        # Credential-scoped failures get one bounded recovery attempt: refresh
+        # a rejected token when possible, otherwise rotate to another account.
+        if response.status_code in {401, 429}:
+            retry_credentials = _retry_codex_stt_credentials(
+                credentials, response.status_code
+            )
+            if retry_credentials is not None:
+                credentials = retry_credentials
+                response = _request(credentials)
+                if response.status_code == 401:
+                    _mark_codex_stt_credentials_failed(
+                        credentials, response.status_code
+                    )
+
+        if 300 <= response.status_code < 400:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "Codex OAuth transcription refused an unexpected redirect.",
+            }
+
+        if (
+            response.status_code == 403
+            and response.headers.get("cf-mitigated") == "challenge"
+        ):
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "ChatGPT blocked Codex OAuth transcription at its edge; retry later.",
+            }
+
+        response.raise_for_status()
+        try:
+            payload = response.json()
+        except ValueError:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "Codex OAuth transcription returned invalid JSON.",
+            }
+        if not isinstance(payload, dict):
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "Codex OAuth transcription returned an invalid response.",
+            }
+        transcript_value = payload.get("text")
+        if not isinstance(transcript_value, str) or not transcript_value.strip():
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "Codex OAuth transcription returned no text.",
+            }
+        transcript = transcript_value.strip()
+
+        logger.info(
+            "Transcribed %s via Codex OAuth (lang=%s, %d chars)",
+            Path(file_path).name,
+            language or "auto",
+            len(transcript),
+        )
+        return {
+            "success": True,
+            "transcript": transcript,
+            "provider": "openai-codex",
+        }
+    except PermissionError:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Permission denied: {file_path}",
+        }
+    except requests.Timeout:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "Codex OAuth transcription request timed out.",
+        }
+    except requests.ConnectionError:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "Could not connect to ChatGPT for Codex OAuth transcription.",
+        }
+    except requests.HTTPError as exc:
+        status = exc.response.status_code if exc.response is not None else "unknown"
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Codex OAuth transcription failed with HTTP {status}.",
+        }
+    except (ValueError, KeyError) as exc:
+        return {"success": False, "transcript": "", "error": str(exc)}
+    except Exception as exc:
+        logger.error("Codex OAuth transcription failed: %s", exc, exc_info=True)
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "Codex OAuth transcription failed unexpectedly.",
+        }
+
+
+# ---------------------------------------------------------------------------
 # Provider: mistral (Voxtral Transcribe API)
 # ---------------------------------------------------------------------------
 
@@ -2434,6 +2694,28 @@ def _transcribe_prepared_audio(file_path: str, model: Optional[str] = None) -> D
         model_name = model or openai_cfg.get("model", DEFAULT_STT_MODEL)
         return _transcribe_openai(file_path, model_name)
 
+    if provider == "openai-codex":
+        codex_cfg = stt_config.get("openai_codex") or {}
+        # An explicitly configured empty string means auto-detect. Do not let
+        # the legacy HERMES_LOCAL_STT_LANGUAGE/default-English fallback turn
+        # that into a forced English hint.
+        if "language" in codex_cfg:
+            language = str(codex_cfg.get("language") or "").strip()
+        else:
+            language = str(
+                _resolve_stt_language("openai-codex", stt_config) or ""
+            ).strip()
+        try:
+            timeout = int(codex_cfg.get("timeout", 120))
+        except (TypeError, ValueError):
+            timeout = 120
+        timeout = max(1, min(timeout, 600))
+        return _transcribe_openai_codex(
+            file_path,
+            language=language,
+            timeout=timeout,
+        )
+
     if provider == "mistral":
         mistral_cfg = stt_config.get("mistral") or {}
         model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
@@ -2513,6 +2795,7 @@ def _transcribe_prepared_audio(file_path: str, model: Optional[str] = None) -> D
         "error": (
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
+            "sign in to OpenAI Codex and set stt.provider to openai-codex, "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
             "Voxtral Transcribe, configure xAI OAuth or set XAI_API_KEY for xAI Grok STT, "
             "set ELEVENLABS_API_KEY for ElevenLabs Scribe, or set VOICE_TOOLS_OPENAI_KEY "

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -72,7 +72,7 @@ Text-to-speech and speech-to-text across all messaging platforms:
 | **xAI TTS** | Good | Paid | `XAI_API_KEY` |
 | **NeuTTS** | Good | Free | None needed |
 
-Speech-to-text supports eight providers: local faster-whisper (free, runs on-device), a local command wrapper, Groq, OpenAI Whisper API, Mistral, xAI, ElevenLabs Scribe, and DeepInfra. Voice message transcription works across Telegram, Discord, WhatsApp, and other messaging platforms. See [Voice & TTS](/user-guide/features/tts) and [Voice Mode](/user-guide/features/voice-mode) for details.
+Speech-to-text supports nine providers: local faster-whisper (free, runs on-device), a local command wrapper, ChatGPT/Codex OAuth subscription dictation, Groq, OpenAI Whisper API, Mistral, xAI, ElevenLabs Scribe, and DeepInfra. Voice message transcription works across Telegram, Discord, WhatsApp, and other messaging platforms. See [Voice & TTS](/user-guide/features/tts) and [Voice Mode](/user-guide/features/voice-mode) for details.
 
 ## IDE & Editor Integration
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -95,6 +95,7 @@ Add to `~/.hermes/.env`:
 ```bash
 # Speech-to-Text — local provider needs NO key at all
 # pip install faster-whisper          # Free, runs locally, recommended
+# OpenAI Codex OAuth also needs no API key; it uses an existing Hermes Codex login
 GROQ_API_KEY=your-key                 # Groq Whisper — fast, free tier (cloud)
 VOICE_TOOLS_OPENAI_KEY=your-key       # OpenAI Whisper — paid (cloud)
 
@@ -106,6 +107,31 @@ ELEVENLABS_API_KEY=***           # ElevenLabs — premium quality
 :::tip
 If `faster-whisper` is installed, voice mode works with **zero API keys** for STT. The model (~150 MB for `base`) downloads automatically on first use.
 :::
+
+To use transcription included with a ChatGPT/Codex subscription, select
+**OpenAI Codex OAuth** under Speech-to-Text in `hermes tools`. The picker runs a
+credential-only login and does not change the model provider used for chat. You
+can also authenticate separately before opening the picker:
+
+```bash
+hermes auth add openai-codex
+```
+
+For manual configuration, use:
+
+```yaml
+stt:
+  enabled: true
+  provider: openai-codex
+  openai_codex:
+    language: "" # automatic detection; use "tr", "en", etc. to force
+    timeout: 120
+```
+
+This uses Codex's subscription-backed dictation endpoint rather than the
+separately billed OpenAI Platform audio API. The endpoint is private and may
+change upstream; Hermes refreshes expired OAuth tokens once and returns a clear
+error if ChatGPT blocks or removes the route.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #77843.

Adds `openai-codex` as a speech-to-text provider so an existing ChatGPT/Codex OAuth login can transcribe voice messages without a separately billed OpenAI Platform API key.

The OAuth flow is credential-only: selecting Codex for STT does not change the model provider used for chat. Existing local `faster-whisper` fallback behavior remains available.

## Changes

- Add a Codex OAuth transcription backend with bounded timeouts, one refresh/retry, clear error mapping, and credential-pool isolation.
- Expose Codex OAuth in CLI, dashboard, and Desktop STT provider selection.
- Keep OAuth sessions bound to their initiating profile and reject cross-profile poll/cancel/code-submission requests, including omitted-profile access to named-profile sessions.
- Guard Desktop OAuth flows with operation generation plus exact session identity; cancel stale flows and dismiss session-specific notifications on every terminal path.
- Reuse the existing first-party Codex request fingerprint (`originator`, user agent, and account ID) to avoid Cloudflare/WAF challenges on server-hosted deployments.
- Preserve the active inference provider during credential-only Codex login.
- Document configuration, local fallback behavior, and the private endpoint stability caveat.

## Validation

| Check | Result |
|---|---|
| Focused Python STT/OAuth/web tests | `237 passed, 1 skipped` |
| Focused Desktop tests | `75 passed` |
| Desktop ESLint | passed |
| Desktop Prettier | passed |
| Desktop TypeScript typecheck | passed |
| Python compile check | passed |
| Live OGG transcription via Codex OAuth | passed (`104` transcript characters) |
| `git diff --check` | passed |

## Notes

This uses ChatGPT's private `https://chatgpt.com/backend-api/transcribe` route, not the public OpenAI Platform `/v1/audio/transcriptions` API. It is intentionally documented as an undocumented/private integration that may change upstream; no specific backing transcription model is claimed.

A broad `tests/hermes_cli` run reached 929 passing tests before an existing pairing-store isolation test observed shared pending state; that same test passes when run independently. The focused STT/OAuth/web suite above passes in a fresh process.
