### PR TITLE
fix(oauth): enforce external ownership for xAI refresh tokens

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -689,19 +689,34 @@ class CredentialPool:
             return matches[0].id if len(matches) == 1 else None
 
     def _replace_entry(self, old: PooledCredential, new: PooledCredential) -> None:
-        """Swap an entry in-place by id, preserving sort order.
+        """Swap an entry by id without allowing replacement-ID duplicates.
 
         Self-locking (RLock) so the deferred refresh path — which
         deliberately runs outside the pool lock — cannot tear
         ``self._entries`` against a concurrent select()/rotation.
         """
         with self._lock:
+            if new.id != old.id:
+                self._entries = [
+                    entry
+                    for entry in self._entries
+                    if entry.id not in {old.id, new.id}
+                ]
+                self._entries.append(new)
+                self._entries.sort(key=lambda entry: entry.priority)
+                return
             for idx, entry in enumerate(self._entries):
                 if entry.id == old.id:
                     self._entries[idx] = new
                     return
 
-    def _persist(self, *, removed_ids: Optional[List[str]] = None) -> None:
+    def _persist(
+        self,
+        *,
+        removed_ids: Optional[List[str]] = None,
+        oauth_token_write_authority: Optional[str] = None,
+        authorized_oauth_entry_ids: Optional[List[str]] = None,
+    ) -> None:
         # Self-locking (RLock): snapshotting self._entries must not race a
         # concurrent rotation when called from the deferred refresh path.
         with self._lock:
@@ -709,6 +724,8 @@ class CredentialPool:
                 self.provider,
                 [entry.to_dict() for entry in self._entries],
                 removed_ids=removed_ids,
+                oauth_token_write_authority=oauth_token_write_authority,
+                authorized_oauth_entry_ids=authorized_oauth_entry_ids,
             )
 
     def _is_terminal_auth_failure(
@@ -922,7 +939,11 @@ class CredentialPool:
         manually added entries are independent credentials with their own
         refresh-token lifecycle.
         """
-        if self.provider != "xai-oauth" or entry.source != "device_code":
+        if (
+            self.provider != "xai-oauth"
+            or entry.source != "device_code"
+            or not auth_mod.runtime_owns_oauth_refresh(self.provider)
+        ):
             return entry
         try:
             with _auth_store_lock():
@@ -1220,7 +1241,76 @@ class CredentialPool:
         except Exception as exc:
             logger.debug("Failed to sync %s pool entry back to auth store: %s", self.provider, exc)
 
+    def _sync_external_entry_from_pool(
+        self, entry: PooledCredential
+    ) -> Optional[PooledCredential]:
+        """Adopt the scheduler-selected entry without writing auth.json.
+
+        External refresh ownership makes the on-disk pool authoritative. The
+        read must happen before reactive recovery decides whether to retry, and
+        this method deliberately does not persist its in-memory snapshot back
+        over a token pair the scheduler may just have rotated.
+        """
+        try:
+            disk_entry = auth_mod._selected_usable_oauth_pool_entry(self.provider)
+            if not isinstance(disk_entry, dict):
+                return None
+            disk_access_token = disk_entry.get("access_token")
+            disk_refresh_token = disk_entry.get("refresh_token")
+            if not isinstance(disk_access_token, str) or not disk_access_token:
+                return None
+            disk_entry_id = disk_entry.get("id")
+            if not isinstance(disk_entry_id, str) or not disk_entry_id:
+                return None
+            credentials_changed = (
+                disk_entry_id != entry.id
+                or disk_access_token != entry.access_token
+                or (
+                    isinstance(disk_refresh_token, str)
+                    and disk_refresh_token
+                    and disk_refresh_token != entry.refresh_token
+                )
+            )
+            if not credentials_changed:
+                return None
+            if disk_entry_id != entry.id:
+                updated = PooledCredential.from_dict(self.provider, disk_entry)
+                self._replace_entry(entry, updated)
+                return updated
+            updated = replace(
+                entry,
+                access_token=disk_access_token,
+                refresh_token=(
+                    disk_refresh_token
+                    if isinstance(disk_refresh_token, str) and disk_refresh_token
+                    else entry.refresh_token
+                ),
+                last_refresh=disk_entry.get("last_refresh") or entry.last_refresh,
+                last_status=disk_entry.get("last_status"),
+                last_status_at=disk_entry.get("last_status_at"),
+                last_error_code=disk_entry.get("last_error_code"),
+                last_error_reason=disk_entry.get("last_error_reason"),
+                last_error_message=disk_entry.get("last_error_message"),
+                last_error_reset_at=disk_entry.get("last_error_reset_at"),
+            )
+            self._replace_entry(entry, updated)
+            return updated
+        except Exception as exc:
+            logger.debug(
+                "Failed to adopt externally refreshed %s pool entry: %s",
+                self.provider,
+                exc,
+            )
+            return None
+
     def _refresh_entry(self, entry: PooledCredential, *, force: bool) -> Optional[PooledCredential]:
+        if not auth_mod.runtime_owns_oauth_refresh(self.provider):
+            synced = self._sync_external_entry_from_pool(entry)
+            logger.warning(
+                "credential pool: refusing %s OAuth refresh because config assigns ownership externally",
+                self.provider,
+            )
+            return synced
         if entry.auth_type != AUTH_TYPE_OAUTH or not entry.refresh_token:
             if force:
                 self._mark_exhausted(entry, None)
@@ -1665,6 +1755,8 @@ class CredentialPool:
 
     def _entry_needs_refresh(self, entry: PooledCredential) -> bool:
         if entry.auth_type != AUTH_TYPE_OAUTH:
+            return False
+        if not auth_mod.runtime_owns_oauth_refresh(self.provider):
             return False
         if self.provider == "anthropic":
             if entry.expires_at_ms is None:
@@ -2246,11 +2338,19 @@ class CredentialPool:
                 return None, None, f"No credential #{index}."
             return None, None, f'No credential matching "{raw}".'
 
-    def add_entry(self, entry: PooledCredential) -> PooledCredential:
+    def add_entry(
+        self,
+        entry: PooledCredential,
+        *,
+        oauth_token_write_authority: Optional[str] = None,
+    ) -> PooledCredential:
         with self._lock:
             entry = replace(entry, priority=_next_priority(self._entries))
             self._entries.append(entry)
-            self._persist()
+            self._persist(
+                oauth_token_write_authority=oauth_token_write_authority,
+                authorized_oauth_entry_ids=[entry.id],
+            )
             return entry
 
 
@@ -2993,7 +3093,16 @@ def load_pool(provider: str) -> CredentialPool:
         changed = raw_needs_sanitization or raw_needs_auth_normalization or custom_changed
         changed |= _prune_stale_seeded_entries(entries, custom_sources)
     else:
-        singleton_changed, singleton_sources = _seed_from_singletons(provider, entries)
+        if (
+            provider == "xai-oauth"
+            and not auth_mod.runtime_owns_oauth_refresh(provider)
+        ):
+            singleton_changed = False
+            singleton_sources = set()
+        else:
+            singleton_changed, singleton_sources = _seed_from_singletons(
+                provider, entries
+            )
         env_changed, env_sources = _seed_from_env(provider, entries)
         changed = (
             raw_needs_sanitization

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -71,6 +71,130 @@ except Exception:
 AUTH_STORE_VERSION = 1
 AUTH_LOCK_TIMEOUT_SECONDS = 15.0
 
+
+def runtime_owns_oauth_refresh(provider: str) -> bool:
+    """Return whether this process may spend the provider's refresh token.
+
+    xAI-only ownership contract: missing ownership configuration preserves
+    standalone Hermes behavior. Once an ``oauth`` block is present, malformed
+    or unknown ownership fails closed so a typo cannot silently create a second
+    refresh-token writer. Non-xAI providers remain runtime-owned.
+    """
+    if provider != "xai-oauth":
+        return True
+    config_path = get_config_path()
+    if not config_path.exists():
+        return True
+    try:
+        raw_config_text = config_path.read_text(encoding="utf-8")
+    except OSError:
+        logger.warning("OAuth refresh ownership unreadable; refusing runtime refresh")
+        return False
+    if not raw_config_text.strip() or all(
+        not line.strip() or line.lstrip().startswith("#")
+        for line in raw_config_text.splitlines()
+    ):
+        return True
+    config = read_raw_config()
+    if not config:
+        if raw_config_text.strip() in {"{}", "---", "---\n{}"}:
+            return True
+        logger.warning("OAuth refresh ownership unavailable; refusing runtime refresh")
+        return False
+    if "oauth" not in config:
+        return True
+    oauth_config = config.get("oauth")
+    if not isinstance(oauth_config, dict):
+        logger.warning("OAuth refresh ownership is invalid; refusing runtime refresh")
+        return False
+    refresh_owner = oauth_config.get("refresh_owner")
+    if refresh_owner == "runtime":
+        return True
+    if refresh_owner == "external":
+        return False
+    logger.warning(
+        "OAuth refresh owner must be runtime or external; refusing runtime refresh"
+    )
+    return False
+
+
+def _parse_persisted_timestamp(value: Any) -> Optional[float]:
+    if isinstance(value, (int, float)):
+        numeric_value = float(value)
+        return numeric_value / 1000.0 if numeric_value > 1_000_000_000_000 else numeric_value
+    if isinstance(value, str) and value.strip():
+        try:
+            numeric_value = float(value)
+            return numeric_value / 1000.0 if numeric_value > 1_000_000_000_000 else numeric_value
+        except ValueError:
+            try:
+                return datetime.fromisoformat(
+                    value.strip().replace("Z", "+00:00")
+                ).timestamp()
+            except ValueError:
+                return None
+    return None
+
+
+def _persisted_pool_entry_is_usable(entry: Dict[str, Any]) -> bool:
+    last_status = entry.get("last_status")
+    if last_status == "dead":
+        return False
+    if last_status != "exhausted":
+        return True
+    reset_timestamp = _parse_persisted_timestamp(entry.get("last_error_reset_at"))
+    if reset_timestamp is not None:
+        return time.time() >= reset_timestamp
+    status_timestamp = _parse_persisted_timestamp(entry.get("last_status_at"))
+    if status_timestamp is None:
+        return True
+    error_code = entry.get("last_error_code")
+    cooldown_seconds = 300 if error_code == 401 else 3600
+    return time.time() >= status_timestamp + cooldown_seconds
+
+
+def _selected_usable_oauth_pool_entry(
+    provider_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Read the scheduler-owned, lowest-priority usable OAuth pool entry."""
+    entries = read_credential_pool(provider_id)
+    if not isinstance(entries, list) or not entries:
+        return None
+    indexed_entries = [
+        (index, entry)
+        for index, entry in enumerate(entries)
+        if isinstance(entry, dict)
+        and _persisted_pool_entry_is_usable(entry)
+    ]
+    if not indexed_entries:
+        return None
+
+    def selection_key(indexed_entry: Tuple[int, Dict[str, Any]]) -> Tuple[int, int]:
+        index, entry = indexed_entry
+        priority = entry.get("priority", 0)
+        return (priority if isinstance(priority, int) else 0, index)
+
+    _, selected_entry = min(indexed_entries, key=selection_key)
+    return selected_entry
+
+
+def _selected_oauth_pool_tokens(provider_id: str) -> Optional[Dict[str, Any]]:
+    selected_entry = _selected_usable_oauth_pool_entry(provider_id)
+    if selected_entry is None:
+        return None
+    access_token = selected_entry.get("access_token")
+    refresh_token = selected_entry.get("refresh_token")
+    if not isinstance(access_token, str) or not access_token.strip():
+        return None
+    if not isinstance(refresh_token, str) or not refresh_token.strip():
+        return None
+    return {
+        "access_token": access_token.strip(),
+        "refresh_token": refresh_token.strip(),
+        "last_refresh": selected_entry.get("last_refresh"),
+    }
+
+
 # Nous Portal defaults
 DEFAULT_NOUS_PORTAL_URL = "https://portal.nousresearch.com"
 DEFAULT_NOUS_INFERENCE_URL = "https://inference-api.nousresearch.com/v1"
@@ -1609,6 +1733,8 @@ def write_credential_pool(
     entries: List[Dict[str, Any]],
     *,
     removed_ids: Optional[Iterable[str]] = None,
+    oauth_token_write_authority: Optional[str] = None,
+    authorized_oauth_entry_ids: Optional[Iterable[str]] = None,
 ) -> Path:
     """Persist one provider's credential pool under auth.json.
 
@@ -1627,6 +1753,15 @@ def write_credential_pool(
 
     Pass ``removed_ids`` for entries the caller intentionally removed, so the
     merge does not resurrect them from the on-disk copy.
+
+    When ``oauth.refresh_owner=external`` for xAI, this is also a same-user
+    accidental-writer fence (not a cryptographic boundary):
+    - ``external-scheduler`` may freely update/remove OAuth rows.
+    - ``interactive-login`` may add/replace only ``authorized_oauth_entry_ids``
+      and must not delete unrelated scheduler-owned OAuth rows.
+    - All other writers freeze scheduler-owned token **and** usability/status
+      fields from disk, and cannot delete scheduler-owned OAuth rows via
+      ``removed_ids``.
     """
     removed = {rid for rid in (removed_ids or ()) if rid}
     with _auth_store_lock():
@@ -1642,6 +1777,80 @@ def write_credential_pool(
         ]
         existing = pool.get(provider_id)
         existing_list = existing if isinstance(existing, list) else []
+        if (
+            oauth_token_write_authority != "external-scheduler"
+            and not runtime_owns_oauth_refresh(provider_id)
+        ):
+            authorized_entry_ids = {
+                entry_id
+                for entry_id in (authorized_oauth_entry_ids or ())
+                if entry_id
+            }
+            existing_by_id_for_protect = {
+                disk_entry.get("id"): disk_entry
+                for disk_entry in existing_list
+                if isinstance(disk_entry, dict) and disk_entry.get("id")
+            }
+            oauth_disk_ids = {
+                disk_id
+                for disk_id, disk_entry in existing_by_id_for_protect.items()
+                if disk_entry.get("auth_type") == "oauth"
+                or disk_entry.get("refresh_token")
+            }
+            # Fence deletes: only the external scheduler may remove arbitrary
+            # scheduler-owned OAuth rows. Interactive login may retire only the
+            # entry ids it explicitly authorized (replace targets). Normal
+            # runtime mark-exhausted / prune paths must not drop them.
+            if oauth_token_write_authority == "interactive-login":
+                removed = {
+                    rid for rid in removed if rid in authorized_entry_ids
+                }
+            else:
+                removed = {rid for rid in removed if rid not in oauth_disk_ids}
+            token_fields = (
+                "access_token",
+                "refresh_token",
+                "id_token",
+                "expires_at_ms",
+                "expires_in",
+                "token_type",
+                "last_refresh",
+            )
+            protected_entries: List[Dict[str, Any]] = []
+            for incoming_entry in sanitized_entries:
+                if not isinstance(incoming_entry, dict):
+                    continue
+                entry_id = incoming_entry.get("id")
+                is_authorized_interactive = (
+                    oauth_token_write_authority == "interactive-login"
+                    and entry_id in authorized_entry_ids
+                )
+                disk_entry = existing_by_id_for_protect.get(entry_id)
+                if not isinstance(disk_entry, dict):
+                    if (
+                        incoming_entry.get("auth_type") == "oauth"
+                        or incoming_entry.get("refresh_token")
+                    ):
+                        if is_authorized_interactive:
+                            protected_entries.append(incoming_entry)
+                        continue
+                    protected_entries.append(incoming_entry)
+                    continue
+                if is_authorized_interactive:
+                    # Explicit interactive re-auth of this entry id may replace
+                    # tokens and clear usability/status fields.
+                    protected_entries.append(incoming_entry)
+                    continue
+                # Unauthorized runtime write: freeze scheduler-owned tokens and
+                # scheduler-owned usability/status so mark-exhausted/dead and
+                # priority reshuffles cannot poison Fleet selection.
+                for token_field in token_fields:
+                    if token_field in disk_entry:
+                        incoming_entry[token_field] = disk_entry[token_field]
+                for status_field in _POOL_STATUS_FIELDS:
+                    incoming_entry[status_field] = disk_entry.get(status_field)
+                protected_entries.append(incoming_entry)
+            sanitized_entries = protected_entries
         existing_by_id = {
             entry.get("id"): entry
             for entry in existing_list
@@ -4391,13 +4600,26 @@ def _xai_oauth_state_from_store(auth_store: Dict[str, Any]) -> Optional[Dict[str
         else None
     )
     if isinstance(entries, list):
-        for entry in entries:
-            if not isinstance(entry, dict):
-                continue
+        usable_entries = [
+            (index, entry)
+            for index, entry in enumerate(entries)
+            if isinstance(entry, dict)
+            and _persisted_pool_entry_is_usable(entry)
+            and str(entry.get("access_token", "") or "").strip()
+            and str(entry.get("refresh_token", "") or "").strip()
+        ]
+        if usable_entries:
+            _, entry = min(
+                usable_entries,
+                key=lambda indexed_entry: (
+                    indexed_entry[1].get("priority", 0)
+                    if isinstance(indexed_entry[1].get("priority", 0), int)
+                    else 0,
+                    indexed_entry[0],
+                ),
+            )
             access_token = str(entry.get("access_token", "") or "").strip()
             refresh_token = str(entry.get("refresh_token", "") or "").strip()
-            if not access_token or not refresh_token:
-                continue
             merged = dict(state or {})
             merged["tokens"] = {
                 "access_token": access_token,
@@ -4561,6 +4783,9 @@ def _save_xai_oauth_tokens(
         )
         if state is None:
             state = {}
+        previous_singleton_tokens = (
+            state.get("tokens") if isinstance(state.get("tokens"), dict) else None
+        )
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
         state["auth_mode"] = auth_mode
@@ -4580,12 +4805,94 @@ def _save_xai_oauth_tokens(
             # (it would create a shadowing providers.xai-oauth key that
             # disables write-through on the next refresh — #74339).
             _write_through_xai_oauth_to_global_root(state)
+            # Interactive/device login may still need the profile pool updated
+            # when this profile holds pool rows for the same grant.
+            _sync_xai_oauth_pool_entries(
+                auth_store,
+                tokens,
+                last_refresh,
+                previous_singleton_tokens=previous_singleton_tokens,
+            )
+            try:
+                _save_auth_store(auth_store)
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.debug("xAI OAuth: profile pool sync after root write failed: %s", exc)
         else:
             # Profile genuinely owns this — write to profile store.
             _store_provider_state(
                 auth_store, "xai-oauth", state, set_active=set_active
             )
+            _sync_xai_oauth_pool_entries(
+                auth_store,
+                tokens,
+                last_refresh,
+                previous_singleton_tokens=previous_singleton_tokens,
+            )
             _save_auth_store(auth_store)
+
+
+
+def _sync_xai_oauth_pool_entries(
+    auth_store: Dict[str, Any],
+    tokens: Dict[str, Any],
+    last_refresh: Optional[str],
+    *,
+    previous_singleton_tokens: Optional[Dict[str, Any]],
+) -> None:
+    """Commit an interactive/singleton xAI login into its pool authority."""
+    access_token = tokens.get("access_token")
+    refresh_token = tokens.get("refresh_token")
+    if not isinstance(access_token, str) or not access_token:
+        return
+    credential_pool = auth_store.setdefault("credential_pool", {})
+    if not isinstance(credential_pool, dict):
+        return
+    provider_entries = credential_pool.setdefault("xai-oauth", [])
+    if not isinstance(provider_entries, list):
+        return
+    previous_access_token = (
+        previous_singleton_tokens.get("access_token")
+        if isinstance(previous_singleton_tokens, dict)
+        else None
+    )
+    updated_existing_entry = False
+    for provider_entry in provider_entries:
+        if not isinstance(provider_entry, dict):
+            continue
+        entry_source = provider_entry.get("source")
+        singleton_alias = entry_source == "device_code" or (
+            entry_source == "manual:device_code"
+            and previous_access_token
+            and provider_entry.get("access_token") == previous_access_token
+        )
+        if not singleton_alias:
+            continue
+        provider_entry["access_token"] = access_token
+        if isinstance(refresh_token, str) and refresh_token:
+            provider_entry["refresh_token"] = refresh_token
+        provider_entry["last_refresh"] = last_refresh
+        for status_field in (
+            "last_status",
+            "last_status_at",
+            "last_error_code",
+            "last_error_reason",
+            "last_error_message",
+            "last_error_reset_at",
+        ):
+            provider_entry[status_field] = None
+        updated_existing_entry = True
+    if not updated_existing_entry and not runtime_owns_oauth_refresh("xai-oauth"):
+        provider_entries.append({
+            "id": uuid.uuid4().hex[:6],
+            "label": "xAI OAuth",
+            "auth_type": "oauth",
+            "priority": len(provider_entries),
+            "source": "device_code",
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "last_refresh": last_refresh,
+            "base_url": DEFAULT_XAI_OAUTH_BASE_URL,
+        })
 
 
 def _xai_access_token_is_expiring(access_token: str, skew_seconds: int = 0) -> bool:
@@ -4793,6 +5100,16 @@ def refresh_xai_oauth_pure(
     token_endpoint: str = "",
     timeout_seconds: float = 20.0,
 ) -> Dict[str, Any]:
+    """Pure xAI OAuth refresh POST — no ownership gate, no disk writes.
+
+    WARNING: this is an unguarded network primitive. Every runtime caller MUST
+    gate with ``runtime_owns_oauth_refresh("xai-oauth")`` (or an equivalent
+    external-owner check) before spending the refresh token. When
+    ``oauth.refresh_owner=external``, only the external scheduler may rotate;
+    unguarded calls create a second writer and can invalidate the fleet grant.
+    Production entrypoints that already gate include
+    ``_refresh_xai_oauth_tokens`` and ``CredentialPool._refresh_entry``.
+    """
     del access_token
     if not isinstance(refresh_token, str) or not refresh_token.strip():
         raise AuthError(
@@ -4891,6 +5208,13 @@ def _refresh_xai_oauth_tokens(
     redirect_uri: str = "",
     timeout_seconds: float,
 ) -> Dict[str, Any]:
+    if not runtime_owns_oauth_refresh("xai-oauth"):
+        raise AuthError(
+            "xAI OAuth refresh is owned externally; this runtime must not spend the refresh token.",
+            provider="xai-oauth",
+            code="xai_external_refresh_forbidden",
+            relogin_required=False,
+        )
     # Re-persist whatever auth_mode is already stored (legacy pre-device-code
     # logins may still carry ``oauth_pkce``): the refresh hot path must not
     # relabel how the grant was originally obtained.
@@ -4933,8 +5257,29 @@ def resolve_xai_oauth_runtime_credentials(
     refresh_if_expiring: bool = True,
     refresh_skew_seconds: Optional[int] = None,
 ) -> Dict[str, Any]:
-    data = _read_xai_oauth_tokens()
-    tokens = dict(data["tokens"])
+    runtime_refresh_allowed = runtime_owns_oauth_refresh("xai-oauth")
+    externally_managed_tokens = (
+        None if runtime_refresh_allowed else _selected_oauth_pool_tokens("xai-oauth")
+    )
+    if not runtime_refresh_allowed and not externally_managed_tokens:
+        raise AuthError(
+            "xAI has no usable scheduler-owned OAuth credential.",
+            provider="xai-oauth",
+            code="xai_external_pool_unavailable",
+            relogin_required=False,
+        )
+    if externally_managed_tokens:
+        try:
+            data = _read_xai_oauth_tokens()
+        except AuthError:
+            data = {"tokens": {}}
+        tokens = dict(data.get("tokens") or {})
+        tokens.update(externally_managed_tokens)
+        data["tokens"] = tokens
+        data["last_refresh"] = externally_managed_tokens.get("last_refresh")
+    else:
+        data = _read_xai_oauth_tokens()
+        tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
     refresh_timeout_seconds = env_float("HERMES_XAI_REFRESH_TIMEOUT_SECONDS", 20)
     discovery = dict(data.get("discovery") or {})
@@ -4946,9 +5291,11 @@ def resolve_xai_oauth_runtime_credentials(
         if refresh_skew_seconds is not None
         else _xai_proactive_refresh_skew_seconds(access_token)
     )
-    should_refresh = bool(force_refresh)
+    should_refresh = runtime_refresh_allowed and bool(force_refresh)
     if (not should_refresh) and refresh_if_expiring:
-        should_refresh = _xai_access_token_is_expiring(access_token, effective_skew)
+        should_refresh = runtime_refresh_allowed and _xai_access_token_is_expiring(
+            access_token, effective_skew
+        )
     if should_refresh:
         with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
             data = _read_xai_oauth_tokens(_lock=False)
@@ -4962,9 +5309,11 @@ def resolve_xai_oauth_runtime_credentials(
                 if refresh_skew_seconds is not None
                 else _xai_proactive_refresh_skew_seconds(access_token)
             )
-            should_refresh = bool(force_refresh)
+            should_refresh = runtime_refresh_allowed and bool(force_refresh)
             if (not should_refresh) and refresh_if_expiring:
-                should_refresh = _xai_access_token_is_expiring(access_token, effective_skew)
+                should_refresh = runtime_refresh_allowed and _xai_access_token_is_expiring(
+                    access_token, effective_skew
+                )
             if should_refresh:
                 if not token_endpoint:
                     token_endpoint = _xai_oauth_discovery(refresh_timeout_seconds)["token_endpoint"]

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -377,7 +377,12 @@ def auth_add_command(args) -> None:
             last_refresh=creds.get("last_refresh"),
         )
         first_credential = not pool.entries()
-        pool.add_entry(entry)
+        # Genuine interactive xAI OAuth login only. Under
+        # oauth.refresh_owner=external, write_credential_pool drops new OAuth
+        # rows unless this authority is explicit — Fleet recovery spawns
+        # exactly `hermes auth add xai-oauth`. Do not grant this for API-key
+        # or non-xAI add paths.
+        pool.add_entry(entry, oauth_token_write_authority="interactive-login")
         # Adding the first xAI credential should make it the active provider
         # (the old singleton save path did this implicitly via
         # _save_provider_state). Subsequent adds leave the active provider as-is.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -9,6 +9,12 @@ DEFAULT_CONFIG = {
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
+    "oauth": {
+        # Runtime-owned preserves standalone Hermes behavior. Managed fleets
+        # can set "external" so one scheduler is the sole refresh-token writer
+        # for xAI Grok subscription OAuth (oauth.refresh_owner=external).
+        "refresh_owner": "runtime",
+    },
     "toolsets": ["hermes-cli"],
     # SQLite journal mode used by every Hermes database opener. WAL is the
     # normal default; set DELETE for weak-fsync/shared filesystems where WAL is

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -987,6 +987,10 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
 # Categories with fewer fields get merged into "general" to avoid tab sprawl.
 _CATEGORY_MERGE: Dict[str, str] = {
     "privacy": "security",
+    # Refresh ownership controls which process may spend OAuth refresh tokens,
+    # so expose the single oauth setting alongside the existing security
+    # controls rather than creating a one-field dashboard tab.
+    "oauth": "security",
     "context": "agent",
     "skills": "agent",
     "cron": "agent",

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -990,3 +990,1066 @@ def test_pool_sync_back_preserves_active_provider(tmp_path, monkeypatch):
     state = raw_after["providers"]["xai-oauth"]["tokens"]
     assert state["access_token"] == new_access
     assert state["refresh_token"] == "rt-rotated"
+
+
+# ---------------------------------------------------------------------------
+# External OAuth refresh ownership (xAI-only)
+# Fleet is the sole rotating refresh-token writer when oauth.refresh_owner=external.
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_owns_oauth_refresh_ownership_matrix(tmp_path, monkeypatch):
+    """Absent config preserves runtime ownership; external/malformed fail closed."""
+    from hermes_cli.auth import runtime_owns_oauth_refresh
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # No config.yaml → standalone runtime-owned behavior.
+    assert runtime_owns_oauth_refresh("xai-oauth") is True
+    # Non-xAI providers are unaffected by this contract.
+    assert runtime_owns_oauth_refresh("openai-codex") is True
+    assert runtime_owns_oauth_refresh("nous") is True
+
+    (hermes_home / "config.yaml").write_text("model: grok-3\n")
+    assert runtime_owns_oauth_refresh("xai-oauth") is True
+
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: runtime\n")
+    assert runtime_owns_oauth_refresh("xai-oauth") is True
+
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: external\n")
+    assert runtime_owns_oauth_refresh("xai-oauth") is False
+
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: fleet\n")
+    assert runtime_owns_oauth_refresh("xai-oauth") is False
+
+    (hermes_home / "config.yaml").write_text("oauth: []\n")
+    assert runtime_owns_oauth_refresh("xai-oauth") is False
+
+    (hermes_home / "config.yaml").write_text("{]\n")
+    assert runtime_owns_oauth_refresh("xai-oauth") is False
+
+
+def test_resolve_xai_runtime_credentials_refuses_external_owner_refresh(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes"
+    fresh = _jwt_with_exp(int(time.time()) + 2 * 60 * 60)
+    _setup_hermes_auth(
+        hermes_home,
+        access_token=fresh,
+        discovery={"token_endpoint": "https://auth.x.ai/oauth2/token"},
+    )
+    (hermes_home / "config.yaml").write_text(
+        "oauth:\n  refresh_owner: external\n"
+    )
+    auth_payload = json.loads((hermes_home / "auth.json").read_text())
+    scheduler_access = _jwt_with_exp(int(time.time()) + 3 * 60 * 60)
+    auth_payload["credential_pool"] = {
+        "xai-oauth": [{
+            "id": "scheduler-selected",
+            "priority": 0,
+            "auth_type": "oauth",
+            "access_token": scheduler_access,
+            "refresh_token": "scheduler-rotated-refresh",
+        }]
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_payload))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    def _refresh_must_not_run(*_args, **_kwargs):
+        raise AssertionError("runtime must not rotate externally managed OAuth")
+
+    monkeypatch.setattr(
+        "hermes_cli.auth._refresh_xai_oauth_tokens", _refresh_must_not_run
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.refresh_xai_oauth_pure", _refresh_must_not_run
+    )
+
+    creds = resolve_xai_oauth_runtime_credentials(
+        force_refresh=True, refresh_if_expiring=False
+    )
+    assert creds["api_key"] == scheduler_access
+
+
+def test_external_refresh_owner_blocks_proactive_and_reactive_xai_rotation(
+    tmp_path, monkeypatch
+):
+    """External owner: select may use access token; refresh POST is forbidden."""
+    from agent.credential_pool import AUTH_TYPE_OAUTH, CredentialPool, PooledCredential
+    import uuid
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(
+        json.dumps({"version": 1, "providers": {}})
+    )
+    (hermes_home / "config.yaml").write_text(
+        "oauth:\n  refresh_owner: external\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    refresh_calls = {"count": 0}
+
+    def _refresh_must_not_run(*_args, **_kwargs):
+        refresh_calls["count"] += 1
+        raise AssertionError("runtime must not rotate externally managed OAuth")
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.refresh_xai_oauth_pure", _refresh_must_not_run
+    )
+
+    near_expiry = _jwt_with_exp(int(time.time()) + 30)
+    entry = PooledCredential(
+        provider="xai-oauth",
+        id=uuid.uuid4().hex[:6],
+        label="test",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source="manual:xai_pkce",
+        access_token=near_expiry,
+        refresh_token="rt-owned-by-scheduler",
+        base_url=DEFAULT_XAI_OAUTH_BASE_URL,
+    )
+    pool = CredentialPool("xai-oauth", [entry])
+    pool._persist(oauth_token_write_authority="external-scheduler")
+
+    assert pool._entry_needs_refresh(entry) is False
+    assert pool.select() is not None
+
+    auth_payload = json.loads((hermes_home / "auth.json").read_text())
+    scheduler_access = _jwt_with_exp(int(time.time()) + 3 * 60 * 60)
+    scheduler_entry = auth_payload["credential_pool"]["xai-oauth"][0]
+    scheduler_entry["access_token"] = scheduler_access
+    scheduler_entry["refresh_token"] = "rt-rotated-by-scheduler"
+    (hermes_home / "auth.json").write_text(json.dumps(auth_payload))
+
+    adopted = pool.try_refresh_current()
+    assert adopted is not None
+    assert adopted.access_token == scheduler_access
+    assert adopted.refresh_token == "rt-rotated-by-scheduler"
+    assert refresh_calls["count"] == 0
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted_entry = persisted["credential_pool"]["xai-oauth"][0]
+    assert persisted_entry["access_token"] == scheduler_access
+    assert persisted_entry["refresh_token"] == "rt-rotated-by-scheduler"
+
+
+def test_external_refresh_owner_preserves_scheduler_tokens_during_round_robin_write(
+    tmp_path, monkeypatch
+):
+    from agent.credential_pool import (
+        AUTH_TYPE_OAUTH,
+        CredentialPool,
+        PooledCredential,
+    )
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "auth.json").write_text(
+        json.dumps({"version": 1, "providers": {}})
+    )
+    (hermes_home / "config.yaml").write_text(
+        "oauth:\n"
+        "  refresh_owner: external\n"
+        "credential_pool_strategies:\n"
+        "  xai-oauth: round_robin\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    entries = [
+        PooledCredential(
+            provider="xai-oauth",
+            id=f"entry-{index}",
+            label=f"entry {index}",
+            auth_type=AUTH_TYPE_OAUTH,
+            priority=index,
+            source=f"manual:{index}",
+            access_token=f"access-old-{index}",
+            refresh_token=f"refresh-old-{index}",
+            base_url=DEFAULT_XAI_OAUTH_BASE_URL,
+        )
+        for index in range(2)
+    ]
+    pool = CredentialPool("xai-oauth", entries)
+    pool._persist(oauth_token_write_authority="external-scheduler")
+
+    auth_payload = json.loads((hermes_home / "auth.json").read_text())
+    scheduler_entry = auth_payload["credential_pool"]["xai-oauth"][0]
+    scheduler_entry["id"] = "scheduler-entry"
+    scheduler_entry["access_token"] = "access-from-scheduler"
+    scheduler_entry["refresh_token"] = "refresh-from-scheduler"
+    (hermes_home / "auth.json").write_text(json.dumps(auth_payload))
+
+    assert pool.select() is not None
+
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    selected_disk_entry = next(
+        entry
+        for entry in persisted["credential_pool"]["xai-oauth"]
+        if entry["id"] == "scheduler-entry"
+    )
+    assert selected_disk_entry["access_token"] == "access-from-scheduler"
+    assert selected_disk_entry["refresh_token"] == "refresh-from-scheduler"
+    assert not any(
+        entry["id"] == "entry-0"
+        for entry in persisted["credential_pool"]["xai-oauth"]
+    )
+
+
+def test_external_refresh_owner_adopts_scheduler_replacement_entry(
+    tmp_path, monkeypatch
+):
+    from agent.credential_pool import (
+        AUTH_TYPE_OAUTH,
+        CredentialPool,
+        PooledCredential,
+    )
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "auth.json").write_text(
+        json.dumps({"version": 1, "providers": {}})
+    )
+    (hermes_home / "config.yaml").write_text(
+        "oauth:\n  refresh_owner: external\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    original_entry = PooledCredential(
+        provider="xai-oauth",
+        id="old-entry",
+        label="old",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source="manual:old",
+        access_token="access-old",
+        refresh_token="refresh-old",
+        base_url=DEFAULT_XAI_OAUTH_BASE_URL,
+    )
+    pool = CredentialPool("xai-oauth", [original_entry])
+    pool._persist(oauth_token_write_authority="external-scheduler")
+    assert pool.select() is not None
+
+    auth_payload = json.loads((hermes_home / "auth.json").read_text())
+    auth_payload["credential_pool"]["xai-oauth"] = [{
+        "id": "scheduler-entry",
+        "label": "scheduler",
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "manual:scheduler",
+        "access_token": "access-from-scheduler",
+        "refresh_token": "refresh-from-scheduler",
+        "base_url": DEFAULT_XAI_OAUTH_BASE_URL,
+    }]
+    (hermes_home / "auth.json").write_text(json.dumps(auth_payload))
+
+    adopted = pool.try_refresh_current()
+
+    assert adopted is not None
+    assert adopted.id == "scheduler-entry"
+    assert adopted.access_token == "access-from-scheduler"
+    assert pool.current() == adopted
+
+
+def test_external_refresh_owner_does_not_report_unchanged_token_as_refreshed(
+    tmp_path, monkeypatch
+):
+    from agent.credential_pool import (
+        AUTH_TYPE_OAUTH,
+        CredentialPool,
+        PooledCredential,
+    )
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "auth.json").write_text(
+        json.dumps({"version": 1, "providers": {}})
+    )
+    (hermes_home / "config.yaml").write_text(
+        "oauth:\n  refresh_owner: external\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    unchanged_entry = PooledCredential(
+        provider="xai-oauth",
+        id="unchanged-entry",
+        label="unchanged",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source="manual:unchanged",
+        access_token="access-unchanged",
+        refresh_token="refresh-unchanged",
+        base_url=DEFAULT_XAI_OAUTH_BASE_URL,
+    )
+    pool = CredentialPool("xai-oauth", [unchanged_entry])
+    pool._persist(oauth_token_write_authority="external-scheduler")
+    assert pool.select() is not None
+
+    assert pool.try_refresh_current() is None
+
+
+def test_external_refresh_owner_allows_interactive_reauth_singleton_sync(
+    tmp_path, monkeypatch
+):
+    from agent.credential_pool import load_pool
+
+    hermes_home = tmp_path / "hermes"
+    _setup_hermes_auth(
+        hermes_home,
+        access_token="access-old-dead",
+        refresh_token="refresh-old-dead",
+    )
+    auth_payload = json.loads((hermes_home / "auth.json").read_text())
+    auth_payload["credential_pool"] = {
+        "xai-oauth": [{
+            "id": "device-entry",
+            "label": "device",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "device_code",
+            "access_token": "access-old-dead",
+            "refresh_token": "refresh-old-dead",
+            "base_url": DEFAULT_XAI_OAUTH_BASE_URL,
+        }]
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_payload))
+    (hermes_home / "config.yaml").write_text(
+        "oauth:\n  refresh_owner: external\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _save_xai_oauth_tokens({
+        "access_token": "access-from-reauth",
+        "refresh_token": "refresh-from-reauth",
+    })
+
+    pool = load_pool("xai-oauth")
+
+    selected = pool.select()
+    assert selected is not None
+    assert selected.access_token == "access-from-reauth"
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted_entry = persisted["credential_pool"]["xai-oauth"][0]
+    assert persisted_entry["access_token"] == "access-from-reauth"
+    assert persisted_entry["refresh_token"] == "refresh-from-reauth"
+    resolved = resolve_xai_oauth_runtime_credentials()
+    assert resolved["api_key"] == "access-from-reauth"
+
+
+def test_external_refresh_owner_keeps_scheduler_pool_over_stale_singleton(
+    tmp_path, monkeypatch
+):
+    from agent.credential_pool import load_pool
+
+    hermes_home = tmp_path / "hermes"
+    _setup_hermes_auth(
+        hermes_home,
+        access_token="access-stale-singleton",
+        refresh_token="refresh-stale-singleton",
+    )
+    auth_payload = json.loads((hermes_home / "auth.json").read_text())
+    auth_payload["credential_pool"] = {
+        "xai-oauth": [{
+            "id": "scheduler-entry",
+            "label": "scheduler",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "device_code",
+            "access_token": "access-scheduler-fresh",
+            "refresh_token": "refresh-scheduler-fresh",
+            "base_url": DEFAULT_XAI_OAUTH_BASE_URL,
+        }]
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_payload))
+    (hermes_home / "config.yaml").write_text(
+        "oauth:\n  refresh_owner: external\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    pool = load_pool("xai-oauth")
+
+    selected = pool.select()
+    assert selected is not None
+    assert selected.access_token == "access-scheduler-fresh"
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    persisted_entry = persisted["credential_pool"]["xai-oauth"][0]
+    assert persisted_entry["access_token"] == "access-scheduler-fresh"
+    assert persisted_entry["refresh_token"] == "refresh-scheduler-fresh"
+    resolved = resolve_xai_oauth_runtime_credentials()
+    assert resolved["api_key"] == "access-scheduler-fresh"
+
+
+def test_external_refresh_owner_resolves_pool_without_singleton(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "xai-oauth": [{
+                "id": "pool-only",
+                "priority": 0,
+                "auth_type": "oauth",
+                "access_token": "access-pool-only",
+                "refresh_token": "refresh-pool-only",
+            }]
+        },
+    }))
+    (hermes_home / "config.yaml").write_text(
+        "oauth:\n  refresh_owner: external\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    resolved = resolve_xai_oauth_runtime_credentials()
+
+    assert resolved["api_key"] == "access-pool-only"
+
+
+def test_external_refresh_owner_reuses_expired_exhaustion_entry(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes"
+    _setup_hermes_auth(
+        hermes_home,
+        access_token="access-stale-singleton",
+        refresh_token="refresh-stale-singleton",
+    )
+    auth_payload = json.loads((hermes_home / "auth.json").read_text())
+    auth_payload["credential_pool"] = {
+        "xai-oauth": [
+            {
+                "id": "cooldown-expired",
+                "priority": 0,
+                "auth_type": "oauth",
+                "last_status": "exhausted",
+                "last_error_reset_at": time.time() - 1,
+                "access_token": "access-after-cooldown",
+                "refresh_token": "refresh-after-cooldown",
+            },
+            {
+                "id": "fallback",
+                "priority": 1,
+                "auth_type": "oauth",
+                "access_token": "access-fallback",
+                "refresh_token": "refresh-fallback",
+            },
+        ]
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_payload))
+    (hermes_home / "config.yaml").write_text(
+        "oauth:\n  refresh_owner: external\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    resolved = resolve_xai_oauth_runtime_credentials(refresh_if_expiring=False)
+
+    assert resolved["api_key"] == "access-after-cooldown"
+
+
+def test_external_owner_persist_drops_stale_id_and_preserves_scheduler_replacement(
+    tmp_path, monkeypatch
+):
+    from agent.credential_pool import AUTH_TYPE_OAUTH, CredentialPool, PooledCredential
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: external\n")
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    stale = PooledCredential(
+        provider="xai-oauth", id="old-id", label="old", auth_type=AUTH_TYPE_OAUTH,
+        priority=0, source="manual:old", access_token="old-access",
+        refresh_token="old-refresh", base_url=DEFAULT_XAI_OAUTH_BASE_URL,
+    )
+    pool = CredentialPool("xai-oauth", [stale])
+    pool._persist(oauth_token_write_authority="external-scheduler")
+    scheduler_entry = {
+        "id": "scheduler-id", "label": "scheduler", "auth_type": "oauth",
+        "priority": 0, "source": "manual:scheduler",
+        "access_token": "scheduler-access", "refresh_token": "scheduler-refresh",
+        "base_url": DEFAULT_XAI_OAUTH_BASE_URL,
+    }
+    payload = json.loads((hermes_home / "auth.json").read_text())
+    payload["credential_pool"]["xai-oauth"] = [scheduler_entry]
+    (hermes_home / "auth.json").write_text(json.dumps(payload))
+
+    pool._persist()
+
+    persisted = json.loads((hermes_home / "auth.json").read_text())
+    assert persisted["credential_pool"]["xai-oauth"] == [scheduler_entry]
+
+
+def test_external_owner_adopts_global_scheduler_replacement_without_local_pool(
+    tmp_path, monkeypatch
+):
+    from agent.credential_pool import AUTH_TYPE_OAUTH, CredentialPool, PooledCredential
+
+    hermes_home = tmp_path / "profile"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: external\n")
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    global_store = {"version": 1, "credential_pool": {}}
+    monkeypatch.setattr("hermes_cli.auth._load_global_auth_store", lambda: global_store)
+    stale = PooledCredential(
+        provider="xai-oauth", id="old-id", label="old", auth_type=AUTH_TYPE_OAUTH,
+        priority=0, source="manual:old", access_token="old-access",
+        refresh_token="old-refresh", base_url=DEFAULT_XAI_OAUTH_BASE_URL,
+    )
+    pool = CredentialPool("xai-oauth", [stale])
+    assert pool.select() == stale
+    global_store["credential_pool"]["xai-oauth"] = [{
+        "id": "global-scheduler-id", "label": "global scheduler",
+        "auth_type": "oauth", "priority": 0, "source": "manual:scheduler",
+        "access_token": "global-access", "refresh_token": "global-refresh",
+        "base_url": DEFAULT_XAI_OAUTH_BASE_URL,
+    }]
+
+    adopted = pool.try_refresh_current()
+
+    assert adopted is not None
+    assert adopted.id == "global-scheduler-id"
+    assert adopted.access_token == "global-access"
+
+
+def test_external_owner_adopts_selected_replacement_when_old_id_is_dead(
+    tmp_path, monkeypatch
+):
+    from agent.credential_pool import AUTH_TYPE_OAUTH, CredentialPool, PooledCredential
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: external\n")
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    stale = PooledCredential(
+        provider="xai-oauth", id="old-id", label="old", auth_type=AUTH_TYPE_OAUTH,
+        priority=0, source="manual:old", access_token="old-access",
+        refresh_token="old-refresh", base_url=DEFAULT_XAI_OAUTH_BASE_URL,
+    )
+    pool = CredentialPool("xai-oauth", [stale])
+    assert pool.select() == stale
+    payload = json.loads((hermes_home / "auth.json").read_text())
+    payload["credential_pool"] = {"xai-oauth": [
+        {**stale.to_dict(), "last_status": "dead"},
+        {
+            "id": "new-id", "label": "new", "auth_type": "oauth", "priority": 1,
+            "source": "manual:scheduler", "access_token": "new-access",
+            "refresh_token": "new-refresh", "base_url": DEFAULT_XAI_OAUTH_BASE_URL,
+        },
+    ]}
+    (hermes_home / "auth.json").write_text(json.dumps(payload))
+
+    adopted = pool.try_refresh_current()
+
+    assert adopted is not None
+    assert adopted.id == "new-id"
+    assert pool.current() == adopted
+
+
+def test_external_owner_replacement_reuses_existing_in_memory_entry_id(
+    tmp_path, monkeypatch
+):
+    from agent.credential_pool import AUTH_TYPE_OAUTH, CredentialPool, PooledCredential
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: external\n")
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    old = PooledCredential(
+        provider="xai-oauth", id="old-id", label="old", auth_type=AUTH_TYPE_OAUTH,
+        priority=0, source="manual:old", access_token="old-access",
+        refresh_token="old-refresh", base_url=DEFAULT_XAI_OAUTH_BASE_URL,
+    )
+    fallback = PooledCredential(
+        provider="xai-oauth", id="fallback-id", label="fallback",
+        auth_type=AUTH_TYPE_OAUTH, priority=1, source="manual:fallback",
+        access_token="fallback-stale-access", refresh_token="fallback-stale-refresh",
+        base_url=DEFAULT_XAI_OAUTH_BASE_URL,
+    )
+    pool = CredentialPool("xai-oauth", [old, fallback])
+    assert pool.select() == old
+    payload = json.loads((hermes_home / "auth.json").read_text())
+    payload["credential_pool"] = {"xai-oauth": [
+        {**old.to_dict(), "last_status": "dead"},
+        {
+            **fallback.to_dict(),
+            "access_token": "fallback-scheduler-access",
+            "refresh_token": "fallback-scheduler-refresh",
+        },
+    ]}
+    (hermes_home / "auth.json").write_text(json.dumps(payload))
+
+    adopted = pool.try_refresh_current()
+
+    assert adopted is not None
+    assert adopted.id == "fallback-id"
+    assert adopted.access_token == "fallback-scheduler-access"
+    assert [entry.id for entry in pool.entries()] == ["fallback-id"]
+    assert pool.current() == adopted
+
+
+def test_runtime_owned_xai_pool_fallback_skips_dead_first_entry(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1, "providers": {}, "credential_pool": {"xai-oauth": [
+            {
+                "id": "dead", "priority": 0, "auth_type": "oauth",
+                "last_status": "dead", "access_token": "dead-access",
+                "refresh_token": "dead-refresh",
+            },
+            {
+                "id": "live", "priority": 1, "auth_type": "oauth",
+                "access_token": "live-access", "refresh_token": "live-refresh",
+            },
+        ]},
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    resolved = resolve_xai_oauth_runtime_credentials(refresh_if_expiring=False)
+
+    assert resolved["api_key"] == "live-access"
+
+
+def test_external_xai_owner_rejects_stale_singleton_when_pool_has_no_usable_entry(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "hermes"
+    _setup_hermes_auth(
+        hermes_home, access_token="stale-singleton", refresh_token="stale-refresh"
+    )
+    payload = json.loads((hermes_home / "auth.json").read_text())
+    payload["credential_pool"] = {"xai-oauth": [{
+        "id": "dead", "priority": 0, "auth_type": "oauth", "last_status": "dead",
+        "access_token": "dead-access", "refresh_token": "dead-refresh",
+    }]}
+    (hermes_home / "auth.json").write_text(json.dumps(payload))
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: external\n")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc_info:
+        resolve_xai_oauth_runtime_credentials(refresh_if_expiring=False)
+
+    assert exc_info.value.code == "xai_external_pool_unavailable"
+    assert exc_info.value.relogin_required is False
+
+
+def test_external_scheduler_write_authority_allows_token_mutation(tmp_path, monkeypatch):
+    from hermes_cli.auth import write_credential_pool, read_credential_pool
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: external\n")
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "xai-oauth": [{
+                "id": "sched-1",
+                "auth_type": "oauth",
+                "priority": 0,
+                "access_token": "old-access",
+                "refresh_token": "old-refresh",
+            }]
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    write_credential_pool(
+        "xai-oauth",
+        [{
+            "id": "sched-1",
+            "auth_type": "oauth",
+            "priority": 0,
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+        }],
+        oauth_token_write_authority="external-scheduler",
+    )
+    entries = read_credential_pool("xai-oauth")
+    assert entries[0]["access_token"] == "new-access"
+    assert entries[0]["refresh_token"] == "new-refresh"
+
+
+def test_xai_http_force_refresh_adopts_without_refresh_post(tmp_path, monkeypatch):
+    """Voice/tool helper route: force_refresh must not POST under external owner."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    near = _jwt_with_exp(int(time.time()) + 30)
+    fresh = _jwt_with_exp(int(time.time()) + 3 * 60 * 60)
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: external\n")
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "xai-oauth": [{
+                "id": "voice-1",
+                "auth_type": "oauth",
+                "priority": 0,
+                "source": "manual:scheduler",
+                "access_token": near,
+                "refresh_token": "rt-voice",
+                "base_url": DEFAULT_XAI_OAUTH_BASE_URL,
+            }]
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    def _refresh_must_not_run(*_args, **_kwargs):
+        raise AssertionError("xai_http force_refresh must not spend refresh token")
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_xai_oauth_pure", _refresh_must_not_run)
+
+    # Scheduler rotates on disk before the helper retries.
+    payload = json.loads((hermes_home / "auth.json").read_text())
+    payload["credential_pool"]["xai-oauth"][0]["access_token"] = fresh
+    payload["credential_pool"]["xai-oauth"][0]["refresh_token"] = "rt-voice-rotated"
+    (hermes_home / "auth.json").write_text(json.dumps(payload))
+
+    from tools.xai_http import resolve_xai_http_credentials
+
+    creds = resolve_xai_http_credentials(force_refresh=True, api_key_hint=near)
+    assert creds["api_key"] == fresh
+    assert creds["provider"] == "xai-oauth"
+
+
+def test_auth_add_xai_oauth_persists_under_external_owner(tmp_path, monkeypatch):
+    """Production path: hermes auth add xai-oauth must keep the new row on disk.
+
+    Fleet recovery spawns exactly this command under oauth.refresh_owner=external.
+    Without interactive-login write authority, write_credential_pool drops the
+    newly authorized OAuth row/token pair.
+    """
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: external\n")
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    access_token = "xai-interactive-access"
+    refresh_token = "xai-interactive-refresh"
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_device_code_login",
+        lambda **_kwargs: {
+            "tokens": {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "id_token": "",
+                "token_type": "Bearer",
+            },
+            "discovery": {"token_endpoint": "https://auth.x.ai/oauth2/token"},
+            "redirect_uri": "",
+            "base_url": DEFAULT_XAI_OAUTH_BASE_URL,
+            "last_refresh": "2026-08-03T12:00:00Z",
+            "source": "oauth-device-code",
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "xai-oauth"
+        auth_type = "oauth"
+        api_key = None
+        label = "fleet-recovery"
+        timeout = None
+        no_browser = True
+
+    auth_add_command(_Args())
+
+    payload = json.loads((hermes_home / "auth.json").read_text())
+    entries = payload["credential_pool"]["xai-oauth"]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["access_token"] == access_token
+    assert entry["refresh_token"] == refresh_token
+    assert entry["auth_type"] == "oauth"
+    assert entry["source"] == "manual:device_code"
+    assert entry["label"] == "fleet-recovery"
+    assert payload.get("active_provider") == "xai-oauth"
+
+
+def test_external_owner_runtime_mark_exhausted_cannot_poison_scheduler_status(
+    tmp_path, monkeypatch
+):
+    """Unauthorized runtime _persist must not poison scheduler usability fields."""
+    from agent.credential_pool import (
+        AUTH_TYPE_OAUTH,
+        STATUS_EXHAUSTED,
+        CredentialPool,
+        PooledCredential,
+    )
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: external\n")
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    entry = PooledCredential(
+        provider="xai-oauth",
+        id="sched-1",
+        label="scheduler",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source="manual:scheduler",
+        access_token="scheduler-access",
+        refresh_token="scheduler-refresh",
+        base_url=DEFAULT_XAI_OAUTH_BASE_URL,
+    )
+    pool = CredentialPool("xai-oauth", [entry])
+    pool._persist(oauth_token_write_authority="external-scheduler")
+
+    # Scheduler marks healthy usability metadata on disk.
+    payload = json.loads((hermes_home / "auth.json").read_text())
+    disk_entry = payload["credential_pool"]["xai-oauth"][0]
+    disk_entry["last_status"] = None
+    disk_entry["last_status_at"] = None
+    disk_entry["last_error_code"] = None
+    disk_entry["last_error_reason"] = None
+    disk_entry["last_error_message"] = None
+    disk_entry["last_error_reset_at"] = None
+    (hermes_home / "auth.json").write_text(json.dumps(payload))
+
+    # Runtime believes the credential is exhausted/dead and tries to persist.
+    pool._mark_exhausted(entry, 429, {"reason": "rate_limit", "message": "slow down"})
+
+    persisted = json.loads((hermes_home / "auth.json").read_text())["credential_pool"][
+        "xai-oauth"
+    ][0]
+    assert persisted["access_token"] == "scheduler-access"
+    assert persisted["refresh_token"] == "scheduler-refresh"
+    assert persisted.get("last_status") in (None, "")
+    assert persisted.get("last_status_at") in (None, "")
+    assert persisted.get("last_error_code") in (None, "")
+    assert persisted.get("last_error_reason") in (None, "")
+    assert STATUS_EXHAUSTED != persisted.get("last_status")
+
+
+def test_external_owner_unauthorized_removed_ids_cannot_delete_scheduler_row(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: external\n")
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {},
+                "credential_pool": {
+                    "xai-oauth": [
+                        {
+                            "id": "sched-keep",
+                            "auth_type": "oauth",
+                            "priority": 0,
+                            "access_token": "keep-access",
+                            "refresh_token": "keep-refresh",
+                        }
+                    ]
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    write_credential_pool(
+        "xai-oauth",
+        [],
+        removed_ids=["sched-keep"],
+    )
+    entries = read_credential_pool("xai-oauth")
+    assert len(entries) == 1
+    assert entries[0]["id"] == "sched-keep"
+    assert entries[0]["access_token"] == "keep-access"
+
+
+def test_external_owner_scheduler_authority_can_delete_and_update(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: external\n")
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {},
+                "credential_pool": {
+                    "xai-oauth": [
+                        {
+                            "id": "old-sched",
+                            "auth_type": "oauth",
+                            "priority": 0,
+                            "access_token": "old-access",
+                            "refresh_token": "old-refresh",
+                            "last_status": "exhausted",
+                            "last_error_code": 429,
+                        }
+                    ]
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    write_credential_pool(
+        "xai-oauth",
+        [
+            {
+                "id": "new-sched",
+                "auth_type": "oauth",
+                "priority": 0,
+                "access_token": "new-access",
+                "refresh_token": "new-refresh",
+                "last_status": None,
+                "last_error_code": None,
+            }
+        ],
+        removed_ids=["old-sched"],
+        oauth_token_write_authority="external-scheduler",
+    )
+    entries = read_credential_pool("xai-oauth")
+    assert len(entries) == 1
+    assert entries[0]["id"] == "new-sched"
+    assert entries[0]["access_token"] == "new-access"
+    assert entries[0]["refresh_token"] == "new-refresh"
+    assert entries[0].get("last_status") is None
+
+
+def test_external_owner_interactive_login_cannot_overwrite_unrelated_scheduler_row(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: external\n")
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {},
+                "credential_pool": {
+                    "xai-oauth": [
+                        {
+                            "id": "sched-unrelated",
+                            "auth_type": "oauth",
+                            "priority": 0,
+                            "label": "scheduler",
+                            "access_token": "scheduler-access",
+                            "refresh_token": "scheduler-refresh",
+                            "last_status": None,
+                            "last_error_code": None,
+                        }
+                    ]
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # Snapshot includes a poisoned view of the scheduler row plus a new login.
+    write_credential_pool(
+        "xai-oauth",
+        [
+            {
+                "id": "sched-unrelated",
+                "auth_type": "oauth",
+                "priority": 0,
+                "label": "scheduler",
+                "access_token": "stolen-access",
+                "refresh_token": "stolen-refresh",
+                "last_status": "dead",
+                "last_error_code": 401,
+                "last_error_reason": "poison",
+            },
+            {
+                "id": "interactive-new",
+                "auth_type": "oauth",
+                "priority": 1,
+                "label": "interactive",
+                "access_token": "interactive-access",
+                "refresh_token": "interactive-refresh",
+            },
+        ],
+        removed_ids=["sched-unrelated"],
+        oauth_token_write_authority="interactive-login",
+        authorized_oauth_entry_ids=["interactive-new"],
+    )
+    entries = {entry["id"]: entry for entry in read_credential_pool("xai-oauth")}
+    assert set(entries) == {"sched-unrelated", "interactive-new"}
+    assert entries["sched-unrelated"]["access_token"] == "scheduler-access"
+    assert entries["sched-unrelated"]["refresh_token"] == "scheduler-refresh"
+    assert entries["sched-unrelated"].get("last_status") is None
+    assert entries["sched-unrelated"].get("last_error_code") is None
+    assert entries["interactive-new"]["access_token"] == "interactive-access"
+    assert entries["interactive-new"]["refresh_token"] == "interactive-refresh"
+
+
+def test_external_owner_interactive_login_can_replace_authorized_entry(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.auth import read_credential_pool, write_credential_pool
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text("oauth:\n  refresh_owner: external\n")
+    (hermes_home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {},
+                "credential_pool": {
+                    "xai-oauth": [
+                        {
+                            "id": "reauth-target",
+                            "auth_type": "oauth",
+                            "priority": 0,
+                            "access_token": "old-access",
+                            "refresh_token": "old-refresh",
+                            "last_status": "dead",
+                            "last_error_code": 401,
+                        }
+                    ]
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    write_credential_pool(
+        "xai-oauth",
+        [
+            {
+                "id": "reauth-target",
+                "auth_type": "oauth",
+                "priority": 0,
+                "access_token": "new-access",
+                "refresh_token": "new-refresh",
+                "last_status": None,
+                "last_error_code": None,
+                "last_error_reason": None,
+                "last_error_message": None,
+                "last_error_reset_at": None,
+            }
+        ],
+        oauth_token_write_authority="interactive-login",
+        authorized_oauth_entry_ids=["reauth-target"],
+    )
+    entries = read_credential_pool("xai-oauth")
+    assert len(entries) == 1
+    assert entries[0]["access_token"] == "new-access"
+    assert entries[0]["refresh_token"] == "new-refresh"
+    assert entries[0].get("last_status") is None
+    assert entries[0].get("last_error_code") is None

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1672,6 +1672,7 @@ class TestBuildSchemaFromConfig:
         cats = Counter(e["category"] for e in CONFIG_SCHEMA.values())
         for cat, count in cats.items():
             assert count >= 2, f"Category '{cat}' has only {count} field(s) — should be merged"
+        assert CONFIG_SCHEMA["oauth.refresh_owner"]["category"] == "security"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Make externally coordinated xAI OAuth a real single-writer contract: when `oauth.refresh_owner` is `external`, Hermes adopts scheduler-published access tokens but cannot rotate the refresh token from gateway, retry, STT, TTS, web-provider or pool paths.

Closes #77553.

## Why

xAI refresh tokens rotate. In a multi-profile installation, one stale or long-running gateway can spend the shared refresh token and leave every other holder with a revoked predecessor. This change provides the Hermes-side fence required for Fleet to own that lineage safely.

## What changed

- Add the xAI-only `oauth.refresh_owner` contract with runtime-owned default and fail-closed handling for malformed values.
- Block non-interactive xAI refresh under external ownership across singleton, pool, forced/retry and helper routes.
- Let scheduler-authorised writes publish successor credentials through a narrow `external-scheduler` compatibility argument.
- Let genuine interactive `hermes auth add xai-oauth` persist a Chief-approved replacement through `interactive-login` authority.
- Preserve scheduler-owned token and usability/status fields from unauthorised runtime writes; unauthorised removals cannot delete scheduler rows.
- Keep non-xAI providers and standalone Hermes behaviour unchanged.

## Security boundary

This is an accidental same-user writer fence, not cryptographic multi-tenant isolation. A process able to execute arbitrary Python as the same user can forge authority strings or call the low-level pure refresh primitive. The supported Hermes runtime call paths are fenced and covered by tests.

## Verification

- `pytest -q tests/hermes_cli/test_auth_xai_oauth_provider.py` — 49 passed
- `pytest -q tests/hermes_cli -k 'xai or oauth or credential_pool'` — 177 passed, 3931 deselected
- `pytest -q tests/tools/test_web_providers_xai.py tests/tools/test_tts_streaming.py` — 52 passed
- `ruff check` on the five changed Python files — clean
- `git diff --check origin/main...HEAD` — clean
- commit-range gitleaks — one commit, approximately 60.39 KB scanned, no leaks
- independent final review of code SHA `1bac38d7f3921795d973930938a8f33695c91a1a` — APPROVE

## Rollout

1. Merge and deploy this Hermes change.
2. Set `oauth.refresh_owner: external` for every first-party shared-lineage consumer and restart/quarantine stale gateways.
3. Deploy the linked Fleet control-plane PR with enforcement still off.
4. Confirm every operated runtime reports scheduler-write authority support.
5. Explicitly enable Fleet enforcement; only then allow Fleet to rotate the shared lineage.

No live credential, gateway, OAuth login or production configuration change is included in this PR.

## Related

- Fleet control-plane PR: BenSheridanEdwards/F.L.E.E.T#1155
- Fleet incident: BenSheridanEdwards/F.L.E.E.T#1150
- Fleet ownership tracking: BenSheridanEdwards/F.L.E.E.T#1020
