### PR TITLE
fix(kanban): make touch drag-and-drop usable on phones

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -395,26 +395,110 @@
   // handler that simulates a drag proxy and fires a custom event on the
   // column under the finger when released. Columns listen for both the
   // standard `drop` event and our `hermes-kanban:drop` event.
+  //
+  // The gesture is *long-press to arm* (not press-to-drag): for the first
+  // 260 ms the page behaves normally, so a swipe that starts on a card still
+  // scrolls the board. Moving more than 8 px before the timer fires cancels
+  // the pending drag outright — that movement was a scroll, not a pick-up.
+  // Only once armed do we start swallowing pointermove.
   // -------------------------------------------------------------------------
+
+  const TOUCH_DRAG_ARM_MS = 260;
+  const TOUCH_DRAG_SLOP_PX = 8;
 
   function attachTouchDrag(el, taskId) {
     if (!el) return;
     function onDown(e) {
       if (e.pointerType !== "touch") return;
-      e.preventDefault();
-      const proxy = el.cloneNode(true);
-      proxy.classList.add("hermes-kanban-touch-proxy");
-      document.body.appendChild(proxy);
+      // Interactive controls inside a card (selection checkbox, action
+      // buttons, links) own their own touch behavior. Arming a drag from
+      // them makes those controls unusable on a phone.
+      // Interactive controls INSIDE the card opt out of drag — but the card
+      // root itself is role="button" (a11y), so only bail when the match is
+      // a descendant control, not the card we were attached to.
+      const ctrl = e.target && e.target.closest &&
+        e.target.closest("input, button, a, textarea, select, [role='button']");
+      if (ctrl && ctrl !== el) return;
+      // Track a single pointer for the life of the gesture. Without this a
+      // second finger landing mid-drag steers the proxy and can drop the
+      // card in the wrong column.
+      const pointerId = e.pointerId;
+      const startX = e.clientX;
+      const startY = e.clientY;
+      let proxy = null;
       let lastTarget = null;
+      let dragging = false;
+      const timer = setTimeout(startDrag, TOUCH_DRAG_ARM_MS);
+
+      // Single teardown path: every exit (drop, cancel, scroll-away, stray
+      // pointerup) goes through here, so we can't leak listeners, a floating
+      // proxy node, or a stuck drop-highlight.
+      function cleanup() {
+        clearTimeout(timer);
+        el.draggable = true;
+        el.removeEventListener("dragstart", killNativeDrag);
+        document.removeEventListener("pointermove", move);
+        document.removeEventListener("pointerup", up);
+        document.removeEventListener("pointercancel", cancel);
+        if (lastTarget) lastTarget.classList.remove("hermes-kanban-column--drop");
+        if (proxy) proxy.remove();
+        lastTarget = null;
+        proxy = null;
+      }
+
+      function killNativeDrag(de) { de.preventDefault(); }
+      function startDrag() {
+        dragging = true;
+        // Chrome/Android starts the card's NATIVE HTML5 drag (draggable=true)
+        // at its own ~600ms long-press threshold, firing pointercancel and
+        // killing this gesture. Once we arm, native drag must be off.
+        el.draggable = false;
+        el.addEventListener("dragstart", killNativeDrag);
+        try { el.setPointerCapture(pointerId); } catch (_e) { /* ignore */ }
+        proxy = el.cloneNode(true);
+        proxy.classList.add("hermes-kanban-touch-proxy");
+        document.body.appendChild(proxy);
+        // Kick off proxy at the pointer origin.
+        proxy.style.position = "fixed";
+        proxy.style.pointerEvents = "none";
+        proxy.style.opacity = "0.85";
+        proxy.style.zIndex = "9999";
+        proxy.style.width = `${el.offsetWidth}px`;
+        proxy.style.left = `${startX - el.offsetWidth / 2}px`;
+        proxy.style.top = `${startY - 24}px`;
+      }
+
+      // The trash zone is `pointer-events: none` until an HTML5 dragstart
+      // sets `--active` — which a touch drag never fires — so elementFromPoint
+      // can never return it. Fall back to its rect so the delete branch below
+      // is reachable on touch at all.
+      function trashAt(x, y) {
+        const node = document.querySelector("[data-kanban-trash]");
+        if (!node) return null;
+        const r = node.getBoundingClientRect();
+        const hit = x >= r.left && x <= r.right && y >= r.top && y <= r.bottom;
+        return hit ? node : null;
+      }
 
       function move(ev) {
+        if (ev.pointerId !== pointerId) return;
+        if (!dragging) {
+          if (Math.abs(ev.clientX - startX) > TOUCH_DRAG_SLOP_PX ||
+              Math.abs(ev.clientY - startY) > TOUCH_DRAG_SLOP_PX) {
+            cleanup();
+          }
+          return;
+        }
+        if (!proxy) return;
+        ev.preventDefault();
         proxy.style.left = `${ev.clientX - proxy.offsetWidth / 2}px`;
         proxy.style.top = `${ev.clientY - 24}px`;
         proxy.style.display = "none";
         const under = document.elementFromPoint(ev.clientX, ev.clientY);
         proxy.style.display = "";
         const col = under && under.closest && under.closest("[data-kanban-column]");
-        const trash = under && under.closest && under.closest("[data-kanban-trash]");
+        const trash = (under && under.closest && under.closest("[data-kanban-trash]")) ||
+          trashAt(ev.clientX, ev.clientY);
         const target = col || trash;
         if (target !== lastTarget) {
           if (lastTarget) lastTarget.classList.remove("hermes-kanban-column--drop");
@@ -422,12 +506,15 @@
           lastTarget = target;
         }
       }
-      function up() {
-        document.removeEventListener("pointermove", move);
-        document.removeEventListener("pointerup", up);
-        document.removeEventListener("pointercancel", up);
+      function up(ev) {
+        if (ev.pointerId !== pointerId) return;
+        if (!dragging) {
+          // Never armed: a tap. Let the click handler run untouched.
+          cleanup();
+          return;
+        }
+        ev.preventDefault();
         if (lastTarget) {
-          lastTarget.classList.remove("hermes-kanban-column--drop");
           const status = lastTarget.getAttribute("data-kanban-column");
           const isTrash = lastTarget.hasAttribute("data-kanban-trash");
           if (isTrash) {
@@ -442,21 +529,19 @@
             }));
           }
         }
-        proxy.remove();
+        cleanup();
       }
-      // Kick off proxy at the pointer origin.
-      proxy.style.position = "fixed";
-      proxy.style.pointerEvents = "none";
-      proxy.style.opacity = "0.85";
-      proxy.style.zIndex = "9999";
-      proxy.style.width = `${el.offsetWidth}px`;
-      proxy.style.left = `${e.clientX - el.offsetWidth / 2}px`;
-      proxy.style.top = `${e.clientY - 24}px`;
-      document.addEventListener("pointermove", move);
-      document.addEventListener("pointerup", up);
-      document.addEventListener("pointercancel", up);
+      function cancel(ev) {
+        if (ev.pointerId !== pointerId) return;
+        cleanup();
+      }
+      document.addEventListener("pointermove", move, { passive: false });
+      document.addEventListener("pointerup", up, { passive: false });
+      document.addEventListener("pointercancel", cancel, { passive: false });
     }
-    el.addEventListener("pointerdown", onDown);
+    // Passive: this handler no longer calls preventDefault, so the browser
+    // does not have to block on it before scrolling.
+    el.addEventListener("pointerdown", onDown, { passive: true });
     return function () { el.removeEventListener("pointerdown", onDown); };
   }
 

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -234,6 +234,10 @@
 
 .hermes-kanban-card {
   cursor: grab;
+  /* Let the browser own vertical panning over a card and reserve horizontal
+     movement for us. Without this the touch-drag handler and the board's
+     native scroll fight over the same gesture. */
+  touch-action: pan-y;
   transition: transform 100ms ease, box-shadow 100ms ease;
 }
 .hermes-kanban-card:hover {
@@ -1589,4 +1593,34 @@
 
 .hermes-kanban-trash-label {
   font-weight: 500;
+}
+
+/* ---- Narrow viewports (phones) --------------------------------------- */
+
+/* The default board is a horizontal strip of fixed 280px columns. On a phone
+   that shows roughly one and a half columns and buries the rest behind a
+   horizontal pan — which also competes with the touch-drag gesture. Below
+   700px, stack the columns instead: each one full-width, the page scrolling
+   vertically as usual.
+
+   Placed at the end of the file so it wins the cascade over the base column
+   rules above without needing extra specificity. */
+@media (max-width: 700px) {
+  .hermes-kanban-columns {
+    flex-direction: column;
+    overflow-x: visible;
+  }
+
+  .hermes-kanban-column {
+    flex: 1 1 auto;
+    width: 100%;
+    min-height: 0;
+    max-height: none;
+  }
+
+  /* Each column grows to fit its cards; the page scrolls, not the column.
+     Nested scroll panes on a phone are near-impossible to drive by touch. */
+  .hermes-kanban-column-body {
+    overflow-y: visible;
+  }
 }


### PR DESCRIPTION
## Why

On a phone the kanban board is close to unusable today, for two reasons that reinforce each other:

1. `attachTouchDrag` treats *every* touch that lands on a card as the start of a drag. `onDown` calls `e.preventDefault()` immediately and appends the drag proxy right there, so the very first touch on a card swallows the gesture — you can't scroll a column or the board, and on a narrow screen almost every touch lands on a card. `pointerdown` is also registered non-passively, so the browser must block on the handler before it can scroll at all.
2. The columns are a horizontal strip of fixed 280px flex items inside an `overflow-x: auto` row. At phone width that shows about one and a half columns; everything else lives behind a horizontal pan — the one gesture that (1) has already taken away.

## What changes

`attachTouchDrag` becomes long-press-to-arm instead of press-to-drag:

- **260 ms arm timer** — until it fires nothing is captured and no proxy exists, so the page scrolls exactly as it would without the handler attached.
- **8 px slop cancel** — movement beyond 8 px before the timer fires cancels the pending drag: that gesture was a scroll, not a pick-up.
- **`pointerId` matching** on move/up/cancel, plus `setPointerCapture` on the armed drag — a second finger can no longer steer the proxy or drop the card in the wrong column.
- **Single `cleanup()`** — every exit path (drop, cancel, scroll-away, stray pointerup) goes through one teardown, so an interrupted drag (incoming call, notification shade) can't leak document listeners, orphan the proxy node, or leave a column stuck with the `--drop` highlight.
- **Form-control opt-out** — a touch starting on `input`/`button`/`a`/`textarea`/`select`/`[role=button]` inside a card never arms a drag, so the selection checkbox and per-card actions stay tappable.
- **Passive `pointerdown`** — `preventDefault()` moves to `pointermove`/`pointerup` (`{ passive: false }`), which only matter once a drag is armed.

CSS:

- `touch-action: pan-y` on `.hermes-kanban-card`, so the browser owns vertical panning over a card instead of fighting the handler for the gesture.
- A `@media (max-width: 700px)` block that stacks the columns full-width so the whole board is reachable by ordinary vertical page scrolling — no nested scroll panes.

## Trash-drop zone

The `data-kanban-trash` / `hermes-kanban:delete` branch is preserved — and made reachable on touch for the first time. It was already dead on touch before this patch: `.hermes-kanban-trash` is `pointer-events: none` until it gets `--active`, which is bound to `draggingTaskId`, which is only ever set by the HTML5 `onDragStart` — a touch drag never fires that, so `elementFromPoint` could never return the trash node. This patch adds a bounding-rect fallback (`trashAt()`) alongside the existing `closest()` hit-test. Deleting still goes through the existing `window.confirm` in `deleteTask`, so an accidental drop is not destructive. If you'd rather keep touch-delete disabled, dropping `trashAt()` and its call site restores the previous (dead) behavior; nothing else in the patch depends on it.

## Scope

Two files, both in `plugins/kanban/dashboard/dist/`. No backend, no API, no manifest, no auth changes. Mouse/pen behavior is untouched: `onDown` returns immediately unless `pointerType === "touch"`, and HTML5 drag-and-drop is not involved on the touch path.

## Testing

- `git apply --check` + `node --check` clean against `v2026.7.30` and current `main`.
- Device-validated 2026-08-03 on a Pixel 10 Pro (Chrome/Android): long-press arms at 260 ms, drag between columns works, drop persists via PATCH (verified against the board API), slop-cancel and plain taps intact.
- Two stacked regressions were found during device validation and are fixed in this patch: the card root's `role="button"` made the form-control opt-out swallow every touch (opt-out now excludes the card root itself), and Chrome/Android's native ~600 ms HTML5 long-press drag fired `pointercancel` into the armed gesture (native draggability is now disabled from arm to cleanup).
- **Not yet re-tested on hardware:** the trash-drop path and the interrupted-drag path (call/notification-shade mid-drag). Both are exercised in code review terms above but deserve a device pass — happy to re-run them during review if maintainers want it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
