### PR TITLE
fix(cron): don't treat absolute-path binaries as referenced scripts in lifecycle guard (#77931)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -219,14 +219,20 @@ def _iter_referenced_shell_scripts(
                 yield _resolve_terminal_script_path(arguments[arg_index], cwd)
             continue
 
-        # A bare "/" token is pathlib's division operator in Python sources
-        # (e.g. `Path.home() / ".hermes"`), not an executable reference.
-        # Resolving it walks to the filesystem root and fails the
-        # regular-file check below, hard-blocking innocent .py scripts
-        # (#77131). Skip pure-separator tokens.
-        if executable.strip("/"):
-            if "/" in executable or executable.endswith((".sh", ".bash", ".zsh")):
-                yield _resolve_terminal_script_path(executable, cwd)
+        # Only EXPLICIT script references are scanned. An executable path is
+        # treated as a referenced script only when its name carries a shell
+        # script suffix; anything else path-shaped (`/bin/echo`, `/usr/bin/
+        # date`, a bare relative name resolved via PATH) is executed directly
+        # by the kernel and is never parsed as script text. Treating every
+        # path-containing executable as a script made the guard open and read
+        # arbitrary binaries (multi-MB ELF decoded as text and re-tokenized
+        # for recursion), which hangs cron/oneshot subprocesses (#77931).
+        # `source`/`.`, shell invocation (`bash script`) and `-c` payloads
+        # are handled above, so lifecycle commands inside real scripts are
+        # still caught. A bare "/" token (pathlib's division operator in
+        # Python sources, #77131) carries no suffix and is skipped here too.
+        if executable.endswith((".sh", ".bash", ".zsh")):
+            yield _resolve_terminal_script_path(executable, cwd)
 
 
 def _iter_shell_command_payloads(command: str) -> Iterator[str]:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -746,6 +746,89 @@ class TestLifecycleGuardModule:
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("daily ops", str(script))
 
+    def test_absolute_path_binary_is_not_read_as_script(self, monkeypatch):
+        """#77931: absolute-path binaries (/bin/echo, /usr/bin/date) must be
+        executed directly, never opened/read as referenced shell scripts.
+
+        Before the fix, ANY executable containing '/' was yielded by
+        _iter_referenced_shell_scripts and read via _read_referenced_script —
+        opening multi-MB ELF binaries and re-tokenizing their decoded bytes,
+        which hangs cron/oneshot subprocesses. The guard must not touch the
+        file at all for bare binary paths.
+        """
+        import cron.lifecycle_guard as lg
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        def _fail_read(path):
+            raise AssertionError(f"guard must not read {path} as a script")
+
+        monkeypatch.setattr(lg, "_read_referenced_script", _fail_read)
+        for command in (
+            "/bin/echo hi",
+            "/usr/bin/date",
+            "/usr/bin/whoami",
+            "/home/linuxbrew/.linuxbrew/bin/gws --version",
+        ):
+            assert (
+                contains_gateway_lifecycle_command_or_referenced_script(command)
+                is False
+            ), command
+
+    def test_cron_prompt_with_absolute_path_binary_passes_guard(self, monkeypatch):
+        """#77931: a cron prompt instructing an absolute-path binary (the
+        exact `hermes chat -Q --source cron` repro) must pass the lifecycle
+        guard without reading the binary."""
+        import cron.lifecycle_guard as lg
+        from cron.lifecycle_guard import check_gateway_lifecycle
+
+        def _fail_read(path):
+            raise AssertionError(f"guard must not read {path} as a script")
+
+        monkeypatch.setattr(lg, "_read_referenced_script", _fail_read)
+        # No exception == job creation is allowed.
+        check_gateway_lifecycle("use terminal to execute /bin/echo hi")
+        check_gateway_lifecycle("run /usr/bin/date and report the output")
+
+    def test_absolute_path_shell_script_still_scanned(self, tmp_path):
+        """#77931: dropping the catch-all '/' branch must NOT weaken the
+        guard for real scripts — an absolute-path .sh script executed
+        directly is still read and its lifecycle command blocked."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "evil.sh"
+        script.write_text("#!/bin/bash\nhermes gateway restart\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                f"{script} --flag"
+            )
+            is True
+        )
+
+    def test_extensionless_script_only_scanned_via_shell(self, tmp_path):
+        """#77931: extension-less files are still scanned when invoked
+        through a shell (`bash script`), but executed directly by absolute
+        path they are treated as plain executables and not read."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        script = tmp_path / "deploy"  # no shell-script suffix
+        script.write_text("#!/bin/bash\nhermes gateway stop\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                f"bash {script}"
+            )
+            is True
+        )
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                f"{script} --prod"
+            )
+            is False
+        )
+
 
 # ---------------------------------------------------------------------------
 # Defense 2 (chokepoint): cron.jobs.create_job blocks the AGENT model-tool path
@@ -863,6 +946,71 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
         assert result["exit_code"] == 1
         assert "referenced script" in result["error"]
         assert any("cat" in c for c in calls)
+
+    def test_remote_binary_read_skipped_via_nul_check(self, monkeypatch, tmp_path):
+        """#77931: the remote `cat` fallback must not feed binary content
+        (NUL bytes) into the referenced-script recursion. A binary path
+        passed to a shell passes the guard unread and executes normally —
+        decoded machine code must never be scanned, even when the bytes
+        happen to embed a lifecycle-looking string."""
+        import tools.terminal_tool as tt
+
+        calls = []
+        script = "/remote/workspace/tool"  # binary exists only on the backend
+
+        class _RemoteEnv:
+            env = {}
+            cwd = str(tmp_path)
+
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                if "cat" in command:
+                    # NUL-bearing binary content — must be treated as
+                    # "nothing to scan", not decoded into the recursion.
+                    return {
+                        "output": "\x00\x00\x7fELF hermes gateway restart\n",
+                        "returncode": 0,
+                    }
+                return {"output": "ran", "returncode": 0}
+
+        self._patch_env(monkeypatch, _RemoteEnv(), inside_gateway=True)
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True}
+        )
+
+        result = json.loads(tt.terminal_tool(command=f"/bin/bash {script}"))
+
+        assert result["exit_code"] == 0
+        assert any("cat" in c for c in calls)
+
+    def test_local_binary_referenced_via_shell_not_scanned(
+        self, monkeypatch, tmp_path
+    ):
+        """#77931: `bash <binary>` in a gateway session must not decode the
+        binary as script text in the local fallback read either — a
+        NUL-bearing file with an embedded lifecycle-looking string passes
+        through unblocked because it is a binary, not a shell script."""
+        import tools.terminal_tool as tt
+
+        binary = tmp_path / "helper"  # extension-less, binary content
+        binary.write_bytes(b"\x7fELF\x00\x00\x00 hermes gateway restart\x00\x00")
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "", "returncode": 0}
+
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True}
+        )
+
+        result = json.loads(tt.terminal_tool(command=f"/bin/bash {binary}"))
+
+        assert result["exit_code"] == 0
 
 
 class TestCronCreateLifecycleBlockExtra:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2545,13 +2545,13 @@ def terminal_tool(
                         if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= 1024 * 1024:
                             data = local_path.read_bytes()
                             if len(data) <= 1024 * 1024:
+                                # Binary content (NUL bytes) is not script
+                                # text: decoding it and feeding it to the
+                                # referenced-script recursion re-tokenizes
+                                # machine code and can hang the guard
+                                # (#76762/#77931). Mirror the skip in
+                                # cron.lifecycle_guard._read_referenced_script.
                                 if b"\x00" in data:
-                                    # Binary (ELF/Mach-O/PE), not a shell script:
-                                    # feeding its decoded bytes back into the guard
-                                    # tokenizes machine code into bogus NUL-bearing
-                                    # paths and crashes the scanner (#77703). Mirror
-                                    # lifecycle_guard._read_referenced_script and
-                                    # treat it as nothing to scan.
                                     return None
                                 return data.decode("utf-8", errors="replace")
                 except Exception:
@@ -2561,9 +2561,10 @@ def terminal_tool(
                     result = env.execute(f"cat {shlex.quote(script_path)}")
                     if result.get("returncode", -1) == 0:
                         output = result.get("output", "")
-                        if output and "\x00" in output:
-                            # Binary content from a remote `cat`: skip for the
-                            # same reason as the local branch above (#77703).
+                        # Same binary guard as the local read: a remote
+                        # `cat` of a binary must not feed decoded machine
+                        # code into the referenced-script recursion.
+                        if "\x00" in output:
                             return None
                         return output
                 except Exception:


### PR DESCRIPTION
## Summary

Cron/oneshot subprocesses (`hermes chat -Q --source cron`) hang indefinitely when the terminal tool executes **any** command containing an absolute path (e.g. `/bin/echo hi`, `/usr/bin/date`, `/home/linuxbrew/.linuxbrew/bin/gws --version`).

Root cause: `cron/lifecycle_guard.py` → `_iter_referenced_shell_scripts()` treated **any** executable whose token contains `/` as a "referenced shell script" and fed it to `_read_referenced_script`, which opens and reads the file — multi-MB ELF binaries decoded as text and re-tokenized for recursion, hanging at ~99% CPU until timeout. The terminal_tool remote fallback (`_read_script_in_env`) also `cat`s binary paths and decodes the output as script text (the `execve("/usr/bin/cat", ["cat", "<binary>"...])` seen in the repro strace).

## Change

- `cron/lifecycle_guard.py` — `_iter_referenced_shell_scripts()` now only yields **explicit** script references: executable paths carrying a shell-script suffix (`.sh`/`.bash`/`.zsh`). `source`/`.`, shell invocation (`bash script`) and shell `-c` payloads are handled by the existing branches, so lifecycle commands inside real scripts are still caught. Absolute-path binaries are executed directly and never opened by the guard.
- `tools/terminal_tool.py` — the `_read_script_in_env` fallback skips NUL-bearing (binary) content in both the local read and the remote `cat` path, so decoded machine code can never enter the referenced-script recursion even when a binary is passed to a shell.

## Verification

- New regression tests in `tests/hermes_cli/test_gateway_restart_loop.py`:
  - absolute-path binaries (`/bin/echo`, `/usr/bin/date`, a `gws`-style path) are never read by the guard (read is monkeypatched to fail)
  - cron prompts with absolute-path binary commands pass `check_gateway_lifecycle`
  - absolute-path `.sh` scripts are still scanned and lifecycle commands still blocked
  - extension-less files are still scanned via `bash script` but not read when executed directly
  - remote/local binary reads through `_read_script_in_env` are skipped (NUL check) instead of being decoded into the recursion
- Full `tests/hermes_cli/test_gateway_restart_loop.py`: 88 passed; `tests/cron/test_cron_script.py` + `tests/cron/test_jobs.py`: 88 passed; `tests/tools/test_terminal_tool.py`: 10 passed.
- Manual check: 5 MB binary referenced directly or via `bash` — guard returns in <1 ms with zero reads.

Closes #77931