### PR TITLE
fix(slack): always emit finalize=True edit after last stream chunk (#77805)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3522,6 +3522,17 @@ class BasePlatformAdapter(ABC):
     # property) so the stream consumer knows not to short-circuit.
     REQUIRES_EDIT_FINALIZE: bool = False
 
+    # Weaker companion to REQUIRES_EDIT_FINALIZE: adapters that attach a
+    # rich payload (e.g. Slack Block Kit ``rich_blocks``) ONLY on the
+    # finalize=True edit must still receive that edit even when the last
+    # streamed chunk already delivered the identical text — otherwise the
+    # payload is silently dropped on single-chunk messages (#77805).
+    # Unlike REQUIRES_EDIT_FINALIZE, a mid-stream finalize edit that DID
+    # run already attached the payload, so the stream consumer's
+    # redundant-final-edit skip stays active for these adapters (no
+    # double finalize edit).
+    FINALIZE_EDIT_ATTACHES_RICH_PAYLOAD: bool = False
+
     async def create_handoff_thread(
         self,
         parent_chat_id: str,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -290,6 +290,17 @@ class GatewayStreamConsumer:
         self._adapter_requires_finalize: bool = (
             getattr(adapter, "REQUIRES_EDIT_FINALIZE", False) is True
         )
+        # Adapters that attach a rich payload (e.g. Slack Block Kit
+        # rich_blocks) only on the finalize=True edit need that edit to run
+        # even when the last streamed chunk already delivered the identical
+        # text — otherwise the payload is silently dropped on single-chunk
+        # messages (#77805).  Weaker than REQUIRES_EDIT_FINALIZE: a
+        # mid-stream finalize edit that DID run already attached the
+        # payload, so the got_done redundant-edit skip stays active for
+        # these adapters (no double finalize edit).
+        self._adapter_finalize_attaches_rich_payload: bool = (
+            getattr(adapter, "FINALIZE_EDIT_ATTACHES_RICH_PAYLOAD", False) is True
+        )
 
         # Session staleness guard — when set to False (e.g. after /new or
         # /stop), the run() loop will abandon the stream early instead of
@@ -2083,9 +2094,18 @@ class GatewayStreamConsumer:
                     # call (REQUIRES_EDIT_FINALIZE) must still receive the
                     # finalize=True edit even when content is unchanged, so
                     # their streaming UI can transition out of the in-
-                    # progress state.  Everyone else short-circuits.
+                    # progress state.  Adapters that attach a rich payload
+                    # only on the finalize edit (Slack Block Kit
+                    # rich_blocks, FINALIZE_EDIT_ATTACHES_RICH_PAYLOAD)
+                    # must also receive it — skipping here would silently
+                    # drop the block payload on single-chunk messages
+                    # (#77805).  Everyone else short-circuits.
                     if text == self._last_sent_text and not (
-                        finalize and self._adapter_requires_finalize
+                        finalize
+                        and (
+                            self._adapter_requires_finalize
+                            or self._adapter_finalize_attaches_rich_payload
+                        )
                     ):
                         return True
                     # Fresh-final for long-lived previews: when finalizing

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -870,6 +870,12 @@ class SlackAdapter(BasePlatformAdapter):
 
     MAX_MESSAGE_LENGTH = 39000  # Slack API allows 40,000 chars; leave margin
     supports_code_blocks = True  # Slack mrkdwn renders fenced code blocks
+    # Slack's edit_message attaches Block Kit blocks (rich_blocks /
+    # markdown_blocks) only on the finalize=True edit.  Without this flag
+    # the stream consumer short-circuits when the last streamed chunk
+    # already delivered the identical text, silently dropping the block
+    # payload on single-chunk messages (#77805).
+    FINALIZE_EDIT_ATTACHES_RICH_PAYLOAD: bool = True
     # Slack's typing indicator is a text status line (assistant.threads
     # .setStatus), so the gateway feeds it live per-tool phrases.
     supports_status_text = True

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -108,6 +108,18 @@ def test_slack_mock_bootstrap_preserves_installed_packages():
     if PathFinder.find_spec("slack_sdk") is not None:
         assert isinstance(importlib.import_module("slack_sdk.errors"), ModuleType)
 
+
+def test_slack_adapter_declares_rich_payload_finalize_flag():
+    """Slack's edit_message attaches Block Kit blocks only on the
+    finalize=True edit, so the adapter must declare
+    FINALIZE_EDIT_ATTACHES_RICH_PAYLOAD for the stream consumer to keep
+    emitting that edit when the last streamed chunk already delivered the
+    identical text (#77805).  It must NOT claim REQUIRES_EDIT_FINALIZE:
+    Slack has no streaming lifecycle to close, and that flag would force
+    a redundant second finalize edit."""
+    assert SlackAdapter.FINALIZE_EDIT_ATTACHES_RICH_PAYLOAD is True
+    assert SlackAdapter.REQUIRES_EDIT_FINALIZE is False
+
 # ---------------------------------------------------------------------------
 # TestIgnoredChannelOutboundSuppression
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -120,6 +120,81 @@ class TestFinalizeCapabilityGate:
         picky.edit_message.assert_called_once()
         assert picky.edit_message.call_args[1]["finalize"] is True
 
+    @pytest.mark.asyncio
+    async def test_identical_text_skip_respects_rich_payload_flag(self):
+        """Adapters that attach a rich payload on the finalize edit (Slack
+        Block Kit rich_blocks, #77805) must still receive the finalize=True
+        edit when the last streamed chunk already delivered the identical
+        text — otherwise the block payload is silently dropped."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.FINALIZE_EDIT_ATTACHES_RICH_PAYLOAD = True
+        adapter.send = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="m1",
+        ))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="m1",
+        ))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        consumer = GatewayStreamConsumer(adapter, "chat_1")
+        await consumer._send_or_edit("hello")  # first send
+        await consumer._send_or_edit("hello", finalize=True)  # identical
+        # The finalize edit must go through so the adapter can attach
+        # its rich payload (blocks) to the final message.
+        adapter.edit_message.assert_called_once()
+        assert adapter.edit_message.call_args[1]["finalize"] is True
+
+    @pytest.mark.asyncio
+    async def test_slack_single_chunk_finalize_edit_after_last_chunk(self):
+        """End-to-end regression for #77805: when the last streamed chunk
+        already delivered the full text, the finalize=True edit that
+        attaches Slack rich_blocks must still run after the stream ends.
+
+        Short single-chunk message on a Slack-like adapter
+        (FINALIZE_EDIT_ATTACHES_RICH_PAYLOAD=True, REQUIRES_EDIT_FINALIZE
+        False): the preview is created by the first send, then the done
+        tick carries text identical to the last frame — the finalize edit
+        must not be short-circuited.  Exactly one finalize edit (the
+        redundant-edit skip must still prevent a double edit)."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.FINALIZE_EDIT_ATTACHES_RICH_PAYLOAD = True
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="m1",
+        ))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="m1",
+        ))
+        # Empty cursor: the done tick's text is identical to the last
+        # streamed frame (no cursor to strip), reproducing the exact
+        # finalize-skip condition reported in #77805.
+        config = StreamConsumerConfig(
+            edit_interval=10.0, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.02)
+        consumer.on_delta("Hello")
+        await asyncio.sleep(0.05)  # buffer_threshold creates the preview
+        consumer.finish()
+        await asyncio.sleep(0.1)
+        await task
+
+        finals = [
+            call.kwargs.get("finalize")
+            for call in adapter.edit_message.call_args_list
+        ]
+        assert finals and finals[-1] is True, (
+            "finalize=True edit skipped when the last chunk already "
+            "delivered the full text — Slack rich_blocks silently "
+            "dropped (#77805)"
+        )
+        assert finals.count(True) == 1, (
+            "expected exactly one finalize edit; got %r" % (finals,)
+        )
+        assert consumer._final_content_delivered is True
+
 
 class TestEditMessageFinalizeSignature:
     """Every concrete platform adapter must accept the ``finalize`` kwarg.


### PR DESCRIPTION
## Summary

Fixes #77805 — the gateway streaming consumer can skip the `finalize=True` edit that attaches Slack Block Kit blocks (`rich_blocks`) to an outbound message. When the last streamed chunk already delivered the full message text, the finalize edit was short-circuited as `text == _last_sent_text`, and the block payload was silently dropped: the text arrives, the blocks never render (single-chunk / short messages).

## Root Cause

`gateway/stream_consumer.py` → `_send_or_edit()` skips an edit when its text is identical to the last frame sent:

```python
if text == self._last_sent_text and not (
    finalize and self._adapter_requires_finalize
):
    return True
```

The only exemption was `REQUIRES_EDIT_FINALIZE` (DingTalk AI Cards, Telegram formatting), which forces the finalize edit to run even on identical content — but it also disables the consumer's redundant-final-edit skip, causing a second redundant finalize edit for adapters that don't have a streaming lifecycle to close.

Slack's `edit_message()` attaches Block Kit blocks **only on the `finalize=True` edit** (`adapter.py` `if finalize: blocks = self._maybe_blocks(content)`). Slack does not set `REQUIRES_EDIT_FINALIZE`, so on a single-chunk stream where the last frame already carried the full text (e.g. empty/cursorless streaming cursor config, or any tick where the done frame matches the last edit), the finalize edit was skipped and `rich_blocks` were dropped with no error or warning.

## Change

Add a weaker, dedicated adapter capability — `FINALIZE_EDIT_ATTACHES_RICH_PAYLOAD` — and honor it in the identical-text skip:

- **`gateway/platforms/base.py`**: document the new default-`False` class attribute next to `REQUIRES_EDIT_FINALIZE`. Unlike that flag, it does **not** disable the redundant-final-edit skip (a mid-stream finalize that *did* run already attached the payload → no double edit).
- **`gateway/stream_consumer.py`**: read the flag in `__init__` (same `is True` MagicMock-safe pattern as `REQUIRES_EDIT_FINALIZE`) and extend the identical-text short-circuit so a `finalize=True` edit is always emitted for such adapters.
- **`plugins/platforms/slack/adapter.py`**: set `FINALIZE_EDIT_ATTACHES_RICH_PAYLOAD = True` — `edit_message(finalize=True)` is the only path that attaches Block Kit blocks to an edit-based streaming message.

## Verification

- New unit test `test_identical_text_skip_respects_rich_payload_flag` (identical text + finalize=True must still reach `edit_message`).
- New end-to-end regression `test_slack_single_chunk_finalize_edit_after_last_chunk`: short single-chunk stream on a Slack-like adapter with an empty cursor (the exact skip condition) — asserts the finalize=True edit fires after the last chunk **and** that exactly one finalize edit runs (no redundant double edit). Both fail without the fix, pass with it.
- New wiring test `test_slack_adapter_declares_rich_payload_finalize_flag`.
- Existing suites pass: `tests/gateway/test_stream_consumer*.py` (incl. draft/fresh_final/silence/thread_routing), `test_slack.py`, `test_telegram_final_delivery.py`, `test_duplicate_reply_suppression.py`, `test_relay_capability_surface.py` — 280+ tests, plus ruff clean.

Closes #77805