### PR TITLE
fix(session): drop empty tool_calls in repair_message_sequence (#77921)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -640,6 +640,22 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 prev["tool_calls"] = prev_calls + new_calls
             elif prev_calls:
                 prev["tool_calls"] = prev_calls
+            else:
+                # Neither turn carries tool calls, but the surviving turn may
+                # still carry a stale ``tool_calls: []`` from the earlier
+                # message.  An empty array is semantically "no tool calls",
+                # yet strict OpenAI-compatible providers (DeepSeek v4,
+                # Moonshot/Kimi) reject it with HTTP 400 ("Invalid
+                # 'messages[N].tool_calls': empty array...").  Drop the key
+                # HERE, at the source: ``sanitize_api_messages`` only fixes
+                # the per-call wire copy, so a ``[]`` left on the repaired
+                # turn survives in the live/persisted trajectory returned to
+                # callers (gateway/WebUI transcripts, session resume,
+                # subagents, cron) and is replayed on the next turn — which
+                # is how #58755 kept reproducing after the chokepoint fix
+                # (#77921).  Popping is non-destructive: an empty array
+                # carries no information.
+                prev.pop("tool_calls", None)
             # Concatenate plain-text content; leave multimodal (list)
             # content on either side alone to avoid mangling attachment
             # blocks — fall back to keeping the existing content.

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -356,6 +356,33 @@ def test_sanitize_drops_empty_tool_calls_array():
     assert assistant["content"] == "answer"
 
 
+def test_repair_drops_stale_empty_tool_calls_on_merged_assistant():
+    """repair_message_sequence must drop a stale ``tool_calls: []`` on the
+    surviving message of a consecutive-assistant merge (#77921).
+
+    The chokepoint sanitizer (sanitize_api_messages) only patches the per-call
+    wire copy — a ``[]`` left on the repaired live/persisted trajectory is
+    replayed on the next turn and 400s strict providers (DeepSeek v4). The
+    merge's union branches only ever set non-empty lists or leave the key
+    untouched, so the empty array survives into the persisted state."""
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        # surviving turn carries a stale empty tool_calls from an earlier pass
+        {"role": "assistant", "content": "first", "tool_calls": []},
+        {"role": "assistant", "content": "second"},
+    ]
+    # A dummy agent object is enough — repair only reads message roles/content.
+    agent = type("Agent", (), {})()
+    n = repair_message_sequence(agent, messages)
+    assert n >= 0
+    assistants = [m for m in messages if m.get("role") == "assistant"]
+    assert len(assistants) == 1
+    assert "tool_calls" not in assistants[0]
+    assert "second" in assistants[0]["content"]
+
+
 
 
 


### PR DESCRIPTION
## Summary

Fixes #77921 — the empty `tool_calls: []` failure (HTTP 400 "Invalid 'messages[N].tool_calls': empty array" on strict providers like DeepSeek v4) **still reproduces in v0.19.1** despite the #59110 chokepoint fix, on long sessions (~370K–395K tokens, always around messages[465]).

## Root Cause

The #59110 fix (`sanitize_api_messages`) drops empty `tool_calls` on the **per-call wire copy** — verified working. But `repair_message_sequence`'s Pass-0 consecutive-assistant merge **preserves a pre-existing `tool_calls: []` on the surviving/live message**: its union branches only ever set non-empty lists or leave the key untouched. Because the chokepoint sanitizer only patches the wire copy, the `[]` lives on in the repaired **live/persisted trajectory** — the same list returned to callers, persisted to state.db, and replayed on the next turn. Every downstream consumer (gateway/WebUI transcript, session resume, subagents, cron) sees the poisoned shape, which is how #58755 keeps reproducing on long sessions. DB round-trips cannot be the source (`append_message` stores empty lists as NULL) — the empty array is created in memory during repair.

## Change

- **`agent/agent_runtime_helpers.py`** — in `repair_message_sequence`'s consecutive-assistant merge, the `else` branch (neither turn carries tool calls) now pops a stale `tool_calls: []` from the surviving message. Dropping the key at the source is non-destructive (an empty array carries no information) and fixes the live/persisted trajectory that the chokepoint sanitizer never sees.
- **`tests/run_agent/test_message_sequence_repair.py`** — new regression `test_repair_drops_stale_empty_tool_calls_on_merged_assistant`: merged consecutive-assistant turn with a stale `tool_calls: []` ends without the key. Verified failing before the fix, passing after.

## Verification

- `pytest tests/run_agent/test_message_sequence_repair.py` → 15 passed.
- Regression test confirmed RED without the fix, GREEN with it.

Closes #77921
