### PR TITLE
fix(buzz): suppress compaction-complete and self-improvement review telemetry from Buzz chat

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -616,6 +616,22 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
         return text
 
     text = _redact_gateway_user_facing_secrets(text)
+
+    # Buzz-specific: agent-internal telemetry is posted as chat messages on
+    # Buzz and treated as noise by users. Suppress compaction-complete status
+    # (which is not matched by _TELEGRAM_NOISY_STATUS_RE) and self-improvement
+    # review summaries (which bypass this function entirely via the direct
+    # background_review_callback path in _deliver_bg_review_message, but catch
+    # any fallback status_callback routes here too). Non-Buzz platforms are
+    # unchanged — COMPACTION_DONE_STATUS remains deliverable on Telegram et al
+    # per test_compression_progress_notices.py.#69546.
+    if _gateway_platform_value(platform) == "buzz" and re.search(
+        r"(Context compaction complete|Self-improvement review)",
+        text,
+        re.IGNORECASE,
+    ):
+        return None
+
     if _TELEGRAM_NOISY_STATUS_RE.search(text):
         # Opt-in #52995: `compression.progress_notices: true` lets ROUTINE
         # compression progress statuses through to chat platforms. The
@@ -4801,6 +4817,15 @@ class TurnRunner:
 
         def _deliver_bg_review_message(message: str) -> None:
             if not ctx._status_adapter or not ctx._run_still_current():
+                return
+            # Buzz-specific: suppress self-improvement review noise from chat.
+            # This path bypasses _prepare_gateway_status_message entirely, so
+            # the filter must be applied here as well (#t_cc3338cf).
+            if _gateway_platform_value(ctx.source.platform) == "buzz" and re.search(
+                r"Self-improvement review",
+                message,
+                re.IGNORECASE,
+            ):
                 return
             safe_schedule_threadsafe(
                 ctx._status_adapter.send(

--- a/tests/gateway/test_compression_progress_notices.py
+++ b/tests/gateway/test_compression_progress_notices.py
@@ -97,6 +97,56 @@ def test_compaction_completion_notice_reaches_chat(monkeypatch, platform, enable
     )
 
 
+def test_compaction_completion_suppressed_on_buzz(monkeypatch):
+    """Buzz suppresses COMPACTION_DONE_STATUS — it's unwanted telemetry noise.
+
+    Unlike Telegram/Discord/Slack where COMPACTION_DONE_STATUS is intentionally
+    deliverable, Buzz users reported compaction-complete status appearing as
+    unwanted chat messages (#t_cc3338cf). The Buzz-specific gate in
+    _prepare_gateway_status_message must return None for this message.
+    """
+    for enabled in (True, False):
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_config",
+            lambda e=enabled: {"compression": {"progress_notices": e}},
+        )
+        assert (
+            _prepare_gateway_status_message("buzz", "compacted", COMPACTION_DONE_STATUS)
+            is None
+        ), f"COMPACTION_DONE_STATUS should be suppressed on Buzz (progress_notices={enabled})"
+
+
+def test_bg_review_self_improvement_suppressed_on_buzz():
+    """Buzz suppresses 'Self-improvement review' background review messages.
+
+    The background_review_callback path bypasses _prepare_gateway_status_message
+    and sends directly via _deliver_bg_review_message. The filter in that path
+    must suppress messages matching 'Self-improvement review'. This test
+    validates the filter logic via _prepare_gateway_status_message as well,
+    which also handles it as a fallback.
+    """
+    review_message = "💾 Self-improvement review: Updated memory with user context"
+    other_messages = [
+        "💾 Skill 'prospect-scanner' created.",
+        "💾 Memory updated: user prefers concise responses",
+    ]
+    assert (
+        _prepare_gateway_status_message("buzz", "lifecycle", review_message)
+        is None
+    )
+    for msg in other_messages:
+        assert (
+            _prepare_gateway_status_message("buzz", "lifecycle", msg)
+            is not None
+        ), f"non-review message should not be suppressed on Buzz: {msg}"
+    # Non-Buzz platforms must keep the review visible
+    assert (
+        _prepare_gateway_status_message("telegram", "lifecycle", review_message)
+        is not None
+    ), "Self-improvement review must remain deliverable on non-Buzz platforms"
+
+
 def test_enabled_gate_does_not_leak_to_raw_platforms(progress_notices_enabled):
     """Programmatic surfaces keep raw text regardless of the gate."""
     message = ROUTINE_COMPRESSION_STATUS_SAMPLES[0]


### PR DESCRIPTION
## Summary

Suppress two agent-internal telemetry sources from appearing as Buzz chat messages:

1. **Compaction-complete status** ("✓ Context compaction complete — continuing turn...") — was leaking through `_prepare_gateway_status_message` because `_TELEGRAM_NOISY_STATUS_RE` does not match it. Added a Buzz-specific filter.

2. **Self-improvement review summaries** ("💾 Self-improvement review: {summary}") — were bypassing the status filter entirely via the direct `background_review_callback` → `_deliver_bg_review_message` path. Added a Buzz-specific filter there.

## Changes

- **`gateway/run.py`** (2 locations):
  - `_prepare_gateway_status_message`: Buzz returns `None` for compaction-complete and self-improvement review messages.
  - `_deliver_bg_review_message`: Buzz returns early for self-improvement review messages (this path bypasses `_prepare_gateway_status_message`).

- **`tests/gateway/test_compression_progress_notices.py`** (+2 tests):
  - `test_compaction_completion_suppressed_on_buzz` — verifies COMPACTION_DONE_STATUS is None on Buzz regardless of `progress_notices` setting.
  - `test_bg_review_self_improvement_suppressed_on_buzz` — verifies "Self-improvement review" is suppressed on Buzz but not other messages, and that non-Buzz platforms are unaffected.

## Design

Both filters are **Buzz-only** — non-Buzz platforms (Telegram, Discord, Slack, WhatsApp, Feishu) are unchanged. COMPACTION_DONE_STATUS remains deliverable on those platforms per the existing `test_compaction_completion_notice_reaches_chat` test.

The approach follows the "per-platform quiet-status flag" route from the task spec — simplest surgical fix that doesn't risk regressions on other platforms.

## Test Plan

- `tests/gateway/test_compression_progress_notices.py` — 40 passed (38 existing + 2 new)
- `tests/gateway/test_telegram_noise_filter.py` — 133 passed (no regressions)

## Kanban Task

Task: t_cc3338cf
URL: https://mc.solobot.cloud/tasks?task=t_cc3338cf
