### PR TITLE
fix(bluebubbles): pass correct chat GUID to attachment endpoint (#77916)

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -588,6 +588,25 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # Media sending (outbound)
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _attachment_target_guid(guid: str) -> str:
+        """Return the GUID form accepted by ``/api/v1/message/attachment``.
+
+        Unlike ``/api/v1/message/text``, the BlueBubbles attachment endpoint
+        treats ``chatGuid`` as the recipient *address*, not a full chat GUID:
+        passing ``any;-;+15551234567`` delivers the file to a phantom handle
+        named ``any`` instead of the real chat (#77916).  For 1:1 chats strip
+        the service prefix and send the bare address; group GUIDs
+        (``chat...`` / ``;+;``) are passed through unchanged.
+        """
+        for prefix in ("any;-;", "iMessage;-;", "SMS;-;"):
+            if guid.startswith(prefix):
+                candidate = guid.split(";-;", 1)[1]
+                if not candidate.startswith("chat"):
+                    return candidate
+                break
+        return guid
+
     async def _send_attachment(
         self,
         chat_id: str,
@@ -611,7 +630,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             with open(file_path, "rb") as f:
                 files = {"attachment": (fname, f, "application/octet-stream")}
                 data: Dict[str, str] = {
-                    "chatGuid": guid,
+                    "chatGuid": self._attachment_target_guid(guid),
                     "name": fname,
                     "tempGuid": uuid.uuid4().hex,
                 }

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -274,6 +274,124 @@ class TestBlueBubblesAttachmentDownload:
         assert result == "/tmp/test_image.png"
 
 
+class TestBlueBubblesAttachmentTargetGuid:
+    """Regression for #77916: /api/v1/message/attachment treats ``chatGuid``
+    as the recipient *address*, not a full chat GUID.  Sending a full 1:1
+    GUID (``any;-;+15551234567``) delivers the file to a phantom handle
+    named after the service prefix (``any`` / ``imessage``) and never to
+    the user.
+    """
+
+    def test_1to1_guid_strips_service_prefix(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert (
+            adapter._attachment_target_guid("any;-;+15551234567")
+            == "+15551234567"
+        )
+
+    def test_imessage_guid_strips_service_prefix(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert (
+            adapter._attachment_target_guid("iMessage;-;user@example.com")
+            == "user@example.com"
+        )
+
+    def test_sms_guid_strips_service_prefix(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert (
+            adapter._attachment_target_guid("SMS;-;+15551234567")
+            == "+15551234567"
+        )
+
+    def test_group_guid_passes_through(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert (
+            adapter._attachment_target_guid("iMessage;+;chat0000000000-family")
+            == "iMessage;+;chat0000000000-family"
+        )
+
+    def test_group_guid_with_chat_identifier_passes_through(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert (
+            adapter._attachment_target_guid("iMessage;-;chat0000000000")
+            == "iMessage;-;chat0000000000"
+        )
+
+    def test_bare_address_passes_through(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert adapter._attachment_target_guid("+15551234567") == "+15551234567"
+
+
+class TestBlueBubblesAttachmentSend:
+    """Regression for #77916: _send_attachment must POST the bare recipient
+    address to /api/v1/message/attachment, not the full resolved chat GUID.
+    """
+
+    @pytest.mark.asyncio
+    async def test_send_attachment_posts_bare_address(self, monkeypatch, tmp_path):
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_resolve(target):
+            return "any;-;+15551234567"
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+
+        posted = {}
+
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"status": 200, "data": {"guid": "msg-1"}}
+
+        async def fake_post(*args, **kwargs):
+            posted["data"] = kwargs.get("data")
+            return FakeResponse()
+
+        adapter.client = type("MockClient", (), {"post": fake_post})()
+
+        file_path = tmp_path / "test.txt"
+        file_path.write_text("hello")
+
+        result = await adapter._send_attachment("+15551234567", str(file_path))
+
+        assert result.success is True
+        assert posted["data"]["chatGuid"] == "+15551234567"
+
+    @pytest.mark.asyncio
+    async def test_send_attachment_keeps_group_guid(self, monkeypatch, tmp_path):
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_resolve(target):
+            return "iMessage;+;chat0000000000-family"
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+
+        posted = {}
+
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"status": 200, "data": {"guid": "msg-1"}}
+
+        async def fake_post(*args, **kwargs):
+            posted["data"] = kwargs.get("data")
+            return FakeResponse()
+
+        adapter.client = type("MockClient", (), {"post": fake_post})()
+
+        file_path = tmp_path / "test.txt"
+        file_path.write_text("hello")
+
+        result = await adapter._send_attachment("chat0000000000-family", str(file_path))
+
+        assert result.success is True
+        assert posted["data"]["chatGuid"] == "iMessage;+;chat0000000000-family"
+
+
 # ---------------------------------------------------------------------------
 # Webhook registration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes attachments sent over BlueBubbles landing in a phantom conversation addressed to a handle literally named `any` (or `imessage`), marked **Not Delivered**, instead of the real chat. Plain-text replies work; only file/media sends are affected.

## Root Cause

`_send_attachment` resolved the chat GUID and passed it verbatim as `chatGuid` to `/api/v1/message/attachment`:

```python
guid = await self._resolve_chat_guid(chat_id)   # -> "any;-;+27xxxxxxxxx"
data = {"chatGuid": guid, ...}
```

Unlike `/api/v1/message/text` (which accepts a full chat GUID), the BlueBubbles attachment endpoint treats `chatGuid` as the recipient **address** and takes the leading segment. So `any;-;+27xxxxxxxxx` is sent to a handle named `any`, and `iMessage;-;+27xxxxxxxxx` to a handle named `imessage` — both create junk chats in `chat.db` that persist and are visible in Messages.

## Change

- Added `BlueBubblesAdapter._attachment_target_guid()` helper: for 1:1 chats it strips the service prefix (`any;-;`, `iMessage;-;`, `SMS;-;`) and sends the bare address; group GUIDs (`chat...`, `;+;`) pass through unchanged.
- `_send_attachment` now posts `chatGuid` through that helper.

## Verification

- 26/26 tests pass in `tests/gateway/test_bluebubbles.py` (8 new): 1:1/SMS/iMessage prefix stripping, group GUID passthrough, bare-address passthrough, and end-to-end assertions that the POSTed `chatGuid` is the bare address for 1:1 chats and the full GUID for groups.
- `ruff check` clean on both changed files.

Closes #77916