### PR TITLE
fix(desktop): guarantee OAuth login window timer/listener cleanup on all exit paths

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6066,6 +6066,7 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
 
       try {
         if (win && !win.isDestroyed()) {
+
           const wc = win.webContents
           if (wc && !wc.isDestroyed()) {
             wc.removeListener('did-navigate', onNavigate)
@@ -6591,6 +6592,7 @@ function openPortalLoginWindow() {
 
       try {
         if (win && !win.isDestroyed()) {
+
           const wc = win.webContents
           if (wc && !wc.isDestroyed()) {
             wc.removeListener('did-navigate', onNavigate)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6042,6 +6042,11 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
     let pollTimer = null
     let revealTimer = null
 
+    // Navigation event handlers (named for removal)
+    const onNavigate = () => void checkCookie()
+    const onRedirect = () => void checkCookie()
+    const onFrameNavigate = () => void checkCookie()
+
     const finish = err => {
       if (settled) {
         return
@@ -6051,10 +6056,25 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
 
       if (pollTimer) {
         clearInterval(pollTimer)
+        pollTimer = null
       }
 
       if (revealTimer) {
         clearTimeout(revealTimer)
+        revealTimer = null
+      }
+
+      try {
+        if (win && !win.isDestroyed()) {
+          const wc = win.webContents
+          if (wc && !wc.isDestroyed()) {
+            wc.removeListener('did-navigate', onNavigate)
+            wc.removeListener('did-redirect-navigation', onRedirect)
+            wc.removeListener('did-frame-navigate', onFrameNavigate)
+          }
+        }
+      } catch {
+        // already torn down
       }
 
       try {
@@ -6111,9 +6131,9 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
     // Re-check the cookie jar on every successful navigation (the callback
     // redirect is the moment cookies get set) plus a low-frequency poll as a
     // belt-and-braces fallback for IDPs that finish via in-page JS.
-    win.webContents.on('did-navigate', () => void checkCookie())
-    win.webContents.on('did-redirect-navigation', () => void checkCookie())
-    win.webContents.on('did-frame-navigate', () => void checkCookie())
+    win.webContents.on('did-navigate', onNavigate)
+    win.webContents.on('did-redirect-navigation', onRedirect)
+    win.webContents.on('did-frame-navigate', onFrameNavigate)
     pollTimer = setInterval(() => void checkCookie(), 750)
 
     // Silent-mode reveal fallback: if the cascade hasn't settled shortly, the
@@ -6136,6 +6156,11 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
     win.on('closed', () => {
       if (!settled) {
         finish(new Error('Login window closed before authentication completed.'))
+      }
+    })
+    win.on('destroyed', () => {
+      if (!settled) {
+        finish(new Error('Login window destroyed before authentication completed.'))
       }
     })
 
@@ -6547,6 +6572,11 @@ function openPortalLoginWindow() {
     let win = null
     let pollTimer = null
 
+    // Navigation event handlers (named for removal)
+    const onNavigate = () => void checkCookie()
+    const onRedirect = () => void checkCookie()
+    const onFrameNavigate = () => void checkCookie()
+
     const finish = err => {
       if (settled) {
         return
@@ -6556,6 +6586,20 @@ function openPortalLoginWindow() {
 
       if (pollTimer) {
         clearInterval(pollTimer)
+        pollTimer = null
+      }
+
+      try {
+        if (win && !win.isDestroyed()) {
+          const wc = win.webContents
+          if (wc && !wc.isDestroyed()) {
+            wc.removeListener('did-navigate', onNavigate)
+            wc.removeListener('did-redirect-navigation', onRedirect)
+            wc.removeListener('did-frame-navigate', onFrameNavigate)
+          }
+        }
+      } catch {
+        // already torn down
       }
 
       try {
@@ -6604,14 +6648,19 @@ function openPortalLoginWindow() {
       return
     }
 
-    win.webContents.on('did-navigate', () => void checkCookie())
-    win.webContents.on('did-redirect-navigation', () => void checkCookie())
-    win.webContents.on('did-frame-navigate', () => void checkCookie())
+    win.webContents.on('did-navigate', onNavigate)
+    win.webContents.on('did-redirect-navigation', onRedirect)
+    win.webContents.on('did-frame-navigate', onFrameNavigate)
     pollTimer = setInterval(() => void checkCookie(), 750)
 
     win.on('closed', () => {
       if (!settled) {
         finish(new Error('Sign-in window closed before authentication completed.'))
+      }
+    })
+    win.on('destroyed', () => {
+      if (!settled) {
+        finish(new Error('Sign-in window destroyed before authentication completed.'))
       }
     })
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5900,6 +5900,11 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
     let pollTimer = null
     let revealTimer = null
 
+    // Navigation event handlers (named for removal)
+    const onNavigate = () => void checkCookie()
+    const onRedirect = () => void checkCookie()
+    const onFrameNavigate = () => void checkCookie()
+
     const finish = err => {
       if (settled) {
         return
@@ -5909,10 +5914,26 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
 
       if (pollTimer) {
         clearInterval(pollTimer)
+        pollTimer = null
       }
 
       if (revealTimer) {
         clearTimeout(revealTimer)
+        revealTimer = null
+      }
+
+      try {
+        if (win && !win.isDestroyed()) {
+
+          const wc = win.webContents
+          if (wc && !wc.isDestroyed()) {
+            wc.removeListener('did-navigate', onNavigate)
+            wc.removeListener('did-redirect-navigation', onRedirect)
+            wc.removeListener('did-frame-navigate', onFrameNavigate)
+          }
+        }
+      } catch {
+        // already torn down
       }
 
       try {
@@ -5969,9 +5990,9 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
     // Re-check the cookie jar on every successful navigation (the callback
     // redirect is the moment cookies get set) plus a low-frequency poll as a
     // belt-and-braces fallback for IDPs that finish via in-page JS.
-    win.webContents.on('did-navigate', () => void checkCookie())
-    win.webContents.on('did-redirect-navigation', () => void checkCookie())
-    win.webContents.on('did-frame-navigate', () => void checkCookie())
+    win.webContents.on('did-navigate', onNavigate)
+    win.webContents.on('did-redirect-navigation', onRedirect)
+    win.webContents.on('did-frame-navigate', onFrameNavigate)
     // Log-only lifecycle diagnostics: a crashed sign-in renderer is invisible
     // to the window's promise path (it never settles), so without this the
     // failure leaves no trace in desktop.log (#81290 follow-up).
@@ -5998,6 +6019,11 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
     win.on('closed', () => {
       if (!settled) {
         finish(new Error('Login window closed before authentication completed.'))
+      }
+    })
+    win.on('destroyed', () => {
+      if (!settled) {
+        finish(new Error('Login window destroyed before authentication completed.'))
       }
     })
 
@@ -6409,6 +6435,11 @@ function openPortalLoginWindow() {
     let win = null
     let pollTimer = null
 
+    // Navigation event handlers (named for removal)
+    const onNavigate = () => void checkCookie()
+    const onRedirect = () => void checkCookie()
+    const onFrameNavigate = () => void checkCookie()
+
     const finish = err => {
       if (settled) {
         return
@@ -6418,6 +6449,21 @@ function openPortalLoginWindow() {
 
       if (pollTimer) {
         clearInterval(pollTimer)
+        pollTimer = null
+      }
+
+      try {
+        if (win && !win.isDestroyed()) {
+
+          const wc = win.webContents
+          if (wc && !wc.isDestroyed()) {
+            wc.removeListener('did-navigate', onNavigate)
+            wc.removeListener('did-redirect-navigation', onRedirect)
+            wc.removeListener('did-frame-navigate', onFrameNavigate)
+          }
+        }
+      } catch {
+        // already torn down
       }
 
       try {
@@ -6466,9 +6512,9 @@ function openPortalLoginWindow() {
       return
     }
 
-    win.webContents.on('did-navigate', () => void checkCookie())
-    win.webContents.on('did-redirect-navigation', () => void checkCookie())
-    win.webContents.on('did-frame-navigate', () => void checkCookie())
+    win.webContents.on('did-navigate', onNavigate)
+    win.webContents.on('did-redirect-navigation', onRedirect)
+    win.webContents.on('did-frame-navigate', onFrameNavigate)
     // Log-only lifecycle diagnostics, same rationale as the OAuth window:
     // a crashed portal sign-in renderer never settles the promise, so the
     // failure would otherwise leave no trace in desktop.log (#81290
@@ -6479,6 +6525,11 @@ function openPortalLoginWindow() {
     win.on('closed', () => {
       if (!settled) {
         finish(new Error('Sign-in window closed before authentication completed.'))
+      }
+    })
+    win.on('destroyed', () => {
+      if (!settled) {
+        finish(new Error('Sign-in window destroyed before authentication completed.'))
       }
     })
 


### PR DESCRIPTION
## What does this PR do?

Fixes timer and event listener leaks in the OAuth login window (`openOauthLoginWindow` and `openPortalLoginWindow`) by ensuring proper cleanup on all exit paths: successful authentication, user closing the window, and forced process termination (`win.destroy()`).

## Background

The desktop app opens OAuth login windows (for both remote gateway connections and Hermes Cloud portal sign-in) using `BrowserWindow` with a dedicated session partition. The original implementation had several resource leaks:

1. **Anonymous navigation handlers** — `did-navigate`, `did-redirect-navigation`, `did-frame-navigate` were registered as anonymous arrow functions, making them impossible to remove with `removeListener`
2. **Missing `destroyed` event handler** — Only `closed` was handled, but Electron emits `destroyed` after `closed` (and `win.destroy()` skips the `close` event while guaranteeing `closed` is emitted)
3. **No `webContents` listener cleanup** — Navigation listeners remained attached after window close
4. **Timer references not nulled** — `pollTimer` and `revealTimer` weren't set to `null` after clearing

These leaks caused:
- Accumulating timers in memory on repeated login attempts
- Orphaned navigation listeners firing on destroyed webContents
- Potential crashes when `checkCookie()` runs after window teardown

## Changes Made

### `apps/desktop/electron/main.ts`

**Both `openOauthLoginWindow` and `openPortalLoginWindow`:**

1. **Named handler functions** — `onNavigate`, `onRedirect`, `onFrameNavigate` defined as named functions so they can be removed
2. **Complete cleanup in `finish()`** — Clears timers, nulls references, removes all `webContents` listeners with `isDestroyed()` guards
3. **Added `destroyed` event handler** — Covers teardown paths beyond the destroy path itself (Electron skips `close` on `destroy()` and guarantees `closed`)
4. **Null timer references** — Set `pollTimer = null` and `revealTimer = null` after clearing

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor

## How to Test

1. **Remote gateway OAuth flow:**
   - Settings → Gateway → Remote → enter OAuth-enabled gateway URL → click "Sign in"
   - Complete authentication in the popup window
   - Verify window closes cleanly, no console errors

2. **Repeat login attempts:**
   - Open/close login window multiple times without authenticating
   - Verify no accumulating timers or listeners (check DevTools Memory panel)

3. **Forced termination test:**
   - Open login window
   - In DevTools Console: `win.destroy()` (simulates process kill)
   - Verify `finish()` is called, no unhandled errors

4. **Cloud portal sign-in:**
   - Settings → Gateway → Cloud → "Sign in to Hermes Cloud"
   - Complete authentication
   - Verify clean window close

## Related Issues/PRs

- Related to PR #77651 (perf: pause background timers when pane/window not visible) — similar cleanup patterns
- Related to `6502e441d` (perf: pause background timers when pane/window is not visible) — same `openOauthLoginWindow` refactor
- Addresses desktop memory leak class identified in performance work

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`fix(desktop):`)
- [x] Searched for existing PRs — no duplicate found
- [x] PR contains only changes related to this fix
- [x] Tested on macOS (Apple Silicon)
- [x] No documentation updates needed (internal implementation fix)
- [x] Cross-platform compatible (Electron APIs are platform-agnostic)