### PR TITLE
fix(copilot): preserve max reasoning for GPT-5.6 Luna

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -4268,7 +4268,15 @@ def github_model_reasoning_efforts(
                         for effort in efforts
                         if str(effort).strip()
                     ]
-                    return list(dict.fromkeys(normalized_efforts))
+                    normalized_efforts = list(dict.fromkeys(normalized_efforts))
+                    # The live Copilot catalog for Luna currently omits
+                    # ``max``, but the authenticated endpoint accepted
+                    # ``reasoning.effort=max`` in a controlled probe. Keep this
+                    # override model-specific; do not invent capabilities for
+                    # other GPT-5 models.
+                    if normalized == "gpt-5.6-luna" and "max" not in normalized_efforts:
+                        normalized_efforts.append("max")
+                    return normalized_efforts
             return []
         legacy_capabilities = {
             str(capability).strip().lower()
@@ -4278,7 +4286,10 @@ def github_model_reasoning_efforts(
         if "reasoning" not in legacy_capabilities:
             return []
 
-    return _github_reasoning_efforts_for_model_id(str(model_id or normalized))
+    fallback_efforts = _github_reasoning_efforts_for_model_id(str(model_id or normalized))
+    if normalized == "gpt-5.6-luna" and "max" not in fallback_efforts:
+        fallback_efforts.append("max")
+    return fallback_efforts
 
 
 def probe_api_models(

--- a/tests/plugins/model_providers/test_copilot_profile.py
+++ b/tests/plugins/model_providers/test_copilot_profile.py
@@ -100,3 +100,46 @@ class TestCopilotReasoningEffortClamp:
             supports_reasoning=True,
         )
         assert extra_body["reasoning"] == {"effort": "low"}
+
+    def test_luna_known_api_capability_adds_max_when_catalog_omits_it(self):
+        """Luna's verified API capability wins over its incomplete catalog."""
+        from hermes_cli.models import github_model_reasoning_efforts
+
+        catalog = [
+            {
+                "id": "gpt-5.6-luna",
+                "capabilities": {
+                    "supports": {
+                        "reasoning_effort": ["minimal", "low", "medium", "high"],
+                    }
+                },
+            }
+        ]
+        assert github_model_reasoning_efforts("gpt-5.6-luna", catalog=catalog) == [
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "max",
+        ]
+
+    def test_other_gpt5_model_does_not_receive_luna_max_override(self):
+        """The verified Luna exception must not broaden other models."""
+        from hermes_cli.models import github_model_reasoning_efforts
+
+        catalog = [
+            {
+                "id": "gpt-5.5",
+                "capabilities": {
+                    "supports": {
+                        "reasoning_effort": ["minimal", "low", "medium", "high"],
+                    }
+                },
+            }
+        ]
+        assert github_model_reasoning_efforts("gpt-5.5", catalog=catalog) == [
+            "minimal",
+            "low",
+            "medium",
+            "high",
+        ]


### PR DESCRIPTION
## Summary

- Preserve `reasoning.effort=max` for `gpt-5.6-luna` when the live Copilot catalog currently omits `max` from its advertised reasoning levels.
- Keep the exception model-specific so other GPT-5 models remain catalog-gated.
- Add regression tests for Luna and for non-Luna GPT-5 models.

The authenticated Copilot endpoint accepted `reasoning.effort=max` in a controlled probe, while Hermes currently downgraded it to `medium` because the catalog reports only `minimal`, `low`, `medium`, and `high`.

## Validation

- `pytest -q -o addopts='' tests/plugins/model_providers/test_copilot_profile.py tests/hermes_cli/test_copilot_context.py`
- Result: 15 passed
- Manual builder check: `{'effort': 'max'}`
