### PR TITLE
chore: release v0.20.0 (2026.8.3)

### DIFF
--- a/contributors/emails/ahmedmoro@gmail.com
+++ b/contributors/emails/ahmedmoro@gmail.com
@@ -1,0 +1,2 @@
+morolab
+# v0.20.0 audit: co-author on #70870 (Arabic locale)

--- a/contributors/emails/akshankrithick305@gmail.com
+++ b/contributors/emails/akshankrithick305@gmail.com
@@ -1,0 +1,2 @@
+akshan-main
+# v0.20.0 audit: co-author on #72244 (/goal indicator)

--- a/contributors/emails/assiri@gmail.com
+++ b/contributors/emails/assiri@gmail.com
@@ -1,0 +1,2 @@
+3ssiri
+# v0.20.0 audit: co-author on #70870 (Arabic locale)

--- a/contributors/emails/brdpedroo@gmail.com
+++ b/contributors/emails/brdpedroo@gmail.com
@@ -1,0 +1,2 @@
+Pebrd
+# v0.20.0 audit: author on #74245 (pinned Telegram sessions)

--- a/contributors/emails/carrion256@proton.me
+++ b/contributors/emails/carrion256@proton.me
@@ -1,0 +1,2 @@
+carrion256
+# v0.20.0 audit: co-author on #75888 (hindsight env 0600)

--- a/contributors/emails/david@lexgenius.ai
+++ b/contributors/emails/david@lexgenius.ai
@@ -1,0 +1,2 @@
+lexgenius
+# v0.20.0 audit: co-author on #65798 (FTS schema v23)

--- a/contributors/emails/gokhansarapevi@gmail.com
+++ b/contributors/emails/gokhansarapevi@gmail.com
@@ -1,0 +1,2 @@
+UltraInstinct0x
+# v0.20.0 audit: co-author on #75565 (TUI paste tokens)

--- a/contributors/emails/harshkamdar67@gmail.com
+++ b/contributors/emails/harshkamdar67@gmail.com
@@ -1,0 +1,2 @@
+Harshkamdar67
+# v0.20.0 audit: co-author on #72240 (/diff)

--- a/contributors/emails/hinablue@gmail.com
+++ b/contributors/emails/hinablue@gmail.com
@@ -1,0 +1,2 @@
+hinablue
+# v0.20.0 audit: direct email match; co-author on #77022

--- a/contributors/emails/jfmusa2024@gmail.com
+++ b/contributors/emails/jfmusa2024@gmail.com
@@ -1,0 +1,2 @@
+jfmusa2024-cyber
+# v0.20.0 audit: author on #72388 salvage (desktop perf)

--- a/contributors/emails/jquesnelle@gmail.com
+++ b/contributors/emails/jquesnelle@gmail.com
@@ -1,0 +1,2 @@
+jquesnelle
+# v0.20.0 audit: NeMo Relay revert/reapply cycle

--- a/contributors/emails/kingdomwarrior23@gmail.com
+++ b/contributors/emails/kingdomwarrior23@gmail.com
@@ -1,0 +1,2 @@
+Kingdomwarrior23
+# v0.20.0 audit: co-author on #69884 (provider onboarding fix)

--- a/contributors/emails/rod@nxtlevel.dev
+++ b/contributors/emails/rod@nxtlevel.dev
@@ -1,0 +1,2 @@
+rod-nxtlevel
+# v0.20.0 audit: co-author on #72835 (remote backend)

--- a/contributors/emails/rodrigo@nxtlevelsaas.com
+++ b/contributors/emails/rodrigo@nxtlevelsaas.com
@@ -1,0 +1,2 @@
+rod-nxtlevel
+# v0.20.0 audit: direct email match on profile

--- a/contributors/emails/rsayar@uvic.ca
+++ b/contributors/emails/rsayar@uvic.ca
@@ -1,0 +1,2 @@
+rsayar
+# v0.20.0 audit: co-author on #71184 (terminal error frames)

--- a/contributors/emails/subhoya@gmail.com
+++ b/contributors/emails/subhoya@gmail.com
@@ -1,0 +1,2 @@
+subhoya
+# v0.20.0 audit: author on #72388 salvage (terminal overlay)

--- a/contributors/emails/vitor@vitorcepedalopes.com
+++ b/contributors/emails/vitor@vitorcepedalopes.com
@@ -1,0 +1,2 @@
+TheAngryPit
+# v0.20.0 audit: direct email match on profile (OAuth sidebar fix)

--- a/contributors/emails/wykim777@naver.com
+++ b/contributors/emails/wykim777@naver.com
@@ -1,0 +1,2 @@
+iamwongeeeee
+# v0.20.0 audit: co-author on #65798 (FTS schema v23)

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.19.1"
-__release_date__ = "2026.7.30"
+__version__ = "0.20.0"
+__release_date__ = "2026.8.3"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "hermes-agent"
-version = "0.19.1"
+version = "0.20.0"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/scripts/contributor_audit.py
+++ b/scripts/contributor_audit.py
@@ -51,6 +51,12 @@ IGNORED_PATTERNS = [
     re.compile(r"^Hermes\s+(Agent|Audit)$", re.IGNORECASE),
     re.compile(r"^nousbot(-eng)?$", re.IGNORECASE),
     re.compile(r"^Ubuntu$", re.IGNORECASE),
+    # v0.20.0 audit additions:
+    re.compile(r"^Blut-?Agent$", re.IGNORECASE),          # self-described AI agent account
+    re.compile(r".*\[bot\]$", re.IGNORECASE),             # any GitHub [bot] suffix (hermes-seaeye[bot] etc.)
+    re.compile(r"^TRON$", re.IGNORECASE),                 # AgentMail agent
+    re.compile(r"^Happy$", re.IGNORECASE),                # happy.engineering AI agent
+    re.compile(r"^Orca$", re.IGNORECASE),                 # Stably AI agent
 ]
 
 IGNORED_EMAILS = {
@@ -65,6 +71,10 @@ IGNORED_EMAILS = {
     "omx@oh-my-codex.dev",
     "codex@openai.com",
     "noreply@commandcode.ai",
+    # v0.20.0 audit additions — AI-agent co-author trailers:
+    "tron-agent@agentmail.to",      # TRON (AgentMail agent)
+    "yesreply@happy.engineering",   # Happy (AI coding agent)
+    "help@stably.ai",               # Orca (Stably AI agent)
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-18T05:39:53.300543645Z"
+exclude-newer = "2026-07-20T16:38:42.729819205Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -1559,7 +1559,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.19.1"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },
@@ -2699,6 +2699,7 @@ wheels = [
 name = "nemo-relay"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/db/44d7258ee620c5cce6dc588983fcb11be3ee03ae71089a65686c14d9ee02/nemo_relay-0.6.0.tar.gz", hash = "sha256:f3d3088019609bc953357b5598a47481dc3e7dc8f11ecf27002ede251f37eb7b", size = 1071046, upload-time = "2026-08-03T14:55:49.702Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/65/d320016505457cc30971f575e8dadffb923b7cfc780ab8bb25a4ce9d305c/nemo_relay-0.6.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:ad5dae6febf6532d7b113abc2a404679c8feffc499df3034b93d9a078185d2bb", size = 9917779, upload-time = "2026-07-22T20:07:48.961Z" },
     { url = "https://files.pythonhosted.org/packages/ae/c0/f33250e71c4206da1b339072893f9a1e39295fe1aceb9a2fef4b8620a0f2/nemo_relay-0.6.0-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0cd9570f64c6956fe3bfb82af1cdb3ee70cb50b51098cdb0de831c3f9b4e904", size = 8888375, upload-time = "2026-07-22T20:07:51.049Z" },


### PR DESCRIPTION
# chore: release v0.20.0 (2026.8.3)

## Summary
Version bump for **v0.20.0 — The Herald Release**: streaming conversational voice with barge-in and wake words, A2A v1.0, signed outbound webhooks, grounded citations, and the desktop platform wave. Rolls up the v0.19.1 infrastructure patch window.

## Changes
- `hermes_cli/__init__.py`: 0.19.1 → 0.20.0, release date 2026.8.3
- `pyproject.toml`: version 0.20.0
- `uv.lock`: regenerated for the version bump
- `scripts/contributor_audit.py`: bot/AI filter widening (Blut-Agent, `[bot]` suffix, TRON/Happy/Orca agent trailers)
- `contributors/emails/`: 18 new email→handle mappings resolved during the v0.20.0 audit

## Validation
| Gate | Result |
|---|---|
| `uv lock --check` | clean (250 packages, 1ms) |
| `rg "0.19.1"` (anchored) in version files | zero hits |
| Contributor audit | 648 contributors, 0 missing from release notes, 2 benign unknowns (empty/machine emails on already-credited PRs) |

## Infographic

![v0.20.0 The Herald Release](https://v3b.fal.media/files/b/0aa4e06b/exIWFlgavvMI8HsGAWhZx_tKjZNdam.png)
