### PR TITLE
fix(desktop): preserve RTL direction in mixed-script chat

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -27,7 +27,8 @@ import {
   normalizeComposerEditorDom,
   placeCaretEnd,
   REF_RE,
-  renderComposerContents
+  renderComposerContents,
+  syncElementTextDirection
 } from '../rich-editor'
 import { useComposerScope } from '../scope'
 import type { ChatBarProps } from '../types'
@@ -251,6 +252,7 @@ export function useComposerDraft({
     normalizeComposerEditorDom(editor)
 
     const text = sanitizeComposerInput(composerPlainText(editor))
+    syncElementTextDirection(editor, text)
 
     if (text !== draftRef.current) {
       draftRef.current = text

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -64,7 +64,8 @@ import {
   deleteSelectionInEditor,
   insertComposerContentsAtCaret,
   normalizeComposerEditorDom,
-  RICH_INPUT_SLOT
+  RICH_INPUT_SLOT,
+  syncElementTextDirection
 } from './rich-editor'
 import { useComposerScope } from './scope'
 import { ComposerStatusStack } from './status-stack'
@@ -383,6 +384,7 @@ export function ChatBar({
     normalizeComposerEditorDom(editor)
 
     const nextDraft = sanitizeComposerInput(composerPlainText(editor))
+    syncElementTextDirection(editor, nextDraft)
 
     if (nextDraft !== draftRef.current) {
       draftRef.current = nextDraft
@@ -953,6 +955,7 @@ export function ChatBar({
         contentEditable={!inputDisabled}
         data-placeholder={placeholder}
         data-slot={RICH_INPUT_SLOT}
+        dir="auto"
         onBeforeInput={handleEditorBeforeInput}
         onBlur={() => window.setTimeout(closeTrigger, 80)}
         onCompositionEnd={event => {

--- a/apps/desktop/src/app/chat/composer/inline-references.test.ts
+++ b/apps/desktop/src/app/chat/composer/inline-references.test.ts
@@ -10,15 +10,15 @@ import { REFERENCE_STYLES, referenceKind, referenceStyle } from '@/components/as
  */
 describe('the inline reference contract', () => {
   it('marks any element as a reference of a given kind', () => {
-    expect(refAttrs('file')).toEqual({ className: 'ref', 'data-ref': 'file' })
-    expect(refAttrsHtml('skill')).toBe('class="ref" data-ref="skill"')
+    expect(refAttrs('file')).toEqual({ className: 'ref', dir: 'ltr', 'data-ref': 'file' })
+    expect(refAttrsHtml('skill')).toBe('class="ref" dir="ltr" data-ref="skill"')
   })
 
   it('an unkinded reference is a plain link, not a broken one', () => {
     // A bare external link has no kind — it keeps the default link colour
     // rather than being tagged with a wrong one.
-    expect(refAttrs()).toEqual({ className: 'ref' })
-    expect(refAttrsHtml()).toBe('class="ref"')
+    expect(refAttrs()).toEqual({ className: 'ref', dir: 'ltr' })
+    expect(refAttrsHtml()).toBe('class="ref" dir="ltr"')
   })
 
   it('normalises an unknown kind instead of emitting it raw', () => {

--- a/apps/desktop/src/app/chat/composer/rich-editor.test.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.test.ts
@@ -31,6 +31,8 @@ describe('renderComposerContents', () => {
 
     expect(editor.querySelector('img')).toBeNull()
     expect(editor.querySelector('b')).toBeNull()
+    expect(editor.querySelector('[data-ref-text]')?.getAttribute('dir')).toBe('ltr')
+    expect(editor.getAttribute('dir')).toBe('ltr')
     expect(editor.textContent).toContain('<img src=x onerror=alert(1)>')
     expect(editor.textContent).toContain('<b>raw</b>')
     expect(composerPlainText(editor)).toBe('@file:`<img src=x onerror=alert(1)>` <b>raw</b>')
@@ -48,8 +50,19 @@ describe('renderComposerContents', () => {
     const pill = editor.querySelector('[data-slash-kind]')
 
     expect(pill?.getAttribute('data-ref-text')).toBe('/some-skill')
+    expect(pill?.getAttribute('dir')).toBe('ltr')
     expect(editor.querySelector('[data-ref-kind="folder"]')).not.toBeNull()
     expect(composerPlainText(editor)).toBe('/some-skill @folder:`Desktop` ')
+  })
+
+  it('sets the editor direction from RTL prose after leading special chips', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+
+    renderComposerContents(editor, '@file:`apps/desktop/a.ts` شوف الملف')
+
+    expect(editor.getAttribute('dir')).toBe('rtl')
+    expect(editor.querySelector('[data-ref-text]')?.getAttribute('dir')).toBe('ltr')
   })
 
   it('keeps a still-typed leading slash token as editable text', () => {

--- a/apps/desktop/src/app/chat/composer/rich-editor.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.ts
@@ -16,6 +16,9 @@ import {
   slashIconElement
 } from '@/components/assistant-ui/directive-text'
 import { referenceKind, referenceRe } from '@/components/assistant-ui/reference-kinds'
+import { syncElementTextDirection } from '@/lib/bidi-direction'
+
+export { syncElementTextDirection }
 
 import { slashCommandMatches, type SlashCommandScanOptions } from './slash-refs'
 
@@ -132,6 +135,7 @@ export function refChipElement(kind: string, rawValue: string, displayLabel?: st
   const chip = document.createElement('span')
 
   chip.contentEditable = 'false'
+  chip.dir = 'ltr'
   chip.title = id
   chip.dataset.refText = text
   chip.dataset.refId = id
@@ -150,6 +154,7 @@ export function slashChipElement(command: string, kind: SlashChipKind, label?: s
   const chip = document.createElement('span')
 
   chip.contentEditable = 'false'
+  chip.dir = 'ltr'
   chip.dataset.refText = command
   chip.dataset.slashKind = kind
   chip.className = 'ref'
@@ -230,6 +235,7 @@ export function renderComposerContents(target: HTMLElement, text: string, option
   // The other writer that reshapes the editor root: painting a restored draft
   // in clears the marker, clearing back to '' sets it.
   markEditorEmptiness(target)
+  syncElementTextDirection(target, text)
 }
 
 /** Caret range when the selection lives inside `editor`; else null. */
@@ -771,4 +777,6 @@ export function normalizeComposerEditorDom(editor: HTMLElement) {
   if (editor.childNodes.length === 0) {
     editor.appendChild(document.createElement('br'))
   }
+
+  syncElementTextDirection(editor, composerPlainText(editor))
 }

--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -36,15 +36,15 @@ const SVG_ATTRS =
  * message's mentions, a markdown link, a completion row's glyph. If it points
  * at something from inside text, it goes through here.
  */
-export function refAttrs(kind?: string, extra?: string): { className: string; 'data-ref'?: string } {
+export function refAttrs(kind?: string, extra?: string): { className: string; dir: 'ltr'; 'data-ref'?: string } {
   const className = extra ? `ref ${extra}` : 'ref'
 
-  return kind ? { className, 'data-ref': referenceKind(kind) } : { className }
+  return kind ? { className, dir: 'ltr', 'data-ref': referenceKind(kind) } : { className, dir: 'ltr' }
 }
 
 /** The same thing as a raw attribute string, for HTML built by hand. */
 export function refAttrsHtml(kind?: string): string {
-  return kind ? `class="ref" data-ref="${referenceKind(kind)}"` : 'class="ref"'
+  return kind ? `class="ref" dir="ltr" data-ref="${referenceKind(kind)}"` : 'class="ref" dir="ltr"'
 }
 
 /** SVG markup string for embedding directly in HTML (composer contenteditable). */

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -8,13 +8,14 @@ import {
   tailBoundedRemend
 } from '@assistant-ui/react-streamdown'
 import type { code as streamdownCode } from '@streamdown/code'
-import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
+import { type ComponentProps, isValidElement, memo, type ReactNode, useEffect, useMemo, useState } from 'react'
 
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
 import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { detectArtifact } from '@/lib/artifact-detect'
+import { resolveTextDirection } from '@/lib/bidi-direction'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
@@ -60,6 +61,34 @@ const mathPlugin = createMemoizedMathPlugin({ singleDollarTextMath: true })
 // `delay` fallback shows), so nothing flashes or reflows unexpectedly.
 type CodePlugin = typeof streamdownCode
 let codePluginCache: CodePlugin | null = null
+
+function markdownNodeText(node: ReactNode): string {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return ''
+  }
+
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(markdownNodeText).join('')
+  }
+
+  if (isValidElement<{ children?: ReactNode; dir?: string; 'data-ref'?: string; 'data-ref-text'?: string }>(node)) {
+    if (node.type === 'code' || node.props.dir === 'ltr' || node.props['data-ref'] || node.props['data-ref-text']) {
+      return ''
+    }
+
+    return markdownNodeText(node.props.children)
+  }
+
+  return ''
+}
+
+function markdownChildrenDirection(children: ReactNode) {
+  return resolveTextDirection(markdownNodeText(children))
+}
 
 function useCodePlugin(): CodePlugin | null {
   const [plugin, setPlugin] = useState(codePluginCache)
@@ -474,23 +503,33 @@ function MarkdownTextSurface({
   const components = useMemo(
     () =>
       ({
-        h1: ({ className, ...props }: ComponentProps<'h1'>) => (
-          <h1 className={cn('my-1 font-semibold', HEADING_SIZES.h1, className)} {...props} />
+        h1: ({ children, className, ...props }: ComponentProps<'h1'>) => (
+          <h1 className={cn('my-1 font-semibold', HEADING_SIZES.h1, className)} {...props} dir={markdownChildrenDirection(children)}>
+            {children}
+          </h1>
         ),
-        h2: ({ className, ...props }: ComponentProps<'h2'>) => (
-          <h2 className={cn('my-1 font-semibold', HEADING_SIZES.h2, className)} {...props} />
+        h2: ({ children, className, ...props }: ComponentProps<'h2'>) => (
+          <h2 className={cn('my-1 font-semibold', HEADING_SIZES.h2, className)} {...props} dir={markdownChildrenDirection(children)}>
+            {children}
+          </h2>
         ),
-        h3: ({ className, ...props }: ComponentProps<'h3'>) => (
-          <h3 className={cn('my-1 font-semibold', HEADING_SIZES.h3, className)} {...props} />
+        h3: ({ children, className, ...props }: ComponentProps<'h3'>) => (
+          <h3 className={cn('my-1 font-semibold', HEADING_SIZES.h3, className)} {...props} dir={markdownChildrenDirection(children)}>
+            {children}
+          </h3>
         ),
-        h4: ({ className, ...props }: ComponentProps<'h4'>) => (
-          <h4 className={cn('my-1 font-semibold', HEADING_SIZES.h4, className)} {...props} />
+        h4: ({ children, className, ...props }: ComponentProps<'h4'>) => (
+          <h4 className={cn('my-1 font-semibold', HEADING_SIZES.h4, className)} {...props} dir={markdownChildrenDirection(children)}>
+            {children}
+          </h4>
         ),
-        p: ({ className, ...props }: ComponentProps<'p'>) => (
+        p: ({ children, className, ...props }: ComponentProps<'p'>) => (
           // Vertical rhythm is owned by styles.css (`--paragraph-gap`), which
           // must out-specify Tailwind Typography's `prose` margins — so no
           // `my-*` here on purpose.
-          <p className={cn('wrap-anywhere leading-(--dt-line-height)', className)} {...props} />
+          <p className={cn('wrap-anywhere leading-(--dt-line-height)', className)} {...props} dir={markdownChildrenDirection(children)}>
+            {children}
+          </p>
         ),
         a: MarkdownLink,
         // Inline code must not vote when an ancestor resolves `dir="auto"`
@@ -506,12 +545,10 @@ function MarkdownTextSurface({
         // Lists and blockquotes have chrome that sits *beside* the text
         // (markers, the quote border), and that side is driven by the CSS
         // `direction` of the box, which `unicode-bidi: plaintext` never
-        // touches — an RTL list otherwise renders its numbers stranded at
-        // the far left. `dir="auto"` lets the browser resolve the box
-        // direction from content; the plaintext rules in styles.css keep
-        // owning per-line text direction. Inline code carries `dir="ltr"`
-        // (see the `code` override) so it doesn't vote here either, same
-        // contract as the CSS isolate.
+        // touches. Browser `dir="auto"` uses the first strong character, which
+        // misclassifies Arabic list items that start with an English brand
+        // (Alibaba, DeepSeek, OpenAI, ...). Resolve from the visible sentence
+        // instead, ignoring isolated inline code/ref chips.
         // A `> [!NOTE]`/`[!WARNING]`/... blockquote renders as a GFM alert
         // callout; everything else stays a plain quote.
         blockquote: ({ children, className, ...props }: ComponentProps<'blockquote'>) => {
@@ -524,21 +561,27 @@ function MarkdownTextSurface({
           return (
             <blockquote
               className={cn('border-s-2 border-(--ui-stroke-tertiary) ps-3 text-muted-foreground italic', className)}
-              dir="auto"
               {...props}
+              dir={markdownChildrenDirection(children)}
             >
               {children}
             </blockquote>
           )
         },
-        ul: ({ className, ...props }: ComponentProps<'ul'>) => (
-          <ul className={cn('my-1 gap-0', className)} dir="auto" {...props} />
+        ul: ({ children, className, ...props }: ComponentProps<'ul'>) => (
+          <ul className={cn('my-1 gap-0', className)} {...props} dir={markdownChildrenDirection(children)}>
+            {children}
+          </ul>
         ),
-        ol: ({ className, ...props }: ComponentProps<'ol'>) => (
-          <ol className={cn('my-1 gap-0', className)} dir="auto" {...props} />
+        ol: ({ children, className, ...props }: ComponentProps<'ol'>) => (
+          <ol className={cn('my-1 gap-0', className)} {...props} dir={markdownChildrenDirection(children)}>
+            {children}
+          </ol>
         ),
-        li: ({ className, ...props }: ComponentProps<'li'>) => (
-          <li className={cn('leading-(--dt-line-height)', className)} {...props} />
+        li: ({ children, className, ...props }: ComponentProps<'li'>) => (
+          <li className={cn('leading-(--dt-line-height)', className)} {...props} dir={markdownChildrenDirection(children)}>
+            {children}
+          </li>
         ),
         table: ({ className, ...props }: ComponentProps<'table'>) => (
           <div className="aui-md-table my-2 max-w-full overflow-x-auto rounded-[0.375rem] border border-(--ui-stroke-tertiary)">

--- a/apps/desktop/src/components/assistant-ui/thread/block-direction.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/block-direction.test.tsx
@@ -1,11 +1,12 @@
 // Lists and blockquotes have chrome beside the text (markers, the quote
 // border) whose side is driven by the box's CSS direction, which the
-// unicode-bidi:plaintext rules never touch. These tests pin the split of
-// responsibilities: ul/ol/blockquote carry dir="auto" so the browser
-// resolves their box direction from content, inline code carries dir="ltr"
-// so it neither votes in that resolution nor reorders, and plain prose
-// blocks stay attribute-free (the plaintext CSS owns them). jsdom does not
-// resolve dir="auto", so the contract is asserted at the attribute level.
+// unicode-bidi isolation never changes. These tests pin the split of
+// responsibilities: block chrome carries a resolved dir so markers/borders
+// follow Arabic/Hebrew text even when an item starts with an English brand or
+// inline code, inline code carries dir="ltr" so it neither votes in that
+// resolution nor reorders, and prose blocks carry the same resolved dir that
+// `text-align:start` needs. jsdom does not resolve browser bidi visually, so
+// the contract is asserted at the attribute level.
 import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
@@ -90,16 +91,18 @@ function Harness({ text }: { text: string }) {
 }
 
 describe('block-level direction chrome', () => {
-  it('lists carry dir="auto" so markers follow the resolved direction', async () => {
+  it('lists resolve rtl so markers follow the sentence direction', async () => {
     render(<Harness text={'מקומות:\n\n1. חוף גורדון\n2. שוק הכרמל\n\n- פריט\n- item'} />)
 
     const item = await screen.findByText(/חוף גורדון/)
 
-    expect(item.closest('ol')?.getAttribute('dir')).toBe('auto')
+    expect(item.closest('ol')?.getAttribute('dir')).toBe('rtl')
+    expect(item.closest('li')?.getAttribute('dir')).toBe('rtl')
 
     const bullet = await screen.findByText(/פריט/)
 
-    expect(bullet.closest('ul')?.getAttribute('dir')).toBe('auto')
+    expect(bullet.closest('ul')?.getAttribute('dir')).toBe('rtl')
+    expect(bullet.closest('li')?.getAttribute('dir')).toBe('rtl')
   })
 
   it('blockquotes carry dir="auto" so the border follows the resolved direction', async () => {
@@ -107,24 +110,46 @@ describe('block-level direction chrome', () => {
 
     const quote = await screen.findByText(/ציטוט קצר/)
 
-    expect(quote.closest('blockquote')?.getAttribute('dir')).toBe('auto')
+    expect(quote.closest('blockquote')?.getAttribute('dir')).toBe('rtl')
   })
 
-  it('inline code carries dir="ltr" so it does not vote in dir="auto" resolution', async () => {
+  it('inline code carries dir="ltr" so it does not vote in resolved direction', async () => {
     render(<Harness text={'1. `npm install` מתקין תלויות'} />)
 
     const code = await screen.findByText('npm install')
 
     expect(code.tagName).toBe('CODE')
     expect(code.getAttribute('dir')).toBe('ltr')
-    expect(code.closest('ol')?.getAttribute('dir')).toBe('auto')
+    expect(code.closest('ol')?.getAttribute('dir')).toBe('rtl')
+    expect(code.closest('li')?.getAttribute('dir')).toBe('rtl')
   })
 
-  it('plain prose blocks stay attribute-free (plaintext CSS owns them)', async () => {
+  it('plain prose blocks carry resolved direction for text-align:start', async () => {
     render(<Harness text={'שלום לכולם'} />)
 
     const paragraph = await screen.findByText(/שלום לכולם/)
 
-    expect(paragraph.closest('p')?.hasAttribute('dir')).toBe(false)
+    expect(paragraph.closest('p')?.getAttribute('dir')).toBe('rtl')
+  })
+
+  it('brand-start Arabic bullet rows stay rtl instead of first-English LTR', async () => {
+    render(
+      <Harness
+        text={
+          '- **Alibaba** نزلت Qwen3.8-Max والمقلب الحلو إنك بتكلم الخبر ده\n' +
+          '- **DeepSeek** نزلت V4 beta شغالة على الأسعار الصينية\n' +
+          '- **Google عندها Gemini 3.5 + Gemini Omni + computer use في Flash** — بس برضه عندهم نزيف باحثين'
+        }
+      />
+    )
+
+    const alibaba = await screen.findByText('Alibaba')
+    const deepseek = await screen.findByText('DeepSeek')
+    const google = await screen.findByText(/Google عندها/)
+
+    expect(alibaba.closest('ul')?.getAttribute('dir')).toBe('rtl')
+    expect(alibaba.closest('li')?.getAttribute('dir')).toBe('rtl')
+    expect(deepseek.closest('li')?.getAttribute('dir')).toBe('rtl')
+    expect(google.closest('li')?.getAttribute('dir')).toBe('rtl')
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -42,7 +42,8 @@ import {
   refChipElement,
   renderComposerContents,
   replaceBeforeCaret,
-  RICH_INPUT_SLOT
+  RICH_INPUT_SLOT,
+  syncElementTextDirection
 } from '@/app/chat/composer/rich-editor'
 import { detectTrigger, openDirectiveScope, textBeforeCaret, type TriggerState } from '@/app/chat/composer/text-utils'
 import { ComposerTriggerPopover } from '@/app/chat/composer/trigger-popover'
@@ -227,6 +228,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   const syncDraftFromEditor = useCallback(
     (editor: HTMLDivElement) => {
       const nextDraft = sanitizeComposerInput(composerPlainText(editor))
+      syncElementTextDirection(editor, nextDraft)
 
       if (nextDraft !== draftRef.current) {
         draftRef.current = nextDraft
@@ -337,8 +339,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
       const directive = !starter && serialized.match(/^@([^:]+):(.+)$/)
 
       const finish = () => {
-        draftRef.current = composerPlainText(editor)
-        aui.composer().setText(draftRef.current)
+        syncDraftFromEditor(editor)
         requestEditFocus()
         starter ? window.setTimeout(refreshTrigger, 0) : closeTrigger()
       }
@@ -779,6 +780,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
               contentEditable
               data-placeholder={copy.editMessage}
               data-slot={RICH_INPUT_SLOT}
+              dir="auto"
               onBeforeInput={handleBeforeInput}
               onBlur={() => window.setTimeout(closeTrigger, 80)}
               onDragOver={handleDragOver}

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-text.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-text.test.tsx
@@ -44,6 +44,25 @@ describe('a sent reference renders as the chip the composer showed', () => {
     const code = document.querySelector('[data-slot="aui_user-inline-code"]')
 
     expect(code?.textContent).toBe('npm test')
+    expect(code?.getAttribute('dir')).toBe('ltr')
+  })
+
+  it('lets user prose resolve its own direction without inline code voting', () => {
+    render(<UserMessageText text="شغّل `npm test` الأول" />)
+
+    const line = document.querySelector('[data-slot="aui_user-inline-text"]')
+    const code = document.querySelector('[data-slot="aui_user-inline-code"]')
+
+    expect(line?.getAttribute('dir')).toBe('rtl')
+    expect(code?.getAttribute('dir')).toBe('ltr')
+  })
+
+  it('keeps RTL direction when special tokens start the sentence', () => {
+    render(<UserMessageText text="@file:`apps/desktop/a.ts` شوف الملف\n`npm test` شغّل الأول\n- راجع ده" />)
+
+    const line = document.querySelector('[data-slot="aui_user-inline-text"]')
+
+    expect(line?.getAttribute('dir')).toBe('rtl')
   })
 
   it('renders code and a reference side by side', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-text.tsx
@@ -3,6 +3,7 @@ import { Fragment, useMemo } from 'react'
 
 import { DirectiveContent } from '@/components/assistant-ui/directive-text'
 import { referenceRe } from '@/components/assistant-ui/reference-kinds'
+import { resolveTextDirection } from '@/lib/bidi-direction'
 import { cn } from '@/lib/utils'
 
 // User messages should render the bare-minimum of markdown: backtick `code`
@@ -148,16 +149,18 @@ export const UserMessageText: FC<UserMessageTextProps> = ({ className, text }) =
 
 const InlineSegmentView: FC<{ text: string }> = ({ text }) => {
   const nodes = useMemo(() => splitInlineCode(text), [text])
+  const direction = useMemo(() => resolveTextDirection(text), [text])
 
   return (
     // styles.css bidi hook (#44150); whitespace-pre-line makes each line its own
     // UAX#9 paragraph so it resolves direction independently.
-    <span className="wrap-anywhere block whitespace-pre-line" data-slot="aui_user-inline-text">
+    <span className="wrap-anywhere block whitespace-pre-line" data-slot="aui_user-inline-text" dir={direction}>
       {nodes.map((node, nodeIndex) =>
         node.kind === 'inline-code' ? (
           <code
             className="mx-px rounded bg-[color-mix(in_srgb,currentColor_8%,transparent)] px-1 py-px font-mono text-[0.92em]"
             data-slot="aui_user-inline-code"
+            dir="ltr"
             key={`code-${nodeIndex}`}
           >
             {node.code}

--- a/apps/desktop/src/lib/bidi-direction.test.ts
+++ b/apps/desktop/src/lib/bidi-direction.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveTextDirection } from './bidi-direction'
+
+describe('resolveTextDirection', () => {
+  it('ignores leading neutral punctuation before RTL text', () => {
+    expect(resolveTextDirection('- شغّل Hermes')).toBe('rtl')
+    expect(resolveTextDirection('؟ شغّل Hermes')).toBe('rtl')
+    expect(resolveTextDirection('(شغّل Hermes)')).toBe('rtl')
+    expect(resolveTextDirection('2026: شغّل Hermes')).toBe('rtl')
+  })
+
+  it('lets RTL text after leading code-like tokens own the sentence direction', () => {
+    expect(resolveTextDirection('`npm test` شغّل الأول')).toBe('rtl')
+    expect(resolveTextDirection('@file:`apps/desktop/a.ts` شوف الملف')).toBe('rtl')
+    expect(resolveTextDirection('./run.sh شغّل السكريبت')).toBe('rtl')
+    expect(resolveTextDirection('/some-skill شغّل ده')).toBe('rtl')
+  })
+
+  it('falls back to the leading strong LTR text when there is no RTL sentence body', () => {
+    expect(resolveTextDirection('run tests الأول')).toBe('ltr')
+    expect(resolveTextDirection('`npm test`')).toBe('ltr')
+    expect(resolveTextDirection('@file:`apps/desktop/a.ts`')).toBe('ltr')
+  })
+
+  it('uses the dominant sentence script when an English brand starts Arabic prose', () => {
+    expect(resolveTextDirection('Alibaba نزلت Qwen3.8-Max والمقلب الحلو إنك بتكلم الخير ده')).toBe('rtl')
+    expect(resolveTextDirection('DeepSeek نزلت V4 beta شغالة على الأسعار الصينية')).toBe('rtl')
+    expect(resolveTextDirection('Moonshot (Kimi) نزلوا K3 وفتحوا الـ infrastructure بتاعهم')).toBe('rtl')
+    expect(resolveTextDirection('Google عندها Gemini 3.5 + Gemini Omni + computer use في Flash')).toBe('rtl')
+  })
+
+  it('keeps leading neutral punctuation outside an English-brand Arabic sentence', () => {
+    expect(resolveTextDirection('• Google عندها Gemini 3.5')).toBe('rtl')
+    expect(resolveTextDirection('— OpenAI لسه مكملة بـ GPT-5.6')).toBe('rtl')
+  })
+})

--- a/apps/desktop/src/lib/bidi-direction.ts
+++ b/apps/desktop/src/lib/bidi-direction.ts
@@ -1,0 +1,115 @@
+export type TextDirection = 'ltr' | 'rtl'
+
+const RTL_STRONG_RE =
+  /[\p{Script=Adlam}\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Nko}\p{Script=Syriac}\p{Script=Thaana}]/u
+
+const LETTER_RE = /\p{Letter}/u
+
+const LEADING_DIRECTIVE_RE = /^@[\w-]{1,64}:(?:`[^`]*`|"[^"]*"|'[^']*'|[^\s]+)/u
+const LEADING_INLINE_CODE_RE = /^(`+)[\s\S]*?\1/u
+
+const LEADING_LATIN_LABEL_RE =
+  /^(?:[\p{Script=Latin}\p{Number}][\p{Script=Latin}\p{Number}._+:/#@-]*)(?:\s+\([\p{Script=Latin}\p{Number}\s._+:/#@-]+\))?/u
+
+const LEADING_PATH_TOKEN_RE = /^(?:\.{1,2}\/|\/|~\/|[A-Za-z]:[\\/])[^\s]+/u
+const LEADING_SLASH_COMMAND_RE = /^\/[A-Za-z][\w-]*(?=\s|$)/u
+
+function firstStrongDirection(text: string): TextDirection | null {
+  for (const ch of text) {
+    if (RTL_STRONG_RE.test(ch)) {
+      return 'rtl'
+    }
+
+    if (LETTER_RE.test(ch)) {
+      return 'ltr'
+    }
+  }
+
+  return null
+}
+
+function dominantStrongDirection(text: string): TextDirection | null {
+  let ltr = 0
+  let rtl = 0
+
+  for (const ch of text) {
+    if (RTL_STRONG_RE.test(ch)) {
+      rtl += 1
+    } else if (LETTER_RE.test(ch)) {
+      ltr += 1
+    }
+  }
+
+  if (rtl > ltr) {
+    return 'rtl'
+  }
+
+  if (ltr > 0) {
+    return 'ltr'
+  }
+
+  return rtl > 0 ? 'rtl' : null
+}
+
+function stripLeadingNonStrong(text: string) {
+  let index = 0
+
+  for (const ch of text) {
+    if (RTL_STRONG_RE.test(ch) || LETTER_RE.test(ch)) {
+      break
+    }
+
+    index += ch.length
+  }
+
+  return text.slice(index)
+}
+
+function stripOneLeadingToken(text: string) {
+  const trimmed = text.trimStart()
+
+  const token =
+    trimmed.match(LEADING_INLINE_CODE_RE)?.[0] ??
+    trimmed.match(LEADING_DIRECTIVE_RE)?.[0] ??
+    trimmed.match(LEADING_SLASH_COMMAND_RE)?.[0] ??
+    trimmed.match(LEADING_PATH_TOKEN_RE)?.[0]
+
+  return token ? trimmed.slice(token.length) : stripLeadingNonStrong(trimmed)
+}
+
+function stripLeadingDirectionalTokens(text: string) {
+  let next = text
+
+  for (let i = 0; i < 8; i += 1) {
+    const stripped = stripOneLeadingToken(next)
+
+    if (stripped === next) {
+      return stripped
+    }
+
+    next = stripped
+  }
+
+  return next
+}
+
+function startsWithLatinLabelThenRtl(text: string) {
+  const label = text.match(LEADING_LATIN_LABEL_RE)?.[0]
+
+  return label ? firstStrongDirection(text.slice(label.length)) === 'rtl' : false
+}
+
+export function resolveTextDirection(text: string, fallback: TextDirection = 'ltr'): TextDirection {
+  const afterSpecialStart = stripLeadingDirectionalTokens(text)
+  const afterSpecialDirection = firstStrongDirection(afterSpecialStart)
+
+  if (afterSpecialDirection === 'rtl' || startsWithLatinLabelThenRtl(afterSpecialStart)) {
+    return 'rtl'
+  }
+
+  return dominantStrongDirection(text) ?? afterSpecialDirection ?? firstStrongDirection(text) ?? fallback
+}
+
+export function syncElementTextDirection(element: HTMLElement, text: string) {
+  element.dir = text.trim() ? resolveTextDirection(text) : 'auto'
+}

--- a/apps/desktop/src/styles-rtl.test.ts
+++ b/apps/desktop/src/styles-rtl.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const styles = readFileSync(resolve(process.cwd(), 'src/styles.css'), 'utf8')
+
+describe('resolved bidi surface styles', () => {
+  it('isolates the resolved direction instead of re-detecting first-strong text', () => {
+    expect(styles).toMatch(
+      /\[data-slot='aui_assistant-message-content'\][\s\S]*?\[data-slot='composer-rich-input'\]\s*\{\s*unicode-bidi:\s*isolate;\s*text-align:\s*start;\s*\}/
+    )
+  })
+})

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1261,16 +1261,17 @@ code {
    content's --message-text-indent). No extra prose indent — a single gutter
    reads cleaner than a ragged tool-vs-reply column. */
 
-/* RTL/bidi chat text (#44150): each block resolves its own base direction from
-   its first strong char (UAX#9 plaintext). text-align:start makes that resolved
-   direction drive alignment too — load-bearing, since the user bubble pins
-   text-left. direction is never set, so chrome/layout/list-indent stay LTR (the
-   issue asks not to flip the whole UI). Covers assistant prose, user lines, and
-   both composers (main + edit share composer-rich-input). */
+/* RTL/bidi chat text (#44150): React-owned text surfaces set their own
+   direction from the user-visible sentence, then isolate that resolved block
+   from surrounding bidi runs. `plaintext` is intentionally wrong here: it
+   re-detects the paragraph from the first strong character, so an English
+   brand or neutral punctuation can undo the resolved RTL direction and make
+   wrapped lines align left. Covers assistant prose, user lines, and both
+   composers (main + edit share composer-rich-input). */
 [data-slot='aui_assistant-message-content'] .aui-md :where(p, h1, h2, h3, h4, h5, h6, li, blockquote),
 [data-slot='aui_user-inline-text'],
 [data-slot='composer-rich-input'] {
-  unicode-bidi: plaintext;
+  unicode-bidi: isolate;
   text-align: start;
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes RTL layout in the Desktop chat when Arabic or Hebrew text starts with an English brand, neutral punctuation, inline code, a directive, a path, or a reference chip.

This also keeps Markdown list markers and wrapped continuation lines aligned with the RTL paragraph while technical tokens remain LTR.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added a shared direction resolver for mixed-script and token-led text.
- Applied the resolved direction to Markdown blocks, user messages, and composer/edit-composer content.
- Kept inline code, fenced code, paths, directives, and reference chips isolated as LTR.
- Switched resolved text blocks from `unicode-bidi: plaintext` to `isolate` so the browser does not override the chosen direction.
- Added regression coverage for English-brand-led Arabic, special-character starts, list markers, wrapped lines, code-like prefixes, and reference chips.

## How to Test

1. Render Arabic or Hebrew messages and list items that start with punctuation, inline code, or English brands such as `Alibaba`, `Google`, and `OpenAI`.
2. Confirm the list marker and wrapped lines stay right-aligned while technical tokens remain LTR.
3. Run:

```bash
cd apps/desktop
npm run test -- src/styles-rtl.test.ts src/lib/bidi-direction.test.ts src/components/assistant-ui/thread/block-direction.test.tsx src/components/assistant-ui/thread/user-message-text.test.tsx src/app/chat/composer/rich-editor.test.ts src/app/chat/composer/inline-references.test.ts
npm run typecheck
npm run lint
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] This PR only contains changes related to the Desktop RTL fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for the change
- [x] I've tested the packaged Desktop app on macOS

### Documentation & Housekeeping

- [x] Documentation update is not needed
- [x] `cli-config.yaml.example` update is not needed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is not needed
- [x] Cross-platform impact was considered
- [x] Tool descriptions and schemas are unchanged

## Screenshots / Logs

Verified in the packaged macOS Desktop app with mixed Arabic/English messages, RTL lists, wrapped lines, and special characters at the start of a sentence.
