### PR TITLE
feat(web): capability-based intent routing and DDGS reliability

### DIFF
--- a/agent/web_search_provider.py
+++ b/agent/web_search_provider.py
@@ -139,12 +139,17 @@ class WebSearchProvider(abc.ABC):
         """
         return False
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5, search_depth: Optional[str] = None) -> Dict[str, Any]:
         """Execute a web search.
 
         Override when :meth:`supports_search` returns True. The default
         raises NotImplementedError; callers should gate on
         :meth:`supports_search` before calling.
+
+        Args:
+            query: The search query string.
+            limit: Maximum number of results.
+            search_depth: Optional depth hint — "fast", "auto", "deep", or "deepest".
         """
         raise NotImplementedError(
             f"{self.name} does not support search (override supports_search)"

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -366,6 +366,19 @@ DEFAULT_CONFIG = {
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
         "extract_char_limit": 15000,  # per-page char budget for web_extract; larger pages truncate + store full text in cache/web
+        # Web Capability Router (V0.1). Feature flag defaults to FALSE: when
+        # disabled (default), web_search/web_extract behave exactly as before
+        # and no router code runs. When enabled, deterministic intent-based
+        # provider selection (Layer B) applies inside the web tools.
+        "router": {
+            "enabled": False,
+            # Domain suffixes that must always be handled by the Browser
+            # (authenticated/session-dependent), via safe suffix matching.
+            # Shipped empty: operators opt in with their own
+            # interactive-only domains (e.g. via user config); no vendor
+            # domain is hard-coded into production defaults.
+            "browser_only_domains": [],
+        },
     },
 
     "browser": {

--- a/plugins/web/brave_free/provider.py
+++ b/plugins/web/brave_free/provider.py
@@ -59,7 +59,7 @@ class BraveFreeWebSearchProvider(WebSearchProvider):
     def supports_extract(self) -> bool:
         return False
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5, **kwargs: Any) -> Dict[str, Any]:
         """Execute a search against the Brave Search API.
 
         Returns ``{"success": True, "data": {"web": [{"title", "url", "description", "position"}]}}``

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -300,7 +300,7 @@ class DDGSWebSearchProvider(WebSearchProvider):
     def supports_extract(self) -> bool:
         return False
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5, **kwargs: Any) -> Dict[str, Any]:
         """Execute a DuckDuckGo search and return normalized results.
 
         The synchronous ``ddgs`` call runs in a disposable child process with

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 # loop has no overall cap, so a slow/rate-limited DuckDuckGo response can hang
 # the (single, shared) agent loop indefinitely (#36776). Enforce a hard cap
 # here by killing a disposable worker process (#68096).
-_SEARCH_TIMEOUT_SECS = 30
+_SEARCH_TIMEOUT_SECS = 45
 
 # How often the parent polls stdout / interrupt flag while waiting.
 _POLL_INTERVAL_SECS = 0.1

--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from agent.web_search_provider import WebSearchProvider
 
@@ -112,12 +112,18 @@ class ExaWebSearchProvider(WebSearchProvider):
     def supports_extract(self) -> bool:
         return True
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5, search_depth: Optional[str] = None) -> Dict[str, Any]:
         """Execute an Exa search.
 
         Returns ``{"success": True, "data": {"web": [{...}, ...]}}`` on
         success, ``{"success": False, "error": str}`` on failure (incl.
         missing API key and SDK install errors).
+
+        search_depth maps to Exa's ``type`` parameter:
+            "fast" → "fast" (~450ms, optimized)
+            "auto" / None → "auto" (~1s, balanced, default)
+            "deep" → "deep" (4-15s, multi-step with reasoning)
+            "deepest" → "deep-reasoning" (12-40s, maximum reasoning)
         """
         try:
             from tools.interrupt import is_interrupted
@@ -125,10 +131,19 @@ class ExaWebSearchProvider(WebSearchProvider):
             if is_interrupted():
                 return {"success": False, "error": "Interrupted"}
 
-            logger.info("Exa search: '%s' (limit=%d)", query, limit)
+            # Map search_depth to Exa type
+            _type_map = {
+                "fast": "fast",
+                "deep": "deep",
+                "deepest": "deep-reasoning",
+            }
+            exa_type = _type_map.get((search_depth or "").lower(), "auto")
+
+            logger.info("Exa search: '%s' (limit=%d, type=%s)", query, limit, exa_type)
             response = _get_exa_client().search(
                 query,
                 num_results=limit,
+                type=exa_type,
                 contents={"highlights": True},
             )
 

--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -101,10 +101,25 @@ class ExaWebSearchProvider(WebSearchProvider):
         return "Exa"
 
     def is_available(self) -> bool:
-        """Return True when ``EXA_API_KEY`` is set to a non-empty value."""
+        """Return True when Exa can service calls.
+
+        Requires BOTH the ``EXA_API_KEY`` credential AND the ``exa_py``
+        SDK to be importable. The SDK check is part of the WebSearchProvider
+        ABC contract ("optional Python dep importable") — a key without the
+        SDK would fail at request time, so it must not be reported as
+        available (see post-B1 readiness audit). Cheap and offline:
+        ``find_spec`` does not import the module.
+        """
         from agent.web_search_provider import get_provider_env
 
-        return bool(get_provider_env("EXA_API_KEY"))
+        if not get_provider_env("EXA_API_KEY"):
+            return False
+        try:
+            import importlib.util
+
+            return importlib.util.find_spec("exa_py") is not None
+        except Exception:  # noqa: BLE001 — a broken import probe means "not ready"
+            return False
 
     def supports_search(self) -> bool:
         return True

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -388,12 +388,15 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
     def supports_extract(self) -> bool:
         return True
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5, search_depth: Optional[str] = None) -> Dict[str, Any]:
         """Execute a Firecrawl search.
 
         Sync; matches the legacy ``_get_firecrawl_client().search(...)``
         call directly. Normalizes the response across SDK/direct/gateway
         shapes via :func:`_extract_web_search_results`.
+
+        When search_depth="deep" or "deepest", passes scrapeOptions to also
+        extract full content from each search result (search+scrape in one call).
 
         Pre-flight errors (``ValueError`` from configuration check,
         ``ImportError`` from missing SDK) propagate to the dispatcher's
@@ -407,12 +410,23 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
         if is_interrupted():
             return {"success": False, "error": "Interrupted"}
 
-        logger.info("Firecrawl search: '%s' (limit=%d)", query, limit)
+        _depth = (search_depth or "").lower()
+        scrape_options = None
+        if _depth in ("deep", "deepest"):
+            scrape_options = {
+                "formats": ["markdown"],
+                "onlyMainContent": True,
+            }
+
+        logger.info("Firecrawl search: '%s' (limit=%d, depth=%s)", query, limit, _depth or "default")
         # _get_firecrawl_client() raises ValueError on unconfigured systems —
         # let it propagate so the dispatcher emits the legacy envelope shape.
         client = _get_firecrawl_client()
         try:
-            response = client.search(query=query, limit=limit)
+            kwargs = {"query": query, "limit": limit}
+            if scrape_options:
+                kwargs["scrapeOptions"] = scrape_options
+            response = client.search(**kwargs)
             web_results = _extract_web_search_results(response)
             logger.info("Firecrawl: found %d search results", len(web_results))
             return {"success": True, "data": {"web": web_results}}

--- a/plugins/web/parallel/provider.py
+++ b/plugins/web/parallel/provider.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from agent.web_search_provider import WebSearchProvider
 
@@ -167,12 +167,15 @@ class ParallelWebSearchProvider(WebSearchProvider):
     def supports_extract(self) -> bool:
         return True
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5, search_depth: Optional[str] = None) -> Dict[str, Any]:
         """Execute a Parallel search (sync).
 
-        Uses the ``beta.search`` endpoint with the configured mode
-        (``PARALLEL_SEARCH_MODE`` env var, default "agentic"). Limit is
-        capped at 20 server-side.
+        Uses the ``beta.search`` endpoint. search_depth overrides
+        PARALLEL_SEARCH_MODE when provided:
+            "fast" → mode="turbo" (lowest latency, ~200ms)
+            "auto" / None → env var or "agentic" (default)
+            "deep" / "deepest" → mode="agentic" (highest quality)
+        Limit is capped at 20 server-side.
         """
         try:
             from tools.interrupt import is_interrupted
@@ -180,7 +183,11 @@ class ParallelWebSearchProvider(WebSearchProvider):
             if is_interrupted():
                 return {"success": False, "error": "Interrupted"}
 
-            mode = _resolve_search_mode()
+            _depth = (search_depth or "").lower()
+            if _depth == "fast":
+                mode = "turbo"
+            else:
+                mode = _resolve_search_mode()  # "agentic" by default
             logger.info(
                 "Parallel search: '%s' (mode=%s, limit=%d)", query, mode, limit
             )

--- a/plugins/web/parallel/provider.py
+++ b/plugins/web/parallel/provider.py
@@ -156,10 +156,25 @@ class ParallelWebSearchProvider(WebSearchProvider):
         return "Parallel"
 
     def is_available(self) -> bool:
-        """Return True when ``PARALLEL_API_KEY`` is set to a non-empty value."""
+        """Return True when Parallel can service calls.
+
+        Requires BOTH the ``PARALLEL_API_KEY`` credential AND the
+        ``parallel`` SDK (parallel-web) to be importable. The SDK check is
+        part of the WebSearchProvider ABC contract ("optional Python dep
+        importable") — a key without the SDK would fail at request time, so
+        it must not be reported as available (see post-B1 readiness audit).
+        Cheap and offline: ``find_spec`` does not import the module.
+        """
         from agent.web_search_provider import get_provider_env
 
-        return bool(get_provider_env("PARALLEL_API_KEY"))
+        if not get_provider_env("PARALLEL_API_KEY"):
+            return False
+        try:
+            import importlib.util
+
+            return importlib.util.find_spec("parallel") is not None
+        except Exception:  # noqa: BLE001 — a broken import probe means "not ready"
+            return False
 
     def supports_search(self) -> bool:
         return True
@@ -172,7 +187,7 @@ class ParallelWebSearchProvider(WebSearchProvider):
 
         Uses the ``beta.search`` endpoint. search_depth overrides
         PARALLEL_SEARCH_MODE when provided:
-            "fast" → mode="turbo" (lowest latency, ~200ms)
+            "fast" → mode="fast" (lowest latency)
             "auto" / None → env var or "agentic" (default)
             "deep" / "deepest" → mode="agentic" (highest quality)
         Limit is capped at 20 server-side.
@@ -185,7 +200,7 @@ class ParallelWebSearchProvider(WebSearchProvider):
 
             _depth = (search_depth or "").lower()
             if _depth == "fast":
-                mode = "turbo"
+                mode = "fast"
             else:
                 mode = _resolve_search_mode()  # "agentic" by default
             logger.info(

--- a/plugins/web/searxng/provider.py
+++ b/plugins/web/searxng/provider.py
@@ -65,7 +65,7 @@ class SearXNGWebSearchProvider(WebSearchProvider):
     def supports_extract(self) -> bool:
         return False
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5, **kwargs: Any) -> Dict[str, Any]:
         """Execute a search against the configured SearXNG instance."""
         import httpx
 

--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from agent.web_search_provider import WebSearchProvider
 
@@ -150,20 +150,33 @@ class TavilyWebSearchProvider(WebSearchProvider):
     def supports_extract(self) -> bool:
         return True
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
-        """Execute a Tavily search."""
+    def search(self, query: str, limit: int = 5, search_depth: Optional[str] = None) -> Dict[str, Any]:
+        """Execute a Tavily search.
+
+        search_depth maps to Tavily's parameters:
+            "fast" / "auto" / None → search_depth="basic", include_answer=False
+            "deep" → search_depth="advanced", include_answer=False
+            "deepest" → search_depth="advanced", include_answer=True
+        """
         try:
             from tools.interrupt import is_interrupted
 
             if is_interrupted():
                 return {"success": False, "error": "Interrupted"}
 
-            logger.info("Tavily search: '%s' (limit=%d)", query, limit)
+            _depth = (search_depth or "").lower()
+            tvly_depth = "advanced" if _depth in ("deep", "deepest") else "basic"
+            include_answer = _depth == "deepest"
+
+            logger.info("Tavily search: '%s' (limit=%d, depth=%s, answer=%s)",
+                        query, limit, tvly_depth, include_answer)
             raw = _tavily_request(
                 "search",
                 {
                     "query": query,
                     "max_results": min(limit, 20),
+                    "search_depth": tvly_depth,
+                    "include_answer": include_answer,
                     "include_raw_content": False,
                     "include_images": False,
                 },

--- a/tests/plugins/web/parallel/test_provider_mode_mapping.py
+++ b/tests/plugins/web/parallel/test_provider_mode_mapping.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Offline mocked tests for the Parallel provider search-depth → mode mapping.
 
-Covers HERMES_PARALLEL_PROVIDER_FAST_MODE_MAPPING_FIX_V0_1 requirements:
+Requirements covered:
 
 1. search_depth="fast" sends mode="fast".
 2. search_depth="fast" never sends mode="turbo".

--- a/tests/plugins/web/parallel/test_provider_mode_mapping.py
+++ b/tests/plugins/web/parallel/test_provider_mode_mapping.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Offline mocked tests for the Parallel provider search-depth → mode mapping.
+
+Covers HERMES_PARALLEL_PROVIDER_FAST_MODE_MAPPING_FIX_V0_1 requirements:
+
+1. search_depth="fast" sends mode="fast".
+2. search_depth="fast" never sends mode="turbo".
+3. default search_depth behavior remains as intended (env var or "agentic").
+4. supported explicit modes (PARALLEL_SEARCH_MODE) remain supported.
+5. an unsupported search_depth value does not result in mode="turbo".
+6. limit and query propagation remain unchanged.
+7. response parsing remains unchanged.
+8. no live network request occurs (fully mocked client).
+9. Router-disabled behavior is unaffected (no router code touched).
+10. no other provider behavior changes.
+
+No live network requests. All client calls are fakes injected into the
+canonical cache slots on :mod:`tools.web_tools`.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
+
+from plugins.web.parallel.provider import ParallelWebSearchProvider
+
+
+class _FakeResults:
+    def __init__(self, items):
+        self.results = items
+
+
+class _FakeSearchResponse:
+    def __init__(self, items):
+        self.results = items
+
+
+def _result(url="https://example.com/1", title="Sample", excerpts=("desc",)):
+    return SimpleNamespace(url=url, title=title, excerpts=list(excerpts))
+
+
+class _FakeBeta:
+    def __init__(self):
+        self.search_calls = []
+
+    def search(self, search_queries=None, objective=None, mode=None, max_results=None):
+        self.search_calls.append(
+            {
+                "search_queries": search_queries,
+                "objective": objective,
+                "mode": mode,
+                "max_results": max_results,
+            }
+        )
+        return _FakeSearchResponse([_result()])
+
+
+class _FakeClient:
+    def __init__(self):
+        self.beta = _FakeBeta()
+
+
+def _make_provider():
+    """Provider whose search() hits the fake client via the cache slot."""
+    fake = _FakeClient()
+    patcher = patch("tools.web_tools._parallel_client", fake)
+    patcher.start()
+    provider = ParallelWebSearchProvider()
+    return provider, fake, patcher
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    """Ensure the canonical client slot is clean before/after each test."""
+    import tools.web_tools as wt
+
+    prev = getattr(wt, "_parallel_client", None)
+    wt._parallel_client = None
+    yield
+    wt._parallel_client = prev
+
+
+def test_fast_depth_sends_fast_mode():
+    provider, fake, patcher = _make_provider()
+    try:
+        resp = provider.search("vector database survey", limit=1, search_depth="fast")
+        call = fake.beta.search_calls[-1]
+        assert call["mode"] == "fast"
+        assert resp["success"] is True
+    finally:
+        patcher.stop()
+
+
+def test_fast_depth_never_sends_turbo():
+    provider, fake, patcher = _make_provider()
+    try:
+        provider.search("vector database survey", limit=1, search_depth="fast")
+        for call in fake.beta.search_calls:
+            assert call["mode"] != "turbo"
+    finally:
+        patcher.stop()
+
+
+def test_default_depth_uses_env_or_agentic():
+    provider, fake, patcher = _make_provider()
+    try:
+        with patch.dict("os.environ", {}, clear=False):
+            resp = provider.search("vector database survey", limit=1, search_depth=None)
+            call = fake.beta.search_calls[-1]
+            assert call["mode"] == "agentic"
+            assert resp["success"] is True
+    finally:
+        patcher.stop()
+
+
+def test_default_depth_honors_env_var():
+    provider, fake, patcher = _make_provider()
+    try:
+        with patch.dict("os.environ", {"PARALLEL_SEARCH_MODE": "one-shot"}, clear=False):
+            provider.search("vector database survey", limit=1, search_depth=None)
+            call = fake.beta.search_calls[-1]
+            assert call["mode"] == "one-shot"
+    finally:
+        patcher.stop()
+
+
+def test_supported_explicit_modes_stay_valid():
+    provider, fake, patcher = _make_provider()
+    try:
+        for env_mode in ("agentic", "fast", "one-shot"):
+            with patch.dict("os.environ", {"PARALLEL_SEARCH_MODE": env_mode}, clear=False):
+                provider.search("query", limit=1, search_depth=None)
+                assert fake.beta.search_calls[-1]["mode"] == env_mode
+    finally:
+        patcher.stop()
+
+
+def test_unsupported_depth_does_not_become_turbo():
+    provider, fake, patcher = _make_provider()
+    try:
+        with patch.dict("os.environ", {}, clear=False):
+            provider.search("query", limit=1, search_depth="bogus-depth")
+            call = fake.beta.search_calls[-1]
+            assert call["mode"] != "turbo"
+            assert call["mode"] == "agentic"  # falls back to default
+    finally:
+        patcher.stop()
+
+
+def test_limit_and_query_propagation_unchanged():
+    provider, fake, patcher = _make_provider()
+    try:
+        provider.search("hello world query", limit=3, search_depth="fast")
+        call = fake.beta.search_calls[-1]
+        assert call["search_queries"] == ["hello world query"]
+        assert call["objective"] == "hello world query"
+        assert call["max_results"] == 3
+    finally:
+        patcher.stop()
+
+
+def test_limit_capped_at_20():
+    provider, fake, patcher = _make_provider()
+    try:
+        provider.search("query", limit=99, search_depth="fast")
+        call = fake.beta.search_calls[-1]
+        assert call["max_results"] == 20
+    finally:
+        patcher.stop()
+
+
+def test_response_parsing_unchanged():
+    provider, fake, patcher = _make_provider()
+    try:
+        resp = provider.search("query", limit=1, search_depth="fast")
+        assert resp == {
+            "success": True,
+            "data": {
+                "web": [
+                    {
+                        "url": "https://example.com/1",
+                        "title": "Sample",
+                        "description": "desc",
+                        "position": 1,
+                    }
+                ]
+            },
+        }
+    finally:
+        patcher.stop()
+
+
+def test_no_network_request_occurs():
+    """The fake client never touches the network; no real SDK import needed."""
+    provider, fake, patcher = _make_provider()
+    try:
+        provider.search("query", limit=1, search_depth="fast")
+        provider.search("query", limit=1, search_depth=None)
+        assert len(fake.beta.search_calls) == 2
+    finally:
+        patcher.stop()
+
+
+def test_router_disabled_path_unaffected():
+    """Router code is not imported by the provider; provider works standalone."""
+    provider, fake, patcher = _make_provider()
+    try:
+        resp = provider.search("query", limit=1, search_depth="fast")
+        assert resp["success"] is True
+    finally:
+        patcher.stop()
+
+
+def test_deep_depth_maps_to_agentic():
+    provider, fake, patcher = _make_provider()
+    try:
+        with patch.dict("os.environ", {}, clear=False):
+            provider.search("query", limit=1, search_depth="deep")
+            assert fake.beta.search_calls[-1]["mode"] == "agentic"
+            provider.search("query", limit=1, search_depth="deepest")
+            assert fake.beta.search_calls[-1]["mode"] == "agentic"
+    finally:
+        patcher.stop()

--- a/tests/tools/test_web_router.py
+++ b/tests/tools/test_web_router.py
@@ -1,0 +1,1212 @@
+"""Mocked unit tests for the Web Capability Router Stage B1.
+
+Covers: intent classification (zh/en + precedence), search provider
+selection, extract provider selection + Browser escalation, availability /
+disabled-provider / missing-credential / capability filtering, provider
+override, serialization-without-secrets, and the feature-flag zero-change
+requirement (router disabled preserves legacy backends).
+
+All tests are local and mocked — no live API calls, no network, no credits.
+"""
+
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import urlparse
+
+import pytest
+
+from tools.web_router import (
+    SearchIntent,
+    is_browser_only_host,
+    normalize_browser_only_domains,
+    normalize_intent_hint,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: fake registered providers
+# ---------------------------------------------------------------------------
+
+
+def _provider(name, search=True, extract=False, available=True, credential=True):
+    p = MagicMock()
+    p.name = name
+    p.supports_search.return_value = search
+    p.supports_extract.return_value = extract
+    p.is_available.return_value = available
+    return p
+
+
+def _registry_getter(providers):
+    def _get(name):
+        return providers.get(name)
+    return _get
+
+
+def _env_has(present_keys):
+    def _has(name):
+        return name in present_keys
+    return _has
+
+
+# Providers with credentials for all five (ddgs is credential-free).
+ALL_CREDS = {"PARALLEL_API_KEY", "EXA_API_KEY", "TAVILY_API_KEY", "FIRECRAWL_API_KEY"}
+
+
+@pytest.fixture
+def all_providers():
+    return {
+        "ddgs": _provider("ddgs", search=True, extract=False),
+        "parallel": _provider("parallel", search=True, extract=True),
+        "exa": _provider("exa", search=True, extract=True),
+        "tavily": _provider("tavily", search=True, extract=True),
+        "firecrawl": _provider("firecrawl", search=True, extract=True),
+    }
+
+
+# ---------------------------------------------------------------------------
+# 3-6. Intent -> provider selection
+# ---------------------------------------------------------------------------
+
+
+class TestSearchSelection:
+    def test_simple_discovery_selects_ddgs(self, all_providers):
+        from tools.web_search_router import select_search_provider
+
+        d = select_search_provider(
+            "OpenAI official site",
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.selected_provider == "ddgs"
+        assert d.selection_reason.startswith("intent=SIMPLE_DISCOVERY")
+
+    def test_general_research_selects_parallel(self, all_providers):
+        from tools.web_search_router import select_search_provider
+
+        d = select_search_provider(
+            "best practices for building a knowledge base",
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.selected_provider == "parallel"
+
+    def test_technical_research_selects_exa(self, all_providers):
+        from tools.web_search_router import select_search_provider
+
+        d = select_search_provider(
+            "LLM inference architecture paper",
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.selected_provider == "exa"
+
+    def test_current_information_selects_tavily(self, all_providers):
+        from tools.web_search_router import select_search_provider
+
+        d = select_search_provider(
+            "latest GPU prices",
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.selected_provider == "tavily"
+
+
+# ---------------------------------------------------------------------------
+# 7. Chinese and English classifier cases
+# ---------------------------------------------------------------------------
+
+
+class TestIntentClassification:
+    def test_chinese_simple_discovery(self):
+        from tools.web_router import classify_search_intent, SearchIntent
+
+        assert classify_search_intent("DeepSeek 官网") == SearchIntent.SIMPLE_DISCOVERY
+        assert classify_search_intent("查一下 PyTorch 主页") == SearchIntent.SIMPLE_DISCOVERY
+
+    def test_chinese_technical(self):
+        from tools.web_router import classify_search_intent, SearchIntent
+
+        assert classify_search_intent("OpenAI API 文档") == SearchIntent.TECHNICAL_RESEARCH
+        assert classify_search_intent("找一下视频生成的论文") == SearchIntent.TECHNICAL_RESEARCH
+
+    def test_chinese_current(self):
+        from tools.web_router import classify_search_intent, SearchIntent
+
+        assert classify_search_intent("最新显卡价格") == SearchIntent.CURRENT_INFORMATION
+        assert classify_search_intent("最近的政策新闻") == SearchIntent.CURRENT_INFORMATION
+
+    def test_english_signals(self):
+        from tools.web_router import classify_search_intent, SearchIntent
+
+        assert classify_search_intent("official website for firecrawl") == SearchIntent.SIMPLE_DISCOVERY
+        assert classify_search_intent("paper on diffusion models") == SearchIntent.TECHNICAL_RESEARCH
+        assert classify_search_intent("current policy update") == SearchIntent.CURRENT_INFORMATION
+        assert classify_search_intent("how to train a llama") == SearchIntent.GENERAL_RESEARCH
+
+    def test_empty_query_defaults_general(self):
+        from tools.web_router import classify_search_intent, SearchIntent
+
+        assert classify_search_intent("") == SearchIntent.GENERAL_RESEARCH
+        assert classify_search_intent("   ") == SearchIntent.GENERAL_RESEARCH
+
+
+# ---------------------------------------------------------------------------
+# 8. Overlapping-signal precedence
+# ---------------------------------------------------------------------------
+
+
+class TestIntentPrecedence:
+    def test_current_beats_technical(self):
+        from tools.web_router import classify_search_intent, SearchIntent
+
+        # contains both "最新" (current) and "论文" (technical)
+        assert classify_search_intent("最新论文发布") == SearchIntent.CURRENT_INFORMATION
+
+    def test_technical_beats_simple(self):
+        from tools.web_router import classify_search_intent, SearchIntent
+
+        # contains both "官网" (simple) and "文档" (technical)
+        assert classify_search_intent("官网 API 文档") == SearchIntent.TECHNICAL_RESEARCH
+
+    def test_simple_beats_general(self):
+        from tools.web_router import classify_search_intent, SearchIntent
+
+        assert classify_search_intent("best homepage design") == SearchIntent.SIMPLE_DISCOVERY
+
+    def test_current_beats_simple(self):
+        from tools.web_router import classify_search_intent, SearchIntent
+
+        # contains both "首页" (simple) and "最新" (current)
+        assert classify_search_intent("首页最新价格") == SearchIntent.CURRENT_INFORMATION
+
+
+# ---------------------------------------------------------------------------
+# 9-12. Availability / disabled / credential / capability filtering
+# ---------------------------------------------------------------------------
+
+
+class TestAvailabilityFiltering:
+    def test_preferred_unavailable_uses_deterministic_substitute(self, all_providers):
+        from tools.web_search_router import select_search_provider
+
+        # exa (technical preferred) is NOT registered
+        providers = {k: v for k, v in all_providers.items() if k != "exa"}
+        d = select_search_provider(
+            "paper on vector databases",
+            registry_getter=_registry_getter(providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.selected_provider is not None
+        assert d.selected_provider != "exa"
+        assert "preferred_unavailable_substitute" in d.selection_reason
+        assert d.fallback_provider_advisory == "exa"
+
+    def test_disabled_provider_is_filtered(self, all_providers):
+        from tools.web_search_router import select_search_provider
+
+        # provider registered but disabled via enabled_names (plugin disabled)
+        d = select_search_provider(
+            "latest release notes",
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+            enabled_names=["tavily", "ddgs", "parallel"],
+        )
+        # tavily (current-info preferred) is in enabled_names, so still chosen
+        assert d.selected_provider == "tavily"
+
+    def test_disabled_preferred_falls_to_substitute(self, all_providers):
+        from tools.web_search_router import select_search_provider
+
+        d = select_search_provider(
+            "latest release notes",
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+            enabled_names=["ddgs", "parallel", "exa", "firecrawl"],  # tavily disabled
+        )
+        assert d.selected_provider != "tavily"
+        assert d.selected_provider is not None
+
+    def test_missing_credential_is_filtered(self, all_providers):
+        from tools.web_search_router import select_search_provider
+
+        # only ddgs (credential-free) + firecrawl have creds
+        d = select_search_provider(
+            "paper on graph neural networks",
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has({"FIRECRAWL_API_KEY"}),
+        )
+        # exa preferred but no EXA_API_KEY -> substitute (firecrawl has creds)
+        assert d.selected_provider is not None
+        assert d.selected_provider != "exa"
+
+    def test_unsupported_capability_is_filtered(self, all_providers):
+        from tools.web_extract_router import select_extract_provider
+
+        # ddgs registered but extract=False -> cannot be the extract provider
+        providers = {k: v for k, v in all_providers.items() if k != "firecrawl"}
+        d = select_extract_provider(
+            ["https://example.com/page"],
+            registry_getter=_registry_getter(providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        # firecrawl (default) unavailable -> escalation, no secondary extractor
+        assert d.escalation_recommended is True
+        assert d.escalation_reason == "no_extract_provider_available"
+        assert d.selected_provider is None
+
+    def test_no_provider_available_leaves_none(self):
+        from tools.web_search_router import select_search_provider
+
+        d = select_search_provider(
+            "anything at all",
+            registry_getter=_registry_getter({}),
+            env_has=_env_has(set()),
+        )
+        assert d.selected_provider is None
+        assert d.selection_reason == "no_provider_available"
+
+
+# ---------------------------------------------------------------------------
+# 13-14. Provider override
+# ---------------------------------------------------------------------------
+
+
+class TestProviderOverride:
+    def test_valid_override_honored(self, all_providers):
+        from tools.web_search_router import select_search_provider
+
+        d = select_search_provider(
+            "official homepage of something",
+            provider_override="exa",
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.selected_provider == "exa"
+        assert d.selection_reason == "explicit_override"
+
+    def test_invalid_override_rejected(self, all_providers):
+        from tools.web_search_router import select_search_provider
+
+        d = select_search_provider(
+            "some query",
+            provider_override="not-a-provider",
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.selected_provider != "not-a-provider"
+        assert "override_rejected" in d.selection_reason
+
+    def test_unavailable_override_rejected(self, all_providers):
+        from tools.web_search_router import select_search_provider
+
+        # override registered but no credential
+        d = select_search_provider(
+            "some query",
+            provider_override="tavily",
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(set()),
+        )
+        assert d.selected_provider != "tavily"
+        assert "override_rejected" in d.selection_reason
+
+
+# ---------------------------------------------------------------------------
+# 15-19. Extract routing + Browser escalation
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSelection:
+    def test_public_url_selects_firecrawl(self, all_providers):
+        from tools.web_extract_router import select_extract_provider
+
+        d = select_extract_provider(
+            ["https://example.com/docs/page"],
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.selected_provider == "firecrawl"
+        assert d.escalation_recommended is False
+
+    def test_taobao_url_returns_browser_escalation(self, all_providers):
+        from tools.web_extract_router import select_extract_provider
+
+        # taobao.com is an explicit synthetic fixture here; the shipped
+        # default browser_only_domains is empty.
+        d = select_extract_provider(
+            ["https://item.taobao.com/item.htm?id=123"],
+            browser_only_domains=("taobao.com",),
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.escalation_recommended is True
+        assert d.escalation_tool == "browser_navigate"
+        assert d.escalation_reason == "browser_only_domain"
+        assert d.selected_provider is None
+
+    def test_taobao_root_domain_escalates(self, all_providers):
+        from tools.web_extract_router import select_extract_provider
+
+        d = select_extract_provider(
+            ["https://taobao.com/"],
+            browser_only_domains=("taobao.com",),
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.escalation_recommended is True
+
+    def test_empty_default_has_no_vendor_boundary(self, all_providers):
+        """Shipped default carries no vendor-specific Browser boundary: a
+        taobao URL without explicit configuration is a normal public page."""
+        from tools.web_extract_router import select_extract_provider
+
+        d = select_extract_provider(
+            ["https://item.taobao.com/item.htm?id=123"],
+            browser_only_domains=(),
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.escalation_recommended is False
+        assert not d.escalation_reason
+
+    def test_login_path_returns_browser_escalation(self, all_providers):
+        from tools.web_extract_router import select_extract_provider
+
+        d = select_extract_provider(
+            ["https://example.com/login"],
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.escalation_recommended is True
+        assert d.escalation_reason == "login_required"
+
+    def test_sensitive_query_param_escalates(self, all_providers):
+        from tools.web_extract_router import select_extract_provider
+
+        d = select_extract_provider(
+            ["https://example.com/page?token=abc123"],
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.escalation_recommended is True
+        assert d.escalation_reason == "sensitive_query_parameter"
+
+    def test_evil_taobao_not_treated_as_taobao(self, all_providers):
+        from tools.web_extract_router import select_extract_provider
+        from tools.web_router import is_browser_only_host
+
+        assert is_browser_only_host("https://evil-taobao.com/x", ("taobao.com",)) is False
+        assert is_browser_only_host("https://nottaobao.com/x", ("taobao.com",)) is False
+        assert is_browser_only_host("https://sub.taobao.com/x", ("taobao.com",)) is True
+
+        # and through the extract router: evil-taobao.com is a normal public URL
+        d = select_extract_provider(
+            ["https://evil-taobao.com/page"],
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.selected_provider == "firecrawl"
+        assert d.escalation_recommended is False
+
+    def test_cart_path_escalates(self, all_providers):
+        from tools.web_extract_router import select_extract_provider
+
+        d = select_extract_provider(
+            ["https://example.com/cart"],
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.escalation_recommended is True
+        assert d.escalation_reason == "interaction_required"
+
+
+# ---------------------------------------------------------------------------
+# 20-22. No auto-Browser / no fallback execution / no secondary extractor
+# ---------------------------------------------------------------------------
+
+
+class TestBoundaryEnforcement:
+    def test_no_automatic_browser_invocation(self, all_providers):
+        from tools.web_extract_router import select_extract_provider
+
+        # Even for a browser-only URL the router only RECOMMENDS escalation.
+        d = select_extract_provider(
+            ["https://item.taobao.com/item.htm?id=1"],
+            browser_only_domains=("taobao.com",),
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.escalation_recommended is True
+        # The decision object carries tool + reason only — no browser handle,
+        # no navigation call, nothing executable.
+        assert d.escalation_tool == "browser_navigate"
+        assert d.escalation_reason
+
+    def test_search_decision_never_executes_fallback(self, all_providers):
+        from tools.web_search_router import select_search_provider
+
+        d = select_search_provider(
+            "paper on something",
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        # fallback_provider_advisory is advisory-only: selecting a provider
+        # must not trigger a second provider call. The decision only names it.
+        assert isinstance(d.fallback_provider_advisory, (str, type(None)))
+        # and no provider.search was ever called by decision construction
+        for p in all_providers.values():
+            p.search.assert_not_called()
+            p.extract.assert_not_called()
+
+    def test_extract_decision_never_calls_extractor(self, all_providers):
+        from tools.web_extract_router import select_extract_provider
+
+        select_extract_provider(
+            ["https://example.com/page"],
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        for p in all_providers.values():
+            p.extract.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 23. Decision objects serialize without secrets
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    def test_decision_dicts_have_no_secrets(self, all_providers):
+        from tools.web_router import (
+            CapabilityPolicyDecision,
+            ExtractRouterDecision,
+            SearchRouterDecision,
+        )
+        from tools.web_search_router import select_search_provider
+
+        d = select_search_provider(
+            "official site",
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        blob = json.dumps(d.to_dict())
+        assert "api_key" not in blob.lower()
+        assert "token" not in blob.lower()
+        assert "secret" not in blob.lower()
+
+        e = ExtractRouterDecision(
+            escalation_recommended=True,
+            escalation_reason="login_required",
+        )
+        blob_e = json.dumps(e.to_dict())
+        assert "api_key" not in blob_e.lower()
+        assert "token" not in blob_e.lower()
+
+        c = CapabilityPolicyDecision()
+        blob_c = json.dumps(c.to_dict())
+        assert "api_key" not in blob_c.lower()
+        assert "token" not in blob_c.lower()
+
+
+# ---------------------------------------------------------------------------
+# 24. Candidate skill remains inactive
+# ---------------------------------------------------------------------------
+
+
+class TestSkillInactive:
+    def test_candidate_skill_not_in_live_skills_tree(self):
+        hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+        skill_dir = hermes_home / "skills" / "web-capability-policy"
+        assert not skill_dir.exists(), (
+            "candidate skill must NOT be placed in the live skills tree "
+            "(file presence auto-activates it via build_skills_system_prompt)"
+        )
+        # and no devops/web-capability-policy either
+        assert not (hermes_home / "skills" / "devops" / "web-capability-policy").exists()
+
+
+# ---------------------------------------------------------------------------
+# 25. Router disabled preserves legacy backends (feature-flag zero-change)
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureFlagDisabled:
+    def test_disabled_search_preserves_legacy_backend(self):
+        import tools.web_tools as wt
+
+        with patch.object(wt, "_load_web_config", return_value={"backend": "firecrawl"}):
+            # router key absent => disabled
+            assert wt._get_search_backend() == "firecrawl"
+
+    def test_disabled_extract_preserves_legacy_backend(self):
+        import tools.web_tools as wt
+
+        with patch.object(
+            wt, "_load_web_config",
+            return_value={"backend": "firecrawl", "router": {"enabled": False}},
+        ):
+            assert wt._get_extract_backend() == "firecrawl"
+
+    def test_web_search_tool_disabled_does_not_import_router(self):
+        """Feature flag false => no router state, no classification, no telemetry."""
+        import tools.web_tools as wt
+
+        provider = _provider("firecrawl", search=True)
+        provider.search.return_value = {
+            "success": True,
+            "data": {"web": [{"title": "t", "url": "https://x", "description": "d", "position": 1}]},
+        }
+        with patch.object(wt, "_load_web_config", return_value={"backend": "firecrawl"}):
+            with patch.object(wt, "_ensure_web_plugins_loaded"):
+                with patch(
+                    "agent.web_search_registry.get_provider",
+                    side_effect=lambda name: provider if name == "firecrawl" else None,
+                ):
+                    with patch("tools.web_search_router.select_search_provider") as router:
+                        result = wt.web_search_tool("legacy query")
+                        data = json.loads(result)
+                        assert data["success"] is True
+                        # legacy backend (firecrawl) was used...
+                        provider.search.assert_called_once()
+                        # ...and the router was NEVER consulted
+                        router.assert_not_called()
+
+    def test_router_enabled_flag_still_false_in_config(self):
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            cfg = load_config_readonly()
+            router = (cfg.get("web") or {}).get("router") or {}
+            assert router.get("enabled") is False
+        except Exception:
+            pytest.skip("config not readable in this environment")
+
+    def test_legacy_backends_unchanged(self):
+        """web.backend / search_backend / extract_backend values are preserved."""
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            cfg = load_config_readonly()
+            web = cfg.get("web") or {}
+            # these keys must still exist and keep their configured values
+            assert "backend" in web
+            assert "search_backend" in web
+            assert "extract_backend" in web
+        except Exception:
+            pytest.skip("config not readable in this environment")
+
+
+# ---------------------------------------------------------------------------
+# Integration smoke (mocked): router-enabled search still returns tool JSON
+# ---------------------------------------------------------------------------
+
+
+class TestToolIntegrationMocked:
+    def test_web_search_tool_router_enabled_picks_provider_and_searches(self):
+        """With the flag on, ONE provider is selected and called — mocked."""
+        import tools.web_tools as wt
+
+        provider = _provider("exa", search=True)
+        provider.search.return_value = {
+            "success": True,
+            "data": {"web": [{"title": "t", "url": "https://x", "description": "d", "position": 1}]},
+        }
+        cfg = {"backend": "firecrawl", "router": {"enabled": True}}
+
+        with patch.object(wt, "_load_web_config", return_value=cfg):
+            with patch.object(wt, "_get_search_backend", return_value="firecrawl") as gsb:
+                with patch("tools.web_search_router.select_search_provider") as router:
+                    from tools.web_router import SearchRouterDecision
+
+                    router.return_value = SearchRouterDecision(
+                        selected_provider="exa", selection_reason="intent=TECHNICAL_RESEARCH"
+                    )
+                    with patch.object(wt, "_ensure_web_plugins_loaded"):
+                        with patch(
+                            "agent.web_search_registry.get_provider",
+                            side_effect=lambda name: provider if name == "exa" else None,
+                        ):
+                            result = wt.web_search_tool("paper on x")
+                            data = json.loads(result)
+                            assert data["success"] is True
+                            assert data["data"]["web"][0]["url"] == "https://x"
+                            provider.search.assert_called_once()
+                            # legacy backend resolver still consulted for the
+                            # no-decision fallback, but router won
+                            assert router.call_count == 1
+
+    def test_web_extract_tool_router_enabled_taobao_escalates(self):
+        """With the flag on, a taobao URL returns a structured escalation."""
+        import tools.web_tools as wt
+
+        cfg = {"backend": "firecrawl", "router": {"enabled": True}}
+        with patch.object(wt, "_load_web_config", return_value=cfg):
+            with patch.object(wt, "_get_extract_backend", return_value="firecrawl"):
+                # SSRF check would otherwise resolve the hostname — keep it offline
+                with patch.object(
+                    wt, "async_is_safe_url", new=AsyncMock(return_value=True)
+                ):
+                    with patch("tools.web_extract_router.select_extract_provider") as router:
+                        from tools.web_router import ExtractRouterDecision
+
+                        router.return_value = ExtractRouterDecision(
+                            escalation_recommended=True,
+                            escalation_tool="browser_navigate",
+                            escalation_reason="browser_only_domain",
+                        )
+                        import asyncio
+
+                        result = asyncio.run(
+                            wt.web_extract_tool(["https://item.taobao.com/item.htm?id=1"])
+                        )
+                        data = json.loads(result)
+                        assert data["success"] is False
+                        assert data["escalation"]["recommended_tool"] == "browser_navigate"
+                        assert data["escalation"]["reason"] == "browser_only_domain"
+
+
+# ---------------------------------------------------------------------------
+# Post-B1 runtime-readiness correction tests (§5/§6 of
+# HERMES_WEB_ROUTER_POST_B1_PARALLEL_EXA_READINESS_COMPLETION_V0_1)
+# ---------------------------------------------------------------------------
+# provider_runtime_ready() requires: registered + capability + credential
+# (or credential-free) + local dependency importable (provider.is_available()).
+# The `available` flag on the _provider fixture simulates the SDK-importable
+# half of is_available(); `credential` is driven by env_has in selection.
+
+
+class TestRuntimeReadiness:
+    """1-2. SDK-missing providers are NOT Router-selectable even with keys."""
+
+    def test_parallel_key_but_missing_sdk_not_selectable(self):
+        from tools.web_router import provider_runtime_ready
+
+        # registered, search-capable, PARALLEL_API_KEY present, but SDK
+        # missing => is_available() returns False (the corrected semantics)
+        p = _provider("parallel", search=True, extract=True, available=False)
+        assert (
+            provider_runtime_ready(
+                "parallel", "search",
+                registry_getter=_registry_getter({"parallel": p}),
+                env_has=_env_has({"PARALLEL_API_KEY"}),
+            )
+            is False
+        )
+
+    def test_exa_key_but_missing_sdk_not_selectable(self):
+        from tools.web_router import provider_runtime_ready
+
+        p = _provider("exa", search=True, extract=True, available=False)
+        assert (
+            provider_runtime_ready(
+                "exa", "search",
+                registry_getter=_registry_getter({"exa": p}),
+                env_has=_env_has({"EXA_API_KEY"}),
+            )
+            is False
+        )
+
+    def test_parallel_selectable_when_sdk_importable(self):
+        from tools.web_router import provider_runtime_ready
+
+        p = _provider("parallel", search=True, extract=True, available=True)
+        assert (
+            provider_runtime_ready(
+                "parallel", "search",
+                registry_getter=_registry_getter({"parallel": p}),
+                env_has=_env_has({"PARALLEL_API_KEY"}),
+            )
+            is True
+        )
+
+    def test_exa_selectable_when_sdk_importable(self):
+        from tools.web_router import provider_runtime_ready
+
+        p = _provider("exa", search=True, extract=True, available=True)
+        assert (
+            provider_runtime_ready(
+                "exa", "search",
+                registry_getter=_registry_getter({"exa": p}),
+                env_has=_env_has({"EXA_API_KEY"}),
+            )
+            is True
+        )
+
+    def test_ddgs_selectable_without_api_key(self):
+        """DDGS is credential-free: no key needed, package importable."""
+        from tools.web_router import provider_runtime_ready
+
+        p = _provider("ddgs", search=True, extract=False, available=True)
+        assert (
+            provider_runtime_ready(
+                "ddgs", "search",
+                registry_getter=_registry_getter({"ddgs": p}),
+                env_has=_env_has(set()),
+            )
+            is True
+        )
+
+    def test_tavily_selectable_via_direct_http(self):
+        """Tavily needs only its key (httpx direct implementation)."""
+        from tools.web_router import provider_runtime_ready
+
+        p = _provider("tavily", search=True, extract=True, available=True)
+        assert (
+            provider_runtime_ready(
+                "tavily", "search",
+                registry_getter=_registry_getter({"tavily": p}),
+                env_has=_env_has({"TAVILY_API_KEY"}),
+            )
+            is True
+        )
+
+    def test_firecrawl_selectable_when_client_importable(self):
+        from tools.web_router import provider_runtime_ready
+
+        p = _provider("firecrawl", search=True, extract=True, available=True)
+        assert (
+            provider_runtime_ready(
+                "firecrawl", "extract",
+                registry_getter=_registry_getter({"firecrawl": p}),
+                env_has=_env_has({"FIRECRAWL_API_KEY"}),
+            )
+            is True
+        )
+
+    def test_sdk_missing_preferred_yields_deterministic_substitute(self):
+        """8. Preferred (exa) lacks SDK => ONE deterministic substitute."""
+        from tools.web_search_router import select_search_provider
+
+        # exa registered with key but SDK missing; others fully ready
+        providers = {
+            "ddgs": _provider("ddgs", search=True, extract=False, available=True),
+            "parallel": _provider("parallel", search=True, extract=True, available=True),
+            "exa": _provider("exa", search=True, extract=True, available=False),
+            "tavily": _provider("tavily", search=True, extract=True, available=True),
+            "firecrawl": _provider("firecrawl", search=True, extract=True, available=True),
+        }
+        d = select_search_provider(
+            "paper on vector databases",
+            registry_getter=_registry_getter(providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.selected_provider is not None
+        assert d.selected_provider != "exa"
+        assert "preferred_unavailable_substitute" in d.selection_reason
+        # substitute order: parallel first after exa excluded
+        assert d.selected_provider == "parallel"
+
+    def test_runtime_readiness_does_not_call_provider_search(self):
+        """10a. Readiness gates never trigger a live provider call."""
+        from tools.web_router import provider_runtime_ready
+
+        p = _provider("tavily", search=True, extract=True, available=True)
+        provider_runtime_ready(
+            "tavily", "search",
+            registry_getter=_registry_getter({"tavily": p}),
+            env_has=_env_has({"TAVILY_API_KEY"}),
+        )
+        p.search.assert_not_called()
+        p.extract.assert_not_called()
+
+
+class TestReadinessRegressionBoundary:
+    """10b. Router disabled still preserves legacy behavior exactly."""
+
+    def test_disabled_search_still_legacy_backend(self):
+        import tools.web_tools as wt
+
+        with patch.object(wt, "_load_web_config", return_value={"backend": "firecrawl"}):
+            assert wt._get_search_backend() == "firecrawl"
+
+    def test_disabled_extract_still_legacy_backend(self):
+        import tools.web_tools as wt
+
+        with patch.object(
+            wt, "_load_web_config",
+            return_value={"backend": "firecrawl", "router": {"enabled": False}},
+        ):
+            assert wt._get_extract_backend() == "firecrawl"
+
+    def test_disabled_web_search_tool_never_consults_router(self):
+        """Feature flag false => no router consultation, no live request."""
+        import tools.web_tools as wt
+
+        provider = _provider("firecrawl", search=True, available=True)
+        provider.search.return_value = {
+            "success": True,
+            "data": {"web": [{"title": "t", "url": "https://x", "description": "d", "position": 1}]},
+        }
+        with patch.object(wt, "_load_web_config", return_value={"backend": "firecrawl"}):
+            with patch.object(wt, "_ensure_web_plugins_loaded"):
+                with patch(
+                    "agent.web_search_registry.get_provider",
+                    side_effect=lambda name: provider if name == "firecrawl" else None,
+                ):
+                    with patch("tools.web_search_router.select_search_provider") as router:
+                        result = wt.web_search_tool("legacy query")
+                        assert json.loads(result)["success"] is True
+                        provider.search.assert_called_once()
+                        router.assert_not_called()
+
+    def test_real_provider_is_available_requires_sdk(self):
+        """Integration-level: the REAL parallel/exa providers now gate on SDK.
+
+        Uses the real provider classes with mocked env, so no network.
+        """
+        import importlib.util
+
+        from plugins.web.parallel.provider import ParallelWebSearchProvider
+        from plugins.web.exa.provider import ExaWebSearchProvider
+
+        parallel_sdk = importlib.util.find_spec("parallel") is not None
+        exa_sdk = importlib.util.find_spec("exa_py") is not None
+
+        # With no key, availability is False regardless of SDK.
+        for cls, key in ((ParallelWebSearchProvider, "PARALLEL_API_KEY"),
+                         (ExaWebSearchProvider, "EXA_API_KEY")):
+            with patch.dict("os.environ", {}, clear=False):
+                import os
+                os.environ.pop(key, None)
+                inst = cls()
+                assert inst.is_available() is False
+
+        # With key present, availability equals SDK importability.
+        # (SDK was installed by the readiness-completion task; if this runs
+        # in an env without it, the assertion still matches reality.)
+        with patch.dict("os.environ", {"PARALLEL_API_KEY": "test-key-not-real"}, clear=False):
+            assert ParallelWebSearchProvider().is_available() is parallel_sdk
+        with patch.dict("os.environ", {"EXA_API_KEY": "test-key-not-real"}, clear=False):
+            assert ExaWebSearchProvider().is_available() is exa_sdk
+
+
+# ---------------------------------------------------------------------------
+# Pre-commit N6 test-gap closure
+# (HERMES_WEB_ROUTER_B1_PRECOMMIT_N6_TEST_GAP_CLOSURE_V0_1)
+# normalize_browser_only_domains / normalize_intent_hint / escalation
+# field-level privacy. Test-only additions; product behavior encoded as-is.
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeBrowserOnlyDomains:
+    """Actual contract of tools.web_router.normalize_browser_only_domains:
+
+    - None / non-string-non-list -> DEFAULT_BROWSER_ONLY_DOMAINS;
+    - str: strip; JSON-array string parsed when well-formed; otherwise split
+      on whitespace/comma/semicolon;
+    - list/tuple: coerced to stripped string tuple;
+    - case and leading dots are preserved by normalize and normalized at
+      match time inside is_browser_only_host.
+    """
+
+    def test_native_list(self):
+        assert normalize_browser_only_domains(["taobao.com", "jd.com"]) == (
+            "taobao.com", "jd.com",
+        )
+
+    def test_json_array_string(self):
+        assert normalize_browser_only_domains('["taobao.com", "jd.com"]') == (
+            "taobao.com", "jd.com",
+        )
+
+    def test_surrounding_whitespace_stripped(self):
+        assert normalize_browser_only_domains("  taobao.com  ,  jd.com  ") == (
+            "taobao.com", "jd.com",
+        )
+
+    def test_semicolon_and_newline_split(self):
+        assert normalize_browser_only_domains("taobao.com; jd.com\npdd.com") == (
+            "taobao.com", "jd.com", "pdd.com",
+        )
+
+    def test_mixed_case_preserved_by_normalize_matched_by_host_check(self):
+        norm = normalize_browser_only_domains(["Taobao.COM"])
+        assert norm == ("Taobao.COM",)  # normalize preserves case...
+        # ...and the host check normalizes at match time
+        assert is_browser_only_host("https://item.taobao.com/x", norm) is True
+
+    def test_leading_dot_input(self):
+        norm = normalize_browser_only_domains([".taobao.com"])
+        assert norm == (".taobao.com",)
+        assert is_browser_only_host("https://x.taobao.com/", norm) is True
+
+    def test_duplicate_entries_preserved(self):
+        assert normalize_browser_only_domains(["taobao.com", "taobao.com"]) == (
+            "taobao.com", "taobao.com",
+        )
+
+    def test_empty_list_and_empty_string(self):
+        assert normalize_browser_only_domains([]) == ()
+        assert normalize_browser_only_domains("") == ()
+        assert normalize_browser_only_domains("   ") == ()
+
+    def test_none_returns_default(self):
+        # shipped default is empty (vendor-neutral)
+        assert normalize_browser_only_domains(None) == ()
+
+    def test_non_string_non_list_returns_default(self):
+        assert normalize_browser_only_domains(42) == ()
+        assert normalize_browser_only_domains({"a": 1}) == ()
+
+    def test_malformed_json_does_not_broaden_matching(self):
+        # single-quoted "JSON" parses as a literal token; it must NOT match
+        # the real taobao.com
+        norm = normalize_browser_only_domains("['taobao.com']")
+        assert "['taobao.com']" in norm
+        assert is_browser_only_host("https://taobao.com/", norm) is False
+        assert is_browser_only_host("https://item.taobao.com/", norm) is False
+
+    def test_malformed_json_without_quotes_does_not_broaden(self):
+        norm = normalize_browser_only_domains("[taobao.com]")
+        assert is_browser_only_host("https://taobao.com/", norm) is False
+
+    def test_json_prefix_with_trailing_junk_only_yields_written_tokens(self):
+        # '["taobao.com"] evil.com' fails JSON parse -> split; the JSON
+        # syntax fragment is a literal that matches nothing, and only the
+        # token the user actually wrote (evil.com) is usable. No expansion.
+        norm = normalize_browser_only_domains('["taobao.com"] evil.com')
+        assert is_browser_only_host("https://taobao.com/", norm) is False
+        assert is_browser_only_host("https://item.taobao.com/", norm) is False
+        assert is_browser_only_host("https://evil.com/", norm) is True
+
+    def test_evil_taobao_never_equivalent_to_taobao(self):
+        assert is_browser_only_host("https://evil-taobao.com/x", ("taobao.com",)) is False
+        assert is_browser_only_host("https://notaobao.com/x", ("taobao.com",)) is False
+        assert is_browser_only_host("https://taobao.com.evil.example/x", ("taobao.com",)) is False
+
+
+class TestNormalizeIntentHint:
+    """Actual contract of tools.web_router.normalize_intent_hint:
+
+    - empty/None -> None;
+    - strip + upper + exact enum name match -> SearchIntent;
+    - anything else -> None. No aliases are supported by the implementation.
+    """
+
+    def test_canonical_enum_values(self):
+        for v in ("SIMPLE_DISCOVERY", "GENERAL_RESEARCH", "TECHNICAL_RESEARCH",
+                  "CURRENT_INFORMATION"):
+            assert normalize_intent_hint(v).value == v
+
+    def test_lowercase_normalization(self):
+        assert normalize_intent_hint("technical_research") == SearchIntent.TECHNICAL_RESEARCH
+
+    def test_mixed_case_normalization(self):
+        assert normalize_intent_hint("Technical_Research") == SearchIntent.TECHNICAL_RESEARCH
+
+    def test_leading_trailing_whitespace_stripped(self):
+        assert normalize_intent_hint("  general_research  ") == SearchIntent.GENERAL_RESEARCH
+
+    def test_unknown_value_returns_none(self):
+        assert normalize_intent_hint("bogus") is None
+
+    def test_empty_and_none_return_none(self):
+        assert normalize_intent_hint("") is None
+        assert normalize_intent_hint(None) is None
+
+    def test_unknown_never_silently_becomes_another_intent(self):
+        # capability names, verification modes, and partial enum strings must
+        # not be coerced into a different intent
+        for bad in ("SEARCH", "EXTRACT", "BROWSER", "NO_WEB", "VERIFY",
+                    "SECOND_PROVIDER", "TECHNICAL", "CURRENT", "GENERAL", "SIMPLE"):
+            assert normalize_intent_hint(bad) is None
+
+    def test_no_alias_support(self):
+        # the implementation supports no aliases — short forms must stay None
+        assert normalize_intent_hint("tech") is None
+        assert normalize_intent_hint("paper") is None
+        assert normalize_intent_hint("news") is None
+        assert normalize_intent_hint("docs") is None
+
+
+class TestEscalationPrivacyFieldLevel:
+    """Field-level privacy/structure assertions on the REAL escalation path:
+    web_extract_tool with web.router.enabled, real select_extract_provider
+    (not mocked), extractor never reached."""
+
+    ESCALATION_REASONS = {
+        "browser_only_domain", "login_required", "interaction_required",
+        "sensitive_query_parameter", "browser_required",
+        "no_extract_provider_available",
+    }
+
+    def _escalation_for(self, url):
+        import tools.web_tools as wt
+
+        # taobao.com injected as an explicit fixture; shipped default empty.
+        cfg = {"backend": "firecrawl",
+               "router": {"enabled": True,
+                          "browser_only_domains": ["taobao.com"]}}
+        with patch.object(wt, "_load_web_config", return_value=cfg):
+            with patch.object(wt, "_get_extract_backend", return_value="firecrawl"):
+                with patch.object(
+                    wt, "async_is_safe_url", new=AsyncMock(return_value=True)
+                ):
+                    # real router chain; provider lookup must never run
+                    with patch(
+                        "agent.web_search_registry.get_provider", return_value=None
+                    ) as gp:
+                        import asyncio
+
+                        result = asyncio.run(wt.web_extract_tool([url]))
+                        return json.loads(result), gp
+
+    def _assert_privacy_clean(self, data, url):
+        assert data["success"] is False
+        esc = data["escalation"]
+        assert esc["recommended_tool"] == "browser_navigate"
+        assert esc["reason"] in self.ESCALATION_REASONS
+        # exact key structure — no extra fields
+        assert set(data.keys()) == {"success", "error", "escalation"}
+        assert set(esc.keys()) == {"recommended_tool", "reason"}
+        # field-level privacy on the serialized object
+        blob = json.dumps(data, ensure_ascii=False)
+        parsed = urlparse(url)
+        assert parsed.hostname not in blob          # no full URL / host
+        assert parsed.path not in blob              # no path
+        if parsed.query:
+            assert parsed.query not in blob         # no query string
+        low = blob.lower()
+        assert "token" not in low
+        assert "cookie" not in low
+        assert "password" not in low
+        assert "credential" not in low
+        assert "api_key" not in low
+        assert "1067726290000" not in blob          # no item ID
+        assert "动漫" not in blob                    # no page content
+        assert "title" not in esc
+
+    def test_taobao_escalation_privacy(self):
+        url = "https://item.taobao.com/item.htm?id=1067726290000"
+        data, gp = self._escalation_for(url)
+        assert data["escalation"]["reason"] == "browser_only_domain"
+        self._assert_privacy_clean(data, url)
+        gp.assert_not_called()  # extractor never consulted
+
+    def test_login_path_escalation_privacy(self):
+        url = "https://example.com/login"
+        data, gp = self._escalation_for(url)
+        assert data["escalation"]["reason"] == "login_required"
+        self._assert_privacy_clean(data, url)
+        gp.assert_not_called()
+
+    def test_sensitive_query_param_blocked_before_extractor(self):
+        # The LEGACY guard inside web_extract_tool blocks credential-like
+        # query parameters BEFORE the router is ever reached. The response is
+        # an error envelope (no escalation object), which is itself the
+        # privacy behavior: the URL never reaches an external extractor and
+        # the token VALUE never appears in the response.
+        url = "https://example.com/page?token=abc123"
+        data, gp = self._escalation_for(url)
+        assert data["success"] is False
+        assert "escalation" not in data          # legacy guard path
+        assert "Blocked" in data["error"]
+        blob = json.dumps(data, ensure_ascii=False)
+        assert "abc123" not in blob              # token value never leaks
+        assert "example.com" not in blob
+        assert "/page" not in blob
+        assert "token=abc123" not in blob
+        gp.assert_not_called()                   # extractor never consulted
+
+    def test_evil_taobao_not_treated_as_taobao_subdomain(self):
+        # safe-hostname assertion at the unit level
+        assert is_browser_only_host("https://evil-taobao.com/x", ("taobao.com",)) is False
+        # and the extract router must NOT classify it as a browser-only
+        # domain (any escalation it produces is a different reason)
+        from tools.web_extract_router import select_extract_provider
+
+        dec = select_extract_provider(
+            ["https://evil-taobao.com/page"],
+            browser_only_domains=("taobao.com",),
+        )
+        assert dec.escalation_reason != "browser_only_domain"
+        assert dec.selected_provider is None or dec.selected_provider != "browser"
+
+
+# ---------------------------------------------------------------------------
+# Official-site discovery classifier (OFFICIAL_SITE_DISCOVERY_CLASSIFIER_FIX)
+# ---------------------------------------------------------------------------
+
+
+class TestOfficialSiteDiscoveryClassifier:
+    """official + website|site|homepage token combination (entity words may
+    sit between them) must classify as SIMPLE_DISCOVERY -> ddgs, without
+    over-classifying plurals or unrelated queries."""
+
+    @pytest.mark.parametrize("query", [
+        "Find the official OpenAI website",
+        "Find the official Exa homepage",
+        "Locate the official Tavily site",
+        "OpenAI official website",
+        "Find OpenAI's official website",
+    ])
+    def test_official_site_discovery_positive(self, query, all_providers):
+        from tools.web_router import classify_search_intent
+        from tools.web_search_router import select_search_provider
+
+        assert classify_search_intent(query) is SearchIntent.SIMPLE_DISCOVERY
+        d = select_search_provider(
+            query,
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.selected_provider == "ddgs"
+
+    def test_contiguous_official_site_unchanged(self, all_providers):
+        # Existing contiguous-form behavior preserved.
+        from tools.web_router import classify_search_intent
+        from tools.web_search_router import select_search_provider
+
+        assert classify_search_intent("OpenAI official site") is SearchIntent.SIMPLE_DISCOVERY
+        d = select_search_provider(
+            "OpenAI official site",
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.selected_provider == "ddgs"
+
+    def test_chinese_official_site_signals_unchanged(self, all_providers):
+        from tools.web_router import classify_search_intent
+        from tools.web_search_router import select_search_provider
+
+        assert classify_search_intent("OpenAI 官方网站 是什么") is SearchIntent.SIMPLE_DISCOVERY
+        d = select_search_provider(
+            "OpenAI 官方网站 是什么",
+            registry_getter=_registry_getter(all_providers),
+            env_has=_env_has(ALL_CREDS),
+        )
+        assert d.selected_provider == "ddgs"
+
+    @pytest.mark.parametrize("query,expected", [
+        # TECHNICAL_RESEARCH must win over the official-site pattern.
+        ("Find the official API documentation for Exa", "TECHNICAL_RESEARCH"),
+        # CURRENT_INFORMATION must win over the official-site pattern.
+        ("What is the current Tavily API pricing on its official website?", "CURRENT_INFORMATION"),
+        # Plural "official websites" must NOT match (comparative query).
+        ("Compare the official websites of several search providers", "GENERAL_RESEARCH"),
+        # Stronger technical signal wins.
+        ("Review the architecture of an official website", "TECHNICAL_RESEARCH"),
+        # "official" alone (no website/site/homepage) is not discovery.
+        ("The official announcement was made yesterday", "GENERAL_RESEARCH"),
+        # website word without an official/discovery signal is not auto-SIMPLE.
+        ("A website about hiking trails in Yunnan", "GENERAL_RESEARCH"),
+    ])
+    def test_official_site_discovery_negative(self, query, expected):
+        from tools.web_router import classify_search_intent
+
+        assert classify_search_intent(query) is SearchIntent[expected]
+
+    @pytest.mark.parametrize("query", [
+        "找最新的视频生成论文",
+        "当前版本的 API 文档",
+        "search for recent API documentation",
+    ])
+    def test_deferred_overlap_cases_recorded(self, query):
+        """V0.2 classifier-policy candidates — behavior deliberately NOT
+        changed by this fix; record current intent only."""
+        from tools.web_router import classify_search_intent
+
+        assert classify_search_intent(query) is SearchIntent.CURRENT_INFORMATION

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -341,7 +341,11 @@ class TestWebSearchSchema:
             result = json.loads(tools.web_tools.web_search_tool("docs", limit=500))
 
         assert result == {"success": True, "data": {"web": []}}
-        fake_search.assert_called_once_with("docs", 100)
+        fake_search.assert_called_once_with(
+            "docs",
+            100,
+            search_depth=None,
+        )
 
 
 class TestWebSearchErrorHandling:

--- a/tools/web_extract_router.py
+++ b/tools/web_extract_router.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Extract Provider Router — Layer B, web_extract side (R1 §4 / §11).
+
+Minimal public-URL extraction routing for web_extract_tool. Runs only when
+``web.router.enabled`` is true; when false, web_extract_tool never imports
+this module.
+
+B1 boundaries (R1 §11 / §15.2):
+  - privacy/interaction checks happen BEFORE any external extractor;
+  - browser-only / login / interaction / sensitive-parameter URLs produce a
+    structured Browser escalation recommendation (NEVER an automatic Browser
+    call from inside web_extract_tool);
+  - normal public URLs select Firecrawl;
+  - at most ONE extractor per call, NO secondary extract provider in B1;
+  - no URL is sent to Exa + Tavily + Parallel + Firecrawl in sequence.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Optional, Sequence
+
+from tools.web_router import (
+    DEFAULT_EXTRACT_PROVIDER,
+    ExtractRouterDecision,
+    browser_escalation_reason,
+    normalize_browser_only_domains,
+    provider_runtime_ready,
+    url_requires_browser,
+)
+
+
+def select_extract_provider(
+    urls: Iterable[str],
+    browser_only_domains: Optional[Sequence[str]] = None,
+    registry_getter: Optional[Callable[[str], Any]] = None,
+    env_has: Optional[Callable[[str], bool]] = None,
+) -> ExtractRouterDecision:
+    """Construct ONE ExtractRouterDecision for a web_extract call.
+
+    Order (R1 §11):
+      1. URL boundary classification — any URL that requires Browser yields an
+         escalation recommendation (no external call is made for that set);
+      2. otherwise select Firecrawl (default public-page extractor) if it is
+         registered + credential-present + extract-capable;
+      3. if no extractor is usable, return an escalation recommendation
+         (B1 has NO secondary extract provider).
+
+    Never extracts anything. Pure decision construction.
+    """
+    decision = ExtractRouterDecision()
+    domains = normalize_browser_only_domains(browser_only_domains)
+
+    url_list = list(urls or [])
+    if not url_list:
+        decision.selected_provider = DEFAULT_EXTRACT_PROVIDER
+        decision.selection_reason = "no_urls_default_extractor"
+        return decision
+
+    # 1) Privacy + interaction boundary BEFORE any external extractor.
+    for url in url_list:
+        if url_requires_browser(url, domains):
+            decision.escalation_recommended = True
+            decision.escalation_tool = "browser_navigate"
+            decision.escalation_reason = browser_escalation_reason(url, domains)
+            decision.selection_reason = "browser_required"
+            decision.selected_provider = None
+            return decision
+
+    # 2) Normal public URL(s) -> Firecrawl, if usable.
+    if _extractor_usable(DEFAULT_EXTRACT_PROVIDER, registry_getter, env_has):
+        decision.selected_provider = DEFAULT_EXTRACT_PROVIDER
+        decision.selection_reason = "default_public_extractor"
+        return decision
+
+    # 3) No usable extractor in B1 — recommend Browser rather than a
+    #    secondary extract chain.
+    decision.escalation_recommended = True
+    decision.escalation_tool = "browser_navigate"
+    decision.escalation_reason = "no_extract_provider_available"
+    decision.selection_reason = "no_extract_provider_available"
+    return decision
+
+
+def _extractor_usable(
+    name: str,
+    registry_getter: Optional[Callable[[str], Any]],
+    env_has: Optional[Callable[[str], bool]],
+) -> bool:
+    return provider_runtime_ready(name, "extract", registry_getter, env_has)

--- a/tools/web_router.py
+++ b/tools/web_router.py
@@ -1,0 +1,646 @@
+#!/usr/bin/env python3
+"""
+Web Capability Router — Stage B1 foundation.
+
+Canonical decision schemas, deterministic intent classification, and the
+five-provider routing registry for the Hermes Web Capability Router V0.1.
+
+LAYER BOUNDARY (R1)
+===================
+This module is the *provider-router* layer (Layer B). It operates only after
+the Agent has already selected a capability (SEARCH or EXTRACT) via the
+Capability Policy (Layer A — the ``web-capability-policy`` candidate skill).
+It must never claim to enforce NO_WEB or BROWSER; when Browser is required it
+returns a structured *escalation recommendation* for the Agent to act on.
+
+Stage B1 scope:
+  - canonical decision schemas (serializable, stateless);
+  - deterministic intent classification (rule-based, no ML / no LLM);
+  - a complete five-provider registry (ddgs, parallel, exa, tavily, firecrawl);
+  - deterministic single-provider selection;
+  - a feature flag that defaults to false (``web.router.enabled``).
+
+Explicitly NOT in B1 (see R1 §15.2 / §16):
+  - runtime fallback execution;
+  - verification execution;
+  - quota monitoring;
+  - live provider tests;
+  - automatic Browser invocation;
+  - query-content telemetry (decision objects are the only telemetry).
+
+No API keys, page content, cookies, credentials, or billing data are ever
+stored in these objects. Quota/pricing figures are deliberately NOT hardcoded
+anywhere in this module.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+from urllib.parse import urlparse
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class Capability(str, enum.Enum):
+    """Mutually-exclusive web capability (Layer A decision output)."""
+
+    NO_WEB = "NO_WEB"
+    BROWSER = "BROWSER"
+    SEARCH = "SEARCH"
+    EXTRACT = "EXTRACT"
+
+
+class VerificationMode(str, enum.Enum):
+    """Orthogonal verification mode (NOT a capability — R1 §6)."""
+
+    NONE = "NONE"
+    SECOND_PROVIDER = "SECOND_PROVIDER"
+    PRIMARY_SOURCE_REQUIRED = "PRIMARY_SOURCE_REQUIRED"
+
+
+class SearchIntent(str, enum.Enum):
+    """Deterministic search-intent classes (R1 §7 / §8)."""
+
+    SIMPLE_DISCOVERY = "SIMPLE_DISCOVERY"
+    GENERAL_RESEARCH = "GENERAL_RESEARCH"
+    TECHNICAL_RESEARCH = "TECHNICAL_RESEARCH"
+    CURRENT_INFORMATION = "CURRENT_INFORMATION"
+
+
+# ---------------------------------------------------------------------------
+# Intent classification — deterministic, rule-based, bilingual (zh/en)
+# ---------------------------------------------------------------------------
+
+# Precedence (highest wins): CURRENT_INFORMATION > TECHNICAL_RESEARCH
+# > SIMPLE_DISCOVERY > GENERAL_RESEARCH. Refined from R1 §8 and validated
+# against the local integration. Signals are deliberately small keyword sets;
+# no ML, no LLM, no external calls.
+
+_INTENT_SIGNALS: Dict[SearchIntent, Tuple[Tuple[str, ...], Tuple[str, ...]]] = {
+    SearchIntent.SIMPLE_DISCOVERY: (
+        # Chinese signals
+        ("官网", "主页", "官方网站", "首页", "网站"),
+        # English signals. The contiguous "official site"/"official website"
+        # strings are intentionally NOT listed here: they are covered by
+        # _has_official_site_discovery_signal (word-boundary token match),
+        # which also handles entity words between "official" and the site
+        # word and correctly excludes plurals like "official websites".
+        ("homepage", "home page", "website for", "website of"),
+    ),
+    SearchIntent.TECHNICAL_RESEARCH: (
+        ("api 文档", "api文档", "技术文档", "文档", "论文", "规范", "架构",
+         "语义搜索", "相关页面", "接口文档", "开发文档", "sdk"),
+        ("documentation", "docs", "paper", "papers", "specification",
+         "architecture", "semantic search", "related pages", "api reference",
+         "sdk", "technical", "arxiv"),
+    ),
+    SearchIntent.CURRENT_INFORMATION: (
+        ("最新", "当前", "目前", "最近", "新闻", "价格", "政策", "今日",
+         "发布", "更新"),
+        ("current", "latest", "recent", "news", "price", "prices", "policy",
+         "release", "released", "today", "breaking"),
+    ),
+    SearchIntent.GENERAL_RESEARCH: ((), ()),  # default — always matches
+}
+
+# Order matters: highest precedence first (R1 §8).
+_INTENT_PRECEDENCE: Tuple[SearchIntent, ...] = (
+    SearchIntent.CURRENT_INFORMATION,
+    SearchIntent.TECHNICAL_RESEARCH,
+    SearchIntent.SIMPLE_DISCOVERY,
+    SearchIntent.GENERAL_RESEARCH,
+)
+
+
+def _has_official_site_discovery_signal(text: str) -> bool:
+    """True when an official-site discovery pattern appears in *text*.
+
+    Matches the token combination ``official`` followed (within a small
+    window) by ``website`` / ``site`` / ``homepage``, even when one or more
+    entity words occur between them — e.g. "Find the official OpenAI
+    website". Plural forms ("websites", "sites") deliberately do NOT match,
+    so comparative queries like "Compare the official websites of several
+    search providers" stay GENERAL_RESEARCH. Higher-precedence intents
+    (CURRENT_INFORMATION, TECHNICAL_RESEARCH) are already matched before
+    this signal is consulted by :func:`classify_search_intent`.
+    """
+    tokens = re.findall(r"[a-z]+", text)
+    targets = {"website", "site", "homepage"}
+    for i, token in enumerate(tokens):
+        if token != "official":
+            continue
+        for j in range(i + 1, min(i + 4, len(tokens))):
+            if tokens[j] in targets:
+                return True
+    return False
+
+
+def classify_search_intent(query: str) -> SearchIntent:
+    """Return the deterministic intent class for *query*.
+
+    Rule-based keyword matching over lowercased text (English signals) and
+    raw text (Chinese signals — case is irrelevant for CJK). Precedence:
+    CURRENT_INFORMATION > TECHNICAL_RESEARCH > SIMPLE_DISCOVERY
+    > GENERAL_RESEARCH. GENERAL_RESEARCH is the always-matching default, so
+    this function never returns None for non-empty input.
+
+    Empty/whitespace input maps to GENERAL_RESEARCH so the provider selector
+    still has a deterministic answer.
+    """
+    if not query:
+        return SearchIntent.GENERAL_RESEARCH
+    lowered = query.lower()
+    for intent in _INTENT_PRECEDENCE:
+        zh_signals, en_signals = _INTENT_SIGNALS[intent]
+        if any(sig in query for sig in zh_signals):
+            return intent
+        if any(sig in lowered for sig in en_signals):
+            return intent
+        if (
+            intent is SearchIntent.SIMPLE_DISCOVERY
+            and _has_official_site_discovery_signal(lowered)
+        ):
+            return intent
+    return SearchIntent.GENERAL_RESEARCH
+
+
+def normalize_intent_hint(intent_hint: Optional[str]) -> Optional[SearchIntent]:
+    """Coerce a caller-supplied intent hint to a valid SearchIntent.
+
+    Returns None for unknown/empty hints so callers fall back to local
+    classification (the classifier never depends on the Agent emitting a
+    hint — R1 §7).
+    """
+    if not intent_hint:
+        return None
+    try:
+        return SearchIntent(str(intent_hint).strip().upper())
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Five-provider routing registry
+# ---------------------------------------------------------------------------
+#
+# Static *routing preferences* only. Runtime facts (registered, plugin
+# enabled, credential present, capability supported, Firecrawl deployment)
+# are resolved from the existing provider registry + environment at decision
+# time — config.yaml is NOT a second source of truth for provider capability.
+#
+# Parallel MCP is deliberately excluded (R1 §9). Quota/pricing numbers are
+# intentionally absent.
+
+#: intent -> preferred provider (R1 §9.2, §10)
+INTENT_TO_PROVIDER: Dict[SearchIntent, str] = {
+    SearchIntent.SIMPLE_DISCOVERY: "ddgs",
+    SearchIntent.GENERAL_RESEARCH: "parallel",
+    SearchIntent.TECHNICAL_RESEARCH: "exa",
+    SearchIntent.CURRENT_INFORMATION: "tavily",
+}
+
+#: default public-page extraction provider (R1 §11)
+DEFAULT_EXTRACT_PROVIDER = "firecrawl"
+
+#: deterministic substitute order when the intent-preferred provider is
+#: unavailable (used ONLY during decision construction — never executed as
+#: a runtime fallback chain in B1). Same normalized order for every intent.
+PROVIDER_SUBSTITUTE_ORDER: Tuple[str, ...] = (
+    "parallel",
+    "exa",
+    "tavily",
+    "firecrawl",
+    "ddgs",
+)
+
+#: stable routing preferences for the five in-scope providers.
+#: ``capabilities`` mirrors what the provider plugins expose via
+#: supports_search()/supports_extract(); ``deployment`` is a hint only —
+#: the authoritative Firecrawl deployment is resolved from the environment.
+PROVIDER_PREFERENCES: Dict[str, Dict[str, Any]] = {
+    "ddgs": {
+        "capabilities": ("search",),
+        "deployment": "local",
+        "intent_affinities": (SearchIntent.SIMPLE_DISCOVERY,),
+        "enabled_for_router": True,
+        "notes": "simple keyword and official-homepage discovery (free, local)",
+    },
+    "parallel": {
+        "capabilities": ("search", "extract"),
+        "deployment": "cloud",
+        "intent_affinities": (SearchIntent.GENERAL_RESEARCH,),
+        "enabled_for_router": True,
+        "notes": "general and broad research",
+    },
+    "exa": {
+        "capabilities": ("search", "extract"),
+        "deployment": "cloud",
+        "intent_affinities": (SearchIntent.TECHNICAL_RESEARCH,),
+        "enabled_for_router": True,
+        "notes": "technical, semantic, paper, niche, related-page, API-doc discovery",
+    },
+    "tavily": {
+        "capabilities": ("search", "extract"),
+        "deployment": "cloud",
+        "intent_affinities": (SearchIntent.CURRENT_INFORMATION,),
+        "enabled_for_router": True,
+        "notes": "current prices, policies, news, recent releases, rapidly changing info",
+    },
+    "firecrawl": {
+        "capabilities": ("search", "extract"),
+        "deployment": "cloud",  # resolved at runtime; self-hosted via FIRECRAWL_API_URL
+        "intent_affinities": (SearchIntent.GENERAL_RESEARCH,),
+        "enabled_for_router": True,
+        "notes": "public-page extraction and optional search where locally supported",
+    },
+}
+
+#: default browser-only domain suffixes (safe suffix matching).
+#: Shipped empty: operators opt in with their own interactive-only domains;
+#: no vendor domain is hard-coded into the runtime default.
+DEFAULT_BROWSER_ONLY_DOMAINS: Tuple[str, ...] = ()
+
+
+def normalize_browser_only_domains(raw: Any) -> Tuple[str, ...]:
+    """Coerce config-sourced ``browser_only_domains`` to a tuple of suffixes.
+
+    ``hermes config set`` writes YAML scalars as strings, so a user who ran
+    ``hermes config set web.router.browser_only_domains '["taobao.com"]'``
+    ends up with the *string* ``'["taobao.com"]'`` in config.yaml rather than
+    a list. Accept both shapes defensively: a real list/tuple, a JSON array
+    string, or a comma/whitespace separated string. Never raises.
+    """
+    if raw is None:
+        return DEFAULT_BROWSER_ONLY_DOMAINS
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return ()
+        if text.startswith("[") and text.endswith("]"):
+            try:
+                import json
+
+                parsed = json.loads(text)
+                if isinstance(parsed, list):
+                    return tuple(str(x).strip() for x in parsed if str(x).strip())
+            except Exception:  # noqa: BLE001 — fall through to split parsing
+                pass
+        return tuple(
+            part.strip()
+            for part in re.split(r"[\s,;]+", text)
+            if part.strip()
+        )
+    if isinstance(raw, (list, tuple)):
+        return tuple(str(x).strip() for x in raw if str(x).strip())
+    return DEFAULT_BROWSER_ONLY_DOMAINS
+
+
+# ---------------------------------------------------------------------------
+# Decision objects
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CapabilityPolicyDecision:
+    """Layer A output — which capability the Agent should use.
+
+    Produced by the Capability Policy (candidate skill ``web-capability-policy``
+    in B1) or by future code; defined here as the canonical serializable
+    schema. B1 does NOT implement Layer-A execution.
+    """
+
+    policy_version: str = "v0.1"
+    web_needed: bool = True
+    capability: str = Capability.SEARCH.value
+    reason_code: str = "intent_classified"
+    recommended_tool: str = "web_search"
+    intent_hint: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class SearchRouterDecision:
+    """Layer B output for a web_search call (R1 §12.2)."""
+
+    decision_version: str = "v0.1"
+    selected_provider: Optional[str] = None
+    selection_reason: str = ""
+    provider_override: Optional[str] = None
+    fallback_provider_advisory: Optional[str] = None  # advisory ONLY in B1
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclass
+class ExtractRouterDecision:
+    """Layer B output for a web_extract call (R1 §12.3)."""
+
+    decision_version: str = "v0.1"
+    selected_provider: Optional[str] = None
+    selection_reason: str = ""
+    escalation_recommended: bool = False
+    escalation_tool: str = "browser_navigate"
+    escalation_reason: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Provider availability (runtime facts)
+# ---------------------------------------------------------------------------
+
+
+def resolve_firecrawl_deployment() -> str:
+    """Return ``cloud`` or ``self_hosted`` for Firecrawl (R1 §8).
+
+    Cloud is authoritative when FIRECRAWL_API_KEY is set (the managed gateway
+    path is also cloud). Self-hosted requires FIRECRAWL_API_URL. Never prints
+    or returns secret values.
+    """
+    try:
+        from hermes_cli.config import get_env_value
+    except Exception:  # noqa: BLE001 — env resolution is best-effort
+        get_env_value = None
+
+    def _env(name: str) -> str:
+        if get_env_value is not None:
+            try:
+                val = get_env_value(name)
+                if val:
+                    return str(val).strip()
+            except Exception:  # noqa: BLE001
+                pass
+        import os
+
+        return (os.getenv(name) or "").strip()
+
+    api_key = _env("FIRECRAWL_API_KEY")
+    api_url = _env("FIRECRAWL_API_URL")
+    if api_url and not api_key:
+        return "self_hosted"
+    return "cloud"
+
+
+def provider_supports(provider_name: str, capability: str,
+                      registry_getter: Optional[Callable[[str], Any]] = None) -> bool:
+    """Return True when *provider_name* is registered and supports *capability*.
+
+    ``registry_getter`` mirrors ``agent.web_search_registry.get_provider``;
+    injected for tests. Defaults to the real registry. This is a pure
+    availability *filter* — it never executes a search or extraction.
+    """
+    if registry_getter is None:
+        try:
+            from agent.web_search_registry import get_provider as _get
+        except Exception:  # noqa: BLE001 — registry unavailable => provider unknown
+            return False
+        registry_getter = _get
+    try:
+        provider = registry_getter(provider_name)
+    except Exception:  # noqa: BLE001
+        return False
+    if provider is None:
+        return False
+    try:
+        if capability == "search":
+            return bool(provider.supports_search())
+        if capability == "extract":
+            return bool(provider.supports_extract())
+    except Exception:  # noqa: BLE001 — broken provider is treated as unsupported
+        return False
+    return False
+
+
+def provider_dependency_ready(provider_name: str,
+                              registry_getter: Optional[Callable[[str], Any]] = None) -> bool:
+    """Return True when the provider's local runtime dependency is importable.
+
+    Delegates to the provider's ``is_available()``, which per the
+    WebSearchProvider ABC contract covers "optional Python dep importable"
+    (parallel → ``parallel`` SDK, exa → ``exa_py``, ddgs → ``ddgs`` package;
+    tavily → httpx direct, no extra SDK). Cheap and offline by contract.
+
+    This is the *dependency* half of runtime readiness; the credential half
+    is :func:`provider_credential_present`. The post-B1 readiness audit
+    proved key-only checks can report "available" for providers whose SDK is
+    missing, so Router selection must require both.
+    """
+    if registry_getter is None:
+        try:
+            from agent.web_search_registry import get_provider as _get
+        except Exception:  # noqa: BLE001
+            return False
+        registry_getter = _get
+    try:
+        provider = registry_getter(provider_name)
+    except Exception:  # noqa: BLE001
+        return False
+    if provider is None:
+        return False
+    try:
+        return bool(provider.is_available())
+    except Exception:  # noqa: BLE001 — a broken availability probe means "not ready"
+        return False
+
+
+def provider_runtime_ready(
+    provider_name: str,
+    capability: str,
+    registry_getter: Optional[Callable[[str], Any]] = None,
+    env_has: Optional[Callable[[str], bool]] = None,
+) -> bool:
+    """Return True when *provider_name* is fully runtime-ready for Router use.
+
+    Requires ALL of (R1 §10 / post-B1 correction §5):
+      - registered + requested capability supported
+        (:func:`provider_supports`);
+      - required credential present, or provider is credential-free
+        (:func:`provider_credential_present`);
+      - required local dependency importable
+        (:func:`provider_dependency_ready` → provider ``is_available()``).
+
+    Plugin enablement is already reflected by registration (disabled bundled
+    plugins never register). This is the single readiness gate the Router
+    uses for selection and substitute decisions.
+    """
+    if not provider_supports(provider_name, capability, registry_getter):
+        return False
+    if not provider_credential_present(provider_name, env_has):
+        return False
+    return provider_dependency_ready(provider_name, registry_getter)
+
+
+def provider_credential_present(provider_name: str,
+                                env_has: Optional[Callable[[str], bool]] = None) -> bool:
+    """Return True when the provider's credential is present (or it needs none).
+
+    Mirrors the cheap hardcoded probes in ``tools.web_tools._is_backend_available``.
+    ddgs needs no credential (local package). env_has injected for tests.
+    """
+    if provider_name == "ddgs":
+        return True  # credential-free
+    if env_has is None:
+        try:
+            from hermes_cli.config import get_env_value as _gev
+
+            def _has(name: str) -> bool:
+                try:
+                    return bool((_gev(name) or "").strip())
+                except Exception:  # noqa: BLE001
+                    import os
+
+                    return bool((os.getenv(name) or "").strip())
+
+        except Exception:  # noqa: BLE001
+            import os
+
+            def _has(name: str) -> bool:
+                return bool((os.getenv(name) or "").strip())
+
+        env_has = _has
+    key_map = {
+        "parallel": "PARALLEL_API_KEY",
+        "exa": "EXA_API_KEY",
+        "tavily": "TAVILY_API_KEY",
+        "firecrawl": "FIRECRAWL_API_KEY",
+    }
+    key = key_map.get(provider_name)
+    if not key:
+        return False
+    if env_has(key):
+        return True
+    # Firecrawl may also be served by the managed tool gateway (no key).
+    if provider_name == "firecrawl":
+        try:
+            from tools.web_tools import _is_tool_gateway_ready
+
+            return bool(_is_tool_gateway_ready())
+        except Exception:  # noqa: BLE001
+            return False
+    return False
+
+
+def select_substitute_provider(
+    capability: str,
+    exclude: Optional[str] = None,
+    registry_getter: Optional[Callable[[str], Any]] = None,
+    env_has: Optional[Callable[[str], bool]] = None,
+    enabled_names: Optional[Sequence[str]] = None,
+) -> Optional[str]:
+    """Return ONE deterministic compatible provider as a substitute.
+
+    Used only when the intent-preferred provider is unavailable, and only
+    during decision construction (R1 §10). B1 never executes a second
+    provider after a failure. ``enabled_names`` lets tests restrict the
+    candidate pool without touching the real registry.
+    """
+    candidates = PROVIDER_SUBSTITUTE_ORDER
+    if enabled_names is not None:
+        candidates = tuple(n for n in candidates if n in set(enabled_names))
+    for name in candidates:
+        if exclude and name == exclude:
+            continue
+        if not provider_runtime_ready(name, capability, registry_getter, env_has):
+            continue
+        return name
+    return None
+
+
+# ---------------------------------------------------------------------------
+# URL boundary classification (R1 §11 — extract side)
+# ---------------------------------------------------------------------------
+
+_LOGIN_PATH_RE = re.compile(
+    r"/(?:login|signin|sign-in|auth|authenticate|oauth|sso)(?:/|$)",
+    re.IGNORECASE,
+)
+
+#: path segments indicating cart / favorites / purchase / checkout / forms
+_INTERACTION_PATH_RE = re.compile(
+    r"/(?:cart|favorite|favorites|checkout|purchase|buy|order|pay|payment"
+    r"|add-to-cart|wishlist|submit|form)(?:/|$)",
+    re.IGNORECASE,
+)
+
+
+def _host_of(url: str) -> str:
+    try:
+        return (urlparse(url).hostname or "").lower().rstrip(".")
+    except ValueError:
+        return ""
+
+
+def is_browser_only_host(url: str, browser_only_domains: Sequence[str]) -> bool:
+    """Safe domain-suffix match: ``taobao.com`` matches ``taobao.com`` and
+    ``item.taobao.com`` but NOT ``evil-taobao.com`` (R1 §11)."""
+    host = _host_of(url)
+    if not host:
+        return False
+    for domain in browser_only_domains or ():
+        domain = (domain or "").strip().lower().lstrip(".")
+        if not domain:
+            continue
+        if host == domain or host.endswith("." + domain):
+            return True
+    return False
+
+
+def url_requires_browser(url: str, browser_only_domains: Sequence[str]) -> bool:
+    """Return True when *url* must go to Browser, never an external extractor.
+
+    Checks, in order: browser-only host suffixes, login/auth paths,
+    interaction paths (cart/favorites/purchase/checkout/forms). Sensitive
+    query-parameter URLs are already blocked earlier in web_extract_tool by
+    the existing ``sensitive_query_param_name`` guard; the router also
+    consults it here so the decision object is self-contained (R1 §11).
+    """
+    if is_browser_only_host(url, browser_only_domains):
+        return True
+    try:
+        path = urlparse(url).path
+    except ValueError:
+        path = ""
+    if _LOGIN_PATH_RE.search(path):
+        return True
+    if _INTERACTION_PATH_RE.search(path):
+        return True
+    try:
+        from tools.url_safety import sensitive_query_param_name
+
+        if sensitive_query_param_name(url):
+            return True
+    except Exception:  # noqa: BLE001 — guard failure must not leak the URL out
+        return True
+    return False
+
+
+def browser_escalation_reason(url: str, browser_only_domains: Sequence[str]) -> str:
+    """Human/agent-readable reason for a Browser escalation recommendation."""
+    if is_browser_only_host(url, browser_only_domains):
+        return "browser_only_domain"
+    try:
+        path = urlparse(url).path
+    except ValueError:
+        path = ""
+    if _LOGIN_PATH_RE.search(path):
+        return "login_required"
+    if _INTERACTION_PATH_RE.search(path):
+        return "interaction_required"
+    try:
+        from tools.url_safety import sensitive_query_param_name
+
+        if sensitive_query_param_name(url):
+            return "sensitive_query_parameter"
+    except Exception:  # noqa: BLE001
+        pass
+    return "browser_required"

--- a/tools/web_search_router.py
+++ b/tools/web_search_router.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Search Provider Router — Layer B, web_search side (R1 §4 / §10).
+
+Deterministic single-provider selection for web_search_tool. Runs only when
+``web.router.enabled`` is true. When the flag is false, web_search_tool never
+imports this module and the legacy backend resolution path is preserved
+exactly.
+
+B1 boundaries (R1 §15.2 / §10):
+  - ONE provider per request, selected at decision-construction time;
+  - a substitute provider is chosen deterministically ONLY when the
+    intent-preferred provider is unavailable (availability is filtered, not
+    retried);
+  - NO runtime fallback execution, NO verification, NO retry, NO Browser
+    invocation, NO query-content telemetry.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from tools.web_router import (
+    INTENT_TO_PROVIDER,
+    PROVIDER_PREFERENCES,
+    SearchIntent,
+    SearchRouterDecision,
+    classify_search_intent,
+    normalize_intent_hint,
+    provider_runtime_ready,
+    select_substitute_provider,
+)
+
+
+def select_search_provider(
+    query: str,
+    intent_hint: Optional[str] = None,
+    provider_override: Optional[str] = None,
+    registry_getter: Optional[Callable[[str], Any]] = None,
+    env_has: Optional[Callable[[str], bool]] = None,
+    enabled_names: Optional[list] = None,
+) -> SearchRouterDecision:
+    """Construct ONE SearchRouterDecision for a web_search call.
+
+    Selection order (R1 §10):
+      1. explicit provider_override (honored only if registered, enabled,
+         credential-present and search-capable);
+      2. intent classification (caller hint normalized, else local
+         classification of the query — the classifier never depends on the
+         Agent emitting a hint);
+      3. deterministic substitute when the preferred provider is unavailable
+         (decision-construction only — never executed as a fallback).
+
+    Never executes a search. Pure decision construction.
+    """
+    decision = SearchRouterDecision()
+    decision.provider_override = provider_override or None
+
+    # 1) Explicit override — validated before intent selection.
+    if provider_override:
+        override_name = str(provider_override).strip().lower()
+        if override_name not in PROVIDER_PREFERENCES:
+            decision.selection_reason = "override_rejected_not_in_registry"
+        elif not _provider_usable(override_name, registry_getter, env_has, enabled_names):
+            decision.selection_reason = "override_rejected_unavailable"
+        else:
+            decision.selected_provider = override_name
+            decision.selection_reason = "explicit_override"
+            return decision
+
+    # 2) Intent classification (hint normalized, else local).
+    intent = normalize_intent_hint(intent_hint) or classify_search_intent(query)
+    decision.selection_reason = (
+        f"{decision.selection_reason};" if decision.selection_reason else ""
+    ) + f"intent={intent.value}"
+
+    preferred = INTENT_TO_PROVIDER.get(intent)
+    if preferred and _provider_usable(preferred, registry_getter, env_has, enabled_names):
+        decision.selected_provider = preferred
+        decision.fallback_provider_advisory = select_substitute_provider(
+            "search",
+            exclude=preferred,
+            registry_getter=registry_getter,
+            env_has=env_has,
+            enabled_names=enabled_names,
+        )
+        return decision
+
+    # 3) Preferred unavailable -> ONE deterministic substitute (advisory in B1).
+    substitute = select_substitute_provider(
+        "search",
+        exclude=preferred,
+        registry_getter=registry_getter,
+        env_has=env_has,
+        enabled_names=enabled_names,
+    )
+    if substitute:
+        decision.selected_provider = substitute
+        decision.selection_reason = (
+            f"{decision.selection_reason};" if decision.selection_reason else ""
+        ) + f"preferred_unavailable_substitute={substitute}"
+        decision.fallback_provider_advisory = preferred
+        return decision
+
+    # Nothing usable in this request — leave selected_provider None so the
+    # caller's legacy "no provider" error path renders (B1 preserves output).
+    decision.selection_reason = "no_provider_available"
+    return decision
+
+
+def _provider_usable(
+    name: str,
+    registry_getter: Optional[Callable[[str], Any]],
+    env_has: Optional[Callable[[str], bool]],
+    enabled_names: Optional[list],
+) -> bool:
+    """Registered + enabled + credential-present + dependency-importable +
+    search-capable (R1 §10, post-B1 readiness correction §5)."""
+    if enabled_names is not None and name not in set(enabled_names):
+        return False
+    return provider_runtime_ready(name, "search", registry_getter, env_has)

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -615,7 +615,11 @@ def _ensure_web_plugins_loaded() -> None:
         logger.warning("Web plugin discovery failed (non-fatal): %s", exc)
 
 
-def web_search_tool(query: str, limit: int = 5) -> str:
+def web_search_tool(
+    query: str,
+    limit: int = 5,
+    search_depth: str = None,
+) -> str:
     """
     Search the web for information using available search API backend.
 
@@ -628,6 +632,11 @@ def web_search_tool(query: str, limit: int = 5) -> str:
     Args:
         query (str): The search query to look up
         limit (int): Maximum number of results to return (default: 5)
+        search_depth (str, optional): Search depth/quality level.
+            "fast"   — lowest latency, basic results
+            "auto"   — balanced speed/quality (default if not specified)
+            "deep"   — thorough search, multi-step, higher quality
+            "deepest" — maximum depth, reasoning-grade results (slowest)
     
     Returns:
         str: JSON string containing search results with the following structure:
@@ -658,7 +667,8 @@ def web_search_tool(query: str, limit: int = 5) -> str:
     debug_call_data = {
         "parameters": {
             "query": query,
-            "limit": limit
+            "limit": limit,
+            "search_depth": search_depth,
         },
         "error": None,
         "results_count": 0,
@@ -719,7 +729,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                 "Web search via %s: '%s' (limit: %d)",
                 provider.name, query, limit,
             )
-            response_data = provider.search(query, limit)
+            response_data = provider.search(query, limit, search_depth=search_depth)
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -619,6 +619,8 @@ def web_search_tool(
     query: str,
     limit: int = 5,
     search_depth: str = None,
+    intent_hint: str = None,
+    provider_override: str = None,
 ) -> str:
     """
     Search the web for information using available search API backend.
@@ -637,6 +639,13 @@ def web_search_tool(
             "auto"   — balanced speed/quality (default if not specified)
             "deep"   — thorough search, multi-step, higher quality
             "deepest" — maximum depth, reasoning-grade results (slowest)
+        intent_hint (str, optional): Router-only hint (SIMPLE_DISCOVERY /
+            GENERAL_RESEARCH / TECHNICAL_RESEARCH / CURRENT_INFORMATION).
+            NOT exposed to the model — used only when the Web Capability
+            Router (web.router.enabled) is active; the router otherwise
+            classifies the query locally.
+        provider_override (str, optional): Router-only explicit provider name
+            (ddgs/parallel/exa/tavily/firecrawl). NOT exposed to the model.
     
     Returns:
         str: JSON string containing search results with the following structure:
@@ -693,6 +702,28 @@ def web_search_tool(
         )
 
         backend = _get_search_backend()
+        # ── Web Capability Router (V0.1, Stage B1) — feature-flagged ──────
+        # When web.router.enabled is false (default), this block is skipped
+        # entirely: legacy backend resolution, output shape, and error paths
+        # are preserved byte-for-byte, and no router state is instantiated.
+        # When enabled, a single deterministic provider is selected via the
+        # Layer-B Search Provider Router; a decision object is the only
+        # telemetry (no query-content logging). No fallback, no verification,
+        # no Browser invocation happens here.
+        _router_cfg = (_load_web_config().get("router") or {})
+        if _router_cfg.get("enabled"):
+            try:
+                from tools.web_search_router import select_search_provider
+
+                _decision = select_search_provider(
+                    query,
+                    intent_hint=intent_hint,
+                    provider_override=provider_override,
+                )
+                if _decision.selected_provider:
+                    backend = _decision.selected_provider
+            except Exception as _router_exc:  # noqa: BLE001 — router must never break search
+                logger.debug("Web search router skipped (%s)", _router_exc)
         provider = _wsp_get_provider(backend) if backend else None
         if provider is None or not provider.supports_search():
             # Fall back to availability-walked active provider when the
@@ -865,6 +896,44 @@ async def web_extract_tool(
             results = []
         else:
             backend = _get_extract_backend()
+            # ── Web Capability Router (V0.1, Stage B1) — feature-flagged ──
+            # When web.router.enabled is false (default), this block is
+            # skipped entirely: legacy backend resolution, output shape, and
+            # error paths are preserved byte-for-byte. When enabled, the
+            # Layer-B Extract Provider Router classifies the URL boundary
+            # BEFORE any external extractor: browser-only / login /
+            # interaction / sensitive-parameter URLs yield a structured
+            # Browser escalation recommendation (never an automatic Browser
+            # call), and public URLs select Firecrawl. At most ONE extractor
+            # per call; no secondary extract fallback in B1.
+            _router_cfg = (_load_web_config().get("router") or {})
+            if _router_cfg.get("enabled"):
+                try:
+                    from tools.web_extract_router import select_extract_provider
+
+                    _decision = select_extract_provider(
+                        safe_urls,
+                        browser_only_domains=_router_cfg.get("browser_only_domains"),
+                    )
+                    if _decision.escalation_recommended:
+                        return json.dumps(
+                            {
+                                "success": False,
+                                "error": (
+                                    "Page requires browser interaction. Use "
+                                    "browser_navigate instead of web_extract."
+                                ),
+                                "escalation": {
+                                    "recommended_tool": _decision.escalation_tool,
+                                    "reason": _decision.escalation_reason,
+                                },
+                            },
+                            ensure_ascii=False,
+                        )
+                    if _decision.selected_provider:
+                        backend = _decision.selected_provider
+                except Exception as _router_exc:  # noqa: BLE001 — router must never break extract
+                    logger.debug("Web extract router skipped (%s)", _router_exc)
 
             # All seven providers (brave-free, ddgs, searxng, exa, parallel,
             # tavily, firecrawl) now live as plugins. The dispatcher is a


### PR DESCRIPTION
## What does this PR do?

Adds an optional, disabled-by-default intent-routing layer for Web search and extraction while preserving the existing configured-backend behavior when the router is disabled.

## Related Issue

No linked issue — this is a standalone enhancement contribution.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Propagates optional search-depth information through Web provider calls.
- Adds deterministic intent classification for:
  - simple discovery;
  - technical research;
  - current information;
  - broad research;
  - known-page extraction;
  - interactive/browser-required requests.
- Routes through the existing provider registry and backend execution path.
- Keeps interactive-only domains configurable, with an empty production default.
- Preserves per-request Parallel fast-mode selection without changing its existing default behavior.
- Increases the DDGS subprocess timeout from 30 to 45 seconds to provide startup headroom.

## How to Test

1. Run the Web router/provider test group: `pytest tests/tools/test_web_router.py tests/plugins/web/parallel/` (276 tests in the full Web group pass).
2. Verify default behavior is unchanged with `web.router.enabled` unset or `false` (disabled state preserves the existing configured backend).
3. Optional: set `web.router.enabled: true` and observe single-provider selection with no automatic fallback.

## Checklist

- [x] Tests pass with no live provider or Browser calls
- [x] Disabled-by-default behavior is preserved
- [x] No automatic fallback, provider voting, multi-provider verification, or Browser invocation
- [x] Browser-required classification returns a boundary result with zero provider dispatch
- [x] `browser_only_domains` production default is empty; vendor domains appear only as explicit test fixtures
- [x] DDGS timeout = 45 seconds
