### PR TITLE
fix(update): exempt non-Hermes venv module holders from update preflight (#77422)

### DIFF
--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -12,6 +12,7 @@ one JSON document on stdout; diagnostics on stderr only.
 from __future__ import annotations
 
 import json
+import re
 import sys
 from typing import NoReturn
 
@@ -126,6 +127,40 @@ def _is_pausable_gateway(cmdline: str) -> bool:
     return looks_like_gateway_command_line(cmdline)
 
 
+def _is_non_hermes_venv_holder(cmdline: str) -> bool:
+    """Return True when *cmdline* runs a non-Hermes module from the venv.
+
+    A process that runs ``python -m <stdlib-or-user-module>`` from the venv
+    interpreter (e.g. an operator's ``python -m http.server 8077`` or a
+    one-off ``-m my_script``) holds the interpreter but does NOT import
+    Hermes' native ``.pyd`` extensions — the actual reason the update
+    preflight blocks venv holders (a dependency sync mid-update dies with
+    access-denied when a ``.pyd`` is mapped). Treating every venv-python
+    process as a blocker gives a misleading "Close other Hermes windows"
+    error for a process that has nothing to do with Hermes (#77422).
+
+    Only recognizably-Hermes invocations count as real blockers:
+    ``-m hermes_cli...``, ``serve``/``dashboard``/``gateway run``, and bare
+    interpreters (a bare REPL can import Hermes' native extensions at any
+    time, so it stays conservative and keeps blocking).
+    """
+    low = cmdline.lower()
+    # Explicit Hermes invocation markers → real blocker. Check the module /
+    # command tokens, not the filesystem path (the venv lives under
+    # .../hermes-agent/, which contains "hermes" but is not a Hermes process).
+    if "hermes_cli" in low or " -m hermes" in low or "hermes.main" in low:
+        return False
+    if re.search(r"(^|[\s\"])hermes(\s|$)", low):
+        return False
+    # A bare interpreter (no -m module) is a REPL — keep blocking
+    # (conservative: it can import .pyd at any time).
+    if " -m " not in low:
+        return False
+    # `python -m <module>` where the module is not Hermes (stdlib or user
+    # module like http.server) → non-Hermes holder, not a blocker.
+    return True
+
+
 def main() -> None:
     """Entry point.  Prints one JSON doc to stdout.  Exits 0 for valid scan."""
     try:
@@ -148,8 +183,13 @@ def main() -> None:
         }
         for pid, name, cmdline in matches
         if not _is_pausable_gateway(cmdline)
+        and not _is_non_hermes_venv_holder(cmdline)
     ]
     exempted = sum(1 for _pid, _name, cmdline in matches if _is_pausable_gateway(cmdline))
+    non_hermes = sum(
+        1 for _pid, _name, cmdline in matches
+        if not _is_pausable_gateway(cmdline) and _is_non_hermes_venv_holder(cmdline)
+    )
     data = {
         "ok": True,
         "blocked": bool(processes),
@@ -157,6 +197,10 @@ def main() -> None:
         # Diagnostic only: gateway processes present but not counted as
         # blockers because the downstream updater pauses them itself.
         "pausable_gateways": exempted,
+        # Diagnostic only: venv-python processes that are not Hermes (stdlib
+        # module, REPL, user script) — they hold the interpreter but not the
+        # native .pyd extensions, so they do not block the update (#77422).
+        "non_hermes_holders": non_hermes,
     }
     print(json.dumps(data))
     sys.exit(0)

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -17,6 +17,7 @@ import pytest
 
 import agent.redact as redact_module
 from hermes_cli._scan_venv_blockers import (
+    _is_non_hermes_venv_holder,
     _is_pausable_gateway,
     _redact_sensitive_cmdline,
     main,
@@ -211,4 +212,76 @@ def test_main_desktop_serve_backend_still_blocks(monkeypatch, capsys):
     assert code == 0
     assert data["blocked"] is True
     assert [p["pid"] for p in data["processes"]] == [78]
-    assert data["pausable_gateways"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _is_non_hermes_venv_holder — the non-Hermes module exemption (#77422)
+# ---------------------------------------------------------------------------
+#
+# A `python -m http.server 8077` (or any stdlib/user module) run from the
+# venv interpreter holds the python.exe but does NOT import Hermes' native
+# .pyd extensions — the actual reason the update preflight blocks venv
+# holders. Reporting it as a blocker gives a misleading "Close other Hermes
+# windows" error for a process that has nothing to do with Hermes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cmdline",
+    [
+        # the exact issue case: operator's stdlib http.server on the venv python
+        r"C:\Users\u\AppData\Local\hermes\hermes-agent\venv\Scripts\python.exe -m http.server 8077",
+        # another stdlib module
+        r"C:\x\venv\Scripts\python.exe -m json.tool",
+        # a user one-off module
+        r"C:\x\venv\Scripts\python.exe -m my_script",
+        # no Hermes marker anywhere in the venv-python cmdline
+        r"C:\x\venv\Scripts\python.exe -m uvicorn app:main",
+    ],
+)
+def test_is_non_hermes_venv_holder_accepts_stdlib_user_modules(cmdline: str) -> None:
+    assert _is_non_hermes_venv_holder(cmdline) is True
+
+
+@pytest.mark.parametrize(
+    "cmdline",
+    [
+        # real Hermes invocations stay blockers
+        "python.exe -m hermes_cli.main serve --host 127.0.0.1",
+        "python.exe -m hermes_cli.main gateway run --replace",
+        "python.exe -m hermes.main",
+        # bare interpreter = REPL, conservative: keep blocking
+        r"C:\x\venv\Scripts\python.exe",
+        r"C:\x\venv\Scripts\python.exe -i",
+    ],
+)
+def test_is_non_hermes_venv_holder_rejects_hermes_and_repl(cmdline: str) -> None:
+    assert _is_non_hermes_venv_holder(cmdline) is False
+
+
+def test_main_exempts_non_hermes_module_holders(monkeypatch, capsys):
+    """A venv-python `-m http.server` must NOT block the update; a real
+    Hermes serve backend alongside it still does."""
+    http_server = (
+        91,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m http.server 8077",
+    )
+    serve = (
+        78,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main serve --host 127.0.0.1",
+    )
+    # http.server alone → clear
+    code, data = _run_main_with_detector(monkeypatch, capsys, [http_server])
+    assert code == 0
+    assert data["blocked"] is False
+    assert data["processes"] == []
+    assert data["non_hermes_holders"] == 1
+
+    # http.server + real Hermes serve backend → blocked, only the serve PID
+    code, data = _run_main_with_detector(monkeypatch, capsys, [http_server, serve])
+    assert code == 0
+    assert data["blocked"] is True
+    assert [p["pid"] for p in data["processes"]] == [78]
+    assert data["non_hermes_holders"] == 1


### PR DESCRIPTION
## Summary

Fixes #77422 — a Windows in-app/desktop update aborts with a misleading "Close other Hermes windows" error when the only blocker is a **non-Hermes** process running from the venv interpreter (e.g. an operator's `python -m http.server 8077`). The message tells the user to close Hermes windows that don't exist.

## Root Cause

`hermes_cli/_scan_venv_blockers.py` reports every process running from the venv interpreter as a blocker, exempting only gateway chains. But the actual reason the preflight blocks venv holders is that a Hermes process keeps native `.pyd` extensions mapped (a dependency sync mid-update dies with access-denied). A `python -m http.server` (or any stdlib/user module) holds the interpreter but never imports Hermes' `.pyd` files — it cannot strand the update, yet it was reported as a blocker with the misleading message.

## Change

- **`hermes_cli/_scan_venv_blockers.py`** — new `_is_non_hermes_venv_holder()`: a venv-python process running a non-Hermes module (`-m http.server`, `-m json.tool`, user scripts) is exempted from the blocker list and reported under a new diagnostic `non_hermes_holders` count. Bare interpreters (REPLs) and any Hermes invocation (`hermes_cli`, `hermes.main`, standalone `hermes` command) still block — REPLs stay conservative since they can import `.pyd` at any time. The check inspects command/module tokens, not the filesystem path (the venv lives under `.../hermes-agent/` which contains "hermes" but is not a Hermes process).
- **`tests/hermes_cli/test_scan_venv_blockers.py`** — new parametrized tests for the helper (stdlib/user modules exempt, Hermes/REPL blocked) plus an integration test proving `http.server` alone scans clear while a real Hermes `serve` backend alongside it still blocks.

## Verification

- `pytest tests/hermes_cli/test_scan_venv_blockers.py` → 33 passed (existing + new).
- `pytest tests/hermes_cli/test_update_venv_health.py tests/hermes_cli/test_update_lock.py` → 30 passed.

Closes #77422
