### PR TITLE
fix(toolsets): keep MCP tools when enabled_toolsets is narrowed

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -291,11 +291,38 @@ def _clear_tool_defs_cache() -> None:
     _tool_defs_cache.clear()
 
 
+def _is_mcp_toolset_name(name: str) -> bool:
+    """Return True for canonical MCP toolsets (``mcp-<server>``)."""
+    return bool(name) and str(name).startswith("mcp-")
+
+
+def _registered_mcp_toolsets() -> List[str]:
+    """Every MCP toolset currently registered in the tool registry.
+
+    MCP toolsets are named ``mcp-<server>`` and only come into existence once
+    that server connects and registers its tools, so a caller assembling a
+    static allowlist has no way to name them up front.
+
+    Canonical names are read straight from the registry: ``get_all_toolsets()``
+    deliberately surfaces an MCP toolset under its bare server alias (e.g.
+    ``dynserver`` rather than ``mcp-dynserver``), so it cannot be used here.
+    """
+    try:
+        return sorted(
+            name
+            for name in registry.get_registered_toolset_names()
+            if _is_mcp_toolset_name(name)
+        )
+    except Exception:
+        return []
+
+
 def get_tool_definitions(
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    preserve_mcp_toolsets: bool = True,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -306,6 +333,11 @@ def get_tool_definitions(
         enabled_toolsets: Only include tools from these toolsets.
         disabled_toolsets: Exclude tools from these toolsets (if enabled_toolsets is None).
         quiet_mode: Suppress status prints.
+        preserve_mcp_toolsets: When an ``enabled_toolsets`` allowlist is given,
+            still include dynamically-registered ``mcp-<server>`` toolsets the
+            allowlist does not name. Defaults to True because such an omission
+            is almost always an oversight — see :func:`_compute_tool_definitions`.
+            Pass False for a strict, literal allowlist.
         skip_tool_search_assembly: When True, return the pre-assembly tool list
             (raw schemas for every enabled tool). Used internally by the
             tool_search / tool_describe bridge handlers so they can read the
@@ -343,6 +375,7 @@ def get_tool_definitions(
                 bool(skip_tool_search_assembly),
                 _is_delegated_child_context(),
                 profile_scope,
+                bool(preserve_mcp_toolsets),
             )
         cached = _tool_defs_cache.get(cache_key) if cache_key is not None else None
         if cached is not None:
@@ -355,7 +388,8 @@ def get_tool_definitions(
             return list(cached)
 
     result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
+                                       skip_tool_search_assembly=skip_tool_search_assembly,
+                                       preserve_mcp_toolsets=preserve_mcp_toolsets)
     if quiet_mode and cache_key is not None:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool
@@ -381,6 +415,7 @@ def _compute_tool_definitions(
     disabled_toolsets: Optional[List[str]] = None,
     quiet_mode: bool = False,
     skip_tool_search_assembly: bool = False,
+    preserve_mcp_toolsets: bool = True,
 ) -> List[Dict[str, Any]]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
@@ -388,6 +423,38 @@ def _compute_tool_definitions(
 
     if enabled_toolsets is not None:
         effective_enabled_toolsets = list(enabled_toolsets)
+        # MCP toolsets are registered dynamically as ``mcp-<server>`` when a
+        # server connects, so a caller narrowing enabled_toolsets — usually to
+        # cut input-token overhead — cannot name them in advance and silently
+        # loses every MCP tool. The failure is invisible: the tools *are*
+        # registered, then filtered straight back out, and the model is simply
+        # told they "do not exist".
+        #
+        # Delegation already guarded its own path (delegation.inherit_mcp_toolsets
+        # / _preserve_parent_mcp_toolsets in tools/delegate_tool.py). Hoisting the
+        # rule here means every other narrowing path inherits it too — cron jobs,
+        # platform_toolsets, ACP sessions, CLI.
+        #
+        # Delegated children are skipped: delegate_tool has already intersected
+        # the child's toolsets with the parent's and re-added only the *parent's*
+        # MCP toolsets, and widening that here would let a child reach servers
+        # its parent cannot.
+        #
+        # An explicit disabled_toolsets entry always wins — that is a deliberate
+        # exclusion, not an oversight, so it is never re-added here.
+        if preserve_mcp_toolsets and not _is_delegated_child_context():
+            _explicitly_disabled = set(disabled_toolsets or ())
+            for _mcp_toolset in _registered_mcp_toolsets():
+                if (
+                    _mcp_toolset not in effective_enabled_toolsets
+                    and _mcp_toolset not in _explicitly_disabled
+                ):
+                    effective_enabled_toolsets.append(_mcp_toolset)
+                    if not quiet_mode:
+                        print(
+                            f"🔌 Preserved MCP toolset '{_mcp_toolset}' "
+                            "(not named in enabled_toolsets)"
+                        )
         if (
             os.environ.get("HERMES_KANBAN_TASK")
             and not _is_delegated_child_context()

--- a/tests/test_mcp_toolset_preservation.py
+++ b/tests/test_mcp_toolset_preservation.py
@@ -1,0 +1,89 @@
+"""MCP toolsets must survive a narrowed ``enabled_toolsets`` allowlist.
+
+MCP toolsets are registered dynamically as ``mcp-<server>`` only once a server
+connects, so a caller building a static allowlist (a cron job, platform_toolsets,
+an ACP session) cannot name them and used to lose every MCP tool silently.
+"""
+
+import model_tools
+from tools.registry import ToolRegistry
+
+MCP_TOOL = "mcp__dynserver__ping"
+MCP_TOOLSET = "mcp-dynserver"
+
+
+def _dummy_handler(args, **kwargs):
+    return "{}"
+
+
+def _registry_with_mcp_server():
+    reg = ToolRegistry()
+    reg.register(
+        name=MCP_TOOL,
+        toolset=MCP_TOOLSET,
+        schema={
+            "name": MCP_TOOL,
+            "description": "Ping",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=_dummy_handler,
+    )
+    reg.register_toolset_alias("dynserver", MCP_TOOLSET)
+    return reg
+
+
+def _install(monkeypatch, reg, *, delegated_child=False):
+    # toolsets.py resolves aliases through tools.registry.registry; model_tools
+    # holds its own module-level reference for schema lookup. Patch both.
+    monkeypatch.setattr("tools.registry.registry", reg)
+    monkeypatch.setattr(model_tools, "registry", reg)
+    monkeypatch.setattr(
+        model_tools, "_is_delegated_child_context", lambda: delegated_child
+    )
+
+
+def _tool_names(defs):
+    return {d["function"]["name"] for d in defs}
+
+
+def _defs(**kwargs):
+    # quiet_mode=False bypasses the memoization path, which keys off the real
+    # registry's generation counter. skip_tool_search_assembly=True returns the
+    # raw catalog: with tool_search active, MCP tools are otherwise collapsed
+    # behind tool_search/tool_describe/tool_call and never appear by name.
+    return model_tools.get_tool_definitions(
+        quiet_mode=False, skip_tool_search_assembly=True, **kwargs
+    )
+
+
+class TestPreserveMcpToolsets:
+    def test_narrowed_allowlist_keeps_mcp_tools(self, monkeypatch):
+        """The regression: ['web'] must not silently drop every MCP tool."""
+        _install(monkeypatch, _registry_with_mcp_server())
+        assert MCP_TOOL in _tool_names(_defs(enabled_toolsets=["web"]))
+
+    def test_opt_out_gives_a_literal_allowlist(self, monkeypatch):
+        _install(monkeypatch, _registry_with_mcp_server())
+        names = _tool_names(
+            _defs(enabled_toolsets=["web"], preserve_mcp_toolsets=False)
+        )
+        assert MCP_TOOL not in names
+
+    def test_explicit_disable_still_wins(self, monkeypatch):
+        """disabled_toolsets is a deliberate exclusion, not an oversight."""
+        _install(monkeypatch, _registry_with_mcp_server())
+        names = _tool_names(
+            _defs(enabled_toolsets=["web"], disabled_toolsets=[MCP_TOOLSET])
+        )
+        assert MCP_TOOL not in names
+
+    def test_delegated_child_is_not_widened(self, monkeypatch):
+        """delegate_tool already re-adds only the *parent's* MCP toolsets;
+        widening here would let a child reach servers its parent cannot."""
+        _install(monkeypatch, _registry_with_mcp_server(), delegated_child=True)
+        assert MCP_TOOL not in _tool_names(_defs(enabled_toolsets=["web"]))
+
+    def test_unrestricted_caller_is_unchanged(self, monkeypatch):
+        """enabled_toolsets=None already loads everything."""
+        _install(monkeypatch, _registry_with_mcp_server())
+        assert MCP_TOOL in _tool_names(_defs(enabled_toolsets=None))


### PR DESCRIPTION
## Problem

MCP toolsets are registered dynamically as `mcp-<server>`, and only once that server connects. A caller building a **static `enabled_toolsets` allowlist** therefore cannot name them in advance — and `_compute_tool_definitions` treats the allowlist as strict, so every MCP tool is filtered straight back out.

The failure is silent and confusing from the model's side: the tools *are* registered, then removed by the filter, so the model is simply told they don't exist.

Real-world symptom — a cron job created with `enabled_toolsets: ['web', 'terminal', 'file']` (a reasonable token-saving narrowing, and exactly what the `cronjob` tool's own schema encourages):

```
Tool 'mcp_google_workspace_list_tasks' does not exist.
Available tools: patch, process, read_file, search_files, terminal,
                 web_extract, web_search, write_file
```

It ran daily for six days returning empty sections, while `last_status` stayed `ok` and the agent papered over the gap with a prose fallback.

## Why here

Delegation already guards against exactly this, via `delegation.inherit_mcp_toolsets` and `_preserve_parent_mcp_toolsets` in `tools/delegate_tool.py` — documented as *"When explicit child toolsets are narrowed, also keep the parent's MCP toolsets (default: true)"*, and defaulted **on**.

So the rule is already considered correct; it just lives in one code path. Every other narrowing path — cron jobs, `platform_toolsets`, ACP sessions, the CLI — has no equivalent. This hoists it into `get_tool_definitions` so they all inherit it.

Note `cron/scheduler.py` was already fixed once for the *other* half of this problem (`discover_mcp_tools()` at startup, *"Without this, cron jobs never saw any MCP tools"*). The servers get discovered; the allowlist then discards them.

## Behaviour

Unchanged for:

- **Delegated children** — `delegate_tool` has already intersected against the parent and re-added only the *parent's* MCP toolsets. Widening here would let a child reach servers its parent cannot, so preservation is skipped via the existing `_is_delegated_child_context()`.
- **`disabled_toolsets`** — a deliberate exclusion, never re-added.
- **Callers wanting a literal allowlist** — opt out with `preserve_mcp_toolsets=False`.
- **`enabled_toolsets=None`** — already loaded everything.

One implementation note: canonical names come from `registry.get_registered_toolset_names()`, not `get_all_toolsets()`, because the latter deliberately surfaces an MCP toolset under its bare server alias (`dynserver`, not `mcp-dynserver`).

## Tests

`tests/test_mcp_toolset_preservation.py` covers all five cases above, reusing the existing `mcp-dynserver` registry pattern from `tests/test_toolsets.py`. They assert with `skip_tool_search_assembly=True`, since tool_search otherwise collapses MCP tools behind `tool_search`/`tool_describe`/`tool_call`.

Verified 5/5 against a live Hermes install (v0.17.0 runtime, patch applied to `main`).

## Notes for reviewers

- Happy to gate this behind a config flag instead of a defaulted-on parameter if you'd prefer symmetry with `delegation.inherit_mcp_toolsets`.
- The `cronjob` tool's `enabled_toolsets` schema description lists only static examples (`web`, `terminal`, `file`, `delegation`) and tells the creating agent to infer them from the prompt. Even with this fix, that guidance can't hint that `mcp-*` toolsets exist — a docs tweak there may be worth a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QasmhHT8SxPiaFZv7XXDKi
