### PR TITLE
chore: add contributor email mapping for ElSnacko

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1445,6 +1445,7 @@ LEGACY_AUTHOR_MAP = {
     "xiayh17@gmail.com": "xiayh0107",
     "zhujianxyz@gmail.com": "opriz",
     "tuancanhnguyen706@gmail.com": "xxxigm",
+    "j.brownemoore@gmail.com": "ElSnacko",
     "timchris.roth@pm.me": "x9x9x9x9x9x91",
     "larcombe.n@gmail.com": "NickLarcombe",
     "54813621+xxxigm@users.noreply.github.com": "xxxigm",


### PR DESCRIPTION
## Summary
Adds `j.brownemoore@gmail.com` → `ElSnacko` to AUTHOR_MAP in `scripts/release.py`.

Required before merging PR #64904 (salvage) — contributor attribution check blocks PRs with unmapped emails.

## Validation
- `py_compile` passes on `scripts/release.py`