### PR TITLE
fix(backup): serialize and atomically publish snapshots (salvage #69411)

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -15,8 +15,10 @@ import shutil
 import sqlite3
 import sys
 import tempfile
+import threading
 import time
 import zipfile
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -84,6 +86,7 @@ _EXCLUDED_SUFFIXES = (
 
 # File names to skip (runtime state that's meaningless on another machine)
 _EXCLUDED_NAMES = {
+    ".backup.lock",
     "gateway.pid",
     "cron.pid",
 }
@@ -130,6 +133,85 @@ _SECRET_FILE_NAMES = {".env", "auth.json", "state.db"}
 # relative to the user's home directory, and restored to their original
 # home-relative location on import. Anything not under home is skipped.
 _EXTERNAL_PREFIX = "_external/"
+
+
+class BackupInProgressError(RuntimeError):
+    """Raised when another process already owns the Hermes backup slot."""
+
+
+class _SQLiteSnapshotError(RuntimeError):
+    pass
+
+
+@contextmanager
+def _backup_operation_lock(hermes_home: Path, timeout_seconds: float = 0.25):
+    """Acquire one cross-process backup slot for full and quick snapshots."""
+    lock_path = hermes_home / ".backup.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("a+b")
+    acquired = False
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            if lock_path.stat().st_size == 0:
+                handle.write(b" ")
+                handle.flush()
+            while True:
+                try:
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                    acquired = True
+                    break
+                except (OSError, PermissionError):
+                    if time.monotonic() >= deadline:
+                        raise BackupInProgressError("another Hermes backup is already running")
+                    time.sleep(0.05)
+        else:
+            import fcntl
+
+            while True:
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    acquired = True
+                    break
+                except (BlockingIOError, OSError):
+                    if time.monotonic() >= deadline:
+                        raise BackupInProgressError("another Hermes backup is already running")
+                    time.sleep(0.05)
+
+        yield
+    finally:
+        if acquired:
+            try:
+                if os.name == "nt":
+                    import msvcrt
+
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            except (OSError, PermissionError):
+                pass
+        handle.close()
+
+
+@contextmanager
+def _atomic_output_path(final_path: Path):
+    """Yield a hidden sibling path and publish it only after a clean close."""
+    partial_path = final_path.with_name(
+        f".{final_path.name}.{os.getpid()}-{threading.get_ident()}.partial"
+    )
+    partial_path.unlink(missing_ok=True)
+    try:
+        yield partial_path
+        os.replace(partial_path, final_path)
+    except BaseException:
+        partial_path.unlink(missing_ok=True)
+        raise
 
 
 def _collect_memory_provider_external_paths() -> List[Path]:
@@ -509,6 +591,17 @@ def run_backup(args) -> None:
         print(f"Error: Hermes home directory not found at {hermes_root}")
         sys.exit(1)
 
+    try:
+        with _backup_operation_lock(hermes_root):
+            _run_backup_locked(args, hermes_root)
+    except BackupInProgressError as exc:
+        print(f"Error: {exc}")
+        raise SystemExit(2) from exc
+
+
+def _run_backup_locked(args, hermes_root: Path) -> None:
+    """Write a full backup while the cross-process backup slot is held."""
+
     # Determine output path
     if args.output:
         out_path = Path(args.output).expanduser().resolve()
@@ -528,6 +621,8 @@ def run_backup(args) -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Collect files
+    scan_started = time.monotonic()
+    logger.info("backup phase=scan status=started")
     print(f"Scanning {display_hermes_home()} ...")
     files_to_add: list[tuple[Path, Path]] = []  # (absolute, relative)
     skipped_dirs = set()
@@ -582,18 +677,30 @@ def run_backup(args) -> None:
             external_to_add.append((fpath, arcname))
 
     if not files_to_add and not external_to_add:
+        logger.info(
+            "backup phase=scan status=empty duration_ms=%.1f",
+            (time.monotonic() - scan_started) * 1000,
+        )
         print("No files to back up.")
         return
 
     # Create the zip
     file_count = len(files_to_add) + len(external_to_add)
+    logger.info(
+        "backup phase=scan status=complete duration_ms=%.1f files=%d",
+        (time.monotonic() - scan_started) * 1000,
+        file_count,
+    )
+    logger.info("backup phase=archive status=started files=%d", file_count)
     print(f"Backing up {file_count} files ...")
 
     total_bytes = 0
     errors = []
     t0 = time.monotonic()
 
-    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+    with _atomic_output_path(out_path) as archive_path, zipfile.ZipFile(
+        archive_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6
+    ) as zf:
         for i, (abs_path, rel_path) in enumerate(files_to_add, 1):
             try:
                 # Safe copy for SQLite databases (handles WAL mode)
@@ -624,6 +731,11 @@ def run_backup(args) -> None:
             # Progress every 500 files
             if i % 500 == 0:
                 print(f"  {i}/{file_count} files ...")
+                logger.info(
+                    "backup phase=archive status=progress completed=%d total=%d",
+                    i,
+                    file_count,
+                )
 
         # External memory-provider state, stored under the ``_external/`` arc
         # prefix. These never include ``.db`` files in practice (config/env
@@ -638,6 +750,13 @@ def run_backup(args) -> None:
 
     elapsed = time.monotonic() - t0
     zip_size = out_path.stat().st_size
+    logger.info(
+        "backup phase=archive status=complete duration_ms=%.1f files=%d errors=%d bytes=%d",
+        elapsed * 1000,
+        file_count,
+        len(errors),
+        zip_size,
+    )
 
     # Summary
     print()
@@ -1014,6 +1133,23 @@ def create_quick_snapshot(
     keep: Optional[int] = None,
     max_file_size: Optional[int] = None,
 ) -> Optional[str]:
+    """Create one atomic quick snapshot while holding the shared backup slot."""
+    home = hermes_home or get_hermes_home()
+    with _backup_operation_lock(home):
+        return _create_quick_snapshot_locked(
+            label=label,
+            hermes_home=home,
+            keep=keep,
+            max_file_size=max_file_size,
+        )
+
+
+def _create_quick_snapshot_locked(
+    label: Optional[str] = None,
+    hermes_home: Optional[Path] = None,
+    keep: Optional[int] = None,
+    max_file_size: Optional[int] = None,
+) -> Optional[str]:
     """Create a quick state snapshot of critical files.
 
     Copies STATE_FILES to a timestamped directory under state-snapshots/.
@@ -1058,9 +1194,17 @@ def create_quick_snapshot(
         return True
 
     ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    snap_id = f"{ts}-{label}" if label else ts
+    base_snap_id = f"{ts}-{label}" if label else ts
+    snap_id = base_snap_id
+    suffix = 2
+    while (root / snap_id).exists():
+        snap_id = f"{base_snap_id}-{suffix}"
+        suffix += 1
     snap_dir = root / snap_id
-    snap_dir.mkdir(parents=True, exist_ok=True)
+    staging_dir = root / f".{snap_id}.{os.getpid()}.partial"
+    shutil.rmtree(staging_dir, ignore_errors=True)
+    staging_dir.mkdir(parents=True, exist_ok=False)
+    logger.info("quick snapshot phase=copy status=started id=%s", snap_id)
 
     manifest: Dict[str, int] = {}  # rel_path -> file size
     failed_dbs: list[str] = []  # present *.db that could not be snapshotted
@@ -1092,7 +1236,7 @@ def create_quick_snapshot(
                     if sub.suffix == ".db":
                         oversized_skipped.append(sub_rel)
                     continue
-                dst = snap_dir / sub_rel
+                dst = staging_dir / sub_rel
                 dst.parent.mkdir(parents=True, exist_ok=True)
                 try:
                     # Route SQLite DBs through the WAL-safe backup() path so a
@@ -1126,7 +1270,7 @@ def create_quick_snapshot(
                 oversized_skipped.append(rel)
             continue
 
-        dst = snap_dir / rel
+        dst = staging_dir / rel
         dst.parent.mkdir(parents=True, exist_ok=True)
 
         try:
@@ -1167,7 +1311,7 @@ def create_quick_snapshot(
         )
 
     if not manifest:
-        shutil.rmtree(snap_dir, ignore_errors=True)
+        shutil.rmtree(staging_dir, ignore_errors=True)
         if failed_dbs:
             # Distinguish "nothing to snapshot" from "state.db present but unreadable"
             print(
@@ -1187,8 +1331,10 @@ def create_quick_snapshot(
         "failed_dbs": failed_dbs,
         "oversized_skipped": oversized_skipped,
     }
-    with open(snap_dir / "manifest.json", "w", encoding="utf-8") as f:
+    with open(staging_dir / "manifest.json", "w", encoding="utf-8") as f:
         json.dump(meta, f, indent=2)
+
+    os.replace(staging_dir, snap_dir)
 
     # Auto-prune. Defaults preserve historical manual /snapshot behavior; callers
     # with known high-churn safety snapshots (for example pre-update) can pass a
@@ -1216,7 +1362,12 @@ def create_quick_snapshot(
             len(failed_dbs), len(oversized_skipped),
         )
 
-    logger.info("State snapshot created: %s (%d files)", snap_id, len(manifest))
+    logger.info(
+        "quick snapshot phase=copy status=complete id=%s files=%d bytes=%d",
+        snap_id,
+        len(manifest),
+        sum(manifest.values()),
+    )
     return snap_id
 
 
@@ -1231,7 +1382,7 @@ def list_quick_snapshots(
 
     results = []
     for d in sorted(root.iterdir(), reverse=True):
-        if not d.is_dir():
+        if not d.is_dir() or d.name.startswith(".") or d.name.endswith(".partial"):
             continue
         manifest_path = d / "manifest.json"
         if manifest_path.exists():
@@ -1440,7 +1591,11 @@ def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:
         return 0
 
     dirs = sorted(
-        (d for d in root.iterdir() if d.is_dir()),
+        (
+            d
+            for d in root.iterdir()
+            if d.is_dir() and not d.name.startswith(".") and not d.name.endswith(".partial")
+        ),
         key=lambda d: d.name,
         reverse=True,
     )
@@ -1482,12 +1637,24 @@ def run_quick_backup(args) -> None:
 # ---------------------------------------------------------------------------
 
 def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
+    """Single-flight wrapper for automatic full zip backups."""
+    try:
+        with _backup_operation_lock(hermes_root):
+            return _write_full_zip_backup_locked(out_path, hermes_root)
+    except BackupInProgressError as exc:
+        logger.warning("Full-zip backup skipped: %s", exc)
+        return None
+
+
+def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional[Path]:
     """Write a full zip snapshot of ``hermes_root`` to ``out_path``.
 
     Uses the same exclusion rules and SQLite safe-copy as :func:`run_backup`.
     Returns the output path on success, None on failure (nothing to back up,
     or write error — caller should surface the outcome but not raise).
     """
+    scan_started = time.monotonic()
+    logger.info("automatic backup phase=scan status=started")
     files_to_add: list[tuple[Path, Path]] = []
     try:
         for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
@@ -1513,10 +1680,18 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
     if not files_to_add:
         return None
 
-    sqlite_snapshot_failed = False
+    logger.info(
+        "automatic backup phase=scan status=complete duration_ms=%.1f files=%d",
+        (time.monotonic() - scan_started) * 1000,
+        len(files_to_add),
+    )
+
+    archive_started = time.monotonic()
     try:
-        with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
-            for abs_path, rel_path in files_to_add:
+        with _atomic_output_path(out_path) as archive_path, zipfile.ZipFile(
+            archive_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6
+        ) as zf:
+            for index, (abs_path, rel_path) in enumerate(files_to_add, 1):
                 try:
                     if abs_path.suffix == ".db":
                         # Stage the snapshot alongside the output zip so that the
@@ -1533,8 +1708,7 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
                                     "Full-zip backup aborted: SQLite snapshot failed for %s",
                                     rel_path,
                                 )
-                                sqlite_snapshot_failed = True
-                                break
+                                raise _SQLiteSnapshotError(str(rel_path))
                             zf.write(tmp_db, arcname=str(rel_path))
                         finally:
                             tmp_db.unlink(missing_ok=True)
@@ -1543,21 +1717,25 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
                 except (PermissionError, OSError, ValueError) as exc:
                     logger.debug("Skipping %s in zip backup: %s", rel_path, exc)
                     continue
-    except OSError as exc:
+                if index % 500 == 0:
+                    logger.info(
+                        "automatic backup phase=archive status=progress completed=%d total=%d",
+                        index,
+                        len(files_to_add),
+                    )
+    except (OSError, _SQLiteSnapshotError) as exc:
         logger.warning("Full-zip backup: zip write failed: %s", exc)
-        # Best-effort cleanup of partial file
-        try:
-            out_path.unlink(missing_ok=True)
-        except OSError:
-            pass
+        # ``_atomic_output_path`` already removed the hidden partial.  Do not
+        # unlink ``out_path`` here: it may be a previous valid backup that the
+        # atomic publisher deliberately preserved.
         return None
 
-    if sqlite_snapshot_failed:
-        try:
-            out_path.unlink(missing_ok=True)
-        except OSError:
-            pass
-        return None
+    logger.info(
+        "automatic backup phase=archive status=complete duration_ms=%.1f files=%d bytes=%d",
+        (time.monotonic() - archive_started) * 1000,
+        len(files_to_add),
+        out_path.stat().st_size,
+    )
 
     return out_path
 

--- a/tests/hermes_cli/test_backup_stability.py
+++ b/tests/hermes_cli/test_backup_stability.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.backup import (
+    BackupInProgressError,
+    _atomic_output_path,
+    _backup_operation_lock,
+    _write_full_zip_backup,
+    create_quick_snapshot,
+    list_quick_snapshots,
+)
+
+
+def test_backup_lock_rejects_a_second_operation(tmp_path) -> None:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+
+    with _backup_operation_lock(home):
+        with pytest.raises(BackupInProgressError):
+            with _backup_operation_lock(home, timeout_seconds=0):
+                raise AssertionError("second backup unexpectedly acquired the lock")
+
+
+def test_atomic_output_publishes_only_after_clean_close(tmp_path) -> None:
+    final = tmp_path / "backup.zip"
+    final.write_bytes(b"previous")
+
+    with _atomic_output_path(final) as partial:
+        partial.write_bytes(b"complete")
+        assert final.read_bytes() == b"previous"
+
+    assert final.read_bytes() == b"complete"
+    assert not partial.exists()
+
+
+def test_atomic_output_keeps_previous_file_after_failure(tmp_path) -> None:
+    final = tmp_path / "backup.zip"
+    final.write_bytes(b"previous")
+
+    with pytest.raises(RuntimeError):
+        with _atomic_output_path(final) as partial:
+            partial.write_bytes(b"incomplete")
+            raise RuntimeError("compression failed")
+
+    assert final.read_bytes() == b"previous"
+    assert not partial.exists()
+
+
+def test_quick_snapshot_is_published_with_manifest(tmp_path, monkeypatch) -> None:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+    published: list[tuple[Path, Path]] = []
+
+    from hermes_cli import backup
+
+    real_replace = backup.os.replace
+
+    def replace(source, destination) -> None:
+        source_path = Path(source)
+        destination_path = Path(destination)
+        if destination_path.parent == home / "state-snapshots":
+            assert source_path.name.endswith(".partial")
+            assert (source_path / "manifest.json").is_file()
+            assert not destination_path.exists()
+            published.append((source_path, destination_path))
+        real_replace(source, destination)
+
+    monkeypatch.setattr(backup.os, "replace", replace)
+    snapshot_id = create_quick_snapshot(hermes_home=home)
+
+    assert snapshot_id is not None
+    assert len(published) == 1
+    manifest = json.loads(
+        (home / "state-snapshots" / snapshot_id / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["id"] == snapshot_id
+    assert manifest["files"] == {"config.yaml": 10}
+
+
+def test_quick_snapshot_listing_ignores_partial_directories(tmp_path) -> None:
+    home = tmp_path / ".hermes"
+    partial = home / "state-snapshots" / ".unfinished.1.partial"
+    partial.mkdir(parents=True)
+    (partial / "manifest.json").write_text('{"id":"unfinished"}', encoding="utf-8")
+
+    assert list_quick_snapshots(hermes_home=home) == []
+
+
+def test_failed_automatic_backup_preserves_previous_archive(tmp_path, monkeypatch) -> None:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "state.db").write_bytes(b"not-a-database")
+    archive = tmp_path / "automatic.zip"
+    archive.write_bytes(b"previous-valid-backup")
+
+    monkeypatch.setattr("hermes_cli.backup._safe_copy_db", lambda _src, _dst: False)
+
+    assert _write_full_zip_backup(archive, home) is None
+    assert archive.read_bytes() == b"previous-valid-backup"
+    assert list(tmp_path.glob(".*.partial")) == []


### PR DESCRIPTION
Salvages the backup-safety commit of #69411 by @Hao Wang — cherry-picked with authorship preserved.

## Context — what this fixes, for whom

Anyone with automatic backups + manual snapshots: `run_backup`, `create_quick_snapshot`, and the automatic full-zip path could run CONCURRENTLY (gateway auto-backup firing while a user runs /snapshot), interleaving SQLite safe-copies and half-written snapshot directories. The commit adds a shared cross-process backup lock (`_backup_operation_lock`, lockfile + BackupInProgressError) and atomic publication: snapshots build in a staging dir and rename into place, so a crashed backup can never leave a half-snapshot that restore would trust.

## Scope decisions (bundle split — the PR carries 4 distinct concerns)

Kept: the backup commit (f0fcaf50c: 241 lines backup.py + 105-line stability test file), the concern with the clearest bug and cleanest boundary.
Adaptations:
- One conflict: main's snapshot path gained a failed-DBs abort message after the PR's base; kept main's message with the PR's staging_dir cleanup.
- Stripped the `track_activity("backup", ...)` telemetry wrappers — they import `hermes_cli.perf_diagnostics`, a module introduced by a DIFFERENT commit of the bundle (e304e97cc) that isn't salvaged here. The locking (the actual fix) is fully preserved; the telemetry can ride with a future perf_diagnostics PR.
Dropped for separate consideration (documented in the close comment):
- Desktop startup-queue + prewarm removal (74c99e182, 0409d5107): removal of the hover-intent prewarm feature is a maintainer taste call, and the desktop stores drifted on main
- Model discovery latency + perf_diagnostics module (e304e97cc): touches tui_gateway/server.py + ws.py which this campaign just modified (#77814); needs its own review against the new warm-list

## Verification

- `tests/hermes_cli/test_backup_stability.py`: 6 passed (concurrent-backup serialization, atomic publish, staging cleanup)
- Full backup suite: 46 passed
- Mutation check: revert backup.py to main → error; restore → 6 passed
- ruff clean

Closes #69411 (backup core superseded by this salvage — original author credited via cherry-pick authorship; remaining concerns documented for re-proposal).
