### PR TITLE
fix(dashboard): scope memory-provider config to the active management profile

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6025,25 +6025,32 @@ async def get_memory_provider_config(name: str, surface: Optional[str] = None, p
     return await asyncio.to_thread(_run)
 
 @app.post("/api/memory/providers/{name}/setup")
-async def setup_memory_provider(name: str, body: MemoryProviderSetupRequest):
+async def setup_memory_provider(
+    name: str, body: MemoryProviderSetupRequest, profile: Optional[str] = None
+):
+    # Same scope as its GET/PUT ``/config`` siblings: this route persists
+    # provider values and runs the provider's install steps, both of which
+    # write per-profile state. Without the scope the whole body ran against
+    # the launch profile no matter which profile the dashboard was managing.
     _require_valid_memory_provider_name(name)
-    provider = _load_memory_provider(name)
-    if provider is None and not _memory_provider_manifest(name):
-        # No discoverable plugin directory → nothing whose manifest could
-        # legitimately declare setup commands. Refuse before the
-        # command-running path. (provider may be None with a manifest present
-        # when its pip deps aren't installed yet — that's the setup use case.)
-        raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
-    if provider is not None and body.values:
-        try:
-            _write_memory_provider_config_values(name, provider, body.values)
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        except Exception:
-            _log.exception("Failed to persist memory provider setup values for %s", name)
-            raise HTTPException(status_code=500, detail="Internal server error")
-    _invalidate_plugins_hub_cache()
-    return _install_memory_provider_setup(name)
+    with _profile_scope(profile):
+        provider = _load_memory_provider(name)
+        if provider is None and not _memory_provider_manifest(name):
+            # No discoverable plugin directory → nothing whose manifest could
+            # legitimately declare setup commands. Refuse before the
+            # command-running path. (provider may be None with a manifest present
+            # when its pip deps aren't installed yet — that's the setup use case.)
+            raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
+        if provider is not None and body.values:
+            try:
+                _write_memory_provider_config_values(name, provider, body.values)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            except Exception:
+                _log.exception("Failed to persist memory provider setup values for %s", name)
+                raise HTTPException(status_code=500, detail="Internal server error")
+        _invalidate_plugins_hub_cache()
+        return _install_memory_provider_setup(name)
 
 
 @app.put("/api/memory/providers/{name}/config")

--- a/tests/hermes_cli/test_memory_provider_profile_scope.py
+++ b/tests/hermes_cli/test_memory_provider_profile_scope.py
@@ -1,0 +1,113 @@
+"""``/api/memory/providers/*`` must run under the requested management profile.
+
+The GET/PUT ``/config`` siblings already take ``profile`` and wrap their body in
+``_profile_scope``; ``POST .../setup`` did not, so it persisted provider values
+and ran the provider's install steps against the dashboard's LAUNCH profile no
+matter which profile the caller asked for.
+
+Asserts the observable contract — what ``get_hermes_home()`` resolves to while
+the handler body runs — rather than mocking ``_profile_scope`` itself.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def profile_env(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    (root / "profiles" / "coder").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    return root
+
+
+@pytest.fixture
+def client(profile_env, monkeypatch):
+    import hermes_cli.web_server as ws
+
+    monkeypatch.setattr(ws, "_require_valid_memory_provider_name", lambda name: None)
+    monkeypatch.setattr(ws, "_memory_provider_manifest", lambda name: {"name": name})
+    monkeypatch.setattr(ws, "_invalidate_plugins_hub_cache", lambda: None)
+    c = TestClient(ws.app)
+    c.headers[ws._SESSION_HEADER_NAME] = ws._SESSION_TOKEN
+    return c
+
+
+def _record_home(monkeypatch, seen: dict):
+    """Capture the HERMES_HOME visible from inside the handler body."""
+    import hermes_cli.web_server as ws
+    from hermes_constants import get_hermes_home
+
+    class _Provider:
+        pass
+
+    monkeypatch.setattr(ws, "_load_memory_provider", lambda name: _Provider())
+
+    def _write(name, provider, values):
+        seen["write"] = str(get_hermes_home())
+
+    def _install(name):
+        seen["install"] = str(get_hermes_home())
+        return {"ok": True}
+
+    monkeypatch.setattr(ws, "_write_memory_provider_config_values", _write)
+    monkeypatch.setattr(ws, "_install_memory_provider_setup", _install)
+
+
+class TestSetupMemoryProviderProfileScope:
+    def test_setup_runs_under_the_requested_profile(
+        self, client, profile_env, monkeypatch
+    ):
+        seen: dict = {}
+        _record_home(monkeypatch, seen)
+
+        resp = client.post(
+            "/api/memory/providers/honcho/setup?profile=coder",
+            json={"values": {"HONCHO_API_KEY": "k"}},
+        )
+
+        assert resp.status_code == 200
+        expected = str(profile_env / "profiles" / "coder")
+        assert seen["write"] == expected
+        assert seen["install"] == expected
+
+    def test_setup_without_profile_uses_the_launch_home(
+        self, client, profile_env, monkeypatch
+    ):
+        seen: dict = {}
+        _record_home(monkeypatch, seen)
+
+        resp = client.post(
+            "/api/memory/providers/honcho/setup",
+            json={"values": {"HONCHO_API_KEY": "k"}},
+        )
+
+        assert resp.status_code == 200
+        assert seen["write"] == str(profile_env)
+        assert seen["install"] == str(profile_env)
+
+    def test_config_read_already_scopes_and_still_does(
+        self, client, profile_env, monkeypatch
+    ):
+        """Guards the sibling this fix is modelled on against regressing."""
+        import hermes_cli.web_server as ws
+        from hermes_constants import get_hermes_home
+
+        seen: dict = {}
+
+        def _payload(name, provider):
+            seen["read"] = str(get_hermes_home())
+            return {"name": name, "fields": []}
+
+        monkeypatch.setattr(ws, "_load_memory_provider", lambda name: object())
+        monkeypatch.setattr(ws, "_memory_provider_payload", _payload)
+
+        resp = client.get("/api/memory/providers/honcho/config?profile=coder")
+
+        assert resp.status_code == 200
+        assert seen["read"] == str(profile_env / "profiles" / "coder")

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { api } from "./api";
+import { api, setManagementProfile } from "./api";
 
 const SESSION_HEADER = "X-Hermes-Session-Token";
 
@@ -102,5 +102,67 @@ describe("api OAuth helpers", () => {
       expect(init.credentials).toBe("include");
       expect((init.headers as Headers).has(SESSION_HEADER)).toBe(false);
     }
+  });
+});
+
+describe("memory-provider config is management-profile scoped", () => {
+  // Regression: /api/memory/providers was missing from PROFILE_SCOPED_PREFIXES,
+  // so with the dashboard switched to a named profile the Memory card read the
+  // LAUNCH profile's provider values and its save wrote them back there —
+  // flipping `memory.provider` in a profile the user was not editing.
+  afterEach(() => {
+    setManagementProfile("");
+  });
+
+  it("scopes the config read to the managed profile", async () => {
+    vi.stubGlobal("window", {});
+    const fetchMock = jsonFetchMock({ name: "honcho", fields: [] });
+    vi.stubGlobal("fetch", fetchMock);
+    setManagementProfile("coder");
+
+    await api.getMemoryProviderConfig("honcho");
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/api/memory/providers/honcho/config?profile=coder",
+    );
+  });
+
+  it("scopes the config write to the managed profile", async () => {
+    vi.stubGlobal("window", {});
+    const fetchMock = jsonFetchMock({ ok: true, active: "honcho" });
+    vi.stubGlobal("fetch", fetchMock);
+    setManagementProfile("coder");
+
+    await api.updateMemoryProviderConfig("honcho", { HONCHO_API_KEY: "k" });
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/api/memory/providers/honcho/config?profile=coder",
+    );
+    expect((fetchMock.mock.calls[0][1] as RequestInit).method).toBe("PUT");
+  });
+
+  it("scopes provider setup to the managed profile", async () => {
+    vi.stubGlobal("window", {});
+    const fetchMock = jsonFetchMock({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+    setManagementProfile("coder");
+
+    await api.setupMemoryProvider("honcho", { HONCHO_API_KEY: "k" });
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/api/memory/providers/honcho/setup?profile=coder",
+    );
+  });
+
+  it("leaves URLs alone when no management profile is selected", async () => {
+    vi.stubGlobal("window", {});
+    const fetchMock = jsonFetchMock({ name: "honcho", fields: [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.getMemoryProviderConfig("honcho");
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/api/memory/providers/honcho/config",
+    );
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -80,6 +80,12 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/model/auxiliary",
   "/api/model/moa",
   "/api/model/options",
+  // Memory-provider config is per-profile state: the credential values land
+  // in that profile's config/.env and a successful save flips
+  // `memory.provider` in its config.yaml. Unscoped, the Memory card reads the
+  // launch profile's values and writes them straight back there, silently
+  // reconfiguring a profile the user is not editing.
+  "/api/memory/providers",
   // A named profile keeps its own pairing whitelist, and its gateway only
   // consults that one — approving into the global store would grant access
   // the running gateway never sees.


### PR DESCRIPTION
## What does this PR do?

The dashboard's Memory card talks to three endpoints, and **all three ignored
the selected management profile** — in opposite directions on each side of the
wire.

### Client side

`/api/memory/providers` was missing from `PROFILE_SCOPED_PREFIXES` in
`web/src/lib/api.ts`, so `withManagementProfile()` never appended
`?profile=<mgmt>`. Switch the dashboard to a named profile (e.g. `coder`), open
Memory, and:

- `GET  /api/memory/providers/{name}/config` reads the **launch** profile's
  provider values, so the card shows the wrong ones.
- `PUT  /api/memory/providers/{name}/config` writes the credentials you just
  typed back into the **launch** profile — and that handler also does
  `config["memory"]["provider"] = name; save_config(config)`, so saving
  **silently swaps the active memory backend of a profile you were not
  editing.**

### Server side

`POST /api/memory/providers/{name}/setup` never accepted a `profile` parameter
at all, unlike its `GET`/`PUT` `/config` siblings which both take one and wrap
their body in `_profile_scope(profile)`. That route persists provider values
(`_write_memory_provider_config_values`) and runs the provider's install steps
(`_install_memory_provider_setup`) — so even a correctly-scoped client request
would have run the entire body against the launch profile.

### How it was found

Generalising #76674: every `web_server.py` route handler that declares
`profile: Optional[str] = None` is profile-scoped on the backend, so it must be
covered by a client prefix. Diffing the two lists gives 42 profile-aware routes
against 17 client prefixes — 14 uncovered, 8 of them reachable from the
dashboard. Six are the `/api/providers/oauth` family already covered by the open
#76680 / #76683. The memory-provider pair was not, and unlike the OAuth reads it
is a **write** path.

## Related Issue

Same class as #76674 (Provider Logins OAuth), whose open fixes only add
`/api/providers/oauth` to the prefix list.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`web/src/lib/api.ts`** — add `"/api/memory/providers"` to
  `PROFILE_SCOPED_PREFIXES`, covering the config `GET`/`PUT` and the `setup`
  `POST`.
- **`hermes_cli/web_server.py`** — `setup_memory_provider()` takes
  `profile: Optional[str] = None` and runs its body under `_profile_scope(profile)`,
  matching the `/config` siblings. Behaviour with no `profile` is unchanged.
- **`web/src/lib/api.test.ts`** — 4 tests.
- **`tests/hermes_cli/test_memory_provider_profile_scope.py`** — 3 tests.

## How to Test

1. Create a second profile: `hermes profile create coder`.
2. Configure a memory provider (e.g. honcho) in the **default** profile.
3. Run `hermes dashboard`, switch the management profile to `coder`, open the
   Memory card and save a provider config.
4. **Before:** the card showed default's values; the save wrote the credentials
   into default's config and set `memory.provider` there. `coder` was untouched.
   **After:** every request carries `?profile=coder` and lands in
   `~/.hermes/profiles/coder/`.

## Test Results

**JS — `web/src/lib/api.test.ts`** (4 new): config read scoped, config write
scoped (and still `PUT`), provider setup scoped, and URLs left untouched when no
management profile is selected.

Red-without-fix, with only `web/src/lib/api.ts` reverted:

```text
Tests  3 failed | 6 passed (9)
```

With the fix:

```text
Test Files  1 passed (1)
     Tests  9 passed (9)
```

**Python — `tests/hermes_cli/test_memory_provider_profile_scope.py`** (3 new).
These assert the observable contract — what `get_hermes_home()` resolves to
while the handler body runs — against a real temp profile tree, rather than
mocking `_profile_scope` itself:

| Test | Asserts |
|---|---|
| `test_setup_runs_under_the_requested_profile` | value-write **and** install step both see `<root>/profiles/coder` |
| `test_setup_without_profile_uses_the_launch_home` | no `profile` still resolves to the launch home |
| `test_config_read_already_scopes_and_still_does` | guards the `GET /config` sibling this fix is modelled on |

Red-without-fix, with only `hermes_cli/web_server.py` reverted:

```text
1 failed, 2 passed
```

With the fix:

```text
3 passed in 0.87s
```

**Regression sweep**

```text
tests/hermes_cli/test_web_server.py + new file:  135 passed, 5 skipped
web vitest (full suite):                         22 files, 160 passed
tsc --noEmit:                                    clean
```