### PR TITLE
test(interrupt): isolate per-thread interrupt registry tests

### DIFF
--- a/tests/run_agent/test_interrupt_propagation.py
+++ b/tests/run_agent/test_interrupt_propagation.py
@@ -9,17 +9,24 @@ import time
 import unittest
 from unittest.mock import MagicMock
 
-from tools.interrupt import set_interrupt, is_interrupted
+from tools.interrupt import (
+    set_interrupt,
+    is_interrupted,
+    _clear_all_interrupts_for_tests,
+)
 
 
 class TestInterruptPropagationToChild(unittest.TestCase):
     """Verify interrupt propagates from parent to child agent."""
 
     def setUp(self):
-        set_interrupt(False)
+        # Wipe the whole per-thread registry: tests below use both the real
+        # current-thread ident and synthetic idents (e.g. 99990001) which
+        # set_interrupt(False) cannot reach from the main thread.
+        _clear_all_interrupts_for_tests()
 
     def tearDown(self):
-        set_interrupt(False)
+        _clear_all_interrupts_for_tests()
 
     def _make_bare_agent(self):
         """Create a bare AIAgent via __new__ with all interrupt-related attrs."""
@@ -208,10 +215,12 @@ class TestPerThreadInterruptIsolation(unittest.TestCase):
     """
 
     def setUp(self):
-        set_interrupt(False)
+        # Full registry wipe — these tests deliberately set bits on synthetic
+        # idents that set_interrupt(False) cannot reach from the main thread.
+        _clear_all_interrupts_for_tests()
 
     def tearDown(self):
-        set_interrupt(False)
+        _clear_all_interrupts_for_tests()
 
     def test_interrupt_only_affects_target_thread(self):
         """set_interrupt(True, tid) only makes is_interrupted() True on that thread."""

--- a/tools/interrupt.py
+++ b/tools/interrupt.py
@@ -85,6 +85,25 @@ def clear_current_thread_interrupt() -> None:
     set_interrupt(False)  # thread_id=None -> current thread (see set_interrupt)
 
 
+def _clear_all_interrupts_for_tests() -> None:
+    """Drop EVERY entry from the per-thread interrupt registry.
+
+    Test-only / internal helper.  Thread idents are recycled by the OS, and
+    ``set_interrupt(False)`` / ``clear_current_thread_interrupt()`` only touch
+    the calling thread, so a synthetic tid left in ``_interrupted_threads``
+    by a prior test (e.g. ``99990001``) can poison a fresh worker that later
+    reuses the ident.  Use this in ``setUp``/``tearDown`` (or a fixture) to
+    guarantee isolation between tests that exercise per-thread semantics.
+
+    Must NEVER be called from production interrupt / cancellation paths:
+    production code only signals or clears the bit on a specific execution
+    thread; clearing the whole registry would silently drop a genuine
+    interrupt that landed on a sibling thread since the last poll.
+    """
+    with _lock:
+        _interrupted_threads.clear()
+
+
 # ---------------------------------------------------------------------------
 # Backward-compatible _interrupt_event proxy
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a test-only helper to clear the full per-thread interrupt registry
- use it in interrupt isolation setup and teardown to prevent stale synthetic thread IDs

## Validation
- `pytest tests/run_agent/test_interrupt_propagation.py`
- `pytest tests/tools/test_interrupt.py tests/tools/test_approval_interrupt.py tests/tools/test_approved_command_clean_slate.py`
- `pytest tests/run_agent/test_concurrent_interrupt.py`
- `ruff check tools/interrupt.py tests/run_agent/test_interrupt_propagation.py`
- `git diff --check`