### PR TITLE
fix(cron): handle embedded null byte in lifecycle guard command tokens (#77988)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -149,6 +149,20 @@ def _command_token_index(segment: list[str]) -> Optional[int]:
     return None
 
 
+def _safe_path_name(token: str) -> Optional[str]:
+    """Like ``Path(token).name`` but returns ``None`` instead of raising.
+
+    A command token can contain a character pathlib rejects (e.g. an
+    embedded NUL byte) without being path-like at all — a guarded path
+    must never crash the guard (mirrors the #76762 fix for binary script
+    content).
+    """
+    try:
+        return Path(token).name
+    except ValueError:
+        return None
+
+
 def contains_launchctl_submit_command(command: str) -> bool:
     """Detect an executed ``launchctl submit``/``bootstrap``, not quoted text.
 
@@ -163,17 +177,25 @@ def contains_launchctl_submit_command(command: str) -> bool:
         index = _command_token_index(segment)
         if index is None:
             continue
-        if Path(segment[index]).name == "launchctl":
+        if _safe_path_name(segment[index]) == "launchctl":
             arguments = segment[index + 1 :]
             if arguments and arguments[0].lower() in {"submit", "bootstrap"}:
                 return True
     return False
 
 
-def _resolve_terminal_script_path(candidate: str, cwd: Optional[str]) -> Path:
-    path = Path(candidate).expanduser()
-    if not path.is_absolute():
-        path = Path(cwd or Path.cwd()) / path
+def _resolve_terminal_script_path(
+    candidate: str, cwd: Optional[str]
+) -> Optional[Path]:
+    try:
+        path = Path(candidate).expanduser()
+        if not path.is_absolute():
+            path = Path(cwd or Path.cwd()) / path
+    except ValueError:
+        # Embedded NUL byte (or other pathlib-rejected character) in the
+        # candidate — treat as "nothing to scan" rather than crashing the
+        # guard (#77988).
+        return None
     return path
 
 
@@ -188,11 +210,13 @@ def _iter_referenced_shell_scripts(
         if index is None:
             continue
         executable = segment[index]
-        executable_name = Path(executable).name
+        executable_name = _safe_path_name(executable)
 
         if executable_name in {".", "source"}:
             if len(segment) > index + 1:
-                yield _resolve_terminal_script_path(segment[index + 1], cwd)
+                resolved = _resolve_terminal_script_path(segment[index + 1], cwd)
+                if resolved is not None:
+                    yield resolved
             continue
 
         if executable_name in _SHELL_EXECUTABLES:
@@ -216,7 +240,9 @@ def _iter_referenced_shell_scripts(
                 "-c",
                 "--command",
             }:
-                yield _resolve_terminal_script_path(arguments[arg_index], cwd)
+                resolved = _resolve_terminal_script_path(arguments[arg_index], cwd)
+                if resolved is not None:
+                    yield resolved
             continue
 
         # A bare "/" token is pathlib's division operator in Python sources
@@ -226,14 +252,16 @@ def _iter_referenced_shell_scripts(
         # (#77131). Skip pure-separator tokens.
         if executable.strip("/"):
             if "/" in executable or executable.endswith((".sh", ".bash", ".zsh")):
-                yield _resolve_terminal_script_path(executable, cwd)
+                resolved = _resolve_terminal_script_path(executable, cwd)
+                if resolved is not None:
+                    yield resolved
 
 
 def _iter_shell_command_payloads(command: str) -> Iterator[str]:
     """Yield code passed through ``sh|bash|... -c`` for recursive scanning."""
     for segment in _iter_command_segments(command):
         index = _command_token_index(segment)
-        if index is None or Path(segment[index]).name not in _SHELL_EXECUTABLES:
+        if index is None or _safe_path_name(segment[index]) not in _SHELL_EXECUTABLES:
             continue
         arguments = segment[index + 1 :]
         for arg_index, argument in enumerate(arguments[:-1]):
@@ -264,6 +292,11 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         # tokenized into a bogus script path by the recursion (#77703). A
         # guarded read must never crash the guard, so treat either as
         # "nothing to scan" (mirrors the resolve() ValueError guard below).
+        return None, False
+    except ValueError:
+        # Embedded NUL byte in the path string itself, distinct from a
+        # NUL byte in the file's content (handled below) — treat as
+        # "nothing to scan" rather than crashing the guard (#77988).
         return None, False
     try:
         metadata = os.fstat(descriptor)

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -736,6 +736,58 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_nul_byte_in_command_token_does_not_crash_guard(self):
+        """#77988: a NUL byte in a command token / path string (as opposed
+        to a NUL byte in a file's content, #76762) must not crash the guard
+        with ``ValueError: embedded null byte``.
+
+        Before the fix, unguarded ``Path()``/``os.open()`` calls on the raw
+        token raised ValueError on every terminal-tool invocation once a NUL
+        byte appeared in a command token, taking down completely benign
+        commands. NUL-laden tokens are not path-like; treat them as
+        "nothing to scan".
+        """
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        # Exact repro from the issue: NUL in a script-path argument.
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            "bash \x00engine/scripts/portfolio_report.py --date 2026-08-03"
+        ) is False
+        # NUL inside a -c payload token.
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            'bash -c "echo \x00hi"'
+        ) is False
+        # NUL inside a referenced .sh path token.
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            "bash ./we\x00ird.sh"
+        ) is False
+
+    def test_nul_byte_in_launchctl_token_does_not_crash_guard(self):
+        """#77988: the label-independent launchctl submit check tolerates a
+        NUL byte in the executable token the same way."""
+        from cron.lifecycle_guard import contains_launchctl_submit_command
+        assert contains_launchctl_submit_command(
+            "launchctl \x00submit -l ai.hermes.svc -- /bin/echo hi"
+        ) is False
+
+    def test_nul_byte_tolerance_does_not_weaken_guard(self):
+        """#77988: treating NUL-laden tokens as "nothing to scan" must not
+        weaken the guard — real lifecycle commands are still blocked."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+            contains_launchctl_submit_command,
+        )
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            "hermes gateway restart"
+        ) is True
+        assert contains_launchctl_submit_command(
+            "launchctl submit -l ai.hermes.svc-reload-tmp -- /bin/echo hi"
+        ) is True
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            "ls -la /tmp"
+        ) is False
+
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:
         a .sh script that itself invokes a lifecycle command is caught."""


### PR DESCRIPTION
## Summary

Fixes #77988 — a `ValueError: embedded null byte` raised by `cron/lifecycle_guard.py` when a NUL byte appears in a terminal command token (executable or script-path string). The unhandled exception propagated out of the guard on **every** terminal-tool invocation once a NUL byte showed up in a command token, taking down completely benign commands ("Operacja nieudana: embedded null byte w lifecycle_guard").

Distinct from #77927 (NUL-byte *security bypass* in file content): this is the opposite failure direction — the guard *crashes* instead of silently letting something through.

## Root Cause

Several sites in `cron/lifecycle_guard.py` construct a `pathlib.Path` (or call `os.open`) directly from a token parsed out of the raw command string, without guarding against `ValueError` (which `pathlib`/`os` raise for an embedded NUL byte):

1. `_resolve_terminal_script_path()` — `Path(candidate).expanduser()` unguarded; runs lazily inside the `_iter_referenced_shell_scripts` generator, so the `try/except (OSError, ValueError)` in `_contains_unsafe_gateway_action` wraps only the *later* `resolve(strict=False)` step and never catches the generator's own `Path()` construction.
2. `contains_launchctl_submit_command()` — `Path(segment[index]).name` unguarded.
3. `_iter_referenced_shell_scripts()` — `Path(executable).name` unguarded.
4. `_iter_shell_command_payloads()` — `Path(segment[index]).name` unguarded.
5. `_read_referenced_script()` — `os.open(path, flags)` catches only `OSError`, but a NUL byte *in the path string* makes `os.open` raise `ValueError`.

Sites 1–4 run on every terminal-tool invocation via `contains_gateway_lifecycle_command_or_referenced_script()` / `contains_launchctl_submit_command()`, which `tools/terminal_tool.py` calls unconditionally before executing any shell command.

## Change

Guard must never crash on unresolvable/invalid path tokens — treat them as "nothing to scan" (mirrors the existing #76762 philosophy for binary content), not as a hard failure:

- Add `_safe_path_name(token)` helper: like `Path(token).name` but returns `None` instead of raising on `ValueError`; use it at all three `Path(...).name` sites.
- `_resolve_terminal_script_path()` now returns `Optional[Path]` and returns `None` on `ValueError`; the three yield sites in `_iter_referenced_shell_scripts()` skip `None` results.
- `_read_referenced_script()` catches `ValueError` from `os.open` (NUL in the path string itself, distinct from NUL in file content handled below) and returns `(None, False)`.

## Verification

- New regression tests in `tests/hermes_cli/test_gateway_restart_loop.py`:
  - `test_nul_byte_in_command_token_does_not_crash_guard` — the issue's exact repro (`bash \x00engine/scripts/portfolio_report.py --date 2026-08-03`) plus NUL in a `-c` payload token and a `.sh` path token all return `False` instead of raising.
  - `test_nul_byte_in_launchctl_token_does_not_crash_guard` — NUL in the launchctl executable token tolerated.
  - `test_nul_byte_tolerance_does_not_weaken_guard` — `hermes gateway restart` still blocked, `launchctl submit -l ai.hermes.svc-reload-tmp -- ...` still blocked, benign `ls -la /tmp` still passes.
- Full existing suite passes: `tests/hermes_cli/test_gateway_restart_loop.py` (85 tests) and `tests/tools/test_terminal_tool_requirements.py` + `test_local_env_blocklist.py` + `test_approved_command_clean_slate.py` (63 tests).

Closes #77988
