### PR TITLE
feat(desktop): restore session when switching profiles

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -39,6 +39,7 @@ import { $previewTarget } from '@/store/preview'
 import {
   $activeGatewayProfile,
   $freshSessionRequest,
+  $profileNavigationRequest,
   $profileScope,
   ensureGatewayProfile,
   newSessionInProfile,
@@ -58,6 +59,8 @@ import {
   $resumeFailedSessionId,
   $selectedStoredSessionId,
   $sessions,
+  getRememberedRoute,
+  getRememberedSessionId,
   sessionMatchesStoredId,
   sessionPinId,
   setAwaitingResponse,
@@ -86,8 +89,11 @@ import { resetProjectTreeState } from '../right-sidebar/files/use-project-tree'
 import { PersistentTerminal } from '../right-sidebar/terminal/persistent'
 import { closeAllTerminals } from '../right-sidebar/terminal/terminals'
 import {
+  appViewForPath,
   CRON_ROUTE,
+  isOverlayView,
   navigateToWorkspacePage,
+  NEW_CHAT_ROUTE,
   routeSessionId,
   sessionRoute,
   SETTINGS_ROUTE,
@@ -476,6 +482,39 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     lastFreshRef.current = freshSessionRequest
     startFreshSessionDraft()
   }, [freshSessionRequest, startFreshSessionDraft])
+
+  // A profile switch is a workspace restore, not a new-chat action. Wait until
+  // the target gateway is active, clear the old live view without changing its
+  // route, then restore the target profile's last non-overlay route. This keeps
+  // the existing per-profile persistence used by cold-start restore and makes
+  // rapid profile switches settle on the latest target.
+  const profileNavigationRequest = useStore($profileNavigationRequest)
+  const lastProfileNavigationRequestRef = useRef(profileNavigationRequest?.sequence ?? 0)
+
+  // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
+  useEffect(() => {
+    if (
+      !profileNavigationRequest ||
+      profileNavigationRequest.sequence === lastProfileNavigationRequestRef.current ||
+      normalizeProfileKey(activeGatewayProfile) !== profileNavigationRequest.profile
+    ) {
+      return
+    }
+
+    lastProfileNavigationRequestRef.current = profileNavigationRequest.sequence
+    startFreshSessionDraft({ preserveRoute: true })
+
+    const rememberedRoute = getRememberedRoute(profileNavigationRequest.profile)
+
+    if (rememberedRoute && rememberedRoute !== NEW_CHAT_ROUTE && !isOverlayView(appViewForPath(rememberedRoute))) {
+      navigate(rememberedRoute, { replace: true })
+
+      return
+    }
+
+    const rememberedSessionId = getRememberedSessionId(profileNavigationRequest.profile)
+    navigate(rememberedSessionId ? sessionRoute(rememberedSessionId) : NEW_CHAT_ROUTE, { replace: true })
+  }, [activeGatewayProfile, navigate, profileNavigationRequest, startFreshSessionDraft])
 
   // Swapping the live gateway to another profile must re-pull that profile's
   // global model + active-profile pill (both are nanostores — the blanket

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -19,8 +19,17 @@ vi.mock('@/hermes', () => ({
 vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
 vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
-const { $activeGatewayProfile, $profiles, ensureGatewayProfile, prewarmProfileBackend, refreshProfiles } =
-  await import('./profile')
+const {
+  $activeGatewayProfile,
+  $newChatProfile,
+  $profileNavigationRequest,
+  $profiles,
+  $showAllProfiles,
+  ensureGatewayProfile,
+  prewarmProfileBackend,
+  refreshProfiles,
+  selectProfile
+} = await import('./profile')
 
 const { $connection } = await import('./session')
 const { invalidateProfileScopedQueries } = await import('@/lib/query-client')
@@ -52,6 +61,9 @@ beforeEach(() => {
   $activeGatewayProfile.set('default')
   $connection.set(localConn())
   $profiles.set([])
+  $newChatProfile.set(null)
+  $profileNavigationRequest.set(null)
+  $showAllProfiles.set(false)
   vi.stubGlobal('window', { hermesDesktop: { getConnection } })
   vi.mocked(invalidateProfileScopedQueries).mockClear()
   resetStarmapGraph.mockClear()
@@ -116,6 +128,23 @@ describe('profile-scoped cache invalidation', () => {
 
     expect(invalidateProfileScopedQueries).toHaveBeenCalled()
     expect(resetStarmapGraph).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('selectProfile navigation restore', () => {
+  it('requests the target profile restore instead of a fresh draft', () => {
+    selectProfile('coder')
+
+    expect($newChatProfile.get()).toBe('coder')
+    expect($profileNavigationRequest.get()).toMatchObject({ profile: 'coder', sequence: 1 })
+  })
+
+  it('restores when leaving the all-profiles view for the active profile', () => {
+    $showAllProfiles.set(true)
+
+    selectProfile('default')
+
+    expect($profileNavigationRequest.get()).toMatchObject({ profile: 'default', sequence: 1 })
   })
 })
 

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -146,6 +146,19 @@ describe('selectProfile navigation restore', () => {
 
     expect($profileNavigationRequest.get()).toMatchObject({ profile: 'default', sequence: 1 })
   })
+
+  it('coalesces rapid switches to the latest target', () => {
+    selectProfile('coder')
+    selectProfile('research')
+
+    expect($profileNavigationRequest.get()).toMatchObject({ profile: 'research', sequence: 2 })
+  })
+
+  it('does not request navigation when the active profile is selected again', () => {
+    selectProfile('default')
+
+    expect($profileNavigationRequest.get()).toBeNull()
+  })
 })
 
 describe('prewarmProfileBackend (hover-intent pool spawn)', () => {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -154,14 +154,34 @@ export const $activeGatewayProfile = atom<string>('default')
 // / default, so single-profile users are unaffected.
 export const $newChatProfile = atom<string | null>(null)
 
-// Bumped whenever the open session should be dropped for a fresh new-session
-// draft: a profile switch/create (below), or deleting the project that owns the
-// currently-open session (store/projects). The chat controller subscribes and
+// Bumped whenever an explicit action must drop the open session for a fresh
+// new-session draft: creating a session from a profile, or deleting the project
+// that owns the currently-open session. The chat controller subscribes and
 // resets to the intro draft, so we never strand the user in an orphaned view.
 export const $freshSessionRequest = atom(0)
 
 export function requestFreshSession(): void {
   $freshSessionRequest.set($freshSessionRequest.get() + 1)
+}
+
+// A profile switch is different from an explicit new-session action. The
+// consumer clears the old live view, then restores the target profile's last
+// route or session. The sequence makes rapid A → B → C switches coalesce to the
+// latest target without replaying an older restore.
+export interface ProfileNavigationRequest {
+  profile: string
+  sequence: number
+}
+
+export const $profileNavigationRequest = atom<ProfileNavigationRequest | null>(null)
+
+export function requestProfileNavigationRestore(profile: string): void {
+  const current = $profileNavigationRequest.get()
+
+  $profileNavigationRequest.set({
+    profile: normalizeProfileKey(profile),
+    sequence: (current?.sequence ?? 0) + 1
+  })
 }
 
 // Route profile-scoped REST settings (config/env/skills/tools/model/…) to the
@@ -335,14 +355,15 @@ export const $profileScope = computed([$showAllProfiles, $activeGatewayProfile],
 // $activeGatewayProfile → name, so $profileScope follows).
 export function selectProfile(name: string): void {
   const target = normalizeProfileKey(name)
-  // Switching profiles (or coming back from the all-profiles browse view) starts
-  // fresh; re-tapping the profile you're already in leaves your session be.
+  // Switching profiles (or coming back from the all-profiles browse view)
+  // restores that profile's last route/session; re-tapping the profile you're
+  // already in leaves your session be.
   const switching = $showAllProfiles.get() || target !== normalizeProfileKey($activeGatewayProfile.get())
   $showAllProfiles.set(false)
   $newChatProfile.set(target)
 
   if (switching) {
-    requestFreshSession()
+    requestProfileNavigationRestore(target)
   }
 
   void ensureGatewayProfile(target)


### PR DESCRIPTION
## Summary

Closes #77952.

Hermes Desktop already stores the last route and session per profile for cold-start restore. Profile switching still discarded the foreground session and opened a fresh draft. This change uses the existing per-profile state for live profile switching.

## Behavior

- Save and restore the last non-overlay route for each profile.
- Restore the remembered session when the route points to a session.
- Open a new chat when the target profile has no remembered session.
- Wait for the target gateway before restoring the route.
- Coalesce rapid profile switches so an older switch cannot restore the wrong profile.
- Keep explicit New Session actions unchanged.
- Restore correctly when leaving All profiles mode.

## Verification

- `npx vitest run --project ui src/store/profile.test.ts` — passed, 15 tests.
- `npm run typecheck` — passed.
- `npx prettier --check src/app/contrib/wiring.tsx src/store/profile.ts src/store/profile.test.ts` — passed.
- `npm run build` — passed.
- `npm run lint -- --quiet` — blocked because the workspace install did not link `eslint`.
- The combined profile/session test command exposed an existing UI test setup failure: its `localStorage` stub has no `setItem`, `removeItem`, or `clear` methods. The changed profile test passes independently.
