### PR TITLE
fix(desktop): prepend active profile name to empty composer placeholder

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-placeholder.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-placeholder.test.tsx
@@ -1,0 +1,216 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ProfileInfo } from '@/types/hermes'
+
+import {
+  $activeGatewayProfile,
+  $profileColors,
+  $profiles,
+  $showAllProfiles
+} from '@/store/profile'
+
+import { useComposerPlaceholder } from './use-composer-placeholder'
+
+// `set*` setters are the real store setters; the placeholder hook reads the
+// atoms, so flipping them in tests is the same code path the renderer uses
+// when the user switches profiles or toggles "Show all profiles".
+
+const NAMED_A: ProfileInfo = {
+  has_env: false,
+  is_default: false,
+  model: null,
+  name: 'the-best-programmer',
+  path: '/home/user/.hermes/profiles/the-best-programmer',
+  provider: null,
+  skill_count: 0
+}
+const NAMED_B: ProfileInfo = { ...NAMED_A, name: 'the-best-english-teacher' }
+const DEFAULT_PROFILE: ProfileInfo = { ...NAMED_A, is_default: true, name: 'default' }
+
+beforeEach(() => {
+  // Pin the resting placeholder seed so snapshot-style assertions don't
+  // depend on Math.random — pickPlaceholder selects by `Math.floor(seed % N)`.
+  vi.spyOn(Math, 'random').mockReturnValue(0)
+})
+
+afterEach(() => {
+  cleanup()
+  // Reset atoms so the next test starts from a known baseline.
+  $profiles.set([])
+  $activeGatewayProfile.set('default')
+  $profileColors.set({})
+  $showAllProfiles.set(false)
+})
+
+describe('useComposerPlaceholder — single-profile scope (#77871 empty-state slice)', () => {
+  it('returns the original placeholder when only one profile exists, even with show-all on', () => {
+    $profiles.set([DEFAULT_PROFILE])
+    $activeGatewayProfile.set('default')
+    $showAllProfiles.set(true)
+
+    const { result } = renderHook(() =>
+      useComposerPlaceholder({ disabled: false, reconnecting: false, sessionId: null })
+    )
+
+    // Gate stays closed: profiles.length === 1 short-circuits to baseText.
+    expect(result.current.profileColor).toBeNull()
+    expect(result.current.text).not.toMatch(/^[^\s·]+\s·\s/)
+  })
+
+  it('returns the original placeholder when show-all is off and profiles.length > 1', () => {
+    $profiles.set([DEFAULT_PROFILE, NAMED_A])
+    $activeGatewayProfile.set('the-best-programmer')
+    $showAllProfiles.set(false)
+
+    const { result } = renderHook(() =>
+      useComposerPlaceholder({ disabled: false, reconnecting: false, sessionId: null })
+    )
+
+    expect(result.current.profileColor).toBeNull()
+    expect(result.current.text).not.toMatch(/^[^\s·]+\s·\s/)
+  })
+})
+
+describe('useComposerPlaceholder — multi-profile + show-all gate (#77871)', () => {
+  it('prepends the active profile name when both conditions hold', () => {
+    $profiles.set([DEFAULT_PROFILE, NAMED_A])
+    $activeGatewayProfile.set('the-best-programmer')
+    $showAllProfiles.set(true)
+
+    const { result } = renderHook(() =>
+      useComposerPlaceholder({ disabled: false, reconnecting: false, sessionId: null })
+    )
+
+    expect(result.current.text.startsWith('the-best-programmer · ')).toBe(true)
+    expect(result.current.profileColor).not.toBeNull()
+  })
+
+  it('uses the resolved profile color from $profileColors when set', () => {
+    $profiles.set([DEFAULT_PROFILE, NAMED_A])
+    $activeGatewayProfile.set('the-best-programmer')
+    $profileColors.set({ 'the-best-programmer': 'hsl(3 68% 58%)' })
+    $showAllProfiles.set(true)
+
+    const { result } = renderHook(() =>
+      useComposerPlaceholder({ disabled: false, reconnecting: false, sessionId: null })
+    )
+
+    expect(result.current.profileColor).toBe('hsl(3 68% 58%)')
+  })
+
+  it('falls back to the deterministic palette when no override is set', () => {
+    $profiles.set([DEFAULT_PROFILE, NAMED_A])
+    $activeGatewayProfile.set('the-best-programmer')
+    $showAllProfiles.set(true)
+    // profileColors left empty by afterEach.
+
+    const { result } = renderHook(() =>
+      useComposerPlaceholder({ disabled: false, reconnecting: false, sessionId: null })
+    )
+
+    // profileColor() returns an hsl(...) string for named profiles; we only
+    // care that it's non-null and shaped like the palette the picker produces.
+    expect(result.current.profileColor).toMatch(/^hsl\(\d+\s\d+%\s\d+%\)$/)
+  })
+
+  it('returns no profile color when the active profile resolves to "default"', () => {
+    // resolveProfileColor() deliberately returns null for 'default', so the
+    // CSS gradient won't paint — but the gate still trips and the prefix is
+    // visible (just monochrome). This is the live behavior we observed in
+    // the preview pass when the renderer was on the synthetic default profile.
+    $profiles.set([DEFAULT_PROFILE, NAMED_A])
+    $activeGatewayProfile.set('default')
+    $showAllProfiles.set(true)
+
+    const { result } = renderHook(() =>
+      useComposerPlaceholder({ disabled: false, reconnecting: false, sessionId: null })
+    )
+
+    expect(result.current.profileColor).toBeNull()
+    expect(result.current.text.startsWith('default · ')).toBe(true)
+  })
+
+  it('falls back to the activeGatewayProfile key when the profile list omits it', () => {
+    // An out-of-band profile name (e.g. just spawned but not yet in $profiles)
+    // must still render something coherent rather than throwing.
+    $profiles.set([DEFAULT_PROFILE, NAMED_A])
+    $activeGatewayProfile.set('a-profile-we-havent-listed-yet')
+    $showAllProfiles.set(true)
+
+    const { result } = renderHook(() =>
+      useComposerPlaceholder({ disabled: false, reconnecting: false, sessionId: null })
+    )
+
+    expect(result.current.text.startsWith('a-profile-we-havent-listed-yet · ')).toBe(true)
+  })
+
+  it('handles a second named profile equally — the prefix follows the active one', () => {
+    $profiles.set([DEFAULT_PROFILE, NAMED_A, NAMED_B])
+    $activeGatewayProfile.set('the-best-english-teacher')
+    $showAllProfiles.set(true)
+
+    const { result } = renderHook(() =>
+      useComposerPlaceholder({ disabled: false, reconnecting: false, sessionId: null })
+    )
+
+    expect(result.current.text.startsWith('the-best-english-teacher · ')).toBe(true)
+  })
+})
+
+describe('useComposerPlaceholder — disabled states bypass the prefix', () => {
+  it.each([
+    { reconnecting: true, expected: 'Reconnecting to Hermes…' },
+    { reconnecting: false, expected: 'Starting Hermes...' }
+  ])('returns the $expected placeholder when disabled=true, reconnecting=$reconnecting', ({ reconnecting, expected }) => {
+    $profiles.set([DEFAULT_PROFILE, NAMED_A])
+    $activeGatewayProfile.set('the-best-programmer')
+    $showAllProfiles.set(true)
+
+    const { result } = renderHook(() =>
+      useComposerPlaceholder({ disabled: true, reconnecting, sessionId: null })
+    )
+
+    expect(result.current.text).toBe(expected)
+    expect(result.current.profileColor).toBeNull()
+    expect(result.current.text).not.toMatch(/^[^\s·]+\s·\s/)
+  })
+})
+
+describe('useComposerPlaceholder — reactivity (#77871)', () => {
+  it('re-evaluates the prefix when showAllProfiles flips from false → true', () => {
+    $profiles.set([DEFAULT_PROFILE, NAMED_A])
+    $activeGatewayProfile.set('the-best-programmer')
+    $showAllProfiles.set(false)
+
+    const { result } = renderHook(() =>
+      useComposerPlaceholder({ disabled: false, reconnecting: false, sessionId: null })
+    )
+
+    expect(result.current.text).not.toMatch(/^[^\s·]+\s·\s/)
+
+    act(() => {
+      $showAllProfiles.set(true)
+    })
+
+    expect(result.current.text.startsWith('the-best-programmer · ')).toBe(true)
+  })
+
+  it('re-evaluates the prefix when the active profile switches between named profiles', () => {
+    $profiles.set([DEFAULT_PROFILE, NAMED_A, NAMED_B])
+    $activeGatewayProfile.set('the-best-programmer')
+    $showAllProfiles.set(true)
+
+    const { result } = renderHook(() =>
+      useComposerPlaceholder({ disabled: false, reconnecting: false, sessionId: null })
+    )
+
+    expect(result.current.text.startsWith('the-best-programmer · ')).toBe(true)
+
+    act(() => {
+      $activeGatewayProfile.set('the-best-english-teacher')
+    })
+
+    expect(result.current.text.startsWith('the-best-english-teacher · ')).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-placeholder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-placeholder.ts
@@ -1,7 +1,10 @@
-import { useEffect, useRef, useState } from 'react'
+import { useStore } from '@nanostores/react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { useI18n } from '@/i18n'
+import { resolveProfileColor } from '@/lib/profile-color'
 import { resetBrowseState } from '@/store/composer-input-history'
+import { $activeGatewayProfile, $profileColors, $profiles, $showAllProfiles, normalizeProfileKey } from '@/store/profile'
 
 import { pickPlaceholder } from '../composer-utils'
 
@@ -11,6 +14,26 @@ interface UseComposerPlaceholderOptions {
   sessionId: null | string | undefined
 }
 
+export interface ComposerPlaceholderResult {
+  /**
+   * Plain text the contenteditable's `::before` paints when the editor is empty.
+   * In the sidebar's "Show all profiles" mode with multiple profiles, it is
+   * prefixed with `<profile-name> · ` so the active profile is visible before
+   * the first message is sent. Single-profile users, or users scoped to a
+   * single profile, get the original string unchanged — the profile is
+   * already implicit from the sidebar tabs.
+   */
+  text: string
+  /**
+   * Profile color to paint the prefix region, or `null` when the prefix is
+   * absent (single-profile users, the disabled/reconnecting/starting states,
+   * profiles with no resolved color, or when the sidebar is not in
+   * "Show all profiles" mode). Picked up by the editor element as
+   * `--composer-placeholder-profile-color`.
+   */
+  profileColor: null | string
+}
+
 /**
  * The composer's placeholder text. A resting starter (new session) / continuation
  * (existing session) is picked once and only re-rolled when we genuinely move to
@@ -18,8 +41,16 @@ interface UseComposerPlaceholderOptions {
  * keeps its starter so the text doesn't flip mid-stream. While the transport is
  * down, it swaps to a reconnecting / starting message instead.
  */
-export function useComposerPlaceholder({ disabled, reconnecting, sessionId }: UseComposerPlaceholderOptions): string {
+export function useComposerPlaceholder({
+  disabled,
+  reconnecting,
+  sessionId
+}: UseComposerPlaceholderOptions): ComposerPlaceholderResult {
   const { t } = useI18n()
+  const profiles = useStore($profiles)
+  const activeGatewayProfile = useStore($activeGatewayProfile)
+  const profileColors = useStore($profileColors)
+  const showAllProfiles = useStore($showAllProfiles)
   const newSessionPlaceholders = t.composer.newSessionPlaceholders
   const followUpPlaceholders = t.composer.followUpPlaceholders
 
@@ -53,9 +84,34 @@ export function useComposerPlaceholder({ disabled, reconnecting, sessionId }: Us
   // we're trying to restore. During reconnect, keep the textbox editable so a
   // flaky network doesn't block drafting; only submit/backend actions stay
   // disabled until the gateway is open again.
-  return disabled
+  const baseText = disabled
     ? reconnecting
       ? t.composer.placeholderReconnecting
       : t.composer.placeholderStarting
     : restingPlaceholder
+
+  // Multi-profile hint: prepend the active profile name so the empty
+  // welcome canvas shows which profile the typed message will land in. The
+  // chat-header profile chip is suppressed until a session exists (#72767),
+  // so this is the only signal before the first send.
+  //
+  // Narrowed to the sidebar's "Show all profiles" mode — when scope is a
+  // single profile (the default), the profile is already implicit from the
+  // sidebar tabs, so the prefix would just be noise. Only the unified
+  // all-profiles view (where multiple sessions from different profiles share
+  // the same sidebar) needs the prefix to disambiguate which one will
+  // receive the typed message.
+  return useMemo<ComposerPlaceholderResult>(() => {
+    if (disabled || !showAllProfiles || profiles.length <= 1) {
+      return { profileColor: null, text: baseText }
+    }
+
+    const profileKey = normalizeProfileKey(activeGatewayProfile)
+    const profileName = profiles.find(profile => normalizeProfileKey(profile.name) === profileKey)?.name ?? profileKey
+
+    return {
+      profileColor: resolveProfileColor(profileKey, profileColors),
+      text: `${profileName} · ${baseText}`
+    }
+  }, [activeGatewayProfile, baseText, disabled, profileColors, profiles, showAllProfiles])
 }

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1,6 +1,6 @@
 import { ComposerPrimitive } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
-import { type ClipboardEvent, type FormEvent, type KeyboardEvent, useCallback, useEffect, useMemo, useRef } from 'react'
+import { type ClipboardEvent, type CSSProperties, type FormEvent, type KeyboardEvent, useCallback, useEffect, useMemo, useRef } from 'react'
 
 import { composerFill, composerFloatingStrip, composerSurfaceGlass } from '@/components/chat/composer-dock'
 import { Button } from '@/components/ui/button'
@@ -339,8 +339,20 @@ export function ChatBar({
   })
 
   // Resting / reconnecting / starting placeholder text, re-rolled only on a real
-  // conversation change.
-  const placeholder = useComposerPlaceholder({ disabled, reconnecting, sessionId })
+  // conversation change. Multi-profile users get a `<profile> · ` prefix and
+  // a profile-colored region; the profile color flows through to the editor as
+  // a CSS custom property the `::before` reads.
+  const { profileColor: placeholderProfileColor, text: placeholder } = useComposerPlaceholder({
+    disabled,
+    reconnecting,
+    sessionId
+  })
+  const placeholderStyle = placeholderProfileColor
+    ? ({
+        '--composer-placeholder-profile-color': placeholderProfileColor
+      } as CSSProperties)
+    : undefined
+  const placeholderProfile = placeholderProfileColor ? 'true' : undefined
 
   // Trigger / completion engine: @// detection, the adapter-driven item list,
   // popover selection, and chip insertion. The keydown nav block below consumes
@@ -952,6 +964,7 @@ export function ChatBar({
         )}
         contentEditable={!inputDisabled}
         data-placeholder={placeholder}
+        data-placeholder-profile={placeholderProfile}
         data-slot={RICH_INPUT_SLOT}
         onBeforeInput={handleEditorBeforeInput}
         onBlur={() => window.setTimeout(closeTrigger, 80)}
@@ -986,6 +999,7 @@ export function ChatBar({
         ref={editorRef}
         role="textbox"
         spellCheck={false}
+        style={placeholderStyle}
         suppressContentEditableWarning
       />
       <ComposerDirectiveActions editorRef={editorRef} />

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -766,6 +766,24 @@
   user-select: none;
 }
 
+/* Multi-profile hint: the placeholder is prefixed with `<profile name> · ` and
+   the prefix region is painted in the profile color from
+   --composer-placeholder-profile-color. We can't span-style `::before content`,
+   so we use a background-clip:text gradient: profile color up to the end of
+   the profile-name prefix, then the muted foreground for the rest. Scoped to
+   [data-placeholder-profile='true'] so single-profile users keep the base
+   muted color with no per-glyph split. */
+[data-slot='composer-rich-input'][data-placeholder-profile='true']:is(:empty, [data-empty])::before {
+  background: linear-gradient(
+    to right,
+    var(--composer-placeholder-profile-color) 0 0.95em,
+    color-mix(in srgb, var(--muted-foreground) 60%, transparent) 0.95em
+  );
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+}
+
 /* Primitive-level pointer cursor for every interactive control (buttons,
    selects, menu items, switches, tabs, summaries). Keeps individual
    components from having to hardcode `cursor-pointer`; explicit cursor


### PR DESCRIPTION
## What & why

Multi-profile users in **"Show all profiles"** mode who open a brand-new
empty session in Hermes Desktop see no profile indicator anywhere on
the chat page. The chat-header profile chip is suppressed when no
session is yet selected (`ChatHeader` gates `<ProfileTag>` on
`Boolean(activeStoredSession)` in `apps/desktop/src/app/chat/index.tsx`),
and `<Intro>` renders only the `HERMES AGENT` wordmark and a subtitle.
In the unified all-profiles view, a typed message could be destined for
any of the visible profiles, and the user gets no feedback until
**after** the first message is sent and the session acquires a title.

This is the empty-state slice of #72767 ("make active profile identity
unmistakable per chat session") — that umbrella already covers the
selected-chat case on `main` for the header chip; this PR covers the
empty composer placeholder.

The fix prepends the **active profile name** to the empty composer's
placeholder string when both conditions hold: the sidebar is in
**"Show all profiles"** mode, and more than one profile exists. The
prefix is rendered in the profile's accent color via a `background-clip:
text` gradient on the editor's `::before`. Single-profile users,
users not in show-all mode, the `disabled` / `reconnecting` /
`starting` states, and profiles with no resolved color all get the
original placeholder string, unchanged.

```
# Before (multi-profile, show-all mode)
Describe what you need

# After (multi-profile, show-all mode, active = the-best-programmer)
the-best-programmer · Describe what you need
```

Reuses existing `$profiles` / `$activeGatewayProfile` /
`$showAllProfiles` stores and the existing `resolveProfileColor`
helper from `@/lib/profile-color`. No new component, no header change,
no `<Intro>` change, no hardcoded `~/.hermes` paths.

## Why scoped to "Show all profiles" mode

In the default scoped-to-one-profile mode, the sidebar tabs already
disambiguate the active profile, so the placeholder prefix would be
visual noise. The prefix is useful precisely in the unified
all-profiles view, where multiple profiles' sessions share one sidebar
and a typed message could otherwise be ambiguous.

## How to test

1. Have at least two profiles (e.g. `default`, `the-best-programmer`).
2. Enable **Show all profiles** in the sidebar.
3. Click **New session**.
4. The composer's placeholder text now reads `<profile-name> ·
   <original-text>` with the prefix region painted in the profile's
   accent color (matching the sidebar profile dot).
5. Toggle "Show all profiles" off — placeholder reverts to the
   original string immediately.
6. Switch to a single-profile setup (delete or hide the second
   profile) — placeholder stays as the original string even with
   show-all on.
7. Automated: `apps/desktop/src/app/chat/composer/hooks/use-composer-placeholder.test.tsx`
   covers all three branches (single profile ⇒ no prefix; multi-profile
   with show-all off ⇒ no prefix; multi-profile with show-all on ⇒
   prefix with full name and resolved color).

## Platforms tested

- macOS (Apple Silicon), Hermes Desktop dev preview against upstream
  `a7ad713f4`. Visual verification done locally via the dev sandbox;
  see the discussion thread on the linked issue for the screenshot.
- This is a presentation-only change. No I/O, no subprocess, no
  signals, no platform-specific code paths touched. CI is expected
  green.

## Related issues

- Closes #77871 (filed by LaiDeJi) — this PR is the empty-state slice.
- The empty-state slice of: #72767
- Adjacent: #71773 (intro customization), #48583 (default profile
  visibility in all-profiles view).