### PR TITLE
fix(gateway): preserve queued turns at recursion cap

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7614,6 +7614,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             overflow.insert(0, next_queued)
         return pending_event
 
+    def _requeue_event_at_front(
+        self,
+        session_key: str,
+        event: "MessageEvent",
+        adapter: Any,
+    ) -> None:
+        """Restore *event* at the head without dropping a staged next turn.
+
+        The recursion cap can fire after the drain consumed the current head
+        and ``_promote_queued_event`` staged the next FIFO item in the adapter
+        slot.  Replacing that slot loses the staged item.  Move it back to the
+        front of overflow before restoring the current event as the head.
+        """
+        if adapter is None:
+            return
+        pending_slot = getattr(adapter, "_pending_messages", None)
+        if pending_slot is None:
+            return
+        staged = pending_slot.get(session_key)
+        if staged is not None:
+            self._session_state(session_key).conversation.queued_events.insert(
+                0, staged
+            )
+        pending_slot[session_key] = event
+
     def _queue_depth(self, session_key: str, *, adapter: Any = None) -> int:
         """Total pending /queue items for a session — slot + overflow."""
         _q_state = self._peek_session_state(session_key)
@@ -25323,7 +25348,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                     adapter = self._adapter_for_source(source)
                     if adapter and pending_event:
-                        merge_pending_message_event(adapter._pending_messages, session_key, pending_event)
+                        self._requeue_event_at_front(session_key, pending_event, adapter)
                     elif adapter and hasattr(adapter, 'queue_message'):
                         adapter.queue_message(session_key, pending)
                     return result_holder[0] or {"final_response": response, "messages": history}

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -169,6 +169,54 @@ class TestQueueConsumptionAfterCompletion:
         # gets the next-in-line item.
         assert adapter._pending_messages[session_key].text == "Q2"
 
+    def test_recursion_cap_requeue_preserves_staged_fifo_head(self):
+        """Requeueing the current item must not overwrite the promoted next item."""
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._queued_events = {}
+        adapter = _StubAdapter()
+        session_key = "discord:thread:coffee"
+
+        for text in ("Q1", "Q2", "Q3"):
+            runner._enqueue_fifo(
+                session_key,
+                MessageEvent(
+                    text=text,
+                    message_type=MessageType.TEXT,
+                    source=MagicMock(),
+                    message_id=f"q-{text}",
+                ),
+                adapter,
+            )
+
+        # Drain Q1 and promote Q2 into the slot; Q3 remains in overflow.
+        pending_event = _dequeue_pending_event(adapter, session_key)
+        pending_event = runner._promote_queued_event(
+            session_key, adapter, pending_event
+        )
+        assert pending_event.text == "Q1"
+        assert adapter._pending_messages[session_key].text == "Q2"
+        assert [event.text for event in runner._queued_events[session_key]] == [
+            "Q3"
+        ]
+
+        # The recursion cap restores Q1 without losing or reordering Q2/Q3.
+        runner._requeue_event_at_front(session_key, pending_event, adapter)
+        assert adapter._pending_messages[session_key].text == "Q1"
+        assert [event.text for event in runner._queued_events[session_key]] == [
+            "Q2",
+            "Q3",
+        ]
+
+        drained = []
+        for _ in range(3):
+            event = _dequeue_pending_event(adapter, session_key)
+            event = runner._promote_queued_event(session_key, adapter, event)
+            drained.append(event.text)
+        assert drained == ["Q1", "Q2", "Q3"]
+        assert runner._queue_depth(session_key, adapter=adapter) == 0
+
 
 class TestBusyInputModeQueueFifo:
     """Regression coverage for issue #28503.


### PR DESCRIPTION
## What does this PR do?

Prevents accepted `/queue` turns from being silently dropped when the gateway reaches its interrupt recursion cap.

The failure occurs after the current FIFO head has been drained and `_promote_queued_event()` has already staged the next item in the adapter's single pending slot. The recursion-cap path then requeues the current event by merging it into that same slot, overwriting the staged successor.

Example state transition before this fix:

```text
initial:             slot=Q1, overflow=[Q2, Q3]
after drain/promote: pending=Q1, slot=Q2, overflow=[Q3]
recursion-cap requeue (old): slot=Q1, overflow=[Q3]  # Q2 lost
```

This PR restores the unprocessed current event at the FIFO head while first moving any staged successor back to the front of overflow:

```text
recursion-cap requeue (new): slot=Q1, overflow=[Q2, Q3]
```

Each accepted queue item therefore remains a separate full turn in original arrival order.

## Related Issue / PR overlap

No dedicated issue found.

The recursion-cap behavior also appears inside broader platform-specific PRs #72674 (Email boundaries) and #76818 (Slack recovery). This PR intentionally isolates the generic message-loss fix and regression test on current `main`, without taking either PR's unrelated Email or Slack changes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - Add `_requeue_event_at_front()` to restore the drained event without overwriting an already promoted successor.
  - Use the helper at the interrupt recursion cap instead of `merge_pending_message_event()`.
- `tests/gateway/test_queue_consumption.py`
  - Add a `Q1 → Q2 → Q3` regression that reproduces drain, promotion, recursion-cap requeue, and complete FIFO consumption.

## How to Test

```bash
scripts/run_tests.sh \
  tests/gateway/test_queue_consumption.py \
  tests/gateway/test_queue_command.py \
  tests/gateway/test_pending_drain_no_recursion.py \
  tests/gateway/test_pending_drain_race.py \
  tests/gateway/test_active_session_text_merge.py \
  tests/gateway/test_steer_fifo_overwrite.py \
  tests/gateway/test_busy_session_ack.py \
  tests/gateway/test_discord_pending_text_batch_shutdown.py \
  -q

python -m ruff check gateway/run.py tests/gateway/test_queue_consumption.py
git diff --check origin/main...HEAD
```

Local result on Linux:

- **35 passed, 0 failed** across the 8 affected Gateway files
- Ruff: passed
- `git diff --check`: passed

The full repository suite was started successfully but not completed locally because it currently contains more than 20,000 tests; the focused Gateway regression set above was run through the canonical wrapper.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues and PRs and documented the overlapping broader PRs above
- [x] This PR contains only the generic queue-loss fix and its regression test
- [ ] Full repository test suite completed locally
- [x] Added behavioral regression coverage
- [x] Tested on Linux

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing behavior or configuration is added
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; existing FIFO architecture is preserved
- [x] Cross-platform impact considered; change uses platform-independent Python data structures
- [x] Tool descriptions/schemas: N/A
