### PR TITLE
fix: make lifecycle guard total against NUL-byte paths

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,11 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # OSError: unreadable/long paths. ValueError: a NUL byte embedded in
+        # the path itself (e.g. a binary's decoded contents re-tokenized as a
+        # path). A guarded path must never crash the guard (#76762) — treat
+        # both as "nothing to scan".
         return None, False
     try:
         metadata = os.fstat(descriptor)
@@ -330,8 +334,19 @@ def _contains_unsafe_gateway_action(
         if not script_text:
             continue
         # Relative references inside a script resolve against that script's
-        # directory, not the original command's cwd.
-        script_dir = _resolve_script_directory(str(resolved)) or cwd
+        # directory, not the original command's cwd. The path may contain a
+        # NUL byte (binary content decoded as text and re-tokenized); the
+        # directory resolver must not crash the guard (#76762) — fall back to
+        # the command's cwd.
+        script_dir = cwd
+        try:
+            script_dir = _resolve_script_directory(str(resolved)) or cwd
+        except (OSError, ValueError):
+            pass
+        if script_text and len(script_text) > _MAX_REFERENCED_SCRIPT_BYTES:
+            # Oversized fallback text (e.g. a hostile/unbounded remote read):
+            # fail closed, mirroring the local read path's oversized handling.
+            return True
         if script_text and _contains_unsafe_gateway_action(
             script_text,
             cwd=script_dir,

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -705,6 +705,42 @@ class TestLifecycleGuardModule:
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("daily ops", str(script))
 
+    def test_binary_with_text_returning_fallback_does_not_crash_guard(self, tmp_path):
+        """#76762 sibling: terminal_tool ALWAYS passes read_remote_script, and
+        that fallback re-reads a binary as decoded text (``cat`` succeeds on
+        binaries). The recursion then re-tokenizes machine code containing NUL
+        bytes and path-touching calls (os.open, the script-directory resolver)
+        receive NUL-containing paths — ValueError must be tolerated at every
+        site so a guarded path never crashes the guard, regardless of what the
+        fallback returns.
+
+        Before this fix the production call shape (binary exists at the
+        resolved path + read_remote_script provided) raised
+        ``ValueError: embedded null byte`` — the existing #76762 regression
+        only exercised the no-fallback shape.
+        """
+        from pathlib import Path
+
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        binary = tmp_path / "tool.bin"
+        binary.write_bytes(b"\x7fELF\x00\x00/usr/bin/foo\x00bar\x00\x01~junk\x00")
+
+        def text_returning_fallback(script_path: str):
+            # Emulates terminal_tool._read_script_in_env decoding a binary as
+            # UTF-8 text (NUL bytes preserved) — the pre-fix behavior.
+            try:
+                return Path(script_path).read_bytes().decode("utf-8", errors="replace")
+            except Exception:
+                return None
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            f"{binary} -c 'print(1)'",
+            read_remote_script=text_returning_fallback,
+        )
+        assert result is False
+
 
 # ---------------------------------------------------------------------------
 # Defense 2 (chokepoint): cron.jobs.create_job blocks the AGENT model-tool path
@@ -821,6 +857,68 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
 
         assert result["exit_code"] == 1
         assert "referenced script" in result["error"]
+        assert any("cat" in c for c in calls)
+
+    def test_local_binary_reference_is_not_scanned_as_text(self, monkeypatch, tmp_path):
+        """A command referencing an existing local binary (e.g. a venv python)
+        must not have its bytes decoded and scanned as shell text.
+
+        Before this fix the remote-fallback reader decoded the binary as
+        UTF-8 (NULs preserved) and the recursion treated the decoded machine
+        code as a shell script — either crashing the guard (ValueError:
+        embedded null byte) or false-positive blocking when the bytes
+        contained a lifecycle-looking string.
+        """
+        import tools.terminal_tool as tt
+
+        binary = tmp_path / "tool.bin"
+        binary.write_bytes(b"\x7fELF\x00\x00" + b"hermes gateway restart\x00")
+        calls = []
+
+        class _LocalEnv:
+            env = {}
+            cwd = str(tmp_path)
+
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "", "returncode": 0}
+
+        fake_env = _LocalEnv()
+        self._patch_env(monkeypatch, fake_env, inside_gateway=True)
+
+        result = json.loads(tt.terminal_tool(command=str(binary)))
+
+        assert "Blocked" not in (result.get("error") or "")
+        # The command itself runs through env.execute, but the guard's script
+        # fallback (cat <path>) must never fire for a local binary.
+        assert not any("cat " in c for c in calls)
+
+    def test_remote_binary_output_is_not_scanned_as_text(self, monkeypatch, tmp_path):
+        """A REMOTE binary (local file absent, env.execute cat returns its
+        bytes) must be treated like the local case: NUL-containing output is
+        "nothing to scan", not a script whose contents are then scanned."""
+        import tools.terminal_tool as tt
+
+        script = "/remote/workspace/tool.bin"
+        calls = []
+
+        class _RemoteEnv:
+            env = {}
+            cwd = str(tmp_path)
+
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                if "cat" in command and "/remote/workspace/tool.bin" in command:
+                    return {"output": "\x7fELF\x00hermes gateway restart\x00junk", "returncode": 0}
+                return {"output": "", "returncode": 0}
+
+        fake_env = _RemoteEnv()
+        fake_env.cwd = "/remote/workspace"
+        self._patch_env(monkeypatch, fake_env, inside_gateway=True)
+
+        result = json.loads(tt.terminal_tool(command=f"/bin/bash {script}"))
+
+        assert "Blocked" not in (result.get("error") or "")
         assert any("cat" in c for c in calls)
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2533,6 +2533,14 @@ def terminal_tool(
                 For local backends the script path is on the host filesystem. For
                 SSH/Modal/Daytona the same path is remote; the local read misses, so we
                 fall back to ``env.execute('cat ...')``.
+
+                Mirrors ``cron.lifecycle_guard._read_referenced_script``: content with
+                NUL bytes is a binary, not a shell script, and must be treated as
+                "nothing to scan". Without this check a referenced binary (e.g.
+                ``.venv/bin/python``) gets decoded as UTF-8 text and the guard's
+                recursion re-tokenizes machine code — crashing on NUL-containing
+                paths or false-positive blocking when the bytes happen to contain a
+                lifecycle-looking string.
                 """
                 if env is None:
                     return None
@@ -2545,6 +2553,8 @@ def terminal_tool(
                         if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= 1024 * 1024:
                             data = local_path.read_bytes()
                             if len(data) <= 1024 * 1024:
+                                if b"\x00" in data:
+                                    return None
                                 return data.decode("utf-8", errors="replace")
                 except Exception:
                     pass
@@ -2552,7 +2562,10 @@ def terminal_tool(
                 try:
                     result = env.execute(f"cat {shlex.quote(script_path)}")
                     if result.get("returncode", -1) == 0:
-                        return result.get("output", "")
+                        output = result.get("output", "")
+                        if "\x00" in output:
+                            return None
+                        return output
                 except Exception:
                     pass
                 return None


### PR DESCRIPTION
## Summary

The gateway lifecycle guard (`cron/lifecycle_guard.py`) can crash with `ValueError: embedded null byte` when a terminal command references a binary (e.g. `.venv/bin/python`). Issue class #76762 was previously fixed at **one** crash site only — `Path.resolve()` — while sibling sites (`os.open`, script-directory resolution) still raised. A security guard must be a total function: every input maps to a decision, none raises.

## Root cause

- The guard treats any `/`-containing executable as a "referenced script" and scans it.
- `_read_referenced_script` correctly detects binaries and skips them locally — **but the caller then fires a remote fallback** (`tools/terminal_tool.py` → `cat <binary>`), which *succeeds* on binaries and decodes the raw bytes as UTF-8 with NUL bytes intact.
- The guard recursively tokenizes that binary garbage as shell text; a NUL-containing "path" reaches `os.open` → uncaught `ValueError`. The #76762 fix covered `resolve()` but missed this sibling (the incomplete-fix pattern).

Two real consequences: any command referencing a binary can crash the guard (observed in production, crashing the terminal tool on ordinary commands), and decoded binary content can contain literal lifecycle-command strings (Python binaries carry docstrings) → false-positive blocking of innocent commands.

## Fix

- Tolerate `ValueError` at every path-resolution site in the guard's referenced-script walk (in addition to the existing `OSError` handling).
- Fail closed with a size bound on referenced-script reads.
- Reject NUL bytes in the terminal tool's script reader — both local and remote fallback branches — so binary content never enters the guard as text.
- Regression tests for all three crash sites + the binary-reference path.

## Testing

- 3 new regression tests in `tests/hermes_cli/test_gateway_restart_loop.py`; all failed pre-fix with the exact bug signatures (red proven), pass post-fix.
- Full file: **85/85 green** on current `origin/main`.
- No collateral damage in adjacent suites.
