### PR TITLE
fix(cli): sync reasoning state after model switch

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9170,6 +9170,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 )
                 return
 
+        # Keep the CLI source-of-truth aligned with every successful switch.
+        # Conversation turns construct fresh agents from this value. When a
+        # live agent exists, preserve its final (including session-scoped)
+        # reasoning state; otherwise resolve the selected model from config.
+        if self.agent is not None:
+            self.reasoning_config = self.agent.reasoning_config
+        else:
+            try:
+                from hermes_constants import resolve_reasoning_config
+                from hermes_cli.config import load_config
+
+                self.reasoning_config = resolve_reasoning_config(
+                    load_config(), self.model
+                )
+            except Exception as exc:
+                logger.debug(
+                    "model switch could not re-resolve CLI reasoning config: %s",
+                    exc,
+                )
+
         from hermes_cli.model_switch import format_model_for_display
         _display_old = format_model_for_display(old_model)
         _display_new = format_model_for_display(result.new_model)

--- a/tests/hermes_cli/test_apply_model_switch_result_reasoning.py
+++ b/tests/hermes_cli/test_apply_model_switch_result_reasoning.py
@@ -1,0 +1,99 @@
+"""Regression tests for CLI reasoning state after ``/model`` switches."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import ModelSwitchResult
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.switches = []
+        self.reasoning_config = {"enabled": True, "effort": "medium"}
+
+    def switch_model(self, **kwargs):
+        self.switches.append(kwargs)
+        self.reasoning_config = {"enabled": False}
+
+
+class _StubCLI:
+    def __init__(self, agent=None):
+        self.agent = agent
+        self.model = "reasoning-model"
+        self.provider = "test-provider"
+        self.requested_provider = "test-provider"
+        self.api_key = "test-key"
+        self._explicit_api_key = "test-key"
+        self.base_url = "https://example.invalid/v1"
+        self._explicit_base_url = self.base_url
+        self.api_mode = "chat_completions"
+        self.reasoning_config = {"enabled": True, "effort": "medium"}
+        self._pending_model_switch_note = ""
+
+
+def _switch_result():
+    return ModelSwitchResult(
+        success=True,
+        new_model="non-reasoning-model",
+        target_provider="test-provider",
+        provider_changed=False,
+        api_key="test-key",
+        base_url="https://example.invalid/v1",
+        api_mode="chat_completions",
+        warning_message="",
+        provider_label="Test Provider",
+        resolved_via_alias="",
+        capabilities=None,
+        model_info=None,
+        is_global=False,
+    )
+
+
+def _apply_switch(cli, monkeypatch):
+    import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_cprint", lambda *_a, **_k: None)
+    config = {
+        "agent": {
+            "reasoning_effort": "medium",
+            "reasoning_overrides": {"non-reasoning-model": "none"},
+        }
+    }
+    with patch("hermes_cli.config.load_config", return_value=config):
+        cli_mod.HermesCLI._apply_model_switch_result(
+            cli, _switch_result(), persist_global=False
+        )
+
+
+def test_preinit_model_switch_updates_cli_reasoning_state(monkeypatch):
+    cli = _StubCLI(agent=None)
+
+    _apply_switch(cli, monkeypatch)
+
+    assert cli.reasoning_config == {"enabled": False}
+
+
+def test_initialized_model_switch_updates_cli_reasoning_state(monkeypatch):
+    agent = _FakeAgent()
+    cli = _StubCLI(agent=agent)
+
+    _apply_switch(cli, monkeypatch)
+
+    assert cli.reasoning_config == {"enabled": False}
+    assert len(agent.switches) == 1
+
+
+def test_initialized_switch_copies_live_agent_state_without_reloading(monkeypatch):
+    import cli as cli_mod
+
+    agent = _FakeAgent()
+    cli = _StubCLI(agent=agent)
+    monkeypatch.setattr(cli_mod, "_cprint", lambda *_a, **_k: None)
+
+    with patch("hermes_cli.config.load_config", side_effect=RuntimeError("unavailable")):
+        cli_mod.HermesCLI._apply_model_switch_result(
+            cli, _switch_result(), persist_global=False
+        )
+
+    assert cli.reasoning_config == {"enabled": False}


### PR DESCRIPTION
## Summary

- keep the CLI reasoning source-of-truth synchronized after every successful `/model` switch
- copy the live agent's final reasoning state when an agent already exists, preserving session-scoped choices
- resolve the selected model's configured reasoning override when switching before lazy agent initialization

## Problem

The CLI creates fresh agent instances for later conversation turns. A live agent could correctly update its reasoning configuration during a model switch while the CLI retained the previous model's settings. The next fresh agent then reused stale reasoning parameters.

For OpenAI-compatible local endpoints, this can make Hermes send a thinking parameter to a model that does not support it, resulting in HTTP 400.

## Tests

Added regression coverage for:

- switching before the first agent initializes
- switching after an agent already exists
- copying the live agent state without reloading configuration

Verification:

```text
8 passed
ruff: all checks passed
py_compile: passed
git diff --check: passed
```

The focused run included the new regression file plus the existing picker-context and agent reasoning-switch tests.
