### PR TITLE
fix(a2a): scope the HTTP handler thread to the adapter's own profile home

### DIFF
--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -241,6 +241,28 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
         self._json(404, {"error": "not found"})
 
     def do_POST(self):  # noqa: N802
+        """Scope this connection's thread to the adapter's own profile home.
+
+        ThreadingHTTPServer hands each connection to a fresh native
+        ``threading.Thread`` — unlike ``asyncio.Task``, plain threads do not
+        copy the spawning context, so the multiplexer's per-profile
+        ``_HERMES_HOME_OVERRIDE`` contextvar (set around adapter creation in
+        ``gateway/run.py::_start_one_profile_adapters``) never reaches this
+        thread. Everything ``_do_POST_scoped`` calls that resolves
+        ``get_hermes_home()`` — the ``a2a.trusted_peers`` config.yaml
+        fallback, the audit log, and on-disk conversation persistence —
+        would otherwise silently read/write the *default* profile's data
+        whenever A2A is configured on a secondary multiplex profile.
+        """
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        home_token = set_hermes_home_override(self.adapter._profile_home)
+        try:
+            self._do_POST_scoped()
+        finally:
+            reset_hermes_home_override(home_token)
+
+    def _do_POST_scoped(self):
         adapter = self.adapter
         client_ip = self.client_address[0] if self.client_address else ""
 
@@ -353,6 +375,16 @@ class A2AAdapter(BasePlatformAdapter):
             ) if str(t).strip()
         ]
         self._active_profile = _active_profile_name()
+        # Captured now, not re-resolved later: __init__ runs inside
+        # gateway/run.py::_start_one_profile_adapters's
+        # ``with _profile_runtime_scope(profile_home):`` block, so
+        # get_hermes_home() here correctly reflects the profile this adapter
+        # instance was created for. The HTTP handler thread that eventually
+        # calls do_POST is a plain threading.Thread (no context propagation),
+        # so it can't re-derive this itself — it must be handed the value.
+        from hermes_constants import get_hermes_home
+
+        self._profile_home = str(get_hermes_home())
         self._agents = self._load_served_agents(extra)
 
         self._httpd: Optional[_A2AServer] = None

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -1225,6 +1225,91 @@ class TestInboundRoundTrip:
 
 
 # --------------------------------------------------------------------------
+# Multiplex-profile scoping: the HTTP handler thread has no ambient context
+# --------------------------------------------------------------------------
+
+@pytest.mark.integration
+class TestMultiplexProfileScoping:
+    def test_do_post_persists_under_own_profile_not_ambient_home(self, monkeypatch, tmp_path):
+        """ThreadingHTTPServer hands each connection to a fresh native thread,
+        which does not inherit the constructing coroutine's context — so
+        do_POST cannot re-derive "which profile am I" via get_hermes_home()
+        the way async code can. The adapter must capture its own profile home
+        at construction time (when it IS correctly scoped, inside
+        gateway/run.py's ``with _profile_runtime_scope(profile_home):``) and
+        hand it to the connection thread explicitly.
+
+        Simulates that exact shape: HERMES_HOME env (what a context-free
+        thread falls back to) points at a "wrong_home" the adapter must NOT
+        touch. The adapter itself is constructed under a context-local
+        override for a *different* directory ("profile_home") that is reset
+        again immediately after construction — by the time a real HTTP
+        request arrives, there is zero ambient context, exactly like the
+        real connection thread ThreadingHTTPServer spawns.
+        """
+        import hermes_constants
+
+        wrong_home = tmp_path / "wrong_home"
+        profile_home = tmp_path / "profile_home"
+        wrong_home.mkdir()
+        profile_home.mkdir()
+
+        monkeypatch.delenv("A2A_BEARER_TOKEN", raising=False)
+        monkeypatch.delenv("A2A_PEER_TOKENS", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(wrong_home))
+
+        from plugins.platforms.a2a.adapter import A2AAdapter
+        from gateway.config import PlatformConfig
+
+        port = _free_port()
+        monkeypatch.setenv("A2A_PORT", str(port))
+
+        reset_token = hermes_constants.set_hermes_home_override(str(profile_home))
+        try:
+            adapter = A2AAdapter(PlatformConfig(enabled=True))
+        finally:
+            # By the time do_POST runs on its own connection thread, there is
+            # no override active at all — matching the real gap: a plain
+            # threading.Thread never inherits it in the first place.
+            hermes_constants.reset_hermes_home_override(reset_token)
+
+        assert adapter._profile_home == str(profile_home)
+
+        async def fake_handle_message(event):
+            # metadata['notify']=True marks a final, user-visible reply — the
+            # marker adapter.send() checks before resolving the pending
+            # JSON-RPC future (see A2AAdapter.send's docstring).
+            await adapter.send(event.source.chat_id, "ECHO: " + event.text, metadata={"notify": True})
+
+        adapter.handle_message = fake_handle_message  # type: ignore
+        adapter._message_handler = object()
+
+        base = f"http://127.0.0.1:{port}"
+
+        async def run():
+            assert await adapter.connect() is True
+            resp = await asyncio.to_thread(_post_json, base + "/", _send_body("hello"))
+            assert resp["result"]["status"]["state"] == "TASK_STATE_COMPLETED"
+            await adapter.disconnect()
+
+        asyncio.run(run())
+
+        assert (profile_home / "a2a_audit.jsonl").exists(), (
+            "audit log must land under the adapter's own profile home"
+        )
+        assert not (wrong_home / "a2a_audit.jsonl").exists(), (
+            "audit log must NOT fall back to the ambient HERMES_HOME env var"
+        )
+        conv_dir = profile_home / "a2a_conversations"
+        assert conv_dir.is_dir() and list(conv_dir.glob("*.jsonl")), (
+            "conversation persistence must land under the adapter's own profile home"
+        )
+        assert not (wrong_home / "a2a_conversations").exists(), (
+            "conversation persistence must NOT fall back to the ambient HERMES_HOME env var"
+        )
+
+
+# --------------------------------------------------------------------------
 # Push notifications end-to-end (inline config in message/send)
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Every other platform adapter processes inbound requests as coroutines inside the gateway's asyncio loop, so the multiplexer's per-profile `_HERMES_HOME_OVERRIDE` contextvar (set around adapter creation and message-handler dispatch in `gateway/run.py`) propagates automatically via `asyncio.Task`'s implicit `copy_context()`. A2A is architecturally different by design (its own `DESIGN.md`: no event-loop dependency at `register()` time) — it runs `http.server.ThreadingHTTPServer` in a plain `threading.Thread`, and each inbound connection is handled on a fresh native OS thread. Plain `threading.Thread` does not copy contextvars — only `asyncio.Task`/`copy_context().run()` do — so `do_POST` runs with zero ambient profile context.

## Root cause / impact

Everything `do_POST` reaches before handing a message off to the async gateway path resolves `get_hermes_home()` directly:
- `security.is_trusted_peer()`'s `config.yaml` fallback (`a2a.trusted_peers`)
- `security.audit()`
- `protocol.persist_message()` / `protocol.load_conversation()`

With no override active on the connection thread, all four fall back through to whatever `HERMES_HOME` resolves to process-wide — the *default* profile's home, whenever A2A is configured on a secondary multiplex profile. Concretely: a peer that should be rejected by profile B's `trusted_peers` allow-list could instead be checked against the default profile's (or another profile's) allow-list, and profile B's inbound conversations/audit trail land in the wrong profile's on-disk store — a cross-profile trust-check and data-isolation gap.

## Fix

`A2AAdapter.__init__` already runs correctly scoped — it's constructed inside `gateway/run.py::_start_one_profile_adapters`'s `with _profile_runtime_scope(profile_home):` block — so this captures `get_hermes_home()` there (`self._profile_home`) and hands it to the HTTP handler thread explicitly. `do_POST` now wraps the whole request in `set_hermes_home_override(self.adapter._profile_home)` before dispatching to the (renamed) `_do_POST_scoped`, matching the codebase's established idiom for exactly this class of thread boundary (`cron/scheduler.py`, `tools/delegate_tool.py`, `acp_adapter/server.py`, `tui_gateway/server.py` all do the equivalent `copy_context()`/override-handoff when spawning a worker thread).

The actual agent turn dispatch was already safe independently — `gateway/run.py::_make_profile_message_handler` re-enters `_profile_runtime_scope` inside the handler coroutine regardless of caller context — so this fix only needs to cover the raw-thread-side work that runs *before* that handoff (`do_GET` doesn't need it: `security.authenticate()` is env-only, and the config.yaml-reading `is_trusted_peer()` path is only reachable from `do_POST`).

## Test plan

- Added `TestMultiplexProfileScoping::test_do_post_persists_under_own_profile_not_ambient_home` (`tests/plugins/test_a2a_plugin.py`, marked `integration` — starts a real `A2AAdapter` server and sends a real HTTP request). Constructs the adapter under a context-local override for one directory (`profile_home`), resets the override immediately after construction (simulating the real gap: the connection thread ThreadingHTTPServer spawns never inherits it in the first place), points ambient `HERMES_HOME` at a *different* directory (`wrong_home`), sends a real `message/send` POST, and asserts the audit log + persisted conversation land under `profile_home` and never under `wrong_home`.
- Mutation-verified two ways: (1) removing the `self._profile_home` capture — the test fails immediately with `AttributeError`; (2) a targeted mutation disabling only the `do_POST` wrapping (keeping `_profile_home` intact) — the test fails on the precise assertion (`audit log must land under the adapter's own profile home`), proving the artifacts land in the wrong place without the wrap, exactly as diagnosed.
- Ran the full A2A suite: `tests/plugins/test_a2a_plugin.py` + `tests/plugins/test_a2a_phase23.py`, both unit (151 tests) and `integration`-marked (18 tests, including the new one) — 169/169 pass.
- `ruff check` clean on both changed files.
- Grepped for other `A2AAdapter(` construction sites in `tests/` and `gateway/` — only the two already-passing test files construct it directly; no other call site needed updating.

## Competitor check

Searched multiple keyword combinations (`a2a threading contextvar`, `a2a profile home`, `a2a do_POST`, `a2a ThreadingHTTPServer`, `a2a multiplex isolation`) against open/closed PRs and issues — no PR or issue targets this specific gap. One adjacent, non-conflicting open PR — **#77655** — hardens file *permissions* (0o755→0o700, 0o644→0o600) on the same two on-disk artifacts (`a2a_conversations/`, `a2a_audit.jsonl`) but touches only `protocol.py`/`security.py` (mode bits at file-creation time), never `adapter.py` — orthogonal fix, no overlap.