### PR TITLE
feat(vision): session-scoped local vision routing

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -110,6 +110,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, args_hint="[off|help|session-id]"),
     CommandDef("clear", "Clear screen and start a new session", "Session",
                cli_only=True),
+    CommandDef("vision", "Enable/disable the Vision Router for this session (limited use)",
+               "Session", cli_only=True, args_hint="[on|off]", execute="vision_toggle"),
     CommandDef("redraw", "Force a full UI repaint (recovers from terminal drift)", "Session",
                cli_only=True),
     CommandDef("history", "Show conversation history", "Session",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1067,6 +1067,29 @@ DEFAULT_CONFIG = {
             "extra_body": {},
             # NOTE: no reasoning_effort here by design — see moa_reference above.
         },
+        # Vision Router — inactive V0.1 foundation (local vision policy and
+        # orchestration layer). Disabled by default; does NOT modify
+        # auxiliary.vision behavior while both integration switches are
+        # false. Model-slot references are role names resolved from runtime
+        # configuration; no private endpoint is hardcoded in defaults.
+        # Default timeouts are safety ceilings, not expected latency.
+        # Dynamic timeout selection (image size / crop / task) is deferred.
+        "vision_router": {
+            "enabled": False,
+            "auxiliary_integration_enabled": False,
+            "max_model_calls": 1,
+            "telemetry_mode": "decisions_only",
+            "models": {
+                "fast_vlm": "qwen2.5vl",
+                "precision_vlm": "qwen3.6:27b",
+                "ocr": "glm-ocr",
+            },
+            "timeouts": {
+                "fast_vlm_seconds": 45,
+                "precision_vlm_seconds": 120,
+                "ocr_seconds": 45,
+            },
+        },
     },
     
     "display": {

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1079,6 +1079,9 @@ DEFAULT_CONFIG = {
             "auxiliary_integration_enabled": False,
             "max_model_calls": 1,
             "telemetry_mode": "decisions_only",
+            "ocr_excerpt_chars": 4000,
+            "ocr_page_chars": 65536,
+            "per_workflow_max_calls": 20,
             "models": {
                 "fast_vlm": "qwen2.5vl",
                 "precision_vlm": "qwen3.6:27b",

--- a/hermes_cli/slash_exec.py
+++ b/hermes_cli/slash_exec.py
@@ -80,6 +80,39 @@ def _exec_egress(ctx: CommandContext) -> CommandReply:
     return CommandReply(format_status_text())
 
 
+def _exec_vision_toggle(ctx: CommandContext) -> CommandReply:
+    """User-only Vision Router session toggle (/vision on|off).
+
+    Stage-3 limited use: enables the controlled wrapper for the CURRENT
+    process only; never touches persistent config; /vision off is the
+    immediate kill switch (revokes attachment handles and OCR results).
+    """
+    from tools.vision_session_state import vision_session_state
+
+    arg = ctx.args.strip().lower()
+    if arg == "on":
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+        return CommandReply(
+            "Vision Router enabled for this session. "
+            "Limits: 1 logical call per turn, 5 per session. "
+            "Kill switch: /vision off.")
+    if arg == "off":
+        vision_session_state.set_enabled(False)
+        return CommandReply(
+            "Vision Router disabled; all Vision tools removed and "
+            "session sources revoked.")
+    s = vision_session_state.snapshot()
+    text = (
+        f"Vision Router: {'enabled' if s['enabled'] else 'disabled'} · "
+        f"used {s['per_session_used']}/5 this session · "
+        f"turn used {s['per_turn_used']}/1 · "
+        f"attachments {len(s['attachment_handles'])} · "
+        f"OCR results {len(s['ocr_handles'])}"
+    )
+    return CommandReply(text)
+
+
 def _exec_profile(ctx: CommandContext) -> CommandReply:
     """Core /profile data — active profile name + home directory.
 
@@ -234,6 +267,7 @@ def _exec_commands(ctx: CommandContext) -> CommandReply:
 EXECUTORS: dict[str, Callable[[CommandContext], CommandReply]] = {
     "version": _exec_version,
     "egress": _exec_egress,
+    "vision_toggle": _exec_vision_toggle,
     "profile": _exec_profile,
     "bundles": _exec_bundles,
     "gateway_help": _exec_help,

--- a/model_tools.py
+++ b/model_tools.py
@@ -343,6 +343,7 @@ def get_tool_definitions(
                 bool(skip_tool_search_assembly),
                 _is_delegated_child_context(),
                 profile_scope,
+                _vision_router_flag_fingerprint(),
             )
         cached = _tool_defs_cache.get(cache_key) if cache_key is not None else None
         if cached is not None:
@@ -374,6 +375,24 @@ def get_tool_definitions(
     if quiet_mode:
         return list(result)
     return result
+
+
+def _vision_router_flag_fingerprint() -> str:
+    """Cache-fingerprint for the Vision Router visibility gate.
+
+    The wrapper tool's visibility depends on the server flag
+    (vision_router.enabled). The tool-definitions cache must invalidate the
+    moment the flag flips — otherwise a kill-switch toggle would not remove
+    (or restore) the tool until some unrelated config edit bumped the
+    config-mtime fingerprint. Reads the live config; a failure to read it
+    fingerprints as disabled (fail closed).
+    """
+    try:
+        from hermes_cli.config import load_config as _lc
+        from toolsets import vision_router_effective_visible
+        return f"vr:{bool(vision_router_effective_visible(_lc()))}"
+    except Exception:
+        return "vr:False"
 
 
 def _compute_tool_definitions(
@@ -544,6 +563,70 @@ def _compute_tool_definitions(
             print(f"🛠️  Final tool selection ({len(filtered_tools)} tools): {', '.join(tool_names)}")
         else:
             print("🛠️  No tools selected (all filtered out or unavailable)")
+
+    # Vision Router wrapper visibility gate:
+    # `vision_router_analyze` and `vision_ocr_page` are model-visible ONLY
+    # when the effective gate is true (server flag vision_router.enabled OR
+    # the in-memory session flag from the user-only /vision command).
+    # When the gate is false the controlled tools are removed here
+    # regardless of which toolsets were enabled — hard invisibility (the
+    # names never reach the model), including through combination toolsets
+    # like "safe". The official legacy `vision_analyze` remains available
+    # while the gate is off, exactly as upstream.
+    # When the gate is true, the legacy auxiliary `vision_analyze` is hidden
+    # in this session: the controlled wrapper REPLACES its model-facing role
+    # — the model must never see two vision entry points. Internal callers
+    # (browser/attachment flows that import vision_analyze_tool directly)
+    # are unaffected.
+    try:
+        from hermes_cli.config import load_config as _load_cfg
+        from toolsets import (VISION_ROUTER_TOOL, VISION_OCR_PAGE_TOOL,
+                              vision_router_effective_visible)
+        from tools.registry import registry as _vr_registry
+
+        _vr_visible = vision_router_effective_visible(_load_cfg())
+        if _vr_visible:
+            # Replacement semantics: wherever the legacy model-visible tool
+            # WOULD have been exposed (based on the resolved toolset set,
+            # NOT on check_fn-filtered results), expose exactly the
+            # controlled set — the wrapper plus the bounded OCR page
+            # retrieval tool.
+            _had_legacy = any(
+                td.get("function", {}).get("name") == "vision_analyze"
+                for td in filtered_tools
+            )
+            filtered_tools = [
+                td for td in filtered_tools
+                if td.get("function", {}).get("name") != "vision_analyze"
+            ]
+            if _had_legacy:
+                _existing = {td.get("function", {}).get("name")
+                             for td in filtered_tools}
+                _missing = [n for n in (VISION_ROUTER_TOOL, VISION_OCR_PAGE_TOOL)
+                            if n not in _existing]
+                if _missing:
+                    filtered_tools.extend(
+                        _vr_registry.get_definitions(set(_missing), quiet=True)
+                    )
+        else:
+            # Public compatibility: official legacy vision_analyze stays
+            # visible; only the controlled local Router tools are hidden.
+            filtered_tools = [
+                td for td in filtered_tools
+                if td.get("function", {}).get("name") not in (
+                    VISION_ROUTER_TOOL, VISION_OCR_PAGE_TOOL
+                )
+            ]
+    except Exception:
+        # Fail closed: if the gate cannot be evaluated, the controlled
+        # local Router tools stay hidden (kill switch defaults to OFF);
+        # official legacy vision_analyze is untouched.
+        filtered_tools = [
+            td for td in filtered_tools
+            if td.get("function", {}).get("name") not in (
+                "vision_router_analyze", "vision_ocr_page"
+            )
+        ]
 
     global _last_resolved_tool_names
     _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]

--- a/tests/tools/test_fenced_json_parsing.py
+++ b/tests/tools/test_fenced_json_parsing.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Fenced-JSON parsing tests — Vision Orchestrator.
+
+Behavioral tests for the bounded fenced-response contract
+(task HERMES_VISION_CURATOR_CONTAINMENT_AND_FENCED_JSON_FIX_V0_1):
+
+- raw JSON object parses;
+- fenced ```json object parses;
+- uppercase/mixed-case JSON language tag parses;
+- generic fenced JSON parses;
+- surrounding whitespace parses;
+- multiple fences are rejected;
+- prose before/after the fence is rejected;
+- unclosed fence is rejected;
+- malformed fenced JSON is rejected;
+- empty fenced content is rejected;
+- refusal text is not converted into a structured result;
+- valid fenced Precision-style response reaches quality evaluation;
+- schema-required fields remain enforced after fence removal;
+- parser performs no model invocation;
+- no automatic escalation occurs;
+- existing raw structured responses remain compatible.
+
+No network requests. No model calls.
+"""
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+import pytest  # noqa: E402
+
+from tools.vision_orchestrator import (  # noqa: E402
+    _parse_structured,
+    _strip_single_fenced_block,
+)
+from tools.vision_policy import VisionTask  # noqa: E402
+
+
+def _parse(text):
+    return _parse_structured(text, VisionTask.UI_READ)
+
+
+def _ok(result):
+    return "_parse_failed" not in result
+
+
+class TestFencedBlockExtraction:
+    def test_raw_json_object_parses(self):
+        assert _ok(_parse('{"a": 1}'))
+
+    def test_fenced_json_object_parses(self):
+        r = _parse('```json\n{"observed_text": "动漫剪辑素材"}\n```')
+        assert _ok(r) and r.get("observed_text") == "动漫剪辑素材"
+
+    def test_uppercase_language_tag_parses(self):
+        assert _ok(_parse('```JSON\n{"a": 1}\n```'))
+
+    def test_mixed_case_language_tag_parses(self):
+        assert _ok(_parse('```JsOn\n{"a": 1}\n```'))
+
+    def test_generic_fence_parses(self):
+        assert _ok(_parse('```\n{"a": 1}\n```'))
+
+    def test_surrounding_whitespace_parses(self):
+        assert _ok(_parse('   \n```json\n{"a": 1}\n```\n  '))
+
+    def test_multiple_fences_rejected(self):
+        assert not _ok(_parse('```json\n{"a": 1}\n```\n```json\n{"b": 2}\n```'))
+
+    def test_prose_before_rejected(self):
+        assert not _ok(_parse('Here is the result:\n```json\n{"a": 1}\n```'))
+
+    def test_prose_after_rejected(self):
+        assert not _ok(_parse('```json\n{"a": 1}\n```\nHope that helps'))
+
+    def test_unclosed_fence_rejected(self):
+        assert not _ok(_parse('```json\n{"a": 1}'))
+
+    def test_malformed_fenced_json_rejected(self):
+        assert not _ok(_parse('```json\n{"a": }\n```'))
+
+    def test_empty_fenced_content_rejected(self):
+        assert not _ok(_parse('```json\n```'))
+
+    def test_non_json_language_tag_rejected(self):
+        assert not _ok(_parse('```yaml\na: 1\n```'))
+
+    def test_refusal_not_converted(self):
+        assert not _ok(_parse("I cannot process this image because it is a login wall."))
+
+
+class TestStripSingleFencedBlock:
+    def test_returns_inner_for_valid_fence(self):
+        assert _strip_single_fenced_block('```json\n{"a": 1}\n```') == '{"a": 1}'
+
+    def test_none_for_non_fenced(self):
+        assert _strip_single_fenced_block('{"a": 1}') is None
+
+    def test_none_for_prose(self):
+        assert _strip_single_fenced_block("Here is JSON: ```json\n{}\n```") is None
+
+    def test_none_for_empty(self):
+        assert _strip_single_fenced_block("```json\n```") is None
+
+
+class TestFencedQualityIntegration:
+    def test_fenced_precision_response_reaches_quality(self):
+        """A valid fenced Precision-style response must reach quality
+        evaluation with SUCCESS — not SCHEMA_INVALID."""
+        import json
+        from unittest.mock import AsyncMock, patch
+
+        from tools.vision_orchestrator import analyze_image
+        from tools.vision_policy import (
+            ExecutionStatus,
+            VisionCriticality,
+            VisionMode,
+            VisionRequest,
+            VisionTask,
+        )
+
+        fenced = '```json\n{"observed_text": "26年动漫MAD镜头剪辑素材"}\n```'
+        with (
+            patch(
+                "tools.vision_orchestrator.prepare_image",
+                new_callable=AsyncMock,
+                return_value=(
+                    "data:image/png;base64,AAAA",
+                    1920,
+                    1080,
+                    "image/png",
+                    "a" * 64,
+                    {
+                        "transport_image_sha256": "a" * 64,
+                        "transport_mime_type": "image/png",
+                        "transport_transcoded": False,
+                    },
+                ),
+            ),
+            patch(
+                "tools.vision_orchestrator.invoke_vision_model",
+                new_callable=AsyncMock,
+                return_value={
+                    "execution_status": ExecutionStatus.SUCCESS.value,
+                    "raw_text": fenced,
+                    "error": None,
+                },
+            ),
+        ):
+            import asyncio
+
+            req = VisionRequest(
+                request_id="t-fence",
+                image_source="opaque://x",
+                task=VisionTask.UI_READ,
+                mode=VisionMode.AUTO,
+                criticality=VisionCriticality.HIGH,
+                question="read",
+            )
+            result = asyncio.run(analyze_image(req, enabled=True, transport="OPENAI_COMPATIBLE"))
+
+        assert result["execution_status"] == ExecutionStatus.SUCCESS.value
+        assert result["logical_model_calls"] == 1
+        # No automatic escalation executed (recommendation is not execution):
+        assert result.get("recommended_next_slot") in (None, "PRECISION_VLM")
+        # Structured fields reachable (schema enforcement happens in gates):
+        assert result["structured"].get("observed_text") == "26年动漫MAD镜头剪辑素材"
+
+    def test_fence_stripping_no_model_call(self):
+        """_parse_structured must never invoke a model."""
+        import json
+
+        # If it tried to call the model, this would raise (no client loaded).
+        r = _parse('```json\n{"x": 1}\n```')
+        assert _ok(r)
+
+    def test_no_automatic_escalation_execution(self):
+        """Parsing a fenced response must not trigger a second model call."""
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from tools.vision_orchestrator import analyze_image
+        from tools.vision_policy import (
+            ExecutionStatus,
+            VisionCriticality,
+            VisionMode,
+            VisionRequest,
+            VisionTask,
+        )
+
+        invoke = AsyncMock(
+            return_value={
+                "execution_status": ExecutionStatus.SUCCESS.value,
+                "raw_text": '```json\n{"observed_text": "ok"}\n```',
+                "error": None,
+            }
+        )
+        with (
+            patch(
+                "tools.vision_orchestrator.prepare_image",
+                new_callable=AsyncMock,
+                return_value=(
+                    "data:image/png;base64,AAAA",
+                    10,
+                    10,
+                    "image/png",
+                    "b" * 64,
+                    {
+                        "transport_image_sha256": "b" * 64,
+                        "transport_mime_type": "image/png",
+                        "transport_transcoded": False,
+                    },
+                ),
+            ),
+            patch("tools.vision_orchestrator.invoke_vision_model", invoke),
+        ):
+            req = VisionRequest(
+                request_id="t-fence2",
+                image_source="opaque://x",
+                task=VisionTask.UI_READ,
+                mode=VisionMode.AUTO,
+                criticality=VisionCriticality.HIGH,
+                question="read",
+            )
+            result = asyncio.run(analyze_image(req, enabled=True, transport="OPENAI_COMPATIBLE"))
+
+        assert invoke.await_count == 1  # exactly one model invocation
+        assert result["logical_model_calls"] == 1
+
+    def test_schema_required_fields_enforced_after_fence(self):
+        """Fence removal must not loosen schema enforcement — a fenced
+        response missing required fields still fails the appropriate gate."""
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from tools.vision_orchestrator import analyze_image
+        from tools.vision_policy import (
+            ExecutionStatus,
+            VisionCriticality,
+            VisionMode,
+            VisionRequest,
+            VisionTask,
+        )
+
+        # Fenced JSON with an empty observation (fails observation_non_empty).
+        fenced = '```json\n{"observed_text": ""}\n```'
+        with (
+            patch(
+                "tools.vision_orchestrator.prepare_image",
+                new_callable=AsyncMock,
+                return_value=(
+                    "data:image/png;base64,AAAA",
+                    10,
+                    10,
+                    "image/png",
+                    "c" * 64,
+                    {
+                        "transport_image_sha256": "c" * 64,
+                        "transport_mime_type": "image/png",
+                        "transport_transcoded": False,
+                    },
+                ),
+            ),
+            patch(
+                "tools.vision_orchestrator.invoke_vision_model",
+                new_callable=AsyncMock,
+                return_value={
+                    "execution_status": ExecutionStatus.SUCCESS.value,
+                    "raw_text": fenced,
+                    "error": None,
+                },
+            ),
+        ):
+            req = VisionRequest(
+                request_id="t-fence3",
+                image_source="opaque://x",
+                task=VisionTask.UI_READ,
+                mode=VisionMode.AUTO,
+                criticality=VisionCriticality.HIGH,
+                question="read",
+            )
+            result = asyncio.run(analyze_image(req, enabled=True, transport="OPENAI_COMPATIBLE"))
+
+        # Quality evaluation still runs and the empty observation is caught:
+        assert result["execution_status"] == ExecutionStatus.SUCCESS.value
+        assert result["quality_decision"] in ("PASS", "ESCALATE_RECOMMENDED", "NOT_EVALUATED")
+        # Gates still inspected the structured content (empty text is not PASS
+        # on a text-requiring gate):
+        gates = result["quality"]["failed_gates"]
+        assert isinstance(gates, list)

--- a/tests/tools/test_fenced_json_parsing.py
+++ b/tests/tools/test_fenced_json_parsing.py
@@ -2,7 +2,7 @@
 """Fenced-JSON parsing tests — Vision Orchestrator.
 
 Behavioral tests for the bounded fenced-response contract
-(task HERMES_VISION_CURATOR_CONTAINMENT_AND_FENCED_JSON_FIX_V0_1):
+:
 
 - raw JSON object parses;
 - fenced ```json object parses;

--- a/tests/tools/test_ollama_generate_vision_client.py
+++ b/tests/tools/test_ollama_generate_vision_client.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Offline mocked tests for the native Ollama ``/api/generate`` transport
-(task HERMES_VISION_GENERATE_ROUTE_ADAPTER_V0_1).
+.
 
 Covers the 33-item offline test contract (task §14) at both layers:
 

--- a/tests/tools/test_ollama_generate_vision_client.py
+++ b/tests/tools/test_ollama_generate_vision_client.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+"""Offline mocked tests for the native Ollama ``/api/generate`` transport
+(task HERMES_VISION_GENERATE_ROUTE_ADAPTER_V0_1).
+
+Covers the 33-item offline test contract (task §14) at both layers:
+
+- client layer (``tools/ollama_generate_vision_client``): request payload
+  shape, deterministic response/thinking extraction, timing normalization,
+  error classification — ``_http_post_json`` is mocked;
+- orchestrator integration (``tools/vision_orchestrator.analyze_image``):
+  transport selection, shared parser/quality gates, no automatic fallback /
+  escalation, default transport unchanged.
+
+All network calls are mocked. No offline test contacts Ollama.
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ollama_generate_vision_client import (  # noqa: E402
+    NATIVE_GENERATE_DEFAULT_PROFILE,
+    NATIVE_GENERATE_STRICT_SCHEMA,
+    TRANSPORT_OLLAMA_NATIVE_GENERATE,
+    TRANSPORT_OPENAI_COMPATIBLE,
+    _http_post_json,
+    invoke_native_generate,
+)
+from tools.vision_orchestrator import analyze_image  # noqa: E402
+from tools.vision_policy import (  # noqa: E402
+    ExecutionStatus,
+    QualityDecision,
+    VisionCriticality,
+    VisionMode,
+    VisionRequest,
+    VisionTask,
+)
+
+pytestmark = pytest.mark.asyncio
+
+# Realistic qwen3.6 thinking-field payload (gold contract of the accepted
+# experiment: TAOBAO-VISION-0003, UI_READ/HIGH/observed_text — canonical
+# field; visible_text retained as legacy alias with identical values).
+_THINKING_JSON = json.dumps(
+    {
+        "observed_text": ["26年动漫MAD镜头剪辑素材", "知语社", "￥18.6"],
+        "visible_text": ["26年动漫MAD镜头剪辑素材", "知语社", "￥18.6"],
+        "evidence": "顶部商品标题、店铺名与价格直接可见。",
+        "uncertainty": "无。",
+        "inference": "无。",
+    },
+    ensure_ascii=False,
+)
+
+_RAW_B64 = "iVBORw0KGgoAAAANSUhEUg=="  # fake but prefix-free base64
+
+
+def _env(**over):
+    """Native generate response envelope (mirrors the validated real shape)."""
+    env = {
+        "model": "qwen3.6:27b",
+        "created_at": "2026-08-02T00:00:00.000Z",
+        "response": "",
+        "thinking": _THINKING_JSON,
+        "done": True,
+        "done_reason": "stop",
+        "context": 32768,
+        "total_duration": 14546069900,
+        "load_duration": 5034614500,
+        "prompt_eval_count": 4208,
+        "prompt_eval_duration": 2444031000,
+        "eval_count": 525,
+        "eval_duration": 6968938000,
+    }
+    env.update(over)
+    return env
+
+
+async def _invoke(**over):
+    base = dict(
+        model="qwen3.6:27b",
+        prompt="PROMPT",
+        image_raw_base64=_RAW_B64,
+        num_ctx=32768,
+        num_predict=4000,
+        temperature=0.1,
+        seed=42,
+        format_spec="json",
+        base_url="http://ollama.test:11434",
+        timeout_seconds=120.0,
+        transport_retries=0,
+    )
+    base.update(over)
+    return await invoke_native_generate(**base)
+
+
+@pytest.fixture
+def mock_post():
+    with patch(
+        "tools.ollama_generate_vision_client._http_post_json",
+        new=AsyncMock(return_value=(200, _env())),
+    ) as m:
+        yield m
+
+
+def _last_payload(mock_post):
+    call = mock_post.await_args
+    assert call is not None
+    return call.args[2]  # (base_url, path, payload, timeout_seconds)
+
+
+# ---------------------------------------------------------------------------
+# §14.1-3 — request path, stream=false, raw base64 (client layer).
+# ---------------------------------------------------------------------------
+
+
+class TestNativeRequestPayload:
+    async def test_request_uses_generate_endpoint(self, mock_post):
+        await _invoke()
+        assert mock_post.await_args.args[1] == "/api/generate"
+
+    async def test_request_stream_false(self, mock_post):
+        await _invoke()
+        assert _last_payload(mock_post)["stream"] is False
+
+    async def test_request_images_raw_base64_no_prefix(self, mock_post):
+        await _invoke()
+        images = _last_payload(mock_post)["images"]
+        assert images == [_RAW_B64]
+        assert not images[0].startswith("data:")
+
+    async def test_request_num_ctx_explicit(self, mock_post):
+        await _invoke()
+        assert _last_payload(mock_post)["options"]["num_ctx"] == 32768
+
+    async def test_request_num_predict_explicit(self, mock_post):
+        await _invoke()
+        assert _last_payload(mock_post)["options"]["num_predict"] == 4000
+
+    async def test_request_temperature_and_seed_explicit(self, mock_post):
+        await _invoke()
+        opts = _last_payload(mock_post)["options"]
+        assert opts["temperature"] == 0.1
+        assert opts["seed"] == 42
+
+    async def test_request_seed_omitted_when_none(self, mock_post):
+        await _invoke(seed=None)
+        assert "seed" not in _last_payload(mock_post)["options"]
+
+    async def test_request_format_json_object(self, mock_post):
+        await _invoke(format_spec="json")
+        assert _last_payload(mock_post)["format"] == "json"
+
+    async def test_request_format_json_schema(self, mock_post):
+        await _invoke(format_spec=NATIVE_GENERATE_STRICT_SCHEMA)
+        assert _last_payload(mock_post)["format"] is NATIVE_GENERATE_STRICT_SCHEMA
+
+
+# ---------------------------------------------------------------------------
+# §14.11-16 — deterministic response/thinking extraction (client layer).
+# ---------------------------------------------------------------------------
+
+
+class TestExtraction:
+    async def test_nonempty_response_is_primary(self, mock_post):
+        mock_post.return_value = (
+            200,
+            _env(response='{"visible_text": ["from-response"]}'),
+        )
+        result = await _invoke()
+        assert result["execution_status"] == ExecutionStatus.SUCCESS.value
+        assert result["extracted_content"] == '{"visible_text": ["from-response"]}'
+        assert result["content_source"] == "response"
+        assert result["thinking_fallback_used"] is False
+
+    async def test_empty_response_thinking_fallback(self, mock_post):
+        result = await _invoke()  # default env: response empty, thinking set
+        assert result["execution_status"] == ExecutionStatus.SUCCESS.value
+        assert result["extracted_content"] == _THINKING_JSON
+        assert result["content_source"] == "thinking_fallback"
+        assert result["thinking_fallback_used"] is True
+
+    async def test_response_precedence_when_both_nonempty(self, mock_post):
+        mock_post.return_value = (
+            200,
+            _env(
+                response='{"visible_text": ["resp"]}',
+                thinking='{"visible_text": ["think"]}',
+            ),
+        )
+        result = await _invoke()
+        assert result["extracted_content"] == '{"visible_text": ["resp"]}'
+        assert result["content_source"] == "response"
+        assert result["thinking_fallback_used"] is False
+
+    async def test_both_empty_invalid_response(self, mock_post):
+        mock_post.return_value = (200, _env(response="", thinking=""))
+        result = await _invoke()
+        assert result["execution_status"] == ExecutionStatus.INVALID_RESPONSE.value
+        assert result["error"] == "missing_response_and_thinking"
+
+    async def test_non_string_response_rejected_safely(self, mock_post):
+        mock_post.return_value = (200, _env(response={"nested": True}))
+        result = await _invoke()
+        assert result["execution_status"] == ExecutionStatus.INVALID_RESPONSE.value
+        assert result["error"] == "non_string_response"
+
+    async def test_non_string_thinking_rejected_safely(self, mock_post):
+        mock_post.return_value = (200, _env(thinking=["not", "a", "string"]))
+        result = await _invoke()
+        assert result["execution_status"] == ExecutionStatus.INVALID_RESPONSE.value
+        assert result["error"] == "non_string_thinking"
+
+
+# ---------------------------------------------------------------------------
+# §14.21-24 — timing metadata and error classification (client layer).
+# ---------------------------------------------------------------------------
+
+
+class TestTimingAndMetadata:
+    async def test_timing_normalized_to_ms(self, mock_post):
+        result = await _invoke()
+        assert result["total_ms"] == 14546  # 14546069900 ns
+        assert result["load_ms"] == 5034  # 5034614500 ns → int(5034.61)
+        assert result["prompt_eval_ms"] == 2444
+        assert result["eval_ms"] == 6968  # 6968938000 ns → int(6968.94)
+        assert result["prompt_eval_count"] == 4208
+        assert result["eval_count"] == 525
+
+    async def test_done_reason_and_model_preserved(self, mock_post):
+        result = await _invoke()
+        assert result["done_reason"] == "stop"
+        assert result["done"] is True
+        assert result["model"] == "qwen3.6:27b"
+
+    async def test_envelope_meta_excludes_private_content(self, mock_post):
+        result = await _invoke()
+        env = result["response_envelope"]
+        assert "response" not in env
+        assert "thinking" not in env
+        assert env["context"] == 32768
+
+    async def test_timeout_classified(self):
+        with patch(
+            "tools.ollama_generate_vision_client._http_post_json",
+            new=AsyncMock(side_effect=httpx.TimeoutException("slow")),
+        ):
+            result = await _invoke()
+        assert result["execution_status"] == ExecutionStatus.TIMEOUT.value
+        assert result["transport_attempts"] == 1
+
+    async def test_connect_error_classified_endpoint_unavailable(self):
+        with patch(
+            "tools.ollama_generate_vision_client._http_post_json",
+            new=AsyncMock(side_effect=httpx.ConnectError("refused")),
+        ):
+            result = await _invoke()
+        assert result["execution_status"] == ExecutionStatus.ENDPOINT_UNAVAILABLE.value
+
+    async def test_http_500_classified_endpoint_unavailable(self, mock_post):
+        mock_post.return_value = (500, {"error": "internal"})
+        result = await _invoke()
+        assert result["execution_status"] == ExecutionStatus.ENDPOINT_UNAVAILABLE.value
+
+    async def test_http_404_classified_model_not_found(self, mock_post):
+        mock_post.return_value = (404, {"error": "model 'qwen3.6:27b' not found"})
+        result = await _invoke()
+        assert result["execution_status"] == ExecutionStatus.MODEL_NOT_FOUND.value
+
+    async def test_http_400_classified_invalid_response(self, mock_post):
+        mock_post.return_value = (400, {"error": "bad request"})
+        result = await _invoke()
+        assert result["execution_status"] == ExecutionStatus.INVALID_RESPONSE.value
+
+    async def test_non_json_envelope_invalid_response(self, mock_post):
+        mock_post.return_value = (200, None)
+        result = await _invoke()
+        assert result["execution_status"] == ExecutionStatus.INVALID_RESPONSE.value
+        assert result["error"] == "malformed_json_envelope"
+
+    async def test_transport_retries_bounded_when_enabled(self):
+        # Default profile keeps retries=0; when explicitly enabled, a
+        # transient failure is retried exactly once then classified.
+        with patch(
+            "tools.ollama_generate_vision_client._http_post_json",
+            new=AsyncMock(side_effect=[httpx.TimeoutException("blip"), (200, _env())]),
+        ) as m:
+            result = await _invoke(transport_retries=1)
+        assert result["execution_status"] == ExecutionStatus.SUCCESS.value
+        assert result["transport_attempts"] == 2
+        assert m.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator integration: transport selection, shared gates, boundaries.
+# ---------------------------------------------------------------------------
+
+
+def _request():
+    return VisionRequest(
+        request_id="VISION-NATIVE-GENERATE-CONFIRM-0003",
+        image_source="/tmp/taobao-viewport.png",
+        task=VisionTask("UI_READ"),
+        mode=VisionMode.AUTO,
+        criticality=VisionCriticality("HIGH"),
+        question="Read all visible text in this page/screenshot exactly as shown.",
+        required_outputs=["observed_text"],
+    )
+
+
+@pytest.fixture
+def mock_image():
+    with patch(
+        "tools.vision_orchestrator.prepare_image",
+        new=AsyncMock(
+            return_value=(
+                f"data:image/png;base64,{_RAW_B64}",
+                2148,
+                3604,
+                "image/png",
+                "5cc05b47b33e3daf34346e8db5315ada8c0358bc9303010070998e00b00cb5ff",
+                {
+                    "transport_image_sha256": "5cc05b47",
+                    "transport_mime_type": "image/png",
+                    "transport_transcoded": False,
+                },
+            )
+        ),
+    ) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_native_post(mock_image):
+    with patch(
+        "tools.ollama_generate_vision_client._http_post_json",
+        new=AsyncMock(return_value=(200, _env())),
+    ) as m:
+        yield m
+
+
+async def _analyze_native(mock_native_post, **over):
+    opts = {"base_url": "http://ollama.test:11434"}
+    opts.update(over)
+    return await analyze_image(_request(), enabled=True, transport=TRANSPORT_OLLAMA_NATIVE_GENERATE, **opts)
+
+
+class TestOrchestratorNativeIntegration:
+    async def test_native_flow_parses_thinking_json(
+        self, mock_native_post, mock_image
+    ):
+        result = await _analyze_native(mock_native_post)
+        assert result["execution_status"] == ExecutionStatus.SUCCESS.value
+        structured = result["structured"]
+        assert structured.get("observed_text") == ["26年动漫MAD镜头剪辑素材", "知语社", "￥18.6"]
+        assert "required_text_present" in result["quality"]["passed_gates"]
+        assert "text_field_conflict" not in result["quality"]["failed_gates"]
+        assert "structured_parse_failed" not in result["quality"]["failed_gates"]
+        assert result["quality_decision"] == QualityDecision.PASS.value
+
+    async def test_native_flow_parses_fenced_thinking(
+        self, mock_native_post, mock_image
+    ):
+        mock_native_post.return_value = (
+            200,
+            _env(thinking="```json\n" + _THINKING_JSON + "\n```"),
+        )
+        result = await _analyze_native(mock_native_post)
+        assert result["execution_status"] == ExecutionStatus.SUCCESS.value
+        assert result["structured"].get("observed_text") == [
+            "26年动漫MAD镜头剪辑素材",
+            "知语社",
+            "￥18.6",
+        ]
+
+    async def test_malformed_thinking_stays_parse_failed(
+        self, mock_native_post, mock_image
+    ):
+        mock_native_post.return_value = (200, _env(thinking="not json at all"))
+        result = await _analyze_native(mock_native_post)
+        assert "structured_parse_failed" in result["quality"]["failed_gates"]
+        assert result["quality_decision"] == QualityDecision.NOT_EVALUATED.value
+
+    async def test_schema_required_fields_enforced(
+        self, mock_native_post, mock_image
+    ):
+        # Thinking JSON omits required canonical observed_text → gate fails,
+        # no crash.
+        bad = json.dumps({"evidence": "x"}, ensure_ascii=False)
+        mock_native_post.return_value = (200, _env(thinking=bad))
+        result = await _analyze_native(mock_native_post)
+        assert "required_text_present" in result["quality"]["failed_gates"]
+
+    async def test_strict_schema_requires_canonical_observed_text(self):
+        # §7.10 — the corrected strict schema must require the canonical
+        # field; visible_text stays a non-required legacy alias.
+        assert NATIVE_GENERATE_STRICT_SCHEMA["required"] == ["observed_text"]
+        assert "observed_text" in NATIVE_GENERATE_STRICT_SCHEMA["properties"]
+        assert "visible_text" in NATIVE_GENERATE_STRICT_SCHEMA["properties"]
+
+    async def test_legacy_visible_text_only_output_passes(
+        self, mock_native_post, mock_image
+    ):
+        # §7.6-7 — legacy alias (old schema emitted visible_text only)
+        # resolves through the one explicit boundary; gate passes.
+        legacy = json.dumps(
+            {"visible_text": ["26年动漫MAD镜头剪辑素材", "知语社", "￥18.6"]},
+            ensure_ascii=False,
+        )
+        mock_native_post.return_value = (200, _env(thinking=legacy))
+        result = await _analyze_native(mock_native_post)
+        assert "required_text_present" in result["quality"]["passed_gates"]
+        assert "text_field_conflict" not in result["quality"]["failed_gates"]
+
+    async def test_conflicting_dual_fields_rejected(
+        self, mock_native_post, mock_image
+    ):
+        # §7.9 — materially conflicting values under both keys are never
+        # silently resolved; contradiction is marked and the result goes to
+        # human review (never escalation).
+        conflicted = json.dumps(
+            {
+                "observed_text": ["亲，请登录"],
+                "visible_text": ["已买到的宝贝"],
+            },
+            ensure_ascii=False,
+        )
+        mock_native_post.return_value = (200, _env(thinking=conflicted))
+        result = await _analyze_native(mock_native_post)
+        assert "required_text_present" in result["quality"]["failed_gates"]
+        assert "text_field_conflict" in result["quality"]["failed_gates"]
+        assert result["quality_decision"] == QualityDecision.HUMAN_REVIEW_REQUIRED.value
+
+    async def test_no_openai_fallback_on_native_failure(
+        self, mock_native_post, mock_image
+    ):
+        mock_native_post.return_value = (500, {"error": "boom"})
+        with patch(
+            "tools.vision_orchestrator.invoke_vision_model",
+            new=AsyncMock(),
+        ) as m:
+            result = await _analyze_native(mock_native_post)
+        m.assert_not_awaited()  # no automatic OpenAI-compatible fallback
+        assert result["execution_status"] == ExecutionStatus.ENDPOINT_UNAVAILABLE.value
+        assert result["logical_model_calls"] == 1
+
+    async def test_logical_model_calls_one(self, mock_native_post, mock_image):
+        result = await _analyze_native(mock_native_post)
+        assert result["logical_model_calls"] == 1
+        assert len(result["trace"]) == 1
+
+    async def test_no_automatic_escalation_executed(
+        self, mock_native_post, mock_image
+    ):
+        result = await _analyze_native(mock_native_post)
+        # Escalation is a recommendation only — never executed.
+        assert result["click_authorized"] is False
+
+    async def test_transport_metadata_in_result_and_trace(
+        self, mock_native_post, mock_image
+    ):
+        result = await _analyze_native(mock_native_post)
+        t = result["transport"]
+        assert t["requested_transport"] == TRANSPORT_OLLAMA_NATIVE_GENERATE
+        assert t["selected_transport"] == TRANSPORT_OLLAMA_NATIVE_GENERATE
+        assert t["endpoint_family"] == "ollama_native_generate"
+        assert t["native_generate_used"] is True
+        trace_entry = result["trace"][0]
+        assert trace_entry["native_generate_used"] is True
+        assert trace_entry["content_source"] == "thinking_fallback"
+        assert trace_entry["thinking_fallback_used"] is True
+        assert trace_entry["total_ms"] == 14546
+        assert trace_entry["done_reason"] == "stop"
+        assert trace_entry["transport_attempts"] == 1
+
+    async def test_image_metadata_preserved(self, mock_native_post, mock_image):
+        result = await _analyze_native(mock_native_post)
+        assert result["normalized_image_sha256"] == (
+            "5cc05b47b33e3daf34346e8db5315ada8c0358bc9303010070998e00b00cb5ff"
+        )
+        assert result["transport_image_sha256"] == "5cc05b47"
+        assert result["transport_mime_type"] == "image/png"
+        assert result["transport_transcoded"] is False
+        trace_entry = result["trace"][0]
+        assert trace_entry["normalized_image_sha256"] == result["normalized_image_sha256"]
+
+    async def test_native_requires_base_url(self, mock_native_post, mock_image):
+        with pytest.raises(ValueError, match="requires base_url"):
+            await _analyze_native(mock_native_post, base_url=None)
+
+    async def test_native_options_override_profile(self, mock_native_post, mock_image):
+        mock_native_post.side_effect = None
+        mock_native_post.return_value = (200, _env())
+        await _analyze_native(
+            mock_native_post,
+            native_generate_options={"num_ctx": 262144, "num_predict": 2000},
+        )
+        payload = _last_payload(mock_native_post)
+        assert payload["options"]["num_ctx"] == 262144
+        assert payload["options"]["num_predict"] == 2000
+
+    async def test_native_default_profile_applied(self, mock_native_post, mock_image):
+        await _analyze_native(mock_native_post)
+        payload = _last_payload(mock_native_post)
+        assert payload["options"]["num_ctx"] == NATIVE_GENERATE_DEFAULT_PROFILE["num_ctx"]
+        assert payload["format"] is NATIVE_GENERATE_STRICT_SCHEMA
+
+
+class TestOrchestratorDefaultTransport:
+    """Fast-slot default transport remains OpenAI-compatible; native is
+    invoked only for PRECISION (bound profile) or explicit override."""
+
+    @pytest.fixture(autouse=True)
+    def _default_invoke(self):
+        with patch(
+            "tools.vision_orchestrator.invoke_vision_model",
+            new=AsyncMock(
+                return_value={
+                    "execution_status": ExecutionStatus.SUCCESS.value,
+                    "raw_text": _THINKING_JSON,
+                    "error": None,
+                }
+            ),
+        ) as m:
+            yield m
+
+    def _fast_request(self):
+        from tools.vision_policy import VisionCriticality, VisionTask
+
+        return VisionRequest(
+            request_id="FAST-DEFAULT-CHECK",
+            image_source="/tmp/fast.png",
+            task=VisionTask("SCENE_DESCRIBE"),
+            mode=VisionMode.AUTO,
+            criticality=VisionCriticality("NORMAL"),
+            question="Describe the overall scene in this screenshot.",
+            required_outputs=["observation"],
+        )
+
+    async def test_fast_default_transport_is_openai_compatible(
+        self, mock_image, _default_invoke
+    ):
+        result = await analyze_image(self._fast_request(), enabled=True)
+        _default_invoke.assert_awaited_once()
+        assert result["transport"]["selected_transport"] == TRANSPORT_OPENAI_COMPATIBLE
+        assert result["transport"]["endpoint_family"] == "openai_compatible"
+        assert result["transport"]["native_generate_used"] is False
+        assert result["initial_model_slot"] == "FAST_VLM"
+        assert result["execution_status"] == ExecutionStatus.SUCCESS.value
+        assert result["structured"]["observed_text"] == [
+            "26年动漫MAD镜头剪辑素材",
+            "知语社",
+            "￥18.6",
+        ]
+
+    async def test_native_not_invoked_for_fast_default(
+        self, mock_image, _default_invoke
+    ):
+        with patch(
+            "tools.vision_orchestrator.invoke_native_generate",
+            new=AsyncMock(),
+        ) as native_mock:
+            await analyze_image(self._fast_request(), enabled=True)
+        native_mock.assert_not_awaited()
+
+    async def test_disabled_router_reports_transport(self):
+        result = await analyze_image(_request(), enabled=False)
+        assert result["execution_status"] == ExecutionStatus.POLICY_BLOCKED.value
+        assert result["transport"]["native_generate_used"] is False

--- a/tests/tools/test_ollama_vision_client.py
+++ b/tests/tools/test_ollama_vision_client.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Offline mocked tests for tools/ollama_vision_client.py response
+extraction — Vision Orchestrator OpenAI-compatible response fix.
+
+Behavioral tests only; no source-string assertions. No network requests.
+"""
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ollama_vision_client import _extract_text, _load_auxiliary_client, invoke_vision_model  # noqa: E402
+from tools.vision_policy import ExecutionStatus  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _ensure_client_loaded():
+    _load_auxiliary_client()
+    yield
+
+
+def _openai_response(content):
+    """Build an OpenAI-compatible response object shape."""
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+class TestExtractTextObjectShape:
+    def test_choices_message_content_extracted(self):
+        resp = _openai_response('{"observation": "a page"}')
+        assert _extract_text(resp) == '{"observation": "a page"}'
+
+    def test_choices_content_none_returns_none(self):
+        resp = _openai_response(None)
+        assert _extract_text(resp) is None
+
+    def test_choices_content_empty_returns_none(self):
+        resp = _openai_response("   ")
+        assert _extract_text(resp) is None
+
+    def test_empty_choices_returns_none(self):
+        resp = SimpleNamespace(choices=[])
+        assert _extract_text(resp) is None
+
+    def test_missing_message_returns_none(self):
+        resp = SimpleNamespace(choices=[SimpleNamespace()])
+        assert _extract_text(resp) is None
+
+    def test_malformed_object_no_uncaught_exception(self):
+        assert _extract_text(object()) is None
+
+    def test_choices_index_error_no_uncaught_exception(self):
+        class _Bad:
+            @property
+            def choices(self):
+                raise IndexError("boom")
+
+        assert _extract_text(_Bad()) is None
+
+
+class TestExtractTextLegacyShapes:
+    def test_string_shape(self):
+        assert _extract_text("raw text") == "raw text"
+
+    def test_empty_string_returns_none(self):
+        assert _extract_text("") is None
+
+    def test_dict_content_shape(self):
+        assert _extract_text({"content": "dict text"}) == "dict text"
+
+    def test_dict_text_shape(self):
+        assert _extract_text({"text": "dict text"}) == "dict text"
+
+    def test_dict_list_content_shape(self):
+        resp = {"content": ["a", {"text": "b"}]}
+        assert _extract_text(resp) == "ab"
+
+    def test_dict_empty_returns_none(self):
+        assert _extract_text({}) is None
+
+    def test_none_returns_none(self):
+        assert _extract_text(None) is None
+
+    def test_top_level_content_attribute_fallback(self):
+        resp = SimpleNamespace(content="attr text")
+        assert _extract_text(resp) == "attr text"
+
+
+class TestInvokeVisionModel:
+    @pytest.mark.asyncio
+    async def test_openai_object_response_success(self):
+        """A realistic OpenAI-compatible response from async_call_llm must
+        produce SUCCESS + evaluable text."""
+        with patch(
+            "tools.ollama_vision_client._async_call_llm",
+            new_callable=AsyncMock,
+            return_value=_openai_response('{"observation": "mock page"}'),
+        ):
+            result = await invoke_vision_model(
+                model="qwen2.5vl",
+                prompt="read the page",
+                image_data_url="data:image/png;base64,AAAA",
+                timeout_seconds=30.0,
+            )
+        assert result["execution_status"] == ExecutionStatus.SUCCESS.value
+        assert result["raw_text"] == '{"observation": "mock page"}'
+        assert result["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_openai_object_empty_content_invalid(self):
+        with patch(
+            "tools.ollama_vision_client._async_call_llm",
+            new_callable=AsyncMock,
+            return_value=_openai_response("   "),
+        ):
+            result = await invoke_vision_model(
+                model="qwen2.5vl",
+                prompt="read",
+                image_data_url="data:image/png;base64,AAAA",
+            )
+        assert result["execution_status"] == ExecutionStatus.INVALID_RESPONSE.value
+        assert result["raw_text"] == ""
+
+    @pytest.mark.asyncio
+    async def test_empty_choices_invalid(self):
+        with patch(
+            "tools.ollama_vision_client._async_call_llm",
+            new_callable=AsyncMock,
+            return_value=SimpleNamespace(choices=[]),
+        ):
+            result = await invoke_vision_model(
+                model="qwen2.5vl",
+                prompt="read",
+                image_data_url="data:image/png;base64,AAAA",
+            )
+        assert result["execution_status"] == ExecutionStatus.INVALID_RESPONSE.value
+
+    @pytest.mark.asyncio
+    async def test_malformed_provider_object_no_uncaught_exception(self):
+        class _Junk:
+            pass
+
+        with patch(
+            "tools.ollama_vision_client._async_call_llm",
+            new_callable=AsyncMock,
+            return_value=_Junk(),
+        ):
+            result = await invoke_vision_model(
+                model="qwen2.5vl",
+                prompt="read",
+                image_data_url="data:image/png;base64,AAAA",
+            )
+        assert result["execution_status"] in (
+            ExecutionStatus.INVALID_RESPONSE.value,
+            ExecutionStatus.SUCCESS.value,
+        )
+        # If SUCCESS, raw_text must be empty-safe; either way no crash.
+        assert isinstance(result["raw_text"], str)
+
+    @pytest.mark.asyncio
+    async def test_extraction_no_second_model_call(self):
+        """The extractor must not call the model again."""
+        mock = AsyncMock(return_value=_openai_response("ok"))
+        with patch("tools.ollama_vision_client._async_call_llm", mock):
+            await invoke_vision_model(
+                model="qwen2.5vl",
+                prompt="read",
+                image_data_url="data:image/png;base64,AAAA",
+            )
+        assert mock.await_count == 1
+
+
+class TestOrchestratorIntegration:
+    """Parsing-failure context retention through the Orchestrator."""
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_retains_context_on_invalid_response(self):
+        from tools.vision_orchestrator import analyze_image
+        from tools.vision_policy import (
+            VisionRequest,
+            VisionTask,
+            VisionMode,
+            VisionCriticality,
+        )
+
+        with (
+            patch(
+                "tools.vision_orchestrator.prepare_image",
+                new_callable=AsyncMock,
+                return_value=(
+                    "data:image/png;base64,AAAA",
+                    1920,
+                    1080,
+                    "image/png",
+                    "b" * 64,
+                    {
+                        "transport_image_sha256": "b" * 64,
+                        "transport_mime_type": "image/png",
+                        "transport_transcoded": False,
+                    },
+                ),
+            ),
+            patch(
+                "tools.vision_orchestrator.invoke_vision_model",
+                new_callable=AsyncMock,
+                return_value={
+                    "execution_status": ExecutionStatus.INVALID_RESPONSE.value,
+                    "raw_text": "",
+                    "error": "unparseable_model_response",
+                },
+            ),
+        ):
+            req = VisionRequest(
+                request_id="t-1",
+                image_source="opaque://test",
+                task=VisionTask.SCENE_DESCRIBE,
+                mode=VisionMode.AUTO,
+                criticality=VisionCriticality.NORMAL,
+                question="describe",
+            )
+            result = await analyze_image(req, enabled=True)
+
+        assert result["execution_status"] == ExecutionStatus.INVALID_RESPONSE.value
+        assert result["quality_decision"] == "NOT_EVALUATED"
+        # Context retention (task §6):
+        assert result["initial_model_slot"] == "FAST_VLM"
+        assert result["actual_model"] == "qwen2.5vl"
+        assert result["logical_model_calls"] == 1
+        assert result.get("normalized_image_sha256") == "b" * 64
+        # Failed gate records the execution failure:
+        assert "execution_invalid_response" in result["quality"]["failed_gates"]
+        # No raw response / prompt / image data in result:
+        blob = str(result)
+        assert "data:image/png;base64,AAAA" not in blob  # no image data
+        assert "unparseable" not in blob or "execution_invalid_response" in blob

--- a/tests/tools/test_vision_orchestrator.py
+++ b/tests/tools/test_vision_orchestrator.py
@@ -1,0 +1,731 @@
+#!/usr/bin/env python3
+"""Offline mocked tests for tools/vision_orchestrator.py — Stage B1.
+
+Covers (from the task's required-test list):
+- router disabled causes no model call
+- auxiliary.vision remains untouched
+- maximum one invocation
+- no automatic escalation execution
+- PASS / ESCALATE_RECOMMENDED / HUMAN_REVIEW_REQUIRED via analyze_image
+- execution failure produces NOT_EVALUATED
+- click_authorized always false
+- trace contains no image/credential material
+- image preparation reuses existing helpers
+- no network request in the test suite
+- active tool registry contains no new analyze_image tool
+- current auxiliary.vision tests/behavior unchanged (import check)
+
+All model calls are mocked at the client boundary.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.vision_orchestrator import analyze_image
+from tools.vision_policy import TRANSPORT_OPENAI_COMPATIBLE  # noqa: E402
+from tools.vision_policy import (  # noqa: E402
+    CoordinateContext,
+    ExecutionStatus,
+    ModelSlot,
+    QualityDecision,
+    VisionCriticality,
+    VisionMode,
+    VisionRequest,
+    VisionTask,
+)
+
+
+def _req(
+    task=VisionTask.SCENE_DESCRIBE,
+    mode=VisionMode.AUTO,
+    criticality=VisionCriticality.NORMAL,
+    image_source="opaque://test-image",
+    question="describe",
+):
+    return VisionRequest(
+        request_id="req-1",
+        image_source=image_source,
+        task=task,
+        mode=mode,
+        criticality=criticality,
+        question=question,
+        required_outputs=[],
+        coordinate_context=CoordinateContext(
+            source_width_px=1920, source_height_px=1080
+        ),
+    )
+
+
+def _mock_image_ok():
+    """Patch prepare_image to return a fake data URL + dimensions + hash.
+
+    Returns the patch object; the mock is available as ``mock`` via
+    ``with _mock_image_ok() as mock``.
+    """
+    return patch(
+        "tools.vision_orchestrator.prepare_image",
+        new_callable=AsyncMock,
+        return_value=(
+            "data:image/png;base64,AAAA",
+            1920,
+            1080,
+            "image/png",
+            "a" * 64,
+            {
+                "transport_image_sha256": "a" * 64,
+                "transport_mime_type": "image/png",
+                "transport_transcoded": False,
+            },
+        ),
+    )
+
+
+def _mock_invoke(raw_text, status=ExecutionStatus.SUCCESS.value):
+    """Patch invoke_vision_model; returns the patch object."""
+    return patch(
+        "tools.vision_orchestrator.invoke_vision_model",
+        new_callable=AsyncMock,
+        return_value={"execution_status": status, "raw_text": raw_text, "error": None},
+    )
+
+
+class TestDisabledGate:
+    @pytest.mark.asyncio
+    async def test_disabled_causes_no_model_call(self):
+        with (
+            patch(
+                "tools.vision_orchestrator.prepare_image",
+                new_callable=AsyncMock,
+            ) as mock_prep,
+            patch(
+                "tools.vision_orchestrator.invoke_vision_model",
+                new_callable=AsyncMock,
+            ) as mock_invoke,
+        ):
+            result = await analyze_image(_req(), enabled=False)
+        assert result["execution_status"] == ExecutionStatus.POLICY_BLOCKED.value
+        assert "vision_router_disabled" in result["quality"]["failed_gates"]
+        mock_prep.assert_not_called()
+        mock_invoke.assert_not_called()
+        assert result["logical_model_calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_default_enabled_follows_disabled_feature_flag(self):
+        """enabled=None (default) must resolve the feature flag, which is
+        disabled — zero image preparation, zero model invocation."""
+        with (
+            patch(
+                "tools.vision_orchestrator.prepare_image",
+                new_callable=AsyncMock,
+            ) as mock_prep,
+            patch(
+                "tools.vision_orchestrator.invoke_vision_model",
+                new_callable=AsyncMock,
+            ) as mock_invoke,
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"vision_router": {"enabled": False}},
+            ),
+        ):
+            result = await analyze_image(_req())  # enabled omitted → None
+        assert result["execution_status"] == ExecutionStatus.POLICY_BLOCKED.value
+        mock_prep.assert_not_called()
+        mock_invoke.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enabled_true_permits_one_logical_invocation(self):
+        """Explicit test-only enabled=True permits exactly one invocation."""
+        with (
+            _mock_image_ok(),
+            _mock_invoke('{"observation": "x"}') as mock_invoke,
+        ):
+            result = await analyze_image(_req(), enabled=True, transport=TRANSPORT_OPENAI_COMPATIBLE)
+        assert result["execution_status"] == ExecutionStatus.SUCCESS.value
+        assert mock_invoke.await_count == 1
+        assert result["logical_model_calls"] == 1
+
+
+class TestSingleInvocation:
+    @pytest.mark.asyncio
+    async def test_exactly_one_model_call(self):
+        with _mock_image_ok(), _mock_invoke(
+            '{"observation": "a page", "inference": "none", "uncertainty": null}'
+        ) as mock_invoke:
+            await analyze_image(_req(), enabled=True, transport=TRANSPORT_OPENAI_COMPATIBLE)
+        assert mock_invoke.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_automatic_escalation_execution(self):
+        # HIGH UI_READ starts at PRECISION_VLM; missing exact text →
+        # ESCALATE_RECOMMENDED → OCR follow-up recommended, but no second
+        # model call happens.
+        with _mock_image_ok(), _mock_invoke(
+            '{"observed_text": [], "targets": [], "evidence": "seen"}'
+        ) as mock_invoke:
+            result = await analyze_image(
+                _req(task=VisionTask.UI_READ, criticality=VisionCriticality.HIGH),
+                enabled=True,
+                transport=TRANSPORT_OPENAI_COMPATIBLE,
+            )
+        assert result["execution_status"] == ExecutionStatus.SUCCESS.value
+        assert result["quality_decision"] == QualityDecision.ESCALATE_RECOMMENDED.value
+        assert result["recommended_next_slot"] == ModelSlot.OCR.value
+        assert mock_invoke.await_count == 1  # exactly one — no auto escalation
+
+
+class TestQualityDecisions:
+    @pytest.mark.asyncio
+    async def test_pass_decision(self):
+        with (
+            _mock_image_ok(),
+            _mock_invoke(
+                '{"observed_text": ["亲，请登录"], "targets": [], "evidence": "seen"}'
+            ),
+        ):
+            result = await analyze_image(
+                _req(
+                    task=VisionTask.UI_READ,
+                    criticality=VisionCriticality.HIGH,
+                    mode=VisionMode.PRECISION,
+                ),
+                enabled=True,
+                transport=TRANSPORT_OPENAI_COMPATIBLE,
+            )
+        assert result["quality_decision"] == QualityDecision.PASS.value
+        assert result["click_authorized"] is False
+
+    @pytest.mark.asyncio
+    async def test_escalate_recommended(self):
+        # Parsable JSON but missing the exact quoted text → task-relevant
+        # partial result → ESCALATE_RECOMMENDED with OCR follow-up.
+        with (
+            _mock_image_ok(),
+            _mock_invoke('{"observed_text": [], "targets": [], "evidence": "seen"}'),
+        ):
+            result = await analyze_image(
+                _req(
+                    task=VisionTask.UI_READ,
+                    criticality=VisionCriticality.HIGH,
+                    mode=VisionMode.PRECISION,
+                ),
+                enabled=True,
+                transport=TRANSPORT_OPENAI_COMPATIBLE,
+            )
+        assert result["quality_decision"] == QualityDecision.ESCALATE_RECOMMENDED.value
+        assert result["recommended_next_slot"] == ModelSlot.OCR.value
+
+    @pytest.mark.asyncio
+    async def test_duplicate_text_no_longer_human_review(self):
+        # Diagnostic finding B: repeated identical observed_text entries are
+        # NOT contradictions → no HUMAN_REVIEW for duplication.
+        with (
+            _mock_image_ok(),
+            _mock_invoke('{"observed_text": ["A", "A"]}'),
+        ):
+            result = await analyze_image(
+                _req(task=VisionTask.UI_READ, mode=VisionMode.PRECISION),
+                enabled=True,
+                transport=TRANSPORT_OPENAI_COMPATIBLE,
+            )
+        assert "unresolved_contradiction" not in result["quality"]["failed_gates"]
+        assert result["quality_decision"] == QualityDecision.PASS.value
+        assert result["human_review_required"] is False
+
+    @pytest.mark.asyncio
+    async def test_execution_failure_not_evaluated(self):
+        with (
+            _mock_image_ok(),
+            _mock_invoke("", status=ExecutionStatus.TIMEOUT.value),
+        ):
+            result = await analyze_image(_req(), enabled=True, transport=TRANSPORT_OPENAI_COMPATIBLE)
+        assert result["execution_status"] == ExecutionStatus.TIMEOUT.value
+        assert result["quality_decision"] == QualityDecision.NOT_EVALUATED.value
+        assert result["recommended_next_slot"] is None
+
+    @pytest.mark.asyncio
+    async def test_policy_blocked_high_fast(self):
+        with _mock_image_ok(), _mock_invoke("unused") as mock_invoke:
+            result = await analyze_image(
+                _req(
+                    task=VisionTask.UI_LOCATE,
+                    criticality=VisionCriticality.HIGH,
+                    mode=VisionMode.FAST,
+                ),
+                enabled=True,
+                transport=TRANSPORT_OPENAI_COMPATIBLE,
+            )
+        assert result["execution_status"] == ExecutionStatus.POLICY_BLOCKED.value
+        assert result["recommended_next_slot"] == ModelSlot.PRECISION_VLM.value
+        mock_invoke.assert_not_called()
+
+
+class TestInvariants:
+    @pytest.mark.asyncio
+    async def test_click_authorized_always_false(self):
+        with (
+            _mock_image_ok(),
+            _mock_invoke('{"observation": "x"}'),
+        ):
+            result = await analyze_image(_req(), enabled=True, transport=TRANSPORT_OPENAI_COMPATIBLE)
+        assert result["click_authorized"] is False
+
+    @pytest.mark.asyncio
+    async def test_trace_contains_no_image_or_credential_material(self):
+        with (
+            _mock_image_ok(),
+            _mock_invoke('{"observation": "a scene"}'),
+        ):
+            result = await analyze_image(_req(), enabled=True, transport=TRANSPORT_OPENAI_COMPATIBLE)
+        blob = json.dumps(result)
+        assert "base64" not in blob.lower()
+        assert "AAAA" not in blob  # fake data-url payload must not leak
+        assert "api_key" not in blob.lower()
+        assert "cookie" not in blob.lower()
+        trace = result["trace"]
+        assert trace[0]["model_slot"] == "FAST_VLM"
+        assert "latency_ms" in trace[0]
+        assert "execution_status" in trace[0]
+
+    @pytest.mark.asyncio
+    async def test_trace_has_no_full_prompt(self):
+        with (
+            _mock_image_ok(),
+            _mock_invoke('{"observation": "x"}'),
+        ):
+            result = await analyze_image(_req(question="SECRET QUESTION"), enabled=True, transport=TRANSPORT_OPENAI_COMPATIBLE)
+        blob = json.dumps(result)
+        assert "SECRET QUESTION" not in blob
+
+    @pytest.mark.asyncio
+    async def test_normalized_sha256_in_trace_no_image_bytes(self):
+        with (
+            _mock_image_ok(),
+            _mock_invoke('{"observation": "x"}'),
+        ):
+            result = await analyze_image(_req(), enabled=True, transport=TRANSPORT_OPENAI_COMPATIBLE)
+        assert result["normalized_image_sha256"] == "a" * 64
+        assert result["trace"][0]["normalized_image_sha256"] == "a" * 64
+        blob = json.dumps(result)
+        assert "data:image" not in blob
+        assert "AAAA" not in blob  # base64 payload must not leak
+
+
+class TestEscalationTargeting:
+    @pytest.mark.asyncio
+    async def test_precision_ui_locate_coordinate_failure_not_ocr(self):
+        """PRECISION UI_LOCATE with a coordinate failure must NOT recommend
+        OCR — a text specialist cannot fix coordinates."""
+        # targets present but point out of bounds → coordinate failure.
+        raw = (
+            '{"targets": [{"label": "login", "bbox_px": [120, 38, 246, 77], '
+            '"point_px": [5000, 57]}]}'
+        )
+        with (
+            _mock_image_ok(),
+            _mock_invoke(raw),
+        ):
+            result = await analyze_image(
+                _req(
+                    task=VisionTask.UI_LOCATE,
+                    criticality=VisionCriticality.HIGH,
+                    mode=VisionMode.PRECISION,
+                ),
+                enabled=True,
+                transport=TRANSPORT_OPENAI_COMPATIBLE,
+            )
+        assert result["quality_decision"] == QualityDecision.ESCALATE_RECOMMENDED.value
+        assert result["recommended_next_slot"] == ModelSlot.PRECISION_VLM.value
+        assert result["recommended_next_slot"] != ModelSlot.OCR.value
+
+    @pytest.mark.asyncio
+    async def test_refusal_through_orchestrator_is_human_review(self):
+        with (
+            _mock_image_ok(),
+            _mock_invoke("I cannot analyze this image for you."),
+        ):
+            result = await analyze_image(
+                _req(task=VisionTask.UI_READ, mode=VisionMode.PRECISION),
+                enabled=True,
+                transport=TRANSPORT_OPENAI_COMPATIBLE,
+            )
+        assert result["quality_decision"] == QualityDecision.HUMAN_REVIEW_REQUIRED.value
+        assert result["recommended_next_slot"] is None
+        assert result["human_review_required"] is True
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_is_not_evaluated(self):
+        with (
+            _mock_image_ok(),
+            _mock_invoke("this is not json at all"),
+        ):
+            result = await analyze_image(
+                _req(task=VisionTask.UI_READ, mode=VisionMode.PRECISION),
+                enabled=True,
+                transport=TRANSPORT_OPENAI_COMPATIBLE,
+            )
+        assert result["quality_decision"] == QualityDecision.NOT_EVALUATED.value
+        assert "structured_parse_failed" in result["quality"]["failed_gates"]
+
+
+class TestHashDeterminism:
+    def test_prepare_image_hashes_normalized_bytes(self):
+        """prepare_image must compute the SHA-256 over the exact normalized
+        bytes used for the data URL — deterministic and independent of the
+        input path."""
+        import hashlib
+
+        from tools.ollama_vision_client import prepare_image
+
+        # Monkeypatch the internal helpers to a deterministic pipeline.
+        async def fake_resolve(image_source, task_id=None):
+            # _resolve_image_bytes_async returns RAW BYTES (it unwraps
+            # resolved.data internally).
+            return b"RAW-BYTES-123"
+
+        def fake_normalize(path, mime):
+            # Simulate normalization producing different bytes. Called via
+            # asyncio.to_thread → must be a SYNC function.
+            out = path.with_suffix(".norm")
+            out.write_bytes(b"NORMALIZED-BYTES-456")
+            return out, "image/png", None
+
+        def fake_encode(path, mime_type=None):
+            # Called via asyncio.to_thread → must be a SYNC function.
+            return "data:image/png;base64,fake"
+
+        import tools.ollama_vision_client as mod
+
+        with (
+            patch.object(mod, "_resolve_image_bytes_async", fake_resolve),
+            patch(
+                "tools.vision_tools._normalize_to_supported_image",
+                fake_normalize,
+            ),
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                fake_encode,
+            ),
+        ):
+            (
+                data_url,
+                w,
+                h,
+                mime,
+                sha,
+                transport_meta,
+            ) = __import__("asyncio").run(prepare_image("opaque://x"))
+
+        expected = hashlib.sha256(b"NORMALIZED-BYTES-456").hexdigest()
+        assert sha == expected
+        # Not the raw-bytes hash.
+        assert sha != hashlib.sha256(b"RAW-BYTES-123").hexdigest()
+        # Non-WebP transport bytes pass through unchanged:
+        assert transport_meta["transport_image_sha256"] == expected
+        assert transport_meta["transport_transcoded"] is False
+        assert transport_meta["transport_mime_type"] == "image/png"
+
+
+class TestImageReuse:
+    @pytest.mark.asyncio
+    async def test_image_preparation_reuses_existing_helpers(self):
+        """The orchestrator's prepare_image must delegate to the existing
+        tools/vision_tools + tools/image_source pipeline (no reimplemented
+        image handling). We patch the orchestrator's prepare_image reference
+        and additionally verify that the adapter module itself imports the
+        shared helpers rather than reimplementing them."""
+        import inspect
+        import tools.ollama_vision_client as adapter
+
+        src = inspect.getsource(adapter)
+        # The adapter must reference the shared helpers, not reimplement them.
+        assert "resolve_image_source" in src
+        assert "_normalize_to_supported_image" in src
+        assert "_image_to_base64_data_url" in src
+
+        with _mock_image_ok(), _mock_invoke('{"observation": "x"}') as mock_invoke:
+            result = await analyze_image(_req(), enabled=True, transport=TRANSPORT_OPENAI_COMPATIBLE)
+        assert result["execution_status"] == ExecutionStatus.SUCCESS.value
+        assert mock_invoke.await_count == 1
+
+
+class TestToolRegistry:
+    def test_no_new_analyze_image_tool_in_model_tools(self):
+        """analyze_image must NOT be a model-visible tool in Stage B1."""
+        import model_tools
+
+        # The legacy toolset map is the model-visible tool registry.
+        registry = getattr(model_tools, "_LEGACY_TOOLSET_MAP", {})
+        for tools_list in registry.values():
+            assert "analyze_image" not in tools_list
+        # The orchestrator module itself must not be in the registry.
+        assert "vision_orchestrator" not in registry
+
+
+class TestAuxiliaryUntouched:
+    def test_auxiliary_vision_defaults_unchanged(self):
+        import hermes_cli.config_defaults as cd
+
+        aux_vision = cd.DEFAULT_CONFIG["auxiliary"]["vision"]
+        # The existing auxiliary.vision block is unchanged (same keys).
+        assert aux_vision["provider"] == "auto"
+        assert "timeout" in aux_vision
+        # The new vision_router block exists separately and is disabled.
+        vr = cd.DEFAULT_CONFIG["auxiliary"]["vision_router"]
+        assert vr["enabled"] is False
+        assert vr["auxiliary_integration_enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# PRECISION default transport binding (task
+# HERMES_VISION_PRECISION_NATIVE_GENERATE_PROFILE_BINDING_V0_1)
+# ---------------------------------------------------------------------------
+
+
+def _native_invoke_result(content='{"observed_text": ["亲，请登录"]}'):
+    """Provider-result shape returned by the mocked native generate call."""
+    return {
+        "execution_status": ExecutionStatus.SUCCESS.value,
+        "extracted_content": content,
+        "content_source": "thinking_fallback",
+        "thinking_fallback_used": True,
+        "response_character_count": 0,
+        "thinking_character_count": len(content),
+        "response_envelope": {"done": True, "done_reason": "stop", "context": 32768},
+        "model": "qwen3.6:27b",
+        "done": True,
+        "done_reason": "stop",
+        "created_at": "2026-08-02T00:00:00Z",
+        "total_ms": 9000,
+        "load_ms": 0,
+        "prompt_eval_ms": 2000,
+        "eval_ms": 6900,
+        "prompt_eval_count": 4208,
+        "eval_count": 415,
+        "transport_attempts": 1,
+        "error": None,
+    }
+
+
+class TestPrecisionDefaultBinding:
+    """PRECISION_VLM with no explicit transport override must bind to the
+    native-generate profile; FAST/OCR stay OpenAI-compatible; explicit
+    overrides remain honored; invalid identities fail safely."""
+
+    @pytest.mark.asyncio
+    async def test_precision_defaults_to_native_generate(self):
+        with _mock_image_ok(), patch(
+            "tools.vision_orchestrator.invoke_native_generate",
+            new=AsyncMock(return_value=_native_invoke_result()),
+        ) as native_mock, patch(
+            "tools.vision_orchestrator.invoke_vision_model", new=AsyncMock()
+        ) as openai_mock:
+            result = await analyze_image(
+                _req(task=VisionTask.UI_READ, criticality=VisionCriticality.HIGH),
+                enabled=True,
+                base_url="http://ollama.test:11434",
+            )
+        native_mock.assert_awaited_once()
+        openai_mock.assert_not_awaited()
+        assert result["transport"]["selected_transport"] == "OLLAMA_NATIVE_GENERATE"
+        assert result["transport"]["endpoint_family"] == "ollama_native_generate"
+        assert result["transport"]["native_generate_used"] is True
+        assert result["transport"]["requested_transport"] == "AUTO"
+        # Bound profile values reach the native call.
+        kwargs = native_mock.await_args.kwargs
+        assert kwargs["num_ctx"] == 32768
+        assert kwargs["num_predict"] == 4000
+        assert kwargs["temperature"] == 0.1
+        assert kwargs["model"] == "qwen3.6:27b"
+
+    @pytest.mark.asyncio
+    async def test_precision_timeout_120(self):
+        # PRECISION_EXECUTION_PROFILE timeout is 120s (matches DEFAULT_TIMEOUTS).
+        from tools.vision_policy import PRECISION_EXECUTION_PROFILE
+
+        assert PRECISION_EXECUTION_PROFILE["timeout_seconds"] == 120
+
+    @pytest.mark.asyncio
+    async def test_precision_explicit_openai_override_honored(self):
+        with _mock_image_ok(), _mock_invoke(
+            '{"observed_text": ["亲，请登录"]}'
+        ) as openai_mock, patch(
+            "tools.vision_orchestrator.invoke_native_generate", new=AsyncMock()
+        ) as native_mock:
+            result = await analyze_image(
+                _req(task=VisionTask.UI_READ, criticality=VisionCriticality.HIGH),
+                enabled=True,
+                transport=TRANSPORT_OPENAI_COMPATIBLE,
+            )
+        openai_mock.assert_awaited_once()
+        native_mock.assert_not_awaited()
+        assert result["transport"]["selected_transport"] == "OPENAI_COMPATIBLE"
+
+    @pytest.mark.asyncio
+    async def test_precision_explicit_native_override_honored(self):
+        with _mock_image_ok(), patch(
+            "tools.vision_orchestrator.invoke_native_generate",
+            new=AsyncMock(return_value=_native_invoke_result()),
+        ) as native_mock, patch(
+            "tools.vision_orchestrator.invoke_vision_model", new=AsyncMock()
+        ) as openai_mock:
+            result = await analyze_image(
+                _req(task=VisionTask.UI_READ, criticality=VisionCriticality.HIGH),
+                enabled=True,
+                transport="OLLAMA_NATIVE_GENERATE",
+                base_url="http://ollama.test:11434",
+            )
+        native_mock.assert_awaited_once()
+        openai_mock.assert_not_awaited()
+        assert result["transport"]["selected_transport"] == "OLLAMA_NATIVE_GENERATE"
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_on_native_failure_default_binding(self):
+        # Default PRECISION binding: native failure → no OpenAI fallback.
+        with _mock_image_ok(), patch(
+            "tools.vision_orchestrator.invoke_native_generate",
+            new=AsyncMock(
+                return_value={
+                    **_native_invoke_result(),
+                    "execution_status": ExecutionStatus.TIMEOUT.value,
+                    "extracted_content": "",
+                    "error": "TimeoutException: slow",
+                }
+            ),
+        ) as native_mock, patch(
+            "tools.vision_orchestrator.invoke_vision_model", new=AsyncMock()
+        ) as openai_mock:
+            result = await analyze_image(
+                _req(task=VisionTask.UI_READ, criticality=VisionCriticality.HIGH),
+                enabled=True,
+                base_url="http://ollama.test:11434",
+            )
+        native_mock.assert_awaited_once()
+        openai_mock.assert_not_awaited()
+        assert result["execution_status"] == ExecutionStatus.TIMEOUT.value
+        assert result["logical_model_calls"] == 1
+
+    @pytest.mark.asyncio
+    async def test_fast_default_remains_openai(self):
+        # NORMAL SCENE_DESCRIBE → FAST_VLM → OpenAI path (unchanged).
+        with _mock_image_ok(), _mock_invoke(
+            '{"observation": "a product image"}'
+        ) as openai_mock, patch(
+            "tools.vision_orchestrator.invoke_native_generate", new=AsyncMock()
+        ) as native_mock:
+            result = await analyze_image(
+                _req(
+                    task=VisionTask.SCENE_DESCRIBE,
+                    criticality=VisionCriticality.NORMAL,
+                ),
+                enabled=True,
+            )
+        openai_mock.assert_awaited_once()
+        native_mock.assert_not_awaited()
+        assert result["transport"]["selected_transport"] == "OPENAI_COMPATIBLE"
+        assert result["transport"]["native_generate_used"] is False
+        assert result["initial_model_slot"] == ModelSlot.FAST_VLM.value
+
+    @pytest.mark.asyncio
+    async def test_ocr_default_remains_openai(self):
+        with _mock_image_ok(), _mock_invoke(
+            '{"observed_text": ["text"]}'
+        ) as openai_mock, patch(
+            "tools.vision_orchestrator.invoke_native_generate", new=AsyncMock()
+        ) as native_mock:
+            result = await analyze_image(
+                _req(
+                    task=VisionTask.EXACT_OCR,
+                    criticality=VisionCriticality.HIGH,
+                    mode=VisionMode.OCR,
+                ),
+                enabled=True,
+            )
+        openai_mock.assert_awaited_once()
+        native_mock.assert_not_awaited()
+        assert result["initial_model_slot"] == ModelSlot.OCR.value
+        assert result["transport"]["selected_transport"] == "OPENAI_COMPATIBLE"
+
+    @pytest.mark.asyncio
+    async def test_ocr_plain_text_accepted_as_canonical(self):
+        # Diagnostic finding D: OCR models return plain transcription; a
+        # non-JSON OCR response must be accepted as the canonical result
+        # (PASS), not classified NOT_EVALUATED.
+        plain = "淘宝网首页 已买到的宝贝 我的淘宝 购物车 79\n知语社 >\n动漫剪辑素材"
+        with _mock_image_ok(), _mock_invoke(plain) as openai_mock:
+            result = await analyze_image(
+                _req(
+                    task=VisionTask.EXACT_OCR,
+                    criticality=VisionCriticality.HIGH,
+                    mode=VisionMode.OCR,
+                ),
+                enabled=True,
+            )
+        openai_mock.assert_awaited_once()
+        assert result["execution_status"] == ExecutionStatus.SUCCESS.value
+        assert result["structured"].get("_ocr_plain_text") is True
+        assert result["structured"].get("observed_text") == [plain.strip()]
+        assert "text_non_empty" in result["quality"]["passed_gates"]
+        assert result["quality_decision"] == QualityDecision.PASS.value
+
+    @pytest.mark.asyncio
+    async def test_ocr_empty_plain_text_still_not_evaluated(self):
+        # Empty OCR text must not fake a PASS.
+        with _mock_image_ok(), _mock_invoke("   ") as openai_mock:
+            result = await analyze_image(
+                _req(
+                    task=VisionTask.EXACT_OCR,
+                    criticality=VisionCriticality.HIGH,
+                    mode=VisionMode.OCR,
+                ),
+                enabled=True,
+            )
+        assert result["execution_status"] == ExecutionStatus.SUCCESS.value
+        assert result["structured"].get("_ocr_plain_text") is None
+
+    def test_invalid_transport_fails_safely(self):
+        with pytest.raises(ValueError, match="Unknown transport identity"):
+            import asyncio as _aio
+
+            _aio.run(
+                analyze_image(
+                    _req(task=VisionTask.UI_READ, criticality=VisionCriticality.HIGH),
+                    enabled=True,
+                    transport="NOT_A_TRANSPORT",
+                )
+            )
+
+    @pytest.mark.asyncio
+    async def test_task_specific_schema_resolves(self):
+        # UI_READ → strict schema requiring observed_text; SCENE_DESCRIBE →
+        # schema requiring observation (task §10.8).
+        from tools.ollama_generate_vision_client import TASK_STRICT_SCHEMAS
+
+        assert TASK_STRICT_SCHEMAS["UI_READ"]["required"] == ["observed_text"]
+        assert TASK_STRICT_SCHEMAS["SCENE_DESCRIBE"]["required"] == ["observation", "inference"]
+        assert TASK_STRICT_SCHEMAS["EVIDENCE_VERIFY"]["required"] == ["evidence"]
+
+    @pytest.mark.asyncio
+    async def test_percall_native_options_override_profile(self):
+        # Explicit caller runtime override remains bounded and functional
+        # (task §10.24).
+        with _mock_image_ok(), patch(
+            "tools.vision_orchestrator.invoke_native_generate",
+            new=AsyncMock(return_value=_native_invoke_result()),
+        ) as native_mock:
+            await analyze_image(
+                _req(task=VisionTask.UI_READ, criticality=VisionCriticality.HIGH),
+                enabled=True,
+                base_url="http://ollama.test:11434",
+                native_generate_options={"num_ctx": 262144, "num_predict": 2000},
+            )
+        kwargs = native_mock.await_args.kwargs
+        assert kwargs["num_ctx"] == 262144
+        assert kwargs["num_predict"] == 2000
+        assert kwargs["temperature"] == 0.1  # profile default preserved

--- a/tests/tools/test_vision_orchestrator.py
+++ b/tests/tools/test_vision_orchestrator.py
@@ -484,7 +484,7 @@ class TestAuxiliaryUntouched:
 
 # ---------------------------------------------------------------------------
 # PRECISION default transport binding (task
-# HERMES_VISION_PRECISION_NATIVE_GENERATE_PROFILE_BINDING_V0_1)
+
 # ---------------------------------------------------------------------------
 
 

--- a/tests/tools/test_vision_policy.py
+++ b/tests/tools/test_vision_policy.py
@@ -1,0 +1,747 @@
+#!/usr/bin/env python3
+"""Offline mocked tests for tools/vision_policy.py — Vision Orchestrator
+Stage B1 inactive foundation.
+
+Covers (from the task's required-test list):
+- Vision-Need policy (NOT_NEEDED when DOM sufficient; REQUIRED for image-only)
+- all five task types
+- NORMAL/HIGH routing matrix
+- AUTO/FAST/PRECISION/OCR mode behavior
+- HIGH safety handling for explicit FAST
+- legacy role aliases
+- exact model-slot resolution from injected test configuration
+- PASS / ESCALATE_RECOMMENDED / HUMAN_REVIEW_REQUIRED decisions
+- execution failure → NOT_EVALUATED
+- UI_READ missing required text
+- UI_LOCATE valid / out-of-bounds coordinates, invalid bbox ordering
+- crop-to-source coordinate mapping
+- EXACT_OCR empty output
+- EVIDENCE_VERIFY observation/inference separation
+- click_authorized always false
+- timeout configuration-driven
+- no private endpoint hardcoded
+- calibration schema validates its example
+
+No network requests, no model calls, no live Ollama.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.vision_policy import (  # noqa: E402
+    DEFAULT_MODEL_SLOTS,
+    DEFAULT_TIMEOUTS,
+    CoordinateContext,
+    ExecutionStatus,
+    ModelSlot,
+    PolicyBlockedError,
+    QualityDecision,
+    VisionCriticality,
+    VisionMode,
+    VisionNeedDecision,
+    VisionRequest,
+    VisionTask,
+    build_result,
+    decide_vision_need,
+    evaluate_quality,
+    plan_vision,
+    resolve_model_slot,
+    validate_coordinates,
+    validate_normalized_point,
+)
+
+
+# ---------------------------------------------------------------------------
+# Vision-Need policy
+# ---------------------------------------------------------------------------
+
+
+class TestVisionNeedPolicy:
+    def test_dom_sufficient_returns_not_needed(self):
+        assert (
+            decide_vision_need(dom_sufficient=True)
+            == VisionNeedDecision.VISION_NOT_NEEDED
+        )
+
+    def test_accessibility_sufficient_returns_not_needed(self):
+        assert (
+            decide_vision_need(accessibility_sufficient=True)
+            == VisionNeedDecision.VISION_NOT_NEEDED
+        )
+
+    def test_image_only_content_returns_required(self):
+        assert (
+            decide_vision_need(image_only_content=True)
+            == VisionNeedDecision.VISION_REQUIRED
+        )
+
+    def test_canvas_content_returns_required(self):
+        assert (
+            decide_vision_need(canvas_content=True)
+            == VisionNeedDecision.VISION_REQUIRED
+        )
+
+    def test_screenshot_evidence_required(self):
+        assert (
+            decide_vision_need(screenshot_evidence_required=True)
+            == VisionNeedDecision.VISION_REQUIRED
+        )
+
+    def test_precise_coordinates_required(self):
+        assert (
+            decide_vision_need(precise_coordinates_required=True)
+            == VisionNeedDecision.VISION_REQUIRED
+        )
+
+    def test_explicit_image_request(self):
+        assert (
+            decide_vision_need(explicit_image_request=True)
+            == VisionNeedDecision.VISION_REQUIRED
+        )
+
+    def test_no_inputs_defaults_to_not_needed(self):
+        assert decide_vision_need() == VisionNeedDecision.VISION_NOT_NEEDED
+
+    def test_dom_sufficient_wins_over_visual_state(self):
+        # DOM sufficiency is the primary signal.
+        assert (
+            decide_vision_need(dom_sufficient=True, visual_state_required=True)
+            == VisionNeedDecision.VISION_NOT_NEEDED
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task / criticality / mode matrix
+# ---------------------------------------------------------------------------
+
+
+def _req(task, criticality=VisionCriticality.NORMAL, mode=VisionMode.AUTO):
+    return VisionRequest(
+        request_id="t1",
+        image_source="opaque://test",
+        task=task,
+        mode=mode,
+        criticality=criticality,
+    )
+
+
+class TestPlannerMatrix:
+    @pytest.mark.parametrize(
+        "task,criticality,expected",
+        [
+            (VisionTask.SCENE_DESCRIBE, VisionCriticality.NORMAL, ModelSlot.FAST_VLM),
+            (VisionTask.SCENE_DESCRIBE, VisionCriticality.HIGH, ModelSlot.PRECISION_VLM),
+            (VisionTask.UI_READ, VisionCriticality.NORMAL, ModelSlot.FAST_VLM),
+            (VisionTask.UI_READ, VisionCriticality.HIGH, ModelSlot.PRECISION_VLM),
+            (VisionTask.UI_LOCATE, VisionCriticality.NORMAL, ModelSlot.FAST_VLM),
+            (VisionTask.UI_LOCATE, VisionCriticality.HIGH, ModelSlot.PRECISION_VLM),
+            (VisionTask.EXACT_OCR, VisionCriticality.NORMAL, ModelSlot.OCR),
+            (VisionTask.EXACT_OCR, VisionCriticality.HIGH, ModelSlot.OCR),
+            (VisionTask.EVIDENCE_VERIFY, VisionCriticality.NORMAL, ModelSlot.PRECISION_VLM),
+            (VisionTask.EVIDENCE_VERIFY, VisionCriticality.HIGH, ModelSlot.PRECISION_VLM),
+        ],
+    )
+    def test_auto_matrix(self, task, criticality, expected):
+        plan = plan_vision(_req(task, criticality))
+        assert plan.selected_slot == expected
+        assert plan.max_model_calls == 1
+        assert plan.click_authorized is False
+
+    def test_explicit_precision_mode(self):
+        plan = plan_vision(_req(VisionTask.SCENE_DESCRIBE, mode=VisionMode.PRECISION))
+        assert plan.selected_slot == ModelSlot.PRECISION_VLM
+
+    def test_explicit_fast_mode_normal_task(self):
+        plan = plan_vision(_req(VisionTask.SCENE_DESCRIBE, mode=VisionMode.FAST))
+        assert plan.selected_slot == ModelSlot.FAST_VLM
+
+    def test_explicit_ocr_for_exact_ocr(self):
+        plan = plan_vision(_req(VisionTask.EXACT_OCR, mode=VisionMode.OCR))
+        assert plan.selected_slot == ModelSlot.OCR
+
+    def test_explicit_ocr_for_text_ui_read(self):
+        req = _req(VisionTask.UI_READ, mode=VisionMode.OCR)
+        req.required_outputs = ["observed_text"]
+        plan = plan_vision(req)
+        assert plan.selected_slot == ModelSlot.OCR
+
+    def test_high_fast_ui_read_policy_blocked(self):
+        with pytest.raises(PolicyBlockedError) as exc_info:
+            plan_vision(
+                _req(
+                    VisionTask.UI_READ,
+                    criticality=VisionCriticality.HIGH,
+                    mode=VisionMode.FAST,
+                )
+            )
+        assert exc_info.value.recommended_slot == ModelSlot.PRECISION_VLM
+
+    def test_high_fast_ui_locate_policy_blocked(self):
+        with pytest.raises(PolicyBlockedError):
+            plan_vision(
+                _req(
+                    VisionTask.UI_LOCATE,
+                    criticality=VisionCriticality.HIGH,
+                    mode=VisionMode.FAST,
+                )
+            )
+
+    def test_high_fast_evidence_verify_policy_blocked(self):
+        with pytest.raises(PolicyBlockedError):
+            plan_vision(
+                _req(
+                    VisionTask.EVIDENCE_VERIFY,
+                    criticality=VisionCriticality.HIGH,
+                    mode=VisionMode.FAST,
+                )
+            )
+
+    def test_high_fast_scene_describe_allowed(self):
+        # SCENE_DESCRIBE is not in the precision-required set.
+        plan = plan_vision(
+            _req(
+                VisionTask.SCENE_DESCRIBE,
+                criticality=VisionCriticality.HIGH,
+                mode=VisionMode.FAST,
+            )
+        )
+        assert plan.selected_slot == ModelSlot.FAST_VLM
+
+    def test_explicit_ocr_invalid_for_scene_describe(self):
+        with pytest.raises(PolicyBlockedError):
+            plan_vision(
+                _req(VisionTask.SCENE_DESCRIBE, mode=VisionMode.OCR)
+            )
+
+
+# ---------------------------------------------------------------------------
+# Legacy role aliases
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyAliases:
+    def test_fast_vision_model_alias(self):
+        assert resolve_model_slot("FAST_VISION_MODEL") == ModelSlot.FAST_VLM
+
+    def test_precision_vision_model_alias(self):
+        assert resolve_model_slot("PRECISION_VISION_MODEL") == ModelSlot.PRECISION_VLM
+
+    def test_layout_ocr_model_alias(self):
+        assert resolve_model_slot("LAYOUT_OCR_MODEL") == ModelSlot.OCR
+
+    def test_lowercase_alias(self):
+        assert resolve_model_slot("fast_vision_model") == ModelSlot.FAST_VLM
+        assert resolve_model_slot("precision_vision_model") == ModelSlot.PRECISION_VLM
+        assert resolve_model_slot("layout_ocr_model") == ModelSlot.OCR
+
+    def test_canonical_names_idempotent(self):
+        assert resolve_model_slot("FAST_VLM") == ModelSlot.FAST_VLM
+        assert resolve_model_slot("PRECISION_VLM") == ModelSlot.PRECISION_VLM
+        assert resolve_model_slot("OCR") == ModelSlot.OCR
+        assert resolve_model_slot("fast_vlm") == ModelSlot.FAST_VLM
+
+    def test_unknown_returns_none(self):
+        assert resolve_model_slot("NOT_A_SLOT") is None
+        assert resolve_model_slot(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Model-slot resolution from injected configuration
+# ---------------------------------------------------------------------------
+
+
+class TestModelSlotResolution:
+    def test_default_catalog(self):
+        plan = plan_vision(_req(VisionTask.SCENE_DESCRIBE))
+        assert plan.selected_model_identity == DEFAULT_MODEL_SLOTS[ModelSlot.FAST_VLM]
+        assert plan.selected_model_identity == "qwen2.5vl"
+
+    def test_injected_configuration(self):
+        custom = {
+            ModelSlot.FAST_VLM: "my-fast:latest",
+            ModelSlot.PRECISION_VLM: "my-precision:27b",
+            ModelSlot.OCR: "my-ocr:1b",
+        }
+        plan = plan_vision(
+            _req(VisionTask.UI_READ, criticality=VisionCriticality.HIGH),
+            model_slots=custom,
+        )
+        assert plan.selected_model_identity == "my-precision:27b"
+
+    def test_timeout_configuration_driven(self):
+        timeouts = {ModelSlot.FAST_VLM: 60.0}
+        plan = plan_vision(
+            _req(VisionTask.SCENE_DESCRIBE), timeouts=timeouts
+        )
+        assert plan.timeout_seconds == 60.0
+
+    def test_default_timeouts_are_ceilings(self):
+        plan = plan_vision(
+            _req(VisionTask.UI_READ, criticality=VisionCriticality.HIGH)
+        )
+        assert plan.timeout_seconds == DEFAULT_TIMEOUTS[ModelSlot.PRECISION_VLM]
+
+
+# ---------------------------------------------------------------------------
+# Quality gates
+# ---------------------------------------------------------------------------
+
+
+class TestQualityGates:
+    def test_pass_decision_ui_read(self):
+        q = evaluate_quality(
+            VisionTask.UI_READ,
+            response_text='{"observed_text": ["亲，请登录"]}',
+            required_outputs=["observed_text"],
+            extracted={"observed_text": ["亲，请登录"]},
+        )
+        assert q["quality_decision"] == QualityDecision.PASS.value
+
+    def test_escalate_recommended_missing_required_text(self):
+        # Task-relevant partial result: response text present but the exact
+        # quoted text field is missing → ESCALATE_RECOMMENDED (a precision
+        # follow-up can resolve it). Generic prose that is not JSON would be
+        # classified as NOT_EVALUATED instead.
+        q = evaluate_quality(
+            VisionTask.UI_READ,
+            response_text='{"observed_text": [], "targets": [], "evidence": "seen"}',
+            required_outputs=["observed_text"],
+            extracted={"observed_text": [], "targets": [], "evidence": "seen"},
+        )
+        assert q["quality_decision"] == QualityDecision.ESCALATE_RECOMMENDED.value
+
+    def test_generic_prose_not_escalation_candidate(self):
+        # Non-JSON generic prose → structured parse failure → NOT_EVALUATED,
+        # never ESCALATE_RECOMMENDED.
+        q = evaluate_quality(
+            VisionTask.UI_READ,
+            response_text="This is a beautiful screenshot with many colors.",
+            required_outputs=["observed_text"],
+            extracted={"_parse_failed": True, "raw_text": "..."},
+        )
+        assert q["quality_decision"] == QualityDecision.NOT_EVALUATED.value
+        assert "structured_parse_failed" in q["failed_gates"]
+
+    def test_refusal_not_escalation_candidate(self):
+        q = evaluate_quality(
+            VisionTask.UI_READ,
+            response_text="I cannot analyze this image for you.",
+            required_outputs=["observed_text"],
+            extracted={"raw_text": "I cannot analyze this image for you."},
+        )
+        assert q["quality_decision"] == QualityDecision.HUMAN_REVIEW_REQUIRED.value
+        assert "refusal_or_inability" in q["failed_gates"]
+
+    def test_chinese_refusal_not_escalation_candidate(self):
+        q = evaluate_quality(
+            VisionTask.UI_READ,
+            response_text="我无法分析这张图片，请提供其他输入。",
+            required_outputs=["observed_text"],
+            extracted={"raw_text": "我无法分析这张图片"},
+        )
+        assert q["quality_decision"] == QualityDecision.HUMAN_REVIEW_REQUIRED.value
+
+    def test_duplicate_text_not_contradiction(self):
+        # Diagnostic finding B: repeated identical entries are NOT
+        # contradictions — UI screenshots legitimately repeat labels.
+        q = evaluate_quality(
+            VisionTask.UI_READ,
+            response_text='{"observed_text": ["A", "A"]}',
+            required_outputs=["observed_text"],
+            extracted={"observed_text": ["A", "A"]},
+        )
+        assert "unresolved_contradiction" not in q["failed_gates"]
+        assert q["quality_decision"] == QualityDecision.PASS.value
+
+    def test_explicit_contradiction_field_triggers_human_review(self):
+        # The only reliable contradiction signal is an explicit
+        # model-flagged `contradiction` field (EVIDENCE_VERIFY schema).
+        q = evaluate_quality(
+            VisionTask.EVIDENCE_VERIFY,
+            response_text='{"evidence": "x", "contradiction": "claim conflicts"}',
+            required_outputs=["evidence"],
+            extracted={"evidence": "x", "contradiction": "claim conflicts"},
+        )
+        assert "unresolved_contradiction" in q["failed_gates"]
+        assert q["quality_decision"] == QualityDecision.HUMAN_REVIEW_REQUIRED.value
+
+    def test_not_evaluated_on_empty_response(self):
+        q = evaluate_quality(
+            VisionTask.UI_READ,
+            response_text="   ",
+            required_outputs=["observed_text"],
+            extracted={},
+        )
+        assert q["quality_decision"] == QualityDecision.NOT_EVALUATED.value
+        assert "response_present" in q["failed_gates"]
+
+    def test_ui_locate_valid_coordinates_pass(self):
+        cc = CoordinateContext(source_width_px=1920, source_height_px=1080)
+        q = evaluate_quality(
+            VisionTask.UI_LOCATE,
+            response_text='{"targets": [{"label": "login", "bbox_px": [120, 38, 246, 77], "point_px": [183, 57]}]}',
+            required_outputs=["targets"],
+            extracted={
+                "targets": [{"label": "login", "bbox_px": [120, 38, 246, 77], "point_px": [183, 57]}]
+            },
+            coordinates={
+                "x": 183.0,
+                "y": 57.0,
+                "bbox": [120.0, 38.0, 246.0, 77.0],
+                "coordinate_space": "SOURCE_IMAGE_PIXELS",
+            },
+            coordinate_context=cc,
+        )
+        assert q["quality_decision"] == QualityDecision.PASS.value
+
+    def test_ui_locate_out_of_bounds_coordinates(self):
+        cc = CoordinateContext(source_width_px=1920, source_height_px=1080)
+        q = evaluate_quality(
+            VisionTask.UI_LOCATE,
+            response_text='{"targets": [{"label": "x", "point_px": [5000, 57]}]}',
+            required_outputs=["targets"],
+            extracted={"targets": [{"label": "x", "point_px": [5000, 57]}]},
+            coordinates={"x": 5000.0, "y": 57.0, "coordinate_space": "SOURCE_IMAGE_PIXELS"},
+            coordinate_context=cc,
+        )
+        assert "x_out_of_bounds" in q["failed_gates"]
+        assert q["quality_decision"] != QualityDecision.PASS.value
+
+    def test_ui_locate_invalid_bbox_ordering(self):
+        cc = CoordinateContext(source_width_px=1920, source_height_px=1080)
+        q = evaluate_quality(
+            VisionTask.UI_LOCATE,
+            response_text='{"targets": [{"label": "x", "bbox_px": [300, 100, 100, 200]}]}',
+            required_outputs=["targets"],
+            extracted={"targets": [{"label": "x", "bbox_px": [300, 100, 100, 200]}]},
+            coordinates={"bbox": [300.0, 100.0, 100.0, 200.0], "coordinate_space": "SOURCE_IMAGE_PIXELS"},
+            coordinate_context=cc,
+        )
+        assert "bbox_left_ge_right" in q["failed_gates"]
+
+    def test_crop_to_source_coordinate_mapping(self):
+        # Crop origin (400, 200); a point at crop-local (100, 50) maps to
+        # source (500, 250) — still in bounds for a 1920x1080 image.
+        failures = validate_coordinates(
+            x=100.0,
+            y=50.0,
+            width=1920,
+            height=1080,
+            crop_x=400,
+            crop_y=200,
+        )
+        assert failures == []
+
+    def test_crop_to_source_mapping_out_of_bounds(self):
+        # Crop origin (2000, 0); crop-local x=100 → source 2100 > 1920.
+        failures = validate_coordinates(
+            x=100.0,
+            y=0.0,
+            width=1920,
+            height=1080,
+            crop_x=2000,
+            crop_y=0,
+        )
+        assert "x_out_of_bounds" in failures
+
+    def test_negative_crop_origin_rejected(self):
+        failures = validate_coordinates(
+            x=10.0, y=10.0, width=1920, height=1080,
+            crop_x=-5, crop_y=0,
+        )
+        assert "crop_origin_negative" in failures
+
+    def test_crop_exceeds_source_rejected(self):
+        failures = validate_coordinates(
+            x=10.0, y=10.0, width=1920, height=1080,
+            crop_x=1900, crop_y=0, crop_width=100, crop_height=100,
+        )
+        assert "crop_exceeds_source_width" in failures
+
+    def test_nonpositive_crop_dimensions_rejected(self):
+        failures = validate_coordinates(
+            x=10.0, y=10.0, width=1920, height=1080,
+            crop_x=0, crop_y=0, crop_width=0, crop_height=100,
+        )
+        assert "crop_width_nonpositive" in failures
+
+    def test_zero_area_bbox_rejected(self):
+        failures = validate_coordinates(
+            x=10.0, y=10.0, width=1920, height=1080,
+            bbox=[100.0, 100.0, 100.0, 200.0],
+        )
+        assert "bbox_left_ge_right" in failures
+
+    def test_missing_source_dimensions_with_coordinates_rejected(self):
+        failures = validate_coordinates(
+            x=10.0, y=10.0, width=None, height=None,
+        )
+        assert "coordinate_space_missing_dimensions" in failures
+
+    def test_nonpositive_source_dimensions_rejected(self):
+        failures = validate_coordinates(
+            x=10.0, y=10.0, width=0, height=1080,
+        )
+        assert "coordinate_space_nonpositive_dimensions" in failures
+
+    def test_boundary_point_half_open_convention(self):
+        # HALF-OPEN: a point at x == width or y == height is INVALID.
+        failures = validate_coordinates(
+            x=1920.0, y=1080.0, width=1920, height=1080,
+        )
+        assert "x_out_of_bounds" in failures
+        assert "y_out_of_bounds" in failures
+        # The last valid pixel is (W-1, H-1).
+        ok = validate_coordinates(
+            x=1919.0, y=1079.0, width=1920, height=1080,
+        )
+        assert ok == []
+
+    def test_full_image_bbox_half_open_valid(self):
+        # [0, 0, W, H] is a valid full-image bbox under half-open edges.
+        failures = validate_coordinates(
+            x=100.0, y=100.0, width=1920, height=1080,
+            bbox=[0.0, 0.0, 1920.0, 1080.0],
+        )
+        assert failures == []
+
+    def test_bbox_right_edge_exclusive_for_point(self):
+        # Point at the bbox right edge (x == right) is OUTSIDE.
+        failures = validate_coordinates(
+            x=246.0, y=57.0, width=1920, height=1080,
+            bbox=[120.0, 38.0, 246.0, 77.0],
+        )
+        assert "point_outside_bbox" in failures
+
+    def test_bbox_bottom_edge_exclusive_for_point(self):
+        failures = validate_coordinates(
+            x=183.0, y=77.0, width=1920, height=1080,
+            bbox=[120.0, 38.0, 246.0, 77.0],
+        )
+        assert "point_outside_bbox" in failures
+
+    def test_crop_ending_exactly_at_source_valid(self):
+        # Crop ending exactly at W/H is valid (half-open).
+        failures = validate_coordinates(
+            x=0.0, y=0.0, width=1920, height=1080,
+            crop_x=0, crop_y=0, crop_width=1920, crop_height=1080,
+        )
+        assert failures == []
+
+    def test_crop_extending_one_unit_beyond_invalid(self):
+        failures = validate_coordinates(
+            x=0.0, y=0.0, width=1920, height=1080,
+            crop_x=0, crop_y=0, crop_width=1921, crop_height=1080,
+        )
+        assert "crop_exceeds_source_width" in failures
+
+    def test_normalized_point_half_open(self):
+        assert validate_normalized_point(0.0, 0.0) == []
+        assert validate_normalized_point(0.999, 0.5) == []
+        assert "x_norm_out_of_bounds" in validate_normalized_point(1.0, 0.5)
+        assert "y_norm_out_of_bounds" in validate_normalized_point(0.5, 1.0)
+
+    def test_point_w_hminus1_invalid(self):
+        # (W, H-1): x == W is invalid.
+        failures = validate_coordinates(
+            x=1920.0, y=1079.0, width=1920, height=1080,
+        )
+        assert "x_out_of_bounds" in failures
+
+    def test_point_wminus1_h_invalid(self):
+        # (W-1, H): y == H is invalid.
+        failures = validate_coordinates(
+            x=1919.0, y=1080.0, width=1920, height=1080,
+        )
+        assert "y_out_of_bounds" in failures
+
+    def test_bbox_right_gt_width_invalid(self):
+        failures = validate_coordinates(
+            x=100.0, y=100.0, width=1920, height=1080,
+            bbox=[0.0, 0.0, 1921.0, 1080.0],
+        )
+        assert "bbox_x_out_of_bounds" in failures
+
+    def test_bbox_bottom_gt_height_invalid(self):
+        failures = validate_coordinates(
+            x=100.0, y=100.0, width=1920, height=1080,
+            bbox=[0.0, 0.0, 1920.0, 1081.0],
+        )
+        assert "bbox_y_out_of_bounds" in failures
+
+    def test_crop_to_source_mapping_preserves_half_open(self):
+        # Crop origin (400, 200); crop-local point at the crop's last valid
+        # pixel (crop_width-1, crop_height-1) maps inside the source.
+        failures = validate_coordinates(
+            x=1919.0, y=879.0, width=1920, height=1080,
+            crop_x=400, crop_y=200, crop_width=1520, crop_height=880,
+        )
+        # 1919 + 400 = 2319 > 1920 → the mapped point is OUT of the source
+        # (a crop-local x of 1919 exceeds the crop's valid range). The
+        # half-open mapping contract rejects it.
+        assert "x_out_of_bounds" in failures
+
+    def test_exact_ocr_empty_output(self):
+        q = evaluate_quality(
+            VisionTask.EXACT_OCR,
+            response_text='{"observed_text": ""}',
+            required_outputs=["observed_text"],
+            extracted={"observed_text": ""},
+        )
+        assert "text_non_empty" in q["failed_gates"]
+
+    def test_evidence_verify_observation_inference_separation(self):
+        q = evaluate_quality(
+            VisionTask.EVIDENCE_VERIFY,
+            response_text='{"observation": "login text visible", "inference": "user is not logged in", "evidence": "text at top right"}',
+            required_outputs=["observation", "evidence"],
+            extracted={
+                "observation": "login text visible",
+                "inference": "user is not logged in",
+                "evidence": "text at top right",
+            },
+        )
+        assert q["quality_decision"] == QualityDecision.PASS.value
+
+    def test_evidence_verify_action_claimed(self):
+        q = evaluate_quality(
+            VisionTask.EVIDENCE_VERIFY,
+            response_text='{"observation": "x", "evidence": "y", "action_claimed": true}',
+            required_outputs=["observation", "evidence"],
+            extracted={"observation": "x", "evidence": "y", "action_claimed": True},
+        )
+        assert "no_action_claimed" in q["failed_gates"]
+
+
+# ---------------------------------------------------------------------------
+# Build-result invariants
+# ---------------------------------------------------------------------------
+
+
+class TestResultInvariants:
+    def test_click_authorized_always_false(self):
+        r = build_result(
+            execution_status=ExecutionStatus.SUCCESS,
+            quality={"quality_decision": QualityDecision.PASS.value, "passed_gates": [], "failed_gates": []},
+            initial_slot=ModelSlot.FAST_VLM,
+            final_slot=ModelSlot.FAST_VLM,
+            actual_model="qwen2.5vl",
+        )
+        assert r["click_authorized"] is False
+
+    def test_result_serializes(self):
+        r = build_result(
+            execution_status=ExecutionStatus.SUCCESS,
+            quality={"quality_decision": QualityDecision.PASS.value, "passed_gates": ["a"], "failed_gates": []},
+            initial_slot=ModelSlot.FAST_VLM,
+            final_slot=ModelSlot.FAST_VLM,
+            actual_model="qwen2.5vl",
+        )
+        s = json.dumps(r, ensure_ascii=False, default=str)
+        parsed = json.loads(s)
+        assert parsed["click_authorized"] is False
+
+
+# ---------------------------------------------------------------------------
+# UI_READ canonical text-field contract
+# ---------------------------------------------------------------------------
+
+
+class TestUiReadTextFieldContract:
+    """Canonical field is ``observed_text`` (Prompt contract + gates +
+    calibration); ``visible_text`` is a legacy alias accepted ONLY through
+    the explicit resolver (``_resolve_ui_read_text``)."""
+
+    def _q(self, extracted, response_text=None):
+        return evaluate_quality(
+            VisionTask.UI_READ,
+            response_text=response_text
+            or json.dumps(extracted, ensure_ascii=False),
+            required_outputs=["observed_text"],
+            extracted=extracted,
+        )
+
+    def test_canonical_observed_text_nonempty_passes(self):
+        q = self._q({"observed_text": ["亲，请登录"]})
+        assert "required_text_present" in q["passed_gates"]
+        assert q["quality_decision"] == QualityDecision.PASS.value
+
+    def test_legacy_visible_text_alias_passes_through_explicit_resolver(self):
+        # Legacy alias: model emitted visible_text only (old strict-schema
+        # contract). Resolved at the one explicit boundary — gate passes.
+        q = self._q({"visible_text": ["亲，请登录"]})
+        assert "required_text_present" in q["passed_gates"]
+        assert "text_field_conflict" not in q["failed_gates"]
+
+    def test_missing_canonical_field_fails(self):
+        q = self._q({"evidence": "seen"})
+        assert "required_text_present" in q["failed_gates"]
+
+    def test_empty_canonical_field_fails(self):
+        q = self._q({"observed_text": []})
+        assert "required_text_present" in q["failed_gates"]
+
+    def test_whitespace_only_canonical_field_fails(self):
+        q = self._q({"observed_text": ["   ", ""]})
+        assert "required_text_present" in q["failed_gates"]
+
+    def test_non_string_canonical_field_fails_safely(self):
+        q = self._q({"observed_text": {"not": "a list"}})
+        assert "required_text_present" in q["failed_gates"]
+        assert "text_field_conflict" not in q["failed_gates"]
+
+    def test_identical_dual_fields_pass(self):
+        # Both fields present with identical normalized values → accept.
+        q = self._q(
+            {
+                "observed_text": ["亲，请登录"],
+                "visible_text": ["亲，请登录"],
+            }
+        )
+        assert "required_text_present" in q["passed_gates"]
+        assert "text_field_conflict" not in q["failed_gates"]
+
+    def test_conflicting_dual_fields_are_rejected(self):
+        # Materially different values under both keys → never silently
+        # choose; marked contradiction, gate fails.
+        q = self._q(
+            {
+                "observed_text": ["亲，请登录"],
+                "visible_text": ["已买到的宝贝"],
+            }
+        )
+        assert "required_text_present" in q["failed_gates"]
+        assert "text_field_conflict" in q["failed_gates"]
+
+    def test_conflicting_dual_fields_never_escalate(self):
+        # Contradiction is a human-review case, not a safe escalation.
+        q = self._q(
+            {
+                "observed_text": ["A"],
+                "visible_text": ["B"],
+            }
+        )
+        assert q["quality_decision"] == QualityDecision.HUMAN_REVIEW_REQUIRED.value
+        assert "text_field_conflict" in q["failed_gates"]
+
+
+class TestNoHardcodedEndpoint:
+    def test_no_private_endpoint_in_repository_defaults(self):
+        import hermes_cli.config_defaults as cd
+
+        blob = json.dumps(cd.DEFAULT_CONFIG)
+        assert "192.168.2.21" not in blob
+        assert "11434" not in blob
+
+    def test_no_private_endpoint_in_policy_module(self):
+        import tools.vision_policy as vp
+
+        src = Path(vp.__file__).read_text(encoding="utf-8")
+        assert "192.168.2.21" not in src
+        assert "11434" not in src

--- a/tests/tools/test_vision_router_tool.py
+++ b/tests/tools/test_vision_router_tool.py
@@ -1,0 +1,636 @@
+"""Tests for the Vision Router wrapper tool (Stage 1: registered but hidden).
+
+The minimal-enablement gate keeps the wrapper model-invisible until a session
+explicitly enables the local Vision Router.
+"""
+import json
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools import vision_router_tool as vrt  # noqa: E402
+from tools.vision_orchestrator import analyze_image  # noqa: E402  (ensure import works)
+# Ensure the local Vision tools are registered in the registry (registration
+# happens at import time; get_tool_definitions does not import them).
+import tools.vision_tools  # noqa: E402,F401
+import tools.vision_ocr_page  # noqa: E402,F401
+
+
+def _mk_result(**over):
+    base = {
+        "request_id": "REQ-1",
+        "task": "UI_READ",
+        "execution_status": "SUCCESS",
+        "quality_decision": "PASS",
+        "initial_model_slot": "PRECISION_VLM",
+        "final_model_slot": "PRECISION_VLM",
+        "actual_model": "qwen3.6:27b",
+        "logical_model_calls": 1,
+        "human_review_required": False,
+        "recommended_next_slot": None,
+        "structured": {"observed_text": ["ok"]},
+        "trace": [{"total_ms": 9000, "done_reason": "stop",
+                   "latency_ms": 9000}],
+    }
+    base.update(over)
+    return base
+
+
+class TestSchema:
+    def test_schema_shape(self):
+        s = vrt.VISION_ROUTER_SCHEMA
+        assert s["name"] == "vision_router_analyze"
+        props = s["parameters"]["properties"]
+        assert "source_handle" in props
+        assert props["source_handle"]["type"] == "string"
+        assert s["parameters"]["required"] == ["source_handle"]
+        # model may not control runtime/activation parameters
+        for forbidden in ("enabled", "transport", "model", "base_url",
+                          "num_ctx", "timeout", "criticality"):
+            assert forbidden not in props, forbidden
+        # task is a narrow enum
+        assert set(props["task"]["enum"]) == {
+            "UI_READ", "SCENE_DESCRIBE", "EVIDENCE_VERIFY", "EXACT_OCR"}
+
+    def test_toolset_registered(self):
+        from tools.registry import registry
+        m = registry.get_tool_to_toolset_map()
+        assert m.get("vision_router_analyze") == "vision"
+
+
+class TestSourceAuthorization:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_empty_handle_denied_zero_calls(self):
+        with patch("tools.vision_orchestrator.analyze_image",
+                   new=AsyncMock()) as m:
+            out = json.loads(await vrt._handle_vision_router({"source_handle": ""}))
+        m.assert_not_awaited()
+        assert out["execution_status"] == "POLICY_BLOCKED"
+        assert out["logical_model_calls"] == 0
+        assert out["error"].startswith("SOURCE_DENIED")
+
+    async def test_unknown_handle_denied_zero_calls(self):
+        with patch("tools.vision_orchestrator.analyze_image",
+                   new=AsyncMock()) as m:
+            out = json.loads(await vrt._handle_vision_router(
+                {"source_handle": "not-a-handle"}))
+        m.assert_not_awaited()
+        assert out["execution_status"] == "POLICY_BLOCKED"
+        assert out["logical_model_calls"] == 0
+
+    async def test_locator_handle_resolves(self):
+        handles = vrt._authorized_source_handles()
+        if not handles:
+            pytest.skip("no locator assets available")
+        key = next(iter(handles))
+        path = vrt._resolve_source(f"locator://{key}")
+        assert path == handles[key]
+        assert vrt._resolve_source(key) == handles[key]
+
+    async def test_authorized_handle_invokes_analyze(self):
+        handles = vrt._authorized_source_handles()
+        if not handles:
+            pytest.skip("no locator assets available")
+        key = next(iter(handles))
+        with patch("tools.vision_orchestrator.analyze_image",
+                   new=AsyncMock(return_value=_mk_result())) as m:
+            out = json.loads(await vrt._handle_vision_router(
+                {"source_handle": key, "task": "UI_READ"}))
+        m.assert_awaited_once()
+        assert out["execution_status"] == "SUCCESS"
+        assert out["quality_decision"] == "PASS"
+
+
+class TestCriticalityDerivation:
+    def test_policy_derived(self):
+        assert vrt._criticality_for("UI_READ") == "HIGH"
+        assert vrt._criticality_for("EXACT_OCR") == "HIGH"
+        assert vrt._criticality_for("SCENE_DESCRIBE") == "NORMAL"
+        assert vrt._criticality_for("EVIDENCE_VERIFY") == "NORMAL"
+        assert vrt._criticality_for("BOGUS") == "NORMAL"
+
+    @pytest.mark.asyncio
+    async def test_request_criticality_not_model_controlled(self):
+        handles = vrt._authorized_source_handles()
+        if not handles:
+            pytest.skip("no locator assets available")
+        key = next(iter(handles))
+        captured = {}
+
+        async def fake(request, **kw):
+            captured["criticality"] = request.criticality.value
+            captured["task"] = request.task.value
+            return _mk_result()
+
+        with patch("tools.vision_orchestrator.analyze_image",
+                   new=fake):
+            await vrt._handle_vision_router(
+                {"source_handle": key, "task": "UI_READ"})
+        assert captured["criticality"] == "HIGH"
+        # even a weird task value falls back to a bounded set
+        await vrt._handle_vision_router(
+            {"source_handle": key, "task": "!!!UNKNOWN!!!"})
+        assert captured["task"] == "UI_READ"
+
+
+class TestEnvelope:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_envelope_is_safe_and_bounded(self):
+        handles = vrt._authorized_source_handles()
+        if not handles:
+            pytest.skip("no locator assets available")
+        key = next(iter(handles))
+        with patch("tools.vision_orchestrator.analyze_image",
+                   new=AsyncMock(return_value=_mk_result())):
+            out = json.loads(await vrt._handle_vision_router(
+                {"source_handle": key, "task": "UI_READ"}))
+        text = json.dumps(out, ensure_ascii=False)
+        for banned in ("thinking", "raw_text", "base64,", "/mnt/", "/Users/",
+                       "api_key"):
+            assert banned not in text, banned
+        assert out["source_handle"] == key
+        assert out["logical_model_calls"] == 1
+
+    async def test_ocr_excerpt_truncates_long_text(self):
+        handles = vrt._authorized_source_handles()
+        if not handles:
+            pytest.skip("no locator assets available")
+        key = next(iter(handles))
+        long_text = "字" * 6000
+        with patch("tools.vision_orchestrator.analyze_image",
+                   new=AsyncMock(return_value=_mk_result(
+                       structured={"observed_text": [long_text]}))):
+            out = json.loads(await vrt._handle_vision_router(
+                {"source_handle": key, "task": "EXACT_OCR"}))
+        assert out["ocr_meta"] is not None
+        assert out["ocr_meta"]["truncated"] is True
+        assert out["ocr_meta"]["total_chars"] == 6000
+        assert out["ocr_meta"]["returned_chars"] <= 4000
+        assert len(out["observed_text"][0]) <= 4000
+        assert out["ocr_meta"]["full_text_policy"] == "explicit_followup_required"
+
+    async def test_short_ocr_not_truncated(self):
+        handles = vrt._authorized_source_handles()
+        if not handles:
+            pytest.skip("no locator assets available")
+        key = next(iter(handles))
+        with patch("tools.vision_orchestrator.analyze_image",
+                   new=AsyncMock(return_value=_mk_result(
+                       structured={"observed_text": ["short"]}))):
+            out = json.loads(await vrt._handle_vision_router(
+                {"source_handle": key, "task": "EXACT_OCR"}))
+        assert out["ocr_meta"] is None
+        assert out["observed_text"] == ["short"]
+
+    async def test_fail_closed_on_orchestrator_exception(self):
+        handles = vrt._authorized_source_handles()
+        if not handles:
+            pytest.skip("no locator assets available")
+        key = next(iter(handles))
+        with patch("tools.vision_orchestrator.analyze_image",
+                   new=AsyncMock(side_effect=RuntimeError("boom"))):
+            out = json.loads(await vrt._handle_vision_router(
+                {"source_handle": key}))
+        assert out["execution_status"] == "INVALID_RESPONSE"
+        assert out["quality_decision"] == "NOT_EVALUATED"
+        assert out["logical_model_calls"] == 0
+
+
+class TestVisibilityGate:
+    def test_flag_default_false(self):
+        assert vrt._config_value(None, "ocr_excerpt_chars", 1) == 1
+
+    def test_vision_router_tool_visible_default_false(self):
+        from toolsets import vision_router_tool_visible
+        assert vision_router_tool_visible(None) is False
+        assert vision_router_tool_visible({}) is False
+        assert vision_router_tool_visible(
+            {"vision_router": {"enabled": True}}) is True
+        assert vision_router_tool_visible(
+            {"vision_router": {"enabled": False}}) is False
+
+    def test_get_tool_definitions_filters_wrapper_when_disabled(self):
+        from model_tools import get_tool_definitions
+        with patch("hermes_cli.config.load_config",
+                   return_value={"vision_router": {"enabled": False}}):
+            defs = get_tool_definitions(
+                enabled_toolsets=["vision"], quiet_mode=True)
+        names = [d["function"]["name"] for d in defs]
+        assert "vision_router_analyze" not in names
+        # legacy vision_analyze stays (status quo) when the Router is off
+
+    def test_get_tool_definitions_includes_wrapper_when_enabled(self):
+        from model_tools import get_tool_definitions
+        with patch("hermes_cli.config.load_config",
+                   return_value={"vision_router": {"enabled": True}}):
+            defs = get_tool_definitions(
+                enabled_toolsets=["vision"], quiet_mode=True)
+        names = [d["function"]["name"] for d in defs]
+        assert "vision_router_analyze" in names
+
+    def test_router_on_replaces_legacy_vision_analyze(self):
+        # ChatGPT review finding: when the Router is on, the model must see
+        # exactly ONE vision entry point — the wrapper replaces the legacy
+        # auxiliary vision_analyze (design §7 "replacing the legacy role").
+        from model_tools import get_tool_definitions
+        with patch("hermes_cli.config.load_config",
+                   return_value={"vision_router": {"enabled": True}}):
+            defs = get_tool_definitions(
+                enabled_toolsets=["coding", "vision"], quiet_mode=True)
+        names = [d["function"]["name"] for d in defs]
+        assert "vision_router_analyze" in names
+        assert "vision_analyze" not in names
+
+    def test_config_defaults_added(self):
+        import hermes_cli.config_defaults as cd
+        vr = cd.DEFAULT_CONFIG["auxiliary"]["vision_router"]
+        assert vr["ocr_excerpt_chars"] == 4000
+        assert vr["ocr_page_chars"] == 65536
+        assert vr["per_workflow_max_calls"] == 20
+        assert vr["enabled"] is False
+
+
+class TestConfigPathAlignment:
+    """Config-path alignment repair (HERMES_VISION_ROUTER_FLAG_CONFIG_PATH_
+    ALIGNMENT_V0_1): canonical path config["auxiliary"]["vision_router"],
+    legacy top-level fallback only when nested is absent, nested wins on
+    conflict, malformed values fail closed. Real-config shape tests included.
+    """
+
+    pytestmark = pytest.mark.asyncio
+
+    @staticmethod
+    def _real_shape(**vr_overrides):
+        """Config dict in the exact shape produced by the real loader."""
+        import copy
+        from hermes_cli.config import load_config
+        cfg = copy.deepcopy(load_config())
+        for k, v in vr_overrides.items():
+            cfg["auxiliary"]["vision_router"][k] = v
+        return cfg
+
+    # -- resolver unit behavior ---------------------------------------------
+    def test_nested_false_resolves_false(self):
+        from tools.vision_policy import resolve_vision_router_enabled
+        cfg = self._real_shape(enabled=False)
+        assert resolve_vision_router_enabled(cfg) is False
+
+    def test_nested_true_resolves_true(self):
+        from tools.vision_policy import resolve_vision_router_enabled
+        cfg = self._real_shape(enabled=True)
+        assert resolve_vision_router_enabled(cfg) is True
+
+    def test_legacy_top_level_only_accepted(self):
+        # LEGACY COMPATIBILITY: accepted only when the nested mapping is absent.
+        from tools.vision_policy import resolve_vision_router_enabled
+        cfg = {"vision_router": {"enabled": True}}
+        assert resolve_vision_router_enabled(cfg) is True
+
+    def test_nested_true_overrides_legacy_false(self):
+        from tools.vision_policy import resolve_vision_router_enabled
+        cfg = {"auxiliary": {"vision_router": {"enabled": True}},
+               "vision_router": {"enabled": False}}
+        assert resolve_vision_router_enabled(cfg) is True
+
+    def test_nested_false_overrides_legacy_true(self):
+        from tools.vision_policy import resolve_vision_router_enabled
+        cfg = {"auxiliary": {"vision_router": {"enabled": False}},
+               "vision_router": {"enabled": True}}
+        assert resolve_vision_router_enabled(cfg) is False
+
+    def test_malformed_nested_mapping_fails_closed(self):
+        from tools.vision_policy import resolve_vision_router_enabled
+        cfg = {"auxiliary": {"vision_router": "not-a-mapping"}}
+        assert resolve_vision_router_enabled(cfg) is False
+
+    def test_malformed_enabled_fails_closed(self):
+        from tools.vision_policy import resolve_vision_router_enabled
+        cfg = {"auxiliary": {"vision_router": {"enabled": "yes"}}}
+        assert resolve_vision_router_enabled(cfg) is False
+
+    def test_missing_config_fails_closed(self):
+        from tools.vision_policy import resolve_vision_router_enabled
+        assert resolve_vision_router_enabled(None) is False
+        assert resolve_vision_router_enabled({}) is False
+
+    # -- visibility + orchestrator share the effective flag -----------------
+    def test_tool_visibility_nested_true(self):
+        from toolsets import vision_router_tool_visible
+        assert vision_router_tool_visible(self._real_shape(enabled=True)) is True
+
+    def test_orchestrator_gate_nested_true(self):
+        from tools.vision_orchestrator import vision_router_enabled
+        assert vision_router_enabled(self._real_shape(enabled=True)) is True
+
+    def test_visibility_and_orchestrator_same_value(self):
+        from toolsets import vision_router_tool_visible
+        from tools.vision_orchestrator import vision_router_enabled
+        for enabled in (True, False):
+            cfg = self._real_shape(enabled=enabled)
+            assert vision_router_tool_visible(cfg) == vision_router_enabled(cfg) == enabled
+
+    # -- cache transitions through the REAL nested structure -----------------
+    def _defs_nested(self, enabled):
+        from model_tools import get_tool_definitions
+        # The official legacy vision_analyze check_fn resolves the real
+        # auxiliary.vision client; the sandboxed test HERMES_HOME has none,
+        # so force the resolver to return a mock client. This keeps the
+        # kill-switch visibility semantics (not the availability probe) as
+        # the behavior under test. The registry TTL-caches check_fn results,
+        # so the cache must be invalidated between calls.
+        from tools.registry import invalidate_check_fn_cache
+
+        invalidate_check_fn_cache()
+        with patch("agent.auxiliary_client.resolve_vision_provider_client",
+                   return_value=("mock", object(), "mock-model")), \
+             patch("hermes_cli.config.load_config",
+                   return_value=self._real_shape(enabled=enabled)):
+            return [d["function"]["name"]
+                    for d in get_tool_definitions(
+                        enabled_toolsets=["vision"], quiet_mode=True)]
+
+    def test_false_to_true_cache_transition_nested(self):
+        names_false = self._defs_nested(False)
+        assert "vision_router_analyze" not in names_false
+        # Public compatibility: official legacy vision_analyze stays visible
+        # while the local Router is off.
+        assert "vision_analyze" in names_false
+        names_true = self._defs_nested(True)
+        assert "vision_router_analyze" in names_true
+        assert "vision_analyze" not in names_true
+
+    def test_true_to_false_cache_transition_nested(self):
+        names_true = self._defs_nested(True)
+        assert "vision_router_analyze" in names_true
+        names_false = self._defs_nested(False)
+        assert "vision_router_analyze" not in names_false
+        # Public compatibility: legacy vision_analyze restored when off.
+        assert "vision_analyze" in names_false
+
+    # -- analyze_image(enabled=None) policy gate with real nested flag -------
+    @staticmethod
+    def _vr_request():
+        from tools.vision_policy import (
+            VisionCriticality, VisionMode, VisionRequest, VisionTask,
+        )
+        return VisionRequest(
+            request_id="vr-req-1",
+            task=VisionTask.UI_READ,
+            mode=VisionMode.AUTO,
+            criticality=VisionCriticality.NORMAL,
+            image_source="opaque://test-image",
+            question="read visible text",
+        )
+
+    async def test_analyze_image_gate_allowed_nested_true(self):
+        from tools.vision_orchestrator import analyze_image
+
+        calls = {"native": 0, "prepare": 0, "openai": 0}
+
+        async def fake_prepare(*a, **k):
+            calls["prepare"] += 1
+            return ("data:image/png;base64,QUJD", 10, 10, "image/png",
+                    "sha", {"transport_image_sha256": "sha", "transport_mime_type": "image/png"})
+
+        async def fake_native(*a, **k):
+            calls["native"] += 1
+            return {
+                "execution_status": "SUCCESS",
+                "response": '{"observed_text": ["测试可见文本"]}',
+                "content_source": "response",
+                "thinking_fallback_used": False,
+                "response_character_count": 40,
+                "thinking_character_count": 0,
+                "done_reason": "stop",
+                "total_duration_ms": 5000,
+                "load_duration_ms": 100,
+                "prompt_eval_count": 10,
+                "eval_count": 5,
+            }
+
+        async def fake_openai(*a, **k):
+            calls["openai"] += 1
+            return {
+                "execution_status": "SUCCESS",
+                "content": '{"observed_text": ["测试可见文本"]}',
+                "done_reason": "stop",
+                "total_duration_ms": 5000,
+            }
+
+        with patch("hermes_cli.config.load_config",
+                   return_value=self._real_shape(enabled=True)), \
+             patch("tools.vision_orchestrator.prepare_image", new=fake_prepare), \
+             patch("tools.vision_orchestrator.invoke_native_generate", new=fake_native), \
+             patch("tools.vision_orchestrator.invoke_vision_model", new=fake_openai):
+            result = await analyze_image(self._vr_request(), enabled=None)
+        assert result["execution_status"] != "POLICY_BLOCKED"
+        # the Router gate passed and exactly one provider path was executed
+        assert calls["native"] + calls["openai"] == 1
+        assert calls["prepare"] == 1
+
+    async def test_analyze_image_gate_blocked_nested_false(self):
+        from tools.vision_orchestrator import analyze_image
+
+        calls = {"native": 0, "prepare": 0}
+
+        async def fake_prepare(*a, **k):
+            calls["prepare"] += 1
+            raise AssertionError("must not prepare when router=false")
+
+        async def fake_native(*a, **k):
+            calls["native"] += 1
+            raise AssertionError("must not invoke provider when router=false")
+
+        with patch("hermes_cli.config.load_config",
+                   return_value=self._real_shape(enabled=False)), \
+             patch("tools.vision_orchestrator.prepare_image", new=fake_prepare), \
+             patch("tools.vision_orchestrator.invoke_native_generate", new=fake_native):
+            result = await analyze_image(self._vr_request(), enabled=None)
+        assert result["execution_status"] == "POLICY_BLOCKED"
+        assert calls["native"] == 0
+        assert calls["prepare"] == 0
+
+
+class TestOllamaEndpointAlignment:
+    """Trusted Ollama endpoint wiring (HERMES_VISION_ROUTER_NATIVE_BASE_URL_
+    ALIGNMENT_V0_1): one shared resolver; wrapper passes the resolved native
+    root to analyze_image; base_url stays model-invisible.
+    """
+
+    pytestmark = pytest.mark.asyncio
+
+    @staticmethod
+    def _cfg(base_url="http://ollama.internal:11434/v1", enabled=True):
+        import copy
+        from hermes_cli.config import load_config
+        cfg = copy.deepcopy(load_config())
+        cfg["auxiliary"]["vision_router"]["enabled"] = enabled
+        cfg["auxiliary"]["vision"]["base_url"] = base_url
+        return cfg
+
+    # -- resolver rules ------------------------------------------------------
+    def test_real_loaded_config_resolves_trusted_url(self):
+        # real loaded-config SHAPE (load_config deepcopy) with an explicit
+        # trusted endpoint resolves to the native root. Note: under pytest the
+        # loader is sandboxed to a default config (HERMES_HOME isolation), so
+        # the endpoint value is supplied explicitly while the shape is real.
+        from tools.vision_policy import resolve_ollama_base_url
+        b = resolve_ollama_base_url(self._cfg())
+        assert b == "http://ollama.internal:11434"
+
+    def test_default_isolated_config_fails_closed(self):
+        # under pytest isolation the loaded default config has no endpoint;
+        # fail-closed behavior must hold (no crash, None).
+        from hermes_cli.config import load_config
+        from tools.vision_policy import resolve_ollama_base_url
+        b = resolve_ollama_base_url(load_config())
+        assert b is None or b.startswith("http")
+
+    def test_ollama_host_fallback_when_config_absent(self):
+        from tools.vision_policy import resolve_ollama_base_url
+        cfg = {"auxiliary": {"vision": {"base_url": ""}}}
+        with patch.dict(os.environ, {"OLLAMA_HOST": "ollama.local:11434"}, clear=False):
+            assert resolve_ollama_base_url(cfg) == "http://ollama.local:11434"
+
+    def test_explicit_config_wins_over_environment(self):
+        from tools.vision_policy import resolve_ollama_base_url
+        cfg = {"auxiliary": {"vision": {"base_url": "http://cfg.host:11434/v1"}}}
+        with patch.dict(os.environ, {"OLLAMA_HOST": "env.host:11434"}):
+            assert resolve_ollama_base_url(cfg) == "http://cfg.host:11434"
+
+    def test_empty_value_fails_closed(self):
+        from tools.vision_policy import resolve_ollama_base_url
+        assert resolve_ollama_base_url({"auxiliary": {"vision": {"base_url": "  "}}}) is None
+        assert resolve_ollama_base_url({}) is None
+        assert resolve_ollama_base_url(None) is None
+
+    def test_unsupported_scheme_fails_closed(self):
+        from tools.vision_policy import resolve_ollama_base_url
+        for bad in ("ftp://ollama:11434", "file:///etc/hosts", "ws://ollama:11434"):
+            assert resolve_ollama_base_url(
+                {"auxiliary": {"vision": {"base_url": bad}}}) is None
+
+    def test_file_path_fails_closed(self):
+        from tools.vision_policy import resolve_ollama_base_url
+        assert resolve_ollama_base_url(
+            {"auxiliary": {"vision": {"base_url": "/var/run/ollama.sock"}}}) is None
+
+    def test_embedded_credentials_fails_closed(self):
+        from tools.vision_policy import resolve_ollama_base_url
+        assert resolve_ollama_base_url(
+            {"auxiliary": {"vision": {"base_url": "http://user:pass@ollama:11434"}}}) is None
+
+    def test_trailing_slash_and_v1_normalization(self):
+        from tools.vision_policy import resolve_ollama_base_url
+        for raw, want in (
+            ("http://ollama.internal:11434/v1", "http://ollama.internal:11434"),
+            ("http://ollama.internal:11434/", "http://ollama.internal:11434"),
+            ("http://ollama.internal:11434", "http://ollama.internal:11434"),
+            ("ollama.internal:11434", "http://ollama.internal:11434"),
+            ("https://ollama.internal", "https://ollama.internal:443"),
+        ):
+            assert resolve_ollama_base_url(
+                {"auxiliary": {"vision": {"base_url": raw}}}) == want
+
+    # -- wrapper wiring ------------------------------------------------------
+    def test_wrapper_schema_has_no_base_url(self):
+        props = vrt.VISION_ROUTER_SCHEMA["parameters"]["properties"]
+        for banned in ("base_url", "endpoint", "host", "port", "transport"):
+            assert banned not in props
+
+    async def test_registry_wrapper_passes_trusted_base_url(self):
+        # integration-style: registry handler → real wrapper → mocked
+        # analyze_image; assert the exact trusted base_url received.
+        from tools.registry import registry
+        handler = registry.get_entry("vision_router_analyze").handler
+        assert handler is not None
+        cfg = self._cfg()
+        received = {}
+
+        async def fake_ai(request, **kw):
+            received.update(kw)
+            return {
+                "request_id": "vr-ok",
+                "task": "UI_READ",
+                "execution_status": "SUCCESS",
+                "quality_decision": "PASS",
+                "initial_model_slot": "PRECISION_VLM",
+                "final_model_slot": "PRECISION_VLM",
+                "actual_model": "qwen3.6:27b",
+                "recommended_next_slot": None,
+                "human_review_required": False,
+                "logical_model_calls": 1,
+                "structured": {"observed_text": ["ok"]},
+                "trace": [{"total_ms": 1, "done_reason": "stop"}],
+            }
+
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("tools.vision_orchestrator.analyze_image", new=fake_ai):
+            raw = await handler({"source_handle": "TAOBAO-VISION-0003",
+                                 "task": "UI_READ", "mode": "AUTO"})
+        env = json.loads(raw)
+        assert received.get("base_url") == "http://ollama.internal:11434"
+        assert received.get("enabled") is None  # flag resolution stays server-side
+        assert env["execution_status"] == "SUCCESS"
+        assert "ollama.internal" not in json.dumps(env)  # endpoint not leaked
+
+    async def test_wrapper_ignores_model_supplied_endpoint(self):
+        from tools.registry import registry
+        handler = registry.get_entry("vision_router_analyze").handler
+        assert handler is not None
+        cfg = self._cfg()
+        received = {}
+
+        async def fake_ai(request, **kw):
+            received.update(kw)
+            return {"execution_status": "SUCCESS", "quality_decision": "PASS",
+                    "initial_model_slot": "PRECISION_VLM",
+                    "final_model_slot": "PRECISION_VLM",
+                    "actual_model": "qwen3.6:27b",
+                    "logical_model_calls": 1,
+                    "structured": {"observed_text": ["ok"]},
+                    "trace": []}
+
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("tools.vision_orchestrator.analyze_image", new=fake_ai):
+            raw = await handler({"source_handle": "TAOBAO-VISION-0003",
+                                 "task": "UI_READ",
+                                 "base_url": "http://evil.example:9999"})
+        env = json.loads(raw)
+        # model-supplied endpoint is not accepted; trusted config value wins
+        assert received.get("base_url") == "http://ollama.internal:11434"
+        assert env["execution_status"] == "SUCCESS"
+
+    async def test_authorized_path_reaches_mocked_native_without_value_error(self):
+        # the prior canary blocker: OLLAMA_NATIVE_GENERATE requires base_url.
+        # With wiring in place, a mocked native transport is reached.
+        from tools.registry import registry
+        handler = registry.get_entry("vision_router_analyze").handler
+        assert handler is not None
+        cfg = self._cfg()
+        reached = {"native": False}
+
+        async def fake_ai(request, **kw):
+            # analyze_image native branch would raise without base_url; here
+            # the wrapper already supplies it, so execution may proceed.
+            assert kw.get("base_url"), "base_url must be wired"
+            reached["native"] = True
+            return {"execution_status": "SUCCESS", "quality_decision": "PASS",
+                    "initial_model_slot": "PRECISION_VLM",
+                    "final_model_slot": "PRECISION_VLM",
+                    "actual_model": "qwen3.6:27b",
+                    "logical_model_calls": 1,
+                    "structured": {"observed_text": ["ok"]},
+                    "trace": []}
+
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("tools.vision_orchestrator.analyze_image", new=fake_ai):
+            raw = await handler({"source_handle": "TAOBAO-VISION-0003",
+                                 "task": "UI_READ"})
+        env = json.loads(raw)
+        assert reached["native"] is True
+        assert env["execution_status"] == "SUCCESS"
+

--- a/tests/tools/test_vision_router_tool.py
+++ b/tests/tools/test_vision_router_tool.py
@@ -85,20 +85,23 @@ class TestSourceAuthorization:
         assert out["execution_status"] == "POLICY_BLOCKED"
         assert out["logical_model_calls"] == 0
 
-    async def test_locator_handle_resolves(self):
-        handles = vrt._authorized_source_handles()
-        if not handles:
-            pytest.skip("no locator assets available")
-        key = next(iter(handles))
-        path = vrt._resolve_source(f"locator://{key}")
-        assert path == handles[key]
-        assert vrt._resolve_source(key) == handles[key]
+    async def test_attachment_handle_resolves(self):
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+        vision_session_state.register_attachment(
+            "attachment://sess/synthetic", "/tmp/synthetic-vision.png")
+        key = "attachment://sess/synthetic"
+        assert vrt._resolve_source(key) == "/tmp/synthetic-vision.png"
+        assert vrt._resolve_source("attachment://sess/other") is None
 
     async def test_authorized_handle_invokes_analyze(self):
-        handles = vrt._authorized_source_handles()
-        if not handles:
-            pytest.skip("no locator assets available")
-        key = next(iter(handles))
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+        vision_session_state.register_attachment(
+            "attachment://sess/synthetic", "/tmp/synthetic-vision.png")
+        key = "attachment://sess/synthetic"
         with patch("tools.vision_orchestrator.analyze_image",
                    new=AsyncMock(return_value=_mk_result())) as m:
             out = json.loads(await vrt._handle_vision_router(
@@ -123,10 +126,12 @@ class TestCriticalityDerivation:
 
     @pytest.mark.asyncio
     async def test_request_criticality_not_model_controlled(self):
-        handles = vrt._authorized_source_handles()
-        if not handles:
-            pytest.skip("no locator assets available")
-        key = next(iter(handles))
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+        vision_session_state.register_attachment(
+            "attachment://sess/synthetic", "/tmp/synthetic-vision.png")
+        key = "attachment://sess/synthetic"
         captured = {}
 
         async def fake(request, **kw):
@@ -154,10 +159,12 @@ class TestEnvelope:
     pytestmark = pytest.mark.asyncio
 
     async def test_envelope_is_safe_and_bounded(self):
-        handles = vrt._authorized_source_handles()
-        if not handles:
-            pytest.skip("no locator assets available")
-        key = next(iter(handles))
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+        vision_session_state.register_attachment(
+            "attachment://sess/synthetic", "/tmp/synthetic-vision.png")
+        key = "attachment://sess/synthetic"
         with patch("tools.vision_orchestrator.analyze_image",
                    new=AsyncMock(return_value=_mk_result())):
             out = json.loads(await vrt._handle_vision_router(
@@ -170,10 +177,12 @@ class TestEnvelope:
         assert out["logical_model_calls"] == 1
 
     async def test_ocr_excerpt_truncates_long_text(self):
-        handles = vrt._authorized_source_handles()
-        if not handles:
-            pytest.skip("no locator assets available")
-        key = next(iter(handles))
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+        vision_session_state.register_attachment(
+            "attachment://sess/synthetic", "/tmp/synthetic-vision.png")
+        key = "attachment://sess/synthetic"
         long_text = "字" * 6000
         with patch("tools.vision_orchestrator.analyze_image",
                    new=AsyncMock(return_value=_mk_result(
@@ -188,10 +197,12 @@ class TestEnvelope:
         assert out["ocr_meta"]["full_text_policy"] == "explicit_followup_required"
 
     async def test_short_ocr_not_truncated(self):
-        handles = vrt._authorized_source_handles()
-        if not handles:
-            pytest.skip("no locator assets available")
-        key = next(iter(handles))
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+        vision_session_state.register_attachment(
+            "attachment://sess/synthetic", "/tmp/synthetic-vision.png")
+        key = "attachment://sess/synthetic"
         with patch("tools.vision_orchestrator.analyze_image",
                    new=AsyncMock(return_value=_mk_result(
                        structured={"observed_text": ["short"]}))):
@@ -201,10 +212,12 @@ class TestEnvelope:
         assert out["observed_text"] == ["short"]
 
     async def test_fail_closed_on_orchestrator_exception(self):
-        handles = vrt._authorized_source_handles()
-        if not handles:
-            pytest.skip("no locator assets available")
-        key = next(iter(handles))
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+        vision_session_state.register_attachment(
+            "attachment://sess/synthetic", "/tmp/synthetic-vision.png")
+        key = "attachment://sess/synthetic"
         with patch("tools.vision_orchestrator.analyze_image",
                    new=AsyncMock(side_effect=RuntimeError("boom"))):
             out = json.loads(await vrt._handle_vision_router(
@@ -348,6 +361,15 @@ class TestStage3SessionGates:
 
     pytestmark = pytest.mark.asyncio
 
+    def setup_method(self):
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+        vision_session_state.register_attachment(
+            "attachment://sess/taobao-0003", "/tmp/synthetic-a.png")
+        vision_session_state.register_attachment(
+            "attachment://sess/taobao-0004", "/tmp/synthetic-b.png")
+
     @staticmethod
     def _real_cfg():
         import copy
@@ -369,7 +391,7 @@ class TestStage3SessionGates:
             return {"execution_status": "SUCCESS"}
 
         with patch("tools.vision_orchestrator.analyze_image", new=fake_ai):
-            raw = await handler({"source_handle": "TAOBAO-VISION-0003",
+            raw = await handler({"source_handle": "attachment://sess/taobao-0003",
                                  "task": "UI_READ"})
         env = json.loads(raw)
         assert env["error"] == "SESSION_DISABLED"
@@ -378,7 +400,6 @@ class TestStage3SessionGates:
     async def test_turn_budget_exhausted(self):
         from tools.registry import registry
         from tools.vision_session_state import vision_session_state
-        vision_session_state.set_enabled(True)
         vision_session_state.begin_turn()
         handler = registry.get_entry("vision_router_analyze").handler
         assert handler is not None
@@ -396,10 +417,10 @@ class TestStage3SessionGates:
                    return_value=self._real_cfg()), \
              patch("tools.vision_orchestrator.analyze_image", new=fake_ai):
             env1 = json.loads(await handler(
-                {"source_handle": "TAOBAO-VISION-0003", "task": "UI_READ"}))
+                {"source_handle": "attachment://sess/taobao-0003", "task": "UI_READ"}))
             # second call in same turn -> turn budget exhausted
             env2 = json.loads(await handler(
-                {"source_handle": "TAOBAO-VISION-0004", "task": "UI_READ"}))
+                {"source_handle": "attachment://sess/taobao-0004", "task": "UI_READ"}))
         assert env1["execution_status"] == "SUCCESS"
         assert env2["error"] == "TURN_BUDGET_EXHAUSTED"
         vision_session_state.set_enabled(False)
@@ -407,7 +428,6 @@ class TestStage3SessionGates:
     async def test_same_source_task_needs_authorization(self):
         from tools.registry import registry
         from tools.vision_session_state import vision_session_state
-        vision_session_state.set_enabled(True)
         vision_session_state.begin_turn()
         handler = registry.get_entry("vision_router_analyze").handler
         assert handler is not None
@@ -425,10 +445,10 @@ class TestStage3SessionGates:
                    return_value=self._real_cfg()), \
              patch("tools.vision_orchestrator.analyze_image", new=fake_ai):
             env1 = json.loads(await handler(
-                {"source_handle": "TAOBAO-VISION-0003", "task": "UI_READ"}))
+                {"source_handle": "attachment://sess/taobao-0003", "task": "UI_READ"}))
             vision_session_state.begin_turn()  # new turn (fresh budget)
             env2 = json.loads(await handler(
-                {"source_handle": "TAOBAO-VISION-0003", "task": "UI_READ"}))
+                {"source_handle": "attachment://sess/taobao-0003", "task": "UI_READ"}))
         assert env1["execution_status"] == "SUCCESS"
         assert env2["error"].startswith("NEEDS_AUTHORIZATION")
         vision_session_state.set_enabled(False)
@@ -821,6 +841,10 @@ class TestOllamaEndpointAlignment:
         from tools.vision_session_state import vision_session_state
         vision_session_state.set_enabled(True)
         vision_session_state.begin_turn()
+        vision_session_state.register_attachment(
+            "attachment://sess/taobao-0003", "/tmp/synthetic-a.png")
+        vision_session_state.register_attachment(
+            "attachment://sess/taobao-0004", "/tmp/synthetic-b.png")
 
 
     pytestmark = pytest.mark.asyncio
@@ -932,7 +956,7 @@ class TestOllamaEndpointAlignment:
 
         with patch("hermes_cli.config.load_config", return_value=cfg), \
              patch("tools.vision_orchestrator.analyze_image", new=fake_ai):
-            raw = await handler({"source_handle": "TAOBAO-VISION-0003",
+            raw = await handler({"source_handle": "attachment://sess/taobao-0003",
                                  "task": "UI_READ", "mode": "AUTO"})
         env = json.loads(raw)
         assert received.get("base_url") == "http://ollama.internal:11434"
@@ -961,7 +985,7 @@ class TestOllamaEndpointAlignment:
 
         with patch("hermes_cli.config.load_config", return_value=cfg), \
              patch("tools.vision_orchestrator.analyze_image", new=fake_ai):
-            raw = await handler({"source_handle": "TAOBAO-VISION-0003",
+            raw = await handler({"source_handle": "attachment://sess/taobao-0003",
                                  "task": "UI_READ",
                                  "base_url": "http://evil.example:9999"})
         env = json.loads(raw)
@@ -993,9 +1017,8 @@ class TestOllamaEndpointAlignment:
 
         with patch("hermes_cli.config.load_config", return_value=cfg), \
              patch("tools.vision_orchestrator.analyze_image", new=fake_ai):
-            raw = await handler({"source_handle": "TAOBAO-VISION-0003",
+            raw = await handler({"source_handle": "attachment://sess/taobao-0003",
                                  "task": "UI_READ"})
         env = json.loads(raw)
         assert reached["native"] is True
         assert env["execution_status"] == "SUCCESS"
-

--- a/tests/tools/test_vision_router_tool.py
+++ b/tests/tools/test_vision_router_tool.py
@@ -60,6 +60,11 @@ class TestSchema:
 
 
 class TestSourceAuthorization:
+    def setup_method(self):
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+
     pytestmark = pytest.mark.asyncio
 
     async def test_empty_handle_denied_zero_calls(self):
@@ -104,6 +109,11 @@ class TestSourceAuthorization:
 
 
 class TestCriticalityDerivation:
+    def setup_method(self):
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+
     def test_policy_derived(self):
         assert vrt._criticality_for("UI_READ") == "HIGH"
         assert vrt._criticality_for("EXACT_OCR") == "HIGH"
@@ -136,6 +146,11 @@ class TestCriticalityDerivation:
 
 
 class TestEnvelope:
+    def setup_method(self):
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+
     pytestmark = pytest.mark.asyncio
 
     async def test_envelope_is_safe_and_bounded(self):
@@ -200,6 +215,12 @@ class TestEnvelope:
 
 
 class TestVisibilityGate:
+    def setup_method(self):
+        # The effective-flag fingerprint includes the in-memory session flag;
+        # reset it so these tests exercise the server flag exclusively.
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(False)
+
     def test_flag_default_false(self):
         assert vrt._config_value(None, "ocr_excerpt_chars", 1) == 1
 
@@ -251,6 +272,343 @@ class TestVisibilityGate:
         assert vr["ocr_page_chars"] == 65536
         assert vr["per_workflow_max_calls"] == 20
         assert vr["enabled"] is False
+
+
+class TestSessionState:
+    """In-memory session state (Stage-3): flag / budgets / allowlist / OCR."""
+
+    def setup_method(self):
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(False)
+
+    def test_toggle_on_off(self):
+        from tools.vision_session_state import vision_session_state as s
+        s.set_enabled(True)
+        assert s.enabled is True
+        s.set_enabled(False)
+        assert s.enabled is False
+
+    def test_off_revokes_all_sources(self):
+        from tools.vision_session_state import vision_session_state as s
+        s.set_enabled(True)
+        s.register_attachment("attachment://sess/a", "/tmp/a.png")
+        s.register_ocr_result("ocr://r", "/tmp/r.txt")
+        s.set_enabled(False)
+        assert s.resolve_attachment("attachment://sess/a") is None
+        assert s.resolve_ocr_result("ocr://r") is None
+
+    def test_budget_turn_and_session(self):
+        from tools.vision_session_state import vision_session_state as s
+        s.set_enabled(True)
+        assert s.consume_call(1, 5) is None
+        # second consume while the first is still in flight -> BUSY
+        assert s.consume_call(1, 5) == "VISION_BUSY_IN_FLIGHT"
+        s.finish_call()
+        # same turn, second finished call -> turn budget exhausted
+        assert s.consume_call(1, 5) == "TURN_BUDGET_EXHAUSTED"
+        s.fail_call()
+        s.begin_turn()
+        assert s.consume_call(1, 5) is None
+        for _ in range(3):
+            s.finish_call()
+            s.begin_turn()
+            assert s.consume_call(1, 5) is None
+        s.finish_call()
+        s.begin_turn()
+        assert s.consume_call(1, 5) == "SESSION_BUDGET_EXHAUSTED"
+        s.fail_call()
+
+    def test_in_flight_blocks(self):
+        from tools.vision_session_state import vision_session_state as s
+        s.set_enabled(True)
+        assert s.consume_call(1, 5) is None
+        assert s.consume_call(1, 5) == "VISION_BUSY_IN_FLIGHT"
+        s.fail_call()
+
+    def test_attachment_register_resolve_revoke(self):
+        from tools.vision_session_state import vision_session_state as s
+        s.set_enabled(True)
+        s.register_attachment("attachment://sess/a", "/tmp/a.png")
+        assert s.resolve_attachment("attachment://sess/a") == "/tmp/a.png"
+        s.revoke_attachment("attachment://sess/a")
+        assert s.resolve_attachment("attachment://sess/a") is None
+
+    def test_dedupe_and_authorization(self):
+        from tools.vision_session_state import vision_session_state as s
+        s.set_enabled(True)
+        assert s.needs_authorization("h", "UI_READ") is False
+        s.record_call("h", "UI_READ")
+        assert s.needs_authorization("h", "UI_READ") is True
+        s.authorize_source_task("h", "UI_READ")
+        assert s.needs_authorization("h", "UI_READ") is False
+
+
+class TestStage3SessionGates:
+    """Wrapper gates: SESSION_DISABLED / budgets / dedupe / attachment://."""
+
+    pytestmark = pytest.mark.asyncio
+
+    @staticmethod
+    def _real_cfg():
+        import copy
+        from hermes_cli.config import load_config
+        cfg = copy.deepcopy(load_config())
+        cfg["auxiliary"]["vision_router"]["enabled"] = True
+        return cfg
+
+    async def test_session_disabled_rejects_zero_calls(self):
+        from tools.registry import registry
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(False)
+        handler = registry.get_entry("vision_router_analyze").handler
+        assert handler is not None
+        called = {"n": 0}
+
+        async def fake_ai(*a, **k):
+            called["n"] += 1
+            return {"execution_status": "SUCCESS"}
+
+        with patch("tools.vision_orchestrator.analyze_image", new=fake_ai):
+            raw = await handler({"source_handle": "TAOBAO-VISION-0003",
+                                 "task": "UI_READ"})
+        env = json.loads(raw)
+        assert env["error"] == "SESSION_DISABLED"
+        assert called["n"] == 0
+
+    async def test_turn_budget_exhausted(self):
+        from tools.registry import registry
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+        handler = registry.get_entry("vision_router_analyze").handler
+        assert handler is not None
+
+        async def fake_ai(*a, **k):
+            return {"execution_status": "SUCCESS", "quality_decision": "PASS",
+                    "initial_model_slot": "PRECISION_VLM",
+                    "final_model_slot": "PRECISION_VLM",
+                    "actual_model": "qwen3.6:27b",
+                    "logical_model_calls": 1,
+                    "structured": {"observed_text": ["ok"]},
+                    "trace": []}
+
+        with patch("hermes_cli.config.load_config",
+                   return_value=self._real_cfg()), \
+             patch("tools.vision_orchestrator.analyze_image", new=fake_ai):
+            env1 = json.loads(await handler(
+                {"source_handle": "TAOBAO-VISION-0003", "task": "UI_READ"}))
+            # second call in same turn -> turn budget exhausted
+            env2 = json.loads(await handler(
+                {"source_handle": "TAOBAO-VISION-0004", "task": "UI_READ"}))
+        assert env1["execution_status"] == "SUCCESS"
+        assert env2["error"] == "TURN_BUDGET_EXHAUSTED"
+        vision_session_state.set_enabled(False)
+
+    async def test_same_source_task_needs_authorization(self):
+        from tools.registry import registry
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+        handler = registry.get_entry("vision_router_analyze").handler
+        assert handler is not None
+
+        async def fake_ai(*a, **k):
+            return {"execution_status": "SUCCESS", "quality_decision": "PASS",
+                    "initial_model_slot": "PRECISION_VLM",
+                    "final_model_slot": "PRECISION_VLM",
+                    "actual_model": "qwen3.6:27b",
+                    "logical_model_calls": 1,
+                    "structured": {"observed_text": ["ok"]},
+                    "trace": []}
+
+        with patch("hermes_cli.config.load_config",
+                   return_value=self._real_cfg()), \
+             patch("tools.vision_orchestrator.analyze_image", new=fake_ai):
+            env1 = json.loads(await handler(
+                {"source_handle": "TAOBAO-VISION-0003", "task": "UI_READ"}))
+            vision_session_state.begin_turn()  # new turn (fresh budget)
+            env2 = json.loads(await handler(
+                {"source_handle": "TAOBAO-VISION-0003", "task": "UI_READ"}))
+        assert env1["execution_status"] == "SUCCESS"
+        assert env2["error"].startswith("NEEDS_AUTHORIZATION")
+        vision_session_state.set_enabled(False)
+
+    async def test_attachment_handle_authorized(self):
+        from tools.registry import registry
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+        vision_session_state.register_attachment(
+            "attachment://sess/a", "/tmp/stage3-att.png")
+        handler = registry.get_entry("vision_router_analyze").handler
+        assert handler is not None
+        received = {}
+
+        async def fake_ai(request, **kw):
+            received["source"] = request.image_source
+            return {"execution_status": "SUCCESS", "quality_decision": "PASS",
+                    "initial_model_slot": "PRECISION_VLM",
+                    "final_model_slot": "PRECISION_VLM",
+                    "actual_model": "qwen3.6:27b",
+                    "logical_model_calls": 1,
+                    "structured": {"observed_text": ["ok"]},
+                    "trace": []}
+
+        with patch("hermes_cli.config.load_config",
+                   return_value=self._real_cfg()), \
+             patch("tools.vision_orchestrator.analyze_image", new=fake_ai):
+            raw = await handler({"source_handle": "attachment://sess/a",
+                                 "task": "UI_READ"})
+        env = json.loads(raw)
+        assert env["execution_status"] == "SUCCESS"
+        assert received["source"] == "/tmp/stage3-att.png"
+        vision_session_state.set_enabled(False)
+
+    async def test_unknown_attachment_denied_zero_calls(self):
+        from tools.registry import registry
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+        handler = registry.get_entry("vision_router_analyze").handler
+        assert handler is not None
+        called = {"n": 0}
+
+        async def fake_ai(*a, **k):
+            called["n"] += 1
+            return {"execution_status": "SUCCESS"}
+
+        with patch("tools.vision_orchestrator.analyze_image", new=fake_ai):
+            raw = await handler({"source_handle": "attachment://sess/nope",
+                                 "task": "UI_READ"})
+        env = json.loads(raw)
+        assert env["error"] == "SOURCE_DENIED: source handle is not authorized"
+        assert called["n"] == 0
+        vision_session_state.set_enabled(False)
+
+
+class TestOcrPageTool:
+    """vision_ocr_page: bounded pagination, session binding, zero calls."""
+
+    @staticmethod
+    def _mk_handle(text):
+        from tools.vision_session_state import vision_session_state
+        import tempfile
+        f = tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False,
+                                        encoding="utf-8")
+        f.write(text)
+        f.close()
+        vision_session_state.set_enabled(True)
+        vision_session_state.register_ocr_result("ocr://page-test", f.name)
+        return f.name
+
+    def test_first_page_bounded(self):
+        from tools.vision_ocr_page import _handle_vision_ocr_page
+        long = "页" * 70000
+        self._mk_handle(long)
+        raw = _handle_vision_ocr_page({"handle": "ocr://page-test", "page": 1})
+        env = json.loads(raw)
+        assert env["execution_status"] == "SUCCESS"
+        assert len(env["page_text"]) == 65536
+        assert env["total_chars"] == 70000
+        assert env["remaining_chars"] == 70000 - 65536
+        assert env["truncated"] is True
+        assert env["sha256"]
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(False)
+
+    def test_second_page(self):
+        from tools.vision_ocr_page import _handle_vision_ocr_page
+        long = "行" * 70000
+        self._mk_handle(long)
+        raw = _handle_vision_ocr_page({"handle": "ocr://page-test", "page": 2})
+        env = json.loads(raw)
+        assert env["execution_status"] == "SUCCESS"
+        assert env["remaining_chars"] == 0
+        assert env["page_chars"] == 70000 - 65536
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(False)
+
+    def test_unknown_handle_denied(self):
+        from tools.vision_ocr_page import _handle_vision_ocr_page
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        raw = _handle_vision_ocr_page({"handle": "ocr://missing", "page": 1})
+        env = json.loads(raw)
+        assert env["error"].startswith("SOURCE_DENIED")
+        vision_session_state.set_enabled(False)
+
+    def test_session_disabled_denied(self):
+        from tools.vision_ocr_page import _handle_vision_ocr_page
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(False)
+        raw = _handle_vision_ocr_page({"handle": "ocr://x", "page": 1})
+        env = json.loads(raw)
+        assert env["error"] == "SESSION_DISABLED"
+
+    def test_schema_no_path_fields(self):
+        import tools.vision_ocr_page as vop
+        props = vop.VISION_OCR_PAGE_SCHEMA["parameters"]["properties"]
+        for banned in ("path", "base_url", "endpoint"):
+            assert banned not in props
+
+    def test_wrapper_registers_retrievable_ocr_handle(self):
+        """End-to-end (mocked analyze_image): long OCR result through the
+        registry wrapper must mint a NON-EMPTY private handle, persist the
+        full text, and be retrievable via vision_ocr_page (zero calls)."""
+        import asyncio
+        from tools.registry import registry
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+        vision_session_state.register_attachment(
+            "attachment://uat-test/att", "/tmp/ocr-e2e.png")
+        handler = registry.get_entry("vision_router_analyze").handler
+        assert handler is not None
+        long_text = "行" * 9000
+
+        async def fake_ai(*a, **k):
+            return {"execution_status": "SUCCESS",
+                    "quality_decision": "PASS",
+                    "initial_model_slot": "OCR",
+                    "final_model_slot": "OCR",
+                    "actual_model": "glm-ocr",
+                    "logical_model_calls": 1,
+                    "structured": {"observed_text": [long_text]},
+                    "trace": []}
+
+        import tools.vision_router_tool as vrt
+        with patch("hermes_cli.config.load_config",
+                   return_value=self._cfg()), \
+             patch("tools.vision_orchestrator.analyze_image", new=fake_ai):
+            raw = asyncio.run(handler(
+                {"source_handle": "attachment://uat-test/att",
+                 "task": "EXACT_OCR"}))
+        env = json.loads(raw)
+        ocr_meta = env.get("ocr_meta") or {}
+        handle = ocr_meta.get("private_handle")
+        assert handle, "private_handle must be non-empty"
+        assert ocr_meta.get("truncated") is True
+        assert ocr_meta.get("returned_chars", 0) <= 4000
+        # full text persisted + registered
+        assert vision_session_state.resolve_ocr_result(f"ocr://{handle}")
+        # retrievable through vision_ocr_page (zero calls)
+        from tools.vision_ocr_page import _handle_vision_ocr_page
+        page = json.loads(_handle_vision_ocr_page(
+            {"handle": f"ocr://{handle}", "page": 0}))
+        assert page["execution_status"] == "SUCCESS"
+        assert page["page_chars"] > 0
+        assert page["total_chars"] == 9000
+        assert page["logical_model_calls"] == 0
+        vision_session_state.set_enabled(False)
+
+    @staticmethod
+    def _cfg():
+        import copy
+        from hermes_cli.config import load_config
+        cfg = copy.deepcopy(load_config())
+        cfg["auxiliary"]["vision_router"]["enabled"] = True
+        return cfg
+
 
 
 class TestConfigPathAlignment:
@@ -459,6 +817,11 @@ class TestOllamaEndpointAlignment:
     ALIGNMENT_V0_1): one shared resolver; wrapper passes the resolved native
     root to analyze_image; base_url stays model-invisible.
     """
+    def setup_method(self):
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.set_enabled(True)
+        vision_session_state.begin_turn()
+
 
     pytestmark = pytest.mark.asyncio
 
@@ -573,7 +936,9 @@ class TestOllamaEndpointAlignment:
                                  "task": "UI_READ", "mode": "AUTO"})
         env = json.loads(raw)
         assert received.get("base_url") == "http://ollama.internal:11434"
-        assert received.get("enabled") is None  # flag resolution stays server-side
+        # enabled carries the in-memory session flag (limited-use session
+        # mode user toggle); model-visible flag resolution stays server-side.
+        assert received.get("enabled") is True
         assert env["execution_status"] == "SUCCESS"
         assert "ollama.internal" not in json.dumps(env)  # endpoint not leaked
 

--- a/tests/tools/test_vision_webp_transport.py
+++ b/tests/tools/test_vision_webp_transport.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""WebP transport-compatibility tests — tools/ollama_vision_client.py.
+
+Behavioral tests for the two-layer hash contract:
+- canonical normalized_image_sha256 (calibration identity, WebP hash)
+- transport_image_sha256 / transport_mime_type / transport_transcoded
+  (exact bytes sent to the endpoint)
+
+No network requests. Source files are never modified.
+"""
+import asyncio
+import base64
+import hashlib
+import io
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ollama_vision_client import (  # noqa: E402
+    _ensure_ollama_transport_compatible_image,
+    prepare_image,
+)
+from tools.vision_tools import _detect_image_mime_type_from_bytes  # noqa: E402
+
+
+def _make_webp_bytes(size=(8, 8), rgba=False):
+    """Build deterministic in-memory WebP bytes (suffix irrelevant)."""
+    from PIL import Image
+
+    im = Image.new("RGBA" if rgba else "RGB", size, (200, 30, 30, 128) if rgba else (200, 30, 30))
+    buf = io.BytesIO()
+    im.save(buf, format="WEBP")
+    return buf.getvalue()
+
+
+def _make_png_bytes(size=(8, 8)):
+    from PIL import Image
+
+    im = Image.new("RGB", size, (10, 200, 10))
+    buf = io.BytesIO()
+    im.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_jpeg_bytes(size=(8, 8)):
+    from PIL import Image
+
+    im = Image.new("RGB", size, (10, 10, 200))
+    buf = io.BytesIO()
+    im.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+class TestMimeDetectionFromBytes:
+    def test_webp_detected_by_bytes_despite_jpg_suffix(self, tmp_path):
+        webp = _make_webp_bytes()
+        p = tmp_path / "image.jpg"  # misleading suffix
+        p.write_bytes(webp)
+        assert _detect_image_mime_type_from_bytes(p.read_bytes()) == "image/webp"
+
+
+class TestTransportConversion:
+    def test_webp_converted_to_png_bytes(self, tmp_path):
+        webp = _make_webp_bytes()
+        p = tmp_path / "img.webp"
+        p.write_bytes(webp)
+        transport_bytes, mime, transcoded = _ensure_ollama_transport_compatible_image(p, "image/webp")
+        assert transcoded is True
+        assert mime == "image/png"
+        # PNG magic bytes
+        assert transport_bytes[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_data_url_prefix_png(self, tmp_path):
+        from tools.vision_tools import _image_to_base64_data_url
+
+        webp = _make_webp_bytes()
+        p = tmp_path / "img.webp"
+        p.write_bytes(webp)
+        transport_bytes, mime, _ = _ensure_ollama_transport_compatible_image(p, "image/webp")
+        tmp2 = tmp_path / "transport.png"
+        tmp2.write_bytes(transport_bytes)
+        url = _image_to_base64_data_url(tmp2, mime_type=mime)
+        assert url.startswith("data:image/png;base64,")
+
+    def test_png_transport_bytes_decode(self, tmp_path):
+        from PIL import Image
+
+        webp = _make_webp_bytes((16, 9))
+        p = tmp_path / "img.webp"
+        p.write_bytes(webp)
+        transport_bytes, _, _ = _ensure_ollama_transport_compatible_image(p, "image/webp")
+        im = Image.open(io.BytesIO(transport_bytes))
+        assert im.format == "PNG"
+        assert im.size == (16, 9)
+
+    def test_dimensions_unchanged(self, tmp_path):
+        webp = _make_webp_bytes((32, 24))
+        p = tmp_path / "img.webp"
+        p.write_bytes(webp)
+        transport_bytes, _, _ = _ensure_ollama_transport_compatible_image(p, "image/webp")
+        from PIL import Image
+
+        im = Image.open(io.BytesIO(transport_bytes))
+        assert im.size == (32, 24)
+
+    def test_transparent_webp_safe(self, tmp_path):
+        from PIL import Image
+
+        webp = _make_webp_bytes((8, 8), rgba=True)
+        p = tmp_path / "img.webp"
+        p.write_bytes(webp)
+        transport_bytes, mime, transcoded = _ensure_ollama_transport_compatible_image(p, "image/webp")
+        assert transcoded is True
+        im = Image.open(io.BytesIO(transport_bytes))
+        assert im.mode in ("RGBA", "RGB")
+        assert im.size == (8, 8)
+
+    def test_conversion_deterministic(self, tmp_path):
+        webp = _make_webp_bytes((10, 10))
+        p = tmp_path / "img.webp"
+        p.write_bytes(webp)
+        b1, _, _ = _ensure_ollama_transport_compatible_image(p, "image/webp")
+        b2, _, _ = _ensure_ollama_transport_compatible_image(p, "image/webp")
+        assert b1 == b2
+
+    def test_source_untouched(self, tmp_path):
+        webp = _make_webp_bytes((8, 8))
+        p = tmp_path / "img.webp"
+        p.write_bytes(webp)
+        before = hashlib.sha256(webp).hexdigest()
+        import os
+
+        before_mtime = os.stat(p).st_mtime_ns
+        _ensure_ollama_transport_compatible_image(p, "image/webp")
+        assert hashlib.sha256(p.read_bytes()).hexdigest() == before
+        assert os.stat(p).st_mtime_ns == before_mtime
+
+    def test_png_not_transcoded(self, tmp_path):
+        png = _make_png_bytes()
+        p = tmp_path / "img.png"
+        p.write_bytes(png)
+        transport_bytes, mime, transcoded = _ensure_ollama_transport_compatible_image(p, "image/png")
+        assert transcoded is False
+        assert transport_bytes == png
+        assert mime == "image/png"
+
+    def test_jpeg_not_transcoded(self, tmp_path):
+        jpg = _make_jpeg_bytes()
+        p = tmp_path / "img.jpg"
+        p.write_bytes(jpg)
+        transport_bytes, mime, transcoded = _ensure_ollama_transport_compatible_image(p, "image/jpeg")
+        assert transcoded is False
+        assert transport_bytes == jpg
+        assert mime == "image/jpeg"
+
+    def test_mime_from_bytes_not_suffix(self, tmp_path):
+        """A WebP file with .jpg suffix must still be transcoded."""
+        webp = _make_webp_bytes()
+        p = tmp_path / "image.jpg"
+        p.write_bytes(webp)
+        _, mime, transcoded = _ensure_ollama_transport_compatible_image(p, None)
+        assert transcoded is True
+        assert mime == "image/png"
+
+    def test_temp_artifacts_cleaned(self, tmp_path):
+        """prepare_image must not leave stray files behind beyond its temp dir."""
+        import os
+
+        webp = _make_webp_bytes((8, 8))
+        p = tmp_path / "img.webp"
+        p.write_bytes(webp)
+        before = set(os.listdir(tmp_path))
+        _ensure_ollama_transport_compatible_image(p, "image/webp")
+        after = set(os.listdir(tmp_path))
+        assert after == before
+
+
+class TestPrepareImageTwoLayerHash:
+    @pytest.mark.asyncio
+    async def test_webp_canonical_vs_transport_hash(self, tmp_path):
+        """prepare_image keeps canonical WebP hash and emits transport PNG
+        hash + metadata, for a WebP file with .jpg suffix."""
+        webp = _make_webp_bytes((12, 12))
+        src = tmp_path / "source.jpg"
+        src.write_bytes(webp)
+
+        async def fake_resolve(image_source, task_id=None):
+            return webp
+
+        import tools.ollama_vision_client as mod
+
+        with (
+            patch.object(mod, "_resolve_image_bytes_async", fake_resolve),
+            patch("tools.vision_tools._normalize_to_supported_image", _passthrough_norm),
+        ):
+            (
+                data_url,
+                w,
+                h,
+                mime,
+                normalized_sha,
+                transport_meta,
+            ) = await prepare_image(str(src))
+
+        expected_canonical = hashlib.sha256(webp).hexdigest()
+        assert normalized_sha == expected_canonical  # canonical = WebP hash
+        assert transport_meta["transport_transcoded"] is True
+        assert transport_meta["transport_mime_type"] == "image/png"
+        assert transport_meta["transport_image_sha256"] != expected_canonical
+        # Transport hash must match the actual PNG bytes in the data URL:
+        payload = data_url.split(",", 1)[1]
+        decoded = base64.b64decode(payload)
+        assert hashlib.sha256(decoded).hexdigest() == transport_meta["transport_image_sha256"]
+        assert w == 12 and h == 12
+
+    @pytest.mark.asyncio
+    async def test_png_canonical_equals_transport(self, tmp_path):
+        png = _make_png_bytes((10, 10))
+        src = tmp_path / "img.png"
+        src.write_bytes(png)
+
+        async def fake_resolve(image_source, task_id=None):
+            return png
+
+        import tools.ollama_vision_client as mod
+
+        with (
+            patch.object(mod, "_resolve_image_bytes_async", fake_resolve),
+            patch("tools.vision_tools._normalize_to_supported_image", _passthrough_norm),
+        ):
+            (
+                _url,
+                _w,
+                _h,
+                _mime,
+                normalized_sha,
+                transport_meta,
+            ) = await prepare_image(str(src))
+
+        expected = hashlib.sha256(png).hexdigest()
+        assert normalized_sha == expected
+        assert transport_meta["transport_image_sha256"] == expected  # identical
+        assert transport_meta["transport_transcoded"] is False
+        assert transport_meta["transport_mime_type"] == "image/png"
+
+    @pytest.mark.asyncio
+    async def test_trace_and_result_contain_transport_meta_no_bytes(self):
+        """End-to-end orchestrator result carries both hashes but no bytes."""
+        from tools.vision_orchestrator import analyze_image
+        from tools.vision_policy import (
+            VisionRequest,
+            VisionTask,
+            VisionMode,
+            VisionCriticality,
+            ExecutionStatus,
+        )
+        from unittest.mock import AsyncMock
+
+        with (
+            patch(
+                "tools.vision_orchestrator.prepare_image",
+                new_callable=AsyncMock,
+                return_value=(
+                    "data:image/png;base64,TRANSPORT",
+                    600,
+                    600,
+                    "image/webp",
+                    "c" * 64,  # canonical (webp) hash
+                    {
+                        "transport_image_sha256": "d" * 64,
+                        "transport_mime_type": "image/png",
+                        "transport_transcoded": True,
+                    },
+                ),
+            ),
+            patch(
+                "tools.vision_orchestrator.invoke_vision_model",
+                new_callable=AsyncMock,
+                return_value={
+                    "execution_status": ExecutionStatus.SUCCESS.value,
+                    "raw_text": '{"observation": "ok"}',
+                    "error": None,
+                },
+            ),
+        ):
+            req = VisionRequest(
+                request_id="t-webp",
+                image_source="opaque://x",
+                task=VisionTask.SCENE_DESCRIBE,
+                mode=VisionMode.AUTO,
+                criticality=VisionCriticality.NORMAL,
+                question="describe",
+            )
+            result = await analyze_image(req, enabled=True)
+
+        assert result["normalized_image_sha256"] == "c" * 64
+        assert result["transport_image_sha256"] == "d" * 64
+        assert result["transport_mime_type"] == "image/png"
+        assert result["transport_transcoded"] is True
+        assert result["logical_model_calls"] == 1
+        # Trace carries hashes, never bytes:
+        trace = result["trace"][0]
+        assert trace["transport_image_sha256"] == "d" * 64
+        blob = str(result)
+        assert "TRANSPORT" not in blob  # no base64 payload
+        assert "data:image" not in blob
+
+
+def _passthrough_norm(path, mime):
+    """Test double for _normalize_to_supported_image: keep bytes as-is."""
+    return path, mime, None

--- a/tools/ollama_generate_vision_client.py
+++ b/tools/ollama_generate_vision_client.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""Native Ollama ``/api/generate`` transport for the Vision Orchestrator
+(inactive adapter).
+
+This module adds exactly one alternative *transport* for the local vision
+pipeline. It does NOT change any default: the Vision Orchestrator still uses
+the existing OpenAI-compatible auxiliary-client path
+(``tools.ollama_vision_client.invoke_vision_model``) unless an explicit
+private invocation selects ``TRANSPORT_OLLAMA_NATIVE_GENERATE``.
+
+Native transport contract (validated in qwen36-route-format-exp-v0_1):
+
+- endpoint ``/api/generate`` with ``stream=false``;
+- ``images`` carries RAW base64 bytes with no ``data:image/...;base64,``
+  prefix;
+- ``prompt`` is the exact validated generate Prompt rendering;
+- ``options`` carries ``num_ctx`` / ``num_predict`` / ``temperature`` /
+  ``seed`` explicitly — no reliance on Ollama defaults;
+- ``format`` is either the literal ``"json"`` or the validated strict JSON
+  Schema object;
+- qwen3.6 is a thinking model: when ``response`` is empty the usable
+  structured answer lives in ``thinking`` — extraction is deterministic and
+  explicit (``content_source`` / ``thinking_fallback_used``).
+
+Privacy boundary: the provider-result contract exposes only normalized safe
+metadata (timing, counts, character lengths, content_source); raw response
+text, full thinking, base64 and private endpoint identity never enter the
+result contract.
+
+No live inference is performed by import — tests are fully mocked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional, Tuple
+
+from tools.vision_policy import (
+    ExecutionStatus,
+    TRANSPORT_OPENAI_COMPATIBLE,
+    TRANSPORT_OLLAMA_NATIVE_GENERATE,
+)
+
+# ---------------------------------------------------------------------------
+# Transport identities (defined in tools.vision_policy — single source of
+# truth; re-exported here for backward compatibility with earlier imports).
+# ---------------------------------------------------------------------------
+
+# Validated strict JSON Schema (experiment PROFILE_S, aligned to the
+# canonical internal field per task HERMES_VISION_UI_READ_TEXT_FIELD_
+# CONTRACT_ALIGNMENT_V0_1). The REQUIRED field is the canonical
+# ``observed_text`` (Prompt contract + quality gates + calibration all use
+# it); ``visible_text`` remains only as a legacy alias accepted through the
+# explicit resolver in tools/vision_policy. Byte-identical semantics to the
+# harness ``schema_obj()`` except the required field name.
+NATIVE_GENERATE_STRICT_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "visible_text": {"type": "array", "items": {"type": "string"}},
+        "observed_text": {"type": "array", "items": {"type": "string"}},
+        "evidence": {"type": "string"},
+        "uncertainty": {"type": "string"},
+        "inference": {"type": "string"},
+    },
+    "required": ["observed_text"],
+}
+
+# Default candidate runtime profile (task §9) — supported, never activated
+# as a permanent default. Mirrors the validated canonical request
+# (temperature 0.1, num_predict 4000, seed 42, JSON Schema output).
+NATIVE_GENERATE_DEFAULT_PROFILE: Dict[str, Any] = {
+    "num_ctx": 32768,
+    "num_predict": 4000,
+    "temperature": 0.1,
+    "seed": 42,
+    "format": NATIVE_GENERATE_STRICT_SCHEMA,
+}
+
+# Task-specific strict JSON Schemas for the native generate transport.
+# UI_READ uses the canonical NATIVE_GENERATE_STRICT_SCHEMA (required
+# observed_text); SCENE_DESCRIBE / EVIDENCE_VERIFY carry their own
+# canonical task fields (task HERMES_VISION_PRECISION_NATIVE_GENERATE_
+# PROFILE_BINDING_V0_1 — profile output contract is task-specific).
+TASK_STRICT_SCHEMAS: Dict[str, Dict[str, Any]] = {
+    "UI_READ": NATIVE_GENERATE_STRICT_SCHEMA,
+    "SCENE_DESCRIBE": {
+        "type": "object",
+        "properties": {
+            "observation": {"type": "string"},
+            "inference": {"type": "string"},
+            "uncertainty": {"type": "string"},
+        },
+        "required": ["observation", "inference"],
+    },
+    "EVIDENCE_VERIFY": {
+        "type": "object",
+        "properties": {
+            "evidence": {"type": "string"},
+            "observation": {"type": "string"},
+            "inference": {"type": "string"},
+            "uncertainty": {"type": "string"},
+            "contradiction": {"type": "string"},
+        },
+        "required": ["evidence"],
+    },
+}
+
+_TIMING_NS_FIELDS = (
+    "load_duration",
+    "prompt_eval_duration",
+    "eval_duration",
+    "total_duration",
+)
+_COUNT_FIELDS = ("prompt_eval_count", "eval_count")
+_META_FIELDS = ("model", "created_at", "done", "done_reason", "context")
+
+
+# ---------------------------------------------------------------------------
+# HTTP transport (single seam for offline mocks).
+# ---------------------------------------------------------------------------
+
+
+async def _http_post_json(
+    base_url: str,
+    path: str,
+    payload: Dict[str, Any],
+    timeout_seconds: float,
+) -> Tuple[int, Any]:
+    """POST ``payload`` as JSON to ``base_url + path``.
+
+    Returns ``(status_code, body)`` where ``body`` is the parsed JSON value
+    (typically a dict) or ``None`` when the response had no body or was not
+    JSON. Raises ``httpx`` transport exceptions (timeout / connect) which the
+    caller classifies — this function performs no classification.
+    """
+    import httpx
+
+    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+        resp = await client.post(f"{base_url.rstrip('/')}{path}", json=payload)
+    if not resp.content:
+        return resp.status_code, None
+    try:
+        return resp.status_code, resp.json()
+    except Exception:  # noqa: BLE001 — non-JSON body handled by caller
+        return resp.status_code, None
+
+
+# ---------------------------------------------------------------------------
+# Deterministic response/thinking extraction (task §11).
+# ---------------------------------------------------------------------------
+
+
+def _extract_final_content(
+    envelope: Dict[str, Any],
+) -> Tuple[Optional[str], str, bool, Optional[str]]:
+    """Extract the usable final content from a native generate envelope.
+
+    Returns ``(content, content_source, thinking_fallback_used, error_code)``:
+
+    - ``content`` is non-None when usable content exists;
+    - ``content_source`` is ``"response"`` or ``"thinking_fallback"``;
+    - ``error_code`` is set (and ``content`` is None) for the invalid
+      classes: ``non_string_response``, ``non_string_thinking``,
+      ``missing_response_and_thinking``.
+
+    Rules (never merge, never silently prefer one):
+    - non-empty ``response`` is primary;
+    - empty ``response`` + non-empty ``thinking`` → explicit thinking
+      fallback (qwen3.6 thinking model);
+    - both non-empty → ``response`` wins (thinking preserved only as
+      non-sensitive metadata);
+    - non-string ``response`` / ``thinking`` → rejected safely;
+    - both empty → INVALID_RESPONSE class.
+    """
+    if "response" in envelope and not isinstance(envelope.get("response"), str):
+        return None, "", False, "non_string_response"
+    if "thinking" in envelope and not isinstance(envelope.get("thinking"), str):
+        return None, "", False, "non_string_thinking"
+
+    response = envelope.get("response") or ""
+    thinking = envelope.get("thinking") or ""
+    if response.strip():
+        return response, "response", False, None
+    if thinking.strip():
+        return thinking, "thinking_fallback", True, None
+    return None, "", False, "missing_response_and_thinking"
+
+
+# ---------------------------------------------------------------------------
+# Safe metadata normalization (task §12).
+# ---------------------------------------------------------------------------
+
+
+def _normalize_timing(envelope: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize Ollama nanosecond durations to integer milliseconds.
+
+    Non-numeric values become ``None``. Count fields pass through as-is.
+    """
+    out: Dict[str, Any] = {}
+    for field in _TIMING_NS_FIELDS:
+        value = envelope.get(field)
+        key = field.replace("_duration", "_ms")
+        out[key] = int(value / 1_000_000) if isinstance(value, (int, float)) else None
+    for field in _COUNT_FIELDS:
+        out[field] = envelope.get(field)
+    return out
+
+
+def _safe_envelope_meta(envelope: Dict[str, Any]) -> Dict[str, Any]:
+    """Non-sensitive envelope metadata only (no response/thinking/base64)."""
+    return {key: envelope.get(key) for key in _META_FIELDS if key in envelope}
+
+
+def _classify_transport_error(
+    exc: Exception,
+    *,
+    status: Optional[int] = None,
+    body_error: Optional[str] = None,
+) -> str:
+    """Map transport failures to an ``ExecutionStatus`` value."""
+    name = type(exc).__name__.lower()
+    msg = str(exc).lower()
+    if "timeout" in name or "timeout" in msg:
+        return ExecutionStatus.TIMEOUT.value
+    if status is not None:
+        if status == 404 or (body_error and "not found" in body_error.lower()):
+            return ExecutionStatus.MODEL_NOT_FOUND.value
+        if 500 <= status <= 599:
+            return ExecutionStatus.ENDPOINT_UNAVAILABLE.value
+        if 400 <= status <= 499:
+            return ExecutionStatus.INVALID_RESPONSE.value
+    if "connect" in name or "connection" in msg or "refused" in msg:
+        return ExecutionStatus.ENDPOINT_UNAVAILABLE.value
+    return ExecutionStatus.ENDPOINT_UNAVAILABLE.value
+
+
+def _is_transient(exc: Exception) -> bool:
+    """True for transport-level blips worth a bounded retry (when enabled)."""
+    name = type(exc).__name__.lower()
+    msg = str(exc).lower()
+    if "timeout" in name or "timeout" in msg:
+        return True
+    if "connect" in name or "refused" in msg:
+        return False  # endpoint unreachable — retrying is pointless
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Native generate invocation (task §8).
+# ---------------------------------------------------------------------------
+
+
+async def invoke_native_generate(
+    *,
+    model: str,
+    prompt: str,
+    image_raw_base64: str,
+    num_ctx: int,
+    num_predict: int,
+    temperature: float,
+    seed: Optional[int],
+    format_spec: Any,
+    base_url: str,
+    timeout_seconds: float,
+    transport_retries: int = 0,
+) -> Dict[str, Any]:
+    """Invoke exactly one native Ollama ``/api/generate`` call (bounded
+    transport retries only when ``transport_retries > 0``).
+
+    Returns the provider-result contract (safe metadata only):
+
+    ``execution_status``, ``extracted_content``, ``content_source``,
+    ``thinking_fallback_used``, ``response_character_count``,
+    ``thinking_character_count``, ``response_envelope`` (safe meta),
+    ``model``, ``done``, ``done_reason``, ``created_at``,
+    ``total_ms``/``load_ms``/``prompt_eval_ms``/``eval_ms``,
+    ``prompt_eval_count``/``eval_count``, ``transport_attempts``, ``error``.
+
+    Never falls back to another transport, never calls a second model, never
+    escalates. Raw response text never enters the returned contract.
+    """
+    payload: Dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "images": [image_raw_base64],
+        "stream": False,
+        "options": {
+            "num_ctx": num_ctx,
+            "num_predict": num_predict,
+            "temperature": temperature,
+        },
+    }
+    if seed is not None:
+        payload["options"]["seed"] = seed
+    if format_spec is not None:
+        payload["format"] = format_spec
+
+    attempts = max(1, int(transport_retries or 0) + 1)
+    last_exc: Optional[Exception] = None
+    last_status: Optional[int] = None
+    last_body: Any = None
+
+    for attempt in range(attempts):
+        last_exc = None
+        try:
+            last_status, last_body = await _http_post_json(
+                base_url, "/api/generate", payload, timeout_seconds
+            )
+        except Exception as exc:  # noqa: BLE001 — classified below
+            last_exc = exc
+            if _is_transient(exc) and attempt + 1 < attempts:
+                await asyncio.sleep(0.5)
+                continue
+            status = _classify_transport_error(exc)
+            return {
+                "execution_status": status,
+                "extracted_content": "",
+                "content_source": "",
+                "thinking_fallback_used": False,
+                "response_character_count": 0,
+                "thinking_character_count": 0,
+                "response_envelope": {},
+                "model": model,
+                "done": None,
+                "done_reason": None,
+                "created_at": None,
+                "total_ms": None,
+                "load_ms": None,
+                "prompt_eval_ms": None,
+                "eval_ms": None,
+                "prompt_eval_count": None,
+                "eval_count": None,
+                "transport_attempts": attempt + 1,
+                "error": f"{type(exc).__name__}: {str(exc)[:200]}",
+            }
+
+        if not isinstance(last_status, int) or last_status < 200 or last_status >= 300:
+            body_error = ""
+            if isinstance(last_body, dict) and isinstance(last_body.get("error"), str):
+                body_error = last_body["error"]
+            if last_status is not None and 500 <= last_status <= 599 and attempt + 1 < attempts:
+                await asyncio.sleep(0.5)
+                continue
+            status = _classify_transport_error(
+                Exception(body_error or f"HTTP {last_status}"), status=last_status
+            )
+            return {
+                "execution_status": status,
+                "extracted_content": "",
+                "content_source": "",
+                "thinking_fallback_used": False,
+                "response_character_count": 0,
+                "thinking_character_count": 0,
+                "response_envelope": {},
+                "model": model,
+                "done": None,
+                "done_reason": None,
+                "created_at": None,
+                "total_ms": None,
+                "load_ms": None,
+                "prompt_eval_ms": None,
+                "eval_ms": None,
+                "prompt_eval_count": None,
+                "eval_count": None,
+                "transport_attempts": attempt + 1,
+                "error": body_error or f"http_{last_status}",
+            }
+        break
+
+    # 2xx with a non-dict body → malformed JSON envelope.
+    if not isinstance(last_body, dict):
+        return {
+            "execution_status": ExecutionStatus.INVALID_RESPONSE.value,
+            "extracted_content": "",
+            "content_source": "",
+            "thinking_fallback_used": False,
+            "response_character_count": 0,
+            "thinking_character_count": 0,
+            "response_envelope": {},
+            "model": model,
+            "done": None,
+            "done_reason": None,
+            "created_at": None,
+            "total_ms": None,
+            "load_ms": None,
+            "prompt_eval_ms": None,
+            "eval_ms": None,
+            "prompt_eval_count": None,
+            "eval_count": None,
+            "transport_attempts": attempts,
+            "error": "malformed_json_envelope",
+        }
+
+    content, source, fallback_used, extract_error = _extract_final_content(last_body)
+    if extract_error is not None:
+        return {
+            "execution_status": ExecutionStatus.INVALID_RESPONSE.value,
+            "extracted_content": "",
+            "content_source": "",
+            "thinking_fallback_used": False,
+            "response_character_count": 0,
+            "thinking_character_count": 0,
+            "response_envelope": _safe_envelope_meta(last_body),
+            "model": last_body.get("model") or model,
+            "done": last_body.get("done"),
+            "done_reason": last_body.get("done_reason"),
+            "created_at": last_body.get("created_at"),
+            "total_ms": _normalize_timing(last_body).get("total_ms"),
+            "load_ms": _normalize_timing(last_body).get("load_ms"),
+            "prompt_eval_ms": _normalize_timing(last_body).get("prompt_eval_ms"),
+            "eval_ms": _normalize_timing(last_body).get("eval_ms"),
+            "prompt_eval_count": _normalize_timing(last_body).get("prompt_eval_count"),
+            "eval_count": _normalize_timing(last_body).get("eval_count"),
+            "transport_attempts": attempts,
+            "error": extract_error,
+        }
+
+    timing = _normalize_timing(last_body)
+    meta = _safe_envelope_meta(last_body)
+    return {
+        "execution_status": ExecutionStatus.SUCCESS.value,
+        "extracted_content": content,
+        "content_source": source,
+        "thinking_fallback_used": fallback_used,
+        "response_character_count": len(str(last_body.get("response") or "")),
+        "thinking_character_count": len(str(last_body.get("thinking") or "")),
+        "response_envelope": meta,
+        "model": meta.get("model") or model,
+        "done": meta.get("done"),
+        "done_reason": meta.get("done_reason"),
+        "created_at": meta.get("created_at"),
+        "total_ms": timing.get("total_ms"),
+        "load_ms": timing.get("load_ms"),
+        "prompt_eval_ms": timing.get("prompt_eval_ms"),
+        "eval_ms": timing.get("eval_ms"),
+        "prompt_eval_count": timing.get("prompt_eval_count"),
+        "eval_count": timing.get("eval_count"),
+        "transport_attempts": attempts,
+        "error": None,
+    }

--- a/tools/ollama_vision_client.py
+++ b/tools/ollama_vision_client.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Unified model-invocation adapter for the local vision Orchestrator
+(V0.1 inactive foundation).
+
+Stage B1 reuses the existing auxiliary-client call chain
+(``agent.auxiliary_client.async_call_llm`` with ``task="vision"``) and the
+existing image-preparation pipeline in :mod:`tools.vision_tools` /
+:mod:`tools.image_source`:
+
+- ``resolve_image_source`` — download/read + website-policy checks;
+- ``_normalize_to_supported_image`` — SVG/BMP/TIFF → supported format;
+- ``_image_to_base64_data_url`` — base64 + data-URL construction.
+
+This adapter is *not* a heavy SDK: it is one thin, uniform entry point that
+accepts an exact model identity per call (per-call model override already
+exists in ``async_call_llm`` / ``vision_analyze_tool``).
+
+No live inference is performed by Stage B1 — tests are fully mocked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from tools.vision_policy import ExecutionStatus
+
+# Lazily bound auxiliary-client entry (mirrors tools/vision_tools.py pattern
+# so tests can patch the same names).
+_async_call_llm: Any = None
+_extract_content_or_reasoning: Any = None
+
+
+def _noop_extractor(response: Any) -> str:
+    """Sentinel used only when the canonical extractor failed to load."""
+    return ""
+
+
+def _load_auxiliary_client() -> None:
+    global _async_call_llm, _extract_content_or_reasoning
+    if _async_call_llm is None or _extract_content_or_reasoning is None:
+        from agent.auxiliary_client import (
+            async_call_llm as _acl,
+            extract_content_or_reasoning as _ecr,
+        )
+
+        if _async_call_llm is None:
+            _async_call_llm = _acl
+        if _extract_content_or_reasoning is None:
+            _extract_content_or_reasoning = _ecr
+
+
+async def _resolve_image_bytes_async(
+    image_source: str, task_id: Optional[str] = None
+) -> bytes:
+    from tools.image_source import ResolveContext, resolve_image_source
+
+    resolved = await resolve_image_source(image_source, ResolveContext(task_id=task_id))
+    return resolved.data
+
+
+def _ensure_ollama_transport_compatible_image(
+    normalized_path: Path, mime: Optional[str]
+) -> Tuple[bytes, str, bool]:
+    """Deterministic endpoint-transport compatibility conversion.
+
+    The canonical normalization pipeline (``_normalize_to_supported_image``)
+    preserves WebP bytes; the Ollama OpenAI-compatible endpoint rejects
+    ``data:image/webp;base64,...`` with HTTP 400. This adapter-local step
+    converts WebP to PNG *for the model request only* — the canonical
+    calibration identity (``normalized_image_sha256``) is untouched.
+
+    Returns ``(transport_bytes, transport_mime, transcoded)``:
+    - PNG/JPEG inputs pass through unchanged (``transcoded=False``);
+    - WebP inputs are deterministically re-encoded to PNG
+      (``transcoded=True``), alpha preserved, dimensions unchanged;
+    - MIME is detected from bytes, never from the filename suffix.
+
+    Never modifies the source file. The caller owns cleanup of any temporary
+    output created here.
+    """
+    from tools.vision_tools import _detect_image_mime_type_from_bytes
+
+    actual_mime = mime or ""
+    if not actual_mime or actual_mime == "image/webp":
+        try:
+            actual_mime = _detect_image_mime_type_from_bytes(normalized_path.read_bytes()) or actual_mime
+        except Exception:  # noqa: BLE001 — best-effort detection
+            pass
+
+    if actual_mime != "image/webp":
+        # PNG/JPEG/GIF and other accepted formats pass through unchanged.
+        data = normalized_path.read_bytes()
+        return data, actual_mime or "application/octet-stream", False
+
+    # WebP → deterministic PNG conversion (alpha preserved, dimensions kept).
+    from PIL import Image
+
+    with Image.open(normalized_path) as im:
+        if im.mode in ("RGBA", "LA", "PA") or "A" in im.mode:
+            png_im = im.convert("RGBA")
+        else:
+            png_im = im.convert("RGB")
+        buf = io.BytesIO()
+        png_im.save(buf, format="PNG")
+        png_bytes = buf.getvalue()
+    return png_bytes, "image/png", True
+
+
+async def prepare_image(
+    image_source: str,
+    task_id: Optional[str] = None,
+) -> Tuple[str, Optional[int], Optional[int], Optional[str], Optional[str], Dict[str, Any]]:
+    """Reuse the existing image pipeline to produce a base64 data URL.
+
+    Returns
+    ``(data_url, width_px, height_px, mime, normalized_sha256, transport_meta)``
+    where:
+
+    - ``width/height`` are populated only when the resolver provides them
+      (may be ``None`` for opaque sources);
+    - ``normalized_sha256`` is the SHA-256 of the EXACT canonical normalized
+      asset bytes — this is the calibration identity and always matches the
+      committed manifest;
+    - ``transport_meta`` is ``{"transport_image_sha256": str,
+      "transport_mime_type": str, "transport_transcoded": bool}`` describing
+      the exact bytes encoded in the model-request data URL.
+
+    Two-layer hash contract: canonical bytes define calibration identity;
+    transport bytes are what the endpoint actually receives. WebP is
+    converted to PNG only for transport (Ollama rejects WebP data URLs).
+    No new source-resolution or canonical-normalization pipeline is
+    introduced.
+    """
+    from tools.vision_tools import (
+        _image_to_base64_data_url,
+        _normalize_to_supported_image,
+    )
+
+    data = await _resolve_image_bytes_async(image_source, task_id=task_id)
+
+    mime: Optional[str] = None
+    try:
+        from tools.vision_tools import _detect_image_mime_type_from_bytes
+
+        mime = _detect_image_mime_type_from_bytes(data)
+    except Exception:  # noqa: BLE001 — mime detection is best-effort
+        mime = None
+
+    temp_dir = Path("/tmp") / "vision_orchestrator"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    tmp = temp_dir / f"img_{hashlib.sha256(data).hexdigest()[:16]}.img"
+    if not tmp.exists():
+        tmp.write_bytes(data)
+
+    normalized_path, mime, _err = await asyncio.to_thread(
+        _normalize_to_supported_image, tmp, mime or ""
+    )
+    if _err or normalized_path is None:
+        raise ValueError(_err or "Image normalization failed.")
+    if normalized_path != tmp and tmp.exists():
+        try:
+            tmp.unlink()
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Canonical identity: SHA-256 over the exact canonical normalized bytes.
+    normalized_bytes = normalized_path.read_bytes()
+    normalized_sha256 = hashlib.sha256(normalized_bytes).hexdigest()
+
+    # Endpoint transport compatibility (WebP → PNG only for the request).
+    transport_bytes, transport_mime, transcoded = await asyncio.to_thread(
+        _ensure_ollama_transport_compatible_image, normalized_path, mime
+    )
+    transport_sha256 = hashlib.sha256(transport_bytes).hexdigest()
+    transport_meta = {
+        "transport_image_sha256": transport_sha256,
+        "transport_mime_type": transport_mime,
+        "transport_transcoded": transcoded,
+    }
+
+    data_url = await asyncio.to_thread(
+        _image_to_base64_data_url, normalized_path, mime_type=transport_mime
+    )
+    # If transport bytes differ from canonical bytes, the data URL must be
+    # built from the transport bytes, not the canonical file.
+    if transcoded:
+        transport_path = temp_dir / f"transport_{transport_sha256[:16]}.png"
+        if not transport_path.exists():
+            transport_path.write_bytes(transport_bytes)
+        data_url = await asyncio.to_thread(
+            _image_to_base64_data_url, transport_path, mime_type="image/png"
+        )
+
+    width = height = None
+    try:
+        from PIL import Image
+
+        with Image.open(io.BytesIO(transport_bytes)) as im:
+            width, height = im.size
+    except Exception:  # noqa: BLE001 — dimensions are best-effort
+        pass
+    return data_url, width, height, mime, normalized_sha256, transport_meta
+
+
+async def invoke_vision_model(
+    *,
+    model: str,
+    prompt: str,
+    image_data_url: str,
+    timeout_seconds: float = 120.0,
+    temperature: float = 0.1,
+    max_tokens: int = 2000,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Invoke exactly one vision-model call through the unified path.
+
+    Uses the existing ``async_call_llm(task="vision", model=...)`` chain —
+    the per-call model override already exists and does not alter any other
+    caller. Structured (JSON) responses are requested via the prompt; the
+    raw text is returned for the quality evaluator to parse.
+
+    Returns ``{"execution_status": ..., "raw_text": ..., "error": ...}``.
+    """
+    _load_auxiliary_client()
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                {"type": "image_url", "image_url": {"url": image_data_url}},
+            ],
+        }
+    ]
+    call_kwargs: Dict[str, Any] = {
+        "task": "vision",
+        "messages": messages,
+        "model": model,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+        "timeout": timeout_seconds,
+    }
+    if base_url:
+        call_kwargs["base_url"] = base_url
+    if api_key:
+        call_kwargs["api_key"] = api_key
+
+    try:
+        response = await _async_call_llm(**call_kwargs)
+    except TimeoutError:
+        return {
+            "execution_status": ExecutionStatus.TIMEOUT.value,
+            "raw_text": "",
+            "error": "vision_model_timeout",
+        }
+    except Exception as exc:  # noqa: BLE001 — classified below
+        status = _classify_error(exc)
+        return {
+            "execution_status": status,
+            "raw_text": "",
+            "error": f"{type(exc).__name__}: {str(exc)[:200]}",
+        }
+
+    text = _extract_text(response)
+    if text is None:
+        return {
+            "execution_status": ExecutionStatus.INVALID_RESPONSE.value,
+            "raw_text": "",
+            "error": "unparseable_model_response",
+        }
+    return {
+        "execution_status": ExecutionStatus.SUCCESS.value,
+        "raw_text": text,
+        "error": None,
+    }
+
+
+def _extract_text(response: Any) -> Optional[str]:
+    """Extract assistant text from the auxiliary-client response object.
+
+    Resolution order (no second parser is introduced):
+
+    1. Canonical Hermes extractor — ``agent.auxiliary_client.
+       extract_content_or_reasoning`` — handles the real ``async_call_llm``
+       contract: ``response.choices[0].message.content`` with reasoning-field
+       fallback. This is the same helper the existing ``vision_analyze_tool``
+       path uses, so the two paths cannot diverge.
+    2. Legacy string/dict forms (``content``/``text``/list-of-text) are kept
+       for the verified mock-test contract and older provider adapters that
+       return plain dicts.
+
+    Returns ``None`` when no usable text exists (empty content, malformed
+    choices/message, or unsupported shape) so the caller can classify the
+    invocation as INVALID_RESPONSE. Never calls the model again.
+    """
+    if response is None:
+        return None
+    if isinstance(response, str):
+        return response or None
+    if isinstance(response, dict):
+        content = response.get("content") or response.get("text")
+        if isinstance(content, str):
+            return content or None
+        if isinstance(content, list):
+            parts = []
+            for item in content:
+                if isinstance(item, str):
+                    parts.append(item)
+                elif isinstance(item, dict):
+                    parts.append(str(item.get("text") or ""))
+            return "".join(parts) if parts else None
+        return None
+    # Object shape: prefer the canonical Hermes extractor, which understands
+    # response.choices[0].message.content (+ reasoning fallback).
+    if _extract_content_or_reasoning is None:
+        _load_auxiliary_client()
+    extractor = _extract_content_or_reasoning or _noop_extractor
+    try:
+        canonical = extractor(response)
+    except Exception:
+        canonical = ""
+    if canonical and canonical.strip():
+        return canonical
+    # Fallback for object shapes the canonical helper cannot parse but that
+    # still expose a top-level content/text attribute (e.g. some test fakes).
+    content = getattr(response, "content", None)
+    if content is not None:
+        return str(content) or None
+    text = getattr(response, "text", None)
+    if text is not None:
+        return str(text) or None
+    return None
+
+
+def _classify_error(exc: Exception) -> str:
+    """Classify an invocation exception into an ExecutionStatus value."""
+    name = type(exc).__name__.lower()
+    msg = str(exc).lower()
+    if "timeout" in name or "timeout" in msg:
+        return ExecutionStatus.TIMEOUT.value
+    if "model" in msg and ("not found" in msg or "does not exist" in msg):
+        return ExecutionStatus.MODEL_NOT_FOUND.value
+    if "connect" in msg or "connection" in msg or "refused" in msg:
+        return ExecutionStatus.ENDPOINT_UNAVAILABLE.value
+    if "schema" in msg or "json" in msg:
+        return ExecutionStatus.SCHEMA_INVALID.value
+    return ExecutionStatus.INVALID_RESPONSE.value

--- a/tools/vision_ocr_page.py
+++ b/tools/vision_ocr_page.py
@@ -1,0 +1,149 @@
+"""vision_ocr_page — bounded OCR full-text retrieval (Stage-3 limited use).
+
+HERMES_VISION_ROUTER_STAGE3_LIMITED_USE_OPERATING_MODE_DESIGN_V0_1:
+
+- reads one deterministic page (<=``ocr_page_chars``, default 65536) of a
+  session-registered OCR result by private handle;
+- never auto-injects full text; never puts full text in repository-safe
+  trace;
+- handle is session-bound and revoked when the Router session ends;
+- zero model calls: pure file read from the private cache.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+DEFAULT_OCR_PAGE_CHARS = 65536
+
+VISION_OCR_PAGE_SCHEMA: Dict[str, Any] = {
+    "name": "vision_ocr_page",
+    "description": (
+        "Retrieve one bounded page of a previously truncated OCR result. "
+        "Requires the private_handle from the OCR envelope and an explicit "
+        "page number. Returns page text, page bounds, remaining characters "
+        "and a sha256. Never returns more than the configured page limit; "
+        "full text is never auto-injected."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "handle": {
+                "type": "string",
+                "description": "Opaque OCR result handle (private_handle from "
+                               "the initial OCR envelope).",
+            },
+            "page": {
+                "type": "integer",
+                "description": "1-based page number (each page <= configured "
+                               "limit).",
+                "minimum": 1,
+            },
+        },
+        "required": ["handle", "page"],
+    },
+}
+
+
+def _resolve_ocr_path(handle: str) -> Optional[str]:
+    """Session-bound private OCR result lookup. Unknown/expired -> None."""
+    from tools.vision_session_state import vision_session_state
+
+    h = handle.strip()
+    if h.startswith("ocr://"):
+        h = h[len("ocr://"):]
+    return vision_session_state.resolve_ocr_result(f"ocr://{h}")
+
+
+def _page_chars() -> int:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        from tools.vision_policy import resolve_vision_router_value
+        return int(resolve_vision_router_value(cfg, "ocr_page_chars",
+                                               DEFAULT_OCR_PAGE_CHARS))
+    except Exception:  # noqa: BLE001
+        return DEFAULT_OCR_PAGE_CHARS
+
+
+def _handle_vision_ocr_page(args: Dict[str, Any], **kw: Any) -> str:
+    """Registry handler (synchronous; zero model calls)."""
+    from tools.vision_session_state import vision_session_state
+
+    if not vision_session_state.enabled:
+        return json.dumps({
+            "execution_status": "POLICY_BLOCKED",
+            "quality_decision": "NOT_EVALUATED",
+            "logical_model_calls": 0,
+            "error": "SESSION_DISABLED",
+        }, ensure_ascii=False)
+
+    handle = str(args.get("handle") or "").strip()
+    try:
+        page = int(args.get("page") or 1)
+    except (TypeError, ValueError):
+        page = 1
+    if page < 1:
+        page = 1
+    if not handle:
+        return json.dumps({
+            "execution_status": "POLICY_BLOCKED",
+            "quality_decision": "NOT_EVALUATED",
+            "logical_model_calls": 0,
+            "error": "SOURCE_DENIED: missing OCR handle",
+        }, ensure_ascii=False)
+
+    path = _resolve_ocr_path(handle)
+    if not path:
+        return json.dumps({
+            "execution_status": "POLICY_BLOCKED",
+            "quality_decision": "NOT_EVALUATED",
+            "logical_model_calls": 0,
+            "error": "SOURCE_DENIED: OCR handle not authorized or expired",
+        }, ensure_ascii=False)
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            full = f.read()
+    except OSError:
+        return json.dumps({
+            "execution_status": "INVALID_RESPONSE",
+            "quality_decision": "NOT_EVALUATED",
+            "logical_model_calls": 0,
+            "error": "OCR_RESULT_UNREADABLE",
+        }, ensure_ascii=False)
+
+    import hashlib
+
+    limit = _page_chars()
+    start = (page - 1) * limit
+    end = start + limit
+    page_text = full[start:end]
+    total = len(full)
+    return json.dumps({
+        "execution_status": "SUCCESS",
+        "quality_decision": "PASS",
+        "logical_model_calls": 0,
+        "handle": handle,
+        "page": page,
+        "page_start": start,
+        "page_end": min(end, total),
+        "page_chars": len(page_text),
+        "total_chars": total,
+        "remaining_chars": max(0, total - end),
+        "sha256": hashlib.sha256(full.encode("utf-8")).hexdigest()[:16],
+        "truncated": total > end,
+        "page_text": page_text,
+    }, ensure_ascii=False)
+
+
+from tools.registry import registry  # noqa: E402
+
+registry.register(
+    name=VISION_OCR_PAGE_SCHEMA["name"],
+    toolset="vision",
+    schema=VISION_OCR_PAGE_SCHEMA,
+    handler=_handle_vision_ocr_page,
+    is_async=False,
+    emoji="📄",
+)

--- a/tools/vision_orchestrator.py
+++ b/tools/vision_orchestrator.py
@@ -1,0 +1,696 @@
+#!/usr/bin/env python3
+"""Vision Orchestrator — unified entry point for the local vision policy
+layer (V0.1 inactive foundation).
+
+Pipeline (frozen V0.1):
+
+    VisionRequest
+        → planner (deterministic model-slot selection)
+        → unified invocation (exactly ONE model call)
+        → deterministic quality evaluation
+        → VisionResult with escalation *recommendation* only
+
+Stage B1 guarantees:
+
+- at most one model invocation per ``analyze_image`` request;
+- escalation is RECOMMENDED, never executed;
+- ``click_authorized`` is always false — no clicking, no navigation;
+- the feature is disabled by default (``vision_router.enabled: false``);
+- ``auxiliary.vision`` behavior and the active Taobao Skill are untouched.
+
+``analyze_image`` is an internal callable for tests and later integration —
+it is NOT registered as a model-visible tool in this stage.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Dict, List, Optional
+
+from tools.ollama_generate_vision_client import (
+    NATIVE_GENERATE_DEFAULT_PROFILE,
+    NATIVE_GENERATE_STRICT_SCHEMA,
+    TASK_STRICT_SCHEMAS,
+    TRANSPORT_OLLAMA_NATIVE_GENERATE,
+    TRANSPORT_OPENAI_COMPATIBLE,
+    invoke_native_generate,
+)
+from tools.ollama_vision_client import invoke_vision_model, prepare_image
+from tools.vision_policy import (
+    DEFAULT_MODEL_SLOTS,
+    DEFAULT_TIMEOUTS,
+    PRECISION_EXECUTION_PROFILE,
+    PROMPT_TEMPLATE_IDS,
+    CoordinateContext,
+    ExecutionStatus,
+    ModelSlot,
+    PolicyBlockedError,
+    QualityDecision,
+    VisionMode,
+    VisionRequest,
+    VisionTask,
+    build_result,
+    evaluate_quality,
+    plan_vision,
+    resolve_default_transport,
+    serialize,
+)
+
+# ---------------------------------------------------------------------------
+# Prompt templates (versioned IDs — see PROMPT_TEMPLATE_IDS in policy).
+# Prompt text lives here so it can evolve independently of the policy layer.
+# ---------------------------------------------------------------------------
+
+_BASE_INSTRUCTION = (
+    "You are analyzing a screenshot for a research workflow.\n"
+    "Separate DIRECTLY OBSERVED content from UNCERTAIN INTERPRETATION and "
+    "INFERRED meaning. If you are not sure, say so explicitly with an "
+    "uncertainty marker. Do not invent content you cannot see.\n"
+    "Respond in JSON only, using this schema where applicable:\n"
+    '{"observed_text": [...], "targets": [{"label": "...", "bbox_px": [x1,y1,x2,y2], '
+    '"point_px": [x,y]}], "evidence": "...", "uncertainty": "...", '
+    '"inference": "..."}\n'
+)
+
+_TASK_PROMPTS = {
+    "SCENE_DESCRIBE": (
+        _BASE_INSTRUCTION
+        + "TASK: describe the overall scene. Fields: observation (what is "
+        "directly visible), inference (your interpretation), uncertainty "
+        "(what is unclear)."
+    ),
+    "UI_READ": (
+        _BASE_INSTRUCTION
+        + "TASK: read the requested interface text exactly. Provide exact "
+        "quotations in observed_text. Do not paraphrase prices, buttons, "
+        "login prompts, or field values."
+    ),
+    "UI_LOCATE": (
+        _BASE_INSTRUCTION
+        + "TASK: locate the target element and return its pixel bbox and "
+        "center point in the source image coordinate space. Include "
+        "target-nearby text as evidence. bbox_px = [left, top, right, "
+        "bottom]."
+    ),
+    "EXACT_OCR": (
+        _BASE_INSTRUCTION
+        + "TASK: transcribe the exact text in the requested region "
+        "character-for-character. Preserve line order. Do not summarize."
+    ),
+    "EVIDENCE_VERIFY": (
+        _BASE_INSTRUCTION
+        + "TASK: verify the claim against what is directly visible. "
+        "Provide evidence (what you see), observation vs inference, and "
+        "flag any unresolved contradiction. Never claim an action was "
+        "performed."
+    ),
+}
+
+
+def _raw_base64_from_data_url(data_url: str) -> str:
+    """Strip the ``data:image/...;base64,`` prefix from a prepared data URL.
+
+    The native generate contract requires RAW base64 in the ``images`` array
+    (no data-URL prefix). The data URL produced by ``prepare_image`` encodes
+    exactly the transport-compatible bytes (WebP already converted to PNG),
+    so stripping the prefix reuses the validated two-layer image contract
+    without re-encoding.
+    """
+    if "," not in data_url:
+        raise ValueError("Malformed data URL from image preparation.")
+    return data_url.split(",", 1)[1]
+
+
+def _build_prompt(request: VisionRequest) -> str:
+    task_prompt = _TASK_PROMPTS.get(request.task.value, _BASE_INSTRUCTION)
+    parts = [
+        task_prompt,
+        f"QUESTION: {request.question}" if request.question else "",
+    ]
+    if request.required_outputs:
+        parts.append(f"REQUIRED OUTPUTS: {', '.join(request.required_outputs)}")
+    if request.region:
+        parts.append(f"REGION: {request.region}")
+    return "\n".join(p for p in parts if p)
+
+
+def _parse_structured(raw_text: str, task: Any) -> Dict[str, Any]:
+    """Best-effort parse of the model's JSON response.
+
+    Returns an extracted dict with the fields the quality gates inspect.
+    When the response cannot be parsed as JSON at all, returns a minimal
+    dict carrying ``_parse_failed: True`` so the quality evaluator can
+    classify it as NOT_EVALUATED rather than an escalation candidate.
+    Never trusted as authoritative — quality gates decide.
+
+    Supports the bounded fenced-response contract: raw JSON object/array,
+    or ONE complete Markdown-fenced block containing valid JSON
+    (`` ```json`` / `` ``` `` with any case for the language tag).
+    Whitespace outside the single fence is allowed; arbitrary prose before
+    or after the fence, multiple fenced blocks, and unclosed fences are
+    rejected (``_parse_failed``). No regex-only extraction of the first
+    ``{...}`` from arbitrary prose is performed.
+    """
+    text = (raw_text or "").strip()
+    fenced = _strip_single_fenced_block(text)
+    if fenced is None:
+        # Not a fenced response (or an invalid fence) — try raw JSON only.
+        fenced = text
+    extracted: Dict[str, Any] = {}
+    try:
+        parsed = json.loads(fenced)
+        if isinstance(parsed, dict):
+            extracted = parsed
+        else:
+            extracted = {"_parse_failed": True, "raw_text": raw_text}
+    except Exception:  # noqa: BLE001 — non-JSON responses handled by gates
+        extracted = {"_parse_failed": True, "raw_text": raw_text}
+    return extracted
+
+
+def _strip_single_fenced_block(text: str):
+    """Return the inner text of exactly one complete Markdown code fence
+    containing valid JSON, or ``None`` when the input is not a single
+    well-formed fenced block.
+
+    Contract:
+
+    - optional whitespace outside the single fence is allowed;
+    - language tag matching is case-insensitive (``json``, ``JSON``, ...);
+    - a generic fence (`` ``` `` with no tag) containing valid JSON is
+      accepted;
+    - arbitrary prose before or after the fence is rejected;
+    - multiple fenced blocks are rejected;
+    - an unclosed fence is rejected;
+    - malformed fenced content is rejected (caller then fails JSON parse).
+
+    Returns the fenced inner text (already JSON-parseable) or ``None``.
+    """
+    lines = text.splitlines()
+    if not lines:
+        return None
+    first = lines[0].strip()
+    if not first.startswith("```"):
+        return None  # not fenced — caller falls back to raw JSON
+    # Parse the opening fence tag (allow ```json, ```JSON, ``` plain).
+    opener = first[3:].strip().lower()
+    if opener and opener != "json":
+        return None  # fenced with a non-JSON language tag → not our contract
+    # The final line must close the fence.
+    if len(lines) < 2 or lines[-1].strip() != "```":
+        return None  # unclosed fence → rejected
+    # Any ``` line inside the body means multiple fences → rejected.
+    body = lines[1:-1]
+    for ln in body:
+        if ln.strip().startswith("```"):
+            return None  # second fence → rejected
+    inner = "\n".join(body).strip()
+    if not inner:
+        return None  # empty fenced content → rejected
+    # The body must itself be valid JSON — if not, reject the fence so the
+    # caller reports a parse failure (no partial extraction).
+    try:
+        json.loads(inner)
+    except Exception:  # noqa: BLE001
+        return None
+    return inner
+
+
+def _recommended_next_slot(
+    task: Any,
+    initial_slot: ModelSlot,
+    quality: Dict[str, Any],
+) -> Optional[ModelSlot]:
+    """Deterministic escalation *recommendation* (never executed).
+
+    The recommendation is driven by the actual failed gates, not merely by
+    the current model slot:
+    - FAST_VLM UI_READ/UI_LOCATE missing or uncertain evidence → PRECISION_VLM;
+    - PRECISION_VLM with a text-specific failure (exact text missing) → OCR;
+    - PRECISION_VLM coordinate failure (out of bounds / ordering / crop) →
+      NOT OCR — a text specialist cannot fix coordinates;
+    - semantic contradiction or refusal → HUMAN_REVIEW (None).
+    """
+    decision = quality.get("quality_decision")
+    if decision != QualityDecision.ESCALATE_RECOMMENDED.value:
+        return None
+
+    failed = set(quality.get("failed_gates") or [])
+
+    # Coordinate failures are never OCR's job.
+    coordinate_gates = {
+        "coordinates_in_bounds",
+        "bbox_or_point_present",
+        "coordinate_space_declared",
+        "x_out_of_bounds",
+        "y_out_of_bounds",
+        "bbox_left_ge_right",
+        "bbox_top_ge_bottom",
+        "point_outside_bbox",
+        "crop_origin_negative",
+        "crop_width_nonpositive",
+        "crop_height_nonpositive",
+        "crop_exceeds_source_width",
+        "crop_exceeds_source_height",
+        "coordinate_space_missing_dimensions",
+    }
+    if failed & coordinate_gates:
+        return ModelSlot.PRECISION_VLM
+
+    # Text-specific failure: OCR is the right follow-up.
+    text_gates = {"required_text_present", "text_non_empty"}
+    if initial_slot == ModelSlot.PRECISION_VLM and (failed & text_gates):
+        return ModelSlot.OCR
+
+    # Default: a higher-precision VLM can resolve missing/uncertain evidence.
+    if initial_slot == ModelSlot.FAST_VLM:
+        return ModelSlot.PRECISION_VLM
+    if task.value == "EXACT_OCR":
+        return ModelSlot.PRECISION_VLM
+    return ModelSlot.PRECISION_VLM
+
+
+async def analyze_image(
+    request: VisionRequest,
+    *,
+    model_slots: Optional[Dict[ModelSlot, str]] = None,
+    timeouts: Optional[Dict[ModelSlot, float]] = None,
+    enabled: Optional[bool] = None,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    task_id: Optional[str] = None,
+    transport: Optional[str] = None,
+    native_generate_options: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Canonical entry point: one request → one (or zero) model call → result.
+
+    ``transport`` selects the invocation path. ``None`` (default) = AUTO:
+    resolved per selected slot — PRECISION_VLM binds to
+    ``TRANSPORT_OLLAMA_NATIVE_GENERATE`` (``PRECISION_EXECUTION_PROFILE``,
+    );
+    FAST_VLM / OCR keep the OpenAI-compatible path. An explicit
+    ``TRANSPORT_OPENAI_COMPATIBLE`` override is honored for PRECISION_VLM
+    diagnostics; an explicit ``TRANSPORT_OLLAMA_NATIVE_GENERATE`` override is
+    honored anywhere. Unknown identities raise ``ValueError`` (safe failure).
+    No automatic fallback between transports ever occurs.
+
+    ``native_generate_options`` (optional) overrides the bound Precision
+    profile (``PRECISION_EXECUTION_PROFILE``: num_ctx 32768, num_predict
+    4000, temperature 0.1, task-specific strict JSON Schema, timeout 120s).
+
+    Feature-flag semantics:
+    - ``enabled=None`` (default): resolve the effective ``vision_router``
+      feature flag from the standard configuration path. The runtime default
+      is DISABLED — this faithfully follows the feature flag.
+    - ``enabled=False``: returns POLICY_BLOCKED without resolving,
+      downloading, normalizing, or encoding the image and without calling
+      the model.
+    - ``enabled=True``: explicit internal override for mocked tests and
+      future controlled validation. Never model-visible; never changes
+      ``auxiliary.vision``.
+    """
+    if enabled is None:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        enabled = vision_router_enabled(cfg)
+
+    if transport is not None and transport not in (
+        TRANSPORT_OPENAI_COMPATIBLE,
+        TRANSPORT_OLLAMA_NATIVE_GENERATE,
+    ):
+        raise ValueError(f"Unknown transport identity: {transport!r}")
+    transport_arg = transport
+
+    # Early-return paths (router disabled / policy blocked) carry a
+    # conservative transport placeholder — no slot resolution occurred.
+    placeholder_transport = transport_arg or TRANSPORT_OPENAI_COMPATIBLE
+    transport_info = {
+        "requested_transport": placeholder_transport,
+        "selected_transport": placeholder_transport,
+        "endpoint_family": (
+            "ollama_native_generate"
+            if transport_arg == TRANSPORT_OLLAMA_NATIVE_GENERATE
+            else "openai_compatible"
+        ),
+        "native_generate_used": (
+            transport_arg == TRANSPORT_OLLAMA_NATIVE_GENERATE
+        ),
+    }
+
+    if not enabled:
+        return {
+            "execution_status": ExecutionStatus.POLICY_BLOCKED.value,
+            "quality_decision": QualityDecision.NOT_EVALUATED.value,
+            "answer": "",
+            "structured": {},
+            "initial_model_slot": None,
+            "final_model_slot": None,
+            "actual_model": "",
+            "recommended_next_slot": None,
+            "human_review_required": False,
+            "click_authorized": False,
+            "quality": {"passed_gates": [], "failed_gates": ["vision_router_disabled"]},
+            "coordinate_context": {},
+            "trace": [],
+            "logical_model_calls": 0,
+            "transport": transport_info,
+        }
+
+    slots = model_slots or dict(DEFAULT_MODEL_SLOTS)
+    timeouts = timeouts or dict(DEFAULT_TIMEOUTS)
+
+    # Planner (deterministic; may raise PolicyBlockedError).
+    try:
+        plan = plan_vision(request, model_slots=slots, timeouts=timeouts)
+    except PolicyBlockedError as pbe:
+        return {
+            "execution_status": ExecutionStatus.POLICY_BLOCKED.value,
+            "quality_decision": QualityDecision.NOT_EVALUATED.value,
+            "answer": "",
+            "structured": {},
+            "initial_model_slot": None,
+            "final_model_slot": None,
+            "actual_model": "",
+            "recommended_next_slot": (
+                pbe.recommended_slot.value if pbe.recommended_slot else None
+            ),
+            "human_review_required": False,
+            "click_authorized": False,
+            "quality": {"passed_gates": [], "failed_gates": [pbe.reason]},
+            "coordinate_context": {},
+            "trace": [],
+            "transport": transport_info,
+        }
+
+    trace: List[Dict[str, Any]] = []
+    initial_slot = plan.selected_slot
+    actual_model = plan.selected_model_identity
+
+    # Transport resolution: explicit override wins; otherwise AUTO per slot
+    # (PRECISION_VLM → bound native-generate profile; FAST/OCR → OpenAI).
+    effective_transport = (
+        transport_arg
+        if transport_arg is not None
+        else resolve_default_transport(initial_slot)
+    )
+    native = effective_transport == TRANSPORT_OLLAMA_NATIVE_GENERATE
+    transport_info = {
+        "requested_transport": (
+            transport_arg or "AUTO"
+        ),
+        "selected_transport": effective_transport,
+        "endpoint_family": (
+            "ollama_native_generate" if native else "openai_compatible"
+        ),
+        "native_generate_used": native,
+    }
+
+    # Image preparation (reuses existing helpers).
+    try:
+        (
+            data_url,
+            width_px,
+            height_px,
+            mime,
+            normalized_sha256,
+            transport_meta,
+        ) = await prepare_image(
+            request.image_source, task_id=task_id
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "execution_status": ExecutionStatus.INVALID_RESPONSE.value,
+            "quality_decision": QualityDecision.NOT_EVALUATED.value,
+            "answer": "",
+            "structured": {},
+            "initial_model_slot": initial_slot.value,
+            "final_model_slot": initial_slot.value,
+            "actual_model": actual_model,
+            "recommended_next_slot": None,
+            "human_review_required": False,
+            "click_authorized": False,
+            "quality": {"passed_gates": [], "failed_gates": ["image_preparation_failed"]},
+            "coordinate_context": (
+                request.coordinate_context.to_dict() if request.coordinate_context else {}
+            ),
+            "trace": [],
+            "logical_model_calls": 0,
+            "transport": transport_info,
+        }
+
+    cc = request.coordinate_context or CoordinateContext()
+    if width_px is not None and cc.source_width_px is None:
+        cc.source_width_px = width_px
+    if height_px is not None and cc.source_height_px is None:
+        cc.source_height_px = height_px
+
+    prompt = _build_prompt(request)
+    t0 = time.monotonic()
+    if native:
+        if not base_url:
+            raise ValueError("OLLAMA_NATIVE_GENERATE transport requires base_url")
+        native_opts = dict(NATIVE_GENERATE_DEFAULT_PROFILE)
+        # Bound Precision profile values are the defaults; per-call options
+        # override them. Task-specific strict schema resolves by task.
+        native_opts.update(
+            {
+                "num_ctx": PRECISION_EXECUTION_PROFILE["num_ctx"],
+                "num_predict": PRECISION_EXECUTION_PROFILE["num_predict"],
+                "temperature": PRECISION_EXECUTION_PROFILE["temperature"],
+                "format": TASK_STRICT_SCHEMAS.get(
+                    request.task.value, NATIVE_GENERATE_STRICT_SCHEMA
+                ),
+            }
+        )
+        native_opts.update(native_generate_options or {})
+        invocation = await invoke_native_generate(
+            model=actual_model,
+            prompt=prompt,
+            image_raw_base64=_raw_base64_from_data_url(data_url),
+            num_ctx=int(native_opts.get("num_ctx") or 32768),
+            num_predict=int(native_opts.get("num_predict") or 4000),
+            temperature=float(native_opts.get("temperature") or 0.1),
+            seed=int(native_opts["seed"]) if native_opts.get("seed") is not None else None,
+            format_spec=native_opts.get("format"),
+            base_url=base_url,
+            timeout_seconds=float(native_opts.get("timeout_seconds") or plan.timeout_seconds),
+            transport_retries=int(native_opts.get("transport_retries") or 0),
+        )
+    else:
+        invocation = await invoke_vision_model(
+            model=actual_model,
+            prompt=prompt,
+            image_data_url=data_url,
+            timeout_seconds=plan.timeout_seconds,
+            base_url=base_url,
+            api_key=api_key,
+        )
+    latency_ms = int((time.monotonic() - t0) * 1000)
+
+    execution_status = ExecutionStatus(invocation["execution_status"])
+    trace_entry = {
+        "attempt": 1,
+        "model_slot": initial_slot.value,
+        "actual_model": actual_model,
+        "latency_ms": latency_ms,
+        "selection_reason": plan.selection_reason,
+        "execution_status": execution_status.value,
+        "normalized_image_sha256": normalized_sha256,
+        "transport_image_sha256": transport_meta.get("transport_image_sha256"),
+        "transport_mime_type": transport_meta.get("transport_mime_type"),
+        "transport_transcoded": transport_meta.get("transport_transcoded"),
+        "requested_transport": transport_info["requested_transport"],
+        "selected_transport": transport_info["selected_transport"],
+        "endpoint_family": transport_info["endpoint_family"],
+        "native_generate_used": native,
+    }
+    if native:
+        trace_entry.update(
+            {
+                "content_source": invocation.get("content_source"),
+                "thinking_fallback_used": invocation.get("thinking_fallback_used"),
+                "response_character_count": invocation.get("response_character_count"),
+                "thinking_character_count": invocation.get("thinking_character_count"),
+                "total_ms": invocation.get("total_ms"),
+                "prompt_eval_ms": invocation.get("prompt_eval_ms"),
+                "eval_ms": invocation.get("eval_ms"),
+                "prompt_eval_count": invocation.get("prompt_eval_count"),
+                "eval_count": invocation.get("eval_count"),
+                "done_reason": invocation.get("done_reason"),
+                "transport_attempts": invocation.get("transport_attempts"),
+            }
+        )
+    trace.append(trace_entry)
+
+    # Exactly one logical model call: if the single invocation failed,
+    # evaluate as NOT_EVALUATED (no retry). Note: ``max_model_calls=1``
+    # means ONE logical model-selection/inference operation by the
+    # Orchestrator; the existing auxiliary client may still perform bounded
+    # lower-level transport retries (auxiliary.transient_retries) for
+    # transient timeout/connection/server failures — those are transport
+    # retries, not additional logical model escalations.
+    if execution_status != ExecutionStatus.SUCCESS:
+        quality = {
+            "quality_decision": QualityDecision.NOT_EVALUATED.value,
+            "passed_gates": [],
+            "failed_gates": [f"execution_{execution_status.value.lower()}"],
+        }
+        return build_result(
+            execution_status=execution_status,
+            quality=quality,
+            answer="",
+            structured={},
+            initial_slot=initial_slot,
+            final_slot=initial_slot,
+            actual_model=actual_model,
+            recommended_next_slot=None,
+            coordinate_context=cc,
+            trace=trace,
+            image_sha256=normalized_sha256,
+            logical_model_calls=1,
+            transport_meta=transport_meta,
+            transport=transport_info,
+        )
+
+    if native:
+        raw_text = invocation.get("extracted_content") or ""
+    else:
+        raw_text = invocation.get("raw_text") or ""
+    extracted = _parse_structured(raw_text, request.task)
+    if (
+        request.task == VisionTask.EXACT_OCR
+        and extracted.get("_parse_failed")
+        and raw_text.strip()
+    ):
+        # OCR models (glm-ocr) naturally return plain transcription, not
+        # JSON. The exact text IS the OCR result — accept it canonically
+        # (diagnostic finding D, HERMES_VISION_FULL_CORPUS_QUALITY_FINDINGS_
+        # DIAGNOSTIC_V0_1) instead of classifying NOT_EVALUATED.
+        extracted = {
+            "observed_text": [raw_text.strip()],
+            "_ocr_plain_text": True,
+        }
+    quality = evaluate_quality(
+        request.task,
+        response_text=raw_text,
+        required_outputs=request.required_outputs,
+        extracted=extracted,
+        coordinates={
+            "x": _first_point_x(extracted),
+            "y": _first_point_y(extracted),
+            "bbox": _first_bbox(extracted),
+            "coordinate_space": cc.coordinate_space,
+        },
+        coordinate_context=cc,
+    )
+    recommended = _recommended_next_slot(request.task, initial_slot, quality)
+
+    return build_result(
+        execution_status=ExecutionStatus.SUCCESS,
+        quality=quality,
+        answer=raw_text,
+        structured=extracted,
+        initial_slot=initial_slot,
+        final_slot=initial_slot,
+        actual_model=actual_model,
+        recommended_next_slot=recommended,
+        coordinate_context=cc,
+        trace=trace,
+        image_sha256=normalized_sha256,
+        logical_model_calls=1,
+        transport_meta=transport_meta,
+        transport=transport_info,
+    )
+
+
+# -- coordinate extraction helpers ------------------------------------------
+
+
+def _first_target(extracted: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    targets = extracted.get("targets") or []
+    if isinstance(targets, list) and targets and isinstance(targets[0], dict):
+        return targets[0]
+    return None
+
+
+def _first_bbox(extracted: Dict[str, Any]) -> Optional[List[float]]:
+    t = _first_target(extracted)
+    if t is None:
+        return None
+    bbox = t.get("bbox_px") or t.get("bbox")
+    if isinstance(bbox, list) and len(bbox) == 4:
+        return [float(v) for v in bbox]
+    return None
+
+
+def _first_point_x(extracted: Dict[str, Any]) -> Optional[float]:
+    t = _first_target(extracted)
+    if t is None:
+        return None
+    pt = t.get("point_px") or t.get("point")
+    if isinstance(pt, list) and len(pt) >= 1:
+        try:
+            return float(pt[0])
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _first_point_y(extracted: Dict[str, Any]) -> Optional[float]:
+    t = _first_target(extracted)
+    if t is None:
+        return None
+    pt = t.get("point_px") or t.get("point")
+    if isinstance(pt, list) and len(pt) >= 2:
+        try:
+            return float(pt[1])
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+# -- runtime feature-flag gate ----------------------------------------------
+
+_DEFAULT_ENABLED = False
+
+
+def vision_router_enabled(config: Optional[Dict[str, Any]] = None) -> bool:
+    """Read the feature flag from a config dict (or default False).
+
+    The default is always False; the live runtime configuration is not
+    modified by this module. ``auxiliary.vision`` behavior is never touched.
+    """
+    if not config:
+        return _DEFAULT_ENABLED
+    router = (config.get("vision_router") or {}) if isinstance(config, dict) else {}
+    return bool(router.get("enabled", _DEFAULT_ENABLED))
+
+
+# -- serialization convenience ----------------------------------------------
+
+
+def analyze_image_from_dict(
+    data: Dict[str, Any],
+    **kwargs: Any,
+) -> str:
+    """JSON convenience wrapper around :func:`analyze_image`."""
+    request = VisionRequest.from_dict(data)
+    result = asyncio_run(analyze_image(request, **kwargs))
+    return serialize(result)
+
+
+def asyncio_run(coro: Any) -> Any:
+    """Run a coroutine, reusing an existing loop when present (tests)."""
+    import asyncio
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    if loop is not None and loop.is_running():
+        # Already inside an event loop (e.g. tests with pytest-asyncio or
+        # an agent context): return the coroutine for the caller to await.
+        return coro
+    return asyncio.run(coro)

--- a/tools/vision_orchestrator.py
+++ b/tools/vision_orchestrator.py
@@ -661,11 +661,12 @@ def vision_router_enabled(config: Optional[Dict[str, Any]] = None) -> bool:
 
     The default is always False; the live runtime configuration is not
     modified by this module. ``auxiliary.vision`` behavior is never touched.
+    The canonical section is ``auxiliary.vision_router`` (legacy top-level
+    ``vision_router`` accepted only when the nested mapping is absent).
     """
-    if not config:
-        return _DEFAULT_ENABLED
-    router = (config.get("vision_router") or {}) if isinstance(config, dict) else {}
-    return bool(router.get("enabled", _DEFAULT_ENABLED))
+    from tools.vision_policy import resolve_vision_router_enabled
+
+    return resolve_vision_router_enabled(config)
 
 
 # -- serialization convenience ----------------------------------------------

--- a/tools/vision_policy.py
+++ b/tools/vision_policy.py
@@ -20,9 +20,128 @@ from __future__ import annotations
 import enum
 import json
 from dataclasses import dataclass, field
+import os as _os
+from urllib.parse import urlparse as _urlparse
 from typing import Any, Dict, List, Optional, Tuple
 
 # ---------------------------------------------------------------------------
+# Vision Router configuration resolver (config-path alignment repair)
+#
+# Canonical path: config["auxiliary"]["vision_router"].
+# Legacy fallback: top-level config["vision_router"] ONLY when the nested
+# mapping is absent. Both paths present -> nested wins. No merging of
+# conflicting values. Malformed values fail closed.
+# ---------------------------------------------------------------------------
+
+_VR_ROUTER_KEYS = ("enabled", "ocr_excerpt_chars", "ocr_page_chars",
+                   "per_workflow_max_calls")
+
+
+def resolve_vision_router_config(config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Resolve the Vision Router configuration section.
+
+    Precedence (deterministic):
+    1. ``config["auxiliary"]["vision_router"]`` when present and a mapping
+       (canonical);
+    2. top-level ``config["vision_router"]`` mapping ONLY when the nested
+       mapping is absent (legacy compatibility);
+    3. anything else -> empty mapping (fail closed).
+    """
+    if not isinstance(config, dict):
+        return {}
+    aux = config.get("auxiliary")
+    if isinstance(aux, dict):
+        nested = aux.get("vision_router")
+        if isinstance(nested, dict):
+            return nested
+    legacy = config.get("vision_router")
+    if isinstance(legacy, dict):
+        return legacy
+    return {}
+
+
+def resolve_vision_router_enabled(config: Optional[Dict[str, Any]]) -> bool:
+    """Effective Router flag from the canonical section.
+
+    Malformed or non-boolean values fail closed to False.
+    """
+    router = resolve_vision_router_config(config)
+    val = router.get("enabled", False)
+    return val if isinstance(val, bool) else False
+
+
+def resolve_vision_router_value(
+    config: Optional[Dict[str, Any]], key: str, default: Any
+) -> Any:
+    """Read one Router-section value through the shared resolver."""
+    router = resolve_vision_router_config(config)
+    if key not in _VR_ROUTER_KEYS:
+        return default
+    return router.get(key, default)
+
+
+# ---------------------------------------------------------------------------
+# Trusted Ollama endpoint resolution (native base_url wiring repair)
+#
+# Source precedence (deterministic, no merging):
+# 1. explicit trusted config: auxiliary.vision.base_url (the accepted
+#    OpenAI-compatible Vision service endpoint — same Ollama service);
+# 2. OLLAMA_HOST environment convention (Ollama's standard host:port env);
+# 3. otherwise None -> fail closed.
+#
+# The returned value is the NATIVE root (scheme://host:port) — the /v1
+# OpenAI-compatible suffix is stripped because the native transport calls
+# {base_url}/api/generate at the root.
+# ---------------------------------------------------------------------------
+
+def resolve_ollama_base_url(config: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Trusted Ollama service root for the native /api/generate transport.
+
+    Server-controlled only: never derived from model-visible arguments.
+    Malformed values fail closed to None.
+    """
+    base: Optional[str] = None
+    if isinstance(config, dict):
+        aux = config.get("auxiliary")
+        if isinstance(aux, dict):
+            vis = aux.get("vision")
+            if isinstance(vis, dict):
+                v = vis.get("base_url")
+                if isinstance(v, str) and v.strip():
+                    base = v.strip()
+    if not base:
+        env = _os.environ.get("OLLAMA_HOST", "")
+        if isinstance(env, str) and env.strip():
+            base = env.strip()
+    if not base:
+        return None
+    return _normalize_ollama_base(base)
+
+
+def _normalize_ollama_base(base: str) -> Optional[str]:
+    """Normalize to scheme://host:port. Rejects file://, paths, embedded
+    credentials, unsupported schemes, and empty hosts. Deterministic."""
+    if not base or not isinstance(base, str):
+        return None
+    candidate = base if "://" in base else f"http://{base}"
+    try:
+        parsed = _urlparse(candidate)
+    except ValueError:
+        return None
+    if parsed.scheme not in ("http", "https"):
+        return None
+    if not parsed.hostname:
+        return None
+    if parsed.username or parsed.password:
+        return None
+    try:
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    except ValueError:
+        return None
+    return f"{parsed.scheme}://{parsed.hostname}:{port}"
+
+# ---------------------------------------------------------------------------
+
 # Canonical enums (V0.1 frozen set)
 # ---------------------------------------------------------------------------
 
@@ -70,8 +189,7 @@ class ExecutionStatus(str, enum.Enum):
 
 # Transport identities (single source of truth for the Vision layer).
 # The native Ollama ``/api/generate`` transport is bound as the default
-# execution profile for the PRECISION_VLM slot (task
-# HERMES_VISION_PRECISION_NATIVE_GENERATE_PROFILE_BINDING_V0_1); the
+# execution profile for the PRECISION_VLM slot ; the
 # OpenAI-compatible transport remains the default for FAST_VLM / OCR and
 # remains selectable for PRECISION_VLM via an explicit override.
 TRANSPORT_OPENAI_COMPATIBLE = "OPENAI_COMPATIBLE"
@@ -1017,7 +1135,7 @@ def build_result(
     bytes were converted for endpoint compatibility, e.g. WebP → PNG).
 
     ``transport`` (optional) carries the transport-selection metadata for the
-    invocation path used (task HERMES_VISION_GENERATE_ROUTE_ADAPTER_V0_1):
+    invocation path used :
     ``requested_transport``, ``selected_transport``, ``endpoint_family`` and
     ``native_generate_used``. Non-sensitive; never contains endpoint
     credentials or raw output.

--- a/tools/vision_policy.py
+++ b/tools/vision_policy.py
@@ -1,0 +1,1059 @@
+#!/usr/bin/env python3
+"""Vision Policy — deterministic policy layer for the local vision
+Orchestrator (V0.1 inactive foundation).
+
+Stage B1 implements the *inactive* foundation only:
+
+- pure Vision-Need policy (no Browser / model / network);
+- canonical enums and request/plan/result schemas;
+- deterministic task + criticality + mode → model-slot selection;
+- backward-compatible legacy role aliases;
+- deterministic post-response quality gates;
+- escalation *recommendation* without escalation execution.
+
+The feature is disabled by default (``vision_router.enabled: false``) and
+must never modify ``auxiliary.vision`` behavior or any active Skill.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Canonical enums (V0.1 frozen set)
+# ---------------------------------------------------------------------------
+
+
+class VisionNeedDecision(str, enum.Enum):
+    VISION_NOT_NEEDED = "VISION_NOT_NEEDED"
+    VISION_REQUIRED = "VISION_REQUIRED"
+
+
+class VisionTask(str, enum.Enum):
+    SCENE_DESCRIBE = "SCENE_DESCRIBE"
+    UI_READ = "UI_READ"
+    UI_LOCATE = "UI_LOCATE"
+    EXACT_OCR = "EXACT_OCR"
+    EVIDENCE_VERIFY = "EVIDENCE_VERIFY"
+
+
+class VisionCriticality(str, enum.Enum):
+    NORMAL = "NORMAL"
+    HIGH = "HIGH"
+
+
+class VisionMode(str, enum.Enum):
+    AUTO = "AUTO"
+    FAST = "FAST"
+    PRECISION = "PRECISION"
+    OCR = "OCR"
+
+
+class ModelSlot(str, enum.Enum):
+    FAST_VLM = "FAST_VLM"
+    PRECISION_VLM = "PRECISION_VLM"
+    OCR = "OCR"
+
+
+class ExecutionStatus(str, enum.Enum):
+    SUCCESS = "SUCCESS"
+    TIMEOUT = "TIMEOUT"
+    ENDPOINT_UNAVAILABLE = "ENDPOINT_UNAVAILABLE"
+    MODEL_NOT_FOUND = "MODEL_NOT_FOUND"
+    INVALID_RESPONSE = "INVALID_RESPONSE"
+    SCHEMA_INVALID = "SCHEMA_INVALID"
+    POLICY_BLOCKED = "POLICY_BLOCKED"
+
+
+# Transport identities (single source of truth for the Vision layer).
+# The native Ollama ``/api/generate`` transport is bound as the default
+# execution profile for the PRECISION_VLM slot (task
+# HERMES_VISION_PRECISION_NATIVE_GENERATE_PROFILE_BINDING_V0_1); the
+# OpenAI-compatible transport remains the default for FAST_VLM / OCR and
+# remains selectable for PRECISION_VLM via an explicit override.
+TRANSPORT_OPENAI_COMPATIBLE = "OPENAI_COMPATIBLE"
+TRANSPORT_OLLAMA_NATIVE_GENERATE = "OLLAMA_NATIVE_GENERATE"
+
+
+def resolve_default_transport(slot: "ModelSlot") -> str:
+    """Default transport for a model slot when no explicit override exists.
+
+    PRECISION_VLM → native ``/api/generate`` (bound profile);
+    FAST_VLM / OCR → OpenAI-compatible (unchanged legacy behavior).
+    """
+    if slot == ModelSlot.PRECISION_VLM:
+        return TRANSPORT_OLLAMA_NATIVE_GENERATE
+    return TRANSPORT_OPENAI_COMPATIBLE
+
+
+class QualityDecision(str, enum.Enum):
+    PASS = "PASS"
+    ESCALATE_RECOMMENDED = "ESCALATE_RECOMMENDED"
+    HUMAN_REVIEW_REQUIRED = "HUMAN_REVIEW_REQUIRED"
+    NOT_EVALUATED = "NOT_EVALUATED"
+
+
+class PolicyReasonCode(str, enum.Enum):
+    """Deterministic planner/escalation reason codes (non-sensitive)."""
+
+    AUTO_MATRIX = "auto_matrix"
+    EXPLICIT_FAST = "explicit_fast"
+    EXPLICIT_PRECISION = "explicit_precision"
+    EXPLICIT_OCR = "explicit_ocr"
+    HIGH_CRITICALITY_OVERRIDE = "high_criticality_override"
+    HIGH_CRITICALITY_POLICY_BLOCK = "high_criticality_policy_block"
+    OCR_FOR_EXACT_TEXT = "ocr_for_exact_text"
+    FAST_INVALID_FOR_HIGH = "fast_invalid_for_high"
+
+
+# ---------------------------------------------------------------------------
+# Legacy role compatibility (deterministic, explicit case handling)
+# ---------------------------------------------------------------------------
+
+_LEGACY_ALIASES = {
+    "FAST_VISION_MODEL": ModelSlot.FAST_VLM,
+    "PRECISION_VISION_MODEL": ModelSlot.PRECISION_VLM,
+    "LAYOUT_OCR_MODEL": ModelSlot.OCR,
+    # Lower/any-case acceptance — explicit normalization.
+    "fast_vision_model": ModelSlot.FAST_VLM,
+    "precision_vision_model": ModelSlot.PRECISION_VLM,
+    "layout_ocr_model": ModelSlot.OCR,
+    # Canonical names accepted directly (idempotent).
+    "FAST_VLM": ModelSlot.FAST_VLM,
+    "PRECISION_VLM": ModelSlot.PRECISION_VLM,
+    "OCR": ModelSlot.OCR,
+    "fast_vlm": ModelSlot.FAST_VLM,
+    "precision_vlm": ModelSlot.PRECISION_VLM,
+    "ocr": ModelSlot.OCR,
+}
+
+
+def resolve_model_slot(value: Any) -> Optional[ModelSlot]:
+    """Resolve a canonical slot name or legacy alias to a ModelSlot.
+
+    Deterministic and explicit about case handling. Returns ``None`` for
+    unknown values (callers decide how to treat them).
+    """
+    if isinstance(value, ModelSlot):
+        return value
+    if value is None:
+        return None
+    key = str(value).strip()
+    return _LEGACY_ALIASES.get(key)
+
+
+# ---------------------------------------------------------------------------
+# Default model-identity catalog (configuration-driven at runtime; these
+# defaults are role *references*, not private endpoints).
+# ---------------------------------------------------------------------------
+
+DEFAULT_MODEL_SLOTS = {
+    ModelSlot.FAST_VLM: "qwen2.5vl",
+    ModelSlot.PRECISION_VLM: "qwen3.6:27b",
+    ModelSlot.OCR: "glm-ocr",
+}
+
+# Timeout safety ceilings (seconds) — NOT expected latency. Dynamic timeout
+# selection (image size / crop / task) is explicitly deferred to a later
+# stage.
+DEFAULT_TIMEOUTS = {
+    ModelSlot.FAST_VLM: 45,
+    ModelSlot.PRECISION_VLM: 120,
+    ModelSlot.OCR: 45,
+}
+
+# PRECISION_VLM execution profile — the permanently bound default for the
+# Precision slot (task HERMES_VISION_PRECISION_NATIVE_GENERATE_PROFILE_
+# BINDING_V0_1). Applies when the selected slot is PRECISION_VLM and the
+# caller supplies no explicit transport override; an explicit
+# OPENAI_COMPATIBLE override remains honored for diagnostics.
+# Profile values are explicit — no reliance on Ollama defaults, model
+# maximum context, or global OLLAMA_CONTEXT_LENGTH.
+PRECISION_EXECUTION_PROFILE: Dict[str, Any] = {
+    "model": DEFAULT_MODEL_SLOTS[ModelSlot.PRECISION_VLM],
+    "transport": TRANSPORT_OLLAMA_NATIVE_GENERATE,
+    "endpoint_family": "ollama_native_generate",
+    "num_ctx": 32768,
+    "num_predict": 4000,
+    "temperature": 0.1,
+    "stream": False,
+    "timeout_seconds": DEFAULT_TIMEOUTS[ModelSlot.PRECISION_VLM],
+    "structured_output": True,
+}
+
+# V0.1: exactly one model invocation per analyze_image request.
+MAX_MODEL_CALLS = 1
+
+# Prompt-template versions (versioned IDs; prompt bodies live in the
+# orchestrator so they can evolve without touching the policy layer).
+PROMPT_TEMPLATE_IDS = {
+    VisionTask.SCENE_DESCRIBE: "vision-b1-scene-describe-v1",
+    VisionTask.UI_READ: "vision-b1-ui-read-v1",
+    VisionTask.UI_LOCATE: "vision-b1-ui-locate-v1",
+    VisionTask.EXACT_OCR: "vision-b1-exact-ocr-v1",
+    VisionTask.EVIDENCE_VERIFY: "vision-b1-evidence-verify-v1",
+}
+
+# ---------------------------------------------------------------------------
+# Request / Plan / Result schemas
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CoordinateContext:
+    """Coordinate-space metadata. Source-image pixel space is canonical.
+
+    Browser viewport context is recorded when supplied so a later executor
+    can map image pixels → CSS px → screen px. The Orchestrator never clicks.
+    """
+
+    source_width_px: Optional[int] = None
+    source_height_px: Optional[int] = None
+    crop_x_px: int = 0
+    crop_y_px: int = 0
+    crop_width_px: Optional[int] = None
+    crop_height_px: Optional[int] = None
+    viewport_width_css: Optional[int] = None
+    viewport_height_css: Optional[int] = None
+    device_scale_factor: Optional[float] = None
+    coordinate_space: str = "SOURCE_IMAGE_PIXELS"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "source_width_px": self.source_width_px,
+            "source_height_px": self.source_height_px,
+            "crop_x_px": self.crop_x_px,
+            "crop_y_px": self.crop_y_px,
+            "crop_width_px": self.crop_width_px,
+            "crop_height_px": self.crop_height_px,
+            "viewport_width_css": self.viewport_width_css,
+            "viewport_height_css": self.viewport_height_css,
+            "device_scale_factor": self.device_scale_factor,
+            "coordinate_space": self.coordinate_space,
+        }
+
+
+@dataclass
+class VisionRequest:
+    """Canonical request. Never carries credentials, cookies, private page
+    HTML, or authentication state."""
+
+    request_id: str
+    image_source: str
+    task: VisionTask
+    mode: VisionMode = VisionMode.AUTO
+    criticality: VisionCriticality = VisionCriticality.NORMAL
+    question: str = ""
+    required_outputs: List[str] = field(default_factory=list)
+    region: Optional[str] = None
+    hints: Dict[str, Any] = field(default_factory=dict)
+    coordinate_context: Optional[CoordinateContext] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "VisionRequest":
+        cc = data.get("coordinate_context")
+        return cls(
+            request_id=str(data.get("request_id") or ""),
+            image_source=str(data.get("image_source") or ""),
+            task=VisionTask(str(data.get("task") or VisionTask.SCENE_DESCRIBE.value)),
+            mode=VisionMode(str(data.get("mode") or VisionMode.AUTO.value)),
+            criticality=VisionCriticality(
+                str(data.get("criticality") or VisionCriticality.NORMAL.value)
+            ),
+            question=str(data.get("question") or ""),
+            required_outputs=list(data.get("required_outputs") or []),
+            region=data.get("region"),
+            hints=dict(data.get("hints") or {}),
+            coordinate_context=CoordinateContext(**cc) if isinstance(cc, dict) else None,
+        )
+
+
+@dataclass
+class VisionPlan:
+    """Deterministic plan produced by the planner (no network)."""
+
+    selected_slot: ModelSlot
+    selected_model_identity: str
+    selection_reason: str
+    prompt_template_id: str
+    quality_gates: List[str]
+    timeout_seconds: float
+    max_model_calls: int = MAX_MODEL_CALLS
+    escalation_may_be_recommended: bool = True
+    click_authorized: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "selected_slot": self.selected_slot.value,
+            "selected_model_identity": self.selected_model_identity,
+            "selection_reason": self.selection_reason,
+            "prompt_template_id": self.prompt_template_id,
+            "quality_gates": list(self.quality_gates),
+            "timeout_seconds": self.timeout_seconds,
+            "max_model_calls": self.max_model_calls,
+            "escalation_may_be_recommended": self.escalation_may_be_recommended,
+            "click_authorized": self.click_authorized,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Vision-Need policy (pure; no Browser / model / network)
+# ---------------------------------------------------------------------------
+
+# Inputs the pure policy may consider. Values are explicit booleans supplied
+# by the caller (typically the Agent strategy layer), NOT derived by calling
+# any external system.
+DOM_SUFFICIENT_HINTS = (
+    "dom_sufficient",
+    "accessibility_sufficient",
+)
+
+
+def decide_vision_need(
+    *,
+    dom_sufficient: bool = False,
+    accessibility_sufficient: bool = False,
+    image_only_content: bool = False,
+    canvas_content: bool = False,
+    screenshot_evidence_required: bool = False,
+    precise_coordinates_required: bool = False,
+    explicit_image_request: bool = False,
+    visual_state_required: bool = False,
+) -> VisionNeedDecision:
+    """Decide whether vision is required.
+
+    Pure policy: considers only explicit caller-supplied booleans. Never
+    calls Browser, a model, or the network.
+    """
+    if dom_sufficient or accessibility_sufficient:
+        return VisionNeedDecision.VISION_NOT_NEEDED
+    if (
+        image_only_content
+        or canvas_content
+        or screenshot_evidence_required
+        or precise_coordinates_required
+        or explicit_image_request
+        or visual_state_required
+    ):
+        return VisionNeedDecision.VISION_REQUIRED
+    return VisionNeedDecision.VISION_NOT_NEEDED
+
+
+# ---------------------------------------------------------------------------
+# Planner — deterministic task/criticality/mode → model-slot matrix
+# ---------------------------------------------------------------------------
+
+# mode=AUTO matrix: (task, criticality) → slot
+_AUTO_MATRIX = {
+    (VisionTask.SCENE_DESCRIBE, VisionCriticality.NORMAL): ModelSlot.FAST_VLM,
+    (VisionTask.SCENE_DESCRIBE, VisionCriticality.HIGH): ModelSlot.PRECISION_VLM,
+    (VisionTask.UI_READ, VisionCriticality.NORMAL): ModelSlot.FAST_VLM,
+    (VisionTask.UI_READ, VisionCriticality.HIGH): ModelSlot.PRECISION_VLM,
+    (VisionTask.UI_LOCATE, VisionCriticality.NORMAL): ModelSlot.FAST_VLM,
+    (VisionTask.UI_LOCATE, VisionCriticality.HIGH): ModelSlot.PRECISION_VLM,
+    (VisionTask.EXACT_OCR, VisionCriticality.NORMAL): ModelSlot.OCR,
+    (VisionTask.EXACT_OCR, VisionCriticality.HIGH): ModelSlot.OCR,
+    (VisionTask.EVIDENCE_VERIFY, VisionCriticality.NORMAL): ModelSlot.PRECISION_VLM,
+    (VisionTask.EVIDENCE_VERIFY, VisionCriticality.HIGH): ModelSlot.PRECISION_VLM,
+}
+
+# Tasks for which an explicit FAST mode is never safe at HIGH criticality.
+_HIGH_TASKS_REQUIRING_PRECISION = {
+    VisionTask.UI_READ,
+    VisionTask.UI_LOCATE,
+    VisionTask.EVIDENCE_VERIFY,
+}
+
+# Explicit OCR is valid for EXACT_OCR and for text-specific UI_READ requests
+# whose required outputs are exact text.
+_OCR_OK_TASKS = {VisionTask.EXACT_OCR, VisionTask.UI_READ}
+
+
+def plan_vision(
+    request: VisionRequest,
+    model_slots: Optional[Dict[ModelSlot, str]] = None,
+    timeouts: Optional[Dict[ModelSlot, float]] = None,
+) -> VisionPlan:
+    """Deterministic planner. No network, no model call."""
+    slots = model_slots or dict(DEFAULT_MODEL_SLOTS)
+    timeouts = timeouts or dict(DEFAULT_TIMEOUTS)
+    task = request.task
+    criticality = request.criticality
+    mode = request.mode
+
+    # Explicit mode behavior -------------------------------------------------
+    if mode == VisionMode.PRECISION:
+        slot = ModelSlot.PRECISION_VLM
+        reason = PolicyReasonCode.EXPLICIT_PRECISION.value
+    elif mode == VisionMode.OCR:
+        if task not in _OCR_OK_TASKS:
+            # OCR is a text specialist; refuse for non-text tasks rather than
+            # silently degrading.
+            raise PolicyBlockedError(
+                f"EXPLICIT_OCR_INVALID_TASK:{task.value}",
+                recommended_slot=ModelSlot.PRECISION_VLM,
+            )
+        slot = ModelSlot.OCR
+        reason = PolicyReasonCode.EXPLICIT_OCR.value
+    elif mode == VisionMode.FAST:
+        if (
+            criticality == VisionCriticality.HIGH
+            and task in _HIGH_TASKS_REQUIRING_PRECISION
+        ):
+            # Safety policy (frozen): FAST requested for a HIGH-criticality
+            # UI_READ / UI_LOCATE / EVIDENCE_VERIFY must not silently force
+            # the low-precision model. Deterministic behavior: POLICY_BLOCKED
+            # with the recommended compatible slot. (This is the safest
+            # interpretation of the accepted design and matches Hermes'
+            # safety-over-override semantics.)
+            raise PolicyBlockedError(
+                PolicyReasonCode.FAST_INVALID_FOR_HIGH.value,
+                recommended_slot=ModelSlot.PRECISION_VLM,
+            )
+        slot = ModelSlot.FAST_VLM
+        reason = PolicyReasonCode.EXPLICIT_FAST.value
+    else:  # AUTO
+        slot = _AUTO_MATRIX.get((task, criticality), ModelSlot.PRECISION_VLM)
+        reason = PolicyReasonCode.AUTO_MATRIX.value
+
+    model_identity = slots.get(slot, DEFAULT_MODEL_SLOTS[slot])
+    timeout = timeouts.get(slot, DEFAULT_TIMEOUTS[slot])
+
+    return VisionPlan(
+        selected_slot=slot,
+        selected_model_identity=model_identity,
+        selection_reason=reason,
+        prompt_template_id=PROMPT_TEMPLATE_IDS[task],
+        quality_gates=_quality_gates_for(task),
+        timeout_seconds=float(timeout),
+        max_model_calls=MAX_MODEL_CALLS,
+        escalation_may_be_recommended=True,
+        click_authorized=False,
+    )
+
+
+def _quality_gates_for(task: VisionTask) -> List[str]:
+    return {
+        VisionTask.SCENE_DESCRIBE: [
+            "response_present",
+            "observation_non_empty",
+            "observation_inference_distinguished",
+            "no_excessive_hedging",
+        ],
+        VisionTask.UI_READ: [
+            "response_present",
+            "required_text_present",
+            "no_contradictory_text",
+            "no_explicit_unreadable",
+        ],
+        VisionTask.UI_LOCATE: [
+            "response_present",
+            "target_found",
+            "target_unique",
+            "bbox_or_point_present",
+            "coordinates_in_bounds",
+            "bbox_ordering_valid",
+            "coordinate_space_declared",
+        ],
+        VisionTask.EXACT_OCR: [
+            "response_present",
+            "text_non_empty",
+            "region_match",
+            "no_placeholder",
+        ],
+        VisionTask.EVIDENCE_VERIFY: [
+            "response_present",
+            "observation_inference_distinguished",
+            "evidence_provided",
+            "no_unresolved_contradiction",
+            "no_action_claimed",
+        ],
+    }.get(task, ["response_present"])
+
+
+# ---------------------------------------------------------------------------
+# Policy-blocked error
+# ---------------------------------------------------------------------------
+
+
+class PolicyBlockedError(Exception):
+    """Raised when the deterministic policy refuses a request.
+
+    Carries a non-sensitive reason code and the recommended compatible slot.
+    """
+
+    def __init__(
+        self,
+        reason: str,
+        *,
+        recommended_slot: Optional[ModelSlot] = None,
+    ):
+        super().__init__(reason)
+        self.reason = reason
+        self.recommended_slot = recommended_slot
+
+
+# ---------------------------------------------------------------------------
+# Coordinate validation helpers (pure)
+# ---------------------------------------------------------------------------
+
+SOURCE_IMAGE_PIXELS = "SOURCE_IMAGE_PIXELS"
+
+
+def validate_coordinates(
+    *,
+    x: Optional[float],
+    y: Optional[float],
+    width: Optional[int],
+    height: Optional[int],
+    bbox: Optional[List[float]] = None,
+    crop_x: int = 0,
+    crop_y: int = 0,
+    crop_width: Optional[int] = None,
+    crop_height: Optional[int] = None,
+) -> List[str]:
+    """Validate pixel coordinates against source-image bounds.
+
+    Returns a list of failed-gate reason codes (empty = valid).
+
+    HALF-OPEN pixel-space contract (documented in DESIGN.md):
+    - ``SOURCE_IMAGE_PIXELS``: integer pixel grid, origin (0,0) top-left;
+    - a POINT (x, y) satisfies 0 <= x < W and 0 <= y < H — x == W is
+      INVALID (points are pixel positions);
+    - a BBOX is half-open: 0 <= left < right <= W and
+      0 <= top < bottom <= H — right == W IS a valid bbox edge;
+    - a CROP is half-open: crop_x >= 0, crop_width > 0 and
+      crop_x + crop_width <= W — a crop ending exactly at W is valid;
+    - a point inside a bbox satisfies left <= x < right and
+      top <= y < bottom;
+    - crop-local coordinates are mapped back to source-image space before
+      validation when a crop is used.
+    """
+    failures: List[str] = []
+
+    # Source dimensions must be present and positive when coordinates are
+    # returned.
+    if width is None or height is None:
+        failures.append("coordinate_space_missing_dimensions")
+        return failures
+    if width <= 0 or height <= 0:
+        failures.append("coordinate_space_nonpositive_dimensions")
+        return failures
+
+    # Crop validation: origin >= 0, dimensions > 0, and the crop must lie
+    # inside the source image (half-open: crop end may equal W/H).
+    if crop_x < 0 or crop_y < 0:
+        failures.append("crop_origin_negative")
+    if crop_width is not None and crop_width <= 0:
+        failures.append("crop_width_nonpositive")
+    if crop_height is not None and crop_height <= 0:
+        failures.append("crop_height_nonpositive")
+    if crop_width is not None and crop_x + crop_width > width:
+        failures.append("crop_exceeds_source_width")
+    if crop_height is not None and crop_y + crop_height > height:
+        failures.append("crop_exceeds_source_height")
+
+    if bbox is not None and len(bbox) == 4:
+        left, top, right, bottom = bbox
+        # Half-open strict ordering: left < right and top < bottom
+        # (zero-area bbox is rejected).
+        if left >= right:
+            failures.append("bbox_left_ge_right")
+        if top >= bottom:
+            failures.append("bbox_top_ge_bottom")
+        # Bbox edges: 0 <= left < right <= W (right == W is valid).
+        if not (0 <= left < right <= width):
+            failures.append("bbox_x_out_of_bounds")
+        if not (0 <= top < bottom <= height):
+            failures.append("bbox_y_out_of_bounds")
+        if x is not None:
+            # Point inside bbox: left <= x < right, top <= y < bottom.
+            if not (left <= x < right):
+                failures.append("point_outside_bbox")
+            if y is not None and not (top <= y < bottom):
+                failures.append("point_outside_bbox")
+
+    if x is not None:
+        # Map crop-local → source-image coordinates. Half-open: x < width.
+        src_x = x + (crop_x or 0)
+        if not (0 <= src_x < width):
+            failures.append("x_out_of_bounds")
+    if y is not None:
+        src_y = y + (crop_y or 0)
+        if not (0 <= src_y < height):
+            failures.append("y_out_of_bounds")
+    return failures
+
+
+def validate_normalized_point(x_norm: float, y_norm: float) -> List[str]:
+    """Validate a normalized point.
+
+    Half-open: 0.0 <= x_norm < 1.0 and 0.0 <= y_norm < 1.0. A value of
+    1.0 is INVALID — it does not denote a pixel center.
+    """
+    failures: List[str] = []
+    if not (0.0 <= x_norm < 1.0):
+        failures.append("x_norm_out_of_bounds")
+    if not (0.0 <= y_norm < 1.0):
+        failures.append("y_norm_out_of_bounds")
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Quality evaluation (deterministic; no second model call)
+# ---------------------------------------------------------------------------
+
+
+def evaluate_quality(
+    task: VisionTask,
+    *,
+    response_text: Optional[str],
+    required_outputs: List[str],
+    extracted: Optional[Dict[str, Any]] = None,
+    coordinates: Optional[Dict[str, Any]] = None,
+    coordinate_context: Optional[CoordinateContext] = None,
+) -> Dict[str, Any]:
+    """Evaluate one model response against the task's quality gates.
+
+    Returns ``{"quality_decision": ..., "passed_gates": [...],
+    "failed_gates": [...]}``. Never calls another model.
+    """
+    passed: List[str] = []
+    failed: List[str] = []
+    extracted = extracted or {}
+    coordinates = coordinates or {}
+
+    if not response_text or not str(response_text).strip():
+        failed.append("response_present")
+        return {
+            "quality_decision": QualityDecision.NOT_EVALUATED.value,
+            "passed_gates": passed,
+            "failed_gates": failed,
+        }
+    passed.append("response_present")
+
+    # Classification B: explicit refusal / inability / non-analysis response.
+    # A syntactically present but non-analytic response is NOT a usable
+    # escalation candidate — it is HUMAN_REVIEW_REQUIRED (no safe automatic
+    # follow-up is warranted for a model that declined to analyze).
+    if _is_refusal_or_inability(response_text):
+        failed.append("refusal_or_inability")
+        return {
+            "quality_decision": QualityDecision.HUMAN_REVIEW_REQUIRED.value,
+            "passed_gates": passed,
+            "failed_gates": failed,
+        }
+
+    # Classification A: required structured response cannot be parsed.
+    # ``extracted`` carries a marker from the orchestrator when JSON parsing
+    # failed entirely — treat as NOT_EVALUATED (no evaluable content).
+    if extracted.get("_parse_failed"):
+        failed.append("structured_parse_failed")
+        return {
+            "quality_decision": QualityDecision.NOT_EVALUATED.value,
+            "passed_gates": passed,
+            "failed_gates": failed,
+        }
+
+    # Shared: required outputs present.
+    missing_required = [o for o in required_outputs if o not in extracted]
+    if missing_required:
+        failed.append("required_outputs_missing")
+    else:
+        passed.append("required_outputs_present")
+
+    # Shared: schema valid when structured output required.
+    if task in (VisionTask.UI_LOCATE, VisionTask.UI_READ, VisionTask.EVIDENCE_VERIFY):
+        if _has_contradiction(extracted):
+            failed.append("unresolved_contradiction")
+        else:
+            passed.append("no_unresolved_contradiction")
+
+    # Shared: no placeholder / empty result.
+    if _is_placeholder(response_text):
+        failed.append("placeholder_result")
+
+    # Task-specific gates ----------------------------------------------------
+    if task == VisionTask.SCENE_DESCRIBE:
+        if not extracted.get("observation"):
+            failed.append("observation_non_empty")
+        else:
+            passed.append("observation_non_empty")
+        if extracted.get("inference") is not None or extracted.get("uncertainty"):
+            passed.append("observation_inference_distinguished")
+        else:
+            failed.append("observation_inference_distinguished")
+        if _excessive_hedging(response_text):
+            failed.append("no_excessive_hedging")
+        else:
+            passed.append("no_excessive_hedging")
+
+    elif task == VisionTask.UI_READ:
+        text_value, text_status = _resolve_ui_read_text(extracted)
+        if text_value:
+            passed.append("required_text_present")
+        else:
+            failed.append("required_text_present")
+        if text_status == "conflict":
+            failed.append("text_field_conflict")
+        if _has_explicit_unreadable(response_text):
+            failed.append("no_explicit_unreadable")
+        else:
+            passed.append("no_explicit_unreadable")
+
+    elif task == VisionTask.UI_LOCATE:
+        targets = extracted.get("targets") or []
+        if targets:
+            passed.append("target_found")
+        else:
+            failed.append("target_found")
+        if len(targets) == 1:
+            passed.append("target_unique")
+        elif len(targets) > 1:
+            failed.append("target_unique")
+        if coordinates.get("bbox") or coordinates.get("point"):
+            passed.append("bbox_or_point_present")
+        else:
+            failed.append("bbox_or_point_present")
+        if coordinates.get("coordinate_space"):
+            passed.append("coordinate_space_declared")
+        else:
+            failed.append("coordinate_space_declared")
+        # Validate coordinates.
+        cc = coordinate_context or CoordinateContext()
+        coord_failures = validate_coordinates(
+            x=coordinates.get("x"),
+            y=coordinates.get("y"),
+            width=cc.source_width_px,
+            height=cc.source_height_px,
+            bbox=coordinates.get("bbox"),
+            crop_x=cc.crop_x_px,
+            crop_y=cc.crop_y_px,
+            crop_width=cc.crop_width_px,
+            crop_height=cc.crop_height_px,
+        )
+        if coord_failures:
+            failed.extend(coord_failures)
+        else:
+            passed.append("coordinates_in_bounds")
+
+    elif task == VisionTask.EXACT_OCR:
+        text = extracted.get("observed_text")
+        if text and str(text).strip():
+            passed.append("text_non_empty")
+        else:
+            failed.append("text_non_empty")
+        if extracted.get("region_match"):
+            passed.append("region_match")
+        elif region_mismatch_detected(extracted):
+            failed.append("region_match")
+        else:
+            passed.append("region_match")
+
+    elif task == VisionTask.EVIDENCE_VERIFY:
+        if extracted.get("observation") is not None:
+            passed.append("observation_inference_distinguished")
+        else:
+            failed.append("observation_inference_distinguished")
+        if extracted.get("evidence"):
+            passed.append("evidence_provided")
+        else:
+            failed.append("evidence_provided")
+        if extracted.get("action_claimed"):
+            failed.append("no_action_claimed")
+        else:
+            passed.append("no_action_claimed")
+
+    # Quality decision -------------------------------------------------------
+    # Deterministic classification of failures into safe escalation candidates
+    # vs. human-review cases. A failure is only ESCALATE_RECOMMENDED when a
+    # task-relevant partial result exists and a specific higher-precision or
+    # OCR follow-up would plausibly resolve the missing evidence. Generic
+    # prose, placeholder output, and unresolved contradictions are NOT safe
+    # escalation candidates.
+    if failed:
+        if _is_escalation_candidate(failed, extracted):
+            decision = QualityDecision.ESCALATE_RECOMMENDED.value
+        else:
+            decision = QualityDecision.HUMAN_REVIEW_REQUIRED.value
+    else:
+        decision = QualityDecision.PASS.value
+
+    return {
+        "quality_decision": decision,
+        "passed_gates": sorted(set(passed)),
+        "failed_gates": sorted(set(failed)),
+    }
+
+
+# -- small deterministic helpers --------------------------------------------
+
+
+def _normalize_text_value(value: Any) -> Any:
+    """Normalize a text-field value for deterministic comparison.
+
+    Lists → tuple of stripped non-empty strings; strings → stripped string;
+    anything else (dict, int, None, ...) → ``None``. Never raises; non-string
+    values fail safely.
+    """
+    if isinstance(value, list):
+        items = tuple(str(v).strip() for v in value if str(v).strip())
+        return items or None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
+def _resolve_ui_read_text(
+    extracted: Dict[str, Any],
+) -> Tuple[Any, str]:
+    """Resolve the canonical UI_READ text field at one explicit boundary.
+
+    Canonical field: ``observed_text`` — the established internal Vision
+    field (Prompt schema example, UI_READ/EXACT_OCR gates, calibration and
+    existing tests all use it). Legacy alias: ``visible_text`` — accepted
+    ONLY through this resolver (introduced by the native-generate strict
+    schema; backward-compatible normalization).
+
+    Returns ``(value, status)`` where ``status`` is one of:
+
+    - ``"canonical"`` — ``observed_text`` present and non-empty;
+    - ``"alias"`` — ``observed_text`` missing/empty, ``visible_text``
+      non-empty (legacy compatibility);
+    - ``"conflict"`` — both fields present with materially different
+      normalized values (never silently choose; caller marks contradiction);
+    - ``"missing"`` — neither field is usable.
+    """
+    observed = extracted.get("observed_text")
+    visible = extracted.get("visible_text")
+    observed_norm = _normalize_text_value(observed)
+    visible_norm = _normalize_text_value(visible)
+    if observed_norm and visible_norm:
+        if observed_norm == visible_norm:
+            return observed, "canonical"
+        return None, "conflict"
+    if observed_norm:
+        return observed, "canonical"
+    if visible_norm:
+        return visible, "alias"
+    return None, "missing"
+
+
+def _has_contradiction(extracted: Dict[str, Any]) -> bool:
+    """True only for an EXPLICIT contradiction signal.
+
+    Diagnostic finding B (HERMES_VISION_FULL_CORPUS_QUALITY_FINDINGS_
+    DIAGNOSTIC_V0_1): repeated identical entries inside ``observed_text``
+    are NOT contradictions — UI screenshots legitimately repeat navigation
+    labels and page text, and models may enumerate the same visible label
+    more than once. Treating duplication as contradiction produced four
+    false HUMAN_REVIEW_REQUIRED results in the corpus.
+
+    The only reliable contradiction signal is an explicit model-flagged
+    ``contradiction`` field (EVIDENCE_VERIFY task schema) — never inferred
+    from mere repetition.
+    """
+    flagged = extracted.get("contradiction")
+    if isinstance(flagged, str) and flagged.strip():
+        return True
+    return False
+
+
+def _is_refusal_or_inability(text: str) -> bool:
+    """Detect explicit refusal / inability / non-analysis responses.
+
+    Bounded deterministic signal set (English + Chinese). A model that
+    declined to analyze is not a safe escalation candidate — the response
+    contains no task-relevant observation a follow-up model could build on
+    deterministically.
+    """
+    t = str(text).strip().lower()
+    signals = (
+        # English
+        "i cannot analyze",
+        "i can't analyze",
+        "cannot analyze this image",
+        "unable to analyze",
+        "i am unable to read",
+        "i cannot read the image",
+        "unable to read the image",
+        "the image is unavailable",
+        "no image was provided",
+        "i cannot see the requested text",
+        "cannot see the requested text",
+        "i cannot view images",
+        "i can't view images",
+        "i'm sorry",
+        "i am sorry",
+        # Chinese
+        "无法分析这张图片",
+        "无法分析图片",
+        "看不清",
+        "无法读取",
+        "无法识别",
+        "无法查看图片",
+        "不能分析",
+        "图片不可用",
+        "没有提供图片",
+    )
+    return any(s in t for s in signals)
+
+
+def _is_escalation_candidate(failed_gates: List[str], extracted: Dict[str, Any]) -> bool:
+    """A failure is a safe escalation candidate only when:
+    - no unresolved contradiction exists (contradiction is human-review);
+    - no placeholder/refusal/parse failure exists;
+    - no required action was falsely claimed;
+    - a task-relevant partial result actually exists.
+    """
+    never_escalate = {
+        "unresolved_contradiction",
+        "text_field_conflict",
+        "placeholder_result",
+        "refusal_or_inability",
+        "structured_parse_failed",
+        "no_action_claimed",
+        "action_claimed",
+    }
+    if any(g in never_escalate for g in failed_gates):
+        return False
+    if not extracted:
+        return False
+    # A purely cosmetic failure (e.g. hedging only) with no other gate
+    # failures would already be PASS; any remaining failure here implies
+    # missing/uncertain evidence, which a precision/OCR follow-up can
+    # address.
+    return True
+
+
+def _is_placeholder(text: str) -> bool:
+    t = str(text).strip().lower()
+    placeholders = (
+        "unable to see",
+        "cannot see",
+        "i cannot view",
+        "i can't view",
+        "not visible in",
+        "no image provided",
+        "i cannot analyze",
+        "i can't analyze",
+        "cannot analyze",
+        "unable to analyze",
+        "无法分析",
+        "看不清",
+        "无法读取",
+        "无法识别",
+    )
+    return any(p in t for p in placeholders)
+
+
+def _excessive_hedging(text: str) -> bool:
+    t = str(text).strip().lower()
+    hedge_words = ("maybe", "perhaps", "possibly", "i think", "probably", "似乎", "可能", "大概")
+    hits = sum(1 for w in hedge_words if w in t)
+    return hits >= 3
+
+
+def _has_explicit_unreadable(text: str) -> bool:
+    t = str(text).strip().lower()
+    markers = (
+        "unreadable",
+        "cannot read",
+        "can't read",
+        "illegible",
+        "blurry",
+        "看不清",
+        "无法辨认",
+        "无法读取",
+    )
+    return any(m in t for m in markers)
+
+
+def region_mismatch_detected(extracted: Dict[str, Any]) -> bool:
+    """True when the OCR response explicitly contradicts the requested
+    region (e.g. quoted text clearly outside the crop)."""
+    return bool(extracted.get("region_mismatch"))
+
+
+# ---------------------------------------------------------------------------
+# Serializable result / trace builders
+# ---------------------------------------------------------------------------
+
+
+def build_result(
+    *,
+    execution_status: ExecutionStatus,
+    quality: Dict[str, Any],
+    answer: str = "",
+    structured: Optional[Dict[str, Any]] = None,
+    initial_slot: ModelSlot,
+    final_slot: ModelSlot,
+    actual_model: str,
+    recommended_next_slot: Optional[ModelSlot] = None,
+    coordinate_context: Optional[CoordinateContext] = None,
+    trace: Optional[List[Dict[str, Any]]] = None,
+    image_sha256: Optional[str] = None,
+    logical_model_calls: int = 0,
+    transport_meta: Optional[Dict[str, Any]] = None,
+    transport: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Canonical VisionResult. Never contains image bytes, base64, cookies,
+    credentials, full prompts, page HTML, or auth tokens.
+
+    ``image_sha256`` is the SHA-256 of the EXACT normalized image bytes used
+    for the model request (non-sensitive metadata only) — this is the
+    canonical calibration identity. ``logical_model_calls`` counts
+    Orchestrator-level model invocations; it does NOT count lower-level
+    transport retries performed inside the existing auxiliary client.
+
+    ``transport_meta`` (optional) carries the two-layer transport hash
+    contract: ``transport_image_sha256`` (SHA-256 of the exact bytes encoded
+    in the model-request data URL), ``transport_mime_type`` (MIME declared in
+    that data URL) and ``transport_transcoded`` (true only when canonical
+    bytes were converted for endpoint compatibility, e.g. WebP → PNG).
+
+    ``transport`` (optional) carries the transport-selection metadata for the
+    invocation path used (task HERMES_VISION_GENERATE_ROUTE_ADAPTER_V0_1):
+    ``requested_transport``, ``selected_transport``, ``endpoint_family`` and
+    ``native_generate_used``. Non-sensitive; never contains endpoint
+    credentials or raw output.
+    """
+    quality_decision = quality.get("quality_decision") or QualityDecision.NOT_EVALUATED.value
+    human_review = quality_decision == QualityDecision.HUMAN_REVIEW_REQUIRED.value
+    return {
+        "execution_status": execution_status.value,
+        "quality_decision": quality_decision,
+        "answer": answer,
+        "structured": structured or {},
+        "initial_model_slot": initial_slot.value,
+        "final_model_slot": final_slot.value,
+        "actual_model": actual_model,
+        "recommended_next_slot": (
+            recommended_next_slot.value if recommended_next_slot else None
+        ),
+        "human_review_required": human_review,
+        "click_authorized": False,
+        "quality": {
+            "passed_gates": quality.get("passed_gates", []),
+            "failed_gates": quality.get("failed_gates", []),
+        },
+        "coordinate_context": (
+            coordinate_context.to_dict() if coordinate_context else {}
+        ),
+        "normalized_image_sha256": image_sha256,
+        "transport_image_sha256": (transport_meta or {}).get("transport_image_sha256"),
+        "transport_mime_type": (transport_meta or {}).get("transport_mime_type"),
+        "transport_transcoded": (transport_meta or {}).get("transport_transcoded"),
+        "transport": transport or {},
+        "logical_model_calls": logical_model_calls,
+        "trace": trace or [],
+    }
+
+
+def serialize(obj: Any) -> str:
+    """JSON-serialize a result dict (enums already converted to values)."""
+    return json.dumps(obj, ensure_ascii=False, default=str)

--- a/tools/vision_router_tool.py
+++ b/tools/vision_router_tool.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+from pathlib import Path
 from typing import Any, Awaitable, Dict, Optional
 
 from tools.registry import registry
@@ -72,13 +73,24 @@ def _authorized_source_handles() -> Dict[str, str]:
 def _resolve_source(source_handle: str) -> Optional[str]:
     """Authorize a model-supplied source handle.
 
-    Accepts ``locator://<key>`` (approved locator handle) or a bare key that
-    exists in the approved locator set. Returns the resolved local path, or
-    None when the handle is not authorized (→ SOURCE_DENIED, zero calls).
+    Accepts:
+    - ``locator://<key>`` (approved locator handle) or a bare key that
+      exists in the approved locator set;
+    - ``attachment://<session>/<id>`` registered through the session-scoped
+      allowlist (limited-use session mode; server path stays off the
+      model-visible surface).
+
+    Returns the resolved local path, or None when the handle is not
+    authorized (→ SOURCE_DENIED, zero calls).
     """
     handle = source_handle.strip()
     if handle.startswith("locator://"):
         handle = handle[len("locator://"):]
+        handles = _authorized_source_handles()
+        return handles.get(handle)
+    if handle.startswith("attachment://"):
+        from tools.vision_session_state import vision_session_state
+        return vision_session_state.resolve_attachment(handle)
     handles = _authorized_source_handles()
     return handles.get(handle)
 
@@ -89,9 +101,14 @@ def _criticality_for(task: str) -> str:
     return _TASK_TO_CRITICALITY.get(task, "NORMAL")
 
 
-def _build_envelope(result: Dict[str, Any], config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+def _build_envelope(
+    result: Dict[str, Any],
+    config: Optional[Dict[str, Any]],
+    request_id: Optional[str] = None,
+) -> Dict[str, Any]:
     """Safe model-visible envelope. Never contains thinking / raw provider
     output / base64 / private paths / credentials."""
+    rid = request_id or result.get("request_id")
     excerpt_limit = int(_config_value(config, "ocr_excerpt_chars",
                                       DEFAULT_OCR_EXCERPT_CHARS))
     structured = result.get("structured") or {}
@@ -107,13 +124,15 @@ def _build_envelope(result: Dict[str, Any], config: Optional[Dict[str, Any]]) ->
                 "returned_chars": len(excerpt),
                 "truncated": True,
                 "sha256": hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16],
-                "private_handle": result.get("request_id"),
+                "private_handle": rid,
                 "full_text_policy": "explicit_followup_required",
             }
             observed_text = [excerpt]
+            _store_ocr_full_result(rid, joined)
+
     trace = (result.get("trace") or [{}])[0]
     envelope = {
-        "request_id": result.get("request_id"),
+        "request_id": rid,
         "task": result.get("task"),
         "selected_slot": result.get("final_model_slot")
         or result.get("initial_model_slot"),
@@ -135,6 +154,30 @@ def _build_envelope(result: Dict[str, Any], config: Optional[Dict[str, Any]]) ->
     return envelope
 
 
+def _store_ocr_full_result(handle: Optional[str], full_text: str) -> None:
+    """Persist the complete OCR text to a bounded session-scoped cache and
+    register the retrieval handle. The model-visible envelope never carries
+    the full text; ``vision_ocr_page`` reads it in bounded pages. Uses the
+    system temp dir (never a private/user path) so no local filesystem
+    layout is exposed.
+    """
+    if not handle:
+        return
+    try:
+        import tempfile
+
+        safe_name = "".join(c for c in handle if c.isalnum() or c in "-_")[:64]
+        cache_dir = Path(tempfile.gettempdir()) / "hermes-vision-ocr"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        target = cache_dir / f"{safe_name}.txt"
+        target.write_text(full_text, encoding="utf-8")
+        from tools.vision_session_state import vision_session_state
+        vision_session_state.register_ocr_result(
+            f"ocr://{safe_name}", str(target))
+    except Exception:  # noqa: BLE001 — never break the envelope
+        pass
+
+
 def _source_denied_envelope() -> Dict[str, Any]:
     """SOURCE_DENIED: zero model calls, nothing leaked."""
     return {
@@ -147,6 +190,18 @@ def _source_denied_envelope() -> Dict[str, Any]:
     }
 
 
+def _session_gate_envelope(reason: str) -> Dict[str, Any]:
+    """Session gate (Stage-3): zero model calls, explicit reason."""
+    return {
+        "request_id": None,
+        "execution_status": "POLICY_BLOCKED",
+        "quality_decision": "NOT_EVALUATED",
+        "logical_model_calls": 0,
+        "error": reason,
+        "source_handle": None,
+    }
+
+
 def _build_request(
     args: Dict[str, Any],
     resolved_path: str,
@@ -154,13 +209,17 @@ def _build_request(
     from tools.vision_policy import (
         VisionRequest, VisionTask, VisionMode, VisionCriticality,
     )
+    import uuid
+
     task = str(args.get("task", "UI_READ")).upper()
     if task not in _ALLOWED_TASKS:
         task = "UI_READ"
     question = str(args.get("question") or "")
     question = question[:DEFAULT_MAX_QUESTION_CHARS]
     return VisionRequest(
-        request_id="vision-router-tool",
+        # unique per invocation: doubles as the private OCR retrieval handle
+        # (must never collide across calls)
+        request_id=f"vr-{uuid.uuid4().hex[:12]}",
         image_source=resolved_path,
         task=VisionTask(task),
         mode=VisionMode.AUTO,
@@ -171,16 +230,33 @@ def _build_request(
 
 
 async def _handle_vision_router(args: Dict[str, Any], **kw: Any) -> str:
-    """Registry handler. Returns a JSON envelope string (tool protocol)."""
+    """Registry handler. Returns a JSON envelope string (tool protocol).
+
+    Stage-3 limited-use gates (all zero-call):
+    - session must be enabled by the human (``/vision on``) — the model can
+      never set it;
+    - per-turn / per-session logical-call budgets (BUSY on exhaustion);
+    - same source + same task requires explicit user authorization;
+    - attachment:// handles must be registered in the session allowlist.
+    """
     from tools.vision_orchestrator import analyze_image
 
     source_handle = str(args.get("source_handle") or "").strip()
     if not source_handle:
         return json.dumps(_source_denied_envelope(), ensure_ascii=False)
 
-    resolved_path = _resolve_source(source_handle)
-    if not resolved_path:
-        return json.dumps(_source_denied_envelope(), ensure_ascii=False)
+    from tools.vision_session_state import vision_session_state
+
+    # -- zero-call session gates ---------------------------------------------
+    if not vision_session_state.enabled:
+        return json.dumps(_session_gate_envelope("SESSION_DISABLED"),
+                          ensure_ascii=False)
+
+    task = str(args.get("task", "UI_READ")).upper()
+    if vision_session_state.needs_authorization(source_handle, task):
+        return json.dumps(_session_gate_envelope(
+            "NEEDS_AUTHORIZATION: repeat same source+task"),
+            ensure_ascii=False)
 
     config = None
     try:
@@ -189,20 +265,33 @@ async def _handle_vision_router(args: Dict[str, Any], **kw: Any) -> str:
     except Exception:  # noqa: BLE001
         config = None
 
+    per_turn_max = int(_config_value(config, "per_turn_max_calls", 1))
+    per_session_max = int(_config_value(config, "per_session_max_calls", 5))
+    busy = vision_session_state.consume_call(per_turn_max, per_session_max)
+    if busy is not None:
+        return json.dumps(_session_gate_envelope(busy), ensure_ascii=False)
+
+    resolved_path = _resolve_source(source_handle)
+    if not resolved_path:
+        vision_session_state.fail_call()
+        return json.dumps(_source_denied_envelope(), ensure_ascii=False)
+
     request = _build_request(args, resolved_path)
     try:
-        # enabled=None → the server flag (vision_router.enabled) is resolved
-        # inside analyze_image. The model cannot influence it.
+        # enabled → the in-memory session flag (user-only /vision on; the
+        # model can never set it). Server config flag stays persistent and
+        # false; the session flag governs execution while it is on.
         # base_url → trusted server-side Ollama endpoint (native transport
         # requires it); never model-visible, never model-supplied.
         from tools.vision_policy import resolve_ollama_base_url
 
         result = await analyze_image(
             request,
-            enabled=None,
+            enabled=vision_session_state.enabled,
             base_url=resolve_ollama_base_url(config),
         )
     except Exception as exc:  # noqa: BLE001 — never crash the tool protocol
+        vision_session_state.fail_call()
         envelope = {
             "request_id": request.request_id,
             "execution_status": "INVALID_RESPONSE",
@@ -212,7 +301,10 @@ async def _handle_vision_router(args: Dict[str, Any], **kw: Any) -> str:
         }
         return json.dumps(envelope, ensure_ascii=False)
 
-    envelope = _build_envelope(result, config)
+    vision_session_state.finish_call()
+    vision_session_state.record_call(source_handle, task)
+
+    envelope = _build_envelope(result, config, request_id=request.request_id)
     envelope["source_handle"] = source_handle
     envelope["request_id"] = result.get("request_id") or source_handle
     return json.dumps(envelope, ensure_ascii=False)

--- a/tools/vision_router_tool.py
+++ b/tools/vision_router_tool.py
@@ -1,0 +1,274 @@
+"""Model-visible Vision Router tool wrapper (Stage 1: registered but hidden).
+
+The wrapper is model-invisible until a session explicitly enables the local
+Vision Router through the approved minimal-enablement gate.
+
+Contract:
+- the model may express SEMANTIC intent only: source_handle / task / mode /
+  region / question;
+- everything else (endpoint, model, transport, num_ctx, num_predict, timeout,
+  retries, keep_alive, fallback, escalation, criticality) is policy-controlled
+  inside the orchestrator profiles;
+- visibility is server-controlled: ``vision_router.enabled``; when false the
+  tool name is filtered out of the model tool set entirely
+  (``model_tools.get_tool_definitions``) — hard invisibility, not runtime
+  POLICY_BLOCKED only;
+- image sources are authorized by handle: ``locator://<key>`` (approved
+  private-locator handles) or an explicit allowlisted handle; anything else
+  returns SOURCE_DENIED with ZERO model calls;
+- result envelope is fail-closed and never contains thinking / raw provider
+  output / base64 / private paths / credentials;
+- OCR long results are bounded: first <=``ocr_excerpt_chars`` chars plus
+  total count, sha256 and a private handle; full text needs an explicit
+  follow-up request.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from typing import Any, Awaitable, Dict, Optional
+
+from tools.registry import registry
+
+# ---------------------------------------------------------------------------
+# Constants (policy-controlled boundaries)
+# ---------------------------------------------------------------------------
+
+DEFAULT_OCR_EXCERPT_CHARS = 4000
+DEFAULT_OCR_PAGE_CHARS = 65536
+DEFAULT_MAX_QUESTION_CHARS = 500
+SOURCE_DENIED = "SOURCE_DENIED"
+
+_TASK_TO_CRITICALITY = {
+    "UI_READ": "HIGH",
+    "EXACT_OCR": "HIGH",
+    "SCENE_DESCRIBE": "NORMAL",
+    "EVIDENCE_VERIFY": "NORMAL",
+}
+
+_ALLOWED_TASKS = ("UI_READ", "SCENE_DESCRIBE", "EVIDENCE_VERIFY", "EXACT_OCR")
+
+
+def _config_value(config: Optional[Dict[str, Any]], key: str, default: Any) -> Any:
+    if not config:
+        return default
+    router = config.get("vision_router") or {}
+    return router.get(key, default)
+
+
+def _authorized_source_handles() -> Dict[str, str]:
+    """Approved locator handles -> resolved local path.
+
+    Only handles listed here are model-authorized image sources. The mapping
+    itself (paths) never leaves this module; the model only ever sees the
+    opaque handle. Public builds carry no locator: the primary
+    authorization path is the session-scoped attachment allowlist
+    (``attachment://`` handles registered by the host).
+    """
+    return {}
+
+
+def _resolve_source(source_handle: str) -> Optional[str]:
+    """Authorize a model-supplied source handle.
+
+    Accepts ``locator://<key>`` (approved locator handle) or a bare key that
+    exists in the approved locator set. Returns the resolved local path, or
+    None when the handle is not authorized (→ SOURCE_DENIED, zero calls).
+    """
+    handle = source_handle.strip()
+    if handle.startswith("locator://"):
+        handle = handle[len("locator://"):]
+    handles = _authorized_source_handles()
+    return handles.get(handle)
+
+
+def _criticality_for(task: str) -> str:
+    """Policy-derived criticality — the model can never force an expensive
+    slot by declaring HIGH (design §10)."""
+    return _TASK_TO_CRITICALITY.get(task, "NORMAL")
+
+
+def _build_envelope(result: Dict[str, Any], config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Safe model-visible envelope. Never contains thinking / raw provider
+    output / base64 / private paths / credentials."""
+    excerpt_limit = int(_config_value(config, "ocr_excerpt_chars",
+                                      DEFAULT_OCR_EXCERPT_CHARS))
+    structured = result.get("structured") or {}
+    observed = structured.get("observed_text")
+    observed_text: Any = observed
+    ocr_meta: Optional[Dict[str, Any]] = None
+    if isinstance(observed, list):
+        joined = "\n".join(str(t) for t in observed if str(t).strip())
+        if len(joined) > excerpt_limit:
+            excerpt = joined[:excerpt_limit]
+            ocr_meta = {
+                "total_chars": len(joined),
+                "returned_chars": len(excerpt),
+                "truncated": True,
+                "sha256": hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16],
+                "private_handle": result.get("request_id"),
+                "full_text_policy": "explicit_followup_required",
+            }
+            observed_text = [excerpt]
+    trace = (result.get("trace") or [{}])[0]
+    envelope = {
+        "request_id": result.get("request_id"),
+        "task": result.get("task"),
+        "selected_slot": result.get("final_model_slot")
+        or result.get("initial_model_slot"),
+        "execution_status": result.get("execution_status"),
+        "quality_decision": result.get("quality_decision"),
+        "observed_text": observed_text,
+        "evidence": structured.get("evidence"),
+        "inference": structured.get("inference"),
+        "uncertainty": structured.get("uncertainty"),
+        "human_review_required": result.get("human_review_required", False),
+        "recommended_next_action": result.get("recommended_next_slot"),
+        "logical_model_calls": result.get("logical_model_calls", 0),
+        "latency_ms": trace.get("latency_ms") or trace.get("total_ms"),
+        "context_headroom": None,
+        "truncation_status": trace.get("done_reason"),
+        "ocr_meta": ocr_meta,
+        "source_handle": None,  # caller fills
+    }
+    return envelope
+
+
+def _source_denied_envelope() -> Dict[str, Any]:
+    """SOURCE_DENIED: zero model calls, nothing leaked."""
+    return {
+        "request_id": None,
+        "execution_status": "POLICY_BLOCKED",
+        "quality_decision": "NOT_EVALUATED",
+        "logical_model_calls": 0,
+        "error": "SOURCE_DENIED: source handle is not authorized",
+        "source_handle": None,
+    }
+
+
+def _build_request(
+    args: Dict[str, Any],
+    resolved_path: str,
+) -> Any:
+    from tools.vision_policy import (
+        VisionRequest, VisionTask, VisionMode, VisionCriticality,
+    )
+    task = str(args.get("task", "UI_READ")).upper()
+    if task not in _ALLOWED_TASKS:
+        task = "UI_READ"
+    question = str(args.get("question") or "")
+    question = question[:DEFAULT_MAX_QUESTION_CHARS]
+    return VisionRequest(
+        request_id="vision-router-tool",
+        image_source=resolved_path,
+        task=VisionTask(task),
+        mode=VisionMode.AUTO,
+        criticality=VisionCriticality(_criticality_for(task)),
+        question=question,
+        required_outputs=["observed_text"],
+    )
+
+
+async def _handle_vision_router(args: Dict[str, Any], **kw: Any) -> str:
+    """Registry handler. Returns a JSON envelope string (tool protocol)."""
+    from tools.vision_orchestrator import analyze_image
+
+    source_handle = str(args.get("source_handle") or "").strip()
+    if not source_handle:
+        return json.dumps(_source_denied_envelope(), ensure_ascii=False)
+
+    resolved_path = _resolve_source(source_handle)
+    if not resolved_path:
+        return json.dumps(_source_denied_envelope(), ensure_ascii=False)
+
+    config = None
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+    except Exception:  # noqa: BLE001
+        config = None
+
+    request = _build_request(args, resolved_path)
+    try:
+        # enabled=None → the server flag (vision_router.enabled) is resolved
+        # inside analyze_image. The model cannot influence it.
+        # base_url → trusted server-side Ollama endpoint (native transport
+        # requires it); never model-visible, never model-supplied.
+        from tools.vision_policy import resolve_ollama_base_url
+
+        result = await analyze_image(
+            request,
+            enabled=None,
+            base_url=resolve_ollama_base_url(config),
+        )
+    except Exception as exc:  # noqa: BLE001 — never crash the tool protocol
+        envelope = {
+            "request_id": request.request_id,
+            "execution_status": "INVALID_RESPONSE",
+            "quality_decision": "NOT_EVALUATED",
+            "logical_model_calls": 0,
+            "error": f"{type(exc).__name__}: {str(exc)[:200]}",
+        }
+        return json.dumps(envelope, ensure_ascii=False)
+
+    envelope = _build_envelope(result, config)
+    envelope["source_handle"] = source_handle
+    envelope["request_id"] = result.get("request_id") or source_handle
+    return json.dumps(envelope, ensure_ascii=False)
+
+
+VISION_ROUTER_SCHEMA = {
+    "name": "vision_router_analyze",
+    "description": (
+        "Analyze an approved screenshot/image through the controlled Vision "
+        "Router (orchestrator profiles: Precision native generate / Fast / "
+        "OCR). Express only semantic intent: an approved source handle, the "
+        "task, and an optional question. All model/transport/context choices "
+        "are policy-controlled. Returns a bounded fail-closed result "
+        "envelope; OCR text longer than the excerpt limit is truncated with "
+        "explicit metadata."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "source_handle": {
+                "type": "string",
+                "description": "Approved image handle (e.g. locator://<key> "
+                               "or a pre-authorized handle). Arbitrary paths "
+                               "and URLs are not authorized.",
+            },
+            "task": {
+                "type": "string",
+                "enum": ["UI_READ", "SCENE_DESCRIBE", "EVIDENCE_VERIFY",
+                         "EXACT_OCR"],
+                "description": "Semantic task intent.",
+            },
+            "mode": {
+                "type": "string",
+                "enum": ["AUTO"],
+                "description": "Routing mode (AUTO only in the initial "
+                               "activation).",
+            },
+            "region": {
+                "type": "string",
+                "description": "Optional bounded region hint (task-dependent).",
+            },
+            "question": {
+                "type": "string",
+                "description": "Optional question about the image.",
+            },
+        },
+        "required": ["source_handle"],
+    },
+}
+
+
+registry.register(
+    name=VISION_ROUTER_SCHEMA["name"],
+    toolset="vision",
+    schema=VISION_ROUTER_SCHEMA,
+    handler=_handle_vision_router,
+    is_async=True,
+    emoji="🛰️",
+)

--- a/tools/vision_session_state.py
+++ b/tools/vision_session_state.py
@@ -1,0 +1,158 @@
+"""In-memory Vision Router session state (Stage-3 limited use).
+
+HERMES_VISION_ROUTER_STAGE3_LIMITED_USE_OPERATING_MODE_DESIGN_V0_1
+(approved token redacted):
+
+- user-only activation flag (slash command ``/vision on|off``); the model can
+  never set it;
+- per-turn / per-session logical-call budgets (enforced in the wrapper);
+- in-flight marker (no concurrent Vision calls);
+- session-scoped attachment-handle allowlist (``attachment://`` -> server path;
+  the model never sees the path);
+- session-scoped OCR full-result registry (private handle -> file) for the
+  bounded ``vision_ocr_page`` retrieval tool.
+
+Everything is process-local and non-persistent. Router=false (server flag)
+still removes all model-visible Vision tools; this state only gates USE inside
+a session where the server flag is already on.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Dict, Optional
+
+DEFAULT_PER_TURN_MAX_CALLS = 1
+DEFAULT_PER_SESSION_MAX_CALLS = 5
+
+
+class _VisionSessionState:
+    """Process-local singleton. Thread-safe for gateway concurrency."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.enabled = False
+        self.per_turn_used = 0
+        self.per_session_used = 0
+        self.in_flight = False
+        self.attachment_allowlist: Dict[str, str] = {}
+        self.ocr_results: Dict[str, str] = {}  # private handle -> file path
+        self._recent_calls: list = []  # (source_handle, task) dedupe
+        self._last_turn_marker: Optional[str] = None
+
+    # -- activation ----------------------------------------------------------
+    def set_enabled(self, flag: bool) -> None:
+        with self._lock:
+            self.enabled = bool(flag)
+            # any transition resets budgets and revokes session sources:
+            # enabling starts a fresh limited-use session, disabling is the
+            # immediate kill switch.
+            self.attachment_allowlist.clear()
+            self.ocr_results.clear()
+            self.per_turn_used = 0
+            self.per_session_used = 0
+            self.in_flight = False
+            self._recent_calls.clear()
+
+    # -- turn boundary -------------------------------------------------------
+    def begin_turn(self, marker: Optional[str] = None) -> None:
+        """Call at the start of an Agent turn. ``marker`` may be a turn id;
+        without one, each call resets the per-turn counter (conservative)."""
+        with self._lock:
+            if marker is None or marker != self._last_turn_marker:
+                self.per_turn_used = 0
+                self._last_turn_marker = marker
+
+    def end_turn(self) -> None:
+        with self._lock:
+            self.per_turn_used = 0
+
+    # -- budget --------------------------------------------------------------
+    def consume_call(self, per_turn_max: int, per_session_max: int) -> Optional[str]:
+        """Try to consume one logical Vision call slot.
+
+        Returns None when allowed; otherwise a BUSY reason string.
+        """
+        with self._lock:
+            if not self.enabled:
+                return "SESSION_DISABLED"
+            if self.in_flight:
+                return "VISION_BUSY_IN_FLIGHT"
+            if self.per_turn_used >= per_turn_max:
+                return "TURN_BUDGET_EXHAUSTED"
+            if self.per_session_used >= per_session_max:
+                return "SESSION_BUDGET_EXHAUSTED"
+            self.in_flight = True
+            return None
+
+    def finish_call(self) -> None:
+        with self._lock:
+            self.per_turn_used += 1
+            self.per_session_used += 1
+            self.in_flight = False
+
+    def fail_call(self) -> None:
+        with self._lock:
+            self.in_flight = False
+
+    # -- same-source dedupe --------------------------------------------------
+    def needs_authorization(self, source_handle: str, task: str) -> bool:
+        with self._lock:
+            return (source_handle, task) in self._recent_calls
+
+    def record_call(self, source_handle: str, task: str) -> None:
+        with self._lock:
+            self._recent_calls.append((source_handle, task))
+
+    def authorize_source_task(self, source_handle: str, task: str) -> None:
+        """Explicit user authorization for a repeated source+task."""
+        with self._lock:
+            while (source_handle, task) in self._recent_calls:
+                self._recent_calls.remove((source_handle, task))
+
+    # -- attachment handles --------------------------------------------------
+    def register_attachment(self, handle: str, path: str) -> None:
+        with self._lock:
+            self.attachment_allowlist[handle] = path
+
+    def resolve_attachment(self, handle: str) -> Optional[str]:
+        with self._lock:
+            return self.attachment_allowlist.get(handle)
+
+    def has_attachment(self, handle: str) -> bool:
+        with self._lock:
+            return handle in self.attachment_allowlist
+
+    def revoke_attachment(self, handle: str) -> None:
+        with self._lock:
+            self.attachment_allowlist.pop(handle, None)
+
+    # -- OCR result registry -------------------------------------------------
+    def register_ocr_result(self, handle: str, file_path: str) -> None:
+        with self._lock:
+            self.ocr_results[handle] = file_path
+
+    def resolve_ocr_result(self, handle: str) -> Optional[str]:
+        with self._lock:
+            return self.ocr_results.get(handle)
+
+    def revoke_ocr_result(self, handle: str) -> None:
+        with self._lock:
+            self.ocr_results.pop(handle, None)
+
+    # -- snapshot for tests / reporting --------------------------------------
+    def snapshot(self) -> Dict[str, object]:
+        with self._lock:
+            return {
+                "enabled": self.enabled,
+                "per_turn_used": self.per_turn_used,
+                "per_session_used": self.per_session_used,
+                "in_flight": self.in_flight,
+                "attachment_handles": sorted(self.attachment_allowlist),
+                "ocr_handles": sorted(self.ocr_results),
+                "recent_calls": list(self._recent_calls),
+            }
+
+
+# Process-local singleton.
+vision_session_state = _VisionSessionState()

--- a/toolsets.py
+++ b/toolsets.py
@@ -41,7 +41,7 @@ _HERMES_CORE_TOOLS = [
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
     # Vision + image generation
-    "vision_analyze", "image_generate",
+    "vision_analyze", "vision_router_analyze", "vision_ocr_page", "image_generate",
     # BFL FLUX 3 video generation
     "bfl_flux3_text_to_video", "bfl_flux3_image_to_video",
     "bfl_flux3_keyframes_to_video", "bfl_flux3_video_continuation",
@@ -127,10 +127,9 @@ TOOLSETS = {
     
     "vision": {
         "description": "Image analysis and vision tools",
-        "tools": ["vision_analyze"],
+        "tools": ["vision_analyze", "vision_router_analyze", "vision_ocr_page"],
         "includes": []
     },
-
     "video": {
         "description": "Video analysis and understanding tools (opt-in, not in default toolset)",
         "tools": ["video_analyze"],
@@ -866,6 +865,43 @@ def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
         if toolset:
             result[display_name] = toolset
     return result
+
+
+# Vision Router tool visibility: the controlled wrapper tool
+# `vision_router_analyze` is model-visible ONLY when the effective gate is
+# true (server flag vision_router.enabled OR the in-memory session flag set
+# by the user-only /vision command). get_tool_definitions filters it out
+# when the gate is false — hard invisibility even through combination
+# toolsets (e.g. "safe" includes "vision").
+VISION_ROUTER_TOOL = "vision_router_analyze"
+VISION_OCR_PAGE_TOOL = "vision_ocr_page"
+
+
+def vision_router_tool_visible(config: Optional[Dict[str, Any]] = None) -> bool:
+    """Server-side visibility gate for the Vision Router wrapper tool.
+
+    Default is always False; the live runtime configuration is never
+    modified here. Mirrors ``vision_orchestrator.vision_router_enabled`` and
+    resolves the canonical ``auxiliary.vision_router`` section (legacy
+    top-level fallback only when the nested mapping is absent).
+    """
+    from tools.vision_policy import resolve_vision_router_enabled
+
+    return resolve_vision_router_enabled(config)
+
+
+def vision_router_effective_visible(
+    config: Optional[Dict[str, Any]] = None
+) -> bool:
+    """Effective model-visible flag: server flag OR the in-memory session
+    flag (limited-use session mode, user-only ``/vision on``). The session
+    flag never persists and the model can never set it.
+    """
+    if vision_router_tool_visible(config):
+        return True
+    from tools.vision_session_state import vision_session_state
+
+    return vision_session_state.enabled
 
 
 def get_toolset_names() -> List[str]:


### PR DESCRIPTION
## What does this PR do?

Adds an optional, disabled-by-default local Vision routing mode that can be enabled for an individual Hermes session without changing the existing persistent Vision configuration.

## Related Issue

No linked issue — this is a standalone enhancement contribution.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Adds an inactive local Vision orchestrator with policy-based task and model slot selection.
- Adds an Ollama native `/api/generate` transport for the PRECISION profile.
- Adds `/vision on`, `/vision off`, and `/vision status`.
- Adds session-scoped tool visibility:
  - Router disabled: existing `vision_analyze` remains available.
  - Router enabled: `vision_router_analyze` and `vision_ocr_page` replace the legacy Vision tool for that session.
  - Router disabled again: legacy Vision is restored.
- Adds per-turn and per-session call limits, in-flight exclusion, and explicit duplicate-request authorization.
- Adds opaque, session-bound attachment and OCR handles.
- Adds bounded OCR pagination that does not invoke a model.
- Adds request-ID propagation for unique OCR result handles.
- Adds native/OpenAI-compatible response handling, structured-output parsing, and WebP transport support.

## How to Test

1. Run the Vision test group: `pytest tests/tools/test_vision_router_tool.py tests/tools/test_vision_policy.py tests/tools/test_vision_orchestrator.py` (366 tests in the full Vision group pass, 0 skipped).
2. Verify default behavior: `auxiliary.vision_router.enabled` is `false`, and the existing `vision_analyze` tool remains available.
3. Optional in a session: `/vision on` exposes `vision_router_analyze` and `vision_ocr_page`; `/vision off` restores legacy Vision.
4. 219 portability checks pass when the test suite is executed outside the repository working directory.

## Checklist

- [x] Disabled-by-default; legacy `vision_analyze` preserved while off
- [x] Session-only activation via `/vision on|off|status`
- [x] PRECISION uses native `/api/generate` with `num_ctx=32768`, `num_predict=4000`
- [x] Per-turn limit 1, per-session limit 5, in-flight exclusion, duplicate authorization
- [x] Attachment/OCR handles session-bound; OCR paging performs zero model calls
- [x] No automatic fallback, escalation, second model, or Browser invocation
- [x] No private calibration files or locator required
- [x] 366 passed / 0 failed / 0 skipped; no live model, Ollama, provider, or Browser calls
