### PR TITLE
fix(gateway): give each queue-mode text follow-up its own turn

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5300,11 +5300,18 @@ class BasePlatformAdapter(ABC):
         # _queue_or_replace_pending_event itself.
         _busy_handler = getattr(self, "_busy_session_handler", None)
         _runner = getattr(_busy_handler, "__self__", None)
+        #
+        # _queue_or_replace_pending_event returns early WITHOUT queueing
+        # when it cannot resolve an adapter for the event source, so only
+        # delegate once we know it resolves back to THIS adapter. Otherwise
+        # keep the historical merge: merging is lossy, but dropping is worse.
         _enqueue = getattr(_runner, "_queue_or_replace_pending_event", None)
-        if callable(_enqueue):
+        _resolve = getattr(_runner, "_adapter_for_source", None)
+        if callable(_enqueue) and callable(_resolve):
             try:
-                _enqueue(session_key, state.event)
-                return True
+                if _resolve(getattr(state.event, "source", None)) is self:
+                    _enqueue(session_key, state.event)
+                    return True
             except Exception:
                 logger.warning(
                     "[%s] FIFO enqueue of debounced burst failed for %s; "

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5298,20 +5298,38 @@ class BasePlatformAdapter(ABC):
         # already installed on this adapter, so no extra wiring is required.
         # Photo/album merge semantics are preserved inside
         # _queue_or_replace_pending_event itself.
+        #
+        # ``_queue_or_replace_pending_event`` can DECLINE silently: it returns
+        # without queueing and without raising when the source resolves to no
+        # adapter, or when the per-session pending cap is reached. Treating the
+        # call as success there would DROP the burst, where the historical
+        # merge would still have delivered it (mashed, but delivered) -- and
+        # the cap was effectively unreachable before, since the old merge
+        # collapsed every follow-up into one slot instead of one entry each.
+        # So confirm the queue actually grew, and fall back to the merge when
+        # it did not. Merging is lossy; dropping is worse.
         _busy_handler = getattr(self, "_busy_session_handler", None)
         _runner = getattr(_busy_handler, "__self__", None)
-        #
-        # _queue_or_replace_pending_event returns early WITHOUT queueing
-        # when it cannot resolve an adapter for the event source, so only
-        # delegate once we know it resolves back to THIS adapter. Otherwise
-        # keep the historical merge: merging is lossy, but dropping is worse.
         _enqueue = getattr(_runner, "_queue_or_replace_pending_event", None)
         _resolve = getattr(_runner, "_adapter_for_source", None)
-        if callable(_enqueue) and callable(_resolve):
+        _depth = getattr(_runner, "_queue_depth", None)
+        _target = None
+        if callable(_resolve):
             try:
-                if _resolve(getattr(state.event, "source", None)) is self:
-                    _enqueue(session_key, state.event)
+                _target = _resolve(getattr(state.event, "source", None))
+            except Exception:
+                _target = None
+        if callable(_enqueue) and callable(_depth) and _target is not None:
+            try:
+                _before = _depth(session_key, adapter=_target)
+                _enqueue(session_key, state.event)
+                if _depth(session_key, adapter=_target) > _before:
                     return True
+                logger.warning(
+                    "[%s] FIFO declined the debounced burst for %s "
+                    "(pending cap reached?); falling back to pending-slot merge",
+                    self.name, session_key,
+                )
             except Exception:
                 logger.warning(
                     "[%s] FIFO enqueue of debounced burst failed for %s; "

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5313,13 +5313,28 @@ class BasePlatformAdapter(ABC):
         _enqueue = getattr(_runner, "_queue_or_replace_pending_event", None)
         _resolve = getattr(_runner, "_adapter_for_source", None)
         _depth = getattr(_runner, "_queue_depth", None)
+        # A media occupant needs the caption-merge semantics that
+        # ``_queue_or_replace_pending_event`` applies internally, and that
+        # merge succeeds WITHOUT growing the queue -- which the depth check
+        # below would misread as a decline and merge a second time. Keep the
+        # historical path for that case; it is what the FIFO would do anyway.
+        _slot = self._pending_messages.get(session_key)
+        _slot_is_media = _slot is not None and (
+            getattr(_slot, "message_type", None) == MessageType.PHOTO
+            or bool(getattr(_slot, "media_urls", None))
+        )
         _target = None
-        if callable(_resolve):
+        if callable(_resolve) and not _slot_is_media:
             try:
                 _target = _resolve(getattr(state.event, "source", None))
             except Exception:
                 _target = None
-        if callable(_enqueue) and callable(_depth) and _target is not None:
+        # Delegate only when the runner routes this source back to THIS
+        # adapter: another adapter owns a different pending slot, and the
+        # drain that delivers this burst runs on ours. Declining to delegate
+        # costs the fix on exotic topologies; delegating blindly would risk
+        # the burst landing where nothing drains it.
+        if callable(_enqueue) and callable(_depth) and _target is self:
             try:
                 _before = _depth(session_key, adapter=_target)
                 _enqueue(session_key, state.event)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5287,6 +5287,30 @@ class BasePlatformAdapter(ABC):
         state = store.pop(session_key, None)
         if state is None:
             return False
+        # Hand the flushed burst to the runner's FIFO so each follow-up gets
+        # its OWN turn in arrival order. The historical
+        # call below newline-merged it into the single pending slot with no
+        # time bound, so everything sent during a long turn arrived as one
+        # mashed-together turn -- the #43066 sub-bug, fixed for interrupt /
+        # steer-fallback / /queue but never for this path.
+        #
+        # The runner is reachable through the bound busy-session handler it
+        # already installed on this adapter, so no extra wiring is required.
+        # Photo/album merge semantics are preserved inside
+        # _queue_or_replace_pending_event itself.
+        _busy_handler = getattr(self, "_busy_session_handler", None)
+        _runner = getattr(_busy_handler, "__self__", None)
+        _enqueue = getattr(_runner, "_queue_or_replace_pending_event", None)
+        if callable(_enqueue):
+            try:
+                _enqueue(session_key, state.event)
+                return True
+            except Exception:
+                logger.warning(
+                    "[%s] FIFO enqueue of debounced burst failed for %s; "
+                    "falling back to pending-slot merge",
+                    self.name, session_key, exc_info=True,
+                )
         merge_pending_message_event(
             self._pending_messages,
             session_key,

--- a/tests/gateway/test_debounce_flush_fifo.py
+++ b/tests/gateway/test_debounce_flush_fifo.py
@@ -1,0 +1,200 @@
+"""Regression tests for the queue-mode debounce flush.
+
+``busy_input_mode: queue`` routes active-session TEXT follow-ups through a
+short debounce so a multi-tap thought stays one turn. The flush then handed
+the burst to ``merge_pending_message_event(merge_text=True)``, which
+newline-joins onto whatever already occupies the single pending slot. That
+merge has no time bound, so every follow-up sent during a long turn collapsed
+into one turn and the agent lost the message boundaries it needs to answer
+each question separately.
+
+The flush now hands the burst to the runner's FIFO instead, which is the same
+entry point interrupt mode, steer-fallback and ``/queue`` already use.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Minimal telegram stub so importing gateway.platforms.base does not pull
+# in the real python-telegram-bot dependency.
+_tg = sys.modules.get("telegram") or types.ModuleType("telegram")
+_tg.constants = sys.modules.get("telegram.constants") or types.ModuleType("telegram.constants")
+_ct = MagicMock()
+_ct.PRIVATE = "private"
+_ct.GROUP = "group"
+_ct.SUPERGROUP = "supergroup"
+_tg.constants.ChatType = _ct
+sys.modules.setdefault("telegram", _tg)
+sys.modules.setdefault("telegram.constants", _tg.constants)
+sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+from gateway.session import SessionSource, build_session_key
+
+
+def _make_event(text: str) -> MessageEvent:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="u1",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id=f"msg-{text[:8]}",
+    )
+
+
+class _DummyAdapter(BasePlatformAdapter):  # type: ignore[misc]
+    async def connect(self, *, is_reconnect: bool = False):
+        pass
+
+    async def disconnect(self):
+        pass
+
+    async def get_chat_info(self, chat_id):
+        return None
+
+    async def send(self, *args, **kwargs):
+        return SendResult(success=True, message_id="x")
+
+
+def _make_adapter() -> BasePlatformAdapter:
+    """Build a BasePlatformAdapter without running its heavy __init__."""
+    adapter = object.__new__(_DummyAdapter)
+    adapter.config = PlatformConfig(enabled=True, token="***")
+    adapter.platform = Platform.TELEGRAM
+    adapter._message_handler = AsyncMock(return_value=None)
+    adapter._busy_session_handler = None
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._session_tasks = {}
+    adapter._background_tasks = set()
+    adapter._post_delivery_callbacks = {}
+    adapter._expected_cancelled_tasks = set()
+    adapter._fatal_error_code = None
+    adapter._fatal_error_message = None
+    adapter._fatal_error_retryable = True
+    adapter._fatal_error_handler = None
+    adapter._running = True
+    adapter._busy_text_mode = "queue"
+    adapter._busy_text_debounce_seconds = 0.1
+    adapter._busy_text_hard_cap_seconds = 1.0
+    adapter._text_debounce = {}
+    adapter._auto_tts_default = False
+    adapter._auto_tts_enabled_chats = set()
+    adapter._auto_tts_disabled_chats = set()
+    adapter._typing_paused = set()
+    return adapter
+
+
+class _FifoRunner:
+    """Stand-in for the gateway runner's FIFO entry point.
+
+    The real runner installs its bound ``_handle_active_session_busy_message``
+    on the adapter; the flush reaches ``_queue_or_replace_pending_event``
+    through that binding, so no extra wiring is needed.
+    """
+
+    def __init__(self, adapter: BasePlatformAdapter) -> None:
+        self._adapter = adapter
+        self.queued: list[MessageEvent] = []
+
+    async def busy_handler(self, event, session_key):
+        return False
+
+    def _queue_or_replace_pending_event(self, session_key, event):
+        slot = self._adapter._pending_messages
+        if session_key in slot:
+            self.queued.append(event)
+        else:
+            slot[session_key] = event
+
+
+async def _busy_adapter_with(runner_attached: bool):
+    adapter = _make_adapter()
+    runner = None
+    if runner_attached:
+        runner = _FifoRunner(adapter)
+        adapter._busy_session_handler = runner.busy_handler
+    session_key = build_session_key(_make_event("probe").source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    return adapter, runner, session_key
+
+
+@pytest.mark.asyncio
+async def test_successive_bursts_each_get_their_own_turn():
+    """Two bursts must arrive as two turns, not one newline-joined turn."""
+    adapter, runner, session_key = await _busy_adapter_with(True)
+
+    await adapter.handle_message(_make_event("one"))
+    await adapter._flush_text_debounce_now(session_key)
+    await adapter.handle_message(_make_event("two"))
+    await adapter._flush_text_debounce_now(session_key)
+
+    assert adapter._pending_messages[session_key].text == "one"
+    assert [e.text for e in runner.queued] == ["two"]
+
+
+@pytest.mark.asyncio
+async def test_third_burst_appends_in_arrival_order():
+    """Order must hold across more than two follow-ups."""
+    adapter, runner, session_key = await _busy_adapter_with(True)
+
+    for text in ("one", "two", "three"):
+        await adapter.handle_message(_make_event(text))
+        await adapter._flush_text_debounce_now(session_key)
+
+    assert adapter._pending_messages[session_key].text == "one"
+    assert [e.text for e in runner.queued] == ["two", "three"]
+    assert "\n" not in adapter._pending_messages[session_key].text
+
+
+@pytest.mark.asyncio
+async def test_merge_preserved_when_no_runner_attached():
+    """No runner means no FIFO to enqueue into, so the merge must still apply.
+
+    This keeps the no-message-loss guarantee for adapters used standalone
+    (TUI, tests) where no gateway runner is installed.
+    """
+    adapter, _runner, session_key = await _busy_adapter_with(False)
+    assert adapter._busy_session_handler is None
+
+    await adapter.handle_message(_make_event("one"))
+    await adapter._flush_text_debounce_now(session_key)
+    await adapter.handle_message(_make_event("two"))
+    await adapter._flush_text_debounce_now(session_key)
+
+    assert adapter._pending_messages[session_key].text == "one\ntwo"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_failure_falls_back_to_merge():
+    """A raising FIFO must not lose the burst."""
+    adapter, runner, session_key = await _busy_adapter_with(True)
+
+    def _boom(session_key, event):
+        raise RuntimeError("fifo unavailable")
+
+    runner._queue_or_replace_pending_event = _boom
+
+    await adapter.handle_message(_make_event("one"))
+    await adapter._flush_text_debounce_now(session_key)
+    await adapter.handle_message(_make_event("two"))
+    await adapter._flush_text_debounce_now(session_key)
+
+    assert adapter._pending_messages[session_key].text == "one\ntwo"

--- a/tests/gateway/test_debounce_flush_fifo.py
+++ b/tests/gateway/test_debounce_flush_fifo.py
@@ -223,3 +223,25 @@ async def test_merge_preserved_when_adapter_unresolvable():
 
     assert not runner.queued
     assert adapter._pending_messages[session_key].text == "one\ntwo"
+
+
+@pytest.mark.asyncio
+async def test_merge_preserved_when_fifo_declines_silently():
+    """A silent FIFO decline must fall back to the merge, not vanish.
+
+    _queue_or_replace_pending_event returns WITHOUT queueing and WITHOUT
+    raising once _BUSY_QUEUE_MAX_PENDING is reached. Treating that as
+    success would drop the burst. The cap was also effectively unreachable
+    before this change, since the old merge collapsed every follow-up into
+    one slot instead of one entry each.
+    """
+    adapter, runner, session_key = await _busy_adapter_with(True)
+    runner._queue_or_replace_pending_event = lambda session_key, event: None
+
+    await adapter.handle_message(_make_event("one"))
+    await adapter._flush_text_debounce_now(session_key)
+    await adapter.handle_message(_make_event("two"))
+    await adapter._flush_text_debounce_now(session_key)
+
+    assert not runner.queued
+    assert adapter._pending_messages[session_key].text == "one\ntwo"

--- a/tests/gateway/test_debounce_flush_fifo.py
+++ b/tests/gateway/test_debounce_flush_fifo.py
@@ -120,6 +120,14 @@ class _FifoRunner:
     def _adapter_for_source(self, source):
         return self._adapter
 
+    def _queue_depth(self, session_key, *, adapter=None):
+        # Mirrors GatewayRunner._queue_depth: overflow + the head slot.
+        depth = len(self.queued)
+        slot = getattr(adapter, '_pending_messages', None) if adapter is not None else None
+        if slot is not None and session_key in slot:
+            depth += 1
+        return depth
+
     def _queue_or_replace_pending_event(self, session_key, event):
         slot = self._adapter._pending_messages
         if session_key in slot:

--- a/tests/gateway/test_debounce_flush_fifo.py
+++ b/tests/gateway/test_debounce_flush_fifo.py
@@ -117,6 +117,9 @@ class _FifoRunner:
     async def busy_handler(self, event, session_key):
         return False
 
+    def _adapter_for_source(self, source):
+        return self._adapter
+
     def _queue_or_replace_pending_event(self, session_key, event):
         slot = self._adapter._pending_messages
         if session_key in slot:
@@ -197,4 +200,26 @@ async def test_enqueue_failure_falls_back_to_merge():
     await adapter.handle_message(_make_event("two"))
     await adapter._flush_text_debounce_now(session_key)
 
+    assert adapter._pending_messages[session_key].text == "one\ntwo"
+
+
+@pytest.mark.asyncio
+async def test_merge_preserved_when_adapter_unresolvable():
+    """An unresolvable source must fall back to the merge, not vanish.
+
+    _queue_or_replace_pending_event returns early WITHOUT queueing when
+    _adapter_for_source yields nothing. Delegating into that path
+    unconditionally would drop the burst where the previous merge kept it,
+    so the flush only delegates once the runner resolves the source back to
+    this adapter.
+    """
+    adapter, runner, session_key = await _busy_adapter_with(True)
+    runner._adapter_for_source = lambda source: None
+
+    await adapter.handle_message(_make_event("one"))
+    await adapter._flush_text_debounce_now(session_key)
+    await adapter.handle_message(_make_event("two"))
+    await adapter._flush_text_debounce_now(session_key)
+
+    assert not runner.queued
     assert adapter._pending_messages[session_key].text == "one\ntwo"


### PR DESCRIPTION
## What does this PR do?

With `display.busy_input_mode: queue`, every TEXT message sent while the agent is busy is newline-joined into a single pending event and answered as one turn. Message boundaries are destroyed, so the model receives an unlabelled blob and pairs answers to the wrong questions.

The path:

1. `run.py::_handle_active_session_busy_message` declines plain TEXT in queue mode and returns `False`:

```python
if (
    event.message_type == MessageType.TEXT
    and busy_text_mode == "queue"
    and effective_mode != "steer"
):
    return False
```

2. Control falls through to the adapter's debounce, and `_flush_text_debounce_now` pushes the burst into the **single** pending slot via `merge_pending_message_event(..., merge_text=True)`, which does:

```python
existing.text = f"{existing.text}\n{event.text}"
```

That merge has no time bound. It applies to a message arriving 30 seconds later exactly as to one arriving 0.3 seconds later, so an entire conversation's worth of follow-ups collapses into one turn. The drain then pops **one** event and runs it as a single turn.

This is already recognised in-tree. The comment at the FIFO site in `run.py` describes the raw merge as destroying message boundaries "so two separate user messages sent while the agent was busy... arrived as one mashed-together turn", and routes through `_enqueue_fifo` to fix it. That fix reached interrupt mode, steer-fallback and `/queue`. The queue-mode text path returns `False` before ever getting there.

**The fix:** hand the flushed burst to the runner's `_queue_or_replace_pending_event` — the same FIFO entry point those other paths use — so each follow-up gets its own turn in arrival order.

Merging **inside** the debounce window (0.35s rolling / 1.0s hard cap) is deliberately preserved. A single thought split across two quick taps should stay one turn; that is what the debounce is for.

The runner is reached through the bound `_busy_session_handler` it already installs on the adapter, so this needs no wiring changes in `run.py` and stays a single-file change. Adapters with no runner attached (TUI, standalone, tests) fall back to the previous merge, keeping #28503's no-message-loss guarantee intact.

## Related Issue

No exact issue exists, so I did not use `Fixes #`.

- **#28503** (closed) — "busy_input_mode: queue silently drops messages". Its fix introduced the FIFO and enabled `merge_text=True` on the debounce path to stop the data loss. This PR completes that work for the one path it did not reach: no messages were being lost after #28503, but their boundaries were.
- **#52991** (open) — "Rapid identical re-sends are stacked into the pending turn". Same code path, different symptom. **This PR does not fix it,** and I want to be explicit about that: identical re-sends inside the debounce window still merge. The two are compatible — a dedup for #52991 belongs in the debounce buffer merge, which this PR leaves in place.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py` — `_flush_text_debounce_now` now routes the flushed burst to the runner's FIFO, falling back to the existing merge when no runner is attached or the enqueue raises.
- `tests/gateway/test_debounce_flush_fifo.py` — new, 6 tests.

## How to Test

Reproduction:

1. Set `display.busy_input_mode: queue` in `config.yaml`.
2. Send a message that starts a long turn.
3. While it runs, send three more distinct questions, spaced a couple of seconds apart.
4. **Before:** one reply that mixes all three, often pairing answers to the wrong questions. **After:** three turns, each answering its own question in arrival order.

Automated:

```bash
pytest tests/gateway/test_debounce_flush_fifo.py -q          # 6 passed
pytest tests/gateway/test_active_session_text_merge.py -q    # 7 passed, unchanged
```

The two behavioural tests fail on `main` and pass with the fix:

```
# with gateway/platforms/base.py reverted
FAILED test_successive_bursts_each_get_their_own_turn
FAILED test_third_burst_appends_in_arrival_order
2 failed, 4 passed

# with the fix
6 passed
```

The other two tests pin the fallback (no runner attached, and a raising FIFO) and pass either way by design.

Wider regression check across the related gateway suites — `test_active_session_text_merge`, `test_queue_command`, `test_queue_consumption`, `test_pending_drain_no_recursion`, `test_pending_drain_race`, `test_pending_event_none`, `test_busy_session_ack`, `test_discord_pending_text_batch_shutdown`, `test_internal_event_never_interrupts_busy_session` — **39 passed**.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (Docker, live gateway, Telegram) and Windows 11 (unit tests)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no user-facing config or API change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A, no file I/O, process or terminal handling; pure in-memory dispatch
- [x] I've updated tool descriptions/schemas — N/A

## Notes for the reviewer

Two things worth a look:

**The 32-message cap now applies here.** Text follow-ups that previously merged now occupy FIFO slots, so `_BUSY_QUEUE_MAX_PENDING` (32) can be reached where it could not before. Far beyond any realistic conversation, but it drops with a `logger.warning` and nothing user-visible. Happy to add a user-facing notice if you'd like it in scope.

**The fallback is deliberate but worth confirming.** The FIFO lives on the runner, so an adapter with no runner has nothing to enqueue into. Falling back to the merge is the only option there that preserves #28503's guarantee. It does mean the existing tests in `test_active_session_text_merge.py` pass unchanged — they use `_make_adapter()`, which sets `_busy_session_handler = None`. That is why the new test file attaches a runner explicitly.

This was found and validated on a live deployment running v0.19.0 (2026.7.20) before being reproduced against `main`.


## Relation to other open PRs

- **#59562** fixes the *photo* follow-up path in the runner fast path. This fixes the *text* path at the adapter debounce. Different branches, no overlap in the diff.
- **#60488** centralizes the interrupt-vs-queue decision. Complementary: this changes what happens once a burst is already destined for the queue.

Happy to rebase or fold this in if maintainers would rather land it alongside either.

## Fallback hardening

`_queue_or_replace_pending_event` can decline **silently** — it returns without queueing and without raising when the source resolves to no adapter, or when `_BUSY_QUEUE_MAX_PENDING` (32) is reached. Treating the call as success would drop the burst, and the cap was effectively unreachable before this change since the old merge collapsed every follow-up into one slot rather than one entry each.

The flush therefore confirms the queue actually grew, and falls back to the historical merge when it did not. Two cases take the historical path directly:

- **A media occupant in the pending slot.** `_queue_or_replace_pending_event` caption-merges into it and does not grow the queue, which the depth check would misread as a decline and merge a second time.
- **A source that resolves to a different adapter.** That adapter owns a different pending slot, and the drain that delivers this burst runs on ours.

Merging is lossy; dropping is worse. Covered by `test_merge_preserved_when_fifo_declines_silently`, `test_merge_preserved_when_adapter_unresolvable`, `test_enqueue_failure_falls_back_to_merge` and `test_merge_preserved_when_no_runner_attached`.
