### PR TITLE
feat(mcp): add genoffice to the optional MCP catalog

### DIFF
--- a/optional-mcps/genoffice/manifest.yaml
+++ b/optional-mcps/genoffice/manifest.yaml
@@ -20,7 +20,7 @@ source: https://github.com/genspark-ai/genoffice
 install:
   type: git
   url: https://github.com/criptogus/mcp-genoffice.git
-  ref: 6530d7bfd46aa7d462c40703596aa8ace612ac58
+  ref: a23f738c5099efc70c6b127c155248c3f498e864
   bootstrap:
     - npm install --no-audit --no-fund
 

--- a/optional-mcps/genoffice/manifest.yaml
+++ b/optional-mcps/genoffice/manifest.yaml
@@ -1,0 +1,51 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: genoffice
+description: Create and byte-preserving-edit Office documents (docx/pptx) via the GenOffice engines.
+source: https://github.com/genspark-ai/genoffice
+
+# mcp-genoffice (MIT — https://github.com/criptogus/mcp-genoffice) exposes the
+# pure-TS GenOffice engines (genspark-ai/genoffice, Apache-2.0) as MCP tools:
+# text extraction, docx blocks/patch/watermark/create/delete and pptx
+# slides/patch/create/delete — all byte-preserving (untouched blocks,
+# elements and zip parts keep their original bytes, so layout never breaks).
+#
+# Why git install: the GenOffice engine packages are NOT published to npm and
+# ship as TypeScript source. The server runs under the tsx loader and, on
+# first tool use, auto-clones a SHA-pinned genoffice revision into
+# ~/.cache/mcp-genoffice/src (one-time shallow fetch + npm install, ~40s).
+# The engine pin lives in src/engine.ts of the pinned server commit below.
+install:
+  type: git
+  url: https://github.com/criptogus/mcp-genoffice.git
+  ref: 6530d7bfd46aa7d462c40703596aa8ace612ac58
+  bootstrap:
+    - npm install --no-audit --no-fund
+
+transport:
+  type: stdio
+  command: node
+  args:
+    - ${INSTALL_DIR}/bin/mcp-genoffice.mjs
+
+auth:
+  type: none
+
+post_install: |
+  The first tool call takes ~40s: the server clones the pinned GenOffice
+  engines into ~/.cache/mcp-genoffice/src and runs npm install once. After
+  that, calls are instant.
+
+  Agent workflow (all intelligence from your agent — no vendor AI needed):
+    1. genoffice_docx_blocks / genoffice_pptx_slides — read the document
+    2. genoffice_docx_patch / genoffice_pptx_patch — edit text with
+       byte-preserving roundtrips (a NEW file is written; the original is
+       never modified)
+    3. genoffice_docx_create / genoffice_pptx_create — new documents from
+       scratch; genoffice_docx_delete / genoffice_pptx_delete — remove
+       blocks/elements; genoffice_docx_watermark — confidentiality marks
+
+  Developers: set GENOFFICE_SRC in mcp_servers.genoffice.env to point at your
+  own genspark-ai/genoffice checkout to skip the auto-clone.

--- a/skills/productivity/genoffice/SKILL.md
+++ b/skills/productivity/genoffice/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: genoffice
+description: "Create and byte-preserving-edit .docx/.pptx via the GenOffice MCP server."
+version: 1.0.0
+author: community
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Office, Documents, Presentations, MCP, Docx, Pptx]
+    homepage: https://github.com/criptogus/mcp-genoffice
+    related_skills: [powerpoint, docx, office-document-generation]
+---
+
+# GenOffice MCP — byte-preserving Office editing
+
+Create and edit `.docx` / `.pptx` files with **byte-preserving roundtrips**
+through the GenOffice engines (pure TypeScript, Apache-2.0, no Electron
+needed). Only the blocks/elements you touch are regenerated; everything else
+in the file keeps its original bytes — layout, styles, headers, comments and
+zip parts survive. This is the fidelity edge over python-docx/python-pptx,
+which rewrite files wholesale.
+
+## Install
+
+```bash
+hermes mcp install genoffice    # catalog entry (git-installs mcp-genoffice)
+```
+
+First tool call takes ~40s (one-time: the server clones the pinned GenOffice
+engines into `~/.cache/mcp-genoffice/src` and runs `npm install`).
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `genoffice_extract_text` | Read text from .docx/.xlsx/.pptx/.pdf (structure preserved) |
+| `genoffice_docx_blocks` | List docx blocks (index, type, style, text) — read before patching |
+| `genoffice_docx_patch` | Rewrite paragraphs (byte-preserving; writes a NEW file) |
+| `genoffice_docx_watermark` | Set/remove a text watermark (header only, body untouched) |
+| `genoffice_docx_create` | New .docx from scratch, optional initial paragraphs |
+| `genoffice_docx_delete` | Delete blocks — remaining blocks keep original bytes |
+| `genoffice_pptx_slides` | List slides + text elements (id, name, type, text) |
+| `genoffice_pptx_patch` | Replace element text on a slide (element-level byte-preserving) |
+| `genoffice_pptx_create` | New .pptx from scratch (one blank slide) |
+| `genoffice_pptx_delete` | Delete elements from a slide |
+
+## Workflow
+
+1. **Read** — `genoffice_docx_blocks` / `genoffice_pptx_slides` to map the file.
+2. **Edit** — `genoffice_docx_patch` / `genoffice_pptx_patch` with the indexes
+   / element names from step 1. Multi-line text: `\n` in pptx = new paragraph.
+3. **Verify** — re-run the read tool on the output path; confirm untouched
+   content is identical.
+4. All edits write a **new file** (`<name>.patched.docx` etc. by default) —
+   the original is never modified.
+
+## Pitfalls
+
+- **pptx element ids are NOT stable across saves** (engine renumbers
+  `cNvPr`). Address elements by **name** (`Title 1`, `Subtitle 2`), not id.
+- pptx patch uses the element's **first run as the formatting template** —
+  font/size/color/alignment/bullets of the first paragraph carry to the new
+  text.
+- xlsx: text extraction works; **editing xlsx is not yet covered** (the
+  GenOffice sheets engine is a Rust sidecar — roadmap).
+- The GenOffice **app** (optional) auto-updates via Squirrel and relaunches
+  without CDP flags — the headless tools above don't touch the app.
+- Errors are actionable: out-of-range indexes/elements tell you to re-run the
+  read tool.
+
+## References
+
+- Server repo: https://github.com/criptogus/mcp-genoffice
+- Engine source: https://github.com/genspark-ai/genoffice (Apache-2.0)

--- a/skills/productivity/genoffice/SKILL.md
+++ b/skills/productivity/genoffice/SKILL.md
@@ -44,6 +44,11 @@ engines into `~/.cache/mcp-genoffice/src` and runs `npm install`).
 | `genoffice_pptx_patch` | Replace element text on a slide (element-level byte-preserving) |
 | `genoffice_pptx_create` | New .pptx from scratch (one blank slide) |
 | `genoffice_pptx_delete` | Delete elements from a slide |
+| `genoffice_app_status` | Is the GenOffice desktop app installed / CDP port up |
+| `genoffice_app_launch` | Launch the app with the CDP debug port (handles auto-update relaunch) |
+| `genoffice_app_open_file` | Open a file in the app (macOS `open -a`, registered doc types) |
+| `genoffice_app_screenshot` | PNG screenshot of the app window over CDP |
+| `genoffice_app_eval` | Evaluate read-only JS in the app page context (DOM) |
 
 ## Workflow
 
@@ -54,6 +59,8 @@ engines into `~/.cache/mcp-genoffice/src` and runs `npm install`).
    content is identical.
 4. All edits write a **new file** (`<name>.patched.docx` etc. by default) —
    the original is never modified.
+5. **Visual check (optional)** — `genoffice_app_launch` + `genoffice_app_open_file`
+   + `genoffice_app_screenshot` to inspect the result in the real app.
 
 ## Pitfalls
 


### PR DESCRIPTION
## What

Adds **genoffice** to the optional MCP catalog (`optional-mcps/genoffice/manifest.yaml`) — the first **git-install** entry in the catalog — plus a usage skill (`skills/productivity/genoffice/SKILL.md`).

The catalog entry installs [`mcp-genoffice`](https://github.com/criptogus/mcp-genoffice) (MIT), an MCP server that exposes the pure-TS [GenOffice engines](https://github.com/genspark-ai/genoffice) (Apache-2.0, no Electron) as **15 tools**:

**Headless (byte-preserving editing, agent intelligence — no vendor AI):**
- `genoffice_extract_text` — text from .docx/.xlsx/.pptx/.pdf
- `genoffice_docx_blocks` / `genoffice_docx_patch` / `genoffice_docx_watermark` / `genoffice_docx_create` / `genoffice_docx_delete`
- `genoffice_pptx_slides` / `genoffice_pptx_patch` / `genoffice_pptx_create` / `genoffice_pptx_delete`

**CDP app mode (drive the installed GenOffice desktop app):**
- `genoffice_app_status` / `genoffice_app_launch` / `genoffice_app_open_file` / `genoffice_app_screenshot` / `genoffice_app_eval`

Core value: **byte-preserving roundtrips**. Only the blocks/elements you edit are regenerated as OOXML fragments; untouched paragraphs, styles, headers, comments and zip parts keep their original bytes — layout never breaks. All edits write a new file; the original is never modified. All intelligence comes from the agent (no vendor AI dependency). The CDP launch handles the app's Squirrel auto-updater relaunch (retries until the debug port answers) and the single-instance lock.

## Why git install

The GenOffice engine packages are **not published to npm** and ship as TypeScript source. The server runs under the tsx loader and auto-clones a SHA-pinned genoffice revision (`src/engine.ts` in the pinned commit) into `~/.cache/mcp-genoffice/src` on first tool use (one-time ~40s: shallow fetch + npm install). The manifest pins the exact mcp-genoffice commit (`a23f738`); the engine pin lives in the server and is bumped by PRs to that repo.

## How to test

```bash
hermes mcp catalog | grep genoffice     # entry listed
hermes mcp install genoffice            # git-installs + bootstraps
# new session, then:
#   genoffice_docx_blocks <file.docx> → genoffice_docx_patch <file.docx> {"index":0,"text":"..."}
```

Validated end-to-end before this PR:
- `hermes mcp install genoffice` in an **isolated `HERMES_HOME`** cloned the pinned commit, ran the bootstrap, and wrote `command: node`, `args: [${INSTALL_DIR}/bin/mcp-genoffice.mjs]` to config
- The installed server answered `list_tools` (**15 tools**) and real calls (docx blocks; app status)
- Server E2E suites pass: headless roundtrips (create/edit/delete/watermark for docx and pptx, byte-preservation verified) against the pinned genoffice revision `4da673d`; CDP app mode live-tested on macOS (launch → DOM eval → screenshot → opened a .docx, page target became the docs editor tab)
- `tests/hermes_cli/test_mcp_catalog.py` — 21/21 pass

## Platforms

macOS (tested headless + CDP app mode), Windows (headless; CDP launch via the packaged binary). Node >= 20. Engines are pure TS; the sheets engine (Rust sidecar) is roadmap for xlsx editing.

## Notes

- No issue tracked this feature; search-first found no open issues/PRs for genoffice.
- The GenOffice app is optional — all headless tools work without it.
