### PR TITLE
feat(desktop): add reasoning effort control equivalent to /reasoning (#77945)

### DIFF
--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -65,6 +65,21 @@ describe('desktop slash command curation', () => {
     expect(desktopSlashUnavailableMessage('/personality')).toBeNull()
   })
 
+  it('unblocks /reasoning as a desktop exec command (config.get/set reasoning)', () => {
+    // #77945 — /reasoning used to be gated behind NO_DESKTOP_SURFACE.advanced;
+    // the desktop must expose the same reasoning effort/display control the
+    // terminal has. It routes through the slash worker to the backend's
+    // /reasoning handler (config.get/config.set reasoning), so it runs with an
+    // exec surface and shows in the slash palette.
+    expect(resolveDesktopCommand('/reasoning')?.surface).toEqual({ kind: 'exec' })
+    expect(isDesktopSlashSuggestion('/reasoning')).toBe(true)
+    expect(isDesktopSlashCommand('/reasoning')).toBe(true)
+    expect(desktopSlashUnavailableMessage('/reasoning')).toBeNull()
+    // Free-form level input (minimal/low/medium/.../ultra) plus finite display
+    // toggles (show/hide/on/off/full/clamp) — mixed keeps both typeable.
+    expect(desktopSlashCommandArgumentMode('/reasoning')).toBe('mixed')
+  })
+
   it('routes /pet through the desktop action handler and drops /pets', () => {
     expect(resolveDesktopCommand('/pet')?.surface).toEqual({ kind: 'action', action: 'pet' })
     expect(desktopSlashCommandArgumentMode('/pet')).toBe('options')

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -236,6 +236,12 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     argumentMode: 'options'
   },
   {
+    name: '/reasoning',
+    description: 'Show or set reasoning effort and display [show|hide|on|off|full|clamp|<level>]',
+    surface: exec(),
+    argumentMode: 'mixed'
+  },
+  {
     name: '/agents',
     description: 'Show active desktop sessions and running tasks',
     aliases: ['/tasks'],
@@ -363,7 +369,7 @@ const NO_DESKTOP_SURFACE: Record<DesktopUnavailableReason, readonly string[]> = 
   ],
   messaging: ['/approve', '/deny'],
   settings: ['/skills', '/pets'],
-  advanced: ['/curator', '/fast', '/insights', '/kanban', '/reasoning', '/voice']
+  advanced: ['/curator', '/fast', '/insights', '/kanban', '/voice']
 }
 
 const ALL_SPECS: readonly DesktopCommandSpec[] = [


### PR DESCRIPTION
## Summary

Fixes #77945 — `/reasoning` is blocked on the Hermes Desktop with no equivalent control, so users cannot view or change reasoning effort/display from the desktop app.

## Root Cause

`apps/desktop/src/lib/desktop-slash-commands.ts` lists `/reasoning` under `NO_DESKTOP_SURFACE.advanced`, which renders "not shown in the desktop slash palette" and never executes the command. The backend already exposes full reasoning semantics (`config.get/set reasoning` in `tui_gateway/methods_config.py`, `/reasoning` handler in the CLI `_handle_reasoning_command`: show/hide/on/off/full/clamp + effort levels).

## Change

- **`apps/desktop/src/lib/desktop-slash-commands.ts`**:
  - Removed `/reasoning` from the `advanced` blocked list.
  - Added a real desktop command spec: `{ name: '/reasoning', description: 'Show or set reasoning effort and display [show|hide|on|off|full|clamp|<level>]', surface: exec(), argumentMode: 'mixed' }`. The `exec()` surface routes through `slash.exec` → `command.dispatch` to the existing backend handler — no backend changes needed. `argumentMode: 'mixed'` keeps effort levels typeable while still offering finite display-toggle completions.
- **`apps/desktop/src/lib/desktop-slash-commands.test.ts`** — regression test asserting `/reasoning` is now an executable desktop command (not blocked).

## Verification

- `vitest run src/lib/desktop-slash-commands.test.ts` → 28 passed (incl. the new test).

Closes #77945
