### PR TITLE
fix(gateway): profile-scoped .env load clobbers shared env under multiplex

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -474,6 +474,25 @@ def load_hermes_dotenv(
     """
     loaded: list[Path] = []
 
+    # In a multiplexed gateway, a context-local profile-home override means this
+    # call is running inside a profile-scoped turn (e.g. a lazily imported module
+    # whose import-time load resolves get_hermes_home() to the routed profile).
+    # Loading that profile's .env into the process-global os.environ with
+    # override=True clobbers shared adapter config for every other profile —
+    # e.g. DISCORD_ALLOWED_CHANNELS collapses to one profile's list and the
+    # other bots start rejecting their own channels (ELS-906). Profile
+    # credentials are served by the isolated secret scope in multiplex mode
+    # (see gateway/run.py::_reload_runtime_env_preserving_config_authority),
+    # so skip the global-env mutation entirely here.
+    try:
+        from agent.secret_scope import is_multiplex_active
+        from hermes_constants import get_hermes_home_override
+
+        if is_multiplex_active() and get_hermes_home_override() is not None:
+            return loaded
+    except Exception:
+        pass
+
     home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
     user_env = home_path / ".env"
     project_env_path = Path(project_env) if project_env else None

--- a/tests/test_env_loader_multiplex_scope_guard.py
+++ b/tests/test_env_loader_multiplex_scope_guard.py
@@ -1,0 +1,101 @@
+"""Regression tests: under ``gateway.multiplex_profiles`` a profile-scoped
+``load_hermes_dotenv()`` must not overwrite process-global ``os.environ``.
+
+One multiplexed gateway process serves every profile, so ``os.environ`` is
+shared by all of their adapters. Agent turns run in-process under a per-profile
+scope, and any module imported lazily mid-turn re-runs its import-time
+``load_hermes_dotenv()`` — which resolves the home to the *routed* profile and
+loaded that profile's ``.env`` over the shared environment with
+``override=True``. Every other profile's adapter config was clobbered as a side
+effect of one profile taking a turn (observed: a shared Discord channel
+allowlist collapsing to one profile's list minutes after each restart, after
+which the other bots silently ignored their own channels).
+
+Profile credentials reach adapters through the isolated secret scope in
+multiplex mode, so the global mutation is skipped entirely when a profile scope
+is active.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import hermes_constants
+from agent import secret_scope
+from hermes_cli import env_loader
+
+SHARED_KEY = "HERMES_TEST_SHARED_ADAPTER_CONFIG"
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    """Keep multiplex state, the home override and the probe key process-local."""
+    monkeypatch.delenv(SHARED_KEY, raising=False)
+    was_multiplex = secret_scope.is_multiplex_active()
+    yield
+    secret_scope.set_multiplex_active(was_multiplex)
+
+
+def _make_home(tmp_path, name: str, shared_value: str):
+    home = tmp_path / name
+    home.mkdir()
+    (home / ".env").write_text(f"{SHARED_KEY}={shared_value}\n")
+    return home
+
+
+def test_profile_scoped_load_does_not_clobber_shared_env(tmp_path, monkeypatch):
+    """Multiplex + active profile scope → shared process env is left alone."""
+    default_home = _make_home(tmp_path, "default", "all-channels")
+    profile_home = _make_home(tmp_path, "profile-a", "profile-a-only")
+
+    # Gateway startup: the default profile's .env populates the shared env.
+    secret_scope.set_multiplex_active(False)
+    env_loader.load_hermes_dotenv(hermes_home=str(default_home))
+    assert os.environ[SHARED_KEY] == "all-channels"
+
+    # A turn routed to profile-a lazily imports a module whose import-time
+    # loader call resolves the home to profile-a.
+    secret_scope.set_multiplex_active(True)
+    token = hermes_constants.set_hermes_home_override(str(profile_home))
+    try:
+        loaded = env_loader.load_hermes_dotenv(hermes_home=str(profile_home))
+    finally:
+        hermes_constants.reset_hermes_home_override(token)
+
+    assert os.environ[SHARED_KEY] == "all-channels", (
+        "profile-scoped .env load overwrote shared process env under multiplex"
+    )
+    assert loaded == [], "no files should be reported as globally applied"
+
+
+def test_multiplex_without_profile_scope_still_loads(tmp_path, monkeypatch):
+    """Multiplex alone must not disable loading — startup has no scope yet."""
+    home = _make_home(tmp_path, "default", "startup-value")
+
+    secret_scope.set_multiplex_active(True)
+    assert hermes_constants.get_hermes_home_override() is None
+
+    loaded = env_loader.load_hermes_dotenv(hermes_home=str(home))
+
+    assert os.environ[SHARED_KEY] == "startup-value"
+    assert (home / ".env") in loaded
+
+
+def test_single_profile_gateway_is_unaffected(tmp_path, monkeypatch):
+    """Without multiplex, a scoped load keeps its historical override behaviour."""
+    default_home = _make_home(tmp_path, "default", "first")
+    other_home = _make_home(tmp_path, "other", "second")
+
+    secret_scope.set_multiplex_active(False)
+    env_loader.load_hermes_dotenv(hermes_home=str(default_home))
+    assert os.environ[SHARED_KEY] == "first"
+
+    token = hermes_constants.set_hermes_home_override(str(other_home))
+    try:
+        loaded = env_loader.load_hermes_dotenv(hermes_home=str(other_home))
+    finally:
+        hermes_constants.reset_hermes_home_override(token)
+
+    assert os.environ[SHARED_KEY] == "second"
+    assert (other_home / ".env") in loaded


### PR DESCRIPTION
## What does this PR do?

Stops a profile-scoped `.env` load from overwriting **process-global** `os.environ` when the gateway is multiplexing profiles.

Under `gateway.multiplex_profiles` one process serves every profile, so `os.environ` is shared by all of their adapters, while the resolved Hermes home is context-local. `load_hermes_dotenv()` writes the resolved home's `.env` into `os.environ` with `override=True` — a context-local read driving a process-global write. Agent turns run in-process under a per-profile scope, so any module imported **lazily during a turn** re-runs its import-time loader call and rewrites shared adapter config for every other profile.

The fix skips the global mutation only when multiplex is active *and* a profile-home override is in scope. Profile credentials already reach adapters through the isolated per-profile secret scope in multiplex mode, which is the documented design — the global write is what leaks. Startup loading (multiplex on, no scope installed yet) and single-profile gateways are deliberately untouched.

## Related Issue

Fixes #77969

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/env_loader.py` — in `load_hermes_dotenv()`, return early (no applied paths) when `secret_scope.is_multiplex_active()` and `hermes_constants.get_hermes_home_override()` is set. The import is local and wrapped so the loader keeps working in contexts where those modules aren't importable.
- `tests/test_env_loader_multiplex_scope_guard.py` — three regression tests:
  - `test_profile_scoped_load_does_not_clobber_shared_env` — the bug; fails on stock code.
  - `test_multiplex_without_profile_scope_still_loads` — startup must keep loading.
  - `test_single_profile_gateway_is_unaffected` — non-multiplex override behaviour unchanged.

## How to Test

1. Reproduce the bug on stock code — the new test fails with exactly the production signature:
   ```
   git stash push hermes_cli/env_loader.py
   pytest tests/test_env_loader_multiplex_scope_guard.py -q
   # AssertionError: profile-scoped .env load overwrote shared process env under multiplex
   # assert 'profile-a-only' == 'all-channels'
   git stash pop
   ```
2. With the fix: `pytest tests/test_env_loader_multiplex_scope_guard.py -q` → 3 passed.
3. No regressions in the adjacent suites:
   ```
   pytest tests/test_env_loader_applied_homes.py tests/test_env_loader_op_bootstrap.py \
          tests/test_env_loader_secret_sources.py tests/test_profile_isolation_runtime.py \
          tests/test_hermes_home_profile_warning.py -q      # 37 passed
   ```
   `pytest tests/ -k "multiplex or secret_scope"` gives an identical pass/fail set before and after (228 passed on stock, 231 with the fix — the delta is this PR's three tests; the pre-existing failures in that selection are unrelated to this change and reproduce on a clean checkout).
4. Real gateway: a multiplexed Discord gateway with per-profile `.env` files kept its full channel allowlist across long turns in other profiles' channels, where it previously collapsed to one profile's list within minutes of every restart.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — closest are #51029 / #52446 / #54675 (adapters reading `os.getenv` instead of the secret scope, already fixed) and #77490 / #61046 (profile `.env` *write* target and per-profile loading). This is the inverse direction: a profile-scoped **read** performing a process-global **write**.
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the adjacent + `-k "multiplex or secret_scope"` selections instead (see above); the full 25k-test suite needs dev extras not installed on this host. Pass/fail set is identical to a clean checkout.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux 6.8), Python 3.11.15, git install

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no config keys or public API changed; rationale is in the code comment and the tests' module docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — no platform-specific code; the guard is pure Python control flow around an existing branch
