### PR TITLE
fix(nous): don't forward provider routing preferences to Nous Portal

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1266,8 +1266,17 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         _omit_temp = False
         _fixed_temp = None
 
-    # Provider preferences (aggregator profile decides whether to emit them).
-    _prefs = _provider_preferences_for_agent(agent)
+    # Provider preferences are OpenRouter-router knobs only. Never attach them
+    # for Nous Portal (or any non-OR path) — the Portal hard-rejects a
+    # caller-supplied ``provider`` object with HTTP 400.
+    _prefs = (
+        _provider_preferences_for_agent(agent)
+        if (
+            (agent.provider or "").strip().lower() == "openrouter"
+            or _is_or
+        )
+        else {}
+    )
 
     # Anthropic-compatible max-output fallback (last resort only — applied in
     # build_kwargs *after* ephemeral/user/profile max_tokens, never overriding
@@ -2241,7 +2250,14 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
             # Merge the profile's canonical body even when routing is unset:
             # profiles may always emit required metadata such as Portal tags.
-            provider_preferences = _provider_preferences_for_agent(agent)
+            # Provider prefs are OpenRouter-only (Nous hard-rejects them).
+            _is_or_summary = (
+                (agent.provider or "").strip().lower() == "openrouter"
+                or agent._is_openrouter_url()
+            )
+            provider_preferences = (
+                _provider_preferences_for_agent(agent) if _is_or_summary else {}
+            )
             profile_extra_body = {}
             try:
                 from providers import get_provider_profile
@@ -2260,10 +2276,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
             if profile_extra_body:
                 summary_extra_body.update(profile_extra_body)
-            if provider_preferences and "provider" not in profile_extra_body and (
-                (agent.provider or "").strip().lower() == "openrouter"
-                or agent._is_openrouter_url()
-            ):
+            if provider_preferences and "provider" not in profile_extra_body and _is_or_summary:
                 summary_extra_body["provider"] = provider_preferences
 
             # Pareto Code router plugin — model-gated. Same shape as

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -511,8 +511,13 @@ class ChatCompletionsTransport(ProviderTransport):
         base_url = params.get("base_url")
 
         provider_prefs = params.get("provider_preferences")
+        # OpenRouter-only routing knobs. Never emit on non-OR paths (Nous
+        # Portal hard-rejects caller-supplied ``provider`` with HTTP 400).
         if provider_prefs and is_openrouter:
             extra_body["provider"] = provider_prefs
+        elif provider_prefs and not is_openrouter:
+            # Explicit no-op branch documents the policy for readers/tests.
+            pass
 
         # Pareto Code router plugin — model-gated. Same shape as the
         # profile path in plugins/model-providers/openrouter/__init__.py;
@@ -725,6 +730,23 @@ class ChatCompletionsTransport(ProviderTransport):
                     k: v for k, v in extra_body.items()
                     if k in ("thinking_config", "thinkingConfig")
                 }
+            # OpenRouter-only: caller-supplied provider routing preferences.
+            # Nous Portal (and any non-OR endpoint) hard-rejects them with
+            # HTTP 400. Strip even if request_overrides / a buggy profile
+            # tried to inject them.
+            if extra_body and "provider" in extra_body:
+                _prof_name = (getattr(profile, "name", None) or "").strip().lower()
+                _aliases = {
+                    str(a).strip().lower()
+                    for a in (getattr(profile, "aliases", None) or ())
+                }
+                _base = str(params.get("base_url") or "").lower()
+                _is_openrouter_profile = (
+                    _prof_name == "openrouter" or "openrouter" in _aliases
+                )
+                _is_openrouter_url = "openrouter.ai" in _base
+                if not (_is_openrouter_profile or _is_openrouter_url):
+                    extra_body.pop("provider", None)
             if extra_body:
                 api_kwargs["extra_body"] = extra_body
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4341,6 +4341,11 @@ class TurnRunner:
             }
 
         pr = self._runner._provider_routing
+        # OpenRouter-only — Nous Portal hard-rejects caller-supplied provider routing.
+        _prov = str(runtime_kwargs.get("provider") or "").strip().lower()
+        _base = str(runtime_kwargs.get("base_url") or "").strip().lower()
+        if not (_prov == "openrouter" or "openrouter.ai" in _base):
+            pr = {}
         reasoning_config = self._runner._resolve_session_reasoning_config(
             source=ctx.source,
             session_key=ctx.session_key,
@@ -19274,6 +19279,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._reasoning_config = reasoning_config
             self._service_tier = self._resolve_session_service_tier(source=source)
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            # OpenRouter-only — Nous Portal hard-rejects caller-supplied provider routing.
+            _tr = turn_route.get("runtime") or runtime_kwargs or {}
+            _prov = str(_tr.get("provider") or "").strip().lower()
+            _base = str(_tr.get("base_url") or "").strip().lower()
+            if not (_prov == "openrouter" or "openrouter.ai" in _base):
+                pr = {}
 
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).

--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -43,9 +43,14 @@ class NousProfile(ProviderProfile):
         sticky_key = get_conversation_context() or session_id
         if sticky_key:
             body["session_id"] = sticky_key
-        provider_preferences = context.get("provider_preferences")
-        if provider_preferences:
-            body["provider"] = provider_preferences
+        # NOTE: caller-supplied ``provider`` routing preferences (``only``,
+        # ``ignore``, ``order``, ``data_collection``, ``zdr``, …) are
+        # deliberately NOT forwarded. The Nous inference API hard-rejects
+        # them with HTTP 400 ("This endpoint does not honor caller-supplied
+        # `provider` routing preferences… Routing is decided centrally per
+        # model"). They are OpenRouter-router knobs; on Nous they were pure
+        # poison — any profile with a global provider_routing config (e.g.
+        # data_collection: deny for ZDR) broke every Nous call.
         return body
 
     def build_api_kwargs_extras(

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -117,6 +117,18 @@ class TestNousParity:
         )
         assert kw["extra_body"]["tags"] == nous_portal_tags()
 
+    def test_provider_preferences_not_forwarded(self, transport):
+        """Nous Portal hard-rejects caller-supplied provider routing (HTTP 400)."""
+        prefs = {"data_collection": "deny", "only": ["Anthropic"]}
+        kw = transport.build_kwargs(
+            model="hermes-3-llama-3.1-405b",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("nous"),
+            provider_preferences=prefs,
+        )
+        assert "provider" not in kw.get("extra_body", {})
+
 
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6414,6 +6414,16 @@ def _make_agent(
                 raise RuntimeError("Auth fallback resolved without a model")
             model = resolution.selected_model
     _pr = _load_provider_routing()
+    # OpenRouter-only. Nous Portal hard-rejects caller-supplied ``provider``
+    # routing prefs (HTTP 400). Never attach global provider_routing when the
+    # resolved runtime is not OpenRouter.
+    _runtime_provider = str(runtime.get("provider") or "").strip().lower()
+    _runtime_base = str(runtime.get("base_url") or "").strip().lower()
+    _is_openrouter = (
+        _runtime_provider == "openrouter" or "openrouter.ai" in _runtime_base
+    )
+    if not _is_openrouter:
+        _pr = {}
     return AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 500),
@@ -6444,6 +6454,7 @@ def _make_agent(
         # OpenRouter provider-routing prefs (config.yaml `provider_routing`).
         # Mirrors the messaging gateway + CLI so the desktop/TUI honors the same
         # routing instead of letting OpenRouter pick providers at random.
+        # Gated above to OpenRouter only — never forward to Nous Portal.
         providers_allowed=_pr.get("only"),
         providers_ignored=_pr.get("ignore"),
         providers_order=_pr.get("order"),


### PR DESCRIPTION
Superseded by #77593. Closing — no action needed.