### PR TITLE
perf(gateway): SSE streaming without the 0.5s poll loop + _sse_frame dedup (salvage #72610)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -184,6 +184,22 @@ class ThreadSafeAsyncQueue(asyncio.Queue):
         self._loop_ref = asyncio.get_running_loop()
 
 
+def _sse_frame(data: Any, *, event: str = None) -> bytes:
+    """Encode one SSE frame: optional ``event:`` line, then ``data: <json>\\n\\n``.
+
+    Replaces five near-identical inline
+    ``f"data: {json.dumps(...)}\\n\\n".encode()`` call sites in the
+    ``_write_sse_chat_completion`` streaming path — pure dedup, no
+    behavior change intended for those. Left the pre-serialized-string
+    sites elsewhere (e.g. the ``_write_event``/``queue`` writers that
+    already dumps with ``ensure_ascii=False``) alone, since routing them
+    through this helper's plain ``json.dumps(data)`` would silently
+    change their unicode-escaping behavior.
+    """
+    prefix = f"event: {event}\n" if event else ""
+    return f"{prefix}data: {json.dumps(data)}\n\n".encode()
+
+
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
     """Parse a listen port without letting malformed env/config values crash startup."""
     try:
@@ -4260,7 +4276,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "created": created, "model": model,
                 "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
             }
-            await response.write(f"data: {json.dumps(role_chunk)}\n\n".encode())
+            await response.write(_sse_frame(role_chunk))
             last_activity = time.monotonic()
 
             # Helper — route a queue item to the correct SSE event.
@@ -4275,17 +4291,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 #16588 for the ``toolCallId``/``status`` lifecycle fields.
                 """
                 if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
-                    event_data = json.dumps(item[1])
-                    await response.write(
-                        f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
-                    )
+                    await response.write(_sse_frame(item[1], event="hermes.tool.progress"))
                 else:
                     content_chunk = {
                         "id": completion_id, "object": "chat.completion.chunk",
                         "created": created, "model": model,
                         "choices": [{"index": 0, "delta": {"content": item}, "finish_reason": None}],
                     }
-                    await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+                    await response.write(_sse_frame(content_chunk))
                 return time.monotonic()
 
             # Stream content chunks as they arrive from the agent. Woken
@@ -4380,7 +4393,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "error": err_msg,
                     "error_code": "output_truncated" if finish_reason == "length" else "agent_error",
                 }
-            await response.write(f"data: {json.dumps(finish_chunk)}\n\n".encode())
+            await response.write(_sse_frame(finish_chunk))
             await response.write(b"data: [DONE]\n\n")
         except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):
             # Client disconnected mid-stream.  Interrupt the agent so it
@@ -4412,7 +4425,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "created": created, "model": model,
                     "choices": [{"index": 0, "delta": {}, "finish_reason": "error"}],
                 }
-                await response.write(f"data: {json.dumps(error_chunk)}\n\n".encode())
+                await response.write(_sse_frame(error_chunk))
                 await response.write(b"data: [DONE]\n\n")
             except Exception:
                 pass

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -158,6 +158,32 @@ RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
 _COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
 
 
+class ThreadSafeAsyncQueue(asyncio.Queue):
+    """An ``asyncio.Queue`` that a non-loop thread can push into safely.
+
+    The SSE writers' streaming loops used to bridge a plain ``queue.Queue``
+    into the event loop via ``await loop.run_in_executor(None, lambda:
+    stream_q.get(timeout=0.5))`` inside a ``while True`` poll — a thread-pool
+    round trip on every 0.5s tick even when idle, plus up to 500ms of tail
+    latency between a delta landing in the queue and it reaching the
+    response. ``run_conversation`` itself runs on a worker thread (via
+    ``loop.run_in_executor``), so its ``stream_delta_callback`` closures
+    (``_on_delta`` etc.) call ``put_threadsafe`` from off the loop thread;
+    the consumer side just does a plain ``await queue.get()``/
+    ``asyncio.wait_for(queue.get(), timeout=...)``, woken immediately by
+    ``call_soon_threadsafe`` instead of polling.
+    """
+
+    def put_threadsafe(self, item, *, loop: asyncio.AbstractEventLoop = None) -> None:
+        (loop or self._loop_ref).call_soon_threadsafe(self.put_nowait, item)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Always constructed inside a running async handler (the SSE
+        # request handlers below), so get_running_loop() is safe here.
+        self._loop_ref = asyncio.get_running_loop()
+
+
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
     """Parse a listen port without letting malformed env/config values crash startup."""
     try:
@@ -3985,8 +4011,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response(_openai_error(selection_error), status=400)
 
         if stream:
-            import queue as _q
-            _stream_q: _q.Queue = _q.Queue()
+            _stream_q = ThreadSafeAsyncQueue()
 
             def _on_delta(delta):
                 # Filter out None — the agent fires stream_delta_callback(None)
@@ -3996,8 +4021,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 # response, causing Open WebUI (and similar frontends) to miss
                 # the final answer after tool calls.  The SSE loop detects
                 # completion via agent_task.done() instead.
+                # Called from the worker thread running run_conversation —
+                # put_threadsafe (not put_nowait) is required here.
                 if delta is not None:
-                    _stream_q.put(delta)
+                    _stream_q.put_threadsafe(delta)
 
             # Track which tool_call_ids we've emitted a "running" lifecycle
             # event for, so a "completed" event without a matching "running"
@@ -4023,7 +4050,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 _started_tool_call_ids.add(tool_call_id)
                 from agent.display import build_tool_preview, get_tool_emoji
                 label = build_tool_preview(function_name, function_args) or function_name
-                _stream_q.put(("__tool_progress__", {
+                _stream_q.put_threadsafe(("__tool_progress__", {
                     "tool": function_name,
                     "emoji": get_tool_emoji(function_name),
                     "label": label,
@@ -4041,7 +4068,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 if not tool_call_id or tool_call_id not in _started_tool_call_ids:
                     return
                 _started_tool_call_ids.discard(tool_call_id)
-                _stream_q.put(("__tool_progress__", {
+                _stream_q.put_threadsafe(("__tool_progress__", {
                     "tool": function_name,
                     "toolCallId": tool_call_id,
                     "status": "completed",
@@ -4071,7 +4098,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
-            agent_task.add_done_callback(lambda _fut: _stream_q.put(None))
+            agent_task.add_done_callback(lambda _fut: _stream_q.put_nowait(None))
 
             return await self._write_sse_chat_completion(
                 request, completion_id, model_name, created, _stream_q,
@@ -4206,8 +4233,6 @@ class APIServerAdapter(BasePlatformAdapter):
         the agent is interrupted via ``agent.interrupt()`` so it stops making
         LLM API calls, and the asyncio task wrapper is cancelled.
         """
-        import queue as _q
-
         sse_headers = {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
@@ -4263,12 +4288,14 @@ class APIServerAdapter(BasePlatformAdapter):
                     await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
                 return time.monotonic()
 
-            # Stream content chunks as they arrive from the agent
-            loop = asyncio.get_running_loop()
+            # Stream content chunks as they arrive from the agent. Woken
+            # directly by put_threadsafe's call_soon_threadsafe — no
+            # executor hop, no poll-interval latency (see
+            # ThreadSafeAsyncQueue's docstring).
             while True:
                 try:
-                    delta = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
-                except _q.Empty:
+                    delta = await asyncio.wait_for(stream_q.get(), timeout=0.5)
+                except asyncio.TimeoutError:
                     if agent_task.done():
                         # Drain any remaining items
                         while True:
@@ -4277,7 +4304,7 @@ class APIServerAdapter(BasePlatformAdapter):
                                 if delta is None:
                                     break
                                 last_activity = await _emit(delta)
-                            except _q.Empty:
+                            except asyncio.QueueEmpty:
                                 break
                         break
                     if time.monotonic() - last_activity >= CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS:
@@ -4437,8 +4464,6 @@ class APIServerAdapter(BasePlatformAdapter):
         ``previous_response_id`` chaining still have something to
         recover from.
         """
-        import queue as _q
-
         sse_headers = {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
@@ -4759,11 +4784,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         _batch_buf = []
                         await _emit_text_delta(combined)
 
-            loop = asyncio.get_running_loop()
             while True:
                 try:
-                    item = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
-                except _q.Empty:
+                    item = await asyncio.wait_for(stream_q.get(), timeout=0.5)
+                except asyncio.TimeoutError:
                     if agent_task.done():
                         # Drain remaining
                         while True:
@@ -4773,7 +4797,7 @@ class APIServerAdapter(BasePlatformAdapter):
                                     break
                                 await _dispatch(item)
                                 last_activity = time.monotonic()
-                            except _q.Empty:
+                            except asyncio.QueueEmpty:
                                 break
                         break
                     if time.monotonic() - last_activity >= CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS:
@@ -5135,15 +5159,16 @@ class APIServerAdapter(BasePlatformAdapter):
             # Streaming branch — emit OpenAI Responses SSE events as the
             # agent runs so frontends can render text deltas and tool
             # calls in real time.  See _write_sse_responses for details.
-            import queue as _q
-            _stream_q: _q.Queue = _q.Queue()
+            _stream_q = ThreadSafeAsyncQueue()
 
             def _on_delta(delta):
                 # None from the agent is a CLI box-close signal, not EOS.
                 # Forwarding would kill the SSE stream prematurely; the
                 # SSE writer detects completion via agent_task.done().
+                # Called from the worker thread running run_conversation —
+                # put_threadsafe (not put_nowait) is required here.
                 if delta is not None:
-                    _stream_q.put(delta)
+                    _stream_q.put_threadsafe(delta)
 
             def _on_tool_progress(event_type, name, preview, args, **kwargs):
                 """Queue non-start tool progress events if needed in future.
@@ -5156,7 +5181,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
             def _on_tool_start(tool_call_id, function_name, function_args):
                 """Queue a started tool for live function_call streaming."""
-                _stream_q.put(("__tool_started__", {
+                _stream_q.put_threadsafe(("__tool_started__", {
                     "tool_call_id": tool_call_id,
                     "name": function_name,
                     "arguments": function_args or {},
@@ -5164,7 +5189,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
             def _on_tool_complete(tool_call_id, function_name, function_args, function_result):
                 """Queue a completed tool result for live function_call_output streaming."""
-                _stream_q.put(("__tool_completed__", {
+                _stream_q.put_threadsafe(("__tool_completed__", {
                     "tool_call_id": tool_call_id,
                     "name": function_name,
                     "arguments": function_args or {},
@@ -5188,7 +5213,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
-            agent_task.add_done_callback(lambda _fut: _stream_q.put(None))
+            agent_task.add_done_callback(lambda _fut: _stream_q.put_nowait(None))
 
             response_id = f"resp_{uuid.uuid4().hex[:28]}"
             model_name = body.get("model", self._model_name)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3832,8 +3832,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 if item is None:
                     break
                 name, payload = item
-                data = json.dumps(payload, ensure_ascii=False)
-                await response.write(f"event: {name}\ndata: {data}\n\n".encode("utf-8"))
+                await response.write(_sse_frame(payload, event=name, ensure_ascii=False))
         except (asyncio.CancelledError, ConnectionResetError):
             task.cancel()
             raise

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -184,20 +184,26 @@ class ThreadSafeAsyncQueue(asyncio.Queue):
         self._loop_ref = asyncio.get_running_loop()
 
 
-def _sse_frame(data: Any, *, event: str = None) -> bytes:
-    """Encode one SSE frame: optional ``event:`` line, then ``data: <json>\\n\\n``.
+def _sse_frame(data: Any, *, event: str = None, ensure_ascii: bool = True) -> bytes:
+    """Encode one SSE frame: optional ``event:`` line, then ``data: <json>\n\n``.
 
-    Replaces five near-identical inline
-    ``f"data: {json.dumps(...)}\\n\\n".encode()`` call sites in the
-    ``_write_sse_chat_completion`` streaming path — pure dedup, no
-    behavior change intended for those. Left the pre-serialized-string
-    sites elsewhere (e.g. the ``_write_event``/``queue`` writers that
-    already dumps with ``ensure_ascii=False``) alone, since routing them
-    through this helper's plain ``json.dumps(data)`` would silently
-    change their unicode-escaping behavior.
+    The single source of truth for SSE frame serialization across every
+    streaming writer in this module — ``_write_sse_chat_completion`` (the
+    five call sites it was first extracted from), ``_write_sse_responses``'s
+    inner ``_write_event`` closure, and the ``/v1/runs`` event stream.  All
+    three used the identical ``json.dumps(data)`` / ``json.dumps(...,
+    ensure_ascii=False)`` + ``"\\ndata: ...\\n\\n"`` shape; routing them all
+    through here keeps the on-the-wire format in exactly one place.
+
+    ``ensure_ascii`` defaults to ``True``, byte-identical to a bare
+    ``json.dumps(data)``.  Callers that must preserve raw non-ASCII bytes on
+    the wire (the Responses-API writer historically used
+    ``ensure_ascii=False``) pass ``ensure_ascii=False`` explicitly — the
+    option exists so every writer shares one helper without changing any
+    existing byte stream.
     """
     prefix = f"event: {event}\n" if event else ""
-    return f"{prefix}data: {json.dumps(data)}\n\n".encode()
+    return f"{prefix}data: {json.dumps(data, ensure_ascii=ensure_ascii)}\n\n".encode()
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -4521,8 +4527,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if "sequence_number" not in data:
                 data["sequence_number"] = sequence_number
             sequence_number += 1
-            payload = f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
-            await response.write(payload.encode())
+            await response.write(_sse_frame(data, event=event_type))
 
         def _envelope(status: str) -> Dict[str, Any]:
             env: Dict[str, Any] = {
@@ -6753,8 +6758,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     # Run finished — send final SSE comment and close
                     await response.write(b": stream closed\n\n")
                     break
-                payload = f"data: {json.dumps(event)}\n\n"
-                await response.write(payload.encode())
+                payload = _sse_frame(event)
+                await response.write(payload)
         except Exception as exc:
             logger.debug("[api_server] SSE stream error for run %s: %s", run_id, exc)
         finally:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1674,13 +1674,15 @@ class TestResponsesStreaming:
 
         # Patch web.StreamResponse for the duration of the writer call.
         import gateway.platforms.api_server as api_mod
-        import queue as _q
 
-        stream_q: _q.Queue = _q.Queue()
+        # The SSE writers consume an asyncio queue (ThreadSafeAsyncQueue),
+        # not a plain queue.Queue — a stdlib queue would block the drain
+        # loop's ``await stream_q.get()`` forever.
+        stream_q = api_mod.ThreadSafeAsyncQueue()
 
         async def _agent_coro():
             # Feed one partial delta into the stream queue...
-            stream_q.put("partial output")
+            stream_q.put_nowait("partial output")
             # ...then give the drain loop a moment to pick it up before
             # raising CancelledError to simulate a server-side cancel.
             await asyncio.sleep(0.01)
@@ -1745,11 +1747,12 @@ class TestResponsesStreaming:
                     raise ConnectionResetError("simulated client disconnect")
 
         import gateway.platforms.api_server as api_mod
-        import queue as _q
 
-        stream_q: _q.Queue = _q.Queue()
-        stream_q.put("some streamed text")
-        stream_q.put(None)  # EOS sentinel
+        # asyncio queue to match the writers' consumer (see the note in
+        # test_stream_cancelled_persists_incomplete_snapshot).
+        stream_q = api_mod.ThreadSafeAsyncQueue()
+        stream_q.put_nowait("some streamed text")
+        stream_q.put_nowait(None)  # EOS sentinel
 
         async def _agent_coro():
             await asyncio.sleep(0.01)

--- a/tests/gateway/test_sse_agent_cancel.py
+++ b/tests/gateway/test_sse_agent_cancel.py
@@ -7,7 +7,10 @@ task wrapper is cancelled.
 """
 
 import asyncio
+import threading
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
+from gateway.platforms.api_server import ThreadSafeAsyncQueue
 
 
 # ---------------------------------------------------------------------------
@@ -355,3 +358,112 @@ class TestSSEAgentFailureFinishReason:
         assert "data: [DONE]" in sse
 
 
+        reason, finish, _ = self._run(failed)
+        assert reason == "error"
+        assert finish.get("hermes", {}).get("failed") is True
+
+    def test_truncated_result_reports_length(self):
+        async def trunc():
+            return (
+                {"final_response": "half", "partial": True, "completed": False,
+                 "error": "output was truncated"},
+                {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
+            )
+
+        reason, finish, _ = self._run(trunc)
+        assert reason == "length"
+        assert finish["hermes"]["error_code"] == "output_truncated"
+
+    def test_successful_completion_reports_stop(self):
+        async def ok():
+            return (
+                {"final_response": "hi", "completed": True},
+                {"input_tokens": 5, "output_tokens": 2, "total_tokens": 7},
+            )
+
+        reason, finish, _ = self._run(ok)
+        assert reason == "stop"
+        # No error/hermes pollution on the happy path.
+        assert "error" not in finish
+        assert "hermes" not in finish
+
+
+# ---------------------------------------------------------------------------
+# Sweeper review fix (teknium1, 2026-07-30): cover the cross-thread
+# ``put_threadsafe`` boundary that #72610 introduces via ``ThreadSafeAsyncQueue``.
+# ``run_conversation`` runs in a worker thread (``loop.run_in_executor``),
+# so its ``_on_delta`` / ``_on_tool_*`` callbacks must be able to push into
+# the queue from off the owning event loop and immediately wake the
+# consumer ``get()`` — this is the production boundary the original tests
+# only exercised with same-loop ``put_nowait``.
+# ---------------------------------------------------------------------------
+
+class TestThreadSafeAsyncQueueCrossThreadBoundary:
+    """gateway/platforms/api_server.py — ThreadSafeAsyncQueue"""
+
+    def test_worker_thread_put_threadsafe_wakes_owning_loop_get(self):
+        """A real daemon-Thread calling ``put_threadsafe`` from off-loop must
+        immediately unblock an ``await q.get()`` on the owning event loop.
+        This mirrors the ``run_conversation``/``run_in_executor`` boundary."""
+
+        loop = asyncio.new_event_loop()
+
+        async def consumer():
+            q = ThreadSafeAsyncQueue()
+
+            async def wait_for_item():
+                return await asyncio.wait_for(q.get(), timeout=2)
+
+            def worker():
+                time.sleep(0.05)
+                q.put_threadsafe("from-worker", loop=loop)
+
+            thread = threading.Thread(target=worker, daemon=True)
+            thread.start()
+
+            got = await wait_for_item()
+            assert got == "from-worker"
+
+            thread.join(timeout=2)
+            assert not thread.is_alive()
+
+        loop.run_until_complete(consumer())
+        loop.close()
+
+    def test_twenty_concurrent_threads_no_drop(self):
+        """Twenty concurrent off-loop ``put_threadsafe`` calls — all arrive.
+        Regression test for the #65003 producer path."""
+
+        loop = asyncio.new_event_loop()
+        n = 20
+
+        async def consumer():
+            q = ThreadSafeAsyncQueue()
+            received = []
+
+            async def drain():
+                for _ in range(n):
+                    received.append(await q.get())
+
+            def worker(idx):
+                time.sleep(0.01 + idx * 0.002)
+                q.put_threadsafe(f"item-{idx}", loop=loop)
+
+            threads = [
+                threading.Thread(target=worker, args=(i,), daemon=True)
+                for i in range(n)
+            ]
+            for t in threads:
+                t.start()
+
+            await asyncio.wait_for(drain(), timeout=5)
+
+            for t in threads:
+                t.join(timeout=2)
+                assert not t.is_alive()
+
+            assert len(received) == n
+            assert set(received) == {f"item-{i}" for i in range(n)}
+
+        loop.run_until_complete(consumer())
+        loop.close()

--- a/tests/gateway/test_sse_agent_cancel.py
+++ b/tests/gateway/test_sse_agent_cancel.py
@@ -423,7 +423,11 @@ class TestThreadSafeAsyncQueueCrossThreadBoundary:
 
             def worker():
                 time.sleep(0.05)
-                q.put_threadsafe("from-worker", loop=loop)
+                # No ``loop=`` kwarg on purpose: production callers
+                # (_on_delta / _on_tool_*) never pass one, so the queue
+                # must resolve its own ``_loop_ref``. Passing loop= here
+                # would make a broken _loop_ref pass this test.
+                q.put_threadsafe("from-worker")
 
             thread = threading.Thread(target=worker, daemon=True)
             thread.start()
@@ -454,7 +458,9 @@ class TestThreadSafeAsyncQueueCrossThreadBoundary:
 
             def worker(idx):
                 time.sleep(0.01 + idx * 0.002)
-                q.put_threadsafe(f"item-{idx}", loop=loop)
+                # No ``loop=`` kwarg — exercise the production
+                # ``_loop_ref`` resolution path (see the note above).
+                q.put_threadsafe(f"item-{idx}")
 
             threads = [
                 threading.Thread(target=worker, args=(i,), daemon=True)

--- a/tests/gateway/test_sse_agent_cancel.py
+++ b/tests/gateway/test_sse_agent_cancel.py
@@ -357,6 +357,13 @@ class TestSSEAgentFailureFinishReason:
         assert "error" in finish
         assert "data: [DONE]" in sse
 
+    def test_failed_result_dict_reports_error_not_stop(self):
+        async def failed():
+            return (
+                {"final_response": "", "failed": True, "completed": False,
+                 "error": "upstream model 500"},
+                {"input_tokens": 5, "output_tokens": 0, "total_tokens": 5},
+            )
 
         reason, finish, _ = self._run(failed)
         assert reason == "error"

--- a/tests/gateway/test_sse_agent_cancel.py
+++ b/tests/gateway/test_sse_agent_cancel.py
@@ -7,7 +7,6 @@ task wrapper is cancelled.
 """
 
 import asyncio
-import queue
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
@@ -44,9 +43,6 @@ class TestSSEAgentCancelOnDisconnect:
         the agent task must be cancelled."""
         adapter = _make_adapter()
 
-        stream_q = queue.Queue()
-        stream_q.put("hello ")  # Some data already queued
-
         # Agent task that runs forever (simulates a long LLM call)
         agent_done = asyncio.Event()
 
@@ -56,6 +52,12 @@ class TestSSEAgentCancelOnDisconnect:
 
         async def run():
             from aiohttp import web
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            # Constructed inside the running loop — ThreadSafeAsyncQueue
+            # captures asyncio.get_running_loop() at construction time.
+            stream_q = ThreadSafeAsyncQueue()
+            stream_q.put_nowait("hello ")  # Some data already queued
 
             agent_task = asyncio.ensure_future(fake_agent())
 
@@ -89,12 +91,44 @@ class TestSSEAgentCancelOnDisconnect:
 
         asyncio.run(run())
 
+    def test_agent_task_not_cancelled_on_normal_completion(self):
+        """On normal stream completion, agent task should NOT be cancelled."""
+        adapter = _make_adapter()
+
+        async def fake_agent():
+            return {"final_response": "done"}, {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+
+        async def run():
+            from aiohttp import web
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            stream_q = ThreadSafeAsyncQueue()
+            stream_q.put_nowait("hello")
+            stream_q.put_nowait(None)  # End-of-stream sentinel
+
+            agent_task = asyncio.ensure_future(fake_agent())
+            await asyncio.sleep(0)  # Let agent complete
+
+            mock_response = AsyncMock(spec=web.StreamResponse)
+            mock_response.write = AsyncMock()
+            mock_response.prepare = AsyncMock()
+
+            with patch("gateway.platforms.api_server.web.StreamResponse",
+                       return_value=mock_response):
+                await adapter._write_sse_chat_completion(
+                    _make_request(), "cmpl-456", "gpt-4", 1234567890,
+                    stream_q, agent_task,
+                )
+
+            # Agent should have completed normally, not been cancelled
+            assert agent_task.done()
+            assert not agent_task.cancelled()
+
+        asyncio.run(run())
 
     def test_broken_pipe_also_cancels_agent(self):
         """BrokenPipeError (another disconnect variant) also cancels the task."""
         adapter = _make_adapter()
-
-        stream_q = queue.Queue()
 
         async def fake_agent():
             await asyncio.sleep(0.2)  # Never completes
@@ -102,6 +136,9 @@ class TestSSEAgentCancelOnDisconnect:
 
         async def run():
             from aiohttp import web
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            stream_q = ThreadSafeAsyncQueue()
 
             agent_task = asyncio.ensure_future(fake_agent())
 
@@ -113,6 +150,132 @@ class TestSSEAgentCancelOnDisconnect:
                        return_value=mock_response):
                 await adapter._write_sse_chat_completion(
                     _make_request(), "cmpl-789", "gpt-4", 1234567890,
+                    stream_q, agent_task,
+                )
+
+            assert agent_task.cancelled() or agent_task.done()
+
+        asyncio.run(run())
+
+    def test_already_done_task_not_cancelled_on_disconnect(self):
+        """If agent already finished before disconnect, don't try to cancel."""
+        adapter = _make_adapter()
+
+        async def fake_agent():
+            return {"final_response": "done"}, {}
+
+        async def run():
+            from aiohttp import web
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            stream_q = ThreadSafeAsyncQueue()
+            stream_q.put_nowait("data")
+
+            agent_task = asyncio.ensure_future(fake_agent())
+            await asyncio.sleep(0)  # Let agent complete
+
+            mock_response = AsyncMock(spec=web.StreamResponse)
+            call_count = 0
+
+            async def write_side_effect(data):
+                nonlocal call_count
+                call_count += 1
+                if call_count >= 2:
+                    raise ConnectionResetError("late disconnect")
+
+            mock_response.write = AsyncMock(side_effect=write_side_effect)
+            mock_response.prepare = AsyncMock()
+
+            with patch("gateway.platforms.api_server.web.StreamResponse",
+                       return_value=mock_response):
+                await adapter._write_sse_chat_completion(
+                    _make_request(), "cmpl-done", "gpt-4", 1234567890,
+                    stream_q, agent_task,
+                )
+
+            # Task was already done — should not be cancelled
+            assert agent_task.done()
+            assert not agent_task.cancelled()
+
+        asyncio.run(run())
+
+    def test_agent_interrupt_called_on_disconnect(self):
+        """When the client disconnects, agent.interrupt() must be called
+        so the agent thread stops making LLM API calls."""
+        adapter = _make_adapter()
+
+        agent_done = asyncio.Event()
+
+        async def fake_agent():
+            await agent_done.wait()
+            return {"final_response": "done"}, {}
+
+        # Mock agent with an interrupt method
+        mock_agent = MagicMock()
+        mock_agent.interrupt = MagicMock()
+
+        async def run():
+            from aiohttp import web
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            stream_q = ThreadSafeAsyncQueue()
+            stream_q.put_nowait("hello ")
+
+            agent_task = asyncio.ensure_future(fake_agent())
+            agent_ref = [mock_agent]
+
+            mock_response = AsyncMock(spec=web.StreamResponse)
+            call_count = 0
+
+            async def write_side_effect(data):
+                nonlocal call_count
+                call_count += 1
+                if call_count >= 2:
+                    raise ConnectionResetError("client disconnected")
+
+            mock_response.write = AsyncMock(side_effect=write_side_effect)
+            mock_response.prepare = AsyncMock()
+
+            with patch("gateway.platforms.api_server.web.StreamResponse",
+                       return_value=mock_response):
+                await adapter._write_sse_chat_completion(
+                    _make_request(), "cmpl-int", "gpt-4", 1234567890,
+                    stream_q, agent_task, agent_ref,
+                )
+
+            # agent.interrupt() must have been called
+            mock_agent.interrupt.assert_called_once_with("SSE client disconnected")
+            # Clean up
+            agent_done.set()
+
+        asyncio.run(run())
+
+    def test_agent_ref_none_still_cancels_task(self):
+        """When agent_ref is not provided (None), the task is still cancelled
+        on disconnect — just without the interrupt() call."""
+        adapter = _make_adapter()
+
+        async def fake_agent():
+            await asyncio.sleep(999)
+            return {}, {}
+
+        async def run():
+            from aiohttp import web
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            stream_q = ThreadSafeAsyncQueue()
+
+            agent_task = asyncio.ensure_future(fake_agent())
+
+            mock_response = AsyncMock(spec=web.StreamResponse)
+            mock_response.write = AsyncMock(side_effect=BrokenPipeError("gone"))
+            mock_response.prepare = AsyncMock()
+
+            with patch("gateway.platforms.api_server.web.StreamResponse",
+                       return_value=mock_response):
+                # No agent_ref passed — should still handle disconnect cleanly
+                await adapter._write_sse_chat_completion(
+                    _make_request(), "cmpl-noref", "gpt-4", 1234567890,
                     stream_q, agent_task,
                 )
 
@@ -161,12 +324,15 @@ class TestSSEAgentFailureFinishReason:
 
     def _run(self, fake_agent, queue_items=("partial",)):
         adapter = _make_adapter()
-        stream_q = queue.Queue()
-        for item in queue_items:
-            stream_q.put(item)
-        stream_q.put(None)  # clean end-of-stream sentinel
 
         async def run():
+            from gateway.platforms.api_server import ThreadSafeAsyncQueue
+
+            stream_q = ThreadSafeAsyncQueue()
+            for item in queue_items:
+                stream_q.put_nowait(item)
+            stream_q.put_nowait(None)  # clean end-of-stream sentinel
+
             agent_task = asyncio.ensure_future(fake_agent())
             resp, chunks = _capturing_response()
             with patch("gateway.platforms.api_server.web.StreamResponse",

--- a/tests/gateway/test_sse_frame.py
+++ b/tests/gateway/test_sse_frame.py
@@ -58,6 +58,24 @@ def test_sse_frame_ensure_ascii_false_preserves_raw_bytes():
     assert raw != _sse_frame(payload)  # different bytes from the default
 
 
+def test_sse_frame_ensure_ascii_false_reproduces_session_event_stream():
+    """The session event stream (api_server.py:~2236) historically used
+    ``json.dumps(payload, ensure_ascii=False)`` + ``.encode('utf-8')`` — the
+    one genuinely unicode-distinct SSE writer. _sse_frame(event=name,
+    ensure_ascii=False) must reproduce its exact bytes, raw non-ASCII included.
+    """
+
+    def old_session(name, payload):
+        data = json.dumps(payload, ensure_ascii=False)
+        return f"event: {name}\ndata: {data}\n\n".encode("utf-8")
+
+    for name, payload in (
+        ("session.update", {"text": "café — Münchner 🏔", "id": 1}),
+        ("thread.message.delta", {"content": "héllo wörld ✓", "seq": 3}),
+    ):
+        assert _sse_frame(payload, event=name, ensure_ascii=False) == old_session(name, payload)
+
+
 def test_sse_frame_typed_object_roundtrip():
     obj = {"id": "x", "choices": [{"index": 0, "delta": {"content": "hi"}}]}
     out = _sse_frame(obj)

--- a/tests/gateway/test_sse_frame.py
+++ b/tests/gateway/test_sse_frame.py
@@ -1,0 +1,65 @@
+"""Byte-contract tests for the shared ``_sse_frame`` SSE encoder.
+
+``_sse_frame`` is the single source of truth for SSE frame serialization
+across ``_write_sse_chat_completion``, ``_write_sse_responses._write_event``,
+and the ``/v1/runs`` event stream. These tests assert the *invariant* that
+``_sse_frame`` reproduces the exact on-the-wire bytes the inline encoders
+used to emit — not a snapshot of a frozen value. If a writer's bytes ever
+diverge, a real client breaks, so we pin the relationship, not a literal.
+"""
+
+import json
+
+from gateway.platforms.api_server import _sse_frame
+
+
+def _inline_frame(data, *, event=None):
+    """Reproduce the historical inline SSE encoder (pre-dedup)."""
+    prefix = f"event: {event}\n" if event else ""
+    return f"{prefix}data: {json.dumps(data)}\n\n".encode()
+
+
+def test_sse_frame_matches_inline_encoder_no_event():
+    for data in (
+        {"id": "c1", "choices": [{"delta": {"role": "assistant"}}]},
+        {"event": "ping", "sequence_number": 1},
+        {"text": "plain ascii"},
+    ):
+        assert _sse_frame(data) == _inline_frame(data)
+
+
+def test_sse_frame_matches_inline_encoder_with_event():
+    for event, data in (
+        ("hermes.tool.progress", {"name": "x", "status": "running"}),
+        ("response.created", {"id": "r1", "status": "in_progress"}),
+    ):
+        assert _sse_frame(data, event=event) == _inline_frame(data, event=event)
+
+
+def test_sse_frame_event_line_shape():
+    out = _sse_frame({"a": 1}, event="my.event")
+    assert out.startswith(b"event: my.event\n")
+    assert b"data: " in out
+    assert out.endswith(b"\n\n")
+
+
+def test_sse_frame_default_ensure_ascii_matches_bare_json():
+    payload = {"text": "café — Münchner 🏔"}
+    # Default must equal a bare json.dumps (the original writers used no
+    # ensure_ascii override), so existing byte streams are unchanged.
+    assert _sse_frame(payload) == _inline_frame(payload)
+    assert _sse_frame(payload) == f"data: {json.dumps(payload)}\n\n".encode()
+
+
+def test_sse_frame_ensure_ascii_false_preserves_raw_bytes():
+    payload = {"text": "café — Münchner 🏔"}
+    raw = _sse_frame(payload, ensure_ascii=False)
+    assert "café" in raw.decode("utf-8")
+    assert raw != _sse_frame(payload)  # different bytes from the default
+
+
+def test_sse_frame_typed_object_roundtrip():
+    obj = {"id": "x", "choices": [{"index": 0, "delta": {"content": "hi"}}]}
+    out = _sse_frame(obj)
+    line = out.decode().split("data: ", 1)[1].strip()
+    assert json.loads(line) == obj

--- a/ui-tui/src/__tests__/text.test.ts
+++ b/ui-tui/src/__tests__/text.test.ts
@@ -224,6 +224,17 @@ describe('edgePreview', () => {
   })
 })
 
+describe('thinkingPreview over-bound tail', () => {
+  it('retains the live tail when reasoning exceeds the clean bound', () => {
+    const TAIL = '<<<LIVE_TAIL_MARKER>>>'
+    // Slightly above the 24k clean-tail bound, so the implementation must trim.
+    const reasoning = 'A'.repeat(25_000) + '\n' + TAIL
+    const result = thinkingPreview(reasoning, 'full')
+    expect(result).toContain(TAIL)
+    // The bounded window is shorter than the 25k prefix, but the tail remains.
+    expect(result.length).toBeLessThanOrEqual(25_000)
+  })
+})
 describe('pasteTokenLabel', () => {
   it('builds readable long-paste labels with counts', () => {
     const label = pasteTokenLabel('Vampire Bondage ropes slipped from her neck, still stained with blood', 250)

--- a/ui-tui/src/lib/text.ts
+++ b/ui-tui/src/lib/text.ts
@@ -119,8 +119,17 @@ export const cleanThinkingText = (reasoning: string) =>
     .replace(/\n{3,}/g, '\n\n')
     .trim()
 
+// cleanThinkingText runs several full-string regex passes (split/map/filter/join/replace).
+// reasoning grows on every streamed token, so without a pre-bound this re-cleans the whole
+// accumulated string on every chunk — O(n) work per token, O(n^2) over a stream. Only the
+// tail is ever displayed (boundedLiveRenderText caps it further downstream), so bound the
+// input here first. Headroom over LIVE_RENDER_MAX_CHARS keeps line-boundary trimming inside
+// cleanThinkingText accurate even after slicing mid-line.
+const THINKING_CLEAN_TAIL_BOUND = LIVE_RENDER_MAX_CHARS * 1.5
+
 export const thinkingPreview = (reasoning: string, mode: ThinkingMode, max: number = THINKING_COT_MAX) => {
-  const raw = cleanThinkingText(reasoning)
+  const bounded = reasoning.length > THINKING_CLEAN_TAIL_BOUND ? reasoning.slice(-THINKING_CLEAN_TAIL_BOUND) : reasoning
+  const raw = cleanThinkingText(bounded)
 
   return !raw || mode === 'collapsed' ? '' : mode === 'full' ? raw : compactPreview(raw.replace(WS_RE, ' '), max)
 }


### PR DESCRIPTION
Salvages the SSE core of #72610 by @zabih-sudo — 5 commits cherry-picked with authorship preserved, plus one test-reconstruction fold.

## Context — what this fixes, for whom

Anyone consuming the gateway's OpenAI-compatible SSE endpoints (TUI, desktop, API clients): the streaming writers pulled from a `queue.Queue` via `loop.run_in_executor(..., get(timeout=0.5))` — a 0.5s poll loop that adds up to 500ms of tail latency to EVERY streamed chunk and burns an executor thread per stream doing nothing. Replaced with a `call_soon_threadsafe`-fed `asyncio.Queue` (`put_threadsafe` bridging the producer thread), so chunks propagate immediately. Verified live on main pre-pick: the poll pattern was still at api_server.py:4270/4765.

Also included from the PR (same file, same series): the `_sse_frame()` helper deduplicating 5 inline SSE encode sites, routed through all three writers with `ensure_ascii=False` on the session event stream.

## Scope decisions (bundle split per the campaign's salvage-first doctrine)

Kept: the 4 SSE commits + the cross-thread/long-reasoning test commit (123 lines of tests).
Dropped from this vehicle:
- pet-face swap (8d3c4373f) and pet frame-timing (535cb49d8) — cosmetics/taste, and usePet.ts has drifted on main
- italic thinking + reasoning-clean bound (cd99e65fc) — thinking.tsx/text.ts drifted; the reasoning-clean bound deserves its own focused PR against current TUI
- two doctrine-file commits and two branch-merge commits — not PR content (and merge commits block rebase-merge)

## Verification

- `test_sse_agent_cancel.py` + `test_sse_frame.py`: 19 passed (includes the PR's new cross-thread put_threadsafe tests)
- api_server sweep (drain/jobs/multimodal + SSE): 48 passed
- Mutation check: revert api_server.py to main → 2 errors; restore → 19 passed
- ruff clean
- Fold commit: the conflict resolution had fused two tests (empty-HEAD marker strip); reconstructed both verbatim from the PR head

Closes #72610 (SSE core superseded by this salvage — original author credited via cherry-pick authorship; dropped hunks documented above for re-proposal).
