### PR TITLE
fix(gateway): preserve clarify context when interims are disabled

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4445,6 +4445,37 @@ class TurnRunner:
                 log_message="interim_assistant_callback scheduling error",
             )
 
+        def _clarify_context_cb(text: str, *, already_streamed: bool = False) -> None:
+            """Deliver decision-critical prose even when generic interims are off."""
+            if (
+                already_streamed
+                or not ctx._run_still_current()
+                or not ctx._status_adapter
+                or not str(text or "").strip()
+            ):
+                return
+            fut = safe_schedule_threadsafe(
+                ctx._status_adapter.send(
+                    ctx._status_chat_id,
+                    text,
+                    metadata=ctx._status_thread_metadata,
+                ),
+                ctx._loop_for_step,
+                logger=logger,
+                log_message="clarify context delivery scheduling error",
+            )
+            if fut is None:
+                return
+            try:
+                # The poll is sent from a separate blocking callback. Waiting
+                # here guarantees that its explanatory packet arrives first.
+                fut.result(timeout=15)
+            except Exception:
+                logger.warning(
+                    "Clarify context delivery failed before prompt",
+                    exc_info=True,
+                )
+
         turn_route = self._runner._resolve_turn_agent_config(ctx.message, model, runtime_kwargs)
 
         # Per-platform skip_context_files — messaging platforms can opt out
@@ -4750,6 +4781,9 @@ class TurnRunner:
         agent.step_callback = ctx._step_callback_sync if ctx._hooks_ref.loaded_hooks else None
         agent.stream_delta_callback = _stream_delta_cb
         agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
+        agent.clarify_context_callback = (
+            None if _want_interim_messages else _clarify_context_cb
+        )
         agent.status_callback = ctx._status_callback_sync
         # Credits / out-of-band notices (usage bands, depletion, restored).
         # Messaging has no persistent status bar, so each notice is a

--- a/run_agent.py
+++ b/run_agent.py
@@ -6022,8 +6022,16 @@ class AIAgent:
         when the only streamed text was unrelated mid-turn commentary. (#65919
         review: response-loss blocker)
         """
+        if not isinstance(assistant_msg, dict):
+            return
         cb = getattr(self, "interim_assistant_callback", None)
-        if cb is None or not isinstance(assistant_msg, dict):
+        if cb is None and self._assistant_message_calls_tool(assistant_msg, "clarify"):
+            # A clarify poll is not self-explanatory when the model put the
+            # decision packet in commentary immediately before the tool call.
+            # Quiet chat profiles may intentionally suppress ordinary interim
+            # narration, but must still receive this decision-critical context.
+            cb = getattr(self, "clarify_context_callback", None)
+        if cb is None:
             return
         commentary_parts = self._extract_codex_interim_visible_parts(assistant_msg)
         undelivered_parts: List[str] = []
@@ -6059,6 +6067,27 @@ class AIAgent:
                 self._record_delivered_interim_text(visible)
         except Exception:
             logger.debug("interim_assistant_callback error", exc_info=True)
+
+    @staticmethod
+    def _assistant_message_calls_tool(
+        assistant_msg: Dict[str, Any], tool_name: str
+    ) -> bool:
+        """Return whether a persisted assistant turn invokes ``tool_name``."""
+        expected = str(tool_name or "").rsplit(".", 1)[-1]
+        for tool_call in assistant_msg.get("tool_calls") or []:
+            if isinstance(tool_call, dict):
+                function = tool_call.get("function") or {}
+                name = (
+                    function.get("name") if isinstance(function, dict) else None
+                ) or tool_call.get("name")
+            else:
+                function = getattr(tool_call, "function", None)
+                name = getattr(function, "name", None) or getattr(
+                    tool_call, "name", None
+                )
+            if str(name or "").rsplit(".", 1)[-1] == expected:
+                return True
+        return False
 
     def _ensure_stream_writer_state(self) -> None:
         """Lazily create the single-writer guard fields (#65991).

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -717,6 +717,23 @@ class CommentaryAgent:
         }
 
 
+class ClarifyContextFallbackAgent:
+    def __init__(self, **kwargs):
+        self.tools = []
+        self.interim_assistant_callback = None
+        self.clarify_context_callback = None
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        assert self.interim_assistant_callback is None
+        assert callable(self.clarify_context_callback)
+        self.clarify_context_callback("Decision context that must precede the poll.")
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class PreviewedResponseAgent:
     def __init__(self, **kwargs):
         self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
@@ -978,6 +995,30 @@ async def test_display_streaming_does_not_enable_gateway_streaming(monkeypatch, 
     assert result.get("already_sent") is not True
     assert adapter.edits == []
     assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
+
+
+@pytest.mark.asyncio
+async def test_clarify_context_fallback_is_wired_when_interim_messages_are_disabled(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ClarifyContextFallbackAgent,
+        session_id="sess-clarify-context-fallback",
+        config_data={
+            "display": {
+                "tool_progress": "off",
+                "interim_assistant_messages": False,
+            },
+            "streaming": {"enabled": False},
+        },
+    )
+
+    assert result["final_response"] == "done"
+    assert [call["content"] for call in adapter.sent] == [
+        "Decision context that must precede the poll."
+    ]
 
 
 class TransformedStreamAgent:

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -158,29 +158,39 @@ def _codex_commentary_message_response(text: str):
     )
 
 
-def _codex_commentary_final_tool_response(commentary: str, final_answer: str = "Done."):
-    return SimpleNamespace(
-        output=[
-            SimpleNamespace(
-                type="message",
-                phase="commentary",
-                status="completed",
-                content=[SimpleNamespace(type="output_text", text=commentary)],
-            ),
+def _codex_commentary_final_tool_response(
+    commentary: str,
+    final_answer: str | None = "Done.",
+    tool_name: str = "terminal",
+):
+    output = [
+        SimpleNamespace(
+            type="message",
+            phase="commentary",
+            status="completed",
+            content=[SimpleNamespace(type="output_text", text=commentary)],
+        )
+    ]
+    if final_answer is not None:
+        output.append(
             SimpleNamespace(
                 type="message",
                 phase="final_answer",
                 status="completed",
                 content=[SimpleNamespace(type="output_text", text=final_answer)],
-            ),
-            SimpleNamespace(
-                type="function_call",
-                id="fc_1",
-                call_id="call_1",
-                name="terminal",
-                arguments="{}",
-            ),
-        ],
+            )
+        )
+    output.append(
+        SimpleNamespace(
+            type="function_call",
+            id="fc_1",
+            call_id="call_1",
+            name=tool_name,
+            arguments="{}",
+        )
+    )
+    return SimpleNamespace(
+        output=output,
         usage=SimpleNamespace(input_tokens=8, output_tokens=5, total_tokens=13),
         status="completed",
         model="gpt-5-codex",
@@ -1642,12 +1652,58 @@ def test_interim_commentary_precedes_content_from_real_codex_normalization(monke
     }
 
 
+def test_clarify_context_is_delivered_when_generic_interim_messages_are_disabled(monkeypatch):
+    """A decision prompt must not lose commentary that explains its choices."""
+    agent = _build_agent(monkeypatch)
+    delivered = []
+    setattr(agent, "interim_assistant_callback", None)
+    setattr(
+        agent,
+        "clarify_context_callback",
+        lambda text, *, already_streamed=False: delivered.append(text),
+    )
+
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    normalized, finish_reason = _normalize_codex_response(
+        _codex_commentary_final_tool_response(
+            "Long decision context and trade-offs.",
+            final_answer=None,
+            tool_name="clarify",
+        )
+    )
+    assert finish_reason == "tool_calls"
+    assert (normalized.content or "") == ""
+
+    agent._emit_interim_assistant_message(
+        agent._build_assistant_message(normalized, finish_reason)
+    )
+
+    assert delivered == ["Long decision context and trade-offs."]
 
 
+def test_clarify_context_fallback_does_not_surface_other_interim_messages(monkeypatch):
+    """The fallback preserves quiet-mode semantics for non-clarify tool turns."""
+    agent = _build_agent(monkeypatch)
+    delivered = []
+    setattr(agent, "interim_assistant_callback", None)
+    setattr(
+        agent,
+        "clarify_context_callback",
+        lambda text, *, already_streamed=False: delivered.append(text),
+    )
 
+    agent._emit_interim_assistant_message(
+        {
+            "role": "assistant",
+            "content": "I'll inspect the repository first.",
+            "tool_calls": [
+                {"function": {"name": "terminal", "arguments": "{}"}}
+            ],
+        }
+    )
 
-
-
+    assert delivered == []
 
 
 def test_stream_delta_strips_leaked_memory_context(monkeypatch):

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1806,7 +1806,7 @@ Platforms without an override fall back to the global `tool_progress` value. Val
 
 Signal is listed as a valid platform key because the setting can be saved per platform, but the current Signal adapter cannot edit sent messages and does not render tool-progress bubbles. Keep Signal `tool_progress` set to `off`; use the CLI or an editing-capable messaging platform if you need to watch each tool call live.
 
-`interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
+`interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming. When disabled, ordinary mid-turn updates stay hidden; decision-critical prose emitted immediately before a `clarify` prompt is still delivered so the interactive choices remain understandable.
 
 `show_commentary` (default `true`) controls Codex Responses models' commentary channel — the polished progress narration these models produce alongside their private reasoning. When enabled, each completed commentary message is delivered as a visible mid-turn update (on the gateway this also requires `interim_assistant_messages`). Set it to `false` if the extra narration annoys you: commentary then falls back to the reasoning channel and is only shown when `show_reasoning` is enabled.
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -85,7 +85,7 @@ gateway:
 
 **Why these defaults:**
 
-- `interim_assistant_messages: false` — prevents intermediate tool results, reasoning comments, and progress updates from being posted as separate messages to the channel. Only the final response goes to the channel.
+- `interim_assistant_messages: false` — prevents ordinary intermediate tool results, reasoning comments, and progress updates from being posted as separate messages to the channel. Decision-critical prose paired with a `clarify` prompt is still delivered before its choices.
 - `tool_progress: off` — suppresses tool progress bubbles (e.g., "Running terminal command...", "Reading file..."). Keeps the channel focused on actual results, not process.
 - `poll_interval: 4` — balances inbound latency (up to 4s delay) against relay load. Lower values increase polling frequency; higher values reduce it.
 - `allowed_users: []` + `allow_all_users: false` — private mode by default. Only listed users can interact. Set `allow_all_users: true` for community mode where everyone can chat (admin tier still restricted to the owner).


### PR DESCRIPTION
## What does this PR do?

When ordinary interim assistant messages are disabled, explanatory prose emitted in the same assistant turn as a `clarify` tool call is currently dropped before platform dispatch. The `clarify` tool still sends its question and choices through a separate path, so users can receive a contextless selector.

This PR preserves only that decision-critical prose and sends it before the interactive prompt. Non-`clarify` commentary remains suppressed, and the existing generic interim path remains authoritative when enabled. The fix is made at the agent/gateway boundary because the loss occurs before any platform adapter; no Telegram-specific behavior, tool schema, or configuration key is added.

## Related Issue

No linked issue. I searched open and closed issues and PRs for `clarify interim assistant context`, `Telegram clarify buttons context`, and `interim_assistant_messages clarify`; no duplicate was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: detect assistant turns containing a `clarify` tool call and use a dedicated context callback only when the generic interim callback is unavailable.
- `gateway/run.py`: install the fallback only while generic interim delivery is disabled, preserve routing metadata, suppress empty/already-streamed text, and wait for context delivery before tool execution continues.
- `tests/run_agent/test_run_agent_codex_responses.py`: cover normalized Codex responses, `clarify` gating, non-`clarify` suppression, namespaced calls, multiple calls, empty text, and streamed text.
- `tests/gateway/test_run_progress_topics.py`: cover gateway ordering and the quiet-mode fallback with a realistic agent callback contract.
- `website/docs/user-guide/configuration.md` and `website/docs/user-guide/messaging/buzz.md`: document the narrow `clarify` exception while ordinary interim commentary is disabled.

## How to Test

### Reproduce the bug

1. Disable ordinary interim assistant messages for a messaging platform.
2. Trigger an assistant response that contains explanatory commentary and a `clarify` tool call in the same turn.
3. Before this change, only the interactive question/options are delivered; the explanatory context is dropped.

### Verify the fix

1. Repeat the scenario and confirm the explanatory context is delivered exactly once before the interactive prompt.
2. Trigger commentary followed by a non-`clarify` tool and confirm it remains suppressed.
3. Enable generic interim delivery and confirm a `clarify` turn is still delivered exactly once through the generic path.
4. Run:

```bash
scripts/run_tests.sh \
  tests/run_agent/test_run_agent_codex_responses.py \
  tests/gateway/test_run_progress_topics.py \
  tests/gateway/test_telegram_clarify_buttons.py \
  tests/gateway/test_clarify_progress_leak.py \
  tests/tools/test_clarify_gateway.py

ruff check .
python scripts/check-windows-footguns.py --all
git diff --check
```

Observed result for the targeted suite: **93 passed, 0 failed**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - The canonical targeted suite passes. The complete macOS suite still has unrelated host/environment failures that reproduce on the untouched exact upstream base; no candidate-related failure remained after differential verification.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.8

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no configuration keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-neutral code path; Windows footgun scan passed across 912 files
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changed

## Screenshots / Logs

No screenshot is applicable to this ordering bug. Additional verification completed:

- `ruff check .` — passed
- `python scripts/check-windows-footguns.py --all` — passed (912 files)
- CI-style ruff/ty differential against the exact base — no new source diagnostics
- documentation generation, diagram checks, link checks, and Docusaurus build — passed
- independent invariant probes for quiet-mode gating, ordering, duplicate suppression, and platform-neutral routing — passed
