### PR TITLE
fix(vision): resolve Git Bash image paths on Windows

### DIFF
--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -89,6 +89,65 @@ class TestLocalBackend:
         assert res.data == svg_bytes
 
 
+class TestWindowsMsysPaths:
+    @pytest.mark.asyncio
+    async def test_local_windows_msys_path_is_translated_with_cygpath(self, tmp_path, monkeypatch):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        image = tmp_path / "image.png"
+        image.write_bytes(PNG)
+
+        with patch("tools.image_source.platform.system", return_value="Windows"), patch(
+            "tools.image_source.subprocess.run",
+            return_value=SimpleNamespace(returncode=0, stdout=str(image)),
+        ) as cygpath:
+            res = await isrc.resolve_image_source(
+                "/tmp/image.png", isrc.ResolveContext())
+
+        assert res.data == PNG
+        assert res.origin == "file"
+        cygpath.assert_called_once_with(
+            ["cygpath", "-w", "/tmp/image.png"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_local_windows_msys_path_without_cygpath_is_actionable(self, tmp_path, monkeypatch):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        with patch("tools.image_source.platform.system", return_value="Windows"), patch(
+            "tools.image_source.subprocess.run", side_effect=FileNotFoundError), pytest.raises(
+                isrc.SourceNotFound, match="Unix-style path"
+            ) as exc_info:
+            await isrc.resolve_image_source("/tmp/image.png", isrc.ResolveContext())
+
+        assert r"C:\Users\...\image.png" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_windows_sandbox_path_is_not_translated(self, tmp_path, monkeypatch):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+        def fake_execute(cmd, **kw):
+            return {"returncode": 0, "output": base64.b64encode(PNG).decode()}
+
+        with patch("tools.image_source.platform.system", return_value="Windows"), patch(
+            "tools.image_source.subprocess.run"
+        ) as cygpath, patch(
+            "tools.image_source._get_active_env",
+            return_value=SimpleNamespace(execute=fake_execute),
+        ):
+            res = await isrc.resolve_image_source(
+                "/workspace/image.png", isrc.ResolveContext(task_id="t1"))
+
+        assert res.origin == "container"
+        cygpath.assert_not_called()
+
+
 class TestNonLocalBackendConfinement:
     """The security model: under a sandbox backend, host reads are confined to
     the media caches; every other path is read inside the sandbox."""

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -115,6 +115,65 @@ class TestLocalBackend:
         assert res.data == svg_bytes
 
 
+class TestWindowsMsysPaths:
+    @pytest.mark.asyncio
+    async def test_local_windows_msys_path_is_translated_with_cygpath(self, tmp_path, monkeypatch):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        image = tmp_path / "image.png"
+        image.write_bytes(PNG)
+
+        with patch("tools.image_source.platform.system", return_value="Windows"), patch(
+            "tools.image_source.subprocess.run",
+            return_value=SimpleNamespace(returncode=0, stdout=str(image)),
+        ) as cygpath:
+            res = await isrc.resolve_image_source(
+                "/tmp/image.png", isrc.ResolveContext())
+
+        assert res.data == PNG
+        assert res.origin == "file"
+        cygpath.assert_called_once_with(
+            ["cygpath", "-w", "/tmp/image.png"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_local_windows_msys_path_without_cygpath_is_actionable(self, tmp_path, monkeypatch):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        with patch("tools.image_source.platform.system", return_value="Windows"), patch(
+            "tools.image_source.subprocess.run", side_effect=FileNotFoundError), pytest.raises(
+                isrc.SourceNotFound, match="Unix-style path"
+            ) as exc_info:
+            await isrc.resolve_image_source("/tmp/image.png", isrc.ResolveContext())
+
+        assert r"C:\Users\...\image.png" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_windows_sandbox_path_is_not_translated(self, tmp_path, monkeypatch):
+        isrc = _reload(monkeypatch, tmp_path / "hermes")
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+        def fake_execute(cmd, **kw):
+            return {"returncode": 0, "output": base64.b64encode(PNG).decode()}
+
+        with patch("tools.image_source.platform.system", return_value="Windows"), patch(
+            "tools.image_source.subprocess.run"
+        ) as cygpath, patch(
+            "tools.image_source._get_active_env",
+            return_value=SimpleNamespace(execute=fake_execute),
+        ):
+            res = await isrc.resolve_image_source(
+                "/workspace/image.png", isrc.ResolveContext(task_id="t1"))
+
+        assert res.origin == "container"
+        cygpath.assert_not_called()
+
+
 class TestNonLocalBackendConfinement:
     """The security model: under a sandbox backend, host reads are confined to
     the media caches; every other path is read inside the sandbox."""

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -35,7 +35,9 @@ from __future__ import annotations
 import asyncio
 import base64
 import os
+import platform
 import re
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -119,7 +121,10 @@ async def resolve_image_source(
 
     # Everything else is a filesystem path — including bare relative names
     # like "pic.png" (accepted on main; a path-shape gate here regressed them).
-    candidate = s[len("file://"):] if s.lower().startswith("file://") else s
+    is_file_uri = s.lower().startswith("file://")
+    candidate = s[len("file://"):] if is_file_uri else s
+    if not is_file_uri:
+        candidate = _translate_windows_msys_path(candidate)
     p = Path(os.path.expanduser(candidate))
     # Confinement decision (see module docstring). Under a non-local backend
     # a path is host-readable ONLY if it lands in a media cache (after
@@ -216,6 +221,47 @@ def _is_local_terminal_backend() -> bool:
     dispatch, which key off ``TERMINAL_ENV``.
     """
     return os.getenv("TERMINAL_ENV", "local").strip().lower() in ("local", "")
+
+
+def _translate_windows_msys_path(path: str) -> str:
+    """Translate a raw Git Bash/MSYS path on a local Windows backend.
+
+    ``Path`` does not understand MSYS paths such as ``/tmp/image.png`` on
+    native Windows.  Do not translate paths for sandbox backends: there,
+    slash-prefixed paths belong to the sandbox's filesystem and must retain
+    the confinement behavior below.  UNC paths likewise remain untouched.
+    """
+    if (
+        platform.system() != "Windows"
+        or not _is_local_terminal_backend()
+        or not path.startswith("/")
+        or path.startswith("//")
+    ):
+        return path
+
+    try:
+        result = subprocess.run(
+            ["cygpath", "-w", path],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        raise SourceNotFound(_windows_msys_path_error(path), src=path, origin="file")
+
+    translated = result.stdout.strip() if result.returncode == 0 else ""
+    if translated:
+        return translated
+    raise SourceNotFound(_windows_msys_path_error(path), src=path, origin="file")
+
+
+def _windows_msys_path_error(path: str) -> str:
+    return (
+        f"'{path}' looks like a Unix-style path. On Windows, provide a "
+        r"Windows-style absolute path such as 'C:\Users\...\image.png', "
+        "or run Hermes from Git Bash with cygpath available."
+    )
 
 
 def _media_cache_roots() -> list:

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 import asyncio
 import base64
 import os
+import platform
 import re
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -70,7 +72,10 @@ async def resolve_image_source(
             src=s)
     # Everything else is a filesystem path — including bare relative names like "pic.png"
     # (a path-shape gate here regressed them once).
-    candidate = s[len("file://"):] if s.lower().startswith("file://") else s
+    is_file_uri = s.lower().startswith("file://")
+    candidate = s[len("file://"):] if is_file_uri else s
+    if not is_file_uri:
+        candidate = _translate_windows_msys_path(candidate)
     p = Path(os.path.expanduser(candidate))
     host_target = _permitted_host_read_target(p, ctx)
     if host_target is not None and host_target.is_file():
@@ -146,6 +151,47 @@ async def _download_to_bytes(url: str) -> bytes:
 def _is_local_terminal_backend() -> bool:
     """True when the terminal backend runs directly on the host (keys off ``TERMINAL_ENV``)."""
     return os.getenv("TERMINAL_ENV", "local").strip().lower() in ("local", "")
+
+
+def _translate_windows_msys_path(path: str) -> str:
+    """Translate a raw Git Bash/MSYS path on a local Windows backend.
+
+    ``Path`` does not understand MSYS paths such as ``/tmp/image.png`` on
+    native Windows. Do not translate paths for sandbox backends: there,
+    slash-prefixed paths belong to the sandbox's filesystem and must retain
+    the confinement behavior below. UNC paths likewise remain untouched.
+    """
+    if (
+        platform.system() != "Windows"
+        or not _is_local_terminal_backend()
+        or not path.startswith("/")
+        or path.startswith("//")
+    ):
+        return path
+
+    try:
+        result = subprocess.run(
+            ["cygpath", "-w", path],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        raise SourceNotFound(_windows_msys_path_error(path), src=path, origin="file")
+
+    translated = result.stdout.strip() if result.returncode == 0 else ""
+    if translated:
+        return translated
+    raise SourceNotFound(_windows_msys_path_error(path), src=path, origin="file")
+
+
+def _windows_msys_path_error(path: str) -> str:
+    return (
+        f"'{path}' looks like a Unix-style path. On Windows, provide a "
+        r"Windows-style absolute path such as 'C:\Users\...\image.png', "
+        "or run Hermes from Git Bash with cygpath available."
+    )
 
 
 # Host-side media caches: the only host paths vision may read under a non-local backend


### PR DESCRIPTION
Fixes #53639

## What changed and why

Raw slash-prefixed paths copied from Git Bash/MSYS (for example `/tmp/image.png`) are not valid native Windows paths. On a local Windows terminal backend, the shared media-source resolver now converts those paths with `cygpath -w` before reading the file. If `cygpath` is unavailable or cannot translate the path, it returns an error that identifies the Unix-style path and gives a Windows-path remedy.

The conversion is intentionally limited to local Windows backends. Sandbox-backed paths stay untouched so they continue to resolve inside the sandbox rather than being redirected to the Windows host. `file://` URI handling is also unchanged.

## How to test

- `pytest tests/tools/test_image_source.py -q --timeout=60`
- `ruff check tools/image_source.py tests/tools/test_image_source.py`
- `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` *(collection is blocked in this checkout because FastAPI/Uvicorn are absent and the system Python cannot install them; the focused tests pass.)*

## What platforms tested on

- macOS (focused unit tests)
- Windows behavior covered with platform-mocked regression tests for local MSYS translation, missing `cygpath`, and Docker sandbox preservation

<!-- autocontrib:worker-id=issue-followup-020ddda1 kind=pr-open -->