### PR TITLE
fix(cli): dispatch /whoami instead of reporting it unknown

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9876,6 +9876,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self.show_help()
         elif canonical == "profile":
             self._handle_profile_command()
+        elif canonical == "whoami":
+            self._handle_whoami_command()
         elif canonical == "tools":
             self._handle_tools_command(cmd_original)
         elif canonical == "toolsets":

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -704,6 +704,22 @@ class CLICommandsMixin:
         print(f"  Home:    {display}")
         print()
 
+    def _handle_whoami_command(self):
+        """Show the local operator's slash-command access on this CLI.
+
+        The classic CLI runs on the operator's own machine, so the operator is
+        the local admin (unrestricted) — mirroring the gateway's
+        ``unrestricted`` tier when no admin list is configured for a scope.
+        """
+        import getpass
+
+        print()
+        print(f"  You — local CLI (this machine)")
+        print(f"  User: {getpass.getuser()}")
+        print(f"  Tier: admin (local operator)")
+        print(f"  Slash commands: all available")
+        print()
+
     def _handle_handoff_command(self, cmd_original: str) -> bool:
         """Handle ``/handoff <platform>`` — transfer this CLI session to a gateway platform.
 

--- a/tests/cli/test_whoami_command.py
+++ b/tests/cli/test_whoami_command.py
@@ -1,0 +1,62 @@
+"""Tests for the /whoami CLI command.
+
+/whoami is registered in COMMAND_REGISTRY but used to have no dispatch branch
+in HermesCLI.process_command — typing it printed "Unknown command:
+/whoami". These tests lock in the dispatch wiring and the handler behavior.
+"""
+
+from __future__ import annotations
+
+import getpass
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _make_cli() -> HermesCLI:
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.config = {}
+    cli_obj.console = MagicMock()
+    cli_obj.agent = None
+    cli_obj.conversation_history = []
+    cli_obj.session_id = None
+    cli_obj._pending_input = MagicMock()
+    cli_obj._app = None
+    cli_obj._pending_resume_sessions = None
+    return cli_obj
+
+
+class TestWhoamiDispatch:
+    """The command must route to its handler — not fall through to "Unknown"."""
+
+    def test_whoami_dispatches_to_handler(self):
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, "_handle_whoami_command") as mock_handler:
+            result = cli_obj.process_command("/whoami")
+
+        mock_handler.assert_called_once_with()
+        assert result is True
+
+    def test_whoami_is_not_unknown_command(self):
+        cli_obj = _make_cli()
+        with (
+            patch("cli._cprint") as mock_cprint,
+            patch.object(cli_obj, "_handle_whoami_command"),
+        ):
+            result = cli_obj.process_command("/whoami")
+
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        assert "Unknown command" not in printed
+        assert result is True
+
+
+class TestHandleWhoamiCommand:
+    def test_reports_local_admin_tier(self, capsys):
+        cli_obj = _make_cli()
+        cli_obj._handle_whoami_command()
+
+        out = capsys.readouterr().out
+        assert "local CLI" in out
+        assert getpass.getuser() in out
+        assert "Tier: admin" in out
+        assert "all available" in out


### PR DESCRIPTION
## What does this PR do?

Fixes the live instance of #74594: `/whoami` is registered in
`COMMAND_REGISTRY` (advertised by `/help` and tab-completion) but
`HermesCLI.process_command` had no dispatch branch for it — typing
`/whoami` printed "Unknown command: /whoami".

- `cli.py` — route `canonical == "whoami"` to `_handle_whoami_command()`
- `hermes_cli/cli_commands_mixin.py` — handler reports the local operator's
  slash-command access: the classic CLI runs on the operator's own machine,
  so the operator is the local admin (unrestricted), mirroring the gateway's
  `unrestricted` tier when no admin list is configured for a scope
- `tests/cli/test_whoami_command.py` — runtime dispatch wiring (handler spy,
  no "Unknown command" fall-through) + handler behavior

## Related Issue

Fixes #74594
Refs #74595 (the parity guard lists `/whoami` in `KNOWN_MISSING_DISPATCH`;
  drop the entry once this lands)

## Type of Change

- [x] ✅ Bug fix (non-breaking change that fixes an issue)

## Test Plan

```
./venv/bin/python -m pytest tests/cli/test_whoami_command.py tests/cli/test_indicator_command.py -q
# 11 passed
```