### PR TITLE
fix(security): harden Kanban logs and MCP redaction

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -918,7 +918,12 @@ def _canonical_structured_key(value: object) -> str:
     text = str(value)
     text = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", text)
     text = re.sub(r"(?<=[A-Z])(?=[A-Z][a-z])", "_", text)
-    return re.sub(r"[^a-z0-9]+", "_", text.casefold()).strip("_")
+    canonical = re.sub(r"[^a-z0-9]+", "_", text.casefold()).strip("_")
+    # The generic acronym splitter sees OAuthToken as O_Auth_Token and
+    # XAPIKey as XAPI_Key. Normalize these established credential acronyms
+    # without collapsing arbitrary lexical boundaries.
+    canonical = re.sub(r"(^|_)o_auth(?=_|$)", r"\1oauth", canonical)
+    return re.sub(r"(^|_)xapi(?=_|$)", r"\1x_api", canonical)
 
 
 def _is_structured_secret_key(value: object) -> bool:

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -663,6 +663,7 @@ def redact_sensitive_text(
     code_file: bool = False,
     file_read: bool = False,
     redact_url_credentials: bool = False,
+    redact_phone_numbers: bool = True,
 ) -> str:
     """Apply all redaction patterns to a block of text.
 
@@ -868,7 +869,7 @@ def redact_sensitive_text(
         text = _redact_form_body(text)
 
     # E.164 phone numbers (Signal, WhatsApp)
-    if "+" in text:
+    if redact_phone_numbers and "+" in text:
         def _redact_phone(m):
             phone = m.group(1)
             if len(phone) <= 8:
@@ -877,6 +878,144 @@ def redact_sensitive_text(
         text = _SIGNAL_PHONE_RE.sub(_redact_phone, text)
 
     return text
+
+
+_STRUCTURED_SECRET_KEYS = frozenset({
+    "access_key", "access_token", "api_key", "api_token", "apikey", "auth_key",
+    "auth_token", "authorization", "bearer", "bearer_token", "bot_token",
+    "client_secret", "consumer_key", "csrf_token",
+    "consumer_secret", "cookie",
+    "credential", "id_token", "key_material", "license_key", "nonce",
+    "oauth_token", "password", "personal_access_token",
+    "passwd", "private_key", "proxy_authorization", "raw_secret",
+    "refresh_token", "secret", "service_token", "session_token",
+    "signing_secret", "signing_token",
+    "secret_input", "secret_key", "secret_value", "session_cookie", "token",
+    "verification_token", "webhook_secret", "webhook_token", "x_api_key",
+})
+_STRUCTURED_SECRET_SUFFIXES = (
+    "access_key", "access_token", "api_key", "api_token", "apikey",
+    "auth_key", "auth_token", "bearer_token", "bot_token", "client_secret",
+    "consumer_key", "consumer_secret", "credential", "csrf_token", "id_token",
+    "key_material", "license_key", "oauth_token", "personal_access_token",
+    "password", "passwd", "private_key", "raw_secret", "refresh_token",
+    "proxy_authorization", "secret_input", "secret_key", "secret_value",
+    "service_token", "session_cookie", "session_token", "signing_secret",
+    "signing_token", "verification_token", "webhook_secret", "webhook_token",
+)
+
+_SECRET_OPTION_NAME_SUFFIXES = (
+    "access_token", "api_key", "apikey", "auth_key", "auth_salt",
+    "auth_token", "client_secret", "consumer_key", "consumer_secret",
+    "credential", "license_key",
+    "logged_in_key", "logged_in_salt", "nonce_key", "nonce_salt",
+    "password", "passwd", "private_key", "refresh_token", "secret",
+    "secret_key", "secure_auth_key", "secure_auth_salt", "token",
+)
+
+
+def _canonical_structured_key(value: object) -> str:
+    text = str(value)
+    text = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", text)
+    text = re.sub(r"(?<=[A-Z])(?=[A-Z][a-z])", "_", text)
+    return re.sub(r"[^a-z0-9]+", "_", text.casefold()).strip("_")
+
+
+def _is_structured_secret_key(value: object) -> bool:
+    """Recognize exact and conservatively suffixed credential field names."""
+    canonical = _canonical_structured_key(value)
+    return canonical in _STRUCTURED_SECRET_KEYS or any(
+        canonical.endswith(f"_{suffix}")
+        and len(canonical) - len(suffix) - 1 >= 2
+        for suffix in _STRUCTURED_SECRET_SUFFIXES
+    )
+
+
+def _is_secret_option_name(value: object) -> bool:
+    """Recognize credential-bearing WordPress option names conservatively."""
+    normalized = _canonical_structured_key(value)
+    return any(
+        normalized == suffix or normalized.endswith(f"_{suffix}")
+        for suffix in _SECRET_OPTION_NAME_SUFFIXES
+    )
+
+
+def redact_sensitive_data(
+    value: object,
+    *,
+    force: bool = False,
+    code_file: bool = False,
+    redact_url_credentials: bool = False,
+    redact_phone_numbers: bool = True,
+) -> object:
+    """Recursively redact structured secrets without mutating the input."""
+    if not (force or _REDACT_ENABLED):
+        return value
+    if isinstance(value, dict):
+        secret_option_prefixes: set[str] = set()
+        for key, item in value.items():
+            canonical_key = _canonical_structured_key(key)
+            if canonical_key == "option_name":
+                prefix = ""
+            elif canonical_key.endswith("_option_name"):
+                prefix = canonical_key[: -len("option_name")]
+            else:
+                continue
+            if _is_secret_option_name(item):
+                secret_option_prefixes.add(prefix)
+        redacted = {}
+        for key, item in value.items():
+            canonical_key = _canonical_structured_key(key)
+            if canonical_key == "option_value":
+                option_prefix = ""
+            elif canonical_key.endswith("_option_value"):
+                option_prefix = canonical_key[: -len("option_value")]
+            else:
+                option_prefix = None
+            if _is_structured_secret_key(key):
+                redacted[key] = "***"
+            elif option_prefix is not None and option_prefix in secret_option_prefixes:
+                redacted[key] = "***"
+            else:
+                redacted[key] = redact_sensitive_data(
+                    item,
+                    force=force,
+                    code_file=code_file,
+                    redact_url_credentials=redact_url_credentials,
+                    redact_phone_numbers=redact_phone_numbers,
+                )
+        return redacted
+    if isinstance(value, list):
+        return [
+            redact_sensitive_data(
+                item,
+                force=force,
+                code_file=code_file,
+                redact_url_credentials=redact_url_credentials,
+                redact_phone_numbers=redact_phone_numbers,
+            )
+            for item in value
+        ]
+    if isinstance(value, tuple):
+        return tuple(
+            redact_sensitive_data(
+                item,
+                force=force,
+                code_file=code_file,
+                redact_url_credentials=redact_url_credentials,
+                redact_phone_numbers=redact_phone_numbers,
+            )
+            for item in value
+        )
+    if isinstance(value, str):
+        return redact_sensitive_text(
+            value,
+            force=force,
+            code_file=code_file,
+            redact_url_credentials=redact_url_credentials,
+            redact_phone_numbers=redact_phone_numbers,
+        )
+    return value
 
 
 # Commands whose stdout is an environment-variable dump (KEY=value lines),

--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -72,7 +72,11 @@ class SlashAccessPolicy:
             # downstream code can keep using ``is_admin`` / ``can_run``
             # uniformly.
             return True
-        if not user_id:
+        if (
+            isinstance(user_id, bool)
+            or not isinstance(user_id, (str, int))
+            or not str(user_id).strip()
+        ):
             return False
         return str(user_id) in self.admin_user_ids
 
@@ -88,14 +92,27 @@ class SlashAccessPolicy:
         return canonical_cmd in self.user_allowed_commands
 
 
-_DM_CHAT_TYPES = frozenset({"dm", "direct", "private", ""})
+_DM_CHAT_TYPES = frozenset({"dm", "direct", "private"})
+_GROUP_CHAT_TYPES = frozenset({"group", "channel", "thread", "supergroup", "forum"})
+
+
+def canonical_scope_for_chat_type(chat_type: Optional[str]) -> Optional[str]:
+    """Return the recognized DM/group scope for *chat_type*, else ``None``."""
+    if not isinstance(chat_type, str):
+        return None
+    normalized = chat_type.strip().lower()
+    if normalized in _DM_CHAT_TYPES:
+        return "dm"
+    if normalized in _GROUP_CHAT_TYPES:
+        return "group"
+    return None
 
 
 def _coerce_id_list(raw: Any) -> FrozenSet[str]:
     """Normalize a YAML-loaded admin/user list into a frozenset of strings.
 
-    Accepts ``None``, list, tuple, or comma-separated string. Stringifies
-    each entry and strips whitespace; empty entries are dropped.
+    Accepts string/integer identities, collections of those values, or a
+    comma-separated string. Booleans and structured values fail closed.
     """
     if raw is None:
         return frozenset()
@@ -108,6 +125,8 @@ def _coerce_id_list(raw: Any) -> FrozenSet[str]:
         items = (raw,)
     out: list[str] = []
     for it in items:
+        if isinstance(it, bool) or not isinstance(it, (str, int)):
+            continue
         s = str(it).strip()
         if s:
             out.append(s)
@@ -138,9 +157,7 @@ def _coerce_command_list(raw: Any) -> FrozenSet[str]:
 
 
 def _scope_for_chat_type(chat_type: Optional[str]) -> str:
-    if chat_type and chat_type.lower() in _DM_CHAT_TYPES:
-        return "dm"
-    return "group"
+    return canonical_scope_for_chat_type(chat_type) or "group"
 
 
 def _platform_extra(platform_config: Any) -> dict:
@@ -224,6 +241,7 @@ def policy_for_source(gateway_config: Any, source: Any) -> SlashAccessPolicy:
 
 __all__ = [
     "SlashAccessPolicy",
+    "canonical_scope_for_chat_type",
     "policy_from_extra",
     "policy_for_source",
 ]

--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -126,10 +126,11 @@ def _coerce_id_list(raw: Any) -> FrozenSet[str]:
     out: list[str] = []
     for it in items:
         if isinstance(it, bool) or not isinstance(it, (str, int)):
-            continue
+            return frozenset()
         s = str(it).strip()
-        if s:
-            out.append(s)
+        if not s:
+            return frozenset()
+        out.append(s)
     return frozenset(out)
 
 

--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -134,6 +134,24 @@ def _coerce_id_list(raw: Any) -> FrozenSet[str]:
     return frozenset(out)
 
 
+def _id_list_is_well_formed(raw: Any) -> bool:
+    """Whether an identity allowlist contains only supported scalar IDs."""
+    if raw is None:
+        return True
+    if isinstance(raw, (list, tuple, set, frozenset)):
+        items: Iterable[Any] = raw
+    elif isinstance(raw, str):
+        items = (s for s in raw.split(",") if s.strip())
+    else:
+        items = (raw,)
+    return all(
+        not isinstance(item, bool)
+        and isinstance(item, (str, int))
+        and bool(str(item).strip())
+        for item in items
+    )
+
+
 def _coerce_command_list(raw: Any) -> FrozenSet[str]:
     """Normalize a slash command allowlist.
 
@@ -195,7 +213,8 @@ def policy_from_extra(extra: dict, scope: str) -> SlashAccessPolicy:
     DMs is not implicitly an admin in a group.
     """
     admin_key, cmd_key = _keys_for_scope(scope)
-    admin_ids = _coerce_id_list(extra.get(admin_key))
+    raw_admin_ids = extra.get(admin_key)
+    admin_ids = _coerce_id_list(raw_admin_ids)
     cmds = _coerce_command_list(extra.get(cmd_key))
 
     if scope == "dm" and not cmds:
@@ -203,7 +222,10 @@ def policy_from_extra(extra: dict, scope: str) -> SlashAccessPolicy:
         # so operators only need to list it once if it's the same.
         cmds = _coerce_command_list(extra.get("group_user_allowed_commands"))
 
-    enabled = bool(admin_ids)
+    # A malformed configured policy must not collapse into the legacy
+    # unrestricted mode. Keep gating active with no admins so authorization
+    # fails closed; only an absent or valid-empty list disables gating.
+    enabled = bool(admin_ids) or not _id_list_is_well_formed(raw_admin_ids)
     return SlashAccessPolicy(
         enabled=enabled,
         admin_user_ids=admin_ids,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -461,20 +461,41 @@ class GatewaySlashCommandsMixin:
         i = 0
         while i < len(tokens):
             tok = tokens[i]
-            if tok == "--board":
+            if tok == "--":
+                i += 1
+                action = tokens[i] if i < len(tokens) else None
+                break
+            option_name, has_equals, option_value = tok.partition("=")
+            is_board_option = option_name == "--board" or (
+                len(option_name) > 2 and "--board".startswith(option_name)
+            )
+            if is_board_option and not has_equals:
                 if i + 1 >= len(tokens):
                     break
                 requested_board = tokens[i + 1]
                 i += 2
                 continue
-            if tok.startswith("--board="):
-                requested_board = tok.split("=", 1)[1]
+            if is_board_option and has_equals:
+                requested_board = option_value
                 i += 1
                 continue
             action = tok
             break
 
         is_create = action == "create"
+
+        # Worker logs are raw subprocess output. Require a real, explicitly
+        # configured admin instead of inheriting the broad /kanban allowlist.
+        if action == "log" and not self._caller_is_explicit_admin(event.source):
+            logger.info(
+                "Gateway /kanban log denied for %s:%s (explicit admin required)",
+                event.source.platform.value if event.source.platform else "?",
+                event.source.user_id,
+            )
+            return (
+                "⛔ /kanban log is admin-only here. "
+                "Ask an admin to add your user ID to this chat scope's admin allowlist."
+            )
 
         try:
             output = await asyncio.to_thread(run_slash, text)
@@ -1008,24 +1029,32 @@ class GatewaySlashCommandsMixin:
         # the same owner — fail closed.
         return False
 
-    def _resume_caller_is_admin(self, source: SessionSource) -> bool:
-        """Whether *source* is an EXPLICITLY-configured admin allowed to make a
-        cross-origin /resume or /sessions listing.
+    def _caller_is_explicit_admin(self, source: SessionSource) -> bool:
+        """Whether *source* is an explicitly configured gateway admin.
 
         Deliberately stricter than ``SlashAccessPolicy.is_admin()``: that returns
-        True for every allowed caller when slash gating is DISABLED (so commands
-        stay runnable by default), but cross-ORIGIN DATA ACCESS must require a
-        real, configured admin. Otherwise the default (no admin list) config
-        would treat every gateway caller as cross-origin-capable and re-open the
-        enumeration IDOR.
+        True for every allowed caller when slash gating is disabled, but
+        privileged data access must require a real, configured admin.
         """
         try:
-            from gateway.slash_access import policy_for_source
+            from gateway.slash_access import (
+                canonical_scope_for_chat_type,
+                policy_for_source,
+            )
+
+            if canonical_scope_for_chat_type(
+                getattr(source, "chat_type", None)
+            ) is None:
+                return False
             policy = policy_for_source(self.config, source)
             uid = getattr(source, "user_id", None)
             return bool(policy.enabled and uid and policy.is_admin(uid))
         except Exception:
             return False
+
+    def _resume_caller_is_admin(self, source: SessionSource) -> bool:
+        """Whether *source* may make cross-origin session requests."""
+        return self._caller_is_explicit_admin(source)
 
     async def _resume_target_allowed(
         self, source: SessionSource, target_id: str, allow_override: bool = False

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -487,9 +487,14 @@ class GatewaySlashCommandsMixin:
         # Worker logs are raw subprocess output. Require a real, explicitly
         # configured admin instead of inheriting the broad /kanban allowlist.
         if action == "log" and not self._caller_is_explicit_admin(event.source):
+            source_platform = getattr(event.source, "platform", None)
             logger.info(
                 "Gateway /kanban log denied for %s:%s (explicit admin required)",
-                event.source.platform.value if event.source.platform else "?",
+                (
+                    source_platform.value
+                    if hasattr(source_platform, "value")
+                    else str(source_platform or "?")
+                ),
                 event.source.user_id,
             )
             return (
@@ -1037,11 +1042,20 @@ class GatewaySlashCommandsMixin:
         privileged data access must require a real, configured admin.
         """
         try:
+            from gateway.config import GatewayConfig, Platform, PlatformConfig
             from gateway.slash_access import (
                 canonical_scope_for_chat_type,
                 policy_for_source,
             )
 
+            platform = getattr(source, "platform", None)
+            if not isinstance(self.config, GatewayConfig) or not isinstance(
+                platform, Platform
+            ):
+                return False
+            platform_config = self.config.platforms.get(platform)
+            if not isinstance(platform_config, PlatformConfig):
+                return False
             if canonical_scope_for_chat_type(
                 getattr(source, "chat_type", None)
             ) is None:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -213,6 +213,20 @@ def _check_dispatcher_presence(
 # Argparse builder
 # ---------------------------------------------------------------------------
 
+def _disable_long_option_abbreviations(parser: argparse.ArgumentParser) -> None:
+    """Disable option-prefix matching across an already-built parser tree."""
+    parser.allow_abbrev = False
+    for action in parser._actions:
+        if not isinstance(action, argparse._SubParsersAction):
+            continue
+        seen: set[int] = set()
+        for child in action.choices.values():
+            if id(child) in seen:
+                continue
+            seen.add(id(child))
+            _disable_long_option_abbreviations(child)
+
+
 def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
     """Attach the ``kanban`` subcommand tree under an existing subparsers.
 
@@ -220,6 +234,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     """
     kanban_parser = parent_subparsers.add_parser(
         "kanban",
+        allow_abbrev=False,
         help="Multi-profile collaboration board (tasks, links, comments)",
         description=(
             "Durable SQLite-backed task board shared across Hermes profiles. "
@@ -950,6 +965,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_repair.add_argument("--json", action="store_true",
                           help="Emit the repair report as JSON")
 
+    _disable_long_option_abbreviations(kanban_parser)
     kanban_parser.set_defaults(_kanban_parser=kanban_parser)
     return kanban_parser
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9024,6 +9024,71 @@ def _open_private_worker_log(log_path: Path, *, dir_fd: Optional[int] = None):
         raise
 
 
+def _open_private_worker_log_for_read(log_path: Path):
+    """Open an existing worker log without following aliases or path swaps."""
+    if os.name == "nt":
+        fd = os.open(log_path, os.O_RDONLY)
+        try:
+            if not stat_module.S_ISREG(os.fstat(fd).st_mode):
+                raise OSError(
+                    errno.EINVAL,
+                    "refusing non-regular Kanban worker log",
+                    log_path,
+                )
+            return os.fdopen(fd, "rb")
+        except Exception:
+            os.close(fd)
+            raise
+
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if not nofollow:
+        raise RuntimeError("secure Kanban worker logs require O_NOFOLLOW support")
+    directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | nofollow
+    absolute_log_dir = Path(os.path.abspath(log_path.parent))
+    dir_fd = os.open(absolute_log_dir.anchor, directory_flags)
+    try:
+        for component in absolute_log_dir.parts[1:]:
+            child_fd = os.open(component, directory_flags, dir_fd=dir_fd)
+            parent_fd = dir_fd
+            dir_fd = child_fd
+            os.close(parent_fd)
+
+        directory_stat = os.fstat(dir_fd)
+        if (
+            not stat_module.S_ISDIR(directory_stat.st_mode)
+            or directory_stat.st_uid != os.geteuid()
+            or stat_module.S_IMODE(directory_stat.st_mode) & 0o077
+        ):
+            raise OSError(
+                errno.EACCES,
+                "refusing non-private Kanban worker log directory",
+                absolute_log_dir,
+            )
+
+        flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | nofollow
+        fd = os.open(log_path.name, flags, dir_fd=dir_fd)
+        try:
+            opened_stat = os.fstat(fd)
+            path_stat = os.stat(log_path.name, dir_fd=dir_fd, follow_symlinks=False)
+            if (
+                not _is_private_worker_log_stat(opened_stat)
+                or stat_module.S_IMODE(opened_stat.st_mode) & 0o077
+                or opened_stat.st_dev != path_stat.st_dev
+                or opened_stat.st_ino != path_stat.st_ino
+            ):
+                raise OSError(
+                    errno.EINVAL,
+                    "refusing aliased or non-private Kanban worker log",
+                    log_path,
+                )
+            return os.fdopen(fd, "rb")
+        except Exception:
+            os.close(fd)
+            raise
+    finally:
+        os.close(dir_fd)
+
+
 def _assert_open_worker_log_paths(
     log_dir: Path,
     log_path: Path,
@@ -10363,6 +10428,14 @@ def worker_log_path(task_id: str, *, board: Optional[str] = None) -> Path:
     current-board file → default). The dispatcher always passes the
     board explicitly to avoid any resolution ambiguity when multiple
     boards exist."""
+    if (
+        not isinstance(task_id, str)
+        or not task_id
+        or task_id in {".", ".."}
+        or "/" in task_id
+        or "\\" in task_id
+    ):
+        raise ValueError("task_id must be a non-empty path component")
     return worker_logs_dir(board=board) / f"{task_id}.log"
 
 
@@ -10373,14 +10446,13 @@ def read_worker_log(
     """Read the worker log for ``task_id``. Returns None if the file
     doesn't exist. If ``tail_bytes`` is set, only the last N bytes are
     returned (useful for the dashboard drawer which shouldn't page megabytes)."""
-    path = worker_log_path(task_id, board=board)
-    if not path.exists():
-        return None
     try:
-        if tail_bytes is None:
-            return path.read_text(encoding="utf-8", errors="replace")
-        size = path.stat().st_size
-        with open(path, "rb") as f:
+        path = worker_log_path(task_id, board=board)
+        opened = _open_private_worker_log_for_read(path)
+        with opened as f:
+            size = os.fstat(f.fileno()).st_size
+            if tail_bytes is None:
+                return f.read().decode("utf-8", errors="replace")
             if size > tail_bytes:
                 f.seek(size - tail_bytes)
                 # Skip a partial line if we tailed mid-line. But if the
@@ -10391,9 +10463,8 @@ def read_worker_log(
                 partial = f.readline()
                 if not partial.endswith(b"\n") and f.tell() >= size:
                     f.seek(probe)
-            data = f.read()
-        return data.decode("utf-8", errors="replace")
-    except OSError:
+            return f.read().decode("utf-8", errors="replace")
+    except (OSError, ValueError):
         return None
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -71,6 +71,7 @@ new locking.
 from __future__ import annotations
 
 import contextlib
+import errno
 import hashlib
 import json
 import os
@@ -79,6 +80,7 @@ import random
 import secrets
 import shutil
 import sqlite3
+import stat as stat_module
 import subprocess
 import sys
 import threading
@@ -8716,6 +8718,8 @@ def _rotate_worker_log(
     log_path: Path,
     max_bytes: int,
     backup_count: int = DEFAULT_LOG_BACKUP_COUNT,
+    *,
+    dir_fd: Optional[int] = None,
 ) -> None:
     """Rotate ``<log>`` when it exceeds ``max_bytes``.
 
@@ -8723,10 +8727,18 @@ def _rotate_worker_log(
     ``<log>`` moves to ``<log>.1`` and any previous ``.1`` is replaced.
     Higher values shift older generations up to ``backup_count``.
     """
-    try:
-        if not log_path.exists():
+    if os.name == "nt":
+        try:
+            current_stat = log_path.lstat()
+        except FileNotFoundError:
             return
-        if log_path.stat().st_size <= max_bytes:
+        if not _is_private_worker_log_stat(current_stat):
+            raise OSError(
+                errno.EINVAL,
+                "refusing non-regular retained Kanban worker log",
+                log_path,
+            )
+        if current_stat.st_size <= max_bytes:
             return
         backup_count = _positive_int(
             backup_count,
@@ -8737,22 +8749,318 @@ def _rotate_worker_log(
             log_path.unlink()
             return
         oldest = _rotated_log_path(log_path, backup_count)
-        try:
-            if oldest.exists():
-                oldest.unlink()
-        except OSError:
-            pass
+        if oldest.exists():
+            if not _is_private_worker_log_stat(oldest.lstat()):
+                raise OSError(
+                    errno.EINVAL,
+                    "refusing non-regular retained Kanban worker log",
+                    oldest,
+                )
+            oldest.unlink()
         for generation in range(backup_count - 1, 0, -1):
-            src = _rotated_log_path(log_path, generation)
-            if not src.exists():
+            source = _rotated_log_path(log_path, generation)
+            if not source.exists():
                 continue
+            if not _is_private_worker_log_stat(source.lstat()):
+                raise OSError(
+                    errno.EINVAL,
+                    "refusing non-regular retained Kanban worker log",
+                    source,
+                )
+            os.replace(source, _rotated_log_path(log_path, generation + 1))
+        os.replace(log_path, _rotated_log_path(log_path, 1))
+        return
+
+    log_ref: str | Path = log_path.name if dir_fd is not None else log_path
+    stat_kwargs = (
+        {"dir_fd": dir_fd, "follow_symlinks": False}
+        if dir_fd is not None
+        else {"follow_symlinks": False}
+    )
+    nofollow = getattr(os, "O_NOFOLLOW", 0) if os.name != "nt" else 0
+    nonblock = getattr(os, "O_NONBLOCK", 0) if os.name != "nt" else 0
+
+    def _open_verified_regular(
+        candidate: str | Path,
+    ) -> Optional[tuple[int, os.stat_result]]:
+        try:
+            fd = os.open(candidate, os.O_RDONLY | nofollow | nonblock, dir_fd=dir_fd)
+        except FileNotFoundError:
+            return None
+        try:
+            opened_stat = os.fstat(fd)
+            path_stat = os.stat(candidate, **stat_kwargs)
+            if (
+                not _is_private_worker_log_stat(opened_stat)
+                or opened_stat.st_dev != path_stat.st_dev
+                or opened_stat.st_ino != path_stat.st_ino
+            ):
+                raise OSError(
+                    errno.EAGAIN,
+                    "refusing changed or non-regular retained Kanban worker log",
+                    str(candidate),
+                )
+            return fd, opened_stat
+        except Exception:
+            os.close(fd)
+            raise
+
+    def _generation_ref(generation: int) -> str | Path:
+        if dir_fd is not None:
+            return f"{log_path.name}.{generation}"
+        return _rotated_log_path(log_path, generation)
+
+    def _verify_moved_file(
+        candidate: str | Path,
+        expected_stat: os.stat_result,
+    ) -> None:
+        moved_stat = os.stat(candidate, **stat_kwargs)
+        if (
+            not _is_private_worker_log_stat(moved_stat)
+            or moved_stat.st_dev != expected_stat.st_dev
+            or moved_stat.st_ino != expected_stat.st_ino
+        ):
+            raise OSError(
+                errno.EAGAIN,
+                "Kanban worker log changed during secure rotation",
+                str(candidate),
+            )
+
+    def _remove_verified_file(
+        candidate: str | Path,
+        expected_stat: os.stat_result,
+    ) -> None:
+        quarantine_name = f".{log_path.name}.rotate-delete-{secrets.token_hex(8)}"
+        quarantine: str | Path = (
+            quarantine_name
+            if dir_fd is not None
+            else log_path.with_name(quarantine_name)
+        )
+        os.replace(
+            candidate,
+            quarantine,
+            src_dir_fd=dir_fd,
+            dst_dir_fd=dir_fd,
+        )
+        _verify_moved_file(quarantine, expected_stat)
+        os.unlink(quarantine, dir_fd=dir_fd)
+
+    current = _open_verified_regular(log_ref)
+    if current is None:
+        return
+    current_fd, current_stat = current
+    try:
+        if current_stat.st_size <= max_bytes:
+            return
+        backup_count = _positive_int(
+            backup_count,
+            DEFAULT_LOG_BACKUP_COUNT,
+            minimum=0,
+        )
+        if backup_count == 0:
+            _remove_verified_file(log_ref, current_stat)
+            return
+
+        oldest = _generation_ref(backup_count)
+        oldest_open = _open_verified_regular(oldest)
+        if oldest_open is not None:
+            oldest_fd, oldest_stat = oldest_open
             try:
-                src.rename(_rotated_log_path(log_path, generation + 1))
-            except OSError:
-                pass
-        log_path.rename(_rotated_log_path(log_path, 1))
-    except OSError:
-        pass
+                _remove_verified_file(oldest, oldest_stat)
+            finally:
+                os.close(oldest_fd)
+
+        for generation in range(backup_count - 1, 0, -1):
+            src = _generation_ref(generation)
+            opened = _open_verified_regular(src)
+            if opened is None:
+                continue
+            src_fd, src_stat = opened
+            destination = _generation_ref(generation + 1)
+            try:
+                os.replace(
+                    src,
+                    destination,
+                    src_dir_fd=dir_fd,
+                    dst_dir_fd=dir_fd,
+                )
+                _verify_moved_file(destination, src_stat)
+            finally:
+                os.close(src_fd)
+
+        first_generation = _generation_ref(1)
+        os.replace(
+            log_ref,
+            first_generation,
+            src_dir_fd=dir_fd,
+            dst_dir_fd=dir_fd,
+        )
+        _verify_moved_file(first_generation, current_stat)
+    finally:
+        os.close(current_fd)
+
+
+def _assert_no_symlinked_path_components(path: Path) -> None:
+    """Reject symlinks anywhere in an existing worker-log path."""
+    absolute = path.absolute()
+    for candidate in reversed((absolute, *absolute.parents)):
+        try:
+            candidate_stat = candidate.lstat()
+        except FileNotFoundError:
+            continue
+        if stat_module.S_ISLNK(candidate_stat.st_mode):
+            raise OSError(
+                errno.ELOOP,
+                "refusing symlinked ancestor in Kanban worker log path",
+                candidate,
+            )
+
+
+def _is_private_worker_log_stat(file_stat: os.stat_result) -> bool:
+    """Return whether a worker log is regular, singly linked, and process-owned."""
+    if not stat_module.S_ISREG(file_stat.st_mode):
+        return False
+    if os.name == "nt":
+        return True
+    return file_stat.st_uid == os.geteuid() and file_stat.st_nlink == 1
+
+
+def _prepare_private_worker_log_storage(
+    log_dir: Path, *, keep_open: bool = False
+) -> Optional[int]:
+    """Create and tighten the board's log directory and retained worker logs."""
+    if os.name == "nt":
+        log_dir.mkdir(parents=True, exist_ok=True)
+        return None
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    if not nofollow:
+        raise RuntimeError("secure Kanban worker logs require O_NOFOLLOW support")
+    directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | nofollow
+    absolute_log_dir = Path(os.path.abspath(log_dir))
+    dir_fd = os.open(absolute_log_dir.anchor, directory_flags)
+    try:
+        for component in absolute_log_dir.parts[1:]:
+            try:
+                try:
+                    child_fd = os.open(component, directory_flags, dir_fd=dir_fd)
+                except FileNotFoundError:
+                    os.mkdir(component, mode=0o700, dir_fd=dir_fd)
+                    child_fd = os.open(component, directory_flags, dir_fd=dir_fd)
+            except OSError as exc:
+                if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+                    raise OSError(
+                        exc.errno,
+                        "refusing symlinked ancestor or non-directory component "
+                        "in Kanban worker log path",
+                        absolute_log_dir,
+                    ) from exc
+                raise
+            parent_fd = dir_fd
+            dir_fd = child_fd
+            os.close(parent_fd)
+        opened_dir_stat = os.fstat(dir_fd)
+        if (
+            not stat_module.S_ISDIR(opened_dir_stat.st_mode)
+            or opened_dir_stat.st_uid != os.geteuid()
+        ):
+            raise OSError(errno.ENOTDIR, "Kanban worker log path is not a directory")
+        os.fchmod(dir_fd, 0o700)
+        with os.scandir(dir_fd) as entries:
+            for candidate in entries:
+                if not Path(candidate.name).match("*.log*"):
+                    continue
+                candidate_stat = candidate.stat(follow_symlinks=False)
+                if not _is_private_worker_log_stat(candidate_stat):
+                    raise OSError(
+                        errno.EINVAL,
+                        "refusing non-regular retained Kanban worker log; expected regular file",
+                        candidate.name,
+                    )
+                flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | nofollow
+                fd = os.open(candidate.name, flags, dir_fd=dir_fd)
+                try:
+                    opened_stat = os.fstat(fd)
+                    if (
+                        not _is_private_worker_log_stat(opened_stat)
+                        or opened_stat.st_dev != candidate_stat.st_dev
+                        or opened_stat.st_ino != candidate_stat.st_ino
+                    ):
+                        raise OSError(
+                            errno.EAGAIN,
+                            "Kanban worker log changed during permission tightening",
+                            candidate.name,
+                        )
+                    os.fchmod(fd, 0o600)
+                finally:
+                    os.close(fd)
+        if keep_open:
+            return dir_fd
+    except Exception:
+        os.close(dir_fd)
+        raise
+    os.close(dir_fd)
+    return None
+
+
+def _open_private_worker_log(log_path: Path, *, dir_fd: Optional[int] = None):
+    """Open a worker log for append with mode 0600, including existing files."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+    log_ref: str | Path = log_path.name if dir_fd is not None else log_path
+    if os.name != "nt":
+        flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    fd = os.open(log_ref, flags, 0o600, dir_fd=dir_fd)
+    try:
+        if not _is_private_worker_log_stat(os.fstat(fd)):
+            raise OSError(
+                errno.EINVAL,
+                "refusing non-regular Kanban worker log; expected regular file",
+                log_path,
+            )
+        if os.name != "nt":
+            os.fchmod(fd, 0o600)
+        return os.fdopen(fd, "ab")
+    except Exception:
+        os.close(fd)
+        raise
+
+
+def _assert_open_worker_log_paths(
+    log_dir: Path,
+    log_path: Path,
+    dir_fd: int,
+    log_f,
+) -> None:
+    """Fail if directory or active-log names changed after secure opening."""
+    _assert_no_symlinked_path_components(log_dir)
+    dir_path_stat = os.stat(log_dir, follow_symlinks=False)
+    opened_dir_stat = os.fstat(dir_fd)
+    if (
+        not stat_module.S_ISDIR(dir_path_stat.st_mode)
+        or dir_path_stat.st_dev != opened_dir_stat.st_dev
+        or dir_path_stat.st_ino != opened_dir_stat.st_ino
+    ):
+        raise OSError(
+            errno.EAGAIN,
+            "Kanban worker log directory changed during secure open",
+            log_dir,
+        )
+    active_path_stat = os.stat(
+        log_path.name,
+        dir_fd=dir_fd,
+        follow_symlinks=False,
+    )
+    opened_log_stat = os.fstat(log_f.fileno())
+    if (
+        not _is_private_worker_log_stat(active_path_stat)
+        or not _is_private_worker_log_stat(opened_log_stat)
+        or active_path_stat.st_dev != opened_log_stat.st_dev
+        or active_path_stat.st_ino != opened_log_stat.st_ino
+    ):
+        raise OSError(
+            errno.EAGAIN,
+            "Kanban worker log changed during secure open",
+            log_path,
+        )
 
 
 def _module_hermes_argv() -> list[str]:
@@ -9144,30 +9452,52 @@ def _default_spawn(
     # `hermes kanban log` on a specific board reads its own file and
     # logs don't collide across boards that happen to share task ids.
     log_dir = worker_logs_dir(board=board)
-    log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / f"{task.id}.log"
-    rotate_bytes, backup_count = worker_log_rotation_config()
-    _rotate_worker_log(log_path, rotate_bytes, backup_count)
-
-    # Use 'a' so a re-run on unblock appends rather than overwrites.
-    log_f = open(log_path, "ab")
+    log_dir_fd = _prepare_private_worker_log_storage(log_dir, keep_open=True)
+    log_f = None
     try:
-        proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
-            cmd,
-            cwd=workspace if os.path.isdir(workspace) else None,
-            stdin=subprocess.DEVNULL,
-            stdout=log_f,
-            stderr=subprocess.STDOUT,
-            env=env,
-            start_new_session=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+        rotate_bytes, backup_count = worker_log_rotation_config()
+        _rotate_worker_log(
+            log_path,
+            rotate_bytes,
+            backup_count,
+            dir_fd=log_dir_fd,
         )
-    except FileNotFoundError:
-        log_f.close()
-        raise RuntimeError(
-            "`hermes` executable not found on PATH. "
-            "Install Hermes Agent or activate its venv before running the kanban dispatcher."
-        )
+
+        # Use append mode so a re-run on unblock preserves prior output.
+        # The verified directory descriptor remains open through rotation and
+        # final open, preventing an ancestor path replacement from redirecting
+        # the worker's output outside the private log directory.
+        log_f = _open_private_worker_log(log_path, dir_fd=log_dir_fd)
+        if log_dir_fd is not None:
+            _assert_open_worker_log_paths(log_dir, log_path, log_dir_fd, log_f)
+        try:
+            proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
+                cmd,
+                cwd=workspace if os.path.isdir(workspace) else None,
+                stdin=subprocess.DEVNULL,
+                stdout=log_f,
+                stderr=subprocess.STDOUT,
+                env=env,
+                start_new_session=True,
+                creationflags=(
+                    getattr(subprocess, "CREATE_NO_WINDOW", 0)
+                    if _IS_WINDOWS
+                    else 0
+                ),
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "`hermes` executable not found on PATH. "
+                "Install Hermes Agent or activate its venv before running the kanban dispatcher."
+            ) from exc
+    except Exception:
+        if log_f is not None:
+            log_f.close()
+        raise
+    finally:
+        if log_dir_fd is not None:
+            os.close(log_dir_fd)
     # NOTE: we intentionally do NOT close log_f here — we want Popen's
     # child process to keep writing after this function returns.  The
     # handle is kept alive by the child's inheritance.  The parent's

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -933,7 +933,8 @@ class TestStructuredDataRedaction:
             "api_token", "apiToken", "x-api-key", "xApiKey",
             "webhook_secret", "signingSecret", "session_token",
             "proxyAuthorization", "service_webhook_token",
-            "id_token", "oauthToken", "csrf_token", "verificationToken",
+            "id_token", "oauthToken", "OAuthToken", "demoOAuthToken",
+            "XAPIKey", "demoXAPIKey", "csrf_token", "verificationToken",
             "personalAccessToken", "bot_token", "serviceToken",
         ],
     )
@@ -946,7 +947,8 @@ class TestStructuredDataRedaction:
         "key",
         [
             "publicKey", "tokenCount", "secretKeyCount", "licenseKeyId",
-            "keyMaterialCount", "hockeyMaterial", "monkeyMaterial",
+            "keyMaterialCount", "OAuthTokenCount", "XAPIKeyId",
+            "hockeyMaterial", "monkeyMaterial",
         ],
     )
     def test_non_credential_camel_case_suffixes_pass_through(self, key):

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -831,3 +831,151 @@ class TestKeywordWordBoundary:
         assert "hunter2hunter2hunter2hh" not in result
 
 
+class TestStructuredDataRedaction:
+    def test_wordpress_secret_option_value_is_masked_without_mutating_input(self):
+        from agent.redact import redact_sensitive_data
+
+        secret = "synthetic-opaque-value-for-tests-only"
+        payload = {
+            "rows": [{
+                "option_name": "demo_service_api_key",
+                "option_value": secret,
+            }]
+        }
+
+        redacted = redact_sensitive_data(payload)
+
+        assert redacted["rows"][0]["option_name"] == "demo_service_api_key"
+        assert redacted["rows"][0]["option_value"] == "***"
+        assert secret not in str(redacted)
+        assert payload["rows"][0]["option_value"] == secret
+
+    def test_non_secret_wordpress_option_value_passes_through(self):
+        from agent.redact import redact_sensitive_data
+
+        payload = {
+            "option_name": "demo_cache_token_count",
+            "option_value": "42",
+        }
+        assert redact_sensitive_data(payload) == payload
+
+    @pytest.mark.parametrize(
+        "option_name",
+        ["woocommerce_api_consumer_key", "woocommerce_api_consumer_secret"],
+    )
+    def test_wordpress_consumer_credential_option_value_is_masked(self, option_name):
+        from agent.redact import redact_sensitive_data
+
+        secret = "synthetic-consumer-credential-value"
+        result = redact_sensitive_data({
+            "option_name": option_name,
+            "option_value": secret,
+        })
+        assert result["option_value"] == "***"
+        assert secret not in str(result)
+
+    def test_namespaced_wordpress_option_columns_are_correlated(self):
+        from agent.redact import redact_sensitive_data
+
+        secret = "synthetic-namespaced-option-value"
+        result = redact_sensitive_data({
+            "wp.option_name": "demo_service_client_secret",
+            "wp.option_value": secret,
+        })
+        assert result["wp.option_value"] == "***"
+        assert secret not in str(result)
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {
+                "option_name": "demo_service_client_secret",
+                "option-name": "demo_public_setting",
+                "option_value": "synthetic-collision-value",
+            },
+            {
+                "option-name": "demo_public_setting",
+                "option_name": "demo_service_client_secret",
+                "option_value": "synthetic-collision-value",
+            },
+        ],
+    )
+    def test_colliding_option_name_alias_cannot_suppress_redaction(self, payload):
+        from agent.redact import redact_sensitive_data
+
+        assert redact_sensitive_data(payload)["option_value"] == "***"
+
+    def test_nested_secret_named_field_is_masked(self):
+        from agent.redact import redact_sensitive_data
+
+        payload = {"result": {"settings": {"password": "synthetic-value", "port": 443}}}
+        assert redact_sensitive_data(payload) == {
+            "result": {"settings": {"password": "***", "port": 443}}
+        }
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "secretKey", "SecretKey", "demoServiceSecretKey",
+            "privateKey", "PrivateKey", "demoServicePrivateKey",
+            "authKey", "AuthKey", "demoServiceAuthKey",
+            "accessKey", "AccessKey", "demoServiceAccessKey",
+            "licenseKey", "LicenseKey", "demoServiceLicenseKey",
+            "keyMaterial", "KeyMaterial", "demoServiceKeyMaterial",
+            "demo_service_api_token", "demoServiceApiToken",
+            "secret_key", "demo-secret-key", "demo.secret_key",
+            "private_key", "demo-private-key", "demo.private_key",
+            "auth_key", "demo-auth-key", "demo.auth_key",
+            "access_key", "demo-access-key", "demo.access_key",
+            "license_key", "demo-license-key", "demo.license_key",
+            "key_material", "demo-key-material", "demo.key_material",
+            "service_api_key", "db_password", "consumer_secret", "consumer_key",
+            "api_token", "apiToken", "x-api-key", "xApiKey",
+            "webhook_secret", "signingSecret", "session_token",
+            "proxyAuthorization", "service_webhook_token",
+            "id_token", "oauthToken", "csrf_token", "verificationToken",
+            "personalAccessToken", "bot_token", "serviceToken",
+        ],
+    )
+    def test_credential_key_case_and_namespace_variants_are_masked(self, key):
+        from agent.redact import redact_sensitive_data
+
+        assert redact_sensitive_data({key: "synthetic-opaque-value"}) == {key: "***"}
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "publicKey", "tokenCount", "secretKeyCount", "licenseKeyId",
+            "keyMaterialCount", "hockeyMaterial", "monkeyMaterial",
+        ],
+    )
+    def test_non_credential_camel_case_suffixes_pass_through(self, key):
+        from agent.redact import redact_sensitive_data
+
+        payload = {key: "synthetic-public-value"}
+        assert redact_sensitive_data(payload) == payload
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "pagination_token", "nextToken", "requiresAuthorization",
+            "cookiePolicy", "requestNonce", "tokenStatus",
+        ],
+    )
+    def test_ambiguous_namespaced_metadata_fields_pass_through(self, key):
+        from agent.redact import redact_sensitive_data
+
+        payload = {key: "synthetic-public-metadata"}
+        assert redact_sensitive_data(payload) == payload
+
+    def test_global_redaction_opt_out_preserves_structured_payload(self, monkeypatch):
+        from agent.redact import redact_sensitive_data
+
+        payload = {
+            "option_name": "demo_service_api_key",
+            "option_value": "synthetic-opt-out-value-for-tests-only",
+        }
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        assert redact_sensitive_data(payload) is payload
+
+

--- a/tests/gateway/test_kanban_log_access.py
+++ b/tests/gateway/test_kanban_log_access.py
@@ -151,6 +151,47 @@ async def test_worker_log_rejects_non_identity_admin_config(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "malformed_admins",
+    [["admin", True], ["admin", {"nested": True}], ["admin", ["nested"]]],
+)
+async def test_worker_log_rejects_mixed_malformed_admin_config(
+    monkeypatch, malformed_admins
+):
+    runner = _runner(admins=[], user_commands=[])
+    runner.config.platforms[Platform.SLACK].extra[
+        "group_allow_admin_from"
+    ] = malformed_admins
+    run_slash = Mock(return_value="raw worker output")
+    monkeypatch.setattr("hermes_cli.kanban.run_slash", run_slash)
+
+    result = await runner._handle_kanban_command(_event("admin"))
+
+    assert "admin-only" in result
+    assert "raw worker output" not in result
+    run_slash.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_worker_log_rejects_malformed_platform_and_config_types(monkeypatch):
+    runner = _runner(admins=[], user_commands=[])
+    runner.config.platforms = cast(
+        dict[Platform, PlatformConfig],
+        {"slack": {"group_allow_admin_from": ["admin"]}},
+    )
+    event = _event("admin")
+    event.source.platform = cast(Platform, "slack")
+    run_slash = Mock(return_value="raw worker output")
+    monkeypatch.setattr("hermes_cli.kanban.run_slash", run_slash)
+
+    result = await runner._handle_kanban_command(event)
+
+    assert "admin-only" in result
+    assert "raw worker output" not in result
+    run_slash.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_worker_log_fails_closed_without_authenticated_user_id(monkeypatch):
     runner = _runner(admins=["admin"], user_commands=["kanban"])
     run_slash = Mock(return_value="raw worker output")

--- a/tests/gateway/test_kanban_log_access.py
+++ b/tests/gateway/test_kanban_log_access.py
@@ -1,0 +1,214 @@
+"""Gateway access control for raw Kanban worker logs."""
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import Mock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _runner(
+    *,
+    admins: list[str],
+    user_commands: list[str],
+    dm_admins: list[str] | None = None,
+):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.SLACK: PlatformConfig(
+                enabled=True,
+                token="synthetic-token-not-used",
+                extra={
+                    "allow_admin_from": dm_admins or [],
+                    "group_allow_admin_from": admins,
+                    "group_user_allowed_commands": user_commands,
+                },
+            )
+        }
+    )
+    return runner
+
+
+def _event(
+    user_id: str | None,
+    text: str = "/kanban log t_abcdef12",
+    *,
+    chat_type: str | None = "channel",
+) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.SLACK,
+            user_id=user_id,
+            chat_id="C123",
+            chat_type=cast(str, chat_type),
+        ),
+        message_id="m1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_admin_allowed_kanban_caller_cannot_read_worker_log(monkeypatch):
+    runner = _runner(admins=["admin"], user_commands=["kanban"])
+    run_slash = Mock(return_value="raw worker output")
+    monkeypatch.setattr("hermes_cli.kanban.run_slash", run_slash)
+
+    result = await runner._handle_kanban_command(_event("member"))
+
+    assert "admin-only" in result
+    assert "raw worker output" not in result
+    run_slash.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "/kanban --board default log t_abcdef12",
+        "/kanban --board=default log t_abcdef12",
+        "/kanban --bo default log t_abcdef12",
+        "/kanban --bo=default log t_abcdef12",
+        "/kanban -- log t_abcdef12",
+        "/kanban --board default -- log t_abcdef12",
+        "/kanban --board=default -- log t_abcdef12",
+    ],
+)
+async def test_non_admin_cannot_bypass_worker_log_guard_with_board_flag_forms(
+    monkeypatch, text
+):
+    runner = _runner(admins=["admin"], user_commands=["kanban"])
+    run_slash = Mock(return_value="raw worker output")
+    monkeypatch.setattr("hermes_cli.kanban.run_slash", run_slash)
+
+    result = await runner._handle_kanban_command(_event("member", text))
+
+    assert "admin-only" in result
+    assert "raw worker output" not in result
+    run_slash.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_explicit_admin_can_read_worker_log(monkeypatch):
+    runner = _runner(admins=["admin"], user_commands=[])
+    run_slash = Mock(return_value="worker output")
+    monkeypatch.setattr("hermes_cli.kanban.run_slash", run_slash)
+
+    result = await runner._handle_kanban_command(_event("admin"))
+
+    assert result == "worker output"
+    run_slash.assert_called_once_with("log t_abcdef12")
+
+
+@pytest.mark.asyncio
+async def test_explicit_dm_admin_can_read_worker_log(monkeypatch):
+    runner = _runner(admins=[], user_commands=[], dm_admins=["admin"])
+    run_slash = Mock(return_value="worker output")
+    monkeypatch.setattr("hermes_cli.kanban.run_slash", run_slash)
+
+    result = await runner._handle_kanban_command(_event("admin", chat_type="dm"))
+
+    assert result == "worker output"
+    run_slash.assert_called_once_with("log t_abcdef12")
+
+
+@pytest.mark.asyncio
+async def test_worker_log_fails_closed_without_configured_admin(monkeypatch):
+    runner = _runner(admins=[], user_commands=[])
+    run_slash = Mock(return_value="raw worker output")
+    monkeypatch.setattr("hermes_cli.kanban.run_slash", run_slash)
+
+    result = await runner._handle_kanban_command(_event("member"))
+
+    assert "admin-only" in result
+    assert "raw worker output" not in result
+    run_slash.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("malformed_admins", [True, [True], {"admin": True}])
+async def test_worker_log_rejects_non_identity_admin_config(
+    monkeypatch, malformed_admins
+):
+    runner = _runner(admins=[], user_commands=[])
+    runner.config.platforms[Platform.SLACK].extra[
+        "group_allow_admin_from"
+    ] = malformed_admins
+    run_slash = Mock(return_value="raw worker output")
+    monkeypatch.setattr("hermes_cli.kanban.run_slash", run_slash)
+
+    result = await runner._handle_kanban_command(_event("True"))
+
+    assert "admin-only" in result
+    assert "raw worker output" not in result
+    run_slash.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_worker_log_fails_closed_without_authenticated_user_id(monkeypatch):
+    runner = _runner(admins=["admin"], user_commands=["kanban"])
+    run_slash = Mock(return_value="raw worker output")
+    monkeypatch.setattr("hermes_cli.kanban.run_slash", run_slash)
+
+    result = await runner._handle_kanban_command(_event(None))
+
+    assert "admin-only" in result
+    assert "raw worker output" not in result
+    run_slash.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_worker_log_fails_closed_when_authorization_resolution_is_malformed(
+    monkeypatch,
+):
+    runner = _runner(admins=["admin"], user_commands=["kanban"])
+    run_slash = Mock(return_value="raw worker output")
+    monkeypatch.setattr("hermes_cli.kanban.run_slash", run_slash)
+
+    def malformed_policy(*_args, **_kwargs):
+        raise ValueError("synthetic malformed authorization")
+
+    monkeypatch.setattr("gateway.slash_access.policy_for_source", malformed_policy)
+
+    result = await runner._handle_kanban_command(_event("admin"))
+
+    assert "admin-only" in result
+    assert "raw worker output" not in result
+    run_slash.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chat_type", [None, "", "unknown-scope"])
+async def test_worker_log_fails_closed_for_unrecognized_chat_scope(
+    monkeypatch, chat_type
+):
+    runner = _runner(admins=["admin"], user_commands=["kanban"])
+    run_slash = Mock(return_value="raw worker output")
+    monkeypatch.setattr("hermes_cli.kanban.run_slash", run_slash)
+
+    result = await runner._handle_kanban_command(
+        _event("admin", chat_type=chat_type)
+    )
+
+    assert "admin-only" in result
+    assert "raw worker output" not in result
+    run_slash.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_group_admin_is_not_implicitly_admin_in_dm_scope(monkeypatch):
+    runner = _runner(admins=["admin"], user_commands=["kanban"])
+    run_slash = Mock(return_value="raw worker output")
+    monkeypatch.setattr("hermes_cli.kanban.run_slash", run_slash)
+
+    result = await runner._handle_kanban_command(_event("admin", chat_type="dm"))
+
+    assert "admin-only" in result
+    assert "raw worker output" not in result
+    run_slash.assert_not_called()

--- a/tests/gateway/test_slash_access.py
+++ b/tests/gateway/test_slash_access.py
@@ -5,6 +5,8 @@ exercise the dispatch site live in test_slash_access_dispatch.py.
 """
 from __future__ import annotations
 
+import pytest
+
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.session import SessionSource
 from gateway.slash_access import (
@@ -31,6 +33,21 @@ class TestPolicyFromExtra:
         p = policy_from_extra({}, "dm")
         assert p.is_admin("anyone") is True
         assert p.can_run("anyone", "stop") is True
+
+    @pytest.mark.parametrize(
+        "malformed",
+        [["admin", True], ["admin", {"nested": True}], ["admin", ["nested"]]],
+    )
+    def test_mixed_malformed_admin_policy_stays_enabled_and_denies(
+        self, malformed
+    ):
+        policy = policy_from_extra(
+            {"group_allow_admin_from": malformed}, "group"
+        )
+        assert policy.enabled
+        assert policy.admin_user_ids == frozenset()
+        assert not policy.is_admin("admin")
+        assert not policy.can_run("member", "restart")
 
 
     def test_id_coercion_ints_become_strings(self):

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -103,6 +103,48 @@ def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch
     assert beta_titles == ["beta-task"]
 
 
+def test_run_slash_rejects_abbreviated_board_flag(kanban_home):
+    out = kc.run_slash("--bo default list")
+
+    assert out.startswith("⚠ /kanban usage error")
+    assert "--bo" in out
+
+
+@pytest.mark.parametrize(
+    ("command", "abbreviation"),
+    [
+        ("create synthetic-task --ass synthetic-user", "--ass"),
+        ("list --js", "--js"),
+        ("boards create synthetic-board --desc synthetic-description", "--desc"),
+    ],
+)
+def test_run_slash_rejects_subparser_option_abbreviations(
+    kanban_home, command, abbreviation
+):
+    out = kc.run_slash(command)
+
+    assert out.startswith("⚠ /kanban usage error")
+    assert abbreviation in out
+
+
+def test_every_kanban_parser_disables_long_option_abbreviations():
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    subparsers = parser.add_subparsers(dest="command")
+    kanban_parser = kc.build_parser(subparsers)
+
+    pending = [kanban_parser]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        assert current.allow_abbrev is False
+        for action in current._actions:
+            if isinstance(action, argparse._SubParsersAction):
+                pending.extend(action.choices.values())
+
+
 # ---------------------------------------------------------------------------
 # Integration with the COMMAND_REGISTRY
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import stat
 import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -235,6 +237,407 @@ def test_read_worker_log_tail(kanban_home):
     assert "line 0" not in tail
     # Missing log returns None.
     assert kb.read_worker_log("t_missing") is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are not portable")
+def test_default_spawn_creates_private_worker_log_storage(kanban_home, monkeypatch):
+    monkeypatch.setattr(
+        "subprocess.Popen", lambda *_args, **_kwargs: SimpleNamespace(pid=123)
+    )
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="private log", assignee="ops")
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        kb._default_spawn(task, str(kb.resolve_workspace(task)))
+    finally:
+        conn.close()
+
+    log_dir = kb.worker_logs_dir()
+    assert stat.S_IMODE(log_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE((log_dir / f"{tid}.log").stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are not portable")
+def test_default_spawn_tightens_existing_worker_logs(kanban_home, monkeypatch):
+    monkeypatch.setattr(
+        "subprocess.Popen", lambda *_args, **_kwargs: SimpleNamespace(pid=124)
+    )
+    monkeypatch.setattr(kb, "worker_log_rotation_config", lambda: (1, 1))
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="legacy log", assignee="ops")
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        workspace = kb.resolve_workspace(task)
+        log_dir = kb.worker_logs_dir()
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / f"{tid}.log"
+        rotated_path = log_dir / f"{tid}.log.1"
+        unrelated_path = log_dir / "t_unrelated.log"
+        unrelated_rotated_path = log_dir / "t_unrelated.log.1"
+        for path in (log_path, rotated_path, unrelated_path, unrelated_rotated_path):
+            path.write_text("synthetic legacy log\n", encoding="utf-8")
+            path.chmod(0o666)
+        log_dir.chmod(0o777)
+
+        kb._default_spawn(task, str(workspace))
+    finally:
+        conn.close()
+
+    assert stat.S_IMODE(log_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE(log_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(rotated_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(unrelated_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(unrelated_rotated_path.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory descriptors only")
+def test_default_spawn_rotates_worker_log_within_verified_directory(
+    kanban_home, monkeypatch
+):
+    monkeypatch.setattr(
+        "subprocess.Popen", lambda *_args, **_kwargs: SimpleNamespace(pid=125)
+    )
+    monkeypatch.setattr(kb, "worker_log_rotation_config", lambda: (1, 1))
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="rotate log", assignee="ops")
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        log_dir = kb.worker_logs_dir()
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / f"{tid}.log"
+        log_path.write_bytes(b"synthetic old worker output\n")
+
+        kb._default_spawn(task, str(kb.resolve_workspace(task)))
+    finally:
+        conn.close()
+
+    rotated_path = log_dir / f"{tid}.log.1"
+    assert log_path.is_file()
+    assert rotated_path.read_bytes() == b"synthetic old worker output\n"
+    assert stat.S_IMODE(log_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(rotated_path.stat().st_mode) == 0o600
+
+
+def test_windows_rotation_does_not_keep_log_open(monkeypatch, tmp_path):
+    log_path = tmp_path / "worker.log"
+    log_path.write_bytes(b"synthetic old worker output\n")
+
+    monkeypatch.setattr(kb.os, "name", "nt")
+    monkeypatch.setattr(
+        kb.os,
+        "open",
+        lambda *_args, **_kwargs: pytest.fail(
+            "Windows rotation must not hold an open descriptor across os.replace"
+        ),
+    )
+
+    kb._rotate_worker_log(log_path, max_bytes=1, backup_count=1)
+
+    assert not log_path.exists()
+    assert (tmp_path / "worker.log.1").read_bytes() == b"synthetic old worker output\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permissions only")
+def test_default_spawn_rejects_symlinked_worker_log(kanban_home, monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "subprocess.Popen",
+        lambda *_args, **_kwargs: pytest.fail("worker must not spawn"),
+    )
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="symlinked log", assignee="dev")
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        log_dir = kb.worker_logs_dir()
+        log_dir.mkdir(parents=True, exist_ok=True)
+        outside = tmp_path / "outside.log"
+        outside.write_text("must remain untouched\n", encoding="utf-8")
+        outside.chmod(0o666)
+        (log_dir / f"{tid}.log").symlink_to(outside)
+
+        with pytest.raises(OSError):
+            kb._default_spawn(task, str(workspace))
+    finally:
+        conn.close()
+
+    assert outside.read_text(encoding="utf-8") == "must remain untouched\n"
+    assert stat.S_IMODE(outside.stat().st_mode) == 0o666
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permissions only")
+def test_private_worker_log_storage_rejects_symlinked_directory(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir(mode=0o777)
+    outside_mode = stat.S_IMODE(outside.stat().st_mode)
+    log_dir = tmp_path / "logs"
+    log_dir.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(OSError):
+        kb._prepare_private_worker_log_storage(log_dir)
+
+    assert stat.S_IMODE(outside.stat().st_mode) == outside_mode
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink behavior only")
+def test_private_worker_log_storage_rejects_symlinked_ancestor(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir(mode=0o777)
+    outside_mode = stat.S_IMODE(outside.stat().st_mode)
+    linked_root = tmp_path / "linked-root"
+    linked_root.symlink_to(outside, target_is_directory=True)
+    log_dir = linked_root / "kanban" / "logs"
+
+    with pytest.raises(OSError, match="symlinked ancestor"):
+        kb._prepare_private_worker_log_storage(log_dir)
+
+    assert stat.S_IMODE(outside.stat().st_mode) == outside_mode
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory descriptors only")
+def test_private_worker_log_storage_resists_ancestor_swap_during_open(
+    tmp_path, monkeypatch
+):
+    trusted = tmp_path / "trusted"
+    trusted.mkdir()
+    moved_trusted = tmp_path / "trusted-original"
+    outside = tmp_path / "outside"
+    outside.mkdir(mode=0o777)
+    outside_logs = outside / "logs"
+    outside_logs.mkdir(mode=0o777)
+    outside_log = outside_logs / "t_synthetic.log"
+    outside_log.write_text("outside\n", encoding="utf-8")
+    outside_log.chmod(0o666)
+    outside_dir_mode = stat.S_IMODE(outside_logs.stat().st_mode)
+    outside_log_mode = stat.S_IMODE(outside_log.stat().st_mode)
+
+    real_open = os.open
+    swapped = False
+
+    def swap_before_log_dir_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if path == "logs" and dir_fd is not None and not swapped:
+            trusted.rename(moved_trusted)
+            trusted.symlink_to(outside, target_is_directory=True)
+            swapped = True
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(kb.os, "open", swap_before_log_dir_open)
+    dir_fd = kb._prepare_private_worker_log_storage(trusted / "logs", keep_open=True)
+    assert dir_fd is not None
+    try:
+        opened_stat = os.fstat(dir_fd)
+        expected_stat = os.stat(moved_trusted / "logs", follow_symlinks=False)
+        assert (opened_stat.st_dev, opened_stat.st_ino) == (
+            expected_stat.st_dev,
+            expected_stat.st_ino,
+        )
+    finally:
+        os.close(dir_fd)
+
+    assert swapped is True
+    assert stat.S_IMODE(outside_logs.stat().st_mode) == outside_dir_mode
+    assert stat.S_IMODE(outside_log.stat().st_mode) == outside_log_mode
+    assert outside_log.read_text(encoding="utf-8") == "outside\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX non-regular path behavior only")
+def test_private_worker_log_storage_rejects_non_regular_retained_log(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    outside = tmp_path / "outside.log"
+    outside.write_text("synthetic outside data\n", encoding="utf-8")
+    (log_dir / "t_synthetic.log.1").symlink_to(outside)
+
+    with pytest.raises(OSError, match="non-regular retained"):
+        kb._prepare_private_worker_log_storage(log_dir)
+
+    assert outside.read_text(encoding="utf-8") == "synthetic outside data\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX hard-link behavior only")
+def test_private_worker_log_storage_rejects_hard_linked_log(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    outside = tmp_path / "outside.log"
+    outside.write_text("synthetic outside data\n", encoding="utf-8")
+    outside.chmod(0o644)
+    os.link(outside, log_dir / "t_synthetic.log")
+
+    with pytest.raises(OSError, match="expected regular file"):
+        kb._prepare_private_worker_log_storage(log_dir)
+
+    assert outside.read_text(encoding="utf-8") == "synthetic outside data\n"
+    assert stat.S_IMODE(outside.stat().st_mode) == 0o644
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory descriptors only")
+def test_default_spawn_fails_if_log_dir_changes_after_verification(
+    kanban_home, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        "subprocess.Popen",
+        lambda *_args, **_kwargs: pytest.fail("worker must not spawn"),
+    )
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="replaced log dir", assignee="dev")
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        log_dir = kb.worker_logs_dir()
+        moved_dir = log_dir.with_name("verified-log-dir")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+
+        def replace_log_dir():
+            log_dir.rename(moved_dir)
+            log_dir.symlink_to(outside, target_is_directory=True)
+            return 1024, 1
+
+        monkeypatch.setattr(kb, "worker_log_rotation_config", replace_log_dir)
+        with pytest.raises(OSError, match="symlinked ancestor|directory changed"):
+            kb._default_spawn(task, str(workspace))
+    finally:
+        conn.close()
+
+    assert not (outside / f"{tid}.log").exists()
+    assert (moved_dir / f"{tid}.log").is_file()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX ancestor identity behavior only")
+def test_default_spawn_fails_if_log_ancestor_becomes_symlink(
+    kanban_home, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        "subprocess.Popen",
+        lambda *_args, **_kwargs: pytest.fail("worker must not spawn"),
+    )
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="raced log ancestor", assignee="dev")
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        log_dir = kb.worker_logs_dir()
+        kanban_dir = log_dir.parent
+        moved_kanban_dir = kanban_dir.with_name("moved-kanban")
+
+        def swap_ancestor():
+            kanban_dir.rename(moved_kanban_dir)
+            kanban_dir.symlink_to(moved_kanban_dir, target_is_directory=True)
+            return kb.DEFAULT_LOG_ROTATE_BYTES, kb.DEFAULT_LOG_BACKUP_COUNT
+
+        monkeypatch.setattr(kb, "worker_log_rotation_config", swap_ancestor)
+        with pytest.raises(OSError, match="symlinked ancestor"):
+            kb._default_spawn(task, str(workspace))
+    finally:
+        conn.close()
+
+    assert (moved_kanban_dir / "logs" / f"{tid}.log").read_bytes() == b""
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX non-regular path behavior only")
+def test_default_spawn_rejects_non_regular_log_before_rotation(
+    kanban_home, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        "subprocess.Popen",
+        lambda *_args, **_kwargs: pytest.fail("worker must not spawn"),
+    )
+    monkeypatch.setattr(kb, "worker_log_rotation_config", lambda: (1, 1))
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="directory log", assignee="dev")
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        log_dir = kb.worker_logs_dir()
+        log_dir.mkdir(parents=True, exist_ok=True)
+        active_path = log_dir / f"{tid}.log"
+        active_path.mkdir()
+
+        with pytest.raises(OSError, match="regular file"):
+            kb._default_spawn(task, str(workspace))
+    finally:
+        conn.close()
+
+    assert active_path.is_dir()
+    assert not (log_dir / f"{tid}.log.1").exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX dir_fd symlink behavior only")
+def test_default_spawn_fails_if_retained_log_changes_during_rotation(
+    kanban_home, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        "subprocess.Popen",
+        lambda *_args, **_kwargs: pytest.fail("worker must not spawn"),
+    )
+    monkeypatch.setattr(kb, "worker_log_rotation_config", lambda: (1, 2))
+    real_replace = os.replace
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="raced retained log", assignee="dev")
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        log_dir = kb.worker_logs_dir()
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (log_dir / f"{tid}.log").write_bytes(b"active output\n")
+        retained = log_dir / f"{tid}.log.1"
+        retained.write_bytes(b"retained output\n")
+        outside = tmp_path / "outside.log"
+        outside.write_text("must remain untouched\n", encoding="utf-8")
+
+        def replace_after_swap(src, dst, **kwargs):
+            if str(src).endswith(".log.1"):
+                os.unlink(src, dir_fd=kwargs.get("src_dir_fd"))
+                os.symlink(outside, src, dir_fd=kwargs.get("src_dir_fd"))
+            return real_replace(src, dst, **kwargs)
+
+        monkeypatch.setattr(os, "replace", replace_after_swap)
+        with pytest.raises(OSError, match="changed during secure rotation"):
+            kb._default_spawn(task, str(kb.resolve_workspace(task)))
+    finally:
+        conn.close()
+
+    assert outside.read_text(encoding="utf-8") == "must remain untouched\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX FIFO behavior only")
+def test_private_worker_log_rejects_fifo_without_blocking(tmp_path):
+    fifo_path = tmp_path / "worker.log"
+    os.mkfifo(fifo_path)
+    script = (
+        "import sys\n"
+        "from pathlib import Path\n"
+        "from hermes_cli import kanban_db as kb\n"
+        "try:\n"
+        "    kb._open_private_worker_log(Path(sys.argv[1]))\n"
+        "except OSError:\n"
+        "    raise SystemExit(0)\n"
+        "raise SystemExit(1)\n"
+    )
+
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", script, str(fifo_path)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail("opening an inert FIFO blocked instead of failing closed")
+
+    assert completed.returncode == 0, completed.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -225,10 +225,14 @@ def test_notify_claim_is_single_owner_and_rewindable(kanban_home):
 
 def test_read_worker_log_tail(kanban_home):
     log_dir = kanban_home / "kanban" / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, mode=0o700, exist_ok=True)
+    if os.name != "nt":
+        log_dir.chmod(0o700)
     p = log_dir / "t_beef.log"
     # 10 lines
     p.write_text("\n".join(f"line {i}" for i in range(10)))
+    if os.name != "nt":
+        p.chmod(0o600)
     full = kb.read_worker_log("t_beef")
     assert full is not None and "line 0" in full
     tail = kb.read_worker_log("t_beef", tail_bytes=30)
@@ -237,6 +241,27 @@ def test_read_worker_log_tail(kanban_home):
     assert "line 0" not in tail
     # Missing log returns None.
     assert kb.read_worker_log("t_missing") is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX link semantics")
+def test_read_worker_log_rejects_path_escape_and_file_aliases(kanban_home, tmp_path):
+    log_dir = kanban_home / "kanban" / "logs"
+    log_dir.mkdir(parents=True, mode=0o700, exist_ok=True)
+    log_dir.chmod(0o700)
+    outside = tmp_path / "outside.log"
+    outside.write_text("opaque synthetic outside content")
+    outside.chmod(0o600)
+
+    assert kb.read_worker_log(str(outside.with_suffix(""))) is None
+
+    symlink = log_dir / "t_symlink.log"
+    symlink.symlink_to(outside)
+    assert kb.read_worker_log("t_symlink") is None
+    symlink.unlink()
+
+    hardlink = log_dir / "t_hardlink.log"
+    os.link(outside, hardlink)
+    assert kb.read_worker_log("t_hardlink") is None
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are not portable")

--- a/tests/tools/test_mcp_lazy_start.py
+++ b/tests/tools/test_mcp_lazy_start.py
@@ -7,6 +7,7 @@ existing connect path.
 """
 
 import json
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -103,6 +104,24 @@ class TestLazyMcpRegistration:
 
         mock_get.assert_not_called()
         mock_run.assert_called_once()
+
+    def test_lazy_registration_exception_log_is_sanitized(self, caplog):
+        secret = "opaque-synthetic-lazy-registration-credential"
+        config = _lazy_config()
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch("tools.mcp_schema_cache.config_fingerprint", return_value="abc"), \
+             patch("tools.mcp_schema_cache.get_cached_entry", return_value=_fake_cache_entry()), \
+             patch(
+                 "tools.mcp_tool._register_from_cache_sync",
+                 side_effect=RuntimeError(f"auth_token: {secret}"),
+             ), \
+             patch("tools.mcp_tool._ensure_mcp_loop"), \
+             patch("tools.mcp_tool._run_on_mcp_loop"), \
+             caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+            mcp.register_mcp_servers(config)
+
+        assert secret not in caplog.text
+        assert "[REDACTED]" in caplog.text
 
     def test_lazy_server_not_reregistered_on_second_pass(self):
         config = _lazy_config()

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -181,6 +181,72 @@ async def test_mcp_background_exception_logs_are_sanitized(monkeypatch, caplog):
     assert "[REDACTED]" in caplog.text
 
 
+def test_mcp_transport_reconnect_exception_log_is_sanitized(caplog):
+    from tools.mcp_tool import MCPServerTask
+
+    secret = "opaque-synthetic-transport-exception-credential"
+    server = MCPServerTask("synthetic")
+    server._ready.set()
+    error = ExceptionGroup(
+        "synthetic transport failure",
+        [RuntimeError(f"api_key: {secret}")],
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="tools.mcp_tool"):
+        assert server._reconnect_or_reraise_group(error) == "reconnect"
+
+    assert secret not in caplog.text
+    assert "synthetic transport failure" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_orphan_reap_exception_log_is_sanitized(monkeypatch, caplog):
+    import tools.mcp_tool as mcp_tool
+
+    secret = "opaque-synthetic-orphan-reap-credential"
+
+    async def fail_start(_self, _config):
+        raise RuntimeError("synthetic primary start failure")
+
+    async def fail_shutdown(_self):
+        raise RuntimeError(f"client_secret: {secret}")
+
+    monkeypatch.setattr(mcp_tool.MCPServerTask, "start", fail_start)
+    monkeypatch.setattr(mcp_tool.MCPServerTask, "shutdown", fail_shutdown)
+
+    with caplog.at_level(logging.DEBUG, logger="tools.mcp_tool"):
+        with pytest.raises(RuntimeError, match="synthetic primary start failure"):
+            await mcp_tool._connect_server("synthetic", {})
+
+    assert secret not in caplog.text
+    assert "[REDACTED]" in caplog.text
+
+
+def test_mcp_schema_cache_write_exception_log_is_sanitized(monkeypatch, caplog):
+    import tools.mcp_tool as mcp_tool
+    from tools.registry import ToolRegistry
+
+    secret = "opaque-synthetic-schema-cache-credential"
+    server = mcp_tool.MCPServerTask("synthetic")
+    server._tools = [_make_mcp_tool(name="synthetic_tool")]
+
+    def fail_cache_write(*_args, **_kwargs):
+        raise RuntimeError(f"password: {secret}")
+
+    monkeypatch.setattr(
+        "tools.mcp_schema_cache.write_cache_entry",
+        fail_cache_write,
+    )
+    monkeypatch.setattr(mcp_tool, "_select_utility_schemas", lambda *_args: [])
+
+    with patch("tools.registry.registry", ToolRegistry()), \
+         caplog.at_level(logging.DEBUG, logger="tools.mcp_tool"):
+        assert mcp_tool._register_server_tools("synthetic", server, {})
+
+    assert secret not in caplog.text
+    assert "[REDACTED]" in caplog.text
+
+
 def test_sanitize_error_redacts_escaped_quotes_inside_assignment():
     from tools.mcp_tool import _sanitize_error
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -50,6 +50,355 @@ def _make_mock_server(name, session=None, tools=None):
     return server
 
 
+def test_mcp_payload_redaction_handles_wordpress_option_rows():
+    from tools.mcp_tool import _redact_mcp_tool_payload
+
+    secret = "synthetic-mcp-option-value-for-tests-only"
+    payload = {
+        "results": [{
+            "option_name": "sample_integration_client_secret",
+            "option_value": secret,
+        }]
+    }
+    redacted = _redact_mcp_tool_payload(payload)
+    assert redacted["results"][0]["option_value"] == "***"
+    assert secret not in json.dumps(redacted)
+
+
+def test_mcp_payload_redaction_parses_prefixed_json_text_blocks():
+    from tools.mcp_tool import _redact_mcp_tool_payload
+
+    secret = "synthetic-json-text-option-value"
+    payload = "Synthetic query failed: " + json.dumps({
+        "option_name": "sample_auth_token",
+        "option_value": secret,
+    })
+    redacted = _redact_mcp_tool_payload(payload)
+    assert isinstance(redacted, str)
+    assert "Synthetic query failed" in redacted
+    assert "***" in redacted
+    assert secret not in redacted
+
+
+def test_mcp_payload_redaction_fails_closed(monkeypatch, caplog):
+    from tools.mcp_tool import _redact_mcp_tool_payload
+
+    secret = "synthetic-redaction-failure-value-for-tests-only"
+
+    def fail_redaction(_payload):
+        raise RuntimeError(f"synthetic redaction failure {secret}")
+
+    monkeypatch.setattr("agent.redact.redact_sensitive_data", fail_redaction)
+    redacted = _redact_mcp_tool_payload({"api_key": secret})
+    assert redacted == "[REDACTED - MCP tool output sanitization failed]"
+    assert secret not in redacted
+    assert secret not in caplog.text
+
+
+def test_sanitize_error_redacts_prefixed_structured_json():
+    from tools.mcp_tool import _sanitize_error
+
+    secret = "synthetic-prefixed-error-secret-for-tests-only"
+    error = "Synthetic failure: " + json.dumps({
+        "option_name": "demo_service_auth_token",
+        "option_value": secret,
+    })
+
+    sanitized = _sanitize_error(error)
+
+    assert "Synthetic failure" in sanitized
+    assert secret not in sanitized
+    assert "***" in sanitized
+
+
+def test_sanitize_error_applies_comprehensive_plain_text_redaction():
+    from tools.mcp_tool import _sanitize_error
+
+    secret = "opaque-synthetic-sentinel-314159"
+    error = (
+        f"api_key: {secret}\n"
+        f"url=https://demo:{secret}@example.test/path?access_token={secret}"
+    )
+
+    sanitized = _sanitize_error(error)
+
+    assert secret not in sanitized
+    assert "example.test" in sanitized
+
+
+def test_sanitize_error_fails_closed(monkeypatch, caplog):
+    from tools.mcp_tool import _sanitize_error
+
+    secret = "synthetic-error-sanitizer-failure-secret"
+
+    def fail_redaction(*_args, **_kwargs):
+        raise RuntimeError(f"redaction failed with {secret}")
+
+    monkeypatch.setattr("agent.redact.redact_sensitive_text", fail_redaction)
+    result = _sanitize_error(f"api_key: {secret}")
+
+    assert result == "[REDACTED - MCP error sanitization failed]"
+    assert secret not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_log_notification_is_sanitized(caplog):
+    from tools.mcp_tool import MCPServerTask
+
+    secret = "opaque-synthetic-notification-credential"
+    callback = MCPServerTask("synthetic")._make_logging_callback()
+    params = SimpleNamespace(
+        level="warning",
+        data={"api_key": secret, "message": "diagnostic retained"},
+        logger=f"api_key={secret}",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+        await callback(params)
+
+    assert secret not in caplog.text
+    assert "diagnostic retained" in caplog.text
+    assert "[REDACTED]" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_background_exception_logs_are_sanitized(monkeypatch, caplog):
+    from tools.mcp_tool import MCPServerTask
+
+    secret = "opaque-synthetic-background-exception-credential"
+    monkeypatch.setattr(
+        MCPServerTask,
+        "_refresh_tools",
+        AsyncMock(side_effect=RuntimeError(f"api_key: {secret}")),
+    )
+    server = MCPServerTask("synthetic")
+
+    with caplog.at_level(logging.DEBUG, logger="tools.mcp_tool"):
+        await server._refresh_tools_task()
+        await server._make_message_handler()(RuntimeError(f"password={secret}"))
+
+    assert secret not in caplog.text
+    assert "[REDACTED]" in caplog.text
+
+
+def test_sanitize_error_redacts_escaped_quotes_inside_assignment():
+    from tools.mcp_tool import _sanitize_error
+
+    secret = "synthetic-secret-after-escaped-quote"
+    error = f'api_key: "prefix\\\"{secret}"'
+
+    sanitized = _sanitize_error(error)
+
+    assert secret not in sanitized
+    assert "prefix" not in sanitized
+
+
+def test_sanitize_error_redacts_full_unquoted_assignment_line():
+    from tools.mcp_tool import _sanitize_error
+
+    secret = "correct horse, battery; staple"
+    sanitized = _sanitize_error(f"password: {secret}\nstatus: failed")
+
+    assert "correct" not in sanitized
+    assert "battery" not in sanitized
+    assert "staple" not in sanitized
+    assert "status: failed" in sanitized
+
+
+def test_mcp_payload_redaction_handles_json_encoded_string_fields():
+    from tools.mcp_tool import _redact_mcp_tool_payload
+
+    secret = "synthetic-json-encoded-field-secret"
+    payload = {
+        "body": json.dumps({
+            "option_name": "demo_service_client_secret",
+            "option_value": secret,
+        })
+    }
+
+    redacted = _redact_mcp_tool_payload(payload)
+
+    assert secret not in json.dumps(redacted)
+    assert "***" in redacted["body"]
+
+
+def test_mcp_payload_redaction_honors_global_opt_out(monkeypatch):
+    from tools.mcp_tool import _redact_mcp_tool_payload
+
+    secret = "synthetic-mcp-opt-out-secret"
+    payload = {"api_key": secret}
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+    assert _redact_mcp_tool_payload(payload) is payload
+
+
+def test_mcp_payload_redaction_opt_out_preserves_exact_json_text(monkeypatch):
+    from tools.mcp_tool import _redact_mcp_tool_payload
+
+    payload = '{  "api_key" : "synthetic-mcp-opt-out-secret"  }\n'
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+
+    assert _redact_mcp_tool_payload(payload) is payload
+
+
+def test_mcp_resource_link_preserves_actionable_url_credentials():
+    from tools.mcp_tool import _render_mcp_resource_block
+
+    secret = "synthetic-resource-link-secret"
+    block = SimpleNamespace(
+        type="resource_link",
+        uri=f"https://demo:{secret}@example.test/data?access_token={secret}",
+        name="fixture",
+        mimeType="application/json",
+    )
+
+    rendered = _render_mcp_resource_block(block, "demo")
+
+    assert secret in rendered
+    assert "example.test" in rendered
+
+
+def test_mcp_embedded_resource_error_force_redacts_uri_credentials():
+    from tools.mcp_tool import _render_mcp_resource_block
+
+    secret = "synthetic-embedded-resource-error-secret"
+    block = SimpleNamespace(
+        type="resource",
+        resource=SimpleNamespace(
+            text=None,
+            blob="a",
+            uri=f"https://example.test/data?access_token={secret}",
+            mimeType="",
+        ),
+    )
+
+    rendered = _render_mcp_resource_block(block, "demo")
+
+    assert secret not in rendered
+    assert "example.test" in rendered
+
+
+def test_mcp_payload_preserves_noncredential_text_and_actionable_urls():
+    from tools.mcp_tool import _redact_mcp_tool_payload
+
+    payload = {
+        "phone": "+14155552671",
+        "download_url": "https://example.test/file?signature=public-demo",
+        "source": 'const api_key = "fixture-value"',
+    }
+
+    assert _redact_mcp_tool_payload(payload) == payload
+
+
+def test_mcp_payload_redacts_line_oriented_plain_text_credentials():
+    from tools.mcp_tool import _redact_mcp_tool_payload
+
+    secret = "opaque-synthetic-success-secret"
+    payload = f"Status: failed\napi_key: {secret}\nRetry later"
+
+    redacted = _redact_mcp_tool_payload(payload)
+
+    assert secret not in redacted
+    assert "api_key: ***" in redacted
+
+
+def test_mcp_payload_redacts_plain_text_api_token_assignment():
+    from tools.mcp_tool import _redact_mcp_tool_payload
+
+    secret = "opaque-synthetic-api-token"
+    redacted = _redact_mcp_tool_payload(f"api_token: {secret}")
+
+    assert secret not in redacted
+    assert redacted == "api_token: ***"
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "webhook_signing_secret", "session_token", "proxy_authorization",
+        "raw_secret", "key_material", "refresh_token", "license_key",
+        "API key", "access token", "client secret", "private key",
+        "id_token", "oauth token", "personal access token", "bot_token",
+    ],
+)
+def test_mcp_payload_redacts_high_signal_plain_text_assignments(key):
+    from tools.mcp_tool import _redact_mcp_tool_payload
+
+    secret = "opaque-synthetic-high-signal-value"
+    redacted = _redact_mcp_tool_payload(f"{key}: {secret}")
+
+    assert secret not in redacted
+    assert redacted == f"{key}: ***"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "token: 42 available",
+        "secret: public metadata",
+        "credential: required",
+        "authorization: pending",
+    ],
+)
+def test_mcp_payload_preserves_ambiguous_plain_text_labels(text):
+    from tools.mcp_tool import _redact_mcp_tool_payload
+
+    assert _redact_mcp_tool_payload(text) == text
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        'api_key = os.getenv("API_KEY")',
+        'client_secret: os.environ["CLIENT_SECRET"]',
+        "access_token = process.env.ACCESS_TOKEN",
+        "password: $ENV{DB_PASSWORD}",
+    ],
+)
+def test_mcp_payload_preserves_line_leading_env_lookup_source(source):
+    from tools.mcp_tool import _redact_mcp_tool_payload
+
+    assert _redact_mcp_tool_payload(source) == source
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "secret: public metadata; api_key: {secret}",
+        "status: failed, client secret: {secret}",
+    ],
+)
+def test_mcp_payload_redacts_secondary_plain_text_assignment(payload):
+    from tools.mcp_tool import _redact_mcp_tool_payload
+
+    secret = "opaque-synthetic-secondary-credential"
+    redacted = _redact_mcp_tool_payload(payload.format(secret=secret))
+
+    assert secret not in redacted
+    assert "***" in redacted
+
+
+@pytest.mark.parametrize("key", ["token", "secret", "credential", "authorization"])
+def test_mcp_payload_redacts_opaque_ambiguous_plain_text_values(key):
+    from tools.mcp_tool import _redact_mcp_tool_payload
+
+    secret = "opaque-synthetic-credential-value"
+    redacted = _redact_mcp_tool_payload(f"{key}: {secret}")
+
+    assert secret not in redacted
+
+
+def test_mcp_resource_filename_drops_credential_shaped_uri_basename():
+    from tools.mcp_tool import _mcp_resource_filename
+
+    secret_name = "ghp_SyntheticCredentialFilename123456789.pdf"
+
+    assert _mcp_resource_filename(
+        f"https://example.test/files/{secret_name}",
+        "application/pdf",
+    ) == "resource.pdf"
+
+
 class TestFilterMCPChildren:
     def test_filters_gateway_children_by_argv_marker(self, monkeypatch):
         """Non-MCP children start with an interpreter/binary, not the marker."""
@@ -495,6 +844,92 @@ class TestToolHandler:
             mock_session.call_tool.assert_called_once_with("greet", arguments={"name": "world"})
         finally:
             _servers.pop("test_srv", None)
+
+    @pytest.mark.parametrize("channel", ["text", "resource", "structured"])
+    def test_successful_call_redacts_wordpress_option_rows(self, channel):
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        server_name = f"redaction_success_{channel}_srv"
+        secret = f"synthetic-{channel}-option-value-for-tests-only"
+        payload = {
+            "option_name": "sample_service_client_secret",
+            "option_value": secret,
+        }
+        content = []
+        structured = None
+        if channel == "text":
+            content = [SimpleNamespace(type="text", text=json.dumps(payload))]
+        elif channel == "resource":
+            resource = SimpleNamespace(
+                uri="mem://synthetic-options",
+                mimeType="application/json",
+                text=json.dumps(payload),
+                blob=None,
+            )
+            content = [SimpleNamespace(type="resource", resource=resource)]
+        else:
+            structured = payload
+        call_result = SimpleNamespace(
+            content=content,
+            isError=False,
+            structuredContent=structured,
+        )
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(return_value=call_result)
+        _servers[server_name] = _make_mock_server(server_name, session=mock_session)
+        try:
+            handler = _make_tool_handler(server_name, "database_query", 120)
+            with self._patch_mcp_loop():
+                result = json.loads(handler({"query": "SELECT synthetic_fixture"}))
+            assert secret not in json.dumps(result)
+            assert "***" in json.dumps(result)
+        finally:
+            _servers.pop(server_name, None)
+
+    def test_mcp_error_result_redacts_multiblock_and_prefixed_option_rows(self):
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        server_name = "redaction_multiblock_error_srv"
+        text_secret = "opaque-violet-castle-47"
+        resource_secret = "opaque-silver-river-92"
+        resource = SimpleNamespace(
+            uri="mem://synthetic-error-options",
+            mimeType="application/json",
+            text=json.dumps({
+                "message": "resource diagnostic retained",
+                "option_name": "sample_service_private_key",
+                "option_value": resource_secret,
+            }),
+            blob=None,
+        )
+        call_result = SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="text",
+                    text="Synthetic query failed: " + json.dumps({
+                        "option_name": "sample_service_client_secret",
+                        "option_value": text_secret,
+                    }),
+                ),
+                SimpleNamespace(type="resource", resource=resource),
+            ],
+            isError=True,
+            structuredContent=None,
+        )
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(return_value=call_result)
+        _servers[server_name] = _make_mock_server(server_name, session=mock_session)
+        try:
+            handler = _make_tool_handler(server_name, "database_query", 120)
+            with self._patch_mcp_loop():
+                result = json.loads(handler({}))
+            assert "Synthetic query failed" in result["error"]
+            assert "resource diagnostic retained" in result["error"]
+            assert result["error"].count("***") == 2
+            assert text_secret not in json.dumps(result)
+            assert resource_secret not in json.dumps(result)
+        finally:
+            _servers.pop(server_name, None)
 
 
     def test_recycled_stdio_server_reconnects_lazily_on_tool_call(self):
@@ -1444,6 +1879,29 @@ class TestUtilityHandlers:
 
 
     # -- read_resource --
+
+    def test_read_resource_redacts_wordpress_option_rows(self):
+        from tools.mcp_tool import _make_read_resource_handler, _servers
+
+        server_name = "redaction_resource_srv"
+        secret = "synthetic-resource-read-option-value"
+        content_block = SimpleNamespace(text=json.dumps({
+            "option_name": "sample_client_secret",
+            "option_value": secret,
+        }))
+        mock_session = MagicMock()
+        mock_session.read_resource = AsyncMock(
+            return_value=SimpleNamespace(contents=[content_block])
+        )
+        _servers[server_name] = _make_mock_server(server_name, session=mock_session)
+        try:
+            handler = _make_read_resource_handler(server_name, 120)
+            with self._patch_mcp_loop():
+                result = json.loads(handler({"uri": "mem://synthetic-option"}))
+            assert secret not in json.dumps(result)
+            assert "***" in result["result"]
+        finally:
+            _servers.pop(server_name, None)
 
 
     # -- list_prompts --

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -978,6 +978,29 @@ class TestToolHandler:
         assert secret not in caplog.text
         assert "[REDACTED]" in caplog.text
 
+    def test_call_failure_log_sanitizes_server_and_tool_names(self, caplog):
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        secret = "opaque-synthetic-call-name-credential"
+        server_name = f"api_key: {secret}"
+        tool_name = f"password: {secret}"
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(
+            side_effect=RuntimeError("synthetic diagnostic retained")
+        )
+        _servers[server_name] = _make_mock_server(server_name, session=mock_session)
+        try:
+            handler = _make_tool_handler(server_name, tool_name, 120)
+            with caplog.at_level(logging.ERROR, logger="tools.mcp_tool"), \
+                 self._patch_mcp_loop():
+                result = json.loads(handler({}))
+        finally:
+            _servers.pop(server_name, None)
+
+        assert "synthetic diagnostic retained" in result["error"]
+        assert secret not in caplog.text
+        assert "[REDACTED]" in caplog.text
+
     @pytest.mark.parametrize("channel", ["text", "resource", "structured"])
     def test_successful_call_redacts_wordpress_option_rows(self, channel):
         from tools.mcp_tool import _make_tool_handler, _servers

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1001,6 +1001,34 @@ class TestToolHandler:
         assert secret not in caplog.text
         assert "[REDACTED]" in caplog.text
 
+    def test_session_reconnect_logs_sanitize_hostile_operation_name(self, caplog):
+        from tools import mcp_tool
+
+        secret = "opaque-synthetic-reconnect-name-credential"
+        server_name = f"api_key: {secret}"
+        operation = f"tools/call password: {secret}"
+        server = SimpleNamespace(_reconnect_event=MagicMock())
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        mcp_tool._servers[server_name] = server
+        try:
+            with patch.object(mcp_tool, "_mcp_loop", loop), \
+                 patch.object(mcp_tool, "_signal_reconnect_and_wait", return_value=False), \
+                 caplog.at_level(logging.INFO, logger="tools.mcp_tool"):
+                result = mcp_tool._handle_session_expired_and_retry(
+                    server_name,
+                    RuntimeError("synthetic session expired"),
+                    MagicMock(),
+                    operation,
+                )
+        finally:
+            mcp_tool._servers.pop(server_name, None)
+
+        assert result is None
+        assert secret not in caplog.text
+        assert "[REDACTED]" in caplog.text
+
     @pytest.mark.parametrize("channel", ["text", "resource", "structured"])
     def test_successful_call_redacts_wordpress_option_rows(self, channel):
         from tools.mcp_tool import _make_tool_handler, _servers

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -161,6 +161,47 @@ async def test_mcp_server_log_notification_is_sanitized(caplog):
     assert "[REDACTED]" in caplog.text
 
 
+def test_mcp_description_warning_sanitizes_server_controlled_fields(caplog):
+    from tools.mcp_tool import _scan_mcp_description
+
+    secret = "opaque-synthetic-description-log-credential"
+    with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+        findings = _scan_mcp_description(
+            f"api_key: {secret}",
+            f"password: {secret}",
+            f"Ignore previous instructions; client_secret: {secret}",
+        )
+
+    assert findings
+    assert secret not in caplog.text
+    assert "[REDACTED]" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("kind", "mime_prefix"),
+    [("image", "image/"), ("audio", "audio/")],
+)
+def test_mcp_media_decode_warning_sanitizes_mime(kind, mime_prefix, caplog):
+    from tools.mcp_tool import _cache_mcp_audio_block, _cache_mcp_image_block
+
+    secret = f"opaque-synthetic-{kind}-mime-credential"
+    block = SimpleNamespace(
+        data="a",
+        mimeType=f"{mime_prefix}api_key: {secret}",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"):
+        result = (
+            _cache_mcp_image_block(block)
+            if kind == "image"
+            else _cache_mcp_audio_block(block)
+        )
+
+    assert result == ""
+    assert secret not in caplog.text
+    assert "[REDACTED]" in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_mcp_background_exception_logs_are_sanitized(monkeypatch, caplog):
     from tools.mcp_tool import MCPServerTask
@@ -910,6 +951,32 @@ class TestToolHandler:
             mock_session.call_tool.assert_called_once_with("greet", arguments={"name": "world"})
         finally:
             _servers.pop("test_srv", None)
+
+    def test_unsupported_block_warning_sanitizes_server_controlled_fields(
+        self, caplog
+    ):
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        secret = "opaque-synthetic-unsupported-block-credential"
+        server_name = f"api_key: {secret}"
+        call_result = SimpleNamespace(
+            content=[SimpleNamespace(type=f"password: {secret}")],
+            isError=False,
+            structuredContent=None,
+        )
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(return_value=call_result)
+        _servers[server_name] = _make_mock_server(server_name, session=mock_session)
+        try:
+            handler = _make_tool_handler(server_name, "synthetic_tool", 120)
+            with caplog.at_level(logging.WARNING, logger="tools.mcp_tool"), \
+                 self._patch_mcp_loop():
+                handler({})
+        finally:
+            _servers.pop(server_name, None)
+
+        assert secret not in caplog.text
+        assert "[REDACTED]" in caplog.text
 
     @pytest.mark.parametrize("channel", ["text", "resource", "structured"])
     def test_successful_call_redacts_wordpress_option_rows(self, channel):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4043,9 +4043,11 @@ def _signal_reconnect_and_wait(
         if reconnect_event is not None and hasattr(reconnect_event, "set"):
             reconnect_event.set()
 
+    safe_server_name = _sanitize_error(server_name)
+    safe_op_description = _sanitize_error(op_description)
     logger.info(
         "MCP server '%s': %s requesting transport reconnect",
-        server_name, op_description,
+        safe_server_name, safe_op_description,
     )
     loop.call_soon_threadsafe(_request_reconnect)
     return _wait_for_server_session_ready(
@@ -4161,6 +4163,9 @@ def _handle_auth_error_and_retry(
     if not _is_auth_error(exc):
         return None
 
+    safe_server_name = _sanitize_error(server_name)
+    safe_op_description = _sanitize_error(op_description)
+
     from tools.mcp_oauth_manager import get_manager
     manager = get_manager()
 
@@ -4172,7 +4177,7 @@ def _handle_auth_error_and_retry(
     except Exception as rec_exc:
         logger.warning(
             "MCP OAuth '%s': recovery attempt failed: %s",
-            server_name, _safe_exc_str(rec_exc),
+            safe_server_name, _safe_exc_str(rec_exc),
         )
         recovered = False
 
@@ -4211,7 +4216,7 @@ def _handle_auth_error_and_retry(
         except Exception as retry_exc:
             logger.warning(
                 "MCP %s/%s retry after auth recovery failed: %s",
-                server_name, op_description, _safe_exc_str(retry_exc),
+                safe_server_name, safe_op_description, _safe_exc_str(retry_exc),
             )
 
     # No recovery available, or retry also failed: surface a structured
@@ -4362,6 +4367,9 @@ def _handle_session_expired_and_retry(
     if not _is_session_expired_error(exc):
         return None
 
+    safe_server_name = _sanitize_error(server_name)
+    safe_op_description = _sanitize_error(op_description)
+
     with _lock:
         srv = _servers.get(server_name)
     if srv is None or not hasattr(srv, "_reconnect_event"):
@@ -4374,7 +4382,7 @@ def _handle_session_expired_and_retry(
     logger.info(
         "MCP server '%s': %s failed with session-expired error (%s); "
         "signalling transport reconnect and retrying once.",
-        server_name, op_description, _safe_exc_str(exc),
+        safe_server_name, safe_op_description, _safe_exc_str(exc),
     )
 
     # Trigger the same reconnect mechanism the OAuth recovery path
@@ -4388,7 +4396,7 @@ def _handle_session_expired_and_retry(
         logger.warning(
             "MCP server '%s': reconnect did not ready within 15s after "
             "session-expired error; falling through to error response.",
-            server_name,
+            safe_server_name,
         )
         return None
 
@@ -4405,7 +4413,7 @@ def _handle_session_expired_and_retry(
     except Exception as retry_exc:
         logger.warning(
             "MCP %s/%s retry after session reconnect failed: %s",
-            server_name, op_description, _safe_exc_str(retry_exc),
+            safe_server_name, safe_op_description, _safe_exc_str(retry_exc),
         )
     return None
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -827,8 +827,10 @@ def _scan_mcp_description(server_name: str, tool_name: str, description: str) ->
         logger.warning(
             "MCP server '%s' tool '%s': suspicious description content — %s. "
             "Description: %.200s",
-            server_name, tool_name, "; ".join(findings),
-            description,
+            _sanitize_error(server_name),
+            _sanitize_error(tool_name),
+            "; ".join(findings),
+            _sanitize_error(description),
         )
     return findings
 
@@ -1006,7 +1008,7 @@ def _cache_mcp_image_block(block) -> str:
     except (TypeError, ValueError) as exc:
         logger.warning(
             "MCP image block decode failed (%s): %s",
-            normalized_mime,
+            _sanitize_error(normalized_mime),
             _safe_exc_str(exc),
         )
         return ""
@@ -1105,7 +1107,7 @@ def _cache_mcp_audio_block(block) -> str:
     except (TypeError, ValueError) as exc:
         logger.warning(
             "MCP audio block decode failed (%s): %s",
-            mime_type,
+            _sanitize_error(mime_type),
             _safe_exc_str(exc),
         )
         return ""
@@ -5308,12 +5310,14 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 if block_type in {"text", "resource", "audio", "image"}:
                     logger.debug(
                         "MCP %s: content block type %r rendered empty",
-                        server_name, block_type,
+                        _sanitize_error(server_name),
+                        _sanitize_error(str(block_type)),
                     )
                 else:
                     logger.warning(
                         "MCP %s: dropping unsupported content block type %r",
-                        server_name, block_type,
+                        _sanitize_error(server_name),
+                        _sanitize_error(str(block_type)),
                     )
             text_result = "\n".join(parts) if parts else ""
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -172,7 +172,10 @@ def _get_mcp_stderr_log() -> Any:
             fh.fileno()
             _mcp_stderr_log_fh = fh
         except Exception as exc:  # pragma: no cover — best-effort fallback
-            logger.debug("Failed to open MCP stderr log, using devnull: %s", exc)
+            logger.debug(
+                "Failed to open MCP stderr log, using devnull: %s",
+                _safe_exc_str(exc),
+            )
             try:
                 _mcp_stderr_log_fh = open(os.devnull, "w", encoding="utf-8")
             except Exception:
@@ -419,6 +422,34 @@ _CREDENTIAL_PATTERN = re.compile(
     r")",
     re.IGNORECASE,
 )
+_CREDENTIAL_ASSIGNMENT_PATTERN = re.compile(
+    r"(?P<prefix>\b(?:api[-_. \t]?(?:key|token)|x[-_. \t]?api[-_. \t]?key|access[-_. \t]?token|"
+    r"auth[-_. \t]?token|(?:id|oauth|csrf|verification|bearer|bot|service|signing)[-_. \t]?token|"
+    r"personal[-_. \t]?access[-_. \t]?token|client[-_. \t]?secret|consumer[-_. \t]?(?:key|secret)|"
+    r"private[-_. \t]?key|secret[-_. \t]?key|password|passwd|token|secret|"
+    r"credential|authorization)\b\s*[:=]\s*)"
+    r"(?:\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|[^\r\n]+)",
+    re.IGNORECASE,
+)
+_MCP_TEXT_CREDENTIAL_ASSIGNMENT_PATTERN = re.compile(
+    r"(?P<prefix>(?:^[ \t]*(?:[-*][ \t]+)?|(?<=[;,])[ \t]*)(?:"
+    r"api[-_. \t]?(?:key|token)|x[-_. \t]?api[-_. \t]?key|"
+    r"access[-_. \t]?token|auth[-_. \t]?token|"
+    r"(?:id|oauth|csrf|verification|bearer|bot|service|signing)[-_. \t]?token|"
+    r"personal[-_. \t]?access[-_. \t]?token|client[-_. \t]?secret|"
+    r"consumer[-_. \t]?(?:key|secret)|private[-_. \t]?key|secret[-_. \t]?key|"
+    r"password|passwd|raw[-_. \t]?secret|refresh[-_. \t]?token|key[-_. \t]?material|"
+    r"license[-_. \t]?key|session[-_. \t]?token|signing[-_. \t]?secret|"
+    r"webhook[-_. \t]?(?:signing[-_. \t]?)?(?:secret|token)|"
+    r"proxy[-_. \t]?authorization)\b\s*[:=]\s*)"
+    r"(?P<value>\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|[^\r\n]+)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_MCP_AMBIGUOUS_TEXT_ASSIGNMENT_PATTERN = re.compile(
+    r"(?P<prefix>^[ \t]*(?:[-*][ \t]+)?(?:token|secret|credential|authorization)"
+    r"\b\s*[:=]\s*)(?P<value>[^\r\n]+)$",
+    re.IGNORECASE | re.MULTILINE,
+)
 
 # Pre-compiled pattern for ${VAR_NAME} style env-var interpolation.
 # Supports any non-} characters in the variable name (hyphens, dots, etc.)
@@ -482,7 +513,213 @@ def _sanitize_error(text: str) -> str:
     Replaces tokens, keys, and other secrets with [REDACTED] to prevent
     accidental credential exposure in tool error responses.
     """
-    return _CREDENTIAL_PATTERN.sub("[REDACTED]", text)
+    try:
+        from agent.redact import redact_sensitive_text
+
+        legacy_redacted = _CREDENTIAL_PATTERN.sub("[REDACTED]", text)
+        assignment_redacted = _CREDENTIAL_ASSIGNMENT_PATTERN.sub(
+            lambda match: f"{match.group('prefix')}[REDACTED]",
+            legacy_redacted,
+        )
+        protected_parts: dict[str, str] = {}
+
+        def _protect_redacted_assignment(match: re.Match) -> str:
+            marker = f"MCPMASKEDBLOCK{len(protected_parts)}QZ"
+            protected_parts[marker] = match.group(0)
+            return marker
+
+        protected_text = _CREDENTIAL_ASSIGNMENT_PATTERN.sub(
+            _protect_redacted_assignment,
+            assignment_redacted,
+        )
+        while "[REDACTED]" in protected_text:
+            marker = f"MCPMASKEDBLOCK{len(protected_parts)}QZ"
+            protected_parts[marker] = "[REDACTED]"
+            protected_text = protected_text.replace("[REDACTED]", marker, 1)
+        robust_redacted = redact_sensitive_text(
+            protected_text,
+            force=True,
+            redact_url_credentials=True,
+        )
+        for marker, original in protected_parts.items():
+            robust_redacted = robust_redacted.replace(marker, original)
+    except Exception:
+        logger.warning("Failed to sanitize MCP error; diagnostic suppressed")
+        return "[REDACTED - MCP error sanitization failed]"
+    decoder = json.JSONDecoder()
+    scan_from = 0
+    while scan_from < len(robust_redacted):
+        starts = [
+            pos for pos in (
+                robust_redacted.find("{", scan_from),
+                robust_redacted.find("[", scan_from),
+            )
+            if pos >= 0
+        ]
+        if not starts:
+            break
+        start = min(starts)
+        try:
+            embedded, end = decoder.raw_decode(robust_redacted[start:])
+        except (TypeError, ValueError):
+            scan_from = start + 1
+            continue
+        if isinstance(embedded, (dict, list)):
+            return str(_redact_mcp_tool_payload(robust_redacted, force=True))
+        scan_from = start + max(end, 1)
+    return robust_redacted
+
+
+def _redact_mcp_tool_payload(payload: Any, *, force: bool = False) -> Any:
+    """Redact structured MCP output before it reaches context or worker logs."""
+    try:
+        from agent.redact import (
+            _ENV_LOOKUP_VALUE_RE,
+            _REDACT_ENABLED,
+            redact_sensitive_data,
+            redact_sensitive_text,
+        )
+
+        if not force and not _REDACT_ENABLED:
+            return payload
+
+        def _redact_text(text: str) -> str:
+            replacement = "[REDACTED]" if force else "***"
+
+            def _redact_high_signal_assignment(match: re.Match) -> str:
+                value = match.group("value").strip().strip("\"'")
+                if not force and _ENV_LOOKUP_VALUE_RE.match(value):
+                    return match.group(0)
+                return f"{match.group('prefix')}{replacement}"
+
+            redacted_text = text
+            if force or _REDACT_ENABLED:
+                redacted_text = _MCP_TEXT_CREDENTIAL_ASSIGNMENT_PATTERN.sub(
+                    _redact_high_signal_assignment,
+                    redacted_text,
+                )
+
+            def _ambiguous_value_looks_sensitive(match: re.Match) -> bool:
+                value = match.group("value").strip().strip("\"'")
+                first_word = value.split(None, 1)[0].casefold() if value else ""
+                return bool(
+                    _CREDENTIAL_PATTERN.search(value)
+                    or first_word in {"bearer", "basic", "digest", "token"}
+                    or (not any(char.isspace() for char in value) and len(value) >= 12)
+                )
+
+            protected_parts: dict[str, str] = {}
+
+            def _protect_benign_ambiguous_line(match: re.Match) -> str:
+                if _ambiguous_value_looks_sensitive(match):
+                    return match.group(0)
+                marker = f"MCPPUBLICBLOCK{len(protected_parts)}QZ"
+                protected_parts[marker] = match.group(0)
+                return marker
+
+            protected_text = redacted_text
+            if not force:
+                protected_text = _MCP_AMBIGUOUS_TEXT_ASSIGNMENT_PATTERN.sub(
+                    _protect_benign_ambiguous_line,
+                    protected_text,
+                )
+            redacted_text = redact_sensitive_text(
+                protected_text,
+                force=force,
+                code_file=not force,
+                redact_url_credentials=force,
+                redact_phone_numbers=force,
+            )
+            for marker, original in protected_parts.items():
+                redacted_text = redacted_text.replace(marker, original)
+            if force or _REDACT_ENABLED:
+                redacted_text = _MCP_AMBIGUOUS_TEXT_ASSIGNMENT_PATTERN.sub(
+                    lambda match: (
+                        f"{match.group('prefix')}{replacement}"
+                        if _ambiguous_value_looks_sensitive(match)
+                        else match.group(0)
+                    ),
+                    redacted_text,
+                )
+            return redacted_text
+
+        if isinstance(payload, str):
+            try:
+                parsed = json.loads(payload)
+            except (TypeError, ValueError):
+                redacted_text = _redact_text(payload)
+                decoder = json.JSONDecoder()
+                parts: List[str] = []
+                cursor = 0
+                scan_from = 0
+                while scan_from < len(redacted_text):
+                    starts = [
+                        pos for pos in (
+                            redacted_text.find("{", scan_from),
+                            redacted_text.find("[", scan_from),
+                        )
+                        if pos >= 0
+                    ]
+                    if not starts:
+                        break
+                    start = min(starts)
+                    try:
+                        embedded, end = decoder.raw_decode(redacted_text[start:])
+                    except (TypeError, ValueError):
+                        scan_from = start + 1
+                        continue
+                    if not isinstance(embedded, (dict, list)):
+                        scan_from = start + max(end, 1)
+                        continue
+                    parts.append(redacted_text[cursor:start])
+                    parts.append(json.dumps(
+                        _redact_mcp_tool_payload(embedded, force=force),
+                        ensure_ascii=False,
+                    ))
+                    cursor = start + end
+                    scan_from = cursor
+                if not parts:
+                    return redacted_text
+                parts.append(redacted_text[cursor:])
+                return "".join(parts)
+            if isinstance(parsed, (dict, list)):
+                return json.dumps(
+                    _redact_mcp_tool_payload(parsed, force=force),
+                    ensure_ascii=False,
+                )
+            return _redact_text(payload)
+        redacted = redact_sensitive_data(
+            payload,
+            force=force,
+            code_file=not force,
+            redact_url_credentials=force,
+            redact_phone_numbers=force,
+        )
+        if isinstance(redacted, dict):
+            return {
+                key: _redact_mcp_tool_payload(item, force=force)
+                if isinstance(item, (dict, list, tuple, str))
+                else item
+                for key, item in redacted.items()
+            }
+        if isinstance(redacted, list):
+            return [
+                _redact_mcp_tool_payload(item, force=force)
+                if isinstance(item, (dict, list, tuple, str))
+                else item
+                for item in redacted
+            ]
+        if isinstance(redacted, tuple):
+            return tuple(
+                _redact_mcp_tool_payload(item, force=force)
+                if isinstance(item, (dict, list, tuple, str))
+                else item
+                for item in redacted
+            )
+        return redacted
+    except Exception:
+        logger.warning("Failed to redact MCP tool payload; output suppressed")
+        return "[REDACTED - MCP tool output sanitization failed]"
 
 
 def _exc_str(exc: BaseException) -> str:
@@ -495,6 +732,11 @@ def _exc_str(exc: BaseException) -> str:
     """
     text = str(exc).strip()
     return text if text else repr(exc)
+
+
+def _safe_exc_str(exc: BaseException) -> str:
+    """Return a sanitized exception description safe for logs and responses."""
+    return _sanitize_error(f"{type(exc).__name__}: {_exc_str(exc)}")
 
 
 # JSON-RPC "method not found" — the error a server returns when it does not
@@ -762,7 +1004,11 @@ def _cache_mcp_image_block(block) -> str:
     try:
         raw_bytes = base64.b64decode(data)
     except (TypeError, ValueError) as exc:
-        logger.warning("MCP image block decode failed (%s): %s", normalized_mime, exc)
+        logger.warning(
+            "MCP image block decode failed (%s): %s",
+            normalized_mime,
+            _safe_exc_str(exc),
+        )
         return ""
 
     try:
@@ -779,7 +1025,7 @@ def _cache_mcp_image_block(block) -> str:
         logger.debug("MCP image caching skipped — gateway.platforms.base unavailable")
         return ""
     except Exception as exc:
-        logger.warning("MCP image block cache failed: %s", exc)
+        logger.warning("MCP image block cache failed: %s", _safe_exc_str(exc))
         return ""
 
     return f"MEDIA:{image_path}"
@@ -820,6 +1066,13 @@ def _mcp_resource_filename(uri: str, mime_type: str) -> str:
     # otherwise land in the filename and the transcript marker) and cap the
     # length, preserving the extension.
     name = _re.sub(r"[\x00-\x1f\x7f]", "", name).strip()
+    if name:
+        redacted_name = str(_redact_mcp_tool_payload(name, force=True))
+        if redacted_name != name:
+            extension = Path(name).suffix
+            if not (0 < len(extension) <= 13):
+                extension = ""
+            name = f"resource{extension}"
     if len(name) > 150:
         stem, dot, ext = name.rpartition(".")
         if dot and 0 < len(ext) <= 12:
@@ -850,7 +1103,11 @@ def _cache_mcp_audio_block(block) -> str:
     try:
         raw_bytes = base64.b64decode(data)
     except (TypeError, ValueError) as exc:
-        logger.warning("MCP audio block decode failed (%s): %s", mime_type, exc)
+        logger.warning(
+            "MCP audio block decode failed (%s): %s",
+            mime_type,
+            _safe_exc_str(exc),
+        )
         return ""
     if len(raw_bytes) > _MCP_RESOURCE_MAX_BYTES:
         return f"[MCP audio resource too large to cache: {len(raw_bytes)} bytes]"
@@ -868,7 +1125,7 @@ def _cache_mcp_audio_block(block) -> str:
         logger.debug("MCP audio caching skipped — gateway.platforms.base unavailable")
         return ""
     except Exception as exc:
-        logger.warning("MCP audio block cache failed: %s", exc)
+        logger.warning("MCP audio block cache failed: %s", _safe_exc_str(exc))
         return ""
     return f"MEDIA:{audio_path}"
 
@@ -897,11 +1154,14 @@ def _render_mcp_resource_block(block, server_name: str = "") -> str:
             return ""
         name = getattr(block, "name", "") or ""
         mime = getattr(block, "mimeType", "") or ""
-        details = f"uri={uri}"
+        safe_uri = str(_redact_mcp_tool_payload(str(uri)))
+        safe_name = str(_redact_mcp_tool_payload(str(name)))
+        safe_mime = str(_redact_mcp_tool_payload(str(mime)))
+        details = f"uri={safe_uri}"
         if name:
-            details += f", name={name}"
+            details += f", name={safe_name}"
         if mime:
-            details += f", mimeType={mime}"
+            details += f", mimeType={safe_mime}"
         reader = (
             mcp_prefixed_tool_name(server_name, "read_resource")
             if server_name
@@ -915,7 +1175,7 @@ def _render_mcp_resource_block(block, server_name: str = "") -> str:
 
     text = getattr(resource, "text", None)
     if text is not None:
-        return str(text)
+        return str(_redact_mcp_tool_payload(str(text)))
 
     blob = getattr(resource, "blob", None)
     if blob is None:
@@ -925,26 +1185,32 @@ def _render_mcp_resource_block(block, server_name: str = "") -> str:
 
     uri = str(getattr(resource, "uri", "") or "")
     mime = str(getattr(resource, "mimeType", "") or "")
+    safe_uri = str(_redact_mcp_tool_payload(uri, force=True))
+    safe_mime = str(_redact_mcp_tool_payload(mime, force=True))
     if len(blob) > _MCP_RESOURCE_MAX_B64_CHARS:
-        return f"[MCP embedded resource too large to cache: ~{len(blob) * 3 // 4} bytes, uri={uri}]"
+        return f"[MCP embedded resource too large to cache: ~{len(blob) * 3 // 4} bytes, uri={safe_uri}]"
     try:
         raw_bytes = base64.b64decode(blob)
     except (TypeError, ValueError) as exc:
-        logger.warning("MCP embedded resource decode failed (%s): %s", mime or uri, exc)
-        return f"[MCP embedded resource could not be decoded: {mime or uri}]"
+        logger.warning(
+            "MCP embedded resource decode failed (%s): %s",
+            safe_mime or safe_uri,
+            _safe_exc_str(exc),
+        )
+        return f"[MCP embedded resource could not be decoded: {safe_mime or safe_uri}]"
     if len(raw_bytes) > _MCP_RESOURCE_MAX_BYTES:
-        return f"[MCP embedded resource too large to cache: {len(raw_bytes)} bytes, uri={uri}]"
+        return f"[MCP embedded resource too large to cache: {len(raw_bytes)} bytes, uri={safe_uri}]"
     try:
         from gateway.platforms.base import cache_document_from_bytes
 
         path = cache_document_from_bytes(raw_bytes, _mcp_resource_filename(uri, mime))
     except ImportError:
         logger.debug("MCP resource caching skipped — gateway.platforms.base unavailable")
-        return f"[MCP embedded resource received ({len(raw_bytes)} bytes, {mime or 'unknown type'}) but document cache unavailable in this process]"
+        return f"[MCP embedded resource received ({len(raw_bytes)} bytes, {safe_mime or 'unknown type'}) but document cache unavailable in this process]"
     except Exception as exc:
-        logger.warning("MCP embedded resource cache failed: %s", exc)
-        return f"[MCP embedded resource could not be cached: {mime or uri}]"
-    detail = mime or "unknown type"
+        logger.warning("MCP embedded resource cache failed: %s", _safe_exc_str(exc))
+        return f"[MCP embedded resource could not be cached: {safe_mime or safe_uri}]"
+    detail = safe_mime or "unknown type"
     return f"[MCP resource saved to {path} ({detail}, {len(raw_bytes)} bytes) — read it with read_file or terminal tools]"
 
 
@@ -1746,7 +2012,7 @@ class ElicitationHandler:
         except Exception as exc:  # pragma: no cover -- defensive
             logger.error(
                 "MCP server '%s' elicitation: approval system unavailable: %s",
-                self.server_name, exc,
+                self.server_name, _safe_exc_str(exc),
             )
             self.metrics["errors"] += 1
             return ElicitResult(action="decline")
@@ -1799,7 +2065,7 @@ class ElicitationHandler:
         except Exception as exc:
             logger.error(
                 "MCP server '%s' elicitation failed: %s",
-                self.server_name, exc, exc_info=True,
+                self.server_name, _safe_exc_str(exc),
             )
             self.metrics["errors"] += 1
             return ElicitResult(action="decline")
@@ -1992,8 +2258,12 @@ class MCPServerTask:
             await self._refresh_tools()
         except asyncio.CancelledError:
             raise
-        except Exception:
-            logger.exception("MCP server '%s': dynamic tool refresh failed", self.name)
+        except Exception as exc:
+            logger.error(
+                "MCP server '%s': dynamic tool refresh failed: %s",
+                self.name,
+                _safe_exc_str(exc),
+            )
 
     def _schedule_tools_refresh(self) -> asyncio.Task:
         """Schedule a background tool refresh and keep it strongly referenced."""
@@ -2022,17 +2292,20 @@ class MCPServerTask:
                         data = json.dumps(data, ensure_ascii=False, default=str)
                     except (TypeError, ValueError):
                         data = str(data)
+                data = _sanitize_error(data)
                 # Cap pathological payloads so a chatty/broken server can't
                 # flood agent.log with megabyte lines.
                 if len(data) > 2000:
                     data = data[:2000] + "... [truncated]"
                 logger_name = getattr(params, "logger", None)
                 origin = f"{self.name}/{logger_name}" if logger_name else self.name
+                origin = _sanitize_error(origin)
                 logger.log(level, "MCP server log [%s]: %s", origin, data)
-            except Exception:
+            except Exception as exc:
                 logger.debug(
-                    "Failed to handle MCP log notification from '%s'",
-                    self.name, exc_info=True,
+                    "Failed to handle MCP log notification from '%s': %s",
+                    self.name,
+                    _safe_exc_str(exc),
                 )
         return _on_log
 
@@ -2046,7 +2319,11 @@ class MCPServerTask:
         async def _handler(message):
             try:
                 if isinstance(message, Exception):
-                    logger.debug("MCP message handler (%s): exception: %s", self.name, message)
+                    logger.debug(
+                        "MCP message handler (%s): exception: %s",
+                        self.name,
+                        _safe_exc_str(message),
+                    )
                     return
                 if _MCP_NOTIFICATION_TYPES and isinstance(message, ServerNotification):
                     match message.root:
@@ -2075,8 +2352,12 @@ class MCPServerTask:
                             logger.debug("MCP server '%s': resources/list_changed (ignored)", self.name)
                         case _:
                             pass
-            except Exception:
-                logger.exception("Error in MCP message handler for '%s'", self.name)
+            except Exception as exc:
+                logger.error(
+                    "Error in MCP message handler for '%s': %s",
+                    self.name,
+                    _safe_exc_str(exc),
+                )
         return _handler
 
     async def _refresh_tools(self):
@@ -2308,8 +2589,8 @@ class MCPServerTask:
                         root = _unwrap_exception_group(exc)
                         logger.warning(
                             "MCP server '%s' keepalive failed, triggering "
-                            "reconnect (state: connected → degraded): %s: %s",
-                            self.name, type(root).__name__, root,
+                            "reconnect (state: connected → degraded): %s",
+                            self.name, _safe_exc_str(root),
                         )
                         self._reconnect_event.set()
                         break
@@ -2784,7 +3065,11 @@ class MCPServerTask:
                     self.name, url, config.get("oauth"),
                 )
             except Exception as exc:
-                logger.warning("MCP OAuth setup failed for '%s': %s", self.name, exc)
+                logger.warning(
+                    "MCP OAuth setup failed for '%s': %s",
+                    self.name,
+                    _safe_exc_str(exc),
+                )
                 raise
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
@@ -3096,7 +3381,7 @@ class MCPServerTask:
             try:
                 _validate_remote_mcp_url(self.name, config.get("url"))
             except InvalidMcpUrlError as exc:
-                logger.warning("%s", exc)
+                logger.warning("%s", _safe_exc_str(exc))
                 self._error = exc
                 self._ready.set()
                 return
@@ -3123,7 +3408,7 @@ class MCPServerTask:
                         client_cert=_resolve_client_cert(self.name, config),
                     )
                 except NonMcpEndpointError as exc:
-                    logger.warning("%s", exc)
+                    logger.warning("%s", _safe_exc_str(exc))
                     self._error = exc
                     self._ready.set()
                     return
@@ -3236,12 +3521,13 @@ class MCPServerTask:
                 # Empty dead-pipe errors still get a name this way
                 # (e.g. "BrokenPipeError: ").
                 root = _unwrap_exception_group(exc)
+                safe_root = _safe_exc_str(root)
                 failure_class = _classify_mcp_failure(root)
                 if self._is_recycled_stdio():
                     logger.warning(
                         "MCP server '%s': lazy reconnect after stdio recycle "
-                        "failed, marking unavailable while retrying: %s: %s",
-                        self.name, type(root).__name__, root,
+                        "failed, marking unavailable while retrying: %s",
+                        self.name, safe_root,
                     )
                     self._recycled_reason = None
 
@@ -3253,8 +3539,8 @@ class MCPServerTask:
                     if _is_auth_error(root):
                         logger.warning(
                             "MCP server '%s' failed initial OAuth authentication, "
-                            "not retrying automatically: %s: %s",
-                            self.name, type(root).__name__, root,
+                            "not retrying automatically: %s",
+                            self.name, safe_root,
                         )
                         self._error = exc
                         self._ready.set()
@@ -3268,8 +3554,8 @@ class MCPServerTask:
                         logger.warning(
                             "MCP server '%s' failed initial connection with a "
                             "permanent error, parking without retries "
-                            "(state: connecting → parked): %s: %s",
-                            self.name, type(root).__name__, root,
+                            "(state: connecting → parked): %s",
+                            self.name, safe_root,
                         )
                         self._error = exc
                         self._ready.set()
@@ -3299,9 +3585,9 @@ class MCPServerTask:
                         logger.warning(
                             "MCP server '%s' failed initial connection after "
                             "%d attempts, parking until a reconnect is "
-                            "requested (state: connecting → parked): %s: %s",
+                            "requested (state: connecting → parked): %s",
                             self.name, _MAX_INITIAL_CONNECT_RETRIES,
-                            type(root).__name__, root,
+                            safe_root,
                         )
                         self._error = exc
                         self._ready.set()
@@ -3328,10 +3614,10 @@ class MCPServerTask:
 
                     logger.debug(
                         "MCP server '%s' initial connection failed "
-                        "(attempt %d/%d), retrying in %.0fs: %s: %s",
+                        "(attempt %d/%d), retrying in %.0fs: %s",
                         self.name, initial_retries,
                         _MAX_INITIAL_CONNECT_RETRIES, backoff,
-                        type(root).__name__, root,
+                        safe_root,
                     )
                     await asyncio.sleep(_jittered(backoff))
                     backoff = min(backoff * 2, _MAX_BACKOFF_SECONDS)
@@ -3346,8 +3632,8 @@ class MCPServerTask:
                 # If shutdown was requested, don't reconnect
                 if self._shutdown_event.is_set():
                     logger.debug(
-                        "MCP server '%s' disconnected during shutdown: %s: %s",
-                        self.name, type(root).__name__, root,
+                        "MCP server '%s' disconnected during shutdown: %s",
+                        self.name, safe_root,
                     )
                     return
 
@@ -3359,9 +3645,9 @@ class MCPServerTask:
                     logger.warning(
                         "MCP server '%s' hit a permanent error, parking "
                         "without retries; will self-probe every %ds "
-                        "(state: connected → parked): %s: %s",
+                        "(state: connected → parked): %s",
                         self.name, _PARKED_RETRY_INTERVAL,
-                        type(root).__name__, root,
+                        safe_root,
                     )
                     self._was_parked = True
                     self._deregister_tools()
@@ -3386,10 +3672,10 @@ class MCPServerTask:
                     logger.warning(
                         "MCP server '%s' failed after %d reconnection attempts, "
                         "parking; will self-probe every %ds until it recovers "
-                        "(state: degraded → parked): %s: %s",
+                        "(state: degraded → parked): %s",
                         self.name, _MAX_RECONNECT_RETRIES,
                         _PARKED_RETRY_INTERVAL,
-                        type(root).__name__, root,
+                        safe_root,
                     )
                     # Do NOT return — exiting the task orphans the server:
                     # nothing would ever listen for _reconnect_event again
@@ -3428,9 +3714,9 @@ class MCPServerTask:
                 # carry the WARNINGs — one line per transition, not per try.
                 logger.debug(
                     "MCP server '%s' connection lost (attempt %d/%d), "
-                    "reconnecting in %.0fs: %s: %s",
+                    "reconnecting in %.0fs: %s",
                     self.name, self._reconnect_retries, _MAX_RECONNECT_RETRIES,
-                    backoff, type(root).__name__, root,
+                    backoff, safe_root,
                 )
                 await asyncio.sleep(_jittered(backoff))
                 backoff = min(backoff * 2, _MAX_BACKOFF_SECONDS)
@@ -3884,7 +4170,7 @@ def _handle_auth_error_and_retry(
     except Exception as rec_exc:
         logger.warning(
             "MCP OAuth '%s': recovery attempt failed: %s",
-            server_name, rec_exc,
+            server_name, _safe_exc_str(rec_exc),
         )
         recovered = False
 
@@ -3923,7 +4209,7 @@ def _handle_auth_error_and_retry(
         except Exception as retry_exc:
             logger.warning(
                 "MCP %s/%s retry after auth recovery failed: %s",
-                server_name, op_description, retry_exc,
+                server_name, op_description, _safe_exc_str(retry_exc),
             )
 
     # No recovery available, or retry also failed: surface a structured
@@ -4086,7 +4372,7 @@ def _handle_session_expired_and_retry(
     logger.info(
         "MCP server '%s': %s failed with session-expired error (%s); "
         "signalling transport reconnect and retrying once.",
-        server_name, op_description, exc,
+        server_name, op_description, _safe_exc_str(exc),
     )
 
     # Trigger the same reconnect mechanism the OAuth recovery path
@@ -4117,7 +4403,7 @@ def _handle_session_expired_and_retry(
     except Exception as retry_exc:
         logger.warning(
             "MCP %s/%s retry after session reconnect failed: %s",
-            server_name, op_description, retry_exc,
+            server_name, op_description, _safe_exc_str(retry_exc),
         )
     return None
 
@@ -4672,7 +4958,7 @@ def _load_mcp_config() -> Dict[str, dict]:
                 safe_servers[name] = interpolated
         return safe_servers
     except Exception as exc:
-        logger.debug("Failed to load MCP config: %s", exc)
+        logger.debug("Failed to load MCP config: %s", _safe_exc_str(exc))
         return {}
 
 
@@ -4759,7 +5045,7 @@ def _request_lazy_reconnect(server_name: str, server: MCPServerTask) -> bool:
     except Exception as exc:
         logger.warning(
             "MCP server '%s': lazy reconnect after stdio recycle failed: %s",
-            server_name, exc,
+            server_name, _safe_exc_str(exc),
         )
         return False
 
@@ -4962,17 +5248,22 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 _mark_proven()
             # MCP CallToolResult has .content (list of content blocks) and .isError
             if result.isError:
-                error_text = ""
+                error_parts: List[str] = []
                 for block in (result.content or []):
                     if getattr(block, "text", None):
-                        error_text += block.text
+                        error_parts.append(str(
+                            _redact_mcp_tool_payload(str(block.text))
+                        ))
                         continue
                     # EmbeddedResource blocks inside error payloads carry
                     # their text under .resource.text — previously dropped,
                     # leaving a bare "MCP tool returned an error".
                     res_text = getattr(getattr(block, "resource", None), "text", None)
                     if res_text:
-                        error_text += str(res_text)
+                        error_parts.append(str(
+                            _redact_mcp_tool_payload(str(res_text))
+                        ))
+                error_text = "".join(error_parts)
                 return tool_error(_sanitize_error(
                     error_text or "MCP tool returned an error"
                 ))
@@ -4991,7 +5282,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             parts: List[str] = []
             for block in (result.content or []):
                 if hasattr(block, "text") and block.text:
-                    parts.append(block.text)
+                    parts.append(str(_redact_mcp_tool_payload(block.text)))
                     continue
                 image_tag = _cache_mcp_image_block(block)
                 if image_tag:
@@ -5032,6 +5323,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             # is the primary payload; structuredContent supplements it.
             structured = getattr(result, "structuredContent", None)
             if structured is not None:
+                structured = _redact_mcp_tool_payload(structured)
                 if text_result:
                     return json.dumps({
                         "result": text_result,
@@ -5079,13 +5371,14 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 return recovered
 
             _bump_server_error(server_name)
+            safe_error = _sanitize_error(
+                f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
+            )
             logger.error(
                 "MCP tool %s/%s call failed: %s",
-                server_name, tool_name, exc,
+                server_name, tool_name, safe_error,
             )
-            return tool_error(_sanitize_error(
-                f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
-            ))
+            return tool_error(safe_error)
 
     return _handler
 
@@ -5116,7 +5409,10 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
                 if hasattr(r, "mimeType") and r.mimeType:
                     entry["mimeType"] = r.mimeType
                 resources.append(entry)
-            return json.dumps({"resources": resources}, ensure_ascii=False)
+            return json.dumps(
+                _redact_mcp_tool_payload({"resources": resources}),
+                ensure_ascii=False,
+            )
 
         def _call_once():
             return _run_on_mcp_loop(_call, timeout=tool_timeout)
@@ -5136,12 +5432,13 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
             )
             if recovered is not None:
                 return recovered
-            logger.error(
-                "MCP %s/list_resources failed: %s", server_name, exc,
-            )
-            return tool_error(_sanitize_error(
+            safe_error = _sanitize_error(
                 f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
-            ))
+            )
+            logger.error(
+                "MCP %s/list_resources failed: %s", server_name, safe_error,
+            )
+            return tool_error(safe_error)
 
     return _handler
 
@@ -5167,7 +5464,7 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
             contents = result.contents if hasattr(result, "contents") else []
             for block in contents:
                 if getattr(block, "text", None) is not None:
-                    parts.append(block.text)
+                    parts.append(str(_redact_mcp_tool_payload(str(block.text))))
                 elif getattr(block, "blob", None) is not None:
                     # Materialize binary resource contents into the document
                     # cache instead of discarding them (same contract as
@@ -5197,12 +5494,13 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
             )
             if recovered is not None:
                 return recovered
-            logger.error(
-                "MCP %s/read_resource failed: %s", server_name, exc,
-            )
-            return tool_error(_sanitize_error(
+            safe_error = _sanitize_error(
                 f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
-            ))
+            )
+            logger.error(
+                "MCP %s/read_resource failed: %s", server_name, safe_error,
+            )
+            return tool_error(safe_error)
 
     return _handler
 
@@ -5238,7 +5536,10 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
                         for a in p.arguments
                     ]
                 prompts.append(entry)
-            return json.dumps({"prompts": prompts}, ensure_ascii=False)
+            return json.dumps(
+                _redact_mcp_tool_payload({"prompts": prompts}),
+                ensure_ascii=False,
+            )
 
         def _call_once():
             return _run_on_mcp_loop(_call, timeout=tool_timeout)
@@ -5258,12 +5559,11 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
             )
             if recovered is not None:
                 return recovered
+            safe_error = _safe_exc_str(exc)
             logger.error(
-                "MCP %s/list_prompts failed: %s", server_name, exc,
+                "MCP %s/list_prompts failed: %s", server_name, safe_error,
             )
-            return tool_error(_sanitize_error(
-                f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
-            ))
+            return tool_error(f"MCP call failed: {safe_error}")
 
     return _handler
 
@@ -5303,7 +5603,7 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
             resp = {"messages": messages}
             if hasattr(result, "description") and result.description:
                 resp["description"] = result.description
-            return json.dumps(resp, ensure_ascii=False)
+            return json.dumps(_redact_mcp_tool_payload(resp), ensure_ascii=False)
 
         def _call_once():
             return _run_on_mcp_loop(_call, timeout=tool_timeout)
@@ -5323,12 +5623,11 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
             )
             if recovered is not None:
                 return recovered
+            safe_error = _safe_exc_str(exc)
             logger.error(
-                "MCP %s/get_prompt failed: %s", server_name, exc,
+                "MCP %s/get_prompt failed: %s", server_name, safe_error,
             )
-            return tool_error(_sanitize_error(
-                f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
-            ))
+            return tool_error(f"MCP call failed: {safe_error}")
 
     return _handler
 
@@ -6655,7 +6954,11 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
 
         for name, outcome in zip(names, outcomes):
             if isinstance(outcome, Exception):
-                logger.debug("Probe: failed to connect to '%s': %s", name, outcome)
+                logger.debug(
+                    "Probe: failed to connect to '%s': %s",
+                    name,
+                    _safe_exc_str(outcome),
+                )
                 continue
             probed_servers.append(outcome)
             tools = []
@@ -6673,7 +6976,7 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
     try:
         _run_on_mcp_loop(_probe_all, timeout=120)
     except Exception as exc:
-        logger.debug("MCP probe failed: %s", exc)
+        logger.debug("MCP probe failed: %s", _safe_exc_str(exc))
     finally:
         _stop_mcp_loop_if_idle()
 
@@ -6877,8 +7180,11 @@ def _reinject_post_build_tools(agent, tools_list: list, name_set: set) -> set:
                 for schema in get_mem_schemas():
                     if isinstance(schema, dict):
                         _add(schema)
-    except Exception:
-        logger.debug("Memory-provider tool re-injection skipped", exc_info=True)
+    except Exception as exc:
+        logger.debug(
+            "Memory-provider tool re-injection skipped: %s",
+            _safe_exc_str(exc),
+        )
 
     # Context-engine tools (lcm_grep/lcm_describe/…) — the `context_engine`
     # toolset is intentionally empty, so these only exist via this append.
@@ -6902,8 +7208,11 @@ def _reinject_post_build_tools(agent, tools_list: list, name_set: set) -> set:
                 # dispatch (matches agent_init.py's `continue`-before-claim).
                 if _add(schema) and name:
                     staged_engine_names.add(name)
-    except Exception:
-        logger.debug("Context-engine tool re-injection skipped", exc_info=True)
+    except Exception as exc:
+        logger.debug(
+            "Context-engine tool re-injection skipped: %s",
+            _safe_exc_str(exc),
+        )
 
     return staged_engine_names
 
@@ -6939,7 +7248,9 @@ def shutdown_mcp_servers():
         for server, result in zip(servers_snapshot, results):
             if isinstance(result, Exception):
                 logger.debug(
-                    "Error closing MCP server '%s': %s", server.name, result,
+                    "Error closing MCP server '%s': %s",
+                    server.name,
+                    _safe_exc_str(result),
                 )
         with _lock:
             _servers.clear()
@@ -6962,7 +7273,7 @@ def shutdown_mcp_servers():
             try:
                 future.result(timeout=15)
             except BaseException as exc:
-                logger.debug("Error during MCP shutdown: %s", exc)
+                logger.debug("Error during MCP shutdown: %s", _safe_exc_str(exc))
 
     # Unconditional final sweep: whether the async ``_shutdown`` ran,
     # timed out, or was never scheduled (loop already stopped), a full
@@ -7073,7 +7384,7 @@ def _kill_orphaned_mcp_children(
                     # the per-pid path so we still try the direct child if alive.
                     logger.debug(
                         "killpg(%d, %d) failed for MCP server '%s': %s; falling back to kill(pid)",
-                        pgid, sig, server_name, exc,
+                        pgid, sig, server_name, _safe_exc_str(exc),
                     )
         try:
             os.kill(pid, sig)
@@ -7143,7 +7454,10 @@ async def _drain_mcp_loop_tasks(
         except asyncio.CancelledError:
             pass
         except Exception as exc:
-            logger.debug("Pending MCP loop task ended during shutdown: %s", exc)
+            logger.debug(
+                "Pending MCP loop task ended during shutdown: %s",
+                _safe_exc_str(exc),
+            )
 
     if still_pending:
         logger.warning(
@@ -7204,14 +7518,17 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
                         _MCP_LOOP_DRAIN_TIMEOUT + 1,
                     )
                 except BaseException as exc:
-                    logger.warning("Error draining MCP loop tasks: %s", exc)
+                    logger.warning("Error draining MCP loop tasks: %s", _safe_exc_str(exc))
         elif not loop.is_closed():
             try:
                 loop.run_until_complete(
                     _drain_mcp_loop_tasks(timeout=_MCP_LOOP_DRAIN_TIMEOUT)
                 )
             except BaseException as exc:
-                logger.warning("Error draining stopped MCP loop tasks: %s", exc)
+                logger.warning(
+                    "Error draining stopped MCP loop tasks: %s",
+                    _safe_exc_str(exc),
+                )
 
         if not stop_owned_by_loop and loop.is_running():
             loop.call_soon_threadsafe(loop.stop)
@@ -7222,7 +7539,10 @@ def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
         try:
             loop.close()
         except Exception as exc:
-            logger.warning("Unable to close MCP event loop cleanly: %s", exc)
+            logger.warning(
+                "Unable to close MCP event loop cleanly: %s",
+                _safe_exc_str(exc),
+            )
         # After closing the loop, any stdio subprocesses that survived the
         # graceful shutdown are now orphaned — include active PIDs too
         # since the loop is gone and no session can still be in flight.

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5380,7 +5380,9 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             )
             logger.error(
                 "MCP tool %s/%s call failed: %s",
-                server_name, tool_name, safe_error,
+                _sanitize_error(server_name),
+                _sanitize_error(tool_name),
+                safe_error,
             )
             return tool_error(safe_error)
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3025,8 +3025,8 @@ class MCPServerTask:
             raise eg
         logger.debug(
             "MCP server '%s': transport TaskGroup exited after a live session "
-            "(%r) — reconnecting immediately instead of backing off",
-            self.name, eg,
+            "(%s) — reconnecting immediately instead of backing off",
+            self.name, _safe_exc_str(eg),
         )
         return "reconnect"
 
@@ -5003,7 +5003,7 @@ async def _connect_server(name: str, config: dict) -> MCPServerTask:
             except Exception as shutdown_exc:  # noqa: BLE001 -- best-effort reap, don't mask the real error
                 logger.debug(
                     "MCP server '%s' shutdown during orphan-reap failed: %s",
-                    name, shutdown_exc,
+                    name, _safe_exc_str(shutdown_exc),
                 )
         raise
     finally:
@@ -6317,7 +6317,11 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
                 utility_tools=utility_payload,
             )
         except Exception as exc:
-            logger.debug("MCP schema cache write failed for '%s': %s", name, exc)
+            logger.debug(
+                "MCP schema cache write failed for '%s': %s",
+                name,
+                _safe_exc_str(exc),
+            )
 
     return registered_names
 
@@ -6613,7 +6617,9 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                 names = _register_from_cache_sync(name, cfg, entry)
             except Exception as exc:
                 logger.warning(
-                    "Failed lazy MCP registration for '%s': %s", name, exc,
+                    "Failed lazy MCP registration for '%s': %s",
+                    name,
+                    _safe_exc_str(exc),
                 )
                 with _lock:
                     _server_connecting.add(name)

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -822,6 +822,38 @@ Every `hermes kanban <action>` verb is also reachable as `/kanban <action>` — 
 
 Quote multi-word arguments the same way you would on a shell — `run_slash` parses the rest of the line with `shlex.split`, so `"..."` and `'...'` both work.
 
+### Worker-log security and upgrade behavior
+
+Worker logs are raw subprocess output and may contain data that a pattern-based
+secret redactor does not recognize. Hermes therefore creates Kanban log
+directories with mode `0700` and log files with mode `0600` on POSIX systems.
+On the first worker spawn after an upgrade, the active board's existing worker
+log directory and retained regular `*.log*` files are tightened to those modes.
+Symlinks in the worker-log path, hard-linked log files, or any non-regular active
+or retained log path fail closed instead of redirecting output or permission
+changes outside the board log directory. This includes FIFOs, which are rejected
+without waiting for a reader. These no-follow, hard-link, and mode guarantees are
+POSIX-specific. On Windows, Python does not expose an equivalent no-follow open
+for reparse points, so the log tree must be protected by filesystem ACLs; Hermes
+uses those ACLs and avoids holding log handles open across rotation.
+
+MCP tool results are redacted before they enter agent context or worker output;
+this includes nested and JSON-encoded structured content, credential-named fields, WordPress
+`option_name` / `option_value` rows, and credential-like text in plain-text and
+embedded-resource blocks. This layer follows Hermes' global redaction setting,
+which is enabled by default; explicitly disabling redaction also disables the
+normal MCP result layer. MCP error diagnostics remain force-sanitized because
+they may be persisted to logs.
+
+The messaging-gateway form `/kanban log <id>` requires the caller to be listed
+as an explicit admin for the current DM or group scope. It fails closed when no
+admin list is configured, even though other slash commands remain unrestricted
+in that legacy configuration. Configure `allow_admin_from` for DMs or
+`group_allow_admin_from` for groups/channels. The local CLI command
+`hermes kanban log <id>` and authenticated dashboard access are unchanged.
+Kanban also disables argparse long-option abbreviations: use the complete
+`--board` flag rather than shortened forms such as `--bo`.
+
 ### Mid-run usage: `/kanban` bypasses the running-agent guard
 
 The gateway normally queues slash commands and user messages while an agent is still thinking — that's what stops you from accidentally starting a second turn while the first is in flight. **`/kanban` is explicitly exempted from this guard.** The board lives in `~/.hermes/kanban.db`, not in the running agent's state, so reads (`list`, `show`, `context`, `tail`, `watch`, `stats`, `runs`) and writes (`comment`, `unblock`, `block`, `assign`, `archive`, `create`, `link`, …) all go through immediately, even mid-turn.


### PR DESCRIPTION
## Summary

This PR hardens three related trust boundaries without changing normal local CLI or authenticated dashboard behavior:

- protect Kanban worker-log creation, rotation, and reads against unsafe permissions, non-regular files, path escapes, symlink/hard-link aliases, and path/inode swaps
- require explicit scoped gateway admin authorization before raw Kanban log access and fail closed on malformed policy/caller data
- extend MCP and WordPress payload redaction across structured, JSON, resource, prompt, success, error, lifecycle, and reconnect paths, including camelCase/PascalCase credential fields

It also disables long-option abbreviation across the Kanban parser tree and documents the platform-specific log guarantees.

## Compatibility

- Local CLI and authenticated dashboard log access remain available.
- Gateway raw-log access requires an explicitly configured admin in the recognized current scope.
- Redaction opt-out preserves original object identity and exact JSON text.
- The MCP changes extend the current lazy-startup/schema-cache architecture rather than replacing it.
- POSIX receives descriptor-based permission/link/inode enforcement; Windows retains the documented ACL/regular-file guarantee.

## Verification

- 727 focused tests passed across the full MCP test set plus redaction, gateway, and Kanban suites
- Ruff passed over all changed Python production and test files
- `git diff --check` passed
- clean worktree and exact patch digest were verified
- independent fail-closed security review passed after fixes for all reported boundary gaps

No deployment, service restart, release, configuration change, or credential action is included in this PR.