### PR TITLE
fix(installer): re-stage updater binary after successful update (#77753)

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -601,6 +601,24 @@ async fn run_update(app: AppHandle) -> Result<()> {
     // every other updater until the age ceiling expires.
     _update_marker.complete();
 
+    // Re-stage the updater binary into HERMES_HOME after a successful update.
+    // A user's staged installer is otherwise only written by a full
+    // install/repair — every later `--update` runs the ORIGINAL binary, so an
+    // installer-protocol change (e.g. the HERMES_UPDATE_HANDOFF_PID fix) can
+    // strand the whole installed base on a binary that predates it, deadlocking
+    // in-app updates forever (#77753, #75788, #76517). Re-staging here keeps
+    // the staged binary in lockstep with the checkout that just updated. Best
+    // effort — the update already succeeded; a staging failure must not fail it.
+    if let Err(err) = crate::paths::copy_self_to_hermes_home() {
+        tracing::warn!(?err, "failed to re-stage updater binary into HERMES_HOME (non-fatal)");
+        emit_log(
+            &app,
+            None,
+            LogStream::Stderr,
+            &format!("[update] warning: could not re-stage updater binary: {err}"),
+        );
+    }
+
     if let Some(target_app) = launch_target {
         if let Err(err) = launch_macos_app_and_exit(&app, &target_app).await {
             emit_log(


### PR DESCRIPTION
## Summary

Fixes #77753 — in-app updates on macOS (and Windows per #75788/#76517) deadlock forever when the staged updater binary (`~/.hermes/hermes-setup`) predates the `HERMES_UPDATE_HANDOFF_PID` fix. The staged binary is only written by a full install/repair; every later `--update` runs the ORIGINAL stale binary, so installer-protocol changes strand the whole installed base on a binary that cannot hand off its own update marker.

## Root Cause

`copy_self_to_hermes_home()` (which stages the updater into `HERMES_HOME`) is only invoked from the install-mode bootstrap path. The `--update` path never re-stages it — the docstring even notes "a user's staged installer is only ever written by a full install/repair". When the desktop pre-writes its update marker and spawns the stale staged updater, that binary (lacking the handoff-PID export) sees its own parent's live marker and refuses with exit 2 → "Hermes is still running", forever. Terminal `hermes update` works only because no parent holds the marker.

## Change

- `apps/bootstrap-installer/src-tauri/src/update.rs` — after a successful `run_update()` completes (marker released), re-stage the updater binary via `copy_self_to_hermes_home()`. The staged binary now tracks the checkout that just updated, so installer-protocol fixes (like the handoff-PID export) reach installed users on their next in-app update. Best-effort: a staging failure logs a warning and does not fail the already-succeeded update.

## Verification

- `cargo check` clean (Linux; Tauri deps installed).
- `cargo test` → 51 passed, 0 failed (existing bootstrap tests unaffected).
- Full macOS runtime validation requires the repo's macOS CI runner (Apple Silicon) — this PR ships the cross-platform code + compile/test verification; the staged-binary refresh behavior is exercised end-to-end there.

Closes #77753
