### PR TITLE
fix(cron): close NUL-padded script bypass in lifecycle guard (#77927)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -253,6 +253,38 @@ def _resolve_script_directory(script_path: str) -> Optional[str]:
     return None
 
 
+_BINARY_MAGICS = (
+    b"\x7fELF",              # ELF — Linux/BSD executables and shared objects
+    b"\xfe\xed\xfa\xce",     # Mach-O 32-bit
+    b"\xfe\xed\xfa\xcf",     # Mach-O 64-bit
+    b"\xce\xfa\xed\xfe",     # Mach-O 32-bit, byte-swapped
+    b"\xcf\xfa\xed\xfe",     # Mach-O 64-bit, byte-swapped
+    b"\xca\xfe\xba\xbe",     # Mach-O universal ("fat") binary
+    b"MZ",                   # PE/COFF — Windows .exe/.dll
+    b"!<arch>",              # static archive (.a)
+    b"\x1f\x8b",             # gzip
+    b"PK\x03\x04",           # zip (also .jar/.whl/.egg)
+)
+
+
+def _has_binary_magic(data: bytes) -> bool:
+    """Return True when *data* starts with a known compiled-binary signature.
+
+    Deliberately narrower than "contains a NUL byte": a shell script that
+    happens to hold a NUL is still executed by ``bash``, so treating every
+    NUL-bearing file as an unscannable binary lets a padded script bypass the
+    lifecycle scan entirely.
+
+    A shebang always wins — an interpreted script is never a binary, however
+    odd its payload. File extensions are deliberately *not* consulted: a
+    suffixless shell script must still be scanned (and, if oversized, still
+    fail closed).
+    """
+    if data.startswith(b"#!"):
+        return False
+    return data.startswith(_BINARY_MAGICS)
+
+
 def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     """Return ``(text, unsafe)`` using bounded, regular-file-only reads."""
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
@@ -272,16 +304,25 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         return None, False
     finally:
         os.close(descriptor)
-    # A NUL byte in the first chunk means this is a binary (ELF/Mach-O/
-    # PE), not a shell script — scanning its decoded contents would
-    # tokenize machine code and feed junk paths into the recursion
-    # (including a `ValueError: embedded null byte` from Path.resolve,
-    # #76762). Treat it as "nothing to scan" rather than unsafe: a binary
-    # executed by the user is not a referenced *shell script*.
-    if b"\x00" in data:
+    # Identify binaries by MAGIC NUMBER, not by the mere presence of a NUL.
+    #
+    # "contains a NUL" and "is a compiled binary" are different questions, and
+    # the gap between them is a guard bypass: `bash` executes a *text* script
+    # straight past an embedded NUL, so a single pad byte in a shell script made
+    # the scan skip a file that still runs its lifecycle command. Match on the
+    # signature instead (ELF/Mach-O/PE/static archive/compressed), and treat a
+    # NUL-bearing *text* file as a script whose NULs are stripped before
+    # scanning — stripping can only splice tokens together, never apart, so it
+    # fails closed.
+    if _has_binary_magic(data):
         return None, False
+    # Check the size BEFORE stripping: stripping shrinks the buffer, so doing it
+    # first would let an oversized file slip under the threshold and skip this
+    # fail-closed branch.
     if len(data) > _MAX_REFERENCED_SCRIPT_BYTES:
         return None, True
+    if b"\x00" in data:
+        data = data.replace(b"\x00", b"")
     return data.decode("utf-8", errors="replace"), False
 
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -568,6 +568,102 @@ class TestTerminalToolGatewayLifecycleGuard:
 class TestLifecycleGuardModule:
     """Direct tests for cron.lifecycle_guard.check_gateway_lifecycle."""
 
+    def test_nul_padded_script_is_still_scanned(self, tmp_path):
+        """A NUL byte in a *text* script must not disable the scan.
+
+        The #76762 binary check treated any NUL in the first chunk as "compiled
+        binary, nothing to scan" — but ``bash`` executes a text script straight
+        past an embedded NUL, so one pad byte bypassed the guard entirely while
+        the script still ran its lifecycle command.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "padded.sh"
+        script.write_bytes(b"#!/bin/bash\n# pad\x00\nhermes gateway restart\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f"bash {script}")
+            is True
+        )
+
+    def test_nul_padded_script_without_shebang_is_scanned(self, tmp_path):
+        """Same bypass without a shebang — bash still runs it, so still scan.
+
+        Keying the fix on a leading ``#!`` alone is insufficient: a shebang-less
+        file with a NUL on any line but the first executes normally.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "padded_noshebang.sh"
+        script.write_bytes(b"# ok\n# pad\x00\nhermes gateway restart\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f"bash {script}")
+            is True
+        )
+
+    def test_elf_binary_is_not_scanned_as_script(self, tmp_path):
+        """#76762 must stay fixed: a real binary is nothing-to-scan, no crash.
+
+        Its decoded machine code must never be tokenized as shell text, and the
+        guard must not fail closed on an innocent interpreter invocation.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        binary = tmp_path / "tool"
+        binary.write_bytes(b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 64 + b"/usr/bin/x\x00")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f"{binary} --version")
+            is False
+        )
+
+    def test_macho_binary_is_not_scanned_as_script(self, tmp_path):
+        """Same for Mach-O, including the universal/fat signature (macOS)."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        for name, magic in (
+            ("macho64", b"\xcf\xfa\xed\xfe"),
+            ("machofat", b"\xca\xfe\xba\xbe"),
+        ):
+            binary = tmp_path / name
+            binary.write_bytes(magic + b"\x00" * 64)
+            assert (
+                contains_gateway_lifecycle_command_or_referenced_script(
+                    f"{binary} --version"
+                )
+                is False
+            )
+
+    def test_oversized_nul_bearing_text_still_fails_closed(self, tmp_path):
+        """An oversized *text* script must keep failing closed.
+
+        Stripping NULs must not let a too-large file skip the size guard — the
+        binary check runs first, the size check still applies afterwards.
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "huge.sh"
+        script.write_bytes(b"#!/bin/bash\n# \x00" + b"x" * (1024 * 1024 + 64) + b"\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f"bash {script}")
+            is True
+        )
+
+    def test_clean_script_without_lifecycle_command_not_blocked(self, tmp_path):
+        """Sanity: the change must not false-block innocent scripts."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "safe.sh"
+        script.write_bytes(b"#!/bin/bash\necho hello\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(f"bash {script}")
+            is False
+        )
+
     def test_prompt_with_command_raises(self):
         from cron.lifecycle_guard import GatewayLifecycleBlocked, check_gateway_lifecycle
         with pytest.raises(GatewayLifecycleBlocked) as exc:


### PR DESCRIPTION
## What does this PR do?

Closes a **guard bypass** introduced by the `#76762` binary check. That check
treats any NUL byte in a file's first chunk as "compiled binary, nothing to
scan" — but `bash` executes a **text** script straight past an embedded NUL, so a
single pad byte disables the scan while the script still runs its lifecycle
command.

```python
# main
if b"\x00" in data:
    return None, False
```

```python
p.write_bytes(b"#!/bin/bash\n# pad\x00\nhermes gateway restart\n")
scan(f"bash {p}")   # -> False on main: allowed, and bash runs it
```

This shape **was blocked before #76762**, so the crash fix traded a loud failure
for a silent one. "Contains a NUL" and "is a compiled binary" are different
questions, and the bypass lives in the gap between them.

### Fix

Identify binaries by **magic number** — ELF, Mach-O (incl. byte-swapped and
universal/fat), PE/COFF, static archive, gzip, zip — with a shebang always
winning. NUL-bearing *text* is scanned with its NULs stripped, which can only
splice tokens together and never apart, so it fails closed. As a side benefit
`hermes gateway rest\x00art` inside a file stops evading the matcher.

Extensions are deliberately **not** consulted: a suffixless shell script must
still be scanned, and an oversized one must still fail closed.

**Return values are unchanged** (`(None, False)` for a binary), so this does not
conflict with the in-flight crash-class fixes to the same function.

## Related Issue

Fixes #77927

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `cron/lifecycle_guard.py`
  - new `_BINARY_MAGICS` tuple + `_has_binary_magic()` helper, documenting why a
    NUL census is the wrong test and why a shebang wins.
  - `_read_referenced_script`: match on signature; strip NULs from text instead
    of skipping the file.
  - **size check moved before the strip** — stripping shrinks the buffer, so
    checking afterwards let an oversized file slip under the threshold and skip
    the fail-closed branch. This was a real bug in the first cut of this patch,
    caught by the oversize test below.
- `tests/hermes_cli/test_gateway_restart_loop.py` — six tests in
  `TestLifecycleGuardModule`.

## How to Test

Reproduce on `main`:

```python
from pathlib import Path
from cron.lifecycle_guard import (
    contains_gateway_lifecycle_command_or_referenced_script as scan,
)

p = Path("/tmp/padded.sh")
p.write_bytes(b"#!/bin/bash\n# pad\x00\nhermes gateway restart\n")
assert scan(f"bash {p}") is False    # BUG on main

q = Path("/tmp/padded2.sh")          # no shebang — also bypassed
q.write_bytes(b"# ok\n# pad\x00\nhermes gateway restart\n")
assert scan(f"bash {q}") is False    # BUG on main
```

Swap the payload for `echo EXECUTED` to confirm bash really runs these without
restarting anything. With this PR both become `True`.

Automated:

```bash
pytest tests/hermes_cli/test_gateway_restart_loop.py -q
```

- **88 passed** with this PR.
- Reverting only `cron/lifecycle_guard.py` to `main` and keeping the new tests
  fails exactly 3 — the two bypass shapes and the oversize case — so the tests
  cover the defect rather than passing vacuously.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_gateway_restart_loop.py -q` and all tests pass (88 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — `_has_binary_magic` documents the reasoning
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture change
- [x] Cross-platform impact considered — PE/COFF (`MZ`) and ELF are in the magic
      list alongside Mach-O, so Windows and Linux binaries are recognised too;
      previously they were caught only incidentally by their NUL bytes
- [x] Tool descriptions/schemas — N/A, no tool behaviour change

## Notes for reviewers

**On the shebang-only shortcut.** My first attempt keyed the check on a leading
`#!` and it was insufficient — a shebang-less file with a NUL on any line but the
first also executes. Measured `bash file` behaviour:

| shape | bash runs it? |
|---|---|
| shebang, NUL anywhere | yes |
| no shebang, NUL on line 2+ | yes |
| no shebang, NUL after the payload | yes |
| no shebang, NUL on **line 1** | no — exit 126 |

Only the last is unrunnable via `bash file`, and even that one is executable via
`. file`. Hence magic-number detection rather than a shebang test.

**On duplicates / overlap.** The open PRs on this function (#77383, #77729,
#77806, #77894) all address the **crash** class. This is the bypass class. Worth
flagging specifically: **#77383's `_looks_like_script` helper preserves the same
premise** — its docstring says *"real scripts are NUL-free text; shebang or
not"* — so `b"\x00" not in head` keeps this hole open. I executed that helper
directly against the shapes above to confirm rather than reading it. Happy to
rebase on whichever crash fix lands first; this patch touches the decision, not
the return contract.

**On NUL in argv vs in a file.** A NUL inside a command-line *argument* is
harmless — `execve(2)` takes NUL-terminated strings, so such a command is
unrunnable. That is **not** true inside a script file, which is why this needs
fixing at the file-read boundary. Same byte, different channel, opposite
conclusion.
