### PR TITLE
fix(desktop): scope session/pin state per gateway window (#77318)

### DIFF
--- a/apps/desktop/src/store/layout-pin-scope.test.ts
+++ b/apps/desktop/src/store/layout-pin-scope.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesConnection } from '@/global'
+
+// The pin store's scope state (`activePinnedScope`, persistence binding) is
+// module-level, so every test boots a FRESH layout module against a clean
+// localStorage — that's what lets a test simulate "a fresh window booting
+// against existing stored pins".
+
+const LEGACY_KEY = 'hermes.desktop.pinnedSessions'
+
+const MIGRATED_KEY = 'hermes.desktop.pinnedSessions.scope-migrated'
+
+const localConnection = (): HermesConnection =>
+  ({ baseUrl: 'http://127.0.0.1:41001', mode: 'local', token: 't', wsUrl: 'ws://x' }) as HermesConnection
+
+const remoteConnection = (baseUrl: string, profile = 'default'): HermesConnection =>
+  ({ baseUrl, mode: 'remote', profile, token: 't', wsUrl: 'ws://x' }) as HermesConnection
+
+async function freshLayout() {
+  vi.resetModules()
+
+  return import('@/store/layout')
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('connectionScopeId', () => {
+  it('is local for a local-mode connection', async () => {
+    const { connectionScopeId } = await freshLayout()
+
+    expect(connectionScopeId(localConnection())).toBe('local')
+  })
+
+  it('is local for a null connection', async () => {
+    const { connectionScopeId } = await freshLayout()
+
+    expect(connectionScopeId(null)).toBe('local')
+  })
+
+  it('is remote.<baseUrl>.<profile> for a remote connection', async () => {
+    const { connectionScopeId } = await freshLayout()
+
+    expect(connectionScopeId(remoteConnection('https://gw.example.com'))).toBe(
+      'remote.https%3A%2F%2Fgw.example.com.default'
+    )
+  })
+
+  it('includes the profile so two profiles on one gateway stay apart', async () => {
+    const { connectionScopeId } = await freshLayout()
+
+    expect(connectionScopeId(remoteConnection('https://gw', 'work'))).toBe('remote.https%3A%2F%2Fgw.work')
+  })
+})
+
+describe('applyPinnedSessionScope', () => {
+  it('seeds the store from the scope key and persists pins to it', async () => {
+    localStorage.setItem('hermes.desktop.pinnedSessions.local', JSON.stringify(['a', 'b']))
+
+    const { $pinnedSessionIds, applyPinnedSessionScope, pinSession } = await freshLayout()
+
+    applyPinnedSessionScope(localConnection())
+    expect($pinnedSessionIds.get()).toEqual(['a', 'b'])
+
+    pinSession('c')
+    expect(localStorage.getItem('hermes.desktop.pinnedSessions.local')).toBe(JSON.stringify(['a', 'b', 'c']))
+    // Pins must never write back to the pre-scope legacy key.
+    expect(localStorage.getItem(LEGACY_KEY)).toBeNull()
+  })
+
+  it('isolates pin sets between two gateways', async () => {
+    const { $pinnedSessionIds, applyPinnedSessionScope, pinSession, unpinSession } = await freshLayout()
+
+    // Window A on gateway A pins two sessions.
+    applyPinnedSessionScope(remoteConnection('https://gw-a'))
+    pinSession('a1')
+    pinSession('a2')
+    expect($pinnedSessionIds.get()).toEqual(['a1', 'a2'])
+
+    // Window B on gateway B must NOT see A's pins.
+    applyPinnedSessionScope(remoteConnection('https://gw-b'))
+    expect($pinnedSessionIds.get()).toEqual([])
+
+    // B pins its own; A's pins are untouched in storage.
+    pinSession('b1')
+    expect(localStorage.getItem('hermes.desktop.pinnedSessions.remote.https%3A%2F%2Fgw-b.default')).toBe(
+      JSON.stringify(['b1'])
+    )
+    expect(localStorage.getItem('hermes.desktop.pinnedSessions.remote.https%3A%2F%2Fgw-a.default')).toBe(
+      JSON.stringify(['a1', 'a2'])
+    )
+
+    // Back on gateway A, the local set is A's again.
+    applyPinnedSessionScope(remoteConnection('https://gw-a'))
+    expect($pinnedSessionIds.get()).toEqual(['a1', 'a2'])
+
+    // And unpinning on A only affects A's key.
+    unpinSession('a1')
+    expect(localStorage.getItem('hermes.desktop.pinnedSessions.remote.https%3A%2F%2Fgw-a.default')).toBe(
+      JSON.stringify(['a2'])
+    )
+    expect(localStorage.getItem('hermes.desktop.pinnedSessions.remote.https%3A%2F%2Fgw-b.default')).toBe(
+      JSON.stringify(['b1'])
+    )
+  })
+
+  it('keeps the pins when the same gateway re-applies its scope (reconnect)', async () => {
+    const { $pinnedSessionIds, applyPinnedSessionScope, pinSession } = await freshLayout()
+
+    applyPinnedSessionScope(remoteConnection('https://gw'))
+    pinSession('p1')
+
+    // A reconnect re-publishes the same connection: scope unchanged, no wipe,
+    // no reseed over the user's in-memory set.
+    applyPinnedSessionScope(remoteConnection('https://gw'))
+    expect($pinnedSessionIds.get()).toEqual(['p1'])
+    expect(localStorage.getItem('hermes.desktop.pinnedSessions.remote.https%3A%2F%2Fgw.default')).toBe(
+      JSON.stringify(['p1'])
+    )
+  })
+
+  it('is a no-op for a null connection (transient request failure)', async () => {
+    const { $pinnedSessionIds, applyPinnedSessionScope, pinSession } = await freshLayout()
+
+    applyPinnedSessionScope(remoteConnection('https://gw'))
+    pinSession('p1')
+
+    applyPinnedSessionScope(null)
+    expect($pinnedSessionIds.get()).toEqual(['p1'])
+  })
+
+  it('distinguishes local from remote instead of sharing one key', async () => {
+    const { $pinnedSessionIds, applyPinnedSessionScope, pinSession } = await freshLayout()
+
+    applyPinnedSessionScope(localConnection())
+    pinSession('local-pin')
+
+    applyPinnedSessionScope(remoteConnection('https://vps'))
+    expect($pinnedSessionIds.get()).toEqual([])
+  })
+
+  it('restores a window booting fresh against its own stored scope', async () => {
+    localStorage.setItem(
+      'hermes.desktop.pinnedSessions.remote.https%3A%2F%2Fgw-a.default',
+      JSON.stringify(['x', 'y'])
+    )
+    localStorage.setItem(
+      'hermes.desktop.pinnedSessions.remote.https%3A%2F%2Fgw-b.default',
+      JSON.stringify(['z'])
+    )
+
+    // Fresh window on gateway A → only A's pins.
+    const first = await freshLayout()
+    first.applyPinnedSessionScope(remoteConnection('https://gw-a'))
+    expect(first.$pinnedSessionIds.get()).toEqual(['x', 'y'])
+
+    // Fresh window on gateway B → only B's pins.
+    const second = await freshLayout()
+    second.applyPinnedSessionScope(remoteConnection('https://gw-b'))
+    expect(second.$pinnedSessionIds.get()).toEqual(['z'])
+  })
+})
+
+describe('pre-scope migration', () => {
+  it('lets the first window claim the legacy pin set, then isolates every other gateway', async () => {
+    localStorage.setItem(LEGACY_KEY, JSON.stringify(['legacy-1', 'legacy-2']))
+
+    const { $pinnedSessionIds, applyPinnedSessionScope, pinSession } = await freshLayout()
+
+    // First window (gateway A) claims the pre-scope pins.
+    applyPinnedSessionScope(remoteConnection('https://gw-a'))
+    expect($pinnedSessionIds.get()).toEqual(['legacy-1', 'legacy-2'])
+    expect(localStorage.getItem('hermes.desktop.pinnedSessions.remote.https%3A%2F%2Fgw-a.default')).toBe(
+      JSON.stringify(['legacy-1', 'legacy-2'])
+    )
+    expect(localStorage.getItem(MIGRATED_KEY)).toBe('true')
+
+    // A second gateway must NOT inherit the legacy set.
+    applyPinnedSessionScope(remoteConnection('https://gw-b'))
+    expect($pinnedSessionIds.get()).toEqual([])
+
+    // Pins made after migration stay in their own scope.
+    pinSession('fresh')
+    expect(localStorage.getItem('hermes.desktop.pinnedSessions.remote.https%3A%2F%2Fgw-b.default')).toBe(
+      JSON.stringify(['fresh'])
+    )
+    expect(localStorage.getItem('hermes.desktop.pinnedSessions.remote.https%3A%2F%2Fgw-a.default')).toBe(
+      JSON.stringify(['legacy-1', 'legacy-2'])
+    )
+  })
+
+  it('does not claim the legacy set once the migration marker exists', async () => {
+    localStorage.setItem(LEGACY_KEY, JSON.stringify(['legacy-1']))
+    localStorage.setItem(MIGRATED_KEY, 'true')
+
+    const { $pinnedSessionIds, applyPinnedSessionScope } = await freshLayout()
+
+    applyPinnedSessionScope(remoteConnection('https://gw'))
+    expect($pinnedSessionIds.get()).toEqual([])
+  })
+
+  it('migrates a local-first install into the local scope key', async () => {
+    localStorage.setItem(LEGACY_KEY, JSON.stringify(['legacy-1']))
+
+    const { $pinnedSessionIds, applyPinnedSessionScope } = await freshLayout()
+
+    applyPinnedSessionScope(localConnection())
+    expect($pinnedSessionIds.get()).toEqual(['legacy-1'])
+    expect(localStorage.getItem('hermes.desktop.pinnedSessions.local')).toBe(JSON.stringify(['legacy-1']))
+    // A later remote window on the same machine starts empty, not with local pins.
+    applyPinnedSessionScope(remoteConnection('https://vps'))
+    expect($pinnedSessionIds.get()).toEqual([])
+  })
+})

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -3,9 +3,10 @@ import { atom, computed, type ReadableAtom, type WritableAtom } from 'nanostores
 import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '@/app/layout-constants'
 import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
 import { isPaneVisible, revealTreePane } from '@/components/pane-shell/tree/store'
+import type { HermesConnection } from '@/global'
 import { matchesQuery } from '@/hooks/use-media-query'
 import { Codecs, persistentAtom } from '@/lib/persisted'
-import { arraysEqual, insertUniqueId, readKey } from '@/lib/storage'
+import { arraysEqual, insertUniqueId, persistBoolean, readKey, writeKey } from '@/lib/storage'
 
 import { $paneStates, ensurePaneRegistered, setPaneOpen, setPaneWidthOverride, togglePane } from './panes'
 
@@ -21,6 +22,10 @@ export const FILE_BROWSER_MAX_WIDTH = '20rem'
 export const SIDEBAR_SESSIONS_PAGE_SIZE = 50
 
 const SIDEBAR_PINNED_STORAGE_KEY = 'hermes.desktop.pinnedSessions'
+// Set once (in localStorage) when the first window claims the pre-scope pin
+// set — see applyPinnedSessionScope. Guards the one-time migration so no
+// second gateway can ever inherit another gateway's pins.
+const PINNED_SCOPE_MIGRATED_KEY = 'hermes.desktop.pinnedSessions.scope-migrated'
 const SIDEBAR_AGENTS_GROUPED_STORAGE_KEY = 'hermes.desktop.agentsGroupedByWorkspace'
 const SIDEBAR_CRON_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarCronOpen'
 const SIDEBAR_MESSAGING_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarMessagingOpen'
@@ -74,7 +79,100 @@ export const $sidebarWidth: ReadableAtom<number> = computed($paneStates, states 
   return typeof override === 'number' ? override : SIDEBAR_DEFAULT_WIDTH
 })
 
-export const $pinnedSessionIds = persistentAtom(SIDEBAR_PINNED_STORAGE_KEY, [] as string[], Codecs.stringArray)
+// ── Connection-scoped pinned set (#77318) ──────────────────────────────────
+// Every BrowserWindow in one app shares the SAME localStorage partition, so a
+// persistentAtom here used to be process-global state: two windows connected
+// to DIFFERENT gateways (local + remote VPS) read and wrote one key — each
+// window's sidebar rendered the other gateway's pins, and each window's
+// pin-sync pull adopted/dropped pins on behalf of the other gateway (#77318).
+// The store is now an in-memory atom whose persistence key is bound to the
+// live connection identity (gateway endpoint + profile, see
+// applyPinnedSessionScope). Windows on different gateways keep fully isolated
+// pin sets; windows on the SAME gateway legitimately share a key, because
+// their pins reconcile against the same backend.
+export const $pinnedSessionIds = atom<string[]>([])
+
+/** Stable scope id for a connection: 'local', or remote.<baseUrl>.<profile>. */
+export function connectionScopeId(connection: HermesConnection | null): string {
+  if (!connection || connection.mode !== 'remote') {
+    return 'local'
+  }
+
+  const base = encodeURIComponent(connection.baseUrl || 'remote')
+  const profile = encodeURIComponent(connection.profile || 'default')
+
+  return `remote.${base}.${profile}`
+}
+
+function pinnedStorageKeyForScope(scope: string): string {
+  return `${SIDEBAR_PINNED_STORAGE_KEY}.${scope}`
+}
+
+let activePinnedScope: string | null = null
+let pinPersistenceBound = false
+
+// Persist the atom to the ACTIVE scope's key. Bound lazily inside
+// applyPinnedSessionScope: a module-load-time bind would fire immediately with
+// the empty seed and clobber the stored pins before the scope is known.
+function bindPinPersistence(): void {
+  if (pinPersistenceBound) {
+    return
+  }
+
+  pinPersistenceBound = true
+  $pinnedSessionIds.subscribe(ids => {
+    if (activePinnedScope !== null) {
+      writeKey(activePinnedScope, Codecs.stringArray.encode([...ids]))
+    }
+  })
+}
+
+/**
+ * Point the sidebar's pinned set at `connection`'s gateway scope, seeding it
+ * from that scope's localStorage key. Wired to `$connection` in
+ * watchSessionPins(), so it runs in every window on boot and on every
+ * connection change (soft gateway-mode apply, reconnect). No-op while the
+ * connection identity is unchanged — a reconnect to the same gateway must
+ * never touch the pins; a null connection keeps the current scope so a
+ * transient request failure can't wipe a window's pin set.
+ *
+ * One-time upgrade: the FIRST scope applied after this fix claims the
+ * pre-scope (unscoped) pin set, which belonged to whichever gateway that
+ * window was connected to. Every later scope starts empty, so a window can
+ * never inherit another gateway's pins again.
+ */
+export function applyPinnedSessionScope(connection: HermesConnection | null): void {
+  if (!connection) {
+    return
+  }
+
+  const scope = pinnedStorageKeyForScope(connectionScopeId(connection))
+
+  if (scope === activePinnedScope) {
+    return
+  }
+
+  activePinnedScope = scope
+
+  let raw = readKey(scope)
+
+  if (readKey(PINNED_SCOPE_MIGRATED_KEY) === null) {
+    if (raw === null) {
+      const legacy = readKey(SIDEBAR_PINNED_STORAGE_KEY)
+
+      if (legacy !== null) {
+        writeKey(scope, legacy)
+        raw = legacy
+      }
+    }
+
+    persistBoolean(PINNED_SCOPE_MIGRATED_KEY, true)
+  }
+
+  $pinnedSessionIds.set(raw !== null ? Codecs.stringArray.decode(raw) : [])
+  bindPinPersistence()
+}
+
 export const $sidebarSessionOrderIds = persistentAtom(
   SIDEBAR_SESSION_ORDER_STORAGE_KEY,
   [] as string[],

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -21,8 +21,8 @@
  */
 
 import { setSessionPinnedRemote } from '@/hermes'
-import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
-import { $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session'
+import { $pinnedSessionIds, applyPinnedSessionScope, pinSession, unpinSession } from '@/store/layout'
+import { $connection, $sessions, sessionMatchesStoredId, sessionPinId } from '@/store/session'
 
 // pin ids we've successfully PATCHed pinned=true this session.
 const mirrored = new Set<string>()
@@ -156,6 +156,14 @@ function reconcile(): void {
 
 // Sync once, then re-sync on pin-set and session-list changes. Call once per app.
 export function watchSessionPins(): void {
+  // Scope the sidebar pin store to THIS window's gateway identity. Every
+  // window shares one localStorage partition, so without a per-connection
+  // scope two windows on different gateways would read/write the same pin set
+  // and cross-reconcile each other's pins (#77318). The subscription fires
+  // immediately with the current connection (boot) and again on every
+  // connection change (soft gateway-mode apply, reconnect); it is a no-op
+  // while the connection identity is unchanged.
+  $connection.subscribe(applyPinnedSessionScope)
   reconcile()
   $pinnedSessionIds.listen(reconcile)
   $sessions.listen(reconcile)


### PR DESCRIPTION
## Summary

Fixes session/pin state bleeding between Desktop windows connected to **different gateways**. After the app update, a window on the LOCAL gateway and a second window on a REMOTE gateway (VPS) showed overlapping/mixed PINNED and SESSIONS sidebar lists, and each window's pin-sync could adopt or drop pins belonging to the other gateway.

Each window's sidebar pin set is now scoped by **connection identity** (gateway endpoint + profile), so one window's reconcile can never mutate another window's view.

## Root Cause

All `BrowserWindow`s in one app share the **same localStorage partition**, but the sidebar's pinned set was a process-global `persistentAtom` backed by a single key (`hermes.desktop.pinnedSessions`):

- Window A (local gateway) and Window B (remote gateway) both read/wrote that **one key**, so each window rendered the other's pins (the observed overlapping/subset PINNED lists).
- Each window's `pullRemotePins()` (in `store/session-pin-sync.ts`) reconciles against its own gateway's session rows but consulted the shared local set — so window B's pull adopted/dropped pins belonging to window A's gateway and vice-versa.
- The pin-sync module state (`mirrored`/`pending`/`unconfirmed`) is per-renderer-process (each window has its own), so the leak was specifically the shared localStorage pin store, not the sync sets.

## Change

**`apps/desktop/src/store/layout.ts`**
- `$pinnedSessionIds` is now an in-memory `atom` instead of a `persistentAtom`; persistence is bound to the **active connection scope's** localStorage key (`hermes.desktop.pinnedSessions.<scope>`).
- New `connectionScopeId(connection)` derives a stable scope id from the connection identity: `local` for local-mode connections, `remote.<baseUrl>.<profile>` for remote ones (mirrors the existing `workspaceCwdKey` precedent in `store/session.ts`, including profile so two profiles on one remote gateway stay apart).
- New `applyPinnedSessionScope(connection)` seeds the store from the current scope's key and re-binds persistence. It is a **no-op while the connection identity is unchanged**, so a reconnect never touches the pins, and a `null` connection keeps the current scope so a transient request failure can't wipe a window's pin set.
- **One-time migration**: the first scope applied after this fix claims the pre-scope (unscoped) pin set (guarded by a persisted `scope-migrated` marker), so upgrading single-window installs keep their pins; every later scope starts empty and can never inherit another gateway's pins.

**`apps/desktop/src/store/session-pin-sync.ts`**
- `watchSessionPins()` now subscribes to `$connection` and applies the scope on boot and on every connection change (soft gateway-mode apply, reconnect). This runs per window, so each window reconciles pins against **its own** gateway's rows and **its own** scoped store.

Windows on the **same** gateway still legitimately share a scope key — their pins reconcile against the same backend, preserving the cross-app pin-sync behavior (PR #72948's contract).

## Verification

- New unit tests (`apps/desktop/src/store/layout-pin-scope.test.ts`, 13 tests): scope id derivation; seeding from the scope key; pin-set isolation between two gateways (and between local vs remote); no-op on same-scope reconnect; no-op on null connection; fresh-window restore of its own stored scope; one-time legacy migration (claim once, then isolate; marker-gated; local-first install).
- Existing suites still pass: `session-pin-sync.test.ts` (14), `updates.test.ts` (30), `gateway-switch.test.ts` (1), plus the full `src/store`, `src/app/chat/sidebar`, and `src/app/command-center` sweep — **724/724 tests green**.
- `tsc --noEmit` (renderer) and `eslint` clean on all touched files.

## Notes

- The gateway-identity-in-titlebar idea from the issue (bonus) is intentionally left out to keep this PR minimal.
- One-time migration edge: if the window on the *remote* gateway happens to boot first after the upgrade, it claims the pre-scope pin set; the local window then starts empty. The pre-fix set was already mixed between gateways, so this one-time assignment is self-consistent and never re-mixes going forward.

Closes #77318
