### PR TITLE
fix(cron): scan dot-operator sourced scripts in lifecycle guard (#77925)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -190,7 +190,11 @@ def _iter_referenced_shell_scripts(
         executable = segment[index]
         executable_name = Path(executable).name
 
-        if executable_name in {".", "source"}:
+        # Compare the RAW token as well as the basename: `Path(".").name` is the
+        # empty string, so a basename-only test silently misses the dot operator
+        # while still catching `source`. `. ./restart.sh` is exactly equivalent
+        # to `source ./restart.sh`, so both must reach the referenced-script scan.
+        if executable in {".", "source"} or executable_name == "source":
             if len(segment) > index + 1:
                 yield _resolve_terminal_script_path(segment[index + 1], cwd)
             continue

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -568,6 +568,49 @@ class TestTerminalToolGatewayLifecycleGuard:
 class TestLifecycleGuardModule:
     """Direct tests for cron.lifecycle_guard.check_gateway_lifecycle."""
 
+    def test_dot_operator_sourced_script_is_scanned(self, tmp_path):
+        """`. ./script.sh` must reach the referenced-script scan.
+
+        The dot operator and `source` are the same POSIX builtin, but the
+        executable test compared only `Path(executable).name` — and
+        `Path(".").name` is the empty string, so `source` was caught while a
+        bare `.` slipped through and the sourced script was never scanned.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/bash\nhermes gateway restart\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f". {script}")
+            is True
+        )
+
+    def test_source_builtin_sourced_script_is_scanned(self, tmp_path):
+        """The `source` spelling must stay blocked (it already was)."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "restart.sh"
+        script.write_text("#!/bin/bash\nhermes gateway restart\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f"source {script}")
+            is True
+        )
+
+    def test_dot_operator_clean_script_not_blocked(self, tmp_path):
+        """Widening the dot check must not false-block an innocent sourced
+        script — e.g. sourcing a venv activate or an env file."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "activate.sh"
+        script.write_text("#!/bin/bash\nexport PATH=/usr/bin:$PATH\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f". {script}")
+            is False
+        )
+
     def test_prompt_with_command_raises(self):
         from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
         with pytest.raises(GatewayLifecycleBlocked) as exc:


### PR DESCRIPTION
## What does this PR do?

`cron/lifecycle_guard.py` scans scripts pulled in with the `source` builtin so a
gateway-lifecycle command inside them is blocked. The equivalent POSIX **dot
operator** was not caught, so `. ./restart.sh` was never scanned.

The executable test compared **basename only**:

```python
executable_name = Path(executable).name
if executable_name in {".", "source"}:
```

`Path(".").name` is the **empty string** — pathlib normalises `"."` to the
current directory, whose `.name` is `""` — so the `"."` entry could never match.
`source` matched; `.` silently fell through, the sourced script was never added
to the reference walk, and its contents were never scanned.

The fix compares the **raw token** as well as the basename:

```python
if executable in {".", "source"} or executable_name == "source":
```

The `executable_name == "source"` arm is kept deliberately so a path-qualified
spelling keeps behaving as before, while the raw-token test catches `.` without
depending on pathlib normalisation.

## Related Issue

Fixes #77925

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `cron/lifecycle_guard.py` — `_iter_referenced_shell_scripts`: compare the raw
  executable token as well as the basename, so the dot operator reaches the
  referenced-script scan. Comment records *why* the basename test cannot work
  for `.`.
- `tests/hermes_cli/test_gateway_restart_loop.py` — three tests in
  `TestLifecycleGuardModule`.

## How to Test

Reproduce on `main` (all three assertions describe current behaviour):

```python
from pathlib import Path
from cron.lifecycle_guard import (
    contains_gateway_lifecycle_command_or_referenced_script as scan,
)

p = Path("/tmp/restart.sh")
p.write_text("#!/bin/bash\nhermes gateway restart\n")

assert scan(f". {p}") is False       # BUG on main: not blocked
assert scan(f"source {p}") is True   # blocked
assert scan(f"bash {p}") is True     # blocked
```

With this PR the first assertion becomes `True`.

Automated:

```bash
pytest tests/hermes_cli/test_gateway_restart_loop.py -q
```

- **85 passed** with this PR.
- Reverting only `cron/lifecycle_guard.py` to `main` and keeping the new tests
  fails exactly `test_dot_operator_sourced_script_is_scanned`
  (`AssertionError: assert False is True`) — so the test genuinely covers the
  defect rather than passing vacuously.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_gateway_restart_loop.py -q` and all tests pass (85 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings/comments) — inline comment explains the pathlib subtlety
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture change
- [x] Cross-platform impact considered — the fix removes a pathlib-normalisation
      dependency rather than adding one. `.` and `source` are POSIX-shell
      builtins, so behaviour is unchanged on Windows, where this walk is not
      reached for shell scripts.
- [x] Tool descriptions/schemas — N/A, no tool behaviour change

## Notes for reviewers

**On duplicates:** there are several open PRs on this file (#77383, #77729,
#77806, #77894) — all of them address the **crash** class (`ValueError:
embedded null byte`). This is a different defect: a **silent scan miss**, no
crash involved. It does not overlap or conflict with those changes; the hunk is
40 lines away from the crash sites.

**Scope:** the same audit turned up a second, independent defect — the `#76762`
binary test (`b"\x00" in data`) treats *any* NUL-bearing file as an unscannable
binary, but `bash` executes a **text** script straight past an embedded NUL, so
a single pad byte bypasses the scan entirely. That is a separate PR; keeping
them apart so each can be reviewed on its own merits.
