### PR TITLE
fix(tts): add sherpa-onnx-core to macOS arm64 lock (#77936)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,12 @@ wake = [
   "openwakeword==0.6.0",
   "onnxruntime==1.27.0",
   "sherpa-onnx==1.13.4",
+  # sherpa-onnx 1.13.4 declares sherpa-onnx-core==1.13.4 as a hard
+  # dependency but the committed lock omitted it, so macOS arm64 installs
+  # reported the Sherpa wake backend as available while the native import
+  # failed (dlopen libonnxruntime missing). Declare it explicitly so the
+  # lock resolves the full native closure (see #77936).
+  "sherpa-onnx-core==1.13.4",
   "sentencepiece==0.2.2",
   "pvporcupine==4.0.3",
   "sounddevice==0.5.5",

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -174,8 +174,12 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # Open-vocabulary keyword spotting: any typed phrase, zero training.
     # sentencepiece is required by sherpa_onnx.text2token (runtime phrase
     # tokenization) even though sherpa-onnx doesn't declare it.
+    # sherpa-onnx-core is sherpa-onnx's native core (onnxruntime bindings);
+    # the committed lock omitted it, making is_available() report the
+    # backend as present while the native import failed (see #77936).
     "wake.sherpa": (
         "sherpa-onnx==1.13.4",
+        "sherpa-onnx-core==1.13.4",
         "sentencepiece==0.2.2",
         "sounddevice==0.5.5",
         "numpy==2.4.3",

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-20T16:38:42.729819205Z"
+exclude-newer = "2026-07-20T19:33:29.279354385Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -1783,6 +1783,7 @@ wake = [
     { name = "pvporcupine" },
     { name = "sentencepiece" },
     { name = "sherpa-onnx" },
+    { name = "sherpa-onnx-core" },
     { name = "sounddevice" },
 ]
 web = [
@@ -1914,6 +1915,7 @@ requires-dist = [
     { name = "sentencepiece", marker = "extra == 'wake'", specifier = "==0.2.2" },
     { name = "setuptools", marker = "extra == 'dev'", specifier = "==83.0.0" },
     { name = "sherpa-onnx", marker = "extra == 'wake'", specifier = "==1.13.4" },
+    { name = "sherpa-onnx-core", marker = "extra == 'wake'", specifier = "==1.13.4" },
     { name = "simple-term-menu", marker = "extra == 'cli'", specifier = "==1.6.6" },
     { name = "slack-bolt", marker = "extra == 'messaging'", specifier = "==1.29.0" },
     { name = "slack-bolt", marker = "extra == 'slack'", specifier = "==1.29.0" },
@@ -4163,6 +4165,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/db/47/da3ea14ab647a4f6580227853fe29353e1173ff77064d42c0bb31d01b453/sherpa_onnx-1.13.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:88af596be24eac32982dd64fcac30af99d9130ca498bfa1a0064189c8498195b", size = 4358385, upload-time = "2026-07-07T13:10:10.265Z" },
     { url = "https://files.pythonhosted.org/packages/44/90/84205ff383ba9335c3821c2cd6d514350f52199cb640ec094517f1f911a0/sherpa_onnx-1.13.4-cp313-cp313-win32.whl", hash = "sha256:0cabb508a15be22138f9fb7695d7ec5f3893ecd088ee419b9df559fed7e8f649", size = 1929707, upload-time = "2026-07-07T12:51:53.196Z" },
     { url = "https://files.pythonhosted.org/packages/82/40/ee8a0a8c83fc6d7f5245a5a031e471d3b115e20cce867e7abb2f9d4185c9/sherpa_onnx-1.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:17050fdfb48d37ae996364f697c554a1399740d18e5a56b143c011d00cfed3e0", size = 2244504, upload-time = "2026-07-07T12:32:59.882Z" },
+]
+
+[[package]]
+name = "sherpa-onnx-core"
+version = "1.13.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/69/ae33a8cb1ecc30e0c4638d76772e56161162d57bef748380790e1257841f/sherpa_onnx_core-1.13.4-py3-none-macosx_10_15_universal2.whl", hash = "sha256:737099a817998e4d74379dcd44d8d1b332a3fa1822780be174334c3d1d1e2451", size = 36025264, upload-time = "2026-07-07T11:41:37.506Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/8c/a1336beab226d228f62bdbe1cacf1439a2f6cf8714baac98f1f031dd2f60/sherpa_onnx_core-1.13.4-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:674ea57eb6458002dab4e39749d21a7364b2f962f4a4958a3ee4c351b093cafd", size = 19325474, upload-time = "2026-07-07T11:31:03.394Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/26/d0d6bebea4ef8b7de6eed1a335235d1acce9197425c08eecb57ef107904d/sherpa_onnx_core-1.13.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7820183581b711a68e30281a4fb36c0af8ef5615bfc789234fb259439824a014", size = 16897650, upload-time = "2026-07-07T11:42:28.755Z" },
+    { url = "https://files.pythonhosted.org/packages/81/29/15859e896574230d5377738ef27e8647cbd19fa325d75b1a00074791798d/sherpa_onnx_core-1.13.4-py3-none-manylinux2014_aarch64.whl", hash = "sha256:b4e4d17eb0d5c569bf4c9effcbc3daef57cf7e2b8418e07ae90f90c9b60b35d5", size = 13023017, upload-time = "2026-07-07T11:41:30.935Z" },
+    { url = "https://files.pythonhosted.org/packages/41/be/38c57721d71ee74d984b1ca21720a8ca8477d6d341026af24ff658866ef9/sherpa_onnx_core-1.13.4-py3-none-manylinux2014_x86_64.whl", hash = "sha256:367aa06cee90b3fd7959d4e071d6fc821710b859af399b4987e5c3119ee6ae2a", size = 10338839, upload-time = "2026-07-07T12:21:33.627Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/17/949ee6d5cff4ec9e2dcda014276a798b814e2eb80d35d820884e6e0614ff/sherpa_onnx_core-1.13.4-py3-none-manylinux_2_35_armv7l.whl", hash = "sha256:3b9cc7da5ce4a2333a9ae211f39c34dee981b13f2c9c8680fbf2d9636e87d617", size = 9889942, upload-time = "2026-07-07T14:25:04.94Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/e2fb4b965b86bd3ee6ca35d81999e9edad47c20d2c8fc4e03db8083494bc/sherpa_onnx_core-1.13.4-py3-none-win32.whl", hash = "sha256:ba9de2f463ae67ee2947f1bd9b981a1e39e6b831e281bf5088068251b8ec4dde", size = 13832564, upload-time = "2026-07-07T11:49:11.781Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b0/c3d59ac76f3db873e41bd0cb4fc30b352a278da3289217985aaae3650211/sherpa_onnx_core-1.13.4-py3-none-win_amd64.whl", hash = "sha256:0a6949cf0fd83adb9fbcfdf5c27b8907a57f7b48626db703c7f6037be9b61764", size = 16450053, upload-time = "2026-07-07T12:03:05.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The Sherpa open-vocabulary wake backend is not installable/runnable on macOS arm64 in v0.20.0: the committed lock omits `sherpa-onnx-core==1.13.4`, which `sherpa-onnx==1.13.4` declares as a hard dependency. Installers that consume the lock (e.g. `uv sync --frozen`) install `sherpa-onnx` without its native core, so `import sherpa_onnx` fails with a missing `libonnxruntime` (`dlopen`) error, while `lazy_deps.is_available("wake.sherpa")` still reports the backend as available because `LAZY_DEPS["wake.sherpa"]` didn't list the core package.

## Root Cause

- `pyproject.toml` declared `sherpa-onnx==1.13.4` in the `wake` extra but not its required core.
- The committed `uv.lock` had no `sherpa-onnx-core` package entry and its `sherpa-onnx` entry had no resolved dependencies.
- `tools.lazy_deps.LAZY_DEPS["wake.sherpa"]` listed only `sherpa-onnx`, `sentencepiece`, `sounddevice`, and `numpy`, so the availability check validated only top-level metadata, not the native import closure.

## Change

- Add `sherpa-onnx-core==1.13.4` to the `wake` extra in `pyproject.toml` (explicit declaration, matching the repo's exact-pin policy).
- Add `sherpa-onnx-core==1.13.4` to `LAZY_DEPS["wake.sherpa"]` in `tools/lazy_deps.py` so the lazy installer installs the full native closure and `is_available()` reflects it.
- Regenerate `uv.lock` with uv 0.9.28 (the version pinned in `.github/workflows/uv-lockfile-check.yml`): adds the `sherpa-onnx-core==1.13.4` package entry with hashes for all platforms (including `macosx_11_0_arm64`) and wires it into the `wake` extra resolution.

## Verification

- `uv lock --check` (uv 0.9.28, same as CI) passes.
- `tests/tools/test_lazy_deps.py`, `tests/test_packaging_metadata.py`: 63 passed.
- `tests/tools/test_wake_word.py`: 22 passed.
- Confirmed against PyPI that `sherpa-onnx==1.13.4` `Requires-Dist: sherpa-onnx-core==1.13.4` and that `sherpa-onnx-core==1.13.4` ships wheels for every platform the `wake` extra supports.

Closes #77936
