### PR TITLE
fix(install): validate Windows Python runtime capabilities

### DIFF
--- a/apps/desktop/electron/backend-probes.test.ts
+++ b/apps/desktop/electron/backend-probes.test.ts
@@ -49,8 +49,14 @@ test('canImportHermesCli returns false when binary does not exist', () => {
   assert.equal(canImportHermesCli(ghost), false)
 })
 
-test('hermes runtime import probe checks config dependencies', () => {
+test('hermes runtime import probe checks native modules and config dependencies', () => {
   const probe = hermesRuntimeImportProbe()
+  // Windows Application Control can allow python.exe --version while blocking
+  // native stdlib modules loaded from .pyd files. Exercise the capability the
+  // desktop backend needs instead of trusting the executable alone.
+  assert.match(probe, /\bimport select\b/)
+  assert.match(probe, /\bimport socket\b/)
+  assert.match(probe, /\bimport ssl\b/)
   assert.match(probe, /\bimport yaml\b/)
   // dotenv is the first third-party import on the CLI boot path
   // (hermes_cli/env_loader.py); a mid-update venv missing python-dotenv

--- a/apps/desktop/electron/backend-probes.ts
+++ b/apps/desktop/electron/backend-probes.ts
@@ -120,7 +120,7 @@ function execProbeSync(
  * @returns {string}
  */
 function hermesRuntimeImportProbe() {
-  return 'import yaml; import dotenv; import hermes_cli.config'
+  return 'import select; import socket; import ssl; import yaml; import dotenv; import hermes_cli.config'
 }
 
 /**
@@ -133,9 +133,12 @@ function hermesRuntimeImportProbe() {
  * site-packages -- and the resolver returns a backend that immediately
  * dies on spawn.
  *
- * The probe intentionally imports hermes_cli.config, not just the top-level
- * package: a broken/empty Windows launcher venv can still see the source tree
- * through PYTHONPATH but lack PyYAML, then die on the first real CLI import.
+ * The probe intentionally imports native standard-library networking modules
+ * before hermes_cli.config. Windows Application Control can allow python.exe
+ * itself while blocking select.pyd or _ssl.pyd, so a version/existence check
+ * is not enough. Importing hermes_cli.config (rather than only the top-level
+ * package) also catches a broken/empty launcher venv that can see the source
+ * tree through PYTHONPATH but lacks PyYAML.
  *
  * @param {string} pythonPath - Absolute path to a python.exe / python.
  * @param {object} [opts.env] - Additional environment for the probe.

--- a/scripts/ci/test_install_ps1_python_runtime_validation.ps1
+++ b/scripts/ci/test_install_ps1_python_runtime_validation.ps1
@@ -1,0 +1,153 @@
+# Behavioral test for install.ps1 Python runtime validation.
+#
+# Run on Windows PowerShell 5.1:
+#   powershell -NoProfile -ExecutionPolicy Bypass -File scripts/ci/test_install_ps1_python_runtime_validation.ps1
+#
+# This parses install.ps1 and executes the shipped runtime-resolution helpers.
+# The fake managed interpreter passes --version but fails native stdlib imports
+# with the Windows Application Control error. The fake system interpreter works.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$installPs1 = Join-Path (Join-Path $PSScriptRoot "..") "install.ps1" | Resolve-Path
+$parseErrors = $null
+$tokens = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $installPs1, [ref]$tokens, [ref]$parseErrors)
+if ($parseErrors.Count -gt 0) {
+    throw "install.ps1 has PowerShell parse errors: $($parseErrors -join '; ')"
+}
+
+foreach ($functionName in @(
+    "Test-HermesPythonRuntime",
+    "Find-UsablePythonForVersion",
+    "Resolve-AvailablePythonVersion"
+)) {
+    $fn = $ast.Find({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq $functionName
+    }, $true)
+    if (-not $fn) {
+        throw "$functionName not found in $installPs1"
+    }
+    Invoke-Expression $fn.Extent.Text
+}
+
+$script:Failures = 0
+$script:Warnings = @()
+
+function Write-Warn {
+    param([string]$Message)
+    $script:Warnings += $Message
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Name)
+    if ($Expected -ceq $Actual) {
+        Write-Host "  PASS  $Name"
+    } else {
+        Write-Host "  FAIL  $Name"
+        Write-Host "        expected: [$Expected]"
+        Write-Host "        actual:   [$Actual]"
+        $script:Failures++
+    }
+}
+
+function Assert-True {
+    param($Condition, [string]$Name)
+    Assert-Equal $true ([bool]$Condition) $Name
+}
+
+function Assert-Match {
+    param([string]$Pattern, [string]$Actual, [string]$Name)
+    Assert-True ($Actual -match $Pattern) $Name
+}
+
+$fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
+    "Hermes Runtime Validation " + [Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $fixtureRoot | Out-Null
+
+try {
+    $script:BadPython = Join-Path $fixtureRoot "blocked python.cmd"
+    $script:GoodPython = Join-Path $fixtureRoot "trusted python.cmd"
+
+    @'
+@echo off
+if "%~1"=="--version" (
+  echo Python 3.11.15
+  exit /b 0
+)
+if "%~1"=="-c" (
+  1>&2 echo ImportError: DLL load failed while importing select: An Application Control policy has blocked this file.
+  exit /b 1
+)
+exit /b 2
+'@ | Set-Content -LiteralPath $script:BadPython -Encoding ASCII
+
+    @'
+@echo off
+if "%~1"=="--version" (
+  echo Python 3.11.9
+  exit /b 0
+)
+if "%~1"=="-c" exit /b 0
+exit /b 2
+'@ | Set-Content -LiteralPath $script:GoodPython -Encoding ASCII
+
+    $script:UvCalls = @()
+    function Invoke-FakeUv {
+        param(
+            [Parameter(ValueFromRemainingArguments = $true)]
+            [string[]]$CommandArgs
+        )
+        $script:UvCalls += ($CommandArgs -join " ")
+        $global:LASTEXITCODE = 0
+        if ($CommandArgs -contains "--system" -and
+            $CommandArgs -contains "--no-managed-python") {
+            return $script:GoodPython
+        }
+        return $script:BadPython
+    }
+
+    $script:UvCmd = "Invoke-FakeUv"
+    $script:PythonVersion = "3.11"
+    $script:PythonFallbackVersions = @("3.12", "3.13", "3.10")
+
+    $version = & $script:BadPython --version
+    Assert-Equal 0 $LASTEXITCODE "blocked runtime still passes --version"
+    Assert-Match "Python 3\.11" ([string]$version) "blocked runtime reports its version"
+
+    $runtimeWorks = Test-HermesPythonRuntime -PythonPath $script:BadPython
+    Assert-Equal $false $runtimeWorks "native-module probe rejects blocked runtime"
+    Assert-Match "Application Control policy has blocked this file" `
+        $script:PythonRuntimeProbeOutput `
+        "underlying Application Control error is preserved"
+
+    $selected = Find-UsablePythonForVersion -Version "3.11"
+    Assert-Equal $script:GoodPython $selected "trusted system runtime is selected"
+    Assert-True ($selected -match " ") "selected exact interpreter path includes spaces"
+    Assert-Equal "python find 3.11" $script:UvCalls[0] "normal uv candidate is tried first"
+    Assert-Equal "python find --system --no-managed-python 3.11" $script:UvCalls[1] `
+        "system-only uv fallback excludes managed Python"
+    Assert-True (($script:Warnings -join "`n") -match [regex]::Escape($script:BadPython)) `
+        "rejected interpreter path is reported"
+
+    $script:UvCalls = @()
+    $resolvedVersion = Resolve-AvailablePythonVersion
+    Assert-Equal "3.11" $resolvedVersion "requested Python version remains preferred"
+    Assert-Equal $script:GoodPython $script:ResolvedPythonPath `
+        "resolver retains the exact validated interpreter path"
+} finally {
+    Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+if ($script:Failures -gt 0) {
+    Write-Host ""
+    Write-Host "$($script:Failures) assertion(s) failed"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "all assertions passed"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -711,10 +711,82 @@ function Resolve-UvCmd {
     throw "uv is not installed. Run install.ps1 -Stage uv first."
 }
 
+function Test-HermesPythonRuntime {
+    param([Parameter(Mandatory = $true)][string]$PythonPath)
+
+    # --version only proves that python.exe can start.  Windows Application
+    # Control can allow that executable while blocking native stdlib modules
+    # loaded later from .pyd files.  Probe the capabilities Hermes needs before
+    # uv creates a venv or installs dependencies from this interpreter.
+    $script:PythonRuntimeProbeOutput = $null
+    $probeOutput = @()
+    $probeExitCode = 1
+    $prevEAP = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $probeOutput = & $PythonPath -c "import select, socket, ssl" 2>&1
+        $probeExitCode = $LASTEXITCODE
+    } catch {
+        $probeOutput = @($_.Exception.Message)
+        $probeExitCode = 1
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+
+    $script:PythonRuntimeProbeOutput = ((@($probeOutput) | ForEach-Object {
+        ([string]$_).Trim()
+    } | Where-Object { $_ }) -join [Environment]::NewLine).Trim()
+    return ($probeExitCode -eq 0)
+}
+
+function Find-UsablePythonForVersion {
+    param([Parameter(Mandatory = $true)][string]$Version)
+
+    # uv normally prefers its managed interpreter.  On locked-down Windows
+    # machines that copy can be blocked while a Python.org installation is
+    # trusted.  Try uv's normal resolution first, then explicitly exclude
+    # managed/downloaded interpreters and ask for a system installation.
+    $queries = @(
+        @{ Label = "default"; Args = @("python", "find", $Version) },
+        @{ Label = "system"; Args = @("python", "find", "--system", "--no-managed-python", $Version) }
+    )
+    $seenPaths = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase
+    )
+
+    foreach ($query in $queries) {
+        try {
+            $findArgs = $query.Args
+            $findOutput = & $UvCmd @findArgs 2>$null
+            if (-not $findOutput) { continue }
+            $candidate = @($findOutput | ForEach-Object {
+                ([string]$_).Trim()
+            } | Where-Object { $_ } | Select-Object -Last 1)[0]
+            if (-not $candidate -or -not $seenPaths.Add($candidate)) { continue }
+
+            if (Test-HermesPythonRuntime -PythonPath $candidate) {
+                return $candidate
+            }
+
+            Write-Warn "Rejected Python $Version candidate ($($query.Label)): $candidate"
+            Write-Warn "Python started, but required native standard-library modules could not load."
+            if ($script:PythonRuntimeProbeOutput) {
+                Write-Host $script:PythonRuntimeProbeOutput -ForegroundColor DarkGray
+            }
+        } catch {
+            # A failed uv lookup is normal while walking the fallback list.
+        }
+    }
+
+    return $null
+}
+
 function Resolve-AvailablePythonVersion {
-    # Return the first Python minor version uv can actually find, preferring the
-    # requested $PythonVersion and then $PythonFallbackVersions.  Returns $null
-    # when none are available.
+    # Return the first Python minor version with a usable runtime, preferring
+    # the requested $PythonVersion and then $PythonFallbackVersions.  The
+    # Find-UsablePythonForVersion helper resolves candidates via `uv python find`
+    # and records the exact validated interpreter in $script:ResolvedPythonPath.
+    # Returns $null when none are available.
     #
     # This is the cross-process-safe counterpart to Test-Python's in-memory
     # ``$script:PythonVersion = $fallbackVer`` mutation.  Under Hermes-Setup.exe
@@ -723,17 +795,30 @@ function Resolve-AvailablePythonVersion {
     # survive into the ``venv`` stage's process -- there $PythonVersion is back
     # at its "3.11" default.  Consumers re-resolve here instead of trusting that
     # default, which is exactly the propagation gap behind issue #50769.
+    $script:ResolvedPythonPath = $null
     $candidates = @($PythonVersion) + $PythonFallbackVersions
     $seen = @{}
     foreach ($ver in $candidates) {
         if (-not $ver -or $seen.ContainsKey($ver)) { continue }
         $seen[$ver] = $true
-        try {
-            $found = & $UvCmd python find $ver 2>$null
-            if ($found) { return $ver }
-        } catch { }
+        $found = Find-UsablePythonForVersion -Version $ver
+        if ($found) {
+            $script:ResolvedPythonPath = $found
+            return $ver
+        }
     }
     return $null
+}
+
+function Resolve-UsablePythonPath {
+    $resolvedVersion = Resolve-AvailablePythonVersion
+    if (-not $resolvedVersion -or -not $script:ResolvedPythonPath) {
+        return $null
+    }
+    if ($resolvedVersion -ne $PythonVersion) {
+        $script:PythonVersion = $resolvedVersion
+    }
+    return $script:ResolvedPythonPath
 }
 
 function Test-Python {
@@ -741,16 +826,17 @@ function Test-Python {
     
     # Let uv find or install Python
     try {
-        $pythonPath = & $UvCmd python find $PythonVersion 2>$null
+        $pythonPath = Find-UsablePythonForVersion -Version $PythonVersion
         if ($pythonPath) {
             $ver = & $pythonPath --version 2>$null
+            $script:ResolvedPythonPath = $pythonPath
             Write-Success "Python found: $ver"
             return $true
         }
     } catch { }
     
-    # Python not found -- use uv to install it (no admin needed!)
-    Write-Info "Python $PythonVersion not found, installing via uv..."
+    # No usable candidate found -- use uv to install one (no admin needed!)
+    Write-Info "No usable Python $PythonVersion runtime found, installing via uv..."
     # Capture EAP outside the try block so the catch's restore call always
     # has a meaningful value (see Install-Uv for the full rationale).
     $prevEAP = $ErrorActionPreference
@@ -772,9 +858,10 @@ function Test-Python {
 
         # Check if Python is now available (more reliable than exit code
         # since uv may return non-zero due to "already installed" etc.)
-        $pythonPath = & $UvCmd python find $PythonVersion 2>$null
+        $pythonPath = Find-UsablePythonForVersion -Version $PythonVersion
         if ($pythonPath) {
             $ver = & $pythonPath --version 2>$null
+            $script:ResolvedPythonPath = $pythonPath
             Write-Success "Python installed: $ver"
             return $true
         }
@@ -794,11 +881,12 @@ function Test-Python {
     Write-Info "Trying to find any existing Python 3.10+..."
     foreach ($fallbackVer in $PythonFallbackVersions) {
         try {
-            $pythonPath = & $UvCmd python find $fallbackVer 2>$null
+            $pythonPath = Find-UsablePythonForVersion -Version $fallbackVer
             if ($pythonPath) {
                 $ver = & $pythonPath --version 2>$null
                 Write-Success "Found fallback: $ver"
                 $script:PythonVersion = $fallbackVer
+                $script:ResolvedPythonPath = $pythonPath
                 return $true
             }
         } catch { }
@@ -828,11 +916,17 @@ function Test-Python {
             try {
                 $prevEAP2 = $ErrorActionPreference
                 $ErrorActionPreference = "Continue"
-                $sysVer = & python --version 2>&1
+                $sysVer = & $pythonSource --version 2>&1
                 $ErrorActionPreference = $prevEAP2
-                if ($sysVer -match "Python 3\.(1[0-9]|[1-9][0-9])") {
+                if ($sysVer -match "Python 3\.(1[0-9]|[1-9][0-9])" -and
+                    (Test-HermesPythonRuntime -PythonPath $pythonSource)) {
+                    $script:ResolvedPythonPath = $pythonSource
                     Write-Success "Using system Python: $sysVer"
                     return $true
+                }
+                if ($script:PythonRuntimeProbeOutput) {
+                    Write-Warn "System Python started, but required native modules could not load:"
+                    Write-Host $script:PythonRuntimeProbeOutput -ForegroundColor DarkGray
                 }
             } catch {
                 if ($prevEAP2) { $ErrorActionPreference = $prevEAP2 }
@@ -840,7 +934,7 @@ function Test-Python {
         }
     }
 
-    Write-Err "Failed to install Python $PythonVersion"
+    Write-Err "Failed to find or install a usable Python $PythonVersion runtime"
     Write-Info "Install Python 3.11 manually, then re-run this script:"
     Write-Info "  https://www.python.org/downloads/"
     Write-Info "  Or: winget install Python.Python.3.11"
@@ -1977,10 +2071,14 @@ function Install-Venv {
     # here made `uv venv venv --python 3.11` fail with exit 2 on machines without
     # 3.11 even though the `python` stage reported success (issue #50769).
     $resolved = Resolve-AvailablePythonVersion
+    if (-not $resolved -or -not $script:ResolvedPythonPath) {
+        throw "No usable Python runtime was found for virtual environment creation."
+    }
     if ($resolved -and $resolved -ne $PythonVersion) {
         Write-Info "Python $PythonVersion not available; using detected Python $resolved"
         $script:PythonVersion = $resolved
     }
+    $resolvedPythonPath = $script:ResolvedPythonPath
 
     Write-Info "Creating virtual environment with Python $PythonVersion..."
     
@@ -2113,7 +2211,7 @@ function Install-Venv {
     # normal progress such as "Using CPython ..." on stderr; under Windows
     # PowerShell 5.1 with EAP=Stop that stderr is a NativeCommandError unless
     # we temporarily relax EAP and trust $LASTEXITCODE for real failures.
-    Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $PythonVersion }
+    Invoke-NativeWithRelaxedErrorAction { & $UvCmd venv venv --python $resolvedPythonPath }
     # Relaxing EAP above means a *genuine* uv-venv failure (exit != 0) no longer
     # aborts on its own. Capture $LASTEXITCODE immediately and fail fast, so the
     # `venv` stage can't falsely report success (and Invoke-Stage can't emit
@@ -2242,7 +2340,14 @@ function Install-Dependencies {
 
     # Parse [project.optional-dependencies].all from pyproject.toml.
     # tomllib is stdlib on Python 3.11+ which the bootstrap guarantees.
-    $pythonExeForParse = if (-not $NoVenv) { "$InstallDir\venv\Scripts\python.exe" } else { (& $UvCmd python find $PythonVersion) }
+    $pythonExeForParse = if (-not $NoVenv) {
+        "$InstallDir\venv\Scripts\python.exe"
+    } else {
+        Resolve-UsablePythonPath
+    }
+    if (-not $pythonExeForParse) {
+        throw "No usable Python runtime was found for dependency validation."
+    }
     $allExtras = @()
     if (Test-Path $pythonExeForParse) {
         $parsed = & $pythonExeForParse -c @"
@@ -2375,7 +2480,14 @@ print(','.join(scripts))
     # users hit and lazy-import errors from `hermes dashboard` are confusing.
     # If tier 1 failed (the common case), [web] was still picked up by tiers
     # 2-3; only tier 4 leaves you without it.
-    $pythonExe = if (-not $NoVenv) { "$InstallDir\venv\Scripts\python.exe" } else { (& $UvCmd python find $PythonVersion) }
+    $pythonExe = if (-not $NoVenv) {
+        "$InstallDir\venv\Scripts\python.exe"
+    } else {
+        Resolve-UsablePythonPath
+    }
+    if (-not $pythonExe) {
+        throw "No usable Python runtime was found for final import validation."
+    }
     if (Test-Path $pythonExe) {
         $webOk = $false
         $webServerSyntaxOk = $false

--- a/tests/test_install_ps1_native_stderr_eap.py
+++ b/tests/test_install_ps1_native_stderr_eap.py
@@ -49,7 +49,7 @@ def test_repository_stage_relieves_eap_for_ssh_and_https_git_clone() -> None:
 
 def test_uv_venv_and_dependency_installs_relax_eap() -> None:
     text = _install_ps1()
-    _assert_relaxed_call(text, r"& \$UvCmd venv venv --python \$PythonVersion")
+    _assert_relaxed_call(text, r"& \$UvCmd venv venv --python \$resolvedPythonPath")
     _assert_relaxed_call(text, r"& \$UvCmd sync --extra all --locked")
     _assert_relaxed_call(text, r"& \$UvCmd pip install -e \$tier\.Spec")
 
@@ -67,7 +67,7 @@ def test_uv_venv_failure_is_not_swallowed_after_eap_relax() -> None:
     # The uv-venv invocation, then an exit-code capture, then a throw — all
     # within a small window after the relaxed call.
     guard = re.search(
-        r"& \$UvCmd venv venv --python \$PythonVersion[\s\S]{0,400}?"
+        r"& \$UvCmd venv venv --python \$resolvedPythonPath[\s\S]{0,400}?"
         r"\$LASTEXITCODE[\s\S]{0,200}?"
         r"-ne 0[\s\S]{0,200}?throw",
         text,


### PR DESCRIPTION
## Problem

On Windows, the installer treated a Python interpreter as usable when `--version` succeeded. Windows Application Control can still block native standard-library modules such as `select`, so the version check passes but editable dependency installation fails later inside setuptools.

This was reproduced with uv-managed CPython 3.11.15: version detection succeeded, while `import select, socket, ssl` failed with the original Application Control error. The official Python.org 3.11.9 interpreter on the same machine loaded those modules successfully.

## Root cause

The installer checked interpreter liveness and version compatibility, but not the native modules needed by the install/runtime path. It also created the virtual environment from a version selector instead of retaining the exact interpreter path that had been validated. The desktop backend probe similarly started with third-party imports, so it could miss this more fundamental runtime failure.

## Solution

- Validate candidate interpreters with `import select, socket, ssl`.
- Try the normal uv resolution first, then a system-only resolution when the managed candidate is unusable.
- Preserve and report the underlying import error for rejected candidates.
- Retain the exact validated interpreter path for venv creation and NoVenv checks.
- Add the same native-module capability check to the desktop backend probe.
- Do not change execution policy, Application Control, or other machine-wide security settings.

## Tests

- Canonical focused Python installer tests: 9 passed.
- New PowerShell behavior test executes the shipped functions with fake blocked and trusted interpreters, including a path containing spaces.
- Installer stage-protocol smoke test passed.
- Installer ASCII and Windows-footgun checks passed.
- Desktop typecheck passed.
- Desktop lint completed with 0 errors; existing warnings remain.
- Focused desktop backend-probe tests: 12 passed.
- Prettier check passed for the touched TypeScript files.
- Isolated Windows install completed through Python selection, repository acquisition, venv creation, locked dependency sync, and final import validation without modifying the installed desktop-app copy or global configuration.

The broader desktop platform command completed with 890 passing tests and 19 failures in unrelated Windows/POSIX-assumption areas such as SSH, relaunch, permissions, and packaging. I am not claiming that broad suite as fully green.

## Environment

- Windows build 10.0.26200.8653
- Blocked candidate: uv-managed CPython 3.11.15
- Working fallback: Python.org CPython 3.11.9
- Node.js 24.18.0
- npm 11.17.0

## Compatibility and scope

The change only rejects an interpreter when required native standard-library imports fail, then prefers an already available usable system interpreter. It does not install a different Python unless the existing installer flow already permits that action, and it preserves actionable native errors.

I searched current issues and pull requests before implementation and found no exact duplicate. #63810 is adjacent but complementary: it improves a later CLI/dashboard diagnostic for a blocked `_ssl` module, while this PR prevents the installer and desktop runtime selection from accepting an unusable interpreter in the first place.