### PR TITLE
fix(deps): resolve current npm security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7417,9 +7417,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13746,9 +13746,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16621,9 +16621,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17774,7 +17774,7 @@
         "ink-text-input": "6.0.0",
         "nanostores": "1.4.0",
         "react": "19.2.7",
-        "undici": "6.27.0",
+        "undici": "6.28.0",
         "unicode-animations": "1.0.3"
       },
       "devDependencies": {
@@ -17800,9 +17800,9 @@
       }
     },
     "ui-tui/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,14 @@
     "lodash": "4.18.1",
     "yauzl": "^3.3.1",
     "protobufjs": "^8.7.1",
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9",
+    "postcss": "8.5.25",
+    "jsdom": {
+      "undici": "7.29.0"
+    },
+    "node-gyp": {
+      "undici": "6.28.0"
+    }
   },
   "engines": {
     "node": ">=22.22.0",

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -25,7 +25,7 @@
     "ink-text-input": "6.0.0",
     "nanostores": "1.4.0",
     "react": "19.2.7",
-    "undici": "6.27.0",
+    "undici": "6.28.0",
     "unicode-animations": "1.0.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- bump `brace-expansion` override to 5.0.9
- keep `postcss` pinned to safe 8.5.25
- bump `undici` 6.x consumers to 6.28.0 and jsdom consumer to 7.29.0 without crossing majors
- update root lockfile narrowly; no `npm audit fix` churn

## Evidence
- baseline `origin/main`: 2 high (`brace-expansion`, `undici`)
- candidate `npm audit --json`: 0 vulnerabilities
- clean `npm ci --ignore-scripts`: PASS
- full `npm run check`: PASS (existing warnings, 0 errors)
- `npm ci --dry-run`: PASS
- `git diff --check`: PASS
- independent fail-closed review: APPROVED

## Scope
Only `package.json`, `package-lock.json`, and `ui-tui/package.json`. No runtime/global install, config, credentials, cron, merge, deploy, or restart.

Internal tracking: HLX-505