### PR TITLE
fix(gateway): compaction completion notice respects progress_notices=false (closes #77549)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -48,6 +48,7 @@ from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union,
 
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
 from agent.conversation_compression import (
+    COMPACTION_DONE_STATUS,
     COMPACTION_STATUS,
     COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE,
     COMPRESSION_RETRY_MESSAGES_STATUS_TEMPLATE,
@@ -115,6 +116,8 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"
     r"|stream\s+(?:drop|drop\s+mid\s+tool-call).+retry\s+\d"
     r"|stale\s+connections\s+from\s+a\s+previous\s+provider\s+issue"
+    # 77549: compaction completion notice must also obey progress_notices gate
+    r"|context\s+compaction\s+complete\s+[—-]\s+continuing\s+turn"
     r")",
     re.IGNORECASE | re.DOTALL,
 )
@@ -168,6 +171,7 @@ _COMPRESSION_PROGRESS_STATUS_RE = re.compile(
     "|".join(
         _status_template_to_regex(_template)
         for _template in (
+            COMPACTION_DONE_STATUS,
             COMPACTION_STATUS,
             PRE_API_COMPRESSION_STATUS_TEMPLATE,
             PREFLIGHT_COMPRESSION_STATUS_TEMPLATE,


### PR DESCRIPTION
Closes #77549

## Problem

 correctly suppresses the routine compaction start message ("🗜️ Compacting context — summarizing...") but allows the completion message ("✓ Context compaction complete — continuing turn...") through to chat platforms unchanged. This makes the setting asymmetric.

## Root Cause

 is not matched by , so  never reaches the  gate for that message. It falls through to a plain delivery.

## Fix

1. Add a regex arm for `context\s+compaction\s+complete` to `_TELEGRAM_NOISY_STATUS_RE` so the completion notice enters the same suppression path as `COMPACTION_STATUS`.
2. Add `COMPACTION_DONE_STATUS` to `_COMPRESSION_PROGRESS_STATUS_RE` so it is correctly classified as a compression progress status when the opt-in gate is open (`progress_notices: true`).

## Verification

`python3 test_fix_77549.py`:
- `_TELEGRAM_NOISY_STATUS_RE` matches `COMPACTION_DONE_STATUS`: **True**
- `_COMPRESSION_PROGRESS_STATUS_RE` matches `COMPACTION_DONE_STATUS`: **True**
- With `progress_notices=false` (default): both start and completion messages are suppressed (**None**)