### PR TITLE
fix(cron): catch ValueError on os.open in lifecycle guard

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,10 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # ValueError catches `embedded null byte` from a malformed path the
+        # model put in a command (e.g. a NUL in a filename). Gracefully skip
+        # instead of letting the uncaught exception hang the turn for minutes.
         return None, False
     try:
         metadata = os.fstat(descriptor)


### PR DESCRIPTION
## Summary

Fixes the null-byte hang in cron/lifecycle_guard.py that can freeze an agent turn for minutes.

## Problem

- Introduced in v0.20.0 (new file, added 2026-08-03).
- `_read_referenced_script` calls `os.open(path)` but only caught `OSError`.
- A path containing a NUL byte raises **ValueError** ("embedded null byte"), not OSError.
- When the model emits such a path in a terminal command, the guard scans it as a referenced script, the uncaught ValueError propagates, and the whole turn hangs (~17 min observed).

## Fix

Catch `(OSError, ValueError)` and return `(None, False)` so a malformed path is skipped gracefully instead of stalling the turn. Line 260 is the only `os.open` call site in the file, so this single patch covers the guard.

## Verification

- Confirmed `os.open` on a null-byte path previously raised ValueError; now returns gracefully.
- Only call site; confirmed there are no sibling `os.open` call sites.
