### PR TITLE
fix(dashboard): honor the management profile when starting WhatsApp onboarding

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8756,10 +8756,19 @@ def _restart_gateway_after_whatsapp_onboarding(profile: Optional[str] = None) ->
 
 
 @app.post("/api/messaging/whatsapp/onboarding/start")
-async def start_whatsapp_onboarding(body: WhatsAppOnboardingStart):
+async def start_whatsapp_onboarding(
+    body: WhatsAppOnboardingStart, profile: Optional[str] = None
+):
     mode = _normalize_whatsapp_onboarding_mode(body.mode)
     allowed_users = _normalize_whatsapp_allowed_users(body.allowed_users)
-    effective_profile = body.profile
+    # Same resolution order as ``apply_whatsapp_onboarding``. The dashboard
+    # sends the management profile as ``?profile=`` (``/api/messaging/whatsapp/
+    # onboarding`` is in the client's PROFILE_SCOPED_PREFIXES) and never
+    # populates ``body.profile``, so reading the body alone silently pinned
+    # the Baileys session directory, the bridge subprocess and the linked
+    # ``creds.json`` to the LAUNCH profile — while ``apply`` honoured the
+    # query param and wrote the config into the managed one.
+    effective_profile = body.profile or profile
 
     with _config_profile_scope(effective_profile):
         session_path = _whatsapp_session_path()

--- a/tests/hermes_cli/test_whatsapp_onboarding_profile_scope.py
+++ b/tests/hermes_cli/test_whatsapp_onboarding_profile_scope.py
@@ -1,0 +1,118 @@
+"""WhatsApp onboarding must start in the profile the dashboard is managing.
+
+``/api/messaging/whatsapp/onboarding`` is in the client's
+``PROFILE_SCOPED_PREFIXES``, so the dashboard appends ``?profile=<mgmt>`` to
+every call in that family. ``apply`` honoured it (``body.profile or profile or
+record.profile``) but ``start`` only ever read ``body.profile`` — which the UI
+never sets — so it had no ``profile`` query parameter at all and FastAPI
+discarded it.
+
+The consequence was a split onboarding: the Baileys session directory, the
+bridge subprocess and the linked ``creds.json`` were created under the LAUNCH
+profile, while ``apply`` wrote the WhatsApp config into the MANAGED profile and
+restarted that profile's gateway — which then had WhatsApp enabled with no
+session on disk.
+
+These assert the observable contract: which home the handler body resolves
+against, and which profile is recorded for the follow-up ``apply``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def profile_env(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    (root / "profiles" / "coder").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    return root
+
+
+@pytest.fixture
+def client(profile_env):
+    import hermes_cli.web_server as ws
+
+    c = TestClient(ws.app)
+    c.headers[ws._SESSION_HEADER_NAME] = ws._SESSION_TOKEN
+    return c
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Record the HERMES_HOME the handler body resolves the session path in."""
+    import hermes_cli.web_server as ws
+    from hermes_constants import get_hermes_home
+
+    seen: dict = {}
+
+    def _session_path():
+        seen["home"] = str(get_hermes_home())
+        p = get_hermes_home() / "platforms" / "whatsapp" / "session"
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    monkeypatch.setattr(ws, "_whatsapp_session_path", _session_path)
+    # Keep the bridge subprocess out of the test.
+    monkeypatch.setattr(ws, "_spawn_whatsapp_pairing", lambda *a, **k: None, raising=False)
+    return seen
+
+
+def _record_for(pairing_id: str):
+    import hermes_cli.web_server as ws
+
+    return ws._whatsapp_onboarding_sessions.get(pairing_id)
+
+
+class TestStartWhatsAppOnboardingProfileScope:
+    def test_query_profile_scopes_the_session_directory(
+        self, client, profile_env, captured
+    ):
+        resp = client.post(
+            "/api/messaging/whatsapp/onboarding/start?profile=coder",
+            json={"mode": "bot"},
+        )
+
+        assert resp.status_code == 200
+        assert captured["home"] == str(profile_env / "profiles" / "coder")
+
+    def test_query_profile_is_recorded_for_the_follow_up_apply(
+        self, client, profile_env, captured
+    ):
+        resp = client.post(
+            "/api/messaging/whatsapp/onboarding/start?profile=coder",
+            json={"mode": "bot"},
+        )
+
+        pairing_id = resp.json()["pairing_id"]
+        record = _record_for(pairing_id)
+        assert record is not None
+        # apply resolves body.profile or profile or record.profile — a None
+        # here is what let start and apply disagree about the target profile.
+        assert record.profile == "coder"
+
+    def test_body_profile_still_wins(self, client, profile_env, captured):
+        """Back-compat: an explicit body profile keeps precedence."""
+        resp = client.post(
+            "/api/messaging/whatsapp/onboarding/start?profile=coder",
+            json={"mode": "bot", "profile": "default"},
+        )
+
+        assert resp.status_code == 200
+        assert captured["home"] == str(profile_env)
+        assert _record_for(resp.json()["pairing_id"]).profile == "default"
+
+    def test_no_profile_uses_the_launch_home(self, client, profile_env, captured):
+        resp = client.post(
+            "/api/messaging/whatsapp/onboarding/start",
+            json={"mode": "bot"},
+        )
+
+        assert resp.status_code == 200
+        assert captured["home"] == str(profile_env)
+        assert _record_for(resp.json()["pairing_id"]).profile is None


### PR DESCRIPTION
## What does this PR do?

`/api/messaging/whatsapp/onboarding` is one of the entries in the dashboard's
`PROFILE_SCOPED_PREFIXES`, so `withManagementProfile()` appends
`?profile=<management profile>` to **every** call in that family.

`apply_whatsapp_onboarding` honours it — it resolves
`body.profile or profile or record.profile`. **`start_whatsapp_onboarding` did
not**: it read `body.profile` only and declared no `profile` query parameter at
all, so FastAPI discarded the one the client actually sends. And
`ChannelsPage.tsx`'s start button posts `{ mode, allowed_users }` — it never
populates the body field either.

So with the dashboard managing a non-default profile, onboarding split in half:

| Step | Profile it actually used |
|---|---|
| `start` — Baileys session dir, bridge subprocess, QR link, `creds.json` | **launch** profile (`_config_profile_scope(None)`) |
| record persisted for the follow-up | `profile=None` |
| `apply` — WhatsApp config write + gateway restart | **managed** profile (sees `?profile=`) |

The managed profile's gateway came up with WhatsApp enabled and **no session on
disk**, so it never connected — while the user's phone stayed linked into a
profile they were not configuring.

Telegram's equivalent route is unaffected: `start_telegram_onboarding` holds no
local per-profile state (it proxies a remote pairing service), and its `/apply`
already takes `profile`. WhatsApp is the one whose `start` creates per-profile
state on disk.

### How it was found

Mirror of the check in #76674's family: for every `web_server.py` route that
sits **under** a client `PROFILE_SCOPED_PREFIX` — so it receives `?profile=` —
does the handler actually declare the parameter? Ten did not. Eight are benign
(`/api/pairing/*` and `/api/messaging/*/onboarding/*apply` take the profile from
the request body, `/api/config/defaults` is static, `/api/gateway/drain` has no
dashboard caller, the status/cancel routes key off an in-process record that
already carries its own profile). `whatsapp/onboarding/start` was the one that
genuinely diverged from its own `apply` sibling.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`hermes_cli/web_server.py`** — `start_whatsapp_onboarding()` takes
  `profile: Optional[str] = None` and resolves `body.profile or profile`, the
  same order `apply_whatsapp_onboarding()` already uses. An explicit
  `body.profile` still wins; a request with no profile at all is unchanged.
- **`tests/hermes_cli/test_whatsapp_onboarding_profile_scope.py`** — 4 tests.

## How to Test

1. `hermes profile create coder`, then `hermes dashboard`.
2. Switch the management profile to `coder` and open Channels → WhatsApp → start
   setup.
3. **Before:** the QR/session was created under `~/.hermes/platforms/whatsapp/session`
   (the launch profile) while Apply wrote the config into
   `~/.hermes/profiles/coder/` and restarted coder's gateway — which then had
   WhatsApp enabled with no session.
   **After:** the session directory, the bridge and the config all land in
   `~/.hermes/profiles/coder/`.

## Test Results

New file `tests/hermes_cli/test_whatsapp_onboarding_profile_scope.py` — 4 tests.
They assert the observable contract (which `HERMES_HOME` the handler body
resolves the session path against, and which profile is recorded for the
follow-up `apply`) against a real temp profile tree, rather than mocking
`_config_profile_scope`:

| Test | Asserts |
|---|---|
| `test_query_profile_scopes_the_session_directory` | body resolves under `<root>/profiles/coder` |
| `test_query_profile_is_recorded_for_the_follow_up_apply` | `record.profile == "coder"`, so `apply` can no longer disagree |
| `test_body_profile_still_wins` | explicit `body.profile` keeps precedence over the query param |
| `test_no_profile_uses_the_launch_home` | unchanged behaviour when no profile is supplied |

Red-without-fix, with only `hermes_cli/web_server.py` reverted:

```text
2 failed, 2 passed
```

With the fix:

```text
4 passed in 1.14s
```

**Regression sweep**

```text
tests/hermes_cli/test_web_server.py + new file:            136 passed, 5 skipped
test_whatsapp_onboarding.py, test_whatsapp_setup_ordering.py,
test_whatsapp_cloud_setup.py:                               14 passed
```