### PR TITLE
fix(tui-gateway): merge agent output on personality-marker history race

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9034,6 +9034,116 @@ def test_prompt_submit_merges_on_model_switch_marker(monkeypatch):
             server._sessions.pop("sid", None)
 
 
+def test_prompt_submit_merges_on_personality_marker(monkeypatch):
+    """Personality changes share the exact race #76870 fixed for model switches:
+    config.set's "personality" key (unlike "model") has no session["running"]
+    guard, so a client can call it while a turn is in flight. That appends a
+    marker to history and bumps history_version mid-turn — without this fix,
+    the version mismatch falls into the "genuine desync" branch and the
+    agent's response for that turn is silently dropped from persisted history.
+
+    Covers both cases: no prior personality marker (first switch), and a
+    prior marker already in the turn-start history (every switch after the
+    first — _apply_personality_to_session does not strip prior markers the
+    way _append_model_switch_marker does, so the prior marker survives into
+    both snapshots and the content-diff must still match).
+    """
+    session_ref = {"s": None}
+
+    def _make_marker(prompt_text: str) -> dict:
+        return {
+            "role": "user",
+            "content": (
+                "[System: The user has changed the assistant's personality. "
+                "From this point forward, adopt the following persona and "
+                f"respond accordingly: {prompt_text}]"
+            ),
+        }
+
+    class _MarkerAgent:
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+            # Simulate a concurrent config.set{key:"personality"} RPC landing
+            # mid-turn via _apply_personality_to_session: append a marker,
+            # bump history_version, with no running-state guard in its way.
+            with session_ref["s"]["history_lock"]:
+                hist = session_ref["s"]["history"]
+                hist.append(_make_marker("new-persona"))
+                session_ref["s"]["history_version"] += 1
+            return {
+                "final_response": "agent reply",
+                "messages": list(conversation_history) + [
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "agent reply"},
+                ],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    for label, prior_history in [
+        ("no prior marker", [{"role": "user", "content": "hello"}]),
+        ("with prior marker", [
+            {"role": "user", "content": "hello"},
+            _make_marker("old-persona"),
+            {"role": "assistant", "content": "hi there"},
+        ]),
+    ]:
+        server._sessions["sid"] = _session(
+            agent=_MarkerAgent(),
+            history=list(prior_history),
+        )
+        session_ref["s"] = server._sessions["sid"]
+        emits: list[tuple] = []
+        try:
+            monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+            monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+            monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
+            monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
+
+            resp = server.handle_request(
+                {
+                    "id": "1",
+                    "method": "prompt.submit",
+                    "params": {"session_id": "sid", "text": "hi"},
+                }
+            )
+            assert resp.get("result"), f"[{label}] got error: {resp.get('error')}"
+
+            final_history = server._sessions["sid"]["history"]
+
+            assistant_msgs = [
+                e for e in final_history
+                if isinstance(e, dict) and e.get("role") == "assistant"
+                and e.get("content") == "agent reply"
+            ]
+            assert len(assistant_msgs) == 1, (
+                f"[{label}] agent output was not merged into history "
+                f"(got {len(assistant_msgs)} assistant 'agent reply' messages) "
+                f"-- a mid-turn personality change must not silently drop the "
+                f"turn's response"
+            )
+
+            markers = [
+                e for e in final_history
+                if server._is_personality_marker(e)
+            ]
+            assert len(markers) >= 1, f"[{label}] personality marker missing from merged history"
+            assert any("new-persona" in m["content"] for m in markers)
+
+            complete_calls = [a for a in emits if a[0] == "message.complete"]
+            assert len(complete_calls) == 1
+            _, _, payload = complete_calls[0]
+            assert "warning" not in payload, (
+                f"[{label}] merge path should not surface a warning"
+            )
+        finally:
+            server._sessions.pop("sid", None)
+
+
 def test_prompt_submit_sanitizes_bracketed_paste_before_agent(monkeypatch):
     """prompt.submit must sanitize corrupted user text before run_conversation."""
     captured: dict[str, str] = {}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3816,6 +3816,36 @@ def _is_model_switch_marker(entry: Any) -> bool:
     return isinstance(content, str) and content.startswith(_MODEL_SWITCH_MARKER_PREFIX)
 
 
+# Stable leading text of the two personality-pivot markers _apply_personality_to_session
+# appends (set vs. cleared). Used the same way as _MODEL_SWITCH_MARKER_PREFIX above: to
+# recognize a mid-turn personality change as a safe, mergeable history mutation rather
+# than a genuine desync (#76870's model-switch fix, applied to personality's identical
+# race — config.set's "personality" key has no session.get("running") guard, unlike
+# "model", so this marker can land while a turn is in flight).
+_PERSONALITY_MARKER_PREFIXES = (
+    "[System: The user has changed the assistant's personality.",
+    "[System: The user has cleared the personality overlay.",
+)
+
+
+def _is_personality_marker(entry: Any) -> bool:
+    """Whether a history entry is a personality-pivot marker.
+
+    Checks both the ``"[System: ..."`` content-prefix (today's shape, and
+    what any already-persisted marker in an existing session has) and
+    ``display_kind == "personality_switch"`` (the structured shape a
+    separate, unrelated fix — #74315/#74350 — may give newly-appended
+    markers), so this stays correct regardless of merge order between the
+    two fixes.
+    """
+    if not isinstance(entry, dict):
+        return False
+    if entry.get("display_kind") == "personality_switch":
+        return True
+    content = entry.get("content")
+    return isinstance(content, str) and content.startswith(_PERSONALITY_MARKER_PREFIXES)
+
+
 def _append_model_switch_marker(session: dict | None, *, model: str, provider: str) -> None:
     """Record a real system-history pivot after a live model switch.
 
@@ -9721,29 +9751,38 @@ def _run_prompt_submit(
                         else:
                             # History mutated externally during the turn.
                             # Check if the only mutation was a model-switch
-                            # marker inserted mid-turn (#76870).  If so the
-                            # agent output is still valid — merge it into the
+                            # and/or personality-pivot marker inserted mid-turn
+                            # (#76870, extended to personality — config.set's
+                            # "personality" key applies immediately even while
+                            # session["running"] is true, so this race is not
+                            # hypothetical for it either).  If so the agent
+                            # output is still valid — merge it into the
                             # current history that now contains the marker.
                             #
                             # _append_model_switch_marker strips prior markers
                             # in-place then appends a new one, so the delta
                             # is NOT a simple tail-slice — we must compare
                             # content, not indices.
+                            def _is_safe_mergeable_marker(e: Any) -> bool:
+                                return _is_model_switch_marker(e) or _is_personality_marker(e)
+
                             current_history = list(session["history"])
                             history_no_markers = [
-                                e for e in history if not _is_model_switch_marker(e)
+                                e for e in history if not _is_safe_mergeable_marker(e)
                             ]
                             current_no_markers = [
-                                e for e in current_history if not _is_model_switch_marker(e)
+                                e
+                                for e in current_history
+                                if not _is_safe_mergeable_marker(e)
                             ]
-                            model_switch_only = (
+                            safe_marker_only = (
                                 current_no_markers == history_no_markers
                                 and any(
-                                    _is_model_switch_marker(e)
+                                    _is_safe_mergeable_marker(e)
                                     for e in current_history
                                 )
                             )
-                            if model_switch_only:
+                            if safe_marker_only:
                                 # The agent's new messages start after the
                                 # turn-start history.  Guard against
                                 # auto-compression making result["messages"]


### PR DESCRIPTION
## Summary

- `config.set`'s `"personality"` key applies immediately regardless of `session["running"]`, unlike `"model"` (which defers to next-turn-start while a turn is in flight — see the `session.get("running")` check in `config.set`'s `key == "model"` branch).
- A personality change mid-turn (e.g. via the desktop/web settings UI while a response is streaming) appends a marker to `session["history"]` and bumps `history_version` — the exact same shape of mutation a model switch makes.
- The turn-completion mismatch guard in `_run_prompt_submit` (added by #76870, three days ago) only recognized **model-switch** markers as a safe, mergeable mutation. A personality-marker-only mismatch fell into the "genuine desync" branch instead: the agent's response for that turn was **silently discarded from persisted history** (only shown transiently with a "not saved to session history" warning).

## Root cause

`_apply_personality_to_session` (`tui_gateway/server.py`) has no `session.get("running")` guard on the `config.set` RPC path — it calls straight through, appending `{"role": "user", "content": marker}` and incrementing `history_version` under `session["history_lock"]`, whether or not a turn is currently in flight.

`_run_prompt_submit`'s post-turn `history_version` check (introduced by #76870 for the analogous model-switch race) only ever compared against `_is_model_switch_marker`, so a personality marker landing mid-turn was treated identically to a genuine external desync (`/undo`, `/compress`, `/retry`) — the agent's output for that turn was dropped instead of merged.

## Fix

Extend the merge-recovery check to also recognize personality-pivot markers as safe to merge, using the exact content-diff technique #76870/cc04825c5d already established and reviewed for model-switch markers:

- Added `_is_personality_marker()` (mirrors `_is_model_switch_marker()`), matching either the marker's stable `"[System: ..."` content-prefix (today's shape) or `display_kind == "personality_switch"` (the structured shape an unrelated open PR, #74350, would give newly-appended markers — checking both keeps this correct regardless of merge order between the two fixes).
- `_run_prompt_submit`'s mismatch branch now strips *both* model-switch and personality markers before the content-diff comparison, and accepts either marker type as the sole safe mutation.

## Test plan

- Added `test_prompt_submit_merges_on_personality_marker`, mirroring the existing `test_prompt_submit_merges_on_model_switch_marker` harness. Covers both cases (no prior personality marker, and a prior marker already in the turn-start history) — simulates the race by appending the marker from inside the stub agent's `run_conversation()`, exactly as a concurrent `config.set` RPC would mid-turn.
- Mutation-verified: reverted the `tui_gateway/server.py` change and confirmed the new test fails with the exact pre-fix symptom (`agent output NOT written to session history`, 0 assistant messages merged).
- `tests/test_tui_gateway_server.py` full suite: 517 passed, 1 pre-existing unrelated failure (`test_write_json_serializes_concurrent_writes`, a thread-scheduling-timing test — confirmed flaky/pre-existing by re-running it in isolation both with and without this change, unaffected either way).
- `ruff check` clean on both changed files.

## Competitor check

- No open/closed PR targets this specific race (searched multiple keyword combinations against `tui_gateway/server.py`'s `config.set`/`_apply_personality_to_session`/`_run_prompt_submit` merge-recovery logic).
- Two adjacent-looking open PRs were read in full and confirmed to be different bugs, not duplicates:
  - **#74350** restructures `_apply_personality_to_session` to persist the marker durably with structured `display_kind`/`display_metadata`, fixing a *different* bug (the marker swallowing the next real prompt on resume/reload via alternation-repair). It never touches `_run_prompt_submit`'s mismatch-merge block. This PR's `_is_personality_marker()` is written to stay correct whether #74350 lands before or after it.
  - **#73708** adds an equivalent personality-pivot marker to the separate `gateway/run.py` / `gateway/slash_commands.py` path (a different gateway surface entirely, not `tui_gateway/server.py`).