### PR TITLE
fix(cron): block profile-flag gateway restart/stop when self-targeting (#78028)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -31,6 +31,11 @@ stop|restart`` separately refuse to self-target from inside the gateway.
 Blocking cron specs at creation time as well means the agent gets an immediate,
 informative rejection instead of scheduling a job that will only fail
 (silently) when it fires.
+
+The profile-flag form (``hermes -p <profile> gateway restart|stop``, #78028)
+is handled profile-aware: it is blocked only when the named profile is the
+profile running the guard. Sibling-profile restarts are legitimate fleet
+operations and stay allowed.
 """
 
 from __future__ import annotations
@@ -92,12 +97,85 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
 _SHELL_LINE_CONTINUATION = re.compile(r"\\\r?\n[ \t]*")
 
 
+# Branch A2 (#78028): the same foot-gun written with an explicit profile
+# selector — `hermes -p <profile> gateway restart|stop` / `--profile <name>`
+# / `--profile=<name>`. The selector token between `hermes` and `gateway`
+# breaks Branch A's literal adjacency. Unlike Branch A this form is NOT
+# unconditionally self-targeting: issued from inside gateway `zeus`,
+# `hermes -p venus gateway restart` operates on a sibling profile's gateway
+# and is a legitimate fleet operation. The pattern captures the named
+# profile so `contains_gateway_lifecycle_command` can block only the
+# self-targeting shape (named profile == the profile running the guard).
+# `start` stays excluded for the same reason as Branch A.
+_PROFILE_FLAG_LIFECYCLE_PATTERN = re.compile(
+    r"(?i)"
+    r"hermes\s+"
+    # Any global flags before the profile selector (each may carry a value).
+    r"(?:-{1,2}\S+(?:\s+\S+)?\s+)*"
+    # The selector itself: `--profile=<name>` or the space-separated
+    # `-p <name>` / `--profile <name>` — exactly the shapes the CLI's
+    # `_apply_profile_override` accepts.
+    r"(?:--profile=([^\s]+)|(?:-p|--profile)\s+([^\s]+))"
+    # Any global flags between the selector and the subcommand.
+    r"(?:\s+-{1,2}\S+(?:\s+\S+)?)*"
+    r"\s+gateway\s+(?:restart|stop)"
+)
+
+
+def _current_profile_name() -> Optional[str]:
+    """Return the name of the profile running the guard, if determinable.
+
+    Prefers the explicit ``HERMES_PROFILE_NAME`` / ``HERMES_PROFILE`` env
+    (set by the profile launcher and kanban worker spawns), falling back to
+    ``hermes_cli.profiles.get_active_profile_name`` (derived from
+    ``HERMES_HOME``, which the gateway process inherits from its launch
+    profile). Returns ``None`` when neither source yields a name.
+    """
+    for env_name in ("HERMES_PROFILE_NAME", "HERMES_PROFILE"):
+        value = os.environ.get(env_name)
+        if value and value.strip():
+            return value.strip()
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return get_active_profile_name() or None
+    except Exception:
+        return None
+
+
+def _named_profile_is_current(named: str) -> bool:
+    """True when *named* is the profile executing the guard (self-targeting)."""
+    current = _current_profile_name()
+    if not current:
+        # No profile identity available: cannot prove self-targeting, so do
+        # not block — sibling restarts must stay allowed (#78028).
+        return False
+    return named.strip().casefold() == current.strip().casefold()
+
+
 def contains_gateway_lifecycle_command(text: str) -> bool:
     """Return True if *text* contains a gateway lifecycle command pattern."""
     if not text:
         return False
     normalized = _SHELL_LINE_CONTINUATION.sub(" ", text)
-    return bool(_GATEWAY_LIFECYCLE_PATTERN.search(normalized))
+    if _GATEWAY_LIFECYCLE_PATTERN.search(normalized):
+        return True
+    # Profile-flag form (#78028): `hermes -p <profile> gateway restart|stop`
+    # bypasses Branch A because the selector sits between `hermes` and
+    # `gateway`. It is only the same foot-gun when the named profile IS the
+    # profile running the guard — sibling-profile restarts are legitimate
+    # fleet operations and stay allowed.
+    profile_match = _PROFILE_FLAG_LIFECYCLE_PATTERN.search(normalized)
+    if profile_match:
+        named = profile_match.group(1) or profile_match.group(2)
+        if named:
+            # Profile ids cannot contain quotes (hermes_cli.profiles
+            # enforces `^[a-z0-9][a-z0-9_-]{0,63}$`), so a shell-quoted
+            # `-p 'zeus'` compares equal to the bare name.
+            named = named.strip().strip("\"'")
+            if _named_profile_is_current(named):
+                return True
+    return False
 
 
 _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -107,6 +107,85 @@ class TestGatewayLifecyclePattern:
         assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
 
 
+class TestProfileFlagGatewayLifecycle:
+    """#78028: `hermes -p <profile> gateway restart|stop` bypasses Branch A's
+    literal adjacency, so it needs its own pattern. It is only the same
+    self-termination foot-gun when the named profile IS the profile running
+    the guard; sibling-profile restarts are legitimate fleet operations and
+    must stay allowed."""
+
+    @pytest.fixture(autouse=True)
+    def _pin_profile_identity(self, monkeypatch):
+        # The ambient test env may carry HERMES_HOME/HERMES_PROFILE; pin the
+        # profile identity explicitly so every assertion is deterministic.
+        monkeypatch.setenv("HERMES_PROFILE", "zeus")
+        monkeypatch.delenv("HERMES_PROFILE_NAME", raising=False)
+
+    @pytest.mark.parametrize("text", [
+        "hermes -p zeus gateway stop",
+        "hermes -p zeus gateway restart",
+        "hermes --profile zeus gateway restart",
+        "hermes --profile zeus gateway stop",
+        "hermes --profile=zeus gateway restart",
+        # Global flags before/after the selector must not hide the shape.
+        "hermes -v -p zeus gateway restart",
+        "hermes -p zeus -v gateway restart",
+        "hermes --debug --profile zeus gateway stop",
+        # Shell quoting of the profile id is equivalent to the bare name.
+        "hermes -p 'zeus' gateway restart",
+        "hermes --profile \"zeus\" gateway stop",
+    ])
+    def test_self_target_blocked(self, text):
+        assert _contains_gateway_lifecycle_command(text), f"Should block: {text!r}"
+
+    @pytest.mark.parametrize("text", [
+        "hermes -p venus gateway stop",
+        "hermes -p venus gateway restart",
+        "hermes --profile venus gateway restart",
+        "hermes --profile=venus gateway stop",
+        "hermes -p venus -v gateway restart",
+    ])
+    def test_sibling_allowed(self, text):
+        assert not _contains_gateway_lifecycle_command(text), f"Should allow: {text!r}"
+
+    @pytest.mark.parametrize("text", [
+        "hermes -p zeus gateway start",
+        "hermes -p zeus gateway start --all",
+    ])
+    def test_start_still_allowed(self, text):
+        # `start` is intentionally excluded from the guard, with or without
+        # the profile flag (#30719 rationale).
+        assert not _contains_gateway_lifecycle_command(text), f"Should allow: {text!r}"
+
+    def test_adjacent_form_still_blocked(self):
+        # Branch A remains unconditional — the profile-flag check is an
+        # additional layer, not a replacement.
+        assert _contains_gateway_lifecycle_command("hermes gateway restart")
+        assert _contains_gateway_lifecycle_command("hermes gateway stop")
+
+    def test_hermes_home_derived_profile(self, monkeypatch):
+        # Without HERMES_PROFILE the guard falls back to the HERMES_HOME-
+        # derived profile identity (get_active_profile_name) — the signal the
+        # gateway process itself carries.
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+        monkeypatch.delenv("HERMES_PROFILE_NAME", raising=False)
+        import hermes_cli.profiles as profiles_mod
+
+        monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "zeus")
+        assert _contains_gateway_lifecycle_command("hermes -p zeus gateway restart")
+        assert not _contains_gateway_lifecycle_command("hermes -p venus gateway restart")
+
+    def test_no_profile_context_conservative_allow(self, monkeypatch):
+        # With no profile identity the guard cannot prove self-targeting, so
+        # the profile-flag form is allowed rather than over-blocking siblings;
+        # the adjacent form stays blocked unconditionally.
+        import cron.lifecycle_guard as lifecycle_guard
+
+        monkeypatch.setattr(lifecycle_guard, "_current_profile_name", lambda: None)
+        assert not _contains_gateway_lifecycle_command("hermes -p zeus gateway restart")
+        assert _contains_gateway_lifecycle_command("hermes gateway restart")
+
+
 class TestCronCreateLifecycleBlock:
     """Verify cron create rejects gateway lifecycle prompts."""
 


### PR DESCRIPTION
## Summary

Closes the `hermes -p <profile> gateway stop|restart` bypass of the gateway
lifecycle guard (`cron/lifecycle_guard.py`). The profile-flag form of the
self-termination foot-gun is now blocked — but **only** when the named
profile is the profile running the guard, so sibling-profile restarts
(`hermes -p venus gateway restart` issued from inside the `zeus` gateway)
remain legitimate fleet operations.

## Root Cause

Branch A of `_GATEWAY_LIFECYCLE_PATTERN` requires literal adjacency:

```python
r"(?:hermes\s+gateway\s+(?:restart|stop))"
```

Any token between `hermes` and `gateway` breaks the match, so
`hermes -p zeus gateway stop` / `hermes --profile zeus gateway restart`
slipped past the guard. This matters for both enforcement points that use
`cron/lifecycle_guard.py`:

- **Cron creation** (`check_gateway_lifecycle`): a job scheduled from inside
  a gateway whose prompt/script self-restarts that gateway reproduces the
  SIGTERM-respawn loop the guard exists to prevent (#30719) — no second
  layer catches it here.
- **Terminal hard-block** (`tools/terminal_tool.py:2560`, `_HERMES_GATEWAY=1`):
  the unconditional refusal is bypassed; the command only falls through to
  the approval layer.

Note: on current `main` the approval layer (`tools/approval.py:790`,
`DANGEROUS_PATTERNS`) already matches the profile-flag forms — its
`(?:-{1,2}\S+(?:\s+\S+)?\s+)*` global-flag tolerance covers `-p <name>` — so
the issue's matrix row for that layer is stale. The uncovered paths are the
cron-creation guard and the unconditional terminal hard-block, both of which
route exclusively through `cron/lifecycle_guard.py`.

## Change

`cron/lifecycle_guard.py`:

- New `_PROFILE_FLAG_LIFECYCLE_PATTERN` (Branch A2) matching
  `hermes [flags] (-p|--profile) <name> [flags] gateway restart|stop` in all
  three CLI-accepted selector shapes (`-p <name>`, `--profile <name>`,
  `--profile=<name>`), capturing the named profile.
- `contains_gateway_lifecycle_command` now blocks the profile-flag form only
  when the named profile equals the profile executing the guard
  (`_named_profile_is_current`). The current profile is resolved from
  `HERMES_PROFILE_NAME` / `HERMES_PROFILE` env, falling back to
  `hermes_cli.profiles.get_active_profile_name()` (HERMES_HOME-derived, the
  identity the gateway process carries).
- Conservative fail-open on the profile-flag form when no profile identity
  can be determined: without proof of self-targeting, sibling operations must
  not be over-blocked. Branch A (`hermes gateway restart|stop`) remains
  blocked unconditionally; `gateway start` stays excluded as before.
- Shell-quoted profile ids (`-p 'zeus'`) are normalized before comparison.

`tests/hermes_cli/test_gateway_restart_loop.py`:

- New `TestProfileFlagGatewayLifecycle` (20 parametrized/unit cases):
  self-target blocked for all selector shapes, sibling restarts allowed,
  `start` still allowed, adjacent form still blocked, HERMES_HOME-derived
  profile fallback, conservative allow with no profile context.

## Verification

- `PYTHONPATH=. python -m pytest tests/hermes_cli/test_gateway_restart_loop.py -q`
  → **102 passed** (82 pre-existing + 20 new; zero regressions).
- `ruff check cron/lifecycle_guard.py tests/hermes_cli/test_gateway_restart_loop.py`
  → All checks passed.
- Repro matrix on the fixed code (`HERMES_PROFILE=zeus`):

| command | blocked |
|---|---|
| `hermes gateway stop` / `hermes gateway restart` | ✅ yes (unchanged) |
| `hermes -p zeus gateway stop` / `restart` | ✅ yes (was allowed) |
| `hermes --profile zeus gateway restart` / `stop` | ✅ yes (was allowed) |
| `hermes --profile=zeus gateway restart` | ✅ yes |
| `hermes -p venus gateway restart` (sibling) | ✅ no — still allowed |
| `hermes -p venus gateway start` | ✅ no — still allowed |

Closes #78028
