### PR TITLE
fix(secrets): validate setup tokens before persistence

### DIFF
--- a/hermes_cli/onepassword_secrets_cli.py
+++ b/hermes_cli/onepassword_secrets_cli.py
@@ -159,6 +159,18 @@ def cmd_setup(args: argparse.Namespace) -> int:
 
     token = (args.token or "").strip()
     if token:
+        console.print("  Verifying service-account token with `op whoami`…")
+        who = _op_whoami(
+            binary,
+            op_cfg.get("account", ""),
+            token_value=token,
+        )
+        if who is None:
+            console.print(
+                "  [red]✗ Token was rejected by op — nothing was changed.[/red]"
+            )
+            return 1
+        console.print(f"  [green]✓[/green] token accepted ({who})")
         save_env_value(token_env, token)
         os.environ[token_env] = token
         console.print(f"  [green]✓[/green] service-account token stored in "

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -192,10 +192,6 @@ def cmd_setup(args: argparse.Namespace) -> int:
             "you pasted something other than a BSM access token.  Continuing anyway.[/yellow]"
         )
 
-    save_env_value(token_env, token)
-    os.environ[token_env] = token  # so the test fetch below sees it
-    console.print(f"  [green]✓[/green] stored in {get_env_path()} as {token_env}")
-
     # ------------------------------------------------------------------ region
     console.print()
     console.print("[bold]Step 3[/bold]  Pick a Bitwarden region")
@@ -285,6 +281,10 @@ def cmd_setup(args: argparse.Namespace) -> int:
         console.print(f"  [yellow]warning:[/yellow] {w}")
 
     # ------------------------------------------------------------------- save
+    save_env_value(token_env, token)
+    os.environ[token_env] = token
+    console.print(f"  [green]✓[/green] stored in {get_env_path()} as {token_env}")
+
     secrets_cfg["enabled"] = True
     secrets_cfg["project_id"] = project_id
     secrets_cfg["server_url"] = server_url

--- a/tests/hermes_cli/test_secrets_setup_validation.py
+++ b/tests/hermes_cli/test_secrets_setup_validation.py
@@ -1,0 +1,139 @@
+"""Setup wizards must validate replacement credentials before persisting them."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from hermes_cli import onepassword_secrets_cli as op_cli
+from hermes_cli import secrets_cli as bw_cli
+
+
+def _bw_args() -> argparse.Namespace:
+    return argparse.Namespace(
+        access_token="0.candidate",
+        server_url="https://vault.bitwarden.com",
+        project_id="project-1",
+    )
+
+
+def _prepare_bitwarden(monkeypatch, tmp_path, events: list[str]) -> None:
+    monkeypatch.setattr(
+        bw_cli.bw,
+        "find_bws",
+        lambda install_if_missing=False: Path("/fake/bws"),
+    )
+    monkeypatch.setattr(bw_cli, "_bws_version", lambda binary: "2.0.0")
+    monkeypatch.setattr(
+        bw_cli,
+        "load_config",
+        lambda: {"secrets": {"bitwarden": {"access_token_env": "BWS_ACCESS_TOKEN"}}},
+    )
+    monkeypatch.setattr(bw_cli, "get_env_path", lambda: tmp_path / ".env")
+    monkeypatch.setattr(
+        bw_cli,
+        "save_env_value",
+        lambda name, value: events.append("save_env"),
+    )
+    monkeypatch.setattr(
+        bw_cli,
+        "save_config",
+        lambda config: events.append("save_config"),
+    )
+
+
+def test_bitwarden_setup_rejected_token_does_not_replace_working_token(
+    monkeypatch, tmp_path
+):
+    events: list[str] = []
+    _prepare_bitwarden(monkeypatch, tmp_path, events)
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "0.working")
+
+    def reject_candidate(**kwargs):
+        events.append("fetch")
+        raise RuntimeError("candidate rejected")
+
+    monkeypatch.setattr(bw_cli.bw, "fetch_bitwarden_secrets", reject_candidate)
+
+    assert bw_cli.cmd_setup(_bw_args()) == 1
+    assert events == ["fetch"]
+    assert bw_cli.os.environ["BWS_ACCESS_TOKEN"] == "0.working"
+
+
+def test_bitwarden_setup_persists_only_after_successful_fetch(monkeypatch, tmp_path):
+    events: list[str] = []
+    _prepare_bitwarden(monkeypatch, tmp_path, events)
+
+    def accept_candidate(**kwargs):
+        assert kwargs["access_token"] == "0.candidate"
+        events.append("fetch")
+        return {"EXAMPLE_SECRET": "value"}, []
+
+    monkeypatch.setattr(bw_cli.bw, "fetch_bitwarden_secrets", accept_candidate)
+
+    assert bw_cli.cmd_setup(_bw_args()) == 0
+    assert events == ["fetch", "save_env", "save_config"]
+    assert bw_cli.os.environ["BWS_ACCESS_TOKEN"] == "0.candidate"
+
+
+def _op_args() -> argparse.Namespace:
+    return argparse.Namespace(
+        account="team.1password.com",
+        binary_path="",
+        token="candidate-token",
+        token_env="OP_SERVICE_ACCOUNT_TOKEN",
+    )
+
+
+def _prepare_onepassword(monkeypatch, tmp_path, events: list[str]) -> None:
+    monkeypatch.setattr(
+        op_cli.op_src, "find_op", lambda binary_path="": Path("/fake/op")
+    )
+    monkeypatch.setattr(op_cli, "_op_version", lambda binary: "2.30.0")
+    monkeypatch.setattr(op_cli, "load_config", lambda: {})
+    monkeypatch.setattr(op_cli, "get_env_path", lambda: tmp_path / ".env")
+    monkeypatch.setattr(
+        op_cli,
+        "save_env_value",
+        lambda name, value: events.append("save_env"),
+    )
+    monkeypatch.setattr(
+        op_cli,
+        "save_config",
+        lambda config: events.append("save_config"),
+    )
+
+
+def test_onepassword_setup_rejected_token_does_not_replace_working_token(
+    monkeypatch, tmp_path
+):
+    events: list[str] = []
+    _prepare_onepassword(monkeypatch, tmp_path, events)
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "working-token")
+
+    def reject_candidate(binary, account, *, token_value=""):
+        assert token_value == "candidate-token"
+        events.append("whoami")
+        return None
+
+    monkeypatch.setattr(op_cli, "_op_whoami", reject_candidate)
+
+    assert op_cli.cmd_setup(_op_args()) == 1
+    assert events == ["whoami"]
+    assert op_cli.os.environ["OP_SERVICE_ACCOUNT_TOKEN"] == "working-token"
+
+
+def test_onepassword_setup_persists_only_after_successful_whoami(monkeypatch, tmp_path):
+    events: list[str] = []
+    _prepare_onepassword(monkeypatch, tmp_path, events)
+
+    def accept_candidate(binary, account, *, token_value=""):
+        assert token_value == "candidate-token"
+        events.append("whoami")
+        return "service-account@example.com"
+
+    monkeypatch.setattr(op_cli, "_op_whoami", accept_candidate)
+
+    assert op_cli.cmd_setup(_op_args()) == 0
+    assert events == ["whoami", "save_env", "save_config"]
+    assert op_cli.os.environ["OP_SERVICE_ACCOUNT_TOKEN"] == "candidate-token"


### PR DESCRIPTION
## Summary

- defer persisting a Bitwarden setup token until the selected project can be fetched successfully
- validate a supplied 1Password service-account token with `op whoami` before writing it or enabling the integration
- preserve the previously working process token and configuration when a candidate is rejected
- add behavior tests for both rejection and successful validate-before-write ordering

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_secrets_setup_validation.py tests/hermes_cli/test_secrets_token_rotation.py tests/hermes_cli/test_secrets_bitwarden_non_tty.py tests/test_onepassword_secrets.py` — 19 passed
- `python -m ruff check hermes_cli/secrets_cli.py hermes_cli/onepassword_secrets_cli.py tests/hermes_cli/test_secrets_setup_validation.py` — passed
- `scripts/audit_pr_attribution.py` — passed

An additional run of `tests/test_bitwarden_secrets.py` produced 16 passes and the same two Windows-only baseline failures on an unmodified `main` worktree: the Unix `bws` archive fixture versus `bws.exe`, and the POSIX `0600` assertion on NTFS.

Closes #77469