### PR TITLE
feat(principle-distiller): config-gated Phase 3 conversation_loop integration

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -22,6 +22,7 @@ import os
 import random
 import re
 import ssl
+import sys
 import time
 from typing import Any, Dict, List, Optional
 
@@ -88,6 +89,22 @@ from tools.skill_provenance import set_current_write_origin
 from utils import base_url_host_matches, env_var_enabled
 
 logger = logging.getLogger(__name__)
+
+# ── Phase 3 principle distiller (optional, config-gated) ─────────────
+# Defensive import: `auto` lives in ~/.hermes (outside the vendored repo),
+# so put both ~/.hermes/auto (bare `from principle_repo import ...` inside
+# the distiller) and ~/.hermes (the `from auto import ...` package path) on
+# sys.path before importing. ANY failure (module missing, path error) must
+# degrade to None — the loop then skips the whole distiller code path.
+try:
+    _pd_auto_dir = os.path.join(os.path.expanduser("~"), ".hermes", "auto")
+    _pd_auto_home = os.path.dirname(_pd_auto_dir)
+    for _pd_path in (_pd_auto_dir, _pd_auto_home):
+        if _pd_path not in sys.path:
+            sys.path.insert(0, _pd_path)
+    from auto import principle_distiller as _principle_distiller
+except Exception:
+    _principle_distiller = None
 
 # Stable prefix of the local interrupt status string emitted when a turn is
 # cancelled while waiting on the provider. Surfaces (ACP, TUI) match on this
@@ -1225,6 +1242,40 @@ def _notify_context_engine_turn_complete(
         )
 
 
+# ── Phase 3 tool-error markers ─────────────────────────────────────
+# Distinctive prefixes of the tool-result error strings the loop and
+# agent.tool_executor append when a tool call failed (invalid name,
+# invalid JSON, execution exception, timeout). Scanned over THIS turn's
+# message slice to compute the distiller's `has_tool_error` signal
+# without instrumenting every append site in the vendored executor
+# (concurrent/sequential/segmented paths all funnel through these).
+_TOOL_ERROR_CONTENT_MARKERS = (
+    "Error executing tool '",
+    "Error: Invalid JSON arguments.",
+    "Skipped: another tool call in this turn used an invalid name",
+    "Skipped: other tool call in this response had invalid JSON.",
+    "Tool call rejected: the tool name was empty",
+    "Tool '",
+)
+
+
+def _turn_slice_has_tool_error(messages: List[Dict[str, Any]], start_idx: int) -> bool:
+    """True when any tool-result message appended after ``start_idx`` carries
+    a tool-error marker. ``start_idx`` is this turn's user-message index
+    (``current_turn_user_idx``), so prior turns' error results can't dirty
+    this turn's distillation."""
+    for msg in messages[start_idx + 1:]:
+        if not isinstance(msg, dict) or msg.get("role") != "tool":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, str):
+            continue
+        for marker in _TOOL_ERROR_CONTENT_MARKERS:
+            if content.startswith(marker):
+                return True
+    return False
+
+
 def run_conversation(
     agent,
     user_message: Any,
@@ -1285,6 +1336,29 @@ def run_conversation(
     agent._last_compaction_in_place = False
     agent._last_compression_attempt_recorded = False
     agent._last_compression_attempt_in_place = None
+
+    # ── Phase 3 principle distiller gate + reward (config-gated) ──
+    # H0b: read the switch ONCE per turn and stash it on the agent — a
+    # mid-conversation config/env edit must not flip behavior mid-turn.
+    # Degrades to False on any config failure; never blocks the loop.
+    try:
+        from hermes_cli.config import principle_distiller_enabled
+
+        agent._principle_distiller_enabled = principle_distiller_enabled()
+    except Exception:
+        agent._principle_distiller_enabled = False
+
+    # W3: start-of-turn reward slot. Consumes the PREVIOUS turn's stashed
+    # ids (apply_principle_rewards deletes them in its finally). Runs before
+    # build_turn_context so W1's fresh stash can't be mistaken for the
+    # previous turn's. Any exception is logged and the loop continues.
+    if agent._principle_distiller_enabled and isinstance(user_message, str):
+        try:
+            from auto.principle_reward_hook import apply_principle_rewards
+
+            apply_principle_rewards(agent, user_message)
+        except Exception:
+            logger.exception("Principle reward failed; continuing without it")
 
     # ── Per-turn setup (the prologue) ──
     # All once-per-turn setup — stdio guarding, retry-counter resets, user
@@ -5976,6 +6050,7 @@ def run_conversation(
                         if _tc_name not in agent.valid_tool_names:
                             # See _invalid_tool_name_error_content for the
                             # blank-name anti-priming rationale (#47967).
+                            agent._turn_had_tool_error = True
                             content = _invalid_tool_name_error_content(
                                 _tc_name, agent.valid_tool_names
                             )
@@ -6026,6 +6101,7 @@ def run_conversation(
                     # hiding the truncation from the length handler above.
                     # Detect truncation: args that don't end with } or ]
                     # (after stripping whitespace) are cut off mid-stream.
+                    agent._turn_had_tool_error = True
                     _truncated = any(
                         not (tc.function.arguments or "").rstrip().endswith(("}", "]"))
                         for tc in assistant_message.tool_calls
@@ -6217,6 +6293,7 @@ def run_conversation(
                 # provider-side tool_call/result pairing stays intact.
                 if _invalid_batch_calls:
                     for tc in _invalid_batch_calls:
+                        agent._turn_had_tool_error = True
                         messages.append({
                             "role": "tool",
                             "name": tc.function.name,
@@ -7223,6 +7300,47 @@ def run_conversation(
                 messages.append({"role": "assistant", "content": final_response})
                 break
     
+    # ── Phase 3 principle distillation (end of turn N, config-gated) ──
+    # Same-turn slot per PRINCIPLE_DISTILLER_INTEGRATION_PLAN.md (D1): the
+    # correction signal for turn N only arrives with turn N+1's message, so
+    # has_user_correction stays False here and the reward hook (W3, start of
+    # turn N+1) is the correction channel. Inputs: this turn's original user
+    # message, the hit dicts W1 stashed at turn start, and the tool-error
+    # tally (loop-flag OR slice-scan of this turn's tool results OR the
+    # loop's `failed` flag). Any exception or malformed return is logged at
+    # ERROR and never crashes the loop; a non-empty `text` is appended to the
+    # final response so the distilled principle is visible to the user.
+    if getattr(agent, "_principle_distiller_enabled", False) and _principle_distiller is not None:
+        try:
+            _pd_record = _principle_distiller.distill_from_turn(
+                user_message=original_user_message or user_message,
+                hit_principles=list(getattr(agent, "_prev_turn_principle_hits", None) or []),
+                has_tool_error=bool(failed)
+                or bool(getattr(agent, "_turn_had_tool_error", False))
+                or _turn_slice_has_tool_error(messages, current_turn_user_idx),
+                has_user_correction=False,
+                dry_run=False,
+            )
+            # Validate the returned record before touching final_response —
+            # malformed output (str/list/{}/missing/non-str text) must never
+            # raise or inject garbage.
+            if (
+                isinstance(_pd_record, dict)
+                and isinstance(_pd_record.get("text"), str)
+                and _pd_record["text"].strip()
+            ):
+                if isinstance(final_response, str):
+                    final_response = final_response + "\n\n" + _pd_record["text"].strip()
+                elif final_response is None:
+                    final_response = _pd_record["text"].strip()
+                logger.info(
+                    "Distilled principle (turn %s): %s",
+                    turn_id,
+                    _pd_record["text"].strip()[:80],
+                )
+        except Exception:
+            logger.exception("Principle distillation failed; continuing without it")
+
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn
     # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled
     # result dict is returned exactly as before.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1258,6 +1258,17 @@ _TOOL_ERROR_CONTENT_MARKERS = (
     "Tool '",
 )
 
+# Substring-only markers: these appear mid-content rather than at the start of
+# the tool-result text, so a prefix scan would miss them. The tool_search
+# scope-block path (tool_executor.py concurrent/sequential) emits
+# "'<name>' is not available in this session. Use tool_search to find tools
+# you can call." — starts with a quote, so no startswith marker matches.
+# Kept long and specific so untrusted tool payloads can't trivially forge the
+# signal (prompt-injection defense posture).
+_TOOL_ERROR_CONTENT_CONTAINS = (
+    "is not available in this session. Use tool_search",
+)
+
 
 def _turn_slice_has_tool_error(messages: List[Dict[str, Any]], start_idx: int) -> bool:
     """True when any tool-result message appended after ``start_idx`` carries
@@ -1272,6 +1283,9 @@ def _turn_slice_has_tool_error(messages: List[Dict[str, Any]], start_idx: int) -
             continue
         for marker in _TOOL_ERROR_CONTENT_MARKERS:
             if content.startswith(marker):
+                return True
+        for marker in _TOOL_ERROR_CONTENT_CONTAINS:
+            if marker in content:
                 return True
     return False
 
@@ -7313,7 +7327,9 @@ def run_conversation(
     if getattr(agent, "_principle_distiller_enabled", False) and _principle_distiller is not None:
         try:
             _pd_record = _principle_distiller.distill_from_turn(
-                user_message=original_user_message or user_message,
+                user_message=original_user_message
+                if (isinstance(original_user_message, str) and original_user_message)
+                else user_message,
                 hit_principles=list(getattr(agent, "_prev_turn_principle_hits", None) or []),
                 has_tool_error=bool(failed)
                 or bool(getattr(agent, "_turn_had_tool_error", False))

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1102,6 +1102,38 @@ def build_turn_context(
     except Exception as exc:
         logger.warning("pre_llm_call hook failed: %s", exc)
 
+    # ── Phase 3 principle injection (optional, config-gated) ──────────
+    # Retrieves principles for this turn's user message, stashes the full
+    # hit dicts for the end-of-turn distill block and the ids for the next
+    # turn's reward hook (W1 in PRINCIPLE_DISTILLER_INTEGRATION_PLAN.md),
+    # and appends the hit texts to the user-message plugin context so they
+    # ride the api_content sidecar (byte-stable persisted == wire). Any
+    # failure degrades to empty stashes and never blocks the turn. Note:
+    # MoA / codex_app_server turns skip the sidecar stamp, so the injected
+    # block is dropped from the wire there, but the stash is still set and
+    # distillation still works.
+    if getattr(agent, "_principle_distiller_enabled", False):
+        agent._turn_had_tool_error = False
+        agent._prev_turn_principle_hits = []
+        agent._prev_turn_principle_ids = []
+        try:
+            from auto.principle_repo import PrincipleRepository
+
+            _pd_repo = PrincipleRepository()
+            _pd_repo.load()
+            _pd_hits = _pd_repo.retrieve(original_user_message, top_k=3)
+            agent._prev_turn_principle_hits = list(_pd_hits)
+            agent._prev_turn_principle_ids = [p.get("id") for p in _pd_hits]
+            if _pd_hits:
+                _pd_block = "\n".join(f"- {p.get('text', '')}" for p in _pd_hits)
+                plugin_user_context = (
+                    f"{plugin_user_context}\n\n{_pd_block}"
+                    if plugin_user_context
+                    else _pd_block
+                )
+        except Exception as _pd_exc:
+            logger.warning("Principle injection failed (%s); continuing", _pd_exc)
+
     # Gateway must-deliver notes (auto-reset note, first-contact intro,
     # voice-channel change) ride the same user-message injection channel as
     # plugin context so the ephemeral system prompt can stay byte-stable.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -556,6 +556,21 @@ compression:
   # auxiliary section below (auxiliary.compression.provider / model).
 
 # =============================================================================
+# Principle self-distillation (Phase 3, OFF by default)
+# =============================================================================
+# Experience-driven principle evolution: when enabled, each CLEAN turn that
+# hit an injected principle distills a new principle record into
+# ~/.hermes/data/principles/principles.jsonl and appends the learned line to
+# the turn's final response. Disabled by default — the conversation loop
+# never imports or calls the distiller unless this is enabled.
+#
+# Env override: HERMES_PRINCIPLE_DISTILLER=1/true/yes/on enables; any other
+# set value disables; unset falls through to this key.
+#
+# principle_distiller:
+#   enabled: false
+
+# =============================================================================
 # Anthropic prompt caching TTL
 # =============================================================================
 # When prompt caching is active (Claude via OpenRouter or native Anthropic),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2049,6 +2049,22 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                 f"Move '{key}' under the appropriate section",
             ))
 
+    # ── principle_distiller section: must be a mapping with a bool `enabled` ──
+    pd_cfg = config.get("principle_distiller")
+    if pd_cfg is not None:
+        if not isinstance(pd_cfg, dict):
+            issues.append(ConfigIssue(
+                "warning",
+                "principle_distiller must be a mapping (e.g. 'principle_distiller:\\n  enabled: true')",
+                "Change to a YAML mapping with an 'enabled' boolean",
+            ))
+        elif not isinstance(pd_cfg.get("enabled", False), bool):
+            issues.append(ConfigIssue(
+                "warning",
+                "principle_distiller.enabled must be a boolean (true/false)",
+                f"Got {type(pd_cfg.get('enabled')).__name__}; use 'enabled: true' or 'enabled: false'",
+            ))
+
     return issues
 
 
@@ -3110,6 +3126,31 @@ def atomic_config_write(config_path: Path, data: Any, **kwargs: Any) -> None:
 
     require_readable_config_before_write(config_path)
     atomic_yaml_write(config_path, data, **kwargs)
+
+
+def principle_distiller_enabled(config: Optional[Dict[str, Any]] = None) -> bool:
+    """Whether the Phase 3 principle self-distillation is enabled.
+
+    Resolution order (see PRINCIPLE_INTEGRATION_DESIGN.md §5):
+      1. ``HERMES_PRINCIPLE_DISTILLER`` env var — 1/true/yes/on (case-insensitive)
+         enables; any other set value disables; unset falls through.
+      2. ``principle_distiller.enabled`` config key (default False).
+
+    A missing/malformed config section degrades to False and never raises,
+    so the caller can stash the result once and never re-read the config.
+    """
+    env_val = os.environ.get("HERMES_PRINCIPLE_DISTILLER")
+    if env_val is not None:
+        return env_val.strip().lower() in ("1", "true", "yes", "on")
+    if config is None:
+        config = load_config_readonly()
+    section = config.get("principle_distiller") if isinstance(config, dict) else None
+    if isinstance(section, dict):
+        enabled = section.get("enabled", False)
+        # Strict bool only: a truthy string ("yes") is a config error, not an
+        # enable signal (validate_config_structure warns about it).
+        return enabled if isinstance(enabled, bool) else False
+    return False
 
 
 def load_config() -> Dict[str, Any]:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -753,6 +753,17 @@ DEFAULT_CONFIG = {
                                       # Example: 1800 = compact after 30 min idle.
     },
 
+    # Phase 3 principle self-distillation (see auto/PRINCIPLE_INTEGRATION_DESIGN.md).
+    # When enabled, each clean conversation turn that hit an injected principle
+    # distills a new principle record into ~/.hermes/data/principles/principles.jsonl
+    # and appends the learned line to the turn's final response. Default is
+    # DISABLED — the loop never imports or calls the distiller unless enabled.
+    # Env override: HERMES_PRINCIPLE_DISTILLER=1/true/yes/on enables; any other
+    # set value disables; unset falls through to this key.
+    "principle_distiller": {
+        "enabled": False,
+    },
+
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
     # cache_ttl: "5m" or "1h" (Anthropic-supported tiers). Other non-falsy
     # values are silently ignored. Falsy values (false, null, "off",

--- a/tests/hermes_cli/test_principle_distiller_config.py
+++ b/tests/hermes_cli/test_principle_distiller_config.py
@@ -157,6 +157,21 @@ class TestConfigSetRoundTrip:
         assert cfg_path.exists()
         assert "principle_distiller" in cfg_path.read_text(encoding="utf-8")
 
+    @pytest.mark.parametrize("off_value", ["false", "off", "no"])
+    def test_set_off_variants_coerce_to_bool_false(self, tmp_path, monkeypatch, capsys, off_value):
+        """Every user-facing 'off' spelling of the switch writes a real YAML
+        boolean False (never a truthy string) and keeps the distiller off."""
+        monkeypatch.delenv("HERMES_PRINCIPLE_DISTILLER", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        set_config_value("principle_distiller.enabled", off_value)
+        capsys.readouterr()
+        assert principle_distiller_enabled() is False
+        cfg_path = tmp_path / "config.yaml"
+        assert cfg_path.exists()
+        # Coerced to a genuine bool, not stored as the raw string (a string
+        # would trip the strict-bool validation warning on the next load).
+        assert "enabled: false" in cfg_path.read_text(encoding="utf-8")
+
 
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch):

--- a/tests/hermes_cli/test_principle_distiller_config.py
+++ b/tests/hermes_cli/test_principle_distiller_config.py
@@ -1,0 +1,167 @@
+"""Unit tests for the ``principle_distiller.enabled`` config switch.
+
+Covers the DEFAULT_CONFIG entry, the ``principle_distiller_enabled()``
+resolution order (env override -> config key -> default False), the
+structure-validation warnings, and ``hermes config set`` key recognition
+plus a real set/get round-trip on an isolated HERMES_HOME.
+
+Contract (PRINCIPLE_INTEGRATION_DESIGN.md §5):
+- ``HERMES_PRINCIPLE_DISTILLER`` = 1/true/yes/on (case-insensitive) enables;
+  any other set value disables; unset falls through to the config key.
+- ``principle_distiller.enabled`` defaults to False (feature off by default).
+- Malformed sections degrade to False and never raise.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from hermes_cli.config import (
+    _validate_config_key,
+    principle_distiller_enabled,
+    set_config_value,
+    validate_config_structure,
+)
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_CONFIG
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultConfig:
+    def test_section_present_and_disabled_by_default(self):
+        section = DEFAULT_CONFIG.get("principle_distiller")
+        assert isinstance(section, dict)
+        assert section.get("enabled") is False
+
+    def test_key_is_known_to_config_set(self):
+        # `hermes config set principle_distiller.enabled true` must not emit
+        # the unknown-key warning (the parent task's CLI contract).
+        is_known, suggestion = _validate_config_key("principle_distiller.enabled")
+        assert is_known is True
+        assert suggestion is None
+
+
+# ---------------------------------------------------------------------------
+# principle_distiller_enabled() resolution order
+# ---------------------------------------------------------------------------
+
+
+class TestPrincipleDistillerEnabled:
+    def test_default_false_when_absent(self, monkeypatch):
+        monkeypatch.delenv("HERMES_PRINCIPLE_DISTILLER", raising=False)
+        assert principle_distiller_enabled({"model": "x"}) is False
+
+    def test_config_true(self, monkeypatch):
+        monkeypatch.delenv("HERMES_PRINCIPLE_DISTILLER", raising=False)
+        assert (
+            principle_distiller_enabled(
+                {"principle_distiller": {"enabled": True}}
+            )
+            is True
+        )
+
+    def test_config_false_explicit(self, monkeypatch):
+        monkeypatch.delenv("HERMES_PRINCIPLE_DISTILLER", raising=False)
+        assert (
+            principle_distiller_enabled(
+                {"principle_distiller": {"enabled": False}}
+            )
+            is False
+        )
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "True", "yes", "on", " ON "])
+    def test_env_truthy_enables_even_when_config_false(self, monkeypatch, value):
+        monkeypatch.setenv("HERMES_PRINCIPLE_DISTILLER", value)
+        assert principle_distiller_enabled({"principle_distiller": {"enabled": False}}) is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "off", "no", "banana", ""])
+    def test_env_falsy_disables_even_when_config_true(self, monkeypatch, value):
+        monkeypatch.setenv("HERMES_PRINCIPLE_DISTILLER", value)
+        assert principle_distiller_enabled({"principle_distiller": {"enabled": True}}) is False
+
+    def test_env_unset_falls_through_to_config(self, monkeypatch):
+        monkeypatch.delenv("HERMES_PRINCIPLE_DISTILLER", raising=False)
+        assert (
+            principle_distiller_enabled(
+                {"principle_distiller": {"enabled": True}}
+            )
+            is True
+        )
+
+    def test_malformed_section_degrades_to_false(self, monkeypatch):
+        monkeypatch.delenv("HERMES_PRINCIPLE_DISTILLER", raising=False)
+        assert principle_distiller_enabled({"principle_distiller": "nope"}) is False
+        assert principle_distiller_enabled({"principle_distiller": 42}) is False
+        assert principle_distiller_enabled({"principle_distiller": {"enabled": "yes"}}) is False
+
+    def test_config_read_from_disk_when_omitted(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_PRINCIPLE_DISTILLER", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert principle_distiller_enabled() is False  # no config.yaml -> default
+
+
+# ---------------------------------------------------------------------------
+# validate_config_structure warnings
+# ---------------------------------------------------------------------------
+
+
+class TestValidationWarnings:
+    def test_non_mapping_section_warns(self):
+        issues = validate_config_structure({"principle_distiller": "enabled: true"})
+        texts = " | ".join(i.message for i in issues)
+        assert "principle_distiller must be a mapping" in texts
+
+    def test_non_bool_enabled_warns(self):
+        issues = validate_config_structure({"principle_distiller": {"enabled": "true"}})
+        texts = " | ".join(i.message for i in issues)
+        assert "principle_distiller.enabled must be a boolean" in texts
+
+    def test_healthy_section_no_issue(self):
+        issues = validate_config_structure({"principle_distiller": {"enabled": False}})
+        assert not [i for i in issues if "principle_distiller" in i.message]
+
+
+# ---------------------------------------------------------------------------
+# hermes config set round-trip (isolated HERMES_HOME)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSetRoundTrip:
+    def test_set_and_read_back(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.delenv("HERMES_PRINCIPLE_DISTILLER", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        set_config_value("principle_distiller.enabled", "true")
+        out = capsys.readouterr().out
+        assert "principle_distiller.enabled" in out
+        # recognized key -> no unknown-key warning (assert on the CLI's actual
+        # warning text, not the bare word "unknown": the printed config path
+        # can legitimately contain it, e.g. pytest-of-unknown on Windows)
+        assert "not a recognized config key" not in out
+        assert principle_distiller_enabled() is True
+
+        set_config_value("principle_distiller.enabled", "false")
+        assert principle_distiller_enabled() is False
+
+    def test_missing_config_yaml_still_writes(self, tmp_path, monkeypatch):
+        """set_config_value must work when no config.yaml exists yet."""
+        monkeypatch.delenv("HERMES_PRINCIPLE_DISTILLER", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        set_config_value("principle_distiller.enabled", "true")
+        assert principle_distiller_enabled() is True
+        cfg_path = tmp_path / "config.yaml"
+        assert cfg_path.exists()
+        assert "principle_distiller" in cfg_path.read_text(encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Never leak HERMES_PRINCIPLE_DISTILLER across tests in this module."""
+    monkeypatch.delenv("HERMES_PRINCIPLE_DISTILLER", raising=False)
+    yield
+    monkeypatch.delenv("HERMES_PRINCIPLE_DISTILLER", raising=False)
+    monkeypatch.delenv("HERMES_HOME", raising=False)

--- a/tests/integration/test_conversation_loop_distiller_config_switch.py
+++ b/tests/integration/test_conversation_loop_distiller_config_switch.py
@@ -1,0 +1,387 @@
+"""End-to-end tests for the principle-distiller config SWITCH driven by the
+``principle_distiller.enabled`` CONFIG KEY (config.yaml), not the env var.
+
+The sibling files cover the env-var-driven paths (``HERMES_PRINCIPLE_DISTILLER``
+set/unset). This file proves the same integration point — the read-once stash
+``agent._principle_distiller_enabled`` in conversation_loop, the W1 injection
+gate in turn_context, the end-of-turn distill block — honors the config-layer
+switch exactly as documented (PRINCIPLE_INTEGRATION_DESIGN.md §5):
+
+- unset (no ``principle_distiller`` section, no config.yaml) preserves the
+  pre-feature behavior: distiller path never runs, response byte-identical;
+- ``enabled: false`` (and the YAML 1.1 ``off`` spelling) keeps it disabled;
+- ``enabled: true`` makes a real parsed boolean reach the integration point:
+  W1 stash populated, distill block executes, record persisted, principles
+  injected into the wire message;
+- invalid values (``enabled: "yes"`` string, non-mapping section) degrade to
+  False exactly like the config layer's validation warns: never raise, never
+  enable, loop completes normally.
+
+Store paths are patched to tmp_path so the tests never touch the real
+~/.hermes/data/principles.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+# Repo root = three levels up from tests/integration/<file>.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+# The principle system lives in ~/.hermes/auto (outside the vendored repo).
+_AUTO_DIR = os.path.join(os.path.expanduser("~"), ".hermes", "auto")
+_AUTO_HOME = os.path.dirname(_AUTO_DIR)
+for _p in (_AUTO_DIR, _AUTO_HOME):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+class _MockHandler(BaseHTTPRequestHandler):
+    # Set by the fixture before each request cycle.
+    captured_requests: list = []
+    response_queue: list = []
+
+    def do_POST(self):  # noqa: N802 (http.server API)
+        length = int(self.headers.get("Content-Length", 0))
+        req = json.loads(self.rfile.read(length).decode())
+        type(self).captured_requests.append(req)
+        is_stream = req.get("stream") is True
+        if type(self).response_queue:
+            resp = type(self).response_queue.pop(0)
+        else:
+            resp = _text_resp("DONE")
+        msg = resp["choices"][0]["message"]
+        if is_stream:
+            content = msg.get("content") or ""
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            chunks = [{"id": "m", "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}]}]
+            if content:
+                chunks.append({"id": "m", "choices": [{"index": 0, "delta": {"content": content}, "finish_reason": None}]})
+            chunks.append({"id": "m", "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]})
+            for c in chunks:
+                self.wfile.write(f"data: {json.dumps(c)}\n\n".encode())
+            self.wfile.write(b"data: [DONE]\n\n")
+            self.wfile.flush()
+        else:
+            body = json.dumps(resp).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    def log_message(self, *a, **kw):  # silence the default stderr logging
+        pass
+
+
+def _text_resp(text: str) -> dict:
+    return {
+        "id": "m",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": text}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10},
+    }
+
+
+SEED_TEXT = "重构前先明确范围，再逐步执行并验证中间结果"
+TURN_MSG = "帮我重构这个 Python 模块并补上测试"
+MODEL_TEXT = "这是模型的原始回答。"
+
+CONFIG_TRUE = "principle_distiller:\n  enabled: true\n"
+CONFIG_FALSE = "principle_distiller:\n  enabled: false\n"
+CONFIG_OFF = "principle_distiller:\n  enabled: off\n"
+# Invalid values — the config layer's validation warns about these and the
+# reader must degrade to False, never raise and never enable (A6).
+CONFIG_STRING_ENABLED = 'principle_distiller:\n  enabled: "yes"\n'
+CONFIG_NON_MAPPING = "principle_distiller: garbage\n"
+
+
+def _make_env(config_text):
+    """Context-manager-lite factory used by the fixture.
+
+    Sets up the mock provider + an isolated HERMES_HOME whose config.yaml
+    carries exactly *config_text* (None -> no config.yaml at all). The
+    HERMES_PRINCIPLE_DISTILLER env var is NEVER set, so the config key is the
+    only thing driving the switch.
+    """
+
+    class _Env:
+        def __init__(self):
+            self.srv = None
+            self.thread = None
+            self.test_home = None
+            self.prev_home = os.environ.get("HERMES_HOME")
+            self.prev_env = os.environ.get("HERMES_PRINCIPLE_DISTILLER")
+
+        def __enter__(self):
+            _MockHandler.captured_requests = []
+            _MockHandler.response_queue = []
+            self.srv = HTTPServer(("127.0.0.1", 0), _MockHandler)
+            self.thread = threading.Thread(target=self.srv.serve_forever, daemon=True)
+            self.thread.start()
+            self.test_home = tempfile.mkdtemp(prefix="hermes_pd_cfg_")
+            os.makedirs(os.path.join(self.test_home, ".hermes"))
+            os.environ["HERMES_HOME"] = os.path.join(self.test_home, ".hermes")
+            # The env override must not leak in from the outer environment:
+            # this file is about the config key, so the switch must be decided
+            # by config.yaml alone.
+            os.environ.pop("HERMES_PRINCIPLE_DISTILLER", None)
+            if config_text:
+                cfg_path = os.path.join(self.test_home, ".hermes", "config.yaml")
+                with open(cfg_path, "w", encoding="utf-8") as f:
+                    f.write(config_text)
+            return self
+
+        def __exit__(self, *exc):
+            self.srv.shutdown()
+            shutil.rmtree(self.test_home, ignore_errors=True)
+            if self.prev_home is None:
+                os.environ.pop("HERMES_HOME", None)
+            else:
+                os.environ["HERMES_HOME"] = self.prev_home
+            if self.prev_env is None:
+                os.environ.pop("HERMES_PRINCIPLE_DISTILLER", None)
+            else:
+                os.environ["HERMES_PRINCIPLE_DISTILLER"] = self.prev_env
+
+    return _Env()
+
+
+def _build_agent(env, tmp_path, monkeypatch):
+    """Patch the principle-store paths, import fresh, build the stub agent."""
+    store_dir = tmp_path / "principles"
+    store_path = store_dir / "principles.jsonl"
+    store_dir.mkdir(parents=True, exist_ok=True)
+    import auto.principle_distiller as _pd
+    import auto.principle_repo as _pr
+
+    # The distiller/reward-hook import the repo with a BARE name
+    # (`from principle_repo import ...`), which would create a second module
+    # instance anchored at the REAL ~/.hermes store. Alias the patched
+    # modules under the bare names so every internal import hits them.
+    sys.modules["principle_distiller"] = _pd
+    sys.modules["principle_repo"] = _pr
+
+    monkeypatch.setattr(_pd, "DATA_DIR", store_dir)
+    monkeypatch.setattr(_pd, "PRINCIPLES_PATH", store_path)
+    monkeypatch.setattr(_pr, "DATA_DIR", store_dir)
+    monkeypatch.setattr(_pr, "DEFAULT_PATH", store_path)
+
+    for mod in list(sys.modules):
+        if mod == "run_agent" or mod.startswith("agent.") or mod.startswith("tools.") or mod.startswith("hermes_"):
+            del sys.modules[mod]
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key", base_url=f"http://127.0.0.1:{env.srv.server_address[1]}/v1",
+        provider="openai-compat", model="test-model",
+        max_iterations=10, enabled_toolsets=[],
+        quiet_mode=True, skip_context_files=True, skip_memory=True,
+        save_trajectories=False, platform="cli",
+    )
+    agent.valid_tool_names = {"terminal", "read_file", "write_file", "execute_code", "session_search"}
+    return agent, store_path
+
+
+@pytest.fixture()
+def agent_env(tmp_path, monkeypatch):
+    """Factory: ``agent_env(config_text)`` -> context manager yielding
+    ``(agent, _MockHandler, store_path)`` with config.yaml set to
+    *config_text* (None -> no config.yaml)."""
+
+    def _factory(config_text):
+        env = _make_env(config_text)
+
+        class _Ctx:
+            def __enter__(self):
+                env.__enter__()
+                try:
+                    agent, store_path = _build_agent(env, tmp_path, monkeypatch)
+                except BaseException:
+                    env.__exit__(None, None, None)
+                    raise
+                return agent, _MockHandler, store_path
+
+            def __exit__(self, *exc):
+                return env.__exit__(*exc)
+
+        return _Ctx()
+
+    return _factory
+
+
+def _seed(store_path) -> dict:
+    from auto.principle_repo import PrincipleRepository
+
+    repo = PrincipleRepository()
+    repo.load()
+    return repo.add(text=SEED_TEXT, tags=[], source="manual", score=0.5)
+
+
+def _store_lines(store_path) -> list[dict]:
+    if not os.path.exists(store_path):
+        return []
+    with open(store_path, encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def _wire_user_contents(handler) -> list[str]:
+    """User-message contents captured by the mock provider (wire bytes)."""
+    out = []
+    for req in handler.captured_requests:
+        for m in req.get("messages", []):
+            if m.get("role") == "user":
+                c = m.get("content", "")
+                out.append(c if isinstance(c, str) else json.dumps(c))
+    return out
+
+
+def _assert_distiller_never_ran(agent, handler, store_path):
+    """The A5 contract: switch off -> the distiller path is never executed."""
+    assert agent._principle_distiller_enabled is False
+    # No stashes; store untouched (only the seed); no principle ever reached
+    # the wire.
+    with open(store_path, encoding="utf-8") as f:
+        assert len([l for l in f if l.strip()]) == 1
+    assert not any(
+        SEED_TEXT in str(m.get("content", ""))
+        for req in handler.captured_requests
+        for m in req.get("messages", [])
+        if m.get("role") == "user"
+    )
+    assert not hasattr(agent, "_prev_turn_principle_hits")
+    assert not hasattr(agent, "_prev_turn_principle_ids")
+    assert not hasattr(agent, "_turn_had_tool_error")
+
+
+class TestConfigUnset:
+    def test_unset_preserves_prior_behavior(self, agent_env):
+        """No config.yaml at all -> the pre-feature behavior: distiller off."""
+        with agent_env(None) as (agent, handler, store_path):
+            _seed(store_path)
+            handler.response_queue.append(_text_resp(MODEL_TEXT))
+
+            result = agent.run_conversation(TURN_MSG, conversation_history=[], task_id="u1")
+
+            assert result["final_response"] == MODEL_TEXT
+            _assert_distiller_never_ran(agent, handler, store_path)
+
+
+class TestConfigDisabled:
+    @pytest.mark.parametrize(
+        "config_text",
+        [CONFIG_FALSE, CONFIG_OFF],
+        ids=["enabled=false", "enabled=off"],
+    )
+    def test_false_and_off_keep_distiller_disabled(self, agent_env, config_text):
+        with agent_env(config_text) as (agent, handler, store_path):
+            _seed(store_path)
+            handler.response_queue.append(_text_resp(MODEL_TEXT))
+
+            result = agent.run_conversation(TURN_MSG, conversation_history=[], task_id="f1")
+
+            assert result["final_response"] == MODEL_TEXT
+            _assert_distiller_never_ran(agent, handler, store_path)
+
+
+class TestConfigEnabled:
+    def test_true_makes_parsed_boolean_reach_integration_point(self, agent_env):
+        """enabled: true -> the loop stashes a real bool and the full
+        distiller path runs: W1 injection, distill block, persistence."""
+        with agent_env(CONFIG_TRUE) as (agent, handler, store_path):
+            seed = _seed(store_path)
+            handler.response_queue.append(_text_resp(MODEL_TEXT))
+
+            result = agent.run_conversation(TURN_MSG, conversation_history=[], task_id="t1")
+
+            # The gate stash is a real parsed boolean (read once at turn start).
+            assert agent._principle_distiller_enabled is True
+
+            # Distilled text landed in the final response (A2).
+            assert isinstance(result["final_response"], str)
+            assert MODEL_TEXT in result["final_response"]
+            distilled_texts = [
+                line["text"] for line in _store_lines(store_path)
+                if line.get("source") == "self-distilled"
+            ]
+            assert len(distilled_texts) == 1
+            assert result["final_response"].endswith(distilled_texts[0])
+
+            # Persisted via repo.add -> raw record (score_history/archived are
+            # backfilled on the NEXT load, not at write time).
+            rec = [line for line in _store_lines(store_path) if line.get("source") == "self-distilled"][0]
+            assert rec.get("score") == 0.3
+            assert not rec.get("score_history")
+            assert not rec.get("archived", False)
+            assert "princ_" in rec["id"]
+
+            # W1 stashed the full hit dicts for the distill block (same-turn).
+            assert [p["id"] for p in agent._prev_turn_principle_hits] == [seed["id"]]
+            assert agent._prev_turn_principle_hits[0]["text"] == SEED_TEXT
+            assert agent._prev_turn_principle_ids == [seed["id"]]
+
+            # Injection reached the wire (A9: sidecar carries the principle block).
+            assert any(SEED_TEXT in c for c in _wire_user_contents(handler))
+
+    def test_recording_fake_sees_exact_turn_state(self, agent_env, monkeypatch):
+        """The config-key switch feeds the same call contract as the env-var
+        path: one distill_from_turn call at end of turn with this turn's state."""
+        with agent_env(CONFIG_TRUE) as (agent, handler, store_path):
+            seed = _seed(store_path)
+            handler.response_queue.append(_text_resp("完成。"))
+
+            import auto.principle_distiller as _pd
+
+            calls: list[dict] = []
+
+            def _fake(user_message, hit_principles, has_tool_error=False, has_user_correction=False, dry_run=False):
+                calls.append({
+                    "user_message": user_message,
+                    "hit_principles": hit_principles,
+                    "has_tool_error": has_tool_error,
+                    "has_user_correction": has_user_correction,
+                    "dry_run": dry_run,
+                })
+                return None
+
+            monkeypatch.setattr(_pd, "distill_from_turn", _fake)
+            result = agent.run_conversation(TURN_MSG, conversation_history=[], task_id="t2")
+
+            assert len(calls) == 1
+            call = calls[0]
+            assert call["user_message"] == TURN_MSG
+            assert [p["id"] for p in call["hit_principles"]] == [seed["id"]]
+            assert call["has_tool_error"] is False
+            assert call["has_user_correction"] is False
+            assert call["dry_run"] is False
+            # None return -> nothing appended, response unchanged.
+            assert result["final_response"] == "完成。"
+
+
+class TestConfigInvalid:
+    @pytest.mark.parametrize(
+        "config_text",
+        [CONFIG_STRING_ENABLED, CONFIG_NON_MAPPING],
+        ids=["enabled-string-yes", "non-mapping-section"],
+    )
+    def test_invalid_values_degrade_consistent_with_config_validation(self, agent_env, config_text):
+        """validate_config_structure warns about these; the reader must turn
+        them into a clean False — no crash, no enable, loop completes."""
+        with agent_env(config_text) as (agent, handler, store_path):
+            _seed(store_path)
+            handler.response_queue.append(_text_resp(MODEL_TEXT))
+
+            result = agent.run_conversation(TURN_MSG, conversation_history=[], task_id="i1")
+
+            assert result["final_response"] == MODEL_TEXT
+            _assert_distiller_never_ran(agent, handler, store_path)

--- a/tests/integration/test_conversation_loop_distiller_enabled.py
+++ b/tests/integration/test_conversation_loop_distiller_enabled.py
@@ -1,0 +1,342 @@
+"""End-to-end tests for the Phase 3 principle distiller wiring — ENABLED path.
+
+Exercises ``run_conversation`` (via ``AIAgent.run_conversation``) against an
+in-process mock provider with ``HERMES_PRINCIPLE_DISTILLER=1``:
+
+- a clean turn with a seeded principle store retrieves principles (W1),
+  injects them into the wire message (api_content sidecar), stashes the hit
+  dicts, and calls ``distill_from_turn`` at the end of the turn with the
+  correct state; a non-empty returned ``text`` lands in ``final_response``
+  and the record is persisted via ``PrincipleRepository.add`` (A2);
+- a recording fake pins the exact call arguments (turn user message, stashed
+  hit dicts, clean flags) (A2);
+- a tool-error turn passes ``has_tool_error=True`` (A3);
+- a two-turn session runs the reward hook (W3) at turn 2 start with turn 1's
+  ids and applies the strong-correction delta (A4).
+
+Store paths are patched to tmp_path so the tests never touch the real
+~/.hermes/data/principles.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+# Repo root = three levels up from tests/integration/<file>.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+# The principle system lives in ~/.hermes/auto (outside the vendored repo).
+_AUTO_DIR = os.path.join(os.path.expanduser("~"), ".hermes", "auto")
+_AUTO_HOME = os.path.dirname(_AUTO_DIR)
+for _p in (_AUTO_DIR, _AUTO_HOME):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+class _MockHandler(BaseHTTPRequestHandler):
+    # Set by the fixture before each request cycle.
+    captured_requests: list = []
+    response_queue: list = []
+
+    def do_POST(self):  # noqa: N802 (http.server API)
+        length = int(self.headers.get("Content-Length", 0))
+        req = json.loads(self.rfile.read(length).decode())
+        type(self).captured_requests.append(req)
+        is_stream = req.get("stream") is True
+        if type(self).response_queue:
+            resp = type(self).response_queue.pop(0)
+        else:
+            resp = _text_resp("DONE")
+        msg = resp["choices"][0]["message"]
+        if is_stream:
+            content = msg.get("content") or ""
+            tcs = msg.get("tool_calls")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            chunks = [{"id": "m", "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}]}]
+            if content:
+                chunks.append({"id": "m", "choices": [{"index": 0, "delta": {"content": content}, "finish_reason": None}]})
+            if tcs:
+                for ti, tc in enumerate(tcs):
+                    chunks.append({"id": "m", "choices": [{"index": 0, "delta": {"tool_calls": [{
+                        "index": ti, "id": tc["id"], "type": "function",
+                        "function": {"name": tc["function"]["name"], "arguments": tc["function"]["arguments"]}}]}, "finish_reason": None}]})
+            chunks.append({"id": "m", "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls" if tcs else "stop"}]})
+            for c in chunks:
+                self.wfile.write(f"data: {json.dumps(c)}\n\n".encode())
+            self.wfile.write(b"data: [DONE]\n\n")
+            self.wfile.flush()
+        else:
+            body = json.dumps(resp).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    def log_message(self, *a, **kw):  # silence the default stderr logging
+        pass
+
+
+def _tc_resp(name: str, args: str = "{}") -> dict:
+    return {
+        "id": "m",
+        "choices": [{"index": 0, "message": {
+            "role": "assistant", "content": "",
+            "tool_calls": [{"id": "call_1", "type": "function",
+                            "function": {"name": name, "arguments": args}}]},
+            "finish_reason": "tool_calls"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10},
+    }
+
+
+def _text_resp(text: str) -> dict:
+    return {
+        "id": "m",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": text}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10},
+    }
+
+
+SEED_TEXT = "重构前先明确范围，再逐步执行并验证中间结果"
+TURN1_MSG = "帮我重构这个 Python 模块并补上测试"
+
+
+@pytest.fixture()
+def agent_env(tmp_path, monkeypatch):
+    """Mock provider + isolated HERMES_HOME + isolated principle store.
+
+    Yields (agent, handler, store_path). The distiller is ENABLED via the
+    HERMES_PRINCIPLE_DISTILLER env var, so the loop's read-once stash
+    (agent._principle_distiller_enabled) is True for every turn.
+    """
+    _MockHandler.captured_requests = []
+    _MockHandler.response_queue = []
+    srv = HTTPServer(("127.0.0.1", 0), _MockHandler)
+    port = srv.server_address[1]
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+
+    test_home = tempfile.mkdtemp(prefix="hermes_pd_e2e_")
+    os.makedirs(os.path.join(test_home, ".hermes"))
+    prev_home = os.environ.get("HERMES_HOME")
+    os.environ["HERMES_HOME"] = os.path.join(test_home, ".hermes")
+    prev_env = os.environ.get("HERMES_PRINCIPLE_DISTILLER")
+    os.environ["HERMES_PRINCIPLE_DISTILLER"] = "1"
+
+    # Isolate the principle store: both the distiller's dedup corpus and the
+    # repository's DEFAULT_PATH must point at tmp_path (the real modules are
+    # anchored to Path.home()/.hermes, not HERMES_HOME).
+    store_dir = tmp_path / "principles"
+    store_path = store_dir / "principles.jsonl"
+    store_dir.mkdir(parents=True, exist_ok=True)
+    import auto.principle_distiller as _pd
+    import auto.principle_repo as _pr
+
+    # The distiller/reward-hook import the repo with a BARE name
+    # (`from principle_repo import ...`), which would create a second module
+    # instance anchored at the REAL ~/.hermes store. Alias the patched
+    # modules under the bare names so every internal import hits them.
+    sys.modules["principle_distiller"] = _pd
+    sys.modules["principle_repo"] = _pr
+
+    monkeypatch.setattr(_pd, "DATA_DIR", store_dir)
+    monkeypatch.setattr(_pd, "PRINCIPLES_PATH", store_path)
+    monkeypatch.setattr(_pr, "DATA_DIR", store_dir)
+    monkeypatch.setattr(_pr, "DEFAULT_PATH", store_path)
+
+    # Import fresh so the patched conversation_loop is exercised even when the
+    # module was imported earlier in the same worker.
+    for mod in list(sys.modules):
+        if mod == "run_agent" or mod.startswith("agent.") or mod.startswith("tools.") or mod.startswith("hermes_"):
+            del sys.modules[mod]
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key", base_url=f"http://127.0.0.1:{port}/v1",
+        provider="openai-compat", model="test-model",
+        max_iterations=10, enabled_toolsets=[],
+        quiet_mode=True, skip_context_files=True, skip_memory=True,
+        save_trajectories=False, platform="cli",
+    )
+    agent.valid_tool_names = {"terminal", "read_file", "write_file", "execute_code", "session_search"}
+
+    try:
+        yield agent, _MockHandler, store_path
+    finally:
+        srv.shutdown()
+        shutil.rmtree(test_home, ignore_errors=True)
+        if prev_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = prev_home
+        if prev_env is None:
+            os.environ.pop("HERMES_PRINCIPLE_DISTILLER", None)
+        else:
+            os.environ["HERMES_PRINCIPLE_DISTILLER"] = prev_env
+
+
+def _seed(store_path: str, text: str = SEED_TEXT, **kw) -> dict:
+    """Seed one principle through the (path-patched) repository."""
+    from auto.principle_repo import PrincipleRepository
+
+    repo = PrincipleRepository()
+    repo.load()
+    return repo.add(text=text, tags=kw.get("tags", []), source=kw.get("source", "manual"),
+                    score=kw.get("score", 0.5))
+
+
+def _store_lines(store_path) -> list[dict]:
+    if not os.path.exists(store_path):
+        return []
+    with open(store_path, encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def _wire_user_contents(handler) -> list[str]:
+    """User-message contents captured by the mock provider (wire bytes)."""
+    out = []
+    for req in handler.captured_requests:
+        for m in req.get("messages", []):
+            if m.get("role") == "user":
+                c = m.get("content", "")
+                out.append(c if isinstance(c, str) else json.dumps(c))
+    return out
+
+
+class TestEnabledDistillation:
+    def test_clean_turn_distills_appends_and_persists(self, agent_env):
+        agent, handler, store_path = agent_env
+        seed = _seed(store_path)
+        handler.response_queue.append(_text_resp("好的，我来重构。"))
+
+        result = agent.run_conversation(TURN1_MSG, conversation_history=[], task_id="t1")
+
+        # Distilled text landed in the final response (A2).
+        assert isinstance(result["final_response"], str)
+        assert "好的，我来重构。" in result["final_response"]
+        distilled_texts = [
+            line["text"] for line in _store_lines(store_path)
+            if line.get("source") == "self-distilled"
+        ]
+        assert len(distilled_texts) == 1
+        assert result["final_response"].endswith(distilled_texts[0])
+
+        # Persisted via repo.add -> raw record (score_history/archived are
+        # backfilled on the NEXT load, not at write time).
+        rec = [line for line in _store_lines(store_path) if line.get("source") == "self-distilled"][0]
+        assert rec.get("score") == 0.3
+        assert not rec.get("score_history")
+        assert not rec.get("archived", False)
+        assert "princ_" in rec["id"]
+
+        # W1 stashes the full hit dicts for the distill block (same-turn).
+        assert [p["id"] for p in agent._prev_turn_principle_hits] == [seed["id"]]
+        assert agent._prev_turn_principle_hits[0]["text"] == SEED_TEXT
+        assert agent._prev_turn_principle_ids == [seed["id"]]
+        # Gate stash read once at turn start.
+        assert agent._principle_distiller_enabled is True
+
+        # Injection reached the wire (A9: sidecar carries the principle block).
+        assert any(SEED_TEXT in c for c in _wire_user_contents(handler))
+
+    def test_recording_fake_receives_exact_turn_state(self, agent_env, monkeypatch):
+        agent, handler, store_path = agent_env
+        seed = _seed(store_path)
+        handler.response_queue.append(_text_resp("完成。"))
+
+        import auto.principle_distiller as _pd
+
+        calls: list[dict] = []
+
+        def _fake(user_message, hit_principles, has_tool_error=False, has_user_correction=False, dry_run=False):
+            calls.append({
+                "user_message": user_message,
+                "hit_principles": hit_principles,
+                "has_tool_error": has_tool_error,
+                "has_user_correction": has_user_correction,
+                "dry_run": dry_run,
+            })
+            return None
+
+        monkeypatch.setattr(_pd, "distill_from_turn", _fake)
+        result = agent.run_conversation(TURN1_MSG, conversation_history=[], task_id="t2")
+
+        # Called exactly once, at the end of the turn, with this turn's state.
+        assert len(calls) == 1
+        call = calls[0]
+        assert call["user_message"] == TURN1_MSG
+        assert [p["id"] for p in call["hit_principles"]] == [seed["id"]]
+        assert call["has_tool_error"] is False
+        assert call["has_user_correction"] is False
+        assert call["dry_run"] is False
+        # None return -> nothing appended, response unchanged.
+        assert result["final_response"] == "完成。"
+
+    def test_tool_error_turn_passes_has_tool_error(self, agent_env, monkeypatch):
+        agent, handler, store_path = agent_env
+        _seed(store_path)
+        # Invalid tool name first, then a plain-text recovery.
+        handler.response_queue.append(_tc_resp("nonsense_tool", "{}"))
+        handler.response_queue.append(_text_resp("已修正。"))
+
+        import auto.principle_distiller as _pd
+
+        calls: list[dict] = []
+
+        def _fake(user_message, hit_principles, has_tool_error=False, has_user_correction=False, dry_run=False):
+            calls.append(has_tool_error)
+            return None
+
+        monkeypatch.setattr(_pd, "distill_from_turn", _fake)
+        agent.run_conversation(TURN1_MSG, conversation_history=[], task_id="t3")
+
+        # A3: the tool-error turn is flagged dirty for the distiller.
+        assert calls == [True]
+        # The error tool-result is visible in the wire transcript too.
+        assert any(
+            "does not exist" in str(m.get("content", ""))
+            for req in handler.captured_requests
+            for m in req.get("messages", [])
+            if m.get("role") == "tool"
+        )
+
+    def test_two_turn_reward_applies_strong_correction(self, agent_env):
+        agent, handler, store_path = agent_env
+        seed = _seed(store_path)
+        handler.response_queue.append(_text_resp("第一轮完成。"))
+
+        r1 = agent.run_conversation(TURN1_MSG, conversation_history=[], task_id="t4")
+        assert "self-distilled" in json.dumps(_store_lines(store_path))
+
+        # Turn 1's ids are stashed for the next turn's reward slot.
+        assert agent._prev_turn_principle_ids == [seed["id"]]
+
+        # Turn 2: strong correction -> -0.2 on turn 1's principle.
+        handler.response_queue.append(_text_resp("你说得对。"))
+        r2 = agent.run_conversation("不对，你搞错了，重构前应该先备份", conversation_history=[], task_id="t5")
+        assert isinstance(r2["final_response"], str)
+
+        from auto.principle_repo import PrincipleRepository
+
+        repo = PrincipleRepository()
+        repo.load()
+        by_id = {p["id"]: p for p in repo.principles}
+        assert by_id[seed["id"]]["score"] == pytest.approx(0.3)  # 0.5 - 0.2 (strong correction)
+        assert by_id[seed["id"]]["score_history"][-1]["reason"] == "strong_correction"
+        assert by_id[seed["id"]]["hit_count"] == 1
+        # Turn 1's ids were consumed; turn 2's fresh stash exists.
+        assert isinstance(agent._prev_turn_principle_ids, list)
+        assert all(isinstance(i, str) for i in agent._prev_turn_principle_ids)
+        # Distillation ran on turn 2 as well (clean tool-wise).
+        assert len(_store_lines(store_path)) >= 3

--- a/tests/integration/test_conversation_loop_distiller_robustness.py
+++ b/tests/integration/test_conversation_loop_distiller_robustness.py
@@ -189,6 +189,70 @@ def agent_env_enabled(tmp_path, monkeypatch):
         yield agent, _MockHandler, store_path
 
 
+class TestTurnSliceHasToolError:
+    """Pure-function coverage for the tool-error slice scan feeding the
+    distiller's ``has_tool_error`` signal (t_d1048be1 advisory #1)."""
+
+    def test_startswith_marker_detected(self):
+        from agent.conversation_loop import _turn_slice_has_tool_error
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "name": "x", "content": "Error executing tool 'boom': timeout"},
+        ]
+        assert _turn_slice_has_tool_error(messages, 0) is True
+
+    def test_scope_block_contains_marker_detected(self):
+        from agent.conversation_loop import _turn_slice_has_tool_error
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "name": "tool_search",
+             "content": "'memory_search' is not available in this session. Use tool_search to find tools you can call."},
+        ]
+        assert _turn_slice_has_tool_error(messages, 0) is True
+
+    def test_contains_marker_buried_mid_content(self):
+        from agent.conversation_loop import _turn_slice_has_tool_error
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "name": "mcp_x",
+             "content": "<untrusted_tool_result>prefix 'foo' is not available in this session. Use tool_search to find tools you can call.</untrusted_tool_result>"},
+        ]
+        assert _turn_slice_has_tool_error(messages, 0) is True
+
+    def test_normal_tool_content_not_flagged(self):
+        from agent.conversation_loop import _turn_slice_has_tool_error
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "name": "x", "content": "all good here"},
+        ]
+        assert _turn_slice_has_tool_error(messages, 0) is False
+
+    def test_prior_turn_messages_ignored(self):
+        from agent.conversation_loop import _turn_slice_has_tool_error
+
+        messages = [
+            {"role": "user", "content": "first"},
+            {"role": "tool", "name": "x", "content": "Error executing tool 'boom'"},
+            {"role": "user", "content": "second"},
+            {"role": "tool", "name": "y", "content": "ok"},
+        ]
+        # start_idx=2 (second user message): only messages after index 2 scanned.
+        assert _turn_slice_has_tool_error(messages, 2) is False
+
+    def test_non_str_content_ignored(self):
+        from agent.conversation_loop import _turn_slice_has_tool_error
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "name": "x", "content": ["not", "a", "string"]},
+        ]
+        assert _turn_slice_has_tool_error(messages, 0) is False
+
+
 class TestDisabledPath:
     def test_disabled_never_executes_distiller_path(self, agent_env):
         agent, handler, store_path = agent_env

--- a/tests/integration/test_conversation_loop_distiller_robustness.py
+++ b/tests/integration/test_conversation_loop_distiller_robustness.py
@@ -1,0 +1,323 @@
+"""End-to-end tests for the Phase 3 principle distiller wiring — DISABLED path
+and failure containment.
+
+- config/env disabled -> the distiller path is never executed: no repo read,
+  no stash writes, final response byte-identical to the model output (A5);
+- the distiller raising -> logged at ERROR, loop completes normally (A7);
+- malformed distiller returns (str/list/{}/missing/non-str text) -> ignored,
+  never raises, never injected into the response;
+- the reward hook raising -> logged, loop completes (A7);
+- W1 injection failing -> empty stashes, turn completes (A7);
+- the distiller module unavailable (``_principle_distiller`` is None) ->
+  the distill block is skipped entirely even when enabled.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+# Repo root = three levels up from tests/integration/<file>.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+# The principle system lives in ~/.hermes/auto (outside the vendored repo).
+_AUTO_DIR = os.path.join(os.path.expanduser("~"), ".hermes", "auto")
+_AUTO_HOME = os.path.dirname(_AUTO_DIR)
+for _p in (_AUTO_DIR, _AUTO_HOME):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+class _MockHandler(BaseHTTPRequestHandler):
+    captured_requests: list = []
+    response_queue: list = []
+
+    def do_POST(self):  # noqa: N802 (http.server API)
+        length = int(self.headers.get("Content-Length", 0))
+        req = json.loads(self.rfile.read(length).decode())
+        type(self).captured_requests.append(req)
+        if type(self).response_queue:
+            resp = type(self).response_queue.pop(0)
+        else:
+            resp = _text_resp("DONE")
+        msg = resp["choices"][0]["message"]
+        if req.get("stream") is True:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            content = msg.get("content") or ""
+            chunks = [{"id": "m", "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}]}]
+            if content:
+                chunks.append({"id": "m", "choices": [{"index": 0, "delta": {"content": content}, "finish_reason": None}]})
+            chunks.append({"id": "m", "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]})
+            for c in chunks:
+                self.wfile.write(f"data: {json.dumps(c)}\n\n".encode())
+            self.wfile.write(b"data: [DONE]\n\n")
+            self.wfile.flush()
+        else:
+            body = json.dumps(resp).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    def log_message(self, *a, **kw):  # silence the default stderr logging
+        pass
+
+
+def _text_resp(text: str) -> dict:
+    return {
+        "id": "m",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": text}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10},
+    }
+
+
+SEED_TEXT = "重构前先明确范围，再逐步执行并验证中间结果"
+TURN_MSG = "帮我重构这个 Python 模块并补上测试"
+MODEL_TEXT = "这是模型的原始回答。"
+
+
+def _make_env(enabled: bool):
+    """Context-manager-lite factory used by the fixture."""
+
+    class _Env:
+        def __init__(self):
+            self.srv = None
+            self.thread = None
+            self.test_home = None
+            self.prev_home = os.environ.get("HERMES_HOME")
+            self.prev_env = os.environ.get("HERMES_PRINCIPLE_DISTILLER")
+
+        def __enter__(self):
+            _MockHandler.captured_requests = []
+            _MockHandler.response_queue = []
+            self.srv = HTTPServer(("127.0.0.1", 0), _MockHandler)
+            self.thread = threading.Thread(target=self.srv.serve_forever, daemon=True)
+            self.thread.start()
+            self.test_home = tempfile.mkdtemp(prefix="hermes_pd_rob_")
+            os.makedirs(os.path.join(self.test_home, ".hermes"))
+            os.environ["HERMES_HOME"] = os.path.join(self.test_home, ".hermes")
+            if enabled:
+                os.environ["HERMES_PRINCIPLE_DISTILLER"] = "1"
+            elif self.prev_env is not None:
+                os.environ.pop("HERMES_PRINCIPLE_DISTILLER", None)
+            return self
+
+        def __exit__(self, *exc):
+            self.srv.shutdown()
+            shutil.rmtree(self.test_home, ignore_errors=True)
+            if self.prev_home is None:
+                os.environ.pop("HERMES_HOME", None)
+            else:
+                os.environ["HERMES_HOME"] = self.prev_home
+            if self.prev_env is None:
+                os.environ.pop("HERMES_PRINCIPLE_DISTILLER", None)
+            else:
+                os.environ["HERMES_PRINCIPLE_DISTILLER"] = self.prev_env
+
+    return _Env()
+
+
+def _build_agent(env, tmp_path, monkeypatch):
+    """Patch the principle-store paths, import fresh, build the stub agent."""
+    store_dir = tmp_path / "principles"
+    store_path = store_dir / "principles.jsonl"
+    store_dir.mkdir(parents=True, exist_ok=True)
+    import auto.principle_distiller as _pd
+    import auto.principle_repo as _pr
+
+    # The distiller/reward-hook import the repo with a BARE name
+    # (`from principle_repo import ...`), which would create a second module
+    # instance anchored at the REAL ~/.hermes store. Alias the patched
+    # modules under the bare names so every internal import hits them.
+    sys.modules["principle_distiller"] = _pd
+    sys.modules["principle_repo"] = _pr
+
+    monkeypatch.setattr(_pd, "DATA_DIR", store_dir)
+    monkeypatch.setattr(_pd, "PRINCIPLES_PATH", store_path)
+    monkeypatch.setattr(_pr, "DATA_DIR", store_dir)
+    monkeypatch.setattr(_pr, "DEFAULT_PATH", store_path)
+
+    for mod in list(sys.modules):
+        if mod == "run_agent" or mod.startswith("agent.") or mod.startswith("tools.") or mod.startswith("hermes_"):
+            del sys.modules[mod]
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key", base_url=f"http://127.0.0.1:{env.srv.server_address[1]}/v1",
+        provider="openai-compat", model="test-model",
+        max_iterations=10, enabled_toolsets=[],
+        quiet_mode=True, skip_context_files=True, skip_memory=True,
+        save_trajectories=False, platform="cli",
+    )
+    agent.valid_tool_names = {"terminal", "read_file", "write_file", "execute_code", "session_search"}
+    return agent, store_path
+
+
+def _seed(store_path) -> dict:
+    from auto.principle_repo import PrincipleRepository
+
+    repo = PrincipleRepository()
+    repo.load()
+    return repo.add(text=SEED_TEXT, tags=[], source="manual", score=0.5)
+
+
+@pytest.fixture()
+def agent_env(tmp_path, monkeypatch):
+    env = _make_env(enabled=False)
+    with env:
+        agent, store_path = _build_agent(env, tmp_path, monkeypatch)
+        yield agent, _MockHandler, store_path
+
+
+@pytest.fixture()
+def agent_env_enabled(tmp_path, monkeypatch):
+    env = _make_env(enabled=True)
+    with env:
+        agent, store_path = _build_agent(env, tmp_path, monkeypatch)
+        yield agent, _MockHandler, store_path
+
+
+class TestDisabledPath:
+    def test_disabled_never_executes_distiller_path(self, agent_env):
+        agent, handler, store_path = agent_env
+        _seed(store_path)
+        handler.response_queue.append(_text_resp(MODEL_TEXT))
+
+        result = agent.run_conversation(TURN_MSG, conversation_history=[], task_id="d1")
+
+        # Gate stash read once at turn start, and it is False.
+        assert agent._principle_distiller_enabled is False
+        # A5: final response byte-identical to the model output.
+        assert result["final_response"] == MODEL_TEXT
+        # No stashes written, no repo interaction via the loop.
+        assert not hasattr(agent, "_prev_turn_principle_hits")
+        assert not hasattr(agent, "_prev_turn_principle_ids")
+        assert not hasattr(agent, "_turn_had_tool_error")
+        # Store untouched: still exactly the seeded record.
+        with open(store_path, encoding="utf-8") as f:
+            lines = [l for l in f if l.strip()]
+        assert len(lines) == 1
+        # The seed principle never reached the wire.
+        assert not any(
+            SEED_TEXT in str(m.get("content", ""))
+            for req in handler.captured_requests
+            for m in req.get("messages", [])
+            if m.get("role") == "user"
+        )
+
+
+class TestFailureContainment:
+    def test_distiller_exception_contained(self, agent_env_enabled, monkeypatch, caplog):
+        agent, handler, store_path = agent_env_enabled
+        _seed(store_path)
+        handler.response_queue.append(_text_resp(MODEL_TEXT))
+
+        import auto.principle_distiller as _pd
+
+        def _boom(*a, **kw):
+            raise RuntimeError("distiller exploded")
+
+        monkeypatch.setattr(_pd, "distill_from_turn", _boom)
+        with caplog.at_level(logging.ERROR, logger="agent.conversation_loop"):
+            result = agent.run_conversation(TURN_MSG, conversation_history=[], task_id="r1")
+
+        assert result["final_response"] == MODEL_TEXT
+        assert "Principle distillation failed" in caplog.text
+
+    @pytest.mark.parametrize("malformed", [
+        "not-a-dict",
+        ["list", "of", "stuff"],
+        {},
+        {"text": 123},
+        {"text": ""},
+        {"text": "   "},
+    ])
+    def test_malformed_distiller_output_ignored(self, agent_env_enabled, monkeypatch, malformed):
+        agent, handler, store_path = agent_env_enabled
+        _seed(store_path)
+        handler.response_queue.append(_text_resp(MODEL_TEXT))
+
+        import auto.principle_distiller as _pd
+
+        monkeypatch.setattr(_pd, "distill_from_turn", lambda *a, **kw: malformed)
+        result = agent.run_conversation(TURN_MSG, conversation_history=[], task_id="r2")
+
+        # Never raises, never injects garbage: response unchanged, store not
+        # grown by a bogus record.
+        assert result["final_response"] == MODEL_TEXT
+        with open(store_path, encoding="utf-8") as f:
+            assert len([l for l in f if l.strip()]) == 1
+
+    def test_reward_exception_contained(self, agent_env_enabled, monkeypatch, caplog):
+        agent, handler, store_path = agent_env_enabled
+        _seed(store_path)
+        handler.response_queue.append(_text_resp(MODEL_TEXT))
+
+        import auto.principle_reward_hook as _rh
+
+        def _boom(agent, user_message):
+            raise RuntimeError("reward exploded")
+
+        monkeypatch.setattr(_rh, "apply_principle_rewards", _boom)
+        # Keep the distiller out of the picture so the response stays
+        # byte-identical to the model output (isolates the reward failure).
+        import auto.principle_distiller as _pd
+
+        monkeypatch.setattr(_pd, "distill_from_turn", lambda *a, **kw: None)
+        with caplog.at_level(logging.ERROR, logger="agent.conversation_loop"):
+            result = agent.run_conversation(TURN_MSG, conversation_history=[], task_id="r3")
+
+        assert result["final_response"] == MODEL_TEXT
+        assert "Principle reward failed" in caplog.text
+
+    def test_injection_failure_contained(self, agent_env_enabled, monkeypatch, caplog):
+        agent, handler, store_path = agent_env_enabled
+        handler.response_queue.append(_text_resp(MODEL_TEXT))
+
+        import auto.principle_repo as _pr
+
+        class _BoomRepo:
+            def load(self):
+                raise RuntimeError("store corrupted")
+
+            def retrieve(self, *a, **kw):
+                raise AssertionError("retrieve must not run")
+
+        monkeypatch.setattr(_pr, "PrincipleRepository", lambda *a, **kw: _BoomRepo())
+        with caplog.at_level(logging.WARNING, logger="agent.turn_context"):
+            result = agent.run_conversation(TURN_MSG, conversation_history=[], task_id="r4")
+
+        assert result["final_response"] == MODEL_TEXT
+        assert "Principle injection failed" in caplog.text
+        # Degraded to empty stashes -> the distill block sees no hits.
+        assert agent._prev_turn_principle_hits == []
+        assert agent._prev_turn_principle_ids == []
+        # No distill record was persisted.
+        assert not os.path.exists(store_path) or os.path.getsize(store_path) == 0
+
+    def test_distiller_module_unavailable_skips_block(self, agent_env_enabled, monkeypatch):
+        """Even with the switch on, a None distiller module skips the block."""
+        agent, handler, store_path = agent_env_enabled
+        _seed(store_path)
+        handler.response_queue.append(_text_resp(MODEL_TEXT))
+
+        import agent.conversation_loop as _cl
+
+        monkeypatch.setattr(_cl, "_principle_distiller", None)
+        result = agent.run_conversation(TURN_MSG, conversation_history=[], task_id="r5")
+
+        assert result["final_response"] == MODEL_TEXT
+        with open(store_path, encoding="utf-8") as f:
+            assert len([l for l in f if l.strip()]) == 1

--- a/tests/integration/test_principle_distiller_smoke.py
+++ b/tests/integration/test_principle_distiller_smoke.py
@@ -1,0 +1,84 @@
+"""Smoke tests for the principle distiller integration.
+
+Two minimal end-to-end checks through the real conversation loop
+(``run_agent.AIAgent.run_conversation``, i.e. conversation_loop.py) against
+an in-process mock provider:
+
+- ENABLED: a single clean turn with ``HERMES_PRINCIPLE_DISTILLER=1`` and a
+  seeded principle store produces a distilled principle — the distilled text
+  is appended to ``final_response`` and the record is persisted (source
+  ``self-distilled``) — and the gate flag is stashed on the agent.
+- DISABLED: the same turn with the feature off is byte-identical to the
+  model output: no gate stash, no principle injection on the wire, and the
+  store keeps exactly the seeded record.
+
+These are deliberately thin (one turn each) so the pair runs in seconds as a
+sanity gate; the exhaustive behavior matrix lives in
+``test_conversation_loop_distiller_enabled.py`` and
+``test_conversation_loop_distiller_robustness.py``. The fixtures/helpers are
+imported from those sibling modules rather than re-implemented, so the smoke
+layer never drifts from the harness the full suites exercise.
+"""
+
+from __future__ import annotations
+
+# The sibling modules self-register the repo root, ~/.hermes/auto, and
+# ~/.hermes on sys.path at import time, and alias the bare-name
+# `principle_distiller`/`principle_repo` modules — so importing them here
+# carries those same guarantees for this file.
+from tests.integration.test_conversation_loop_distiller_enabled import (
+    agent_env as agent_env_enabled,  # yields (agent, handler, store_path)
+    _seed,
+    _store_lines,
+    _text_resp,
+    _wire_user_contents,
+    SEED_TEXT,
+    TURN1_MSG,
+)
+from tests.integration.test_conversation_loop_distiller_robustness import (
+    agent_env as agent_env_disabled,  # yields (agent, handler, store_path)
+    MODEL_TEXT,
+)
+
+
+class TestPrincipleDistillerSmoke:
+    def test_smoke_enabled_distills_appends_and_persists(self, agent_env_enabled):
+        """Feature on: one turn produces a recorded distilled principle."""
+        agent, handler, store_path = agent_env_enabled
+        _seed(store_path)
+        handler.response_queue.append(_text_resp(MODEL_TEXT))
+
+        result = agent.run_conversation(TURN1_MSG, conversation_history=[], task_id="smoke-on")
+
+        # Gate flag read once at turn start, and it is True.
+        assert agent._principle_distiller_enabled is True
+        # Model output preserved; distilled text appended to the response.
+        distilled = [
+            line for line in _store_lines(store_path)
+            if line.get("source") == "self-distilled"
+        ]
+        assert len(distilled) == 1
+        assert result["final_response"].startswith(MODEL_TEXT)
+        assert result["final_response"].endswith(distilled[0]["text"])
+        # The seeded principle reached the wire as context (W1 injection).
+        assert any(SEED_TEXT in c for c in _wire_user_contents(handler))
+
+    def test_smoke_disabled_no_behavioral_change(self, agent_env_disabled):
+        """Feature off: response byte-identical, store and wire untouched."""
+        agent, handler, store_path = agent_env_disabled
+        _seed(store_path)
+        handler.response_queue.append(_text_resp(MODEL_TEXT))
+
+        result = agent.run_conversation(TURN1_MSG, conversation_history=[], task_id="smoke-off")
+
+        # Gate flag read once at turn start, and it is False.
+        assert agent._principle_distiller_enabled is False
+        # A5: final response byte-identical to the model output.
+        assert result["final_response"] == MODEL_TEXT
+        # No stash attributes were ever written.
+        assert not hasattr(agent, "_prev_turn_principle_hits")
+        assert not hasattr(agent, "_prev_turn_principle_ids")
+        # Store untouched: still exactly the seeded record.
+        assert len(_store_lines(store_path)) == 1
+        # The seed principle never reached the wire.
+        assert not any(SEED_TEXT in c for c in _wire_user_contents(handler))

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -881,6 +881,19 @@ Points at a custom OpenAI-compatible endpoint. Uses `OPENAI_API_KEY` for auth.
 The summary model **must** have a context window at least as large as your main agent model's. The compressor sends the full middle section of the conversation to the summary model — if that model's context window is smaller than the main model's, the summarization call will fail with a context length error. When this happens, the middle turns are **dropped without a summary**, losing conversation context silently. If you override the model, verify its context length meets or exceeds your main model's.
 :::
 
+## Principle Distiller
+
+Optional Phase 3 self-distillation of strategic principles from successful conversation turns (experience-driven agent evolution). When enabled, each clean turn that hit an injected principle retrieves matching principles from `~/.hermes/data/principles/principles.jsonl`, distills a new principle record, persists it, and appends the learned line to the turn's final response. Corrections are handled by the reward hook at the start of the next turn (strong correction −0.2, weak −0.1, clean run +0.05).
+
+**Off by default.** The conversation loop never imports or calls the distiller while disabled.
+
+```yaml
+principle_distiller:
+  enabled: false          # true = enable self-distillation
+```
+
+Environment override: `HERMES_PRINCIPLE_DISTILLER` — set to `1`, `true`, `yes`, or `on` to enable; any other set value disables; unset falls through to the config key. The switch is read once per turn at loop startup; mid-conversation edits do not flip behavior mid-turn. The injected principle block is carried by the `api_content` sidecar, so the persisted transcript and the wire payload stay byte-identical.
+
 ## Session Stall Watchdog
 
 The gateway runs a notify-only stall watchdog (`agent.session_stall_timeout`, default `300` seconds, `0` = disabled). When a busy session has a **pending inbound follow-up** and the agent's shared activity clock has been idle for at least this long, the gateway logs a WARNING and sends the user a one-shot notification:


### PR DESCRIPTION
## Phase 3 principle distiller — config-gated conversation_loop hook

Recovered from `hermes-update-autostash-20260803-104527` (worker crash during autostash) and independently re-validated. Four commits on `feat/principle-distiller-phase3` (base: current `origin/main`):

- `feat(principle-distiller): restore Phase 3 integration` — lazy defensive import of `auto/principle_distiller`; config gate `principle_distiller.enabled` (default false) + `HERMES_PRINCIPLE_DISTILLER` env override, read once at loop startup; turn-start principle retrieval/stash for the reward hook (W1); turn-end distill with validated dict/text append to final response (D1); tool-error marker scan; exception containment on every path.
- `test(principle-distiller): add enabled/disabled smoke tests` — full-loop smoke coverage.
- `test(principle-distiller): config-key e2e switch coverage + off-spelling coercion`.
- `fix(principle-distiller): scope-block marker gap + isinstance guard` (sibling task `t_d1048be1` advisory #1/#2) — substring marker for the tool_search scope-block error plus `isinstance(original_user_message, str)` non-empty guard; 6 pure-function unit tests for `_turn_slice_has_tool_error`.

## Validation

### New tests (59 total, all passing)

| File | Count | Covers |
|---|---|---|
| `tests/hermes_cli/test_principle_distiller_config.py` | 29 | default-disabled, env-override truthy/falsy matrix (`1/true/TRUE/True/yes/on/" ON "`/empty), config-key precedence, malformed-section degradation, `hermes config set` round-trip, off-spelling coercion |
| `tests/integration/test_conversation_loop_distiller_enabled.py` | 4 | clean turn distills+appends+persists, exact turn-state passed to distiller, tool-error flag, two-turn reward-hook strong-correction delta |
| `tests/integration/test_conversation_loop_distiller_robustness.py` | 17 | disabled path never executes distiller, distiller exception contained, malformed outputs (str/list/{}/missing/non-str text) ignored, reward-hook exception contained, injection failure contained, module-unavailable skip, `_turn_slice_has_tool_error` pure-function cases (startswith markers, mid-content substring, normal content not flagged) |
| `tests/integration/test_principle_distiller_smoke.py` | 2 | enabled/disabled smoke over the full loop |
| `tests/integration/test_conversation_loop_distiller_config_switch.py` | 7 | config-unset preserves prior behavior, false/off keep disabled, true reaches integration point, invalid values degrade per config validation |

**Edge cases covered:** env-override precedence (incl. whitespace `" ON "` and empty string), malformed config section degrades to false without raising, disabled path byte-identical to model output, distiller exceptions logged at ERROR and loop continues, every malformed return shape is ignored and never leaks into the response, reward-hook failures contained, missing `auto/` module degrades to skip even when enabled, non-str/empty user_message falls back to the raw turn message.

### Exact test command

```bash
python -m pytest -o addopts="" \
  tests/hermes_cli/test_principle_distiller_config.py \
  tests/integration/test_conversation_loop_distiller_enabled.py \
  tests/integration/test_conversation_loop_distiller_robustness.py \
  tests/integration/test_principle_distiller_smoke.py \
  tests/integration/test_conversation_loop_distiller_config_switch.py
```

Result: **59 passed in 91.84s**.

The new tests are hermetic (in-process mock HTTP provider, zero network/LLM calls) and carry no `integration` marker, so they also collect under the repo's default `-m 'not integration'` deselect (verified: 29 collected with default addopts; 9 collected from smoke+config-switch with default addopts). `-o addopts=""` is used only for an explicit, reproducible command.

### Runtime regression

Scoped to the code paths the feature touches (`tests/agent` turn-context/loop/finalizer set — 8 files):

```bash
python -m pytest tests/agent/test_turn_context.py \
  tests/agent/test_empty_tool_name_loop_dampening.py \
  tests/agent/test_crossloop_client_cache.py \
  tests/agent/test_turn_retry_state.py tests/agent/test_turn_summary.py \
  tests/agent/test_turn_finalizer_final_response_persistence.py \
  tests/agent/test_turn_finalizer_iteration_limit_exit.py \
  tests/agent/test_turn_finalizer_cleanup_guard.py -q
```

Result: **45 passed in 29.49s**.

The full `tests/agent` suite exceeds this Windows environment's time budget (~10 min and still running), so the run was scoped. Full-suite collection is at parity with the pre-feature baseline (`aad8f7412`): the same 3 pre-existing gateway/relay collection errors (`tests/gateway/test_teams.py`, `relay/test_relay_going_idle.py`, `relay/test_ws_transport.py`) on both trees — no new collection failures introduced.
