### PR TITLE
fix(desktop): reap stale gateway orphans on Desktop backend startup

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -184,6 +184,29 @@ def _resolve_restart_drain_timeout() -> float:
         return DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
 
 
+def _reap_stale_desktop_gateway_orphans() -> None:
+    """Sweep for gateway orphans an abrupt Desktop restart left behind.
+
+    Desktop tears down the previous backend with a plain SIGTERM on POSIX
+    or a full process-tree kill on Windows (see backend-child.ts) — neither
+    path reaches a gateway spawned via ``hermes gateway restart``, which
+    detaches into its own session (``start_new_session=True``). On hosts
+    without a service supervisor this stacked a duplicate, unsupervised
+    gateway on every Desktop restart, splitting/duplicating inbound
+    messages on connected platforms (#77276).
+    ``_reap_unsupervised_gateway_orphans`` already solves this exact class
+    of bug for the CLI restart path (#51325, #75936), including the
+    systemd-aware no-op gate — reusing it here closes the Desktop-restart
+    gap without inventing new kill logic. No-op when a service supervisor
+    is present or no orphan is found.
+    """
+    try:
+        from hermes_cli.gateway import _reap_unsupervised_gateway_orphans
+        _reap_unsupervised_gateway_orphans()
+    except Exception:
+        _log.debug("Desktop startup gateway-orphan sweep failed", exc_info=True)
+
+
 @asynccontextmanager
 async def _lifespan(app: "FastAPI"):
     app.state.event_channels = {}  # dict[str, set]
@@ -209,6 +232,7 @@ async def _lifespan(app: "FastAPI"):
     cron_stop: "threading.Event | None" = None
     cron_thread: "threading.Thread | None" = None
     if os.getenv("HERMES_DESKTOP") == "1":
+        _reap_stale_desktop_gateway_orphans()
         cron_stop = threading.Event()
         cron_thread = threading.Thread(
             target=_start_desktop_cron_ticker,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3967,6 +3967,39 @@ class TestDesktopCronTicker:
         with self._client():
             assert called.wait(3.0), "expected cron tick under HERMES_DESKTOP=1"
 
+    def test_startup_reaps_gateway_orphans_when_desktop(self, monkeypatch, _isolate_hermes_home):
+        """#77276: an abrupt Desktop restart leaves a detached gateway
+        (start_new_session=True) behind — neither the POSIX SIGTERM nor the
+        Windows tree-kill Desktop uses to stop the old backend reaches it.
+        The next Desktop-spawned backend must sweep for it on startup so a
+        restart never stacks a duplicate, unsupervised gateway."""
+        import hermes_cli.gateway as gw
+
+        called = []
+        monkeypatch.setattr(
+            gw, "_reap_unsupervised_gateway_orphans", lambda *a, **k: called.append(True)
+        )
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+
+        with self._client():
+            pass
+
+        assert called, "expected gateway-orphan sweep on Desktop startup"
+
+    def test_startup_skips_gateway_reap_when_not_desktop(self, monkeypatch, _isolate_hermes_home):
+        import hermes_cli.gateway as gw
+
+        called = []
+        monkeypatch.setattr(
+            gw, "_reap_unsupervised_gateway_orphans", lambda *a, **k: called.append(True)
+        )
+        monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+
+        with self._client():
+            pass
+
+        assert not called, "server-mode backend must not run the desktop-only orphan sweep"
+
 
 class TestServeIndexMissingIndex:
     """_serve_index must not raise per-request when index.html vanishes


### PR DESCRIPTION
Fixes #77276

## Summary

Desktop restarts can leave a gateway process orphaned on hosts without a service supervisor (WSL, no-systemd Linux, some Windows setups), causing a duplicate gateway to run alongside the freshly-started one — which splits or duplicates inbound messages on connected platforms (QQ, Discord, etc.).

## Root cause

Desktop tears down the previous backend two ways, neither of which reaches a detached gateway:

- **POSIX:** a plain `SIGTERM` to the backend's direct child only (`apps/desktop/electron/backend-child.ts`) — deliberately, since the backend itself isn't spawned detached and there's no process group to negative-PID-kill.
- **Windows:** a full process-tree kill (`taskkill /T /F`).

But the actual gateway daemon is spawned via `hermes gateway restart`, which detaches into its own session (`start_new_session=True` / Windows detach flags) specifically so it *does* survive backend churn intentionally for one-shot maintenance actions (backup, `hermes-update`, `doctor`, etc.). That same detachment means a plain SIGTERM never reaches it — and on hosts without a supervisor watching the gateway's lifecycle, the old instance just keeps running after the new backend starts and spawns its own.

I first considered patching `_lifespan`'s shutdown to `terminate()` everything tracked in `_ACTION_PROCS`. Rejected: that dict also tracks legitimate one-shot actions that are *supposed* to outlive a backend restart (backup, `hermes-update`, `doctor`, `skills-install`...) — a blanket kill would corrupt in-flight backups/updates, trading one bug for a worse one.

## Fix

`hermes_cli/gateway.py` already has `_reap_unsupervised_gateway_orphans()` — built and tested for the exact same failure mode on the CLI restart path (#51325, #75936), including the `supports_systemd_services()` gate so it's a no-op wherever a real supervisor already owns the gateway's lifecycle. This PR calls it once, on Desktop backend startup, before the new backend can spawn its own gateway — closing the Desktop-restart gap with already-proven logic instead of inventing new kill paths.

## Test plan

- [x] `test_startup_reaps_gateway_orphans_when_desktop` — sweep runs when `HERMES_DESKTOP=1`
- [x] `test_startup_skips_gateway_reap_when_not_desktop` — server-mode backend does not run the desktop-only sweep
- [x] `tests/hermes_cli/test_web_server.py` full suite: 134 passed, 5 skipped
- [x] `tests/hermes_cli/test_gateway.py` full suite: 10 passed, 5 skipped (no regression on the reused reaper)

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[🩸 Desktop Restart] -->|POSIX SIGTERM / Win taskkill /T| B[⚰️ Old Backend Dies]
    C[🔥 Detached Gateway Session] -->|start_new_session=True| D[👻 Survives As Orphan]
    B --> D
    D --> E{New Backend Boots}
    E -->|HERMES_DESKTOP=1| F[⚔️ _reap_stale_desktop_gateway_orphans]
    F -->|Reuses #51325/#75936 Reaper| G[🕯️ Orphan Exorcised Before Fresh Gateway Spawns]
```

## Infographic : 
<img width="1024" height="1024" alt="infographic" src="https://github.com/user-attachments/assets/586e7685-3497-40cd-984d-8b94f8c19111" />



