### PR TITLE
fix(dashboard): forward model refresh requests

### DIFF
--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -32,6 +32,7 @@ import { ModelReloadConfirm } from "@/components/ModelReloadConfirm";
 import { ReasoningPicker } from "@/components/ReasoningPicker";
 import { GatewayClient, type ConnectionState } from "@/lib/gatewayClient";
 import { api, buildWsUrl } from "@/lib/api";
+import { chatSidebarModelOptionsLoader } from "@/lib/chat-sidebar-model-options";
 import { titleFromSessionInfoPayload } from "@/lib/chat-title";
 
 import { cn } from "@/lib/utils";
@@ -405,7 +406,7 @@ export function ChatSidebar({
           // Same path the Models page uses (REST /api/model/set), not the
           // sidecar config.set RPC, which didn't reliably land in the
           // config.yaml the agent boots from. Always persisted (alwaysGlobal).
-          loader={() => api.getModelOptions(profile)}
+          loader={chatSidebarModelOptionsLoader(profile)}
           alwaysGlobal
           onApply={async ({ provider, model, confirmExpensiveModel }) => {
             setModelNotice(null);

--- a/web/src/lib/chat-sidebar-model-options.test.ts
+++ b/web/src/lib/chat-sidebar-model-options.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { chatSidebarModelOptionsLoader } from "./chat-sidebar-model-options";
+import { api } from "./api";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("chatSidebarModelOptionsLoader", () => {
+  it("forwards the picker refresh request with its scoped profile", async () => {
+    const getModelOptions = vi
+      .spyOn(api, "getModelOptions")
+      .mockResolvedValue({ providers: [] } as never);
+
+    await chatSidebarModelOptionsLoader("developer")({ refresh: true });
+
+    expect(getModelOptions).toHaveBeenCalledWith({
+      profile: "developer",
+      refresh: true,
+    });
+  });
+});

--- a/web/src/lib/chat-sidebar-model-options.ts
+++ b/web/src/lib/chat-sidebar-model-options.ts
@@ -1,0 +1,16 @@
+import { api } from "./api";
+
+/**
+ * Build the model-catalog loader used by Dashboard chat.
+ *
+ * ModelPickerDialog calls this with ``refresh: true`` when the user requests a
+ * live catalog. Preserve that option alongside the chat's profile scope so a
+ * custom provider such as Bifrost reaches its ``/v1/models`` endpoint.
+ */
+export function chatSidebarModelOptionsLoader(profile?: string) {
+  return (options?: { refresh?: boolean }) =>
+    api.getModelOptions({
+      profile,
+      refresh: options?.refresh,
+    });
+}


### PR DESCRIPTION
## Summary
- forward the Dashboard model picker refresh flag through its profile-scoped loader
- allow the existing Refresh Models action to re-fetch custom-provider catalogs such as Bifrost
- add a regression test covering profile + refresh propagation

## Verification
- `cd web && npm run check` (157 tests passed; lint completed with 26 pre-existing warnings)
- `cd web && npm run build`

The Dashboard keeps the existing explicit refresh control and one-hour catalog cache; the fix makes that control actually issue `refresh=1`.