### PR TITLE
fix(streaming): fire finalize edit for adapters with extra content (#77805)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3522,6 +3522,17 @@ class BasePlatformAdapter(ABC):
     # property) so the stream consumer knows not to short-circuit.
     REQUIRES_EDIT_FINALIZE: bool = False
 
+    #: When True, the adapter attaches extra content during the finalize
+    #: edit (e.g. Slack Block Kit blocks) that is NOT captured by the text
+    #: string used for the stream consumer's no-op skip.  When set, the
+    #: consumer must not short-circuit a finalize edit even when the text is
+    #: identical to the last streamed frame — the extra content (blocks)
+    #: would be silently dropped (#77805).  Unlike ``REQUIRES_EDIT_FINALIZE``
+    #: (a lifecycle need), this flags a *content* need, so it is typically a
+    #: property that returns True only when a block / formatting mode is
+    #: actually enabled at runtime.
+    FINALIZE_APPLIES_EXTRA_CONTENT: bool = False
+
     async def create_handoff_thread(
         self,
         parent_chat_id: str,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -291,6 +291,17 @@ class GatewayStreamConsumer:
             getattr(adapter, "REQUIRES_EDIT_FINALIZE", False) is True
         )
 
+        # Cache whether the adapter attaches extra content (e.g. Block Kit
+        # blocks) on the finalize edit that is NOT captured by the text
+        # string.  When True, the no-op skip must not fire on a finalize
+        # edit even when text is unchanged — the extra content would be
+        # silently dropped (#77805).  Use ``is True`` for the same MagicMock
+        # safety as ``_adapter_requires_finalize`` above; concrete adapters
+        # that need dynamic behaviour expose it as a property.
+        self._finalize_carries_extras: bool = (
+            getattr(adapter, "FINALIZE_APPLIES_EXTRA_CONTENT", False) is True
+        )
+
         # Session staleness guard — when set to False (e.g. after /new or
         # /stop), the run() loop will abandon the stream early instead of
         # continuing to edit and deliver stale deltas.
@@ -2083,9 +2094,18 @@ class GatewayStreamConsumer:
                     # call (REQUIRES_EDIT_FINALIZE) must still receive the
                     # finalize=True edit even when content is unchanged, so
                     # their streaming UI can transition out of the in-
-                    # progress state.  Everyone else short-circuits.
+                    # progress state.  The same exception applies to adapters
+                    # that attach extra content on finalize
+                    # (FINALIZE_APPLIES_EXTRA_CONTENT, e.g. Slack Block Kit
+                    # blocks) — the extra payload is invisible to the text
+                    # comparison and would be silently dropped (#77805).
+                    # Everyone else short-circuits.
                     if text == self._last_sent_text and not (
-                        finalize and self._adapter_requires_finalize
+                        finalize
+                        and (
+                            self._adapter_requires_finalize
+                            or self._finalize_carries_extras
+                        )
                     ):
                         return True
                     # Fresh-final for long-lived previews: when finalizing

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3433,6 +3433,19 @@ class SlackAdapter(BasePlatformAdapter):
             return False
         return str(raw).strip().lower() in {"1", "true", "yes", "on"}
 
+    @property
+    def FINALIZE_APPLIES_EXTRA_CONTENT(self) -> bool:  # noqa: N802
+        """Whether the finalize edit carries Block Kit payload (#77805).
+
+        When either ``rich_blocks`` or ``markdown_blocks`` is enabled the
+        finalize ``edit_message`` call renders Block Kit content that is
+        invisible to the stream consumer's text-based no-op skip.  Returning
+        True ensures that edit always fires so blocks are attached even on
+        single-chunk streamed messages where the last progressive edit
+        already delivered the full text.
+        """
+        return self._rich_blocks_enabled() or self._markdown_blocks_enabled()
+
     def _markdown_blocks_enabled(self) -> bool:
         """Whether to render outbound messages via Slack's ``markdown`` block.
 

--- a/tests/gateway/test_slack_block_kit_adapter.py
+++ b/tests/gateway/test_slack_block_kit_adapter.py
@@ -185,3 +185,25 @@ class TestMarkdownBlockMode:
         assert kwargs["blocks"][0]["text"] == RICH_TABLE_MD
 
 
+class TestFinalizeAppliesExtraContentFlag:
+    """FINALIZE_APPLIES_EXTRA_CONTENT signals the stream consumer that the
+    finalize edit carries Block Kit payload (#77805).
+
+    When the flag is True the consumer must not no-op-skip a finalize edit
+    even when the text is identical to the last streamed frame, so blocks
+    are never silently dropped on single-chunk messages.
+    """
+
+    def test_disabled_by_default(self):
+        adapter, _ = _make_adapter()
+        assert adapter.FINALIZE_APPLIES_EXTRA_CONTENT is False
+
+    def test_enabled_with_rich_blocks(self):
+        adapter, _ = _make_adapter({"rich_blocks": "true"})
+        assert adapter.FINALIZE_APPLIES_EXTRA_CONTENT is True
+
+    def test_enabled_with_markdown_blocks(self):
+        adapter, _ = _make_adapter({"markdown_blocks": True})
+        assert adapter.FINALIZE_APPLIES_EXTRA_CONTENT is True
+
+

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -121,6 +121,55 @@ class TestFinalizeCapabilityGate:
         assert picky.edit_message.call_args[1]["finalize"] is True
 
 
+class TestFinalizeExtraContentGate:
+    """Verify FINALIZE_APPLIES_EXTRA_CONTENT gates the no-op skip (#77805).
+
+    Adapters that attach extra payload (e.g. Slack Block Kit blocks) during
+    the finalize edit — content that is NOT captured by the text string —
+    must still receive the finalize edit even when text is identical to the
+    last streamed frame.  Without this, single-chunk messages silently drop
+    their rich_blocks payload.
+    """
+
+    @pytest.mark.asyncio
+    async def test_extras_adapter_not_skipped_on_finalize(self):
+        """An adapter with FINALIZE_APPLIES_EXTRA_CONTENT=True must always
+        receive the finalize edit, even on identical text."""
+        extras = MagicMock()
+        extras.REQUIRES_EDIT_FINALIZE = False
+        extras.FINALIZE_APPLIES_EXTRA_CONTENT = True
+        extras.send = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="m1",
+        ))
+        extras.edit_message = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="m1",
+        ))
+        extras.MAX_MESSAGE_LENGTH = 4096
+        c = GatewayStreamConsumer(extras, "chat_1")
+        await c._send_or_edit("hello")  # first send (creates message)
+        await c._send_or_edit("hello", finalize=True)  # identical text, finalize
+        # The finalize edit MUST fire so the adapter can attach blocks.
+        extras.edit_message.assert_called_once()
+        assert extras.edit_message.call_args[1]["finalize"] is True
+
+    @pytest.mark.asyncio
+    async def test_extras_disabled_adapter_still_skips(self):
+        """An adapter WITHOUT extras must still skip redundant finalize
+        edits (regression guard — no unnecessary API calls)."""
+        plain = MagicMock()
+        plain.REQUIRES_EDIT_FINALIZE = False
+        plain.FINALIZE_APPLIES_EXTRA_CONTENT = False
+        plain.send = AsyncMock(return_value=SimpleNamespace(
+            success=True, message_id="m1",
+        ))
+        plain.edit_message = AsyncMock()
+        plain.MAX_MESSAGE_LENGTH = 4096
+        c = GatewayStreamConsumer(plain, "chat_1")
+        await c._send_or_edit("hello")
+        await c._send_or_edit("hello", finalize=True)  # identical → skip
+        plain.edit_message.assert_not_called()
+
+
 class TestEditMessageFinalizeSignature:
     """Every concrete platform adapter must accept the ``finalize`` kwarg.
 


### PR DESCRIPTION
## What

On a streaming-enabled Slack connection, the stream consumer's no-op skip can
suppress the `finalize=True` edit when the last progressive frame already
delivered the full text. That finalize edit is the **only** edit that attaches
Block Kit content (`rich_blocks` / `markdown_blocks`), so single-chunk / short
messages silently render as plain text — the blocks are dropped with no error
or warning.

## Root cause

`GatewayStreamConsumer._send_or_edit()` short-circuits a finalize edit when
`text == self._last_sent_text` unless the adapter sets
`REQUIRES_EDIT_FINALIZE`. That flag covers a **lifecycle** need (Telegram
MarkdownV2, DingTalk AI Cards — they need the finalize call to transition their
streaming UI). It does not cover a **content** need: adapters that attach extra
payload on finalize (Slack Block Kit) that is invisible to the text comparison.

The Slack adapter's `edit_message` only calls `_maybe_blocks(content)` inside
`if finalize:` — so when the skip suppresses that call, blocks never attach.

## Fix

Add a sibling capability flag `FINALIZE_APPLIES_EXTRA_CONTENT` (default
`False`) alongside `REQUIRES_EDIT_FINALIZE` on `BasePlatformAdapter`. The stream
consumer includes it in the skip condition, so adapters that attach extra
content always receive the finalize edit even on identical text.

- `gateway/platforms/base.py` — new class attribute with docstring
- `gateway/stream_consumer.py` — cache flag at init (`is True` for MagicMock
  safety, mirroring `_adapter_requires_finalize`); include in skip condition
- `plugins/platforms/slack/adapter.py` — override as a property returning
  `_rich_blocks_enabled() or _markdown_blocks_enabled()`

Adapters without extra content (the default) keep the fast skip path — no extra
API calls on rate-limited platforms.

## Verification

**RED → GREEN proof:** `test_extras_adapter_not_skipped_on_finalize` fails on
`upstream/main` (finalize edit skipped despite identical text) and passes after
the fix.

```
tests/gateway/test_stream_consumer.py::TestFinalizeExtraContentGate (2)   PASS
tests/gateway/test_stream_consumer.py::TestFinalizeCapabilityGate (1)     PASS
tests/gateway/test_slack_block_kit_adapter.py::TestFinalizeAppliesExtraContentFlag (3)  PASS
```

Broader nearby suites: **81 passed, 0 failed**
(`test_stream_consumer.py` + `test_slack_block_kit_adapter.py`).

Regression guard `test_extras_disabled_adapter_still_skips` confirms plain
adapters still skip redundant finalize edits.

Fixes #77805.

---

Auto-published by Moonsong via Path B automated pipeline.