### PR TITLE
fix: Windows update pipeline — first-attempt race, marker deadlock, orphaned venv helpers, ZIP-fallback binary loss

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -166,6 +166,24 @@ fn live_marker_owner(path: &Path) -> Option<MarkerOwner> {
     Some(MarkerOwner { pid, age_secs })
 }
 
+/// True when the on-disk marker names THIS process as its owner.
+///
+/// `live_marker_owner` cannot answer this: it deliberately maps
+/// self-ownership to `None` (the #74761 pre-write adoption). The exit-2
+/// self-heal below needs the raw fact, because a `hermes update` child that
+/// refuses over OUR marker is a handoff-recognition failure, not a real
+/// concurrent update.
+fn marker_owned_by_self(path: &Path) -> bool {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| {
+            raw.lines()
+                .next()
+                .and_then(|line| line.trim().parse::<u32>().ok())
+        })
+        == Some(std::process::id())
+}
+
 /// True when a process with `pid` currently exists.
 #[cfg(windows)]
 fn pid_is_alive(pid: u32) -> bool {
@@ -417,6 +435,40 @@ async fn run_update(app: AppHandle) -> Result<()> {
             "[update] first update attempt failed; retrying once (the fix it just \
              pulled loads on the second run)…",
         );
+        update = run_streamed(
+            &app,
+            &hermes,
+            &update_args,
+            &install_root,
+            &child_env,
+            Some("update"),
+        )
+        .await?;
+    }
+
+    // Self-owned-marker heal (#75788). Exit 2 means the child refused over a
+    // live update marker with a foreign owner. When that "foreign" owner is
+    // THIS process, the child simply failed to recognize the handoff — a
+    // checkout predating the HERMES_UPDATE_HANDOFF_PID env fix (8c76fe19f)
+    // and the ancestor-pid fallback runs its pre-pull update_lock.py, reads
+    // our marker, and exits 2 every time. The refusal loop is unbreakable
+    // from the user's side because the update being refused is the one that
+    // ships the fix. The marker exists to serialize updates and this process
+    // IS the update: drop our claim and retry once with the marker absent.
+    // The guard re-removes on Drop (idempotent), and the desktop is already
+    // gone at this point, so nothing races the brief marker-free window.
+    if update.exit_code == Some(UPDATE_EXIT_CONCURRENT)
+        && marker_owned_by_self(&crate::paths::update_in_progress_marker())
+    {
+        emit_log(
+            &app,
+            Some("update"),
+            LogStream::Stdout,
+            "[update] child refused over this updater's own marker (stale \
+             checkout without handoff recognition); clearing the claim and \
+             retrying once…",
+        );
+        _update_marker.complete();
         update = run_streamed(
             &app,
             &hermes,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2717,6 +2717,23 @@ function forceKillProcessTree(pid) {
   }
 }
 
+// Liveness probe for a PID we just tree-killed. `taskkill /T /F` returns once
+// termination is INITIATED, not completed: a dying python.exe stays in the
+// process table while it unmaps .pyd files (AV / NTFS filter drivers stretch
+// this out), and the venv-blocker scan downstream has no liveness filter — it
+// reports any enumerable venv process as a holder. Waiting for actual exit
+// here is what closes the #74805 first-attempt race.
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0)
+
+    return true
+  } catch (err) {
+    // EPERM ⇒ exists but inaccessible (still alive); ESRCH ⇒ gone.
+    return Boolean(err) && err.code === 'EPERM'
+  }
+}
+
 // Before handing off the update on Windows, the desktop MUST stop every backend
 // it spawned and WAIT for the venv shim to actually unlock. The old code did
 // `hermesProcess.kill('SIGTERM')` + `app.quit()` fire-and-forget: SIGTERM on
@@ -2784,9 +2801,21 @@ async function releaseBackendLock(updateRoot, tag) {
   const shim = venvHermesShimPath(updateRoot)
   const deadlineMs = Date.now() + 15000
 
+  // Every PID we have ever signalled. The unlock gate below must wait for
+  // these to actually LEAVE the process table, not just for the shim to
+  // unlock: the shim probe only covers venv\Scripts\hermes.exe, but the
+  // backend is `python.exe -m hermes_cli.main serve`, which need not hold the
+  // shim at all — so the old shim-only gate could pass on its first iteration
+  // with zero dwell while the killed pythons were still terminating, and the
+  // venv-blocker scan then reported those dying processes as holders,
+  // aborting every first update attempt (#74805).
+  const killedPids = new Set(pids)
+
   while (Date.now() < deadlineMs) {
-    if (!isShimLocked(shim)) {
-      rememberLog(`[${tag}] venv shim unlocked; safe to proceed`)
+    const lingering = [...killedPids].filter(isPidAlive)
+
+    if (!isShimLocked(shim) && lingering.length === 0) {
+      rememberLog(`[${tag}] venv shim unlocked and backend PID(s) exited; safe to proceed`)
 
       return { unlocked: true }
     }
@@ -2809,10 +2838,24 @@ async function releaseBackendLock(updateRoot, tag) {
     }
 
     for (const pid of stragglers) {
+      killedPids.add(pid)
       forceKillProcessTree(pid)
     }
 
     await new Promise(r => setTimeout(r, 300))
+  }
+
+  // Deadline reached. Keep the old success criterion — an unlocked shim —
+  // rather than inventing a new failure mode for PIDs that linger past 15s;
+  // the venv-blocker re-scan in applyUpdates covers that residue.
+  if (!isShimLocked(shim)) {
+    const lingering = [...killedPids].filter(isPidAlive)
+
+    rememberLog(
+      `[${tag}] proceeding after 15s: venv shim unlocked, but ${lingering.length} killed backend PID(s) still enumerable`
+    )
+
+    return { unlocked: true }
   }
 
   // Do NOT proceed past a held lock: handing off to the updater while another
@@ -2964,7 +3007,23 @@ async function applyUpdates(opts = {}) {
     // malformed output, missing psutil) abort the handoff — never proceed
     // to the detached updater when the venv state is unknown.
     if (IS_WINDOWS) {
-      const scanOutcome = await scanVenvBlockers(updateRoot)
+      // Re-scan before aborting on 'blocked'. Process-table teardown is
+      // asynchronous: even after releaseBackendLock's PID-exit wait, a
+      // grandchild we never tracked (or a process an AV driver is holding in
+      // teardown) can stay enumerable for a few more seconds and read as a
+      // holder. Each scan itself costs seconds (spawns a venv python +
+      // psutil sweep), so two retries with a short dwell give the table
+      // ample time to settle without meaningfully delaying the abort path
+      // when a REAL holder (a user terminal, second window) is present.
+      let scanOutcome = await scanVenvBlockers(updateRoot)
+
+      for (let attempt = 0; scanOutcome.kind === 'blocked' && attempt < 2; attempt++) {
+        rememberLog(
+          `[updates] venv-blocker scan reported ${scanOutcome.result.processes.length} holder(s); re-scanning (attempt ${attempt + 2}/3)`
+        )
+        await new Promise(r => setTimeout(r, 1500))
+        scanOutcome = await scanVenvBlockers(updateRoot)
+      }
 
       if (scanOutcome.kind === 'blocked') {
         const message = formatBlockerMessage(scanOutcome.result)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5090,6 +5090,7 @@ from hermes_cli.update_cmd import (  # noqa: F401
     _validate_critical_modules_import,
     _venv_core_imports_healthy,
     _venv_launcher_ancestors,
+    _venv_resident_descendants,
     _wait_for_windows_update_gateway_exit,
     _warn_incomplete_gateway_fleet_restart,
     _web_build_toolchain_ready,

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2978,6 +2978,14 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
         "  Close the Hermes desktop app / other Hermes terminals, then re-run:"
     )
     lines.append("    hermes update")
+    lines.append(
+        "  If they persist with everything closed, they are likely orphaned"
+    )
+    lines.append(
+        "  helpers from a previous session (MCP servers, monitoring probes):"
+    )
+    for pid, _name, _cmdline in matches[:6]:
+        lines.append(f"    taskkill /PID {pid} /F")
     lines.append("  (or use `hermes update --force-venv` to proceed anyway at your own risk)")
     return "\n".join(lines)
 
@@ -3044,6 +3052,61 @@ def _venv_launcher_ancestors(pids: list[int]) -> list[int]:
             continue
         if exe.startswith(venv_prefix):
             found.append(ppid)
+    return found
+
+
+def _venv_resident_descendants(pids: list[int]) -> list[int]:
+    """Venv-resident descendants of *pids*, snapshotted while they are alive.
+
+    Stopping a gateway on Windows does not reap the helpers it spawned from
+    the install venv's python — stdio MCP servers, the perfmon probe. A
+    gracefully drained gateway exits before the force-kill pass ever runs,
+    so ``taskkill /T`` never sees its tree; the orphans keep venv ``.pyd``
+    files mapped and dead-end the venv-holder guard downstream on every
+    retry (#61514). Snapshot the descendants up front — a dead pid's
+    children cannot be recovered — and keep only venv-resident ones, so the
+    pause never widens its blast radius beyond processes that actually
+    block the update. Never raises.
+    """
+    if not _m()._is_windows() or not pids:
+        return []
+    try:
+        import psutil
+    except Exception:
+        return []
+
+    venv_dir = _m().PROJECT_ROOT / "venv"
+    try:
+        venv_prefix = str(venv_dir.resolve()).lower().rstrip(os.sep) + os.sep
+    except OSError:
+        venv_prefix = str(venv_dir).lower().rstrip(os.sep) + os.sep
+
+    skip: set[int] = {os.getpid()}
+    try:
+        for anc in psutil.Process().parents():
+            skip.add(int(anc.pid))
+    except Exception:
+        pass
+
+    found: list[int] = []
+    seen: set[int] = set(int(p) for p in pids) | skip
+    for pid in pids:
+        try:
+            children = psutil.Process(int(pid)).children(recursive=True)
+        except Exception:
+            continue
+        for child in children:
+            cpid = int(child.pid)
+            if cpid in seen:
+                continue
+            seen.add(cpid)
+            try:
+                exe = (child.exe() or "").lower()
+                cmdline = " ".join(child.cmdline() or []).lower()
+            except Exception:
+                continue
+            if exe.startswith(venv_prefix) or venv_prefix in cmdline:
+                found.append(cpid)
     return found
 
 
@@ -3181,6 +3244,12 @@ def _pause_windows_gateways_for_update() -> dict | None:
     # update even though the gateway itself is stopped.
     launcher_pids = _m()._venv_launcher_ancestors(mapped_pids)
 
+    # Same pre-drain-snapshot rationale, one hop DOWN instead of up: a
+    # gracefully drained gateway orphans its venv-resident helper children
+    # (stdio MCP servers, the perfmon probe), which then trip the venv-holder
+    # guard downstream and dead-end the update permanently (#61514).
+    helper_pids = _m()._venv_resident_descendants(list(running_pids))
+
     print("→ Stopping Windows gateway process(es) before updating Hermes...")
     try:
         drain_timeout = max(float(_get_restart_drain_timeout()), 1.0)
@@ -3220,6 +3289,24 @@ def _pause_windows_gateways_for_update() -> dict | None:
         except (ProcessLookupError, PermissionError, OSError):
             pass
 
+    # Reap helpers that outlived their gateway. A drained gateway's children
+    # were reparented before any tree kill could reach them; left alive they
+    # hold venv .pyd files and the guard downstream refuses the update.
+    helpers_stopped = []
+    for pid in helper_pids:
+        if pid in force_killed:
+            continue
+        try:
+            terminate_pid(int(pid), force=True)
+            helpers_stopped.append(int(pid))
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+    if helpers_stopped:
+        print(
+            f"  → Stopped {len(helpers_stopped)} venv helper process(es) "
+            "left behind by paused gateways"
+        )
+
     if profiles:
         print(f"  ✓ Paused gateway profile(s): {', '.join(sorted(profiles))}")
     if force_killed:
@@ -3240,6 +3327,10 @@ def _pause_windows_gateways_for_update() -> dict | None:
         "profiles": profiles,
         "unmapped_pids": unmapped_pids,
         "unmapped": unmapped,
+        # Pre-drain snapshot of gateway helper descendants — the venv-holder
+        # guard treats these as stoppable (they are gateway-owned, and the
+        # gateways they belonged to are being resumed after the update).
+        "helper_pids": helper_pids,
     }
 
 def _cold_start_windows_gateway_after_update() -> None:
@@ -3666,6 +3757,30 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # --force-venv is the explicit escape hatch.
     if _m()._is_windows() and not getattr(args, "force_venv", False):
         _venv_holders = _m()._detect_venv_python_processes()
+        if _venv_holders and _windows_gateway_resume:
+            # Holders from the pause's own helper snapshot are gateway-owned
+            # (MCP servers, perfmon probe) — stop them instead of dead-ending
+            # on processes the pause machinery was responsible for (#61514).
+            _known_helpers = set(_windows_gateway_resume.get("helper_pids") or [])
+            _helper_holders = [m for m in _venv_holders if m[0] in _known_helpers]
+            if _helper_holders:
+                from gateway.status import terminate_pid
+
+                print(
+                    f"  ⚠ {len(_helper_holders)} gateway helper process(es) "
+                    "still hold the venv after the pause; stopping them"
+                )
+                for _pid, _name, _cmd in _helper_holders:
+                    try:
+                        terminate_pid(int(_pid), force=True)
+                    except Exception as exc:
+                        logger.debug(
+                            "Could not stop leftover gateway helper %s: %s",
+                            _pid,
+                            exc,
+                        )
+                _time.sleep(1.0)
+                _venv_holders = _m()._detect_venv_python_processes()
         if _venv_holders:
             _gateway_holders = _m()._leftover_pausable_gateway_pids(_venv_holders)
             if _gateway_holders is not None:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -652,7 +652,20 @@ def _discard_staged(staged) -> None:
             logger.warning("could not remove staging path %s: %s", staging, exc)
 
 
-def _commit_staged_replacements(staged) -> None:
+# Locally built artifacts that live INSIDE swapped top-level entries. The
+# GitHub source ZIP carries no build outputs, so a plain swap of ``apps/``
+# deletes the built desktop app (apps/desktop/dist + release, incl. the
+# win-unpacked exe the user launched this update from) and its nested
+# node_modules (#70337). ``_commit_staged_replacements`` grafts these back
+# from the swap backup before the backups are dropped.
+_ZIP_PRESERVE_NESTED: tuple[tuple[str, ...], ...] = (
+    ("apps", "desktop", "dist"),
+    ("apps", "desktop", "release"),
+    ("apps", "desktop", "node_modules"),
+)
+
+
+def _commit_staged_replacements(staged, preserve_nested=None) -> None:
     """Phase 2: swap every staged entry into place, rolling back all on failure.
 
     ``_atomic_replace_dir`` makes each *individual* directory swap safe, but
@@ -701,7 +714,32 @@ def _commit_staged_replacements(staged) -> None:
                 # so say so rather than swallowing it.
                 logger.warning("rollback failed for %s: %s", dst, exc)
         raise
-    # All swaps succeeded — drop the backups (best-effort, never fatal).
+    # All swaps succeeded — graft preserved nested paths (locally built
+    # artifacts the source archive cannot contain) from each entry's backup
+    # into the swapped-in tree. Same-filesystem renames, so this costs
+    # nothing; best-effort, because a failed graft loses a rebuildable
+    # artifact, never the committed update's consistency.
+    for parts in preserve_nested or ():
+        top, rest = parts[0], parts[1:]
+        if not rest:
+            continue  # top-level entries belong in the caller's preserve set
+        for dst, backup in swapped:
+            if not backup or os.path.basename(dst) != top:
+                continue
+            old_sub = os.path.join(backup, *rest)
+            new_sub = os.path.join(dst, *rest)
+            if not os.path.exists(old_sub) or os.path.exists(new_sub):
+                continue
+            try:
+                os.makedirs(os.path.dirname(new_sub), exist_ok=True)
+                os.rename(old_sub, new_sub)
+            except OSError as exc:
+                logger.warning(
+                    "could not preserve %s across ZIP update: %s",
+                    os.path.join(*parts),
+                    exc,
+                )
+    # Drop the backups (best-effort, never fatal).
     for _dst, backup in swapped:
         if backup and os.path.isdir(backup):
             shutil.rmtree(backup, ignore_errors=True)
@@ -841,7 +879,7 @@ def _update_via_zip(args):
             raise
 
         try:
-            _commit_staged_replacements(staged)
+            _commit_staged_replacements(staged, preserve_nested=_ZIP_PRESERVE_NESTED)
         except Exception:
             # The rollback already restored every swapped entry, but staging
             # copies for the not-yet-swapped entries (potentially most of a

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -227,6 +227,9 @@ def test_pause_windows_gateways_for_update_stops_profile_and_unmapped_pids(
         return set()
 
     monkeypatch.setattr(cli_main, "_wait_for_windows_update_gateway_exit", fake_wait)
+    # Hermetic: never walk the real process table for descendants — PIDs 101
+    # and 202 may exist on the machine running the tests.
+    monkeypatch.setattr(cli_main, "_venv_resident_descendants", lambda pids: [])
     monkeypatch.setattr(
         gateway_mod,
         "_capture_gateway_argv",
@@ -254,6 +257,7 @@ def test_pause_windows_gateways_for_update_stops_profile_and_unmapped_pids(
                 "argv": ["pythonw.exe", "-m", "hermes_cli.main", "gateway", "run"],
             }
         ],
+        "helper_pids": [],
     }
     assert waited_for == [101]
     assert terminated == [(202, True)]

--- a/tests/hermes_cli/test_update_zip_two_phase.py
+++ b/tests/hermes_cli/test_update_zip_two_phase.py
@@ -115,6 +115,54 @@ def test_commit_handles_entries_absent_from_the_install(tmp_path):
     assert (live / "brand_new" / "version.txt").read_text() == "new"
 
 
+def test_commit_grafts_preserved_nested_paths_from_the_backup(tmp_path):
+    """Locally built artifacts inside a swapped entry survive the swap (#70337).
+
+    The GitHub source ZIP has no build outputs, so a plain swap of ``apps/``
+    deletes ``apps/desktop/dist`` + ``release`` (including the win-unpacked
+    exe the user launched the update from). The commit phase grafts those
+    back from the swap backup before the backups are dropped.
+    """
+    live, new = tmp_path / "live", tmp_path / "new"
+    _live_tree(live, {"apps": "old"})
+    _live_tree(new, {"apps": "new"})
+    built = live / "apps" / "desktop" / "dist"
+    built.mkdir(parents=True)
+    (built / "electron-main.mjs").write_text("locally built")
+
+    update_cmd._commit_staged_replacements(
+        _stage_all(live, new, ["apps"]),
+        preserve_nested=(("apps", "desktop", "dist"),),
+    )
+
+    # The entry itself is at the new version...
+    assert (live / "apps" / "version.txt").read_text() == "new"
+    # ...but the build output the archive could not contain was grafted back.
+    assert (built / "electron-main.mjs").read_text() == "locally built"
+    # No staging/backup litter left behind.
+    assert not [p for p in os.listdir(live) if "hermes-update" in p]
+
+
+def test_commit_graft_never_overwrites_an_archive_provided_path(tmp_path):
+    """If the new tree DOES ship the preserved path, the archive copy wins."""
+    live, new = tmp_path / "live", tmp_path / "new"
+    _live_tree(live, {"apps": "old"})
+    _live_tree(new, {"apps": "new"})
+    for root, marker in ((live, "stale build"), (new, "shipped build")):
+        built = root / "apps" / "desktop" / "dist"
+        built.mkdir(parents=True)
+        (built / "electron-main.mjs").write_text(marker)
+
+    update_cmd._commit_staged_replacements(
+        _stage_all(live, new, ["apps"]),
+        preserve_nested=(("apps", "desktop", "dist"),),
+    )
+
+    assert (
+        live / "apps" / "desktop" / "dist" / "electron-main.mjs"
+    ).read_text() == "shipped build"
+
+
 def test_staging_clears_leftovers_from_an_interrupted_run(tmp_path):
     live, new = tmp_path / "live", tmp_path / "new"
     _live_tree(live, {"agent": "old"})


### PR DESCRIPTION
## What & why

Four tightly-coupled fixes in the Windows update pipeline (desktop `applyUpdates` → bootstrap updater → `hermes update`), one commit per issue. They share one flow and several of them mask each other in the field, which is why they are bundled; happy to split into separate PRs if preferred.

### 1. #74805 — first update attempt consistently fails, retry succeeds (`apps/desktop/electron/main.ts`)
`taskkill /T /F` returns when termination is *initiated*, and the unlock gate only probed the venv `hermes.exe` shim — which the `python.exe -m hermes_cli.main serve` backend need not hold — so the gate could pass with zero dwell while the killed pythons were still tearing down. The venv-blocker scan has no liveness filter and reported them as holders, aborting the hand-off; the abort respawned a fresh short-lived backend, which is why the manual retry then succeeded.
**Fix:** track every signalled PID and wait for actual process-table exit alongside the shim probe (same 15s deadline; on timeout the shim still decides, as before), plus re-scan up to 2× with a 1.5s dwell before aborting on `blocked`.

### 2. #75788 — stale updater exe deadlocks the in-app update forever (`apps/bootstrap-installer/src-tauri/src/update.rs`)
A checkout predating the `HERMES_UPDATE_HANDOFF_PID` fix (8c76fe19f) and the ancestor-pid fallback reads the updater's own marker as a live foreign update and exits 2 — and the updater deliberately skips its retry for exit 2, so the update that would ship the fix is the one being refused, every time.
**Fix:** on exit 2, do a raw marker read (`live_marker_owner` deliberately maps self-ownership to `None`, so it cannot answer this); if the refused marker is our own, drop the claim and retry the child once. Genuinely foreign owners still refuse exactly as before.

### 3. #61514 — `hermes update` dead-ends permanently at the venv-process guard (`hermes_cli/update_cmd.py`)
Pausing gateways never reaped their venv-resident helper children (stdio MCP servers, perfmon probe). A gracefully drained gateway orphans them before the force-kill pass, they keep venv `.pyd` files mapped, and the guard's pausable-gateway escape hatch doesn't apply to them — permanent `exit 2`.
**Fix:** snapshot venv-resident descendants *before* the drain (a dead pid's children cannot be recovered — same rationale as the existing launcher-ancestor snapshot), reap survivors after, and let the guard stop holders from that snapshot. The refusal message now prints exact `taskkill` commands for orphans left by older versions.

### 4. #70337 — ZIP-fallback update deletes the built desktop app (`hermes_cli/update_cmd.py`)
The two-phase swap preserves only top-level `venv`/`node_modules`/`.git`/`.env`, so the source archive's `apps/` replaced the live one and deleted `apps/desktop/dist` + `release` (including the exe the update was launched from) and nested `node_modules`.
**Fix:** `_commit_staged_replacements` grafts those paths back from the swap backup after all swaps commit — same-filesystem renames, best-effort, archive-shipped copies always win. Two regression tests added.

## How to test
- `pytest tests/hermes_cli/test_update_zip_two_phase.py test_update_lock.py test_scan_venv_blockers.py test_update_zip_atomic_replace.py test_update_venv_health.py test_update_concurrent_quarantine.py test_update_gateway_launcher_refresh.py` — 107 passed (includes 2 new tests for the graft).
- `cargo check` on `apps/bootstrap-installer/src-tauri` — clean (only pre-existing dead-code warnings).
- Manual repro paths: (1) footbar update with a long-running session → first attempt now survives teardown lag; (3) gateway with stdio MCP servers running → `hermes update` no longer dead-ends; (4) `hermes update` on a git-broken install → `apps/desktop/release/win-unpacked/Hermes.exe` survives.

## Platforms
Developed and tested on Windows 11 (the affected pipeline is Windows-only; every change is behind the existing `IS_WINDOWS` / `_is_windows()` guards, POSIX paths untouched).

Fixes #74805, fixes #75788, fixes #61514, fixes #70337. Related context: #26670, #74761, #74782, #50238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)