### PR TITLE
fix(session): create Home project on new desktop session (#77496)

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -144,10 +144,12 @@ describe('resolveNewSessionCwd', () => {
     expect(resolveNewSessionCwd()).toBe('/home/user/configured')
   })
 
-  it('inherits the focused session workspace when not drilled into a project', () => {
-    // Simulate a primary session whose stored row carries a project cwd —
-    // the common case: you're in a chat that has a pwd, hit ⌘N/⌘T, and
-    // expect the new draft to stay in that project without sidebar drill-in.
+  it('does not inherit the focused session workspace — a new chat outside a project stays detached', () => {
+    // #77496: "New session" must land in the Home bucket, not under the
+    // project of the conversation you happen to be looking at. The focused
+    // chat's workspace is never a new-session target unless the user
+    // explicitly drilled into that project in the sidebar.
+    applyConfiguredDefaultProjectDir(null)
     $selectedStoredSessionId.set('sess-a')
     $sessions.set([
       {
@@ -166,18 +168,21 @@ describe('resolveNewSessionCwd', () => {
       } as never
     ])
 
-    expect(resolveNewSessionCwd()).toBe('/Users/me/www/hermes-agent')
+    // No configured default and no project scope → detached, so the backend
+    // places the new session in the Home bucket.
+    expect(resolveNewSessionCwd()).toBe('')
   })
 
-  it('does not re-attach a remembered cwd when the focused session is detached', () => {
-    $currentCwd.set('/Users/me/stale-remembered')
-    $selectedStoredSessionId.set('sess-detached')
+  it('ignores the focused session workspace even when a default dir is configured', () => {
+    // Same as above but with the configured default set: the new session falls
+    // back to the default dir — never to the focused chat's project cwd.
+    $selectedStoredSessionId.set('sess-a')
     $sessions.set([
       {
         archived: false,
-        cwd: null,
+        cwd: '/Users/me/www/hermes-agent',
         ended_at: null,
-        id: 'sess-detached',
+        id: 'sess-a',
         input_tokens: 0,
         is_active: true,
         last_active: 0,
@@ -185,12 +190,10 @@ describe('resolveNewSessionCwd', () => {
         model: null,
         output_tokens: 0,
         started_at: 0,
-        title: 'loose'
+        title: 'work'
       } as never
     ])
 
-    // Focused session has no workspace → fall through to configured default,
-    // not the stale $currentCwd from an earlier chat.
     expect(resolveNewSessionCwd()).toBe('/home/user/configured')
   })
 })

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -17,15 +17,12 @@ import { setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
 import { $activeGatewayProfile, requestFreshSession } from '@/store/profile'
 import {
-  $currentCwd,
   $selectedStoredSessionId,
   $sessions,
-  idsShareLineage,
   sessionMatchesStoredId,
   setSessions,
   workspaceCwdForNewSession
 } from '@/store/session'
-import { $focusedSessionState, $focusedStoredSessionId } from '@/store/session-states'
 import type { ProjectInfo, ProjectsPayload } from '@/types/hermes'
 
 // First-class, per-profile Projects (named, multi-folder workspaces). State is
@@ -204,15 +201,14 @@ export function goToProject(id: string, options?: { newSession?: boolean }): voi
 //
 // Priority (first hit wins):
 //   1. Explicit sidebar project scope (drilled into a project / Home bucket)
-//   2. The FOCUSED session's workspace — so ⌘N / ⌘T from a chat that's already
-//      in a project/worktree stay there without requiring a sidebar drill-in
-//   3. Configured default project dir / remote remembered cwd (detached otherwise)
+//   2. Configured default project dir / remote remembered cwd (detached otherwise)
 //
 // The "active project" is just an atom ($projectScope) — so when you're inside
 // a project, a new session (cmd-n, the trunk "+") starts at that project's root
-// (its primary repo = the default-branch checkout). Outside a project it used
-// to fall straight to the plain default (detached), which dropped the workspace
-// of the chat you were looking at — that's the case (2) covers.
+// (its primary repo = the default-branch checkout). Outside a project the new
+// session stays detached: it must NOT inherit the workspace of the chat you're
+// looking at, or every "New session" would land under that conversation's
+// project instead of the Home bucket (#77496).
 export function resolveNewSessionCwd(): string {
   const scope = $projectScope.get()
 
@@ -230,56 +226,7 @@ export function resolveNewSessionCwd(): string {
     }
   }
 
-  // Inherit the focused chat's workspace. ⌘N/⌘T from a session that already
-  // has a project/pwd should stay there — drilling into the sidebar project
-  // is the uncommon path, not the requirement.
-  const focusedCwd = focusedSessionWorkspaceCwd()
-
-  if (focusedCwd) {
-    return focusedCwd
-  }
-
   return workspaceCwdForNewSession()
-}
-
-/** Live workspace of the session the user is looking at (tile or primary). */
-function focusedSessionWorkspaceCwd(): string {
-  const focusedStoredId = $focusedStoredSessionId.get()
-  const state = $focusedSessionState.get()
-
-  // Prefer the live runtime slice when it belongs to the focused chat
-  // (agent can relocate mid-turn). Cold tabs / mid-switch lag fall through
-  // to the stored session row.
-  const stateCwd = state?.cwd?.trim() || ''
-  const stateStoredId = state?.storedSessionId?.trim() || ''
-
-  if (
-    stateCwd &&
-    (!focusedStoredId ||
-      !stateStoredId ||
-      stateStoredId === focusedStoredId ||
-      idsShareLineage(focusedStoredId, stateStoredId, $sessions.get()))
-  ) {
-    return stateCwd
-  }
-
-  if (focusedStoredId) {
-    const row = $sessions.get().find(s => sessionMatchesStoredId(s, focusedStoredId))
-    const rowCwd = row?.cwd?.trim() || ''
-
-    if (rowCwd) {
-      return rowCwd
-    }
-
-    // Focused a real session with no workspace → stay detached. Do NOT fall
-    // through to `$currentCwd` (it may still hold a remembered path from an
-    // earlier chat and would re-attach a project the user left).
-    return ''
-  }
-
-  // No focused stored session: primary draft. The composer atom is the draft's
-  // workspace target (set by startFreshSession / startSessionInWorkspace).
-  return $currentCwd.get().trim()
 }
 
 const underPath = (parent: string, child: string): boolean =>


### PR DESCRIPTION
## Summary

When clicking **New session** in Hermes Desktop, the new conversation now lands in the **Home** bucket instead of silently inheriting the project/workspace of the conversation you were currently looking at.

## Root Cause

`resolveNewSessionCwd()` (in `apps/desktop/src/store/projects.ts`) gained a "focused session workspace" fallback (commit 883076ccd): when the user was not drilled into a sidebar project, a new session inherited the cwd of the focused chat. The new session was therefore created with a cwd inside the existing project, so the backend (`tui_gateway/project_tree.py`) placed it under that project and the **Home** bucket (`__no_project__`, label "Home") never appeared under Projects.

## Change

- `apps/desktop/src/store/projects.ts` — `resolveNewSessionCwd()` no longer inherits the focused session's workspace. Priority is now:
  1. Explicit sidebar project scope (drilled into a project / Home bucket)
  2. Configured default project dir / remote remembered cwd (detached otherwise → Home bucket)
- Removed the now-dead `focusedSessionWorkspaceCwd()` helper and its unused imports.
- `apps/desktop/src/store/projects.test.ts` — replaced the two tests asserting the old inheritance behavior with regression tests: a new session outside a project stays detached (→ Home), and a configured default dir still wins over the focused chat's workspace.

## Verification

- `vitest run --project ui src/store/projects.test.ts` → 27/27 pass (incl. new regression tests)
- Related session-flow suites all pass: `workspace-session-target`, `use-session-actions`, `use-route-resume`, `store/session`, `store/session-states` (118 tests)
- Full desktop `ui` project: 383/387 files pass; the 5 remaining failures are pre-existing, environment/locale-dependent (Intl thousands separators, billing bounds) and unrelated to this change.

Closes #77496