### PR TITLE
fix(gateway): run pre_gateway_dispatch and media sanitization on busy-session path (#77976)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8620,7 +8620,82 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return text
         return (enriched_text or text).strip()
 
+    def _apply_pre_gateway_dispatch(self, event: MessageEvent) -> Optional[MessageEvent]:
+        """Run the ``pre_gateway_dispatch`` plugin hook for an inbound message.
+
+        Shared by the cold dispatch path (``_handle_message``) and the
+        busy-session path (``_handle_active_session_busy_message``) so
+        plugin-based authorization (e.g. publishing a dynamic allowlist)
+        and event sanitization (e.g. clearing ``media_urls``) apply
+        identically on both paths (#77976).
+
+        Plugins receive the MessageEvent and may return a dict influencing
+        flow:
+          {"action": "skip",    "reason": ...} -> return None (drop; plugin handled)
+          {"action": "rewrite", "text":  ...}  -> replace event.text, continue
+          {"action": "allow"}   /  None        -> normal dispatch
+        The hook runs BEFORE auth so plugins can handle unauthorized
+        senders without triggering the pairing flow.
+
+        Internal (system-generated) events skip the hook entirely.
+        Returns the (possibly rewritten) event, or None when a plugin
+        requested the message be skipped.
+        """
+        if getattr(event, "internal", False):
+            return event
+        try:
+            from hermes_cli.lifecycle import invoke_hook as _invoke_hook
+            _hook_results = _invoke_hook(
+                "pre_gateway_dispatch",
+                event=event,
+                gateway=self,
+                # getattr: bare-runner tests build GatewayRunner via
+                # object.__new__ without __init__ (pitfall #17), and the
+                # hook must not fail dispatch over a missing attribute.
+                session_store=getattr(self, "session_store", None),
+            )
+        except Exception as _hook_exc:
+            logger.warning("pre_gateway_dispatch invocation failed: %s", _hook_exc)
+            return event
+
+        for _result in _hook_results:
+            if not isinstance(_result, dict):
+                continue
+            _action = _result.get("action")
+            if _action == "skip":
+                _source = event.source
+                logger.info(
+                    "pre_gateway_dispatch skip: reason=%s platform=%s chat=%s",
+                    _result.get("reason"),
+                    _source.platform.value if _source.platform else "unknown",
+                    _source.chat_id or "unknown",
+                )
+                return None
+            if _action == "rewrite":
+                _new_text = _result.get("text")
+                if isinstance(_new_text, str):
+                    # Mutate in place so callers that keep a reference to
+                    # the original event (busy-path queueing in base.py)
+                    # observe the rewritten text.
+                    event.text = _new_text
+                return event
+            if _action == "allow":
+                return event
+        return event
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
+        # --- pre_gateway_dispatch plugin hook (#77976) ---
+        # The cold path (_handle_message) runs the hook before its auth
+        # gate so plugins can publish dynamic allowlists and sanitize
+        # events (e.g. clear media_urls).  The busy path must run the same
+        # hook; otherwise plugin-authorized senders are silently dropped
+        # (the allowlist was never published) and queued media reaches the
+        # model unsanitized on replay.
+        event = self._apply_pre_gateway_dispatch(event)
+        if event is None:
+            # Plugin requested the message be dropped (action=skip).
+            return True  # handled; do not fall through
+
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
         # creating a session.  The busy path must enforce the same check;
@@ -14274,49 +14349,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not is_internal:
             self._scale_to_zero_note_real_inbound()
 
-        # Fire pre_gateway_dispatch plugin hook for user-originated messages.
-        # Plugins receive the MessageEvent and may return a dict influencing flow:
+        # Fire pre_gateway_dispatch plugin hook for user-originated messages
+        # (see _apply_pre_gateway_dispatch). Plugins receive the MessageEvent
+        # and may return a dict influencing flow:
         #   {"action": "skip",    "reason": ...}    -> drop (no reply, plugin handled)
         #   {"action": "rewrite", "text":  ...}     -> replace event.text, continue
         #   {"action": "allow"}   /   None          -> normal dispatch
         # Hook runs BEFORE auth so plugins can handle unauthorized senders
         # (e.g. customer handover ingest) without triggering the pairing flow.
-        if not is_internal:
-            try:
-                from hermes_cli.lifecycle import invoke_hook as _invoke_hook
-                _hook_results = _invoke_hook(
-                    "pre_gateway_dispatch",
-                    event=event,
-                    gateway=self,
-                    # getattr: bare-runner tests build GatewayRunner via
-                    # object.__new__ without __init__ (pitfall #17), and the
-                    # hook must not fail dispatch over a missing attribute.
-                    session_store=getattr(self, "session_store", None),
-                )
-            except Exception as _hook_exc:
-                logger.warning("pre_gateway_dispatch invocation failed: %s", _hook_exc)
-                _hook_results = []
-
-            for _result in _hook_results:
-                if not isinstance(_result, dict):
-                    continue
-                _action = _result.get("action")
-                if _action == "skip":
-                    logger.info(
-                        "pre_gateway_dispatch skip: reason=%s platform=%s chat=%s",
-                        _result.get("reason"),
-                        source.platform.value if source.platform else "unknown",
-                        source.chat_id or "unknown",
-                    )
-                    return None
-                if _action == "rewrite":
-                    _new_text = _result.get("text")
-                    if isinstance(_new_text, str):
-                        event = dataclasses.replace(event, text=_new_text)
-                        source = event.source
-                    break
-                if _action == "allow":
-                    break
+        event = self._apply_pre_gateway_dispatch(event)
+        if event is None:
+            return None
+        source = event.source
 
         if is_internal:
             pass

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionSource
 
 
@@ -118,3 +118,171 @@ async def test_hook_fires_without_session_store_attribute(monkeypatch):
     # Hook actually fired (skip short-circuited before auth) with a None store.
     assert seen == {"session_store": None}
     adapter.send.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Busy-session path (#77976)
+# ---------------------------------------------------------------------------
+# Regression: _handle_active_session_busy_message skipped pre_gateway_dispatch
+# entirely, so plugin-published allowlists never authorized senders (silent
+# drop) and hook-based media sanitization never ran on queued follow-ups
+# (unsanitized media reached the model on replay). The busy path must run the
+# same hook, before the auth gate, as the cold path (_handle_message).
+
+def _make_busy_runner(platform=Platform.WHATSAPP, authorized=True):
+    """Build a minimal GatewayRunner for the busy-session path.
+
+    Uses busy_input_mode=queue so the handler terminates at the pending
+    queue (no steer/interrupt machinery) while still exercising the
+    pre_gateway_dispatch hook and the auth gate.
+    """
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={platform: PlatformConfig(enabled=True)})
+    runner._draining = False
+    runner._busy_input_mode = "queue"
+    runner._busy_text_mode = "interrupt"
+    runner._running_agents = {}
+    runner._busy_ack_ts = {}
+    runner._pending_messages = {}
+    runner.session_store = None
+    adapter = SimpleNamespace(
+        _pending_messages={},
+        send=AsyncMock(),
+        _send_with_retry=AsyncMock(),
+    )
+    runner.adapters = {platform: adapter}
+    runner._adapter_for_source = lambda source: adapter
+    runner._peek_session_state = lambda session_key: None
+    runner._is_user_authorized = lambda source: authorized
+    return runner, adapter
+
+
+@pytest.mark.asyncio
+async def test_busy_path_runs_hook_before_auth(monkeypatch):
+    """#77976: the busy path must run pre_gateway_dispatch BEFORE the auth
+    gate so a plugin-published allowlist authorizes the sender (instead of
+    the message being silently dropped as unauthorized)."""
+    published = {"allowed": set()}
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            published["allowed"].add(kwargs["event"].source.user_id)
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, adapter = _make_busy_runner(authorized=False)
+    # Static authz config denies everyone; only the plugin-published
+    # allowlist can authorize this sender.
+    runner._is_user_authorized = lambda source: source.user_id in published["allowed"]
+
+    event = _make_event("follow-up while busy")
+    sk = "agent:main:whatsapp:dm:15551234567"
+
+    result = await runner._handle_active_session_busy_message(event, sk)
+
+    # Hook ran → allowlist published → auth passes → queued, not dropped.
+    assert event.source.user_id in published["allowed"]
+    assert adapter._pending_messages.get(sk) is event
+    assert result is True  # handled (queued; busy ack suppressed by cooldown)
+
+
+@pytest.mark.asyncio
+async def test_busy_path_hook_sanitizes_media(monkeypatch):
+    """#77976: media sanitized by the hook on the busy path must not reach
+    the queued event — and therefore cannot reach the model on replay."""
+    def _fake_hook(name, **kwargs):
+        event = kwargs["event"]
+        event.media_urls = []
+        event.media_types = []
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, adapter = _make_busy_runner(authorized=True)
+    event = _make_event("photo burst follow-up")
+    event.message_type = MessageType.PHOTO
+    event.media_urls = ["/tmp/photo.jpg"]
+    event.media_types = ["image/jpeg"]
+
+    sk = "agent:main:whatsapp:dm:15551234567"
+    await runner._handle_active_session_busy_message(event, sk)
+
+    queued = adapter._pending_messages.get(sk)
+    assert queued is not None
+    assert queued.media_urls == []
+    assert queued.media_types == []
+
+
+@pytest.mark.asyncio
+async def test_busy_path_hook_skip_drops_message(monkeypatch):
+    """#77976: a plugin ``skip`` on the busy path drops the message without
+    consulting auth or queueing anything."""
+    def _fake_hook(name, **kwargs):
+        return [{"action": "skip", "reason": "plugin-handled"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, adapter = _make_busy_runner(authorized=False)
+    auth_calls = {"count": 0}
+
+    def _auth(source):
+        auth_calls["count"] += 1
+        return True
+
+    runner._is_user_authorized = _auth
+
+    event = _make_event("hi")
+    sk = "agent:main:whatsapp:dm:15551234567"
+    result = await runner._handle_active_session_busy_message(event, sk)
+
+    assert result is True
+    assert sk not in adapter._pending_messages
+    # Hook skip short-circuits BEFORE the auth gate.
+    assert auth_calls["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_busy_path_internal_events_bypass_hook(monkeypatch):
+    """Internal (system-generated) events skip the hook on the busy path too,
+    matching cold-path semantics."""
+    called = {"count": 0}
+
+    def _fake_hook(name, **kwargs):
+        called["count"] += 1
+        return [{"action": "skip"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, adapter = _make_busy_runner(authorized=True)
+    event = _make_event("background completion")
+    event.internal = True
+
+    sk = "agent:main:whatsapp:dm:15551234567"
+    result = await runner._handle_active_session_busy_message(event, sk)
+
+    assert called["count"] == 0
+    # Internal events fall through to the base adapter for silent queueing.
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_busy_path_hook_rewrite_flows_to_queued_event(monkeypatch):
+    """#77976: a plugin ``rewrite`` on the busy path must reach the queued
+    event (in-place mutation is observed by the adapter's pending slot)."""
+    def _fake_hook(name, **kwargs):
+        return [{"action": "rewrite", "text": "rewritten follow-up"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, adapter = _make_busy_runner(authorized=True)
+    event = _make_event("original follow-up")
+
+    sk = "agent:main:whatsapp:dm:15551234567"
+    await runner._handle_active_session_busy_message(event, sk)
+
+    queued = adapter._pending_messages.get(sk)
+    assert queued is not None
+    assert queued.text == "rewritten follow-up"


### PR DESCRIPTION
## Summary

Closes #77976

The busy-session path (`_handle_active_session_busy_message`) enforced the authorization gate but **never ran the `pre_gateway_dispatch` plugin hook**. For plugins that use the hook to (a) publish a dynamic allowlist (e.g. `WHATSAPP_ALLOWED_USERS` from plugin state) and (b) sanitize the event (clear `media_urls`/`media_types` after out-of-band moderation), every follow-up message arriving while a turn was running was:

- **Bug 1 — silently dropped**: the allowlist was never published, so `_is_user_authorized()` denied the sender and the message was discarded with no user-visible feedback.
- **Bug 2 — sanitization bypass**: any event that did reach `_pending_messages` was replayed into the agent with its `media_urls` intact, so raw images reached the model via `vision_analyze` — exactly the leak the hook exists to prevent.

## Root Cause

The hook logic lived inline in `_handle_message` (the cold path) only. The busy handler at `gateway/run.py:5862` (and the queued-follow-up replay that drains `_pending_messages`) never called it. Two code paths, one security-relevant step — classic path divergence.

## Change

- Extract the hook loop into a shared helper `GatewayRunner._apply_pre_gateway_dispatch(event)` in `gateway/run.py`, preserving cold-path semantics exactly: skip → drop; rewrite → replace `event.text` (now in-place, so the adapter's pending slot observes it); allow/None → normal dispatch; internal events bypass the hook; hook failures are non-fatal.
- `_handle_message` (cold path) now calls the helper.
- `_handle_active_session_busy_message` (busy path) now calls the helper **before** the authorization gate (#17775), matching the cold path's ordering. A plugin `skip` returns `True` (handled, dropped). Because the event is mutated in place, the sanitized/rewritten event is what gets queued to `_pending_messages` — so the replay path (drain → `_prepare_profile_scoped_inbound_message_text` → `_run_agent`) can no longer route unsanitized media to the model.

## Verification

- New regression tests in `tests/gateway/test_pre_gateway_dispatch.py`:
  - busy path runs the hook **before** auth → plugin-published allowlist authorizes the sender (message queued, not dropped)
  - hook media sanitization on the busy path → queued event carries no `media_urls`/`media_types`
  - plugin `skip` on the busy path → dropped, auth gate never consulted
  - internal events bypass the hook on the busy path (cold-path parity)
  - plugin `rewrite` on the busy path → rewritten text reaches the queued event
- Existing suite green: `test_pre_gateway_dispatch.py`, `test_busy_session_auth_bypass.py`, `test_busy_session_ack.py`, `test_internal_event_never_interrupts_busy_session.py`, `test_subagent_protection_30170.py`, `test_plaintext_approval_routing.py`, plus 180 more gateway tests across session-race, drain, resume, Discord/Telegram/Slack/Feishu and command tests — all pass.
