### PR TITLE
fix(buzz): support media in standalone sends

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -320,14 +320,21 @@ async def _exec_buzz(
 _MAX_CLI_MESSAGE_CHARS = 900
 
 
-def _bounded_cli_message(message: str) -> str:
+def _bounded_cli_message(message: str, redact_path: Optional[Path] = None) -> str:
     """Keep untrusted CLI detail useful without exposing unbounded output."""
+    if redact_path is not None:
+        message = message.replace(str(redact_path), redact_path.name)
     if len(message) <= _MAX_CLI_MESSAGE_CHARS:
         return message
     return f"{message[: _MAX_CLI_MESSAGE_CHARS - 3]}..."
 
 
-def _cli_error_message(stderr: str, returncode: int) -> str:
+def _cli_error_message(
+    stderr: str,
+    returncode: int,
+    *,
+    redact_path: Optional[Path] = None,
+) -> str:
     """Extract a bounded human-readable message from the CLI error contract."""
     text = (stderr or "").strip()
     try:
@@ -338,11 +345,15 @@ def _cli_error_message(stderr: str, returncode: int) -> str:
             if isinstance(detail, str) and detail.strip():
                 label = category.strip() if isinstance(category, str) and category.strip() else "error"
                 return _bounded_cli_message(
-                    f"{label}: {detail.strip()} (exit {returncode})"
+                    f"{label}: {detail.strip()} (exit {returncode})",
+                    redact_path,
                 )
     except ValueError:
         pass
-    return _bounded_cli_message(text or f"buzz CLI failed with exit code {returncode}")
+    return _bounded_cli_message(
+        text or f"buzz CLI failed with exit code {returncode}",
+        redact_path,
+    )
 
 
 def _parse_send_receipt(stdout: str) -> Tuple[Optional[str], Optional[str]]:
@@ -716,7 +727,7 @@ class BuzzAdapter(BasePlatformAdapter):
         if code != 0:
             return SendResult(
                 success=False,
-                error=_cli_error_message(err, code),
+                error=_cli_error_message(err, code, redact_path=local),
                 retryable=code == 2,
             )
         event_id, receipt_error = _parse_send_receipt(out)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1362,7 +1362,7 @@ async def _standalone_send(
     message: str,
     *,
     thread_id: Optional[str] = None,
-    media_files: Optional[List[str]] = None,
+    media_files: Optional[List[Any]] = None,
     force_document: bool = False,
 ) -> Dict[str, Any]:
     """One-shot send without a live adapter (out-of-process cron delivery).
@@ -1388,7 +1388,8 @@ async def _standalone_send(
     args = ["messages", "send", "--channel", target, "--content", "-"]
     if thread_id:
         args += ["--reply-to", str(thread_id)]
-    for path in media_files or []:
+    for media in media_files or []:
+        path = media[0] if isinstance(media, (list, tuple)) and media else media
         args += ["--file", str(path)]
     try:
         code, out, err = await _exec_buzz(
@@ -1404,7 +1405,10 @@ async def _standalone_send(
         data = json.loads(out or "{}")
     except ValueError:
         data = {}
-    return {"success": True, "message_id": str(data.get("event_id") or "")}
+    result = {"success": True, "message_id": str(data.get("event_id") or "")}
+    if media_files:
+        result["media_delivered"] = True
+    return result
 
 
 def interactive_setup() -> None:

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -317,20 +317,53 @@ async def _exec_buzz(
     )
 
 
-def _cli_error_message(stderr: str, returncode: int) -> str:
-    """Extract the human-readable message from the CLI's JSON error contract.
+_MAX_CLI_MESSAGE_CHARS = 900
 
-    stderr is ``{"error": "<category>", "message": "<detail>"}`` on failure;
-    fall back to the raw (stripped) stderr when it isn't JSON.
-    """
+
+def _bounded_cli_message(message: str) -> str:
+    """Keep untrusted CLI detail useful without exposing unbounded output."""
+    if len(message) <= _MAX_CLI_MESSAGE_CHARS:
+        return message
+    return f"{message[: _MAX_CLI_MESSAGE_CHARS - 3]}..."
+
+
+def _cli_error_message(stderr: str, returncode: int) -> str:
+    """Extract a bounded human-readable message from the CLI error contract."""
     text = (stderr or "").strip()
     try:
         data = json.loads(text)
-        if isinstance(data, dict) and data.get("message"):
-            return f"{data.get('error', 'error')}: {data['message']} (exit {returncode})"
+        if isinstance(data, dict):
+            detail = data.get("message")
+            category = data.get("error")
+            if isinstance(detail, str) and detail.strip():
+                label = category.strip() if isinstance(category, str) and category.strip() else "error"
+                return _bounded_cli_message(
+                    f"{label}: {detail.strip()} (exit {returncode})"
+                )
     except ValueError:
         pass
-    return text or f"buzz CLI failed with exit code {returncode}"
+    return _bounded_cli_message(text or f"buzz CLI failed with exit code {returncode}")
+
+
+def _parse_send_receipt(stdout: str) -> Tuple[Optional[str], Optional[str]]:
+    """Validate the buzz-cli success receipt and return ``(event_id, error)``."""
+    try:
+        data = json.loads(stdout or "{}")
+    except ValueError:
+        return None, "invalid CLI response"
+    if not isinstance(data, dict):
+        return None, "invalid CLI response"
+    if data.get("accepted") is False:
+        detail = data.get("message")
+        if not isinstance(detail, str) or not detail.strip():
+            detail = "message was not accepted"
+        return None, _bounded_cli_message(detail.strip())
+    if data.get("accepted") is not True:
+        return None, "invalid CLI response"
+    event_id = data.get("event_id")
+    if not isinstance(event_id, str) or not event_id.strip():
+        return None, "invalid CLI response"
+    return event_id.strip(), None
 
 
 def _parse_json_list(stdout: str) -> List[dict]:
@@ -619,20 +652,14 @@ class BuzzAdapter(BasePlatformAdapter):
                 error=_cli_error_message(err, code),
                 retryable=code == 2,
             )
-        try:
-            data = json.loads(out or "{}")
-        except ValueError:
-            data = {}
-        event_id = data.get("event_id")
-        if event_id:
-            # Belt-and-braces echo suppression: the poll loop already skips
-            # our own pubkey, but marking the id seen makes de-dupe explicit.
-            self._mark_seen(str(chat_id), str(event_id))
-        return SendResult(
-            success=bool(data.get("accepted", True)),
-            message_id=str(event_id) if event_id else None,
-            raw_response=data,
-        )
+        event_id, receipt_error = _parse_send_receipt(out)
+        if receipt_error:
+            return SendResult(success=False, error=receipt_error)
+        assert event_id is not None
+        # Belt-and-braces echo suppression: the poll loop already skips our own
+        # pubkey, but marking the verified id seen makes de-dupe explicit.
+        self._mark_seen(str(chat_id), event_id)
+        return SendResult(success=True, message_id=event_id)
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Buzz has no typing indicator API — no-op."""
@@ -664,6 +691,41 @@ class BuzzAdapter(BasePlatformAdapter):
             return False
         return True
 
+    async def _send_local_file(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Upload one local file through the Buzz CLI and verify its receipt."""
+        local = Path(file_path).expanduser()
+        if not local.is_file():
+            return SendResult(success=False, error="Media file not found")
+        args = [
+            "messages", "send",
+            "--channel", str(chat_id),
+            "--file", str(local),
+            "--content", "-",
+        ]
+        reply_target = reply_to or (metadata or {}).get("thread_id")
+        if reply_target:
+            args += ["--reply-to", str(reply_target)]
+        code, out, err = await self._run_cli(args, input_text=caption or "")
+        if code != 0:
+            return SendResult(
+                success=False,
+                error=_cli_error_message(err, code),
+                retryable=code == 2,
+            )
+        event_id, receipt_error = _parse_send_receipt(out)
+        if receipt_error:
+            return SendResult(success=False, error=receipt_error)
+        assert event_id is not None
+        self._mark_seen(str(chat_id), event_id)
+        return SendResult(success=True, message_id=event_id)
+
     async def send_image(
         self,
         chat_id: str,
@@ -675,32 +737,65 @@ class BuzzAdapter(BasePlatformAdapter):
         """Send an image: local files upload via --file, URLs go as a link."""
         local = Path(image_url).expanduser() if not image_url.startswith(("http://", "https://")) else None
         if local is not None and local.is_file():
-            args = [
-                "messages", "send",
-                "--channel", str(chat_id),
-                "--file", str(local),
-                "--content", "-",
-            ]
-            if reply_to:
-                args += ["--reply-to", str(reply_to)]
-            code, out, err = await self._run_cli(args, input_text=caption or "")
-            if code != 0:
-                return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
-            try:
-                data = json.loads(out or "{}")
-            except ValueError:
-                data = {}
-            event_id = data.get("event_id")
-            if event_id:
-                self._mark_seen(str(chat_id), str(event_id))
-            return SendResult(
-                success=bool(data.get("accepted", True)),
-                message_id=str(event_id) if event_id else None,
-                raw_response=data,
+            return await self._send_local_file(
+                chat_id, str(local), caption, reply_to, metadata
             )
         # Markdown renders in Buzz, so a URL arrives as a clickable image link.
         text = f"{caption}\n{image_url}" if caption else image_url
         return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_local_file(
+            chat_id, image_path, caption, reply_to, metadata
+        )
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_local_file(
+            chat_id, video_path, caption, reply_to, metadata
+        )
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_local_file(
+            chat_id, audio_path, caption, reply_to, metadata
+        )
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        return await self._send_local_file(
+            chat_id, file_path, caption, reply_to, metadata
+        )
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         chat_id = str(chat_id)
@@ -1398,14 +1493,14 @@ async def _standalone_send(
     except asyncio.CancelledError:
         raise
     except OSError as e:
-        return {"error": f"Buzz standalone send failed to launch CLI: {e}"}
+        detail = _bounded_cli_message(str(e))
+        return {"error": f"Buzz standalone send failed to launch CLI: {detail}"}
     if code != 0:
         return {"error": f"Buzz standalone send failed: {_cli_error_message(err, code)}"}
-    try:
-        data = json.loads(out or "{}")
-    except ValueError:
-        data = {}
-    result = {"success": True, "message_id": str(data.get("event_id") or "")}
+    event_id, receipt_error = _parse_send_receipt(out)
+    if receipt_error:
+        return {"error": f"Buzz standalone send failed: {receipt_error}"}
+    result = {"success": True, "message_id": event_id}
     if media_files:
         result["media_delivered"] = True
     return result

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -546,6 +546,38 @@ class TestBuzzAdapterSend:
         assert result.raw_response is None
 
     @pytest.mark.asyncio
+    async def test_live_media_redacts_long_path_before_bounding(self, tmp_path):
+        parent = tmp_path
+        private_parts = []
+        for index in range(6):
+            part = f"private-{index}-" + ("x" * 150)
+            private_parts.append(part)
+            parent = parent / part
+            parent.mkdir()
+        media = parent / "handoff.txt"
+        media.write_text("safe handoff", encoding="utf-8")
+        adapter = _make_adapter()
+        adapter._run_cli = AsyncMock(
+            return_value=(
+                2,
+                "",
+                json.dumps(
+                    {
+                        "error": "network",
+                        "message": f"upload failed for {media}: " + ("z" * 1_000),
+                    }
+                ),
+            )
+        )
+
+        result = await adapter.send_document(CHANNEL, str(media))
+
+        assert result.success is False
+        assert all(part not in result.error for part in private_parts)
+        assert "handoff.txt" in result.error
+        assert len(result.error) <= 900
+
+    @pytest.mark.asyncio
     async def test_send_to_platform_live_buzz_delivers_all_media(self, monkeypatch, tmp_path):
         from gateway.config import Platform
         from tools.send_message_tool import _send_to_platform

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+from types import SimpleNamespace
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
@@ -151,6 +152,18 @@ class TestCliErrorContract:
     def test_parses_json_error(self):
         msg = _cli_error_message('{"error":"relay_error","message":"boom","retryable":false}', 2)
         assert "relay_error" in msg and "boom" in msg and "exit 2" in msg
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "x" * 100_000,
+            json.dumps({"error": "relay_error", "message": "x" * 100_000}),
+        ],
+    )
+    def test_bounds_untrusted_cli_error_output(self, stderr):
+        msg = _cli_error_message(stderr, 2)
+        assert len(msg) <= 900
+        assert msg.endswith("...")
 
 
 # ── Seeding / high-water mark / de-dupe ───────────────────────────────────
@@ -407,6 +420,67 @@ class TestBuzzAdapterSend:
         # Our own event id is marked seen for echo suppression
         assert "evt123" in adapter._channel_state[CHANNEL]["seen"]
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("stdout", "error_fragment"),
+        [
+            ("not json", "invalid CLI response"),
+            (json.dumps([]), "invalid CLI response"),
+            (json.dumps({"event_id": "evt"}), "invalid CLI response"),
+            (json.dumps({"accepted": True}), "invalid CLI response"),
+            (json.dumps({"accepted": True, "event_id": "   "}), "invalid CLI response"),
+        ],
+    )
+    async def test_send_rejects_invalid_zero_exit_receipt(self, stdout, error_fragment):
+        adapter = _make_adapter()
+        adapter._run_cli = AsyncMock(return_value=(0, stdout, ""))
+
+        result = await adapter.send(CHANNEL, "hello")
+
+        assert result.success is False
+        assert error_fragment in result.error
+        assert result.message_id is None
+        assert result.raw_response is None
+
+    @pytest.mark.asyncio
+    async def test_send_rejection_is_useful_and_bounded(self):
+        adapter = _make_adapter()
+        adapter._run_cli = AsyncMock(
+            return_value=(
+                0,
+                json.dumps({"accepted": False, "message": "upload rejected " + "x" * 100_000}),
+                "",
+            )
+        )
+
+        result = await adapter.send(CHANNEL, "hello")
+
+        assert result.success is False
+        assert "upload rejected" in result.error
+        assert len(result.error) <= 1024
+        assert result.raw_response is None
+
+    @pytest.mark.asyncio
+    async def test_send_success_exposes_only_verified_receipt(self):
+        adapter = _make_adapter()
+        adapter._run_cli = AsyncMock(
+            return_value=(
+                0,
+                json.dumps({
+                    "accepted": True,
+                    "event_id": " evt-safe ",
+                    "message": "x" * 100_000,
+                    "raw_response": "y" * 100_000,
+                }),
+                "",
+            )
+        )
+
+        result = await adapter.send(CHANNEL, "hello")
+
+        assert result.success is True
+        assert result.message_id == "evt-safe"
+        assert result.raw_response is None
 
     @pytest.mark.asyncio
     async def test_send_image_local_file_uses_file_flag(self, tmp_path):
@@ -420,6 +494,100 @@ class TestBuzzAdapterSend:
         assert result.success is True
         args, _stdin = cli.calls[0]
         assert args[args.index("--file") + 1] == str(img)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "suffix"),
+        [
+            ("send_image_file", ".png"),
+            ("send_video", ".mp4"),
+            ("send_voice", ".ogg"),
+            ("send_document", ".pdf"),
+        ],
+    )
+    async def test_live_media_capabilities_upload_local_file_with_caption_and_reply(
+        self, tmp_path, method_name, suffix
+    ):
+        media = tmp_path / f"attachment{suffix}"
+        media.write_bytes(b"media")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-media"})
+        adapter._run_cli = cli
+
+        result = await getattr(adapter, method_name)(
+            CHANNEL,
+            str(media),
+            caption="caption",
+            reply_to="root-event",
+            metadata={"thread_id": "ignored-thread"},
+        )
+
+        assert result.success is True
+        assert result.message_id == "evt-media"
+        args, stdin_text = cli.calls[0]
+        assert args[args.index("--file") + 1] == str(media)
+        assert args[args.index("--reply-to") + 1] == "root-event"
+        assert stdin_text == "caption"
+
+    @pytest.mark.asyncio
+    async def test_live_media_rejects_zero_exit_without_verified_event_id(self, tmp_path):
+        media = tmp_path / "attachment.pdf"
+        media.write_bytes(b"media")
+        adapter = _make_adapter()
+        adapter._run_cli = AsyncMock(
+            return_value=(0, json.dumps({"accepted": True}), "")
+        )
+
+        result = await adapter.send_document(CHANNEL, str(media))
+
+        assert result.success is False
+        assert result.error == "invalid CLI response"
+        assert result.raw_response is None
+
+    @pytest.mark.asyncio
+    async def test_send_to_platform_live_buzz_delivers_all_media(self, monkeypatch, tmp_path):
+        from gateway.config import Platform
+        from tools.send_message_tool import _send_to_platform
+
+        first = tmp_path / "first.txt"
+        second = tmp_path / "second.pdf"
+        first.write_text("first", encoding="utf-8")
+        second.write_text("second", encoding="utf-8")
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-text"})
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-first"})
+        cli.script("messages", "send", {"accepted": True, "event_id": "evt-second"})
+        adapter._run_cli = cli
+        platform = Platform("buzz")
+        runner = SimpleNamespace(adapters={platform: adapter})
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+
+        result = await _send_to_platform(
+            platform,
+            SimpleNamespace(enabled=True, token=None, extra={}),
+            CHANNEL,
+            "attached files",
+            thread_id="root-event",
+            media_files=[(str(first), False), (str(second), False)],
+        )
+
+        assert result == {
+            "success": True,
+            "message_id": "evt-second",
+            "media_delivered": True,
+        }
+        assert len(cli.calls) == 3
+        assert cli.calls[0][1] == "attached files"
+        assert [call[0][call[0].index("--file") + 1] for call in cli.calls[1:]] == [
+            str(first),
+            str(second),
+        ]
+        assert all(
+            call[0][call[0].index("--reply-to") + 1] == "root-event"
+            for call in cli.calls
+        )
 
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────
@@ -571,4 +739,72 @@ class TestStandaloneSend:
         }
         file_index = captured["args"].index("--file")
         assert captured["args"][file_index + 1] == str(document)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "stdout",
+        [
+            "not json",
+            json.dumps([]),
+            json.dumps({"event_id": "evt"}),
+            json.dumps({"accepted": True}),
+            json.dumps({"accepted": True, "event_id": ""}),
+        ],
+    )
+    async def test_standalone_send_rejects_invalid_zero_exit_receipt(
+        self, monkeypatch, tmp_path, stdout
+    ):
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        monkeypatch.setattr(
+            _buzz_mod,
+            "_exec_buzz",
+            AsyncMock(return_value=(0, stdout, "")),
+        )
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}), CHANNEL, "hello"
+        )
+
+        assert result == {"error": "Buzz standalone send failed: invalid CLI response"}
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_rejection_is_useful_bounded_and_not_delivered(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+        monkeypatch.setattr(
+            _buzz_mod,
+            "_exec_buzz",
+            AsyncMock(
+                return_value=(
+                    0,
+                    json.dumps({"accepted": False, "message": "upload rejected " + "x" * 100_000}),
+                    "",
+                )
+            ),
+        )
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            CHANNEL,
+            "hello",
+            media_files=[("/tmp/report.txt", False)],
+        )
+
+        assert "upload rejected" in result["error"]
+        assert len(result["error"]) <= 1024
+        assert "success" not in result
+        assert "media_delivered" not in result
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -537,4 +537,38 @@ class TestStandaloneSend:
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
 
+    @pytest.mark.asyncio
+    async def test_standalone_send_extracts_path_from_media_descriptor(self, monkeypatch, tmp_path):
+        from gateway.config import PlatformConfig
+
+        fake_cli = tmp_path / "buzz"
+        fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+        document = tmp_path / "report.txt"
+        document.write_text("report", encoding="utf-8")
+        monkeypatch.setenv("BUZZ_RELAY_URL", "https://r")
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec1x")
+        monkeypatch.setenv("BUZZ_CLI_PATH", str(fake_cli))
+
+        captured = {}
+
+        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0):
+            captured["args"] = args
+            return 0, json.dumps({"accepted": True, "event_id": "evt-media"}), ""
+
+        monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
+
+        result = await _standalone_send(
+            PlatformConfig(enabled=True, extra={}),
+            CHANNEL,
+            "attached",
+            media_files=[(str(document), False)],
+        )
+
+        assert result == {
+            "success": True,
+            "message_id": "evt-media",
+            "media_delivered": True,
+        }
+        file_index = captured["args"].index("--file")
+        assert captured["args"][file_index + 1] == str(document)
 

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -23,29 +23,174 @@ def test_buzz_uuid_target_is_explicit() -> None:
     assert _parse_target_ref("buzz", channel_id) == (channel_id, None, True)
 
 
-def test_plugin_media_receipt_suppresses_omitted_warning() -> None:
-    media_result = {
-        "success": True,
-        "message_id": "evt-media",
-        "media_delivered": True,
-    }
+def test_live_buzz_media_delivers_every_file_with_reply_metadata(tmp_path) -> None:
+    from gateway.platforms.base import SendResult
 
-    with patch(
-        "tools.send_message_tool._send_via_adapter",
-        new=AsyncMock(return_value=media_result),
-    ):
+    platform = Platform("buzz")
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.pdf"
+    first.write_text("first", encoding="utf-8")
+    second.write_text("second", encoding="utf-8")
+    calls = []
+
+    class Adapter:
+        async def send(self, *, chat_id, content, metadata=None):
+            calls.append(("text", content, metadata))
+            return SendResult(success=True, message_id="evt-text")
+
+        async def send_document(self, chat_id, file_path, **kwargs):
+            calls.append(("document", file_path, kwargs))
+            return SendResult(success=True, message_id=f"evt-{len(calls)}")
+
+    runner = SimpleNamespace(adapters={platform: Adapter()})
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
         result = asyncio.run(
             _send_to_platform(
-                Platform("buzz"),
+                platform,
                 SimpleNamespace(enabled=True, token=None, extra={}),
                 "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
-                "attached",
-                media_files=[("/tmp/report.txt", False)],
+                "attached files",
+                thread_id="reply-root",
+                media_files=[(str(first), False), (str(second), False)],
             )
         )
 
-    assert result == media_result
-    assert "warnings" not in result
+    assert result["success"] is True
+    assert result["media_delivered"] is True
+    assert calls == [
+        ("text", "attached files", {"thread_id": "reply-root"}),
+        ("document", str(first), {"caption": None, "reply_to": "reply-root", "metadata": {"thread_id": "reply-root"}}),
+        ("document", str(second), {"caption": None, "reply_to": "reply-root", "metadata": {"thread_id": "reply-root"}}),
+    ]
+
+
+def test_live_buzz_single_image_uses_caption_without_duplicate_text(tmp_path) -> None:
+    from gateway.platforms.base import SendResult
+
+    platform = Platform("buzz")
+    image = tmp_path / "shot.png"
+    image.write_bytes(b"png")
+    calls = []
+
+    class Adapter:
+        async def send(self, **kwargs):
+            calls.append(("text", kwargs))
+            return SendResult(success=True, message_id="unexpected")
+
+        async def send_image_file(self, chat_id, image_path, **kwargs):
+            calls.append(("image", image_path, kwargs))
+            return SendResult(success=True, message_id="evt-image")
+
+    runner = SimpleNamespace(adapters={platform: Adapter()})
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
+        result = asyncio.run(
+            _send_to_platform(
+                platform,
+                SimpleNamespace(enabled=True, token=None, extra={}),
+                "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
+                "screenshot caption",
+                thread_id="reply-root",
+                media_files=[(str(image), False)],
+            )
+        )
+
+    assert result == {
+        "success": True,
+        "message_id": "evt-image",
+        "media_delivered": True,
+    }
+    assert calls == [
+        ("image", str(image), {"caption": "screenshot caption", "reply_to": "reply-root", "metadata": {"thread_id": "reply-root"}})
+    ]
+
+
+def test_live_buzz_media_failure_is_explicit_not_omitted(tmp_path) -> None:
+    from gateway.platforms.base import SendResult
+
+    platform = Platform("buzz")
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_text("first", encoding="utf-8")
+    second.write_text("second", encoding="utf-8")
+    media_calls = []
+
+    class Adapter:
+        async def send(self, **kwargs):
+            return SendResult(success=True, message_id="evt-text")
+
+        async def send_document(self, chat_id, file_path, **kwargs):
+            media_calls.append(file_path)
+            if file_path == str(second):
+                return SendResult(success=False, error="relay rejected upload")
+            return SendResult(success=True, message_id="evt-first")
+
+    runner = SimpleNamespace(adapters={platform: Adapter()})
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
+        result = asyncio.run(
+            _send_to_platform(
+                platform,
+                SimpleNamespace(enabled=True, token=None, extra={}),
+                "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
+                "attached files",
+                media_files=[(str(first), False), (str(second), False)],
+            )
+        )
+
+    assert media_calls == [str(first), str(second)]
+    assert "relay rejected upload" in result["error"]
+    assert "media_delivered" not in result
+
+
+def test_live_adapter_inherited_media_fallback_is_not_claimed_as_delivery(tmp_path) -> None:
+    from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+    platform = Platform("buzz")
+    document = tmp_path / "report.txt"
+    document.write_text("report", encoding="utf-8")
+
+    class Adapter:
+        name = "Fallback-only"
+        send_document = BasePlatformAdapter.send_document
+
+        async def send(self, **kwargs):
+            return SendResult(success=True, message_id="warning-text-only")
+
+    runner = SimpleNamespace(adapters={platform: Adapter()})
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
+        result = asyncio.run(
+            _send_to_platform(
+                platform,
+                SimpleNamespace(enabled=True, token=None, extra={}),
+                "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
+                "attached",
+                media_files=[(str(document), False)],
+            )
+        )
+
+    assert "does not implement native document delivery" in result["error"]
+    assert "media_delivered" not in result
+
+
+def test_live_buzz_adapter_exception_is_bounded() -> None:
+    platform = Platform("buzz")
+
+    class Adapter:
+        async def send(self, **kwargs):
+            raise RuntimeError("x" * 100_000)
+
+    runner = SimpleNamespace(adapters={platform: Adapter()})
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
+        result = asyncio.run(
+            _send_to_platform(
+                platform,
+                SimpleNamespace(enabled=True, token=None, extra={}),
+                "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
+                "hello",
+            )
+        )
+
+    assert result["error"].startswith("Plugin platform send failed: ")
+    assert len(result["error"]) <= 1024
 
 
 def test_send_message_routes_buzz_uuid_without_home_fallback() -> None:

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -10,11 +10,80 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from gateway.config import Platform
-from tools.send_message_tool import _parse_target_ref, send_message_tool
+from tools.send_message_tool import _parse_target_ref, _send_to_platform, send_message_tool
 
 
 def _run_async_immediately(coro):
     return asyncio.run(coro)
+
+
+def test_buzz_uuid_target_is_explicit() -> None:
+    channel_id = "31b543d5-80d4-4df5-8a5c-cefca1a58fdd"
+
+    assert _parse_target_ref("buzz", channel_id) == (channel_id, None, True)
+
+
+def test_plugin_media_receipt_suppresses_omitted_warning() -> None:
+    media_result = {
+        "success": True,
+        "message_id": "evt-media",
+        "media_delivered": True,
+    }
+
+    with patch(
+        "tools.send_message_tool._send_via_adapter",
+        new=AsyncMock(return_value=media_result),
+    ):
+        result = asyncio.run(
+            _send_to_platform(
+                Platform("buzz"),
+                SimpleNamespace(enabled=True, token=None, extra={}),
+                "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
+                "attached",
+                media_files=[("/tmp/report.txt", False)],
+            )
+        )
+
+    assert result == media_result
+    assert "warnings" not in result
+
+
+def test_send_message_routes_buzz_uuid_without_home_fallback() -> None:
+    buzz_platform = Platform("buzz")
+    buzz_cfg = SimpleNamespace(enabled=True, token=None, extra={})
+    config = SimpleNamespace(
+        platforms={buzz_platform: buzz_cfg},
+        get_home_channel=lambda _platform: SimpleNamespace(chat_id="home-channel"),
+    )
+    channel_id = "31b543d5-80d4-4df5-8a5c-cefca1a58fdd"
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("tools.interrupt.is_interrupted", return_value=False), \
+         patch("gateway.channel_directory.resolve_channel_name", side_effect=AssertionError("raw UUID should not resolve via directory")), \
+         patch("model_tools._run_async", side_effect=_run_async_immediately), \
+         patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+         patch("gateway.mirror.mirror_to_session", return_value=True):
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": f"buzz:{channel_id}",
+                    "message": "hello group",
+                }
+            )
+        )
+
+    assert result["success"] is True
+    assert "note" not in result
+    send_mock.assert_awaited_once_with(
+        buzz_platform,
+        buzz_cfg,
+        channel_id,
+        "hello group",
+        thread_id=None,
+        media_files=[],
+        force_document=False,
+    )
 
 
 def test_photon_e164_target_is_explicit() -> None:

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -141,6 +141,78 @@ def test_live_buzz_media_failure_is_explicit_not_omitted(tmp_path) -> None:
     assert "media_delivered" not in result
 
 
+def test_live_buzz_media_only_send_reaches_adapter(tmp_path) -> None:
+    from gateway.platforms.base import SendResult
+
+    platform = Platform("buzz")
+    document = tmp_path / "report.txt"
+    document.write_text("report", encoding="utf-8")
+    media_calls = []
+
+    class Adapter:
+        async def send(self, **kwargs):
+            raise AssertionError("media-only send must not emit an empty text message")
+
+        async def send_document(self, chat_id, file_path, **kwargs):
+            media_calls.append((chat_id, file_path, kwargs))
+            return SendResult(success=True, message_id="evt-document")
+
+    runner = SimpleNamespace(adapters={platform: Adapter()})
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
+        result = asyncio.run(
+            _send_to_platform(
+                platform,
+                SimpleNamespace(enabled=True, token=None, extra={}),
+                "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
+                "",
+                media_files=[(str(document), False)],
+            )
+        )
+
+    assert result == {
+        "success": True,
+        "message_id": "evt-document",
+        "media_delivered": True,
+    }
+    assert len(media_calls) == 1
+    assert media_calls[0][1] == str(document)
+
+
+def test_live_buzz_media_exception_reports_partial_delivery(tmp_path) -> None:
+    from gateway.platforms.base import SendResult
+
+    platform = Platform("buzz")
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_text("first", encoding="utf-8")
+    second.write_text("second", encoding="utf-8")
+
+    class Adapter:
+        async def send(self, **kwargs):
+            return SendResult(success=True, message_id="evt-text")
+
+        async def send_document(self, chat_id, file_path, **kwargs):
+            if file_path == str(second):
+                raise RuntimeError("relay transport failed")
+            return SendResult(success=True, message_id="evt-first")
+
+    runner = SimpleNamespace(adapters={platform: Adapter()})
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
+        result = asyncio.run(
+            _send_to_platform(
+                platform,
+                SimpleNamespace(enabled=True, token=None, extra={}),
+                "31b543d5-80d4-4df5-8a5c-cefca1a58fdd",
+                "attached files",
+                media_files=[(str(first), False), (str(second), False)],
+            )
+        )
+
+    assert "after 1/2 files" in result["error"]
+    assert "relay transport failed" in result["error"]
+    assert "media_delivered" not in result
+
+
 def test_live_adapter_inherited_media_fallback_is_not_claimed_as_delivery(tmp_path) -> None:
     from gateway.platforms.base import BasePlatformAdapter, SendResult
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -769,7 +769,17 @@ async def _send_live_adapter_media(
                     f"media file {index + 1}/{total} was not sent"
                 )
             }
-        last_result = await getattr(adapter, method_name)(chat_id, media_path, **kwargs)
+        try:
+            last_result = await getattr(adapter, method_name)(chat_id, media_path, **kwargs)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return {
+                "error": (
+                    f"Adapter media send failed after {index}/{total} files: "
+                    f"{_bounded_send_error(exc)}"
+                )
+            }
         if not last_result.success:
             detail = _bounded_send_error(last_result.error or "media send failed")
             return {
@@ -1216,7 +1226,9 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         return last_result
 
     # --- Non-media platforms ---
-    if media_files and not message.strip():
+    # Buzz is a plugin platform with verified native media delivery through
+    # _send_via_adapter below, including valid media-only sends.
+    if media_files and not message.strip() and platform.value != "buzz":
         return {
             "error": (
                 f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack; "
@@ -1224,7 +1236,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             )
         }
     warning = None
-    if media_files:
+    if media_files and platform.value != "buzz":
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
             "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -695,6 +695,96 @@ def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id:
     }
 
 
+def _bounded_send_error(detail, max_chars=900):
+    """Bound untrusted adapter/plugin error detail returned by send_message."""
+    text = str(detail or "send failed")
+    if len(text) <= max_chars:
+        return text
+    return f"{text[: max_chars - 3]}..."
+
+
+async def _send_live_adapter_media(
+    adapter,
+    chat_id,
+    message,
+    media_files,
+    *,
+    thread_id=None,
+    metadata=None,
+    force_document=False,
+):
+    """Deliver text and every media descriptor through adapter media APIs."""
+    caption, separate_text = _media_caption_split(
+        message, media_files, max_caption_len=_DEFAULT_CAPTION_LIMIT
+    )
+    last_result = None
+    if separate_text and separate_text.strip():
+        last_result = await adapter.send(
+            chat_id=chat_id, content=separate_text, metadata=metadata
+        )
+        if not last_result.success:
+            return {"error": f"Adapter send failed: {_bounded_send_error(last_result.error)}"}
+
+    total = len(media_files)
+    for index, descriptor in enumerate(media_files):
+        if not isinstance(descriptor, (list, tuple)) or not descriptor:
+            return {"error": f"Adapter media send failed: invalid media descriptor {index + 1}/{total}"}
+        media_path = descriptor[0]
+        is_voice = bool(descriptor[1]) if len(descriptor) > 1 else False
+        if not isinstance(media_path, str) or not media_path:
+            return {"error": f"Adapter media send failed: invalid media descriptor {index + 1}/{total}"}
+        if not os.path.exists(media_path):
+            return {"error": f"Adapter media send failed: media file {index + 1}/{total} was not found"}
+
+        ext = os.path.splitext(media_path)[1].lower()
+        kwargs = {
+            "caption": caption if index == 0 else None,
+            "reply_to": thread_id,
+            "metadata": metadata,
+        }
+        if force_document:
+            method_name = "send_document"
+            media_kind = "document"
+        elif ext in _IMAGE_EXTS:
+            method_name = "send_image_file"
+            media_kind = "image"
+        elif ext in _VIDEO_EXTS:
+            method_name = "send_video"
+            media_kind = "video"
+        elif is_voice or ext in _AUDIO_EXTS:
+            method_name = "send_voice"
+            media_kind = "audio"
+        else:
+            method_name = "send_document"
+            media_kind = "document"
+
+        from gateway.platforms.base import BasePlatformAdapter
+
+        adapter_method = getattr(type(adapter), method_name, None)
+        base_fallback = getattr(BasePlatformAdapter, method_name)
+        if adapter_method is None or adapter_method is base_fallback:
+            return {
+                "error": (
+                    f"Live adapter does not implement native {media_kind} delivery; "
+                    f"media file {index + 1}/{total} was not sent"
+                )
+            }
+        last_result = await getattr(adapter, method_name)(chat_id, media_path, **kwargs)
+        if not last_result.success:
+            detail = _bounded_send_error(last_result.error or "media send failed")
+            return {
+                "error": f"Adapter media send failed after {index}/{total} files: {detail}"
+            }
+
+    if last_result is None:
+        return {"error": "No deliverable text or media remained after processing MEDIA tags"}
+    return {
+        "success": True,
+        "message_id": last_result.message_id,
+        "media_delivered": True,
+    }
+
+
 async def _send_via_adapter(
     platform,
     pconfig,
@@ -738,14 +828,24 @@ async def _send_via_adapter(
                     metadata["publish_topic"] = chat_id
                 if not metadata:
                     metadata = None
+                if media_files:
+                    return await _send_live_adapter_media(
+                        adapter,
+                        chat_id,
+                        chunk,
+                        media_files,
+                        thread_id=thread_id,
+                        metadata=metadata,
+                        force_document=force_document,
+                    )
                 result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
             except asyncio.CancelledError:
                 raise
             except Exception as e:
-                return {"error": f"Plugin platform send failed: {e}"}
+                return {"error": f"Plugin platform send failed: {_bounded_send_error(e)}"}
             if result.success:
                 return {"success": True, "message_id": result.message_id}
-            return {"error": f"Adapter send failed: {result.error}"}
+            return {"error": f"Adapter send failed: {_bounded_send_error(result.error)}"}
 
     entry = None
     try:
@@ -768,9 +868,11 @@ async def _send_via_adapter(
             raise
         except Exception as e:
             logger.debug("Plugin standalone send for %s raised", platform_name, exc_info=True)
-            return {"error": f"Plugin standalone send failed: {e}"}
+            return {"error": f"Plugin standalone send failed: {_bounded_send_error(e)}"}
 
         if isinstance(result, dict) and (result.get("success") or result.get("error")):
+            if result.get("error"):
+                return {**result, "error": _bounded_send_error(result["error"])}
             return result
         return {
             "error": (
@@ -1129,7 +1231,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         )
 
     last_result = None
-    for chunk in chunks:
+    for i, chunk in enumerate(chunks):
         if platform == Platform.WHATSAPP:
             result = await _registry_standalone_send("whatsapp", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.SIGNAL:
@@ -1159,7 +1261,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 chat_id,
                 chunk,
                 thread_id=thread_id,
-                media_files=media_files,
+                media_files=media_files if i == len(chunks) - 1 else [],
                 force_document=force_document,
             )
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -52,6 +52,12 @@ _WHATSAPP_JID_RE = re.compile(
     r"^\s*[\w-]+@(?:g\.us|s\.whatsapp\.net|lid|broadcast|newsletter)\s*$",
     re.IGNORECASE,
 )
+# Buzz channel IDs are UUIDs. Treat exact UUIDs as native targets rather than
+# trying directory-name resolution and then falling back to the home channel.
+_BUZZ_CHANNEL_RE = re.compile(
+    r"^\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\s*$",
+    re.IGNORECASE,
+)
 # Email addresses — a valid email like "user@domain.com" should be treated as
 # an explicit target for the email platform, not fall through to channel-name
 # resolution which has no way to resolve a raw address.
@@ -591,6 +597,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         # through to the _PHONE_PLATFORMS handler below.
         if _WHATSAPP_JID_RE.fullmatch(target_ref):
             return target_ref.strip(), None, True
+    if platform_name == "buzz":
+        match = _BUZZ_CHANNEL_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
     stripped_target = target_ref.strip()
     if platform_name == "signal" and stripped_target.startswith("group:"):
         group_id = stripped_target[len("group:"):].strip()
@@ -1157,7 +1167,12 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             return result
         last_result = result
 
-    if warning and isinstance(last_result, dict) and last_result.get("success"):
+    if (
+        warning
+        and isinstance(last_result, dict)
+        and last_result.get("success")
+        and not last_result.get("media_delivered")
+    ):
         warnings = list(last_result.get("warnings", []))
         warnings.append(warning)
         last_result["warnings"] = warnings


### PR DESCRIPTION
## Summary

Fix standalone Buzz sends that include `MEDIA:` attachments and target a native Buzz channel UUID.

Hermes passes standalone sender media entries as `(path, is_voice)` descriptors. The Buzz plugin previously stringified the entire descriptor, producing an invalid `--file` argument. Raw Buzz UUID targets also fell through friendly-name resolution and could silently use the configured home channel. Finally, successful native uploads still received a generic warning claiming the attachment was omitted.

## Changes

- extract the file path from Hermes media descriptors while preserving plain-path compatibility
- return `media_delivered: true` after a successful Buzz media upload
- suppress the generic omitted-media warning only when a plugin explicitly confirms delivery
- recognize canonical Buzz UUIDs as explicit native targets
- add parser, routing, delivery-receipt, and CLI-argument regressions

## Behavior and compatibility

- plain string/path media callers continue to work
- friendly Buzz channel names continue through the existing directory-resolution path
- plugins that do not return `media_delivered` retain the existing omitted-media warning
- only canonical UUID-shaped Buzz targets bypass directory and home-channel resolution

## Validation

- `python -m pytest tests/gateway/test_buzz_adapter.py tests/tools/test_send_message_target_parse.py tests/tools/test_send_message_tool.py -q --tb=short` — 77 passed
- `ruff check plugins/platforms/buzz/adapter.py tools/send_message_tool.py tests/gateway/test_buzz_adapter.py tests/tools/test_send_message_target_parse.py`
- `python -m py_compile plugins/platforms/buzz/adapter.py tools/send_message_tool.py`
- `git diff --check`

An independent read-only review passed against frozen patch SHA-256 `8282b09e4e286de5411b68056b96bec641d1b42090f3799eaa239a90b38c87c7`.

This PR is intentionally separate from native inbound attachment handling and the outbound document implementation in #77118.
