### PR TITLE
fix(cron): tolerate NUL-byte path tokens from the command string in lifecycle guard

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,11 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # ValueError: an embedded NUL byte in the path itself — the token
+        # came straight from the command string, not from file contents, so
+        # the #76762 binary-content skip never sees it. No such file can
+        # exist on POSIX; there is nothing to read.
         return None, False
     try:
         metadata = os.fstat(descriptor)

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -695,6 +695,25 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_nul_byte_in_command_string_does_not_crash_guard(self):
+        """A NUL byte in the command string itself must not crash the guard.
+
+        #76762 covered NUL bytes read out of a referenced binary's contents,
+        but a path token containing a literal NUL can also arrive straight
+        from the command string (e.g. an agent emitting "\\x00" inside a
+        JSON-encoded command). os.open() raises ValueError — not OSError —
+        for such a path, which escaped _read_referenced_script's handler and
+        crashed the guard. A NUL-bearing path can never exist on POSIX, so
+        it reads as "nothing to scan".
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "bash /tmp/junk\x00fragment.sh"
+        )
+        assert result is False
+
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:
         a .sh script that itself invokes a lifecycle command is caught."""


### PR DESCRIPTION
## Problem

`_read_referenced_script` catches only `OSError` around `os.open()`, but `os.open()` raises `ValueError` for a path containing an embedded NUL byte. A NUL can arrive in a path token straight from the command string — e.g. an agent emitting `\x00` inside a JSON-encoded terminal command — and the guard crashes:

```
>>> from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
>>> contains_gateway_lifecycle_command_or_referenced_script("bash /tmp/junk\x00fragment.sh")
ValueError: open: embedded null character in path
```

In production this failed every terminal tool call in the affected agent turn, and agent retry loops multiplied the damage (we measured this driving a runaway token burn on a cron-driven agent before diagnosing it).

## Relation to #76762

#76762 fixed the sibling vector — NUL bytes read out of a referenced binary's *contents* — by skipping binaries in `_read_referenced_script` and tolerating `ValueError` at the `Path.resolve()` site. But the `os.open()` call two lines above the binary check still catches only `OSError`, so a NUL-bearing path token that arrives directly from the command string still crashes the guard before the content check can run.

## Fix

Catch `(OSError, ValueError)` at the `os.open()` site, matching the treatment #76762 gave `Path.resolve()`. This is fail-safe: a NUL-bearing path can never exist on POSIX and can never reach `execve`, so there is no script to scan and nothing for the guard to miss.

## Testing

Added `test_nul_byte_in_command_string_does_not_crash_guard` beside the existing #76762 regression test. Verified:
- new test fails with `ValueError` before the fix, passes after
- `test_absolute_path_binary_does_not_crash_guard` and `test_binary_script_does_not_silently_bypass` still pass
- lifecycle detection intact (`bash -c "hermes gateway restart"` still returns `True`)