### PR TITLE
fix(bluebubbles): raise send_file timeout to cover slow uploads (#77918)

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -165,6 +165,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     SUPPORTS_MESSAGE_EDITING = False
     MAX_MESSAGE_LENGTH = MAX_TEXT_LENGTH
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
+    # BlueBubbles Server itself allows up to 300s for attachment uploads; the
+    # previous 120s client timeout fired on macOS 26 even for successful sends
+    # that take ~2min, producing a bogus "couldn't deliver" notice (#77918).
+    ATTACHMENT_UPLOAD_TIMEOUT = 300
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.BLUEBUBBLES)
@@ -621,7 +625,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                     self._api_url("/api/v1/message/attachment"),
                     files=files,
                     data=data,
-                    timeout=120,
+                    timeout=self.ATTACHMENT_UPLOAD_TIMEOUT,
                 )
                 res.raise_for_status()
                 result = res.json()

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -274,6 +274,53 @@ class TestBlueBubblesAttachmentDownload:
         assert result == "/tmp/test_image.png"
 
 
+class TestBlueBubblesAttachmentUpload:
+    """Verify _send_attachment uses a timeout that covers slow uploads."""
+
+    def test_send_attachment_uses_300s_upload_timeout(self, monkeypatch, tmp_path):
+        """Attachment upload posts with the raised timeout, not the old 120s."""
+        import asyncio
+
+        from gateway.platforms.bluebubbles import BlueBubblesAdapter
+
+        adapter = _make_adapter(monkeypatch)
+
+        class MockResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"status": 200, "data": {"guid": "msg-123"}}
+
+        captured = {}
+
+        class MockClient:
+            async def post(self, url, files=None, data=None, timeout=None):
+                captured["url"] = url
+                captured["timeout"] = timeout
+                return MockResponse()
+
+        adapter.client = MockClient()
+
+        async def fake_resolve(target):
+            return "iMessage;-;+1234567890"
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+
+        payload = tmp_path / "test.txt"
+        payload.write_text("hello")
+
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter._send_attachment("+1234567890", str(payload), filename="test.txt")
+        )
+
+        assert result.success is True
+        assert result.message_id == "msg-123"
+        assert "/api/v1/message/attachment" in captured["url"]
+        assert captured["timeout"] == BlueBubblesAdapter.ATTACHMENT_UPLOAD_TIMEOUT
+        assert captured["timeout"] == 300
+
+
 # ---------------------------------------------------------------------------
 # Webhook registration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #77918. The BlueBubbles attachment upload in `_send_attachment` used a hardcoded `timeout=120`, but on macOS 26 a successful attachment send routinely takes ~2 minutes to return. The client-side timeout fired first, `_send_attachment` returned `SendResult(success=False)`, and the user saw "Couldn't deliver the file attachment" moments after the file actually arrived.

## Root Cause

`gateway/platforms/bluebubbles.py` posted to `/api/v1/message/attachment` with `timeout=120`, well below BlueBubbles Server's own internal upload timeout of 300s. The gateway log showed the failure warning exactly 120s after the send started, even though delivery succeeded.

## Change

- Added a class constant `BlueBubblesAdapter.ATTACHMENT_UPLOAD_TIMEOUT = 300`, matching BlueBubbles Server's own 300s internal limit, and used it for the attachment upload request instead of the hardcoded 120s.

## Verification

- New test `TestBlueBubblesAttachmentUpload::test_send_attachment_uses_300s_upload_timeout` asserts `_send_attachment` posts to `/api/v1/message/attachment` with `timeout == 300` and returns success.
- Full BlueBubbles test file: `19 passed`.

Closes #77918