### PR TITLE
fix(matrix): stop substring-matching sync errors for permanent auth detection

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -85,6 +85,13 @@ try:
         TrustState,
         UserID,
     )
+    from mautrix.errors import (  # type: ignore[assignment]
+        MatrixConnectionError,
+        MatrixStandardRequestError,
+        MForbidden,
+        MUnknownToken,
+        MUnauthorized,
+    )
 except ImportError:
     # Stubs so the module is importable without mautrix installed.
     # check_matrix_requirements() will return False and the adapter
@@ -119,6 +126,24 @@ except ImportError:
         TRUSTED_PRIVATE = "trusted_private_chat"
 
     RoomCreatePreset = _RoomCreatePresetStub  # type: ignore[misc,assignment]
+
+    # Stubs for the error classes used in the sync loop's permanent-failure
+    # detection.  Without mautrix installed the adapter is never instantiated
+    # in production, but tests may import the module, so these must exist.
+    class MatrixConnectionError(Exception):  # type: ignore[no-redef]
+        pass
+
+    class MatrixStandardRequestError(Exception):  # type: ignore[no-redef]
+        pass
+
+    class MForbidden(MatrixStandardRequestError):  # type: ignore[no-redef]
+        pass
+
+    class MUnknownToken(MatrixStandardRequestError):  # type: ignore[no-redef]
+        pass
+
+    class MUnauthorized(MatrixStandardRequestError):  # type: ignore[no-redef]
+        pass
 
     class _TrustStateStub:  # type: ignore[no-redef]
         UNVERIFIED = 0
@@ -2950,16 +2975,36 @@ class MatrixAdapter(BasePlatformAdapter):
             except Exception as exc:
                 if self._closing:
                     return
-                # Detect permanent auth/permission failures.
-                err_str = str(exc).lower()
-                if (
-                    "401" in err_str
-                    or "403" in err_str
-                    or "unauthorized" in err_str
-                    or "forbidden" in err_str
-                ):
+                # Detect permanent auth/permission failures by exception TYPE,
+                # not by substring-matching the whole error string.  The old
+                # check looked for "401"/"403"/"unauthorized"/"forbidden"
+                # anywhere in str(exc), but the sync URL embeds the `since`
+                # token, which can itself contain those substrings (e.g. a
+                # token like "...11340138189...").  A transient connection
+                # timeout whose URL happened to contain "401" was therefore
+                # misclassified as a permanent auth failure and killed the
+                # sync loop permanently.  mautrix raises distinct exception
+                # types for these cases, so branch on those instead.
+                if isinstance(exc, MatrixConnectionError):
+                    # Transient network/DNS failure: retry, never stop.
+                    logger.warning(
+                        "Matrix: sync connection error: %s — retrying in 5s", exc
+                    )
+                    await asyncio.sleep(5)
+                    continue
+                if isinstance(exc, (MForbidden, MUnknownToken, MUnauthorized)):
                     logger.error(
                         "Matrix: permanent auth error: %s — stopping sync", exc
+                    )
+                    return
+                # Fall back to the HTTP status code for any other
+                # MatrixStandardRequestError (e.g. M_NOT_JOINED, M_LIMIT_EXCEEDED).
+                status = getattr(exc, "http_status", None)
+                if isinstance(exc, MatrixStandardRequestError) and status in (401, 403):
+                    logger.error(
+                        "Matrix: permanent auth error (HTTP %s): %s — stopping sync",
+                        status,
+                        exc,
                     )
                     return
                 logger.warning("Matrix: sync error: %s — retrying in 5s", exc)

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1341,6 +1341,93 @@ class TestMatrixSyncLoop:
         assert captured[0].source.chat_type == "dm"
 
     @pytest.mark.asyncio
+    async def test_sync_loop_connection_error_with_401_in_url_retries_not_stops(self):
+        """A transient connection error whose string contains '401' (e.g. a
+        `since` token like '...11340138189...' embedded in the sync URL) must
+        NOT be treated as a permanent auth failure. Regression for the bug
+        where the old substring match on str(exc) killed the sync loop."""
+        from mautrix.errors import MatrixConnectionError
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter.__new__(MatrixAdapter)
+        adapter._closing = False
+        adapter._user_id = "@bot:example.org"
+        adapter._startup_ts = time.time() - 10
+        adapter._dm_rooms = {}
+        adapter._text_batch_delay_seconds = 0
+        adapter._background_read_receipt = MagicMock()
+
+        sync_count = 0
+
+        async def _sync_once(**kwargs):
+            nonlocal sync_count
+            sync_count += 1
+            if sync_count == 1:
+                # First call raises a connection error whose message contains
+                # "401" (the exact failure mode from the bug report).
+                raise MatrixConnectionError(
+                    "Connection timeout to host https://matrix.org/_matrix/client/v3/sync"
+                    "?timeout=30000&since=s7229943229_757284980_13700910_4939298983_"
+                    "5746160314_269792054_1667497935_11340138189_0_733956_34_1_2397457"
+                )
+            # Second call succeeds and ends the loop.
+            adapter._closing = True
+            return {"rooms": {"join": {}}, "next_batch": "s1234"}
+
+        mock_sync_store = MagicMock()
+        mock_sync_store.get_next_batch = AsyncMock(return_value=None)
+        mock_sync_store.put_next_batch = AsyncMock()
+
+        fake_client = MagicMock()
+        fake_client.sync = AsyncMock(side_effect=_sync_once)
+        fake_client.sync_store = mock_sync_store
+        fake_client.handle_sync = MagicMock(return_value=[])
+        adapter._client = fake_client
+
+        await adapter._sync_loop()
+
+        # The loop must have retried (2 sync calls), not stopped after the
+        # first connection error.
+        assert sync_count == 2
+
+    @pytest.mark.asyncio
+    async def test_sync_loop_real_auth_error_stops(self):
+        """A genuine MForbidden/MUnknownToken/MUnauthorized error must still
+        stop the sync loop (permanent auth failure)."""
+        from mautrix.errors import MForbidden
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        adapter = MatrixAdapter.__new__(MatrixAdapter)
+        adapter._closing = False
+        adapter._user_id = "@bot:example.org"
+        adapter._startup_ts = time.time() - 10
+        adapter._dm_rooms = {}
+        adapter._text_batch_delay_seconds = 0
+        adapter._background_read_receipt = MagicMock()
+
+        sync_count = 0
+
+        async def _sync_once(**kwargs):
+            nonlocal sync_count
+            sync_count += 1
+            raise MForbidden(403, "forbidden")
+
+        mock_sync_store = MagicMock()
+        mock_sync_store.get_next_batch = AsyncMock(return_value=None)
+        mock_sync_store.put_next_batch = AsyncMock()
+
+        fake_client = MagicMock()
+        fake_client.sync = AsyncMock(side_effect=_sync_once)
+        fake_client.sync_store = mock_sync_store
+        fake_client.handle_sync = MagicMock(return_value=[])
+        adapter._client = fake_client
+
+        await adapter._sync_loop()
+
+        # Loop must stop after the first auth error: no retry.
+        assert sync_count == 1
+
+    @pytest.mark.asyncio
     async def test_connect_receives_dm_from_initial_sync_dispatch(self):
         """A DM delivered by initial sync should reach the message handler after connect."""
         from plugins.platforms.matrix.adapter import MatrixAdapter


### PR DESCRIPTION
## Problem

The Matrix sync loop permanent-failure detection substring-matches the entire exception string for "401"/"403"/"unauthorized"/"forbidden":

    err_str = str(exc).lower()
    if ("401" in err_str or "403" in err_str or ...):
        logger.error("Matrix: permanent auth error: %s — stopping sync", exc)
        return

The sync URL embeds the since token, which can itself contain those substrings. A transient connection timeout whose URL happened to contain "401" (e.g. a token like "...11340138189...") was therefore misclassified as a permanent auth failure, and the sync loop returned permanently. The bot went deaf (stopped receiving messages) while outbound sends kept working. DNS recovery did not restart the loop; only a gateway restart did.

## Fix

Branch on the mautrix exception type instead of substring-matching the whole string:

- MatrixConnectionError (transient network/DNS) -> retry, never stop
- MForbidden / MUnknownToken / MUnauthorized -> permanent, stop
- other MatrixStandardRequestError -> fall back to HTTP status (401/403)

## Tests

Added two regression tests in tests/gateway/test_matrix.py:
- connection error whose message contains "401" retries instead of stopping
- genuine MForbidden still stops the loop

113 passed, 1 pre-existing unrelated failure (test_password_login_uses_device_id).

Assisted by Hermes