### PR TITLE
feat(skills): add index-excluded visibility state

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -27,10 +27,12 @@ from agent.skill_utils import (
     extract_skill_description,
     get_all_skills_dirs,
     get_disabled_skill_names,
+    get_index_excluded_skill_names,
     iter_skill_index_files,
     org_id_of_path,
     parse_frontmatter,
     read_active_org_id,
+    resolve_skill_config_platform,
     skill_matches_environment,
     skill_matches_platform,
     skill_matches_platform_list,
@@ -1567,14 +1569,14 @@ def _skill_should_show(
 
 def _current_session_platform_hint() -> str:
     """Return the active platform without importing the gateway package on CLI startup."""
-    platform = os.environ.get("HERMES_PLATFORM") or os.environ.get("HERMES_SESSION_PLATFORM")
+    platform = os.environ.get("HERMES_PLATFORM")
     if platform:
         return platform
 
     session_context = sys.modules.get("gateway.session_context")
     get_session_env = getattr(session_context, "get_session_env", None) if session_context else None
     if get_session_env is None:
-        return ""
+        return os.environ.get("HERMES_SESSION_PLATFORM") or ""
     try:
         return get_session_env("HERMES_SESSION_PLATFORM") or ""
     except Exception:
@@ -1585,6 +1587,7 @@ def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
     compact_categories: "frozenset[str] | None" = None,
+    platform: str | None = None,
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -1615,8 +1618,13 @@ def build_skills_system_prompt(
     # ── Layer 1: in-process LRU cache ─────────────────────────────────
     # Include the resolved platform so per-platform disabled-skill lists
     # produce distinct cache entries (gateway serves multiple platforms).
-    _platform_hint = _current_session_platform_hint()
+    # HERMES_PLATFORM is an explicit runtime override and historically drove
+    # platform-disabled prompt filtering. Preserve that authority while using
+    # the agent surface when no session/environment hint exists.
+    _platform_hint = _current_session_platform_hint() or platform
     disabled = get_disabled_skill_names(_platform_hint or None)
+    index_excluded = get_index_excluded_skill_names(_platform_hint or None)
+    hidden = disabled | index_excluded
     cache_key = (
         str(skills_dir),
         tuple(str(d) for d in external_dirs),
@@ -1624,6 +1632,7 @@ def build_skills_system_prompt(
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
         tuple(sorted(disabled)),
+        tuple(sorted(index_excluded)),
         tuple(sorted(compact_categories or ())),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
@@ -1652,7 +1661,7 @@ def build_skills_system_prompt(
             platforms = entry.get("platforms") or []
             if not skill_matches_platform_list(platforms):
                 continue
-            if frontmatter_name in disabled or skill_name in disabled:
+            if frontmatter_name in hidden or skill_name in hidden:
                 continue
             if not _skill_should_show(
                 entry.get("conditions") or {},
@@ -1674,7 +1683,7 @@ def build_skills_system_prompt(
             if not is_compatible:
                 continue
             skill_name = entry["skill_name"]
-            if entry["frontmatter_name"] in disabled or skill_name in disabled:
+            if entry["frontmatter_name"] in hidden or skill_name in hidden:
                 continue
             if not _skill_should_show(
                 extract_skill_conditions(frontmatter),
@@ -1757,7 +1766,7 @@ def build_skills_system_prompt(
                 frontmatter_name = entry["frontmatter_name"]
                 if frontmatter_name in seen_skill_names:
                     continue
-                if frontmatter_name in disabled or skill_name in disabled:
+                if frontmatter_name in hidden or skill_name in hidden:
                     continue
                 if not _skill_should_show(
                     extract_skill_conditions(frontmatter),

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -381,16 +381,26 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     _skill_commands_platform = _resolve_skill_commands_platform()
     _skill_commands = {}
     try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
+        from tools.skills_tool import (
+            _get_disabled_skill_names,
+            _get_index_excluded_skill_names,
+            _parse_frontmatter,
+            _skills_dir,
+            skill_matches_environment,
+            skill_matches_platform,
+        )
         from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
         from hermes_cli.commands import resolve_command
         disabled = _get_disabled_skill_names()
+        index_excluded = _get_index_excluded_skill_names()
+        hidden = disabled | index_excluded
         seen_names: set = set()
 
-        # Scan local dir first, then external dirs
+        # Scan the live profile's local dir first, then external dirs.
         dirs_to_scan = []
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
+        active_skills_dir = _skills_dir()
+        if active_skills_dir.exists():
+            dirs_to_scan.append(active_skills_dir)
         dirs_to_scan.extend(get_external_skills_dirs())
 
         for scan_dir in dirs_to_scan:
@@ -410,8 +420,8 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     name = frontmatter.get('name', skill_md.parent.name)
                     if name in seen_names:
                         continue
-                    # Respect user's disabled skills config
-                    if name in disabled:
+                    # Respect disabled and index-excluded discovery state.
+                    if {name, skill_md.parent.name} & hidden:
                         continue
                     description = frontmatter.get('description', '')
                     if not description:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -371,7 +371,7 @@ def skill_matches_environment(frontmatter: Dict[str, Any]) -> bool:
     return False
 
 
-# ── Disabled skills ───────────────────────────────────────────────────────
+# ── Skill visibility state ────────────────────────────────────────────────
 
 
 _RAW_CONFIG_CACHE: Dict[Tuple[str, int, int], Dict[str, Any]] = {}
@@ -417,6 +417,44 @@ def _load_raw_config() -> Dict[str, Any]:
     return parsed
 
 
+def _normalize_skill_config_platform(platform: str | None) -> str | None:
+    """Map runtime surface identities onto skill-config platform keys."""
+    value = str(platform or "").strip().lower()
+    if not value:
+        return None
+    if value in {"tui", "desktop", "kanban", "subagent", "tool"}:
+        return "cli"
+    return value
+
+
+def resolve_skill_config_platform(
+    platform: str | None = None, *, default_local: bool = False
+) -> str | None:
+    """Resolve the authoritative platform key for skill visibility config.
+
+    Precedence matches existing platform-disabled behavior: an explicit caller
+    value, ``HERMES_PLATFORM``, then gateway session platform. Local runtime
+    source names are normalized to the shared ``cli`` config surface.
+    """
+    resolved = platform or os.getenv("HERMES_PLATFORM")
+    source = ""
+    if not resolved:
+        try:
+            from gateway.session_context import get_session_env
+
+            resolved = get_session_env("HERMES_SESSION_PLATFORM") or ""
+            if not resolved:
+                source = get_session_env("HERMES_SESSION_SOURCE") or ""
+        except Exception:
+            resolved = os.getenv("HERMES_SESSION_PLATFORM", "")
+            source = os.getenv("HERMES_SESSION_SOURCE", "")
+    if not resolved and source:
+        resolved = source
+    if not resolved and default_local:
+        resolved = "cli"
+    return _normalize_skill_config_platform(resolved)
+
+
 def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
     """Read disabled skill names from config.yaml.
 
@@ -439,12 +477,7 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
     if not isinstance(skills_cfg, dict):
         return set()
 
-    from gateway.session_context import get_session_env
-    resolved_platform = (
-        platform
-        or os.getenv("HERMES_PLATFORM")
-        or get_session_env("HERMES_SESSION_PLATFORM")
-    )
+    resolved_platform = resolve_skill_config_platform(platform)
     global_disabled = _normalize_string_set(skills_cfg.get("disabled"))
     if resolved_platform:
         platform_disabled = (skills_cfg.get("platform_disabled") or {}).get(
@@ -453,6 +486,34 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
         if platform_disabled is not None:
             return global_disabled | _normalize_string_set(platform_disabled)
     return global_disabled
+
+
+def get_index_excluded_skill_names(platform: str | None = None) -> Set[str]:
+    """Return skills hidden from discovery but still explicitly loadable.
+
+    ``skills.index_excluded`` applies on every surface. When a platform is
+    resolved, ``skills.platform_index_excluded.<platform>`` is unioned with
+    the global list, mirroring :func:`get_disabled_skill_names`. This state is
+    deliberately separate from ``disabled``: use the disabled helper for load
+    authorization and this helper only for offer/index paths.
+    """
+    parsed = _load_raw_config()
+    if not parsed:
+        return set()
+
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return set()
+
+    resolved_platform = resolve_skill_config_platform(platform)
+    global_excluded = _normalize_string_set(skills_cfg.get("index_excluded"))
+    if resolved_platform:
+        platform_excluded = (
+            skills_cfg.get("platform_index_excluded") or {}
+        ).get(resolved_platform)
+        if platform_excluded is not None:
+            return global_excluded | _normalize_string_set(platform_excluded)
+    return global_excluded
 
 
 def _normalize_string_set(values) -> Set[str]:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -322,6 +322,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             available_tools=agent.valid_tool_names,
             available_toolsets=avail_toolsets,
             compact_categories=_compact_cats or None,
+            platform=agent.platform,
         )
     else:
         skills_prompt = ""

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -812,6 +812,17 @@ skills:
   #   - ~/.agents/skills
   #   - /home/shared/team-skills
 
+  # Hide skills from the always-on prompt index, skills_list, and generated
+  # slash commands without disabling exact skill_view or --skills preloading.
+  # Disabled always wins if a skill appears in both lists.
+  # index_excluded: [large-specialist-skill]
+
+  # Add surface-specific exclusions to the global list. Supported keys match
+  # skills.platform_disabled (cli, telegram, discord, slack, etc.). The cli
+  # surface includes the classic CLI, TUI, desktop, and local worker sessions.
+  # platform_index_excluded:
+  #   telegram: [desktop-only-helper]
+
 # =============================================================================
 # Agent Behavior
 # =============================================================================

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1789,6 +1789,11 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # Skills hidden from prompt indexes, skills_list, and generated slash
+        # commands while remaining loadable by exact skill_view and --skills.
+        "index_excluded": [],
+        # Per-surface additions to index_excluded. Global entries always apply.
+        "platform_index_excluded": {},
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -204,6 +204,56 @@ def _compute_skills_breakdown(skills_block: str) -> List[Dict[str, Any]]:
     return entries
 
 
+def _compute_skill_state_counts(platform: str) -> Dict[str, int]:
+    """Count installed skills by configured discovery/load state.
+
+    Local skills win over external directories by declared name, matching prompt
+    assembly. Platform-specific config is resolved for the requested surface.
+    Disabled has precedence when a name appears in both visibility lists.
+    """
+    from agent.skill_utils import (
+        get_all_skills_dirs,
+        get_disabled_skill_names,
+        get_index_excluded_skill_names,
+        iter_skill_index_files,
+        parse_frontmatter,
+        skill_matches_platform,
+    )
+
+    disabled = get_disabled_skill_names(platform)
+    index_excluded = get_index_excluded_skill_names(platform)
+    counts = {"active": 0, "index_excluded": 0, "disabled": 0, "total": 0}
+    seen: set[str] = set()
+
+    for skills_dir in get_all_skills_dirs():
+        if not skills_dir.exists():
+            continue
+        for skill_file in iter_skill_index_files(skills_dir, "SKILL.md"):
+            directory_name = skill_file.parent.name
+            frontmatter: Dict[str, Any] = {}
+            try:
+                frontmatter, _ = parse_frontmatter(
+                    skill_file.read_text(encoding="utf-8")
+                )
+            except Exception:
+                pass
+            if not skill_matches_platform(frontmatter):
+                continue
+            name = str(frontmatter.get("name") or directory_name)
+            if name in seen:
+                continue
+            seen.add(name)
+            counts["total"] += 1
+            aliases = {name, directory_name}
+            if aliases & disabled:
+                counts["disabled"] += 1
+            elif aliases & index_excluded:
+                counts["index_excluded"] += 1
+            else:
+                counts["active"] += 1
+    return counts
+
+
 def _compute_toolsets_breakdown(tools: List[Any]) -> List[Dict[str, Any]]:
     """Per-toolset schema-byte breakdown of the resolved tool list.
 
@@ -241,6 +291,7 @@ def compute_prompt_breakdown(platform: str = "cli") -> Dict[str, Any]:
     largest-first). The last two answer "what should I disable to cut tokens?".
     """
     from agent.system_prompt import build_system_prompt, build_system_prompt_parts
+    from agent.skill_utils import resolve_skill_config_platform
 
     agent = _build_inspection_agent(platform)
 
@@ -276,6 +327,15 @@ def compute_prompt_breakdown(platform: str = "cli") -> Dict[str, Any]:
     tools = getattr(agent, "tools", None) or []
     tools_json = json.dumps(tools, ensure_ascii=False)
 
+    # Prompt assembly preserves an explicit runtime/session platform override
+    # over the agent surface. Count skill states in that same effective scope
+    # so the summary cannot disagree with the rendered skills index.
+    skills_platform = (
+        resolve_skill_config_platform(default_local=False)
+        or resolve_skill_config_platform(platform)
+        or platform
+    )
+
     sections: List[Tuple[str, int, int]] = [
         ("stable (identity/guidance/skills)", len(stable), _bytes(stable)),
         ("context (AGENTS.md/cwd files)", len(context), _bytes(context)),
@@ -290,6 +350,7 @@ def compute_prompt_breakdown(platform: str = "cli") -> Dict[str, Any]:
         "memory": {"chars": len(memory_block), "bytes": _bytes(memory_block)},
         "user_profile": {"chars": len(user_block), "bytes": _bytes(user_block)},
         "tools": {"count": len(tools), "json_bytes": _bytes(tools_json)},
+        "skills": _compute_skill_state_counts(skills_platform),
         "sections": sections,
         "skills_breakdown": _compute_skills_breakdown(skills_index),
         "toolsets_breakdown": _compute_toolsets_breakdown(tools),
@@ -313,6 +374,14 @@ def render_breakdown(data: Dict[str, Any]) -> str:
     mem = data["memory"]
     up = data["user_profile"]
     lines.append(f"    skills index       : {si['bytes']:>8,} B  ({_fmt_kb(si['bytes'])})")
+    skill_states = data.get("skills") or {}
+    if skill_states:
+        lines.append(
+            "    skill states       : "
+            f"{skill_states.get('active', 0)} active, "
+            f"{skill_states.get('index_excluded', 0)} index-excluded, "
+            f"{skill_states.get('disabled', 0)} disabled"
+        )
     lines.append(f"    memory             : {mem['bytes']:>8,} B  ({_fmt_kb(mem['bytes'])})")
     lines.append(f"    user profile       : {up['bytes']:>8,} B  ({_fmt_kb(up['bytes'])})")
     lines.append("")

--- a/tests/agent/test_skill_index_excluded.py
+++ b/tests/agent/test_skill_index_excluded.py
@@ -1,0 +1,476 @@
+"""End-to-end coverage for hidden-but-loadable skill catalog entries."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+def _write_skill(
+    root: Path,
+    name: str,
+    body: str | None = None,
+    *,
+    frontmatter_name: str | None = None,
+) -> Path:
+    skill_dir = root / "general" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    declared_name = frontmatter_name or name
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {declared_name}\ndescription: Description for {declared_name}.\n---\n\n"
+        f"# {name}\n\n{body or f'Body for {name}.'}\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+@pytest.fixture
+def isolated_profile(tmp_path, monkeypatch):
+    home = tmp_path / "profile-home"
+    skills = home / "skills"
+    skills.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    monkeypatch.delenv("HERMES_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+
+    from agent import prompt_builder, skill_commands, skill_utils
+    from gateway import session_context
+    from tools import skills_tool
+
+    for var in session_context._VAR_MAP.values():
+        var.set(session_context._UNSET)
+    prompt_builder.drain_truncation_warnings()
+    skill_utils._external_dirs_cache_clear()
+    prompt_builder.clear_skills_system_prompt_cache(clear_snapshot=True)
+    skills_tool._SKILLS_CACHE.clear()
+    skill_commands._skill_commands = {}
+    skill_commands._skill_commands_platform = None
+    yield home, skills
+    for var in session_context._VAR_MAP.values():
+        var.set(session_context._UNSET)
+    prompt_builder.drain_truncation_warnings()
+    skill_utils._external_dirs_cache_clear()
+    prompt_builder.clear_skills_system_prompt_cache(clear_snapshot=True)
+    skills_tool._SKILLS_CACHE.clear()
+    skill_commands._skill_commands = {}
+    skill_commands._skill_commands_platform = None
+
+
+def _write_config(home: Path, text: str) -> None:
+    (home / "config.yaml").write_text(text, encoding="utf-8")
+    from agent import prompt_builder, skill_utils
+    from tools import skills_tool
+
+    skill_utils._external_dirs_cache_clear()
+    prompt_builder.clear_skills_system_prompt_cache(clear_snapshot=True)
+    skills_tool._SKILLS_CACHE.clear()
+
+
+def test_index_excluded_skill_is_hidden_from_prompt_list_and_slash_discovery(
+    isolated_profile,
+):
+    home, skills = isolated_profile
+    _write_skill(skills, "visible-skill")
+    _write_skill(skills, "hidden-skill")
+    _write_config(home, "skills:\n  index_excluded: [hidden-skill]\n")
+
+    from agent.prompt_builder import build_skills_system_prompt
+    from agent.skill_commands import scan_skill_commands
+    from tools.skills_tool import skills_list
+
+    prompt = build_skills_system_prompt()
+    listed = json.loads(skills_list())
+    with patch("tools.skills_tool.SKILLS_DIR", skills):
+        commands = scan_skill_commands()
+
+    assert "visible-skill" in prompt
+    assert "hidden-skill" not in prompt
+    assert {item["name"] for item in listed["skills"]} == {"visible-skill"}
+    assert "/visible-skill" in commands
+    assert "/hidden-skill" not in commands
+
+
+def test_index_excluded_skill_remains_exactly_viewable_and_force_loadable(
+    isolated_profile,
+):
+    home, skills = isolated_profile
+    _write_skill(skills, "hidden-skill", "HIDDEN BUT LOADABLE")
+    _write_config(home, "skills:\n  index_excluded: [hidden-skill]\n")
+
+    from agent.skill_commands import build_preloaded_skills_prompt
+    from tools.skills_tool import skill_view
+
+    viewed = json.loads(skill_view("hidden-skill", preprocess=False))
+    preloaded, loaded, missing = build_preloaded_skills_prompt(["hidden-skill"])
+
+    assert viewed["success"] is True
+    assert "HIDDEN BUT LOADABLE" in viewed["content"]
+    assert loaded == ["hidden-skill"]
+    assert missing == []
+    assert "HIDDEN BUT LOADABLE" in preloaded
+
+
+def test_disabled_wins_over_index_excluded_for_view_and_force_load(
+    isolated_profile,
+):
+    home, skills = isolated_profile
+    _write_skill(skills, "blocked-skill", "MUST NOT LOAD")
+    _write_config(
+        home,
+        "skills:\n"
+        "  disabled: [blocked-skill]\n"
+        "  index_excluded: [blocked-skill]\n",
+    )
+
+    from agent.skill_commands import build_preloaded_skills_prompt
+    from tools.skills_tool import skill_view
+
+    viewed = json.loads(skill_view("blocked-skill", preprocess=False))
+    preloaded, loaded, missing = build_preloaded_skills_prompt(["blocked-skill"])
+
+    assert viewed["success"] is False
+    assert "disabled" in viewed["error"].lower()
+    assert loaded == []
+    assert missing == ["blocked-skill"]
+    assert "MUST NOT LOAD" not in preloaded
+
+
+def test_index_excluded_applies_to_external_dirs_without_blocking_exact_view(
+    isolated_profile,
+):
+    home, skills = isolated_profile
+    external = home.parent / "external-skills"
+    _write_skill(external, "external-hidden", "EXTERNAL LOADABLE")
+    _write_config(
+        home,
+        f"skills:\n  external_dirs: [{external}]\n  index_excluded: [external-hidden]\n",
+    )
+
+    from agent.prompt_builder import build_skills_system_prompt
+    from tools.skills_tool import skill_view, skills_list
+
+    prompt = build_skills_system_prompt()
+    listed = json.loads(skills_list())
+    viewed = json.loads(skill_view("external-hidden", preprocess=False))
+
+    assert "external-hidden" not in prompt
+    assert "external-hidden" not in {item["name"] for item in listed["skills"]}
+    assert viewed["success"] is True
+    assert "EXTERNAL LOADABLE" in viewed["content"]
+
+
+def test_directory_alias_exclusion_hides_every_discovery_surface(isolated_profile):
+    home, skills = isolated_profile
+    _write_skill(skills, "directory-alias", frontmatter_name="canonical-name")
+    _write_config(home, "skills:\n  index_excluded: [directory-alias]\n")
+
+    from agent.prompt_builder import build_skills_system_prompt
+    from agent.skill_commands import scan_skill_commands
+    from tools.skills_tool import skill_view, skills_list
+
+    prompt = build_skills_system_prompt()
+    listed = {item["name"] for item in json.loads(skills_list())["skills"]}
+    commands = scan_skill_commands()
+    viewed = json.loads(skill_view("canonical-name", preprocess=False))
+
+    assert "canonical-name" not in prompt
+    assert "canonical-name" not in listed
+    assert "/canonical-name" not in commands
+    assert viewed["success"] is True
+
+
+def test_platform_index_excluded_is_additive_and_platform_scoped(isolated_profile, monkeypatch):
+    home, skills = isolated_profile
+    _write_skill(skills, "global-hidden")
+    _write_skill(skills, "telegram-hidden")
+    _write_skill(skills, "visible-skill")
+    _write_config(
+        home,
+        "skills:\n"
+        "  index_excluded: [global-hidden]\n"
+        "  platform_index_excluded:\n"
+        "    telegram: [telegram-hidden]\n",
+    )
+
+    from agent import skill_utils
+    from agent.prompt_builder import build_skills_system_prompt, clear_skills_system_prompt_cache
+
+    assert skill_utils.get_index_excluded_skill_names("telegram") == {
+        "global-hidden",
+        "telegram-hidden",
+    }
+    assert skill_utils.get_index_excluded_skill_names("discord") == {"global-hidden"}
+
+    monkeypatch.setenv("HERMES_PLATFORM", "telegram")
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    telegram_prompt = build_skills_system_prompt()
+    monkeypatch.setenv("HERMES_PLATFORM", "discord")
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    discord_prompt = build_skills_system_prompt()
+
+    assert "global-hidden" not in telegram_prompt
+    assert "telegram-hidden" not in telegram_prompt
+    assert "visible-skill" in telegram_prompt
+    assert "global-hidden" not in discord_prompt
+    assert "telegram-hidden" in discord_prompt
+
+
+def test_hermes_platform_drives_list_slash_and_disabled_precedence(
+    isolated_profile, monkeypatch
+):
+    home, skills = isolated_profile
+    _write_skill(skills, "tg-hidden")
+    _write_skill(skills, "tg-disabled")
+    _write_skill(skills, "visible-skill")
+    _write_config(
+        home,
+        "skills:\n"
+        "  platform_index_excluded:\n"
+        "    telegram: [tg-hidden]\n"
+        "  platform_disabled:\n"
+        "    telegram: [tg-disabled]\n",
+    )
+    monkeypatch.setenv("HERMES_PLATFORM", "telegram")
+
+    from agent.skill_commands import scan_skill_commands
+    from tools.skills_tool import skill_view, skills_list
+
+    listed = {item["name"] for item in json.loads(skills_list())["skills"]}
+    commands = scan_skill_commands()
+
+    assert listed == {"visible-skill"}
+    assert set(commands) == {"/visible-skill"}
+    assert json.loads(skill_view("tg-disabled", preprocess=False))["success"] is False
+    assert json.loads(skill_view("tg-hidden", preprocess=False))["success"] is True
+
+
+def test_cli_platform_exclusion_reaches_prompt_and_tool_discovery_without_env_override(
+    isolated_profile, monkeypatch
+):
+    home, skills = isolated_profile
+    _write_skill(skills, "cli-hidden")
+    _write_skill(skills, "visible-skill")
+    _write_config(
+        home,
+        "skills:\n"
+        "  platform_index_excluded:\n"
+        "    cli: [cli-hidden]\n",
+    )
+    monkeypatch.delenv("HERMES_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "desktop")
+
+    from agent.prompt_builder import build_skills_system_prompt
+    from tools.skills_tool import skills_list
+
+    prompt = build_skills_system_prompt(platform="desktop")
+    listed = json.loads(skills_list())
+
+    assert "cli-hidden" not in prompt
+    assert "cli-hidden" not in {item["name"] for item in listed["skills"]}
+    assert "visible-skill" in prompt
+
+
+def test_hermes_platform_override_wins_over_agent_surface_for_prompt_index(
+    isolated_profile, monkeypatch
+):
+    home, skills = isolated_profile
+    _write_skill(skills, "telegram-hidden")
+    _write_skill(skills, "visible-skill")
+    _write_config(
+        home,
+        "skills:\n"
+        "  platform_index_excluded:\n"
+        "    telegram: [telegram-hidden]\n",
+    )
+    monkeypatch.setenv("HERMES_PLATFORM", "telegram")
+
+    from agent.prompt_builder import build_skills_system_prompt
+
+    prompt = build_skills_system_prompt(platform="desktop")
+
+    assert "telegram-hidden" not in prompt
+    assert "visible-skill" in prompt
+
+
+def test_cleared_session_context_masks_stale_session_platform_env(
+    isolated_profile, monkeypatch
+):
+    home, skills = isolated_profile
+    _write_skill(skills, "cli-hidden")
+    _write_skill(skills, "telegram-hidden")
+    _write_config(
+        home,
+        "skills:\n"
+        "  platform_index_excluded:\n"
+        "    cli: [cli-hidden]\n"
+        "    telegram: [telegram-hidden]\n",
+    )
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+
+    from agent.prompt_builder import build_skills_system_prompt
+    from gateway.session_context import clear_session_vars
+
+    clear_session_vars([])
+    prompt = build_skills_system_prompt(platform="desktop")
+
+    assert "cli-hidden" not in prompt
+    assert "telegram-hidden" in prompt
+
+
+def test_profile_scoped_hermes_home_controls_index_exclusion(tmp_path, monkeypatch):
+    default_home = tmp_path / "default"
+    profile_home = tmp_path / "profiles" / "thin"
+    _write_skill(default_home / "skills", "shared-skill")
+    _write_skill(profile_home / "skills", "shared-skill")
+    (default_home / "config.yaml").write_text("skills: {}\n", encoding="utf-8")
+    (profile_home / "config.yaml").write_text(
+        "skills:\n  index_excluded: [shared-skill]\n", encoding="utf-8"
+    )
+
+    from agent import prompt_builder, skill_utils
+
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    skill_utils._external_dirs_cache_clear()
+    prompt_builder.clear_skills_system_prompt_cache(clear_snapshot=True)
+    assert "shared-skill" in prompt_builder.build_skills_system_prompt()
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    skill_utils._external_dirs_cache_clear()
+    prompt_builder.clear_skills_system_prompt_cache(clear_snapshot=True)
+    assert "shared-skill" not in prompt_builder.build_skills_system_prompt()
+
+
+def test_default_config_keeps_all_skills_discoverable(isolated_profile):
+    home, skills = isolated_profile
+    _write_skill(skills, "legacy-skill")
+    _write_config(home, "skills: {}\n")
+
+    from agent.prompt_builder import build_skills_system_prompt
+    from tools.skills_tool import skills_list
+
+    assert "legacy-skill" in build_skills_system_prompt()
+    assert "legacy-skill" in {
+        item["name"] for item in json.loads(skills_list())["skills"]
+    }
+
+
+def test_prompt_size_platform_counts_match_rendered_skill_index(isolated_profile):
+    home, skills = isolated_profile
+    _write_skill(skills, "cli-hidden")
+    _write_config(
+        home,
+        "skills:\n"
+        "  platform_index_excluded:\n"
+        "    cli: [cli-hidden]\n",
+    )
+
+    from hermes_cli import prompt_size
+
+    data = prompt_size.compute_prompt_breakdown("cli")
+
+    assert data["skills"]["index_excluded"] == 1
+    assert "cli-hidden" not in {
+        item["name"] for item in data["skills_breakdown"]
+    }
+
+
+def test_prompt_size_counts_follow_runtime_platform_override(
+    isolated_profile, monkeypatch
+):
+    home, skills = isolated_profile
+    _write_skill(skills, "cli-hidden")
+    _write_skill(skills, "cli-hidden-two")
+    _write_skill(skills, "telegram-hidden")
+    _write_config(
+        home,
+        "skills:\n"
+        "  platform_index_excluded:\n"
+        "    cli: [cli-hidden, cli-hidden-two]\n"
+        "    telegram: [telegram-hidden]\n",
+    )
+    monkeypatch.setenv("HERMES_PLATFORM", "telegram")
+
+    from hermes_cli import prompt_size
+
+    data = prompt_size.compute_prompt_breakdown("cli")
+    rendered_names = {item["name"] for item in data["skills_breakdown"]}
+
+    assert data["skills"]["index_excluded"] == 1
+    assert "telegram-hidden" not in rendered_names
+    assert "cli-hidden" in rendered_names
+    assert "cli-hidden-two" in rendered_names
+
+
+def test_prompt_size_reports_active_index_excluded_and_disabled_counts(isolated_profile):
+    home, skills = isolated_profile
+    _write_skill(skills, "active-skill")
+    _write_skill(skills, "hidden-skill")
+    _write_skill(skills, "disabled-skill")
+    _write_config(
+        home,
+        "skills:\n"
+        "  index_excluded: [hidden-skill]\n"
+        "  disabled: [disabled-skill]\n",
+    )
+
+    from hermes_cli import prompt_size
+
+    data = prompt_size.compute_prompt_breakdown("cli")
+    rendered = prompt_size.render_breakdown(data)
+
+    assert data["skills"]["active"] == 1
+    assert data["skills"]["index_excluded"] == 1
+    assert data["skills"]["disabled"] == 1
+    assert "1 active" in rendered
+    assert "1 index-excluded" in rendered
+    assert "1 disabled" in rendered
+    assert "hidden-skill" not in {
+        item["name"] for item in data["skills_breakdown"]
+    }
+
+
+def test_real_cli_preload_accepts_index_excluded_and_rejects_disabled(
+    isolated_profile,
+):
+    home, skills = isolated_profile
+    _write_skill(skills, "hidden-skill", "HIDDEN CLI LOADABLE")
+    _write_skill(skills, "disabled-skill", "DISABLED CLI BLOCKED")
+    _write_config(
+        home,
+        "skills:\n"
+        "  index_excluded: [hidden-skill]\n"
+        "  disabled: [disabled-skill]\n",
+    )
+    repo = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+    env["PYTHONPATH"] = str(repo)
+
+    hidden = subprocess.run(
+        [sys.executable, str(repo / "cli.py"), "--skills", "hidden-skill", "--list-tools"],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=60,
+    )
+    disabled = subprocess.run(
+        [sys.executable, str(repo / "cli.py"), "--skills", "disabled-skill", "--list-tools"],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=60,
+    )
+
+    assert hidden.returncode == 0, hidden.stderr
+    assert disabled.returncode != 0
+    assert "Unknown skill(s): disabled-skill" in disabled.stdout + disabled.stderr

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -624,21 +624,25 @@ def _get_disabled_skill_names() -> Set[str]:
     as a public re-export so existing callers don't need updating.
     """
     from agent.skill_utils import get_disabled_skill_names
-    return get_disabled_skill_names()
+    return get_disabled_skill_names(_get_session_platform())
+
+
+def _get_index_excluded_skill_names() -> Set[str]:
+    """Load names omitted from discovery while remaining explicitly loadable."""
+    from agent.skill_utils import get_index_excluded_skill_names
+    return get_index_excluded_skill_names(_get_session_platform())
 
 
 def _get_session_platform() -> str:
-    """Resolve the current platform from gateway session context.
+    """Resolve the platform for gateway and local discovery surfaces.
 
-    Mirrors the platform-resolution logic in
-    ``agent.skill_utils.get_disabled_skill_names`` so that
-    ``_is_skill_disabled`` respects ``HERMES_SESSION_PLATFORM``.
+    Use the shared resolver so explicit ``HERMES_PLATFORM`` overrides,
+    messaging session platforms, and local TUI/desktop sources match prompt
+    assembly. A bare process is the classic CLI surface.
     """
-    try:
-        from gateway.session_context import get_session_env
-        return get_session_env("HERMES_SESSION_PLATFORM") or ""
-    except Exception:
-        return ""
+    from agent.skill_utils import resolve_skill_config_platform
+
+    return resolve_skill_config_platform(default_local=True) or "cli"
 
 
 def _is_skill_disabled(name: str, platform: str = None) -> bool:
@@ -648,6 +652,7 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
     1. Explicit ``platform`` argument
     2. ``HERMES_PLATFORM`` environment variable
     3. ``HERMES_SESSION_PLATFORM`` from gateway session context
+    4. Local source mapped to ``cli`` (including bare CLI)
     """
     try:
         from hermes_cli.config import load_config
@@ -686,9 +691,11 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
     cache_key = _SKILLS_CACHE_KEY_DISABLED if skip_disabled else _SKILLS_CACHE_KEY_FILTERED
 
-    # Load disabled set once (not per-skill). Part of the cache signature:
-    # disabling a skill is a config change with no filesystem mtime bump.
+    # Load visibility sets once (not per-skill). They are part of the cache
+    # signature because config changes do not bump skill directory mtimes.
     disabled = set() if skip_disabled else _get_disabled_skill_names()
+    index_excluded = set() if skip_disabled else _get_index_excluded_skill_names()
+    hidden = disabled | index_excluded
 
     # Collect directories to scan — same resolution as the scan loop below
     # (_skills_dir() resolves the LIVE profile HERMES_HOME; the module-level
@@ -699,7 +706,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
         dirs_to_scan.append(active_skills_dir)
     dirs_to_scan.extend(get_external_skills_dirs())
 
-    signature = _skills_scan_signature(dirs_to_scan, disabled)
+    signature = _skills_scan_signature(dirs_to_scan, hidden)
     now = time.monotonic()
 
     cached = _SKILLS_CACHE.get(cache_key)
@@ -738,7 +745,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 name = frontmatter.get("name", skill_dir.name)[:MAX_NAME_LENGTH]
                 if name in seen_names:
                     continue
-                if name in disabled:
+                if {name, skill_dir.name} & hidden:
                     continue
 
                 description = frontmatter.get("description", "")
@@ -1278,7 +1285,7 @@ def skill_view(
 
         # Check if the skill is disabled by the user
         resolved_name = parsed_frontmatter.get("name", skill_md.parent.name)
-        if _is_skill_disabled(resolved_name):
+        if _is_skill_disabled(resolved_name) or _is_skill_disabled(skill_md.parent.name):
             return json.dumps(
                 {
                     "success": False,

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -627,6 +627,29 @@ hermes config set skills.config.myplugin.path ~/myplugin-data
 
 For details on declaring config settings in your own skills, see [Creating Skills — Config Settings](/developer-guide/creating-skills#config-settings-configyaml).
 
+### Skill availability and index visibility
+
+`skills.disabled` makes a skill unavailable, including exact `skill_view` and
+`--skills` loads. `skills.index_excluded` only removes it from the prompt index,
+`skills_list`, and generated slash-command discovery, so explicit loads still
+work. Both accept global lists plus additive per-platform maps. The `cli` platform
+covers classic CLI, TUI, desktop, Kanban workers, and other local agent surfaces:
+
+```yaml
+skills:
+  disabled: [retired-skill]
+  platform_disabled:
+    telegram: [unsafe-on-telegram]
+  index_excluded: [large-specialist-skill]
+  platform_index_excluded:
+    telegram: [desktop-only-helper]
+```
+
+Disabled takes precedence when a name appears in both states. All four settings
+default to empty, and apply equally to local and `skills.external_dirs` skills.
+Use `hermes prompt-size` to see active, index-excluded, and disabled counts for
+the selected platform.
+
 ### Guard on agent-created skill writes
 
 When the agent uses `skill_manage` to create, edit, patch, or delete a skill, Hermes can optionally scan the new/updated content for dangerous keyword patterns (credential harvesting, obvious prompt injection, exfil instructions). The scanner is **off by default** — real agent workflows that legitimately touch `~/.ssh/` or mention `$OPENAI_API_KEY` were tripping the heuristic too often. Turn it back on if you want the scanner to prompt you before the agent's skill writes land:

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -139,6 +139,34 @@ Level 2: skill_view(name, path)  → Specific reference file       (varies)
 
 The agent only loads the full skill content when it actually needs it.
 
+### Hiding skills from discovery without disabling them
+
+Use `skills.index_excluded` when a profile should keep a thin always-on catalog
+without losing task-scoped capabilities:
+
+```yaml
+skills:
+  index_excluded:
+    - large-specialist-skill
+  platform_index_excluded:
+    telegram:
+      - desktop-only-helper
+```
+
+Index-excluded skills are omitted from the `<available_skills>` system-prompt
+index, `skills_list`, and generated slash-command discovery. They remain
+loadable by an exact `skill_view(name)` call and by explicit session/task
+preloading such as `hermes --skills large-specialist-skill`. The
+`platform_index_excluded` map uses the same additive platform keys as
+`platform_disabled`; global exclusions still apply on every platform.
+
+This is intentionally different from `skills.disabled` and
+`skills.platform_disabled`: disabled skills are unavailable and cannot be
+loaded explicitly. If a skill is both disabled and index-excluded, disabled
+wins. The default lists are empty, so existing profiles keep their current
+behavior. Local skills and skills from `skills.external_dirs` follow the same
+rules.
+
 ## SKILL.md Format
 
 ```markdown


### PR DESCRIPTION
## Summary

- add `skills.index_excluded` and `skills.platform_index_excluded` as a third visibility state: hidden from discovery indexes but still exact-loadable
- apply the state consistently across prompt assembly, `skills_list`, slash-command discovery, `--skills` forced preload, external skill dirs, profile-scoped homes, and platform-specific sessions
- preserve `disabled` precedence and session-ContextVar isolation, add prompt-size active/index-excluded/disabled reporting, and document the configuration

## Verification

- `scripts/run_tests.sh` across 13 focused skill/prompt/config/security test files: **176 passed, 0 failed**
- isolated one-shot canary: local + external excluded skills hidden from discovery, exact-loadable and forced-loadable; disabled skill rejected; CLI `--skills` exit behavior verified; state counts `1 active / 2 index-excluded / 1 disabled`
- Ruff on all changed Python files: pass
- `git diff --check`: pass
- added-line security scan: no hardcoded secrets, shell injection, eval/exec, unsafe pickle, or SQL-format findings
- independent final review after remediation: **PASS**

## Notes

The focused suite uses the repository's canonical `scripts/run_tests.sh` per-file isolation. No live profile configuration or secrets were modified.
