### PR TITLE
fix(security): fail closed for unattended sudo

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -239,74 +239,6 @@ def test_quoted_and_brace_paths_are_hardline_blocked(command):
     assert desc
 
 
-# Multi-line QUOTED arguments are data, not command sequences: a newline
-# inside quotes is part of the argument the shell passes to the program.
-# These previously tripped the hardline floor because the flat command-start
-# class treated every raw newline — even inside quotes — as a command
-# boundary, blocking `hermes send` message bodies, multi-line
-# `git commit -m` messages, and heredoc text that merely MENTION
-# shutdown/reboot commands.
-_QUOTED_NEWLINE_DATA_ALLOW = [
-    # hermes send with a multi-line message body (the reported symptom)
-    'hermes send -t telegram -s "spark1" "console output:\nsudo reboot\ndone"',
-    'hermes send -t telegram "line1\nshutdown -h now\nline3"',
-    # git commit -m with a multi-line message
-    "git commit -m 'ops notes:\nreboot the box after the deploy'",
-    'git commit -m "fix startup\nsystemctl reboot was flaky here"',
-    # heredoc bodies quoting dangerous strings as data
-    "python3 - <<'EOF'\nmsg = 'run sudo reboot later'\nprint(msg)\nEOF",
-    "cat > /tmp/notes.txt <<'EOF'\nremember: shutdown -h now\nEOF",
-    # rm hardline floor is anchored to the same class — quoted prose about it
-    # across a line break must stay data too
-    'git commit -m "docs:\nwarn about rm -rf / in the guide"',
-]
-
-# The masking must be strictly scoped to quoted data: real command
-# boundaries around/inside those same shapes still hit the floor.
-_QUOTED_NEWLINE_THREATS_BLOCK = [
-    # unquoted newline is a real command separator
-    "echo hi\nsudo reboot",
-    'echo "a"\nsudo reboot',
-    'git commit -m "safe message"\nshutdown -h now',
-    # command substitution inside double quotes really executes
-    'hermes send -t telegram "$(sudo reboot)"',
-    'echo "`shutdown -h now`"',
-    # multi-line quoted data followed by a REAL chained command
-    'hermes send "line1\nline2" && sudo reboot',
-    # a heredoc whose body is data, but the delivery command itself is hardline
-    "sudo reboot <<'EOF'\nignored\nEOF",
-]
-
-
-@pytest.mark.parametrize("command", _QUOTED_NEWLINE_DATA_ALLOW)
-def test_quoted_newline_data_not_blocked(command):
-    """Newlines inside quoted arguments are data, not command starts."""
-    is_hl, desc = detect_hardline_command(command)
-    assert not is_hl, (
-        f"multi-line quoted data false-positived the hardline floor: "
-        f"{command!r} (got: {desc})"
-    )
-
-
-@pytest.mark.parametrize("command", _QUOTED_NEWLINE_THREATS_BLOCK)
-def test_real_newline_separated_threats_still_blocked(command):
-    """Unquoted newlines / $() / backticks remain real command boundaries."""
-    is_hl, desc = detect_hardline_command(command)
-    assert is_hl, f"real threat leaked through hardline floor: {command!r}"
-    assert desc
-
-
-def test_quoted_newline_data_not_blocked_by_full_guard_chain(clean_session):
-    """End-to-end: the guard chain must not hardline-block a multi-line
-    quoted message (yolo on, so only the unconditional floor can block)."""
-    enable_session_yolo("hardline_test")
-    command = 'hermes send -t telegram "status:\nsudo reboot happened at 3am"'
-    result = check_all_command_guards(command, "local")
-    assert result["approved"], (
-        f"guard chain blocked multi-line quoted data: {result.get('message')}"
-    )
-
-
 # Commands that carry the literal string "rm -rf /" (or a sibling) as DATA in
 # another command's quoted argument — a PR title, a commit message, an echo /
 # printf argument. The shell never executes that text as an rm command, so the
@@ -333,6 +265,13 @@ _DATA_ARG_NOT_A_COMMAND = [
     "echo '{ rm -rf /; }'",
     'find . -name "*(reboot)*"',
 ]
+
+
+@pytest.mark.parametrize("command", _DATA_ARG_NOT_A_COMMAND)
+def test_root_wipe_string_as_data_arg_is_not_hardline(command):
+    """"rm -rf /" as a quoted argument to another command is data, not a wipe."""
+    is_hl, desc = detect_hardline_command(command)
+    assert not is_hl, f"false positive: quoted data arg hit hardline floor: {command!r} ({desc})"
 
 
 # Real root wipes at every command position — bare, chained after a separator,
@@ -574,7 +513,7 @@ def test_container_backends_still_bypass(clean_session):
 
     Hardline only protects environments with real host impact (local, ssh).
     """
-    for env in ("docker", "singularity", "modal", "daytona", "vercel_sandbox"):
+    for env in ("docker", "singularity", "modal", "daytona"):
         r1 = check_dangerous_command("rm -rf /", env)
         assert r1["approved"] is True, f"container {env} should still bypass"
         r2 = check_all_command_guards("rm -rf /", env)
@@ -664,9 +603,70 @@ def test_sudo_stdin_guard_detects_without_password():
         assert "sudo" in desc.lower()
 
 
+def test_sudo_stdin_guard_allows_benign_commands():
+    """Commands without explicit sudo -S are not blocked."""
+    import tools.approval as approval_mod
+
+    for cmd in _SUDO_STDIN_ALLOW:
+        is_blocked, desc = approval_mod._check_sudo_stdin_guard(cmd)
+        assert not is_blocked, f"expected sudo stdin guard NOT to block {cmd!r}"
+
+
+def test_sudo_stdin_guard_blocks_even_when_password_configured(monkeypatch):
+    """SUDO_PASSWORD must never legitimize an agent-authored ``sudo -S``.
+
+    Hermes's own password pipe is injected internally by
+    ``_transform_sudo_command`` on a *bare* ``sudo``, never by the agent
+    writing ``-S`` itself. An agent-authored ``sudo -S`` is always a
+    guessing/exfiltration attempt (e.g. piping the inherited
+    $SUDO_PASSWORD env var straight into sudo), so it stays blocked
+    regardless of whether SUDO_PASSWORD happens to be configured.
+    """
+    import tools.approval as approval_mod
+
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    for cmd in _SUDO_STDIN_BLOCK:
+        is_blocked, desc = approval_mod._check_sudo_stdin_guard(cmd)
+        assert is_blocked, f"with SUDO_PASSWORD set, {cmd!r} should still be blocked"
+        assert "sudo" in desc.lower()
+
+
+def test_sudo_stdin_guard_blocks_in_gateway_session_with_password_configured(
+    monkeypatch, clean_session
+):
+    """Integration: gateway/cron sessions must not let SUDO_PASSWORD
+    unlock an explicit ``sudo -S`` through the full approval pipeline."""
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+
+    for cmd in _SUDO_STDIN_BLOCK:
+        result = check_all_command_guards(cmd, "local")
+        assert result["approved"] is False, f"expected block on {cmd!r} in gateway session"
+
+
+def test_sudo_stdin_guard_blocks_via_check_all_command_guards(clean_session):
+    """Integration: check_all_command_guards returns block for sudo -S."""
+    for cmd in _SUDO_STDIN_BLOCK:
+        result = check_all_command_guards(cmd, "local")
+        assert result["approved"] is False, f"expected block on {cmd!r}"
+        # Should NOT be marked as hardline (it's sudo-specific)
+        assert result.get("hardline") is not True
+        assert "BLOCKED" in result["message"]
+        assert "sudo -S" in result["message"].lower() or "sudo password" in result["message"].lower()
+
+
+def test_sudo_stdin_guard_not_blocked_by_yolo(clean_session, monkeypatch):
+    """yolo/approvals.mode=off must NOT bypass sudo stdin guard."""
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+
+    for cmd in _SUDO_STDIN_BLOCK_YOLO:
+        result = check_all_command_guards(cmd, "local")
+        assert result["approved"] is False, f"yolo leaked sudo guard on {cmd!r}"
+
+
 def test_sudo_stdin_guard_container_bypass(clean_session):
     """Containerized backends still bypass — they can't touch the host."""
-    for env in ("docker", "singularity", "modal", "daytona", "vercel_sandbox"):
+    for env in ("docker", "singularity", "modal", "daytona"):
         for cmd in _SUDO_STDIN_BLOCK:
             result = check_all_command_guards(cmd, env)
             assert result["approved"] is True, f"container {env} should bypass sudo guard on {cmd!r}"

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -27,7 +27,7 @@ def test_terminal_schema_advertises_persistent_env_state():
 
     assert "exported environment variables persist between calls" in description
     assert "activate a virtualenv" in description
-    assert "once per session" in description
+    assert "do not re-source the same environment before every command" in description
 
 
 def test_printf_literal_sudo_does_not_trigger_rewrite(monkeypatch):
@@ -52,29 +52,185 @@ def test_non_command_argument_named_sudo_does_not_trigger_rewrite(monkeypatch):
     assert sudo_stdin is None
 
 
-def test_actual_sudo_command_uses_configured_password(monkeypatch):
+def test_configured_sudo_password_never_used_in_noninteractive_context(monkeypatch):
+    """SUDO_PASSWORD must never be piped to sudo for a noninteractive run.
+
+    No HERMES_INTERACTIVE and no registered callback means nobody is
+    watching a terminal to have set that password on purpose for THIS
+    command — treat it the same as gateway/cron.
+    """
     monkeypatch.setenv("SUDO_PASSWORD", "testpass")
     monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False)
 
     transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo apt install -y ripgrep")
 
-    assert transformed == "sudo -S -p '' apt install -y ripgrep"
-    assert sudo_stdin == "testpass\n"
+    assert transformed == "sudo apt install -y ripgrep"
+    assert sudo_stdin is None
 
 
-def test_explicit_empty_sudo_password_tries_empty_without_prompt(monkeypatch):
-    monkeypatch.setenv("SUDO_PASSWORD", "")
+def test_configured_sudo_password_ignored_after_leading_env_assignment(monkeypatch):
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("DEBUG=1 sudo whoami")
+
+    assert transformed == "DEBUG=1 sudo whoami"
+    assert sudo_stdin is None
+
+
+def test_configured_sudo_password_ignored_in_gateway_session(monkeypatch):
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo apt install -y ripgrep")
+
+    assert transformed == "sudo apt install -y ripgrep"
+    assert sudo_stdin is None
+
+
+def test_configured_sudo_password_ignored_in_cron_session(monkeypatch):
+    monkeypatch.setenv("SUDO_PASSWORD", "testpass")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo apt install -y ripgrep")
+
+    assert transformed == "sudo apt install -y ripgrep"
+    assert sudo_stdin is None
+
+
+def test_configured_sudo_password_never_piped_even_when_interactive(monkeypatch):
+    """Interactive CLI sudo must come from the live prompt, never from .env.
+
+    Even with HERMES_INTERACTIVE set, an env-configured SUDO_PASSWORD is
+    not a substitute for the user prompt callback / interactive UI.
+    """
+    monkeypatch.setenv("SUDO_PASSWORD", "from-env")
     monkeypatch.setenv("HERMES_INTERACTIVE", "1")
-
-    def _fail_prompt(*_args, **_kwargs):
-        raise AssertionError("interactive sudo prompt should not run for explicit empty password")
-
-    monkeypatch.setattr(terminal_tool, "_prompt_for_sudo_password", _fail_prompt)
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False)
+    monkeypatch.setattr(
+        terminal_tool, "_prompt_for_sudo_password", lambda **_kw: "typed-pass"
+    )
 
     transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo true")
 
     assert transformed == "sudo -S -p '' true"
-    assert sudo_stdin == "\n"
+    assert sudo_stdin == "typed-pass\n"
+
+
+def test_cached_sudo_password_is_used_when_env_is_unset(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False)
+    terminal_tool._set_cached_sudo_password("cached-pass")
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("echo ok && sudo whoami")
+
+    assert transformed == "echo ok && sudo -S -p '' whoami"
+    assert sudo_stdin == "cached-pass\n"
+
+
+def test_registered_sudo_callback_is_used_without_interactive_env(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False)
+
+    calls = []
+
+    def sudo_callback():
+        calls.append("called")
+        return "callback-pass"
+
+    terminal_tool.set_sudo_password_callback(sudo_callback)
+    try:
+        transformed, sudo_stdin = terminal_tool._transform_sudo_command(
+            "echo ok | sudo tee /tmp/hermes-test"
+        )
+    finally:
+        terminal_tool.set_sudo_password_callback(None)
+
+    assert calls == ["called"]
+    assert transformed == "echo ok | sudo -S -p '' tee /tmp/hermes-test"
+    assert sudo_stdin == "callback-pass\n"
+
+
+def test_cached_sudo_password_isolated_by_session_key(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    monkeypatch.setenv("HERMES_SESSION_KEY", "session-a")
+    terminal_tool._set_cached_sudo_password("alpha-pass")
+
+    monkeypatch.setenv("HERMES_SESSION_KEY", "session-b")
+    assert terminal_tool._get_cached_sudo_password() == ""
+
+    monkeypatch.setenv("HERMES_SESSION_KEY", "session-a")
+    assert terminal_tool._get_cached_sudo_password() == "alpha-pass"
+
+
+def test_passwordless_sudo_skips_interactive_prompt_and_rewrite(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+    def _fail_prompt(*_args, **_kwargs):
+        raise AssertionError(
+            "interactive sudo prompt should not run when sudo -n already works"
+        )
+
+    monkeypatch.setattr(terminal_tool, "_prompt_for_sudo_password", _fail_prompt)
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: True, raising=False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo whoami")
+
+    assert transformed == "sudo whoami"
+    assert sudo_stdin is None
+
+
+def test_passwordless_sudo_probe_rechecks_local_terminal(monkeypatch):
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    calls = []
+
+    class Result:
+        def __init__(self, returncode):
+            self.returncode = returncode
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        return Result(0 if len(calls) == 1 else 1)
+
+    monkeypatch.setattr(terminal_tool.subprocess, "run", fake_run)
+
+    assert terminal_tool._sudo_nopasswd_works() is True
+    assert terminal_tool._sudo_nopasswd_works() is False
+    assert len(calls) == 2
+    assert calls[0][0] == ["sudo", "-n", "true"]
+    assert calls[1][0] == ["sudo", "-n", "true"]
+
+
+def test_passwordless_sudo_probe_is_disabled_for_nonlocal_terminal_env(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    def _fail_run(*_args, **_kwargs):
+        raise AssertionError("host sudo probe must not run for non-local terminal envs")
+
+    monkeypatch.setattr(terminal_tool.subprocess, "run", _fail_run)
+
+    assert terminal_tool._sudo_nopasswd_works() is False
+
+
+def test_validate_workdir_allows_windows_drive_paths():
+    assert terminal_tool._validate_workdir(r"C:\Users\Alice\project") is None
+    assert terminal_tool._validate_workdir("C:/Users/Alice/project") is None
+
+
+def test_validate_workdir_allows_windows_unc_paths():
+    assert terminal_tool._validate_workdir(r"\\server\share\project") is None
 
 
 def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():
@@ -83,12 +239,125 @@ def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():
     assert terminal_tool._validate_workdir("C:\\Users\\Alice\\project\nwhoami")
 
 
-def test_validate_workdir_allows_unicode_filesystem_paths():
-    assert terminal_tool._validate_workdir(
-        "/Users/alice/Documents/Obs_Hermes_Data/项目-projects/客户拜访"
-    ) is None
-    assert terminal_tool._validate_workdir("/tmp/テスト") is None
-    assert terminal_tool._validate_workdir("/home/jürgen/über projekt") is None
+def test_get_env_config_ignores_bad_docker_json_for_local_backend(monkeypatch):
+    """Docker-only JSON env vars must not break the default local backend."""
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_DOCKER_VOLUMES", "None")
+    monkeypatch.setenv("TERMINAL_DOCKER_ENV", "not-json")
+    monkeypatch.setenv("TERMINAL_DOCKER_FORWARD_ENV", "not-json")
+    monkeypatch.setenv("TERMINAL_DOCKER_EXTRA_ARGS", "not-json")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "local"
+    assert config["docker_volumes"] == []
+    assert config["docker_env"] == {}
+    assert config["docker_forward_env"] == []
+    assert config["docker_extra_args"] == []
+
+
+def test_get_env_config_ignores_bad_docker_json_for_ssh_backend(monkeypatch):
+    """Non-container remote backends should also ignore Docker-only JSON."""
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_DOCKER_VOLUMES", "None")
+    monkeypatch.setenv("TERMINAL_DOCKER_ENV", "not-json")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "ssh"
+    assert config["docker_volumes"] == []
+    assert config["docker_env"] == {}
+
+
+def test_get_env_config_preserves_ssh_tilde_cwd(monkeypatch):
+    """SSH cwd '~' is expanded by the remote shell, not the Hermes host."""
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_CWD", "~")
+    monkeypatch.setenv("HOME", "/opt/data")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "ssh"
+    assert config["cwd"] == "~"
+
+
+def test_get_env_config_preserves_ssh_tilde_child_cwd(monkeypatch):
+    """SSH cwd '~/x' must not become the local/container HOME path."""
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_CWD", "~/project")
+    monkeypatch.setenv("HOME", "/opt/data")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "ssh"
+    assert config["cwd"] == "~/project"
+
+
+def test_get_env_config_still_rejects_bad_docker_json_for_docker_backend(monkeypatch):
+    """Selecting Docker should keep the existing actionable config error."""
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_DOCKER_VOLUMES", "None")
+
+    try:
+        terminal_tool._get_env_config()
+    except ValueError as exc:
+        assert "TERMINAL_DOCKER_VOLUMES" in str(exc)
+    else:
+        raise AssertionError("Docker backend must validate TERMINAL_DOCKER_VOLUMES")
+
+
+def test_sudo_wrong_password_failure_detects_rejection_output():
+    output = (
+        "sudo: Authentication failed, try again.\n\n"
+        "sudo: maximum 3 incorrect authentication attempts\n"
+    )
+    assert terminal_tool._sudo_wrong_password_failure(output) is True
+
+
+def test_sudo_wrong_password_failure_ignores_tty_required_message():
+    output = "sudo: a terminal is required to authenticate"
+    assert terminal_tool._sudo_wrong_password_failure(output) is False
+
+
+def test_invalidate_cached_sudo_on_auth_failure_clears_session_cache(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    terminal_tool._set_cached_sudo_password("wrong-pass")
+
+    cleared = terminal_tool._invalidate_cached_sudo_on_auth_failure(
+        "sudo apt install fprintd",
+        "sudo: Authentication failed, try again.",
+    )
+
+    assert cleared is True
+    assert terminal_tool._get_cached_sudo_password() == ""
+
+
+def test_invalidate_cached_sudo_on_auth_failure_ignores_legacy_env_password(monkeypatch):
+    monkeypatch.setenv("SUDO_PASSWORD", "from-env")
+    terminal_tool._set_cached_sudo_password("wrong-pass")
+
+    cleared = terminal_tool._invalidate_cached_sudo_on_auth_failure(
+        "sudo true",
+        "sudo: Authentication failed, try again.",
+    )
+
+    assert cleared is True
+    assert terminal_tool._get_cached_sudo_password() == ""
+
+
+def test_transform_sudo_command_pipes_one_password_line_per_invocation(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False)
+    terminal_tool._set_cached_sudo_password("testpass")
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command(
+        "sudo true && sudo whoami"
+    )
+
+    assert transformed == "sudo -S -p '' true && sudo -S -p '' whoami"
+    assert sudo_stdin == "testpass\ntestpass\n"
+
 
 
 def test_validate_workdir_still_blocks_metachars_in_unicode_paths():
@@ -106,3 +375,93 @@ def test_validate_workdir_still_blocks_metachars_in_unicode_paths():
 def test_count_real_sudo_invocations_ignores_mentions(monkeypatch):
     assert terminal_tool._count_real_sudo_invocations("grep sudo README.md") == 0
     assert terminal_tool._count_real_sudo_invocations("sudo a; sudo b") == 2
+
+
+def test_passwordless_sudo_still_works_in_gateway_session(monkeypatch):
+    """Local sudoers NOPASSWD is a host policy, not a Hermes secret — it
+    must keep working unattended even though SUDO_PASSWORD is never
+    honored for gateway/cron runs."""
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: True)
+
+    def _fail_prompt(*_args, **_kwargs):
+        raise AssertionError("gateway session must never prompt for sudo")
+
+    monkeypatch.setattr(terminal_tool, "_prompt_for_sudo_password", _fail_prompt)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo whoami")
+
+    assert transformed == "sudo whoami"
+    assert sudo_stdin is None
+
+
+# =============================================================================
+# _handle_sudo_failure — fail-closed messaging for unattended sudo
+# =============================================================================
+
+_SUDO_MISSING_PASSWORD_OUTPUT = "sudo: a password is required\n"
+
+
+def test_handle_sudo_failure_fails_closed_in_gateway_session(monkeypatch):
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+
+    result = terminal_tool._handle_sudo_failure(_SUDO_MISSING_PASSWORD_OUTPUT, "local")
+
+    assert "visible terminal" in result.lower()
+    assert ".env" not in result
+    assert "SUDO_PASSWORD" not in result
+
+
+def test_handle_sudo_failure_fails_closed_in_cron_session(monkeypatch):
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+
+    result = terminal_tool._handle_sudo_failure(_SUDO_MISSING_PASSWORD_OUTPUT, "local")
+
+    assert "visible terminal" in result.lower()
+    assert ".env" not in result
+    assert "SUDO_PASSWORD" not in result
+
+
+def test_handle_sudo_failure_fails_closed_for_plain_noninteractive_run(monkeypatch):
+    """No gateway, no cron, no HERMES_INTERACTIVE, no callback — still
+    nobody present to answer a sudo prompt, so this must fail closed too."""
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+
+    result = terminal_tool._handle_sudo_failure(_SUDO_MISSING_PASSWORD_OUTPUT, "local")
+
+    assert "visible terminal" in result.lower()
+
+
+def test_handle_sudo_failure_leaves_output_alone_when_interactive(monkeypatch):
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+    result = terminal_tool._handle_sudo_failure(_SUDO_MISSING_PASSWORD_OUTPUT, "local")
+
+    assert result == _SUDO_MISSING_PASSWORD_OUTPUT
+
+
+def test_handle_sudo_failure_fails_closed_with_gateway_callback(monkeypatch):
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    terminal_tool.set_sudo_password_callback(lambda: "x")
+    try:
+        result = terminal_tool._handle_sudo_failure(_SUDO_MISSING_PASSWORD_OUTPUT, "local")
+    finally:
+        terminal_tool.set_sudo_password_callback(None)
+
+    assert "visible terminal" in result.lower()
+
+
+def test_handle_sudo_failure_leaves_unrelated_output_alone(monkeypatch):
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+
+    result = terminal_tool._handle_sudo_failure("total 0\ndrwxr-xr-x\n", "local")
+
+    assert result == "total 0\ndrwxr-xr-x\n"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -485,31 +485,25 @@ HARDLINE_PATTERNS_COMPILED = [
 # =========================================================================
 # Sudo stdin guard — block password guessing via "sudo -S"
 # =========================================================================
-# When SUDO_PASSWORD is not configured, any explicit "sudo -S" in the
-# command is the LLM piping a guessed password via stdin.  This is a
-# brute-force attack vector: the model iterates through candidate
-# passwords, inspects sudo's "Sorry, try again" output, and refines.
-# Treat this as an unconditional block — there is never a legitimate
-# reason for the agent to pipe passwords to sudo -S when no password
-# has been configured.
+# Any explicit "sudo -S" in the submitted command is an attempt to pipe a
+# password through stdin. Hermes may inject ``-S`` internally only after an
+# interactive local prompt; that transformed command never re-enters this
+# submitted-command guard. Treat all explicit uses as an unconditional block.
 _SUDO_STDIN_RE = re.compile(
     r'(?:^|[;&|`\n]|&&|\|\||\$\()\s*sudo\s+-S\b',
     re.IGNORECASE)
 
 
 def _check_sudo_stdin_guard(command: str) -> tuple:
-    """Detect ``sudo -S`` (stdin password) without configured SUDO_PASSWORD.
+    """Detect an agent-authored ``sudo -S`` password pipe.
 
-    When SUDO_PASSWORD is set, ``_transform_sudo_command`` injects ``-S``
-    internally — that path is legitimate and handled elsewhere.  This guard
-    only fires when SUDO_PASSWORD is *not* set, meaning the LLM explicitly
-    wrote ``sudo -S`` to pipe a guessed password.
+    Hermes only adds ``-S`` after an interactive local password prompt. An
+    ``-S`` already present in the submitted command is always untrusted,
+    including when a legacy ``SUDO_PASSWORD`` environment variable exists.
 
     Returns:
         (is_blocked: bool, description: str | None)
     """
-    if "SUDO_PASSWORD" in os.environ:
-        return (False, None)
     normalized = _normalize_command_for_detection(command).lower()
     if _SUDO_STDIN_RE.search(normalized):
         return (True, "sudo password guessing via stdin (sudo -S)")
@@ -678,9 +672,8 @@ def _sudo_stdin_block_result(description: str) -> dict:
         "message": (
             f"BLOCKED: {description}. "
             "Do not pipe passwords to 'sudo -S' — this is a brute-force "
-            "attack vector. Set SUDO_PASSWORD in your .env file if the "
-            "agent needs passwordless sudo, or run the sudo command "
-            "manually in your own terminal."
+            "attack vector. Run the sudo command manually from a visible "
+            "terminal and enter the password locally."
         ),
     }
 
@@ -929,8 +922,8 @@ DANGEROUS_PATTERNS = [
     # or via an askpass helper (-A/--askpass). The shell-launch (-s) and
     # list-privileges (-a) flags are also gated since they are
     # privilege-relevant invocations the agent can chain after acquiring
-    # the password (e.g. read SUDO_PASSWORD from .env -> sudo -S -s ->
-    # root shell). Plain `sudo cmd` (no flag) is TTY-bound and excluded.
+    # a password into sudo -S -s to obtain a root shell). Plain `sudo cmd` (no
+    # flag) is TTY-bound and excluded.
     # `_normalize_command_for_detection` lowercases input before pattern
     # matching, so case variants of S/s and A/a collapse — both forms
     # are gated below. Lazy `[^;|&\n]*?` allows flag arguments (e.g.
@@ -3559,9 +3552,9 @@ def check_all_command_guards(command: str, env_type: str,
 
     # == Sudo stdin guard ==
     # Like the hardline floor above, this is unconditional: there is never a
-    # legitimate reason for the agent to pipe passwords to sudo -S when no
-    # SUDO_PASSWORD has been configured.  This must fire BEFORE the yolo
-    # check so even yolo/smart approval/mode=off cannot bypass it.
+    # legitimate reason for an agent-submitted command to pipe passwords to
+    # sudo -S. This must fire BEFORE the yolo check so even yolo/smart
+    # approval/mode=off cannot bypass it.
     is_sudo_guess, sudo_guess_desc = _check_sudo_stdin_guard(command)
     if is_sudo_guess:
         logger.warning("Sudo stdin guard block: %s (command: %s)",

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3,18 +3,16 @@
 Terminal Tool Module
 
 A terminal tool that executes commands in local, Docker, Modal, SSH,
-Singularity, Daytona, and Vercel Sandbox environments. Supports local
-execution, containerized backends, and cloud sandboxes, including managed
-Modal mode.
+Singularity, and Daytona environments. Supports local execution,
+containerized backends, and cloud sandboxes, including managed Modal mode.
 
-Environment Selection (via TERMINAL_ENV environment variable):
+Supported environments:
 - "local": Execute directly on the host machine (default, fastest)
 - "docker": Execute in Docker containers (isolated, requires Docker)
 - "modal": Execute in Modal cloud sandboxes (direct Modal or managed gateway)
-- "vercel_sandbox": Execute in Vercel Sandbox cloud sandboxes
 
 Features:
-- Multiple execution backends (local, docker, modal, vercel_sandbox)
+- Multiple execution backends (local, docker, modal)
 - Background task support
 - VM/container lifecycle management
 - Automatic cleanup after inactivity
@@ -39,8 +37,6 @@ import logging
 import os
 import platform
 import re
-import shlex
-import stat
 import time
 import threading
 import atexit
@@ -60,7 +56,6 @@ logger = logging.getLogger(__name__)
 # long-running subprocesses immediately instead of blocking until timeout.
 # ---------------------------------------------------------------------------
 from tools.interrupt import is_interrupted, _interrupt_event  # noqa: F401 — re-exported
-from tools.registry import tool_error
 # display_hermes_home imported lazily at call site (stale-module safety during hermes update)
 
 
@@ -123,90 +118,10 @@ DISK_USAGE_WARNING_THRESHOLD_GB = _safe_parse_import_env(
     float,
     "number",
 )
-_VERCEL_SANDBOX_DEFAULT_CWD = "/vercel/sandbox"
-_SUPPORTED_VERCEL_RUNTIMES = ("node24", "node22", "python3.13")
-
-
-def _is_supported_vercel_runtime(runtime: str) -> bool:
-    return not runtime or runtime in _SUPPORTED_VERCEL_RUNTIMES
-
-
-def _check_vercel_sandbox_requirements(config: dict[str, Any]) -> bool:
-    """Validate Vercel Sandbox terminal backend requirements."""
-    runtime = (config.get("vercel_runtime") or "").strip()
-    if not _is_supported_vercel_runtime(runtime):
-        supported = ", ".join(_SUPPORTED_VERCEL_RUNTIMES)
-        logger.error(
-            "Vercel Sandbox runtime %r is not supported. "
-            "Set TERMINAL_VERCEL_RUNTIME to one of: %s.",
-            runtime,
-            supported,
-        )
-        return False
-
-    disk = config.get("container_disk", 51200)
-    if disk not in {0, 51200}:
-        logger.error(
-            "Vercel Sandbox does not support custom TERMINAL_CONTAINER_DISK=%s. "
-            "Use the default shared setting (51200 MB).",
-            disk,
-        )
-        return False
-
-    if importlib.util.find_spec("vercel") is None:
-        logger.error(
-            "vercel is required for the Vercel Sandbox terminal backend: pip install vercel"
-        )
-        return False
-
-    from agent.secret_scope import get_secret
-
-    has_oidc = bool(get_secret("VERCEL_OIDC_TOKEN"))
-    has_token = bool(get_secret("VERCEL_TOKEN"))
-    has_project = bool(get_secret("VERCEL_PROJECT_ID"))
-    has_team = bool(get_secret("VERCEL_TEAM_ID"))
-
-    if has_oidc:
-        return True
-
-    if has_token or has_project or has_team:
-        if has_token and has_project and has_team:
-            return True
-        logger.error(
-            "Vercel Sandbox backend selected with token auth, but "
-            "VERCEL_TOKEN, VERCEL_PROJECT_ID, and VERCEL_TEAM_ID must all "
-            "be set together. VERCEL_OIDC_TOKEN is supported for one-off "
-            "local development only."
-        )
-        return False
-
-    logger.error(
-        "Vercel Sandbox backend selected but no supported auth configuration "
-        "was found. Set VERCEL_TOKEN, VERCEL_PROJECT_ID, and VERCEL_TEAM_ID "
-        "for normal use. VERCEL_OIDC_TOKEN is supported for one-off local "
-        "development only."
-    )
-    return False
-
-
-# Cache for disk usage warning to avoid full rglob scan on every call.
-# The check is advisory-only — staleness for up to 5 minutes is acceptable.
-_disk_usage_cache: dict = {"timestamp": 0.0, "result": False}
-_DISK_USAGE_CACHE_TTL = 300.0  # seconds
 
 
 def _check_disk_usage_warning():
-    """Check if total disk usage exceeds warning threshold.
-
-    Result is cached for :data:`_DISK_USAGE_CACHE_TTL` seconds (default:
-    5 minutes) to avoid an expensive recursive filesystem scan on every
-    terminal command.  The check is advisory-only so a stale result is
-    harmless.
-    """
-    import time as _time_mod
-    now = _time_mod.monotonic()
-    if now - _disk_usage_cache["timestamp"] < _DISK_USAGE_CACHE_TTL:
-        return _disk_usage_cache["result"]
+    """Check if total disk usage exceeds warning threshold."""
     try:
         scratch_dir = _get_scratch_dir()
 
@@ -223,16 +138,14 @@ def _check_disk_usage_warning():
         
         total_gb = total_bytes / (1024 ** 3)
         
-        exceeded = total_gb > DISK_USAGE_WARNING_THRESHOLD_GB
-        if exceeded:
+        if total_gb > DISK_USAGE_WARNING_THRESHOLD_GB:
             logger.warning("Disk usage (%.1fGB) exceeds threshold (%.0fGB). Consider running cleanup_all_environments().",
                            total_gb, DISK_USAGE_WARNING_THRESHOLD_GB)
-        _disk_usage_cache["timestamp"] = _time_mod.monotonic()
-        _disk_usage_cache["result"] = exceeded
-        return exceeded
+            return True
+
+        return False
     except Exception as e:
         logger.debug("Disk usage warning check failed: %s", e, exc_info=True)
-        # Don't update cache on error so the next call retries.
         return False
 
 
@@ -374,24 +287,10 @@ def _check_all_guards(command: str, env_type: str,
 
 
 # Allowlist: characters that can legitimately appear in directory paths.
-# Covers Unicode letters/digits, path separators, Windows drive/UNC separators,
-# tilde, dot, hyphen, underscore, space, plus, at, equals, and comma.  Shell
-# metacharacters remain rejected.  This intentionally fixes the old ASCII-only
-# guard that blocked perfectly normal workdirs such as Chinese Obsidian vault
-# paths while preserving the injection boundary around command execution
-# (the cwd is additionally shlex-quoted before it reaches the shell; this
-# allowlist is defense-in-depth).
-_WORKDIR_SAFE_ASCII_CHARS = frozenset('/\\:_-.~ +@=,')
-
-
-def _is_safe_workdir_char(ch: str) -> bool:
-    if not ch:
-        return False
-    # Reject control characters (including newlines/tabs) and NUL bytes before
-    # considering Unicode categories.
-    if ord(ch) < 32 or ord(ch) == 127:
-        return False
-    return ch.isalnum() or ch in _WORKDIR_SAFE_ASCII_CHARS
+# Covers alphanumeric, path separators, Windows drive/UNC separators, tilde,
+# dot, hyphen, underscore, space, plus, at, equals, and comma.  Everything
+# else is rejected.
+_WORKDIR_SAFE_RE = re.compile(r'^[A-Za-z0-9/\\:_\-.~ +@=,]+$')
 
 
 def _validate_workdir(workdir: str) -> str | None:
@@ -404,12 +303,15 @@ def _validate_workdir(workdir: str) -> str | None:
     """
     if not workdir:
         return None
-    for ch in workdir:
-        if not _is_safe_workdir_char(ch):
-            return (
-                f"Blocked: workdir contains disallowed character {repr(ch)}. "
-                "Use a simple filesystem path without shell metacharacters."
-            )
+    if not _WORKDIR_SAFE_RE.match(workdir):
+        # Find the first offending character for a helpful message.
+        for ch in workdir:
+            if not _WORKDIR_SAFE_RE.match(ch):
+                return (
+                    f"Blocked: workdir contains disallowed character {repr(ch)}. "
+                    "Use a simple filesystem path without shell metacharacters."
+                )
+        return "Blocked: workdir contains disallowed characters."
     return None
 
 
@@ -419,24 +321,26 @@ def _handle_sudo_failure(output: str, env_type: str) -> str:
     
     Returns enhanced output if sudo failed in messaging context, else original.
     """
-    is_gateway = env_var_enabled("HERMES_GATEWAY_SESSION")
-    
-    if not is_gateway:
-        return output
-    
-    # Check for sudo failure indicators
-    sudo_failures = [
+    sudo_failures = (
         "sudo: a password is required",
         "sudo: no tty present",
         "sudo: a terminal is required",
-    ]
-    
-    for failure in sudo_failures:
-        if failure in output:
-            from hermes_constants import display_hermes_home as _dhh
-            return output + f"\n\n💡 Tip: To enable sudo over messaging, add SUDO_PASSWORD to {_dhh()}/.env on the agent machine."
-    
-    return output
+    )
+    if not any(failure in output for failure in sudo_failures):
+        return output
+
+    is_interactive_local = (
+        env_var_enabled("HERMES_INTERACTIVE")
+        and not env_var_enabled("HERMES_GATEWAY_SESSION")
+        and not env_var_enabled("HERMES_CRON_SESSION")
+    )
+    if is_interactive_local:
+        return output
+
+    return output + (
+        "\n\nSudo is unavailable for unattended runs. "
+        "Run this command from a visible terminal and enter the password locally."
+    )
 
 
 # sudo -S rejects a bad cached/interactive password with these messages.
@@ -459,13 +363,7 @@ def _sudo_wrong_password_failure(output: str) -> bool:
 def _invalidate_cached_sudo_on_auth_failure(
     command: str | None, output: str
 ) -> bool:
-    """Drop a session-cached sudo password after sudo rejects it.
-
-    Env-configured ``SUDO_PASSWORD`` is left alone — that is an explicit
-    operator choice, not an interactive cache entry.
-    """
-    if "SUDO_PASSWORD" in os.environ:
-        return False
+    """Drop a session-cached sudo password after sudo rejects it."""
     if not _sudo_wrong_password_failure(output):
         return False
     if _count_real_sudo_invocations(command or "") == 0:
@@ -968,7 +866,7 @@ def _rewrite_compound_background(command: str) -> str:
 
 def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None]:
     """
-    Transform sudo commands to use -S flag if SUDO_PASSWORD is available.
+    Transform bare sudo commands after an interactive local password prompt.
 
     This is a shared helper used by all execution environments to provide
     consistent sudo handling across local, SSH, and container environments.
@@ -990,17 +888,14 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     should prepend sudo_stdin to their stdin_data and pass the merged bytes to
     Popen's stdin pipe.
 
-    Callers that cannot pipe subprocess stdin (modal, daytona,
-    vercel_sandbox) must embed the password in the command string
-    themselves; see their execute() methods for how they handle the
-    non-None sudo_stdin case.
+    Callers that cannot pipe subprocess stdin (modal, daytona) must embed
+    the password in the command string themselves; see their execute()
+    methods for how they handle the non-None sudo_stdin case.
 
-    If SUDO_PASSWORD is not set and an interactive UI is available
-    (HERMES_INTERACTIVE=1 or a registered sudo password callback):
-      Prompts user for password with 45s timeout, caches for session.
-
-    If SUDO_PASSWORD is not set and NOT interactive:
-      Command runs as-is (fails gracefully with "sudo: a password is required").
+    Only an interactive local UI (HERMES_INTERACTIVE=1 or a registered sudo
+    password callback) may prompt and populate the session cache. Gateway,
+    cron, and other unattended runs leave the command unchanged; local
+    sudoers NOPASSWD remains supported without a password.
     """
     if command is None:
         return None, None
@@ -1008,44 +903,32 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     if sudo_count == 0:
         return command, None
 
-    # Scope-aware read (Slack pattern): under multiplex the process env may
-    # hold another profile's SUDO_PASSWORD, so honor the installed scope's
-    # verdict; unscoped callers keep the legacy os.environ read.
-    try:
-        from agent.secret_scope import UnscopedSecretError, get_secret
-
-        try:
-            _configured_password = get_secret("SUDO_PASSWORD")
-        except UnscopedSecretError:
-            _configured_password = os.environ.get("SUDO_PASSWORD")
-    except Exception:
-        _configured_password = os.environ.get("SUDO_PASSWORD")
-    has_configured_password = _configured_password is not None
-    sudo_password = (
-        _configured_password
-        if has_configured_password
-        else _get_cached_sudo_password()
+    has_sudo_prompt_callback = _get_sudo_password_callback() is not None
+    is_unattended = (
+        env_var_enabled("HERMES_GATEWAY_SESSION")
+        or env_var_enabled("HERMES_CRON_SESSION")
+        or not (
+            env_var_enabled("HERMES_INTERACTIVE")
+            or has_sudo_prompt_callback
+        )
     )
 
-    # Local hosts with sudoers NOPASSWD should not be forced through the
-    # interactive Hermes password prompt or the sudo -S password-pipe path.
-    # Scoped to the local terminal backend so Docker/SSH/Modal/etc. can't
-    # inherit host sudo state. Re-probes every call (no process-lifetime
-    # cache) so an expired sudo timestamp doesn't make a later command block
-    # silently without Hermes prompting.
-    if not has_configured_password and not sudo_password and _sudo_nopasswd_works():
+    # Local hosts with sudoers NOPASSWD remain passwordless in every context.
+    if _sudo_nopasswd_works():
         return command, None
 
-    has_sudo_prompt_callback = _get_sudo_password_callback() is not None
-    should_prompt_for_sudo = (
+    # Legacy SUDO_PASSWORD is deliberately ignored. Only an interactive local
+    # prompt may populate the session-local cache used for this command.
+    sudo_password = "" if is_unattended else _get_cached_sudo_password()
+    should_prompt_for_sudo = not is_unattended and (
         env_var_enabled("HERMES_INTERACTIVE") or has_sudo_prompt_callback
     )
-    if not has_configured_password and not sudo_password and should_prompt_for_sudo:
+    if not sudo_password and should_prompt_for_sudo:
         sudo_password = _prompt_for_sudo_password(timeout_seconds=45)
         if sudo_password:
             _set_cached_sudo_password(sudo_password)
 
-    if has_configured_password or sudo_password:
+    if sudo_password:
         # Trailing newline is required: sudo -S reads one line per invocation.
         # Compound commands (`sudo a && sudo b`) need one password line each.
         password_line = sudo_password + "\n"
@@ -1068,13 +951,25 @@ import sys
 # Tool description for LLM
 TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem, current working directory, and exported environment variables persist between calls.
 
-Do NOT use cat/head/tail (use read_file), grep/rg/find/ls (use search_files), sed/awk (use patch), or echo/heredoc file creation (use write_file). Reserve terminal for: builds, installs, git, processes, scripts, network, package managers, and anything that needs a shell.
-Environment state persists: activate a virtualenv or export variables once per session, not before every command.
+Do NOT use cat/head/tail to read files — use read_file instead.
+Do NOT use grep/rg/find to search — use search_files instead.
+Do NOT use ls to list directories — use search_files(target='files') instead.
+Do NOT use sed/awk to edit files — use patch instead.
+Do NOT use echo/cat heredoc to create files — use write_file instead.
+Reserve terminal for: builds, installs, git, processes, scripts, network, package managers, and anything that needs a shell.
+Because exported environment state persists, activate a virtualenv or export setup variables once per session; do not re-source the same environment before every command unless a command proves the shell state was reset.
 
-Foreground (default): returns INSTANTLY when the command finishes, even with a high timeout — set timeout generously for long builds.
-Background: set background=true (returns a session_id). Pair with notify_on_complete=true for bounded tasks; leave silent only for servers/daemons that never exit. Never use nohup/setsid/trailing '&' — use background=true so Hermes tracks the process. After starting a server, verify readiness with a health check, then act in a separate call; no blind sleep loops. Manage with process(action="poll"/"wait").
-Working directory: use 'workdir' for per-command cwd. When a command changes the session cwd (cd, pushd), the result includes a "cwd" field — trust it instead of prefixing every command with 'cd'.
-PTY: set pty=true for interactive CLIs (they hang without it). Pipe git output to cat if it might page.
+Foreground (default): Commands return INSTANTLY when done, even if the timeout is high. Set timeout=300 for long builds/scripts — you'll still get the result in seconds if it's fast. Prefer foreground for short commands.
+Background: Set background=true to get a session_id. Almost always pair with notify_on_complete=true — bg without notify runs SILENTLY and you have no way to learn it finished short of calling process(action='poll') yourself. Two legitimate uses:
+  (1) Long-lived processes that never exit (servers, watchers, daemons) — silent is correct, there's no exit to notify on.
+  (2) Long-running bounded tasks (tests, builds, deploys, CI pollers, batch jobs) — MUST set notify_on_complete=true. Without it you'll either forget to poll or sit blocked waiting for the user to surface the result.
+For servers/watchers, do NOT use shell-level background wrappers (nohup/disown/setsid/trailing '&') in foreground mode. Use background=true so Hermes can track lifecycle and output.
+After starting a server, verify readiness with a health check or log signal, then run tests in a separate terminal() call. Avoid blind sleep loops.
+Use process(action="poll") for progress checks, process(action="wait") to block until done.
+Working directory: Use 'workdir' for per-command cwd.
+PTY mode: Set pty=true for interactive CLI tools (Codex, Claude Code, Python REPL).
+
+Do NOT use vim/nano/interactive tools without pty=true — they hang without a pseudo-terminal. Pipe git output to cat if it might page.
 """
 
 # Global state for environment lifecycle management
@@ -1364,7 +1259,7 @@ def _safe_getcwd() -> str:
 # cwd looks when it leaks toward a Linux container's ``-w`` flag.
 _HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")
 
-_CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
+_CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona"})
 
 
 def _is_ssh_remote_tilde_cwd(backend: str, cwd: str) -> bool:
@@ -1424,34 +1319,21 @@ def _ensure_terminal_env_bridged() -> None:
     config.yaml selects ``terminal.backend: docker``, running commands on the
     host the user intended to sandbox (#63141, #54449, #61115, #65696).
 
-    Explicit terminal config keys win: when config.yaml has a ``terminal``
-    section, each key present there overrides its matching env value (which may
-    be stale from ``hermes setup``). Environment values for omitted terminal
-    keys are preserved. When no terminal section exists, exported/.env values
-    keep working unchanged.
+    Explicit env always wins: when TERMINAL_ENV is already set (a launcher's
+    bridge or the user's .env made a deliberate choice) this is a no-op.  The
+    config bridge only fills the unset case, so it changes an accidental
+    default — never an explicit selection.
     """
     global _terminal_config_bridge_attempted
-    if _terminal_config_bridge_attempted:
+    if "TERMINAL_ENV" in os.environ or _terminal_config_bridge_attempted:
         return
     _terminal_config_bridge_attempted = True
     try:
-        from hermes_cli.config import apply_terminal_config_to_env, read_raw_config
+        from hermes_cli.config import apply_terminal_config_to_env
 
-        # If config.yaml has an explicit terminal section, bridge with
-        # override enabled. The helper only overrides env vars for keys present
-        # in that raw section; merged defaults remain backfill-only. Without a
-        # terminal section, preserve an existing TERMINAL_ENV selection or
-        # backfill defaults when no selection exists.
-        raw_config = read_raw_config()
-        has_terminal_section = isinstance(raw_config.get("terminal"), dict)
-
-        if has_terminal_section:
-            # Explicit terminal keys in config.yaml win over matching env values.
-            apply_terminal_config_to_env(env=None, override=True)
-        elif "TERMINAL_ENV" not in os.environ:
-            # No terminal section in config.yaml, TERMINAL_ENV not set —
-            # backfill from config defaults
-            apply_terminal_config_to_env(env=None, override=False)
+        # env=None targets os.environ inside the helper; override=False keeps
+        # any already-set TERMINAL_* values (e.g. from .env) authoritative.
+        apply_terminal_config_to_env(env=None, override=False)
     except Exception:
         # Never let a config problem take the terminal tool down — the
         # historical local default still applies.
@@ -1466,7 +1348,7 @@ def _get_env_config() -> Dict[str, Any]:
     env_type = os.getenv("TERMINAL_ENV", "local")
     
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
-    container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
+    container_backend = env_type in {"docker", "singularity", "modal", "daytona"}
     docker_backend = env_type == "docker"
 
     # Docker/container-only env vars may be bridged from config.yaml even when
@@ -1487,23 +1369,19 @@ def _get_env_config() -> Dict[str, Any]:
         docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
         docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
         docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
-        docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
     else:
         docker_forward_env = []
         docker_volumes = []
         docker_env = {}
         docker_extra_args = []
-        docker_shm_size = "1g"
 
     # Default cwd: local uses the host's current directory, ssh uses the
-    # remote home, Vercel uses its documented workspace root, and everything
-    # else starts in the backend's default root-like cwd.
+    # remote home, and everything else starts in the backend's default
+    # root-like cwd.
     if env_type == "local":
         default_cwd = _safe_getcwd()
     elif env_type == "ssh":
         default_cwd = "~"
-    elif env_type == "vercel_sandbox":
-        default_cwd = _VERCEL_SANDBOX_DEFAULT_CWD
     else:
         default_cwd = "/root"
 
@@ -1540,7 +1418,6 @@ def _get_env_config() -> Dict[str, Any]:
         "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
         "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
         "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
-        "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
@@ -1560,7 +1437,7 @@ def _get_env_config() -> Dict[str, Any]:
         ).lower() in {"true", "1", "yes"},
         "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
         # Container resource config (applies to docker, singularity, modal,
-        # daytona, and vercel_sandbox -- ignored for local/ssh)
+        # daytona -- ignored for local/ssh)
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
@@ -1570,7 +1447,6 @@ def _get_env_config() -> Dict[str, Any]:
         "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
         "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
         "docker_extra_args": docker_extra_args,
-        "docker_shm_size": docker_shm_size,
         # Cross-process container reuse (issue #20561).  The docs claim
         # "ONE long-lived container shared across sessions" — this toggle
         # makes that real by probing for a labeled container at startup and
@@ -1609,8 +1485,8 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     
     Args:
         env_type: One of "local", "docker", "singularity", "modal",
-            "daytona", "vercel_sandbox", "ssh"
-        image: Docker/Singularity/Modal image name (ignored for local/ssh/vercel)
+            "daytona", "ssh"
+        image: Docker/Singularity/Modal image name (ignored for local/ssh)
         cwd: Working directory
         timeout: Default command timeout
         ssh_config: SSH connection config (for env_type="ssh")
@@ -1656,7 +1532,6 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             network=docker_network,
             extra_args=docker_extra_args,
             persist_across_processes=cc.get("docker_persist_across_processes", True),
-            shm_size=cc.get("docker_shm_size", "1g"),
         )
     
     elif env_type == "singularity":
@@ -1733,21 +1608,6 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             persistent_filesystem=persistent, task_id=task_id,
         )
 
-    elif env_type == "vercel_sandbox":
-        from tools.environments.vercel_sandbox import (
-            VercelSandboxEnvironment as _VercelSandboxEnvironment,
-        )
-        return _VercelSandboxEnvironment(
-            runtime=cc.get("vercel_runtime") or None,
-            cwd=cwd,
-            timeout=timeout,
-            cpu=cpu,
-            memory=memory,
-            disk=disk,
-            persistent_filesystem=persistent,
-            task_id=task_id,
-        )
-
     elif env_type == "ssh":
         if not ssh_config or not ssh_config.get("host") or not ssh_config.get("user"):
             raise ValueError("SSH environment requires ssh_host and ssh_user to be configured")
@@ -1763,7 +1623,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     else:
         raise ValueError(
             f"Unknown environment type: {env_type}. Use 'local', 'docker', "
-            f"'singularity', 'modal', 'daytona', 'vercel_sandbox', or 'ssh'"
+            f"'singularity', 'modal', 'daytona', or 'ssh'"
         )
 
 
@@ -2163,16 +2023,14 @@ def _foreground_background_guidance(command: str) -> str | None:
     if _SHELL_LEVEL_BACKGROUND_RE.search(unquoted):
         return (
             "Foreground command uses shell-level background wrappers (nohup/disown/setsid). "
-            "Re-send WITHOUT the wrapper as terminal(command=\"<cmd>\", background=true, "
-            "notify_on_complete=true) so Hermes tracks the process, then run readiness "
-            "checks and tests in separate commands."
+            "Use terminal(background=true) so Hermes can track the process, then run "
+            "readiness checks and tests in separate commands."
         )
 
     if _INLINE_BACKGROUND_AMP_RE.search(unquoted) or _TRAILING_BACKGROUND_AMP_RE.search(unquoted):
         return (
-            "Foreground command uses '&' backgrounding. Re-send WITHOUT the '&' as "
-            "terminal(command=\"<cmd>\", background=true) — add notify_on_complete=true "
-            "for bounded jobs — then run health checks and tests in follow-up terminal calls."
+            "Foreground command uses '&' backgrounding. Use terminal(background=true) for long-lived "
+            "processes, then run health checks and tests in follow-up terminal calls."
         )
 
     for pattern in _LONG_LIVED_FOREGROUND_PATTERNS:
@@ -2340,26 +2198,18 @@ def terminal_tool(
                 )
             cwd = config["cwd"]
         default_timeout = config["timeout"]
-
-        # Validate an explicit timeout before it flows into deadline math.
-        # ``timeout or default`` silently turns 0 into the default (0 can't mean
-        # "no timeout" here), and a negative value is truthy so it would sail
-        # through to ``deadline = now + timeout`` and fire an immediate,
-        # nonsensical "-Ns" timeout. Reject non-positive values outright.
-        if timeout is not None and timeout <= 0:
-            return tool_error(
-                f"timeout must be a positive number of seconds (got {timeout})."
-            )
         effective_timeout = timeout or default_timeout
 
         # Reject foreground commands where the model explicitly requests
         # a timeout above FOREGROUND_MAX_TIMEOUT — nudge it toward background.
         if not background and timeout and timeout > FOREGROUND_MAX_TIMEOUT:
-            return tool_error(
-                f"Foreground timeout {timeout}s exceeds the maximum of "
-                f"{FOREGROUND_MAX_TIMEOUT}s. Use background=true with "
-                f"notify_on_complete=true for long-running commands."
-            )
+            return json.dumps({
+                "error": (
+                    f"Foreground timeout {timeout}s exceeds the maximum of "
+                    f"{FOREGROUND_MAX_TIMEOUT}s. Use background=true with "
+                    f"notify_on_complete=true for long-running commands."
+                ),
+            }, ensure_ascii=False)
 
         # Guardrail: long-lived server/watch commands should run as managed
         # background sessions, not foreground shell hacks.
@@ -2380,7 +2230,7 @@ def terminal_tool(
         # Use a per-task creation lock so concurrent tool calls for the same
         # task_id wait for the first one to finish creating the sandbox,
         # instead of each creating their own (wasting Modal resources).
-        env: Any = None
+        env = None
         with _env_lock:
             # Prefer the collapsed container id, but fall back to an env cached
             # under the raw task_id. Per-session surfaces (ACP/gateway/dashboard)
@@ -2433,21 +2283,19 @@ def terminal_tool(
                             }
 
                         container_config = None
-                        if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
+                        if env_type in {"docker", "singularity", "modal", "daytona"}:
                             container_config = {
                                 "container_cpu": config.get("container_cpu", 1),
                                 "container_memory": config.get("container_memory", 5120),
                                 "container_disk": config.get("container_disk", 51200),
                                 "container_persistent": config.get("container_persistent", True),
                                 "modal_mode": config.get("modal_mode", "auto"),
-                                "vercel_runtime": config.get("vercel_runtime", ""),
                                 "docker_volumes": config.get("docker_volumes", []),
                                 "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
                                 "docker_forward_env": config.get("docker_forward_env", []),
                                 "docker_env": config.get("docker_env", {}),
                                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                                 "docker_extra_args": config.get("docker_extra_args", []),
-                                "docker_shm_size": config.get("docker_shm_size", "1g"),
                                 "docker_network": config.get("docker_network", True),
                                 "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
                                 "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
@@ -2484,15 +2332,15 @@ def terminal_tool(
                         env = new_env
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
 
-        assert env is not None  # all creation failure paths return above
-
-        # The session key that drives cwd records: get_current_session_key()'s
-        # contextvar doesn't cross tool-worker threads, so fall back to the raw
-        # task_id (which IS the session_key for the top-level agent) — a
-        # stable, thread-safe anchor.
-        from tools.approval import get_current_session_key
-
-        session_key = get_current_session_key(default="") or (task_id or "")
+        if env is None:
+            # Unreachable in practice (either the cached branch or the creation
+            # branch assigned env above); guard for type-safety and so a future
+            # refactor of the branches can't fall through to an AttributeError.
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": "Terminal environment unavailable (creation raced cleanup)",
+            }, ensure_ascii=False)
 
         # Hard-block: gateway lifecycle commands (systemctl/launchctl/hermes
         # restart|stop targeting hermes-gateway) must never run inside the
@@ -2502,75 +2350,17 @@ def terminal_tool(
         # hermes_cli/gateway.py and the cron-path guard in hermes_cli/cron.py,
         # but applies unconditionally (force=True cannot help here).
         if os.environ.get("_HERMES_GATEWAY") == "1":
-            from cron.lifecycle_guard import (
-                contains_gateway_lifecycle_command_or_referenced_script,
-                contains_launchctl_submit_command,
-            )
-            if contains_launchctl_submit_command(command):
+            from hermes_cli.cron import _contains_gateway_lifecycle_command
+            if _contains_gateway_lifecycle_command(command):
                 return json.dumps({
                     "output": "",
                     "exit_code": 1,
                     "error": (
-                        "Blocked: launchctl submit/bootstrap registers a persistent "
-                        "KeepAlive job and is unsafe from inside the gateway process. "
-                        "Use Hermes cron for one-shot delayed work, or install an "
-                        "explicit LaunchAgent from a separate shell."
-                    ),
-                    "status": "error",
-                }, ensure_ascii=False)
-            guard_cwd_base = get_session_cwd(session_key)
-            if guard_cwd_base is None:
-                guard_cwd_base = getattr(env, "cwd", None) or cwd
-            guard_cwd = _resolve_command_cwd(
-                workdir=workdir,
-                default_cwd=guard_cwd_base,
-                session_key=session_key,
-            )
-
-            def _read_script_in_env(script_path: str) -> Optional[str]:
-                """Best-effort script read; uses env.execute only when local read fails.
-
-                For local backends the script path is on the host filesystem. For
-                SSH/Modal/Daytona the same path is remote; the local read misses, so we
-                fall back to ``env.execute('cat ...')``.
-                """
-                if env is None:
-                    return None
-                try:
-                    local_path = Path(script_path).expanduser()
-                    if not local_path.is_absolute():
-                        local_path = Path(guard_cwd) / local_path
-                    if local_path.is_file():
-                        metadata = local_path.stat()
-                        if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= 1024 * 1024:
-                            data = local_path.read_bytes()
-                            if len(data) <= 1024 * 1024:
-                                return data.decode("utf-8", errors="replace")
-                except Exception:
-                    pass
-                # Remote / sandboxed backend: read via the environment's shell.
-                try:
-                    result = env.execute(f"cat {shlex.quote(script_path)}")
-                    if result.get("returncode", -1) == 0:
-                        return result.get("output", "")
-                except Exception:
-                    pass
-                return None
-
-            if contains_gateway_lifecycle_command_or_referenced_script(
-                command,
-                cwd=guard_cwd,
-                read_remote_script=_read_script_in_env,
-            ):
-                return json.dumps({
-                    "output": "",
-                    "exit_code": 1,
-                    "error": (
-                        "Blocked: command or referenced script cannot restart or stop "
-                        "the gateway from inside the gateway process. The gateway would "
-                        "kill this command before it could complete (SIGTERM propagates "
-                        "to child processes). Run `hermes gateway restart` from a "
-                        "separate shell outside the running gateway."
+                        "Blocked: cannot restart or stop the gateway from inside the "
+                        "gateway process. The gateway would kill this command before "
+                        "it could complete (SIGTERM propagates to child processes). "
+                        "Run `hermes gateway restart` from a separate shell outside "
+                        "the running gateway."
                     ),
                     "status": "error",
                 }, ensure_ascii=False)
@@ -2649,7 +2439,14 @@ def terminal_tool(
                 "EOF."
             )
 
-        # The session key is already computed above the gateway guard.
+        # The session key that drives cwd records: get_current_session_key()'s
+        # contextvar doesn't cross tool-worker threads, so fall back to the raw
+        # task_id (which IS the session_key for the top-level agent) — a
+        # stable, thread-safe anchor.
+        from tools.approval import get_current_session_key
+
+        session_key = get_current_session_key(default="") or (task_id or "")
+
         if background:
             # Spawn a tracked background process via the process registry.
             # For local backends: uses subprocess.Popen with output buffering.
@@ -2809,10 +2606,12 @@ def terminal_tool(
                         get_session_env as _gse,
                     )
 
-                    # Finite sessions (stateless HTTP requests and one-shot
-                    # Kanban workers) cannot route a completion back to the
-                    # agent after the turn/process ends. Refuse the promise:
-                    # drop the flags and tell the agent to poll.
+                    # Stateless request/response sessions (the API server /
+                    # WebUI path) cannot route a completion back to the agent
+                    # after the turn ends — there is no persistent channel and
+                    # send() is a no-op. Registering a watcher there silently
+                    # no-ops (issue #10760). Refuse the promise instead: drop
+                    # the flags and tell the agent to poll.
                     if not _async_ok():
                         notify_on_complete = False
                         watch_patterns = None
@@ -2820,9 +2619,8 @@ def terminal_tool(
                         result_data["notify_unsupported"] = (
                             "notify_on_complete / watch_patterns are not available in "
                             "this session — it cannot receive an async completion after "
-                            "the turn ends (a one-shot runner such as `hermes -z`, a "
-                            "cron job, a Kanban worker, or a stateless HTTP endpoint). "
-                            "The process is "
+                            "the turn ends (a one-shot runner such as `hermes -z` or a "
+                            "cron job, or a stateless HTTP endpoint). The process is "
                             "running in the background; retrieve its result with "
                             "process(action='poll') or process(action='wait')."
                         )
@@ -2967,21 +2765,11 @@ def terminal_tool(
             # session — record it under the session key so the durable record
             # never depends on the shared env surviving or on who drives the
             # env next.
-            #
-            # BUT: a per-command ``workdir`` override is transient by contract
-            # (docstring: "Working directory for this command"). Recording it
-            # would hijack the session's durable cwd for every later command
-            # that doesn't pass ``workdir``. Skip the dual-write in that case.
-            if not workdir:
-                record_session_cwd(session_key, getattr(env, "cwd", None))
+            record_session_cwd(session_key, getattr(env, "cwd", None))
 
             # Extract output
             output = result.get("output", "")
             returncode = result.get("returncode", 0)
-            # Spill metadata from the bounded collector: present only when
-            # output overflowed the capture window (see _wait_for_process).
-            spill_total_chars = result.get("output_total_chars")
-            spill_file_path = result.get("full_output_path")
 
             # Add helpful message for sudo failures in messaging context
             output = _handle_sudo_failure(output, env_type)
@@ -3005,7 +2793,7 @@ def terminal_tool(
             # still subject to the final output limit below.
             # The hook is fail-open, and the first valid string return wins.
             try:
-                from hermes_cli.lifecycle import invoke_hook
+                from hermes_cli.plugins import invoke_hook
                 hook_results = invoke_hook(
                     "transform_terminal_output",
                     command=command,
@@ -3055,64 +2843,11 @@ def terminal_tool(
             # (e.g. grep=1 means "no matches", diff=1 means "files differ")
             exit_note = _interpret_exit_code(command, returncode)
 
-            # Output-pattern failure hints: map well-known error shapes
-            # (command-not-found, ModuleNotFoundError, gh field drift,
-            # merge conflicts, ...) to one short recovery hint so the model
-            # fixes the root cause on the next call instead of spending
-            # turns on re-diagnosis. See tools/terminal_hints.py.
-            failure_hint = None
-            if returncode != 0 and not exit_note:
-                try:
-                    from tools.terminal_hints import annotate_failure
-                    failure_hint = annotate_failure(command, returncode, output)
-                except Exception:
-                    failure_hint = None
-
             result_dict = {
                 "output": output,
                 "exit_code": returncode,
                 "error": None,
             }
-            # cwd echo: when the command changed the session's working
-            # directory (cd, pushd, ...), tell the model where it ended up.
-            # Production mining shows 60% of terminal calls carry a
-            # defensive 'cd X && ' prefix because the model can't see cwd
-            # state; echoing it on change removes the guesswork (pattern
-            # borrowed from crush's <cwd> injection).
-            try:
-                post_cwd = getattr(env, "cwd", None)
-                if post_cwd and command_cwd and os.path.realpath(str(post_cwd)) != os.path.realpath(str(command_cwd)):
-                    result_dict["cwd"] = str(post_cwd)
-            except Exception:
-                pass
-            # Truncation metadata (codex/opencode/goose pattern): report the
-            # pre-truncation size and a spill-file handle so the model can
-            # retrieve the omitted middle with read_file/search_files instead
-            # of re-running the command. The spill was written raw by the
-            # collector; redact it here with the same pass as the visible
-            # output so no secret persists unmasked on disk.
-            if spill_file_path:
-                try:
-                    _sp = Path(spill_file_path)
-                    raw_spill = _sp.read_text(encoding="utf-8", errors="replace")
-                    _sp.write_text(
-                        redact_terminal_output(strip_ansi(raw_spill), command),
-                        encoding="utf-8", errors="replace",
-                    )
-                    result_dict["output_total_chars"] = spill_total_chars
-                    result_dict["full_output_path"] = spill_file_path
-                    result_dict["truncation_note"] = (
-                        "Output exceeded the capture window (head+tail shown). "
-                        f"Full output ({spill_total_chars:,} chars) saved to "
-                        f"{spill_file_path} — search it with search_files or page it "
-                        "with read_file instead of re-running the command."
-                    )
-                except Exception:
-                    logger.debug("spill redaction failed; dropping spill handle", exc_info=True)
-                    try:
-                        Path(spill_file_path).unlink()
-                    except OSError:
-                        pass
             try:
                 from agent.verification_evidence import record_terminal_result
 
@@ -3148,8 +2883,6 @@ def terminal_tool(
                     result_dict["approval"] = approval_note
             if exit_note:
                 result_dict["exit_code_meaning"] = exit_note
-            if failure_hint:
-                result_dict["hint"] = failure_hint
             if sudo_auth_failed:
                 result_dict["sudo_auth_failed"] = True
             if sudo_cache_cleared:
@@ -3264,18 +2997,14 @@ def check_terminal_requirements() -> bool:
 
             return True
 
-        elif env_type == "vercel_sandbox":
-            return _check_vercel_sandbox_requirements(config)
-
         elif env_type == "daytona":
             from daytona import Daytona  # noqa: F401 — SDK presence check
-            from agent.secret_scope import get_secret
-            return get_secret("DAYTONA_API_KEY") is not None
+            return os.getenv("DAYTONA_API_KEY") is not None
 
         else:
             logger.error(
                 "Unknown TERMINAL_ENV '%s'. Use one of: local, docker, singularity, "
-                "modal, daytona, vercel_sandbox, ssh.",
+                "modal, daytona, ssh.",
                 env_type,
             )
             return False
@@ -3318,7 +3047,7 @@ if __name__ == "__main__":
     print(
         "  TERMINAL_ENV: "
         f"{os.getenv('TERMINAL_ENV', 'local')} "
-        "(local/docker/singularity/modal/daytona/vercel_sandbox/ssh)"
+        "(local/docker/singularity/modal/daytona/ssh)"
     )
     print(f"  TERMINAL_DOCKER_IMAGE: {os.getenv('TERMINAL_DOCKER_IMAGE', default_img)}")
     print(f"  TERMINAL_SINGULARITY_IMAGE: {os.getenv('TERMINAL_SINGULARITY_IMAGE', f'docker://{default_img}')}")
@@ -3348,7 +3077,7 @@ TERMINAL_SCHEMA = {
             },
             "background": {
                 "type": "boolean",
-                "description": "Run in the background, returning a session_id. Pair with notify_on_complete=true for anything with a defined end (tests, builds, deploys) — without it the process runs silently. Only servers/watchers/daemons that never exit should stay silent. Short commands: prefer foreground with a generous timeout.",
+                "description": "Run the command in the background. Almost always pair with notify_on_complete=true — without it, the process runs silently and you'll have no way to learn it finished short of calling process(action='poll') yourself (easy to forget, leading to silent blindness on long jobs). Two legitimate patterns: (1) Long-lived processes that never exit (servers, watchers, daemons) — these stay silent because there's no exit to notify on. (2) Long-running bounded tasks (tests, builds, deploys, CI pollers, batch jobs) — these MUST set notify_on_complete=true. For short commands, prefer foreground with a generous timeout instead.",
                 "default": False
             },
             "timeout": {
@@ -3367,13 +3096,13 @@ TERMINAL_SCHEMA = {
             },
             "notify_on_complete": {
                 "type": "boolean",
-                "description": "With background=true: get exactly one notification when the process exits. The right choice for nearly every bounded long task — set it and keep working. MUTUALLY EXCLUSIVE with watch_patterns (watch_patterns is dropped when both are set).",
+                "description": "When true (and background=true), you'll be automatically notified exactly once when the process finishes. **This is the right choice for almost every long-running task** — tests, builds, deployments, multi-item batch jobs, anything that takes over a minute and has a defined end. Use this and keep working on other things; the system notifies you on exit. MUTUALLY EXCLUSIVE with watch_patterns — when both are set, watch_patterns is dropped.",
                 "default": False
             },
             "watch_patterns": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Strings to watch for in background output. ONLY for rare one-shot mid-process signals on processes that never exit (e.g. ['Application startup complete'] on a server). NOT for end-of-run markers (use notify_on_complete) and NOT for per-iteration patterns like 'ERROR' in loops — rate-limited to 1 notification/15s; repeated over-firing auto-disables it and falls back to notify-on-exit. When in doubt, use notify_on_complete. MUTUALLY EXCLUSIVE with notify_on_complete."
+                "description": "Strings to watch for in background process output. HARD RATE LIMIT: at most 1 notification per 15 seconds per process — matches arriving inside the cooldown are dropped. After 3 consecutive 15-second windows with dropped matches, watch_patterns is automatically disabled for that process and promoted to notify_on_complete behavior (one notification on exit, no more mid-process spam). USE ONLY for truly rare, one-shot mid-process signals on LONG-LIVED processes that will never exit on their own — e.g. ['Application startup complete'] on a server so you know when to hit its endpoint, or ['migration done'] on a daemon. DO NOT use for: (1) end-of-run markers like 'DONE'/'PASS' — use notify_on_complete instead; (2) error patterns like 'ERROR'/'Traceback' in loops or multi-item batch jobs — they fire on every iteration and you'll hit the strike limit fast; (3) anything you'd ever combine with notify_on_complete. When in doubt, choose notify_on_complete. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both."
             }
         },
         "required": ["command"]


### PR DESCRIPTION
## Summary
- reject legacy `SUDO_PASSWORD` injection for unattended gateway and cron executions
- retain NOPASSWD support and interactive prompt/callback handling
- prevent explicit agent-authored `sudo -S` from bypassing the approval guard

## Validation
- `uv run --extra dev pytest -q tests/tools/test_terminal_tool.py tests/tools/test_hardline_blocklist.py` (223 passed)
- `git diff --check origin/main...HEAD`