### PR TITLE
fix(ssh): isolate prompt backend probes from file sync

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1033,6 +1033,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
     if cached is not None:
         return cached or None
 
+    env = None
     try:
         # Import locally: tools/ imports are heavy and only relevant when a
         # non-local backend is actually configured.
@@ -1097,6 +1098,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
             container_config=container_config,
             task_id="prompt-backend-probe",
             host_cwd=config.get("host_cwd"),
+            probe_only=env_type == "ssh",
         )
         # Single-line POSIX probe — works on any Unixy backend. Wrapped in
         # `2>/dev/null` so a missing binary doesn't pollute the output.
@@ -1119,6 +1121,12 @@ def _probe_remote_backend(env_type: str) -> str | None:
         logger.debug("Backend probe failed: %s", e)
         _BACKEND_PROBE_CACHE[cache_key] = ""
         return None
+    finally:
+        if env_type == "ssh" and env is not None:
+            try:
+                env.cleanup()
+            except Exception as e:
+                logger.debug("Backend probe cleanup failed: %s", e)
 
     # Parse key=value lines back into a tidy summary.
     parsed: dict[str, str] = {}

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -4,6 +4,7 @@ import builtins
 import importlib
 import logging
 import sys
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -738,6 +739,7 @@ class TestEnvironmentHints:
 
         monkeypatch.setenv("TERMINAL_ENV", "docker")
         _pb._clear_backend_probe_cache()
+        cleanup_calls = []
 
         class _FakeEnv:
             def execute(self, cmd, timeout=None):
@@ -748,6 +750,9 @@ class TestEnvironmentHints:
                         "cwd=/workspace\nuser=root\n"
                     ),
                 }
+
+            def cleanup(self):
+                cleanup_calls.append(True)
 
         created = {}
 
@@ -765,7 +770,67 @@ class TestEnvironmentHints:
         assert line is not None
         assert "Linux 6.8.0" in line
         assert "root" in line
+        assert cleanup_calls == []
 
+    def test_ssh_probe_uses_probe_only_environment_and_cleans_up(self, monkeypatch):
+        import agent.prompt_builder as _pb
+        import tools.terminal_tool as _tt
+
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "example.com")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "alice")
+        _pb._clear_backend_probe_cache()
+
+        env = MagicMock()
+        env.execute.return_value = {
+            "returncode": 0,
+            "output": "os=Linux\nkernel=6.8.0\nhome=/home/alice\ncwd=/workspace\nuser=alice\n",
+        }
+        created = {}
+
+        def _fake_ssh_environment(**kwargs):
+            created.update(kwargs)
+            return env
+
+        monkeypatch.setattr(_tt, "_SSHEnvironment", _fake_ssh_environment)
+
+        line = _pb._probe_remote_backend("ssh")
+
+        assert created.get("probe_only") is True
+        env.cleanup.assert_called_once_with()
+        assert line is not None
+        assert "Linux 6.8.0" in line
+        assert "alice" in line
+
+    @pytest.mark.parametrize(
+        ("returncode", "execute_error", "cleanup_error", "has_result"),
+        [
+            (23, None, None, False),
+            (0, RuntimeError("probe failed"), None, False),
+            (0, None, RuntimeError("cleanup failed"), True),
+        ],
+        ids=("nonzero", "execute-error", "cleanup-error"),
+    )
+    def test_ssh_probe_cleanup_paths(
+        self, monkeypatch, returncode, execute_error, cleanup_error, has_result
+    ):
+        import agent.prompt_builder as _pb
+        import tools.terminal_tool as _tt
+
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "example.com")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "alice")
+        _pb._clear_backend_probe_cache()
+
+        env = MagicMock()
+        env.execute.return_value = {"returncode": returncode, "output": "os=Linux\n"}
+        env.execute.side_effect = execute_error
+        env.cleanup.side_effect = cleanup_error
+
+        monkeypatch.setattr(_tt, "_create_environment", lambda **kwargs: env)
+
+        line = _pb._probe_remote_backend("ssh")
+
+        assert (line is not None) is has_result
+        env.cleanup.assert_called_once_with()
 
     def test_environment_hint_from_env_var_is_appended(self, monkeypatch):
         """HERMES_ENVIRONMENT_HINT lets an embedder describe the runtime env."""

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -172,6 +172,64 @@ class TestSSHPreflight:
         assert env.user == "alice"
 
 
+@pytest.fixture
+def _mock_ssh_runtime(monkeypatch, tmp_path):
+    hooks = {
+        "_establish_connection": MagicMock(),
+        "_detect_remote_home": MagicMock(return_value="/home/alice"),
+        "_ensure_remote_dirs": MagicMock(),
+        "init_session": MagicMock(),
+    }
+    monkeypatch.setattr(ssh_env.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr(ssh_env.shutil, "which", lambda _name: "/usr/bin/ssh")
+    for name, hook in hooks.items():
+        monkeypatch.setattr(ssh_env.SSHEnvironment, name, hook)
+    hooks["sync_factory"] = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(ssh_env, "FileSyncManager", hooks["sync_factory"])
+    return hooks
+
+
+class TestSSHProbeOnly:
+    def test_probe_only_skips_state_sync_and_session_setup(self, _mock_ssh_runtime):
+        env = ssh_env.SSHEnvironment(host="example.com", user="alice", probe_only=True)
+        env._before_execute()
+        env.cleanup()
+
+        _mock_ssh_runtime["_establish_connection"].assert_called_once_with()
+        _mock_ssh_runtime["_detect_remote_home"].assert_not_called()
+        _mock_ssh_runtime["_ensure_remote_dirs"].assert_not_called()
+        _mock_ssh_runtime["sync_factory"].assert_not_called()
+        _mock_ssh_runtime["init_session"].assert_not_called()
+        assert env._sync_manager is None
+
+    def test_probe_only_control_socket_is_isolated(self, monkeypatch, _mock_ssh_runtime):
+        control_exit_calls = []
+
+        def _fake_run(*args, **kwargs):
+            control_exit_calls.append(args[0])
+            return subprocess.CompletedProcess([], 0)
+
+        monkeypatch.setattr(ssh_env.subprocess, "run", _fake_run)
+
+        normal = ssh_env.SSHEnvironment(host="example.com", user="alice")
+        first_probe = ssh_env.SSHEnvironment(host="example.com", user="alice", probe_only=True)
+        second_probe = ssh_env.SSHEnvironment(host="example.com", user="alice", probe_only=True)
+
+        assert first_probe.control_socket != normal.control_socket
+        assert second_probe.control_socket != first_probe.control_socket
+        assert len(first_probe.control_socket.name) == len(normal.control_socket.name)
+
+        normal.control_socket.touch()
+        first_probe.control_socket.touch()
+        first_probe.cleanup()
+        first_probe.cleanup()
+
+        assert normal.control_socket.exists()
+        assert not first_probe.control_socket.exists()
+        assert len(control_exit_calls) == 1
+        normal.cleanup()
+
+
 def _setup_ssh_env(monkeypatch, persistent: bool):
     monkeypatch.setenv("TERMINAL_ENV", "ssh")
     monkeypatch.setenv("TERMINAL_SSH_HOST", _SSH_HOST)

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -40,15 +40,19 @@ class SSHEnvironment(BaseEnvironment):
     Session snapshot preserves env vars across calls.
     CWD persists via in-band stdout markers.
     Uses SSH ControlMaster for connection reuse.
+    Probe-only instances use an isolated connection without sync or session state.
     """
 
     def __init__(self, host: str, user: str, cwd: str = "~",
-                 timeout: int = 60, port: int = 22, key_path: str = ""):
+                 timeout: int = 60, port: int = 22, key_path: str = "",
+                 probe_only: bool = False):
         super().__init__(cwd=cwd, timeout=timeout)
         self.host = host
         self.user = user
         self.port = port
         self.key_path = key_path
+        self._probe_only = probe_only
+        self._sync_manager = None
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
         self.control_dir.mkdir(parents=True, exist_ok=True)
@@ -60,12 +64,17 @@ class SSHEnvironment(BaseEnvironment):
         # deeply-nested $TMPDIR (e.g. /var/folders/xx/yy/T/). Hashing the
         # triple keeps the path stable across reconnects so ControlMaster
         # reuse still works.
-        _socket_id = hashlib.sha256(
-            f"{user}@{host}:{port}".encode()
-        ).hexdigest()[:16]
+        socket_key = f"{user}@{host}:{port}"
+        if self._probe_only:
+            socket_key = f"{socket_key}:probe:{self._session_id}"
+        _socket_id = hashlib.sha256(socket_key.encode()).hexdigest()[:16]
         self.control_socket = self.control_dir / f"{_socket_id}.sock"
         _ensure_ssh_available()
         self._establish_connection()
+        if self._probe_only:
+            self._remote_home = ""
+            return
+
         self._remote_home = self._detect_remote_home()
 
         self._ensure_remote_dirs()
@@ -334,7 +343,8 @@ class SSHEnvironment(BaseEnvironment):
 
     def _before_execute(self) -> None:
         """Sync files to remote via FileSyncManager (rate-limited internally)."""
-        self._sync_manager.sync()
+        if self._sync_manager is not None:
+            self._sync_manager.sync()
 
     # ------------------------------------------------------------------
     # Execution

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1603,7 +1603,8 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
                         ssh_config: dict = None, container_config: dict = None,
                         local_config: dict = None,
                         task_id: str = "default",
-                        host_cwd: str = None):
+                        host_cwd: str = None,
+                        probe_only: bool = False):
     """
     Create an execution environment for sandboxed command execution.
     
@@ -1617,6 +1618,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
         container_config: Resource config for container backends (cpu, memory, disk, persistent)
         task_id: Task identifier for environment reuse and snapshot keying
         host_cwd: Optional host working directory to bind into Docker when explicitly enabled
+        probe_only: Create a lightweight SSH environment for prompt introspection
         
     Returns:
         Environment instance with execute() method
@@ -1758,6 +1760,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             key_path=ssh_config.get("key", ""),
             cwd=cwd,
             timeout=timeout,
+            probe_only=probe_only,
         )
 
     else:


### PR DESCRIPTION
## What does this PR do?

The prompt-time backend probe currently constructs a normal `SSHEnvironment`. Before the one-line introspection command can run, that constructor detects the remote home, creates Hermes directories, performs a forced upload, and initializes a session snapshot. When the temporary object is later finalized, normal SSH cleanup can also run `sync_back()` concurrently with the real terminal environment.

This makes the SSH prompt probe lightweight and deterministic:

- add an internal `probe_only` construction path for SSH
- give each probe an isolated, fixed-length ControlMaster socket
- skip remote directory setup, file sync, and session snapshot initialization
- clean up the probe on success, non-zero exit, and exceptions without replacing the probe result if cleanup fails
- preserve the default behavior for every normal SSH caller and every non-SSH backend

Related to #72594: that PR adds generic post-probe cleanup and container lifecycle changes, but SSH has already completed its full constructor-time sync before cleanup becomes possible. This PR addresses that SSH-specific setup path.

Related to #77508: probe sockets are intentionally isolated so probe cleanup cannot close a normal SSH environment shared by endpoint identity.

## Related Issue

No exact issue found; searched open issues and PRs for SSH prompt-probe sync and lifecycle reports.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/prompt_builder.py`: request a probe-only SSH environment and explicitly clean it up.
- `tools/terminal_tool.py`: pass the internal probe-only flag only to the SSH backend.
- `tools/environments/ssh.py`: isolate probe sockets and skip sync/session setup for probe instances.
- `tests/agent/test_prompt_builder.py`: cover success, non-zero, execute-error, and cleanup-error paths.
- `tests/tools/test_ssh_environment.py`: cover skipped setup and socket isolation/idempotent cleanup.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_prompt_builder.py tests/tools/test_ssh_environment.py tests/tools/test_sync_back_backends.py tests/tools/test_file_sync_back.py tests/tools/test_terminal_tool.py tests/tools/test_file_tools_container_config.py tests/tools/test_code_execution.py tests/tools/test_code_execution_modes.py --file-retries 0`.
2. Run `ruff check agent/prompt_builder.py tools/terminal_tool.py tools/environments/ssh.py tests/agent/test_prompt_builder.py tests/tools/test_ssh_environment.py`.
3. With an SSH backend configured, build environment hints and verify the probe returns remote metadata without constructing `FileSyncManager`, creating remote Hermes directories, or initializing a session; verify the probe ControlMaster socket is removed afterward.

Focused result on the upstream branch: 169 passed, 0 failed across the eight files. A live SSH smoke on macOS 26.1 returned remote metadata, invoked none of the forbidden setup paths, and restored the ControlMaster socket set after cleanup.

The full `pytest tests/ -q` suite was not run. Two unrelated macOS `/tmp` versus `/private/tmp` assertions in `tests/tools/test_file_tools.py` reproduce on the unmodified base.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I have run `pytest tests/ -q` and all tests pass (focused suite passed; full suite not run)
- [x] I have added tests for the bug fix
- [x] I have tested on macOS 26.1

### Documentation & Housekeeping

- [x] Relevant documentation/docstrings updated, or N/A
- [x] `cli-config.yaml.example` updated, or N/A (no config keys added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` updated, or N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas updated, or N/A

## Screenshots / Logs

Not applicable; this is an internal SSH lifecycle fix with automated and live transport verification.