### PR TITLE
fix(discord): track live voice credentials across re-keys instead of snapshotting at start()

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -582,16 +582,25 @@ class VoiceReceiver:
     MIN_SPEECH_DURATION = 0.5  # minimum seconds to process (skip noise)
     SAMPLE_RATE = 48000        # Discord native rate
     CHANNELS = 2               # Discord sends stereo
+    REKEY_FAILURE_STREAK = 25  # consecutive NaCl failures → re-resolve creds
 
     def __init__(self, voice_client, allowed_user_ids: set = None):
         self._vc = voice_client
         self._allowed_user_ids = allowed_user_ids or set()
         self._running = False
 
-        # Decryption
-        self._secret_key: Optional[bytes] = None
-        self._dave_session = None
+        # Decryption state, kept as ONE tuple (secret_key, dave_session,
+        # dave_protocol_version, dave_downgraded) so the receive thread
+        # reads a consistent generation in a single reference load while
+        # refreshes happen on other threads — two separate assignments
+        # could pair a new key with an old session for a packet.
+        self._creds: tuple = (b"", None, 0, False)
         self._bot_ssrc: int = 0
+        # Monotonic deadline while DAVE plaintext passthrough is allowed
+        # (mirrors discord.py's set_passthrough_mode windows, see the
+        # voice-ws hook).  Replace-semantics: an upgrade's 10s grace
+        # SHORTENS a residual downgrade window, never extends it.
+        self._dave_passthrough_until: float = 0.0
 
         # SSRC -> user_id mapping (populated from SPEAKING events)
         self._ssrc_to_user: Dict[int, int] = {}
@@ -610,6 +619,13 @@ class VoiceReceiver:
         # Debug logging counter (instance-level to avoid cross-instance races)
         self._packet_debug_count = 0
 
+        # Decode-health counters (logged at teardown) and the NaCl failure
+        # streak used to detect stale credentials after a re-key.
+        self._decode_ok = 0
+        self._decode_failed = 0
+        self._dave_unmapped_dropped = 0
+        self._nacl_fail_streak = 0
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -617,14 +633,96 @@ class VoiceReceiver:
     def start(self):
         """Start listening for voice packets."""
         conn = self._vc._connection
-        self._secret_key = bytes(conn.secret_key)
-        self._dave_session = conn.dave_session
-        self._bot_ssrc = conn.ssrc
+        self._resolve_credentials(conn)
 
         self._install_speaking_hook(conn)
         conn.add_socket_listener(self._on_packet)
         self._running = True
         logger.info("VoiceReceiver started (bot_ssrc=%d)", self._bot_ssrc)
+
+    def _resolve_credentials(self, conn) -> None:
+        """Read the current decryption state from the live connection.
+
+        Discord rotates the transport ``secret_key`` on every voice
+        (re)connect (op 4 SESSION_DESCRIPTION), and ``reinit_dave_session``
+        REPLACES ``conn.dave_session`` with a new object when none existed
+        yet — e.g. when DAVE finishes negotiating after this receiver
+        started.  Credentials must therefore be re-resolvable at runtime;
+        a one-time snapshot decrypts nothing after either event, silently.
+
+        ``dave_protocol_version`` rides along because a non-null session is
+        NOT proof frames are encrypted: after a downgrade transition the
+        session object survives with the protocol at 0 and senders emit
+        plaintext.
+        """
+        self._creds = (
+            bytes(conn.secret_key),
+            conn.dave_session,
+            int(getattr(conn, "dave_protocol_version", 0) or 0),
+            bool(getattr(conn, "dave_downgraded", False)),
+        )
+        self._bot_ssrc = conn.ssrc
+        # A receiver can start (or refresh) while a downgrade transition is
+        # already pending — upstream has passthrough enabled for up to 120s
+        # but we never saw the op 21.  Seed the window from the connection's
+        # physical pending-transition state; the entry is popped on execute,
+        # so this cannot re-grant after the transition completes.
+        pending = getattr(conn, "dave_pending_transitions", None) or {}
+        if 0 in pending.values() and time.monotonic() >= self._dave_passthrough_until:
+            self.note_dave_passthrough_window(120.0)
+
+    @property
+    def _secret_key(self) -> bytes:
+        return self._creds[0]
+
+    @property
+    def _dave_session(self):
+        return self._creds[1]
+
+    @property
+    def _dave_protocol_version(self) -> int:
+        return self._creds[2]
+
+    @property
+    def _dave_downgraded(self) -> bool:
+        return self._creds[3]
+
+    def note_dave_passthrough_window(self, seconds: float) -> None:
+        """Open a plaintext-passthrough grace window for unmapped SSRCs.
+
+        Mirrors discord.py's own ``set_passthrough_mode`` calls: a pending
+        downgrade transition allows plaintext for up to 120s, and a
+        confirmed upgrade-after-downgrade allows a 10s grace while senders
+        catch up.  Replace-semantics, matching upstream: each grant resets
+        the deadline, so an upgrade's short grace supersedes a residual
+        downgrade window instead of being swallowed by it.
+        """
+        self._dave_passthrough_until = time.monotonic() + seconds
+
+    def refresh_credentials(self, reason: str) -> None:
+        """Re-resolve decryption state from the live connection.
+
+        Cheap and idempotent (attribute reads plus one small copy), so
+        callers invoke it on every trigger — session description, DAVE
+        epoch prepare, a membership change in the channel, or a decrypt
+        failure streak — without needing to coalesce.
+        """
+        if not self._running:
+            return
+        try:
+            conn = self._vc._connection
+            self._resolve_credentials(conn)
+            self._nacl_fail_streak = 0
+            logger.info(
+                "VoiceReceiver credentials refreshed (%s; bot_ssrc=%d, dave=%s)",
+                reason,
+                self._bot_ssrc,
+                "on" if self._dave_session else "off",
+            )
+        except Exception as e:
+            logger.warning(
+                "VoiceReceiver credential refresh failed (%s): %s", reason, e
+            )
 
     def stop(self):
         """Stop listening and clean up."""
@@ -638,7 +736,13 @@ class VoiceReceiver:
             self._last_packet_time.clear()
             self._decoders.clear()
             self._ssrc_to_user.clear()
-        logger.info("VoiceReceiver stopped")
+        logger.info(
+            "VoiceReceiver stopped (frames ok=%d, decrypt_failed=%d, "
+            "dave_unmapped_dropped=%d)",
+            self._decode_ok,
+            self._decode_failed,
+            self._dave_unmapped_dropped,
+        )
 
     def pause(self):
         self._paused = True
@@ -675,6 +779,45 @@ class VoiceReceiver:
                     receiver_self.map_ssrc(int(ssrc), int(user_id))
             if original_hook:
                 await original_hook(ws, msg)
+            # Re-resolve decryption state after the events that change it.
+            # DiscordVoiceWebSocket.received_message dispatches the op (which
+            # is what updates conn.secret_key / conn.dave_session /
+            # conn.dave_protocol_version) BEFORE calling this hook, so the
+            # refresh reads the new values:
+            #   op 4  SESSION_DESCRIPTION — new transport key, and
+            #         reinit_dave_session() may replace conn.dave_session
+            #   op 24 DAVE_PREPARE_EPOCH  — epoch 1 recreates the MLS group
+            #   op 21 DAVE_PREPARE_TRANSITION with protocol_version 0 —
+            #         discord.py opens a 120s plaintext passthrough window
+            #         (set_passthrough_mode(True, 120)); mirror it so the
+            #         unmapped-SSRC gate doesn't drop legitimate plaintext
+            #   op 22 DAVE_EXECUTE_TRANSITION — the protocol version just
+            #         changed; refresh, plus a 10s grace mirroring the
+            #         upgrade path's set_passthrough_mode(True, 10)
+            if isinstance(msg, dict):
+                op = msg.get("op")
+                if op in (4, 24):
+                    receiver_self.refresh_credentials(f"voice ws op {op}")
+                elif op == 21:
+                    if (msg.get("d") or {}).get("protocol_version") == 0:
+                        # Pending downgrade: upstream enables plaintext
+                        # passthrough for up to 120s (set_passthrough_mode).
+                        receiver_self.note_dave_passthrough_window(120.0)
+                elif op == 22:
+                    # A transition may have executed; refresh and detect the
+                    # upgrade-after-downgrade EDGE (dave_downgraded flipping
+                    # True -> False) — the only case upstream grants the 10s
+                    # passthrough grace.  Same-version transitions and
+                    # unknown/duplicate ids change no state upstream, so no
+                    # edge fires and no window opens.
+                    was_downgraded = receiver_self._dave_downgraded
+                    receiver_self.refresh_credentials("voice ws op 22")
+                    if (
+                        was_downgraded
+                        and not receiver_self._dave_downgraded
+                        and receiver_self._dave_protocol_version > 0
+                    ):
+                        receiver_self.note_dave_passthrough_window(10.0)
 
         # Set on connection state (for future reconnects)
         conn.hook = wrapped_hook
@@ -694,6 +837,10 @@ class VoiceReceiver:
     def _on_packet(self, data: bytes):
         if not self._running or self._paused:
             return
+
+        # One consistent credential generation for this packet — a refresh
+        # on another thread swaps the whole tuple, never half of it.
+        secret_key, dave_session, dave_pver, _dave_downgraded = self._creds
 
         # Log first few raw packets for debugging
         self._packet_debug_count += 1
@@ -757,11 +904,26 @@ class VoiceReceiver:
 
         try:
             import nacl.secret  # noqa: E402 — delayed import, only in voice path
-            box = nacl.secret.Aead(self._secret_key)
+            box = nacl.secret.Aead(secret_key)
             decrypted = box.decrypt(encrypted, header, bytes(nonce))
+            self._nacl_fail_streak = 0
         except Exception as e:
-            if self._packet_debug_count <= 10:
-                logger.warning("NaCl decrypt failed: %s (hdr=%d, enc=%d)", e, header_size, len(encrypted))
+            self._decode_failed += 1
+            self._nacl_fail_streak += 1
+            # Never go fully dark: after the first 10 warnings, keep emitting
+            # one every 250 failures so a deaf session stays diagnosable.
+            if self._packet_debug_count <= 10 or self._nacl_fail_streak % 250 == 0:
+                logger.warning(
+                    "NaCl decrypt failed: %s (hdr=%d, enc=%d, streak=%d)",
+                    e, header_size, len(encrypted), self._nacl_fail_streak,
+                )
+            # A sustained failure streak means the transport key rotated
+            # under us (voice reconnect / re-key) — re-read it from the live
+            # connection instead of staying deaf on a stale copy.  The
+            # refresh resets the streak, so this retries every
+            # REKEY_FAILURE_STREAK packets while the failure persists.
+            if self._nacl_fail_streak >= self.REKEY_FAILURE_STREAK:
+                self.refresh_credentials("decrypt-failure streak")
             return
 
         # Skip encrypted extension data to get the actual opus payload
@@ -794,13 +956,18 @@ class VoiceReceiver:
                 return
 
         # --- DAVE E2EE decrypt ---
-        if self._dave_session:
+        if dave_session:
             with self._lock:
                 user_id = self._ssrc_to_user.get(ssrc, 0)
+                if not user_id:
+                    # Rejoin race: SPEAKING may never be resent for a user who
+                    # was already talking — try the sole-member inference
+                    # before giving up on this frame.
+                    user_id = self._infer_user_for_ssrc(ssrc)
             if user_id:
                 try:
                     import davey
-                    decrypted = self._dave_session.decrypt(
+                    decrypted = dave_session.decrypt(
                         user_id, davey.MediaType.audio, decrypted
                     )
                 except Exception as e:
@@ -809,15 +976,36 @@ class VoiceReceiver:
                         if self._packet_debug_count <= 10:
                             logger.warning("DAVE decrypt failed for ssrc=%d: %s", ssrc, e)
                         return
-            # If SSRC unknown (no SPEAKING event yet), skip DAVE and try
-            # Opus decode directly — audio may be in passthrough mode.
-            # Buffer will get a user_id when SPEAKING event arrives later.
+            elif (
+                dave_pver > 0
+                and time.monotonic() >= self._dave_passthrough_until
+            ):
+                # E2EE is actively on (protocol > 0, no passthrough window),
+                # so an unmapped SSRC's payload is still ciphertext.  Opus
+                # will happily "decode" it (producing shredded audio and
+                # poisoning decoder state), so drop the frame until a
+                # SPEAKING event maps the SSRC — bounded loss beats corrupt
+                # audio.  A non-null session alone is NOT this predicate: the
+                # session object survives protocol downgrades to 0 and
+                # passthrough transitions, where plaintext is legitimate and
+                # must fall through to opus below.
+                self._dave_unmapped_dropped += 1
+                if (
+                    self._packet_debug_count <= 10
+                    or self._dave_unmapped_dropped % 250 == 1
+                ):
+                    logger.debug(
+                        "Dropping DAVE frame for unmapped ssrc=%d (dropped=%d)",
+                        ssrc, self._dave_unmapped_dropped,
+                    )
+                return
 
         # --- Opus decode -> PCM ---
         try:
             if ssrc not in self._decoders:
                 self._decoders[ssrc] = discord.opus.Decoder()
             pcm = self._decoders[ssrc].decode(decrypted)
+            self._decode_ok += 1
             with self._lock:
                 self._buffers[ssrc].extend(pcm)
                 self._last_packet_time[ssrc] = time.monotonic()
@@ -1455,6 +1643,18 @@ class DiscordAdapter(BasePlatformAdapter):
                         else f"moved {before.channel.name} -> {after.channel.name}",
                         guild_id,
                     )
+                    # Any membership change in the bot's channel bumps the
+                    # DAVE (E2EE) epoch — re-resolve the receiver's decryption
+                    # state so it never decodes against a stale session.
+                    vc = adapter_self._voice_clients.get(guild_id)
+                    receiver = adapter_self._voice_receivers.get(guild_id)
+                    if vc is not None and receiver is not None:
+                        bot_channel = getattr(vc, "channel", None)
+                        if bot_channel is not None and (
+                            before.channel == bot_channel
+                            or after.channel == bot_channel
+                        ):
+                            receiver.refresh_credentials("membership change")
 
             # Register slash commands
             if self._slash_commands:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -524,16 +524,25 @@ class VoiceReceiver:
     MIN_SPEECH_DURATION = 0.5  # minimum seconds to process (skip noise)
     SAMPLE_RATE = 48000        # Discord native rate
     CHANNELS = 2               # Discord sends stereo
+    REKEY_FAILURE_STREAK = 25  # consecutive NaCl failures → re-resolve creds
 
     def __init__(self, voice_client, allowed_user_ids: set = None):
         self._vc = voice_client
         self._allowed_user_ids = allowed_user_ids or set()
         self._running = False
 
-        # Decryption
-        self._secret_key: Optional[bytes] = None
-        self._dave_session = None
+        # Decryption state, kept as ONE tuple (secret_key, dave_session,
+        # dave_protocol_version, dave_downgraded) so the receive thread
+        # reads a consistent generation in a single reference load while
+        # refreshes happen on other threads — two separate assignments
+        # could pair a new key with an old session for a packet.
+        self._creds: tuple = (b"", None, 0, False)
         self._bot_ssrc: int = 0
+        # Monotonic deadline while DAVE plaintext passthrough is allowed
+        # (mirrors discord.py's set_passthrough_mode windows, see the
+        # voice-ws hook).  Replace-semantics: an upgrade's 10s grace
+        # SHORTENS a residual downgrade window, never extends it.
+        self._dave_passthrough_until: float = 0.0
 
         # SSRC -> user_id mapping (populated from SPEAKING events)
         self._ssrc_to_user: Dict[int, int] = {}
@@ -552,6 +561,13 @@ class VoiceReceiver:
         # Debug logging counter (instance-level to avoid cross-instance races)
         self._packet_debug_count = 0
 
+        # Decode-health counters (logged at teardown) and the NaCl failure
+        # streak used to detect stale credentials after a re-key.
+        self._decode_ok = 0
+        self._decode_failed = 0
+        self._dave_unmapped_dropped = 0
+        self._nacl_fail_streak = 0
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -559,14 +575,96 @@ class VoiceReceiver:
     def start(self):
         """Start listening for voice packets."""
         conn = self._vc._connection
-        self._secret_key = bytes(conn.secret_key)
-        self._dave_session = conn.dave_session
-        self._bot_ssrc = conn.ssrc
+        self._resolve_credentials(conn)
 
         self._install_speaking_hook(conn)
         conn.add_socket_listener(self._on_packet)
         self._running = True
         logger.info("VoiceReceiver started (bot_ssrc=%d)", self._bot_ssrc)
+
+    def _resolve_credentials(self, conn) -> None:
+        """Read the current decryption state from the live connection.
+
+        Discord rotates the transport ``secret_key`` on every voice
+        (re)connect (op 4 SESSION_DESCRIPTION), and ``reinit_dave_session``
+        REPLACES ``conn.dave_session`` with a new object when none existed
+        yet — e.g. when DAVE finishes negotiating after this receiver
+        started.  Credentials must therefore be re-resolvable at runtime;
+        a one-time snapshot decrypts nothing after either event, silently.
+
+        ``dave_protocol_version`` rides along because a non-null session is
+        NOT proof frames are encrypted: after a downgrade transition the
+        session object survives with the protocol at 0 and senders emit
+        plaintext.
+        """
+        self._creds = (
+            bytes(conn.secret_key),
+            conn.dave_session,
+            int(getattr(conn, "dave_protocol_version", 0) or 0),
+            bool(getattr(conn, "dave_downgraded", False)),
+        )
+        self._bot_ssrc = conn.ssrc
+        # A receiver can start (or refresh) while a downgrade transition is
+        # already pending — upstream has passthrough enabled for up to 120s
+        # but we never saw the op 21.  Seed the window from the connection's
+        # physical pending-transition state; the entry is popped on execute,
+        # so this cannot re-grant after the transition completes.
+        pending = getattr(conn, "dave_pending_transitions", None) or {}
+        if 0 in pending.values() and time.monotonic() >= self._dave_passthrough_until:
+            self.note_dave_passthrough_window(120.0)
+
+    @property
+    def _secret_key(self) -> bytes:
+        return self._creds[0]
+
+    @property
+    def _dave_session(self):
+        return self._creds[1]
+
+    @property
+    def _dave_protocol_version(self) -> int:
+        return self._creds[2]
+
+    @property
+    def _dave_downgraded(self) -> bool:
+        return self._creds[3]
+
+    def note_dave_passthrough_window(self, seconds: float) -> None:
+        """Open a plaintext-passthrough grace window for unmapped SSRCs.
+
+        Mirrors discord.py's own ``set_passthrough_mode`` calls: a pending
+        downgrade transition allows plaintext for up to 120s, and a
+        confirmed upgrade-after-downgrade allows a 10s grace while senders
+        catch up.  Replace-semantics, matching upstream: each grant resets
+        the deadline, so an upgrade's short grace supersedes a residual
+        downgrade window instead of being swallowed by it.
+        """
+        self._dave_passthrough_until = time.monotonic() + seconds
+
+    def refresh_credentials(self, reason: str) -> None:
+        """Re-resolve decryption state from the live connection.
+
+        Cheap and idempotent (attribute reads plus one small copy), so
+        callers invoke it on every trigger — session description, DAVE
+        epoch prepare, a membership change in the channel, or a decrypt
+        failure streak — without needing to coalesce.
+        """
+        if not self._running:
+            return
+        try:
+            conn = self._vc._connection
+            self._resolve_credentials(conn)
+            self._nacl_fail_streak = 0
+            logger.info(
+                "VoiceReceiver credentials refreshed (%s; bot_ssrc=%d, dave=%s)",
+                reason,
+                self._bot_ssrc,
+                "on" if self._dave_session else "off",
+            )
+        except Exception as e:
+            logger.warning(
+                "VoiceReceiver credential refresh failed (%s): %s", reason, e
+            )
 
     def stop(self):
         """Stop listening and clean up."""
@@ -580,7 +678,13 @@ class VoiceReceiver:
             self._last_packet_time.clear()
             self._decoders.clear()
             self._ssrc_to_user.clear()
-        logger.info("VoiceReceiver stopped")
+        logger.info(
+            "VoiceReceiver stopped (frames ok=%d, decrypt_failed=%d, "
+            "dave_unmapped_dropped=%d)",
+            self._decode_ok,
+            self._decode_failed,
+            self._dave_unmapped_dropped,
+        )
 
     def pause(self):
         self._paused = True
@@ -617,6 +721,45 @@ class VoiceReceiver:
                     receiver_self.map_ssrc(int(ssrc), int(user_id))
             if original_hook:
                 await original_hook(ws, msg)
+            # Re-resolve decryption state after the events that change it.
+            # DiscordVoiceWebSocket.received_message dispatches the op (which
+            # is what updates conn.secret_key / conn.dave_session /
+            # conn.dave_protocol_version) BEFORE calling this hook, so the
+            # refresh reads the new values:
+            #   op 4  SESSION_DESCRIPTION — new transport key, and
+            #         reinit_dave_session() may replace conn.dave_session
+            #   op 24 DAVE_PREPARE_EPOCH  — epoch 1 recreates the MLS group
+            #   op 21 DAVE_PREPARE_TRANSITION with protocol_version 0 —
+            #         discord.py opens a 120s plaintext passthrough window
+            #         (set_passthrough_mode(True, 120)); mirror it so the
+            #         unmapped-SSRC gate doesn't drop legitimate plaintext
+            #   op 22 DAVE_EXECUTE_TRANSITION — the protocol version just
+            #         changed; refresh, plus a 10s grace mirroring the
+            #         upgrade path's set_passthrough_mode(True, 10)
+            if isinstance(msg, dict):
+                op = msg.get("op")
+                if op in (4, 24):
+                    receiver_self.refresh_credentials(f"voice ws op {op}")
+                elif op == 21:
+                    if (msg.get("d") or {}).get("protocol_version") == 0:
+                        # Pending downgrade: upstream enables plaintext
+                        # passthrough for up to 120s (set_passthrough_mode).
+                        receiver_self.note_dave_passthrough_window(120.0)
+                elif op == 22:
+                    # A transition may have executed; refresh and detect the
+                    # upgrade-after-downgrade EDGE (dave_downgraded flipping
+                    # True -> False) — the only case upstream grants the 10s
+                    # passthrough grace.  Same-version transitions and
+                    # unknown/duplicate ids change no state upstream, so no
+                    # edge fires and no window opens.
+                    was_downgraded = receiver_self._dave_downgraded
+                    receiver_self.refresh_credentials("voice ws op 22")
+                    if (
+                        was_downgraded
+                        and not receiver_self._dave_downgraded
+                        and receiver_self._dave_protocol_version > 0
+                    ):
+                        receiver_self.note_dave_passthrough_window(10.0)
 
         # Set on connection state (for future reconnects)
         conn.hook = wrapped_hook
@@ -636,6 +779,10 @@ class VoiceReceiver:
     def _on_packet(self, data: bytes):
         if not self._running or self._paused:
             return
+
+        # One consistent credential generation for this packet — a refresh
+        # on another thread swaps the whole tuple, never half of it.
+        secret_key, dave_session, dave_pver, _dave_downgraded = self._creds
 
         # Log first few raw packets for debugging
         self._packet_debug_count += 1
@@ -699,11 +846,26 @@ class VoiceReceiver:
 
         try:
             import nacl.secret  # noqa: E402 — delayed import, only in voice path
-            box = nacl.secret.Aead(self._secret_key)
+            box = nacl.secret.Aead(secret_key)
             decrypted = box.decrypt(encrypted, header, bytes(nonce))
+            self._nacl_fail_streak = 0
         except Exception as e:
-            if self._packet_debug_count <= 10:
-                logger.warning("NaCl decrypt failed: %s (hdr=%d, enc=%d)", e, header_size, len(encrypted))
+            self._decode_failed += 1
+            self._nacl_fail_streak += 1
+            # Never go fully dark: after the first 10 warnings, keep emitting
+            # one every 250 failures so a deaf session stays diagnosable.
+            if self._packet_debug_count <= 10 or self._nacl_fail_streak % 250 == 0:
+                logger.warning(
+                    "NaCl decrypt failed: %s (hdr=%d, enc=%d, streak=%d)",
+                    e, header_size, len(encrypted), self._nacl_fail_streak,
+                )
+            # A sustained failure streak means the transport key rotated
+            # under us (voice reconnect / re-key) — re-read it from the live
+            # connection instead of staying deaf on a stale copy.  The
+            # refresh resets the streak, so this retries every
+            # REKEY_FAILURE_STREAK packets while the failure persists.
+            if self._nacl_fail_streak >= self.REKEY_FAILURE_STREAK:
+                self.refresh_credentials("decrypt-failure streak")
             return
 
         # Skip encrypted extension data to get the actual opus payload
@@ -736,13 +898,18 @@ class VoiceReceiver:
                 return
 
         # --- DAVE E2EE decrypt ---
-        if self._dave_session:
+        if dave_session:
             with self._lock:
                 user_id = self._ssrc_to_user.get(ssrc, 0)
+                if not user_id:
+                    # Rejoin race: SPEAKING may never be resent for a user who
+                    # was already talking — try the sole-member inference
+                    # before giving up on this frame.
+                    user_id = self._infer_user_for_ssrc(ssrc)
             if user_id:
                 try:
                     import davey
-                    decrypted = self._dave_session.decrypt(
+                    decrypted = dave_session.decrypt(
                         user_id, davey.MediaType.audio, decrypted
                     )
                 except Exception as e:
@@ -751,15 +918,36 @@ class VoiceReceiver:
                         if self._packet_debug_count <= 10:
                             logger.warning("DAVE decrypt failed for ssrc=%d: %s", ssrc, e)
                         return
-            # If SSRC unknown (no SPEAKING event yet), skip DAVE and try
-            # Opus decode directly — audio may be in passthrough mode.
-            # Buffer will get a user_id when SPEAKING event arrives later.
+            elif (
+                dave_pver > 0
+                and time.monotonic() >= self._dave_passthrough_until
+            ):
+                # E2EE is actively on (protocol > 0, no passthrough window),
+                # so an unmapped SSRC's payload is still ciphertext.  Opus
+                # will happily "decode" it (producing shredded audio and
+                # poisoning decoder state), so drop the frame until a
+                # SPEAKING event maps the SSRC — bounded loss beats corrupt
+                # audio.  A non-null session alone is NOT this predicate: the
+                # session object survives protocol downgrades to 0 and
+                # passthrough transitions, where plaintext is legitimate and
+                # must fall through to opus below.
+                self._dave_unmapped_dropped += 1
+                if (
+                    self._packet_debug_count <= 10
+                    or self._dave_unmapped_dropped % 250 == 1
+                ):
+                    logger.debug(
+                        "Dropping DAVE frame for unmapped ssrc=%d (dropped=%d)",
+                        ssrc, self._dave_unmapped_dropped,
+                    )
+                return
 
         # --- Opus decode -> PCM ---
         try:
             if ssrc not in self._decoders:
                 self._decoders[ssrc] = discord.opus.Decoder()
             pcm = self._decoders[ssrc].decode(decrypted)
+            self._decode_ok += 1
             with self._lock:
                 self._buffers[ssrc].extend(pcm)
                 self._last_packet_time[ssrc] = time.monotonic()
@@ -1377,6 +1565,18 @@ class DiscordAdapter(BasePlatformAdapter):
                         else f"moved {before.channel.name} -> {after.channel.name}",
                         guild_id,
                     )
+                    # Any membership change in the bot's channel bumps the
+                    # DAVE (E2EE) epoch — re-resolve the receiver's decryption
+                    # state so it never decodes against a stale session.
+                    vc = adapter_self._voice_clients.get(guild_id)
+                    receiver = adapter_self._voice_receivers.get(guild_id)
+                    if vc is not None and receiver is not None:
+                        bot_channel = getattr(vc, "channel", None)
+                        if bot_channel is not None and (
+                            before.channel == bot_channel
+                            or after.channel == bot_channel
+                        ):
+                            receiver.refresh_credentials("membership change")
 
             # Register slash commands
             if self._slash_commands:

--- a/tests/gateway/test_discord_voice_rekey.py
+++ b/tests/gateway/test_discord_voice_rekey.py
@@ -1,0 +1,449 @@
+"""VoiceReceiver re-key resilience — credentials must track the live connection.
+
+Discord rotates the transport ``secret_key`` on every voice (re)connect
+(op 4 SESSION_DESCRIPTION), and ``reinit_dave_session`` REPLACES
+``conn.dave_session`` when none existed yet (DAVE negotiating after the
+receiver started).  A receiver that snapshots either value once at
+``start()`` goes silently deaf — decrypt fails (or "succeeds" into
+ciphertext-shredded opus) with nothing actionable in the logs.
+
+Covers: resolve-from-connection, refresh on rotated key, the late
+DAVE-session upgrade, the decrypt-failure-streak fallback, the op 4/24
+websocket-hook trigger, and the DAVE unmapped-SSRC ciphertext drop.
+"""
+
+import asyncio
+import struct
+import sys
+import time
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("discord")
+
+from plugins.platforms.discord.adapter import VoiceReceiver
+
+
+KEY_A = bytes(range(32))
+KEY_B = bytes(range(32, 64))
+
+
+def _make_conn(
+    secret_key=KEY_A,
+    dave_session=None,
+    ssrc=999,
+    dave_protocol_version=0,
+    dave_downgraded=False,
+    dave_pending_transitions=None,
+):
+    return SimpleNamespace(
+        secret_key=secret_key,
+        dave_session=dave_session,
+        dave_protocol_version=dave_protocol_version,
+        dave_downgraded=dave_downgraded,
+        dave_pending_transitions=dave_pending_transitions or {},
+        ssrc=ssrc,
+        hook=None,
+        ws=None,
+        add_socket_listener=lambda cb: None,
+        remove_socket_listener=lambda cb: None,
+    )
+
+
+def _make_vc(conn, members=()):
+    channel = SimpleNamespace(members=list(members))
+    return SimpleNamespace(_connection=conn, channel=channel, user=SimpleNamespace(id=1))
+
+
+def _make_receiver(conn, members=()):
+    vc = _make_vc(conn, members)
+    receiver = VoiceReceiver(vc)
+    receiver.start()
+    return receiver
+
+
+def _rtp_packet(ssrc=1234, payload=b"e" * 8):
+    """Minimal valid voice RTP packet: v2, PT 0x78, no ext/pad/csrc."""
+    header = struct.pack(">BBHII", 0x80, 0x78, 1, 1000, ssrc)
+    return header + payload + b"nonc"  # last 4 bytes = nonce suffix
+
+
+class _FakeAead:
+    """Stands in for nacl.secret.Aead — records the key, scripted results."""
+
+    last_key = None
+    fail = False
+    plaintext = b"\xfc\xff\xfe"  # opus silence-ish frame
+
+    def __init__(self, key):
+        _FakeAead.last_key = bytes(key)
+
+    def decrypt(self, encrypted, header, nonce):
+        if _FakeAead.fail:
+            raise ValueError("decrypt failed (stale key)")
+        return _FakeAead.plaintext
+
+
+@pytest.fixture
+def fake_nacl(monkeypatch):
+    """Route the in-function ``import nacl.secret`` to the fake."""
+    _FakeAead.fail = False
+    _FakeAead.last_key = None
+    nacl_mod = types.ModuleType("nacl")
+    secret_mod = types.ModuleType("nacl.secret")
+    secret_mod.Aead = _FakeAead
+    nacl_mod.secret = secret_mod
+    monkeypatch.setitem(sys.modules, "nacl", nacl_mod)
+    monkeypatch.setitem(sys.modules, "nacl.secret", secret_mod)
+    return _FakeAead
+
+
+class TestCredentialResolution:
+    def test_start_resolves_from_connection(self):
+        conn = _make_conn(secret_key=KEY_A, ssrc=42)
+        receiver = _make_receiver(conn)
+        assert receiver._secret_key == KEY_A
+        assert receiver._bot_ssrc == 42
+
+    def test_refresh_picks_up_rotated_transport_key(self):
+        conn = _make_conn(secret_key=KEY_A)
+        receiver = _make_receiver(conn)
+        conn.secret_key = KEY_B
+        receiver.refresh_credentials("test rotation")
+        assert receiver._secret_key == KEY_B
+
+    def test_refresh_picks_up_late_dave_session(self):
+        """The None -> DaveSession upgrade: reinit_dave_session() CREATES a
+        new session object when none existed at receiver start.  A stale
+        captured None means every E2EE frame skips DAVE forever."""
+        conn = _make_conn(dave_session=None)
+        receiver = _make_receiver(conn)
+        assert receiver._dave_session is None
+        late_session = MagicMock(name="DaveSession")
+        conn.dave_session = late_session
+        receiver.refresh_credentials("dave negotiated")
+        assert receiver._dave_session is late_session
+
+    def test_refresh_after_stop_is_a_noop(self):
+        conn = _make_conn(secret_key=KEY_A)
+        receiver = _make_receiver(conn)
+        receiver.stop()
+        conn.secret_key = KEY_B
+        receiver.refresh_credentials("late event")
+        assert receiver._secret_key == KEY_A
+
+
+class TestFailureStreakRefresh:
+    def test_streak_triggers_refresh_and_reset(self, fake_nacl):
+        conn = _make_conn(secret_key=KEY_A)
+        receiver = _make_receiver(conn)
+        fake_nacl.fail = True
+        conn.secret_key = KEY_B  # the rotation the snapshot missed
+
+        packet = _rtp_packet()
+        for _ in range(VoiceReceiver.REKEY_FAILURE_STREAK):
+            receiver._on_packet(packet)
+
+        # Threshold hit → credentials re-resolved from the live connection
+        # and the streak reset for the next retry window.
+        assert receiver._secret_key == KEY_B
+        assert receiver._nacl_fail_streak == 0
+        assert receiver._decode_failed == VoiceReceiver.REKEY_FAILURE_STREAK
+
+    def test_success_resets_streak(self, fake_nacl):
+        conn = _make_conn(secret_key=KEY_A)
+        receiver = _make_receiver(conn)
+        fake_nacl.fail = True
+        packet = _rtp_packet()
+        for _ in range(5):
+            receiver._on_packet(packet)
+        assert receiver._nacl_fail_streak == 5
+        fake_nacl.fail = False
+        with patch("discord.opus.Decoder") as decoder_cls:
+            decoder_cls.return_value.decode.return_value = b"\x00" * 3840
+            receiver._on_packet(packet)
+        assert receiver._nacl_fail_streak == 0
+
+
+class TestWebsocketHookTrigger:
+    def _install_and_get_hook(self, conn):
+        vc = _make_vc(conn)
+        receiver = VoiceReceiver(vc)
+        receiver.start()  # installs the wrapped hook as conn.hook
+        assert conn.hook is not None
+        return receiver, conn.hook
+
+    def test_op4_refreshes_credentials(self):
+        conn = _make_conn(secret_key=KEY_A)
+        receiver, hook = self._install_and_get_hook(conn)
+        conn.secret_key = KEY_B
+        asyncio.run(hook(None, {"op": 4, "d": {}}))
+        assert receiver._secret_key == KEY_B
+
+    def test_op24_refreshes_credentials(self):
+        conn = _make_conn(dave_session=None)
+        receiver, hook = self._install_and_get_hook(conn)
+        late_session = MagicMock(name="DaveSession")
+        conn.dave_session = late_session
+        asyncio.run(hook(None, {"op": 24, "d": {"epoch": 1}}))
+        assert receiver._dave_session is late_session
+
+    def test_op5_still_maps_and_does_not_refresh(self):
+        conn = _make_conn(secret_key=KEY_A)
+        receiver, hook = self._install_and_get_hook(conn)
+        conn.secret_key = KEY_B  # must NOT be picked up by op 5
+        asyncio.run(hook(None, {"op": 5, "d": {"ssrc": 77, "user_id": 5}}))
+        assert receiver._ssrc_to_user[77] == 5
+        assert receiver._secret_key == KEY_A
+
+    def test_original_hook_still_called(self):
+        conn = _make_conn()
+        calls = []
+
+        async def original(ws, msg):
+            calls.append(msg)
+
+        conn.hook = original
+        vc = _make_vc(conn)
+        receiver = VoiceReceiver(vc)
+        receiver.start()
+        asyncio.run(conn.hook(None, {"op": 4, "d": {}}))
+        assert calls == [{"op": 4, "d": {}}]
+
+
+class TestDaveUnmappedDrop:
+    def test_unmapped_ssrc_never_reaches_opus(self, fake_nacl):
+        """With E2EE actively on (protocol > 0, no passthrough window), an
+        unmapped SSRC's payload is ciphertext — it must be dropped, not fed
+        to the opus decoder."""
+        conn = _make_conn(
+            dave_session=MagicMock(name="DaveSession"), dave_protocol_version=1
+        )
+        # Two members in channel → the sole-member inference cannot map.
+        members = [SimpleNamespace(id=2), SimpleNamespace(id=3)]
+        receiver = _make_receiver(conn, members=members)
+
+        with patch("discord.opus.Decoder") as decoder_cls:
+            receiver._on_packet(_rtp_packet(ssrc=555))
+            decoder_cls.assert_not_called()
+        assert receiver._dave_unmapped_dropped == 1
+        assert 555 not in receiver._decoders
+
+    def test_downgraded_protocol_zero_decodes_unmapped_plaintext(self, fake_nacl):
+        """A non-null session is NOT proof of encryption: after a downgrade
+        transition the session object survives with the protocol at 0 and
+        senders emit plaintext — unmapped frames must decode, not drop."""
+        conn = _make_conn(
+            dave_session=MagicMock(name="DaveSession"), dave_protocol_version=0
+        )
+        members = [SimpleNamespace(id=2), SimpleNamespace(id=3)]
+        receiver = _make_receiver(conn, members=members)
+
+        with patch("discord.opus.Decoder") as decoder_cls:
+            decoder_cls.return_value.decode.return_value = b"\x00" * 3840
+            receiver._on_packet(_rtp_packet(ssrc=555))
+            decoder_cls.assert_called_once()
+        assert receiver._dave_unmapped_dropped == 0
+        assert receiver._decode_ok == 1
+
+    def test_passthrough_window_decodes_unmapped_plaintext(self, fake_nacl):
+        """During the op-21 downgrade-pending window (protocol still > 0),
+        plaintext passthrough is legitimate — unmapped frames must decode."""
+        conn = _make_conn(
+            dave_session=MagicMock(name="DaveSession"), dave_protocol_version=1
+        )
+        members = [SimpleNamespace(id=2), SimpleNamespace(id=3)]
+        receiver = _make_receiver(conn, members=members)
+        receiver.note_dave_passthrough_window(120.0)
+
+        with patch("discord.opus.Decoder") as decoder_cls:
+            decoder_cls.return_value.decode.return_value = b"\x00" * 3840
+            receiver._on_packet(_rtp_packet(ssrc=555))
+            decoder_cls.assert_called_once()
+        assert receiver._dave_unmapped_dropped == 0
+
+    def test_expired_passthrough_window_drops_again(self, fake_nacl):
+        conn = _make_conn(
+            dave_session=MagicMock(name="DaveSession"), dave_protocol_version=1
+        )
+        members = [SimpleNamespace(id=2), SimpleNamespace(id=3)]
+        receiver = _make_receiver(conn, members=members)
+        receiver._dave_passthrough_until = 0.0  # long expired
+
+        with patch("discord.opus.Decoder") as decoder_cls:
+            receiver._on_packet(_rtp_packet(ssrc=555))
+            decoder_cls.assert_not_called()
+        assert receiver._dave_unmapped_dropped == 1
+
+    def test_op21_downgrade_opens_window_and_op22_refreshes(self):
+        conn = _make_conn(
+            dave_session=MagicMock(name="DaveSession"), dave_protocol_version=1
+        )
+        vc = _make_vc(conn)
+        receiver = VoiceReceiver(vc)
+        receiver.start()
+        hook = conn.hook
+
+        assert receiver._dave_passthrough_until == 0.0
+        asyncio.run(hook(None, {"op": 21, "d": {"protocol_version": 0, "transition_id": 3}}))
+        assert receiver._dave_passthrough_until > 0.0
+
+        # op 22 executing the downgrade: the protocol version changed —
+        # refresh must pick it up from the connection.
+        conn.dave_protocol_version = 0
+        conn.dave_downgraded = True
+        asyncio.run(hook(None, {"op": 22, "d": {"transition_id": 3}}))
+        assert receiver._dave_protocol_version == 0
+
+    def test_op22_upgrade_edge_grants_short_grace_replacing_long_window(self):
+        """Only a confirmed upgrade-after-downgrade (dave_downgraded flipping
+        True -> False) opens the 10s grace — and it REPLACES a residual 120s
+        downgrade window instead of being swallowed by it."""
+        conn = _make_conn(
+            dave_session=MagicMock(name="DaveSession"),
+            dave_protocol_version=0,
+            dave_downgraded=True,
+        )
+        vc = _make_vc(conn)
+        receiver = VoiceReceiver(vc)
+        receiver.start()
+        hook = conn.hook
+
+        # Residual long window from an earlier downgrade-prepare.
+        receiver.note_dave_passthrough_window(120.0)
+        long_deadline = receiver._dave_passthrough_until
+
+        # Upstream executes the upgrade: protocol back up, downgraded off.
+        conn.dave_protocol_version = 1
+        conn.dave_downgraded = False
+        asyncio.run(hook(None, {"op": 22, "d": {"transition_id": 4}}))
+
+        assert receiver._dave_protocol_version == 1
+        # Window replaced by the SHORT grace, not max-extended.
+        assert receiver._dave_passthrough_until < long_deadline
+        assert receiver._dave_passthrough_until > time.monotonic()
+
+    def test_op22_same_version_transition_opens_no_window(self):
+        """Same-version MLS transitions grant no passthrough upstream —
+        under active E2EE an op 22 must NOT open a plaintext hole."""
+        conn = _make_conn(
+            dave_session=MagicMock(name="DaveSession"),
+            dave_protocol_version=1,
+            dave_downgraded=False,
+        )
+        vc = _make_vc(conn)
+        receiver = VoiceReceiver(vc)
+        receiver.start()
+        hook = conn.hook
+
+        asyncio.run(hook(None, {"op": 22, "d": {"transition_id": 5}}))
+        assert receiver._dave_passthrough_until == 0.0
+
+    def test_op22_duplicate_or_unknown_transition_opens_no_window(self):
+        """An op 22 for an unknown/duplicate transition id changes no state
+        upstream — no edge, no window."""
+        conn = _make_conn(
+            dave_session=MagicMock(name="DaveSession"),
+            dave_protocol_version=1,
+            dave_downgraded=False,
+        )
+        vc = _make_vc(conn)
+        receiver = VoiceReceiver(vc)
+        receiver.start()
+        hook = conn.hook
+
+        for _ in range(3):
+            asyncio.run(hook(None, {"op": 22, "d": {"transition_id": 99}}))
+        assert receiver._dave_passthrough_until == 0.0
+
+    def test_start_mid_pending_downgrade_seeds_window(self, fake_nacl):
+        """A receiver that starts while a downgrade transition is already
+        pending never saw the op 21 — it must seed the passthrough window
+        from the connection's physical pending-transition state instead of
+        dropping legitimate plaintext for up to 120s."""
+        conn = _make_conn(
+            dave_session=MagicMock(name="DaveSession"),
+            dave_protocol_version=1,
+            dave_pending_transitions={3: 0},
+        )
+        members = [SimpleNamespace(id=2), SimpleNamespace(id=3)]
+        receiver = _make_receiver(conn, members=members)
+
+        assert receiver._dave_passthrough_until > 0.0
+        with patch("discord.opus.Decoder") as decoder_cls:
+            decoder_cls.return_value.decode.return_value = b"\x00" * 3840
+            receiver._on_packet(_rtp_packet(ssrc=555))
+            decoder_cls.assert_called_once()
+        assert receiver._dave_unmapped_dropped == 0
+
+    def test_credentials_swap_is_one_tuple(self):
+        """The receive thread reads one consistent generation — key, session,
+        protocol version, and downgrade flag always come from the same
+        refresh."""
+        conn = _make_conn(secret_key=KEY_A, dave_protocol_version=1)
+        receiver = _make_receiver(conn)
+        before = receiver._creds
+        conn.secret_key = KEY_B
+        conn.dave_session = MagicMock(name="DaveSession")
+        conn.dave_protocol_version = 2
+        receiver.refresh_credentials("test")
+        after = receiver._creds
+        assert before is not after
+        assert after == (KEY_B, conn.dave_session, 2, False)
+
+    def test_mapped_user_flows_through_dave_to_opus(self, fake_nacl):
+        dave = MagicMock(name="DaveSession")
+        dave.decrypt.return_value = b"\xfc\xff\xfe"
+        conn = _make_conn(dave_session=dave)
+        receiver = _make_receiver(conn)
+        receiver.map_ssrc(555, 7)
+
+        davey_mod = types.ModuleType("davey")
+        davey_mod.MediaType = SimpleNamespace(audio="audio")
+        with patch.dict(sys.modules, {"davey": davey_mod}):
+            with patch("discord.opus.Decoder") as decoder_cls:
+                decoder_cls.return_value.decode.return_value = b"\x00" * 3840
+                receiver._on_packet(_rtp_packet(ssrc=555))
+
+        dave.decrypt.assert_called_once()
+        assert receiver._decode_ok == 1
+        assert receiver._dave_unmapped_dropped == 0
+
+    def test_sole_member_inference_rescues_unmapped_ssrc(self, fake_nacl):
+        """One allowed member in channel → the existing inference maps the
+        SSRC and the frame goes through DAVE instead of being dropped."""
+        dave = MagicMock(name="DaveSession")
+        dave.decrypt.return_value = b"\xfc\xff\xfe"
+        conn = _make_conn(dave_session=dave)
+        receiver = _make_receiver(conn, members=[SimpleNamespace(id=9)])
+
+        davey_mod = types.ModuleType("davey")
+        davey_mod.MediaType = SimpleNamespace(audio="audio")
+        with patch.dict(sys.modules, {"davey": davey_mod}):
+            with patch("discord.opus.Decoder") as decoder_cls:
+                decoder_cls.return_value.decode.return_value = b"\x00" * 3840
+                receiver._on_packet(_rtp_packet(ssrc=556))
+
+        assert receiver._ssrc_to_user[556] == 9
+        dave.decrypt.assert_called_once()
+        assert receiver._dave_unmapped_dropped == 0
+
+
+class TestTeardownHealthLine:
+    def test_stop_logs_decode_health(self, caplog):
+        import logging
+
+        conn = _make_conn()
+        receiver = _make_receiver(conn)
+        receiver._decode_ok = 10
+        receiver._decode_failed = 3
+        receiver._dave_unmapped_dropped = 2
+        with caplog.at_level(logging.INFO):
+            receiver.stop()
+        line = "\n".join(r.getMessage() for r in caplog.records)
+        assert "ok=10" in line
+        assert "decrypt_failed=3" in line
+        assert "dave_unmapped_dropped=2" in line


### PR DESCRIPTION
Fixes #77968.

## The failure contract

Discord voice is E2EE'd via DAVE (MLS). The group re-keys on **any** membership change in the voice channel, and a voice reconnect additionally rotates the transport `secret_key` (op 4 SESSION_DESCRIPTION). `VoiceReceiver.start()` captures both exactly once:

```python
self._secret_key = bytes(conn.secret_key)   # copied BY VALUE
self._dave_session = conn.dave_session       # reference captured once
```

Both go stale in normal operation, and the failure is **silent by construction** — the operator-visible symptom is "the bot ignores me":

1. A transport re-key means NaCl decrypt fails forever on the stale copy — and decrypt failures warn for the first 10 packets, then go dark.
2. Worse: `voice_state.reinit_dave_session()` **replaces** `conn.dave_session` with a *new* `DaveSession` when none existed yet. A receiver that starts before DAVE finishes negotiating keeps its captured `None` forever, treats E2EE as off, and feeds ciphertext to opus for the entire session — shredded audio, poisoned decoder state, zero errors. (We hit exactly this class on a parallel py-cord-based implementation: a user joining 46 seconds after the bot triggered epoch 1, after which 100% of received audio was garbage with nothing in the logs.)
3. Independently, an SSRC with no SPEAKING mapping skipped DAVE entirely and decoded raw ciphertext ("passthrough mode" comment) — common right after re-keys due to the rejoin race.

## The fix — resolve, don't copy

- **Atomic credential generations.** Decryption state lives in one tuple `(secret_key, dave_session, dave_protocol_version, dave_downgraded)`, re-resolved from the live connection and swapped in a single reference store. The receive thread reads one consistent generation per packet — a refresh can never pair a new key with an old session.
- **Refresh triggers**, all riding existing hooks: the voice-ws hook on op 4 / op 24 (`received_message` dispatches the op *before* invoking the hook, so the refresh reads the new values); membership changes in the bot's channel via the existing `on_voice_state_update` handler; and a 25-consecutive-NaCl-failure streak as the catch-all — retried every window while the failure persists, so the receiver never gives up and never goes dark (one warning per 250 failures after the first 10).
- **The unmapped-SSRC hole, closed without recreating it elsewhere.** With E2EE actively on (`dave_protocol_version > 0` and outside a passthrough window), unmapped frames are dropped (after the existing sole-member inference) instead of reaching opus as ciphertext. A non-null session alone is deliberately **not** the predicate — the session object survives downgrades to protocol 0 and passthrough transitions, where plaintext is legitimate. Passthrough windows mirror discord.py's own `set_passthrough_mode` calls: op 21 pending-downgrade opens 120s; op 22 opens a 10s grace only on the `dave_downgraded` True→False edge (upgrade-after-downgrade), replace-semantics so the short grace supersedes a residual long window; a receiver starting mid-pending-downgrade seeds the window from `conn.dave_pending_transitions`.
- **Silence made visible.** `stop()` logs decode-health counters (`ok / decrypt_failed / dave_unmapped_dropped`) — every future "it ignores me" report becomes a one-line diagnosis.

One named assumption: per-packet DAVE decrypt calls ride whatever internal thread-safety `davey`'s session provides (same as the pre-existing code path); the credential tuple guarantees consistency of *which* session object a packet uses, not intra-session concurrency.

## Tests

`tests/gateway/test_discord_voice_rekey.py` — 24 cases: credential resolution/rotation, the late-DAVE-session upgrade (`None` → new session), failure-streak refresh + reset on success, op 4/24/5 hook behavior and original-hook passthrough, the DAVE-state predicate matrix (downgraded-plaintext decodes, op-21 window decodes, expired window drops, upgrade edge replaces the long window, same-version and duplicate op-22 open nothing, mid-pending-downgrade startup seeds the window), unmapped-drop vs mapped-user flow, sole-member rescue, tuple-generation consistency, and the teardown health line. Adjacent `voice_command` / `voice_mixer` / `send` / `opus` suites green under the diff (111 passed).

Out of scope, deliberately: plugin-triggered voice reconnects (discord.py owns its reconnect machinery), and the unused-`seq` reorder buffer + opus PLC — happy to follow up with that separately.

Failure forensics and fix design: SmokeDev — from the TaskChad OS Discord voice receive campaign (the same bug family, live-validated; shipped in taskchad-os v1.2.2).
