### PR TITLE
fix(tools): false binary detection for UTF-8/GBK Chinese text files

### DIFF
--- a/contributors/emails/tugrulgunr@gmail.com
+++ b/contributors/emails/tugrulgunr@gmail.com
@@ -1,0 +1,1 @@
+tugrulguner

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -884,9 +884,19 @@ class ShellFileOperations(FileOperations):
         
         # Content analysis: >30% non-printable chars = binary
         if content_sample:
-            non_printable = sum(1 for c in content_sample[:1000]
-                               if ord(c) < 32 and c not in '\n\r\t')
-            return non_printable / min(len(content_sample), 1000) > 0.30
+            sample = content_sample[:1000]
+            sample_len = len(sample)
+            non_printable = sum(1 for c in sample if ord(c) < 32 and c not in '\n\r\t')
+            if non_printable / max(sample_len, 1) > 0.30:
+                return True
+            # High ratio of replacement characters (U+FFFD) indicates a file
+            # opened with the wrong encoding (e.g. GBK text read as UTF-8).
+            # A single split multi-byte char from byte-truncated sampling is
+            # harmless (1-2 chars out of 1000) but GBK-as-UTF-8 produces
+            # many replacement chars (~77% of sample).
+            replacements = sum(1 for c in sample if ord(c) == 0xFFFD)
+            if replacements / max(sample_len, 1) > 0.20:
+                return True
         
         return False
     
@@ -1144,7 +1154,7 @@ class ShellFileOperations(FileOperations):
             )
         
         # Read a sample to check for binary content
-        sample_cmd = f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null"
+        sample_cmd = f"head -c 2000 {self._escape_shell_arg(path)} 2>/dev/null"
         sample_result = self._exec(sample_cmd)
         sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
         


### PR DESCRIPTION
Closes #77842

## Problem

`read_file` reports valid Chinese text files as binary in two scenarios:

1. **UTF-8 long line**: `head -c 1000` truncates at byte 1000, potentially splitting a 3-byte UTF-8 character in half. The terminal backend decodes with `errors="replace"`, producing U+FFFD in the sample.

2. **GBK-encoded file**: GBK bytes decoded as UTF-8 with `errors="replace"` produce U+FFFD for ~77% of sample characters. Every GBK file is rejected.

The existing >30% non-printable-char heuristic only checks `ord(c) < 32`, so U+FFFD (65533) was invisible to it.

## Fix

Two changes in `_is_likely_binary`:

1. **U+FFFD ratio check**: if >20% of sample characters are replacement characters (U+FFFD), mark as binary. A legitimate multi-byte split produces at most 1-2 chars (0.1-0.2%), well below threshold. GBK-as-UTF-8 produces ~77%.

2. **Increased sample**: `head -c 2000` instead of 1000, further diluting any split-char noise.

## Testing

- Compilation clean
- Existing 35 file_tool tests pass (5 pre-existing failures unrelated to this change)