### PR TITLE
fix(runtime): scope execution state per profile

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -33,6 +33,7 @@ from urllib.parse import parse_qs, urlparse, urlunparse
 from agent.context_compressor import ContextCompressor
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import StreamingContextScrubber
+from profile_runtime_context import terminal_getenv
 from agent.session_activity import ActivityProvenance
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
@@ -2622,7 +2623,7 @@ def init_agent(
             _ra().logger.debug("Context engine on_session_start: %s", _ce_err)
 
     agent._subdirectory_hints = SubdirectoryHintTracker(
-        working_dir=os.getenv("TERMINAL_CWD") or None,
+        working_dir=terminal_getenv("TERMINAL_CWD") or None,
     )
     agent._user_turn_count = 0
     # Copilot x-initiator flag: first API call of a user turn sends "user" (#3040).

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -17,6 +17,7 @@ from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
 from typing import Optional
 
 from agent.runtime_cwd import resolve_agent_cwd
+from profile_runtime_context import terminal_getenv
 from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS,
     ORG_ACTIVE_MARKER,
@@ -1027,7 +1028,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
     per process. Used only for non-local backends where the agent's tools
     operate on a different machine than the host Hermes runs on.
     """
-    cwd_hint = os.getenv("TERMINAL_CWD", "")
+    cwd_hint = terminal_getenv("TERMINAL_CWD", "")
     cache_key = (env_type, cwd_hint)
     cached = _BACKEND_PROBE_CACHE.get(cache_key)
     if cached is not None:
@@ -1173,7 +1174,7 @@ def build_environment_hints() -> str:
 
     hints: list[str] = []
 
-    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    backend = (terminal_getenv("TERMINAL_ENV") or "local").strip().lower()
     is_remote_backend = backend in _REMOTE_TERMINAL_BACKENDS
 
     if not is_remote_backend:

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -16,6 +16,8 @@ from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import Any
 
+from profile_runtime_context import terminal_getenv
+
 logger = logging.getLogger(__name__)
 
 _UNSET: Any = object()
@@ -64,7 +66,7 @@ def resolve_agent_cwd() -> Path:
         if p.is_dir():
             return p
         logger.warning("configured working directory does not exist: %s", override)
-    raw = os.environ.get("TERMINAL_CWD", "").strip()
+    raw = (terminal_getenv("TERMINAL_CWD") or "").strip()
     if raw:
         p = Path(raw).expanduser()
         if p.is_dir():
@@ -90,7 +92,7 @@ def resolve_context_cwd() -> Path | None:
         else:
             return p
         return None
-    raw = os.environ.get("TERMINAL_CWD", "").strip()
+    raw = (terminal_getenv("TERMINAL_CWD") or "").strip()
     if raw:
         p = Path(raw).expanduser()
         if not p.is_dir():

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -657,7 +657,9 @@ def _begin_tool_execution(
         try:
             command = function_args.get("command", "")
             if _is_destructive_command(command):
-                cwd = function_args.get("workdir") or os.getenv(
+                from profile_runtime_context import terminal_getenv
+
+                cwd = function_args.get("workdir") or terminal_getenv(
                     "TERMINAL_CWD", os.getcwd()
                 )
                 agent._checkpoint_mgr.ensure_checkpoint(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1034,16 +1034,37 @@ def _resolve_home_env_var(platform_name: str) -> str:
     return _plugin_cron_env_var(name)
 
 
+_CRON_PROCESS_FALLBACK_ENV = {
+    "HERMES_CRON_SCRIPT_TIMEOUT",
+    "HERMES_CRON_SESSION_DB_TIMEOUT",
+    "HERMES_CRON_TIMEOUT",
+    "HERMES_CRON_MAX_PARALLEL",
+}
+
+
+def _cron_env_get(name: str) -> str:
+    from agent.secret_scope import current_secret_scope
+
+    scope = current_secret_scope()
+    if scope is not None:
+        scoped_value = scope.get(name)
+        if scoped_value is not None:
+            return scoped_value or ""
+        if name not in _CRON_PROCESS_FALLBACK_ENV:
+            return ""
+    return os.getenv(name, "")
+
+
 def _get_home_target_chat_id(platform_name: str) -> str:
     """Return the configured home target chat/room ID for a delivery platform."""
     env_var = _resolve_home_env_var(platform_name)
     if not env_var:
         return ""
-    value = os.getenv(env_var, "")
+    value = _cron_env_get(env_var)
     if not value:
         legacy = _LEGACY_HOME_TARGET_ENV_VARS.get(env_var)
         if legacy:
-            value = os.getenv(legacy, "")
+            value = _cron_env_get(legacy)
     return value
 
 
@@ -1062,14 +1083,14 @@ def _get_home_target_thread_id(platform_name: str) -> Optional[str]:
     if not env_var:
         return None
     if platform_name.lower() == "telegram":
-        cron_thread = os.getenv("TELEGRAM_CRON_THREAD_ID", "").strip()
+        cron_thread = _cron_env_get("TELEGRAM_CRON_THREAD_ID").strip()
         if cron_thread:
             return cron_thread
-    value = os.getenv(f"{env_var}_THREAD_ID", "").strip()
+    value = _cron_env_get(f"{env_var}_THREAD_ID").strip()
     if not value:
         legacy = _LEGACY_HOME_TARGET_ENV_VARS.get(env_var)
         if legacy:
-            value = os.getenv(f"{legacy}_THREAD_ID", "").strip()
+            value = _cron_env_get(f"{legacy}_THREAD_ID").strip()
     return value or None
 
 
@@ -2120,7 +2141,7 @@ def _get_script_timeout() -> int:
         except Exception:
             logger.warning("Invalid patched _SCRIPT_TIMEOUT=%r; using env/config/default", _SCRIPT_TIMEOUT)
 
-    env_value = os.getenv("HERMES_CRON_SCRIPT_TIMEOUT", "").strip()
+    env_value = _cron_env_get("HERMES_CRON_SCRIPT_TIMEOUT").strip()
     if env_value:
         try:
             timeout = int(float(env_value))
@@ -2915,7 +2936,7 @@ def run_job(
         # Resolve timeout: env override → config.yaml → default 10s.
         # Mirrors the script_timeout_seconds resolution pattern.
         _session_db_timeout: float | None = None
-        _raw_env_timeout = os.getenv("HERMES_CRON_SESSION_DB_TIMEOUT", "").strip()
+        _raw_env_timeout = _cron_env_get("HERMES_CRON_SESSION_DB_TIMEOUT").strip()
         if _raw_env_timeout:
             try:
                 _session_db_timeout = float(_raw_env_timeout)
@@ -3085,42 +3106,33 @@ def run_job(
         _VAR_MAP[_var_name].set("")
 
     # Per-job working directory — _SESSION_CWD was already set via
-    # set_session_vars(cwd=...) above. Here we only handle the
-    # process-global TERMINAL_CWD env var, which is serialized by
-    # _terminal_cwd_lock to avoid leaking into concurrent jobs.
-    #
-    # os.environ["TERMINAL_CWD"] is process-global, so this override is
-    # serialized by _terminal_cwd_lock (acquired just below): a workdir job
-    # holds it as a writer for its whole run, excluding every other job, while
-    # workdir-less jobs hold it as readers and stay parallel with each other.
-    # The sequential pool only keeps workdir jobs from overlapping EACH OTHER;
-    # the lock is what additionally keeps a concurrently-firing workdir-less
-    # parallel-pool job from observing this override and running its shell /
-    # file / code-exec commands in the wrong directory.  For workdir-less jobs
-    # we leave TERMINAL_CWD untouched — preserves the original behaviour
-    # (skip_context_files=True, tools use whatever cwd the scheduler has).
-    #
-    # The critical path (resolve_context_cwd / build_context_files_prompt)
-    # checks _SESSION_CWD first, so gateway sessions with no override see
-    # their own cwd, not the cron's workdir (#69396).
+    # set_session_vars(cwd=...) above. In a multiplexed profile runtime, keep the
+    # terminal override context-local. Legacy single-profile cron retains the
+    # process-global TERMINAL_CWD bridge and readers-writer lock unchanged.
+    from profile_runtime_context import (
+        reset_terminal_env_overrides,
+        set_terminal_env_overrides,
+        terminal_scope_active,
+    )
 
-    # Snapshot the current env value BEFORE acquiring the lock so the finally
-    # below can always restore it, even if an exception fires before we set the
-    # override inside the try.  This read can't leak the lock (it precedes the
-    # acquire) and is a no-op for workdir-less jobs (they never mutate the env).
-    _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
+    _scoped_terminal_runtime = terminal_scope_active()
+    _prior_terminal_cwd = (
+        "_SCOPED_"
+        if _scoped_terminal_runtime
+        else os.environ.get("TERMINAL_CWD", "_UNSET_")
+    )
+    _terminal_cwd_override_token = None
 
-    _holds_cwd_write = _job_workdir is not None
-    if _holds_cwd_write:
-        _terminal_cwd_lock.acquire_write()
-    else:
-        _terminal_cwd_lock.acquire_read()
+    _holds_cwd_lock = not _scoped_terminal_runtime
+    _holds_cwd_write = _holds_cwd_lock and _job_workdir is not None
+    if _holds_cwd_lock:
+        if _holds_cwd_write:
+            _terminal_cwd_lock.acquire_write()
+        else:
+            _terminal_cwd_lock.acquire_read()
 
-    # Everything after the acquire MUST live inside this try, so the finally
-    # below always releases the lock even if the env override or any later
-    # statement raises.  A leaked writer would deadlock the whole scheduler
-    # (every future job blocks on acquire_*); a leaked reader blocks all
-    # future writers.  Acquire itself can't leak (it either blocks or returns).
+    # Everything after a legacy lock acquire MUST live inside this try so the
+    # finally below always releases it. Scoped jobs own only a ContextVar token.
     _cron_session_var = _VAR_MAP["HERMES_CRON_SESSION"]
     _cron_session_token = None
     try:
@@ -3130,27 +3142,32 @@ def run_job(
         # cron entrypoints and tests.
         _cron_session_token = _cron_session_var.set("1")
         if _job_workdir:
-            os.environ["TERMINAL_CWD"] = _job_workdir
+            if _scoped_terminal_runtime:
+                _terminal_cwd_override_token, _ = set_terminal_env_overrides(
+                    {"TERMINAL_CWD": _job_workdir}
+                )
+            else:
+                os.environ["TERMINAL_CWD"] = _job_workdir
             logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
 
-        # Re-read .env and config.yaml fresh every run so provider/key
-        # changes take effect without a gateway restart. Route through
-        # load_hermes_dotenv (not a bare load_dotenv) and reset the secret-
-        # source cache first: startup already applied external secrets and
-        # recorded this HERMES_HOME in _APPLIED_HOMES, so a naive reload would
-        # re-apply only the .env placeholder and never re-resolve a Bitwarden/
-        # BSM-backed secret — leaving cron jobs 401'ing on the placeholder
-        # (#33465). Clearing the cache forces the re-pull; the resolved secret
-        # overrides the placeholder only when secrets.bitwarden.override_existing
-        # is set (mirrors startup), and the Bitwarden value-cache keeps the
-        # forced re-pull off the network. load_hermes_dotenv also handles the
-        # utf-8/latin-1 encoding fallback internally.
-        from hermes_cli.env_loader import (
-            load_hermes_dotenv,
-            reset_secret_source_cache,
-        )
-        reset_secret_source_cache()
-        load_hermes_dotenv(hermes_home=_get_hermes_home())
+        # Re-read .env and config.yaml fresh every ordinary single-profile run
+        # so provider/key changes take effect without a gateway restart. A
+        # multiplexed run already has fresh routed secret and terminal scopes
+        # installed by run_one_job(); reloading here would mutate process-global
+        # os.environ with one profile and race concurrent jobs.
+        if not terminal_scope_active():
+            # Route through load_hermes_dotenv (not a bare load_dotenv) and reset
+            # the secret-source cache first. Startup already applied external
+            # secrets and recorded this HERMES_HOME in _APPLIED_HOMES, so a naive
+            # reload would re-apply only the .env placeholder and never re-resolve
+            # a Bitwarden/BSM-backed secret (#33465).
+            from hermes_cli.env_loader import (
+                load_hermes_dotenv,
+                reset_secret_source_cache,
+            )
+
+            reset_secret_source_cache()
+            load_hermes_dotenv(hermes_home=_get_hermes_home())
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
@@ -3168,7 +3185,7 @@ def run_job(
         # re-read from storage every tick so a ``cronjob action=update
         # model=...`` after a failed run takes effect on the next tick — there
         # is no in-memory cache.
-        model = job.get("model") or os.getenv("HERMES_MODEL") or ""
+        model = job.get("model") or _cron_env_get("HERMES_MODEL") or ""
 
         # cron.model / cron.model_provider: a deliberate cron-fleet default
         # so unattended jobs stop shadowing chat `/model` switches. When an
@@ -3254,7 +3271,7 @@ def run_job(
         prefill_messages = None
         agent_cfg = _cfg.get("agent", {}) if isinstance(_cfg.get("agent", {}), dict) else {}
         prefill_file = (
-            os.getenv("HERMES_PREFILL_MESSAGES_FILE", "")
+            _cron_env_get("HERMES_PREFILL_MESSAGES_FILE")
             or _cfg.get("prefill_messages_file", "")
             or agent_cfg.get("prefill_messages_file", "")
         )
@@ -3528,7 +3545,7 @@ def run_job(
         #
         # Uses the agent's built-in activity tracker (updated by
         # _touch_activity() on every tool call, API call, and stream delta).
-        _raw_cron_timeout = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
+        _raw_cron_timeout = _cron_env_get("HERMES_CRON_TIMEOUT").strip()
         if _raw_cron_timeout:
             try:
                 _cron_timeout = float(_raw_cron_timeout)
@@ -3757,20 +3774,19 @@ def run_job(
         return False, output, "", error_msg
 
     finally:
-        # Restore TERMINAL_CWD to whatever it was before this job ran.  We
-        # only ever mutate it when the job has a workdir; see the setup block
-        # at the top of run_job for the serialization guarantee.
-        if _job_workdir:
+        if _terminal_cwd_override_token is not None:
+            reset_terminal_env_overrides(_terminal_cwd_override_token)
+        elif _job_workdir:
+            # Legacy single-profile bridge only.
             if _prior_terminal_cwd == "_UNSET_":
                 os.environ.pop("TERMINAL_CWD", None)
             else:
                 os.environ["TERMINAL_CWD"] = _prior_terminal_cwd
-        # Release the cwd lock now that the env is restored, so a waiting
-        # workdir job (or queued reader) can proceed without seeing the override.
-        if _holds_cwd_write:
-            _terminal_cwd_lock.release_write()
-        else:
-            _terminal_cwd_lock.release_read()
+        if _holds_cwd_lock:
+            if _holds_cwd_write:
+                _terminal_cwd_lock.release_write()
+            else:
+                _terminal_cwd_lock.release_read()
         # Clean up ContextVar session/delivery state for this job.
         # clear_session_vars also clears _SESSION_CWD internally, so no
         # separate clear_session_cwd() call is needed.
@@ -3938,14 +3954,22 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # resolve_runtime_provider() raised UnscopedSecretError before model
         # selection, breaking every cron job. Mirrors the per-turn pattern in
         # gateway/run.py (_profile_runtime_scope).
+        from contextlib import nullcontext
+        from profile_runtime_context import use_profile_runtime_context
         from agent.secret_scope import (
             build_profile_secret_scope,
+            is_multiplex_active,
             reset_secret_scope,
             set_secret_scope,
         )
 
+        _profile_home = _get_hermes_home()
+        if is_multiplex_active():
+            from hermes_cli.env_loader import refresh_profile_secret_sources
+
+            refresh_profile_secret_sources(_profile_home)
         _scope_token = set_secret_scope(
-            build_profile_secret_scope(_get_hermes_home())
+            build_profile_secret_scope(_profile_home)
         )
         # Defer the cron agent's async-resource teardown until AFTER delivery.
         # run_job normally closes the agent (and reaps stale async clients) in
@@ -3956,18 +3980,22 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # interpreter-shutdown guard in _deliver_result.
         _deferred_agents: list = []
         try:
-            success, output, final_response, error = run_job(
-                job, defer_agent_teardown=_deferred_agents
+            _runtime_scope = (
+                use_profile_runtime_context(_profile_home)
+                if is_multiplex_active()
+                else nullcontext()
             )
-        except BaseException:
-            # run_job's finally still hands back the agent when it raises; tear
-            # it down here so a failed run never leaks its async resources
-            # (#10200), then re-raise into the outer handler. BaseException
-            # (not just Exception) so a KeyboardInterrupt/SystemExit mid-run
-            # still triggers teardown before propagating.
-            for _deferred_agent in _deferred_agents:
-                _teardown_cron_agent(_deferred_agent, job["id"])
-            raise
+            with _runtime_scope:
+                try:
+                    success, output, final_response, error = run_job(
+                        job, defer_agent_teardown=_deferred_agents
+                    )
+                except BaseException:
+                    # run_job's finally still hands back the agent when it raises;
+                    # tear it down before leaving the profile cache scope.
+                    for _deferred_agent in _deferred_agents:
+                        _teardown_cron_agent(_deferred_agent, job["id"])
+                    raise
         finally:
             reset_secret_scope(_scope_token)
 
@@ -3978,7 +4006,15 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         # deferred agent is still torn down. Otherwise the outer `except` would
         # swallow the error and leak the agent's subprocesses/clients (#10200).
         delivery_error = None
+        _delivery_scope = None
+        _delivery_secret_token = None
         try:
+            if is_multiplex_active():
+                _delivery_secret_token = set_secret_scope(
+                    build_profile_secret_scope(_profile_home)
+                )
+                _delivery_scope = use_profile_runtime_context(_profile_home)
+                _delivery_scope.__enter__()
             output_file = save_job_output(job["id"], output)
             if verbose:
                 logger.info("Output saved to: %s", output_file)
@@ -4027,11 +4063,14 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)
         finally:
-            # Tear down the deferred agent(s) now that save + delivery have run
-            # (or raised). Must happen on every path so cron agents never leak
-            # their subprocesses/clients (#10200).
-            for _deferred_agent in _deferred_agents:
-                _teardown_cron_agent(_deferred_agent, job["id"])
+            try:
+                for _deferred_agent in _deferred_agents:
+                    _teardown_cron_agent(_deferred_agent, job["id"])
+            finally:
+                if _delivery_scope is not None:
+                    _delivery_scope.__exit__(None, None, None)
+                if _delivery_secret_token is not None:
+                    reset_secret_scope(_delivery_secret_token)
 
         # Treat empty final_response as a soft failure so last_status
         # is not "ok" — the agent ran but produced nothing useful.
@@ -4189,7 +4228,7 @@ def tick(
         # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
         _max_workers: Optional[int] = None
         try:
-            _env_par = os.getenv("HERMES_CRON_MAX_PARALLEL", "").strip()
+            _env_par = _cron_env_get("HERMES_CRON_MAX_PARALLEL").strip()
             if _env_par:
                 _max_workers = int(_env_par) or None
         except (ValueError, TypeError):
@@ -4219,12 +4258,13 @@ def tick(
             body."""
             return run_one_job(job, adapters=adapters, loop=loop, verbose=verbose)
 
-        # Partition due jobs: those with a per-job workdir mutate
-        # os.environ["TERMINAL_CWD"] inside run_job, which is process-global, so
-        # they queue on the single-thread sequential pool to run one at a time.
-        # That alone only keeps workdir jobs from overlapping EACH OTHER;
-        # run_job's _terminal_cwd_lock is what additionally stops a concurrently
-        # firing workdir-less parallel-pool job from observing the override.
+        # Partition due jobs conservatively: legacy single-profile workdir jobs
+        # mutate process-global TERMINAL_CWD, while multiplexed jobs use a
+        # ContextVar override. Keeping one partition preserves legacy ordering
+        # without coupling tick() to the runtime-scope implementation.
+        # That alone only keeps legacy workdir jobs from overlapping each other;
+        # the unscoped run_job lock additionally stops a concurrent workdir-less
+        # job from observing the process-global override.
         sequential_jobs = [j for j in due_jobs if (j.get("workdir") or "").strip()]
         parallel_jobs = [j for j in due_jobs if not (j.get("workdir") or "").strip()]
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1834,6 +1834,7 @@ def _profile_runtime_scope(profile_home: "Path"):
     returns an isolated dict — which is what keeps subprocesses (MCP, kanban)
     from inheriting cross-profile secrets.
     """
+    from profile_runtime_context import use_profile_runtime_context
     from hermes_constants import set_hermes_home_override, reset_hermes_home_override
     from agent.secret_scope import (
         build_profile_secret_scope,
@@ -1843,12 +1844,17 @@ def _profile_runtime_scope(profile_home: "Path"):
     from hermes_cli.env_loader import hydrate_profile_secret_sources
 
     home_token = set_hermes_home_override(str(profile_home))
-    hydrate_profile_secret_sources(Path(profile_home))
-    secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+    secret_token = None
     try:
-        yield
+        hydrate_profile_secret_sources(Path(profile_home))
+        secret_token = set_secret_scope(
+            build_profile_secret_scope(Path(profile_home))
+        )
+        with use_profile_runtime_context(profile_home):
+            yield
     finally:
-        reset_secret_scope(secret_token)
+        if secret_token is not None:
+            reset_secret_scope(secret_token)
         reset_hermes_home_override(home_token)
 
 
@@ -6176,7 +6182,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Docker, so users commonly need a dedicated export mount such as
         `host-dir:/output`.
         """
-        if os.getenv("TERMINAL_ENV", "").strip().lower() != "docker":
+        from profile_runtime_context import terminal_getenv
+
+        if (terminal_getenv("TERMINAL_ENV") or "").strip().lower() != "docker":
             return
 
         connected = self.config.get_connected_platforms()
@@ -6184,7 +6192,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not messaging_platforms:
             return
 
-        raw_volumes = os.getenv("TERMINAL_DOCKER_VOLUMES", "").strip()
+        raw_volumes = (terminal_getenv("TERMINAL_DOCKER_VOLUMES") or "").strip()
         volumes: List[str] = []
         if raw_volumes:
             try:
@@ -15955,7 +15963,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 from agent.context_references import preprocess_context_references_async
                 from agent.model_metadata import get_model_context_length_async
 
-                _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
+                from profile_runtime_context import terminal_getenv
+
+                _msg_cwd = terminal_getenv("TERMINAL_CWD", os.path.expanduser("~"))
                 _msg_config_ctx = None
                 _msg_cfg = None
                 _msg_model_cfg = {}
@@ -17605,6 +17615,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # text, so we fire a separate trailing send below.
             _footer_line = ""
             try:
+                from profile_runtime_context import terminal_getenv
                 from gateway.runtime_footer import build_footer_line as _bfl
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
@@ -17612,7 +17623,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
-                    cwd=os.environ.get("TERMINAL_CWD", ""),
+                    cwd=terminal_getenv("TERMINAL_CWD", ""),
                     turn_seconds=_turn_seconds,
                 )
             except Exception as _footer_err:

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -138,7 +138,9 @@ def format_runtime_footer(
             if turn_seconds is not None and turn_seconds >= 0:
                 parts.append(_format_latency(turn_seconds))
         elif field == "cwd":
-            rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
+            from profile_runtime_context import terminal_getenv
+
+            rel = _home_relative_cwd(cwd or terminal_getenv("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
         # Unknown field names are silently ignored.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -27,6 +27,8 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
+
+from profile_runtime_context import terminal_getenv
 from typing import Any, Optional, Union
 
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
@@ -3009,7 +3011,7 @@ class GatewaySlashCommandsMixin:
             max_file_size_mb=cp_kwargs["checkpoint_max_file_size_mb"],
         )
 
-        cwd = os.getenv("TERMINAL_CWD", str(Path.home()))
+        cwd = terminal_getenv("TERMINAL_CWD", str(Path.home()))
         arg = event.get_command_args().strip()
 
         if not arg:
@@ -3068,7 +3070,7 @@ class GatewaySlashCommandsMixin:
             elif low == "session":
                 mode = "session"
 
-        cwd = os.getenv("TERMINAL_CWD", str(Path.home()))
+        cwd = terminal_getenv("TERMINAL_CWD", str(Path.home()))
 
         if mode == "session":
             return await self._gateway_session_diff(cwd, stat_only)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -29,7 +29,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Tuple, Set
+from typing import Dict, Any, Optional, List, Tuple, Set, Callable
 
 from hermes_cli.route_identity import normalize_route_base_url
 from hermes_cli.secret_prompt import masked_secret_prompt
@@ -2483,7 +2483,10 @@ def _strip_dotted_keys(cfg: dict, dotted_keys: set) -> Tuple[dict, set]:
     return cfg, stripped
 
 
-def _env_expand_match(m: re.Match) -> str:
+def _env_expand_match(
+    m: re.Match,
+    getenv: Callable[[str], Optional[str]] = os.environ.get,
+) -> str:
     """Expand one ``${...}`` config reference.
 
     Two accepted shapes, matching what MCP server config already resolves
@@ -2507,7 +2510,7 @@ def _env_expand_match(m: re.Match) -> str:
         name = inner[len("env:"):].strip()
         if not name:
             return raw
-        val = os.environ.get(name)
+        val = getenv(name)
         if val is not None:
             return val
         logger.warning(
@@ -2528,7 +2531,8 @@ def _env_expand_match(m: re.Match) -> str:
         )
         return raw
     # Legacy ``${VAR}`` — bare name.
-    return os.environ.get(inner, raw)
+    value = getenv(inner)
+    return value if value is not None else raw
 
 
 def _env_ref_var_name(ref: str) -> Optional[str]:
@@ -2543,26 +2547,49 @@ def _env_ref_var_name(ref: str) -> Optional[str]:
     return ref
 
 
-def _expand_env_vars(obj):
+def _active_profile_env_get(name: str) -> Optional[str]:
+    """Resolve env refs from the active profile scope, or process env unscoped."""
+    try:
+        from agent.secret_scope import current_secret_scope
+
+        scope = current_secret_scope()
+        if scope is not None:
+            return scope.get(name)
+    except Exception:
+        pass
+    return os.environ.get(name)
+
+
+def _expand_env_vars(
+    obj,
+    getenv: Optional[Callable[[str], Optional[str]]] = None,
+):
     """Recursively expand ``${VAR}`` / ``${env:VAR}`` references in config
     values.
 
     Only string values are processed; dict keys, numbers, booleans, and
-    None are left untouched.  Unresolved references (variable not in
-    ``os.environ``) are kept verbatim so callers can detect them.
+    None are left untouched. ``getenv`` defaults to ``os.environ.get``;
+    callers with a context-local environment may supply their own resolver.
+    Unresolved references are kept verbatim so callers can detect them.
     """
+    if getenv is None:
+        getenv = _active_profile_env_get
     if isinstance(obj, str):
-        return re.sub(r"\${([^}]+)}", _env_expand_match, obj)
+        return re.sub(
+            r"\${([^}]+)}",
+            lambda match: _env_expand_match(match, getenv),
+            obj,
+        )
     if isinstance(obj, dict):
-        return {k: _expand_env_vars(v) for k, v in obj.items()}
+        return {k: _expand_env_vars(v, getenv) for k, v in obj.items()}
     if isinstance(obj, list):
-        return [_expand_env_vars(item) for item in obj]
+        return [_expand_env_vars(item, getenv) for item in obj]
     return obj
 
 
-def _env_ref_snapshot(obj, snapshot=None):
+def _env_ref_snapshot(obj, snapshot=None, *, getenv=None, key_prefix: str = ""):
     """Map every ``${VAR}`` / ``${env:VAR}`` name referenced in config values
-    to its current ``os.environ`` value (``None`` when unset).
+    to its current routed environment value (``None`` when unset).
 
     Stored alongside cached ``load_config()`` results so a cache hit can
     detect that the cached expansion was made against a *different*
@@ -2575,20 +2602,36 @@ def _env_ref_snapshot(obj, snapshot=None):
     with a non-env source prefix never read the environment, so they are
     excluded from the snapshot.
     """
+    if getenv is None:
+        getenv = _active_profile_env_get
     if snapshot is None:
         snapshot = {}
     if isinstance(obj, str):
         for raw in re.findall(r"\${([^}]+)}", obj):
             name = _env_ref_var_name(raw)
             if name is not None:
-                snapshot[name] = os.environ.get(name)
+                snapshot[f"{key_prefix}{name}"] = getenv(name)
     elif isinstance(obj, dict):
         for value in obj.values():
-            _env_ref_snapshot(value, snapshot)
+            _env_ref_snapshot(value, snapshot, getenv=getenv, key_prefix=key_prefix)
     elif isinstance(obj, list):
         for item in obj:
-            _env_ref_snapshot(item, snapshot)
+            _env_ref_snapshot(item, snapshot, getenv=getenv, key_prefix=key_prefix)
     return snapshot
+
+
+def _env_ref_snapshot_matches(snapshot: Dict[str, Optional[str]]) -> bool:
+    for tagged_name, expected in snapshot.items():
+        if tagged_name.startswith("profile:"):
+            actual = _active_profile_env_get(tagged_name[len("profile:"):])
+        elif tagged_name.startswith("process:"):
+            actual = os.environ.get(tagged_name[len("process:"):])
+        else:
+            # Backward-compatible in-process cache entries from pre-routing code.
+            actual = os.environ.get(tagged_name)
+        if actual != expected:
+            return False
+    return True
 
 
 def _items_by_unique_name(items):
@@ -3184,6 +3227,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "backend": "TERMINAL_ENV",
     "modal_mode": "TERMINAL_MODAL_MODE",
     "cwd": "TERMINAL_CWD",
+    "home_mode": "TERMINAL_HOME_MODE",
     "timeout": "TERMINAL_TIMEOUT",
     "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
     "docker_image": "TERMINAL_DOCKER_IMAGE",
@@ -3233,6 +3277,7 @@ def apply_terminal_config_to_env(
     env: Optional[Dict[str, str]] = None,
     config: Optional[Dict[str, Any]] = None,
     override: Optional[bool] = None,
+    explicit_terminal_keys: Optional[Set[str]] = None,
 ) -> Dict[str, str]:
     """Bridge ``terminal.*`` config into the env vars terminal tools read.
 
@@ -3263,7 +3308,10 @@ def apply_terminal_config_to_env(
     # normal merged-config path, only keys present in raw config.yaml may
     # override existing env values; keys inherited from DEFAULT_CONFIG are
     # backfill-only.
-    explicit_keys = terminal_cfg.keys() if config is not None else raw_terminal_cfg.keys()
+    if explicit_terminal_keys is not None:
+        explicit_keys = explicit_terminal_keys
+    else:
+        explicit_keys = terminal_cfg.keys() if config is not None else raw_terminal_cfg.keys()
 
     for cfg_key, env_var in TERMINAL_CONFIG_ENV_MAP.items():
         if cfg_key not in terminal_cfg:
@@ -3327,7 +3375,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             # pins unexpanded literals (e.g. auxiliary.<task>.api_key) for the
             # life of the process (#58514).
             env_snapshot = cached[5] if len(cached) > 5 else {}
-            if all(os.environ.get(k) == v for k, v in env_snapshot.items()):
+            if _env_ref_snapshot_matches(env_snapshot):
                 return copy.deepcopy(cached[4]) if want_deepcopy else cached[4]
 
         config = copy.deepcopy(DEFAULT_CONFIG)
@@ -3395,7 +3443,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         # keys the managed layer pins — see docs/design/managed-scope.md §4.1.
         managed_config = managed_scope.load_managed_config()
         if managed_config:
-            managed_expanded = _expand_env_vars(managed_config)
+            managed_expanded = _expand_env_vars(managed_config, os.environ.get)
             expanded = _deep_merge(expanded, managed_expanded)
         _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(expanded)
         if cache_sig is not None:
@@ -3408,9 +3456,14 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             # this expansion was made against so later loads can detect env
             # drift (late .env load, in-process rotation) — see cache hit above.
             cached_copy = copy.deepcopy(expanded)
-            env_snapshot = _env_ref_snapshot(normalized)
+            env_snapshot = _env_ref_snapshot(normalized, key_prefix="profile:")
             if managed_config:
-                _env_ref_snapshot(managed_config, env_snapshot)
+                _env_ref_snapshot(
+                    managed_config,
+                    env_snapshot,
+                    getenv=os.environ.get,
+                    key_prefix="process:",
+                )
             _LOAD_CONFIG_CACHE[path_key] = (*cache_sig, cached_copy, env_snapshot)
             # On the readonly path return the same cached object subsequent
             # calls will see — keeps "two readonly calls return the same

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -185,6 +185,19 @@ def hydrate_profile_secret_sources(
         return _hydrate_profile_secret_sources(Path(hermes_home))
 
 
+def refresh_profile_secret_sources(
+    hermes_home: str | os.PathLike,
+) -> dict[str, str]:
+    """Atomically invalidate and rehydrate one profile's source snapshot."""
+
+    home = Path(hermes_home)
+    home_key = str(home.resolve())
+    with _SECRET_SOURCE_CACHE_LOCK:
+        _APPLIED_HOMES.discard(home_key)
+        _SECRET_SOURCE_VALUES_BY_HOME.pop(home_key, None)
+        return _hydrate_profile_secret_sources(home)
+
+
 def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
     """Locked implementation for :func:`hydrate_profile_secret_sources`."""
     home_key = str(home.resolve())
@@ -238,19 +251,25 @@ def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
     return dict(values)
 
 
-def reset_secret_source_cache() -> None:
-    """Forget which HERMES_HOME paths have already had external secrets applied.
+def reset_secret_source_cache(
+    hermes_home: str | os.PathLike | None = None,
+) -> None:
+    """Forget cached external-secret state globally or for one home.
 
-    The first call to ``_apply_external_secret_sources(home_path)`` in a
-    process pulls from Bitwarden (or other configured backend), records the
-    applied keys in ``_SECRET_SOURCES``, and remembers ``home_path`` so
-    subsequent calls in the same process are no-ops.  Call this to force the
-    next call to re-pull — useful for tests, and for long-running processes
-    that want to refresh after a config change.
+    With no argument, preserve the historical clear-all behavior. Passing a
+    home invalidates only that routed profile so multiplex cron can refresh its
+    external sources without discarding concurrent profiles' snapshots.
     """
-    _APPLIED_HOMES.clear()
-    _SECRET_SOURCES.clear()
-    _SECRET_SOURCE_VALUES_BY_HOME.clear()
+    with _SECRET_SOURCE_CACHE_LOCK:
+        if hermes_home is None:
+            _APPLIED_HOMES.clear()
+            _SECRET_SOURCES.clear()
+            _SECRET_SOURCE_VALUES_BY_HOME.clear()
+            return
+
+        home_key = str(Path(hermes_home).resolve())
+        _APPLIED_HOMES.discard(home_key)
+        _SECRET_SOURCE_VALUES_BY_HOME.pop(home_key, None)
 
 
 def format_secret_source_suffix(env_var: str) -> str:

--- a/profile_runtime_context.py
+++ b/profile_runtime_context.py
@@ -1,0 +1,240 @@
+"""Context-local runtime settings for profile-multiplexed execution.
+
+A multiplexed Hermes process serves profiles with different terminal backends.
+Process-global ``TERMINAL_*`` variables cannot represent that safely, so this
+module carries the routed profile's resolved terminal mapping in a ContextVar.
+Profile config references resolve against the already-installed profile secret
+scope; the result is never written into ``os.environ``.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+import copy
+import hashlib
+import os
+from pathlib import Path
+from types import MappingProxyType
+from typing import Iterator, Mapping
+
+
+@dataclass(frozen=True)
+class ProfileRuntimeContext:
+    """Immutable execution settings derived from one profile home."""
+
+    profile_key: str
+    terminal_env: Mapping[str, str]
+
+
+_PROFILE_RUNTIME_CONTEXT: ContextVar[ProfileRuntimeContext | None] = ContextVar(
+    "hermes_profile_runtime_context",
+    default=None,
+)
+_TERMINAL_ENV_OVERRIDES: ContextVar[Mapping[str, str] | None] = ContextVar(
+    "hermes_terminal_env_overrides",
+    default=None,
+)
+
+# Documented terminal settings that predate the YAML bridge and remain
+# environment-only. Routed profiles source them from their own secret scope;
+# they must never fall through to the launch profile's process environment.
+_PROFILE_TERMINAL_ENV_ONLY_KEYS = (
+    "TERMINAL_SCRATCH_DIR",
+    "TERMINAL_MAX_FOREGROUND_TIMEOUT",
+    "TERMINAL_DISK_WARNING_GB",
+)
+
+
+def current_profile_runtime_context() -> ProfileRuntimeContext | None:
+    """Return the active profile execution context, if one is installed."""
+
+    return _PROFILE_RUNTIME_CONTEXT.get()
+
+
+def current_profile_cache_key() -> str | None:
+    """Return the opaque profile key used to partition process-local caches."""
+
+    context = current_profile_runtime_context()
+    return context.profile_key if context is not None else None
+
+
+def profile_scoped_key(raw_key: str) -> str:
+    """Qualify *raw_key* while preserving legacy unscoped behavior."""
+
+    profile_key = current_profile_cache_key()
+    if not profile_key:
+        return raw_key
+    prefix = f"profile:{profile_key}:"
+    return raw_key if raw_key.startswith(prefix) else f"{prefix}{raw_key}"
+
+
+def terminal_getenv(name: str, default: str | None = None) -> str | None:
+    """Read terminal settings from the routed profile before process env."""
+
+    overrides = _TERMINAL_ENV_OVERRIDES.get()
+    if overrides is not None and name in overrides:
+        return overrides[name]
+    context = current_profile_runtime_context()
+    if context is not None:
+        return context.terminal_env.get(name, default)
+    return os.getenv(name, default)
+
+
+def overlay_terminal_env(
+    target: dict[str, str],
+    names: tuple[str, ...] | None = None,
+) -> None:
+    """Overlay the active profile terminal mapping onto a child environment."""
+
+    context = current_profile_runtime_context()
+    if context is None:
+        return
+    source = context.terminal_env
+    if names is None:
+        target.update(source)
+    else:
+        for name in names:
+            value = source.get(name)
+            if value is not None:
+                target[name] = value
+    overrides = _TERMINAL_ENV_OVERRIDES.get()
+    if overrides:
+        if names is None:
+            target.update(overrides)
+        else:
+            for name in names:
+                value = overrides.get(name)
+                if value is not None:
+                    target[name] = value
+
+
+def terminal_scope_active() -> bool:
+    """Return whether terminal settings are bound to a routed profile."""
+
+    return current_profile_runtime_context() is not None
+
+
+@contextmanager
+def use_terminal_env_overrides(
+    overrides: Mapping[str, str],
+) -> Iterator[Mapping[str, str]]:
+    """Temporarily override terminal settings without mutating ``os.environ``."""
+
+    token, merged = set_terminal_env_overrides(overrides)
+    try:
+        yield merged
+    finally:
+        reset_terminal_env_overrides(token)
+
+
+def set_terminal_env_overrides(
+    overrides: Mapping[str, str],
+) -> tuple[Token[Mapping[str, str] | None], Mapping[str, str]]:
+    """Install nested terminal overrides and return a reset token plus mapping."""
+
+    merged = dict(_TERMINAL_ENV_OVERRIDES.get() or {})
+    merged.update({str(key): str(value) for key, value in overrides.items()})
+    immutable = MappingProxyType(merged)
+    return _TERMINAL_ENV_OVERRIDES.set(immutable), immutable
+
+
+def reset_terminal_env_overrides(token: Token[Mapping[str, str] | None]) -> None:
+    """Restore the previous terminal override mapping."""
+
+    _TERMINAL_ENV_OVERRIDES.reset(token)
+
+
+def _build_profile_context(profile_home: Path) -> ProfileRuntimeContext:
+    """Resolve one profile's canonical terminal mapping without global writes."""
+
+    from agent.secret_scope import current_secret_scope
+    from hermes_cli import managed_scope
+    from hermes_cli.config import (
+        DEFAULT_CONFIG,
+        _deep_merge,
+        _expand_env_vars,
+        apply_terminal_config_to_env,
+        read_user_config_raw,
+    )
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    resolved_home = profile_home.expanduser().resolve()
+    home_token = set_hermes_home_override(str(resolved_home))
+    try:
+        raw_config = read_user_config_raw()
+        effective_config = _deep_merge(copy.deepcopy(DEFAULT_CONFIG), raw_config)
+        profile_secrets = current_secret_scope() or {}
+        effective_config = _expand_env_vars(
+            effective_config,
+            profile_secrets.get,
+        )
+        # Managed administrator values intentionally retain their documented
+        # process-env expansion semantics and win after user-profile expansion.
+        managed_config = managed_scope.load_managed_config()
+        effective_config = managed_scope.apply_managed_overlay(effective_config)
+        raw_terminal = raw_config.get("terminal")
+        managed_terminal = managed_config.get("terminal") if isinstance(managed_config, dict) else None
+        explicit_terminal_keys = {
+            *(
+                raw_terminal.keys()
+                if isinstance(raw_terminal, dict)
+                else ()
+            ),
+            *(
+                managed_terminal.keys()
+                if isinstance(managed_terminal, dict)
+                else ()
+            ),
+        }
+        terminal_env: dict[str, str] = {
+            str(key): str(value)
+            for key, value in profile_secrets.items()
+            if str(key).startswith("TERMINAL_")
+        }
+        apply_terminal_config_to_env(
+            env=terminal_env,
+            config=effective_config,
+            override=True,
+            explicit_terminal_keys=explicit_terminal_keys,
+        )
+        for env_key in _PROFILE_TERMINAL_ENV_ONLY_KEYS:
+            value = profile_secrets.get(env_key)
+            if value is not None:
+                terminal_env[env_key] = value
+    finally:
+        reset_hermes_home_override(home_token)
+
+    digest = hashlib.sha256(str(resolved_home).encode("utf-8")).hexdigest()[:16]
+    return ProfileRuntimeContext(
+        profile_key=digest,
+        terminal_env=MappingProxyType(terminal_env),
+    )
+
+
+@contextmanager
+def use_profile_runtime_context(profile_home: str | Path) -> Iterator[ProfileRuntimeContext]:
+    """Install one profile's home/execution settings and reset them reliably."""
+
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    resolved_home = Path(profile_home).expanduser().resolve()
+    home_token = set_hermes_home_override(str(resolved_home))
+    try:
+        context = _build_profile_context(resolved_home)
+        token: Token[ProfileRuntimeContext | None] = _PROFILE_RUNTIME_CONTEXT.set(context)
+        override_token = _TERMINAL_ENV_OVERRIDES.set(None)
+        try:
+            try:
+                from tools.process_registry import process_registry
+
+                process_registry.recover_from_checkpoint()
+            except Exception:
+                pass
+            yield context
+        finally:
+            _TERMINAL_ENV_OVERRIDES.reset(override_token)
+            _PROFILE_RUNTIME_CONTEXT.reset(token)
+    finally:
+        reset_hermes_home_override(home_token)

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -163,6 +163,7 @@ class TestRunJobTerminalCwd:
         import os
         import sys
         import cron.scheduler as sched
+        from profile_runtime_context import terminal_getenv
 
         class FakeAgent:
             def __init__(self, **kwargs):
@@ -171,9 +172,15 @@ class TestRunJobTerminalCwd:
                 observed["terminal_cwd_during_init"] = os.environ.get(
                     "TERMINAL_CWD", "_UNSET_"
                 )
+                observed["effective_cwd_during_init"] = terminal_getenv(
+                    "TERMINAL_CWD", "_UNSET_"
+                )
 
             def run_conversation(self, *_a, **_kw):
                 observed["terminal_cwd_during_run"] = os.environ.get(
+                    "TERMINAL_CWD", "_UNSET_"
+                )
+                observed["effective_cwd_during_run"] = terminal_getenv(
                     "TERMINAL_CWD", "_UNSET_"
                 )
                 return {"final_response": "done", "messages": []}
@@ -211,6 +218,14 @@ class TestRunJobTerminalCwd:
         # has TERMINAL_CWD set (common on dev boxes).  Stub it out.
         import dotenv
         monkeypatch.setattr(dotenv, "load_dotenv", lambda *_a, **_kw: True)
+        import hermes_cli.env_loader as env_loader
+        monkeypatch.setattr(
+            env_loader,
+            "load_hermes_dotenv",
+            lambda *_a, **_kw: observed.__setitem__(
+                "dotenv_loads", observed.get("dotenv_loads", 0) + 1
+            ) or True,
+        )
 
 
     def test_no_workdir_leaves_terminal_cwd_untouched(self, monkeypatch):
@@ -248,6 +263,50 @@ class TestRunJobTerminalCwd:
         assert observed["load_soul_identity"] is True
         # TERMINAL_CWD saw the same value during init as it had before.
         assert observed["terminal_cwd_during_init"] == before
+        assert observed["dotenv_loads"] == 1
         # And after run_job completes, it's still the sentinel (nothing
         # overwrote or cleared it).
         assert os.environ["TERMINAL_CWD"] == before
+
+    def test_multiplex_workdir_is_context_local(self, tmp_path, monkeypatch):
+        import os
+        import cron.scheduler as sched
+        from profile_runtime_context import use_profile_runtime_context
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        profile_home = tmp_path / "profile"
+        profile_home.mkdir()
+        (profile_home / "config.yaml").write_text(
+            "terminal:\n  backend: local\n  cwd: /profile-base\n",
+            encoding="utf-8",
+        )
+        workdir = tmp_path / "job-workdir"
+        workdir.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", "/launch-cwd")
+
+        observed: dict = {}
+        self._install_stubs(monkeypatch, observed)
+        job = {
+            "id": "scoped",
+            "name": "scoped-wd-job",
+            "workdir": str(workdir),
+            "schedule_display": "manual",
+        }
+
+        home_token = set_hermes_home_override(str(profile_home))
+        try:
+            with use_profile_runtime_context(profile_home):
+                success, *_ = sched.run_job(job)
+        finally:
+            reset_hermes_home_override(home_token)
+
+        assert success is True
+        assert observed["terminal_cwd_during_init"] == "/launch-cwd"
+        assert observed["terminal_cwd_during_run"] == "/launch-cwd"
+        assert observed["effective_cwd_during_init"] == str(workdir)
+        assert observed["effective_cwd_during_run"] == str(workdir)
+        assert observed.get("dotenv_loads", 0) == 0
+        assert os.environ["TERMINAL_CWD"] == "/launch-cwd"

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -109,3 +109,190 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
     assert ss.current_secret_scope() is None
 
 
+def test_run_one_job_scopes_terminal_config_and_deferred_teardown(monkeypatch, tmp_path):
+    from profile_runtime_context import current_profile_runtime_context
+    from agent import secret_scope as ss
+    from hermes_cli import env_loader
+    from tools.terminal_tool import _get_env_config
+
+    (tmp_path / "config.yaml").write_text(
+        "terminal:\n  backend: docker\n  timeout: 17\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".env").write_text(
+        "TELEGRAM_HOME_CHANNEL=profile-home\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+    seen = {}
+    deferred_agent = object()
+
+    def fake_run_job(job, *, defer_agent_teardown=None):
+        seen["run_context"] = current_profile_runtime_context()
+        seen["run_backend"] = _get_env_config()["env_type"]
+        defer_agent_teardown.append(deferred_agent)
+        return (True, "out", "final", None)
+
+    def fake_teardown(agent, job_id):
+        seen["teardown_context"] = current_profile_runtime_context()
+        seen["teardown_backend"] = _get_env_config()["env_type"]
+        assert agent is deferred_agent
+        assert job_id == "j8"
+
+    def fake_delivery(*_args, **_kwargs):
+        from agent.secret_scope import current_secret_scope
+        from hermes_constants import get_hermes_home
+
+        seen["delivery_context"] = (
+            str(get_hermes_home()),
+            current_secret_scope().get("TELEGRAM_HOME_CHANNEL"),
+            _get_env_config()["env_type"],
+        )
+        return None
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(
+        env_loader,
+        "refresh_profile_secret_sources",
+        lambda home: seen.__setitem__("refreshed_home", home) or {},
+    )
+    monkeypatch.setattr(s, "_teardown_cron_agent", fake_teardown)
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", fake_delivery)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+
+    ss.set_multiplex_active(True)
+    try:
+        assert s.run_one_job({"id": "j8", "name": "t"}) is True
+    finally:
+        ss.set_multiplex_active(False)
+    assert seen["run_context"] is not None
+    assert seen["refreshed_home"] == tmp_path
+    assert seen["run_backend"] == "docker"
+    assert seen["teardown_context"] is not None
+    assert seen["teardown_backend"] == "docker"
+    assert seen["delivery_context"] == (str(tmp_path), "profile-home", "docker")
+    assert current_profile_runtime_context() is None
+
+
+def test_cron_home_targets_read_profile_secret_scope(monkeypatch):
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "launch-home")
+    monkeypatch.setenv("TELEGRAM_CRON_THREAD_ID", "launch-thread")
+    token = set_secret_scope(
+        {
+            "TELEGRAM_HOME_CHANNEL": "profile-home",
+            "TELEGRAM_CRON_THREAD_ID": "profile-thread",
+        }
+    )
+    try:
+        assert s._get_home_target_chat_id("telegram") == "profile-home"
+        assert s._get_home_target_thread_id("telegram") == "profile-thread"
+    finally:
+        reset_secret_scope(token)
+
+
+def test_two_profiles_keep_cron_delivery_scope_isolated(monkeypatch, tmp_path):
+    from agent import secret_scope as ss
+    from hermes_constants import get_hermes_home
+    from profile_runtime_context import current_profile_runtime_context
+    from tools.terminal_tool import _get_env_config
+
+    homes = []
+    for name in ("a", "b"):
+        home = tmp_path / name
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "terminal:\n  backend: local\n",
+            encoding="utf-8",
+        )
+        (home / ".env").write_text(
+            f"TELEGRAM_HOME_CHANNEL=profile-{name}-home\n",
+            encoding="utf-8",
+        )
+        homes.append(home)
+
+    active = {"home": homes[0]}
+    records = []
+
+    def record(stage):
+        scope = ss.current_secret_scope()
+        records.append(
+            (
+                active["home"].name,
+                stage,
+                str(get_hermes_home()),
+                None if scope is None else scope.get("TELEGRAM_HOME_CHANNEL"),
+                _get_env_config()["env_type"],
+                current_profile_runtime_context() is not None,
+            )
+        )
+
+    def fake_run_job(_job, *, defer_agent_teardown=None):
+        record("run")
+        assert s._resolve_delivery_target(_job)["chat_id"] == (
+            f"profile-{active['home'].name}-home"
+        )
+        record("target")
+        defer_agent_teardown.append(object())
+        return True, "output", "final", None
+
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: active["home"])
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda *_args: record("save") or "/tmp/x")
+    def fake_delivery(*_args, **_kwargs):
+        record("deliver")
+        if active["home"].name == "b":
+            raise RuntimeError("synthetic delivery failure")
+        return None
+
+    monkeypatch.setattr(s, "_deliver_result", fake_delivery)
+    monkeypatch.setattr(s, "_teardown_cron_agent", lambda *_args: record("teardown"))
+    monkeypatch.setattr(s, "mark_job_run", lambda *_args, **_kwargs: None)
+
+    ss.set_multiplex_active(True)
+    try:
+        for home in homes:
+            active["home"] = home
+            assert s.run_one_job(
+                {"id": f"job-{home.name}", "name": home.name, "deliver": "telegram"}
+            ) is True
+    finally:
+        ss.set_multiplex_active(False)
+
+    for name, stage, home, chat, backend, runtime_active in records:
+        assert stage in {"run", "target", "save", "deliver", "teardown"}
+        assert home == str((tmp_path / name).resolve()), records
+        assert chat == f"profile-{name}-home", records
+        assert backend == "local"
+        assert runtime_active is True
+
+
+def test_run_one_job_preserves_unscoped_terminal_behavior_outside_multiplex(
+    monkeypatch, tmp_path
+):
+    from profile_runtime_context import current_profile_runtime_context
+    from agent import secret_scope as ss
+
+    (tmp_path / "config.yaml").write_text(
+        "terminal:\n  backend: docker\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(s, "_get_hermes_home", lambda: tmp_path)
+    seen = {}
+
+    def fake_run_job(job, *, defer_agent_teardown=None):
+        seen["context"] = current_profile_runtime_context()
+        return (True, "out", "final", None)
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", lambda jid, out: f"/tmp/{jid}.txt")
+    monkeypatch.setattr(s, "_deliver_result", lambda *a, **k: None)
+    monkeypatch.setattr(s, "mark_job_run", lambda *a, **k: None)
+
+    ss.set_multiplex_active(False)
+    assert s.run_one_job({"id": "j9", "name": "t"}) is True
+    assert seen["context"] is None
+
+

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -5,6 +5,7 @@ interpolation) rather than mocking it, proving the property that matters: two
 profiles with different keys never see each other's, and an unscoped read in
 multiplex mode fails closed instead of leaking.
 """
+import os
 import pytest
 
 from pathlib import Path
@@ -87,6 +88,55 @@ class TestProfilePathResolutionUnderMultiplexScope:
         assert a_seen == prof_a / "skills"
         assert b_seen == prof_b / "skills"
 
+    def test_terminal_config_and_cache_key_follow_multiplex_scope(self, tmp_path):
+        from profile_runtime_context import current_profile_runtime_context
+        from gateway.run import _profile_runtime_scope
+        from tools.terminal_tool import _get_env_config, _resolve_container_task_id
+
+        prof_a, prof_b = self._profiles(tmp_path)
+        (prof_a / "config.yaml").write_text(
+            "terminal:\n  backend: docker\n  timeout: 11\n",
+            encoding="utf-8",
+        )
+        (prof_b / "config.yaml").write_text(
+            "terminal:\n  backend: local\n  timeout: 22\n",
+            encoding="utf-8",
+        )
+
+        with _profile_runtime_scope(prof_a):
+            a_config = _get_env_config()
+            a_key = _resolve_container_task_id(None)
+        with _profile_runtime_scope(prof_b):
+            b_config = _get_env_config()
+            b_key = _resolve_container_task_id(None)
+
+        assert a_config["env_type"] == "docker"
+        assert a_config["timeout"] == 11
+        assert b_config["env_type"] == "local"
+        assert b_config["timeout"] == 22
+        assert a_key != b_key
+        assert current_profile_runtime_context() is None
+
+    def test_terminal_config_ref_uses_routed_profile_dotenv(self, tmp_path, monkeypatch):
+        from gateway.run import _profile_runtime_scope
+        from tools.terminal_tool import _get_env_config
+
+        profile = tmp_path / "profile"
+        profile.mkdir()
+        (profile / ".env").write_text(
+            "PROFILE_TERMINAL_BACKEND=docker\n",
+            encoding="utf-8",
+        )
+        (profile / "config.yaml").write_text(
+            "terminal:\n  backend: ${env:PROFILE_TERMINAL_BACKEND}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("PROFILE_TERMINAL_BACKEND", "local")
+
+        with _profile_runtime_scope(profile):
+            assert _get_env_config()["env_type"] == "docker"
+        assert os.environ["PROFILE_TERMINAL_BACKEND"] == "local"
+
 
 def test_cold_profile_hydrates_external_source_without_global_env(
     tmp_path, monkeypatch
@@ -164,5 +214,41 @@ def test_cold_profile_hydrates_external_source_without_global_env(
     assert calls["count"] == 1
     assert "TEST_PROVIDER_API_KEY" not in os.environ
     assert "EXPLICIT_API_KEY" not in os.environ
+
+
+@pytest.mark.parametrize("failure_site", ["hydrate", "build"])
+def test_profile_runtime_scope_resets_home_when_setup_raises(
+    tmp_path, monkeypatch, failure_site
+):
+    from profile_runtime_context import current_profile_runtime_context
+    from gateway.run import _profile_runtime_scope
+    from hermes_constants import get_hermes_home
+    from hermes_cli import env_loader
+
+    profile = tmp_path / failure_site
+    profile.mkdir()
+    before = get_hermes_home()
+
+    if failure_site == "hydrate":
+        monkeypatch.setattr(
+            env_loader,
+            "hydrate_profile_secret_sources",
+            lambda _home: (_ for _ in ()).throw(RuntimeError("hydrate failed")),
+        )
+    else:
+        monkeypatch.setattr(env_loader, "hydrate_profile_secret_sources", lambda _home: {})
+        monkeypatch.setattr(
+            ss,
+            "build_profile_secret_scope",
+            lambda _home: (_ for _ in ()).throw(RuntimeError("build failed")),
+        )
+
+    with pytest.raises(RuntimeError):
+        with _profile_runtime_scope(profile):
+            pass
+
+    assert get_hermes_home() == before
+    assert ss.current_secret_scope() is None
+    assert current_profile_runtime_context() is None
 
 

--- a/tests/hermes_cli/test_config_env_expansion.py
+++ b/tests/hermes_cli/test_config_env_expansion.py
@@ -10,6 +10,20 @@ class TestExpandEnvVars:
             mp.setenv("MY_KEY", "secret123")
             assert _expand_env_vars("${MY_KEY}") == "secret123"
 
+    def test_custom_resolver_is_used_recursively(self, monkeypatch):
+        monkeypatch.setenv("PROFILE_ONLY", "launch-profile")
+        scoped = {"PROFILE_ONLY": "routed-profile", "EMPTY": ""}
+
+        assert _expand_env_vars(
+            {"a": "${PROFILE_ONLY}", "b": ["${env:EMPTY}"]},
+            scoped.get,
+        ) == {"a": "routed-profile", "b": [""]}
+
+    def test_custom_resolver_does_not_fall_through_to_process_env(self, monkeypatch):
+        monkeypatch.setenv("PROFILE_ONLY", "launch-profile")
+
+        assert _expand_env_vars("${PROFILE_ONLY}", {}.get) == "${PROFILE_ONLY}"
+
 
 
 

--- a/tests/test_env_loader_applied_homes.py
+++ b/tests/test_env_loader_applied_homes.py
@@ -133,3 +133,29 @@ def test_success_marks_applied_and_second_call_noop(tmp_path, monkeypatch):
     env_loader._apply_external_secret_sources(home)
     assert calls["n"] == 1
     monkeypatch.delenv("KEY_OK_40597", raising=False)
+
+
+def test_refresh_one_home_preserves_other_profile_snapshot(tmp_path, monkeypatch):
+    home_a = tmp_path / "a"
+    home_b = tmp_path / "b"
+    home_a.mkdir()
+    home_b.mkdir()
+    key_a = str(home_a.resolve())
+    key_b = str(home_b.resolve())
+    env_loader._APPLIED_HOMES.update({key_a, key_b})
+    env_loader._SECRET_SOURCE_VALUES_BY_HOME[key_a] = {"A_KEY": "old"}
+    env_loader._SECRET_SOURCE_VALUES_BY_HOME[key_b] = {"B_KEY": "keep"}
+
+    def fake_hydrate(home):
+        assert str(home.resolve()) == key_a
+        assert key_a not in env_loader._APPLIED_HOMES
+        assert key_b in env_loader._APPLIED_HOMES
+        env_loader._APPLIED_HOMES.add(key_a)
+        env_loader._SECRET_SOURCE_VALUES_BY_HOME[key_a] = {"A_KEY": "fresh"}
+        return {"A_KEY": "fresh"}
+
+    monkeypatch.setattr(env_loader, "_hydrate_profile_secret_sources", fake_hydrate)
+
+    assert env_loader.refresh_profile_secret_sources(home_a) == {"A_KEY": "fresh"}
+    assert env_loader._SECRET_SOURCE_VALUES_BY_HOME[key_a] == {"A_KEY": "fresh"}
+    assert env_loader._SECRET_SOURCE_VALUES_BY_HOME[key_b] == {"B_KEY": "keep"}

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -687,30 +687,34 @@ def test_profile_scoped_agent_build_starts_mcp_discovery_in_profile_home(
 
 
 def test_profile_scoped_agent_build_installs_secret_scope(monkeypatch, tmp_path):
-    """Agent construction must install the selected profile's secret scope.
-
-    Without it, get_secret() falls through to process os.environ, so a session
-    "switched" to profile X resolves credentials from the LAUNCH profile's
-    .env (#67605 item 2).
-    """
+    """Agent construction installs the selected profile's secret/runtime scope."""
     import threading
 
     from agent.secret_scope import current_secret_scope
+    from profile_runtime_context import current_profile_runtime_context, terminal_getenv
 
     profile_home = tmp_path / "profiles" / "grace"
     profile_home.mkdir(parents=True)
     (profile_home / ".env").write_text(
         "PROXMOX_TOKEN=grace-secret\n", encoding="utf-8"
     )
+    (profile_home / "config.yaml").write_text(
+        "terminal:\n  backend: docker\n  timeout: 17\n",
+        encoding="utf-8",
+    )
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default"))
 
     scopes = []
+    runtime_contexts = []
     built = threading.Event()
 
     def _fake_make_agent(*args, **kwargs):
         scope = current_secret_scope()
         scopes.append(dict(scope) if scope else None)
+        runtime_contexts.append(
+            (current_profile_runtime_context(), terminal_getenv("TERMINAL_ENV"))
+        )
         built.set()
         return type("Agent", (), {"model": "test"})()
 
@@ -735,10 +739,13 @@ def test_profile_scoped_agent_build_installs_secret_scope(monkeypatch, tmp_path)
     try:
         server._start_agent_build(sid, session)
         assert built.wait(timeout=2)
+        assert ready.wait(timeout=2)
     finally:
         server._sessions.pop(sid, None)
 
     assert scopes == [{"PROXMOX_TOKEN": "grace-secret"}]
+    assert runtime_contexts[0][0] is not None
+    assert runtime_contexts[0][1] == "docker"
 
 
 def test_profile_configured_cwd_reads_target_profile(tmp_path):
@@ -747,6 +754,38 @@ def test_profile_configured_cwd_reads_target_profile(tmp_path):
     project.mkdir()
     home = _write_profile_cfg(tmp_path / "home", str(project))
     assert server._profile_configured_cwd(home) == str(project)
+
+
+def test_profile_configured_cwd_expands_target_profile_env(monkeypatch, tmp_path):
+    project = tmp_path / "profile-project"
+    project.mkdir()
+    home = tmp_path / "profile-home"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "terminal:\n  cwd: ${env:PROFILE_CWD}\n",
+        encoding="utf-8",
+    )
+    (home / ".env").write_text(
+        f"PROFILE_CWD={project}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PROFILE_CWD", str(tmp_path / "launch-project"))
+
+    assert server._profile_configured_cwd(home) == str(project)
+    assert os.environ["PROFILE_CWD"] == str(tmp_path / "launch-project")
+
+
+def test_launch_configured_cwd_expands_process_env(monkeypatch, tmp_path):
+    project = tmp_path / "launch-project"
+    project.mkdir()
+    monkeypatch.setenv("LAUNCH_CWD", str(project))
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"terminal": {"cwd": "${env:LAUNCH_CWD}"}},
+    )
+
+    assert server._launch_configured_cwd() == str(project)
 
 
 def test_profile_configured_cwd_skips_placeholders_and_missing(tmp_path):
@@ -816,6 +855,44 @@ def test_default_session_cwd_prefers_launch_config(monkeypatch, tmp_path):
     # No launch config → fall back to the process env var.
     monkeypatch.setattr(server, "_load_cfg", lambda: {})
     assert server._default_session_cwd() == str(stale)
+
+
+def test_profile_config_set_cwd_does_not_mutate_launch_env(monkeypatch, tmp_path):
+    import yaml
+
+    profile_home = tmp_path / "profile-home"
+    profile_home.mkdir()
+    (profile_home / "config.yaml").write_text(
+        "terminal:\n  backend: local\n",
+        encoding="utf-8",
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", "/launch-cwd")
+    sid = "profile-config-set"
+    server._sessions[sid] = {
+        "session_key": "profile-config-set-key",
+        "profile_home": str(profile_home),
+    }
+    try:
+        response = server.handle_request(
+            {
+                "id": "cfg-1",
+                "method": "config.set",
+                "params": {
+                    "session_id": sid,
+                    "key": "terminal.cwd",
+                    "value": str(workspace),
+                },
+            }
+        )
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert "result" in response
+    assert os.environ["TERMINAL_CWD"] == "/launch-cwd"
+    saved = yaml.safe_load((profile_home / "config.yaml").read_text())
+    assert saved["terminal"]["cwd"] == str(workspace)
 
 
 def test_completion_cwd_explicit_cwd_wins_over_profile(monkeypatch, tmp_path):

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -572,3 +572,34 @@ class TestMasterCredentialStoresAreNeverMountable:
             assert cf.get_credential_file_mounts() == []
         rec = next(r for r in caplog.records if "read guard raised" in r.message)
         assert rec.exc_info is not None, "traceback must be attached (logger.exception)"
+
+
+def test_config_cache_is_partitioned_by_profile_home(tmp_path):
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    from tools.credential_files import _load_config_files
+
+    homes = []
+    for name in ("a", "b"):
+        home = tmp_path / name
+        home.mkdir()
+        token = home / f"{name}.token"
+        token.write_text(name, encoding="utf-8")
+        (home / "config.yaml").write_text(
+            f"terminal:\n  credential_files:\n    - {name}.token\n",
+            encoding="utf-8",
+        )
+        homes.append((home, token))
+
+    loaded = []
+    for home, _token in homes:
+        scope = set_hermes_home_override(str(home))
+        try:
+            loaded.append(_load_config_files())
+        finally:
+            reset_hermes_home_override(scope)
+
+    assert loaded[0][0]["host_path"] == str(homes[0][1])
+    assert loaded[1][0]["host_path"] == str(homes[1][1])

--- a/tests/tools/test_docker_orphan_reaper_integration.py
+++ b/tests/tools/test_docker_orphan_reaper_integration.py
@@ -14,6 +14,7 @@ import os
 from unittest.mock import patch
 
 import tools.terminal_tool as terminal_tool
+from profile_runtime_context import use_profile_runtime_context
 
 
 def _reset_reaper_gate():
@@ -42,6 +43,33 @@ def test_maybe_reap_runs_once_per_process(monkeypatch):
     assert call_count["reap"] == 1, (
         f"reaper must run exactly once per process; got {call_count['reap']} calls"
     )
+
+
+def test_maybe_reap_runs_once_per_routed_profile(tmp_path):
+    terminal_tool._docker_orphan_reaper_profile_keys.clear()
+    profile_a = tmp_path / "a"
+    profile_b = tmp_path / "b"
+    for profile in (profile_a, profile_b):
+        profile.mkdir()
+        (profile / "config.yaml").write_text(
+            "terminal:\n  backend: docker\n",
+            encoding="utf-8",
+        )
+
+    calls = []
+
+    def _fake_reap(**kwargs):
+        calls.append(kwargs)
+        return 0
+
+    with patch("tools.environments.docker.reap_orphan_containers", _fake_reap):
+        with use_profile_runtime_context(profile_a):
+            terminal_tool._maybe_reap_docker_orphans({"docker_orphan_reaper": True})
+            terminal_tool._maybe_reap_docker_orphans({"docker_orphan_reaper": True})
+        with use_profile_runtime_context(profile_b):
+            terminal_tool._maybe_reap_docker_orphans({"docker_orphan_reaper": True})
+
+    assert len(calls) == 2
 
 
 def test_maybe_reap_passes_current_profile_as_filter(monkeypatch):

--- a/tests/tools/test_env_probe.py
+++ b/tests/tools/test_env_probe.py
@@ -317,3 +317,31 @@ class TestRunBoundedByTimeout:
         assert elapsed < 3.0, f"_run blocked on grandchild for {elapsed:.1f}s"
         assert rc == 0, f"expected clean exit, got rc={rc} err={err!r}"
         assert out == "ok"
+
+
+def test_profile_probe_cache_and_worker_context_are_partitioned(tmp_path, monkeypatch):
+    from profile_runtime_context import terminal_getenv, use_profile_runtime_context
+
+    profiles = []
+    for name, backend in (("a", "docker"), ("b", "local")):
+        home = tmp_path / name
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            f"terminal:\n  backend: {backend}\n",
+            encoding="utf-8",
+        )
+        profiles.append((home, backend))
+
+    monkeypatch.setattr(
+        env_probe,
+        "_build_probe_line",
+        lambda: terminal_getenv("TERMINAL_ENV", "missing"),
+    )
+
+    env_probe._reset_cache_for_tests()
+    for home, backend in profiles:
+        with use_profile_runtime_context(home):
+            assert env_probe.get_environment_probe_line(force_refresh=True) == backend
+            assert env_probe.get_environment_probe_line() == backend
+
+    assert len(env_probe._PROFILE_PROBE_STATES) == 2

--- a/tests/tools/test_profile_terminal_runtime_scope.py
+++ b/tests/tools/test_profile_terminal_runtime_scope.py
@@ -1,0 +1,611 @@
+"""Regression coverage for profile-scoped terminal execution state (#68559)."""
+
+from __future__ import annotations
+
+import contextvars
+from concurrent.futures import ThreadPoolExecutor
+import os
+import threading
+
+import pytest
+
+from profile_runtime_context import (
+    current_profile_runtime_context,
+    use_profile_runtime_context,
+    use_terminal_env_overrides,
+)
+from tools import terminal_tool
+
+
+def _profile(tmp_path, name: str, terminal_yaml: str):
+    home = tmp_path / name
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        f"terminal:\n{terminal_yaml}",
+        encoding="utf-8",
+    )
+    return home
+
+
+def test_profile_terminal_config_is_context_local_and_process_env_is_unchanged(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_TIMEOUT", "999")
+    profile_a = _profile(
+        tmp_path,
+        "a",
+        "  backend: docker\n  timeout: 11\n  docker_image: a/image\n",
+    )
+    profile_b = _profile(
+        tmp_path,
+        "b",
+        "  backend: local\n  timeout: 22\n",
+    )
+
+    with use_profile_runtime_context(profile_a):
+        config_a = terminal_tool._get_env_config()
+        assert config_a["env_type"] == "docker"
+        assert config_a["timeout"] == 11
+        assert config_a["docker_image"] == "a/image"
+        assert os.environ["TERMINAL_ENV"] == "ssh"
+        assert os.environ["TERMINAL_TIMEOUT"] == "999"
+
+        with use_profile_runtime_context(profile_b):
+            config_b = terminal_tool._get_env_config()
+            assert config_b["env_type"] == "local"
+            assert config_b["timeout"] == 22
+
+        assert terminal_tool._get_env_config()["env_type"] == "docker"
+
+    assert current_profile_runtime_context() is None
+    assert os.environ["TERMINAL_ENV"] == "ssh"
+    assert os.environ["TERMINAL_TIMEOUT"] == "999"
+
+
+def test_profile_terminal_refs_use_secret_scope_without_process_fallback(
+    tmp_path, monkeypatch
+):
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+
+    monkeypatch.setenv("PROFILE_TERMINAL_BACKEND", "local")
+    profile = _profile(
+        tmp_path,
+        "scoped-ref",
+        "  backend: ${env:PROFILE_TERMINAL_BACKEND}\n",
+    )
+
+    token = set_secret_scope({"PROFILE_TERMINAL_BACKEND": "docker"})
+    try:
+        with use_profile_runtime_context(profile):
+            assert terminal_tool._get_env_config()["env_type"] == "docker"
+    finally:
+        reset_secret_scope(token)
+
+    with use_profile_runtime_context(profile):
+        # Missing profile value stays unresolved instead of inheriting the
+        # launch profile's `local` backend. Environment creation will reject
+        # this unknown backend rather than execute on the host.
+        assert terminal_tool._get_env_config()["env_type"] == "${env:PROFILE_TERMINAL_BACKEND}"
+    assert os.environ["PROFILE_TERMINAL_BACKEND"] == "local"
+
+
+def test_profile_dotenv_terminal_values_win_defaults_but_not_explicit_config(
+    tmp_path, monkeypatch
+):
+    from agent.secret_scope import (
+        build_profile_secret_scope,
+        reset_secret_scope,
+        set_secret_scope,
+    )
+
+    dotenv_only = tmp_path / "dotenv-only"
+    dotenv_only.mkdir()
+    (dotenv_only / "config.yaml").write_text("{}\n", encoding="utf-8")
+    (dotenv_only / ".env").write_text(
+        "TERMINAL_ENV=docker\nTERMINAL_TIMEOUT=77\n",
+        encoding="utf-8",
+    )
+    explicit = _profile(
+        tmp_path,
+        "explicit",
+        "  backend: local\n  timeout: 22\n",
+    )
+    (explicit / ".env").write_text(
+        "TERMINAL_ENV=docker\nTERMINAL_TIMEOUT=77\n",
+        encoding="utf-8",
+    )
+
+    for home, expected in ((dotenv_only, ("docker", 77)), (explicit, ("local", 22))):
+        token = set_secret_scope(build_profile_secret_scope(home))
+        try:
+            with use_profile_runtime_context(home):
+                config = terminal_tool._get_env_config()
+                assert (config["env_type"], config["timeout"]) == expected
+        finally:
+            reset_secret_scope(token)
+
+
+def test_load_config_uses_profile_scope_and_invalidates_on_secret_rotation(
+    tmp_path, monkeypatch
+):
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from hermes_cli.config import load_config
+
+    home = tmp_path / "config-profile"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "profile_value: ${env:PROFILE_CONFIG_VALUE}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PROFILE_CONFIG_VALUE", "launch-value")
+
+    for scoped_value in ("routed-a", "routed-b"):
+        token = set_secret_scope({"PROFILE_CONFIG_VALUE": scoped_value})
+        try:
+            with use_profile_runtime_context(home):
+                assert load_config()["profile_value"] == scoped_value
+        finally:
+            reset_secret_scope(token)
+
+    assert os.environ["PROFILE_CONFIG_VALUE"] == "launch-value"
+
+
+def test_managed_config_refs_keep_process_env_precedence(tmp_path, monkeypatch):
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from hermes_cli import managed_scope
+    from hermes_cli.config import load_config
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "managed_probe: ${env:MANAGED_PROBE}\n",
+        encoding="utf-8",
+    )
+    managed = tmp_path / "managed-config"
+    managed.mkdir()
+    (managed / "config.yaml").write_text(
+        "managed_probe: ${env:MANAGED_PROBE}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    monkeypatch.setenv("MANAGED_PROBE", "managed-process")
+    managed_scope.invalidate_managed_cache()
+
+    token = set_secret_scope({"MANAGED_PROBE": "profile-secret"})
+    try:
+        with use_profile_runtime_context(home):
+            assert load_config()["managed_probe"] == "managed-process"
+    finally:
+        reset_secret_scope(token)
+
+
+def test_singularity_scratch_dir_uses_profile_secret_scope(tmp_path, monkeypatch):
+    from agent.secret_scope import reset_secret_scope, set_secret_scope
+    from tools.environments.singularity import _get_scratch_dir
+
+    profile = _profile(
+        tmp_path,
+        "profile",
+        f"  backend: singularity\n  cwd: {tmp_path / 'profile-cwd'}\n",
+    )
+    launch_scratch = tmp_path / "launch-scratch"
+    profile_scratch = tmp_path / "profile-scratch"
+    monkeypatch.setenv("TERMINAL_SCRATCH_DIR", str(launch_scratch))
+
+    token = set_secret_scope({"TERMINAL_SCRATCH_DIR": str(profile_scratch)})
+    try:
+        with use_profile_runtime_context(profile):
+            assert _get_scratch_dir() == profile_scratch
+            assert os.environ["TERMINAL_SCRATCH_DIR"] == str(launch_scratch)
+    finally:
+        reset_secret_scope(token)
+
+    assert _get_scratch_dir() == launch_scratch
+
+
+def test_managed_terminal_policy_wins_over_profile_config(tmp_path, monkeypatch):
+    from hermes_cli import managed_scope
+
+    profile = _profile(tmp_path, "profile", "  backend: docker\n")
+    (profile / ".env").write_text("TERMINAL_ENV=local\n", encoding="utf-8")
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    (managed / "config.yaml").write_text(
+        "terminal:\n  backend: ssh\n  ssh_host: managed.example\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    managed_scope.invalidate_managed_cache()
+
+    from agent.secret_scope import (
+        build_profile_secret_scope,
+        reset_secret_scope,
+        set_secret_scope,
+    )
+
+    token = set_secret_scope(build_profile_secret_scope(profile))
+    try:
+        with use_profile_runtime_context(profile):
+            config = terminal_tool._get_env_config()
+            assert config["env_type"] == "ssh"
+            assert config["ssh_host"] == "managed.example"
+    finally:
+        reset_secret_scope(token)
+
+
+def test_malformed_profile_config_fails_closed(tmp_path):
+    profile = tmp_path / "malformed"
+    profile.mkdir()
+    (profile / "config.yaml").write_text("terminal: [", encoding="utf-8")
+
+    with pytest.raises(Exception):
+        with use_profile_runtime_context(profile):
+            pytest.fail("malformed profile config must not enter runtime scope")
+
+
+def test_profile_scope_propagates_only_when_context_is_copied(tmp_path):
+    profile = _profile(tmp_path, "threaded", "  backend: docker\n")
+    seen = []
+
+    with use_profile_runtime_context(profile):
+        copied = contextvars.copy_context()
+        thread = threading.Thread(
+            target=lambda: seen.append(
+                copied.run(lambda: terminal_tool._get_env_config()["env_type"])
+            )
+        )
+        thread.start()
+        thread.join(timeout=5)
+
+    assert seen == ["docker"]
+
+
+def test_concurrent_profiles_do_not_cross_terminal_config_or_cache_keys(tmp_path):
+    profile_a = _profile(tmp_path, "a", "  backend: docker\n  timeout: 11\n")
+    profile_b = _profile(tmp_path, "b", "  backend: local\n  timeout: 22\n")
+    barrier = threading.Barrier(2, timeout=5)
+
+    def read_profile(home):
+        from hermes_cli.config import load_config
+        from hermes_constants import get_hermes_home
+
+        with use_profile_runtime_context(home):
+            barrier.wait()
+            config = terminal_tool._get_env_config()
+            return (
+                config["env_type"],
+                config["timeout"],
+                terminal_tool._resolve_container_task_id(None),
+                str(get_hermes_home()),
+                load_config()["terminal"]["backend"],
+            )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        result_a = pool.submit(read_profile, profile_a)
+        result_b = pool.submit(read_profile, profile_b)
+
+    backend_a, timeout_a, key_a, home_a, loaded_a = result_a.result()
+    backend_b, timeout_b, key_b, home_b, loaded_b = result_b.result()
+    assert (backend_a, timeout_a) == ("docker", 11)
+    assert (backend_b, timeout_b) == ("local", 22)
+    assert key_a != key_b
+    assert home_a == str(profile_a.resolve())
+    assert home_b == str(profile_b.resolve())
+    assert loaded_a == "docker"
+    assert loaded_b == "local"
+
+
+def test_profile_keys_partition_environment_overrides_and_cwd(tmp_path):
+    profile_a = _profile(tmp_path, "a", "  backend: local\n")
+    profile_b = _profile(tmp_path, "b", "  backend: local\n")
+
+    with use_profile_runtime_context(profile_a):
+        key_a = terminal_tool._resolve_container_task_id("same-task")
+        terminal_tool.register_task_env_overrides("same-task", {"cwd": "/profile-a"})
+        terminal_tool.record_session_cwd("same-task", "/profile-a")
+
+    with use_profile_runtime_context(profile_b):
+        key_b = terminal_tool._resolve_container_task_id("same-task")
+        terminal_tool.register_task_env_overrides("same-task", {"cwd": "/profile-b"})
+        terminal_tool.record_session_cwd("same-task", "/profile-b")
+
+    assert key_a != key_b
+    try:
+        with use_profile_runtime_context(profile_a):
+            assert terminal_tool.resolve_task_overrides("same-task")["cwd"] == "/profile-a"
+            assert terminal_tool.get_session_cwd("same-task") == "/profile-a"
+        with use_profile_runtime_context(profile_b):
+            assert terminal_tool.resolve_task_overrides("same-task")["cwd"] == "/profile-b"
+            assert terminal_tool.get_session_cwd("same-task") == "/profile-b"
+    finally:
+        with use_profile_runtime_context(profile_a):
+            terminal_tool.clear_task_env_overrides("same-task")
+        with use_profile_runtime_context(profile_b):
+            terminal_tool.clear_task_env_overrides("same-task")
+
+
+def test_profile_keys_prevent_cached_environment_reuse(tmp_path):
+    profile_a = _profile(tmp_path, "a", "  backend: local\n")
+    profile_b = _profile(tmp_path, "b", "  backend: local\n")
+    env_a = object()
+    env_b = object()
+
+    with use_profile_runtime_context(profile_a):
+        key_a = terminal_tool._resolve_container_task_id(None)
+    with use_profile_runtime_context(profile_b):
+        key_b = terminal_tool._resolve_container_task_id(None)
+
+    with terminal_tool._env_lock:
+        terminal_tool._active_environments[key_a] = env_a
+        terminal_tool._active_environments[key_b] = env_b
+    try:
+        with use_profile_runtime_context(profile_a):
+            assert terminal_tool.get_active_env("default") is env_a
+        with use_profile_runtime_context(profile_b):
+            assert terminal_tool.get_active_env("default") is env_b
+    finally:
+        with terminal_tool._env_lock:
+            terminal_tool._active_environments.pop(key_a, None)
+            terminal_tool._active_environments.pop(key_b, None)
+
+
+def test_file_state_caches_are_profile_partitioned(tmp_path):
+    from tools.file_tools import (
+        _check_not_found_cache,
+        _patch_failure_tracker,
+        _read_tracker,
+        _record_not_found,
+        _record_patch_failure,
+    )
+
+    profile_a = _profile(tmp_path, "a-cache", "  backend: local\n")
+    profile_b = _profile(tmp_path, "b-cache", "  backend: local\n")
+    missing = str(tmp_path / "missing")
+
+    try:
+        with use_profile_runtime_context(profile_a):
+            _record_not_found("read", missing, "shared-task", "A-NOTFOUND")
+            assert _record_patch_failure("shared-task", missing) == 1
+            assert _check_not_found_cache("read", missing, "shared-task") == "A-NOTFOUND"
+
+        with use_profile_runtime_context(profile_b):
+            assert _check_not_found_cache("read", missing, "shared-task") is None
+            assert _record_patch_failure("shared-task", missing) == 1
+    finally:
+        _read_tracker.clear()
+        _patch_failure_tracker.clear()
+
+
+def test_file_read_limit_cache_is_profile_partitioned(tmp_path):
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from tools import file_tools
+
+    profiles = []
+    for name, limit in (("a", 111_111), ("b", 222_222)):
+        home = tmp_path / name
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            f"file_read_max_chars: {limit}\nterminal:\n  backend: local\n",
+            encoding="utf-8",
+        )
+        profiles.append((home, limit))
+
+    file_tools._max_read_chars_cached = {}
+    seen = []
+    for home, expected in profiles:
+        token = set_hermes_home_override(str(home))
+        try:
+            with use_profile_runtime_context(home):
+                seen.append(file_tools._get_max_read_chars())
+        finally:
+            reset_hermes_home_override(token)
+        assert seen[-1] == expected
+
+    assert seen == [111_111, 222_222]
+
+
+def test_cleanup_preserves_legacy_raw_fallback_but_not_inside_profile_scope(tmp_path):
+    cleaned = []
+
+    class LegacyEnv:
+        def cleanup(self):
+            cleaned.append(True)
+
+    raw_key = "legacy-raw-task"
+    with terminal_tool._env_lock:
+        terminal_tool._active_environments[raw_key] = LegacyEnv()
+    terminal_tool.cleanup_vm(raw_key)
+    assert cleaned == [True]
+    assert raw_key not in terminal_tool._active_environments
+
+    profile = _profile(tmp_path, "profile", "  backend: local\n")
+    with terminal_tool._env_lock:
+        terminal_tool._active_environments[raw_key] = LegacyEnv()
+    try:
+        with use_profile_runtime_context(profile):
+            terminal_tool.cleanup_vm(raw_key)
+        assert raw_key in terminal_tool._active_environments
+        assert cleaned == [True]
+    finally:
+        with terminal_tool._env_lock:
+            terminal_tool._active_environments.pop(raw_key, None)
+
+
+def test_all_runtime_cwd_readers_follow_profile_scope(tmp_path, monkeypatch):
+    from agent.runtime_cwd import resolve_agent_cwd, resolve_context_cwd
+    from tools.code_execution_tool import _resolve_child_cwd
+    from tools.file_tools import _configured_terminal_cwd
+
+    launch_cwd = tmp_path / "launch"
+    profile_cwd = tmp_path / "profile"
+    launch_cwd.mkdir()
+    profile_cwd.mkdir()
+    profile = _profile(
+        tmp_path,
+        "cwd-profile",
+        f"  backend: local\n  cwd: {profile_cwd}\n",
+    )
+    monkeypatch.setenv("TERMINAL_CWD", str(launch_cwd))
+
+    with use_profile_runtime_context(profile):
+        assert _configured_terminal_cwd() == str(profile_cwd)
+        assert _resolve_child_cwd("project", str(tmp_path / "staging")) == str(
+            profile_cwd
+        )
+        session_cwd = tmp_path / "session-cwd"
+        session_cwd.mkdir()
+        terminal_tool.register_task_env_overrides(
+            "execute-session", {"cwd": str(session_cwd)}
+        )
+        try:
+            assert _resolve_child_cwd(
+                "project", str(tmp_path / "staging"), task_id="execute-session"
+            ) == str(session_cwd)
+        finally:
+            terminal_tool.clear_task_env_overrides("execute-session")
+        assert resolve_agent_cwd() == profile_cwd
+        assert resolve_context_cwd() == profile_cwd
+
+
+def test_nested_terminal_overrides_do_not_mutate_process_env(tmp_path, monkeypatch):
+    from hermes_constants import get_hermes_home
+
+    profile = _profile(
+        tmp_path,
+        "override-profile",
+        "  backend: local\n  cwd: /profile\n",
+    )
+    monkeypatch.setenv("TERMINAL_CWD", "/launch")
+    foreign = _profile(
+        tmp_path,
+        "foreign-profile",
+        "  backend: local\n  cwd: /foreign\n",
+    )
+
+    with use_profile_runtime_context(profile):
+        assert str(get_hermes_home()) == str(profile.resolve())
+        assert terminal_tool._get_env_config()["cwd"] == "/profile"
+        with use_terminal_env_overrides({"TERMINAL_CWD": "/cron-job"}):
+            assert terminal_tool._get_env_config()["cwd"] == "/cron-job"
+            with use_profile_runtime_context(foreign):
+                assert str(get_hermes_home()) == str(foreign.resolve())
+                assert terminal_tool._get_env_config()["cwd"] == "/foreign"
+            assert str(get_hermes_home()) == str(profile.resolve())
+            assert terminal_tool._get_env_config()["cwd"] == "/cron-job"
+            assert os.environ["TERMINAL_CWD"] == "/launch"
+        assert terminal_tool._get_env_config()["cwd"] == "/profile"
+
+    assert os.environ["TERMINAL_CWD"] == "/launch"
+
+
+def test_process_reader_thread_keeps_profile_checkpoint_context(tmp_path):
+    import json
+    import shlex
+    import sys
+
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    from profile_runtime_context import profile_scoped_key
+    from tools.process_registry import ProcessRegistry
+
+    launch_home = tmp_path / "launch-home"
+    profile_home = tmp_path / "profile-home"
+    launch_home.mkdir()
+    _profile(tmp_path, "profile-home", "  backend: local\n")
+
+    home_token = set_hermes_home_override(str(launch_home))
+    try:
+        registry = ProcessRegistry()
+        code = 'print("done")'
+        command = f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+        with use_profile_runtime_context(profile_home):
+            session = registry.spawn_local(
+                command,
+                task_id=profile_scoped_key("checkpoint-test"),
+            )
+            assert session._reader_thread is not None
+            session._reader_thread.join(timeout=5)
+            assert not session._reader_thread.is_alive()
+
+        profile_checkpoint = profile_home / "processes.json"
+        assert profile_checkpoint.exists()
+        assert json.loads(profile_checkpoint.read_text(encoding="utf-8")) == []
+        assert not (launch_home / "processes.json").exists()
+    finally:
+        reset_hermes_home_override(home_token)
+
+
+def test_scoped_runtime_policy_reaches_safe_child_env_and_checkpoint(
+    tmp_path, monkeypatch
+):
+    from agent.secret_scope import (
+        build_profile_secret_scope,
+        reset_secret_scope,
+        set_secret_scope,
+    )
+    from hermes_constants import (
+        apply_subprocess_home_env,
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    from tools.code_execution_tool import _scrub_child_env
+    from tools.process_registry import (
+        ProcessSession,
+        _checkpoint_path,
+        _process_visible_to_active_profile,
+    )
+    from profile_runtime_context import profile_scoped_key
+    from tools.terminal_tool import (
+        _disk_warning_threshold_gb,
+        _foreground_max_timeout,
+    )
+
+    profile = _profile(
+        tmp_path,
+        "child-policy",
+        "  backend: ssh\n"
+        "  cwd: /remote/workspace\n"
+        "  timeout: 777\n"
+        "  home_mode: profile\n",
+    )
+    (profile / "home").mkdir()
+    (profile / ".env").write_text(
+        "TERMINAL_MAX_FOREGROUND_TIMEOUT=333\n"
+        "TERMINAL_DISK_WARNING_GB=12.5\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_TIMEOUT", "11")
+    monkeypatch.setenv("TERMINAL_DOCKER_ENV", "SECRET=launch")
+
+    home_token = set_hermes_home_override(str(profile))
+    secret_token = set_secret_scope(build_profile_secret_scope(profile))
+    try:
+        with use_profile_runtime_context(profile):
+            child = _scrub_child_env(
+                dict(os.environ),
+                is_passthrough=lambda _name: False,
+                is_windows=False,
+            )
+            assert child["TERMINAL_ENV"] == "ssh"
+            assert child["TERMINAL_TIMEOUT"] == "777"
+            assert child["TERMINAL_MAX_FOREGROUND_TIMEOUT"] == "333"
+            assert child["TERMINAL_HOME_MODE"] == "profile"
+            assert "TERMINAL_DOCKER_ENV" not in child
+            assert _foreground_max_timeout() == 333
+            assert _disk_warning_threshold_gb() == 12.5
+            apply_subprocess_home_env(child)
+            assert child["HOME"] == str(profile / "home")
+            assert _checkpoint_path() == profile / "processes.json"
+            own = ProcessSession(id="own", command="x", task_id=profile_scoped_key("default"))
+            foreign = ProcessSession(
+                id="foreign", command="x", task_id="profile:other-profile:default"
+            )
+            assert _process_visible_to_active_profile(own) is True
+            assert _process_visible_to_active_profile(foreign) is False
+    finally:
+        reset_secret_scope(secret_token)
+        reset_hermes_home_override(home_token)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -899,7 +899,9 @@ def _is_local_backend() -> bool:
         return False
     # When terminal runs in a container, browser on host can access
     # internal networks the terminal can't → treat as non-local.
-    terminal_backend = os.getenv("TERMINAL_ENV", "local").strip().lower()
+    from profile_runtime_context import terminal_getenv
+
+    terminal_backend = terminal_getenv("TERMINAL_ENV", "local").strip().lower()
     return terminal_backend in ("local", "")
 
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -48,6 +48,7 @@ import uuid
 _IS_WINDOWS = platform.system() == "Windows"
 from typing import Any, Dict, List, Optional, Tuple
 
+from profile_runtime_context import terminal_getenv
 from tools.thread_context import propagate_context_to_thread
 
 # Availability gate.  On Windows we fall back to loopback TCP for the
@@ -296,6 +297,21 @@ def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
             scrubbed = scrub_kanban_env(scrubbed)
     except Exception:
         pass
+    from profile_runtime_context import overlay_terminal_env, terminal_scope_active
+
+    safe_terminal_names = (
+        "TERMINAL_ENV",
+        "TERMINAL_CWD",
+        "TERMINAL_TIMEOUT",
+        "TERMINAL_MAX_FOREGROUND_TIMEOUT",
+        "TERMINAL_HOME_MODE",
+        "TERMINAL_SCRATCH_DIR",
+    )
+    if terminal_scope_active():
+        for name in list(scrubbed):
+            if name.startswith("TERMINAL_"):
+                scrubbed.pop(name, None)
+    overlay_terminal_env(scrubbed, names=safe_terminal_names)
     return scrubbed
 
 
@@ -1481,6 +1497,7 @@ def execute_code(
         child_env.pop("HERMES_TIMEZONE", None)
 
         from hermes_constants import apply_subprocess_home_env
+
         apply_subprocess_home_env(child_env)
 
         # Resolve interpreter + CWD based on execute_code mode.
@@ -1936,7 +1953,7 @@ def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
             session_cwd = None
         if session_cwd and os.path.isdir(session_cwd):
             return session_cwd
-    raw = os.environ.get("TERMINAL_CWD", "").strip()
+    raw = (terminal_getenv("TERMINAL_CWD") or "").strip()
     if raw:
         expanded = os.path.expanduser(raw)
         if os.path.isdir(expanded):

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -27,6 +27,7 @@ from contextvars import ContextVar
 from pathlib import Path
 from typing import Dict, List, Optional
 from hermes_cli.config import cfg_get
+from profile_runtime_context import terminal_getenv
 
 try:  # pragma: no cover - exercised via the fail-closed test below
     from agent.file_safety import get_read_block_error
@@ -50,8 +51,9 @@ def _get_registered() -> Dict[str, str]:
         return val
 
 
-# Cache for config-based file list (loaded once per process).
-_config_files: List[Dict[str, str]] | None = None
+# Cache for config-based file lists, partitioned by resolved HERMES_HOME.
+# ``None`` remains a supported test/reset sentinel.
+_config_files: dict[str, List[Dict[str, str]]] | None = {}
 
 
 def _resolve_hermes_home() -> Path:
@@ -174,16 +176,21 @@ def register_credential_files(
 
 
 def _load_config_files() -> List[Dict[str, str]]:
-    """Load ``terminal.credential_files`` from config.yaml (cached)."""
+    """Load ``terminal.credential_files`` from the active profile (cached)."""
     global _config_files
-    if _config_files is not None:
-        return _config_files
+    if _config_files is None:
+        _config_files = {}
+
+    hermes_home = _resolve_hermes_home()
+    home_key = str(hermes_home.resolve())
+    if home_key in _config_files:
+        return _config_files[home_key]
 
     result: List[Dict[str, str]] = []
     try:
-        from hermes_cli.config import read_raw_config
-        hermes_home = _resolve_hermes_home()
-        cfg = read_raw_config()
+        from hermes_cli.config import read_user_config_raw
+
+        cfg = read_user_config_raw(hermes_home / "config.yaml")
         cred_files = cfg_get(cfg, "terminal", "credential_files")
         if isinstance(cred_files, list):
             from tools.path_security import validate_within_dir
@@ -214,8 +221,8 @@ def _load_config_files() -> List[Dict[str, str]]:
     except Exception as e:
         logger.warning("Could not read terminal.credential_files from config: %s", e)
 
-    _config_files = result
-    return _config_files
+    _config_files[home_key] = result
+    return _config_files[home_key]
 
 
 def get_credential_file_mounts() -> List[Dict[str, str]]:
@@ -462,7 +469,7 @@ def from_agent_visible_cache_path(
     auto-mounted cache directory — the caller then treats a still-container
     path as "no host file" and falls back to an in-container read.
     """
-    if os.environ.get("TERMINAL_ENV", "local") != "docker":
+    if terminal_getenv("TERMINAL_ENV", "local") != "docker":
         return container_path
 
     path = Path(container_path)
@@ -489,7 +496,7 @@ def to_agent_visible_cache_path(
     # (Modal, Daytona, Vercel) use different mount semantics and will be
     # addressed separately if needed.  Backend is identified by TERMINAL_ENV
     # (same env var tools/terminal_tool.py reads in _get_environment_config).
-    if os.environ.get("TERMINAL_ENV", "local") != "docker":
+    if terminal_getenv("TERMINAL_ENV", "local") != "docker":
         return host_path
 
     mapped = map_cache_path_to_container(host_path, container_base=container_base)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -33,6 +33,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit, urlunsplit
 
 from toolsets import TOOLSETS
+from profile_runtime_context import terminal_getenv
 from agent.interrupt_compat import request_hard_interrupt
 
 # Sentinel value used by the runtime provider system for providers that are
@@ -872,7 +873,7 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
     guessing `/workspace/...` for local repo tasks.
     """
     candidates = [
-        os.getenv("TERMINAL_CWD"),
+        terminal_getenv("TERMINAL_CWD"),
         getattr(
             getattr(parent_agent, "_subdirectory_hints", None), "working_dir", None
         ),

--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -35,9 +35,12 @@ import shutil
 import subprocess
 import tempfile
 import threading
+from contextvars import copy_context
+from dataclasses import dataclass, field
 from typing import Optional
 
 from hermes_cli._subprocess_compat import windows_hide_flags
+from profile_runtime_context import current_profile_cache_key, terminal_getenv
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +71,18 @@ _PROBE_WAIT_TIMEOUT = 10.0
 # stop paying it too — they just peek at the event.  If the stuck worker
 # ever finishes, the published line resumes appearing in new prompts.
 _WAIT_ALREADY_TIMED_OUT = False
+
+
+@dataclass
+class _ProfileProbeState:
+    line: Optional[str] = None
+    done: threading.Event = field(default_factory=threading.Event)
+    thread: Optional[threading.Thread] = None
+    generation: int = 0
+    wait_timed_out: bool = False
+
+
+_PROFILE_PROBE_STATES: dict[str, _ProfileProbeState] = {}
 
 # Remote backends — keep in sync with agent/prompt_builder.py:_REMOTE_TERMINAL_BACKENDS.
 # Duplicated rather than imported to avoid a circular import (prompt_builder
@@ -194,7 +209,7 @@ def _build_probe_line() -> str:
     """
     # Bail out if a remote terminal backend is configured; the host's
     # Python state isn't where the agent's tools run.
-    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    backend = (terminal_getenv("TERMINAL_ENV") or "local").strip().lower()
     if backend in _REMOTE_BACKENDS:
         return ""
 
@@ -268,6 +283,66 @@ def _build_probe_line() -> str:
     return "Python toolchain: " + ", ".join(bits) + "."
 
 
+def _profile_probe_worker(profile_key: str, generation: int) -> None:
+    try:
+        line = _build_probe_line()
+    except Exception as exc:
+        logger.debug("env_probe failed for profile %s: %s", profile_key, exc)
+        line = ""
+    with _CACHE_LOCK:
+        state = _PROFILE_PROBE_STATES.get(profile_key)
+        if state is None or generation != state.generation:
+            return
+        state.line = line
+        state.done.set()
+
+
+def _ensure_profile_probe_started(profile_key: str, state: _ProfileProbeState) -> None:
+    with _CACHE_LOCK:
+        if state.done.is_set():
+            return
+        if state.thread is not None and state.thread.is_alive():
+            return
+        context = copy_context()
+        state.thread = threading.Thread(
+            target=lambda: context.run(
+                _profile_probe_worker,
+                profile_key,
+                state.generation,
+            ),
+            name=f"env-probe-{profile_key}",
+            daemon=True,
+        )
+        state.thread.start()
+
+
+def _get_profile_probe_line(profile_key: str, *, force_refresh: bool) -> str:
+    with _CACHE_LOCK:
+        state = _PROFILE_PROBE_STATES.setdefault(profile_key, _ProfileProbeState())
+        if force_refresh:
+            state.line = None
+            state.done.clear()
+            state.thread = None
+            state.generation += 1
+            state.wait_timed_out = False
+        if state.done.is_set():
+            return state.line or ""
+
+    _ensure_profile_probe_started(profile_key, state)
+    wait_timeout = 0.05 if state.wait_timed_out else _PROBE_WAIT_TIMEOUT
+    if not state.done.wait(timeout=wait_timeout):
+        if not state.wait_timed_out:
+            state.wait_timed_out = True
+            logger.warning(
+                "env_probe for profile %s did not finish within %.0fs; "
+                "building without the Python toolchain line",
+                profile_key,
+                _PROBE_WAIT_TIMEOUT,
+            )
+        return ""
+    return state.line or ""
+
+
 def get_environment_probe_line(*, force_refresh: bool = False) -> str:
     """Return the cached probe line (building it on first call).
 
@@ -284,6 +359,10 @@ def get_environment_probe_line(*, force_refresh: bool = False) -> str:
 
     ``force_refresh`` is for tests; real callers should never need it.
     """
+    profile_key = current_profile_cache_key()
+    if profile_key:
+        return _get_profile_probe_line(profile_key, force_refresh=force_refresh)
+
     global _CACHED_LINE, _PROBE_THREAD, _PROBE_GEN, _WAIT_ALREADY_TIMED_OUT
     if force_refresh:
         with _CACHE_LOCK:
@@ -356,6 +435,15 @@ def warm_environment_probe_async() -> None:
     completion event instead of recomputing.  Called from agent init
     (all platforms); safe to call from anywhere.
     """
+    profile_key = current_profile_cache_key()
+    if profile_key:
+        with _CACHE_LOCK:
+            state = _PROFILE_PROBE_STATES.setdefault(
+                profile_key,
+                _ProfileProbeState(),
+            )
+        _ensure_profile_probe_started(profile_key, state)
+        return
     _ensure_probe_started()
 
 
@@ -363,6 +451,7 @@ def _reset_cache_for_tests() -> None:
     """Test helper — clear the cache between probe scenarios."""
     global _CACHED_LINE, _PROBE_THREAD, _PROBE_GEN, _WAIT_ALREADY_TIMED_OUT
     with _CACHE_LOCK:
+        _PROFILE_PROBE_STATES.clear()
         _CACHED_LINE = None
         _PROBE_DONE.clear()
         _PROBE_THREAD = None

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -25,6 +25,7 @@ from typing import IO, Callable, Iterable, Protocol
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from tools.interrupt import is_interrupted
+from profile_runtime_context import terminal_getenv
 
 logger = logging.getLogger(__name__)
 
@@ -252,7 +253,7 @@ def get_sandbox_dir() -> Path:
 
     Configurable via TERMINAL_SANDBOX_DIR. Defaults to {HERMES_HOME}/sandboxes/.
     """
-    custom = os.getenv("TERMINAL_SANDBOX_DIR")
+    custom = terminal_getenv("TERMINAL_SANDBOX_DIR")
     if custom:
         p = Path(custom)
     else:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -395,13 +395,19 @@ def _is_hermes_internal_secret(key: str) -> bool:
 
 
 def _inject_context_hermes_home(env: dict) -> None:
-    """Bridge the context-local Hermes home override into subprocess env."""
+    """Bridge context-local profile settings into a subprocess env."""
     try:
         from hermes_constants import get_hermes_home_override
 
         value = get_hermes_home_override()
         if value:
             env["HERMES_HOME"] = value
+    except Exception:
+        pass
+    try:
+        from profile_runtime_context import overlay_terminal_env
+
+        overlay_terminal_env(env)
     except Exception:
         pass
 

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -14,6 +14,7 @@ import uuid
 from pathlib import Path
 from typing import Optional
 
+from profile_runtime_context import terminal_getenv
 from hermes_constants import get_hermes_home
 from tools.environments.base import (
     BaseEnvironment,
@@ -70,7 +71,7 @@ def _save_snapshots(data: dict) -> None:
 
 
 def _get_scratch_dir() -> Path:
-    custom_scratch = os.getenv("TERMINAL_SCRATCH_DIR")
+    custom_scratch = terminal_getenv("TERMINAL_SCRATCH_DIR")
     if custom_scratch:
         scratch_path = Path(custom_scratch)
         scratch_path.mkdir(parents=True, exist_ok=True)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -11,6 +11,11 @@ import threading
 from pathlib import Path, PurePosixPath
 
 from agent.file_safety import get_read_block_error
+from profile_runtime_context import (
+    current_profile_cache_key,
+    profile_scoped_key,
+    terminal_getenv,
+)
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import (
     ShellFileOperations,
@@ -58,30 +63,32 @@ def _expand_tilde(path: str) -> str:
 # Configurable via config.yaml:  file_read_max_chars: 200000
 # ---------------------------------------------------------------------------
 _DEFAULT_MAX_READ_CHARS = 100_000
-_max_read_chars_cached: int | None = None
+_max_read_chars_cached: dict[str, int] | None = {}
 
 
 def _get_max_read_chars() -> int:
     """Return the configured max characters per file read.
 
-    Reads ``file_read_max_chars`` from config.yaml on first call, caches
-    the result for the lifetime of the process.  Falls back to the
-    built-in default if the config is missing or invalid.
+    Reads ``file_read_max_chars`` from config.yaml on first call per profile.
+    Falls back to the built-in default if the config is missing or invalid.
     """
     global _max_read_chars_cached
-    if _max_read_chars_cached is not None:
-        return _max_read_chars_cached
+    if _max_read_chars_cached is None:
+        _max_read_chars_cached = {}
+    cache_key = current_profile_cache_key() or "process"
+    if cache_key in _max_read_chars_cached:
+        return _max_read_chars_cached[cache_key]
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
         val = cfg.get("file_read_max_chars")
         if isinstance(val, (int, float)) and val > 0:
-            _max_read_chars_cached = int(val)
-            return _max_read_chars_cached
+            _max_read_chars_cached[cache_key] = int(val)
+            return _max_read_chars_cached[cache_key]
     except Exception:
         pass
-    _max_read_chars_cached = _DEFAULT_MAX_READ_CHARS
-    return _max_read_chars_cached
+    _max_read_chars_cached[cache_key] = _DEFAULT_MAX_READ_CHARS
+    return _max_read_chars_cached[cache_key]
 
 
 def _truncate_to_char_budget(content: str, max_chars: int) -> tuple[str, int, bool]:
@@ -180,9 +187,10 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
         try:
             container_key = _resolve_container_task_id(task_id)
         except Exception:
-            container_key = task_id
+            container_key = profile_scoped_key(task_id)
+        raw_key = profile_scoped_key(task_id)
         with _env_lock:
-            env = _active_environments.get(container_key) or _active_environments.get(task_id)
+            env = _active_environments.get(container_key) or _active_environments.get(raw_key)
         if env is not None:
             name = env.__class__.__name__.lower()
             if "local" in name:
@@ -198,9 +206,9 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
             if "daytona" in name:
                 return "daytona"
         cfg = _get_env_config()
-        return str(cfg.get("env_type") or os.getenv("TERMINAL_ENV") or "local").lower()
+        return str(cfg.get("env_type") or terminal_getenv("TERMINAL_ENV") or "local").lower()
     except Exception:
-        return str(os.getenv("TERMINAL_ENV") or "local").lower()
+        return str(terminal_getenv("TERMINAL_ENV") or "local").lower()
 
 
 def _uses_container_paths(task_id: str = "default") -> bool:
@@ -247,7 +255,7 @@ def _configured_terminal_cwd() -> str | None:
     relative to, which is exactly the ambiguity that misroutes worktree edits.
     Only an absolute, sentinel-free value is honored.
     """
-    return _sentinel_free_abs_cwd(os.environ.get("TERMINAL_CWD"))
+    return _sentinel_free_abs_cwd(terminal_getenv("TERMINAL_CWD"))
 
 
 def _registered_task_cwd_override(task_id: str = "default") -> str | None:
@@ -713,12 +721,13 @@ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | Non
         )
 
         container_key = _resolve_container_task_id(task_id)
+        raw_key = profile_scoped_key(task_id)
     except Exception:
         return None
 
     try:
         with _env_lock:
-            env = _active_environments.get(container_key) or _active_environments.get(task_id)
+            env = _active_environments.get(container_key) or _active_environments.get(raw_key)
 
         if env is not None:
             if env.__class__.__name__ == "DockerEnvironment" and bool(
@@ -835,10 +844,16 @@ _patch_failure_lock = threading.Lock()
 _patch_failure_tracker: dict = {}  # {task_id: {resolved_path: count}}
 
 
+def _tracker_key(task_id: str | None) -> str:
+    """Return the profile-qualified key for file-tool in-memory state."""
+
+    return profile_scoped_key(task_id or "default")
+
+
 def _record_patch_failure(task_id: str, resolved_path: str) -> int:
     """Increment and return the consecutive-failure count for this path."""
     with _patch_failure_lock:
-        task_failures = _patch_failure_tracker.setdefault(task_id, {})
+        task_failures = _patch_failure_tracker.setdefault(_tracker_key(task_id), {})
         # Cap dict size per task to avoid unbounded growth in long sessions
         # where the agent fails on many distinct files.  64 distinct
         # failing files per task is generous; older entries get evicted.
@@ -857,7 +872,7 @@ def _reset_patch_failures(task_id: str, resolved_paths: list) -> None:
     if not resolved_paths:
         return
     with _patch_failure_lock:
-        task_failures = _patch_failure_tracker.get(task_id)
+        task_failures = _patch_failure_tracker.get(_tracker_key(task_id))
         if not task_failures:
             return
         for rp in resolved_paths:
@@ -957,7 +972,7 @@ def _check_not_found_cache(op: str, resolved_str: str, task_id: str) -> str | No
     import os as _os
     import time
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
+        task_data = _read_tracker.get(_tracker_key(task_id))
         if not task_data:
             return None
         nf = task_data.get("not_found")
@@ -983,7 +998,7 @@ def _check_not_found_cache(op: str, resolved_str: str, task_id: str) -> str | No
     # task's read/search bookkeeping.
     if _os.path.exists(resolved_str):
         with _read_tracker_lock:
-            task_data = _read_tracker.get(task_id)
+            task_data = _read_tracker.get(_tracker_key(task_id))
             nf = task_data.get("not_found") if task_data else None
             if nf:
                 nf.pop((op, resolved_str), None)
@@ -995,7 +1010,7 @@ def _record_not_found(op: str, resolved_str: str, task_id: str, error_json: str)
     """Cache a not-found error so the next *op* call for *resolved_str* skips I/O."""
     import time
     with _read_tracker_lock:
-        task_data = _read_tracker.setdefault(task_id, {
+        task_data = _read_tracker.setdefault(_tracker_key(task_id), {
             "last_key": None, "consecutive": 0,
             "read_history": set(), "dedup": {},
             "dedup_hits": {}, "read_timestamps": {},
@@ -1373,7 +1388,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         resolved_str = str(_resolved)
         dedup_key = (resolved_str, offset, limit)
         with _read_tracker_lock:
-            task_data = _read_tracker.setdefault(task_id, {
+            task_data = _read_tracker.setdefault(_tracker_key(task_id), {
                 "last_key": None, "consecutive": 0,
                 "read_history": set(), "dedup": {},
                 "dedup_hits": {}, "read_timestamps": {},
@@ -1586,7 +1601,7 @@ def reset_file_dedup(task_id: str = None):
     """
     with _read_tracker_lock:
         if task_id:
-            task_data = _read_tracker.get(task_id)
+            task_data = _read_tracker.get(_tracker_key(task_id))
             if task_data:
                 if "dedup" in task_data:
                     task_data["dedup"].clear()
@@ -1610,7 +1625,7 @@ def notify_other_tool_call(task_id: str = "default"):
     resets and the next read is treated as fresh.
     """
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
+        task_data = _read_tracker.get(_tracker_key(task_id))
         if task_data:
             task_data["last_key"] = None
             task_data["consecutive"] = 0
@@ -1647,7 +1662,7 @@ def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
     except (OSError, ValueError):
         return
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
+        task_data = _read_tracker.get(_tracker_key(task_id))
         if task_data is None:
             return
         dedup = task_data.get("dedup")
@@ -1683,7 +1698,7 @@ def _update_read_timestamp(filepath: str, task_id: str) -> None:
     except (OSError, ValueError):
         return
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
+        task_data = _read_tracker.get(_tracker_key(task_id))
         if task_data is not None:
             task_data.setdefault("read_timestamps", {})[resolved] = current_mtime
             _cap_read_tracker_data(task_data)
@@ -1701,7 +1716,7 @@ def _check_file_staleness(filepath: str, task_id: str) -> str | None:
     except (OSError, ValueError):
         return None
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
+        task_data = _read_tracker.get(_tracker_key(task_id))
         if not task_data:
             return None
         read_mtime = task_data.get("read_timestamps", {}).get(resolved)
@@ -2060,7 +2075,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             offset,
         )
         with _read_tracker_lock:
-            task_data = _read_tracker.setdefault(task_id, {
+            task_data = _read_tracker.setdefault(_tracker_key(task_id), {
                 "last_key": None, "consecutive": 0, "read_history": set(),
             })
             if task_data["last_key"] == search_key:

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -28,6 +28,8 @@ import threading
 import uuid
 from typing import Any, Dict, Optional
 
+from profile_runtime_context import terminal_getenv
+
 # fal_client is imported lazily — see _load_fal_client(). Pulling it
 # eagerly added ~64 ms to every CLI cold start because
 # discover_builtin_tools() imports this module unconditionally during
@@ -768,7 +770,7 @@ def _agent_cache_base_for_env(env: Any) -> str | None:
     # Hermes cache roots can be translated without side effects. SSH can still
     # use a shell-visible tilde path; its first environment sync will upload
     # the cache file before the first command runs.
-    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    backend = (terminal_getenv("TERMINAL_ENV") or "local").strip().lower()
     if backend in {"docker", "singularity", "modal"}:
         return "/root/.hermes"
     if backend == "ssh":

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -40,6 +40,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from profile_runtime_context import terminal_getenv
+
 # Raw-bytes INGEST budget — what the resolver will load before handing off.
 # This is deliberately the 50MB download cap (tools/vision_tools._VISION_MAX_DOWNLOAD_BYTES),
 # NOT the 20MB provider payload cap. The 20MB cap (_MAX_BASE64_BYTES) is a
@@ -215,7 +217,7 @@ def _is_local_terminal_backend() -> bool:
     Mirrors ``tools.browser_tool._is_local_backend`` and terminal_tool's own
     dispatch, which key off ``TERMINAL_ENV``.
     """
-    return os.getenv("TERMINAL_ENV", "local").strip().lower() in ("local", "")
+    return terminal_getenv("TERMINAL_ENV", "local").strip().lower() in ("local", "")
 
 
 def _media_cache_roots() -> list:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -40,6 +40,7 @@ import subprocess
 import threading
 import time
 import uuid
+from contextvars import copy_context
 
 _IS_WINDOWS = platform.system() == "Windows"
 from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
@@ -47,6 +48,7 @@ from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from profile_runtime_context import terminal_getenv
 from hermes_cli.config import get_hermes_home
 
 logger = logging.getLogger(__name__)
@@ -54,6 +56,14 @@ logger = logging.getLogger(__name__)
 
 # Checkpoint file for crash recovery (gateway only)
 CHECKPOINT_PATH = get_hermes_home() / "processes.json"
+
+
+def _checkpoint_path():
+    """Return the routed profile's checkpoint path when scoped."""
+
+    from profile_runtime_context import terminal_scope_active
+
+    return get_hermes_home() / "processes.json" if terminal_scope_active() else CHECKPOINT_PATH
 
 # Limits
 MAX_OUTPUT_CHARS = 200_000      # 200KB rolling output buffer
@@ -162,6 +172,7 @@ class ProcessRegistry:
         self._running: Dict[str, ProcessSession] = {}
         self._finished: Dict[str, ProcessSession] = {}
         self._lock = threading.Lock()
+        self._recovered_checkpoint_paths: set[str] = set()
 
         # Side-channel for check_interval watchers (gateway reads after agent run)
         self.pending_watchers: List[Dict[str, Any]] = []
@@ -746,9 +757,10 @@ class ProcessRegistry:
                 session._pty = pty_proc
 
                 # PTY reader thread
+                reader_context = copy_context()
                 reader = threading.Thread(
-                    target=self._pty_reader_loop,
-                    args=(session,),
+                    target=reader_context.run,
+                    args=(self._pty_reader_loop, session),
                     daemon=True,
                     name=f"proc-pty-reader-{session.id}",
                 )
@@ -798,9 +810,10 @@ class ProcessRegistry:
 
         try:
             # Start output reader thread
+            reader_context = copy_context()
             reader = threading.Thread(
-                target=self._reader_loop,
-                args=(session,),
+                target=reader_context.run,
+                args=(self._reader_loop, session),
                 daemon=True,
                 name=f"proc-reader-{session.id}",
             )
@@ -916,9 +929,10 @@ class ProcessRegistry:
 
         if not session.exited:
             # Start a poller thread that periodically reads the log file
+            reader_context = copy_context()
             reader = threading.Thread(
-                target=self._env_poller_loop,
-                args=(session, env, log_path, pid_path, exit_path),
+                target=reader_context.run,
+                args=(self._env_poller_loop, session, env, log_path, pid_path, exit_path),
                 daemon=True,
                 name=f"proc-poller-{session.id}",
             )
@@ -1534,7 +1548,7 @@ class ProcessRegistry:
         from tools.interrupt import is_interrupted as _is_interrupted
 
         try:
-            default_timeout = int(os.getenv("TERMINAL_TIMEOUT", "180"))
+            default_timeout = int(terminal_getenv("TERMINAL_TIMEOUT", "180"))
         except (ValueError, TypeError):
             default_timeout = 180
         max_timeout = default_timeout
@@ -2059,6 +2073,8 @@ class ProcessRegistry:
             with self._lock:
                 entries = []
                 for s in self._running.values():
+                    if not _process_visible_to_active_profile(s):
+                        continue
                     if not s.exited:
                         # Lazily backfill the kernel start time for host PIDs so
                         # recovery after restart can detect PID recycling even
@@ -2088,7 +2104,7 @@ class ProcessRegistry:
             
             # Atomic write to avoid corruption on crash
             from utils import atomic_json_write
-            atomic_json_write(CHECKPOINT_PATH, entries)
+            atomic_json_write(_checkpoint_path(), entries)
         except Exception as e:
             logger.debug("Failed to write checkpoint file: %s", e, exc_info=True)
 
@@ -2098,11 +2114,17 @@ class ProcessRegistry:
 
         Returns the number of processes recovered as detached.
         """
-        if not CHECKPOINT_PATH.exists():
+        checkpoint_path = _checkpoint_path()
+        checkpoint_key = str(checkpoint_path.resolve())
+        with self._lock:
+            if checkpoint_key in self._recovered_checkpoint_paths:
+                return 0
+            self._recovered_checkpoint_paths.add(checkpoint_key)
+        if not checkpoint_path.exists():
             return 0
 
         try:
-            entries = json.loads(CHECKPOINT_PATH.read_text(encoding="utf-8"))
+            entries = json.loads(checkpoint_path.read_text(encoding="utf-8"))
         except Exception:
             return 0
 
@@ -2477,6 +2499,20 @@ def _redact_process_result(result: dict) -> dict:
     return result
 
 
+def _process_visible_to_active_profile(session: ProcessSession | None) -> bool:
+    """Keep process discovery/control inside the active routed profile."""
+
+    if session is None:
+        return False
+    from profile_runtime_context import current_profile_cache_key
+
+    profile_key = current_profile_cache_key()
+    task_id = str(session.task_id or "")
+    if profile_key is None:
+        return not task_id.startswith("profile:")
+    return task_id.startswith(f"profile:{profile_key}:")
+
+
 def _handle_process(args, **kw):
     task_id = kw.get("task_id")
     action = args.get("action", "")
@@ -2492,13 +2528,20 @@ def _handle_process(args, **kw):
             session_key = get_current_session_key(default="") or ""
         except Exception:
             session_key = ""
-        return json.dumps(
-            {"processes": process_registry.list_sessions(task_id=task_id, session_key=session_key or None)},
-            ensure_ascii=False,
+        processes = process_registry.list_sessions(
+            task_id=task_id, session_key=session_key or None
         )
+        processes = [
+            item
+            for item in processes
+            if _process_visible_to_active_profile(process_registry.get(item.get("id", "")))
+        ]
+        return json.dumps({"processes": processes}, ensure_ascii=False)
     elif action in {"poll", "log", "wait", "kill", "write", "submit", "close"}:
         if not session_id:
             return tool_error(f"session_id is required for {action}")
+        if not _process_visible_to_active_profile(process_registry.get(session_id)):
+            return tool_error(f"No process with ID {session_id}")
         if action == "poll":
             return json.dumps(_redact_process_result(process_registry.poll(session_id)), ensure_ascii=False)
         elif action == "log":

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -489,7 +489,9 @@ def _is_gateway_surface() -> bool:
 
 
 def _get_terminal_backend_name() -> str:
-    return str(os.getenv("TERMINAL_ENV", "local")).strip().lower() or "local"
+    from profile_runtime_context import terminal_getenv
+
+    return str(terminal_getenv("TERMINAL_ENV", "local")).strip().lower() or "local"
 
 
 def _is_env_var_persisted(

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -50,6 +50,12 @@ from pathlib import Path
 from typing import Optional, Dict, Any, List
 
 from utils import env_var_enabled
+from profile_runtime_context import (
+    current_profile_cache_key,
+    profile_scoped_key,
+    terminal_getenv as _terminal_getenv,
+    terminal_scope_active,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +129,37 @@ DISK_USAGE_WARNING_THRESHOLD_GB = _safe_parse_import_env(
     float,
     "number",
 )
+
+
+def _safe_parse_runtime_env(name: str, default: Any, converter, type_label: str):
+    """Parse a profile-aware terminal setting without freezing it at import."""
+
+    raw = _terminal_getenv(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return converter(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid value for %s: %r (expected %s). Falling back to %r.",
+            name,
+            raw,
+            type_label,
+            default,
+        )
+        return default
+
+
+def _foreground_max_timeout() -> int:
+    return _safe_parse_runtime_env(
+        "TERMINAL_MAX_FOREGROUND_TIMEOUT", 600, int, "integer"
+    )
+
+
+def _disk_warning_threshold_gb() -> float:
+    return _safe_parse_runtime_env(
+        "TERMINAL_DISK_WARNING_GB", 500.0, float, "number"
+    )
 _VERCEL_SANDBOX_DEFAULT_CWD = "/vercel/sandbox"
 _SUPPORTED_VERCEL_RUNTIMES = ("node24", "node22", "python3.13")
 
@@ -191,7 +228,7 @@ def _check_vercel_sandbox_requirements(config: dict[str, Any]) -> bool:
 
 # Cache for disk usage warning to avoid full rglob scan on every call.
 # The check is advisory-only — staleness for up to 5 minutes is acceptable.
-_disk_usage_cache: dict = {"timestamp": 0.0, "result": False}
+_disk_usage_cache: dict[str, dict[str, Any]] = {}
 _DISK_USAGE_CACHE_TTL = 300.0  # seconds
 
 
@@ -205,8 +242,15 @@ def _check_disk_usage_warning():
     """
     import time as _time_mod
     now = _time_mod.monotonic()
-    if now - _disk_usage_cache["timestamp"] < _DISK_USAGE_CACHE_TTL:
-        return _disk_usage_cache["result"]
+    cache_key = current_profile_cache_key() or "process"
+    threshold = _disk_warning_threshold_gb()
+    cache = _disk_usage_cache.get(cache_key)
+    if (
+        cache
+        and cache.get("threshold") == threshold
+        and now - cache["timestamp"] < _DISK_USAGE_CACHE_TTL
+    ):
+        return cache["result"]
     try:
         scratch_dir = _get_scratch_dir()
 
@@ -223,12 +267,15 @@ def _check_disk_usage_warning():
         
         total_gb = total_bytes / (1024 ** 3)
         
-        exceeded = total_gb > DISK_USAGE_WARNING_THRESHOLD_GB
+        exceeded = total_gb > threshold
         if exceeded:
             logger.warning("Disk usage (%.1fGB) exceeds threshold (%.0fGB). Consider running cleanup_all_environments().",
-                           total_gb, DISK_USAGE_WARNING_THRESHOLD_GB)
-        _disk_usage_cache["timestamp"] = _time_mod.monotonic()
-        _disk_usage_cache["result"] = exceeded
+                           total_gb, threshold)
+        _disk_usage_cache[cache_key] = {
+            "timestamp": _time_mod.monotonic(),
+            "result": exceeded,
+            "threshold": threshold,
+        }
         return exceeded
     except Exception as e:
         logger.debug("Disk usage warning check failed: %s", e, exc_info=True)
@@ -783,7 +830,7 @@ def _sudo_nopasswd_works() -> bool:
     cache) so an expired sudo timestamp cannot make a later command silently
     block waiting for a password.
     """
-    terminal_env = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
+    terminal_env = _terminal_getenv("TERMINAL_ENV", "local").strip().lower() or "local"
     if terminal_env != "local":
         return False
 
@@ -1086,15 +1133,16 @@ _creation_locks_lock = threading.Lock()  # Protects _creation_locks dict itself
 _cleanup_thread = None
 _cleanup_running = False
 
-# Once-per-process guard for the docker orphan reaper (issue #20561).
-# Set when _maybe_reap_docker_orphans first runs; concurrent _create_environment
-# calls for parallel subagents won't re-trigger the sweep.
+# Legacy once-per-process guard plus routed-profile guards for the docker orphan
+# reaper (issue #20561). Parallel calls within one profile never re-trigger it;
+# a different routed profile gets its own conservative sweep.
 _docker_orphan_reaper_ran = False
+_docker_orphan_reaper_profile_keys: set[str] = set()
 _docker_orphan_reaper_lock = threading.Lock()
 
 
 def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
-    """Run the docker orphan reaper once per process, if enabled.
+    """Run the docker orphan reaper once per process/profile, if enabled.
 
     Sweeps long-Exited containers labeled ``hermes-agent=1`` for the current
     profile that match the issue #20561 leak class — containers left behind
@@ -1109,21 +1157,33 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
       operator opted out — usually because they're running multiple
       Hermes processes in the same profile and don't trust the
       conservative defaults).
-    * ``_docker_orphan_reaper_ran`` flag — sweep runs once per Python
-      interpreter, not on every subagent / RL-rollout / parallel
-      ``terminal()`` call.
+    * guard state — unscoped execution sweeps once per interpreter; routed
+      execution sweeps once per profile, never per subagent / rollout / call.
     """
     global _docker_orphan_reaper_ran
     if not container_config.get("docker_orphan_reaper", True):
         return
+    profile_key = current_profile_cache_key()
     # Cheap double-checked-locking: read without the lock, take the lock
     # only on first run, recheck inside.
-    if _docker_orphan_reaper_ran:
+    if (
+        profile_key in _docker_orphan_reaper_profile_keys
+        if profile_key is not None
+        else _docker_orphan_reaper_ran
+    ):
         return
     with _docker_orphan_reaper_lock:
-        if _docker_orphan_reaper_ran:
+        already_ran = (
+            profile_key in _docker_orphan_reaper_profile_keys
+            if profile_key is not None
+            else _docker_orphan_reaper_ran
+        )
+        if already_ran:
             return
-        _docker_orphan_reaper_ran = True
+        if profile_key is None:
+            _docker_orphan_reaper_ran = True
+        else:
+            _docker_orphan_reaper_profile_keys.add(profile_key)
 
     # 2 × lifetime_seconds gives sibling Hermes processes a generous grace
     # window. Floor at 60s so an operator with TERMINAL_LIFETIME_SECONDS=0
@@ -1131,7 +1191,7 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
     # ``container_config`` only carries container_* keys, so read
     # lifetime_seconds from the env var the rest of the module uses.
     try:
-        lifetime = int(os.getenv("TERMINAL_LIFETIME_SECONDS", "300"))
+        lifetime = int(_terminal_getenv("TERMINAL_LIFETIME_SECONDS", "300"))
     except (TypeError, ValueError):
         lifetime = 300
     lifetime = max(60, lifetime)
@@ -1197,7 +1257,7 @@ def record_session_cwd(session_key: Optional[str], cwd: Optional[str]) -> None:
     """
     if not isinstance(cwd, str) or not cwd.strip():
         return
-    key = str(session_key or "default")
+    key = profile_scoped_key(str(session_key or "default"))
     with _session_cwd_lock:
         if _session_cwd.get(key) != cwd:
             _session_cwd[key] = cwd
@@ -1210,7 +1270,7 @@ def get_session_cwd(session_key: Optional[str]) -> Optional[str]:
     means (config default, TERMINAL_CWD seed, process cwd). ``None``/empty
     keys read the ``"default"`` record.
     """
-    key = str(session_key or "default")
+    key = profile_scoped_key(str(session_key or "default"))
     with _session_cwd_lock:
         return _session_cwd.get(key)
 
@@ -1218,7 +1278,7 @@ def get_session_cwd(session_key: Optional[str]) -> Optional[str]:
 def clear_session_cwd(session_key: str) -> None:
     """Drop a session's cwd record (session teardown)."""
     with _session_cwd_lock:
-        _session_cwd.pop(session_key, None)
+        _session_cwd.pop(profile_scoped_key(session_key), None)
 
 
 def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
@@ -1237,7 +1297,8 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         task_id: The rollout's unique task identifier
         overrides: Dict of config keys to override
     """
-    _task_env_overrides[task_id] = overrides
+    scoped_task_id = profile_scoped_key(task_id)
+    _task_env_overrides[scoped_task_id] = overrides
 
     # If a live environment already exists for this task, a freshly registered
     # ``cwd`` override (e.g. the ACP client switching the editor's project root
@@ -1256,7 +1317,7 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         # updates the originating session's env.
         container_id = _resolve_container_task_id(task_id)
         with _env_lock:
-            env = _active_environments.get(task_id) or _active_environments.get(container_id)
+            env = _active_environments.get(scoped_task_id) or _active_environments.get(container_id)
         if env is not None and getattr(env, "cwd", None) is not None:
             env.cwd = new_cwd
 
@@ -1267,7 +1328,7 @@ def clear_task_env_overrides(task_id: str):
 
     Called during cleanup to avoid stale entries accumulating.
     """
-    _task_env_overrides.pop(task_id, None)
+    _task_env_overrides.pop(profile_scoped_key(task_id), None)
     clear_session_cwd(task_id)
 
 
@@ -1299,11 +1360,12 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
         "docker_image", "modal_image", "singularity_image",
         "daytona_image", "env_type",
     })
-    if task_id and task_id in _task_env_overrides:
-        overrides = _task_env_overrides[task_id]
+    scoped_task_id = profile_scoped_key(task_id) if task_id else None
+    if scoped_task_id and scoped_task_id in _task_env_overrides:
+        overrides = _task_env_overrides[scoped_task_id]
         if set(overrides.keys()) & _ISOLATION_KEYS:
-            return task_id
-    return "default"
+            return scoped_task_id
+    return profile_scoped_key("default")
 
 
 def resolve_task_overrides(task_id: Optional[str]) -> Dict[str, Any]:
@@ -1318,10 +1380,10 @@ def resolve_task_overrides(task_id: Optional[str]) -> Dict[str, Any]:
     the originating session's override is silently dropped. This is the single
     source of that lookup so the terminal and file layers can't drift apart.
     """
-    raw = task_id or "default"
+    raw = profile_scoped_key(task_id or "default")
     return (
         _task_env_overrides.get(raw)
-        or _task_env_overrides.get(_resolve_container_task_id(raw))
+        or _task_env_overrides.get(_resolve_container_task_id(task_id))
         or {}
     )
 
@@ -1334,7 +1396,7 @@ def _parse_env_var(name: str, default: str, converter: Any = int, type_label: st
     Without this wrapper, a single malformed env var (e.g. TERMINAL_TIMEOUT=5m)
     causes an unhandled ValueError that kills every terminal command.
     """
-    raw = os.getenv(name, default)
+    raw = _terminal_getenv(name, default)
     try:
         return converter(raw)
     except (ValueError, json.JSONDecodeError):
@@ -1355,7 +1417,7 @@ def _safe_getcwd() -> str:
     try:
         return os.getcwd()
     except FileNotFoundError:
-        return os.getenv("TERMINAL_CWD") or os.path.expanduser("~")
+        return _terminal_getenv("TERMINAL_CWD") or os.path.expanduser("~")
 
 
 # Path prefixes that identify a *host* working directory which cannot exist
@@ -1431,6 +1493,8 @@ def _ensure_terminal_env_bridged() -> None:
     keep working unchanged.
     """
     global _terminal_config_bridge_attempted
+    if terminal_scope_active():
+        return
     if _terminal_config_bridge_attempted:
         return
     _terminal_config_bridge_attempted = True
@@ -1463,9 +1527,9 @@ def _get_env_config() -> Dict[str, Any]:
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
     _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    env_type = _terminal_getenv("TERMINAL_ENV", "local")
     
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    mount_docker_cwd = _terminal_getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
     container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
     docker_backend = env_type == "docker"
 
@@ -1487,7 +1551,7 @@ def _get_env_config() -> Dict[str, Any]:
         docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
         docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
         docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
-        docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
+        docker_shm_size = _terminal_getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
     else:
         docker_forward_env = []
         docker_volumes = []
@@ -1511,12 +1575,12 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = _terminal_getenv("TERMINAL_CWD", default_cwd)
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+        docker_cwd_source = _terminal_getenv("TERMINAL_CWD") or _safe_getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
@@ -1534,41 +1598,41 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
-        "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
+        "modal_mode": coerce_modal_mode(_terminal_getenv("TERMINAL_MODAL_MODE", "auto")),
+        "docker_image": _terminal_getenv("TERMINAL_DOCKER_IMAGE", default_image),
         "docker_forward_env": docker_forward_env,
-        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
-        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
-        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
-        "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
+        "singularity_image": _terminal_getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
+        "modal_image": _terminal_getenv("TERMINAL_MODAL_IMAGE", default_image),
+        "daytona_image": _terminal_getenv("TERMINAL_DAYTONA_IMAGE", default_image),
+        "vercel_runtime": _terminal_getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
         "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
         "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
         # SSH-specific config
-        "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
-        "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
+        "ssh_host": _terminal_getenv("TERMINAL_SSH_HOST", ""),
+        "ssh_user": _terminal_getenv("TERMINAL_SSH_USER", ""),
         "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
-        "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        "ssh_key": _terminal_getenv("TERMINAL_SSH_KEY", ""),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
-        "ssh_persistent": os.getenv(
+        "ssh_persistent": _terminal_getenv(
             "TERMINAL_SSH_PERSISTENT",
-            os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
+            _terminal_getenv("TERMINAL_PERSISTENT_SHELL", "true"),
         ).lower() in {"true", "1", "yes"},
-        "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+        "local_persistent": _terminal_getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
         # Container resource config (applies to docker, singularity, modal,
         # daytona, and vercel_sandbox -- ignored for local/ssh)
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+        "container_persistent": _terminal_getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
         "docker_volumes": docker_volumes,
         "docker_env": docker_env,
-        "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
+        "docker_run_as_host_user": _terminal_getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
+        "docker_network": _terminal_getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,
         # Cross-process container reuse (issue #20561).  The docs claim
@@ -1577,14 +1641,14 @@ def _get_env_config() -> Dict[str, Any]:
         # attaching to it instead of always starting a fresh one.  Set to
         # ``false`` for hard per-process isolation (no reuse, container is
         # removed on exit).
-        "docker_persist_across_processes": os.getenv(
+        "docker_persist_across_processes": _terminal_getenv(
             "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
         ).lower() in {"true", "1", "yes"},
         # Startup orphan reaper for hermes-tagged containers left behind by
         # crashed / SIGKILL'd previous processes that bypassed atexit.
         # Conservative: only sweeps Exited containers older than 2× the
         # idle-reap window AND scoped to the current profile. Issue #20561.
-        "docker_orphan_reaper": os.getenv(
+        "docker_orphan_reaper": _terminal_getenv(
             "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
         ).lower() in {"true", "1", "yes"},
     }
@@ -1870,7 +1934,10 @@ def get_active_env(task_id: str):
     """Return the active BaseEnvironment for *task_id*, or None."""
     lookup = _resolve_container_task_id(task_id)
     with _env_lock:
-        return _active_environments.get(lookup) or _active_environments.get(task_id)
+        env = _active_environments.get(lookup)
+        if env is not None or current_profile_cache_key() is not None:
+            return env
+        return _active_environments.get(task_id)
 
 
 def is_persistent_env(task_id: str) -> bool:
@@ -1944,18 +2011,28 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
     # actual (potentially slow) env.cleanup() call to outside the lock
     # so other tool calls aren't blocked.
     env = None
+    resolved_key = (
+        task_id
+        if task_id.startswith("profile:")
+        else _resolve_container_task_id(task_id)
+    )
     with _env_lock:
-        env = _active_environments.pop(task_id, None)
-        _last_activity.pop(task_id, None)
+        cache_key = (
+            task_id
+            if current_profile_cache_key() is None and task_id in _active_environments
+            else resolved_key
+        )
+        env = _active_environments.pop(cache_key, None)
+        _last_activity.pop(cache_key, None)
 
     # Clean up per-task creation lock
     with _creation_locks_lock:
-        _creation_locks.pop(task_id, None)
+        _creation_locks.pop(cache_key, None)
 
     # Invalidate stale file_ops cache entry
     try:
         from tools.file_tools import clear_file_ops_cache
-        clear_file_ops_cache(task_id)
+        clear_file_ops_cache(cache_key)
     except ImportError:
         pass
 
@@ -2353,11 +2430,12 @@ def terminal_tool(
         effective_timeout = timeout or default_timeout
 
         # Reject foreground commands where the model explicitly requests
-        # a timeout above FOREGROUND_MAX_TIMEOUT — nudge it toward background.
-        if not background and timeout and timeout > FOREGROUND_MAX_TIMEOUT:
+        # a timeout above the routed profile's cap — nudge it toward background.
+        foreground_max_timeout = _foreground_max_timeout()
+        if not background and timeout and timeout > foreground_max_timeout:
             return tool_error(
                 f"Foreground timeout {timeout}s exceeds the maximum of "
-                f"{FOREGROUND_MAX_TIMEOUT}s. Use background=true with "
+                f"{foreground_max_timeout}s. Use background=true with "
                 f"notify_on_complete=true for long-running commands."
             )
 
@@ -2387,9 +2465,14 @@ def terminal_tool(
             # with a CWD-only override collapse to "default" for container
             # sharing, yet an env may already be cached under the originating
             # task_id; honor it instead of spawning a duplicate.
+            raw_cache_key = profile_scoped_key(task_id) if task_id else None
             _existing_key = (
                 effective_task_id if effective_task_id in _active_environments
-                else (task_id if task_id and task_id in _active_environments else None)
+                else (
+                    raw_cache_key
+                    if raw_cache_key and raw_cache_key in _active_environments
+                    else None
+                )
             )
             if _existing_key is not None:
                 _last_activity[_existing_key] = time.time()
@@ -2410,7 +2493,11 @@ def terminal_tool(
                 with _env_lock:
                     _existing_key = (
                         effective_task_id if effective_task_id in _active_environments
-                        else (task_id if task_id and task_id in _active_environments else None)
+                        else (
+                            raw_cache_key
+                            if raw_cache_key and raw_cache_key in _active_environments
+                            else None
+                        )
                     )
                     if _existing_key is not None:
                         _last_activity[_existing_key] = time.time()
@@ -3317,18 +3404,18 @@ if __name__ == "__main__":
     default_img = "nikolaik/python-nodejs:python3.11-nodejs20"
     print(
         "  TERMINAL_ENV: "
-        f"{os.getenv('TERMINAL_ENV', 'local')} "
+        f"{_terminal_getenv('TERMINAL_ENV', 'local')} "
         "(local/docker/singularity/modal/daytona/vercel_sandbox/ssh)"
     )
-    print(f"  TERMINAL_DOCKER_IMAGE: {os.getenv('TERMINAL_DOCKER_IMAGE', default_img)}")
-    print(f"  TERMINAL_SINGULARITY_IMAGE: {os.getenv('TERMINAL_SINGULARITY_IMAGE', f'docker://{default_img}')}")
-    print(f"  TERMINAL_MODAL_IMAGE: {os.getenv('TERMINAL_MODAL_IMAGE', default_img)}")
-    print(f"  TERMINAL_DAYTONA_IMAGE: {os.getenv('TERMINAL_DAYTONA_IMAGE', default_img)}")
-    print(f"  TERMINAL_CWD: {os.getenv('TERMINAL_CWD', _safe_getcwd())}")
+    print(f"  TERMINAL_DOCKER_IMAGE: {_terminal_getenv('TERMINAL_DOCKER_IMAGE', default_img)}")
+    print(f"  TERMINAL_SINGULARITY_IMAGE: {_terminal_getenv('TERMINAL_SINGULARITY_IMAGE', f'docker://{default_img}')}")
+    print(f"  TERMINAL_MODAL_IMAGE: {_terminal_getenv('TERMINAL_MODAL_IMAGE', default_img)}")
+    print(f"  TERMINAL_DAYTONA_IMAGE: {_terminal_getenv('TERMINAL_DAYTONA_IMAGE', default_img)}")
+    print(f"  TERMINAL_CWD: {_terminal_getenv('TERMINAL_CWD', _safe_getcwd())}")
     from hermes_constants import display_hermes_home as _dhh
-    print(f"  TERMINAL_SANDBOX_DIR: {os.getenv('TERMINAL_SANDBOX_DIR', f'{_dhh()}/sandboxes')}")
-    print(f"  TERMINAL_TIMEOUT: {os.getenv('TERMINAL_TIMEOUT', '60')}")
-    print(f"  TERMINAL_LIFETIME_SECONDS: {os.getenv('TERMINAL_LIFETIME_SECONDS', '300')}")
+    print(f"  TERMINAL_SANDBOX_DIR: {_terminal_getenv('TERMINAL_SANDBOX_DIR', f'{_dhh()}/sandboxes')}")
+    print(f"  TERMINAL_TIMEOUT: {_terminal_getenv('TERMINAL_TIMEOUT', '60')}")
+    print(f"  TERMINAL_LIFETIME_SECONDS: {_terminal_getenv('TERMINAL_LIFETIME_SECONDS', '300')}")
 
 
 # ---------------------------------------------------------------------------

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -32,6 +32,11 @@ from hermes_constants import (
     set_hermes_home_override,
 )
 from hermes_cli.env_loader import load_hermes_dotenv
+from profile_runtime_context import (
+    terminal_getenv,
+    terminal_scope_active,
+    use_profile_runtime_context,
+)
 from utils import is_truthy_value
 from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
@@ -1401,24 +1406,31 @@ def _profile_home(profile: str | None) -> Path | None:
 
 
 def _profile_scoped(handler):
-    """Bind ``params['profile']``'s HERMES_HOME around a pet RPC handler.
-
-    Pets are per-profile: ``display.pet.*`` lives in the profile's config.yaml and
-    sprites install under its ``pets/`` dir (both resolve via ``get_hermes_home``).
-    The desktop sends ``profile`` on pet calls so config + pets dir resolve to the
-    focused profile even in app-global remote mode, where one backend serves every
-    profile. No-op for the launch profile (own-profile backends already resolve it).
-    """
+    """Bind a request's profile home, secrets, and terminal runtime."""
 
     def wrapper(rid, params):
-        home = _profile_home(params.get("profile") if isinstance(params, dict) else None)
+        params = params if isinstance(params, dict) else {}
+        home = _profile_home(params.get("profile"))
+        if home is None:
+            session = _sessions.get(params.get("session_id") or "")
+            profile_home = session.get("profile_home") if session else None
+            home = Path(profile_home) if profile_home else None
         if home is None:
             return handler(rid, params)
-        token = set_hermes_home_override(home)
+
+        from hermes_cli.env_loader import hydrate_profile_secret_sources
+
+        home_token = set_hermes_home_override(str(home))
+        secret_token = None
         try:
-            return handler(rid, params)
+            hydrate_profile_secret_sources(home)
+            secret_token = set_secret_scope(build_profile_secret_scope(home))
+            with use_profile_runtime_context(home):
+                return handler(rid, params)
         finally:
-            reset_hermes_home_override(token)
+            if secret_token is not None:
+                reset_secret_scope(secret_token)
+            reset_hermes_home_override(home_token)
 
     return wrapper
 
@@ -1459,19 +1471,19 @@ def _profile_configured_cwd(profile_home: Path | None) -> str | None:
     if profile_home is None:
         return None
     try:
+        from agent.secret_scope import build_profile_secret_scope
         from hermes_cli.config import _expand_env_vars, read_user_config_raw
 
         p = Path(profile_home) / "config.yaml"
         if not p.exists():
             return None
-        # Behavioral read of a NON-launch profile's config: load_config()
-        # would resolve the ACTIVE profile's path, so read this profile's
-        # file directly, then apply the same read-side pipeline as
-        # _load_cfg (managed overlay + ${VAR} expansion). Fail-open.
-        data = _apply_managed(read_user_config_raw(p))
-        expanded = _expand_env_vars(data)
-        if isinstance(expanded, dict):
-            data = expanded
+        # Behavioral read of a NON-launch profile's config: expand user refs
+        # through THAT profile's secret scope, then apply managed policy (whose
+        # refs deliberately use process env). Fail-open for completion/CWD UI.
+        raw = read_user_config_raw(p)
+        profile_secrets = build_profile_secret_scope(Path(profile_home))
+        expanded = _expand_env_vars(raw, getenv=profile_secrets.get)
+        data = _apply_managed(expanded if isinstance(expanded, dict) else raw)
         return _configured_cwd_from_cfg(data)
     except Exception:
         return None
@@ -1489,7 +1501,10 @@ def _launch_configured_cwd() -> str | None:
     new in-memory TUI sessions too.
     """
     try:
-        return _configured_cwd_from_cfg(_load_cfg())
+        from hermes_cli.config import _expand_env_vars
+
+        expanded = _expand_env_vars(_load_cfg(), getenv=os.environ.get)
+        return _configured_cwd_from_cfg(expanded if isinstance(expanded, dict) else {})
     except Exception:
         return None
 
@@ -1502,7 +1517,7 @@ def _default_session_cwd() -> str:
     than ``os.getcwd()`` when the in-memory gateway's process env has no bridged
     ``TERMINAL_CWD``.
     """
-    return _launch_configured_cwd() or os.getenv("TERMINAL_CWD") or os.getcwd()
+    return _launch_configured_cwd() or terminal_getenv("TERMINAL_CWD") or os.getcwd()
 
 
 def write_json(obj: dict) -> bool:
@@ -2105,6 +2120,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
         notify_registered = False
         home_token = None
         secret_token = None
+        runtime_scope = None
         profile_home = current.get("profile_home")
         try:
             tokens = _set_session_context(key)
@@ -2114,12 +2130,13 @@ def _start_agent_build(sid: str, session: dict) -> None:
             session_db = None
             if profile_home:
                 home_token = set_hermes_home_override(profile_home)
-                try:
-                    from agent.secret_scope import build_profile_secret_scope, set_secret_scope
+                from agent.secret_scope import build_profile_secret_scope, set_secret_scope
+                from hermes_cli.env_loader import hydrate_profile_secret_sources
 
-                    secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
-                except Exception:
-                    pass
+                hydrate_profile_secret_sources(Path(profile_home))
+                secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+                runtime_scope = use_profile_runtime_context(profile_home)
+                runtime_scope.__enter__()
                 try:
                     from hermes_state import SessionDB
 
@@ -2238,6 +2255,11 @@ def _start_agent_build(sid: str, session: dict) -> None:
             current["agent_error"] = str(e)
             _emit("error", sid, {"message": f"agent init failed: {e}"})
         finally:
+            if runtime_scope is not None:
+                try:
+                    runtime_scope.__exit__(None, None, None)
+                except Exception:
+                    pass
             if home_token is not None:
                 reset_hermes_home_override(home_token)
             if secret_token is not None:
@@ -2309,7 +2331,7 @@ def _completion_cwd(params: dict | None = None) -> str:
         # TERMINAL_CWD. Read the launch profile's config.yaml directly so a
         # configured terminal.cwd wins over a stale process env / launch dir.
         or _launch_configured_cwd()
-        or os.environ.get("TERMINAL_CWD")
+        or terminal_getenv("TERMINAL_CWD")
         or os.getcwd()
     )
     try:
@@ -2334,7 +2356,7 @@ def _terminal_task_cwd(session: dict | None) -> str:
     resolution path is taken even when the dashboard entrypoint did not call
     ``apply_terminal_config_to_env`` on its own ``os.environ``.
     """
-    backend = (os.environ.get("TERMINAL_ENV") or "").strip().lower()
+    backend = (terminal_getenv("TERMINAL_ENV") or "").strip().lower()
     if not backend or backend == "local":
         # Fall back to config when TERMINAL_ENV is unset (dashboard/TUI process
         # never calls apply_terminal_config_to_env on os.environ).
@@ -2348,7 +2370,7 @@ def _terminal_task_cwd(session: dict | None) -> str:
             pass
 
     if backend and backend != "local":
-        raw = os.environ.get("TERMINAL_CWD", "").strip()
+        raw = (terminal_getenv("TERMINAL_CWD") or "").strip()
         if not raw:
             try:
                 terminal_cfg = _load_cfg().get("terminal", {})
@@ -2440,7 +2462,7 @@ def _heal_dead_cwd(cwd: str) -> str:
 
 
 def _is_local_terminal_backend() -> bool:
-    backend = (os.environ.get("TERMINAL_ENV") or "").strip().lower()
+    backend = (terminal_getenv("TERMINAL_ENV") or "").strip().lower()
     return not backend or backend == "local"
 
 
@@ -3007,7 +3029,9 @@ def _save_cfg(cfg: dict):
 
     from hermes_cli.config import atomic_config_write
 
-    path = _hermes_home / "config.yaml"
+    override = get_hermes_home_override()
+    home = Path(override) if isinstance(override, str) and override else _hermes_home
+    path = home / "config.yaml"
     atomic_config_write(path, cfg)
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)
@@ -9376,6 +9400,7 @@ def _run_prompt_submit(
         session_tokens = []
         home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
         secret_token = None
+        runtime_scope = None
         goal_followup = None  # set by the post-turn goal hook below
         result = None  # turn outcome; read after the finally for leftover /steer
         tts_queue = None  # streaming-TTS feed for this turn (voice mode)
@@ -9410,7 +9435,12 @@ def _run_prompt_submit(
             _profile_home_str = session.get("profile_home")
             if _profile_home_str:
                 home_token = set_hermes_home_override(_profile_home_str)
+                from hermes_cli.env_loader import hydrate_profile_secret_sources
+
+                hydrate_profile_secret_sources(Path(_profile_home_str))
                 secret_token = set_secret_scope(build_profile_secret_scope(Path(_profile_home_str)))
+                runtime_scope = use_profile_runtime_context(_profile_home_str)
+                runtime_scope.__enter__()
             # The sudo password callback is thread-local (tools.terminal_tool
             # _callback_tls), so wiring it on the build thread doesn't reach this
             # turn thread — terminal sudo prompts would fall through to /dev/tty
@@ -10070,6 +10100,11 @@ def _run_prompt_submit(
                     reset_current_session_key(approval_token)
             except Exception:
                 pass
+            if runtime_scope is not None:
+                try:
+                    runtime_scope.__exit__(None, None, None)
+                except Exception:
+                    pass
             if home_token is not None:
                 reset_hermes_home_override(home_token)
             if secret_token is not None:
@@ -10466,6 +10501,7 @@ def _respond(rid, params, key, *, allow_expired=False):
 # opt/model-resolution-core PR touches its body; move it to methods_config.py
 # in a follow-up once that PR lands.
 @method("config.set")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     key, value = params.get("key", ""), params.get("value", "")
     session = _sessions.get(params.get("session_id", ""))
@@ -11112,7 +11148,8 @@ def _(rid, params: dict) -> dict:
         if not os.path.isdir(cwd):
             return _err(rid, 4002, f"working directory does not exist: {raw}")
         _write_config_key("terminal.cwd", cwd)
-        os.environ["TERMINAL_CWD"] = cwd
+        if not terminal_scope_active():
+            os.environ["TERMINAL_CWD"] = cwd
         return _ok(
             rid,
             {"key": "terminal.cwd", "value": cwd, "cwd": cwd, "branch": _git_branch_for_cwd(cwd)},


### PR DESCRIPTION
## What changed

- add a top-level ContextVar-backed routed-profile runtime context that resolves the profile's effective `terminal.*` mapping once per gateway/TUI turn or multiplexed cron job;
- extend the canonical config expander and generic `load_config()` so routed `${env:...}`/`${VAR}` user refs resolve from the installed profile secret scope with profile-aware cache snapshots; managed refs remain process-env by contract, and precedence is dotenv < explicit user config < managed policy;
- route terminal, file, execute-code, delegation, browser/media, credential, process, runtime-CWD, prompt, gateway, TUI, and cron consumers through the scoped mapping;
- qualify reusable environment/task/CWD/file-read/negative/patch/read-limit/credential/env-probe/disk-warning/orphan-reaper/process state by active profile;
- propagate profile context into env-probe workers, process reader/poller threads, and existing tool/subagent thread hops;
- install/reset home, secret, and terminal runtime scope around multiplex gateway turns, TUI build/turn/config requests, and cron run/target-resolution/delivery/teardown paths, including setup-exception cleanup;
- resolve non-launch TUI profile CWD references through that target profile's `.env`/secret scope without touching launch env;
- replace multiplex cron's process-global dotenv/CWD mutation with atomic per-home external-secret refresh and nested context-local CWD override while preserving ordinary cron behavior;
- route cron home targets, model/prefill, and delivery-time reads through profile scope while preserving process fallback only for `HERMES_CRON_*` tuning knobs;
- overlay routed terminal policy into local subprocesses and scrub execute-code children to a safe terminal allowlist so launch-profile terminal secrets cannot leak;
- partition process checkpoint path, payload, lazy recovery, list, and direct-ID visibility by active profile;
- preserve process-global behavior when no profile runtime scope is active.

## Why

The gateway can route multiple profiles in one process, but terminal settings and reusable execution state were selected from launch-time process globals. A turn routed to profile B could therefore inherit profile A's backend, CWD, timeout/HOME policy, cached environment, file state, credential mounts, probe result, or process metadata.

The fix reuses Hermes' canonical config bridge and existing ContextVar propagation machinery instead of copying terminal parsing logic. Profile-specific `${env:...}` expansion is fail-closed: missing values remain unresolved rather than falling through to launch-profile env. Malformed routed config aborts scope construction. Managed administrator config retains documented process-env expansion and overlays last.

This is a current-main replacement for the author-closed #68611. It credits @x7peeps' original diagnosis while avoiding that patch's duplicated parser.

## Security and compatibility boundaries

- No profile scope: legacy single-profile process-env behavior remains.
- Routed scope: terminal config, execution caches, child policy, credentials, and process state are partitioned by profile.
- Nested profile scopes clear inherited terminal overrides and restore the outer scope afterward.
- Multiplex cron never reloads routed profile dotenv into global env and never mutates global `TERMINAL_CWD`; ordinary cron retains its historical reload and readers-writer lock.
- Execute-code children receive only safe scoped terminal identity/policy fields, not `docker_env` or arbitrary terminal secrets.
- This patch establishes profile-owned execution state; it does **not** claim to implement the separate `hermes.access.v1` principal/grant contract or Teams authorization policy.

## How to test

```bash
scripts/run_tests.sh \
  tests/test_tui_gateway_server.py \
  tests/tools/test_profile_terminal_runtime_scope.py \
  tests/gateway/test_multiplex_credential_isolation.py \
  tests/tools/test_process_registry.py \
  tests/tools/test_execute_code_approval_cluster.py \
  tests/tools/test_terminal_config_env_sync.py \
  tests/tools/test_terminal_foreground_timeout_cap.py \
  tests/test_subprocess_home_isolation.py \
  tests/tools/test_credential_files.py \
  tests/tools/test_env_probe.py \
  tests/cron \
  tests/test_env_loader_applied_homes.py \
  tests/test_env_loader_secret_sources.py \
  tests/test_env_loader_op_bootstrap.py \
  tests/hermes_cli/test_env_loader.py
```

Exact candidate result: **1,217 passed, 0 failed across 61 files**, including sequential two-profile cron target/save/delivery/teardown isolation with a synthetic delivery failure and explicit non-launch TUI profile env expansion.

Repository-wide:

```bash
python -m ruff check .
python -m compileall -q agent tools gateway tui_gateway cron hermes_cli profile_runtime_context.py
git diff --check
git diff --cached --check
```

All clean.

A broader file-tools matrix passed 47 tests with only two known macOS `/tmp` canonicalization failures; both reproduce on pristine current main. Prior broad full-suite optional/platform failures were likewise baseline-classified, and no changed-path suite failed.

## Platforms tested

- macOS, Python 3.11
- CI should exercise the repository's supported Linux/Python matrix

## Credit

Builds on the diagnosis and earlier implementation attempt in #68611 by @x7peeps.

Addresses #68559.
