### PR TITLE
fix(kanban): preserve continuation across iteration-budget retries

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -94,6 +94,36 @@ logger = logging.getLogger(__name__)
 # to treat it as cancellation metadata rather than assistant prose.
 INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
 
+
+def _is_root_kanban_worker() -> bool:
+    """Return true only for the dispatcher-owned agent, never its children."""
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        return False
+    from agent.delegation_context import is_delegated_child_process_context
+
+    return not is_delegated_child_process_context()
+
+
+def _kanban_soft_iteration_limit(max_iterations: int) -> int:
+    """Reserve up to 10% (capped at ten calls) for a Kanban handoff."""
+    limit = max(1, int(max_iterations))
+    if not _is_root_kanban_worker() or limit <= 1:
+        return limit
+    reserve = max(1, min(10, limit // 10))
+    return max(1, limit - reserve)
+
+
+def _kanban_soft_checkpoint_due(agent: Any, api_call_count: int) -> bool:
+    """Return whether a root worker may checkpoint before its next API call."""
+    if agent._budget_grace_call or agent._interrupt_requested:
+        return False
+    effective_turn_limit = min(
+        agent.max_iterations,
+        api_call_count + max(0, int(agent.iteration_budget.remaining)),
+    )
+    soft_limit = _kanban_soft_iteration_limit(effective_turn_limit)
+    return soft_limit < effective_turn_limit and api_call_count >= soft_limit
+
 # Modules that indicate a deterministic local processing error when they
 # appear in an exception traceback WITHOUT any API-call module. Used by the
 # outer-loop error classifier to avoid retrying bugs that will fail
@@ -1387,7 +1417,11 @@ def run_conversation(
 
     # Optional opt-in runtime: if api_mode == codex_app_server, hand the
     # turn to the codex app-server subprocess (terminal/file ops/patching
-    # all run inside Codex). Default Hermes path is bypassed entirely.
+    # all run inside Codex). That runtime owns one whole turn and does not
+    # consume Hermes' per-tool ``iteration_budget``; its native thread/turn
+    # persistence and watchdog retirement are handled in codex_runtime.py.
+    # The soft iteration checkpoint below therefore applies only to the
+    # Hermes-managed tool loop it actually budgets.
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
@@ -1419,6 +1453,13 @@ def run_conversation(
             _turn_exit_reason = "interrupted_by_user"
             if not agent.quiet_mode:
                 agent._safe_print("\n⚡ Breaking out of tool loop due to interrupt...")
+            break
+
+        # The shared iteration budget may be smaller than max_iterations (for
+        # example after delegated work). Check only after redirects and user
+        # cancellation so a checkpoint never wins over active steering.
+        if _kanban_soft_checkpoint_due(agent, api_call_count):
+            _turn_exit_reason = "kanban_soft_budget_checkpoint"
             break
         
         api_call_count += 1

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -89,17 +89,25 @@ def finalize_turn(
     Lifted verbatim from ``run_conversation`` (the region after the main agent
     loop). See module docstring.
     """
-    from agent.conversation_loop import logger
+    from agent.conversation_loop import _is_root_kanban_worker, logger
 
+    soft_budget_checkpoint = (
+        str(_turn_exit_reason) == "kanban_soft_budget_checkpoint"
+    )
     budget_exhausted = (
         api_call_count >= agent.max_iterations
         or agent.iteration_budget.remaining <= 0
+        or soft_budget_checkpoint
     )
     budget_fallback_eligible = (
         budget_exhausted
         and not interrupted
         and not failed
-        and str(_turn_exit_reason) in {"unknown", "budget_exhausted"}
+        and str(_turn_exit_reason) in {
+            "unknown",
+            "budget_exhausted",
+            "kanban_soft_budget_checkpoint",
+        }
     )
     continuation_budget_exhausted = (
         final_response is None
@@ -121,14 +129,22 @@ def finalize_turn(
         # response-loss blocker)
         if _pending_verification_response_previewed:
             agent._response_was_previewed = True
-        _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+        _turn_exit_reason = (
+            f"kanban_soft_budget_checkpoint({api_call_count}/{agent.max_iterations})"
+            if soft_budget_checkpoint
+            else f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+        )
         iteration_limit_fallback = True
         preserved_verification_fallback = True
     elif final_response is None and budget_fallback_eligible:
         # Budget exhausted — ask the model for a summary via one extra
         # API call with tools stripped.  _handle_max_iterations injects a
         # user message and makes a single toolless request.
-        _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+        _turn_exit_reason = (
+            f"kanban_soft_budget_checkpoint({api_call_count}/{agent.max_iterations})"
+            if soft_budget_checkpoint
+            else f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+        )
         agent._emit_status(
             f"⚠️ Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
             "— asking model to summarise"
@@ -138,57 +154,31 @@ def finalize_turn(
                 f"\n⚠️  Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
                 "— requesting summary..."
             )
-        final_response = agent._handle_max_iterations(messages, api_call_count)
+        # A Kanban timeout summary is a durable handoff, not a new user turn.
+        # The helper appends a synthetic summary request, so give it a shallow
+        # list copy and keep the resumable transcript/cache prefix unchanged.
+        _summary_messages = list(messages) if _is_root_kanban_worker() else messages
+        final_response = agent._handle_max_iterations(
+            _summary_messages, api_call_count
+        )
         iteration_limit_fallback = True
 
+    _kanban_timeout_pending = None
     if iteration_limit_fallback:
-        # If running as a kanban worker, signal the dispatcher that the
-        # worker could not complete (rather than treating it as a
-        # protocol violation). This applies whether the user-facing fallback
-        # came from the summary call or an explicitly pending continuation;
-        # both exhausted the task budget and must advance the failure circuit.
-        #
-        # We route through ``_record_task_failure(outcome="timed_out")``
-        # rather than ``kanban_block`` so this counts toward the dispatcher's
-        # consecutive-failure circuit breaker (#29747 gap 2).
-        _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
-        if _kanban_task:
+        # Defer the dispatcher transition until after session persistence.
+        # Releasing first creates a race where another worker can claim the
+        # task before the continuation snapshot exists.
+        _kanban_task = (
+            os.environ.get("HERMES_KANBAN_TASK")
+            if _is_root_kanban_worker()
+            else None
+        )
+        _kanban_run = os.environ.get("HERMES_KANBAN_RUN_ID")
+        if _kanban_task and _kanban_run:
             try:
-                from hermes_cli import kanban_db as _kb
-                _conn = _kb.connect()
-                try:
-                    _kb._record_task_failure(
-                        _conn,
-                        _kanban_task,
-                        error=(
-                            f"Iteration budget exhausted "
-                            f"({api_call_count}/{agent.max_iterations}) — "
-                            "task could not complete within the allowed "
-                            "iterations"
-                        ),
-                        outcome="timed_out",
-                        release_claim=True,
-                        end_run=True,
-                        event_payload_extra={
-                            "budget_used": api_call_count,
-                            "budget_max": agent.max_iterations,
-                        },
-                    )
-                    logger.info(
-                        "recorded budget-exhausted failure for task %s (%d/%d)",
-                        _kanban_task, api_call_count, agent.max_iterations,
-                    )
-                finally:
-                    try:
-                        _conn.close()
-                    except Exception:
-                        pass
-            except Exception:
-                logger.warning(
-                    "Failed to record budget-exhausted failure for task %s",
-                    _kanban_task,
-                    exc_info=True,
-                )
+                _kanban_timeout_pending = (_kanban_task, int(_kanban_run))
+            except (TypeError, ValueError):
+                logger.warning("invalid HERMES_KANBAN_RUN_ID=%r", _kanban_run)
 
     # Determine if conversation completed successfully
     normal_text_response = str(_turn_exit_reason).startswith("text_response(")
@@ -199,6 +189,7 @@ def finalize_turn(
             api_call_count < agent.max_iterations
             or normal_text_response
         )
+        and not iteration_limit_fallback
     )
 
     # Preflight can seed the display count before the provider receives the
@@ -263,6 +254,7 @@ def finalize_turn(
     # scaffolding has been removed. Otherwise a later user "continue" turn
     # can replay assistant("(empty)") / recovery nudges and fall into the
     # same empty-response loop again.
+    _session_persisted = False
     try:
         agent._drop_trailing_empty_response_scaffolding(messages)
 
@@ -408,9 +400,57 @@ def finalize_turn(
                 logger.info("Micro-compaction failed: %s", _mc_err)
 
         agent._persist_session(messages, conversation_history)
+        _session_persisted = True
     except Exception as _persist_err:
         _cleanup_errors.append(f"persist_session: {_persist_err}")
         logger.error("finalize_turn: _persist_session failed: %s", _persist_err, exc_info=True)
+
+    # Release only after attempting to persist the resumable transcript.
+    # ``record_iteration_timeout`` checks the exact active run in its write
+    # transaction, preventing a stale worker from releasing a newer claim.
+    if _kanban_timeout_pending is not None and _session_persisted:
+        _kanban_task, _kanban_run_id = _kanban_timeout_pending
+        try:
+            from hermes_cli import kanban_db as _kb
+
+            _checkpoint = _kb.capture_worker_checkpoint(
+                worker_session_id=getattr(agent, "session_id", None),
+                workspace=os.environ.get("HERMES_KANBAN_WORKSPACE"),
+                profile=os.environ.get("HERMES_PROFILE"),
+                model=getattr(agent, "model", None),
+                provider=getattr(agent, "provider", None),
+            )
+            _conn = _kb.connect()
+            try:
+                _kb.record_iteration_timeout(
+                    _conn,
+                    _kanban_task,
+                    expected_run_id=_kanban_run_id,
+                    summary=final_response or "",
+                    checkpoint=_checkpoint,
+                    budget_used=api_call_count,
+                    budget_max=agent.max_iterations,
+                    soft_checkpoint=soft_budget_checkpoint,
+                )
+            finally:
+                try:
+                    _conn.close()
+                except Exception:
+                    pass
+            logger.info(
+                "recorded durable budget checkpoint for task %s run %s (%d/%d)",
+                _kanban_task,
+                _kanban_run_id,
+                api_call_count,
+                agent.max_iterations,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to record budget checkpoint for task %s run %s",
+                _kanban_task,
+                _kanban_run_id,
+                exc_info=True,
+            )
 
     # ── Turn-exit diagnostic log ─────────────────────────────────────
     # Always logged at INFO so agent.log captures WHY every turn ended.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7796,6 +7796,10 @@ def _record_task_failure(
     release_claim: bool = False,
     end_run: bool = False,
     event_payload_extra: Optional[dict] = None,
+    expected_run_id: Optional[int] = None,
+    run_summary: Optional[str] = None,
+    run_metadata: Optional[dict] = None,
+    failure_count_override: Optional[int] = None,
 ) -> bool:
     """Record a non-success outcome (spawn_failed / crashed / timed_out)
     and maybe trip the circuit breaker.
@@ -7845,12 +7849,20 @@ def _record_task_failure(
     blocked = False
     with write_txn(conn):
         row = conn.execute(
-            "SELECT consecutive_failures, status, max_retries "
+            "SELECT consecutive_failures, status, max_retries, current_run_id "
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if row is None:
             return False
-        failures = int(row["consecutive_failures"]) + 1
+        if expected_run_id is not None and row["current_run_id"] != expected_run_id:
+            raise KanbanContinuationConflict(
+                f"task {task_id} is no longer owned by run {expected_run_id}"
+            )
+        failures = (
+            max(0, int(failure_count_override))
+            if failure_count_override is not None
+            else int(row["consecutive_failures"]) + 1
+        )
 
         # Per-task override wins over both caller-supplied and default
         # thresholds. None (the common case) falls through.
@@ -7891,8 +7903,10 @@ def _record_task_failure(
                 run_id = _end_run(
                     conn, task_id,
                     outcome="gave_up", status="gave_up",
+                    summary=run_summary,
                     error=error[:500],
                     metadata={
+                        **(run_metadata or {}),
                         "failures": failures,
                         "trigger_outcome": outcome,
                         "effective_limit": effective_limit,
@@ -7936,16 +7950,432 @@ def _record_task_failure(
                 run_id = _end_run(
                     conn, task_id,
                     outcome=outcome, status=outcome,
+                    summary=run_summary,
                     error=error[:500],
-                    metadata={"failures": failures},
+                    metadata={**(run_metadata or {}), "failures": failures},
                 )
                 _append_event(
                     conn, task_id, outcome,
-                    {"error": error[:500], "failures": failures},
+                    {
+                        "error": error[:500],
+                        "failures": failures,
+                        **(event_payload_extra or {}),
+                    },
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.
     return blocked
+
+
+class KanbanContinuationConflict(RuntimeError):
+    """A stale worker attempted to checkpoint a run it no longer owns."""
+
+
+def _canonical_workspace(value: Any) -> str:
+    if not value:
+        return ""
+    try:
+        return str(Path(str(value)).expanduser().resolve())
+    except (OSError, RuntimeError):
+        return os.path.abspath(os.path.expanduser(str(value)))
+
+
+def _checkpoint_progress_fingerprint(checkpoint: Mapping[str, Any]) -> str:
+    progress = {
+        "head": checkpoint.get("head"),
+        "dirty_hash": checkpoint.get("dirty_hash"),
+        "dirty_files": checkpoint.get("dirty_files") or [],
+    }
+    return hashlib.sha256(
+        json.dumps(progress, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+
+
+def capture_worker_checkpoint(
+    *,
+    worker_session_id: Optional[str],
+    workspace: Optional[str],
+    profile: Optional[str],
+    model: Optional[str],
+    provider: Optional[str],
+) -> dict[str, Any]:
+    """Capture fail-open worker/session and git state for a durable handoff."""
+    canonical_workspace = _canonical_workspace(workspace)
+    checkpoint: dict[str, Any] = {
+        "worker_session_id": worker_session_id,
+        "workspace": canonical_workspace,
+        "profile": profile,
+        "model": model,
+        "provider": provider,
+        "branch": None,
+        "head": None,
+        "dirty_hash": None,
+        "dirty_files": [],
+    }
+    if not canonical_workspace or not os.path.isdir(canonical_workspace):
+        return checkpoint
+
+    def _git(*args: str, text: bool = True):
+        return subprocess.run(
+            ["git", "-C", canonical_workspace, *args],
+            check=False,
+            capture_output=True,
+            text=text,
+            timeout=5,
+        )
+
+    try:
+        head = _git("rev-parse", "--verify", "HEAD")
+        if head.returncode != 0:
+            return checkpoint
+        checkpoint["head"] = head.stdout.strip() or None
+
+        branch = _git("symbolic-ref", "--quiet", "--short", "HEAD")
+        if branch.returncode == 0:
+            checkpoint["branch"] = branch.stdout.strip() or None
+
+        status = _git(
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "-z",
+            text=False,
+        )
+        if status.returncode == 0:
+            raw = status.stdout or b""
+            entries = [part for part in raw.split(b"\0") if part]
+            dirty_paths: list[bytes] = []
+            index = 0
+            while index < len(entries):
+                entry = entries[index]
+                status_code = entry[:2]
+                dirty_paths.append(entry[3:])
+                index += 1
+                if any(code in status_code for code in (b"R", b"C")):
+                    if index < len(entries):
+                        dirty_paths.append(entries[index])
+                        index += 1
+
+            digest = hashlib.sha256(raw)
+            # Porcelain records only status codes and paths. Include the
+            # index's staged blob IDs so index-only changes cannot look like
+            # an identical resumable workspace.
+            index_state = _git("ls-files", "--stage", "-z", text=False)
+            if index_state.returncode == 0:
+                digest.update(b"index\0")
+                digest.update(index_state.stdout or b"")
+            else:
+                digest.update(b"index-unavailable\0")
+            workspace_root = Path(canonical_workspace)
+            decoded_paths: list[str] = []
+            for raw_path in dirty_paths:
+                relative = os.fsdecode(raw_path)
+                decoded_paths.append(relative)
+                digest.update(len(raw_path).to_bytes(8, "big"))
+                digest.update(raw_path)
+                candidate = workspace_root / relative
+                try:
+                    resolved_parent = candidate.parent.resolve()
+                    resolved_parent.relative_to(workspace_root)
+                    if candidate.is_symlink():
+                        digest.update(b"symlink\0")
+                        digest.update(os.fsencode(os.readlink(candidate)))
+                    elif candidate.is_file():
+                        digest.update(b"file\0")
+                        with candidate.open("rb") as handle:
+                            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                                digest.update(chunk)
+                    elif candidate.exists():
+                        digest.update(b"other\0")
+                    else:
+                        digest.update(b"missing\0")
+                except (OSError, RuntimeError, ValueError):
+                    digest.update(b"unreadable\0")
+            checkpoint["dirty_hash"] = digest.hexdigest()
+            checkpoint["dirty_files"] = decoded_paths[:200]
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return checkpoint
+
+
+def record_iteration_timeout(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_run_id: int,
+    summary: str,
+    checkpoint: Mapping[str, Any],
+    budget_used: int,
+    budget_max: int,
+    soft_checkpoint: bool,
+) -> bool:
+    """Atomically persist a resumable timeout handoff and release its claim.
+
+    The exact run identity is checked inside the same write transaction that
+    closes the run.  A stale process therefore cannot overwrite a newer
+    worker's handoff or release its claim.
+    """
+    task_row = conn.execute(
+        "SELECT assignee, workspace_kind, workspace_path, model_override, "
+        "provider_override, reasoning_effort, max_retries, current_run_id "
+        "FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if task_row is None or task_row["current_run_id"] != expected_run_id:
+        raise KanbanContinuationConflict(
+            f"task {task_id} is no longer owned by run {expected_run_id}"
+        )
+    if checkpoint.get("profile") != task_row["assignee"]:
+        raise KanbanContinuationConflict(
+            f"task {task_id} ownership changed from {checkpoint.get('profile')!r} "
+            f"to {task_row['assignee']!r}"
+        )
+
+    prior_rows = conn.execute(
+        "SELECT metadata FROM task_runs "
+        "WHERE task_id = ? AND outcome = 'timed_out' AND ended_at IS NOT NULL "
+        "ORDER BY id ASC",
+        (task_id,),
+    ).fetchall()
+    prior_meta: list[dict[str, Any]] = []
+    for row in prior_rows:
+        try:
+            parsed = json.loads(row["metadata"]) if row["metadata"] else {}
+        except (TypeError, ValueError, json.JSONDecodeError):
+            parsed = {}
+        if isinstance(parsed, dict):
+            prior_meta.append(parsed)
+
+    metadata = dict(checkpoint)
+    metadata["task_id"] = task_id
+    metadata["run_id"] = int(expected_run_id)
+    metadata["workspace"] = _canonical_workspace(metadata.get("workspace"))
+    metadata["model_override"] = task_row["model_override"]
+    metadata["provider_override"] = task_row["provider_override"]
+    metadata["reasoning_effort"] = task_row["reasoning_effort"]
+    metadata["budget_used"] = int(budget_used)
+    metadata["budget_max"] = int(budget_max)
+    metadata["soft_checkpoint"] = bool(soft_checkpoint)
+    metadata["timeout_retries"] = len(prior_meta) + 1
+    metadata["cumulative_iterations"] = sum(
+        int(item.get("budget_used") or 0) for item in prior_meta
+    ) + int(budget_used)
+    fingerprint = _checkpoint_progress_fingerprint(metadata)
+    metadata["progress_fingerprint"] = fingerprint
+    previous_fingerprint = (
+        prior_meta[-1].get("progress_fingerprint") if prior_meta else None
+    )
+    # The first timeout has no dispatch-start baseline, so it cannot prove
+    # progress and must not erase failures accumulated by other failure paths.
+    # Later checkpoints demonstrate progress only by differing from the last
+    # durable timeout fingerprint.
+    metadata["progress_made"] = (
+        previous_fingerprint is not None and previous_fingerprint != fingerprint
+    )
+    previous_no_progress = (
+        int(prior_meta[-1].get("no_progress_retries") or 0) if prior_meta else 0
+    )
+    metadata["no_progress_retries"] = (
+        0 if metadata["progress_made"] else previous_no_progress + 1
+    )
+
+    error = (
+        f"Iteration budget checkpoint ({int(budget_used)}/{int(budget_max)}) — "
+        "task yielded with a durable continuation handoff"
+    )
+    event_extra = {
+        "budget_used": int(budget_used),
+        "budget_max": int(budget_max),
+        "soft_checkpoint": bool(soft_checkpoint),
+        "timeout_retries": metadata["timeout_retries"],
+        "cumulative_iterations": metadata["cumulative_iterations"],
+        "progress_made": metadata["progress_made"],
+        "no_progress_retries": metadata["no_progress_retries"],
+    }
+    stagnation_limit = int(task_row["max_retries"] or DEFAULT_FAILURE_LIMIT)
+    # Productive checkpoints reset the stagnant-timeout circuit. A separate
+    # bounded total cap prevents a worker that makes tiny changes forever from
+    # retrying without limit.
+    failure_count_override: Optional[int] = (
+        0 if metadata["progress_made"] else None
+    )
+    if metadata["timeout_retries"] >= stagnation_limit * 4:
+        failure_count_override = stagnation_limit
+    return _record_task_failure(
+        conn,
+        task_id,
+        error=error,
+        outcome="timed_out",
+        release_claim=True,
+        end_run=True,
+        event_payload_extra=event_extra,
+        expected_run_id=int(expected_run_id),
+        run_summary=str(summary or "").strip() or None,
+        run_metadata=metadata,
+        failure_count_override=failure_count_override,
+    )
+
+
+def _session_provider(session: Mapping[str, Any]) -> Optional[str]:
+    raw = session.get("model_config")
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            raw = {}
+    if not isinstance(raw, Mapping):
+        return None
+    value = raw.get("provider") or raw.get("requested_provider")
+    return str(value) if value else None
+
+
+def compatible_worker_resume_session(
+    prior: Mapping[str, Any],
+    current: Mapping[str, Any],
+    session: Mapping[str, Any],
+) -> Optional[str]:
+    """Return the resumable session id only for an exact worker identity match."""
+    session_id = str(prior.get("worker_session_id") or "").strip()
+    if not session_id or str(session.get("id") or "") != session_id:
+        return None
+    if int(current.get("active_run_count") or 0) != 1:
+        return None
+    if str(session.get("source") or "") != "kanban":
+        return None
+
+    exact_keys = (
+        "task_id",
+        "workspace",
+        "profile",
+        "model",
+        "provider",
+        "model_override",
+        "provider_override",
+        "reasoning_effort",
+        "branch",
+        "head",
+        "dirty_hash",
+        "dirty_files",
+    )
+    for key in exact_keys:
+        left = prior.get(key)
+        right = current.get(key)
+        if key == "workspace":
+            left = _canonical_workspace(left)
+            right = _canonical_workspace(right)
+        if left != right:
+            return None
+
+    if prior.get("run_id") == current.get("run_id"):
+        return None
+    if str(session.get("profile_name") or "") != str(current.get("profile") or ""):
+        return None
+    if _canonical_workspace(session.get("cwd")) != _canonical_workspace(
+        current.get("workspace")
+    ):
+        return None
+    if session.get("model") != current.get("model"):
+        return None
+    session_provider = _session_provider(session)
+    if not session_provider or session_provider != current.get("provider"):
+        return None
+    return session_id
+
+
+def _worker_route_identity(task: Task, profile_home: str) -> tuple[Optional[str], Optional[str]]:
+    """Resolve the effective model route without mutating process profile state."""
+    model = task.model_override
+    provider = task.provider_override
+    if model and provider:
+        return model, provider
+    try:
+        import yaml
+
+        raw = yaml.safe_load(
+            Path(profile_home, "config.yaml").read_text(encoding="utf-8")
+        ) or {}
+        model_config = raw.get("model") if isinstance(raw, dict) else {}
+        if isinstance(model_config, str):
+            model = model or model_config.strip() or None
+        elif isinstance(model_config, dict):
+            model = model or (
+                str(model_config.get("default") or model_config.get("model") or "").strip()
+                or None
+            )
+            provider = provider or (
+                str(model_config.get("provider") or "").strip() or None
+            )
+    except (OSError, ValueError, TypeError):
+        pass
+    return model, provider
+
+
+def _resolve_worker_resume_session(
+    task: Task,
+    workspace: str,
+    profile_home: str,
+    *,
+    board: Optional[str] = None,
+) -> Optional[str]:
+    """Select the latest prior timeout only when every resume invariant holds."""
+    try:
+        with connect_closing(board=board) as conn:
+            prior_row = conn.execute(
+                "SELECT metadata FROM task_runs "
+                "WHERE task_id = ? AND outcome = 'timed_out' "
+                "AND ended_at IS NOT NULL AND metadata IS NOT NULL "
+                "ORDER BY id DESC LIMIT 1",
+                (task.id,),
+            ).fetchone()
+            active_run_count = int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM task_runs "
+                    "WHERE task_id = ? AND ended_at IS NULL",
+                    (task.id,),
+                ).fetchone()[0]
+            )
+        if prior_row is None:
+            return None
+        prior = json.loads(prior_row["metadata"])
+        if not isinstance(prior, dict):
+            return None
+
+        model, provider = _worker_route_identity(task, profile_home)
+        current = capture_worker_checkpoint(
+            worker_session_id=None,
+            workspace=workspace,
+            profile=task.assignee,
+            model=model,
+            provider=provider,
+        )
+        current.update(
+            {
+                "task_id": task.id,
+                "run_id": task.current_run_id,
+                "model_override": task.model_override,
+                "provider_override": task.provider_override,
+                "reasoning_effort": task.reasoning_effort,
+                "active_run_count": active_run_count,
+            }
+        )
+
+        from hermes_state import SessionDB
+
+        state = SessionDB(Path(profile_home) / "state.db", read_only=True)
+        try:
+            session = state.get_session(str(prior.get("worker_session_id") or ""))
+        finally:
+            state.close()
+        if not session:
+            return None
+        return compatible_worker_resume_session(prior, current, session)
+    except (OSError, sqlite3.Error, TypeError, ValueError, json.JSONDecodeError):
+        _log.warning(
+            "Could not resolve continuation session for task %s; using handoff only",
+            task.id,
+            exc_info=True,
+        )
+        return None
 
 
 # Backward-compat alias. Old name is referenced from tests and possibly
@@ -9128,6 +9558,16 @@ def _default_spawn(
     worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
     if worker_toolsets:
         cmd.extend(["--toolsets", ",".join(worker_toolsets)])
+    resume_session = _resolve_worker_resume_session(
+        task,
+        workspace,
+        env.get("HERMES_HOME", ""),
+        board=board,
+    )
+    if resume_session:
+        # Workspace compatibility was already verified against the checkpoint;
+        # do not let generic resume handling chdir based on stale row metadata.
+        cmd.extend(["--resume", resume_session, "--no-restore-cwd"])
     cmd.extend([
         "chat",
         "-q", prompt,

--- a/tasks/issue-77881-progress.md
+++ b/tasks/issue-77881-progress.md
@@ -1,0 +1,38 @@
+# Issue #77881 / PR #77883 progress
+
+Last updated: 2026-08-03 13:31 UTC
+
+## Goal
+Preserve safe continuation context when a dispatcher-owned Kanban worker yields at its iteration budget, while rejecting unsafe resume and retaining bounded retry/circuit-breaker behavior.
+
+## Investigation
+- [x] Confirm current finalizer generated a summary but closed the run before persisting it.
+- [x] Confirm dispatcher launched every retry as a fresh `hermes ... chat -q` session.
+- [x] Trace run schema, claim identity, worker argv, session resume support, and board/profile routing.
+- [x] Confirm exact resume compatibility inputs and deterministic fallback behavior with tests.
+
+## TDD slices
+- [x] RED/GREEN: timeout closure atomically stores summary, worker session, run/task identity, workspace/profile/model/provider, git branch/head/content-sensitive dirty state, and cumulative counters.
+- [x] RED/GREEN: compatible timed-out run adds `--resume <session> --no-restore-cwd` to the worker argv.
+- [x] RED/GREEN: ownership/workspace/profile/model/provider/branch/head/dirty-state mismatch or competing run suppresses resume and leaves the durable prior-run handoff available.
+- [x] RED/GREEN: root Kanban workers stop at a soft iteration threshold, use the reserved summary call, and record a checkpoint rather than consuming the hard limit.
+- [x] RED/GREEN: timeout metadata tracks progress/no-progress and bounded cumulative retry/iteration observability without weakening the existing circuit breaker.
+- [x] E2E: timeout -> re-claim -> spawn retains continuation context through the real board DB, session DB, Git state, and argv path.
+
+## Implemented behavior
+- Root Kanban workers reserve a bounded soft checkpoint budget; delegated children and pending user interrupts bypass it.
+- Timeout summaries use an isolated message-list view, then persist the real transcript before the exact-run atomic handoff transition.
+- Closed run metadata records session/workspace/profile/model/provider/reasoning identity, branch/head, worktree and staged-index fingerprints, retry counters, progress fingerprints, and cumulative iterations.
+- Dispatcher resume is accepted only when the previous run, current task/workspace/route, one active run, and durable session row match exactly; otherwise the normal `kanban_show` prior-run summary is the deterministic fallback.
+- Productive Git progress resets timeout stagnation. Repeated no-progress checkpoints trip the existing per-task circuit breaker, with a bounded cumulative timeout cap.
+- Persistence, board-routing, or ownership conflicts fail closed without releasing a newer/current claim.
+
+## Verification / publication
+- [x] Focused CI-parity tests pass with `scripts/run_tests.sh`.
+- [x] Broad affected suite passes: 49 files / 279 tests.
+- [x] Ruff and `git diff --check` pass.
+- [x] Local Codex review findings resolved: board pinning, persistence-before-release, delegated-child isolation, content-sensitive worktree/index fingerprints, and interrupt precedence.
+- [x] Codex app-server applicability reviewed: it does not consume Hermes' per-tool iteration budget and owns native turn persistence/watchdog retirement, so this timeout behavior correctly remains scoped to the Hermes-managed loop.
+- [ ] Coherent conventional commit pushed to `fork/resolve/issue-77881-kanban-resume`.
+- [ ] Draft PR updated; GitHub `@codex review` loop reaches current-head all-clear.
+- [ ] Exact Kanban review-required handoff written before blocking.

--- a/tasks/issue-77881-progress.md
+++ b/tasks/issue-77881-progress.md
@@ -33,6 +33,6 @@ Preserve safe continuation context when a dispatcher-owned Kanban worker yields 
 - [x] Ruff and `git diff --check` pass.
 - [x] Local Codex review findings resolved: board pinning, persistence-before-release, delegated-child isolation, content-sensitive worktree/index fingerprints, and interrupt precedence.
 - [x] Codex app-server applicability reviewed: it does not consume Hermes' per-tool iteration budget and owns native turn persistence/watchdog retirement, so this timeout behavior correctly remains scoped to the Hermes-managed loop.
-- [ ] Coherent conventional commit pushed to `fork/resolve/issue-77881-kanban-resume`.
+- [x] Coherent conventional commit `a807631f9` pushed to `fork/resolve/issue-77881-kanban-resume`.
 - [ ] Draft PR updated; GitHub `@codex review` loop reaches current-head all-clear.
 - [ ] Exact Kanban review-required handoff written before blocking.

--- a/tests/agent/test_kanban_timeout_checkpoint.py
+++ b/tests/agent/test_kanban_timeout_checkpoint.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent import conversation_loop
+from agent.turn_finalizer import finalize_turn
+from tests.agent.test_turn_finalizer_iteration_limit_exit import _LimitAgent
+
+
+def test_kanban_soft_limit_reserves_summary_capacity(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t-soft")
+
+    assert conversation_loop._kanban_soft_iteration_limit(100) == 90
+    assert conversation_loop._kanban_soft_iteration_limit(10) == 9
+    assert conversation_loop._kanban_soft_iteration_limit(1) == 1
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK")
+    assert conversation_loop._kanban_soft_iteration_limit(100) == 100
+
+
+def test_delegated_child_does_not_reserve_parent_kanban_budget(monkeypatch):
+    from agent.delegation_context import delegated_child_context
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t-parent")
+    with delegated_child_context("child-session"):
+        assert conversation_loop._kanban_soft_iteration_limit(100) == 100
+
+
+def test_pending_interrupt_wins_over_soft_kanban_checkpoint(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t-parent")
+    agent = SimpleNamespace(
+        max_iterations=100,
+        iteration_budget=SimpleNamespace(remaining=10),
+        _budget_grace_call=False,
+        _interrupt_requested=True,
+    )
+
+    assert conversation_loop._kanban_soft_checkpoint_due(agent, 90) is False
+
+
+def test_soft_checkpoint_persists_session_before_releasing_claim(monkeypatch, tmp_path):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t-soft")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("HERMES_PROFILE", "worker-a")
+
+    agent = _LimitAgent(max_iterations=100, budget_remaining=10)
+    agent.session_id = "sess-soft"
+    agent.model = "model-a"
+    agent.provider = "provider-a"
+    agent.reasoning_config = {"effort": "high"}
+    order: list[str] = []
+    live_messages = [{"role": "user", "content": "task"}]
+    summary_input = None
+
+    def handle_max_iterations(messages, _api_call_count):
+        nonlocal summary_input
+        summary_input = messages
+        messages.append({"role": "user", "content": "ephemeral summary request"})
+        return "durable handoff summary"
+
+    def persist(messages, _history):
+        order.append("persist")
+        assert all(m.get("content") != "ephemeral summary request" for m in messages)
+
+    recorded = {}
+
+    def record_timeout(conn, task_id, **kwargs):
+        order.append("release")
+        recorded.update(task_id=task_id, **kwargs)
+        return False
+
+    agent._handle_max_iterations = handle_max_iterations
+    agent._persist_session = persist
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db.capture_worker_checkpoint",
+        lambda **kwargs: {**kwargs, "branch": "fix/continuation", "head": "a" * 40},
+    )
+    monkeypatch.setattr("hermes_cli.kanban_db.record_iteration_timeout", record_timeout)
+    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: SimpleNamespace(close=lambda: None))
+
+    result = finalize_turn(
+        agent,
+        final_response=None,
+        api_call_count=90,
+        interrupted=False,
+        failed=False,
+        messages=live_messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="task",
+        original_user_message="task",
+        _should_review_memory=False,
+        _turn_exit_reason="kanban_soft_budget_checkpoint",
+    )
+
+    assert result["final_response"] == "durable handoff summary"
+    assert result["completed"] is False
+    assert summary_input is not live_messages
+    assert order == ["persist", "release"]
+    assert recorded["task_id"] == "t-soft"
+    assert recorded["expected_run_id"] == 42
+    assert recorded["summary"] == "durable handoff summary"
+    assert recorded["budget_used"] == 90
+    assert recorded["budget_max"] == 100
+    assert recorded["soft_checkpoint"] is True
+    assert recorded["checkpoint"]["worker_session_id"] == "sess-soft"
+
+
+def test_checkpoint_does_not_release_claim_when_session_persistence_fails(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t-soft")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(tmp_path))
+    monkeypatch.setenv("HERMES_PROFILE", "worker-a")
+    agent = _LimitAgent(max_iterations=100, budget_remaining=10)
+    agent._persist_session = MagicMock(side_effect=OSError("disk full"))
+    release = MagicMock()
+    monkeypatch.setattr("hermes_cli.kanban_db.record_iteration_timeout", release)
+
+    result = finalize_turn(
+        agent,
+        final_response=None,
+        api_call_count=90,
+        interrupted=False,
+        failed=False,
+        messages=[{"role": "user", "content": "task"}],
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="task",
+        original_user_message="task",
+        _should_review_memory=False,
+        _turn_exit_reason="kanban_soft_budget_checkpoint",
+    )
+
+    release.assert_not_called()
+    assert any("persist_session" in error for error in result["cleanup_errors"])
+
+
+def test_delegated_child_does_not_release_parent_claim(monkeypatch, tmp_path):
+    from agent.delegation_context import delegated_child_context
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t-parent")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(tmp_path))
+    agent = _LimitAgent(max_iterations=100, budget_remaining=0)
+    release = MagicMock()
+    monkeypatch.setattr("hermes_cli.kanban_db.record_iteration_timeout", release)
+
+    with delegated_child_context("child-session"):
+        finalize_turn(
+            agent,
+            final_response=None,
+            api_call_count=100,
+            interrupted=False,
+            failed=False,
+            messages=[{"role": "user", "content": "delegated work"}],
+            conversation_history=[],
+            effective_task_id="child-task",
+            turn_id="turn",
+            user_message="delegated work",
+            original_user_message="delegated work",
+            _should_review_memory=False,
+            _turn_exit_reason="budget_exhausted",
+        )
+
+    release.assert_not_called()

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -168,10 +168,17 @@ def test_pending_response_does_not_mask_later_terminal_exit(
 def test_pending_response_records_kanban_timeout(monkeypatch):
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
     monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
-    record = MagicMock(name="record_task_failure")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "7")
+    monkeypatch.setenv("HERMES_PROFILE", "worker-a")
+    record = MagicMock(name="record_iteration_timeout")
+    checkpoint = {"worker_session_id": "sess"}
     conn = SimpleNamespace(close=lambda: None)
     monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: conn)
-    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", record)
+    monkeypatch.setattr(
+        "hermes_cli.kanban_db.capture_worker_checkpoint",
+        lambda **_kwargs: checkpoint,
+    )
+    monkeypatch.setattr("hermes_cli.kanban_db.record_iteration_timeout", record)
     agent = _LimitAgent()
 
     result = _finalize(
@@ -185,14 +192,12 @@ def test_pending_response_records_kanban_timeout(monkeypatch):
     record.assert_called_once_with(
         conn,
         "task-123",
-        error=(
-            "Iteration budget exhausted (60/60) — task could not complete "
-            "within the allowed iterations"
-        ),
-        outcome="timed_out",
-        release_claim=True,
-        end_run=True,
-        event_payload_extra={"budget_used": 60, "budget_max": 60},
+        expected_run_id=7,
+        summary="composed report",
+        checkpoint=checkpoint,
+        budget_used=60,
+        budget_max=60,
+        soft_checkpoint=False,
     )
 
 

--- a/tests/hermes_cli/test_kanban_continuation.py
+++ b/tests/hermes_cli/test_kanban_continuation.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        yield conn, tmp_path
+    finally:
+        conn.close()
+
+
+def _claimed_task(conn, workspace: Path, *, model="model-a", provider="provider-a"):
+    task_id = kb.create_task(
+        conn,
+        title="continue safely",
+        assignee="worker-a",
+        workspace_kind="dir",
+        workspace_path=str(workspace),
+        model_override=model,
+        provider_override=provider,
+        max_retries=3,
+    )
+    task = kb.claim_task(conn, task_id, claimer="host:1")
+    assert task is not None
+    return task
+
+
+def test_iteration_timeout_atomically_persists_durable_handoff_and_cumulative_usage(board):
+    conn, tmp_path = board
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    task = _claimed_task(conn, workspace)
+
+    blocked = kb.record_iteration_timeout(
+        conn,
+        task.id,
+        expected_run_id=task.current_run_id,
+        summary="Implemented parser; remaining: integration tests.",
+        checkpoint={
+            "worker_session_id": "sess-worker-1",
+            "workspace": str(workspace),
+            "profile": "worker-a",
+            "model": "model-a",
+            "provider": "provider-a",
+            "model_override": "model-a",
+            "provider_override": "provider-a",
+            "reasoning_effort": None,
+            "branch": "fix/continuation",
+            "head": "a" * 40,
+            "dirty_hash": "dirty-1",
+            "dirty_files": ["parser.py", "tests/test_parser.py"],
+        },
+        budget_used=90,
+        budget_max=100,
+        soft_checkpoint=True,
+    )
+
+    assert blocked is False
+    stored_task = kb.get_task(conn, task.id)
+    assert stored_task is not None
+    assert stored_task.status == "ready"
+    assert stored_task.current_run_id is None
+
+    run = kb.list_runs(conn, task.id, include_active=False)[-1]
+    assert run.outcome == "timed_out"
+    assert run.summary == "Implemented parser; remaining: integration tests."
+    assert run.metadata is not None
+    assert run.metadata["worker_session_id"] == "sess-worker-1"
+    assert run.metadata["task_id"] == task.id
+    assert run.metadata["run_id"] == task.current_run_id
+    assert run.metadata["workspace"] == str(workspace.resolve())
+    assert run.metadata["budget_used"] == 90
+    assert run.metadata["budget_max"] == 100
+    assert run.metadata["soft_checkpoint"] is True
+    assert run.metadata["timeout_retries"] == 1
+    assert run.metadata["cumulative_iterations"] == 90
+    assert run.metadata["progress_made"] is False
+    assert run.metadata["no_progress_retries"] == 1
+    assert stored_task.consecutive_failures == 1
+
+    event = kb.list_events(conn, task.id)[-1]
+    assert event.kind == "timed_out"
+    assert event.run_id == task.current_run_id
+    assert event.payload["cumulative_iterations"] == 90
+    assert event.payload["timeout_retries"] == 1
+
+
+def test_iteration_timeout_rejects_stale_run_without_releasing_current_claim(board):
+    conn, tmp_path = board
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    task = _claimed_task(conn, workspace)
+
+    with pytest.raises(kb.KanbanContinuationConflict):
+        kb.record_iteration_timeout(
+            conn,
+            task.id,
+            expected_run_id=int(task.current_run_id) + 1,
+            summary="stale worker",
+            checkpoint={"worker_session_id": "stale"},
+            budget_used=90,
+            budget_max=100,
+            soft_checkpoint=True,
+        )
+
+    stored = kb.get_task(conn, task.id)
+    assert stored is not None
+    assert stored.status == "running"
+    assert stored.current_run_id == task.current_run_id
+
+
+def test_timeout_retry_limit_counts_stagnation_not_productive_checkpoints(board):
+    conn, tmp_path = board
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    task = _claimed_task(conn, workspace)
+
+    def timeout(head: str) -> bool:
+        nonlocal task
+        blocked = kb.record_iteration_timeout(
+            conn,
+            task.id,
+            expected_run_id=task.current_run_id,
+            summary=f"checkpoint at {head}",
+            checkpoint={
+                "worker_session_id": f"sess-{task.current_run_id}",
+                "workspace": str(workspace),
+                "profile": "worker-a",
+                "model": "model-a",
+                "provider": "provider-a",
+                "branch": "fix/continuation",
+                "head": head,
+                "dirty_hash": "clean",
+                "dirty_files": [],
+            },
+            budget_used=90,
+            budget_max=100,
+            soft_checkpoint=True,
+        )
+        if not blocked:
+            task = kb.claim_task(conn, task.id, claimer=f"host:{head}:{task.current_run_id}")
+            assert task is not None
+        return blocked
+
+    assert timeout("a" * 40) is False
+    assert timeout("b" * 40) is False  # new commit resets stagnation
+    assert timeout("b" * 40) is False
+    assert timeout("b" * 40) is False
+    assert timeout("b" * 40) is True
+
+    stored = kb.get_task(conn, task.id)
+    assert stored is not None
+    assert stored.status == "blocked"
+    assert stored.consecutive_failures == 3
+    latest = kb.list_runs(conn, task.id, include_active=False)[-1]
+    assert latest.metadata["timeout_retries"] == 5
+    assert latest.metadata["no_progress_retries"] == 3
+    assert latest.metadata["cumulative_iterations"] == 450
+
+
+def test_checkpoint_hash_changes_when_dirty_file_contents_change(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    def git(*args):
+        subprocess.run(
+            ["git", *args],
+            cwd=workspace,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    git("init", "-q")
+    git("config", "user.name", "Test User")
+    git("config", "user.email", "test@example.com")
+    tracked = workspace / "tracked.txt"
+    tracked.write_text("base\n", encoding="utf-8")
+    git("add", "tracked.txt")
+    git("commit", "-qm", "test: seed repository")
+
+    tracked.write_text("first dirty contents\n", encoding="utf-8")
+    untracked = workspace / "untracked.txt"
+    untracked.write_text("first untracked contents\n", encoding="utf-8")
+    first = kb.capture_worker_checkpoint(
+        worker_session_id="session",
+        workspace=str(workspace),
+        profile="worker",
+        model="model",
+        provider="provider",
+    )
+
+    tracked.write_text("second dirty contents\n", encoding="utf-8")
+    untracked.write_text("second untracked contents\n", encoding="utf-8")
+    second = kb.capture_worker_checkpoint(
+        worker_session_id="session",
+        workspace=str(workspace),
+        profile="worker",
+        model="model",
+        provider="provider",
+    )
+
+    assert first["dirty_files"] == second["dirty_files"]
+    assert first["dirty_hash"] != second["dirty_hash"]
+
+
+def test_checkpoint_hash_changes_when_only_staged_contents_change(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    def git(*args):
+        subprocess.run(
+            ["git", *args],
+            cwd=workspace,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    git("init", "-q")
+    git("config", "user.name", "Test User")
+    git("config", "user.email", "test@example.com")
+    tracked = workspace / "tracked.txt"
+    tracked.write_text("base\n", encoding="utf-8")
+    git("add", "tracked.txt")
+    git("commit", "-qm", "test: seed repository")
+
+    tracked.write_text("staged version a\n", encoding="utf-8")
+    git("add", "tracked.txt")
+    tracked.write_text("worktree version\n", encoding="utf-8")
+    first = kb.capture_worker_checkpoint(
+        worker_session_id="session",
+        workspace=str(workspace),
+        profile="worker",
+        model="model",
+        provider="provider",
+    )
+
+    tracked.write_text("staged version c\n", encoding="utf-8")
+    git("add", "tracked.txt")
+    tracked.write_text("worktree version\n", encoding="utf-8")
+    second = kb.capture_worker_checkpoint(
+        worker_session_id="session",
+        workspace=str(workspace),
+        profile="worker",
+        model="model",
+        provider="provider",
+    )
+
+    assert first["dirty_files"] == second["dirty_files"]
+    assert first["dirty_hash"] != second["dirty_hash"]
+
+
+def _resume_metadata(tmp_path: Path) -> tuple[dict, dict, dict]:
+    workspace = str((tmp_path / "workspace").resolve())
+    prior = {
+        "task_id": "t_resume",
+        "run_id": 11,
+        "worker_session_id": "sess-1",
+        "workspace": workspace,
+        "profile": "worker-a",
+        "model": "model-a",
+        "provider": "provider-a",
+        "model_override": "model-a",
+        "provider_override": "provider-a",
+        "reasoning_effort": "high",
+        "branch": "fix/continuation",
+        "head": "b" * 40,
+    }
+    current = {
+        "task_id": "t_resume",
+        "run_id": 12,
+        "workspace": workspace,
+        "profile": "worker-a",
+        "model": "model-a",
+        "provider": "provider-a",
+        "model_override": "model-a",
+        "provider_override": "provider-a",
+        "reasoning_effort": "high",
+        "branch": "fix/continuation",
+        "head": "b" * 40,
+        "active_run_count": 1,
+    }
+    session = {
+        "id": "sess-1",
+        "source": "kanban",
+        "profile_name": "worker-a",
+        "cwd": workspace,
+        "model": "model-a",
+        "model_config": json.dumps({"provider": "provider-a"}),
+    }
+    return prior, current, session
+
+
+def test_compatible_worker_resume_requires_exact_identity_match(tmp_path):
+    prior, current, session = _resume_metadata(tmp_path)
+
+    assert kb.compatible_worker_resume_session(prior, current, session) == "sess-1"
+
+
+def test_resolver_selects_persisted_compatible_kanban_session(board):
+    from hermes_state import SessionDB
+
+    conn, tmp_path = board
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_home = tmp_path / ".hermes" / "profiles" / "worker-a"
+    profile_home.mkdir(parents=True)
+    profile_home.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+
+    task = _claimed_task(conn, workspace)
+    sessions = SessionDB(profile_home / "state.db")
+    sessions.create_session(
+        session_id="sess-compatible",
+        source="kanban",
+        model="model-a",
+        model_config={"provider": "provider-a"},
+        cwd=str(workspace.resolve()),
+        profile_name="worker-a",
+    )
+    sessions.close()
+
+    blocked = kb.record_iteration_timeout(
+        conn,
+        task.id,
+        expected_run_id=task.current_run_id,
+        summary="safe handoff",
+        checkpoint={
+            "worker_session_id": "sess-compatible",
+            "workspace": str(workspace),
+            "profile": "worker-a",
+            "model": "model-a",
+            "provider": "provider-a",
+            "branch": None,
+            "head": None,
+            "dirty_hash": None,
+            "dirty_files": [],
+        },
+        budget_used=90,
+        budget_max=100,
+        soft_checkpoint=True,
+    )
+    assert blocked is False
+    retry = kb.claim_task(conn, task.id, claimer="host:retry")
+    assert retry is not None
+
+    assert kb._resolve_worker_resume_session(
+        retry, str(workspace), str(profile_home), board="default"
+    ) == "sess-compatible"
+
+
+@pytest.mark.parametrize(
+    ("surface", "key", "changed"),
+    [
+        ("prior", "task_id", "t_other"),
+        ("prior", "workspace", "/tmp/other"),
+        ("prior", "profile", "worker-b"),
+        ("prior", "model", "model-b"),
+        ("prior", "provider", "provider-b"),
+        ("prior", "model_override", "model-b"),
+        ("prior", "provider_override", "provider-b"),
+        ("prior", "reasoning_effort", "low"),
+        ("prior", "branch", "other"),
+        ("prior", "head", "c" * 40),
+        ("prior", "dirty_hash", "dirty-2"),
+        ("current", "active_run_count", 2),
+        ("session", "source", "cli"),
+        ("session", "profile_name", "worker-b"),
+        ("session", "cwd", "/tmp/other"),
+        ("session", "model", "model-b"),
+        ("session", "model_config", "{}"),
+    ],
+)
+def test_compatible_worker_resume_rejects_changed_ownership_workspace_route_or_head(
+    tmp_path, surface, key, changed
+):
+    prior, current, session = _resume_metadata(tmp_path)
+    {"prior": prior, "current": current, "session": session}[surface][key] = changed
+
+    assert kb.compatible_worker_resume_session(prior, current, session) is None

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -161,3 +161,55 @@ toolsets:
     assert "web" in resolved
     assert "kanban" in resolved  # recovered worker lifecycle surface
     assert resolved != ["kanban"]
+
+
+def test_default_spawn_resumes_only_dispatcher_selected_session(monkeypatch, tmp_path):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "elias"
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    selected = {}
+
+    def resolve_resume(task, workspace, profile_home, *, board=None):
+        selected.update(
+            task=task.id,
+            workspace=workspace,
+            profile_home=profile_home,
+            board=board,
+        )
+        return "sess-compatible"
+
+    monkeypatch.setattr(kb, "_resolve_worker_resume_session", resolve_resume)
+    captured = {}
+
+    class FakeProc:
+        pid = 4245
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["env"] = dict(kwargs["env"])
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    kb._default_spawn(
+        _make_task(kb, assignee="elias"), str(workspace), board="project-a"
+    )
+
+    assert selected == {
+        "task": "t_spawn_tools",
+        "workspace": str(workspace),
+        "profile_home": str(profile),
+        "board": "project-a",
+    }
+    resume_idx = captured["cmd"].index("--resume")
+    assert captured["cmd"][resume_idx + 1] == "sess-compatible"
+    assert "--no-restore-cwd" in captured["cmd"]
+    assert captured["env"]["HERMES_SESSION_SOURCE"] == "kanban"


### PR DESCRIPTION
## Summary

- reserve a soft iteration-budget checkpoint for root Kanban workers without overriding interrupts or delegated child execution
- persist timeout session state before atomically closing the exact owned run and publishing resumable metadata
- resume only exact-compatible profile, route, workspace, Git, session, and ownership identities; otherwise retain the prior-run summary as deterministic handoff context
- track cumulative iterations and progress-aware stagnation while preserving bounded retry/circuit-breaker behavior
- add regression and real DB/session/Git/worker-argv coverage

## Safety invariants

- resumable continuation metadata is never published when session persistence fails
- stale workers cannot release or mutate a newer run claim
- changed ownership, workspace, model/provider route, branch, HEAD, worktree contents, staged index, or competing run suppresses resume
- summary generation uses an isolated message-list view and does not mutate the persisted prompt/cache prefix

## Test plan

- [x] focused continuation/finalizer/spawn tests: 39 passed
- [x] broad affected CI-parity suite: 49 files, 279 tests passed
- [x] Ruff on every changed Python file
- [x] `git diff --check`

Closes #77881.
