### PR TITLE
fix(gateway): give each queue-mode text follow-up its own turn

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5287,6 +5287,30 @@ class BasePlatformAdapter(ABC):
         state = store.pop(session_key, None)
         if state is None:
             return False
+        # Hand the flushed burst to the runner's FIFO so each follow-up gets
+        # its OWN turn in arrival order. The historical
+        # call below newline-merged it into the single pending slot with no
+        # time bound, so everything sent during a long turn arrived as one
+        # mashed-together turn -- the #43066 sub-bug, fixed for interrupt /
+        # steer-fallback / /queue but never for this path.
+        #
+        # The runner is reachable through the bound busy-session handler it
+        # already installed on this adapter, so no extra wiring is required.
+        # Photo/album merge semantics are preserved inside
+        # _queue_or_replace_pending_event itself.
+        _busy_handler = getattr(self, "_busy_session_handler", None)
+        _runner = getattr(_busy_handler, "__self__", None)
+        _enqueue = getattr(_runner, "_queue_or_replace_pending_event", None)
+        if callable(_enqueue):
+            try:
+                _enqueue(session_key, state.event)
+                return True
+            except Exception:
+                logger.warning(
+                    "[%s] FIFO enqueue of debounced burst failed for %s; "
+                    "falling back to pending-slot merge",
+                    self.name, session_key, exc_info=True,
+                )
         merge_pending_message_event(
             self._pending_messages,
             session_key,


### PR DESCRIPTION
## Problem

In `busy_input_mode: queue`, text messages sent while an agent turn is running are newline-merged into a **single** pending event and answered as one turn. Message boundaries are destroyed, so the model receives an unlabelled blob and pairs answers to the wrong questions.

This only bites after the first few seconds of a run, which is why it can look like queue mode already works.

## Root cause

There are two busy paths, and they disagree.

**Runner fast path** — `GatewayRunner._handle_message` correctly FIFO-queues text, but only inside a grace window:

```python
_telegram_followup_grace = float(
    os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")
)
...
if self._busy_input_mode == "queue":
    self._enqueue_fifo(_quick_key, event, adapter)
```

**Adapter path** — anything arriving *after* that ~3s window reaches `_handle_active_session_busy_message`, which declines queue-mode text outright:

```python
if (
    event.message_type == MessageType.TEXT
    and busy_text_mode == "queue"
    and effective_mode != "steer"
):
    return False
```

It then falls through to the adapter debounce, whose flush merges into the single pending slot:

```python
# _flush_text_debounce_now
merge_pending_message_event(
    self._pending_messages, session_key, state.event, merge_text=True,
)
```

```python
# merge_pending_message_event
existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
```

That merge has **no time bound**. Everything sent across a long turn accumulates into one event, and the drain pops one event and runs it as a single turn.

Since agent turns routinely run far longer than 3 seconds, the FIFO path covers the opening moments and the merging path covers the rest.

This is the same defect the codebase already names. The comment above `_queue_or_replace_pending_event` describes the raw merge as destroying message boundaries "so two separate user messages sent while the agent was busy ... arrived as one mashed-together turn", and routes through `_enqueue_fifo` to fix it. That fix reached interrupt mode, steer-fallback and `/queue`. The queue-mode text path returns `False` before it can get there.

Every other branch around that early return carries a rationale comment. That one does not.

## Fix

Route the flushed debounce burst through `_queue_or_replace_pending_event`, the FIFO entry point the other modes already use, instead of merging it into the pending slot.

The runner is reached through the bound `_busy_session_handler` it already installs on the adapter, so **no wiring changes are needed in `run.py`** and this stays a single-file, 24-line change.

Deliberately preserved:

- **Sub-second merging inside the debounce window** (0.35s rolling / 1.0s hard cap). A single thought split across two quick taps should stay one turn. Only the unbounded post-flush merge changes.
- **Photo / album semantics** — `_queue_or_replace_pending_event` keeps the head-slot media merge internally.
- **Fallback** — if no runner is attached (standalone adapter use, tests), the original merge still runs, wrapped so an enqueue failure degrades to today's behavior rather than dropping the burst.

## Testing

Running in production on a Telegram deployment since 2026-08-02 on v0.19.0, with a test written **failing-first** against unpatched code to confirm it reproduces the merge:

```
BASELINE (unpatched):  7 failures   <- merge reproduced
AFTER PATCH:           0 failures
```

Also exercised through the real `handle_message` entry point with real `MessageEvent` / `SessionSource` / `GatewayRunner` objects, firing 10 back-to-back messages at a busy session: every queued turn came back as one message, in arrival order, nothing lost.

Verified present at `7eefb09` before opening this.

## Relation to other open PRs

- **#59562** fixes the *photo* follow-up path in the runner fast path. This fixes the *text* path at the adapter debounce. Different branches, no overlap in the diff.
- **#60488** centralizes the interrupt-vs-queue decision. Complementary: this changes what happens once a burst is already destined for the queue.

Happy to rebase or fold this in if maintainers would rather land it alongside either.
