### PR TITLE
fix(auth): scope the resolve_nous_access_token memo to the active profile

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5800,8 +5800,17 @@ def _agent_key_is_usable(state: Dict[str, Any], min_ttl_seconds: int) -> bool:
 # serial burst stretches startup to many minutes. A short-TTL memo collapses the
 # burst into a single network round-trip; callers that need freshness use
 # separate flows (force_fresh / refresh_nous_oauth_pure) and are unaffected.
+#
+# Keyed by the resolved Hermes home (str(get_hermes_home())), not a single
+# slot: the underlying resolution is profile-scoped via the context-local
+# _HERMES_HOME_OVERRIDE (see hermes_constants.set_hermes_home_override,
+# which gateway/run.py and tui_gateway/server.py set per-profile for
+# multiplex-gateway concurrency). A single unscoped slot would let a
+# multiplex profile's context read another profile's already-resolved
+# access token for up to _RESOLVE_TOKEN_CACHE_TTL_S seconds whenever two
+# profiles' contexts call this within that window of each other.
 _RESOLVE_TOKEN_CACHE_LOCK = threading.Lock()
-_RESOLVE_TOKEN_CACHE: "tuple[float, str] | None" = None
+_RESOLVE_TOKEN_CACHE: "dict[str, tuple[float, str]]" = {}
 _RESOLVE_TOKEN_CACHE_TTL_S = 5.0
 
 
@@ -5813,14 +5822,18 @@ def resolve_nous_access_token(
     refresh_skew_seconds: int = ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
 ) -> str:
     """Resolve a refresh-aware Nous Portal access token for managed tool gateways."""
-    global _RESOLVE_TOKEN_CACHE
     # Memo: collapse the startup burst of managed-tool check_fns into one
     # network refresh. Only cache a successful, non-forced resolution for a
     # short window; force_fresh / error paths bypass and don't populate it.
+    # Keyed by the resolved Hermes home so a multiplex profile's context
+    # never reads a sibling profile's cached token — see the module comment
+    # on _RESOLVE_TOKEN_CACHE.
+    cache_key = str(get_hermes_home())
     if not insecure and ca_bundle is None:
         with _RESOLVE_TOKEN_CACHE_LOCK:
-            if _RESOLVE_TOKEN_CACHE is not None:
-                cached_at, cached_token = _RESOLVE_TOKEN_CACHE
+            cached = _RESOLVE_TOKEN_CACHE.get(cache_key)
+            if cached is not None:
+                cached_at, cached_token = cached
                 if (time.monotonic() - cached_at) < _RESOLVE_TOKEN_CACHE_TTL_S:
                     return cached_token
     with _provider_state_transaction("nous") as (
@@ -5885,7 +5898,7 @@ def resolve_nous_access_token(
                 # can never serve an expired token.
                 if not insecure and ca_bundle is None:
                     with _RESOLVE_TOKEN_CACHE_LOCK:
-                        _RESOLVE_TOKEN_CACHE = (time.monotonic(), access_token)
+                        _RESOLVE_TOKEN_CACHE[cache_key] = (time.monotonic(), access_token)
                 return access_token
 
             if not isinstance(refresh_token, str) or not refresh_token:
@@ -5946,7 +5959,7 @@ def resolve_nous_access_token(
             resolved = state["access_token"]
             if not insecure and ca_bundle is None:
                 with _RESOLVE_TOKEN_CACHE_LOCK:
-                    _RESOLVE_TOKEN_CACHE = (time.monotonic(), resolved)
+                    _RESOLVE_TOKEN_CACHE[cache_key] = (time.monotonic(), resolved)
             return resolved
 
 

--- a/tests/hermes_cli/test_nous_portal_staging_allowlist.py
+++ b/tests/hermes_cli/test_nous_portal_staging_allowlist.py
@@ -90,7 +90,7 @@ class TestResolveAccessTokenEnvOverrideWins:
         # The resolve memo is module-level state; clear it so each test's
         # resolution actually exercises the refresh path instead of serving
         # a token cached by a previous test.
-        monkeypatch.setattr(auth, "_RESOLVE_TOKEN_CACHE", None)
+        monkeypatch.setattr(auth, "_RESOLVE_TOKEN_CACHE", {})
 
         def _fake_refresh(*, client, portal_base_url, client_id, refresh_token):
             seen_portal_urls.append(portal_base_url)

--- a/tests/hermes_cli/test_resolve_token_memo.py
+++ b/tests/hermes_cli/test_resolve_token_memo.py
@@ -19,7 +19,7 @@ def _fresh_memo(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.delenv("HERMES_PORTAL_BASE_URL", raising=False)
     monkeypatch.delenv("NOUS_PORTAL_BASE_URL", raising=False)
-    monkeypatch.setattr(auth, "_RESOLVE_TOKEN_CACHE", None)
+    monkeypatch.setattr(auth, "_RESOLVE_TOKEN_CACHE", {})
     yield
 
 
@@ -75,11 +75,12 @@ def test_memo_expires_after_ttl(monkeypatch, tmp_path):
     calls = _count_transactions(monkeypatch)
 
     auth.resolve_nous_access_token()
-    cached_at, tok = auth._RESOLVE_TOKEN_CACHE
+    cache_key = str(auth.get_hermes_home())
+    cached_at, tok = auth._RESOLVE_TOKEN_CACHE[cache_key]
     monkeypatch.setattr(
         auth,
         "_RESOLVE_TOKEN_CACHE",
-        (cached_at - auth._RESOLVE_TOKEN_CACHE_TTL_S - 1.0, tok),
+        {cache_key: (cached_at - auth._RESOLVE_TOKEN_CACHE_TTL_S - 1.0, tok)},
     )
     auth.resolve_nous_access_token()
 
@@ -94,3 +95,40 @@ def test_insecure_callers_bypass_memo(monkeypatch, tmp_path):
     auth.resolve_nous_access_token(insecure=True)
 
     assert calls["n"] == 2, "insecure callers must bypass the memo entirely"
+
+
+def test_memo_does_not_leak_across_multiplex_profile_contexts(tmp_path):
+    """A multiplex gateway scopes each profile's context via
+    hermes_constants.set_hermes_home_override (gateway/run.py,
+    tui_gateway/server.py), not the HERMES_HOME env var — the memo must key
+    on that same resolved home, or one profile's context can read another
+    profile's already-cached Nous access token for up to the TTL window.
+    """
+    import hermes_constants
+
+    profile_a = tmp_path / "profile-a"
+    profile_b = tmp_path / "profile-b"
+    profile_a.mkdir()
+    profile_b.mkdir()
+    _write_valid_auth_file(profile_a, token="token-a")
+    _write_valid_auth_file(profile_b, token="token-b")
+
+    token_a = token_b = None
+    reset_token = hermes_constants.set_hermes_home_override(str(profile_a))
+    try:
+        token_a = auth.resolve_nous_access_token()
+    finally:
+        hermes_constants.reset_hermes_home_override(reset_token)
+
+    # Still well within the 5s TTL — this is exactly the race window: profile
+    # B's context calls resolve_nous_access_token() shortly after profile A's.
+    reset_token = hermes_constants.set_hermes_home_override(str(profile_b))
+    try:
+        token_b = auth.resolve_nous_access_token()
+    finally:
+        hermes_constants.reset_hermes_home_override(reset_token)
+
+    assert token_a == "token-a"
+    assert token_b == "token-b", (
+        "profile B's context must not receive profile A's cached access token"
+    )


### PR DESCRIPTION
## Summary

`resolve_nous_access_token()`'s 5-second startup-burst memo (added by #76930, merged today) caches the resolved Nous Portal access token in a single module-level slot (`_RESOLVE_TOKEN_CACHE: tuple[float, str] | None`) keyed by nothing but wall-clock time. The underlying resolution it memoizes is profile-scoped, but the cache slot isn't.

## Root cause

`_auth_file_path()` (and therefore `_provider_state_transaction("nous")`, which `resolve_nous_access_token()` uses) reads `get_hermes_home()`, which checks the context-local `_HERMES_HOME_OVERRIDE` `ContextVar` (`hermes_constants.py`) before falling back to the `HERMES_HOME` env var. `gateway/run.py` and `tui_gateway/server.py` set that override per-profile (`set_hermes_home_override`) so a multiplex gateway can serve several profiles' requests concurrently from one process without their credential reads/writes crossing.

The memo added in #76930 doesn't participate in that scoping — it's a single `(timestamp, token)` slot shared by every context in the process. In a multiplex gateway serving two profiles with different authenticated Nous accounts: if profile A's context resolves a token, and profile B's context calls `resolve_nous_access_token()` within the next 5 seconds, profile B receives profile A's cached token instead of resolving its own — used to authenticate against the managed tool gateway / relay self-provisioning under the wrong account.

## Fix

Key the memo by `str(get_hermes_home())` instead of a single slot: `_RESOLVE_TOKEN_CACHE` becomes `dict[str, tuple[float, str]]`. Each profile's context now only ever reads/writes its own entry. The lock discipline and TTL are unchanged — only the cache's shape changed, so each profile pays its own first-call cost and gets its own 5s collapse window, same as before #76930 introduced the shared-slot regression.

## Test plan

- Updated the two existing tests that poked `_RESOLVE_TOKEN_CACHE` directly (`tests/hermes_cli/test_resolve_token_memo.py`, `tests/hermes_cli/test_nous_portal_staging_allowlist.py`) to the new dict shape.
- Added `test_memo_does_not_leak_across_multiplex_profile_contexts`, which reproduces the real trigger mechanism: uses `hermes_constants.set_hermes_home_override` (the exact call the multiplex gateway makes) to enter profile A's context, resolve its token, then enter profile B's context within the TTL window and assert it gets its own token, not profile A's.
- Mutation-verified two ways: (1) reverting `hermes_cli/auth.py` entirely — the dict-shaped test fixtures then throw `ValueError: not enough values to unpack` against the old tuple-shaped cache, confirming the fix is required for compatibility; (2) a targeted mutation (cache key forced to a constant, keeping the dict structure intact) reproduces the exact real-world symptom — `test_memo_does_not_leak_across_multiplex_profile_contexts` fails with `token_b == 'token-a'` instead of `'token-b'`.
- Ran every test file referencing `resolve_nous_access_token` (9 files, 83 tests) plus the full `tests/hermes_cli/` auth/nous-filtered suite (549 tests) — all pass except one pre-existing, unrelated failure (`test_qwen_oauth_auto_fallthrough_on_auth_failure`), confirmed to fail identically on unmodified `hermes_cli/auth.py`.
- `ruff check` clean on all three changed files.

## Competitor check

Searched multiple keyword combinations — no PR or issue targets this specific memo/cache-key gap. Two adjacent items, read in full and confirmed not to overlap:
- **#56302** (open) fixes the same general bug *class* (multiplex profile isolation) but a different, older mechanism — three modules that freeze a profile-scoped path in a module-level constant at **import time** (`agent/anthropic_adapter.py`, `agent/auxiliary_client.py`, `gateway/mirror.py`). It doesn't touch `hermes_cli/auth.py` or `resolve_nous_access_token`'s TTL memo at all.
- **Issue #30286** (open) is a broader, general Nous-OAuth reliability report about multi-process/multi-`HERMES_HOME` deployments losing sync over time — not specific to this in-process 5s memo.