### PR TITLE
fix(config): refuse platform-field writes when config.yaml has a YAML syntax error

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3086,6 +3086,42 @@ def require_readable_config_before_write(config_path: Optional[Path] = None) -> 
         ) from exc
 
 
+def require_parsable_config_before_write(config_path: Optional[Path] = None) -> None:
+    """Refuse to replace an existing config.yaml that cannot be PARSED.
+
+    :func:`require_readable_config_before_write` only proves the bytes are
+    reachable — a file full of valid bytes and invalid YAML sails through it.
+    That is not enough for read-modify-write callers, because every reader
+    (:func:`read_raw_config`, :func:`load_config`) degrades a parse failure to
+    ``{}``. A caller that reads, mutates one key and saves therefore writes a
+    document containing ONLY that key, silently destroying every user setting
+    (#75431, fixed for ``hermes config set/unset`` in #75885/#75900).
+
+    Full-document replacement callers that intentionally rebuild the file
+    (first-run creation, ``hermes doctor`` reset, migrations) must NOT call
+    this — repairing a broken config is exactly their job. Only read-modify-
+    write paths need it.
+
+    Raises ``RuntimeError`` (mirroring the readability guard) so non-CLI
+    callers such as the dashboard route surface an error instead of exiting
+    the process.
+    """
+    if config_path is None:
+        config_path = get_config_path()
+    require_readable_config_before_write(config_path)
+    if not config_path.exists():
+        return
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            fast_safe_load(f)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Refusing to overwrite {config_path}: the existing config.yaml has a "
+            f"YAML syntax error ({exc}). Fix it first — `hermes config edit` opens "
+            f"it in your editor — then retry."
+        ) from exc
+
+
 def atomic_config_write(config_path: Path, data: Any, **kwargs: Any) -> None:
     """Fail-closed atomic write for ``config.yaml``.
 
@@ -3165,6 +3201,10 @@ def write_platform_config_field(
     user's raw config file. Dashboard routes use the default loaded-config path
     so they retain their existing profile-scoped ``load_config`` behavior.
     """
+    # Read-modify-write: both readers below return {} for an unparsable file,
+    # so without this guard a single YAML typo turns "toggle one platform
+    # field" into "replace config.yaml with just that field" (#75431 class).
+    require_parsable_config_before_write()
     config = read_raw_config() if raw else load_config()
     platforms = config.setdefault("platforms", {})
     if not isinstance(platforms, dict):

--- a/tests/hermes_cli/test_config_parse_guard.py
+++ b/tests/hermes_cli/test_config_parse_guard.py
@@ -1,0 +1,149 @@
+"""A read-modify-write of config.yaml must never clobber an unparsable file.
+
+Class regression for #75431: every config reader (``read_raw_config``,
+``load_config``) degrades a YAML syntax error to ``{}``/defaults, so a caller
+that reads, mutates one key and saves writes a document containing only that
+key — destroying every user setting. #75885/#75900 closed that for
+``hermes config set/unset``; ``write_platform_config_field`` is the shared
+read-modify-write helper behind the dashboard platform toggle
+(``hermes_cli/web_server.py::_write_platform_enabled``), the gateway's
+unauthorized-DM setter, and the photon CLI, and was still unguarded.
+
+These drive the real functions against a real temp ``HERMES_HOME`` — no mocks
+on the resolution chain, since the bug lives in how the readers degrade.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BROKEN_CONFIG = """\
+model:
+  default: claude-opus-4
+terminal:
+  backend: docker
+  cwd: /srv/work
+memory:
+  provider: honcho
+broken: [unclosed
+"""
+
+VALID_CONFIG = """\
+model:
+  default: claude-opus-4
+terminal:
+  backend: docker
+  cwd: /srv/work
+memory:
+  provider: honcho
+"""
+
+
+@pytest.fixture
+def config_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _config_path():
+    from hermes_cli.config import get_config_path
+
+    return get_config_path()
+
+
+class TestRequireParsableConfigBeforeWrite:
+    def test_absent_file_is_allowed(self, config_home):
+        """First-run creation must not be blocked — there is nothing to lose."""
+        from hermes_cli.config import require_parsable_config_before_write
+
+        assert not _config_path().exists()
+        require_parsable_config_before_write()  # must not raise
+
+    def test_valid_file_is_allowed(self, config_home):
+        from hermes_cli.config import require_parsable_config_before_write
+
+        _config_path().write_text(VALID_CONFIG, encoding="utf-8")
+        require_parsable_config_before_write()  # must not raise
+
+    def test_syntax_error_refuses(self, config_home):
+        from hermes_cli.config import require_parsable_config_before_write
+
+        _config_path().write_text(BROKEN_CONFIG, encoding="utf-8")
+        with pytest.raises(RuntimeError, match="YAML syntax error"):
+            require_parsable_config_before_write()
+
+
+class TestWritePlatformConfigFieldPreservesBrokenConfig:
+    """The defect: one toggle replaced the whole file with just that toggle."""
+
+    @pytest.mark.parametrize("raw", [False, True])
+    def test_refuses_and_leaves_file_byte_identical(self, config_home, raw):
+        from hermes_cli.config import write_platform_config_field
+
+        path = _config_path()
+        path.write_text(BROKEN_CONFIG, encoding="utf-8")
+        before = path.read_bytes()
+
+        with pytest.raises(RuntimeError, match="YAML syntax error"):
+            write_platform_config_field("telegram", "enabled", True, raw=raw)
+
+        assert path.read_bytes() == before
+
+    def test_user_sections_survive(self, config_home):
+        """Without the guard every one of these disappeared."""
+        from hermes_cli.config import write_platform_config_field
+
+        path = _config_path()
+        path.write_text(BROKEN_CONFIG, encoding="utf-8")
+
+        with pytest.raises(RuntimeError):
+            write_platform_config_field("telegram", "enabled", True)
+
+        after = path.read_text(encoding="utf-8")
+        for section in ("terminal:", "backend: docker", "cwd: /srv/work",
+                        "memory:", "provider: honcho"):
+            assert section in after
+
+    def test_dashboard_toggle_helper_is_guarded(self, config_home):
+        """The real dashboard entry point, not just the shared helper."""
+        from hermes_cli.web_server import _write_platform_enabled
+
+        path = _config_path()
+        path.write_text(BROKEN_CONFIG, encoding="utf-8")
+        before = path.read_bytes()
+
+        with pytest.raises(RuntimeError, match="YAML syntax error"):
+            _write_platform_enabled("telegram", True)
+
+        assert path.read_bytes() == before
+
+
+class TestWritePlatformConfigFieldStillWorks:
+    """The guard must not cost the happy path."""
+
+    @pytest.mark.parametrize("raw", [False, True])
+    def test_writes_field_and_keeps_other_sections(self, config_home, raw):
+        from hermes_cli.config import read_user_config_raw, write_platform_config_field
+
+        path = _config_path()
+        path.write_text(VALID_CONFIG, encoding="utf-8")
+
+        write_platform_config_field("telegram", "enabled", True, raw=raw)
+
+        saved = read_user_config_raw(path)
+        assert saved["platforms"]["telegram"]["enabled"] is True
+        assert saved["terminal"]["backend"] == "docker"
+        assert saved["terminal"]["cwd"] == "/srv/work"
+        assert saved["memory"]["provider"] == "honcho"
+
+    def test_creates_config_when_absent(self, config_home):
+        from hermes_cli.config import read_user_config_raw, write_platform_config_field
+
+        path = _config_path()
+        assert not path.exists()
+
+        write_platform_config_field("discord", "enabled", False)
+
+        assert read_user_config_raw(path)["platforms"]["discord"]["enabled"] is False


### PR DESCRIPTION
## What does this PR do?

`write_platform_config_field()` is a read-modify-write helper: it reads the
user's `config.yaml`, sets one key under `platforms.<id>`, and saves the whole
document back. Every config reader degrades a YAML **parse failure** to an
empty result — `read_raw_config()` returns `{}`, `load_config()` returns bare
`DEFAULT_CONFIG`. So on a `config.yaml` containing a single YAML typo, that
helper reads nothing, sets one key, and writes it back — **replacing the
user's entire config with just that one key.**

Three shipped entry points reach it:

| Entry point | Call site |
|---|---|
| Dashboard platform enable/disable toggle | `hermes_cli/web_server.py::_write_platform_enabled` |
| Gateway unauthorized-DM policy setter | `hermes_cli/gateway.py::_set_platform_unauthorized_dm_behavior` (`raw=True`) |
| Photon CLI enable path | `plugins/platforms/photon/cli.py` (`raw=True`) |

This is the same data-loss class as #75431 — which #75885 / #75900 closed for
`hermes config set` / `hermes config unset` by parse-checking before the write.
Those two sites open-coded the check inline; `write_platform_config_field()` is
the remaining read-modify-write helper and was never covered.

**Why the existing guard doesn't catch it:** `require_readable_config_before_write()`
only proves the bytes are reachable (`stat()` + read 1 byte). A file full of
valid bytes and invalid YAML sails straight through it.

### Reproduction (before this PR)

`~/.hermes/config.yaml`:

```yaml
model:
  default: claude-opus-4
terminal:
  backend: docker
  cwd: /srv/work
gateway:
  platforms:
    telegram: true
    discord: true
memory:
  provider: honcho
skills:
  auto_load: true
broken: [unclosed
```

Open the dashboard and toggle any platform on/off (or run the gateway's
unauthorized-DM setter). Result:

```text
user section 'terminal' survived: False
user section 'gateway'  survived: False
user section 'memory'   survived: False
user section 'skills'   survived: False
```

The file is replaced with the default template plus only
`platforms.telegram.enabled`. Every user setting is gone.

## Related Issue

Same class as #75431 (fixed for `config set`/`unset` via #75885 / #75900);
this completes it for the remaining read-modify-write site.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`hermes_cli/config.py`** — new `require_parsable_config_before_write()`:
  runs the existing readability guard, then verifies the file actually parses.
  Returns cleanly when the file is absent (first-run creation must still work),
  raises `RuntimeError` on a syntax error.
- **`hermes_cli/config.py`** — `write_platform_config_field()` calls the guard
  before its read-modify-write cycle.
- **`tests/hermes_cli/test_config_parse_guard.py`** — 10 regression tests.

### Two deliberate design choices

1. **Not wired into `atomic_config_write()`.** That helper's docstring calls
   itself "the single chokepoint every config-update path should use", but
   putting a parse guard there would break the callers whose *job* is to repair
   a broken file — first-run creation, `hermes doctor`'s config reset,
   `migrate_config`. Only read-modify-write paths can lose data; only they get
   the guard.
2. **Raises `RuntimeError`, not `sys.exit(1)`.** `set_config_value` /
   `unset_config_value` are CLI-only so they print and exit; this helper is
   reached from the dashboard's FastAPI route, where `sys.exit` would kill the
   server process. Raising matches `require_readable_config_before_write()`,
   which already raises through this exact call path — so the route's error
   handling is unchanged.

## How to Test

1. Write the broken `config.yaml` above to a temp `HERMES_HOME`.
2. Call `write_platform_config_field("telegram", "enabled", True)` (or use the
   dashboard toggle).
3. **Before:** the call succeeds and every user section is gone.
   **After:** it raises
   `Refusing to overwrite …: the existing config.yaml has a YAML syntax error (…)`
   and the file is **byte-identical** to before.
4. Repeat with a valid `config.yaml` — the write still lands and every other
   section is preserved.

## Test Results

New file `tests/hermes_cli/test_config_parse_guard.py` — 10 tests:

| Group | Covers |
|---|---|
| `TestRequireParsableConfigBeforeWrite` | absent file allowed (first-run), valid file allowed, syntax error refused |
| `TestWritePlatformConfigFieldPreservesBrokenConfig` | refuses + file byte-identical (`raw=True` **and** `raw=False`), user sections survive, real dashboard entry point `_write_platform_enabled` guarded |
| `TestWritePlatformConfigFieldStillWorks` | happy path unchanged (`raw=True`/`False`), config created when absent |

Tests drive the real functions against a real temp `HERMES_HOME` — no mocks on
the resolution chain, since the bug lives in *how the readers degrade*.

**Red-without-fix proof** (fix stashed, tests unchanged):

```text
7 failed, 3 passed
```

**With the fix:**

```text
10 passed in 0.99s
```

**Regression sweep** — `test_config.py`, `test_config_read_guard.py`,
`test_config_validation.py`, `test_config_loader_e2e.py`,
`test_set_config_value.py`, `test_config_parse_guard.py`:

```text
1 failed, 177 passed in 7.39s
```

The single failure is `TestGetHermesHome::test_default_path`, a pre-existing
native-Windows environment artifact (`~/.hermes` vs `%LOCALAPPDATA%\hermes`) —
verified failing identically on clean `main` with this branch stashed, and
untouched by this change.

