### PR TITLE
fix(skills): key security-scan cache by source identifier, not name (#78004)

### DIFF
--- a/tests/tools/test_skills_hub_clawhub.py
+++ b/tests/tools/test_skills_hub_clawhub.py
@@ -619,6 +619,85 @@ class TestFetchOwnerHandleRetry(unittest.TestCase):
         self.assertEqual(call_count["n"], 6)
         mock_sleep.assert_called()
 
+    # -- identifier namespacing (issue #78004) --------------------------------
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_fetch_rejects_foreign_identifier_with_same_name(self, mock_get):
+        """A fully-qualified identifier from another registry must not resolve.
+
+        Regression for #78004: ClawHubSource.fetch() previously took the last
+        path segment of ANY identifier as its slug, so
+        ``owner/repo/skills/todoist`` silently resolved to the ClawHub skill
+        named ``todoist`` when the owning source failed.  Foreign identifiers
+        must return None without hitting the ClawHub API.
+        """
+        # Simulate a ClawHub skill that shares the name with the foreign one.
+        mock_get.return_value = _MockResponse(
+            status_code=200,
+            json_data={"slug": "todoist", "latestVersion": {"version": "1.0.0"}},
+        )
+
+        bundle = self.src.fetch("owner/hermes-skills/skills/todoist")
+
+        self.assertIsNone(bundle)
+        mock_get.assert_not_called()
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_inspect_rejects_foreign_identifier_with_same_name(self, mock_get):
+        """inspect() must reject foreign identifiers the same way fetch() does."""
+        mock_get.return_value = _MockResponse(
+            status_code=200,
+            json_data={"slug": "todoist", "displayName": "Todoist", "summary": "x"},
+        )
+
+        meta = self.src.inspect("owner/hermes-skills/skills/todoist")
+
+        self.assertIsNone(meta)
+        mock_get.assert_not_called()
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_fetch_resolves_clawhub_prefixed_identifier(self, mock_get):
+        """'clawhub/<slug>' is an accepted explicit identifier form."""
+        import io
+        import zipfile
+
+        def side_effect(url, *args, **kwargs):
+            if url.endswith("/skills/todoist"):
+                return _MockResponse(
+                    status_code=200,
+                    json_data={"slug": "todoist", "latestVersion": {"version": "1.0.0"}},
+                )
+            if "download" in url:
+                buf = io.BytesIO()
+                with zipfile.ZipFile(buf, "w") as zf:
+                    zf.writestr("SKILL.md", "---\nname: todoist\n---\n# Todoist\n")
+                resp = _MockResponse(status_code=200)
+                resp.content = buf.getvalue()
+                return resp
+            return _MockResponse(status_code=404, json_data={})
+
+        mock_get.side_effect = side_effect
+
+        bundle = self.src.fetch("clawhub/todoist")
+
+        self.assertIsNotNone(bundle)
+        self.assertEqual(bundle.name, "todoist")
+        self.assertEqual(bundle.identifier, "todoist")
+        self.assertEqual(bundle.source, "clawhub")
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_inspect_resolves_clawhub_prefixed_identifier(self, mock_get):
+        mock_get.return_value = _MockResponse(
+            status_code=200,
+            json_data={"slug": "todoist", "displayName": "Todoist", "summary": "Task manager"},
+        )
+
+        meta = self.src.inspect("clawhub/todoist")
+
+        self.assertIsNotNone(meta)
+        self.assertEqual(meta.identifier, "todoist")
+        self.assertEqual(meta.name, "Todoist")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2437,8 +2437,30 @@ class ClawHubSource(SkillSource):
         _write_index_cache(cache_key, [_skill_meta_to_dict(s) for s in final_results])
         return final_results
 
+    @staticmethod
+    def _slug_from_identifier(identifier: str) -> str:
+        """Extract the ClawHub slug from an identifier, or "" if not ours.
+
+        ClawHub identifiers are bare slugs (``todoist``) and may carry an
+        explicit ``clawhub/`` prefix (``clawhub/todoist`` — the form the
+        docs use for install).  Any other identifier shape — notably a
+        fully-qualified identifier from another registry, e.g. a GitHub tap
+        identifier ``owner/repo/skills/todoist`` — does NOT belong to
+        ClawHub and must be rejected.  Resolving it by its last path
+        segment would silently install a same-named ClawHub skill under a
+        foreign identifier, overwriting the skill the user actually asked
+        for (issue #78004).
+        """
+        if identifier.startswith("clawhub/"):
+            return identifier[len("clawhub/"):]
+        if "/" in identifier:
+            return ""
+        return identifier
+
     def fetch(self, identifier: str) -> Optional[SkillBundle]:
-        slug = identifier.split("/")[-1]
+        slug = self._slug_from_identifier(identifier)
+        if not slug:
+            return None
 
         skill_data = self._get_json(f"{self.BASE_URL}/skills/{slug}")
         if not isinstance(skill_data, dict):
@@ -2480,7 +2502,9 @@ class ClawHubSource(SkillSource):
         )
 
     def inspect(self, identifier: str) -> Optional[SkillMeta]:
-        slug = identifier.split("/")[-1]
+        slug = self._slug_from_identifier(identifier)
+        if not slug:
+            return None
         data = self._coerce_skill_payload(self._get_json(f"{self.BASE_URL}/skills/{slug}"))
         if not isinstance(data, dict):
             return None


### PR DESCRIPTION
## Summary

`hermes skills install <full-qualified-identifier>` could silently install the **wrong** same-named skill. `ClawHubSource.fetch()` / `inspect()` derived the slug as `identifier.split("/")[-1]` — the last path segment (the skill **name**) — with no check that the identifier actually belongs to ClawHub's namespace.

Because `_resolve_source_meta_and_bundle` walks every source adapter in order and takes the first one that returns a bundle, a fully-qualified identifier from another registry (e.g. a GitHub tap: `owner/repo/skills/todoist`) was silently resolved **by name** to a ClawHub skill whenever the owning source failed to fetch (GitHub API rate limit, transient 404, network hiccup). No error, no mismatch warning. The wrong content was then scanned and cached under the name-derived identity, so subsequent installs showed `provenance: cached` — making the wrong install look legitimate and destructive: it overwrote a working hand-authored local skill directory in place.

## Root cause

ClawHub identifiers are bare slugs (`todoist`). `ClawHubSource.fetch`/`inspect` accepted **any** identifier and used its last path segment as the slug, so a foreign identifier with the same trailing name (`owner/hermes-skills/skills/todoist` → slug `todoist`) hit the ClawHub API for a same-named skill. The scan-result cache in `tools/skills_guard.py::scan_skill_cached` is content+source-keyed and correct; it merely cached the **wrong** bundle under the ClawHub identity (`Source: todoist` in the scan report), which is why the issue manifests as a name-keyed cache.

## Change

`tools/skills_hub.py` — `ClawHubSource`:

- Added `_slug_from_identifier()` which only claims identifiers in ClawHub's own namespace:
  - bare slug (`todoist`) — accepted (resolved via `_resolve_short_name` or typed directly)
  - explicit `clawhub/<slug>` prefix — accepted (the install form the docs use)
  - **any other identifier containing `/` (e.g. a GitHub tap identifier) → rejected (`None`)**
- `fetch()` and `inspect()` now use it, so a foreign identifier returns `None` instead of silently resolving to a same-named ClawHub skill. The router then never sees a substitute bundle, and no wrong content reaches the scan cache.

## Verification

- New regression tests in `tests/tools/test_skills_hub_clawhub.py`:
  - `fetch`/`inspect` with `owner/hermes-skills/skills/todoist` return `None` and make **no** ClawHub API call (fails before this fix: resolves to `SkillMeta(identifier='todoist', ...)`).
  - `fetch`/`inspect` with the `clawhub/todoist` prefixed form still resolve correctly.
- `python -m pytest tests/tools/test_skills_hub_clawhub.py` → 25 passed (21 existing + 4 new).
- Related suites (`test_skills_hub.py`, `test_skills_hub_browse_sh.py`, `test_skill_bundle_provenance.py`, `test_skill_provenance.py`, `test_skills_guard.py`) pass; the one batch-order failure in `test_real_temp_repo_and_home_install_e2e` reproduces identically on clean `upstream/main` (pre-existing test-isolation issue, unrelated).

Closes #78004