### PR TITLE
perf(cli): propagate --prefer-offline to sibling npm install sites

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2042,6 +2042,10 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             "--silent",
             "--no-fund",
             "--no-audit",
+            # --prefer-offline: reuse npm's local cache instead of
+            # re-fetching metadata on every launch-time reinstall (same
+            # flag the update path adopted; see perf(cli) #39267/#39399).
+            "--prefer-offline",
             "--progress=false",
         ]
 
@@ -2754,6 +2758,47 @@ def cmd_proxy(args):
         raise SystemExit(rc)
 
 
+def _install_whatsapp_bridge_deps(bridge_dir: Path) -> bool:
+    """Install the WhatsApp bridge dependencies; True on success.
+
+    Extracted from ``cmd_whatsapp`` so the npm command shape is directly
+    testable. ``--prefer-offline`` reuses npm's local cache instead of
+    re-fetching registry metadata (same flag the update/web paths adopted,
+    perf(cli) #39267/#39399).
+    """
+    print(
+        "\n→ Installing WhatsApp bridge dependencies (this can take a few minutes)..."
+    )
+    from hermes_constants import find_node_executable, with_hermes_node_path
+
+    npm = find_node_executable("npm")
+    if not npm:
+        print("  ✗ npm not found on PATH — install Node.js first")
+        return False
+    try:
+        result = subprocess.run(
+            [npm, "install", "--no-fund", "--no-audit", "--prefer-offline", "--progress=false"],
+            cwd=str(bridge_dir),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=with_hermes_node_path(),
+        )
+    except KeyboardInterrupt:
+        print("\n  ✗ Install cancelled")
+        return False
+    if result.returncode != 0:
+        err = (result.stderr or "").strip()
+        preview = "\n".join(err.splitlines()[-30:]) if err else "(no output)"
+        print("  ✗ npm install failed:")
+        print(preview)
+        return False
+    print("  ✓ Dependencies installed")
+    return True
+
+
 def cmd_whatsapp(args):
     """Set up WhatsApp: choose mode, configure, install bridge, pair via QR."""
     _require_tty("whatsapp")
@@ -2870,34 +2915,8 @@ def cmd_whatsapp(args):
         return
 
     if not (bridge_dir / "node_modules").exists():
-        print(
-            "\n→ Installing WhatsApp bridge dependencies (this can take a few minutes)..."
-        )
-        npm = find_node_executable("npm")
-        if not npm:
-            print("  ✗ npm not found on PATH — install Node.js first")
+        if not _install_whatsapp_bridge_deps(bridge_dir):
             return
-        try:
-            result = subprocess.run(
-                [npm, "install", "--no-fund", "--no-audit", "--progress=false"],
-                cwd=str(bridge_dir),
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                env=with_hermes_node_path(),
-            )
-        except KeyboardInterrupt:
-            print("\n  ✗ Install cancelled")
-            return
-        if result.returncode != 0:
-            err = (result.stderr or "").strip()
-            preview = "\n".join(err.splitlines()[-30:]) if err else "(no output)"
-            print("  ✗ npm install failed:")
-            print(preview)
-            return
-        print("  ✓ Dependencies installed")
     else:
         print("✓ Bridge dependencies already installed")
 
@@ -7064,7 +7083,11 @@ def cmd_gui(args: argparse.Namespace):
             # NixOS build env keeps its PYTHON hint while restoring managed Node
             # ahead of a bare PATH (same idiom as the `hermes update` path).
             nixos_env = with_hermes_node_path(_nixos_build_env())
-            install_result = _run_npm_install_deterministic(npm, PROJECT_ROOT, capture_output=False, env=nixos_env)
+            install_result = _run_npm_install_deterministic(
+                npm, PROJECT_ROOT,
+                extra_args=("--prefer-offline",),
+                capture_output=False, env=nixos_env,
+            )
             if install_result.returncode != 0:
                 if not _electron_pkg_staged_missing_dist(PROJECT_ROOT):
                     print("✗ Desktop dependency install failed")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8508,7 +8508,7 @@ def _ensure_whatsapp_bridge_dependencies(bridge_dir: Path) -> None:
     timeout = env_int("WHATSAPP_NPM_INSTALL_TIMEOUT", 300)
     try:
         result = subprocess.run(
-            [npm, "install", "--silent"],
+            [npm, "install", "--silent", "--prefer-offline"],
             cwd=str(bridge_dir),
             capture_output=True,
             text=True,

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -75,6 +75,9 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     mock_install.assert_called_once()
     assert mock_install.call_args.args == ("/usr/bin/npm", root)
     assert mock_install.call_args.kwargs["capture_output"] is False
+    # perf(cli): the desktop dependency install reuses npm's local cache —
+    # same --prefer-offline flag the update/web paths adopted (#39267/#39399).
+    assert mock_install.call_args.kwargs.get("extra_args") == ("--prefer-offline",)
     install_env = mock_install.call_args.kwargs["env"]
     assert install_env is not None and "PATH" in install_env
     assert mock_run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -176,3 +176,40 @@ def test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile(
     assert install_cmd[:2] == ["/bin/npm", "install"]
     # cwd must be tui_dir (standalone), not parent
     assert calls[0][1]["cwd"] == str(tui_dir)
+
+
+def test_tui_install_cmd_prefers_offline_cache(main_mod, monkeypatch, tmp_path) -> None:
+    """Measured-work pin: the launch-time TUI npm install reuses the cache.
+
+    The update path adopted ``--prefer-offline`` (perf(cli) #39267/#39399) so
+    npm stops re-fetching metadata on repeat installs. The TUI auto-install —
+    which runs on every launch while deps are stale — was a sibling that
+    missed the flag. Without it the launch-time reinstall hits the network
+    every time; with it, npm reuses its local cache.
+    """
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    # Parent (workspace root) has the lockfile; install uses --workspace.
+    (tmp_path / "package-lock.json").write_text("{}")
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+    calls = []
+
+    def fake_run(*args, **kwargs):
+        calls.append((args, kwargs))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    install_cmd = calls[0][0][0]
+    assert install_cmd[:2] == ["/bin/npm", "install"]
+    assert "--prefer-offline" in install_cmd, (
+        f"TUI npm install should pass --prefer-offline (same as the update "
+        f"path, perf(cli) #39267), got: {install_cmd}"
+    )

--- a/tests/hermes_cli/test_whatsapp_bridge_npm_offline.py
+++ b/tests/hermes_cli/test_whatsapp_bridge_npm_offline.py
@@ -1,0 +1,99 @@
+"""Measured-work pins for npm --prefer-offline at the WhatsApp bridge sites.
+
+perf(cli) #39267/#39399 adopted ``--prefer-offline`` for the update/web
+npm installs so npm reuses its local cache instead of re-fetching
+metadata. The WhatsApp bridge installs (CLI setup and dashboard surface)
+were sibling sites that missed the flag; these pins hold the propagation
+in place.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def bridge_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "whatsapp-bridge"
+    d.mkdir(parents=True)
+    (d / "bridge.js").write_text("// bridge")
+    return d
+
+
+def test_cli_whatsapp_bridge_install_prefers_offline(bridge_dir: Path, monkeypatch) -> None:
+    """``cmd_whatsapp``'s bridge install passes ``--prefer-offline``.
+
+    The setup wizard runs ``npm install`` in the bridge dir when
+    node_modules is missing. It must reuse npm's local cache (same flag
+    as the update path) rather than re-fetching metadata.
+    """
+    import hermes_cli.main as cli_main
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    import hermes_constants
+
+    monkeypatch.setattr(cli_main.subprocess, "run", fake_run)
+    # The helper imports these from hermes_constants inside the function,
+    # so patch the source module.
+    monkeypatch.setattr(
+        hermes_constants, "find_node_executable", lambda name: f"/usr/bin/{name}"
+    )
+    monkeypatch.setattr(hermes_constants, "with_hermes_node_path", lambda: {})
+
+    ok = cli_main._install_whatsapp_bridge_deps(bridge_dir)
+
+    assert ok, "install helper should report success"
+    assert calls, "npm install should have run"
+    cmd = calls[0][0]
+    assert cmd[0] == "/usr/bin/npm" and cmd[1] == "install"
+    assert "--prefer-offline" in cmd, (
+        f"WhatsApp bridge npm install should pass --prefer-offline "
+        f"(same as update path, perf(cli) #39267), got: {cmd}"
+    )
+
+
+def test_dashboard_whatsapp_bridge_install_prefers_offline(bridge_dir: Path, monkeypatch) -> None:
+    """``_ensure_whatsapp_bridge_dependencies`` passes ``--prefer-offline``.
+
+    The dashboard-initiated bridge install is the second sibling npm
+    install site (web_server.py). Without the flag a dashboard-triggered
+    reinstall re-fetches registry metadata.
+    """
+    import hermes_cli.web_server as ws
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    import hermes_constants
+    import utils
+
+    monkeypatch.setattr(ws.subprocess, "run", fake_run)
+    # The function imports these from the source modules inside its body,
+    # so patch the modules themselves.
+    monkeypatch.setattr(
+        hermes_constants, "find_node_executable", lambda name: f"/usr/bin/{name}"
+    )
+    monkeypatch.setattr(hermes_constants, "with_hermes_node_path", lambda: {})
+    monkeypatch.setattr(utils, "env_int", lambda _k, _d: 300)
+    monkeypatch.setattr(ws, "windows_hide_flags", lambda: 0)
+
+    ws._ensure_whatsapp_bridge_dependencies(bridge_dir)
+
+    assert calls, "npm install should have run"
+    cmd = calls[0][0]
+    assert cmd[0] == "/usr/bin/npm" and cmd[1] == "install"
+    assert "--prefer-offline" in cmd, (
+        f"Dashboard WhatsApp bridge npm install should pass --prefer-offline, got: {cmd}"
+    )


### PR DESCRIPTION
## What does this PR do?

Add `--prefer-offline` to the four sibling npm install sites the merged fix missed, so installs reuse npm's local cache instead of hitting the registry when the cached package is available.

## Related Issue

No linked issue — discovered by diffing the merged fix against every npm install call site in the CLI (fix-propagation sweep).

Merged #39267/#39399 added `--prefer-offline` to the update and web-UI-build npm installs but missed four sibling sites in the same class: the TUI launch auto-install (`_make_tui_argv` — runs on every TUI start when deps are stale), the desktop dependency install (`cmd_gui`), the WhatsApp bridge install (`cmd_whatsapp`), and the dashboard bridge install (`web_server._ensure_whatsapp_bridge_dependencies`). Each of these can stall on a flaky network when the package is already in the local cache.

## Changes Made

- `fix/cli-npm-prefer-offline-siblings` — 5 file(s) changed vs base:
  - `hermes_cli/main.py`
  - `hermes_cli/web_server.py`
  - `tests/hermes_cli/test_gui_command.py`
  - `tests/hermes_cli/test_tui_npm_install.py`
  - `tests/hermes_cli/test_whatsapp_bridge_npm_offline.py`

In hermes_cli/main.py the TUI install command list gains `--prefer-offline`, `cmd_gui`'s desktop install passes `extra_args=('--prefer-offline',)` through `_run_npm_install_deterministic`, and the WhatsApp setup block gets the flag; `_install_whatsapp_bridge_deps` is extracted as a testable helper `cmd_whatsapp` now calls. In hermes_cli/web_server.py the dashboard bridge install gets the flag. Regression tests cover the CLI helper and the web_server dependency helper directly (patching the source modules, since the functions import inside their bodies).

## How to Test

Validation completed:
1. Sabotage check: pre-fix code fails the regression tests (1 failed), with the fix all pass (4 passed, 0 failed) — target `tests/hermes_cli/test_tui_npm_install.py`.
2. Duplicate check: 169 potential matches reviewed — none covers this change.
3. The full repo-wide suite was not run for this change; GitHub CI owns full-suite validation.

## Logs

Sabotage verification output:

```
# base leg (pre-fix code + branch tests):
#   tests: 3 passed, 1 failed
# head leg (with fix):
#   tests: 4 passed, 0 failed
```
