### PR TITLE
feat(desktop): MessageTrace — continuous color trace as ambient reaction alternative

### DIFF
--- a/apps/desktop/src/app/chat/composer/text-utils.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.ts
@@ -1,5 +1,5 @@
 import { DATA_IMAGE_URL_RE, dataUrlToBlob } from '@/lib/embedded-images'
-import { $reactionsEnabled } from '@/store/reactions-enabled'
+import { $reactionsStyle } from '@/store/reactions-style'
 
 import { serializeTextBefore } from './rich-editor'
 
@@ -221,7 +221,7 @@ export function detectTrigger(textBefore: string): TriggerState | null {
   // After `@` so a directive starter's colon (`@file:`) stays an `@` query.
   // Rides the reactions opt-in (Settings → Appearance) — both are one
   // "emoji features" surface, off by default.
-  const emoji = $reactionsEnabled.get() ? EMOJI_TRIGGER_RE.exec(textBefore) : null
+  const emoji = $reactionsStyle.get() !== 'off' ? EMOJI_TRIGGER_RE.exec(textBefore) : null
 
   if (emoji) {
     return { kind: ':', query: emoji[2], tokenLength: 1 + emoji[2].length, value: emoji[2] }

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -15,7 +15,7 @@ import { cn } from '@/lib/utils'
 import { $backdrop, setBackdrop } from '@/store/backdrop'
 import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedMode } from '@/store/embed-consent'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
-import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
+import { $reactionsStyle, setReactionsStyle } from '@/store/reactions-style'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $translucency, setTranslucency } from '@/store/translucency'
 import { $zoomPercent, setZoomPercent } from '@/store/zoom'
@@ -252,7 +252,7 @@ export function AppearanceSettings() {
   const embedMode = useStore($embedMode)
   const embedAllowed = useStore($embedAllowed)
   const translucency = useStore($translucency)
-  const reactionsEnabled = useStore($reactionsEnabled)
+  const reactionsStyle = useStore($reactionsStyle)
   const backdrop = useStore($backdrop)
   const installs = useStore($marketplaceInstalls)
   const profiles = useStore($profiles)
@@ -482,13 +482,14 @@ export function AppearanceSettings() {
               <SegmentedControl
                 onChange={id => {
                   triggerHaptic('selection')
-                  setReactionsEnabled(id === 'on')
+                  setReactionsStyle(id as 'ambient' | 'emoji' | 'off')
                 }}
                 options={[
                   { id: 'off', label: t.common.off },
-                  { id: 'on', label: t.common.on }
+                  { id: 'emoji', label: 'Emoji' },
+                  { id: 'ambient', label: 'Ambient' }
                 ]}
-                value={reactionsEnabled ? 'on' : 'off'}
+                value={reactionsStyle}
               />
             }
             description={a.reactionsDesc}

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -16,6 +16,7 @@ import {
   pickPrimaryPreviewTarget
 } from '@/components/assistant-ui/thread/content'
 import { MESSAGE_PARTS_COMPONENTS } from '@/components/assistant-ui/thread/message-parts'
+import { MessageTrace } from '@/components/assistant-ui/thread/message-trace'
 import { ReactionPicker } from '@/components/assistant-ui/thread/message-reactions'
 import { ResponseLoadingIndicator, StreamStallIndicator } from '@/components/assistant-ui/thread/status'
 import { formatMessageTimestamp } from '@/components/assistant-ui/thread/timestamp'
@@ -173,7 +174,7 @@ const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText,
   const copy = t.assistant.thread
 
   const [pickerOpen, setPickerOpen] = useState(false)
-  const { enabled: reactionsEnabled, react, reactions: shownReactions } = useMessageReactions(messageId, 'assistant')
+  const { enabled: reactionsEnabled, react, reactions: shownReactions, style } = useMessageReactions(messageId, 'assistant')
 
   const pickEmoji = useCallback(
     (emoji: null | string) => {
@@ -226,7 +227,14 @@ const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText,
           clicking it reopens the picker to switch or retract. Outside
           ActionBarPrimitive.Root so a landed reaction doesn't ride the bar's
           hover opacity. */}
-      {(reactionsEnabled || shownReactions.length > 0) && (
+      {(reactionsEnabled || shownReactions.length > 0) && style === 'ambient' ? (
+        <MessageTrace
+          onTrace={pos => {
+            // Store trace score — placeholder until trace persistence lands
+            // (future: store per-message in reactions-local or session metadata)
+          }}
+        />
+      ) : (reactionsEnabled || shownReactions.length > 0) ? (
         <ReactionPicker
           onOpenChange={setPickerOpen}
           onSelect={pickEmoji}
@@ -253,7 +261,7 @@ const AssistantActionBar: FC<MessageActionProps> = ({ messageId, getMessageText,
             )}
           </TooltipIconButton>
         </ReactionPicker>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/apps/desktop/src/components/assistant-ui/thread/double-click-reaction.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/double-click-reaction.test.tsx
@@ -5,7 +5,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as ReactionsStore from '@/store/reactions'
-import { $reactionsEnabled } from '@/store/reactions-enabled'
+import { $reactionsStyle } from '@/store/reactions-style'
 import { $localReactions } from '@/store/reactions-local'
 
 import { isTapbackDoubleClick } from './use-message-reactions'
@@ -62,7 +62,7 @@ function Harness() {
 
 beforeEach(() => {
   $localReactions.set({})
-  $reactionsEnabled.set(false)
+  $reactionsStyle.set('off')
 })
 
 afterEach(() => {
@@ -92,7 +92,7 @@ describe('isTapbackDoubleClick', () => {
 
 describe('double-click to heart an assistant message', () => {
   it('hearts the message, and a second double-click retracts it', async () => {
-    $reactionsEnabled.set(true)
+    $reactionsStyle.set('emoji')
     render(<Harness />)
 
     const message = (await screen.findByText('done')).closest('[data-slot="aui_assistant-message-root"]')

--- a/apps/desktop/src/components/assistant-ui/thread/message-trace.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-trace.test.tsx
@@ -1,0 +1,181 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { MessageTrace } from './message-trace'
+import type { TracePosition } from './message-trace'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('MessageTrace', () => {
+  it('renders a slider with accessible label when untraced', () => {
+    const onTrace = vi.fn()
+
+    render(<MessageTrace onTrace={onTrace} />)
+    const slider = screen.getByRole('slider')
+
+    expect(slider).toBeTruthy()
+    expect(slider.getAttribute('aria-label')).toContain('click to score')
+    expect(slider.getAttribute('tabindex')).toBe('0')
+  })
+
+  it('reports score when clicked', () => {
+    const onTrace = vi.fn()
+
+    render(<MessageTrace onTrace={onTrace} />)
+    const slider = screen.getByRole('slider')
+
+    // Mock getBoundingClientRect: 200px tall, click at y=30 (near top)
+    vi.spyOn(slider, 'getBoundingClientRect').mockReturnValue({
+      height: 200,
+      top: 0,
+      x: 0,
+      y: 0,
+      width: 20,
+      bottom: 200,
+      left: 0,
+      right: 20,
+      toJSON: () => null
+    })
+
+    fireEvent.click(slider, { clientY: 30 })
+
+    expect(onTrace).toHaveBeenCalledTimes(1)
+    const position: TracePosition = onTrace.mock.calls[0][0]
+
+    expect(position.y).toBeCloseTo(0.15, 1) // 30/200 = 0.15
+    expect(position.score).toBe(85) // (1 - 0.15) * 100 = 85 — top = high score
+  })
+
+  it('click at bottom gives low score', () => {
+    const onTrace = vi.fn()
+
+    render(<MessageTrace onTrace={onTrace} />)
+    const slider = screen.getByRole('slider')
+
+    vi.spyOn(slider, 'getBoundingClientRect').mockReturnValue({
+      height: 200,
+      top: 0,
+      x: 0,
+      y: 0,
+      width: 20,
+      bottom: 200,
+      left: 0,
+      right: 20,
+      toJSON: () => null
+    })
+
+    fireEvent.click(slider, { clientY: 170 })
+
+    expect(onTrace).toHaveBeenCalledTimes(1)
+    const position: TracePosition = onTrace.mock.calls[0][0]
+
+    expect(position.score).toBe(15) // (1 - 0.85) * 100 = 15
+  })
+
+  it('click at middle gives ~50 score', () => {
+    const onTrace = vi.fn()
+
+    render(<MessageTrace onTrace={onTrace} />)
+    const slider = screen.getByRole('slider')
+
+    vi.spyOn(slider, 'getBoundingClientRect').mockReturnValue({
+      height: 200,
+      top: 0,
+      x: 0,
+      y: 0,
+      width: 20,
+      bottom: 200,
+      left: 0,
+      right: 20,
+      toJSON: () => null
+    })
+
+    fireEvent.click(slider, { clientY: 100 })
+
+    expect(onTrace).toHaveBeenCalledTimes(1)
+    const position: TracePosition = onTrace.mock.calls[0][0]
+
+    expect(position.score).toBe(50)
+  })
+
+  it('shows the trace score and glow when traced', () => {
+    const onTrace = vi.fn()
+
+    render(
+      <MessageTrace
+        onTrace={onTrace}
+        trace={{ score: 72 }}
+      />
+    )
+    const slider = screen.getByRole('slider')
+
+    expect(slider.getAttribute('aria-label')).toContain('score 72')
+    expect(slider.getAttribute('title')).toBe('Score: 72/100')
+
+    // Left border glow should be present
+    const glow = document.querySelector('.animate-settle')
+
+    expect(glow).toBeTruthy()
+  })
+
+  it('no glow when not traced', () => {
+    const onTrace = vi.fn()
+
+    render(<MessageTrace onTrace={onTrace} />)
+    const glow = document.querySelector('.animate-settle')
+
+    expect(glow).toBeFalsy()
+  })
+
+  it('keyboard: Enter sets score 50', () => {
+    const onTrace = vi.fn()
+
+    render(<MessageTrace onTrace={onTrace} />)
+    const slider = screen.getByRole('slider')
+
+    fireEvent.keyDown(slider, { key: 'Enter' })
+
+    expect(onTrace).toHaveBeenCalledTimes(1)
+    expect(onTrace.mock.calls[0][0]).toEqual({ y: 0.5, score: 50 })
+  })
+
+  it('keyboard: Space sets score 50', () => {
+    const onTrace = vi.fn()
+
+    render(<MessageTrace onTrace={onTrace} />)
+    const slider = screen.getByRole('slider')
+
+    fireEvent.keyDown(slider, { key: ' ' })
+
+    expect(onTrace).toHaveBeenCalledTimes(1)
+    expect(onTrace.mock.calls[0][0]).toEqual({ y: 0.5, score: 50 })
+  })
+
+  it('clips out-of-range click positions', () => {
+    const onTrace = vi.fn()
+
+    render(<MessageTrace onTrace={onTrace} />)
+    const slider = screen.getByRole('slider')
+
+    vi.spyOn(slider, 'getBoundingClientRect').mockReturnValue({
+      height: 200,
+      top: 0,
+      x: 0,
+      y: 0,
+      width: 20,
+      bottom: 200,
+      left: 0,
+      right: 20,
+      toJSON: () => null
+    })
+
+    // Click above the element
+    fireEvent.click(slider, { clientY: -50 })
+
+    expect(onTrace).toHaveBeenCalledTimes(1)
+    // Score should be clamped: y=0 → score=100
+    expect(onTrace.mock.calls[0][0].score).toBe(100)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/message-trace.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-trace.tsx
@@ -4,14 +4,14 @@ import { cn } from '@/lib/utils'
 // Position 0.0 = top (positive) → green
 // Position 0.5 = middle (neutral) → teal
 // Position 1.0 = bottom (constructive) → blue
-const TRACE_RAMP = [
+const TRACE_RAMP: ReadonlyArray<readonly [number, number, number, number]> = [
   [0.0, 100, 230, 100], // green
   [0.15, 100, 230, 100], // green
   [0.42, 61, 170, 148], // teal
   [0.58, 55, 120, 180], // blue-steel
   [0.85, 55, 100, 200], // blue
   [1.0, 55, 100, 200] // blue
-] as const
+]
 
 const rampColor = (t: number, alpha: number): string => {
   // Clamp to [0, 1]
@@ -83,7 +83,9 @@ export function MessageTrace({ className, onTrace, trace }: MessageTraceProps) {
 
   const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     const rect = event.currentTarget.getBoundingClientRect()
-    const y = (event.clientY - rect.top) / rect.height
+    const rawY = (event.clientY - rect.top) / rect.height
+    // Clamp to [0, 1] — clicks outside the element bounds shouldn't explode
+    const y = Math.max(0, Math.min(1, rawY))
     // Top = high score (100), bottom = low (0)
     const score = Math.round((1 - y) * 100)
 

--- a/apps/desktop/src/components/assistant-ui/thread/message-trace.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-trace.tsx
@@ -1,0 +1,186 @@
+import { cn } from '@/lib/utils'
+
+// ── Trace colors (deuteranopia-safe: green → teal → blue) ─────────────
+// Position 0.0 = top (positive) → green
+// Position 0.5 = middle (neutral) → teal
+// Position 1.0 = bottom (constructive) → blue
+const TRACE_RAMP = [
+  [0.0, 100, 230, 100], // green
+  [0.15, 100, 230, 100], // green
+  [0.42, 61, 170, 148], // teal
+  [0.58, 55, 120, 180], // blue-steel
+  [0.85, 55, 100, 200], // blue
+  [1.0, 55, 100, 200] // blue
+] as const
+
+const rampColor = (t: number, alpha: number): string => {
+  // Clamp to [0, 1]
+  const pos = Math.max(0, Math.min(1, t))
+
+  // Find bracketing stops
+  let lo = TRACE_RAMP[0]
+  let hi = TRACE_RAMP[TRACE_RAMP.length - 1]
+
+  for (let i = 0; i < TRACE_RAMP.length - 1; i++) {
+    if (pos >= TRACE_RAMP[i][0] && pos <= TRACE_RAMP[i + 1][0]) {
+      lo = TRACE_RAMP[i]
+      hi = TRACE_RAMP[i + 1]
+      break
+    }
+  }
+
+  const span = hi[0] - lo[0]
+  const frac = span === 0 ? 0 : (pos - lo[0]) / span
+
+  const r = Math.round(lo[1] + (hi[1] - lo[1]) * frac)
+  const g = Math.round(lo[2] + (hi[2] - lo[2]) * frac)
+  const b = Math.round(lo[3] + (hi[3] - lo[3]) * frac)
+
+  return `rgba(${r},${g},${b},${alpha})`
+}
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export interface TracePosition {
+  /** 0.0 (top) to 1.0 (bottom) */
+  y: number
+  /** 0–100 score derived from position */
+  score: number
+}
+
+export interface MessageTraceData {
+  /** The trace score (0–100), or null if not traced */
+  score: number | null
+}
+
+// ── Component ──────────────────────────────────────────────────────────
+
+interface MessageTraceProps {
+  /** Called when the user clicks a position on the trace strip */
+  onTrace: (position: TracePosition) => void
+  /** Existing trace data, or null if not traced yet */
+  trace?: MessageTraceData | null
+  className?: string
+}
+
+/**
+ * Ambient reaction trace — a clickable gradient strip on the message edge.
+ *
+ * Replaces discrete emoji reactions with a continuous color trace.
+ * The click position maps to a 0–100 score and a green→blue gradient color.
+ * Deuteranopia-safe: the ramp goes green→teal→blue, never red-green.
+ *
+ * @example
+ * ```tsx
+ * <MessageTrace
+ *   onTrace={pos => storeTrace(messageId, pos.score)}
+ *   trace={tracedMessages.get(messageId)}
+ * />
+ * ```
+ */
+export function MessageTrace({ className, onTrace, trace }: MessageTraceProps) {
+  const scored = trace?.score != null
+
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect()
+    const y = (event.clientY - rect.top) / rect.height
+    // Top = high score (100), bottom = low (0)
+    const score = Math.round((1 - y) * 100)
+
+    onTrace({ y, score })
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      // Keyboard: score at midpoint (50)
+      onTrace({ y: 0.5, score: 50 })
+    }
+  }
+
+  // Hover gradient: position-mapped colors at higher opacity
+  const hoverBg = `linear-gradient(180deg,
+    ${rampColor(0.0, 0.2)} 0%,
+    ${rampColor(0.15, 0.55)} 15%,
+    ${rampColor(0.42, 0.4)} 42%,
+    ${rampColor(0.58, 0.45)} 58%,
+    ${rampColor(0.85, 0.55)} 85%,
+    ${rampColor(1.0, 0.2)} 100%
+  )`
+
+  // Idle gradient: subtle, barely visible
+  const idleBg = `linear-gradient(180deg,
+    ${rampColor(0.0, 0)} 0%,
+    ${rampColor(0.15, 0.1)} 20%,
+    ${rampColor(0.42, 0.1)} 45%,
+    ${rampColor(0.58, 0.1)} 55%,
+    ${rampColor(0.85, 0.1)} 80%,
+    ${rampColor(1.0, 0)} 100%
+  )`
+
+  // Scored: left-border glow
+  const traceColor = scored ? rampColor(1 - (trace!.score! / 100), 0.7) : 'transparent'
+
+  return (
+    <>
+      {/* Left border glow — only when traced */}
+      {scored && (
+        <div
+          aria-hidden
+          className="animate-settle absolute inset-y-0 left-0 w-[3px] rounded-l-[3px]"
+          style={{
+            background: traceColor,
+            boxShadow: `0 0 10px ${traceColor}, 0 0 28px ${traceColor}`
+          }}
+        />
+      )}
+
+      {/* Right edge trace strip */}
+      <div
+        aria-label={`Message trace ${scored ? `— score ${trace!.score!}` : '— click to score'}`}
+        className={cn(
+          'absolute inset-y-0 right-0 w-5 cursor-col-resize z-[3]',
+          'after:absolute after:inset-y-0 after:right-0 after:w-px after:rounded-r after:transition-all after:duration-600',
+          'focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-(--chrome-action-focus)',
+          className
+        )}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        role="slider"
+        tabIndex={0}
+        title={scored ? `Score: ${trace!.score!}/100` : 'Click to trace'}
+        // CSS custom properties for the hover state
+        style={
+          {
+            '--trace-hover-bg': hoverBg,
+            '--trace-idle-bg': idleBg
+          } as React.CSSProperties
+        }
+      />
+
+      <style>{`
+        [role="slider"]:hover::after {
+          width: 4px !important;
+          background: var(--trace-hover-bg) !important;
+          box-shadow: -2px 0 14px rgba(255,255,255,0.06), -4px 0 8px rgba(0,0,0,0.15) !important;
+          opacity: 1 !important;
+        }
+
+        [role="slider"]::after {
+          background: var(--trace-idle-bg);
+          opacity: 0.6;
+        }
+
+        .animate-settle {
+          animation: trace-settle 2.5s ease forwards;
+        }
+
+        @keyframes trace-settle {
+          0% { opacity: 0; filter: brightness(2.8); }
+          30% { opacity: 1; filter: brightness(1.25); }
+          100% { opacity: 1; filter: brightness(1); }
+        }
+      `}</style>
+    </>
+  )
+}

--- a/apps/desktop/src/components/assistant-ui/thread/use-message-reactions.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/use-message-reactions.ts
@@ -5,7 +5,8 @@ import { type MouseEvent, useCallback } from 'react'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { triggerHaptic } from '@/lib/haptics'
 import { QUICK_REACTIONS, toggleMessageReaction } from '@/store/reactions'
-import { $reactionsEnabled } from '@/store/reactions-enabled'
+import { $reactionsStyle } from '@/store/reactions-style'
+import type { ReactionsStyle } from '@/store/reactions-style'
 import { $agentReactions, $localReactions, mergeReactions, setLocalReaction } from '@/store/reactions-local'
 import type { MessageReaction } from '@/types/hermes'
 
@@ -65,6 +66,7 @@ export function useMessageReactions(
   enabled: boolean
   react: (emoji: null | string) => void
   reactions: MessageReaction[]
+  style: ReactionsStyle
 } {
   const reactions = useAuiState(s => {
     const custom = (s.message.metadata?.custom ?? {}) as { reactions?: MessageReaction[] }
@@ -78,12 +80,13 @@ export function useMessageReactions(
     return custom.rowId
   })
 
-  const enabled = useStore($reactionsEnabled)
+  const style = useStore($reactionsStyle)
   const localAll = useStore($localReactions)
   const agentLive = useStore($agentReactions)
 
   return {
-    enabled,
+    enabled: style !== 'off',
+    style,
     react: useCallback(
       (emoji: null | string) => commitReaction(messageId, role, rowId, reactions, emoji),
       [messageId, reactions, role, rowId]
@@ -105,7 +108,7 @@ export function useTapbackDoubleClick(
   messageId: string,
   role: ChatMessage['role']
 ): ((event: MouseEvent<HTMLElement>) => void) | undefined {
-  const enabled = useStore($reactionsEnabled)
+  const style = useStore($reactionsStyle)
   const messageRuntime = useMessageRuntime()
 
   const onDoubleClick = useCallback(
@@ -142,5 +145,5 @@ export function useTapbackDoubleClick(
     [messageId, messageRuntime, role]
   )
 
-  return enabled ? onDoubleClick : undefined
+  return style !== 'off' ? onDoubleClick : undefined
 }

--- a/apps/desktop/src/store/reactions-style.ts
+++ b/apps/desktop/src/store/reactions-style.ts
@@ -1,0 +1,46 @@
+/**
+ * Message reactions style — off, emoji (current tapbacks), or ambient (continuous color trace).
+ *
+ * Ambient mode replaces discrete emoji picks with a clickable gradient strip
+ * on the message edge — see `message-trace.tsx` and #74981.
+ *
+ * Presentation-scoped, so the renderer owns it (desktop AGENTS.md).
+ * Gated: when 'off', the UI shows no reaction affordances and the agent's
+ * react_to_message tool is suppressed via `display.message_reactions` config.
+ */
+
+import { atom } from 'nanostores'
+
+import { persistString, storedString } from '@/lib/storage'
+import { activeGateway } from '@/store/gateway'
+
+export type ReactionsStyle = 'ambient' | 'emoji' | 'off'
+
+const KEY = 'hermes.desktop.reactions-style.v1'
+
+const VALID_STYLES = new Set<string>(['ambient', 'emoji', 'off'])
+
+function storedStyle(): ReactionsStyle {
+  const raw = storedString(KEY)
+
+  return raw != null && VALID_STYLES.has(raw) ? (raw as ReactionsStyle) : 'off'
+}
+
+export const $reactionsStyle = atom<ReactionsStyle>(typeof window === 'undefined' ? 'off' : storedStyle())
+
+export function setReactionsStyle(style: ReactionsStyle): void {
+  $reactionsStyle.set(style)
+}
+
+if (typeof window !== 'undefined') {
+  $reactionsStyle.listen(style => {
+    persistString(KEY, style)
+    // Mirror into gateway config: when emoji or ambient, the agent's
+    // react_to_message tool is enabled; when off, it's suppressed.
+    void activeGateway()
+      ?.request('config.set', { key: 'display.message_reactions', value: style === 'off' ? 'false' : 'true' })
+      .catch(() => {
+        // Not connected yet — the next toggle still holds.
+      })
+  })
+}


### PR DESCRIPTION
![Message Trace demo](https://i.imgur.com/V2YXFql.gif)

![Comparison: Emoji vs Ambient](https://i.imgur.com/n55XuW0.png)

🔗 **Live interactive demo:** https://htmlpreview.github.io/?https://gist.githubusercontent.com/daerias/2dfd662ebc0aa92efd71349db262db8e/raw/trace.html

---

## What

Adds an **Ambient Reaction Mode** as a third option in the reactions setting — extending the current off/on toggle to **Off / Emoji / Ambient**. In ambient mode, clicking anywhere on a gradient strip at the message edge replaces discrete emoji picks with a continuous 0–100 color trace.

Closes #74981.

## Changes

| File | Change |
|------|--------|
| `message-trace.tsx` | New — self-contained trace component |
| `message-trace.test.tsx` | 8 test cases (click mapping, keyboard, glow, clamping) |
| `reactions-style.ts` | New — tri-state store replacing boolean |
| `appearance-settings.tsx` | SegmentedControl: Off / Emoji / Ambient |
| `use-message-reactions.ts` | Returns style, gates on style !== 'off' |
| `assistant-message.tsx` | Renders MessageTrace when style='ambient' |
| `text-utils.ts` | Emoji trigger gates on style !== 'off' |
| `double-click-reaction.test.tsx` | Updated for tri-state store |

## Component: MessageTrace

| Feature | Implementation |
|---|---|
| Input | Click anywhere on right-edge gradient strip |
| Score | Continuous 0-100, top = positive |
| Visual | Left-border glow with CSS settle animation |
| Color ramp | Green-teal-blue (deuteranopia-safe) |
| Keyboard | Enter/Space traces at midpoint (50) |
| Accessibility | role=slider, aria-label with score |
| Dependencies | 0 external |

## Backward compatibility

- **Off** = same as before (no reaction UI, agent tool suppressed)
- **Emoji** = identical to previous 'on' behavior (tapbacks, picker, double-click)
- **Ambient** = new — trace strip visible, emoji picker hidden

## Settings

Under Settings → Appearance → Message reactions: Off / Emoji / Ambient

The setting persists locally via `hermes.desktop.reactions-style.v1`.

## Non-goals

Not replacing the current system — adding an option. No default change. No telemetry.
