### PR TITLE
chore: add contributor email mapping for zabih-sudo

### DIFF
--- a/contributors/emails/zabih.mosafer@gmail.com
+++ b/contributors/emails/zabih.mosafer@gmail.com
@@ -1,0 +1,1 @@
+zabih-sudo


### PR DESCRIPTION
Attribution mapping for @zabih-sudo, needed by the #72610 salvage.