### PR TITLE
fix(lsp): preserve Windows npm launcher provenance

### DIFF
--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -1,9 +1,10 @@
 """Auto-installation of LSP server binaries.
 
 Tries to install missing servers using whatever package manager is
-appropriate.  All installs go to a Hermes-owned bin staging dir,
-``<HERMES_HOME>/lsp/bin/``, so we don't pollute the user's global
-toolchain.
+appropriate.  All installs go under the Hermes-owned
+``<HERMES_HOME>/lsp/`` tree, so we don't pollute the user's global
+toolchain. Windows npm launchers remain at their original managed
+``node_modules/.bin`` location because those wrappers can be location-sensitive.
 
 Strategies:
 
@@ -41,8 +42,8 @@ logger = logging.getLogger("agent.lsp.install")
 
 # Package-name → install-strategy hint registry.  Each entry is a
 # tuple of strategy name + package name + executable name.  When the
-# install completes, we look for the executable in
-# ``<HERMES_HOME>/lsp/bin/`` first, then on PATH.
+# install completes, we look for the executable in the Hermes-managed npm
+# location, then ``<HERMES_HOME>/lsp/bin/``, then on PATH.
 #
 # Optional fields:
 #   - ``extra_pkgs``: list of sibling packages to install alongside
@@ -115,7 +116,7 @@ INSTALL_RECIPES: Dict[str, Dict[str, Any]] = {
 _install_locks: Dict[str, threading.Lock] = {}
 _install_results: Dict[str, Optional[str]] = {}
 _install_lock_meta = threading.Lock()
-_WINDOWS_WRAPPER_SUFFIXES = (".cmd", ".exe", ".bat")
+_WINDOWS_WRAPPER_SUFFIXES = (".exe", ".cmd", ".bat")
 
 
 def _is_windows() -> bool:
@@ -133,25 +134,52 @@ def hermes_lsp_bin_dir() -> Path:
 
 def _native_binary_candidates(base: Path) -> list[Path]:
     """Return platform-native executable candidates for a staged binary."""
-    candidates = [base]
-    if _is_windows():
-        existing = {str(base).lower()}
-        for suffix in _WINDOWS_WRAPPER_SUFFIXES:
-            candidate = Path(str(base) + suffix)
-            key = str(candidate).lower()
-            if key not in existing:
-                candidates.append(candidate)
-                existing.add(key)
+    if not _is_windows():
+        return [base]
+    candidates: list[Path] = []
+    existing: set[str] = set()
+    for suffix in _WINDOWS_WRAPPER_SUFFIXES:
+        candidate = Path(str(base) + suffix)
+        key = str(candidate).lower()
+        if key not in existing:
+            candidates.append(candidate)
+            existing.add(key)
+    candidates.append(base)
     return candidates
 
 
+def _is_windows_posix_shim(path: str | Path) -> bool:
+    """Return true for an extensionless shebang shim Windows cannot spawn."""
+    candidate = Path(path)
+    if not _is_windows() or candidate.suffix:
+        return False
+    try:
+        with candidate.open("rb") as stream:
+            return stream.read(2) == b"#!"
+    except OSError:
+        return False
+
+
 def _existing_binary(name: str) -> Optional[str]:
-    """Probe the staging dir + PATH for a binary named ``name``."""
+    """Probe authoritative managed/PATH locations without parsing wrappers."""
+    if _is_windows():
+        managed_npm = hermes_lsp_bin_dir().parent / "node_modules" / ".bin" / name
+        for candidate in _native_binary_candidates(managed_npm):
+            if candidate.exists() and not _is_windows_posix_shim(candidate):
+                return str(candidate)
     for staged in _native_binary_candidates(hermes_lsp_bin_dir() / name):
         if staged.exists() and os.access(staged, os.X_OK):
+            # Older Hermes releases copied location-sensitive npm wrappers here.
+            # This Hermes-owned relocation is stale provenance, so ignore only
+            # staged .cmd files; wrappers at their managed origin or on PATH are
+            # authoritative and remain opaque.
+            if _is_windows() and staged.suffix.lower() == ".cmd":
+                continue
+            if _is_windows_posix_shim(staged):
+                continue
             return str(staged)
     on_path = shutil.which(name)
-    if on_path:
+    if on_path and not _is_windows_posix_shim(on_path):
         return on_path
     if _is_windows():
         for suffix in _WINDOWS_WRAPPER_SUFFIXES:
@@ -242,8 +270,9 @@ def _install_npm(
     """Install an npm package into our staging dir.
 
     Uses ``npm install --prefix`` so the binaries land in
-    ``<staging>/node_modules/.bin/<bin_name>`` and we symlink them up
-    one level for direct PATH-style access.
+    ``<staging>/node_modules/.bin/<bin_name>``. On Windows the native launcher
+    is returned from that original location; other platforms symlink it into
+    the bin staging directory for direct PATH-style access.
 
     ``extra_pkgs`` is a list of sibling packages to install in the
     same ``node_modules`` tree.  Used for LSP servers with runtime
@@ -283,8 +312,14 @@ def _install_npm(
         logger.warning("[install] npm install errored for %s: %s", pkg, e)
         return None
 
-    # Find the bin
+    # Find the bin. Windows npm launchers remain in the original managed
+    # node_modules/.bin directory. Their contents are intentionally opaque:
+    # provenance, rather than wrapper syntax, establishes authority here.
     nm_bin = staging / "node_modules" / ".bin" / bin_name
+    if _is_windows():
+        for candidate in _native_binary_candidates(nm_bin):
+            if candidate.exists() and not _is_windows_posix_shim(candidate):
+                return str(candidate)
     for c in _native_binary_candidates(nm_bin):
         if c.exists():
             # Symlink into our `lsp/bin/` for stable PATH access.

--- a/tests/agent/lsp/test_install_and_lint_fixes.py
+++ b/tests/agent/lsp/test_install_and_lint_fixes.py
@@ -15,7 +15,11 @@ Covers:
 from __future__ import annotations
 
 import io
+import os
+import shutil
+import subprocess
 from contextlib import redirect_stdout
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -28,8 +32,35 @@ from agent.lsp.install import INSTALL_RECIPES
 # ---------------------------------------------------------------------------
 
 
-
-
+def _write_realistic_npm_cmd(launcher: Path, package: str, entrypoint: str) -> Path:
+    """Write an npm-compatible Windows launcher fixture with exact CRLF bytes."""
+    launcher.parent.mkdir(parents=True, exist_ok=True)
+    target = launcher.parent.parent / package / entrypoint
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b'console.log("npm-wrapper-spawned")\n')
+    launcher.write_bytes(
+        (
+            "@ECHO off\r\n"
+            "GOTO start\r\n"
+            ":find_dp0\r\n"
+            "SET dp0=%~dp0\r\n"
+            "EXIT /b\r\n"
+            ":start\r\n"
+            "SETLOCAL\r\n"
+            "CALL :find_dp0\r\n"
+            "\r\n"
+            'IF EXIST "%dp0%\\node.exe" (\r\n'
+            '  SET "_prog=%dp0%\\node.exe"\r\n'
+            ") ELSE (\r\n"
+            '  SET "_prog=node"\r\n'
+            "  SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
+            ")\r\n"
+            "\r\n"
+            'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & '
+            f'"%_prog%"  "%dp0%\\..\\{package}\\{entrypoint}" %*\r\n'
+        ).encode("utf-8")
+    )
+    return target
 
 
 def test_install_npm_works_without_extras(tmp_path, monkeypatch):
@@ -45,7 +76,7 @@ def test_install_npm_works_without_extras(tmp_path, monkeypatch):
     from agent.lsp import install as install_mod
 
     monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
-    monkeypatch.setattr(install_mod.shutil, "which", lambda c: "/usr/bin/npm" if c == "npm" else None)
+    monkeypatch.setattr(install_mod, "find_node_executable", lambda c: "/usr/bin/npm" if c == "npm" else None)
 
     install_mod._install_npm("pyright", "pyright-langserver")
 
@@ -58,6 +89,223 @@ def test_install_npm_works_without_extras(tmp_path, monkeypatch):
     }]
     assert install_targets == ["pyright"]
 
+
+def test_install_npm_keeps_realistic_windows_cmd_in_node_modules_bin(tmp_path, monkeypatch):
+    """A stock npm shim remains beside the package target it resolves."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from agent.lsp import install as install_mod
+
+    def fake_run(cmd, **kwargs):
+        managed = (
+            install_mod.hermes_lsp_bin_dir().parent
+            / "node_modules"
+            / ".bin"
+            / "pyright-langserver.cmd"
+        )
+        _write_realistic_npm_cmd(managed, "pyright", "langserver.index.js")
+        return MagicMock(returncode=0, stderr="")
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    monkeypatch.setattr(install_mod, "find_node_executable", lambda name: "npm.cmd")
+    monkeypatch.setattr(install_mod.subprocess, "run", fake_run)
+
+    resolved = install_mod._install_npm("pyright", "pyright-langserver")
+
+    managed = (
+        install_mod.hermes_lsp_bin_dir().parent
+        / "node_modules"
+        / ".bin"
+        / "pyright-langserver.cmd"
+    )
+    assert resolved == str(managed)
+    assert not (install_mod.hermes_lsp_bin_dir() / "pyright-langserver.cmd").exists()
+
+
+def test_existing_binary_recovers_realistic_managed_npm_cmd(tmp_path, monkeypatch):
+    """Next-process recovery accepts npm's launcher at its managed origin."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    managed = (
+        install_mod.hermes_lsp_bin_dir().parent
+        / "node_modules"
+        / ".bin"
+        / "pyright-langserver.cmd"
+    )
+    _write_realistic_npm_cmd(managed, "pyright", "langserver.index.js")
+
+    assert install_mod._existing_binary("pyright-langserver") == str(managed)
+
+
+def test_existing_binary_skips_stale_cmd_in_hermes_staging_dir(tmp_path, monkeypatch):
+    """Historical Hermes-relocated npm .cmd files are not authoritative."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    staged = install_mod.hermes_lsp_bin_dir() / "pyright-langserver.cmd"
+    staged.write_bytes(b"@ECHO off\r\necho stale Hermes relocation\r\n")
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+
+    assert install_mod._existing_binary("pyright-langserver") is None
+
+
+_FALLBACK_CMD_BODIES = [
+    b"@ECHO off\r\n"
+    b'IF EXIST "%dp0%\\..\\optional\\helper.exe" (\r\n'
+    b'  "%dp0%\\..\\optional\\helper.exe" %*\r\n'
+    b") ELSE (\r\n"
+    b'  node "%dp0%\\..\\package\\index.js" %*\r\n'
+    b")\r\n",
+    b"@ECHO off\r\n"
+    b'IF EXIST "%dp0%\\..\\node-helper\\helper.js" (\r\n'
+    b'  node "%dp0%\\..\\node-helper\\helper.js" %*\r\n'
+    b") ELSE (\r\n"
+    b'  node "%dp0%\\..\\package\\index.js" %*\r\n'
+    b")\r\n",
+]
+
+
+@pytest.mark.parametrize("body", _FALLBACK_CMD_BODIES)
+def test_existing_binary_accepts_fallback_cmd_at_managed_origin(tmp_path, monkeypatch, body):
+    """Managed wrappers are accepted by provenance, not parsed control flow."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    managed = (
+        install_mod.hermes_lsp_bin_dir().parent
+        / "node_modules"
+        / ".bin"
+        / "fixture-language-server.cmd"
+    )
+    managed.parent.mkdir(parents=True, exist_ok=True)
+    managed.write_bytes(body)
+    fallback = managed.parent.parent / "package" / "index.js"
+    fallback.parent.mkdir()
+    fallback.write_bytes(b'console.log("fallback")\n')
+
+    assert install_mod._existing_binary("fixture-language-server") == str(managed)
+
+
+@pytest.mark.parametrize("body", _FALLBACK_CMD_BODIES)
+def test_existing_binary_accepts_fallback_cmd_on_path(tmp_path, monkeypatch, body):
+    """PATH wrappers are accepted without diagnosing third-party relocation."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    on_path = tmp_path / "path" / "fixture-language-server.cmd"
+    on_path.parent.mkdir(parents=True)
+    on_path.write_bytes(body)
+    fallback = on_path.parent.parent / "package" / "index.js"
+    fallback.parent.mkdir()
+    fallback.write_bytes(b'console.log("fallback")\n')
+    monkeypatch.setattr(
+        install_mod.shutil,
+        "which",
+        lambda name: str(on_path) if name in {"fixture-language-server", "fixture-language-server.cmd"} else None,
+    )
+
+    assert install_mod._existing_binary("fixture-language-server") == str(on_path)
+
+
+def test_existing_binary_accepts_path_cmd_without_reading_it(tmp_path, monkeypatch):
+    """A .cmd found on PATH is authoritative and its contents stay opaque."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    on_path = tmp_path / "path" / "fixture-language-server.cmd"
+    on_path.parent.mkdir(parents=True)
+    on_path.write_bytes(b"not for Hermes to classify\r\n")
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: str(on_path))
+
+    original_open = Path.open
+
+    def guarded_open(path, *args, **kwargs):
+        if path.suffix.lower() == ".cmd":
+            raise AssertionError(f"wrapper was opened: {path}")
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", guarded_open)
+
+    assert install_mod._existing_binary("fixture-language-server") == str(on_path)
+
+
+def test_existing_binary_rejects_windows_posix_shim(tmp_path, monkeypatch):
+    """An extensionless npm shell shim cannot be spawned by CreateProcess."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    posix_shim = install_mod.hermes_lsp_bin_dir() / "pyright-langserver"
+    posix_shim.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+
+    assert install_mod._existing_binary("pyright-langserver") is None
+
+
+def test_native_candidates_prefer_exe_without_reading_native_or_wrapper_files(tmp_path, monkeypatch):
+    """Native executables win and .exe/.bat/.cmd contents remain opaque."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from agent.lsp import install as install_mod
+
+    monkeypatch.setattr(install_mod, "_is_windows", lambda: True)
+    base = install_mod.hermes_lsp_bin_dir() / "fake-language-server"
+    exe = base.with_suffix(".exe")
+    cmd = base.with_suffix(".cmd")
+    bat = base.with_suffix(".bat")
+    exe.write_bytes(b"MZ" + b"x" * 64)
+    cmd.write_text("@ECHO off\r\n", encoding="utf-8")
+    bat.write_text("@ECHO off\r\n", encoding="utf-8")
+
+    original_open = Path.open
+
+    def guarded_open(path, *args, **kwargs):
+        if path.suffix.lower() in {".exe", ".bat", ".cmd"}:
+            raise AssertionError(f"launcher was opened: {path}")
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", guarded_open)
+    monkeypatch.setattr(install_mod.shutil, "which", lambda _name: None)
+
+    assert install_mod._existing_binary("fake-language-server") == str(exe)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires native cmd.exe launcher semantics")
+def test_recovered_managed_npm_cmd_spawns_through_cmd(tmp_path, monkeypatch):
+    """The path returned by recovery actually reaches the package entrypoint."""
+    cmd_exe = shutil.which("cmd.exe")
+    node_exe = shutil.which("node.exe")
+    if cmd_exe is None or node_exe is None:
+        pytest.skip("cmd.exe and node.exe are required")
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from agent.lsp import install as install_mod
+
+    managed = (
+        install_mod.hermes_lsp_bin_dir().parent
+        / "node_modules"
+        / ".bin"
+        / "fixture-language-server.cmd"
+    )
+    _write_realistic_npm_cmd(managed, "fixture-language-server", "index.js")
+
+    resolved = install_mod._existing_binary("fixture-language-server")
+    assert resolved is not None
+    proc = subprocess.run(
+        [cmd_exe, "/d", "/s", "/c", resolved],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert resolved == str(managed)
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "npm-wrapper-spawned"
 
 
 


### PR DESCRIPTION
## Summary

Keep npm-generated Windows LSP launchers at their managed `node_modules/.bin` origin instead of copying or symlinking them into Hermes’s generic `lsp/bin` staging directory.

## Problem

Windows npm `.cmd` launchers resolve their package entrypoint relative to their own directory. Relocating one from `node_modules/.bin` to `lsp/bin` breaks that relationship and can produce `MODULE_NOT_FOUND` when Hermes starts the language server.

Content-parsing arbitrary batch files is not a safe solution: valid wrappers can contain conditional helpers and fallbacks that cannot be classified reliably with regexes.

## Fix

- Prefer native Windows executable candidates, with `.exe` before wrapper scripts.
- Probe Hermes-managed npm launchers under `lsp/node_modules/.bin` first.
- Return the original managed launcher after npm installation; do not copy or symlink Windows wrappers into `lsp/bin`.
- Skip historical `.cmd` relocations specifically inside Hermes-owned `lsp/bin`.
- Treat managed and PATH `.cmd` launchers as opaque; do not read or interpret their batch contents.
- Continue rejecting extensionless POSIX shebang shims that native Windows process creation cannot execute.
- Preserve the existing POSIX npm staging/symlink path.

## Why this is upstream-generic

This fixes stock Hermes’s Windows npm installation and recovery path. It uses `$HERMES_HOME` through existing profile-safe helpers and contains no private path, provider, MCP, plugin, model, or configuration assumption.

`lsp/bin` is Hermes-owned internal staging. Stock npm launchers live under the managed `node_modules/.bin` tree; stock Go and Python launchers use native executables. Skipping stale `.cmd` files only in the internal staging directory therefore does not remove a supported stock installation path.

## Tests

- Managed npm launcher recovery across processes.
- npm install returns the original managed launcher and creates no staged copy.
- Historical staged `.cmd` copies are skipped.
- Managed and PATH wrappers with optional helper/fallback logic remain usable.
- Opaque PATH `.cmd` wrappers are accepted without content reads.
- `.exe` precedence and no `.exe`/`.bat`/`.cmd` reads.
- Extensionless POSIX shim rejection on Windows.
- Native `cmd.exe /c` launcher spawn.
- POSIX behavior remains on the existing non-Windows branch.

## Verification

- Targeted Windows LSP suite: **16 passed** on current `main`.
- Native Windows managed npm launcher spawn: passed.
- Independent review: **APPROVE**, no medium-or-higher findings.
- Ruff: passed.
- `py_compile`: passed.
- `git diff --check`: passed.

## Scope

- `agent/lsp/install.py`
- `tests/agent/lsp/test_install_and_lint_fixes.py`
