### PR TITLE
fix(tts): report unknown-provider fallback truthfully

### DIFF
--- a/tests/tools/test_tts_plugin_dispatch.py
+++ b/tests/tools/test_tts_plugin_dispatch.py
@@ -28,6 +28,8 @@ helpers.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Optional
 
 import pytest
@@ -175,6 +177,37 @@ class TestPluginDispatch:
             tts_config={},
         )
         assert result is None
+
+    def test_unknown_provider_fallback_reports_edge(self, tmp_path, monkeypatch):
+        """Legacy fallback remains available, but its response names Edge.
+
+        Before this regression, the unknown configured name fell through to
+        Edge synthesis while the success payload incorrectly claimed that the
+        unknown provider generated the audio.
+        """
+        monkeypatch.setattr(
+            tts_tool,
+            "_load_tts_config",
+            lambda: {"provider": "missing-provider"},
+        )
+        monkeypatch.setattr(
+            tts_tool,
+            "_dispatch_to_plugin_provider",
+            lambda *args: None,
+        )
+        monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+
+        async def fake_edge(text, output_path, tts_config):
+            Path(output_path).write_bytes(b"fake edge audio")
+
+        monkeypatch.setattr(tts_tool, "_generate_edge_tts", fake_edge)
+        result = json.loads(
+            tts_tool.text_to_speech_tool("hello", output_path=str(tmp_path / "out.mp3"))
+        )
+
+        assert result["success"] is True
+        assert result["provider"] == "edge"
+        assert result["fallback_from"] == "missing-provider"
 
 
     def test_provider_exception_bubbles_up(self):

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -731,7 +731,9 @@ def _dispatch_to_plugin_provider(
        a refactor of the caller can't silently break the invariant.
     3. Plugin dispatch fires only when ``provider`` matches a registered
        :class:`TTSProvider` whose ``name`` equals the configured value.
-       Unknown names return None (caller falls through to Edge default).
+       Unknown names return None so the caller can use its Edge fallback.
+       The caller must report that fallback as ``edge``, not as the unknown
+       configured name.
 
     Plugin exceptions are caught and re-raised — the outer
     ``text_to_speech_tool`` try/except converts them to the standard
@@ -2923,8 +2925,21 @@ def text_to_speech_tool(
     file_path.parent.mkdir(parents=True, exist_ok=True)
     file_str = str(file_path)
 
+    fallback_from: Optional[str] = None
     try:
-        # Generate audio with the configured provider
+        # Resolve a plugin before native dispatch. An unknown provider has
+        # historically fallen back to Edge; preserve that behavior, but record
+        # the actual backend so result/error reporting is truthful.
+        plugin_path: Optional[str] = None
+        if command_provider_config is None and provider not in BUILTIN_TTS_PROVIDERS:
+            plugin_path = _dispatch_to_plugin_provider(
+                text, file_str, provider, tts_config,
+            )
+            if plugin_path is None:
+                fallback_from = provider
+                provider = DEFAULT_PROVIDER
+
+        # Generate audio with the resolved provider.
         if command_provider_config is not None:
             logger.info(
                 "Generating speech with command TTS provider '%s'...", provider,
@@ -2933,20 +2948,10 @@ def text_to_speech_tool(
                 text, file_str, provider, command_provider_config, tts_config,
             )
 
-        # Plugin-registered TTS backend (issue #30398). Fires when the
-        # configured provider is neither a built-in nor a command-type
-        # entry, AND a plugin is registered under that name. The walrus
-        # binds `_plugin_path` only when the dispatcher returns a path
-        # (i.e. a plugin was actually found); a None return falls
-        # through to the built-in elif chain so unknown names hit the
-        # Edge TTS default at the bottom. The dispatcher itself enforces
-        # built-ins-always-win + command-wins-over-plugin defensively.
-        elif provider not in BUILTIN_TTS_PROVIDERS and (
-            _plugin_path := _dispatch_to_plugin_provider(
-                text, file_str, provider, tts_config,
-            )
-        ) is not None:
-            file_str = _plugin_path
+        # A plugin path was resolved above. Unknown custom names are rewritten
+        # to ``edge`` there, so they use the normal native fallback below.
+        elif plugin_path is not None:
+            file_str = plugin_path
 
         elif provider == "elevenlabs":
             try:
@@ -3132,13 +3137,16 @@ def text_to_speech_tool(
         if voice_compatible:
             media_tag = f"[[audio_as_voice]]\n{media_tag}"
 
-        return json.dumps({
+        response = {
             "success": True,
             "file_path": file_str,
             "media_tag": media_tag,
             "provider": provider,
             "voice_compatible": voice_compatible,
-        }, ensure_ascii=False)
+        }
+        if fallback_from is not None:
+            response["fallback_from"] = fallback_from
+        return json.dumps(response, ensure_ascii=False)
 
     except ValueError as e:
         # Configuration errors (missing API keys, etc.)


### PR DESCRIPTION
## Summary

Unknown TTS provider names have historically fallen back to Edge TTS. The fallback worked, but the success payload still reported the unknown configured provider as the backend that generated the file.

This keeps the fallback behavior for compatibility while reporting it truthfully:

- `provider` is now `edge`, the backend that actually synthesized audio.
- `fallback_from` records the unresolved configured or overridden provider name.
- Other built-in, command, and plugin providers continue reporting their own provider name.
- If Edge is unavailable and NeuTTS handles the fallback, the payload reports `provider: "neutts"` while preserving `fallback_from`.

## Regression coverage

Adds an end-to-end dispatch regression that configures an unregistered provider, stubs Edge generation, and verifies that the successful response identifies Edge while retaining the unresolved name in `fallback_from`.

An independent path review also exercised configured and explicit built-ins, registered plugins, command providers, explicit unknown overrides, fallback generation failure, Edge-to-NeuTTS fallback, and the no-backend-available path.

## Validation

- `pytest -q tests/tools/test_tts_plugin_dispatch.py tests/tools/test_tts_command_providers.py tests/agent/test_tts_registry.py tests/tools/test_tts_opus_routing.py`
  - `83 passed`
- `ruff check tools/tts_tool.py tests/tools/test_tts_plugin_dispatch.py`
- `git diff --check origin/main...HEAD`
