### PR TITLE
fix(terminal): deadlock-proof _bash_starts probe on Windows

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -908,16 +908,39 @@ def _bash_starts(bash: str) -> bool:
         return cached
 
     try:
-        result = subprocess.run(
+        proc = subprocess.Popen(
             [bash, "--noprofile", "--norc", "-c", _BASH_EXTERNAL_PROGRAM_PROBE],
-            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True, encoding="utf-8", errors="replace",
-            timeout=15,
             creationflags=windows_hide_flags() if _IS_WINDOWS else 0,
         )
-        ok = result.returncode == 0
+        try:
+            stdout, stderr = proc.communicate(timeout=15)
+        except subprocess.TimeoutExpired:
+            # Kill the WHOLE tree, not just the direct child. On Windows an
+            # MSYS bash that hangs in its external-program spawn leaves
+            # orphaned grandchild processes holding the stdout pipe, so
+            # subprocess.run's unbounded cleanup communicate() would block
+            # forever (observed: ACP adapter tools stall indefinitely).
+            # Use taskkill /T /F and only bounded post-kill reads.
+            try:
+                if _IS_WINDOWS:
+                    subprocess.run(
+                        ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+                        capture_output=True, timeout=15,
+                    )
+                proc.kill()
+            except Exception:
+                pass
+            try:
+                stdout, stderr = proc.communicate(timeout=5)
+            except Exception:
+                stdout = stderr = ""
+        ok = proc.returncode == 0
         if not ok:
-            combined = f"{result.stdout or ''}{result.stderr or ''}"
+            combined = f"{stdout or ''}{stderr or ''}"
             _bash_probe_details_cache[bash] = combined.strip()[:2000]
             logger.debug("bash probe failed for %s: %s", bash, combined.strip()[:200])
     except Exception as exc:


### PR DESCRIPTION
## What does this PR do?

Fixes a permanent hang of the bash availability probe (`_bash_starts`) on Windows. The probe previously used `subprocess.run(timeout=15)`, whose Windows cleanup path has a fatal flaw: when the timeout fires, Python kills **only the direct child** and then runs an **unbounded** `communicate()` cleanup. If MSYS bash (Git-for-Windows) hangs while spawning an external program (`/usr/bin/true; /usr/bin/cat --version`), orphaned grandchild processes keep the stdout pipe open, so the cleanup `communicate()` blocks forever.

Because `_bash_starts` is called during every `LocalEnvironment` init, the hang stalled **every tool that uses the local environment** (terminal, file reads) indefinitely. Inside the ACP adapter process this meant ACP turns never completed and every delegated task hung forever.

The fix replaces `subprocess.run` with a `Popen` + explicit `communicate(timeout=15)` pair, and on timeout:
- kills the **whole process tree** via `taskkill /PID <pid> /T /F` on Windows (not just the direct child),
- does a **bounded** 5s post-kill read — never an unbounded cleanup.

Verified end-to-end on Windows 11: standalone ACP probes (`read_file` -> 11.6s full reply; `terminal echo hi` -> 3.3s, exit 0) and a real Multica issue that completed in 1 minute and posted its finalization comment — the exact action that had hung for days.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/local.py` — rewrite `_bash_starts` probe:
  - `Popen` with `stdin=DEVNULL`, `stdout`/`stderr=PIPE` (was `capture_output=True`),
  - explicit `communicate(timeout=15)`,
  - on `TimeoutExpired`: `taskkill /PID <pid> /T /F` tree-kill on Windows + `proc.kill()` fallback, then a bounded 5s `communicate()` read,
  - on success path, `returncode` read from the `Popen` object.

## How to Test

1. Windows host with Git-for-Windows/MSYS bash installed.
2. Reproduce the hang: with the old code, run a Hermes ACP task under conditions where MSYS bash hangs in external-program spawn (system-wide Mandatory ASLR enabled reproduces it reliably); observe the tool thread blocking forever.
3. Apply this PR; repeat — the probe now times out at 15s, tree-kills, and returns `False`; tools initialize and complete.
4. Regression: on macOS/Linux, `_bash_starts` still returns `True` for a healthy bash.

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I have tested on my platform: Windows 11 (E2E ACP + terminal) and macOS (existing behavior unchanged)