### PR TITLE
feat(cron): route failures to a separate target

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -364,6 +364,15 @@ terminal:
 #   sudo_password: "your-password-here"
 
 # =============================================================================
+# Cron Configuration
+# =============================================================================
+cron:
+  # Optional destination for failed-run notices. Successful output still uses
+  # each job's `deliver` target. Accepts the same delivery syntax as cron jobs.
+  # Example: "telegram:123456", "telegram:-100123:17585", or "whatsapp".
+  failure_deliver: ""  # Empty = use each job's normal delivery target
+
+# =============================================================================
 # Security Scanning (tirith)
 # =============================================================================
 # Optional pre-exec command security scanning via tirith.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -151,6 +151,32 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     return f"⚠️ Cron '{job_name}' failed: {cleaned}"
 
 
+def _job_for_failure_delivery(job: dict) -> dict:
+    """Return a copy routed to ``cron.failure_deliver`` when configured.
+
+    Failure routing is profile-scoped because ``load_config`` resolves against
+    the active ``HERMES_HOME``. Invalid or unavailable config deliberately
+    falls back to the job's normal destination.
+    """
+    try:
+        config = load_config() or {}
+    except Exception:
+        return job
+
+    cron_config = config.get("cron") if isinstance(config, dict) else None
+    failure_deliver = (
+        cron_config.get("failure_deliver")
+        if isinstance(cron_config, dict)
+        else None
+    )
+    if not isinstance(failure_deliver, str) or not failure_deliver.strip():
+        return job
+
+    delivery_job = job.copy()
+    delivery_job["deliver"] = failure_deliver.strip()
+    return delivery_job
+
+
 class CronPromptInjectionBlocked(Exception):
     """Raised by _build_job_prompt when the fully-assembled prompt trips the
     injection scanner. Caught in run_job so the operator sees a clean
@@ -4623,6 +4649,7 @@ def run_one_job(
                 )
             else:
                 deliver_content = final_response if success else _summarize_cron_failure_for_delivery(job, error)
+            delivery_job = job if success else _job_for_failure_delivery(job)
             # Treat whitespace-only final responses the same as empty
             # responses: do not deliver a blank message, and let the
             # empty-response guard below mark the run as a soft failure.
@@ -4642,11 +4669,16 @@ def run_one_job(
 
             if should_deliver:
                 unresolved_origin = (
-                    _normalize_deliver_value(job.get("deliver", "local")) == "origin"
-                    and not _resolve_delivery_targets(job)
+                    _normalize_deliver_value(delivery_job.get("deliver", "local")) == "origin"
+                    and not _resolve_delivery_targets(delivery_job)
                 )
                 try:
-                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    delivery_error = _deliver_result(
+                        delivery_job,
+                        deliver_content,
+                        adapters=adapters,
+                        loop=loop,
+                    )
                 except Exception as de:
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)
@@ -4672,7 +4704,7 @@ def run_one_job(
                 )
             else:
                 mark_job_run(job["id"], success, error, delivery_error=delivery_error)
-        normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
+        normalized_deliver = _normalize_deliver_value(delivery_job.get("deliver", "local"))
         if delivery_error:
             delivery_outcome = "failed"
         elif should_deliver and unresolved_origin:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2261,6 +2261,10 @@ DEFAULT_CONFIG = {
         # Wrap delivered cron responses with a header (task name) and footer
         # ("The agent cannot see this message").  Set to false for clean output.
         "wrap_response": True,
+        # Optional profile-scoped destination for failed-run notices. Empty
+        # preserves the job's normal `deliver` target. Uses the same delivery
+        # syntax as jobs (for example `telegram:123456` or `whatsapp`).
+        "failure_deliver": "",
         # Make cron deliveries CONTINUABLE: a user can reply to a cron brief
         # and the agent has it in context (no "what is Task #2?" amnesia).
         # Default False preserves the historical isolation guarantee (cron

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -10,6 +10,8 @@ The first test characterizes the sequence as driven through `tick()` (proving
 the extraction didn't change `tick`'s behavior); the rest unit-test the
 extracted helper directly.
 """
+import pytest
+
 import cron.scheduler as s
 
 
@@ -64,6 +66,154 @@ def test_run_one_job_success_sequence(monkeypatch):
     assert ok is True
     assert [c[0] for c in calls] == ["run_job", "save", "deliver", "mark"]
     assert calls[-1] == ("mark", "j2", True)
+
+
+def test_run_one_job_routes_failure_to_configured_target_without_mutating_job(monkeypatch):
+    """A failed run uses cron.failure_deliver without changing the stored job."""
+    _patch_pipeline(monkeypatch, success=False, final="", error="boom")
+    delivered = []
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda job, content, adapters=None, loop=None: delivered.append((job, content)),
+    )
+    monkeypatch.setattr(
+        s,
+        "load_config",
+        lambda: {"cron": {"failure_deliver": "  whatsapp:operator-id  "}},
+    )
+    original = {
+        "id": "j-failure-route",
+        "name": "user reminder",
+        "deliver": "whatsapp:user-id",
+        "origin": {"platform": "whatsapp", "chat_id": "user-id"},
+    }
+
+    s.run_one_job(original)
+
+    delivery_job, content = delivered[0]
+    assert delivery_job is not original
+    assert delivery_job["deliver"] == "whatsapp:operator-id"
+    assert delivery_job["origin"] == original["origin"]
+    assert content == "⚠️ Cron 'user reminder' failed: boom"
+    assert original["deliver"] == "whatsapp:user-id"
+
+
+def test_run_one_job_success_ignores_failure_delivery_target(monkeypatch):
+    """A successful run still uses the job's normal delivery target."""
+    _patch_pipeline(monkeypatch, success=True, final="completed")
+    delivered = []
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda job, content, adapters=None, loop=None: delivered.append((job, content)),
+    )
+    monkeypatch.setattr(
+        s,
+        "load_config",
+        lambda: {"cron": {"failure_deliver": "whatsapp:operator-id"}},
+    )
+    original = {
+        "id": "j-success-route",
+        "name": "user reminder",
+        "deliver": "whatsapp:user-id",
+    }
+
+    s.run_one_job(original)
+
+    assert delivered == [(original, "completed")]
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {},
+        None,
+        {"cron": {"failure_deliver": ""}},
+        {"cron": {"failure_deliver": 42}},
+        {"cron": []},
+    ],
+)
+def test_run_one_job_failure_delivery_falls_back_for_invalid_config(
+    monkeypatch, config
+):
+    """Absent or invalid failure routing preserves the job's normal target."""
+    _patch_pipeline(monkeypatch, success=False, final="", error="boom")
+    delivered = []
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda job, content, adapters=None, loop=None: delivered.append(job),
+    )
+    monkeypatch.setattr(s, "load_config", lambda: config)
+    original = {
+        "id": "j-failure-fallback",
+        "name": "user reminder",
+        "deliver": "whatsapp:user-id",
+    }
+
+    s.run_one_job(original)
+
+    assert delivered == [original]
+    assert original["deliver"] == "whatsapp:user-id"
+
+
+def test_run_one_job_failure_delivery_falls_back_when_config_load_fails(monkeypatch):
+    """A config read failure must not suppress the normal failure notice."""
+    _patch_pipeline(monkeypatch, success=False, final="", error="boom")
+    delivered = []
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda job, content, adapters=None, loop=None: delivered.append(job),
+    )
+
+    def fail_config_load():
+        raise OSError("config unavailable")
+
+    monkeypatch.setattr(s, "load_config", fail_config_load)
+    original = {
+        "id": "j-failure-config-error",
+        "name": "user reminder",
+        "deliver": "whatsapp:user-id",
+    }
+
+    s.run_one_job(original)
+
+    assert delivered == [original]
+
+
+def test_run_one_job_records_delivery_outcome_for_failure_target(monkeypatch):
+    """Execution metadata reflects the effective failure route."""
+    _patch_pipeline(monkeypatch, success=False, final="", error="boom")
+    delivered = []
+    outcomes = []
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda job, content, adapters=None, loop=None: delivered.append(job),
+    )
+    monkeypatch.setattr(
+        s,
+        "load_config",
+        lambda: {"cron": {"failure_deliver": "local"}},
+    )
+    monkeypatch.setattr(
+        s,
+        "finish_execution",
+        lambda execution_id, **kwargs: outcomes.append(kwargs),
+    )
+    job = {
+        "id": "j-failure-outcome",
+        "execution_id": "exec-failure-outcome",
+        "name": "user reminder",
+        "deliver": "whatsapp:user-id",
+    }
+
+    s.run_one_job(job)
+
+    assert delivered[0]["deliver"] == "local"
+    assert outcomes[-1]["delivery_outcome"] == "suppressed"
 
 
 def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path):

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -332,6 +332,28 @@ When scheduling jobs, you specify where the output goes:
 
 The agent's final response is automatically delivered to the configured `deliver:` target — the agent does not send messages itself, so there is nothing to call in the cron prompt.
 
+### Sending failures to a separate destination
+
+By default, failed-run notices go to the job's normal `deliver` target. Operators
+can route those notices elsewhere at the profile level while keeping successful
+output at each job's intended destination:
+
+```yaml
+cron:
+  failure_deliver: "telegram:123456"
+```
+
+Or configure it from the CLI:
+
+```bash
+hermes config set cron.failure_deliver telegram:123456
+```
+
+`failure_deliver` accepts the same target syntax as a job's `deliver` setting,
+including platform home channels, explicit chats/topics, and comma-separated
+fan-out targets. It applies only when a run fails. If it is unset or blank,
+Hermes preserves the job's normal delivery behavior.
+
 ### Routing intent (`all`)
 
 `all` lets you ship one cron job to every messaging channel you have configured, without having to enumerate them by name. It is **resolved at fire time**, so a job created before you wired up Telegram will pick up Telegram on the next tick after you set `TELEGRAM_HOME_CHANNEL`.


### PR DESCRIPTION
## What does this PR do?

Adds an optional profile-scoped `cron.failure_deliver` setting. When a cron run fails, Hermes delivers the compact failure notice to that configured destination; successful output continues to use the job's normal `deliver` target.

This is useful for public, family, or customer-facing profiles where scheduled results belong with the recipient but provider errors, timeouts, and other operational failures belong with an operator. Unset, blank, invalid, or unreadable configuration preserves the existing delivery behavior.

## Related Issue

No existing issue or PR found for separate cron failure destinations.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py`: route failed-run delivery through a non-mutating job copy using `cron.failure_deliver`; keep success routing unchanged and record metadata against the effective route.
- `hermes_cli/config_defaults.py`: add the empty-by-default configuration key.
- `cli-config.yaml.example`: document the new configuration option.
- `website/docs/user-guide/features/cron.md`: document behavior, syntax, and CLI configuration.
- `tests/cron/test_run_one_job.py`: cover failure override, success behavior, fallback behavior, config-read errors, immutability, whitespace normalization, and effective delivery metadata.

## How to Test

1. Set `cron.failure_deliver` to a destination different from a job's `deliver` target.
2. Run the job successfully and confirm output uses the job target.
3. Trigger a failed run and confirm the compact failure notice uses the configured failure target.

Automated verification:

```text
481 passed: tests/cron/ + tests/hermes_cli/test_set_config_value.py
Ruff: clean on all modified Python files
cli-config.yaml.example: parses successfully
Independent pre-commit review: passed (no security or logic errors)
```

The canonical full-suite runner was also executed. Current upstream produced 33 failures across 16 unrelated test files (credential pool, platform service probes, voice/STT, TUI concurrency, and other untouched areas); the cron/config test scope is green.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — full upstream suite is currently red in unrelated files; targeted scope passes
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example`
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes: N/A
- [x] I've considered cross-platform impact; the change is platform-neutral Python/config routing
- [x] Tool descriptions/schemas: N/A — no tool behavior or schema changed
