### PR TITLE
fix(runtime): preserve Codex and Kanban worker continuity

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 
 import json
 import logging
+import math
+import os
 import time
+from collections.abc import Mapping
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
 
@@ -615,6 +618,44 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
     return on_event
 
 
+def _codex_app_server_runtime_key(agent) -> tuple[str | None, str | None]:
+    reasoning_config = vars(agent).get("reasoning_config")
+    if not reasoning_config:
+        reasoning_config = {}
+    elif not isinstance(reasoning_config, Mapping):
+        raise TypeError("reasoning_config must be a mapping or None")
+    model = str(getattr(agent, "model", None) or "").strip() or None
+    reasoning_effort = (
+        "none"
+        if reasoning_config.get("enabled") is False
+        else str(reasoning_config.get("effort") or "").strip() or None
+    )
+    return model, reasoning_effort
+
+
+def _retire_codex_app_server_session(agent) -> None:
+    codex_session = getattr(agent, "_codex_session", None)
+    agent._codex_session = None
+    vars(agent).pop("_codex_session_runtime_key", None)
+    if codex_session is None:
+        return
+    try:
+        codex_session.close()
+    except Exception:
+        pass
+
+
+def _codex_app_server_session_for_runtime(agent, runtime_key):
+    codex_session = getattr(agent, "_codex_session", None)
+    if (
+        codex_session is not None
+        and vars(agent).get("_codex_session_runtime_key", runtime_key) != runtime_key
+    ):
+        _retire_codex_app_server_session(agent)
+        return None
+    return codex_session
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -636,10 +677,25 @@ def run_codex_app_server_turn(
         _ServerRequestRouting,
     )
 
-    # Lazy session: one CodexAppServerSession per AIAgent instance.
-    # Spawned on first turn, reused across turns, closed at AIAgent
-    # shutdown (see _cleanup hook).
-    if not hasattr(agent, "_codex_session") or agent._codex_session is None:
+    try:
+        runtime_key = _codex_app_server_runtime_key(agent)
+    except TypeError as exc:
+        return {
+            "final_response": f"Codex app-server configuration invalid: {exc}.",
+            "messages": messages,
+            "api_calls": 0,
+            "completed": False,
+            "partial": True,
+            "error": str(exc),
+        }
+    model, reasoning_effort = runtime_key
+
+    # Lazy session: one CodexAppServerSession per unchanged process runtime.
+    # Model and reasoning are process config, so a live selection change must
+    # retire the old thread before the next turn instead of billing stale config.
+    codex_session = _codex_app_server_session_for_runtime(agent, runtime_key)
+
+    if codex_session is None:
         from agent.runtime_cwd import resolve_agent_cwd
 
         cwd = getattr(agent, "session_cwd", None) or str(resolve_agent_cwd())
@@ -682,6 +738,8 @@ def run_codex_app_server_turn(
         # Supersedes the narrower item/started-only bridge from #38835.
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
+            model=model,
+            reasoning_effort=reasoning_effort,
             approval_callback=approval_callback,
             request_routing=_ServerRequestRouting(
                 auto_approve_exec=auto_approve_requests,
@@ -689,24 +747,74 @@ def run_codex_app_server_turn(
             ),
             on_event=make_codex_app_server_event_bridge(agent),
         )
+        agent._codex_session_runtime_key = runtime_key
 
     # NOTE: the user message is ALREADY appended to messages by the
     # standard run_conversation() flow (line ~11823) before the early
     # return reaches us. Do NOT append again — that would duplicate.
 
-    try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
-    except Exception as exc:
-        logger.exception("codex app-server turn failed")
-        # Crash → unconditionally drop the session so the next turn
-        # respawns from scratch instead of reusing a dead client.
+    timeout_kwargs = {}
+    if os.environ.get("HERMES_KANBAN_TASK"):
         try:
-            agent._codex_session.close()
-        except Exception:
+            terminal_timeout = float(os.environ.get("TERMINAL_TIMEOUT", ""))
+            if terminal_timeout > 0 and math.isfinite(terminal_timeout):
+                timeout_kwargs = {
+                    "turn_timeout": terminal_timeout,
+                    "post_tool_quiet_timeout": terminal_timeout,
+                }
+        except (TypeError, ValueError):
             pass
-        agent._codex_session = None
+
+    api_calls = 0
+    total_tool_iterations = 0
+    usage_results = []
+    kanban_stop_attempts = getattr(agent, "_kanban_stop_nudges", 0)
+
+    while True:
+        try:
+            turn = agent._codex_session.run_turn(
+                user_input=user_message, **timeout_kwargs
+            )
+        except Exception as exc:
+            logger.exception("codex app-server turn failed")
+            # Crash → unconditionally drop the session so the next turn
+            # respawns from scratch instead of reusing a dead client.
+            _retire_codex_app_server_session(agent)
+            _user_interrupted = bool(
+                getattr(agent, "_interrupt_requested", False)
+            )
+            _interrupt_message = (
+                getattr(agent, "_interrupt_message", None)
+                if _user_interrupted
+                else None
+            )
+            if _user_interrupted:
+                agent.clear_interrupt()
+            return {
+                "final_response": (
+                    f"Codex app-server turn failed: {exc}. "
+                    f"Fall back to default runtime with `/codex-runtime auto`."
+                ),
+                "messages": messages,
+                "api_calls": api_calls,
+                "completed": False,
+                "partial": True,
+                "interrupted": _user_interrupted,
+                **(
+                    {"interrupt_message": _interrupt_message}
+                    if _interrupt_message
+                    else {}
+                ),
+                "error": str(exc),
+            }
+
+        api_calls += 1
+
+        # This runtime bypasses the normal conversation-loop finalizer. Mirror
+        # its interrupt handoff/cleanup so a hard stop cannot poison the next
+        # turn and a message-bearing compatibility interrupt can still replay.
         _user_interrupted = bool(
-            getattr(agent, "_interrupt_requested", False)
+            turn.interrupted and getattr(agent, "_interrupt_requested", False)
         )
         _interrupt_message = (
             getattr(agent, "_interrupt_message", None)
@@ -715,57 +823,69 @@ def run_codex_app_server_turn(
         )
         if _user_interrupted:
             agent.clear_interrupt()
-        return {
-            "final_response": (
-                f"Codex app-server turn failed: {exc}. "
-                f"Fall back to default runtime with `/codex-runtime auto`."
-            ),
-            "messages": messages,
-            "api_calls": 0,
-            "completed": False,
-            "partial": True,
-            "interrupted": _user_interrupted,
-            **(
-                {"interrupt_message": _interrupt_message}
-                if _interrupt_message
-                else {}
-            ),
-            "error": str(exc),
-        }
 
-    # This runtime bypasses the normal conversation-loop finalizer. Mirror its
-    # interrupt handoff/cleanup so a hard stop cannot poison the next turn and a
-    # message-bearing compatibility interrupt can still be replayed by callers.
-    _user_interrupted = bool(
-        turn.interrupted and getattr(agent, "_interrupt_requested", False)
-    )
-    _interrupt_message = (
-        getattr(agent, "_interrupt_message", None) if _user_interrupted else None
-    )
-    if _user_interrupted:
-        agent.clear_interrupt()
+        # If the turn signalled the underlying client is wedged (deadline
+        # blown, post-tool watchdog tripped, OAuth refresh died, subprocess
+        # exited), retire the session so the next turn respawns codex
+        # rather than riding the broken process. Mirrors openclaw beta.8's
+        # "retire timed-out app-server clients" fix.
+        if getattr(turn, "should_retire", False):
+            logger.warning(
+                "codex app-server session retired (turn error: %s)",
+                turn.error,
+            )
+            _retire_codex_app_server_session(agent)
 
-    # If the turn signalled the underlying client is wedged (deadline
-    # blown, post-tool watchdog tripped, OAuth refresh died, subprocess
-    # exited), retire the session so the next turn respawns codex
-    # rather than riding the broken process. Mirrors openclaw beta.8's
-    # "retire timed-out app-server clients" fix.
-    if getattr(turn, "should_retire", False):
-        logger.warning(
-            "codex app-server session retired (turn error: %s)",
-            turn.error,
-        )
-        try:
-            agent._codex_session.close()
-        except Exception:
-            pass
-        agent._codex_session = None
+        projected_messages = list(turn.projected_messages or [])
+        messages.extend(projected_messages)
+        total_tool_iterations += turn.tool_iterations
+        _record_codex_app_server_compaction(agent, turn)
+        turn_usage = _record_codex_app_server_usage(agent, turn)
+        if turn_usage:
+            usage_results.append(turn_usage)
 
-    # Splice projected messages into the conversation. The projector emits
-    # standard {role, content, tool_calls, tool_call_id} entries, which
-    # is exactly what curator.py / sessions DB expect.
-    if turn.projected_messages:
-        messages.extend(turn.projected_messages)
+        kanban_nudge = None
+        if (
+            not turn.interrupted
+            and turn.error is None
+            and not getattr(turn, "should_retire", False)
+        ):
+            try:
+                from agent.kanban_stop import build_kanban_stop_nudge
+
+                kanban_nudge = build_kanban_stop_nudge(
+                    messages=messages,
+                    attempts=kanban_stop_attempts,
+                )
+            except Exception:
+                logger.debug("kanban app-server stop-loop check failed", exc_info=True)
+
+        if kanban_nudge:
+            kanban_stop_attempts += 1
+            agent._kanban_stop_nudges = kanban_stop_attempts
+            if projected_messages and projected_messages[-1].get("role") == "assistant":
+                projected_messages[-1]["_kanban_stop_synthetic"] = True
+            else:
+                messages.append({
+                    "role": "assistant",
+                    "content": turn.final_text or "",
+                    "_kanban_stop_synthetic": True,
+                })
+            messages.append({
+                "role": "user",
+                "content": kanban_nudge,
+                "_kanban_stop_synthetic": True,
+            })
+            agent._session_messages = messages
+            logger.info(
+                "kanban app-server stop-loop nudge issued (attempt %d) task=%s",
+                kanban_stop_attempts,
+                os.environ.get("HERMES_KANBAN_TASK", ""),
+            )
+            agent._emit_status(
+                "⚠️ Kanban worker tried to exit without "
+                "kanban_complete/kanban_block — nudging to finish"
+            )
 
         # Persist the newly-projected assistant/tool messages ourselves.
         # This path is an early return that bypasses conversation_loop, whose
@@ -778,7 +898,8 @@ def run_codex_app_server_turn(
         # agent_persisted=True below, so the gateway skips its own DB write and
         # we avoid the #860/#42039 duplicate user-message write (append_message
         # is a raw INSERT with no dedup, so a gateway re-write would duplicate
-        # the already-flushed user turn). See gateway/run.py agent_persisted.
+        # the already-flushed user turn). Synthetic stop-loop scaffolding is
+        # skipped by the shared persister. See gateway/run.py agent_persisted.
         if getattr(agent, "_session_db", None) is not None:
             try:
                 _codex_flush_ok = agent._flush_messages_to_session_db(messages)
@@ -803,6 +924,36 @@ def run_codex_app_server_turn(
                     getattr(agent, "session_id", None),
                 )
 
+        if not kanban_nudge:
+            break
+        user_message = kanban_nudge
+
+    usage_result = {}
+    if usage_results:
+        for key in (
+            "prompt_tokens",
+            "completion_tokens",
+            "total_tokens",
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "reasoning_tokens",
+        ):
+            usage_result[key] = sum(result.get(key, 0) for result in usage_results)
+        known_costs = [
+            result["estimated_cost_usd"]
+            for result in usage_results
+            if result.get("estimated_cost_usd") is not None
+        ]
+        usage_result.update(
+            {
+                "last_prompt_tokens": usage_results[-1]["last_prompt_tokens"],
+                "estimated_cost_usd": sum(known_costs) if known_costs else None,
+                "cost_status": usage_results[-1]["cost_status"],
+                "cost_source": usage_results[-1]["cost_source"],
+            }
+        )
 
     # Counter ticks for the agent-improvement loop.
     # _turns_since_memory and _user_turn_count are ALREADY incremented
@@ -812,11 +963,8 @@ def run_codex_app_server_turn(
     # chat_completions loop bumps it per tool iteration (line ~12110)
     # and that loop is bypassed on this path.
     agent._iters_since_skill = (
-        getattr(agent, "_iters_since_skill", 0) + turn.tool_iterations
+        getattr(agent, "_iters_since_skill", 0) + total_tool_iterations
     )
-    _record_codex_app_server_compaction(agent, turn)
-    usage_result = _record_codex_app_server_usage(agent, turn)
-    api_calls = 1
 
     # Now check the skill nudge AFTER iters were incremented — same
     # pattern the chat_completions path uses (line ~15432).

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3571,7 +3571,21 @@ def _compress_context_via_codex_app_server(
             existing_prompt = agent._build_system_prompt(system_message)
         return messages, existing_prompt
 
-    codex_session = getattr(agent, "_codex_session", None)
+    from agent.codex_runtime import (
+        _codex_app_server_runtime_key,
+        _codex_app_server_session_for_runtime,
+        _retire_codex_app_server_session,
+    )
+
+    try:
+        runtime_key = _codex_app_server_runtime_key(agent)
+    except TypeError as exc:
+        logger.warning("codex app-server compaction skipped: %s", exc)
+        existing_prompt = getattr(agent, "_cached_system_prompt", None)
+        if not existing_prompt:
+            existing_prompt = agent._build_system_prompt(system_message)
+        return messages, existing_prompt
+    codex_session = _codex_app_server_session_for_runtime(agent, runtime_key)
     if codex_session is None:
         logger.info(
             "codex app-server compaction skipped: no active codex thread "
@@ -3621,11 +3635,7 @@ def _compress_context_via_codex_app_server(
         _activity_heartbeat.stop("context compression completed")
 
     if getattr(result, "should_retire", False):
-        try:
-            codex_session.close()
-        except Exception:
-            pass
-        agent._codex_session = None
+        _retire_codex_app_server_session(agent)
 
     if getattr(result, "interrupted", False) or getattr(result, "error", None):
         try:

--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -6,9 +6,9 @@ Kanban workers must end with ``kanban_complete`` or ``kanban_block``. Models
 tool calls. Hermes treats that as a clean exit → ``rc=0`` → dispatcher
 ``protocol_violation``.
 
-This module is policy-only: when a kanban worker tries to finish without a
-terminal board tool, return a bounded synthetic nudge so the conversation
-loop continues instead of exiting.
+This module is policy-only: when a kanban worker tries to finish while its
+authoritative board task is still running, return a bounded synthetic nudge so
+the conversation loop continues instead of exiting.
 """
 
 from __future__ import annotations
@@ -66,6 +66,21 @@ def session_called_kanban_terminal(messages: Iterable[dict] | None) -> bool:
     return False
 
 
+def _current_kanban_task_status(task_id: Optional[str] = None) -> Optional[str]:
+    """Return the dispatcher task's authoritative board status."""
+    tid = (task_id or os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    if not tid:
+        return None
+    try:
+        from hermes_cli import kanban_db as kb
+
+        with kb.connect_closing() as conn:
+            task = kb.get_task(conn, tid)
+        return task.status if task is not None else None
+    except Exception:
+        return None
+
+
 def build_kanban_stop_nudge(
     *,
     messages: Iterable[dict] | None = None,
@@ -73,16 +88,16 @@ def build_kanban_stop_nudge(
     max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
     task_id: Optional[str] = None,
 ) -> Optional[str]:
-    """Return a synthetic follow-up when a kanban worker exits without a terminal tool.
+    """Return a synthetic follow-up while a kanban worker task is still running.
 
     Returns ``None`` when the guard should not fire (not a kanban worker,
-    already completed/blocked, or nudge budget exhausted).
+    board task no longer running, or nudge budget exhausted).
     """
     if not kanban_stop_nudge_enabled():
         return None
     if attempts >= max_attempts:
         return None
-    if session_called_kanban_terminal(messages):
+    if _current_kanban_task_status(task_id) != "running":
         return None
 
     tid = (task_id or os.environ.get("HERMES_KANBAN_TASK") or "").strip() or "this task"

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -74,6 +74,7 @@ class CodexAppServerClient:
         codex_home: Optional[str] = None,
         extra_args: Optional[list[str]] = None,
         env: Optional[dict[str, str]] = None,
+        workspace_cwd: Optional[str] = None,
     ) -> None:
         self._codex_bin = codex_bin
         # codex app-server is a model-driving CLI executor: it runs a
@@ -112,12 +113,141 @@ class CodexAppServerClient:
                     ),
                 )
             )
+            writable_roots = [kanban_root]
+            workspace = os.path.abspath(workspace_cwd or os.getcwd())
+            authorized_git_roots = [os.path.realpath(os.path.abspath(kanban_root))]
+            assigned_workspace = spawn_env.get("HERMES_KANBAN_WORKSPACE")
+            assigned_workspace_matches = bool(assigned_workspace) and (
+                os.path.abspath(assigned_workspace) == workspace
+            )
+            workspace_kind = (spawn_env.get("HERMES_KANBAN_WORKSPACE_KIND") or "").strip()
+            explicit_worktree = assigned_workspace_matches and workspace_kind == "worktree"
+            source_workspace_authorized = assigned_workspace_matches and (
+                os.path.realpath(os.path.join(os.path.dirname(__file__), "..", ".."))
+                == workspace
+            )
+            worktrees_dir = os.path.dirname(workspace)
+            legacy_worktree = (
+                assigned_workspace_matches
+                and os.path.basename(workspace) == spawn_env["HERMES_KANBAN_TASK"]
+                and os.path.basename(worktrees_dir) == ".worktrees"
+            )
+            validated_common: Optional[str] = None
+            if explicit_worktree:
+                try:
+                    git_probe = subprocess.run(
+                        [
+                            "git",
+                            "-C",
+                            workspace,
+                            "rev-parse",
+                            "--path-format=absolute",
+                            "--show-toplevel",
+                            "--git-common-dir",
+                            "--git-dir",
+                        ],
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                        timeout=5,
+                    )
+                    git_paths = [line.strip() for line in git_probe.stdout.splitlines()]
+                    if git_probe.returncode == 0 and len(git_paths) == 3:
+                        git_top, git_common, git_dir = map(os.path.realpath, git_paths)
+                        common_worktrees = os.path.join(git_common, "worktrees")
+                        if (
+                            git_top == os.path.realpath(workspace)
+                            and os.path.isdir(git_common)
+                            and os.path.basename(git_common) == ".git"
+                            and git_dir != git_common
+                            and os.path.commonpath((git_dir, common_worktrees))
+                            == common_worktrees
+                        ):
+                            validated_common = git_common
+                except (OSError, subprocess.SubprocessError, ValueError):
+                    pass
+            if explicit_worktree and validated_common:
+                authorized_git_roots.append(validated_common)
+            elif legacy_worktree:
+                authorized_git_roots.append(
+                    os.path.join(os.path.dirname(worktrees_dir), ".git")
+                )
+            git_marker = os.path.join(workspace, ".git")
+            try:
+                if (
+                    os.path.isfile(git_marker)
+                    and not os.path.islink(git_marker)
+                    and os.path.realpath(git_marker) == git_marker
+                ):
+                    with open(git_marker, encoding="utf-8") as marker_file:
+                        marker = marker_file.read().strip()
+                    if marker.startswith("gitdir:"):
+                        git_dir = marker.removeprefix("gitdir:").strip()
+                        if git_dir:
+                            git_dir = os.path.abspath(
+                                git_dir
+                                if os.path.isabs(git_dir)
+                                else os.path.join(workspace, git_dir)
+                            )
+                            commondir_file = os.path.join(git_dir, "commondir")
+                            backlink_file = os.path.join(git_dir, "gitdir")
+                            if (
+                                os.path.isdir(git_dir)
+                                and not os.path.islink(git_dir)
+                                and os.path.realpath(git_dir) == git_dir
+                                and os.path.isfile(commondir_file)
+                                and not os.path.islink(commondir_file)
+                                and os.path.realpath(commondir_file) == commondir_file
+                                and os.path.isfile(backlink_file)
+                                and not os.path.islink(backlink_file)
+                                and os.path.realpath(backlink_file) == backlink_file
+                            ):
+                                with open(commondir_file, encoding="utf-8") as common_file:
+                                    common = common_file.read().strip()
+                                with open(backlink_file, encoding="utf-8") as backlink_file:
+                                    backlink = backlink_file.read().strip()
+                                if common and backlink:
+                                    common = os.path.abspath(
+                                        common
+                                        if os.path.isabs(common)
+                                        else os.path.join(git_dir, common)
+                                    )
+                                    backlink = os.path.abspath(
+                                        backlink
+                                        if os.path.isabs(backlink)
+                                        else os.path.join(git_dir, backlink)
+                                    )
+                                    if (
+                                        os.path.isdir(common)
+                                        and not os.path.islink(common)
+                                        and os.path.realpath(common) == common
+                                        and os.path.dirname(git_dir)
+                                        == os.path.join(common, "worktrees")
+                                        and os.path.realpath(backlink)
+                                        == os.path.realpath(git_marker)
+                                        and (
+                                            not explicit_worktree
+                                            or validated_common == os.path.realpath(common)
+                                        )
+                                        and (
+                                            source_workspace_authorized
+                                            or any(
+                                                os.path.commonpath((common, root))
+                                                == root
+                                                for root in authorized_git_roots
+                                            )
+                                        )
+                                    ):
+                                        writable_roots.append(common)
+            except (OSError, UnicodeError, ValueError):
+                pass
             app_server_args.extend(
                 [
                     "-c",
                     'sandbox_mode="workspace-write"',
                     "-c",
-                    f'sandbox_workspace_write.writable_roots=["{kanban_root}"]',
+                    "sandbox_workspace_write.writable_roots="
+                    f"{json.dumps(writable_roots)}",
                     "-c",
                     "sandbox_workspace_write.network_access=false",
                 ]

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -24,6 +24,8 @@ call is synchronous and behaves like AIAgent's existing chat_completions loop.
 
 from __future__ import annotations
 
+import inspect
+import json
 import logging
 import os
 import threading
@@ -277,6 +279,8 @@ class CodexAppServerSession:
         cwd: Optional[str] = None,
         codex_bin: str = "codex",
         codex_home: Optional[str] = None,
+        model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
         permission_profile: Optional[str] = None,
         approval_callback: Optional[Callable[..., str]] = None,
         on_event: Optional[Callable[[dict], None]] = None,
@@ -286,6 +290,10 @@ class CodexAppServerSession:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
         self._codex_home = codex_home
+        self._model = str(model).strip() if model else None
+        self._reasoning_effort = (
+            str(reasoning_effort).strip() if reasoning_effort else None
+        )
         self._permission_profile = (
             permission_profile or _HERMES_TO_CODEX_PERMISSION_PROFILE.get(
                 os.environ.get("HERMES_TERMINAL_SECURITY_MODE", "auto"),
@@ -319,9 +327,39 @@ class CodexAppServerSession:
         if self._thread_id is not None:
             return self._thread_id
         if self._client is None:
-            self._client = self._client_factory(
-                codex_bin=self._codex_bin, codex_home=self._codex_home
-            )
+            extra_args: list[str] = []
+            if self._model:
+                extra_args.extend(["-c", f"model={json.dumps(self._model)}"])
+            if self._reasoning_effort:
+                extra_args.extend(
+                    [
+                        "-c",
+                        "model_reasoning_effort="
+                        f"{json.dumps(self._reasoning_effort)}",
+                    ]
+                )
+            factory_kwargs = {
+                "codex_bin": self._codex_bin,
+                "codex_home": self._codex_home,
+                "extra_args": extra_args,
+                "workspace_cwd": self._cwd,
+            }
+            try:
+                parameters = inspect.signature(self._client_factory).parameters
+            except (TypeError, ValueError):
+                accepted = {"codex_bin", "codex_home"}
+            else:
+                accepted = None if any(
+                    parameter.kind is inspect.Parameter.VAR_KEYWORD
+                    for parameter in parameters.values()
+                ) else parameters
+            if accepted is not None:
+                factory_kwargs = {
+                    name: value
+                    for name, value in factory_kwargs.items()
+                    if name in accepted
+                }
+            self._client = self._client_factory(**factory_kwargs)
         self._client.initialize(
             client_name="hermes",
             client_title="Hermes Agent",

--- a/cli.py
+++ b/cli.py
@@ -1223,8 +1223,10 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
     # Shut down memory provider (on_session_end + shutdown_all) at actual
     # session boundary — NOT per-turn inside run_conversation().
     if notify_session_finalize:
-        cleanup_session_id = _active_agent_ref.session_id if _active_agent_ref else None
-        if _should_emit_cleanup_session_finalize(cleanup_session_id):
+        cleanup_session_id = getattr(_active_agent_ref, "session_id", None)
+        if cleanup_session_id and _should_emit_cleanup_session_finalize(
+            cleanup_session_id
+        ):
             _notify_session_finalize(
                 session_id=cleanup_session_id,
                 platform="cli",
@@ -1267,6 +1269,12 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
                 _active_agent_ref.shutdown_memory_provider()
     except Exception as e:
         logger.warning("CLI cleanup memory shutdown failed: %s", e, exc_info=True)
+    # close() clears _session_messages, so it must follow memory shutdown above.
+    try:
+        if _active_agent_ref and hasattr(_active_agent_ref, "close"):
+            _active_agent_ref.close()
+    except Exception as e:
+        logger.warning("CLI cleanup agent close failed: %s", e, exc_info=True)
 
 
 def _should_emit_cleanup_session_finalize(session_id: str | None) -> bool:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9018,6 +9018,7 @@ def _default_spawn(
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id
     env["HERMES_KANBAN_WORKSPACE"] = workspace
+    env["HERMES_KANBAN_WORKSPACE_KIND"] = task.workspace_kind or "scratch"
     # Tag the worker's session so it lands in state.db as `kanban`, not as an
     # untitled `cli` row. A worker is a dispatcher-owned run whose transcript is
     # read on the board and in `hermes kanban log` — it is not a conversation

--- a/run_agent.py
+++ b/run_agent.py
@@ -758,6 +758,10 @@ class AIAgent:
         instead of a bare reset. Default callers pass nothing and keep the
         existing reset-only behavior.
         """
+        from agent.codex_runtime import _retire_codex_app_server_session
+
+        _retire_codex_app_server_session(self)
+
         # Token usage counters
         self.session_total_tokens = 0
         self.session_input_tokens = 0
@@ -4154,12 +4158,17 @@ class AIAgent:
         We DO close:
           - OpenAI/httpx client pool (big chunk of held memory + sockets;
             the rebuilt agent gets a fresh client anyway)
+          - Codex app-server subprocess owned by this agent
           - Active child subagents (per-turn artefacts; safe to drop)
 
         Safe to call multiple times.  Distinct from close() — which is the
         hard teardown for actual session boundaries (/new, /reset, session
         expiry).
         """
+        from agent.codex_runtime import _retire_codex_app_server_session
+
+        _retire_codex_app_server_session(self)
+
         # Close active child agents (per-turn; no cross-turn persistence).
         try:
             with self._active_children_lock:
@@ -4202,6 +4211,7 @@ class AIAgent:
         """Release all resources held by this agent instance.
 
         Cleans up subprocess resources that would otherwise become orphans:
+        - Codex app-server subprocess owned by this agent
         - Background processes tracked in ProcessRegistry
         - Terminal sandbox environments
         - Browser daemon sessions
@@ -4212,6 +4222,9 @@ class AIAgent:
         Safe to call multiple times (idempotent).  Each cleanup step is
         independently guarded so a failure in one does not prevent the rest.
         """
+        from agent.codex_runtime import _retire_codex_app_server_session
+
+        _retire_codex_app_server_session(self)
         task_id = getattr(self, "session_id", None) or ""
 
         # 1. Kill background processes for this task

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -350,6 +350,8 @@ class TestBridgeWiredInRuntime:
         # Minimal stub agent — the runtime only touches a handful of
         # attributes and we mock the heavy ones to keep the test fast.
         agent = SimpleNamespace(
+            model="gpt-5.6-terra",
+            reasoning_config={"enabled": True, "effort": "high"},
             session_cwd=None,
             _codex_session=None,
             tool_progress_callback=MagicMock(),
@@ -388,6 +390,8 @@ class TestBridgeWiredInRuntime:
         assert callable(captured["on_event"]), (
             "on_event must be the bridge callable, not None or a sentinel"
         )
+        assert captured["model"] == "gpt-5.6-terra"
+        assert captured["reasoning_effort"] == "high"
 
         # And the bridge must actually drive the agent's callbacks when
         # fed a representative notification.

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -29,8 +29,14 @@ def test_env_can_disable(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=[]) is None
 
 
-def test_nudge_when_no_terminal_tool(clear_kanban_env):
-    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_46be8aa5")
+def test_nudge_when_no_terminal_tool(clear_kanban_env, tmp_path):
+    clear_kanban_env.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    from hermes_cli import kanban_db as kb
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="worker", assignee="worker")
+        kb.claim_task(conn, task_id)
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", task_id)
     messages = [
         {"role": "user", "content": "work kanban task"},
         {
@@ -50,7 +56,7 @@ def test_nudge_when_no_terminal_tool(clear_kanban_env):
     assert nudge is not None
     assert "kanban_complete" in nudge
     assert "kanban_block" in nudge
-    assert "t_46be8aa5" in nudge
+    assert task_id in nudge
     assert "protocol violation" in nudge.lower() or "protocol" in nudge.lower()
 
 

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -7,6 +7,8 @@ covered by a separate live test gated on `codex --version`.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from hermes_cli.runtime_provider import (
@@ -146,6 +148,9 @@ class TestSpawnEnvIsolation:
             def poll(self):
                 return None
 
+            def communicate(self, input=None, timeout=None):
+                return "", ""
+
             def terminate(self):
                 pass
 
@@ -188,6 +193,9 @@ class TestSpawnEnvIsolation:
             def poll(self):
                 return None
 
+            def communicate(self, input=None, timeout=None):
+                return "", ""
+
             def terminate(self):
                 pass
 
@@ -209,16 +217,78 @@ class TestSpawnEnvIsolation:
         # And HOME still passes through unchanged
         assert captured["env"].get("HOME") == "/users/alice"
 
-    def test_kanban_worker_adds_only_kanban_writable_root(self, monkeypatch):
-        """Codex-runtime Kanban workers need to write board state outside
-        their scratch/worktree workspace, but should not fall back to
-        danger-full-access. Hermes passes a narrow app-server config override
-        for the Kanban root only.
+    @staticmethod
+    def _spawn_kanban_client(monkeypatch, workspace):
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["cmd"] = list(cmd)
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def poll(self):
+                return None
+
+            def communicate(self, input=None, timeout=None):
+                return "", ""
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_smoke")
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+        monkeypatch.setenv(
+            "HERMES_KANBAN_DB",
+            "/users/alice/.hermes/kanban/boards/smoke/kanban.db",
+        )
+        client = cas.CodexAppServerClient(codex_bin="codex", workspace_cwd=str(workspace))
+        client._closed = True
+        return json.loads(
+            next(
+                part.split("=", 1)[1]
+                for part in captured["cmd"]
+                if part.startswith("sandbox_workspace_write.writable_roots=")
+            )
+        )
+
+    def test_kanban_linked_worktree_adds_board_and_git_writable_roots(
+        self, monkeypatch, tmp_path
+    ):
+        """Linked-worktree workers need the board and shared Git metadata,
+        without falling back to danger-full-access.
         """
         import subprocess
         from agent.transports import codex_app_server as cas
 
         captured = {}
+        repo = tmp_path / "repo"
+        workspace = repo / ".worktrees" / "t_smoke"
+        git_dir = repo / ".git" / "worktrees" / "t_smoke"
+        workspace.mkdir(parents=True)
+        git_dir.mkdir(parents=True)
+        (workspace / ".git").write_text(f"gitdir: {git_dir}\n")
+        (git_dir / "commondir").write_text("../..\n")
+        (git_dir / "gitdir").write_text(f"{workspace / '.git'}\n")
 
         class FakePopen:
             def __init__(self, cmd, *args, **kwargs):
@@ -233,6 +303,9 @@ class TestSpawnEnvIsolation:
             def poll(self):
                 return None
 
+            def communicate(self, input=None, timeout=None):
+                return "", ""
+
             def terminate(self):
                 pass
 
@@ -246,23 +319,188 @@ class TestSpawnEnvIsolation:
         monkeypatch.setenv("HOME", "/users/alice")
         monkeypatch.setenv("HERMES_HOME", "/users/alice/.hermes/profiles/backend-worker")
         monkeypatch.setenv("HERMES_KANBAN_TASK", "t_smoke")
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
         monkeypatch.setenv(
             "HERMES_KANBAN_DB",
             "/users/alice/.hermes/kanban/boards/smoke/kanban.db",
         )
 
-        client = cas.CodexAppServerClient(codex_bin="codex")
+        client = cas.CodexAppServerClient(
+            codex_bin="codex", workspace_cwd=str(workspace)
+        )
         client._closed = True
 
         cmd = captured["cmd"]
         assert cmd[:2] == ["codex", "app-server"]
         assert 'sandbox_mode="workspace-write"' in cmd
         assert (
-            'sandbox_workspace_write.writable_roots=["/users/alice/.hermes/kanban/boards/smoke"]'
+            "sandbox_workspace_write.writable_roots="
+            f'["/users/alice/.hermes/kanban/boards/smoke", "{repo / ".git"}"]'
             in cmd
         )
         assert "sandbox_workspace_write.network_access=false" in cmd
         assert all("danger" not in part for part in cmd)
+
+    def test_kanban_worker_rejects_self_consistent_foreign_git_admin(
+        self, monkeypatch, tmp_path
+    ):
+        """Workspace-controlled Git metadata cannot authorize a foreign root."""
+        workspace = tmp_path / "workspace"
+        git_common = tmp_path / "foreign-admin.git"
+        git_dir = git_common / "worktrees" / "slot"
+        marker = workspace / ".git"
+        workspace.mkdir()
+        git_dir.mkdir(parents=True)
+        marker.write_text(f"gitdir: {git_dir}\n")
+        (git_dir / "commondir").write_text("../..\n")
+        (git_dir / "gitdir").write_text(f"{marker}\n")
+
+        assert self._spawn_kanban_client(monkeypatch, workspace) == [
+            "/users/alice/.hermes/kanban/boards/smoke"
+        ]
+
+    @pytest.mark.parametrize(
+        "case",
+        (
+            "root_gitdir",
+            "symlink_marker",
+            "symlink_commondir",
+            "symlink_backlink",
+            "malformed_metadata",
+            "unreadable_metadata",
+            "foreign_backlink",
+        ),
+    )
+    def test_kanban_linked_worktree_rejects_untrusted_git_metadata(
+        self, monkeypatch, tmp_path, case
+    ):
+        """Untrusted worktree metadata cannot widen Codex's writable roots."""
+        repo = tmp_path / "repo"
+        workspace = repo / ".worktrees" / "t_smoke"
+        git_dir = repo / ".git" / "worktrees" / "t_smoke"
+        marker = workspace / ".git"
+        workspace.mkdir(parents=True)
+        git_dir.mkdir(parents=True)
+        marker.write_text(f"gitdir: {git_dir}\n")
+        (git_dir / "commondir").write_text("../..\n")
+        (git_dir / "gitdir").write_text(f"{marker}\n")
+
+        if case == "root_gitdir":
+            marker.write_text("gitdir: /\n")
+        elif case == "symlink_marker":
+            marker.unlink()
+            symlink_target = tmp_path / "marker-target"
+            symlink_target.write_text(f"gitdir: {git_dir}\n")
+            marker.symlink_to(symlink_target)
+        elif case == "symlink_commondir":
+            (git_dir / "commondir").unlink()
+            (git_dir / "commondir").symlink_to(repo / ".git")
+        elif case == "symlink_backlink":
+            (git_dir / "gitdir").unlink()
+            (git_dir / "gitdir").symlink_to(marker)
+        elif case == "malformed_metadata":
+            (git_dir / "commondir").write_text("\n")
+        elif case == "unreadable_metadata":
+            (git_dir / "commondir").chmod(0)
+        elif case == "foreign_backlink":
+            foreign_marker = tmp_path / "foreign" / ".git"
+            foreign_marker.parent.mkdir()
+            foreign_marker.write_text("gitdir: ignored\n")
+            (git_dir / "gitdir").write_text(f"{foreign_marker}\n")
+
+        assert self._spawn_kanban_client(monkeypatch, workspace) == [
+            "/users/alice/.hermes/kanban/boards/smoke"
+        ]
+
+
+    def test_explicit_worktree_target_can_use_custom_directory_name(
+        self, monkeypatch, tmp_path
+    ):
+        """Dispatcher-owned worktree metadata must not require task-id basenames."""
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+        (repo / "README").write_text("seed\n")
+        subprocess.run(["git", "-C", str(repo), "add", "README"], check=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "-c", "user.name=Hermes", "-c", "user.email=hermes@example.invalid", "commit", "-qm", "seed"],
+            check=True,
+        )
+        workspace = repo / ".worktrees" / "custom-target"
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "worktree",
+                "add",
+                "-qb",
+                "wt/custom-target",
+                str(workspace),
+            ],
+            check=True,
+        )
+
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["cmd"] = list(cmd)
+                self.stdin = None
+                self.stdout = None
+                self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def poll(self):
+                return None
+
+            def communicate(self, input=None, timeout=None):
+                return "", ""
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        real_popen = subprocess.Popen
+
+        def _popen(cmd, *args, **kwargs):
+            if cmd and cmd[0] == "git":
+                return real_popen(cmd, *args, **kwargs)
+            return FakePopen(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "Popen", _popen)
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_smoke")
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACE_KIND", "worktree")
+        monkeypatch.setenv(
+            "HERMES_KANBAN_DB",
+            "/users/alice/.hermes/kanban/boards/smoke/kanban.db",
+        )
+
+        cas.CodexAppServerClient(codex_bin="codex", workspace_cwd=str(workspace))
+        writable = json.loads(
+            next(
+                part.split("=", 1)[1]
+                for part in captured["cmd"]
+                if part.startswith("sandbox_workspace_write.writable_roots=")
+            )
+        )
+        assert str(repo / ".git") in writable
 
 
 class TestSpawnEnvSecretStripping:
@@ -297,6 +535,9 @@ class TestSpawnEnvSecretStripping:
 
             def poll(self):
                 return None
+
+            def communicate(self, input=None, timeout=None):
+                return "", ""
 
             def terminate(self):
                 pass

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -174,6 +174,51 @@ class TestLifecycle:
         assert params["cwd"] == "/tmp"
         assert "permissions" not in params  # see session.ensure_started() comment
 
+    def test_model_and_effort_are_forwarded_as_process_config(self):
+        client = FakeClient()
+        captured: dict = {}
+
+        def factory(**kwargs):
+            captured.update(kwargs)
+            return client
+
+        session = CodexAppServerSession(
+            cwd="/tmp",
+            model="gpt-5.6-terra",
+            reasoning_effort="high",
+            client_factory=factory,
+        )
+        session.ensure_started()
+
+        assert captured["extra_args"] == [
+            "-c",
+            'model="gpt-5.6-terra"',
+            "-c",
+            'model_reasoning_effort="high"',
+        ]
+
+    def test_legacy_client_factory_without_new_kwargs_is_supported(self):
+        client = FakeClient()
+        captured: dict = {}
+
+        def factory(codex_bin, codex_home) -> Any:
+            captured.update(codex_bin=codex_bin, codex_home=codex_home)
+            return client
+
+        session = CodexAppServerSession(
+            cwd="/tmp",
+            codex_bin="codex-test",
+            codex_home="/tmp/codex-home",
+            model="gpt-5.6-terra",
+            client_factory=factory,
+        )
+        session.ensure_started()
+
+        assert captured == {
+            "codex_bin": "codex-test",
+            "codex_home": "/tmp/codex-home",
+        }
+
     def test_close_idempotent(self):
         client = FakeClient()
         s = make_session(client)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -843,6 +843,7 @@ class TestSharedBoardPaths:
             default_home / "kanban" / "workspaces"
         )
         assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
+        assert env["HERMES_KANBAN_WORKSPACE_KIND"] == "worktree"
         assert env["HERMES_KANBAN_BRANCH"] == "wt/t_dispatch_env"
         for key in sc._VAR_MAP:
             if key == "HERMES_SESSION_SOURCE":

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -21,12 +21,38 @@ import run_agent
 from agent.transports.codex_app_server_session import CodexAppServerSession, TurnResult
 
 
+@pytest.fixture(autouse=True)
+def refresh_cached_hermes_home(monkeypatch):
+    from hermes_constants import get_hermes_home
+
+    monkeypatch.setattr(run_agent, "_hermes_home", get_hermes_home())
+
+
+def _create_running_kanban_task(monkeypatch, tmp_path):
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="normal app-server worker",
+            assignee="codex",
+            goal_mode=False,
+        )
+        assert kb.claim_task(conn, task_id, claimer="test-dispatcher") is not None
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    return kb, task_id
+
+
 @pytest.fixture
 def fake_session(monkeypatch):
     """Replace CodexAppServerSession with a stub that returns a fixed
     TurnResult, so we can drive AIAgent without spawning real codex."""
 
+    calls = []
+
     def fake_run_turn(self, user_input: str, **kwargs):
+        calls.append(kwargs)
         return TurnResult(
             final_text=f"echo: {user_input}",
             projected_messages=[
@@ -48,6 +74,7 @@ def fake_session(monkeypatch):
     monkeypatch.setattr(
         CodexAppServerSession, "ensure_started", lambda self: "thread-stub-1"
     )
+    return calls
 
 
 def _make_codex_agent(**kwargs):
@@ -85,6 +112,304 @@ class TestRunConversationCodexPath:
         assert result["api_calls"] == 1
         assert result["codex_thread_id"] == "thread-stub-1"
         assert result["codex_turn_id"] == "turn-stub-1"
+
+    def test_kanban_turn_uses_worker_runtime_for_both_timeouts(
+        self, fake_session, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_timeout")
+        monkeypatch.setenv("TERMINAL_TIMEOUT", "2370")
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+
+        assert fake_session == [{
+            "turn_timeout": 2370,
+            "post_tool_quiet_timeout": 2370,
+        }]
+
+    def test_non_kanban_turn_keeps_app_server_defaults(
+        self, fake_session, monkeypatch
+    ):
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        monkeypatch.setenv("TERMINAL_TIMEOUT", "2370")
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+
+        assert fake_session == [{}]
+
+    @pytest.mark.parametrize(
+        "terminal_timeout", [None, "", "invalid", "0", "-1", "nan", "inf"]
+    )
+    def test_invalid_kanban_timeout_keeps_app_server_defaults(
+        self, fake_session, monkeypatch, terminal_timeout
+    ):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_timeout")
+        if terminal_timeout is None:
+            monkeypatch.delenv("TERMINAL_TIMEOUT", raising=False)
+        else:
+            monkeypatch.setenv("TERMINAL_TIMEOUT", terminal_timeout)
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hello")
+
+        assert fake_session == [{}]
+
+    def test_running_kanban_task_continues_in_same_codex_session(
+        self, monkeypatch, tmp_path
+    ):
+        kb, task_id = _create_running_kanban_task(monkeypatch, tmp_path)
+        monkeypatch.setenv("TERMINAL_TIMEOUT", "2370")
+        session_ids = []
+        inputs = []
+        timeout_calls = []
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            session_ids.append(id(self))
+            inputs.append(user_input)
+            timeout_calls.append(kwargs)
+            if len(inputs) == 1:
+                return TurnResult(
+                    final_text="I will finish the task next.",
+                    projected_messages=[{
+                        "role": "assistant",
+                        "content": "I will finish the task next.",
+                    }],
+                    turn_id="turn-progress",
+                    thread_id="thread-worker",
+                    token_usage_last={
+                        "totalTokens": 10,
+                        "inputTokens": 6,
+                        "cachedInputTokens": 2,
+                        "outputTokens": 2,
+                        "reasoningOutputTokens": 0,
+                    },
+                )
+            with kb.connect_closing() as conn:
+                assert kb.complete_task(conn, task_id, summary="done") is True
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                turn_id="turn-done",
+                thread_id="thread-worker",
+                token_usage_last={
+                    "totalTokens": 20,
+                    "inputTokens": 12,
+                    "cachedInputTokens": 4,
+                    "outputTokens": 4,
+                    "reasoningOutputTokens": 0,
+                },
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-worker"
+        )
+        from hermes_state import SessionDB
+
+        session_db = SessionDB(tmp_path / "state.db")
+        session_id = "session-kanban-continuity"
+        session_db.create_session(
+            session_id=session_id,
+            source="test",
+            model="codex",
+        )
+        agent = _make_codex_agent(session_db=session_db, session_id=session_id)
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("work the task")
+
+        assert result["final_response"] == "done"
+        assert result["api_calls"] == 2
+        assert result["prompt_tokens"] == 24
+        assert result["completion_tokens"] == 6
+        assert result["total_tokens"] == 30
+        assert result["last_prompt_tokens"] == 16
+        assert len(set(session_ids)) == 1
+        assert inputs[0] == "work the task"
+        assert "kanban_complete" in inputs[1]
+        assert timeout_calls == [
+            {"turn_timeout": 2370, "post_tool_quiet_timeout": 2370},
+            {"turn_timeout": 2370, "post_tool_quiet_timeout": 2370},
+        ]
+        assert [message["role"] for message in result["messages"][-4:]] == [
+            "user",
+            "assistant",
+            "user",
+            "assistant",
+        ]
+        persisted = session_db.get_messages(session_id, include_inactive=True)
+        persisted_contents = [message["content"] for message in persisted]
+        assert persisted_contents.count("work the task") == 1
+        assert persisted_contents.count("I will finish the task next.") == 0
+        assert all(
+            "protocol violation" not in str(value or "")
+            for value in persisted_contents
+        )
+        assert persisted_contents.count("done") == 1
+        with kb.connect_closing() as conn:
+            task = kb.get_task(conn, task_id)
+            assert task is not None
+            assert task.goal_mode is False
+            assert task.status == "done"
+
+    @pytest.mark.parametrize("terminal_status", ["done", "blocked"])
+    def test_terminal_board_state_does_not_nudge_app_server(
+        self, monkeypatch, tmp_path, terminal_status
+    ):
+        kb, task_id = _create_running_kanban_task(monkeypatch, tmp_path)
+        calls = []
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            calls.append(user_input)
+            with kb.connect_closing() as conn:
+                if terminal_status == "done":
+                    assert kb.complete_task(conn, task_id, summary="done") is True
+                else:
+                    assert kb.block_task(
+                        conn,
+                        task_id,
+                        reason="needs input",
+                        kind="needs_input",
+                    ) is True
+            tool_name = f"kanban_{'complete' if terminal_status == 'done' else 'block'}"
+            return TurnResult(
+                final_text=terminal_status,
+                projected_messages=[
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [{
+                            "id": "terminal_1",
+                            "type": "function",
+                            "function": {"name": tool_name, "arguments": "{}"},
+                        }],
+                    },
+                    {
+                        "role": "tool",
+                        "name": tool_name,
+                        "tool_call_id": "terminal_1",
+                        "content": terminal_status,
+                    },
+                    {"role": "assistant", "content": terminal_status},
+                ],
+                turn_id=f"turn-{terminal_status}",
+                thread_id="thread-terminal",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-terminal"
+        )
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("finish the task")
+
+        assert result["final_response"] == terminal_status
+        assert result["api_calls"] == 1
+        assert calls == ["finish the task"]
+        with kb.connect_closing() as conn:
+            assert kb.get_task(conn, task_id).status == terminal_status
+
+    def test_rejected_terminal_tool_nudges_while_board_is_running(
+        self, monkeypatch, tmp_path
+    ):
+        kb, task_id = _create_running_kanban_task(monkeypatch, tmp_path)
+        inputs = []
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            inputs.append(user_input)
+            if len(inputs) == 1:
+                return TurnResult(
+                    final_text="completion was rejected",
+                    projected_messages=[
+                        {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [{
+                                "id": "complete_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "kanban_complete",
+                                    "arguments": "{}",
+                                },
+                            }],
+                        },
+                        {
+                            "role": "tool",
+                            "name": "kanban_complete",
+                            "tool_call_id": "complete_1",
+                            "content": '{"error":"completion rejected"}',
+                        },
+                    ],
+                    turn_id="turn-rejected",
+                    thread_id="thread-rejected",
+                )
+            with kb.connect_closing() as conn:
+                assert kb.complete_task(conn, task_id, summary="done") is True
+            return TurnResult(
+                final_text="done",
+                projected_messages=[{"role": "assistant", "content": "done"}],
+                turn_id="turn-recovered",
+                thread_id="thread-rejected",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-rejected"
+        )
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("finish the task")
+
+        assert result["final_response"] == "done"
+        assert result["api_calls"] == 2
+        assert "kanban_complete" in inputs[1]
+        assert [message["role"] for message in result["messages"][-3:]] == [
+            "assistant",
+            "user",
+            "assistant",
+        ]
+        with kb.connect_closing() as conn:
+            assert kb.get_task(conn, task_id).status == "done"
+
+    def test_running_board_nudge_is_bounded(self, monkeypatch, tmp_path):
+        kb, task_id = _create_running_kanban_task(monkeypatch, tmp_path)
+        inputs = []
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            inputs.append(user_input)
+            return TurnResult(
+                final_text="still working",
+                projected_messages=[{
+                    "role": "assistant",
+                    "content": "still working",
+                }],
+                turn_id=f"turn-{len(inputs)}",
+                thread_id="thread-bounded",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            CodexAppServerSession, "ensure_started", lambda self: "thread-bounded"
+        )
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("work the task")
+
+        assert result["final_response"] == "still working"
+        assert result["api_calls"] == 3
+        assert len(inputs) == 3
+        assert all("kanban_complete" in value for value in inputs[1:])
+        assert agent._kanban_stop_nudges == 2
+        with kb.connect_closing() as conn:
+            assert kb.get_task(conn, task_id).status == "running"
 
     def test_codex_app_server_token_usage_updates_session_accounting(self, monkeypatch):
         def fake_run_turn(self, user_input: str, **kwargs):
@@ -692,6 +1017,189 @@ class TestSessionRetirementOnRunAgent:
         assert agent._codex_session is None
         assert result["completed"] is False
         assert "codex segfaulted" in result["error"]
+
+
+class TestSessionRuntimeSelection:
+    @pytest.mark.parametrize("reasoning_config", ["high", ["high"], True])
+    def test_malformed_reasoning_config_fails_without_mutating_session(
+        self, reasoning_config
+    ):
+        agent = _make_codex_agent()
+        agent.model = "gpt-5.6-sol"
+        agent.reasoning_config = reasoning_config
+        session = MagicMock()
+        agent._codex_session = session
+        agent._codex_session_runtime_key = ("gpt-5.6-sol", "max")
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert "reasoning_config must be a mapping" in result["error"]
+        assert agent._codex_session is session
+        session.run_turn.assert_not_called()
+        session.close.assert_not_called()
+
+    def test_session_reset_starts_fresh_thread_at_same_runtime(self, monkeypatch):
+        sessions = []
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                self.thread_id = f"thread-{len(sessions) + 1}"
+                self.inputs = []
+                self.close_calls = 0
+                sessions.append(self)
+
+            def run_turn(self, user_input, **kwargs):
+                self.inputs.append(user_input)
+                return TurnResult(
+                    final_text="ok",
+                    projected_messages=[],
+                    turn_id=f"turn-{user_input}",
+                    thread_id=self.thread_id,
+                )
+
+            def close(self):
+                self.close_calls += 1
+
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerSession",
+            FakeSession,
+        )
+        agent = _make_codex_agent()
+        agent.model = "gpt-5.6-sol"
+        agent.reasoning_config = {"enabled": True, "effort": "max"}
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            first = agent.run_conversation("old-session-secret")
+            agent.session_id = "fresh-session"
+            agent.reset_session_state()
+            second = agent.run_conversation("fresh-session-question")
+
+        assert len(sessions) == 2
+        assert sessions[0].close_calls == 1
+        assert sessions[0].inputs == ["old-session-secret"]
+        assert sessions[1].inputs == ["fresh-session-question"]
+        assert first["codex_thread_id"] == "thread-1"
+        assert second["codex_thread_id"] == "thread-2"
+
+    def test_live_runtime_switch_replaces_session_before_next_turn(self, monkeypatch):
+        events = []
+        sessions = []
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                self.runtime = (
+                    str(kwargs.get("model") or "").strip() or None,
+                    str(kwargs.get("reasoning_effort") or "").strip() or None,
+                )
+                self.thread_id = f"thread-{len(sessions) + 1}"
+                self.close_calls = 0
+                sessions.append(self)
+                events.append(("constructed", self.runtime))
+
+            def run_turn(self, user_input, **kwargs):
+                events.append(("turn", self.runtime, user_input))
+                return TurnResult(
+                    final_text="ok",
+                    projected_messages=[],
+                    turn_id=f"turn-{user_input}",
+                    thread_id=self.thread_id,
+                )
+
+            def close(self):
+                self.close_calls += 1
+                events.append(("closed", self.runtime))
+
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerSession",
+            FakeSession,
+        )
+        agent = _make_codex_agent()
+        agent.model = " gpt-5.6-terra "
+        agent.reasoning_config = {"enabled": True, "effort": " high "}
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            first = agent.run_conversation("first")
+            agent.model = "gpt-5.6-terra"
+            agent.reasoning_config = {"enabled": True, "effort": "high"}
+            second = agent.run_conversation("[Persistent goal continuation]")
+            event = agent.run_conversation("[Kanban task completed]")
+            agent.model = "gpt-5.6-sol"
+            agent.reasoning_config = {"enabled": True, "effort": "max"}
+            third = agent.run_conversation("third")
+
+        assert len(sessions) == 2
+        assert sessions[0].close_calls == 1
+        assert sessions[1].close_calls == 0
+        assert (
+            first["codex_thread_id"]
+            == second["codex_thread_id"]
+            == event["codex_thread_id"]
+            == "thread-1"
+        )
+        assert third["codex_thread_id"] == "thread-2"
+        assert events == [
+            ("constructed", ("gpt-5.6-terra", "high")),
+            ("turn", ("gpt-5.6-terra", "high"), "first"),
+            (
+                "turn",
+                ("gpt-5.6-terra", "high"),
+                "[Persistent goal continuation]",
+            ),
+            ("turn", ("gpt-5.6-terra", "high"), "[Kanban task completed]"),
+            ("closed", ("gpt-5.6-terra", "high")),
+            ("constructed", ("gpt-5.6-sol", "max")),
+            ("turn", ("gpt-5.6-sol", "max"), "third"),
+        ]
+
+    def test_reasoning_disable_reaches_codex_process_config(
+        self, monkeypatch
+    ):
+        captured = {}
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            def initialize(self, **kwargs):
+                pass
+
+            def request(self, method, params=None, timeout=30.0):
+                assert method == "thread/start"
+                return {"thread": {"id": "thread-disabled"}}
+
+            def close(self):
+                pass
+
+        def fake_run_turn(session, user_input, **kwargs):
+            thread_id = session.ensure_started()
+            return TurnResult(
+                final_text="ok",
+                projected_messages=[],
+                turn_id="turn-disabled",
+                thread_id=thread_id,
+            )
+
+        monkeypatch.setattr(
+            "agent.transports.codex_app_server_session.CodexAppServerClient",
+            FakeClient,
+        )
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        agent = _make_codex_agent()
+        agent.model = "gpt-5.6-sol"
+        agent.reasoning_config = {"enabled": False}
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("no reasoning")
+
+        assert captured["extra_args"] == [
+            "-c",
+            'model="gpt-5.6-sol"',
+            "-c",
+            'model_reasoning_effort="none"',
+        ]
 
 
 class TestCodexToolProgressBridge:


### PR DESCRIPTION
Recreates the closed #69034 change from the restored fork, rebased onto current `main`, with review feedback addressed.

- Passes dispatcher-derived `TERMINAL_TIMEOUT` to native Codex app-server turns.
- Stop guard reads authoritative board task status.
- Dispatcher-owned workspace-kind metadata plus `git rev-parse` validates linked worktrees, including explicit custom directory names.

Original PR/review: https://github.com/NousResearch/hermes-agent/pull/69034

Verification: 152 targeted tests passed.