### PR TITLE
fix(kanban): detect WS client disconnect on idle board, prevent zombie poll tasks

### DIFF
--- a/contributors/emails/tugrulgunr@gmail.com
+++ b/contributors/emails/tugrulgunr@gmail.com
@@ -1,0 +1,1 @@
+tugrulguner

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2804,10 +2804,24 @@ async def stream_events(ws: WebSocket):
                 conn.close()
 
         while True:
+            # Race receive() against the poll interval to detect client
+            # disconnect even when no events are being sent. Without this,
+            # a disconnect is only detected via send_json() raising
+            # WebSocketDisconnect, so an idle board leaks zombie poll tasks.
+            try:
+                msg = await asyncio.wait_for(
+                    ws.receive(), timeout=_EVENT_POLL_SECONDS
+                )
+                if msg["type"] == "websocket.disconnect":
+                    return
+                # Any other client message (pong, text) is ignored; we
+                # continue polling.
+            except asyncio.TimeoutError:
+                pass  # no client message — poll the DB
+
             cursor, events = await asyncio.to_thread(_fetch_new, cursor)
             if events:
                 await ws.send_json({"events": events, "cursor": cursor})
-            await asyncio.sleep(_EVENT_POLL_SECONDS)
     except WebSocketDisconnect:
         return
     except asyncio.CancelledError:


### PR DESCRIPTION
Closes #77833

## Problem

`stream_events()` in `plugins/kanban/dashboard/plugin_api.py` only detects client disconnect when `ws.send_json()` raises `WebSocketDisconnect`. When no events are pending (idle board), `send_json` is never called, so the poll loop runs indefinitely after the client disconnects.

Each undetected disconnect leaks one poll task that opens a new SQLite connection every 300ms. On a host with repeated connect/disconnect cycles (e.g. the Kanban Recovery Controller), zombie tasks accumulate until the executor thread pool saturates — sustained 100%+ CPU, ~37 leaked SQLite connections, memory exhaustion.

## Fix

Race `ws.receive()` with a timeout matching the poll interval instead of a blind `asyncio.sleep()`:

- On timeout: poll the DB as before (no events, no disconnect)
- On `websocket.disconnect`: return cleanly
- Other client messages (pong, text) are ignored — polling continues

This replaces the `asyncio.sleep` with the receive timeout, so the polling cadence is unchanged.