### PR TITLE
fix(delegate): gate parent completion on blocking results

### DIFF
--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -605,6 +605,8 @@ def test_delegate_task_background_routes_async_and_does_not_block(monkeypatch):
     assert parsed["status"] == "dispatched"
     assert parsed["mode"] == "background"
     assert parsed["delegation_id"].startswith("deleg_")
+    assert "If its result is BLOCKING" in parsed["note"]
+    assert "still pending and not incorporated" in parsed["note"]
     # Non-blocking invariant: delegate_task returned while the child is STILL
     # blocked on the closed gate, so no completion event exists yet.
     assert process_registry.completion_queue.empty()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -107,6 +107,17 @@ class TestDelegateRequirements(unittest.TestCase):
         ):
             self.assertIn(keyword, desc, f"top-level description lost: {keyword!r}")
 
+    def test_background_description_enforces_completion_gate(self):
+        from tools.delegate_tool import _build_top_level_description
+
+        desc = _build_top_level_description()
+        self.assertIn("COMPLETION GATE", desc)
+        self.assertIn("before dispatch", desc)
+        self.assertIn("BLOCKING", desc)
+        self.assertIn("ADVISORY", desc)
+        self.assertIn("do not conclude", desc)
+        self.assertIn("pending and unincorporated", desc)
+
     def test_dynamic_limits_moved_to_param_descriptions(self):
         """Concurrency and nesting ceilings must reach the model through the
         tasks/role parameter descriptions (the top-level text no longer

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3339,16 +3339,21 @@ def delegate_task(
         if dispatch.get("status") == "dispatched":
             n = len(_goals)
             note = (
-                "Subagent is running in the background. You and the user can "
-                "keep working; its full result re-enters the conversation as a "
-                "new message when it finishes. Do not wait or poll — just "
-                "continue."
+                "Subagent is running in the background. Continue only work that "
+                "does not depend on its result. If its result is BLOCKING for the "
+                "current answer, do not give the final conclusion, claim completion, "
+                "or imply integration until it re-enters and is checked. If it is "
+                "ADVISORY, you may finish first only by explicitly saying it is still "
+                "pending and not incorporated. Do not poll."
                 if n == 1 else
-                f"{n} subagents are running in parallel in the background. You "
-                f"and the user can keep working; they wait on each other and "
-                f"their consolidated results re-enter the conversation as a "
-                f"single message once ALL of them finish. Do not wait or poll "
-                f"— just continue."
+                f"{n} subagents are running in parallel in the background and "
+                f"will return one consolidated result after ALL have finished. "
+                f"Continue only work that does not depend on those results. If they "
+                f"are BLOCKING for the current answer, do not give the final "
+                f"conclusion, claim completion, or imply integration until the "
+                f"consolidated result re-enters and is checked. If they are ADVISORY, "
+                f"you may finish first only by explicitly saying they are still "
+                f"pending and not incorporated. Do not poll."
             )
             payload = {
                 "status": "dispatched",
@@ -3668,6 +3673,10 @@ def _build_top_level_description() -> str:
         "transcript paths, and the completed result (one consolidated message "
         "for a batch) re-enters the conversation on its own. Do NOT wait or "
         "poll; continue other work.\n\n"
+        "COMPLETION GATE: before dispatch, classify work as BLOCKING or ADVISORY "
+        "for this answer. For BLOCKING, do not conclude or claim completion until "
+        "the result returns and is checked. For ADVISORY, finishing first requires "
+        "explicitly saying the result is pending and unincorporated.\n\n"
         "USE FOR: reasoning-heavy subtasks, work that would flood your context "
         "with intermediate data, or independent parallel workstreams.\n"
         "DO NOT USE FOR (use these instead):\n"


### PR DESCRIPTION
## Summary

- add a completion gate to the `delegate_task` tool description so coordinators classify delegated work as blocking or advisory before dispatch
- prevent a parent from claiming completion or implying integration while blocking subagent results are still pending
- allow advisory work to remain non-blocking only when the parent explicitly discloses that the pending result was not incorporated
- mirror the contract in the background dispatch note and add regression coverage for both surfaces

## Motivation

Background delegation returns immediately, so the parent can otherwise reach a final answer before a required child result re-enters the conversation. That creates a correctness gap: the answer can claim completion or synthesis without the delegated evidence.

This is related to #75058 but addresses a separate failure mode. That PR focuses on transcript polling. This PR focuses on premature finalization and result-incorporation claims. It intentionally does not change live transcript guidance.

## Tests

- `scripts/run_tests.sh tests/tools/test_delegate.py tests/tools/test_async_delegation.py -q` (83 passed)
- `python -m pytest -q tests/tools/test_delegate*.py` (85 passed)
- `uvx ruff check tools/delegate_tool.py tests/tools/test_delegate.py tests/tools/test_async_delegation.py`
- `python -m py_compile tools/delegate_tool.py tests/tools/test_delegate.py tests/tools/test_async_delegation.py`
- `git diff --check`
