### PR TITLE
fix(gateway): drain active work before macOS service restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5125,6 +5125,44 @@ def launchd_restart():
 
     try:
         pid = get_running_pid()
+        if pid is not None and _launchd_unsupported_marker_exists():
+            # launchd cannot relaunch a detached fallback after SIGUSR1 makes
+            # it exit. Arm the existing watcher first so a replacement starts
+            # only after the old gateway has drained and stopped. Do not clear
+            # the marker: successful detached restart does not mean launchd
+            # supervision has recovered.
+            if not _spawn_gateway_restart_watcher(pid, _gateway_run_command()):
+                raise RuntimeError(
+                    "Could not prepare a replacement for the detached gateway; "
+                    "the running gateway was left untouched"
+                )
+            wait_budget = _get_restart_exit_wait_budget()
+            print(
+                f"⏳ Detached gateway restarting gracefully (PID {pid}) — "
+                f"waiting up to {wait_budget:.0f}s for in-flight turns + drain..."
+            )
+            if _request_gateway_self_restart(pid) or _graceful_restart_via_sigusr1(
+                pid, wait_budget
+            ):
+                print("✓ Detached gateway restart requested")
+                return
+
+            # The watcher remains armed, so the hard fallback below still
+            # brings the detached gateway back after the old PID exits.
+            try:
+                terminate_pid(pid, force=False)
+            except (ProcessLookupError, PermissionError, OSError):
+                pid = None
+            if pid is None or _wait_for_gateway_exit(
+                timeout=drain_timeout, force_after=None
+            ):
+                print("✓ Detached gateway restart requested")
+                return
+            raise RuntimeError(
+                f"Detached gateway PID {pid} did not exit after "
+                f"{drain_timeout:.0f}s; replacement remains armed"
+            )
+
         if pid is not None and _request_gateway_self_restart(pid):
             print("✓ Service restart requested")
             _clear_launchd_unsupported_marker()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5144,6 +5144,21 @@ def launchd_restart():
             _escalate_wedged_gateway(pid)
             pid = None
         if pid is not None:
+            # An external macOS CLI can use the same drain-aware SIGUSR1 path
+            # as systemd. Wait before stop() until active chat and cron work
+            # finishes instead of force-killing a legitimate long cron run.
+            wait_budget = _get_restart_exit_wait_budget()
+            print(
+                f"⏳ Launchd service restarting gracefully (PID {pid}) — "
+                f"waiting up to {wait_budget:.0f}s for in-flight turns + drain..."
+            )
+            if _graceful_restart_via_sigusr1(pid, wait_budget):
+                print("✓ Service restart requested")
+                _clear_launchd_unsupported_marker()
+                return
+
+            # Preserve the existing hard fallback when SIGUSR1 is unavailable
+            # or the configured after-turn safety cap expires.
             # Announce the drain BEFORE waiting on it. This wait can run for
             # the full drain budget (180s by default) while the old gateway
             # finishes in-flight agent runs, and it streams into surfaces with

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4543,6 +4543,21 @@ def launchd_restart():
             _clear_launchd_unsupported_marker()
             return
         if pid is not None:
+            # An external macOS CLI can use the same drain-aware SIGUSR1 path
+            # as systemd. Wait before stop() until active chat and cron work
+            # finishes instead of force-killing a legitimate long cron run.
+            wait_budget = _get_restart_exit_wait_budget()
+            print(
+                f"⏳ Launchd service restarting gracefully (PID {pid}) — "
+                f"waiting up to {wait_budget:.0f}s for in-flight turns + drain..."
+            )
+            if _graceful_restart_via_sigusr1(pid, wait_budget):
+                print("✓ Service restart requested")
+                _clear_launchd_unsupported_marker()
+                return
+
+            # Preserve the existing hard fallback when SIGUSR1 is unavailable
+            # or the configured after-turn safety cap expires.
             # Announce the drain BEFORE waiting on it. This wait can run for
             # the full drain budget (180s by default) while the old gateway
             # finishes in-flight agent runs, and it streams into surfaces with

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -796,6 +796,73 @@ class TestGatewaySystemServiceRouting:
         assert "restarting gracefully" in out
         assert "42" in out
 
+    def test_launchd_restart_rearms_detached_fallback_before_graceful_exit(
+        self, monkeypatch, capsys
+    ):
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 180.0)
+        monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 42.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 987)
+        monkeypatch.setattr(gateway_cli, "_launchd_unsupported_marker_exists", lambda: True)
+        monkeypatch.setattr(gateway_cli, "_gateway_run_command", lambda: ["python", "gateway"])
+        monkeypatch.setattr(
+            gateway_cli,
+            "_spawn_gateway_restart_watcher",
+            lambda pid, argv: calls.append(("watcher", pid, argv)) or True,
+        )
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("launchctl must not run for a detached fallback")
+            ),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_clear_launchd_unsupported_marker",
+            lambda: (_ for _ in ()).throw(
+                AssertionError("a detached restart must preserve the unsupported marker")
+            ),
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [
+            ("watcher", 987, ["python", "gateway"]),
+            ("graceful", 987, 42.0),
+        ]
+        assert "detached gateway restart requested" in capsys.readouterr().out.lower()
+
+    def test_launchd_restart_leaves_detached_gateway_running_if_watcher_fails(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 180.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 987)
+        monkeypatch.setattr(gateway_cli, "_launchd_unsupported_marker_exists", lambda: True)
+        monkeypatch.setattr(gateway_cli, "_gateway_run_command", lambda: ["python", "gateway"])
+        monkeypatch.setattr(gateway_cli, "_spawn_gateway_restart_watcher", lambda *args: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda pid: (_ for _ in ()).throw(
+                AssertionError("must not stop the old gateway without a replacement")
+            ),
+        )
+
+        with pytest.raises(RuntimeError, match="left untouched"):
+            gateway_cli.launchd_restart()
+
 
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -764,6 +764,38 @@ class TestGatewaySystemServiceRouting:
         assert "21627" not in out  # must use the mocked budget, not live defaults
         assert "27" in out
 
+    def test_launchd_restart_uses_after_turn_sigusr1_before_hard_restart(
+        self, monkeypatch, capsys
+    ):
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0.0)
+        monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 42.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 987)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append((pid, timeout)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("hard launchctl restart must not run after a graceful exit")
+            ),
+        )
+        monkeypatch.setattr(gateway_cli, "_clear_launchd_unsupported_marker", lambda: None)
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [(987, 42.0)]
+        out = capsys.readouterr().out.lower()
+        assert "restarting gracefully" in out
+        assert "42" in out
+
 
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -539,6 +539,38 @@ class TestGatewaySystemServiceRouting:
         assert "21627" not in out  # must use the mocked budget, not live defaults
         assert "27" in out
 
+    def test_launchd_restart_uses_after_turn_sigusr1_before_hard_restart(
+        self, monkeypatch, capsys
+    ):
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0.0)
+        monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 42.0)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 987)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append((pid, timeout)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("hard launchctl restart must not run after a graceful exit")
+            ),
+        )
+        monkeypatch.setattr(gateway_cli, "_clear_launchd_unsupported_marker", lambda: None)
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [(987, 42.0)]
+        out = capsys.readouterr().out.lower()
+        assert "restarting gracefully" in out
+        assert "42" in out
+
 
 
 
@@ -1759,4 +1791,3 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is True
         assert attempts["bootstrap"] >= 2  # the timeout was retried, not raised
-


### PR DESCRIPTION
## What changed

External macOS `hermes gateway restart` calls now use the same SIGUSR1 after-turn restart path as systemd. The gateway waits for active chat and cron work to finish before stopping, up to the existing configured safety cap. The previous launchctl restart remains the fallback if SIGUSR1 cannot be acknowledged or the cap expires.

## Why

`launchd_restart()` only requested an in-process restart when the caller was a descendant of the gateway. A normal external CLI call skipped that path and proceeded to SIGTERM / launchctl restart. Long-running cron work could therefore be interrupted even though the gateway already has an official six-hour after-turn drain mechanism.

In a live macOS reproduction, a daily cron execution was claimed at 02:00, the external upgrade restart sent SIGTERM at 02:00:37, and the recovered execution ledger recorded `unknown` because the owner exited before a durable terminal state. Since the scheduler had already advanced `next_run_at`, the run was not caught up after restart.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py`: 71 passed
- Latest `origin/main` focused rerun with `-k "launchd_restart or systemd_restart_gracefully"`: 3 passed
- `ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- `git diff --check`
- Live launchd verification: an external restart logged `Restart requested with 1 active work unit(s); deferring stop() until they finish (cap=21600s)` and kept the gateway alive while the cron execution continued.