### PR TITLE
fix(gateway): typing refresh loop exits once its turn stops it, even if the cancel is lost

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3312,6 +3312,14 @@ class BasePlatformAdapter(ABC):
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
         self._typing_paused: set = set()
+        # Live _keep_typing tasks.  A loop registers itself on start and
+        # re-checks its membership every tick; _stop_typing_refresh removes
+        # the task it was handed *before* cancelling it.  That gives the loop
+        # a second stop signal that survives a lost cancellation: on Python
+        # 3.11 asyncio.wait_for drops an external cancel() that lands in the
+        # same loop iteration as send_typing() completing (CPython gh-86296),
+        # after which nothing else would ever stop the refresh loop.
+        self._typing_refresh_tasks: set = set()
         # Dynamic working-state status text per chat (chat_id -> phrase).
         # Set by the gateway on tool starts ("is running pytest…") and read
         # by adapters whose typing indicator renders text (Slack's
@@ -5461,8 +5469,21 @@ class BasePlatformAdapter(ABC):
         # gated on network health.  Must stay below ``interval`` so a slow
         # call gets abandoned before the next scheduled tick.
         _send_typing_timeout = max(0.25, min(1.5, interval - 0.25))
+        # Register as a live loop.  getattr-guard: bare object.__new__()
+        # adapters in tests may lack the set (same idiom as _status_text).
+        live = getattr(self, "_typing_refresh_tasks", None)
+        if live is None:
+            live = set()
+            self._typing_refresh_tasks = live
+        me = asyncio.current_task()
+        live.add(me)
         try:
             while True:
+                if me not in live:
+                    # _stop_typing_refresh already stopped this turn's loop
+                    # and the cancel() it sent was lost — exit here instead
+                    # of refreshing a turn that no longer exists.
+                    return
                 if stop_event is not None and stop_event.is_set():
                     return
                 if chat_id not in self._typing_paused:
@@ -5501,6 +5522,7 @@ class BasePlatformAdapter(ABC):
         except asyncio.CancelledError:
             pass  # Normal cancellation when handler completes
         finally:
+            live.discard(me)
             # Ensure the underlying platform typing loop is stopped.
             # _keep_typing may have called send_typing() after an outer
             # stop_typing() cleared the task dict, recreating the loop.
@@ -5526,6 +5548,15 @@ class BasePlatformAdapter(ABC):
         stop_attempts: int = 2,
     ) -> None:
         """Stop the refresh task and platform typing state as one operation."""
+        # Deregister the loop *before* cancelling it so it exits on its next
+        # tick even if the cancel() below never reaches it (Python 3.11
+        # wait_for can lose a cancel that races send_typing() completing;
+        # an adapter's send_typing may swallow it).  Only the task this turn
+        # was handed is touched: other live loops for the same chat_id
+        # belong to concurrent sessions (per-user group sessions, Slack
+        # threads sharing a channel) and must keep running.
+        if typing_task is not None:
+            getattr(self, "_typing_refresh_tasks", set()).discard(typing_task)
         self._typing_paused.add(chat_id)
         try:
             if typing_task is not None and not typing_task.done():

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2839,6 +2839,12 @@ class BasePlatformAdapter(ABC):
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
         self._typing_paused: set = set()
+        # At most one live _keep_typing loop per chat (chat_id -> owning task).
+        # A loop claims its chat on start and re-checks the claim every tick,
+        # so a refresh task that leaks past its turn (cancellation lost in a
+        # shutdown race) self-terminates as soon as it is stopped or a newer
+        # turn's loop supersedes it, instead of refreshing typing forever.
+        self._typing_refresh_owners: Dict[str, asyncio.Task] = {}
         # Dynamic working-state status text per chat (chat_id -> phrase).
         # Set by the gateway on tool starts ("is running pytest…") and read
         # by adapters whose typing indicator renders text (Slack's
@@ -4705,8 +4711,22 @@ class BasePlatformAdapter(ABC):
         # gated on network health.  Must stay below ``interval`` so a slow
         # call gets abandoned before the next scheduled tick.
         _send_typing_timeout = max(0.25, min(1.5, interval - 0.25))
+        # Claim this chat's refresh slot and re-check the claim every tick.
+        # getattr-guard: bare object.__new__() adapters in tests may lack the
+        # dict (same idiom as _status_text below).
+        owners = getattr(self, "_typing_refresh_owners", None)
+        if owners is None:
+            owners = {}
+            self._typing_refresh_owners = owners
+        me = asyncio.current_task()
+        owners[str(chat_id)] = me
         try:
             while True:
+                if owners.get(str(chat_id)) is not me:
+                    # Superseded by a newer turn's loop, or stopped via
+                    # _stop_typing_refresh — exit instead of refreshing a
+                    # turn that no longer exists.
+                    return
                 if stop_event is not None and stop_event.is_set():
                     return
                 if chat_id not in self._typing_paused:
@@ -4745,11 +4765,17 @@ class BasePlatformAdapter(ABC):
         except asyncio.CancelledError:
             pass  # Normal cancellation when handler completes
         finally:
+            # Only the current owner may clear platform typing state — a
+            # superseded loop clearing it would stomp the newer turn's live
+            # indicator.
+            still_owner = owners.get(str(chat_id)) is me
+            if still_owner:
+                owners.pop(str(chat_id), None)
             # Ensure the underlying platform typing loop is stopped.
             # _keep_typing may have called send_typing() after an outer
             # stop_typing() cleared the task dict, recreating the loop.
             # Cancelling _keep_typing alone won't clean that up.
-            if hasattr(self, "stop_typing"):
+            if still_owner and hasattr(self, "stop_typing"):
                 try:
                     await self._stop_typing_with_metadata(chat_id, metadata)
                 except Exception:
@@ -4770,6 +4796,17 @@ class BasePlatformAdapter(ABC):
         stop_attempts: int = 2,
     ) -> None:
         """Stop the refresh task and platform typing state as one operation."""
+        # Revoke the stopped task's ownership claim so a refresh loop that
+        # somehow survives cancellation self-terminates on its next tick
+        # instead of typing forever. A claim held by a different live task
+        # (a newer turn already running) is left alone.
+        owners = getattr(self, "_typing_refresh_owners", None)
+        if owners is not None:
+            current = owners.get(str(chat_id))
+            if current is not None and (
+                typing_task is None or current is typing_task or current.done()
+            ):
+                owners.pop(str(chat_id), None)
         self._typing_paused.add(chat_id)
         try:
             if typing_task is not None and not typing_task.done():

--- a/tests/gateway/test_typing_refresh_lost_cancel.py
+++ b/tests/gateway/test_typing_refresh_lost_cancel.py
@@ -1,0 +1,172 @@
+"""Tests for BasePlatformAdapter._keep_typing surviving a lost cancel().
+
+The bug: ``_keep_typing`` (gateway/platforms/base.py) trusts that the
+``cancel()`` sent by ``_stop_typing_refresh`` reaches it.  When that cancel
+is lost, the orphaned loop keeps refreshing the platform typing indicator
+on its 2-second cadence with nothing left to stop it: ``_stop_typing_refresh``
+gives up its bounded wait after 0.5s, un-pauses the chat, and the session's
+``stop_event`` is only ever set by a user interrupt.  Observed in production
+(Python 3.11, Matrix): a leaked refresh task hammered the homeserver's
+``PUT /typing`` every 2 seconds for over three hours after its turn had
+ended normally, pinning every client's "working" indicator.
+
+Two real ways the cancel gets lost, both exercised below by one stub:
+
+* Python 3.11's ``asyncio.wait_for`` returns the inner result and drops an
+  external ``cancel()`` that lands in the same loop iteration as the inner
+  awaitable completing (CPython gh-86296; rewritten in 3.12).  The per-tick
+  ``wait_for(self.send_typing(...))`` in ``_keep_typing`` is exactly that
+  shape, so any turn whose cleanup coincides with a ``send_typing``
+  round-trip finishing can leak its loop.
+* An adapter or client library that catches ``CancelledError`` inside
+  ``send_typing`` swallows the cancel on any Python version.
+
+The fix: ``_keep_typing`` registers itself in ``_typing_refresh_tasks`` and
+re-checks its membership every tick; ``_stop_typing_refresh`` removes the
+task it was handed *before* cancelling it.  A loop whose cancel was lost
+exits on its next tick instead of refreshing forever.  Only the handed-in
+task is touched: other live loops for the same chat_id belong to concurrent
+sessions (per-user group sessions, Slack threads sharing a channel) and
+must keep running.
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    Platform,
+    PlatformConfig,
+    SendResult,
+)
+
+
+class _StubAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+        self.send_typing_calls = 0
+        self.stop_typing_calls = 0
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="m1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+    async def send_typing(self, chat_id, metadata=None):
+        self.send_typing_calls += 1
+
+    async def stop_typing(self, chat_id):
+        self.stop_typing_calls += 1
+
+
+async def _drain(*tasks):
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def _finished(task: asyncio.Task, timeout: float = 2.0) -> bool:
+    """True if ``task`` completes within ``timeout``.
+
+    Uses ``asyncio.wait`` rather than ``wait_for``: a ``wait_for`` timeout
+    cancels the task, and ``_keep_typing`` treats cancellation as a normal
+    exit — which would make a leaked loop look like it stopped on its own.
+    """
+    done, _ = await asyncio.wait({task}, timeout=timeout)
+    return task in done
+
+
+class TestTypingRefreshLostCancel:
+    @pytest.mark.asyncio
+    async def test_loop_exits_after_stop_even_when_cancel_is_lost(self):
+        """_stop_typing_refresh must stop the loop it was handed even if the
+        cancel() it sends never takes effect."""
+        adapter = _StubAdapter()
+        loop = asyncio.get_running_loop()
+        entered = asyncio.Event()
+        gate = loop.create_future()
+
+        async def send_typing(chat_id, metadata=None):
+            adapter.send_typing_calls += 1
+            entered.set()
+            try:
+                await gate
+            except asyncio.CancelledError:
+                # A library/adapter swallowing the cancel (any Python).
+                pass
+
+        adapter.send_typing = send_typing
+        task = asyncio.create_task(adapter._keep_typing("123", interval=0.05))
+        await asyncio.wait_for(entered.wait(), timeout=2.0)
+
+        # Complete send_typing in the same loop iteration as the turn's
+        # cleanup cancels the loop: on Python 3.11 wait_for returns the
+        # result and the cancel is dropped (gh-86296).  _stop_typing_refresh
+        # calls typing_task.cancel() before its first await, so this is one
+        # iteration.
+        gate.set_result(None)
+        await adapter._stop_typing_refresh("123", task)
+
+        if not await _finished(task):
+            await _drain(task)
+            pytest.fail("refresh loop kept running after its turn stopped it")
+
+        calls_at_exit = adapter.send_typing_calls
+        assert adapter.stop_typing_calls >= 1, "loop exit must clear platform typing"
+        assert task not in adapter._typing_refresh_tasks
+        # A finished task cannot refresh again.
+        await asyncio.sleep(0.15)
+        assert adapter.send_typing_calls == calls_at_exit
+
+    @pytest.mark.asyncio
+    async def test_stopping_one_turn_leaves_sibling_loop_in_same_chat_alone(self):
+        """Two sessions can run turns in one chat_id at once (per-user group
+        sessions, Slack threads).  Stopping one turn's loop, or the
+        handle-less final stop, must not kill the other turn's loop."""
+        adapter = _StubAdapter()
+        first = asyncio.create_task(adapter._keep_typing("123", interval=0.05))
+        second = asyncio.create_task(adapter._keep_typing("123", interval=0.05))
+        await asyncio.sleep(0.12)
+        assert not first.done() and not second.done()
+
+        await adapter._stop_typing_refresh("123", first)
+        assert await _finished(first)
+        assert not second.done(), "sibling loop must survive the other turn's stop"
+
+        # The handle-less safety-net stop at the end of a turn.
+        await adapter._stop_typing_refresh("123", None, stop_attempts=1)
+        await asyncio.sleep(0.15)
+        assert not second.done(), "handle-less stop must not touch a live loop"
+        assert second in adapter._typing_refresh_tasks
+
+        await _drain(second)
+
+    @pytest.mark.asyncio
+    async def test_normal_stop_paths_leave_no_registration_behind(self):
+        """Neither the cancel path nor the stop_event path may leak a task
+        reference in the registry."""
+        adapter = _StubAdapter()
+
+        task = asyncio.create_task(adapter._keep_typing("123", interval=0.05))
+        await asyncio.sleep(0.12)
+        assert task in adapter._typing_refresh_tasks
+        await adapter._stop_typing_refresh("123", task)
+        assert await _finished(task)
+        assert task not in adapter._typing_refresh_tasks
+
+        stop_event = asyncio.Event()
+        task = asyncio.create_task(
+            adapter._keep_typing("123", interval=0.05, stop_event=stop_event)
+        )
+        await asyncio.sleep(0.12)
+        stop_event.set()
+        assert await _finished(task)
+        assert adapter._typing_refresh_tasks == set()

--- a/tests/gateway/test_typing_refresh_ownership.py
+++ b/tests/gateway/test_typing_refresh_ownership.py
@@ -1,0 +1,144 @@
+"""Tests for BasePlatformAdapter._keep_typing per-chat ownership.
+
+The bug: ``_keep_typing`` trusts that whoever started it will cancel it.
+When that cancellation is lost (e.g. a shutdown race between the turn
+finishing and the refresh task being awaited), the orphaned loop keeps
+refreshing the platform typing indicator on its 2-second cadence with
+nothing to stop it. Observed in production: a leaked refresh task hammered
+a Matrix homeserver's ``PUT /typing`` every 2 seconds for over three hours
+after its turn had ended normally, pinning clients' "working" indicator
+the whole time.
+
+The fix encodes the invariant instead of patching one leak path: at most
+one live refresh loop per chat. A loop claims its chat in
+``_typing_refresh_owners`` on start and re-checks the claim every tick, so
+any orphan self-terminates within one tick of being stopped or superseded
+— whatever path leaked it. Only the current owner may clear platform
+typing state, so a dying stale loop can't stomp a newer turn's indicator.
+"""
+
+import asyncio
+
+import pytest
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    Platform,
+    PlatformConfig,
+    SendResult,
+)
+
+
+class _StubAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+        self.stop_typing_calls = []
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="m1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+    async def send_typing(self, chat_id, metadata=None):
+        pass
+
+    async def stop_typing(self, chat_id):
+        self.stop_typing_calls.append(chat_id)
+
+
+class TestTypingRefreshOwnership:
+    @pytest.mark.asyncio
+    async def test_superseded_loop_self_terminates(self):
+        """A leaked refresh loop must exit on its own — without being
+        cancelled — as soon as a newer turn's loop claims the same chat."""
+        adapter = _StubAdapter()
+
+        leaked = asyncio.create_task(adapter._keep_typing("123", interval=0.05))
+        await asyncio.sleep(0.12)
+        assert not leaked.done()
+
+        newer = asyncio.create_task(adapter._keep_typing("123", interval=0.05))
+        await asyncio.sleep(0.2)
+
+        assert leaked.done(), "orphaned loop should exit once superseded"
+        assert not newer.done(), "the newer turn's loop must keep running"
+
+        newer.cancel()
+        await asyncio.gather(newer, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_stop_refresh_kills_loop_even_when_cancellation_is_lost(self):
+        """_stop_typing_refresh must revoke the claim so a loop whose task
+        handle was lost (cancellation never delivered) still self-terminates
+        on its next tick instead of typing forever."""
+        adapter = _StubAdapter()
+
+        leaked = asyncio.create_task(adapter._keep_typing("123", interval=0.05))
+        await asyncio.sleep(0.12)
+        assert not leaked.done()
+
+        # No task handle passed — simulates the caller having lost track of
+        # the task, the exact condition of the production leak.
+        await adapter._stop_typing_refresh("123", None)
+        await asyncio.sleep(0.2)
+
+        assert leaked.done(), "loop must exit after its claim is revoked"
+
+    @pytest.mark.asyncio
+    async def test_stale_loop_does_not_clear_newer_turns_typing(self):
+        """A superseded loop's cleanup must not call stop_typing — that
+        would kill the typing indicator of the turn that superseded it."""
+        adapter = _StubAdapter()
+
+        stale = asyncio.create_task(adapter._keep_typing("123", interval=0.05))
+        await asyncio.sleep(0.12)
+        newer = asyncio.create_task(adapter._keep_typing("123", interval=0.05))
+        await asyncio.sleep(0.2)
+
+        assert stale.done()
+        assert adapter.stop_typing_calls == [], (
+            "superseded loop cleared platform typing state it no longer owns"
+        )
+
+        newer.cancel()
+        await asyncio.gather(newer, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_stopping_stale_task_leaves_live_claim_alone(self):
+        """Stopping an old task must not revoke a claim now held by a
+        different live loop (a newer turn already running)."""
+        adapter = _StubAdapter()
+
+        stale = asyncio.create_task(adapter._keep_typing("123", interval=0.05))
+        await asyncio.sleep(0.12)
+        newer = asyncio.create_task(adapter._keep_typing("123", interval=0.05))
+        await asyncio.sleep(0.2)
+        assert stale.done()
+
+        await adapter._stop_typing_refresh("123", stale)
+        assert adapter._typing_refresh_owners.get("123") is newer
+
+        newer.cancel()
+        await asyncio.gather(newer, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_normal_stop_releases_claim(self):
+        """The normal stop_event path must leave no claim behind."""
+        adapter = _StubAdapter()
+        stop_event = asyncio.Event()
+
+        task = asyncio.create_task(
+            adapter._keep_typing("123", interval=0.05, stop_event=stop_event)
+        )
+        await asyncio.sleep(0.12)
+        stop_event.set()
+        await asyncio.wait_for(task, timeout=1.0)
+
+        assert "123" not in adapter._typing_refresh_owners


### PR DESCRIPTION
## What does this PR do?

Fixes a leaked typing-refresh loop in `BasePlatformAdapter`: once a turn's `_stop_typing_refresh` has run, the `_keep_typing` loop it was meant to stop can keep sending typing indicators forever.

**Where it manifests on current main (`gateway/platforms/base.py`):**

- `_process_message_background` spawns `_keep_typing(chat_id, stop_event=interrupt_event)` at 6588-6593.
- `_stop_typing_refresh` (5531-5550) calls `typing_task.cancel()`, waits `wait_for(shield(task), 0.5)`, then un-pauses the chat at 5550. If that cancel never takes effect, nothing else stops the loop: `stop_event` is the session interrupt event, set only by `interrupt_session_activity` (5569) and cleared in the drain path (7141).
- The cancel is lost inside the per-tick `await asyncio.wait_for(self.send_typing(...), timeout=...)` at 5470-5473. On Python 3.11 (the project floor, and what CI pins) `asyncio.wait_for` drops an external `cancel()` that lands in the same loop iteration as the inner awaitable completing (CPython gh-86296, rewritten in 3.12). A cleanup that coincides with a typing round-trip finishing orphans the loop. Adapters whose `send_typing` swallows `CancelledError` hit the same outcome on any interpreter.

**Reproduction** against unmodified main with a well-behaved stub adapter (no exception swallowing), stopping the loop in the same iteration `send_typing` completes:

```
py3.11: task.done()=False refreshes after stop=10
py3.12: task.done()=True  refreshes after stop=0
```

With this change on 3.11: `task.done()=True refreshes after stop=0`.

**Fix:** the adapter keeps a set of live refresh tasks. `_keep_typing` registers itself on start, re-checks its membership at the top of every tick, and discards itself in `finally`. `_stop_typing_refresh` removes only the task it was handed, before cancelling it. That gives the loop a second stop signal that does not depend on the cancel arriving. The `finally` cleanup is unchanged from main.

**Why not per-chat ownership (the first version of this PR):** "one live refresh loop per chat" is not an invariant main holds. `group_sessions_per_user` defaults to true and group sessions are keyed by participant, so two users in one group run concurrent turns on the same chat_id; Slack threads share the channel as chat_id. A per-chat revoke would have killed a sibling turn's typing loop. This version touches only the task the turn owns; siblings keep running.

## Related Issue

#62394 (open). Sibling approach: #66526 threads a per-turn completion event through `_keep_typing`'s signature; this one keeps the signature (the LINE adapter's `_keep_typing` override keeps working untouched).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: `_typing_refresh_tasks` set; registration and per-tick check in `_keep_typing`; deregister-before-cancel in `_stop_typing_refresh`. +31 lines, no deletions.
- `tests/gateway/test_typing_refresh_lost_cancel.py`: the lost-cancel case (fails on main under 3.11 and 3.12 when the stub swallows the cancel), a normal stop, and the concurrent-same-chat contract (stopping turn A leaves turn B's loop alive).

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_typing_refresh_lost_cancel.py
scripts/run_tests.sh tests/gateway/ -k typing
```

Tests: tests/gateway/test_typing_refresh_lost_cancel.py (3 passed on 3.12 and 3.11) + tests/gateway -k typing (60 passed) + full tests/gateway (7598 passed; 4 failures in test_scale_to_zero/test_wecom_callback reproduce on unmodified main).

## Checklist

- [x] I have read the CONTRIBUTING guide.
- [x] I have performed a self-review of my code.
- [x] My changes are covered by tests and the tests pass.
- [x] I have added a concise, focused commit message.
