### PR TITLE
feat(providers): add alibaba-token-plan provider profile (Token Plan Personal Edition)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -546,6 +546,25 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-4.7",
         "MiniMax-M2.5",
     ],
+    # Alibaba Token Plan (Personal Edition) — dedicated token-plan endpoint
+    # (token-plan.ap-southeast-1.maas.aliyuncs.com), key tier `sk-sp-...`.
+    # Catalog verified against a live Token Plan subscription (2026-08-03).
+    "alibaba-token-plan": [
+        "qwen3.8-max-preview",
+        "qwen3.7-max",
+        "qwen3.7-plus",
+        "qwen3.6-plus",
+        "qwen3.6-flash",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "deepseek-v3.2",
+        "kimi-k2.7-code",
+        "kimi-k2.6",
+        "kimi-k2.5",
+        "glm-5.2",
+        "glm-5.1",
+        "glm-5",
+    ],
     # Curated HF model list — only agentic models that map to OpenRouter defaults.
     "huggingface": [
         "moonshotai/Kimi-K2.5",
@@ -1196,7 +1215,7 @@ PROVIDER_GROUPS: dict[str, tuple[str, str, list[str]]] = {
     "xai":      ("xAI Grok",        "Direct API or SuperGrok / Premium+ OAuth",        ["xai", "xai-oauth"]),
     "google":   ("Google Gemini",   "Google AI Studio (API key)",                     ["gemini"]),
     "openai":   ("OpenAI",          "Codex CLI or direct OpenAI API",                  ["openai-codex", "openai-api"]),
-    "qwen":     ("Qwen",            "Qwen Cloud / DashScope, Coding Plan & Qwen CLI OAuth", ["alibaba", "alibaba-coding-plan", "qwen-oauth"]),
+    "qwen":     ("Qwen",            "Qwen Cloud / DashScope, Coding Plan, Token Plan & Qwen CLI OAuth", ["alibaba", "alibaba-coding-plan", "alibaba-token-plan", "qwen-oauth"]),
     "opencode": ("OpenCode",        "Zen pay-as-you-go or Go subscription",            ["opencode-zen", "opencode-go"]),
     "copilot":  ("GitHub Copilot",  "GitHub token API or copilot --acp process",       ["copilot", "copilot-acp"]),
 }

--- a/plugins/model-providers/alibaba-token-plan/__init__.py
+++ b/plugins/model-providers/alibaba-token-plan/__init__.py
@@ -1,0 +1,30 @@
+"""Alibaba Cloud Token Plan (Personal Edition) provider profile.
+
+Separate from `alibaba` (DashScope compatible-mode) and
+`alibaba-coding-plan` (coding-intl) because Token Plan Personal Edition
+hits a dedicated endpoint (token-plan.ap-southeast-1.maas.aliyuncs.com)
+with its own key tier (`sk-sp-...`).
+
+Endpoints (OpenAI-compatible):
+  https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
+Anthropic-compatible:
+  https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic
+
+The key also appears in the Qwen CLI as `BAILIAN_TOKEN_PLAN_API_KEY`.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+alibaba_token_plan = ProviderProfile(
+    name="alibaba-token-plan",
+    aliases=("alibaba_token", "alibaba-token", "dashscope-token", "bailian-token"),
+    display_name="Alibaba Cloud (Token Plan)",
+    description="Alibaba Cloud Token Plan Personal Edition (dedicated token tier)",
+    signup_url="https://help.aliyun.com/zh/model-studio/",
+    env_vars=("ALIBABA_TOKEN_PLAN_API_KEY", "BAILIAN_TOKEN_PLAN_API_KEY", "DASHSCOPE_API_KEY"),
+    base_url="https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+    auth_type="api_key",
+)
+
+register_provider(alibaba_token_plan)

--- a/plugins/model-providers/alibaba-token-plan/plugin.yaml
+++ b/plugins/model-providers/alibaba-token-plan/plugin.yaml
@@ -1,0 +1,5 @@
+name: alibaba-token-plan-provider
+kind: model-provider
+version: 1.0.0
+description: Alibaba Cloud Token Plan (Personal Edition)
+author: Nous Research


### PR DESCRIPTION
## Summary

Adds a native **`alibaba-token-plan`** provider profile for Alibaba Cloud Token Plan (Personal Edition) — a separate tier from DashScope compatible-mode (`alibaba`) and Coding Plan (`alibaba-coding-plan`), with its own endpoint and `sk-sp-...` key tier.

This resolves the workaround described in #69323 (manual `provider: custom` + inline base_url/api_key in config.yaml).

## Changes

1. **`plugins/model-providers/alibaba-token-plan/`** — new `ProviderProfile`:
   - `name: alibaba-token-plan`
   - env vars: `ALIBABA_TOKEN_PLAN_API_KEY`, `BAILIAN_TOKEN_PLAN_API_KEY` (the name the Qwen CLI uses), `DASHSCOPE_API_KEY` fallback
   - base URL: `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1` (OpenAI-compatible)

2. **`hermes_cli/models.py`**:
   - `_PROVIDER_MODELS["alibaba-token-plan"]` — catalog verified against a **live Token Plan subscription** (2026-08-03): `qwen3.8-max-preview`, `qwen3.7-max`, `qwen3.7-plus`, `qwen3.6-plus`, `qwen3.6-flash`, `deepseek-v4-pro/flash/v3.2`, `kimi-k2.7-code/k2.6/k2.5`, `glm-5.2/5.1/5`
   - `PROVIDER_GROUPS["qwen"]` now includes `alibaba-token-plan`

## Verification (performed against a live Token Plan key)

- `curl` to token-plan endpoint with `qwen3.8-max-preview` → 200, model responds (`pong`)
- Same key against coding-intl endpoint → `invalid_api_key` (confirms separate key tier)
- `hermes_cli` runtime resolution: provider + base_url + api_key all resolve correctly
- Full `hermes chat -q` round-trip through the new provider name → model responds
- `tests/providers/test_plugin_discovery.py` (3 passed), `tests/hermes_cli/test_model_validation.py` (29 passed)

## Notes

- The Anthropic-compatible endpoint (`.../apps/anthropic`) exists but is not wired; the provider defaults to OpenAI-compatible. Can be added as an api_mode variant later if needed.
- Key tier verification evidence (redacted): token-plan OK / coding-plan `invalid_api_key` — happy to share full output with maintainers.