### PR TITLE
feat(browser): per-call userId on Camofox tools for multi-account operation

### DIFF
--- a/tests/tools/test_browser_camofox_multi_user.py
+++ b/tests/tools/test_browser_camofox_multi_user.py
@@ -1,0 +1,877 @@
+"""Per-call ``user_id`` on the Camofox backend (issue #77273).
+
+Camofox maps each ``userId`` to its own browser profile, so passing a distinct
+one per call lets a single Hermes process drive several signed-in accounts.
+These tests pin the resolution precedence, the session isolation contract, the
+validation floor on a model-supplied identity, and the Camofox-gated schema.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.browser_camofox import (
+    InvalidCamofoxUserId,
+    _get_session,
+    _validate_call_user_id,
+    camofox_click,
+    camofox_close,
+    camofox_navigate,
+    camofox_snapshot,
+    list_camofox_sessions,
+)
+from tools.browser_camofox_state import get_camofox_identity
+
+
+def _mock_response(status=200, json_data=None):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = json_data or {}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _tab_response(tab_id="tab-1", url="https://example.com"):
+    return _mock_response(json_data={"tabId": tab_id, "url": url})
+
+
+@pytest.fixture(autouse=True)
+def _clear_session_state():
+    import tools.browser_camofox as mod
+    yield
+    with mod._sessions_lock:
+        mod._sessions.clear()
+    mod._vnc_url = None
+    mod._vnc_url_checked = False
+
+
+@pytest.fixture
+def camofox_env(tmp_path, monkeypatch):
+    """A clean Camofox-enabled environment with no configured identity."""
+    import tools.browser_camofox as mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+    for var in ("CAMOFOX_USER_ID", "CAMOFOX_SESSION_KEY", "CAMOFOX_ADOPT_EXISTING_TAB",
+                "BROWSER_CDP_URL"):
+        monkeypatch.delenv(var, raising=False)
+    # Mark the VNC probe as already done (no VNC). camofox_navigate calls
+    # get_vnc_url(), which would otherwise issue a real GET /health — unrelated
+    # to identity routing, and a network round-trip in every test.
+    mod._vnc_url = None
+    mod._vnc_url_checked = True
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Identity resolution precedence
+# ---------------------------------------------------------------------------
+
+
+class TestResolutionPrecedence:
+    """per-call user_id > CAMOFOX_USER_ID / config > managed profile > random."""
+
+    def test_per_call_beats_env_identity(self, camofox_env, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_USER_ID", "env-identity")
+
+        session = _get_session("task-1", user_id="acct-alice")
+
+        assert session["user_id"] == "acct-alice"
+        assert session["managed"] is True
+
+    def test_per_call_beats_config_identity(self, camofox_env):
+        config = {"browser": {"camofox": {"user_id": "config-identity"}}}
+
+        with patch("tools.browser_camofox.load_config", return_value=config):
+            session = _get_session("task-1", user_id="acct-alice")
+
+        assert session["user_id"] == "acct-alice"
+
+    def test_per_call_beats_managed_persistence(self, camofox_env):
+        config = {"browser": {"camofox": {"managed_persistence": True}}}
+
+        with patch("tools.browser_camofox.load_config", return_value=config):
+            session = _get_session("task-1", user_id="acct-alice")
+            profile_identity = get_camofox_identity("task-1")
+
+        assert session["user_id"] == "acct-alice"
+        assert session["user_id"] != profile_identity["user_id"]
+
+    def test_env_identity_still_wins_when_no_per_call_id(self, camofox_env, monkeypatch):
+        """Omitting user_id must not disturb the existing precedence chain."""
+        monkeypatch.setenv("CAMOFOX_USER_ID", "env-identity")
+
+        session = _get_session("task-1")
+
+        assert session["user_id"] == "env-identity"
+
+    def test_omitting_user_id_keeps_ephemeral_behaviour(self, camofox_env):
+        session = _get_session("task-1")
+
+        assert session["user_id"].startswith("hermes_")
+        assert session["managed"] is False
+        assert session["session_key"] == "task_task-1"
+
+    def test_default_session_still_keyed_by_bare_task_id(self, camofox_env):
+        """The no-user_id key space must stay byte-identical to pre-#77273."""
+        import tools.browser_camofox as mod
+
+        _get_session("task-1")
+
+        with mod._sessions_lock:
+            assert "task-1" in mod._sessions
+
+
+# ---------------------------------------------------------------------------
+# Session isolation
+# ---------------------------------------------------------------------------
+
+
+class TestSessionIsolation:
+    def test_two_identities_get_independent_sessions(self, camofox_env):
+        alice = _get_session("task-1", user_id="acct-alice")
+        bob = _get_session("task-1", user_id="acct-bob")
+
+        assert alice is not bob
+        assert alice["user_id"] == "acct-alice"
+        assert bob["user_id"] == "acct-bob"
+
+    def test_second_identity_does_not_evict_the_first(self, camofox_env):
+        alice = _get_session("task-1", user_id="acct-alice")
+        alice["tab_id"] = "tab-alice"
+        _get_session("task-1", user_id="acct-bob")
+
+        assert _get_session("task-1", user_id="acct-alice")["tab_id"] == "tab-alice"
+
+    def test_same_identity_reuses_the_session(self, camofox_env):
+        first = _get_session("task-1", user_id="acct-alice")
+        second = _get_session("task-1", user_id="acct-alice")
+
+        assert first is second
+
+    def test_per_call_identity_does_not_disturb_default_session(self, camofox_env):
+        default = _get_session("task-1")
+        scoped = _get_session("task-1", user_id="acct-alice")
+
+        assert default["user_id"] != scoped["user_id"]
+        assert _get_session("task-1") is default
+
+    def test_navigate_sends_requested_user_id(self, camofox_env):
+        with patch("tools.browser_camofox.requests.post",
+                   return_value=_tab_response()) as mock_post:
+            result = json.loads(
+                camofox_navigate("https://example.com", task_id="t1", user_id="acct-alice")
+            )
+
+        assert result["success"] is True
+        assert mock_post.call_args.kwargs["json"]["userId"] == "acct-alice"
+
+    def test_repeat_navigate_same_identity_reuses_tab(self, camofox_env):
+        posts = []
+
+        def _capture(url, json=None, timeout=None, headers=None):
+            posts.append((url, json))
+            return _tab_response(tab_id="tab-alice")
+
+        with patch("tools.browser_camofox.requests.post", side_effect=_capture):
+            camofox_navigate("https://example.com", task_id="t1", user_id="acct-alice")
+            camofox_navigate("https://example.com/two", task_id="t1", user_id="acct-alice")
+
+        # First call creates the tab; the second navigates the existing one.
+        assert posts[0][0].endswith("/tabs")
+        assert posts[1][0].endswith("/tabs/tab-alice/navigate")
+        assert posts[1][1]["userId"] == "acct-alice"
+
+    def test_two_identities_create_two_tabs(self, camofox_env):
+        created = []
+
+        def _capture(url, json=None, timeout=None, headers=None):
+            created.append(json["userId"])
+            return _tab_response(tab_id=f"tab-{len(created)}")
+
+        with patch("tools.browser_camofox.requests.post", side_effect=_capture):
+            camofox_navigate("https://example.com", task_id="t1", user_id="acct-alice")
+            camofox_navigate("https://example.com", task_id="t1", user_id="acct-bob")
+
+        assert created == ["acct-alice", "acct-bob"]
+
+
+# ---------------------------------------------------------------------------
+# Validation of a model-supplied identity
+# ---------------------------------------------------------------------------
+
+
+class TestUserIdValidation:
+    """A per-call user_id reaches DELETE /sessions/<id> as a path segment."""
+
+    @pytest.mark.parametrize("value", [
+        "acct-alice", "acct_bob", "a", "user.name", "ns:account", "user@example.com",
+        "A1", "x" * 64,
+    ])
+    def test_accepts_reasonable_identities(self, value):
+        assert _validate_call_user_id(value) == value
+
+    @pytest.mark.parametrize("value", [
+        "../evil",          # path traversal
+        "..",               # DELETE /sessions/.. can normalize to DELETE /sessions
+        ".",
+        "a/b",              # path separator
+        "a%2Fb",            # percent-encoded separator
+        "a\\b",
+        "-leading-dash",
+        ".leading-dot",
+        "has space",
+        "new\nline",
+        "",
+        "   ",
+        "x" * 65,           # over the length cap
+    ])
+    def test_rejects_unsafe_identities(self, value):
+        with pytest.raises(InvalidCamofoxUserId):
+            _validate_call_user_id(value)
+
+    @pytest.mark.parametrize("value", ["acct\n", "acct\n\n", "acct\r\n", "acct-a\n"])
+    def test_charset_rejects_trailing_newline_on_its_own(self, value):
+        """Python's ``$`` matches before a trailing newline; fullmatch does not.
+
+        The charset is a security boundary (the value becomes a URL path
+        segment), so it must hold without depending on the .strip() that
+        happens to run first. Surrounding whitespace is still normalized away
+        by the caller, so the validator itself accepts these and returns the
+        trimmed value — the point is that the *pattern* would not.
+        """
+        import tools.browser_camofox as mod
+
+        assert mod._CALL_USER_ID_RE.fullmatch(value) is None
+        assert _validate_call_user_id(value) == value.strip()
+
+    @pytest.mark.parametrize("value", ["ac\nct", "acct\nevil", "a\rb"])
+    def test_rejects_interior_newlines(self, value):
+        with pytest.raises(InvalidCamofoxUserId):
+            _validate_call_user_id(value)
+
+    @pytest.mark.parametrize("value", [0, False, 12345, 1.5, [], {}, ["acct-alice"]])
+    def test_rejects_non_strings_instead_of_falling_back(self, value):
+        """A type-confused argument must error, never select another account.
+
+        ``0``/``False`` are falsy: a truthiness gate would skip validation and
+        silently run under the *default* identity while the caller believes it
+        addressed a named account — the exact cross-account action the
+        parameter exists to prevent.
+        """
+        with pytest.raises(InvalidCamofoxUserId):
+            _validate_call_user_id(value)
+
+    @pytest.mark.parametrize("value", [0, False, 12345, []])
+    def test_non_string_is_rejected_end_to_end(self, camofox_env, value):
+        import tools.browser_camofox as mod
+
+        with patch("tools.browser_camofox.requests.post") as mock_post:
+            result = json.loads(
+                camofox_navigate("https://example.com", task_id="t1", user_id=value)
+            )
+
+        assert result["success"] is False
+        assert "expected a string" in result["error"]
+        mock_post.assert_not_called()
+        with mod._sessions_lock:
+            assert mod._sessions == {}
+
+    @pytest.mark.parametrize("value", [None, "", "   "])
+    def test_absent_identity_uses_default_session(self, camofox_env, value):
+        """None and empty strings mean "not supplied", not "invalid"."""
+        import tools.browser_camofox as mod
+
+        session = _get_session("task-1", user_id=value)
+
+        assert session["user_id"].startswith("hermes_")
+        with mod._sessions_lock:
+            assert list(mod._sessions) == ["task-1"]
+
+    def test_invalid_identity_short_circuits_before_any_request(self, camofox_env):
+        with (
+            patch("tools.browser_camofox.requests.post") as mock_post,
+            patch("tools.browser_camofox.requests.get") as mock_get,
+            patch("tools.browser_camofox.requests.delete") as mock_delete,
+        ):
+            result = json.loads(
+                camofox_navigate("https://example.com", task_id="t1", user_id="../evil")
+            )
+
+        assert result["success"] is False
+        assert "user_id" in result["error"]
+        mock_post.assert_not_called()
+        mock_get.assert_not_called()
+        mock_delete.assert_not_called()
+
+    def test_invalid_identity_rejected_by_close(self, camofox_env):
+        with patch("tools.browser_camofox.requests.delete") as mock_delete:
+            result = json.loads(camofox_close("t1", user_id=".."))
+
+        assert result["success"] is False
+        mock_delete.assert_not_called()
+
+    def test_invalid_identity_rejected_by_console(self, camofox_env):
+        """camofox_console has no session to fall back on; it must still error."""
+        from tools.browser_camofox import camofox_console
+
+        result = json.loads(camofox_console(user_id=12345))
+
+        assert result["success"] is False
+        assert "expected a string" in result["error"]
+
+    def test_invalid_identity_creates_no_session(self, camofox_env):
+        import tools.browser_camofox as mod
+
+        with pytest.raises(InvalidCamofoxUserId):
+            _get_session("task-1", user_id="../evil")
+
+        with mod._sessions_lock:
+            assert mod._sessions == {}
+
+    def test_operator_configured_identity_bypasses_call_validation(self, camofox_env, monkeypatch):
+        """Config/env identities are operator-owned and predate the charset rule."""
+        monkeypatch.setenv("CAMOFOX_USER_ID", "legacy identity/with weird chars")
+
+        session = _get_session("task-1")
+
+        assert session["user_id"] == "legacy identity/with weird chars"
+
+
+class TestConsoleDoesNotRubberStampIdentity:
+    """camofox_console never opens a session, so it must not echo an identity."""
+
+    def test_does_not_echo_unresolved_identity(self, camofox_env):
+        from tools.browser_camofox import camofox_console
+
+        result = json.loads(camofox_console(user_id="acct-never-created"))
+
+        assert result["success"] is True
+        assert "user_id" not in result
+
+    def test_does_not_create_a_session(self, camofox_env):
+        import tools.browser_camofox as mod
+        from tools.browser_camofox import camofox_console
+
+        camofox_console(user_id="acct-alice")
+
+        with mod._sessions_lock:
+            assert mod._sessions == {}
+
+
+class TestErrorsDiscloseIdentity:
+    """Echoing only on success can't distinguish failure from acting as someone else."""
+
+    def test_missing_tab_error_echoes_identity(self, camofox_env):
+        _get_session("task-1", user_id="acct-alice")
+
+        result = json.loads(camofox_click("@e1", task_id="task-1", user_id="acct-alice"))
+
+        assert result["success"] is False
+        assert result["user_id"] == "acct-alice"
+
+    def test_http_failure_echoes_identity(self, camofox_env):
+        session = _get_session("task-1", user_id="acct-alice")
+        session["tab_id"] = "tab-alice"
+
+        with (
+            patch("tools.browser_camofox._camofox_private_page_block", return_value=None),
+            patch("tools.browser_camofox._post", side_effect=RuntimeError("boom")),
+        ):
+            result = json.loads(camofox_click("@e1", task_id="task-1", user_id="acct-alice"))
+
+        assert result["success"] is False
+        assert result["user_id"] == "acct-alice"
+
+    def test_private_page_block_echoes_identity(self, camofox_env):
+        import tools.browser_camofox as mod
+
+        session = _get_session("task-1", user_id="acct-alice")
+        session["tab_id"] = "tab-alice"
+
+        with (
+            patch("tools.browser_tool._eval_ssrf_guard_active", return_value=True),
+            patch("tools.browser_tool._camofox_current_page_private_url",
+                  return_value="http://169.254.169.254/"),
+        ):
+            blocked = json.loads(
+                mod._camofox_private_page_block(session, "task-1", "click")
+            )
+
+        assert blocked["success"] is False
+        assert blocked["user_id"] == "acct-alice"
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_close_does_not_destroy_per_call_profile(self, camofox_env):
+        """DELETE /sessions/<id> wipes all of a user's data — never for a
+        caller-owned identity."""
+        _get_session("task-1", user_id="acct-alice")
+
+        with patch("tools.browser_camofox.requests.delete",
+                   return_value=_mock_response()) as mock_delete:
+            result = json.loads(camofox_close("task-1", user_id="acct-alice"))
+
+        assert result["closed"] is True
+        assert not [c for c in mock_delete.call_args_list if "/sessions/" in c.args[0]]
+
+    def test_close_reclaims_the_per_call_tab(self, camofox_env):
+        """Closing the tab is what keeps each new identity from leaking a window.
+
+        Camofox's POST /pressure/cleanup is caller-triggered, not an automatic
+        reaper, so a tab Hermes opened and never closed stays open.
+        """
+        session = _get_session("task-1", user_id="acct-alice")
+        session["tab_id"] = "tab-alice"
+
+        with patch("tools.browser_camofox.requests.delete",
+                   return_value=_mock_response()) as mock_delete:
+            camofox_close("task-1", user_id="acct-alice")
+
+        mock_delete.assert_called_once()
+        assert mock_delete.call_args.args[0].endswith("/tabs/tab-alice")
+        # userId is a query parameter on this endpoint, not a path segment.
+        assert mock_delete.call_args.kwargs["params"] == {"userId": "acct-alice"}
+
+    def test_close_skips_tab_delete_when_no_tab_was_opened(self, camofox_env):
+        _get_session("task-1", user_id="acct-alice")
+
+        with patch("tools.browser_camofox.requests.delete") as mock_delete:
+            camofox_close("task-1", user_id="acct-alice")
+
+        mock_delete.assert_not_called()
+
+    def test_close_still_destroys_ephemeral_default_session(self, camofox_env):
+        """Regression guard: the pre-existing teardown path is unchanged."""
+        _get_session("task-1")
+
+        with patch("tools.browser_camofox.requests.delete",
+                   return_value=_mock_response()) as mock_delete:
+            camofox_close("task-1")
+
+        mock_delete.assert_called_once()
+        assert "/sessions/hermes_" in mock_delete.call_args.args[0]
+
+    def test_mixed_teardown_uses_the_right_verb_per_identity(self, camofox_env):
+        default = _get_session("task-1")
+        default["tab_id"] = "tab-default"
+        alice = _get_session("task-1", user_id="acct-alice")
+        alice["tab_id"] = "tab-alice"
+
+        with patch("tools.browser_camofox.requests.delete",
+                   return_value=_mock_response()) as mock_delete:
+            camofox_close("task-1")
+
+        targets = sorted(c.args[0].rsplit("/", 2)[-2:] for c in mock_delete.call_args_list)
+        assert targets == [["sessions", default["user_id"]], ["tabs", "tab-alice"]]
+
+    def test_one_failing_delete_does_not_strand_the_others(self, camofox_env):
+        """_drop_sessions already removed every entry, so a skipped sibling
+        could never be reclaimed by anyone."""
+        for name in ("acct-a", "acct-b", "acct-c"):
+            _get_session("task-1", user_id=name)["tab_id"] = f"tab-{name}"
+
+        attempted = []
+
+        def _flaky(url, json=None, params=None, timeout=None, headers=None):
+            attempted.append(params["userId"])
+            if params["userId"] == "acct-a":
+                raise RuntimeError("camofox 500")
+            return _mock_response()
+
+        with patch("tools.browser_camofox.requests.delete", side_effect=_flaky):
+            result = json.loads(camofox_close("task-1"))
+
+        assert attempted == ["acct-a", "acct-b", "acct-c"]
+        assert "acct-a" in result["warning"]
+        assert result["closed"] is True
+
+    def test_close_without_user_id_reaps_every_identity(self, camofox_env):
+        """Task teardown must not leak per-user sessions."""
+        import tools.browser_camofox as mod
+
+        _get_session("task-1")
+        _get_session("task-1", user_id="acct-alice")
+        _get_session("task-1", user_id="acct-bob")
+
+        with patch("tools.browser_camofox.requests.delete", return_value=_mock_response()):
+            camofox_close("task-1")
+
+        with mod._sessions_lock:
+            assert mod._sessions == {}
+
+    def test_close_leaves_other_tasks_alone(self, camofox_env):
+        import tools.browser_camofox as mod
+
+        _get_session("task-1", user_id="acct-alice")
+        _get_session("task-2", user_id="acct-alice")
+
+        with patch("tools.browser_camofox.requests.delete", return_value=_mock_response()):
+            camofox_close("task-1")
+
+        assert [s["task_id"] for s in list_camofox_sessions()] == ["task-2"]
+        with mod._sessions_lock:
+            assert len(mod._sessions) == 1
+
+    def test_soft_cleanup_reaps_per_user_sessions(self, camofox_env):
+        import tools.browser_camofox as mod
+        from tools.browser_camofox import camofox_soft_cleanup
+
+        config = {"browser": {"camofox": {"managed_persistence": True}}}
+        with patch("tools.browser_camofox.load_config", return_value=config):
+            _get_session("task-1")
+            _get_session("task-1", user_id="acct-alice")
+
+            with patch("tools.browser_camofox.requests.delete") as mock_delete:
+                assert camofox_soft_cleanup("task-1") is True
+
+        # No tab was opened for either session, so nothing to release; the
+        # managed profile must not be touched regardless.
+        assert not [c for c in mock_delete.call_args_list if "/sessions/" in c.args[0]]
+        with mod._sessions_lock:
+            assert mod._sessions == {}
+
+    def test_soft_cleanup_closes_per_call_tabs_but_spares_managed_profile(self, camofox_env):
+        from tools.browser_camofox import camofox_soft_cleanup
+
+        config = {"browser": {"camofox": {"managed_persistence": True}}}
+        with patch("tools.browser_camofox.load_config", return_value=config):
+            _get_session("task-1")["tab_id"] = "tab-managed"
+            _get_session("task-1", user_id="acct-alice")["tab_id"] = "tab-alice"
+
+            with patch("tools.browser_camofox.requests.delete",
+                       return_value=_mock_response()) as mock_delete:
+                camofox_soft_cleanup("task-1")
+
+        # Only the per-call tab is closed. The managed profile keeps its tab
+        # AND its cookies — that is the point of soft cleanup.
+        mock_delete.assert_called_once()
+        assert mock_delete.call_args.args[0].endswith("/tabs/tab-alice")
+
+
+# ---------------------------------------------------------------------------
+# Tab adoption follows the existing operator opt-in
+# ---------------------------------------------------------------------------
+
+
+class TestTabAdoption:
+    def test_adoption_off_by_default(self, camofox_env):
+        with patch("tools.browser_camofox._get") as mock_get:
+            session = _get_session("task-1", user_id="acct-alice")
+
+        assert session["adopt_existing_tab"] is False
+        mock_get.assert_not_called()
+
+    def test_adoption_honours_config_flag(self, camofox_env, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_ADOPT_EXISTING_TAB", "true")
+
+        with patch("tools.browser_camofox._get",
+                   return_value={"tabs": [{"tabId": "existing-tab", "listItemId": "other"}]}) as mock_get:
+            session = _get_session("task-1", user_id="acct-alice")
+
+        assert session["adopt_existing_tab"] is True
+        assert session["tab_id"] == "existing-tab"
+        mock_get.assert_called_once_with(
+            "/tabs", params={"userId": "acct-alice"}, timeout=5
+        )
+
+
+# ---------------------------------------------------------------------------
+# Result contract
+# ---------------------------------------------------------------------------
+
+
+class TestResultEchoesIdentity:
+    def test_navigate_echoes_user_id(self, camofox_env):
+        with patch("tools.browser_camofox.requests.post", return_value=_tab_response()):
+            result = json.loads(
+                camofox_navigate("https://example.com", task_id="t1", user_id="acct-alice")
+            )
+
+        assert result["user_id"] == "acct-alice"
+
+    def test_navigate_echoes_resolved_identity_without_per_call_id(self, camofox_env):
+        with patch("tools.browser_camofox.requests.post", return_value=_tab_response()):
+            result = json.loads(camofox_navigate("https://example.com", task_id="t1"))
+
+        assert result["user_id"].startswith("hermes_")
+
+    def test_click_echoes_user_id(self, camofox_env):
+        session = _get_session("task-1", user_id="acct-alice")
+        session["tab_id"] = "tab-alice"
+
+        with (
+            patch("tools.browser_camofox._camofox_private_page_block", return_value=None),
+            patch("tools.browser_camofox._post", return_value={"url": "https://example.com"}),
+        ):
+            result = json.loads(camofox_click("@e5", task_id="task-1", user_id="acct-alice"))
+
+        assert result["user_id"] == "acct-alice"
+
+    def test_snapshot_echoes_user_id(self, camofox_env):
+        session = _get_session("task-1", user_id="acct-alice")
+        session["tab_id"] = "tab-alice"
+
+        with (
+            patch("tools.browser_camofox._camofox_private_page_block", return_value=None),
+            patch("tools.browser_camofox._get",
+                  return_value={"snapshot": "- button", "refsCount": 1}),
+        ):
+            result = json.loads(camofox_snapshot(task_id="task-1", user_id="acct-alice"))
+
+        assert result["user_id"] == "acct-alice"
+
+
+class TestListSessions:
+    def test_lists_every_active_identity(self, camofox_env):
+        _get_session("task-1")
+        _get_session("task-1", user_id="acct-alice")
+        _get_session("task-2", user_id="acct-bob")
+
+        sessions = {(s["task_id"], s["user_id"]): s for s in list_camofox_sessions()}
+
+        assert len(sessions) == 3
+        assert sessions[("task-1", "acct-alice")]["explicit_user_id"] is True
+        assert sessions[("task-2", "acct-bob")]["explicit_user_id"] is True
+        default = next(s for s in sessions.values() if not s["explicit_user_id"])
+        assert default["task_id"] == "task-1"
+
+    def test_reports_tab_ids(self, camofox_env):
+        with patch("tools.browser_camofox.requests.post",
+                   return_value=_tab_response(tab_id="tab-alice")):
+            camofox_navigate("https://example.com", task_id="t1", user_id="acct-alice")
+
+        [session] = list_camofox_sessions()
+        assert session["tab_id"] == "tab-alice"
+        assert session["user_id"] == "acct-alice"
+
+    def test_empty_when_no_sessions(self):
+        assert list_camofox_sessions() == []
+
+
+# ---------------------------------------------------------------------------
+# Model-facing schema is Camofox-gated
+# ---------------------------------------------------------------------------
+
+
+_CAMOFOX_BACKED_TOOLS = [
+    "browser_navigate", "browser_snapshot", "browser_click", "browser_type",
+    "browser_scroll", "browser_back", "browser_press", "browser_console",
+    "browser_get_images", "browser_vision",
+]
+
+
+def _resolved_schema(tool_name):
+    """Schema the model would see, with dynamic overrides applied."""
+    from tools.registry import registry
+
+    entry = registry._tools[tool_name]
+    schema = {**entry.schema}
+    schema.update(entry.dynamic_schema_overrides() or {})
+    return schema
+
+
+@pytest.fixture
+def _no_cdp_override(monkeypatch):
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    with patch("tools.browser_camofox._config_cdp_url", return_value=""):
+        yield
+
+
+class TestSchemaGating:
+    """user_id costs nothing on backends that cannot honour it."""
+
+    @pytest.mark.parametrize("tool_name", _CAMOFOX_BACKED_TOOLS)
+    def test_absent_without_camofox(self, tool_name, monkeypatch, _no_cdp_override):
+        monkeypatch.delenv("CAMOFOX_URL", raising=False)
+
+        properties = _resolved_schema(tool_name)["parameters"]["properties"]
+
+        assert "user_id" not in properties
+
+    @pytest.mark.parametrize("tool_name", _CAMOFOX_BACKED_TOOLS)
+    def test_present_with_camofox(self, tool_name, monkeypatch, _no_cdp_override):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+
+        properties = _resolved_schema(tool_name)["parameters"]["properties"]
+
+        assert properties["user_id"]["type"] == "string"
+
+    @pytest.mark.parametrize("tool_name", _CAMOFOX_BACKED_TOOLS)
+    def test_only_user_id_changes(self, tool_name, monkeypatch, _no_cdp_override):
+        """The override must not disturb required fields or descriptions."""
+        monkeypatch.delenv("CAMOFOX_URL", raising=False)
+        without = _resolved_schema(tool_name)
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        with_camofox = _resolved_schema(tool_name)
+
+        assert without["description"] == with_camofox["description"]
+        assert without["parameters"].get("required") == with_camofox["parameters"].get("required")
+        assert (
+            set(with_camofox["parameters"]["properties"])
+            - set(without["parameters"]["properties"])
+            == {"user_id"}
+        )
+
+    def test_static_schema_is_not_mutated(self, monkeypatch, _no_cdp_override):
+        """Building the override twice must not leak user_id into the base."""
+        import tools.browser_tool as bt
+
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        _resolved_schema("browser_navigate")
+        _resolved_schema("browser_navigate")
+
+        static_props = bt._BROWSER_SCHEMA_MAP["browser_navigate"]["parameters"]["properties"]
+        assert "user_id" not in static_props
+
+    def test_handler_forwards_user_id(self, monkeypatch, _no_cdp_override):
+        from tools.registry import registry
+
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        seen = {}
+
+        def _fake_navigate(url, task_id=None, user_id=None):
+            seen.update(url=url, task_id=task_id, user_id=user_id)
+            return json.dumps({"success": True})
+
+        with patch("tools.browser_tool.browser_navigate", _fake_navigate):
+            registry._tools["browser_navigate"].handler(
+                {"url": "https://example.com", "user_id": "acct-alice"}, task_id="t1"
+            )
+
+        assert seen == {
+            "url": "https://example.com", "task_id": "t1", "user_id": "acct-alice",
+        }
+
+    def test_description_does_not_invite_omitting_mid_sequence(self, monkeypatch, _no_cdp_override):
+        """Refs are not identity-scoped, so 'omit to use the default session'
+        would invite applying one account's refs to another profile's page."""
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+
+        description = (
+            _resolved_schema("browser_navigate")["parameters"]["properties"]["user_id"]
+            ["description"].lower()
+        )
+
+        assert "does not continue" in description
+        assert "every call" in description
+
+
+class TestBackendMismatchIsRejected:
+    """A backend that changed underneath the model must fail loud, not silently
+    run the call on a shared browser signed in as someone else."""
+
+    @pytest.fixture
+    def cdp_backend(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        monkeypatch.setenv("BROWSER_CDP_URL", "ws://127.0.0.1:9222/devtools/x")
+        import tools.browser_tool as bt
+
+        assert bt._is_camofox_mode() is False
+        return bt
+
+    @pytest.mark.parametrize(("attr", "kwargs"), [
+        ("browser_navigate", {"url": "https://example.com"}),
+        ("browser_snapshot", {}),
+        ("browser_click", {"ref": "@e1"}),
+        ("browser_type", {"ref": "@e1", "text": "bob-password"}),
+        ("browser_scroll", {"direction": "down"}),
+        ("browser_back", {}),
+        ("browser_press", {"key": "Enter"}),
+        ("browser_console", {}),
+        ("browser_get_images", {}),
+        ("browser_vision", {"question": "what is here?"}),
+    ])
+    def test_rejects_user_id_without_running_the_call(self, cdp_backend, attr, kwargs):
+        with (
+            patch.object(cdp_backend, "_is_safe_url", lambda url: True),
+            patch.object(cdp_backend, "_is_always_blocked_url", lambda url: False),
+            patch.object(cdp_backend, "check_website_access", lambda url: None),
+            patch.object(cdp_backend, "_run_browser_command") as mock_cmd,
+        ):
+            result = json.loads(
+                getattr(cdp_backend, attr)(task_id="t1", user_id="acct-bob", **kwargs)
+            )
+
+        assert result["success"] is False
+        assert "Camofox backend" in result["error"]
+        mock_cmd.assert_not_called()
+
+    def test_eval_path_rejects_user_id(self, cdp_backend):
+        with patch.object(cdp_backend, "_run_browser_command") as mock_cmd:
+            result = json.loads(
+                cdp_backend.browser_console(
+                    expression="document.title", task_id="t1", user_id="acct-bob"
+                )
+            )
+
+        assert result["success"] is False
+        assert "Camofox backend" in result["error"]
+        mock_cmd.assert_not_called()
+
+    def test_calls_without_user_id_are_unaffected(self, cdp_backend):
+        with (
+            patch.object(cdp_backend, "_is_safe_url", lambda url: True),
+            patch.object(cdp_backend, "_is_always_blocked_url", lambda url: False),
+            patch.object(cdp_backend, "check_website_access", lambda url: None),
+            patch.object(cdp_backend, "_run_browser_command",
+                         return_value={"success": True, "data": {}}) as mock_cmd,
+        ):
+            result = json.loads(cdp_backend.browser_click(ref="@e1", task_id="t1"))
+
+        assert result["success"] is True
+        assert mock_cmd.called
+
+
+class TestEvalErrorClassification:
+    """_camofox_eval degrades gracefully on 404/405/501 by substring-matching
+    the error text, which must not swallow a validation failure."""
+
+    def test_identity_error_is_not_reported_as_unsupported_server(self, camofox_env):
+        import tools.browser_tool as bt
+
+        result = json.loads(
+            bt._camofox_eval("document.title", task_id="t1", user_id="team/404-ops")
+        )
+
+        assert result["success"] is False
+        assert "Invalid user_id" in result["error"]
+        assert "not supported by this Camofox server" not in result["error"]
+
+    def test_genuine_unsupported_server_still_degrades(self, camofox_env):
+        import tools.browser_tool as bt
+
+        with (
+            patch("tools.browser_camofox._ensure_tab",
+                  return_value={"tab_id": "tab-1", "user_id": "acct-alice"}),
+            patch("tools.browser_camofox._post", side_effect=RuntimeError("404 Not Found")),
+        ):
+            result = json.loads(
+                bt._camofox_eval("document.title", task_id="t1", user_id="acct-alice")
+            )
+
+        assert result["success"] is False
+        assert "not supported by this Camofox server" in result["error"]
+
+    def test_eval_result_echoes_identity(self, camofox_env):
+        import tools.browser_tool as bt
+
+        with (
+            patch("tools.browser_camofox._ensure_tab",
+                  return_value={"tab_id": "tab-1", "user_id": "acct-alice"}),
+            patch("tools.browser_camofox._post", return_value={"result": "Example"}),
+            patch("tools.browser_tool._eval_ssrf_guard_active", return_value=False),
+        ):
+            result = json.loads(
+                bt._camofox_eval("document.title", task_id="t1", user_id="acct-alice")
+            )
+
+        assert result["success"] is True
+        assert result["user_id"] == "acct-alice"

--- a/tests/tools/test_browser_camofox_private_page_guard.py
+++ b/tests/tools/test_browser_camofox_private_page_guard.py
@@ -21,7 +21,9 @@ PRIVATE_URL = "http://169.254.169.254/latest/meta-data/"
 @pytest.fixture
 def _session(monkeypatch):
     session = {"tab_id": "tab-1", "user_id": "user-1"}
-    monkeypatch.setattr(browser_camofox, "_get_session", lambda task_id: session)
+    monkeypatch.setattr(
+        browser_camofox, "_get_session", lambda task_id, user_id=None: session
+    )
     return session
 
 

--- a/tests/tools/test_browser_eval_ssrf.py
+++ b/tests/tools/test_browser_eval_ssrf.py
@@ -153,7 +153,10 @@ class TestCamofoxEvalGuard:
 
         import tools.browser_camofox as camofox
 
-        monkeypatch.setattr(camofox, "_ensure_tab", lambda task_id: {"tab_id": "tab-1", "user_id": "user-1"})
+        monkeypatch.setattr(
+            camofox, "_ensure_tab",
+            lambda task_id, user_id=None: {"tab_id": "tab-1", "user_id": "user-1"},
+        )
 
         def fake_post(path, body=None, **_kwargs):
             if body and body.get("expression") == "window.location.href":
@@ -185,7 +188,7 @@ class TestCamofoxEvalGuard:
 
         seen = {}
 
-        def record_tab(task_id):
+        def record_tab(task_id, user_id=None):
             seen["task_id"] = task_id
             return {"tab_id": "tab-1", "user_id": "user-1"}
 

--- a/tests/tools/test_browser_private_page_action_guard.py
+++ b/tests/tools/test_browser_private_page_action_guard.py
@@ -99,7 +99,10 @@ def test_camofox_short_circuits_before_guard(monkeypatch):
 
     import tools.browser_camofox as camofox
 
-    monkeypatch.setattr(camofox, "camofox_click", lambda ref, task_id: '{"success": true, "camofox": true}')
+    monkeypatch.setattr(
+        camofox, "camofox_click",
+        lambda ref, task_id, user_id=None: '{"success": true, "camofox": true}',
+    )
 
     out = json.loads(browser_tool.browser_click("@e1", task_id="task-1"))
 
@@ -158,7 +161,10 @@ def test_browser_back_camofox_short_circuits_before_guard(monkeypatch):
 
     import tools.browser_camofox as camofox
 
-    monkeypatch.setattr(camofox, "camofox_back", lambda task_id: '{"success": true, "camofox": true}')
+    monkeypatch.setattr(
+        camofox, "camofox_back",
+        lambda task_id, user_id=None: '{"success": true, "camofox": true}',
+    )
 
     out = json.loads(browser_tool.browser_back(task_id="task-1"))
 

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -21,6 +21,14 @@ Then set ``CAMOFOX_URL=http://localhost:9377`` in ``~/.hermes/.env``.
 For Docker Camofox, optionally set ``CAMOFOX_REWRITE_LOOPBACK_URLS=true``
 so page URLs like ``http://127.0.0.1:3000`` are opened inside the
 container as ``http://host.docker.internal:3000``.
+
+Multi-account operation
+-----------------------
+Every tool here takes an optional ``user_id``.  Camofox maps each ``userId``
+to its own browser profile (its own cookies and logins), so passing a
+different one per call lets a single Hermes process drive several signed-in
+accounts without spawning extra Hermes profiles or instances.  Omitting it
+keeps the historical single-identity behaviour.
 """
 
 from __future__ import annotations
@@ -29,9 +37,10 @@ import base64
 import json
 import logging
 import os
+import re
 import threading
 import uuid
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 import requests
@@ -313,9 +322,102 @@ def _rewrite_loopback_url_for_camofox(url: str) -> tuple[str, Optional[Dict[str,
 # ---------------------------------------------------------------------------
 # Session management
 # ---------------------------------------------------------------------------
-# Maps task_id -> {"user_id": str, "tab_id": str|None}
+# Maps session cache key -> {"user_id": str, "tab_id": str|None, ...}
+#
+# The cache key is the bare ``task_id`` for the default (single-identity) path
+# and ``<task_id>::camofox_user::<user_id>`` when a caller pins an explicit
+# per-call identity.  Suffixing keeps today's key space byte-identical for
+# every existing caller while letting one task drive several Camofox accounts
+# side by side; it mirrors the ``::local`` sidecar key convention in
+# ``browser_tool._is_local_sidecar_key``.
 _sessions: Dict[str, Dict[str, Any]] = {}
 _sessions_lock = threading.Lock()
+
+_USER_SCOPE_SEP = "::camofox_user::"
+
+# Charset for a per-call userId.  Deliberately narrow because the value reaches
+# ``DELETE /sessions/{user_id}`` as a *path segment* (see :func:`camofox_close`)
+# and, unlike the config/env identity, it can originate from a model tool call:
+#
+#   - first char must be alphanumeric, which rejects ``.`` / ``..`` / ``-flag``.
+#     ``DELETE /sessions/..`` normalizes to ``DELETE /sessions`` on some servers,
+#     which would wipe every user rather than one.
+#   - no ``/``, ``\``, ``%`` or whitespace, so neither path traversal nor
+#     percent-encoded traversal can be expressed.
+#
+# Matched with ``fullmatch``: Python's ``$`` also matches just before a trailing
+# newline, so ``match(...)`` would accept ``"acct\n"``.  The ``.strip()`` below
+# happens to remove it today, but a security check must not depend on that.
+_CALL_USER_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:@-]{0,63}")
+
+
+class InvalidCamofoxUserId(ValueError):
+    """Raised when a per-call ``user_id`` fails validation."""
+
+
+def _validate_call_user_id(user_id: Any) -> str:
+    """Validate and return a caller-supplied Camofox ``userId``.
+
+    Only applies to per-call identities.  ``CAMOFOX_USER_ID`` /
+    ``browser.camofox.user_id`` are operator-configured and stay unvalidated —
+    tightening those retroactively would break working deployments, and they
+    are not attacker-reachable the way a tool argument is.
+
+    The type check is not defensive nit-picking: models emit type-confused tool
+    arguments, and a bare truthiness gate would let ``user_id=0`` fall through
+    to the *default* identity while the caller believes it addressed a specific
+    account — silently producing the cross-account action this parameter exists
+    to prevent.
+    """
+    if not isinstance(user_id, str):
+        raise InvalidCamofoxUserId(
+            f"Invalid user_id {user_id!r}: expected a string, got "
+            f"{type(user_id).__name__}."
+        )
+    candidate = user_id.strip()
+    if not _CALL_USER_ID_RE.fullmatch(candidate):
+        raise InvalidCamofoxUserId(
+            f"Invalid user_id {user_id!r}. Must be 1-64 characters, start with a "
+            "letter or digit, and contain only letters, digits, and '.', '_', "
+            "'-', ':', '@'."
+        )
+    return candidate
+
+
+def _normalize_call_user_id(user_id: Any) -> Optional[str]:
+    """Return the validated per-call identity, or ``None`` when none was given.
+
+    An empty/whitespace string means "not supplied" — models routinely emit
+    ``""`` for an optional string parameter.  Any *other* non-string (``0``,
+    ``False``, ``12345``) is an error rather than a fallback to the default
+    identity: falling back would run the action under a different account than
+    the caller named, with nothing in the result to distinguish it.
+    """
+    if user_id is None:
+        return None
+    if isinstance(user_id, str) and not user_id.strip():
+        return None
+    return _validate_call_user_id(user_id)
+
+
+def _session_cache_key(task_id: Optional[str], user_id: Optional[str]) -> str:
+    """Return the ``_sessions`` key for a task, optionally scoped to a user."""
+    base = task_id or "default"
+    if not user_id:
+        return base
+    return f"{base}{_USER_SCOPE_SEP}{user_id}"
+
+
+def _session_keys_for_task(task_id: Optional[str]) -> List[str]:
+    """Return every live ``_sessions`` key owned by ``task_id``.
+
+    Includes the bare key plus every per-user key scoped to that task, so task
+    teardown reaps multi-account sessions instead of leaking them.  Callers must
+    hold ``_sessions_lock``.
+    """
+    base = task_id or "default"
+    prefix = f"{base}{_USER_SCOPE_SEP}"
+    return [key for key in _sessions if key == base or key.startswith(prefix)]
 
 
 def _adopt_existing_tab(session: Dict[str, Any]) -> Dict[str, Any]:
@@ -356,19 +458,51 @@ def _adopt_existing_tab(session: Dict[str, Any]) -> Dict[str, Any]:
     return session
 
 
-def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
-    """Get or create a camofox session for the given task.
+def _get_session(task_id: Optional[str], user_id: Optional[str] = None) -> Dict[str, Any]:
+    """Get or create a camofox session for the given task (and optional user).
 
-    When managed persistence is enabled, uses a deterministic userId
-    derived from the Hermes profile so the Camofox server can map it
-    to the same persistent browser profile across restarts.
+    Identity resolution, highest precedence first:
+
+    1. ``user_id`` — an explicit per-call identity.  Lets one Hermes process
+       drive several Camofox accounts side by side (issue #77273).
+    2. ``CAMOFOX_USER_ID`` / ``browser.camofox.user_id`` — an externally
+       managed identity shared with another app.
+    3. ``managed_persistence`` — a deterministic userId derived from the Hermes
+       profile so the Camofox server can map it to the same persistent browser
+       profile across restarts.
+    4. A random ephemeral userId.
+
+    Sessions are cached per ``(task_id, user_id)`` so repeated calls with the
+    same identity reuse the same tab.
+
+    Raises:
+        InvalidCamofoxUserId: when an explicit ``user_id`` fails validation.
+            Raised before any HTTP request, so a rejected identity never
+            reaches the Camofox server.
     """
     task_id = task_id or "default"
+    user_id = _normalize_call_user_id(user_id)
+    cache_key = _session_cache_key(task_id, user_id)
     with _sessions_lock:
-        if task_id in _sessions:
-            return _adopt_existing_tab(_sessions[task_id])
+        if cache_key in _sessions:
+            return _adopt_existing_tab(_sessions[cache_key])
 
         camofox_cfg = _get_camofox_config()
+        if user_id:
+            # Per-call identity: treated like the externally managed path — the
+            # profile belongs to a caller-named account, so destructive cleanup
+            # is off and tab adoption follows the same operator opt-in.
+            session = {
+                "user_id": user_id,
+                "tab_id": None,
+                "session_key": f"task_{task_id[:16]}",
+                "managed": True,
+                "adopt_existing_tab": _adopt_existing_tab_enabled(camofox_cfg),
+                "destroy_on_close": False,
+            }
+            _sessions[cache_key] = session
+            return _adopt_existing_tab(session)
+
         identity_override = _camofox_identity_override(task_id, camofox_cfg)
         if identity_override:
             session = {
@@ -377,6 +511,7 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
                 "session_key": identity_override["session_key"],
                 "managed": True,
                 "adopt_existing_tab": _adopt_existing_tab_enabled(camofox_cfg),
+                "destroy_on_close": True,
             }
         elif bool(camofox_cfg.get("managed_persistence")):
             identity = get_camofox_identity(task_id)
@@ -386,6 +521,7 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
                 "session_key": identity["session_key"],
                 "managed": True,
                 "adopt_existing_tab": _adopt_existing_tab_enabled(camofox_cfg),
+                "destroy_on_close": True,
             }
         else:
             session = {
@@ -394,14 +530,19 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
                 "session_key": f"task_{task_id[:16]}",
                 "managed": False,
                 "adopt_existing_tab": False,
+                "destroy_on_close": True,
             }
-        _sessions[task_id] = session
+        _sessions[cache_key] = session
         return _adopt_existing_tab(session)
 
 
-def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, Any]:
+def _ensure_tab(
+    task_id: Optional[str],
+    url: str = "about:blank",
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
     """Ensure a tab exists for the session, creating one if needed."""
-    session = _get_session(task_id)
+    session = _get_session(task_id, user_id)
     if session["tab_id"]:
         return session
     base = get_camofox_url()
@@ -421,11 +562,49 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
     return session
 
 
-def _drop_session(task_id: Optional[str]) -> Optional[Dict[str, Any]]:
-    """Remove and return session info."""
-    task_id = task_id or "default"
+def _drop_sessions(
+    task_id: Optional[str], user_id: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    """Remove and return session info.
+
+    With ``user_id`` set, drops only that identity's session.  Without it, drops
+    the task's default session *and* every per-user session scoped to the task
+    so teardown doesn't leak multi-account state.
+    """
     with _sessions_lock:
-        return _sessions.pop(task_id, None)
+        if user_id:
+            keys = [_session_cache_key(task_id, user_id)]
+        else:
+            keys = _session_keys_for_task(task_id)
+        return [s for s in (_sessions.pop(key, None) for key in keys) if s]
+
+
+def _drop_session(task_id: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Remove the task's default session and return it (back-compat shim)."""
+    with _sessions_lock:
+        return _sessions.pop(task_id or "default", None)
+
+
+def list_camofox_sessions() -> List[Dict[str, Any]]:
+    """Return a snapshot of the active Camofox sessions.
+
+    One entry per live ``(task_id, user_id)`` pair — useful for skills and
+    debugging multi-account runs.  Not exposed as a model tool; the resolved
+    ``user_id`` is echoed in every tool result instead.
+    """
+    with _sessions_lock:
+        items = list(_sessions.items())
+    sessions = []
+    for key, session in items:
+        task_id, sep, _ = key.partition(_USER_SCOPE_SEP)
+        sessions.append({
+            "task_id": task_id,
+            "user_id": session.get("user_id", ""),
+            "session_key": session.get("session_key", ""),
+            "tab_id": session.get("tab_id"),
+            "explicit_user_id": bool(sep),
+        })
+    return sessions
 
 
 def camofox_soft_cleanup(task_id: Optional[str] = None) -> bool:
@@ -433,13 +612,26 @@ def camofox_soft_cleanup(task_id: Optional[str] = None) -> bool:
 
     When managed persistence is enabled the browser profile (and its cookies)
     must survive across agent tasks.  This helper drops only the local tracking
-    entry and returns ``True``.  When managed persistence is *not* enabled it
+    entries and returns ``True``.  When managed persistence is *not* enabled it
     does nothing and returns ``False`` so the caller can fall back to
     :func:`camofox_close`.
     """
     camofox_cfg = _get_camofox_config()
     if bool(camofox_cfg.get("managed_persistence")) or _camofox_identity_override(task_id, camofox_cfg):
-        _drop_session(task_id)
+        for session in _drop_sessions(task_id):
+            # The managed/override profile is left completely untouched — that
+            # is the point of soft cleanup.  Per-call identities still get
+            # their tab closed, which is non-destructive (the profile and its
+            # cookies survive) and keeps multi-account runs from leaking
+            # windows on the Camofox server.
+            if session.get("destroy_on_close"):
+                continue
+            try:
+                _release_session(session)
+            except Exception as exc:
+                logger.debug(
+                    "Camofox tab release failed for %s: %s", session["user_id"], exc
+                )
         logger.debug("Camofox soft cleanup for task %s (managed persistence)", task_id)
         return True
     return False
@@ -479,12 +671,14 @@ def _get_raw(path: str, params: dict = None, timeout: Optional[int] = None) -> r
     return resp
 
 
-def _delete(path: str, body: dict = None, timeout: Optional[int] = None) -> dict:
+def _delete(path: str, body: dict = None, timeout: Optional[int] = None,
+            params: dict = None) -> dict:
     """DELETE to camofox and return parsed response."""
     if timeout is None:
         timeout = _get_command_timeout()
     url = f"{get_camofox_url()}{path}"
-    resp = requests.delete(url, json=body, timeout=timeout, headers=_auth_headers())
+    resp = requests.delete(url, json=body, params=params, timeout=timeout,
+                           headers=_auth_headers())
     resp.raise_for_status()
     return resp.json()
 
@@ -493,14 +687,29 @@ def _delete(path: str, body: dict = None, timeout: Optional[int] = None) -> dict
 # Tool implementations
 # ---------------------------------------------------------------------------
 
-def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
+def _identity_error(message: str, session: Optional[Dict[str, Any]] = None) -> str:
+    """Return a tool error that also discloses the identity it acted as.
+
+    Success payloads echo ``user_id`` so a multi-account agent can confirm it
+    did not cross accounts.  Errors must do the same: an agent that only sees
+    the echo on success cannot tell "this failed" from "this ran as someone
+    else", which is the failure mode the echo exists to surface.
+    """
+    if session and session.get("user_id"):
+        return tool_error(message, success=False, user_id=session["user_id"])
+    return tool_error(message, success=False)
+
+
+def camofox_navigate(url: str, task_id: Optional[str] = None,
+                     user_id: Optional[str] = None) -> str:
     """Navigate to a URL via Camofox."""
+    session = None
     try:
         browser_url, rewrite_info = _rewrite_loopback_url_for_camofox(url)
-        session = _get_session(task_id)
+        session = _get_session(task_id, user_id)
         if not session["tab_id"]:
             # Create tab with the target URL directly
-            session = _ensure_tab(task_id, browser_url)
+            session = _ensure_tab(task_id, browser_url, user_id)
             data = {"ok": True, "url": browser_url}
         else:
             # Navigate existing tab — recover from stale tab 404
@@ -518,7 +727,7 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
                         session["tab_id"],
                     )
                     session["tab_id"] = None
-                    session = _ensure_tab(task_id, browser_url)
+                    session = _ensure_tab(task_id, browser_url, user_id)
                     data = {"ok": True, "url": browser_url}
                 else:
                     raise
@@ -526,6 +735,7 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
             "success": True,
             "url": data.get("url", browser_url),
             "title": data.get("title", ""),
+            "user_id": session["user_id"],
         }
         if rewrite_info:
             result["requested_url"] = url
@@ -571,7 +781,7 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
                      "or: docker run -p 9377:9377 -e CAMOFOX_PORT=9377 jo-inc/camofox-browser",
         })
     except Exception as e:
-        return tool_error(str(e), success=False)
+        return _identity_error(str(e), session)
 
 
 def _camofox_private_page_block(session: Dict[str, Any], task_id: Optional[str], action: str) -> Optional[str]:
@@ -605,16 +815,19 @@ def _camofox_private_page_block(session: Dict[str, Any], task_id: Optional[str],
             f"({blocked_url}). Refusing to {action} on this page in this "
             "browser mode."
         ),
+        "user_id": session["user_id"],
     }, ensure_ascii=False)
 
 
 def camofox_snapshot(full: bool = False, task_id: Optional[str] = None,
-                     user_task: Optional[str] = None) -> str:
+                     user_task: Optional[str] = None,
+                     user_id: Optional[str] = None) -> str:
     """Get accessibility tree snapshot from Camofox."""
+    session = None
     try:
-        session = _get_session(task_id)
+        session = _get_session(task_id, user_id)
         if not session["tab_id"]:
-            return tool_error("No browser session. Call browser_navigate first.", success=False)
+            return _identity_error("No browser session. Call browser_navigate first.", session)
 
         blocked = _camofox_private_page_block(session, task_id, "read a page snapshot")
         if blocked:
@@ -645,17 +858,20 @@ def camofox_snapshot(full: bool = False, task_id: Optional[str] = None,
             "success": True,
             "snapshot": snapshot,
             "element_count": refs_count,
+            "user_id": session["user_id"],
         })
     except Exception as e:
-        return tool_error(str(e), success=False)
+        return _identity_error(str(e), session)
 
 
-def camofox_click(ref: str, task_id: Optional[str] = None) -> str:
+def camofox_click(ref: str, task_id: Optional[str] = None,
+                  user_id: Optional[str] = None) -> str:
     """Click an element by ref via Camofox."""
+    session = None
     try:
-        session = _get_session(task_id)
+        session = _get_session(task_id, user_id)
         if not session["tab_id"]:
-            return tool_error("No browser session. Call browser_navigate first.", success=False)
+            return _identity_error("No browser session. Call browser_navigate first.", session)
 
         blocked = _camofox_private_page_block(session, task_id, "click")
         if blocked:
@@ -672,17 +888,20 @@ def camofox_click(ref: str, task_id: Optional[str] = None) -> str:
             "success": True,
             "clicked": clean_ref,
             "url": data.get("url", ""),
+            "user_id": session["user_id"],
         })
     except Exception as e:
-        return tool_error(str(e), success=False)
+        return _identity_error(str(e), session)
 
 
-def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
+def camofox_type(ref: str, text: str, task_id: Optional[str] = None,
+                 user_id: Optional[str] = None) -> str:
     """Type text into an element by ref via Camofox."""
+    session = None
     try:
-        session = _get_session(task_id)
+        session = _get_session(task_id, user_id)
         if not session["tab_id"]:
-            return tool_error("No browser session. Call browser_navigate first.", success=False)
+            return _identity_error("No browser session. Call browser_navigate first.", session)
 
         blocked = _camofox_private_page_block(session, task_id, "type")
         if blocked:
@@ -709,6 +928,7 @@ def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
             # the page; only the returned display value is redacted.
             "typed": display_text,
             "element": clean_ref,
+            "user_id": session["user_id"],
         }
         response = redact_browser_typed_text_for_display(response, text)
         return json.dumps(response)
@@ -718,44 +938,58 @@ def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
         return tool_error(redact_browser_typed_text_for_display(str(e), text), success=False)
 
 
-def camofox_scroll(direction: str, task_id: Optional[str] = None) -> str:
+def camofox_scroll(direction: str, task_id: Optional[str] = None,
+                   user_id: Optional[str] = None) -> str:
     """Scroll the page via Camofox."""
+    session = None
     try:
-        session = _get_session(task_id)
+        session = _get_session(task_id, user_id)
         if not session["tab_id"]:
-            return tool_error("No browser session. Call browser_navigate first.", success=False)
+            return _identity_error("No browser session. Call browser_navigate first.", session)
 
         _post(
             f"/tabs/{session['tab_id']}/scroll",
             {"userId": session["user_id"], "direction": direction},
         )
-        return json.dumps({"success": True, "scrolled": direction})
+        return json.dumps({
+            "success": True,
+            "scrolled": direction,
+            "user_id": session["user_id"],
+        })
     except Exception as e:
-        return tool_error(str(e), success=False)
+        return _identity_error(str(e), session)
 
 
-def camofox_back(task_id: Optional[str] = None) -> str:
+def camofox_back(task_id: Optional[str] = None,
+                 user_id: Optional[str] = None) -> str:
     """Navigate back via Camofox."""
+    session = None
     try:
-        session = _get_session(task_id)
+        session = _get_session(task_id, user_id)
         if not session["tab_id"]:
-            return tool_error("No browser session. Call browser_navigate first.", success=False)
+            return _identity_error("No browser session. Call browser_navigate first.", session)
 
         data = _post(
             f"/tabs/{session['tab_id']}/back",
             {"userId": session["user_id"]},
         )
-        return json.dumps({"success": True, "url": data.get("url", "")})
+        return json.dumps({
+            "success": True,
+            "url": data.get("url", ""),
+            "user_id": session["user_id"],
+        })
     except Exception as e:
-        return tool_error(str(e), success=False)
+        return _identity_error(str(e), session)
 
 
-def camofox_press(key: str, task_id: Optional[str] = None) -> str:
+def camofox_press(key: str, task_id: Optional[str] = None,
+                  user_id: Optional[str] = None) -> str:
     """Press a keyboard key via Camofox."""
+    session = None
     try:
-        session = _get_session(task_id)
+        session = _get_session(task_id, user_id)
         if not session["tab_id"]:
-            return tool_error("No browser session. Call browser_navigate first.", success=False)
+            return _identity_error("No browser session. Call browser_navigate first.", session)
 
         blocked = _camofox_private_page_block(session, task_id, "press")
         if blocked:
@@ -765,42 +999,94 @@ def camofox_press(key: str, task_id: Optional[str] = None) -> str:
             f"/tabs/{session['tab_id']}/press",
             {"userId": session["user_id"], "key": key},
         )
-        return json.dumps({"success": True, "pressed": key})
+        return json.dumps({
+            "success": True,
+            "pressed": key,
+            "user_id": session["user_id"],
+        })
     except Exception as e:
-        return tool_error(str(e), success=False)
+        return _identity_error(str(e), session)
 
 
-def camofox_close(task_id: Optional[str] = None) -> str:
-    """Close the browser session via Camofox."""
+def _release_session(session: Dict[str, Any]) -> None:
+    """Release one session's server-side resources.
+
+    Two distinct operations on the Camofox API, and the difference matters:
+
+    * ``DELETE /sessions/<userId>`` destroys the whole profile — "Closes all
+      tabs and cleans up state for the given userId".  Only for identities
+      Hermes owns (``destroy_on_close``).
+    * ``DELETE /tabs/<tabId>?userId=`` just closes the window and leaves the
+      profile, cookies, and logins intact.  This is what a caller-supplied
+      identity gets: without it every distinct ``user_id`` would leak an open
+      tab that nothing ever reclaims (the server's ``POST /pressure/cleanup``
+      is caller-triggered, not an automatic reaper).
+    """
+    if session.get("destroy_on_close"):
+        _delete(f"/sessions/{session['user_id']}")
+        return
+    tab_id = session.get("tab_id")
+    if tab_id:
+        _delete(f"/tabs/{tab_id}", params={"userId": session["user_id"]})
+
+
+def camofox_close(task_id: Optional[str] = None,
+                  user_id: Optional[str] = None) -> str:
+    """Close the browser session(s) via Camofox.
+
+    With ``user_id`` set, closes only that identity's session.  Without it,
+    closes the task's default session *and* every per-user session scoped to
+    the task.
+
+    Identities supplied per call are caller-owned, so their profile survives —
+    only their tab is closed.  See :func:`_release_session`.
+    """
     try:
-        session = _drop_session(task_id)
-        if not session:
-            return json.dumps({"success": True, "closed": True})
+        user_id = _normalize_call_user_id(user_id)
+    except InvalidCamofoxUserId as exc:
+        return tool_error(str(exc), success=False)
 
-        _delete(
-            f"/sessions/{session['user_id']}",
-        )
+    sessions = _drop_sessions(task_id, user_id)
+    if not sessions:
         return json.dumps({"success": True, "closed": True})
-    except Exception as e:
-        return json.dumps({"success": True, "closed": True, "warning": str(e)})
+
+    # Release each session independently. A single failing DELETE must not
+    # abort the loop: _drop_sessions has already removed every entry from the
+    # local map, so a sibling skipped here could never be reclaimed by anyone.
+    warnings = []
+    for session in sessions:
+        try:
+            _release_session(session)
+        except Exception as exc:
+            warnings.append(f"{session['user_id']}: {exc}")
+            logger.debug("Camofox release failed for %s: %s", session["user_id"], exc)
+
+    result = {
+        "success": True,
+        "closed": True,
+        "user_ids": [s["user_id"] for s in sessions],
+    }
+    if warnings:
+        result["warning"] = "; ".join(warnings)
+    return json.dumps(result)
 
 
-def camofox_get_images(task_id: Optional[str] = None) -> str:
+def camofox_get_images(task_id: Optional[str] = None,
+                       user_id: Optional[str] = None) -> str:
     """Get images on the current page via Camofox.
 
     Extracts image information from the accessibility tree snapshot,
     since Camofox does not expose a dedicated /images endpoint.
     """
+    session = None
     try:
-        session = _get_session(task_id)
+        session = _get_session(task_id, user_id)
         if not session["tab_id"]:
-            return tool_error("No browser session. Call browser_navigate first.", success=False)
+            return _identity_error("No browser session. Call browser_navigate first.", session)
 
         blocked = _camofox_private_page_block(session, task_id, "extract page images")
         if blocked:
             return blocked
-
-        import re
 
         data = _get(
             f"/tabs/{session['tab_id']}/snapshot",
@@ -831,18 +1117,21 @@ def camofox_get_images(task_id: Optional[str] = None) -> str:
             "success": True,
             "images": images,
             "count": len(images),
+            "user_id": session["user_id"],
         })
     except Exception as e:
-        return tool_error(str(e), success=False)
+        return _identity_error(str(e), session)
 
 
 def camofox_vision(question: str, annotate: bool = False,
-                   task_id: Optional[str] = None) -> str:
+                   task_id: Optional[str] = None,
+                   user_id: Optional[str] = None) -> str:
     """Take a screenshot and analyze it with vision AI via Camofox."""
+    session = None
     try:
-        session = _get_session(task_id)
+        session = _get_session(task_id, user_id)
         if not session["tab_id"]:
-            return tool_error("No browser session. Call browser_navigate first.", success=False)
+            return _identity_error("No browser session. Call browser_navigate first.", session)
 
         blocked = _camofox_private_page_block(session, task_id, "capture a screenshot")
         if blocked:
@@ -928,17 +1217,28 @@ def camofox_vision(question: str, annotate: bool = False,
             "success": True,
             "analysis": analysis,
             "screenshot_path": screenshot_path,
+            "user_id": session["user_id"],
         })
     except Exception as e:
-        return tool_error(str(e), success=False)
+        return _identity_error(str(e), session)
 
 
-def camofox_console(clear: bool = False, task_id: Optional[str] = None) -> str:
+def camofox_console(clear: bool = False, task_id: Optional[str] = None,
+                    user_id: Optional[str] = None) -> str:
     """Get console output — limited support in Camofox.
 
     Camofox does not expose browser console logs via its REST API.
     Returns an empty result with a note.
+
+    ``user_id`` is validated for signature parity with the other Camofox tools
+    but deliberately *not* echoed: this path never opens a session, so echoing
+    it back would rubber-stamp an identity that was never resolved against the
+    server — the opposite of the confirmation the echo is meant to provide.
     """
+    try:
+        _normalize_call_user_id(user_id)
+    except InvalidCamofoxUserId as exc:
+        return tool_error(str(exc), success=False)
     return json.dumps({
         "success": True,
         "console_messages": [],

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -190,6 +190,40 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+
+def _reject_non_camofox_user_id(tool_name: str, user_id: Optional[str]) -> Optional[str]:
+    """Return an error payload when a per-call identity cannot be honoured.
+
+    ``user_id`` selects a Camofox browser profile, so it is meaningless for
+    agent-browser / CDP / cloud sessions. Failing loudly rather than dropping
+    it: the parameter's whole job is keeping accounts apart, and the way to
+    reach here is a backend that changed underneath the model (``/browser
+    connect`` mid-conversation, while the model still holds a tool schema built
+    when Camofox was active). Silently continuing would run the action on the
+    single shared browser — which may still be signed in as a different
+    account — while reporting success.
+
+    Under Camofox the parameter is not in the schema at all (see
+    ``_camofox_user_id_schema_override``), so this never fires in normal use.
+    """
+    if not user_id:
+        return None
+    logger.warning(
+        "%s: rejecting user_id — per-call Camofox identities require the "
+        "Camofox backend, which is not active",
+        tool_name,
+    )
+    return json.dumps({
+        "success": False,
+        "error": (
+            "user_id requires the Camofox backend, which is not active for "
+            "this session. The current browser backend has a single shared "
+            "profile and cannot isolate accounts, so this call was not run. "
+            "Retry without user_id only if acting as whatever account that "
+            "shared browser is already signed in as is acceptable."
+        ),
+    }, ensure_ascii=False)
+
 # Standard PATH entries for environments with minimal PATH (e.g. systemd services).
 # Includes Android/Termux and macOS Homebrew locations needed for agent-browser,
 # npx, node, and Android's glibc runner (grun).
@@ -2978,13 +3012,17 @@ def evaluate_url_safety(url: str) -> Optional[dict]:
     return None
 
 
-def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
+def browser_navigate(url: str, task_id: Optional[str] = None,
+                     user_id: Optional[str] = None) -> str:
     """
     Navigate to a URL in the browser.
 
     Args:
         url: The URL to navigate to
         task_id: Task identifier for session isolation
+        user_id: Camofox account identity for this call.  Ignored on other
+            backends (the parameter is only exposed to the model when the
+            Camofox backend is active).
 
     Returns:
         JSON string with navigation result (includes stealth features info on first nav)
@@ -3073,7 +3111,11 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
     # Camofox backend — delegate after safety checks pass
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_navigate
-        return camofox_navigate(url, task_id)
+        return camofox_navigate(url, task_id, user_id)
+
+    _rejected = _reject_non_camofox_user_id("browser_navigate", user_id)
+    if _rejected is not None:
+        return _rejected
 
     if auto_local_this_nav:
         logger.info(
@@ -3207,7 +3249,8 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
 def browser_snapshot(
     full: bool = False,
     task_id: Optional[str] = None,
-    user_task: Optional[str] = None
+    user_task: Optional[str] = None,
+    user_id: Optional[str] = None
 ) -> str:
     """
     Get a text-based snapshot of the current page's accessibility tree.
@@ -3216,13 +3259,18 @@ def browser_snapshot(
         full: If True, return complete snapshot. If False, return compact view.
         task_id: Task identifier for session isolation
         user_task: The user's current task (for task-aware extraction)
+        user_id: Camofox account identity for this call (Camofox backend only)
 
     Returns:
         JSON string with page snapshot
     """
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_snapshot
-        return camofox_snapshot(full, task_id, user_task)
+        return camofox_snapshot(full, task_id, user_task, user_id)
+
+    _rejected = _reject_non_camofox_user_id("browser_snapshot", user_id)
+    if _rejected is not None:
+        return _rejected
 
     effective_task_id = _last_session_key(task_id or "default")
 
@@ -3304,20 +3352,26 @@ def browser_snapshot(
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_click(ref: str, task_id: Optional[str] = None) -> str:
+def browser_click(ref: str, task_id: Optional[str] = None,
+                  user_id: Optional[str] = None) -> str:
     """
     Click on an element.
 
     Args:
         ref: Element reference (e.g., "@e5")
         task_id: Task identifier for session isolation
+        user_id: Camofox account identity for this call (Camofox backend only)
 
     Returns:
         JSON string with click result
     """
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_click
-        return camofox_click(ref, task_id)
+        return camofox_click(ref, task_id, user_id)
+
+    _rejected = _reject_non_camofox_user_id("browser_click", user_id)
+    if _rejected is not None:
+        return _rejected
 
     effective_task_id = _last_session_key(task_id or "default")
     blocked = _blocked_private_page_action(effective_task_id, "click")
@@ -3344,7 +3398,8 @@ def browser_click(ref: str, task_id: Optional[str] = None) -> str:
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
+def browser_type(ref: str, text: str, task_id: Optional[str] = None,
+                 user_id: Optional[str] = None) -> str:
     """
     Type text into an input field.
 
@@ -3352,13 +3407,18 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
         ref: Element reference (e.g., "@e3")
         text: Text to type
         task_id: Task identifier for session isolation
+        user_id: Camofox account identity for this call (Camofox backend only)
 
     Returns:
         JSON string with type result
     """
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_type
-        return camofox_type(ref, text, task_id)
+        return camofox_type(ref, text, task_id, user_id)
+
+    _rejected = _reject_non_camofox_user_id("browser_type", user_id)
+    if _rejected is not None:
+        return _rejected
 
     effective_task_id = _last_session_key(task_id or "default")
     blocked = _blocked_private_page_action(effective_task_id, "type")
@@ -3402,13 +3462,15 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
         return json.dumps(response, ensure_ascii=False)
 
 
-def browser_scroll(direction: str, task_id: Optional[str] = None) -> str:
+def browser_scroll(direction: str, task_id: Optional[str] = None,
+                   user_id: Optional[str] = None) -> str:
     """
     Scroll the page.
 
     Args:
         direction: "up" or "down"
         task_id: Task identifier for session isolation
+        user_id: Camofox account identity for this call (Camofox backend only)
 
     Returns:
         JSON string with scroll result
@@ -3431,8 +3493,12 @@ def browser_scroll(direction: str, task_id: Optional[str] = None) -> str:
         _SCROLL_REPEATS = 5
         result = None
         for _ in range(_SCROLL_REPEATS):
-            result = camofox_scroll(direction, task_id)
+            result = camofox_scroll(direction, task_id, user_id)
         return result
+
+    _rejected = _reject_non_camofox_user_id("browser_scroll", user_id)
+    if _rejected is not None:
+        return _rejected
 
     effective_task_id = _last_session_key(task_id or "default")
 
@@ -3451,19 +3517,25 @@ def browser_scroll(direction: str, task_id: Optional[str] = None) -> str:
     return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_back(task_id: Optional[str] = None) -> str:
+def browser_back(task_id: Optional[str] = None,
+                 user_id: Optional[str] = None) -> str:
     """
     Navigate back in browser history.
 
     Args:
         task_id: Task identifier for session isolation
+        user_id: Camofox account identity for this call (Camofox backend only)
 
     Returns:
         JSON string with navigation result
     """
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_back
-        return camofox_back(task_id)
+        return camofox_back(task_id, user_id)
+
+    _rejected = _reject_non_camofox_user_id("browser_back", user_id)
+    if _rejected is not None:
+        return _rejected
 
     effective_task_id = _last_session_key(task_id or "default")
     result = _run_browser_command(effective_task_id, "back", [])
@@ -3502,20 +3574,26 @@ def browser_back(task_id: Optional[str] = None) -> str:
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_press(key: str, task_id: Optional[str] = None) -> str:
+def browser_press(key: str, task_id: Optional[str] = None,
+                  user_id: Optional[str] = None) -> str:
     """
     Press a keyboard key.
 
     Args:
         key: Key to press (e.g., "Enter", "Tab")
         task_id: Task identifier for session isolation
+        user_id: Camofox account identity for this call (Camofox backend only)
 
     Returns:
         JSON string with key press result
     """
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_press
-        return camofox_press(key, task_id)
+        return camofox_press(key, task_id, user_id)
+
+    _rejected = _reject_non_camofox_user_id("browser_press", user_id)
+    if _rejected is not None:
+        return _rejected
 
     effective_task_id = _last_session_key(task_id or "default")
     blocked = _blocked_private_page_action(effective_task_id, "press")
@@ -3554,7 +3632,9 @@ def _blocked_private_page_action(effective_task_id: str, action: str) -> Optiona
     }, ensure_ascii=False)
 
 
-def browser_console(clear: bool = False, expression: Optional[str] = None, task_id: Optional[str] = None) -> str:
+def browser_console(clear: bool = False, expression: Optional[str] = None,
+                    task_id: Optional[str] = None,
+                    user_id: Optional[str] = None) -> str:
     """Get browser console messages and JavaScript errors, or evaluate JS in the page.
 
     When ``expression`` is provided, evaluates JavaScript in the page context
@@ -3565,6 +3645,7 @@ def browser_console(clear: bool = False, expression: Optional[str] = None, task_
         clear: If True, clear the message/error buffers after reading
         expression: JavaScript expression to evaluate in the page context
         task_id: Task identifier for session isolation
+        user_id: Camofox account identity for this call (Camofox backend only)
 
     Returns:
         JSON string with console messages/errors, or eval result
@@ -3574,12 +3655,16 @@ def browser_console(clear: bool = False, expression: Optional[str] = None, task_
         policy_error = _enforce_browser_eval_policy(expression)
         if policy_error:
             return json.dumps({"success": False, "error": policy_error}, ensure_ascii=False)
-        return _browser_eval(expression, task_id)
+        return _browser_eval(expression, task_id, user_id)
 
     # --- Console output mode (original behaviour) ---
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_console
-        return camofox_console(clear, task_id)
+        return camofox_console(clear, task_id, user_id)
+
+    _rejected = _reject_non_camofox_user_id("browser_console", user_id)
+    if _rejected is not None:
+        return _rejected
 
     effective_task_id = _last_session_key(task_id or "default")
 
@@ -3852,7 +3937,8 @@ def _enforce_browser_eval_policy(expression: str) -> Optional[str]:
     )
 
 
-def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
+def _browser_eval(expression: str, task_id: Optional[str] = None,
+                  user_id: Optional[str] = None) -> str:
     """Evaluate a JavaScript expression in the page context and return the result."""
     effective_task_id = _last_session_key(task_id or "default")
 
@@ -3873,7 +3959,11 @@ def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
     # id (matching every other Camofox tool) rather than the resolved
     # agent-browser session key.  The literal pre-scan above already ran.
     if _is_camofox_mode():
-        return _camofox_eval(expression, task_id)
+        return _camofox_eval(expression, task_id, user_id)
+
+    _rejected = _reject_non_camofox_user_id("browser_console", user_id)
+    if _rejected is not None:
+        return _rejected
 
     # ── Private-network guard (eval return-value path) ──────────────────────
     # The literal pre-scan above closes the direct-fetch sub-path
@@ -4033,14 +4123,23 @@ def _camofox_current_page_private_url(tab_id: str, user_id: str) -> Optional[str
     return None
 
 
-def _camofox_eval(expression: str, task_id: Optional[str] = None) -> str:
+def _camofox_eval(expression: str, task_id: Optional[str] = None,
+                  user_id: Optional[str] = None) -> str:
     """Evaluate JS via Camofox's /tabs/{tab_id}/evaluate endpoint (if available)."""
-    from tools.browser_camofox import _ensure_tab, _post
+    from tools.browser_camofox import InvalidCamofoxUserId, _ensure_tab, _post
     try:
-        tab_info = _ensure_tab(task_id or "default")
+        tab_info = _ensure_tab(task_id or "default", user_id=user_id)
+    except InvalidCamofoxUserId as e:
+        # Handled before the generic block below: its ("404","405","501")
+        # substring probe would match a rejected identity that merely contains
+        # "404", and report a charset error as "this server can't eval".
+        return tool_error(str(e), success=False)
+    try:
         tab_id = tab_info.get("tab_id") or tab_info.get("id")
-        user_id = tab_info["user_id"]
-        resp = _post(f"/tabs/{tab_id}/evaluate", body={"expression": expression, "userId": user_id})
+        # The session's identity, which is the requested ``user_id`` when one
+        # was supplied and the env/config/managed/random fallback otherwise.
+        user_id_used = tab_info["user_id"]
+        resp = _post(f"/tabs/{tab_id}/evaluate", body={"expression": expression, "userId": user_id_used})
 
         # Camofox returns the result in a JSON envelope
         raw_result = resp.get("result") if isinstance(resp, dict) else resp
@@ -4052,7 +4151,7 @@ def _camofox_eval(expression: str, task_id: Optional[str] = None) -> str:
                 pass
 
         if _eval_ssrf_guard_active(task_id or "default"):
-            _blocked_url = _camofox_current_page_private_url(tab_id, user_id)
+            _blocked_url = _camofox_current_page_private_url(tab_id, user_id_used)
             if _blocked_url:
                 return json.dumps({
                     "success": False,
@@ -4061,12 +4160,14 @@ def _camofox_eval(expression: str, task_id: Optional[str] = None) -> str:
                         f"({_blocked_url}). This may have been caused by a "
                         "JavaScript navigation via browser_console."
                     ),
+                    "user_id": user_id_used,
                 }, ensure_ascii=False)
 
         return json.dumps({
             "success": True,
             "result": _redact_browser_output(parsed),
             "result_type": type(parsed).__name__,
+            "user_id": user_id_used,
         }, ensure_ascii=False, default=str)
     except Exception as e:
         error_msg = str(e)
@@ -4129,19 +4230,25 @@ def _maybe_stop_recording(task_id: str):
             _recording_sessions.discard(task_id)
 
 
-def browser_get_images(task_id: Optional[str] = None) -> str:
+def browser_get_images(task_id: Optional[str] = None,
+                       user_id: Optional[str] = None) -> str:
     """
     Get all images on the current page.
 
     Args:
         task_id: Task identifier for session isolation
+        user_id: Camofox account identity for this call (Camofox backend only)
 
     Returns:
         JSON string with list of images (src and alt)
     """
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_get_images
-        return camofox_get_images(task_id)
+        return camofox_get_images(task_id, user_id)
+
+    _rejected = _reject_non_camofox_user_id("browser_get_images", user_id)
+    if _rejected is not None:
+        return _rejected
 
     effective_task_id = _last_session_key(task_id or "default")
 
@@ -4203,7 +4310,8 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_vision(question: str, annotate: bool = False, task_id: Optional[str] = None) -> Union[str, Dict[str, Any]]:
+def browser_vision(question: str, annotate: bool = False, task_id: Optional[str] = None,
+                   user_id: Optional[str] = None) -> Union[str, Dict[str, Any]]:
     """
     Take a screenshot of the current page for visual inspection.
 
@@ -4221,6 +4329,7 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         question: What you want to know about the page visually
         annotate: If True, overlay numbered [N] labels on interactive elements
         task_id: Task identifier for session isolation
+        user_id: Camofox account identity for this call (Camofox backend only)
 
     Returns:
         A JSON string with vision analysis results and screenshot_path, or a
@@ -4228,7 +4337,11 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
     """
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_vision
-        return camofox_vision(question, annotate, task_id)
+        return camofox_vision(question, annotate, task_id, user_id)
+
+    _rejected = _reject_non_camofox_user_id("browser_vision", user_id)
+    if _rejected is not None:
+        return _rejected
 
     import base64
     import uuid as uuid_mod
@@ -5056,12 +5169,65 @@ from tools.registry import registry, tool_error
 
 _BROWSER_SCHEMA_MAP = {s["name"]: s for s in BROWSER_TOOL_SCHEMAS}
 
+# Per-call Camofox identity (issue #77273).  Camofox maps each userId to its
+# own browser profile, so passing a different one per call lets a single Hermes
+# process drive several signed-in accounts.  Meaningless for agent-browser /
+# CDP / cloud backends, so the property is grafted onto the schema only while
+# Camofox is the active backend — see _camofox_user_id_schema_override.
+_CAMOFOX_USER_ID_PARAM = {
+    "type": "string",
+    "description": (
+        "Optional Camofox account identity for this call. Each user_id maps to "
+        "its own browser profile with its own cookies, logins, and tabs, so "
+        "pass a distinct value per account to drive several signed-in accounts "
+        "in one session (e.g. 'acct-alice' then 'acct-bob'). Reuse the same "
+        "value to stay in that account's tab. IMPORTANT: omitting it does not "
+        "continue the account you last used — it switches to the default "
+        "session, which is a separate browser profile again. Once a sequence "
+        "is acting as an account, pass that same user_id on every call in the "
+        "sequence, and never reuse element refs from one account's snapshot "
+        "against another. Every result echoes the user_id it acted as. "
+        "Allowed characters: letters, digits, and '.', '_', '-', ':', '@' "
+        "(must start with a letter or digit, max 64 characters)."
+    ),
+}
+
+
+def _camofox_user_id_schema_override(tool_name: str):
+    """Build a ``dynamic_schema_overrides`` callable that adds ``user_id``.
+
+    Returns an empty override (i.e. the static schema) unless the Camofox
+    backend is active, so the parameter costs nothing for every other backend.
+
+    The parameter can therefore appear and disappear mid-conversation:
+    ``model_tools.get_tool_definitions`` memoizes on registry generation and
+    config mtime, both of which move for unrelated reasons (an MCP refresh, a
+    plugin load, a config edit), so a ``/browser connect`` will eventually be
+    reflected here. That costs a prompt-cache miss, the same as the other
+    dynamic schemas (discord, image/video generation). It also means a model
+    can still emit ``user_id`` against a schema that has since changed —
+    ``_reject_non_camofox_user_id`` catches exactly that and fails the call
+    rather than running it on the wrong browser.
+    """
+    def _build() -> dict:
+        if not _is_camofox_mode():
+            return {}
+        base = _BROWSER_SCHEMA_MAP[tool_name]["parameters"]
+        properties = {k: dict(v) for k, v in base.get("properties", {}).items()}
+        properties["user_id"] = dict(_CAMOFOX_USER_ID_PARAM)
+        return {"parameters": {**base, "properties": properties}}
+
+    return _build
+
+
 registry.register(
     name="browser_navigate",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_navigate"],
-    handler=lambda args, **kw: browser_navigate(url=args.get("url", ""), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_navigate(
+        url=args.get("url", ""), task_id=kw.get("task_id"), user_id=args.get("user_id")),
     check_fn=check_browser_requirements,
+    dynamic_schema_overrides=_camofox_user_id_schema_override("browser_navigate"),
     emoji="🌐",
 )
 registry.register(
@@ -5069,48 +5235,62 @@ registry.register(
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_snapshot"],
     handler=lambda args, **kw: browser_snapshot(
-        full=args.get("full", False), task_id=kw.get("task_id"), user_task=kw.get("user_task")),
+        full=args.get("full", False), task_id=kw.get("task_id"), user_task=kw.get("user_task"),
+        user_id=args.get("user_id")),
     check_fn=check_browser_requirements,
+    dynamic_schema_overrides=_camofox_user_id_schema_override("browser_snapshot"),
     emoji="📸",
 )
 registry.register(
     name="browser_click",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_click"],
-    handler=lambda args, **kw: browser_click(ref=args.get("ref", ""), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_click(
+        ref=args.get("ref", ""), task_id=kw.get("task_id"), user_id=args.get("user_id")),
     check_fn=check_browser_requirements,
+    dynamic_schema_overrides=_camofox_user_id_schema_override("browser_click"),
     emoji="👆",
 )
 registry.register(
     name="browser_type",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_type"],
-    handler=lambda args, **kw: browser_type(ref=args.get("ref", ""), text=args.get("text", ""), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_type(
+        ref=args.get("ref", ""), text=args.get("text", ""), task_id=kw.get("task_id"),
+        user_id=args.get("user_id")),
     check_fn=check_browser_requirements,
+    dynamic_schema_overrides=_camofox_user_id_schema_override("browser_type"),
     emoji="⌨️",
 )
 registry.register(
     name="browser_scroll",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_scroll"],
-    handler=lambda args, **kw: browser_scroll(direction=args.get("direction", "down"), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_scroll(
+        direction=args.get("direction", "down"), task_id=kw.get("task_id"),
+        user_id=args.get("user_id")),
     check_fn=check_browser_requirements,
+    dynamic_schema_overrides=_camofox_user_id_schema_override("browser_scroll"),
     emoji="📜",
 )
 registry.register(
     name="browser_back",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_back"],
-    handler=lambda args, **kw: browser_back(task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_back(
+        task_id=kw.get("task_id"), user_id=args.get("user_id")),
     check_fn=check_browser_requirements,
+    dynamic_schema_overrides=_camofox_user_id_schema_override("browser_back"),
     emoji="◀️",
 )
 registry.register(
     name="browser_press",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_press"],
-    handler=lambda args, **kw: browser_press(key=args.get("key", ""), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_press(
+        key=args.get("key", ""), task_id=kw.get("task_id"), user_id=args.get("user_id")),
     check_fn=check_browser_requirements,
+    dynamic_schema_overrides=_camofox_user_id_schema_override("browser_press"),
     emoji="⌨️",
 )
 
@@ -5118,23 +5298,31 @@ registry.register(
     name="browser_get_images",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_get_images"],
-    handler=lambda args, **kw: browser_get_images(task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_get_images(
+        task_id=kw.get("task_id"), user_id=args.get("user_id")),
     check_fn=check_browser_requirements,
+    dynamic_schema_overrides=_camofox_user_id_schema_override("browser_get_images"),
     emoji="🖼️",
 )
 registry.register(
     name="browser_vision",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_vision"],
-    handler=lambda args, **kw: browser_vision(question=args.get("question", ""), annotate=args.get("annotate", False), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_vision(
+        question=args.get("question", ""), annotate=args.get("annotate", False),
+        task_id=kw.get("task_id"), user_id=args.get("user_id")),
     check_fn=check_browser_vision_requirements,
+    dynamic_schema_overrides=_camofox_user_id_schema_override("browser_vision"),
     emoji="👁️",
 )
 registry.register(
     name="browser_console",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_console"],
-    handler=lambda args, **kw: browser_console(clear=args.get("clear", False), expression=args.get("expression"), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_console(
+        clear=args.get("clear", False), expression=args.get("expression"),
+        task_id=kw.get("task_id"), user_id=args.get("user_id")),
     check_fn=check_browser_requirements,
+    dynamic_schema_overrides=_camofox_user_id_schema_override("browser_console"),
     emoji="🖥️",
 )

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -328,6 +328,49 @@ Adoption only fires until `tab_id` is populated for the session. If the external
 
 **Concurrency note:** the external app and Hermes can drive the same Camofox `userId` simultaneously, but Camofox does not coordinate per-tab focus between clients. Coordinate ownership at the application layer (e.g. the external app pauses while Hermes runs).
 
+#### Multi-account operation (per-call `user_id`)
+
+The settings above pin **one** identity for the whole process. When you need several signed-in accounts at once — daily sign-ins for a handful of accounts, parallel account testing — pass a `user_id` on the individual browser tool call instead. Camofox maps each `userId` to its own browser profile, so each value gets its own cookies and logins.
+
+The parameter appears on `browser_navigate`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_scroll`, `browser_back`, `browser_press`, `browser_console`, `browser_get_images`, and `browser_vision` — **only while the Camofox backend is actually active**, i.e. `CAMOFOX_URL` is set *and* no CDP override is in play. Setting `BROWSER_CDP_URL` or `browser.cdp_url` (or running `/browser connect`) takes priority over Camofox, and the parameter disappears along with it. On agent-browser, CDP, and cloud backends it is not part of the tool schema at all, so it costs nothing there.
+
+A two-account sign-in run looks like this:
+
+```
+browser_navigate(url="https://example.com/login", user_id="acct-alice")
+browser_type(ref="@e3", text="alice@example.com", user_id="acct-alice")
+browser_press(key="Enter", user_id="acct-alice")
+
+browser_navigate(url="https://example.com/login", user_id="acct-bob")
+browser_type(ref="@e3", text="bob@example.com", user_id="acct-bob")
+browser_press(key="Enter", user_id="acct-bob")
+```
+
+Each account keeps its own tab. Reusing the same `user_id` returns to that account's tab; switching values switches accounts; omitting it entirely uses the default session, which is **another separate profile again** — not a continuation of the account you last named. Mixing all three freely in one conversation is supported and is the intended usage; the agent picks per call.
+
+:::warning Pass `user_id` on every call in a sequence
+Element refs (`@e3`) come from a snapshot of one specific account's page and mean nothing in another profile's tab. Because omitting `user_id` switches to the default session rather than continuing the current account, dropping it midway through a signed-in sequence can apply that sequence's refs to a different profile's page. Keep the same `user_id` on every call from navigate through to the last interaction, and re-snapshot after any switch.
+:::
+
+Tool results echo the `user_id` they acted as — on success, on errors, and on blocked pages — so the agent can always confirm which account a call ran under.
+
+**Identity resolution order** (highest precedence first):
+
+1. `user_id` passed on the call
+2. `CAMOFOX_USER_ID` / `browser.camofox.user_id`
+3. `browser.camofox.managed_persistence` (profile-scoped stable identity)
+4. A random ephemeral identity
+
+Omitting `user_id` therefore preserves the existing behavior exactly.
+
+**Allowed values:** a string of 1–64 characters, starting with a letter or digit, containing only letters, digits, and `.` `_` `-` `:` `@`. Anything else — including a non-string such as `0` or `12345` — is rejected before a request is sent, rather than falling back to the default identity. The value reaches Camofox as a URL path segment on session teardown, so the charset is deliberately narrow. This check applies only to per-call values; `CAMOFOX_USER_ID` and `browser.camofox.user_id` are operator-configured and are not re-validated.
+
+**If the backend changes mid-conversation** (e.g. you run `/browser connect`), calls that still carry a `user_id` are **rejected with an error** rather than silently run on the now-shared browser. A shared CDP/cloud browser has one profile and cannot isolate accounts, so running the call anyway could act as whatever account that browser happens to be signed in as.
+
+**Cleanup:** a session created with an explicit `user_id` is treated as caller-owned. At task end Hermes closes its **tab** (`DELETE /tabs/<tabId>`) but never calls `DELETE /sessions/<user_id>`, so the profile, cookies, and logins survive — next time you use the same `user_id` you are still signed in, just in a fresh tab. Closing the tab matters because Camofox's `POST /pressure/cleanup` is caller-triggered, not an automatic reaper; without it every distinct `user_id` would leave a window open indefinitely.
+
+**Tab reuse:** per-call identities follow the same `adopt_existing_tab` setting described above. With it off (the default) each account gets a fresh tab; turn it on if you want Hermes to reattach to an account's existing tab rather than opening another one.
+
 #### VNC live view
 
 When Camofox runs in headed mode (with a visible browser window), it exposes a VNC port in its health check response. Hermes automatically discovers this and includes the VNC URL in navigation responses, so the agent can share a link for you to watch the browser live.


### PR DESCRIPTION
Camofox maps each userId to its own browser profile, but Hermes resolved a single identity per process (CAMOFOX_USER_ID / browser.camofox.user_id -> managed profile -> random) and sent it on every request, so one process could not drive several signed-in accounts without extra Hermes profiles.

Add an optional user_id to the Camofox-backed browser tools and thread it into _get_session. Precedence: per-call user_id -> CAMOFOX_USER_ID / browser.camofox.user_id -> managed profile identity -> random. Sessions cache per (task_id, user_id) so repeated calls with the same identity reuse the same tab. Omitting user_id keeps today's behaviour and key space byte for byte.

The parameter joins the schema only while Camofox is the active backend, via dynamic_schema_overrides, so it costs nothing on agent-browser / CDP / cloud. A call carrying user_id on a non-Camofox backend is rejected rather than run: a shared browser has one profile and cannot isolate accounts, so continuing could act as whatever account it is already signed in as.

Per-call identities are caller-owned. Teardown closes their tab (DELETE /tabs/<tabId>?userId=) but never DELETE /sessions/<userId>, so the profile and its logins survive while windows are still reclaimed — Camofox's POST /pressure/cleanup is caller-triggered, not an automatic reaper. Releases are independent, so one failing DELETE no longer strands its siblings after local tracking has been dropped.

A per-call user_id is model-supplied and reaches DELETE /sessions/<id> as a path segment, so it is validated against a narrow charset (leading alphanumeric, no separators or whitespace, fullmatch) before any request is sent. Non-string values error instead of silently falling back to the default identity. Operator-configured identities are not re-validated.

Every result echoes the user_id it acted as — success, error, and blocked-page paths alike — so a multi-account run can always confirm which account it ran under. camofox_console is the exception: it never opens a session, so echoing would rubber-stamp an unresolved identity.

Test doubles for _get_session / _ensure_tab / camofox_click / camofox_back are updated to match the new signatures.

Closes #77273

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #77273

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**`tools/browser_camofox.py`**

- `_get_session(task_id, user_id=None)` — precedence is now per-call `user_id` →
  `CAMOFOX_USER_ID` / `browser.camofox.user_id` → managed profile identity → random.
- Sessions cache per `(task_id, user_id)` using a `::camofox_user::` suffixed key,
  mirroring the existing `::local` sidecar convention in `browser_tool.py`. Omitting
  `user_id` leaves the key space byte-identical to before.
- `_validate_call_user_id` / `_normalize_call_user_id` — a per-call `user_id` is
  model-supplied and reaches `DELETE /sessions/<id>` as a **path segment**, so it is
  validated against a narrow charset (leading alphanumeric, no separators or whitespace,
  `re.fullmatch`) before any request is sent. Rejecting a leading `.` matters:
  `DELETE /sessions/..` normalizes to `DELETE /sessions` on some servers. Non-string
  values (`0`, `False`, `12345`) error rather than silently falling back to the default
  identity. Operator-configured identities are not re-validated.
- `_release_session` — per-call identities are caller-owned, so teardown closes their
  **tab** (`DELETE /tabs/<tabId>?userId=`) and never `DELETE /sessions/<userId>`. The
  profile and its logins survive while windows are still reclaimed; Camofox's
  `POST /pressure/cleanup` is caller-triggered, not an automatic reaper.
- `camofox_close` releases each session independently, so one failing DELETE no longer
  strands its siblings after local tracking has already been dropped.
- All `camofox_*` tools take `user_id` and echo the identity they acted as — on success,
  on errors, and on blocked pages. `camofox_console` is the deliberate exception: it
  never opens a session, so echoing would rubber-stamp an unresolved identity.
- New `list_camofox_sessions()` helper for skills and debugging (not a model tool).

**`tools/browser_tool.py`**

- `user_id` threaded through all ten Camofox-backed wrappers, including the
  `browser_console` → `_browser_eval` → `_camofox_eval` chain.
- `_camofox_user_id_schema_override` adds the parameter to the schema only when
  `is_camofox_mode()` is true, wired via `dynamic_schema_overrides`.
- `_reject_non_camofox_user_id` — a call carrying `user_id` on a non-Camofox backend is
  **rejected rather than run**. Reachable when the backend changes underneath the model
  (`/browser connect` mid-conversation while the model still holds a Camofox-era schema).
  A shared browser has one profile and cannot isolate accounts, so continuing would act
  as whatever account it is already signed in as.
- `_camofox_eval` handles `InvalidCamofoxUserId` before its `("404","405","501")`
  substring probe, which would otherwise report a rejected identity containing `404` as
  "this server does not support eval".

**Tests / docs**

- `tests/tools/test_browser_camofox_multi_user.py` — new, 132 tests.
- Test doubles for `_get_session` / `_ensure_tab` / `camofox_click` / `camofox_back` in
  `test_browser_camofox_private_page_guard.py`, `test_browser_eval_ssrf.py`, and
  `test_browser_private_page_action_guard.py` updated to match the new signatures.
- `website/docs/user-guide/features/browser.md` — new "Multi-account operation
  (per-call `user_id`)" section.

No new config keys.

## How to Test

1. **Run the browser tests:**
   ```bash
   pytest tests/tools/ -k browser -q
tests/tools/test_browser_camofox_multi_user.py covers resolution precedence, session
isolation, the validation floor, teardown semantics, and the schema gating.

Verify the schema is gated — user_id must be absent without Camofox and present
with it:


CAMOFOX_URL= python -c "
from tools.registry import registry; import tools.browser_tool
e = registry._tools['browser_navigate']
s = {**e.schema}; s.update(e.dynamic_schema_overrides() or {})
print('user_id' in s['parameters']['properties'])"   # False

CAMOFOX_URL=http://localhost:9377 python -c "
from tools.registry import registry; import tools.browser_tool
e = registry._tools['browser_navigate']
s = {**e.schema}; s.update(e.dynamic_schema_overrides() or {})
print('user_id' in s['parameters']['properties'])"   # True
End-to-end with a real Camofox server (CAMOFOX_URL=http://localhost:9377), sign
in to any site as two different accounts in one conversation:


browser_navigate(url="https://example.com/login", user_id="acct-alice")   # signs in as alice
browser_navigate(url="https://example.com/login", user_id="acct-bob")     # separate profile
browser_navigate(url="https://example.com/account", user_id="acct-alice") # still alice, same tab
GET /tabs?userId=acct-alice and ?userId=acct-bob should each show one tab, and each
account should remain independently signed in. Omitting user_id reaches the default
session — a third, separate profile.

Backward compatibility — with no user_id anywhere, behaviour is unchanged:
managed_persistence, CAMOFOX_USER_ID, and the random-ephemeral paths all resolve
exactly as before, and the session cache key is still the bare task_id.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

