### PR TITLE
fix(agent): take the compression lock before micro-compaction's DB sync

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5771,12 +5771,50 @@ This compaction should PRIORITISE preserving all information related to the focu
         Without this, the in-memory-only splice leaves old exchange rows at
         ``active=1``, and a session resume double-loads both the summary and
         the original messages — blowing past the model's context limit.
+
+        Takes the same durable ``compression_locks`` row batch compression
+        uses (:meth:`SessionDB.try_acquire_compression_lock`) before calling
+        ``archive_and_compact``.  Without it, a micro-compact here and a
+        batch compression running concurrently on the same session_id (e.g.
+        an old worker still finishing a rotation after a gateway restart, or
+        two multiplex/cron processes sharing a session) can both soft-archive
+        the ``active=1`` rows and insert their own replacement set — whichever
+        commits second silently discards the other's already-committed
+        write, the exact "split session lineage" corruption the lock exists
+        to prevent (see :meth:`try_acquire_compression_lock`'s docstring).
+        The critical section here is one short transaction, so unlike the
+        batch path this does not need a lease refresher — acquire, write,
+        release, all synchronously.
         """
         session_db = getattr(self, "_session_db", None)
         session_id = getattr(self, "_session_id", "")
         if not session_db or not session_id:
             return
+
+        from agent.conversation_compression import _compression_lock_holder
+
+        holder = _compression_lock_holder(self)
+        lock_acquired = False
         try:
+            try_acquire = getattr(session_db, "try_acquire_compression_lock", None)
+            if callable(try_acquire):
+                lock_acquired = try_acquire(session_id, holder, ttl_seconds=30.0)
+            else:
+                # Legacy SessionDB instance predating the lock API (hot-reload
+                # version skew) — nothing to coordinate against, so proceed
+                # the same as before this fix existed.
+                lock_acquired = True
+
+            if not lock_acquired:
+                logger.info(
+                    "Micro-compaction DB sync skipped for session=%s — a "
+                    "batch compression currently holds the compression "
+                    "lock; resume will double-load compacted messages "
+                    "until it finishes",
+                    session_id,
+                )
+                return
+
             session_db.archive_and_compact(session_id, compacted_messages)
             for msg in compacted_messages:
                 if isinstance(msg, dict):
@@ -5786,6 +5824,16 @@ This compaction should PRIORITISE preserving all information related to the focu
                 "Micro-compaction DB sync failed — resume will double-load "
                 "compacted messages until the next batch compression"
             )
+        finally:
+            if lock_acquired:
+                try:
+                    release = getattr(session_db, "release_compression_lock", None)
+                    if callable(release):
+                        release(session_id, holder)
+                except Exception:
+                    logger.debug(
+                        "micro-compaction lock release failed", exc_info=True
+                    )
 
     def _splice_micro_compact_result(
         self,

--- a/tests/agent/test_micro_compaction.py
+++ b/tests/agent/test_micro_compaction.py
@@ -753,6 +753,76 @@ class TestMicroCompaction:
             "splice must not strip _db_persisted from surviving messages"
         )
 
+    def test_sync_to_db_takes_the_compression_lock_batch_compression_uses(self):
+        """_sync_micro_compact_to_db must hold the SAME durable lock the
+        batch compression path (SessionDB.try_acquire_compression_lock)
+        uses before calling archive_and_compact.
+
+        Without this, a micro-compact racing a concurrent batch compression
+        on the same session_id can both soft-archive the active rows and
+        insert their own replacement set — whichever commits second
+        silently discards the other's write (a split session lineage), the
+        exact class of corruption the lock exists to prevent.
+        """
+        from agent.context_compressor import _DB_PERSISTED_MARKER
+
+        class _FakeSessionDB:
+            def __init__(self, *, acquire_returns: bool):
+                self.acquire_returns = acquire_returns
+                self.acquire_calls: list = []
+                self.release_calls: list = []
+                self.archive_calls: list = []
+
+            def try_acquire_compression_lock(self, session_id, holder, ttl_seconds=300.0):
+                self.acquire_calls.append((session_id, holder, ttl_seconds))
+                return self.acquire_returns
+
+            def release_compression_lock(self, session_id, holder):
+                self.release_calls.append((session_id, holder))
+
+            def archive_and_compact(self, session_id, compacted_messages):
+                self.archive_calls.append((session_id, list(compacted_messages)))
+
+        # Lock acquired: archive_and_compact runs, then the lock is released,
+        # and surviving messages are stamped as DB-persisted.
+        cc = _compressor()
+        cc._session_db = _FakeSessionDB(acquire_returns=True)
+        cc._session_id = "sess-1"
+        messages = [{"role": "user", "content": "hi"}]
+
+        cc._sync_micro_compact_to_db(messages)
+
+        db = cc._session_db
+        assert len(db.acquire_calls) == 1
+        assert db.acquire_calls[0][0] == "sess-1"
+        assert len(db.archive_calls) == 1, "archive_and_compact must run once the lock is held"
+        assert db.archive_calls[0] == ("sess-1", messages)
+        assert len(db.release_calls) == 1
+        assert db.release_calls[0] == ("sess-1", db.acquire_calls[0][1]), (
+            "release must use the exact holder token the acquire call used"
+        )
+        assert messages[0].get(_DB_PERSISTED_MARKER) is True
+
+        # Lock busy (another path — e.g. a concurrent batch compression —
+        # already holds it): archive_and_compact must NOT run, and nothing
+        # must be released (this holder never acquired it).
+        cc2 = _compressor()
+        cc2._session_db = _FakeSessionDB(acquire_returns=False)
+        cc2._session_id = "sess-2"
+        messages2 = [{"role": "user", "content": "hi"}]
+
+        cc2._sync_micro_compact_to_db(messages2)
+
+        db2 = cc2._session_db
+        assert len(db2.acquire_calls) == 1
+        assert db2.archive_calls == [], (
+            "archive_and_compact must not run while another path holds the lock"
+        )
+        assert db2.release_calls == [], "must not release a lock this holder never acquired"
+        assert messages2[0].get(_DB_PERSISTED_MARKER) is None, (
+            "messages must not be stamped as DB-persisted when the sync was skipped"
+        )
+
 
 class TestDefragFlushCursorInvalidation:
     """Sibling of the finalize_turn pop site (#75170): defrag pops


### PR DESCRIPTION
## Summary

`_sync_micro_compact_to_db()` (`agent/context_compressor.py`) persists micro-compaction's result by calling `session_db.archive_and_compact(session_id, compacted_messages)` directly — with zero lock coordination. The batch compression path (`agent/conversation_compression.py`) always acquires `SessionDB`'s durable `compression_locks` row (`try_acquire_compression_lock`) before doing any rotation or in-place compaction, including its own call to the exact same `archive_and_compact()`. The lock's own docstring (`hermes_state.py::try_acquire_compression_lock`) states the invariant in absolute terms:

> Returns `False` if another holder already owns a non-expired lock — the caller **MUST NOT proceed with compression in that case** (its rotation would race against the holder's, splitting the session lineage).

Micro-compaction fires on essentially every turn (cadence=1 by default) and violates that invariant unconditionally.

## Root cause / impact

`archive_and_compact()` itself does a blanket, unguarded write:

```python
conn.execute(
    "UPDATE messages SET active = 0, compacted = 1 WHERE session_id = ? AND active = 1",
    (session_id,),
)
```

The lock is a purely application-level contract around this call — nothing inside `archive_and_compact()` enforces it. If two writers touch the same `session_id` concurrently (a gateway restart racing an old worker still finishing a batch compression, or two multiplex/cron/kanban processes dispatching to the same session), both can soft-archive the `active=1` rows and insert their own replacement set in the same short window. Whichever transaction commits second silently discards the other's already-committed write — the "split session lineage" corruption class the lock exists to prevent.

## Fix

Wrap the `archive_and_compact` call in `_sync_micro_compact_to_db` with the same `try_acquire_compression_lock` / `release_compression_lock` pair the batch path uses (same public API, same holder-token helper, `_compression_lock_holder`). Unlike the batch path, no lease refresher is needed: the critical section here is one short transaction, not a long-running LLM summarization call, so acquire → write → release happens synchronously in one call. If the lock is held elsewhere, the sync is skipped for this cycle and degrades exactly the way an `archive_and_compact` failure already does today (messages aren't stamped `_DB_PERSISTED_MARKER`, so the next append-only flush picks them up — resume double-loads until the next successful compaction, no data loss).

Also handles the same hot-reload version-skew case the batch path guards against: if `try_acquire_compression_lock` isn't present on the live `SessionDB` instance, proceeds unlocked (matches pre-fix behavior) rather than crashing.

## Test plan

- Added `test_sync_to_db_takes_the_compression_lock_batch_compression_uses` (`tests/agent/test_micro_compaction.py`) with a fake `SessionDB` recording acquire/archive/release calls. Covers both outcomes: lock acquired (archive runs, lock releases with the exact holder token, messages get stamped) and lock busy (archive never runs, nothing gets released, messages are not stamped).
- Mutation-verified: reverted `agent/context_compressor.py` and confirmed the new test fails (`archive_and_compact` called with zero lock coordination — 0 acquire calls recorded).
- Ran the full `tests/agent/test_micro_compaction.py` (37 passed) plus every test file in the repo referencing `try_acquire_compression_lock` (`test_hermes_state.py`, `test_hermes_state_compression_busy_retry.py`, `test_hermes_state_compression_locks.py`, `test_compression_concurrent_fork.py`, `test_compress_signal_leak.py`, `test_idle_compaction_lock_and_guards.py`, `test_compression_review_76354.py`, `test_compression_worker_isolation_76354.py`, `test_compression_rotation_state.py`, `test_compression_lineage_guard.py`, `test_413_compression.py`, `test_compression_concurrent_sessions.py`, `test_session_system_prompt_dedup.py`) — 347 passed, no regressions.
- `ruff check` clean on both changed files.

## Competitor check

Searched multiple keyword combinations (`micro compact compression lock`, `_sync_micro_compact_to_db`, `session lineage split concurrent`, `micro-compaction race`) against open/closed PRs and issues — no PR or issue targets this specific gap. The closest tangential match, #68929 (closed), makes batch rotation's parent/child transition atomic — a different mechanism in a different file, doesn't touch `context_compressor.py` or micro-compaction at all.