### PR TITLE
fix(memory/holographic): surface entity-bound facts when FTS5 recall is empty (#77919)

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -65,6 +65,19 @@ class FactRetriever:
         # Stage 1: Get FTS5 candidates (more than limit for reranking headroom)
         candidates = self._fts_candidates(query, category, min_trust, limit * 3)
 
+        # FTS5 scores on content-token overlap only. When recall is thin or
+        # empty, consult the entity index: facts bound to entities whose
+        # name/alias token-overlaps the query would otherwise be invisible
+        # to prefetch even though probe() finds them (#77919).
+        if len(candidates) < limit:
+            candidates += self._entity_candidates(
+                query,
+                category,
+                min_trust,
+                limit - len(candidates),
+                exclude_ids={f["fact_id"] for f in candidates},
+            )
+
         if not candidates:
             return []
 
@@ -491,6 +504,72 @@ class FactRetriever:
 
         scored.sort(key=lambda x: x["score"], reverse=True)
         return scored[:limit]
+
+    def _entity_candidates(
+        self,
+        query: str,
+        category: str | None,
+        min_trust: float,
+        limit: int,
+        exclude_ids: set[int] | None = None,
+    ) -> list[dict]:
+        """Facts bound to entities whose name/alias token-overlaps the query.
+
+        FTS5 scores on content-token overlap only. A query that describes a
+        fact's topic with different words than the stored content gets zero
+        candidates, so search() bails before the HRR/Jaccard rerank ever
+        runs and prefetch returns empty context — even though the entity
+        index knows the query's terms are bound to those facts (#77919).
+
+        This stage consults the entities table (name + comma-separated
+        aliases) and returns the bound facts as neutral candidates
+        (fts_rank=0.0) for the reranker to score.
+        """
+        query_tokens = self._tokenize(query)
+        if not query_tokens:
+            return []
+
+        conn = self.store._conn
+        matched_ids: list[int] = []
+        for row in conn.execute(
+            "SELECT entity_id, name, aliases FROM entities"
+        ).fetchall():
+            haystack = f"{row['name'] or ''} {row['aliases'] or ''}"
+            if self._tokenize(haystack) & query_tokens:
+                matched_ids.append(row["entity_id"])
+
+        if not matched_ids:
+            return []
+
+        placeholders = ",".join("?" * len(matched_ids))
+        where = f"fe.entity_id IN ({placeholders}) AND f.trust_score >= ?"
+        params: list = list(matched_ids) + [min_trust]
+        if category:
+            where += " AND f.category = ?"
+            params.append(category)
+
+        sql = f"""
+            SELECT f.*
+            FROM fact_entities fe
+            JOIN facts f ON f.fact_id = fe.fact_id
+            WHERE {where}
+            LIMIT ?
+        """
+        params.append(limit)
+
+        try:
+            rows = conn.execute(sql, params).fetchall()
+        except Exception:
+            return []
+
+        results = []
+        for row in rows:
+            fact = dict(row)
+            if exclude_ids and fact["fact_id"] in exclude_ids:
+                continue
+            fact["fts_rank"] = 0.0  # neutral — Jaccard/HRR/trust decide
+            results.append(fact)
+        return results
 
     def _fts_candidates(
         self,

--- a/tests/plugins/memory/test_holographic_retrieval.py
+++ b/tests/plugins/memory/test_holographic_retrieval.py
@@ -95,6 +95,95 @@ def test_prefetch_recovers_prose_query(retriever_with_facts):
     assert "deployment rollback" in results[0]["content"].lower()
 
 
+# ---------------------------------------------------------------------------
+# Entity-bound recall — search/prefetch must consult the entity index when
+# FTS5 content-token overlap is zero (#77919)
+# ---------------------------------------------------------------------------
+
+def test_search_recovers_entity_bound_facts(tmp_path):
+    """Facts bound to an entity the query names must surface even when the
+    fact content shares no tokens with the query.
+
+    Regression for #77919: search() short-circuited on empty FTS5
+    candidates, so prefetch returned empty context even though probe()
+    would find the entity-bound facts (chicken-and-egg: the agent never
+    learns the entity exists to probe it).
+    """
+    db_path = tmp_path / "entity_recall.db"
+    store = MemoryStore(str(db_path))
+    try:
+        # Content deliberately shares no tokens with the query terms.
+        store.add_fact(
+            "The nightly run rebuilds the indexes before the first user opens the app.",
+            category="project",
+        )
+        # Bind the fact to an entity whose NAME contains the query terms.
+        entity_id = store._resolve_entity("Morning Briefing")
+        fact_id = store._conn.execute(
+            "SELECT fact_id FROM facts LIMIT 1"
+        ).fetchone()["fact_id"]
+        store._link_fact_entity(fact_id, entity_id)
+
+        retriever = FactRetriever(store=store)
+        results = retriever.search("morning briefing")
+        assert results, "entity-bound fact should be recovered via entity index"
+        assert any("nightly run" in r["content"].lower() for r in results)
+    finally:
+        store.close()
+
+
+def test_search_recovers_entity_alias_facts(tmp_path):
+    """Entity aliases participate in the entity-index recall path (#77919)."""
+    db_path = tmp_path / "entity_alias_recall.db"
+    store = MemoryStore(str(db_path))
+    try:
+        store.add_fact(
+            "Uses a CPAP machine every night at low pressure.",
+            category="general",
+        )
+        entity_id = store._resolve_entity("OSA")
+        store._conn.execute(
+            "UPDATE entities SET aliases = ? WHERE entity_id = ?",
+            ("sleep apnea, apnea", entity_id),
+        )
+        store._conn.commit()
+        fact_id = store._conn.execute(
+            "SELECT fact_id FROM facts LIMIT 1"
+        ).fetchone()["fact_id"]
+        store._link_fact_entity(fact_id, entity_id)
+
+        retriever = FactRetriever(store=store)
+        results = retriever.search("sleep apnea")
+        assert results, "alias-matched entity fact should be recovered"
+        assert any("CPAP" in r["content"] for r in results)
+    finally:
+        store.close()
+
+
+def test_search_entity_augmentation_respects_category(tmp_path):
+    """Entity augmentation honors the category filter (#77919)."""
+    db_path = tmp_path / "entity_category_recall.db"
+    store = MemoryStore(str(db_path))
+    try:
+        store.add_fact(
+            "The nightly run rebuilds the indexes before the first user opens the app.",
+            category="project",
+        )
+        entity_id = store._resolve_entity("Morning Briefing")
+        fact_id = store._conn.execute(
+            "SELECT fact_id FROM facts LIMIT 1"
+        ).fetchone()["fact_id"]
+        store._link_fact_entity(fact_id, entity_id)
+
+        retriever = FactRetriever(store=store)
+        # Same entity, but the fact lives in category 'project' — a 'general'
+        # search must NOT surface it via the entity index.
+        results = retriever.search("morning briefing", category="general")
+        assert all(r.get("category") != "project" for r in results)
+    finally:
+        store.close()
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Holographic memory's automatic prefetch (`prefetch()` → `FactRetriever.search()`) is FTS5-first: if the query shares no content tokens with stored facts, `_fts_candidates()` returns zero rows and `search()` short-circuits to `[]` before the HRR/Jaccard rerank ever runs. Facts bound to entities are invisible to prefetch even though `probe(entity)` finds them — a chicken-and-egg gap: the agent never learns the entity exists to probe it.

Example: entity "Morning Briefing" is bound to facts about a daily cron routine, but `search("morning briefing")` returns nothing when the fact content is phrased differently ("The nightly run rebuilds the indexes…"). The query vocabulary differs from the fact content, so token-overlap-only recall misses it.

## Fix

`FactRetriever.search()` now consults the entity index when FTS5 recall is thin:

- After `_fts_candidates()`, if the pool has fewer than `limit` candidates, call the new `_entity_candidates()` helper.
- The helper token-overlaps the query against entity **names and comma-separated aliases** (case-insensitive), fetches facts bound to matching entities via `fact_entities` (respecting `category` and `min_trust`), dedupes against existing candidates, and adds them as neutral candidates (`fts_rank=0.0`).
- The existing Jaccard + HRR + trust reranking then scores them, so entity-bound facts surface in prefetch without any behavior change when FTS5 recall is already good.

## Tests

Added 3 regression tests in `tests/plugins/memory/test_holographic_retrieval.py`:

- `test_search_recovers_entity_bound_facts` — fact content shares zero tokens with the query; entity name matches; fact is recovered.
- `test_search_recovers_entity_alias_facts` — entity alias ("sleep apnea" on "OSA") bridges the vocabulary gap.
- `test_search_entity_augmentation_respects_category` — category filter is honored by the augmentation path.

Full holographic suite: 43 passed.

Closes #77919
