### PR TITLE
fix(ci): re-enable Desktop E2E gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,15 +94,7 @@ jobs:
     # + `hermes serve` backend, which never import anything under tests/.
     # Tests-only PRs (~17% of commits) skip this 5-minute job — the longest
     # single job in the workflow — while still running the full pytest lanes.
-    #
-    # ⛔ TEMPORARILY DISABLED (Aug 2, 2026, Teknium) — the suite is red on
-    # every PR and on main itself since the Aug 1 night engines/npm churn
-    # (#76499 → #76562 → #76575): the mock-backend Electron window never
-    # gets a title, so boot/chat/setup/interim specs all fail identically
-    # regardless of the PR's diff (verified on #76573 and the docs-only
-    # #76582). Tracking issue: #76627 (assigned: Ari). To re-enable,
-    # delete the `false &&` below — nothing else changed.
-    if: ${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true') }}
+    if: ${{ needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true' }}
     uses: ./.github/workflows/e2e-desktop.yml
 
   docs-site:


### PR DESCRIPTION
Fixes #76627

## Summary

The `e2e-desktop` job in `ci.yml` has been unconditionally short-circuited (`false && (...)`) since Aug 2, 2026, after the Aug 1 night engines/npm churn (#76499 → #76562 → #76575) broke the mock-backend Electron window title, turning every boot/chat/setup/interim spec red regardless of the PR's diff.

That churn was reverted the same night (`34b31b3a3`, "Revert bundled-node-path-windows-layout"). Since then every workflow — `js-tests.yml`, `js-autofix.yml`, `deploy-site.yml`, `docs-site-checks.yml`, and `e2e-desktop.yml` itself — pins Node 26 through the identical `setup-node@49933ea5` action, uniformly. The disable's stated root cause no longer exists in the codebase; the gate was just never flipped back per the comment's own instruction ("To re-enable, delete the `false &&` below — nothing else changed.").

This PR does exactly that: removes the short-circuit and the now-stale disable comment. No other line changes — the job's original trigger condition (`python_prod == 'true' || frontend == 'true'`) is untouched.

## Root cause

- **Was:** `if: ${{ false && (...) }}` — permanently skips the job, masking any real Desktop regression from CI for 5+ weeks.
- **Why it was added:** a same-night Node/npm engines migration (#76459) broke Electron window titling in the mock-backend harness.
- **Why it's safe to remove now:** the migration that caused the breakage was reverted within hours, and the subsequent, coordinated Node 26 rollout across all JS workflows is a different, uniform change — not the broken intermediate state the disable comment describes.

## Verification

This is a CI-config change — the real verification is this PR's own `Desktop E2E` check run. If the suite is still red for an unrelated reason, that's a distinct, newly-surfaced regression to track under #76627, not a reason to keep the gate permanently off.

## Test plan

- [ ] `Desktop E2E / Playwright E2E (Linux)` check on this PR is green
- [ ] No other jobs in `ci.yml` regress

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[🔒 Aug 1 Engines Churn] -->|Broke Window Title| B[⛔ Desktop E2E Disabled]
    C[⚡ Same-Night Revert 34b31b3a3] -->|Root Cause Cleared| D[🧬 Uniform Node 26 Rollout]
    D --> E{Stale Gate Still False?}
    B --> E
    E -->|Yes, Never Flipped Back| F[🚀 This PR: Remove false and-gate]
    F --> G[🛰️ Live CI Verification on This PR]
```

