### PR TITLE
feat(tui): pending steers in the queue strip (editable, tagged, first)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3390,6 +3390,25 @@ class AIAgent:
                 self._pending_steer = cleaned
         return True
 
+    def clear_pending_steer(self) -> bool:
+        """Drop any queued /steer text before it is injected.
+
+        Returns True if there was a pending steer to drop, False otherwise.
+        Thread-safe like steer(): the gateway/TUI calls this when the user
+        deletes the pending-steer row from the queue strip, so the text is
+        not injected on the next tool result behind their back.
+        """
+        _lock = getattr(self, "_pending_steer_lock", None)
+        if _lock is None:
+            # Test stubs that built AIAgent via object.__new__ skip __init__.
+            had = getattr(self, "_pending_steer", None) is not None
+            self._pending_steer = None
+            return had
+        with _lock:
+            had = self._pending_steer is not None
+            self._pending_steer = None
+            return had
+
     def redirect(self, text: str) -> bool:
         """Redirect the active turn without converting it into a new task.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3254,6 +3254,25 @@ class AIAgent:
                 self._pending_steer = cleaned
         return True
 
+    def clear_pending_steer(self) -> bool:
+        """Drop any queued /steer text before it is injected.
+
+        Returns True if there was a pending steer to drop, False otherwise.
+        Thread-safe like steer(): the gateway/TUI calls this when the user
+        deletes the pending-steer row from the queue strip, so the text is
+        not injected on the next tool result behind their back.
+        """
+        _lock = getattr(self, "_pending_steer_lock", None)
+        if _lock is None:
+            # Test stubs that built AIAgent via object.__new__ skip __init__.
+            had = getattr(self, "_pending_steer", None) is not None
+            self._pending_steer = None
+            return had
+        with _lock:
+            had = self._pending_steer is not None
+            self._pending_steer = None
+            return had
+
     def redirect(self, text: str) -> bool:
         """Redirect the active turn without converting it into a new task.
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9840,7 +9840,7 @@ def test_rollback_restore_skips_legacy_compaction_handoff(monkeypatch):
 
 def test_session_steer_calls_agent_steer_when_agent_supports_it():
     """The TUI RPC method must call agent.steer(text) and return a
-    queued status without touching interrupt state.
+    steered status without touching interrupt state.
     """
     calls = {}
 
@@ -9865,7 +9865,7 @@ def test_session_steer_calls_agent_steer_when_agent_supports_it():
         server._sessions.pop("sid", None)
 
     assert "result" in resp, resp
-    assert resp["result"]["status"] == "queued"
+    assert resp["result"]["status"] == "steered"
     assert resp["result"]["text"] == "also check auth.log"
     assert calls["steer_text"] == "also check auth.log"
     assert "interrupt_called" not in calls  # must NOT interrupt
@@ -9905,6 +9905,83 @@ def test_session_steer_errors_when_agent_has_no_steer_method():
 
     assert "error" in resp, resp
     assert resp["error"]["code"] == 4010
+
+
+def test_session_steer_rejected_when_agent_refuses():
+    """When the agent refuses the steer, the RPC must report 'rejected' so the
+    client falls back to the queue instead of showing a phantom pending steer.
+    """
+    server._sessions["sid"] = _session(agent=types.SimpleNamespace(steer=lambda t: False))
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.steer",
+                "params": {"session_id": "sid", "text": "nope"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert "result" in resp, resp
+    assert resp["result"]["status"] == "rejected"
+    assert resp["result"]["text"] == "nope"
+
+
+def test_session_steer_clear_drops_pending_steer():
+    """session.steer_clear must drop the agent's stashed pending steer and
+    report whether there was anything to drop."""
+    lock = threading.Lock()
+    agent = types.SimpleNamespace(_pending_steer="inject me", _pending_steer_lock=lock)
+    server._sessions["sid"] = _session(agent=agent)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.steer_clear",
+                "params": {"session_id": "sid"},
+            }
+        )
+        assert resp["result"]["status"] == "cleared"
+        assert resp["result"]["cleared"] is True
+        assert agent._pending_steer is None
+
+        resp = server.handle_request(
+            {
+                "id": "2",
+                "method": "session.steer_clear",
+                "params": {"session_id": "sid"},
+            }
+        )
+        assert resp["result"]["status"] == "noop"
+        assert resp["result"]["cleared"] is False
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_session_pending_snapshots_steer_and_queue():
+    """session.pending must expose the pending steer plus every queued prompt
+    so a reconnect can rebuild the TUI pending strip."""
+    agent = types.SimpleNamespace(_pending_steer="wait, use SQLite")
+    server._sessions["sid"] = _session(
+        agent=agent,
+        queued_prompt={"text": "first queued", "transport": object()},
+        queued_prompts=[{"text": "second queued", "transport": object()}],
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.pending",
+                "params": {"session_id": "sid"},
+            }
+        )
+        assert resp["result"] == {
+            "steer": "wait, use SQLite",
+            "queue": ["first queued", "second queued"],
+        }
+    finally:
+        server._sessions.pop("sid", None)
 
 
 def test_session_redirect_calls_capable_core_agent(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -8530,7 +8530,7 @@ def test_rollback_restore_truncates_from_real_user_turn_not_marker(monkeypatch):
 
 def test_session_steer_calls_agent_steer_when_agent_supports_it():
     """The TUI RPC method must call agent.steer(text) and return a
-    queued status without touching interrupt state.
+    steered status without touching interrupt state.
     """
     calls = {}
 
@@ -8555,7 +8555,7 @@ def test_session_steer_calls_agent_steer_when_agent_supports_it():
         server._sessions.pop("sid", None)
 
     assert "result" in resp, resp
-    assert resp["result"]["status"] == "queued"
+    assert resp["result"]["status"] == "steered"
     assert resp["result"]["text"] == "also check auth.log"
     assert calls["steer_text"] == "also check auth.log"
     assert "interrupt_called" not in calls  # must NOT interrupt
@@ -8595,6 +8595,83 @@ def test_session_steer_errors_when_agent_has_no_steer_method():
 
     assert "error" in resp, resp
     assert resp["error"]["code"] == 4010
+
+
+def test_session_steer_rejected_when_agent_refuses():
+    """When the agent refuses the steer, the RPC must report 'rejected' so the
+    client falls back to the queue instead of showing a phantom pending steer.
+    """
+    server._sessions["sid"] = _session(agent=types.SimpleNamespace(steer=lambda t: False))
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.steer",
+                "params": {"session_id": "sid", "text": "nope"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert "result" in resp, resp
+    assert resp["result"]["status"] == "rejected"
+    assert resp["result"]["text"] == "nope"
+
+
+def test_session_steer_clear_drops_pending_steer():
+    """session.steer_clear must drop the agent's stashed pending steer and
+    report whether there was anything to drop."""
+    lock = threading.Lock()
+    agent = types.SimpleNamespace(_pending_steer="inject me", _pending_steer_lock=lock)
+    server._sessions["sid"] = _session(agent=agent)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.steer_clear",
+                "params": {"session_id": "sid"},
+            }
+        )
+        assert resp["result"]["status"] == "cleared"
+        assert resp["result"]["cleared"] is True
+        assert agent._pending_steer is None
+
+        resp = server.handle_request(
+            {
+                "id": "2",
+                "method": "session.steer_clear",
+                "params": {"session_id": "sid"},
+            }
+        )
+        assert resp["result"]["status"] == "noop"
+        assert resp["result"]["cleared"] is False
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_session_pending_snapshots_steer_and_queue():
+    """session.pending must expose the pending steer plus every queued prompt
+    so a reconnect can rebuild the TUI pending strip."""
+    agent = types.SimpleNamespace(_pending_steer="wait, use SQLite")
+    server._sessions["sid"] = _session(
+        agent=agent,
+        queued_prompt={"text": "first queued", "transport": object()},
+        queued_prompts=[{"text": "second queued", "transport": object()}],
+    )
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "session.pending",
+                "params": {"session_id": "sid"},
+            }
+        )
+        assert resp["result"] == {
+            "steer": "wait, use SQLite",
+            "queue": ["first queued", "second queued"],
+        }
+    finally:
+        server._sessions.pop("sid", None)
 
 
 def test_session_redirect_calls_capable_core_agent(monkeypatch):

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3328,7 +3328,71 @@ def _(rid, params: dict) -> dict:
             # settle (same class as redirect).
             _drop_queued_duplicates_of_inflight_user(session)
             session["last_active"] = time.time()
-    return _ok(rid, {"status": "queued" if accepted else "rejected", "text": text})
+    return _ok(rid, {"status": "steered" if accepted else "rejected", "text": text})
+
+
+@method("session.steer_clear")
+def _(rid, params: dict) -> dict:
+    """Drop any pending /steer text that has not been injected yet.
+
+    The TUI shows a pending steer as the top row of its queue strip; when the
+    user deletes that row (Ctrl+X) it calls this so the agent's stashed slot is
+    cleared too — otherwise the text would still be injected on the next tool
+    result. ``cleared`` is True when there was a pending steer to drop.
+    """
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    agent = session.get("agent")
+    if agent is None:
+        return _err(rid, 4010, "no active agent")
+    clearer = getattr(agent, "clear_pending_steer", None)
+    if callable(clearer):
+        try:
+            cleared = bool(clearer())
+        except Exception as exc:
+            return _err(rid, 5000, f"steer clear failed: {exc}")
+        return _ok(rid, {"status": "cleared" if cleared else "noop", "cleared": cleared})
+    # Older runtimes / test stubs without the method: clear the internal slot
+    # directly under its lock when present.
+    _steer_lock = getattr(agent, "_pending_steer_lock", None)
+    try:
+        if _steer_lock is not None:
+            with _steer_lock:
+                had = getattr(agent, "_pending_steer", None) is not None
+                agent._pending_steer = None
+        else:
+            had = getattr(agent, "_pending_steer", None) is not None
+            setattr(agent, "_pending_steer", None)
+    except Exception as exc:
+        return _err(rid, 5000, f"steer clear failed: {exc}")
+    return _ok(rid, {"status": "cleared" if had else "noop", "cleared": bool(had)})
+
+
+@method("session.pending")
+def _(rid, params: dict) -> dict:
+    """Snapshot of what will run on the next turn: the pending steer (if any)
+    plus the queued prompts. The TUI renders this as the pending strip, and a
+    reconnect can rebuild it from here so a pending steer is never invisible
+    after a resume."""
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    agent = session.get("agent")
+    steer: str | None = None
+    if agent is not None:
+        pending = getattr(agent, "_pending_steer", None)
+        if isinstance(pending, str) and pending:
+            steer = pending
+    queue: list[str] = []
+    queued = session.get("queued_prompt")
+    if queued and isinstance(queued.get("text"), str):
+        queue.append(queued["text"])
+    for extra in session.get("queued_prompts", []) or []:
+        text = extra.get("text") if isinstance(extra, dict) else None
+        if isinstance(text, str):
+            queue.append(text)
+    return _ok(rid, {"steer": steer, "queue": queue})
 
 
 @method("session.redirect")

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3008,7 +3008,71 @@ def _(rid, params: dict) -> dict:
         with session["history_lock"]:
             _record_inflight_correction(session, text)
             session["last_active"] = time.time()
-    return _ok(rid, {"status": "queued" if accepted else "rejected", "text": text})
+    return _ok(rid, {"status": "steered" if accepted else "rejected", "text": text})
+
+
+@method("session.steer_clear")
+def _(rid, params: dict) -> dict:
+    """Drop any pending /steer text that has not been injected yet.
+
+    The TUI shows a pending steer as the top row of its queue strip; when the
+    user deletes that row (Ctrl+X) it calls this so the agent's stashed slot is
+    cleared too — otherwise the text would still be injected on the next tool
+    result. ``cleared`` is True when there was a pending steer to drop.
+    """
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    agent = session.get("agent")
+    if agent is None:
+        return _err(rid, 4010, "no active agent")
+    clearer = getattr(agent, "clear_pending_steer", None)
+    if callable(clearer):
+        try:
+            cleared = bool(clearer())
+        except Exception as exc:
+            return _err(rid, 5000, f"steer clear failed: {exc}")
+        return _ok(rid, {"status": "cleared" if cleared else "noop", "cleared": cleared})
+    # Older runtimes / test stubs without the method: clear the internal slot
+    # directly under its lock when present.
+    _steer_lock = getattr(agent, "_pending_steer_lock", None)
+    try:
+        if _steer_lock is not None:
+            with _steer_lock:
+                had = getattr(agent, "_pending_steer", None) is not None
+                agent._pending_steer = None
+        else:
+            had = getattr(agent, "_pending_steer", None) is not None
+            setattr(agent, "_pending_steer", None)
+    except Exception as exc:
+        return _err(rid, 5000, f"steer clear failed: {exc}")
+    return _ok(rid, {"status": "cleared" if had else "noop", "cleared": bool(had)})
+
+
+@method("session.pending")
+def _(rid, params: dict) -> dict:
+    """Snapshot of what will run on the next turn: the pending steer (if any)
+    plus the queued prompts. The TUI renders this as the pending strip, and a
+    reconnect can rebuild it from here so a pending steer is never invisible
+    after a resume."""
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    agent = session.get("agent")
+    steer: str | None = None
+    if agent is not None:
+        pending = getattr(agent, "_pending_steer", None)
+        if isinstance(pending, str) and pending:
+            steer = pending
+    queue: list[str] = []
+    queued = session.get("queued_prompt")
+    if queued and isinstance(queued.get("text"), str):
+        queue.append(queued["text"])
+    for extra in session.get("queued_prompts", []) or []:
+        text = extra.get("text") if isinstance(extra, dict) else None
+        if isinstance(text, str):
+            queue.append(text)
+    return _ok(rid, {"steer": steer, "queue": queue})
 
 
 @method("session.redirect")

--- a/ui-tui/src/__tests__/pendingMessages.test.tsx
+++ b/ui-tui/src/__tests__/pendingMessages.test.tsx
@@ -1,0 +1,141 @@
+import { PassThrough } from 'stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { Theme } from '../theme.js'
+import { QueuedMessages, STEER_BRAILLE } from '../components/queuedMessages.js'
+import { DEFAULT_THEME } from '../theme.js'
+import { stripAnsi } from '../lib/text.js'
+
+const mounted: Array<() => void> = []
+
+const mountTree = (tree: React.ReactElement) => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+
+  let output = ''
+
+  Object.assign(stdout, { columns: 120, isTTY: false, rows: 20 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(tree, {
+    patchConsole: false,
+    stderr: stderr as NodeJS.WriteStream,
+    stdin: stdin as NodeJS.ReadStream,
+    stdout: stdout as NodeJS.WriteStream
+  })
+
+  mounted.push(() => {
+    instance.unmount()
+    instance.cleanup()
+  })
+
+  // @hermes/ink flushes the rendered frame to the stream at unmount/cleanup,
+  // so read the settled frame now (same pattern as the other renderSync tests).
+  for (const dispose of mounted.splice(0)) {
+    dispose()
+  }
+
+  return {
+    read: () => stripAnsi(output),
+    clear: () => {
+      output = ''
+    }
+  }
+}
+
+const t: Theme = DEFAULT_THEME
+
+beforeEach(() => {
+  // no per-test store state needed; QueuedMessages is a pure leaf
+})
+
+afterEach(() => {
+  while (mounted.length) {
+    mounted.pop()?.()
+  }
+})
+
+describe('QueuedMessages pending strip', () => {
+  it('renders a pending steer as row 1 with the steer tag and braille marker, above queue rows', () => {
+    const view = mountTree(
+      <QueuedMessages
+        cols={100}
+        pendingSteer="fix the path mapping before restarting"
+        queueEditIdx={null}
+        queued={['after that, run verify-paths.sh', 'then commit']}
+        t={t}
+      />
+    )
+
+    const text = view.read()
+
+    // Header counts steer + queue together.
+    expect(text).toContain('pending (3)')
+
+    // Steer row is row 1, tagged, with a braille spinner.
+    expect(text).toContain('1. ⠋ [steer] fix the path mapping before restarting')
+
+    // Queue rows render below with their shifted indices.
+    expect(text).toContain('2. after that, run verify-paths.sh')
+    expect(text).toContain('3. then commit')
+
+    // Row order: steer text appears before the first queue row.
+    expect(text.indexOf('fix the path mapping')).toBeLessThan(text.indexOf('run verify-paths.sh'))
+  })
+
+  it('keeps the legacy "queued (N)" header and plain rows when no steer is pending', () => {
+    const view = mountTree(
+      <QueuedMessages cols={100} queueEditIdx={null} queued={['plain follow-up']} t={t} />
+    )
+
+    const text = view.read()
+
+    expect(text).toContain('queued (1)')
+    expect(text).toContain('1. plain follow-up')
+    expect(text).not.toContain('[steer]')
+    expect(text).not.toContain(STEER_BRAILLE)
+  })
+
+  it('renders nothing when both steer and queue are empty', () => {
+    const view = mountTree(<QueuedMessages cols={100} queueEditIdx={null} queued={[]} t={t} />)
+
+    expect(view.read().trim()).toBe('')
+  })
+
+  it('shows the editing hint on the steer row when steerEditIdx is active', () => {
+    const view = mountTree(
+      <QueuedMessages
+        cols={100}
+        pendingSteer="edit me"
+        queueEditIdx={null}
+        queued={['queue item']}
+        steerEditIdx={0}
+        t={t}
+      />
+    )
+
+    const text = view.read()
+
+    expect(text).toContain('editing 1')
+    expect(text).toContain('Ctrl+X delete · Esc cancel')
+    // Active steer row gets the ▸ cursor.
+    expect(text).toContain('▸ 1.')
+  })
+
+  it('advertises edit affordances in the header when a steer is pending', () => {
+    const view = mountTree(
+      <QueuedMessages cols={100} pendingSteer="pending steer" queueEditIdx={null} queued={[]} t={t} />
+    )
+
+    expect(view.read()).toContain('↑↓ edit')
+  })
+})

--- a/ui-tui/src/__tests__/pendingMessages.test.tsx
+++ b/ui-tui/src/__tests__/pendingMessages.test.tsx
@@ -1,0 +1,135 @@
+import { PassThrough } from 'stream'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { Theme } from '../theme.js'
+import { QueuedMessages, STEER_BRAILLE } from '../components/queuedMessages.js'
+import { DEFAULT_THEME } from '../theme.js'
+import { stripAnsi } from '../lib/text.js'
+
+const mounted: Array<() => void> = []
+
+const mountTree = (tree: React.ReactElement) => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+
+  let output = ''
+
+  Object.assign(stdout, { columns: 120, isTTY: false, rows: 20 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(tree, {
+    patchConsole: false,
+    stderr: stderr as NodeJS.WriteStream,
+    stdin: stdin as NodeJS.ReadStream,
+    stdout: stdout as NodeJS.WriteStream
+  })
+
+  mounted.push(() => {
+    instance.unmount()
+    instance.cleanup()
+  })
+
+  return {
+    read: () => stripAnsi(output),
+    clear: () => {
+      output = ''
+    }
+  }
+}
+
+const t: Theme = DEFAULT_THEME
+
+beforeEach(() => {
+  // no per-test store state needed; QueuedMessages is a pure leaf
+})
+
+afterEach(() => {
+  while (mounted.length) {
+    mounted.pop()?.()
+  }
+})
+
+describe('QueuedMessages pending strip', () => {
+  it('renders a pending steer as row 1 with the steer tag and braille marker, above queue rows', () => {
+    const view = mountTree(
+      <QueuedMessages
+        cols={100}
+        pendingSteer="fix the path mapping before restarting"
+        queueEditIdx={null}
+        queued={['after that, run verify-paths.sh', 'then commit']}
+        t={t}
+      />
+    )
+
+    const text = view.read()
+
+    // Header counts steer + queue together.
+    expect(text).toContain('pending (3)')
+
+    // Steer row is row 1, tagged, with a braille spinner.
+    expect(text).toContain('1. ⠋ [steer] fix the path mapping before restarting')
+
+    // Queue rows render below with their shifted indices.
+    expect(text).toContain('2. after that, run verify-paths.sh')
+    expect(text).toContain('3. then commit')
+
+    // Row order: steer text appears before the first queue row.
+    expect(text.indexOf('fix the path mapping')).toBeLessThan(text.indexOf('run verify-paths.sh'))
+  })
+
+  it('keeps the legacy "queued (N)" header and plain rows when no steer is pending', () => {
+    const view = mountTree(
+      <QueuedMessages cols={100} queueEditIdx={null} queued={['plain follow-up']} t={t} />
+    )
+
+    const text = view.read()
+
+    expect(text).toContain('queued (1)')
+    expect(text).toContain('1. plain follow-up')
+    expect(text).not.toContain('[steer]')
+    expect(text).not.toContain(STEER_BRAILLE)
+  })
+
+  it('renders nothing when both steer and queue are empty', () => {
+    const view = mountTree(<QueuedMessages cols={100} queueEditIdx={null} queued={[]} t={t} />)
+
+    expect(view.read().trim()).toBe('')
+  })
+
+  it('shows the editing hint on the steer row when steerEditIdx is active', () => {
+    const view = mountTree(
+      <QueuedMessages
+        cols={100}
+        pendingSteer="edit me"
+        queueEditIdx={null}
+        queued={['queue item']}
+        steerEditIdx={0}
+        t={t}
+      />
+    )
+
+    const text = view.read()
+
+    expect(text).toContain('editing 1')
+    expect(text).toContain('Ctrl+X delete · Esc cancel')
+    // Active steer row gets the ▸ cursor.
+    expect(text).toContain('▸ 1.')
+  })
+
+  it('advertises edit affordances in the header when a steer is pending', () => {
+    const view = mountTree(
+      <QueuedMessages cols={100} pendingSteer="pending steer" queueEditIdx={null} queued={[]} t={t} />
+    )
+
+    expect(view.read()).toContain('↑↓ edit')
+  })
+})

--- a/ui-tui/src/__tests__/useSubmission.test.ts
+++ b/ui-tui/src/__tests__/useSubmission.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { ComposerToken } from '../app/interfaces.js'
-import { prepareSubmission, shouldInterpolateSubmission } from '../app/useSubmission.js'
+import { isSteerAccepted, prepareSubmission, shouldInterpolateSubmission } from '../app/useSubmission.js'
 
 describe('prepareSubmission', () => {
   it('keeps the collapsed paste for display and expands the model payload', () => {
@@ -60,5 +60,24 @@ describe('visible interpolation combined with a collapsed paste', () => {
 
     const preInterpolation = `show {!date} for ${label}`
     expect(prepareSubmission(preInterpolation, tokens).display).toContain('{!')
+  })
+})
+
+describe('isSteerAccepted (status contract)', () => {
+  it('accepts steered — the unified success status from both gateway steer paths', () => {
+    expect(isSteerAccepted({ status: 'steered' })).toBe(true)
+  })
+
+  it('accepts the legacy queued status', () => {
+    expect(isSteerAccepted({ status: 'queued' })).toBe(true)
+  })
+
+  it('rejects rejected — the only explicit failure status', () => {
+    expect(isSteerAccepted({ status: 'rejected' })).toBe(false)
+  })
+
+  it('rejects missing or errored responses', () => {
+    expect(isSteerAccepted(null)).toBe(false)
+    expect(isSteerAccepted(undefined)).toBe(false)
   })
 })

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -373,6 +373,8 @@ export interface ComposerActions {
   /** Attach an image by path in as a token. */
   attachImagePath: (path: string) => void
   clearIn: () => void
+  /** Drop the pending steer (agent slot cleared via session.steer_clear). */
+  clearSteer: () => void
   dequeue: () => string | undefined
   enqueue: (text: string, display?: string) => void
   handleTextPaste: (event: PasteEvent) => MaybePromise<ComposerPasteResult | null>
@@ -380,12 +382,17 @@ export interface ComposerActions {
   prependQueue: (item: QueueItem) => void
   pushHistory: (text: string) => void
   removeQueue: (index: number) => void
+  /** Replace the pending steer text in place (post-edit re-steer). */
+  replaceSteer: (text: string) => void
   setCompIdx: StateSetter<number>
   setComposerTokens: StateSetter<ComposerToken[]>
   setHistoryIdx: StateSetter<null | number>
   setInput: StateSetter<string>
   setInputBuf: StateSetter<string[]>
   setQueueEdit: (index: null | number) => void
+  /** Park an accepted steer so the queue strip renders it first. */
+  setSteer: (text: string) => void
+  setSteerEdit: (index: null | number) => void
   takeQueue: (index: number, editedDisplay?: string) => QueueItem | undefined
   /** Reconcile attached payloads against tokens still present in the text. */
   syncTokens: (value: string) => void
@@ -396,6 +403,9 @@ export interface ComposerRefs {
   historyRef: MutableRefObject<string[]>
   queueEditRef: MutableRefObject<null | number>
   queueRef: MutableRefObject<QueueItem[]>
+  /** Source of truth for the pending steer text (read in keystroke handlers). */
+  steerRef: MutableRefObject<null | string>
+  steerEditRef: MutableRefObject<null | number>
   submitRef: MutableRefObject<(value: string) => void>
   tokensRef: MutableRefObject<ComposerToken[]>
 }
@@ -407,8 +417,11 @@ export interface ComposerState {
   historyIdx: null | number
   input: string
   inputBuf: string[]
+  /** Pending steer text accepted by the gateway; rendered as strip row 1. */
+  pendingSteer: null | string
   queueEditIdx: null | number
   queuedDisplay: string[]
+  steerEditIdx: null | number
   tokens: ComposerToken[]
 }
 
@@ -573,8 +586,10 @@ export interface AppLayoutComposerProps {
   input: string
   inputBuf: string[]
   pagerPageSize: number
+  pendingSteer: null | string
   queueEditIdx: null | number
   queuedDisplay: string[]
+  steerEditIdx: null | number
   submit: (value: string) => void
   updateInput: StateSetter<string>
   voiceRecordKey: ParsedVoiceRecordKey

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -369,6 +369,8 @@ export interface ComposerActions {
   /** Attach an image by path in as a token. */
   attachImagePath: (path: string) => void
   clearIn: () => void
+  /** Drop the pending steer (agent slot cleared via session.steer_clear). */
+  clearSteer: () => void
   dequeue: () => string | undefined
   enqueue: (text: string, display?: string) => void
   handleTextPaste: (event: PasteEvent) => MaybePromise<ComposerPasteResult | null>
@@ -376,12 +378,17 @@ export interface ComposerActions {
   prependQueue: (item: QueueItem) => void
   pushHistory: (text: string) => void
   removeQueue: (index: number) => void
+  /** Replace the pending steer text in place (post-edit re-steer). */
+  replaceSteer: (text: string) => void
   setCompIdx: StateSetter<number>
   setComposerTokens: StateSetter<ComposerToken[]>
   setHistoryIdx: StateSetter<null | number>
   setInput: StateSetter<string>
   setInputBuf: StateSetter<string[]>
   setQueueEdit: (index: null | number) => void
+  /** Park an accepted steer so the queue strip renders it first. */
+  setSteer: (text: string) => void
+  setSteerEdit: (index: null | number) => void
   takeQueue: (index: number, editedDisplay?: string) => QueueItem | undefined
   /** Reconcile attached payloads against tokens still present in the text. */
   syncTokens: (value: string) => void
@@ -392,6 +399,9 @@ export interface ComposerRefs {
   historyRef: MutableRefObject<string[]>
   queueEditRef: MutableRefObject<null | number>
   queueRef: MutableRefObject<QueueItem[]>
+  /** Source of truth for the pending steer text (read in keystroke handlers). */
+  steerRef: MutableRefObject<null | string>
+  steerEditRef: MutableRefObject<null | number>
   submitRef: MutableRefObject<(value: string) => void>
   tokensRef: MutableRefObject<ComposerToken[]>
 }
@@ -403,8 +413,11 @@ export interface ComposerState {
   historyIdx: null | number
   input: string
   inputBuf: string[]
+  /** Pending steer text accepted by the gateway; rendered as strip row 1. */
+  pendingSteer: null | string
   queueEditIdx: null | number
   queuedDisplay: string[]
+  steerEditIdx: null | number
   tokens: ComposerToken[]
 }
 
@@ -569,8 +582,10 @@ export interface AppLayoutComposerProps {
   input: string
   inputBuf: string[]
   pagerPageSize: number
+  pendingSteer: null | string
   queueEditIdx: null | number
   queuedDisplay: string[]
+  steerEditIdx: null | number
   submit: (value: string) => void
   updateInput: StateSetter<string>
   voiceRecordKey: ParsedVoiceRecordKey

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -707,7 +707,7 @@ export const coreCommands: SlashCommand[] = [
         .rpc<SessionSteerResponse>('session.steer', { session_id: ctx.sid, text: payload })
         .then(
           ctx.guarded<SessionSteerResponse>(r => {
-            if (r?.status === 'queued') {
+            if (r?.status === 'steered' || r?.status === 'queued') {
               ctx.transcript.sys(
                 `steer queued — arrives after next tool call: "${payload.slice(0, 50)}${payload.length > 50 ? '…' : ''}"`
               )

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -706,7 +706,7 @@ export const coreCommands: SlashCommand[] = [
         .rpc<SessionSteerResponse>('session.steer', { session_id: ctx.sid, text: payload })
         .then(
           ctx.guarded<SessionSteerResponse>(r => {
-            if (r?.status === 'queued') {
+            if (r?.status === 'steered' || r?.status === 'queued') {
               ctx.transcript.sys(
                 `steer queued — arrives after next tool call: "${payload.slice(0, 50)}${payload.length > 50 ? '…' : ''}"`
               )

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -141,6 +141,40 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
     takeQ
   } = useQueue()
 
+  // Pending steer: text accepted by the gateway (session.steer) that will be
+  // injected on the next tool result. Mirrors the queue pattern — a ref is the
+  // source of truth for keystroke handlers, the state drives the strip render.
+  const steerRef = useRef<string | null>(null)
+  const [steerText, setSteerText] = useState<string | null>(null)
+  const steerEditRef = useRef<number | null>(null)
+  const [steerEditIdx, setSteerEditIdx] = useState<number | null>(null)
+
+  const setSteer = useCallback((text: string) => {
+    steerRef.current = text
+    setSteerText(text)
+    steerEditRef.current = null
+    setSteerEditIdx(null)
+  }, [])
+
+  const clearSteer = useCallback(() => {
+    steerRef.current = null
+    setSteerText(null)
+    steerEditRef.current = null
+    setSteerEditIdx(null)
+  }, [])
+
+  const setSteerEdit = useCallback((idx: number | null) => {
+    steerEditRef.current = idx
+    setSteerEditIdx(idx)
+  }, [])
+
+  // Post-edit re-steer: swap the text in place. The edit flag was already
+  // cleared by the submit path, so this must NOT touch edit state.
+  const replaceSteer = useCallback((text: string) => {
+    steerRef.current = text
+    setSteerText(text)
+  }, [])
+
   const { historyRef, historyIdx, setHistoryIdx, historyDraftRef, pushHistory } = useInputHistory()
   const { completions, compIdx, setCompIdx, compReplace } = useCompletion(input, isBlocked, gw)
 
@@ -149,9 +183,10 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
     setInputBuf([])
     setComposerTokens([])
     setQueueEdit(null)
+    setSteerEdit(null)
     setHistoryIdx(null)
     historyDraftRef.current = ''
-  }, [historyDraftRef, setComposerTokens, setHistoryIdx, setInput, setQueueEdit])
+  }, [historyDraftRef, setComposerTokens, setHistoryIdx, setInput, setQueueEdit, setSteerEdit])
 
   /**
    * Deleting an `[[ Image N ]]` token IS how you unattach the image — there is
@@ -425,6 +460,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
       attachClipboardImage,
       attachImagePath,
       clearIn,
+      clearSteer,
       dequeue,
       enqueue,
       handleTextPaste,
@@ -432,12 +468,15 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
       prependQueue: prependQ,
       pushHistory,
       removeQueue: removeQ,
+      replaceSteer,
       setCompIdx,
       setComposerTokens,
       setHistoryIdx,
       setInput,
       setInputBuf,
       setQueueEdit,
+      setSteer,
+      setSteerEdit,
       takeQueue: takeQ,
       syncTokens
     }),
@@ -445,6 +484,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
       attachClipboardImage,
       attachImagePath,
       clearIn,
+      clearSteer,
       dequeue,
       enqueue,
       handleTextPaste,
@@ -452,11 +492,14 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
       prependQ,
       pushHistory,
       removeQ,
+      replaceSteer,
       setCompIdx,
       setComposerTokens,
       setHistoryIdx,
       setInput,
       setQueueEdit,
+      setSteer,
+      setSteerEdit,
       takeQ,
       syncTokens
     ]
@@ -468,10 +511,12 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
       historyRef,
       queueEditRef,
       queueRef,
+      steerEditRef,
+      steerRef,
       submitRef,
       tokensRef
     }),
-    [historyDraftRef, historyRef, queueEditRef, queueRef, submitRef]
+    [historyDraftRef, historyRef, queueEditRef, queueRef, steerEditRef, steerRef, submitRef]
   )
 
   const state = useMemo(
@@ -482,11 +527,13 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
       historyIdx,
       input,
       inputBuf,
+      pendingSteer: steerText,
       queueEditIdx,
       queuedDisplay,
+      steerEditIdx,
       tokens
     }),
-    [compIdx, compReplace, completions, historyIdx, input, inputBuf, queueEditIdx, queuedDisplay, tokens]
+    [compIdx, compReplace, completions, historyIdx, input, inputBuf, steerText, queueEditIdx, queuedDisplay, steerEditIdx, tokens]
   )
 
   return {

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -241,12 +241,36 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     }
   }
 
+  // Draft the input held when the user arrowed up into the pending steer, so
+  // Esc during a steer edit restores it instead of wiping the composer.
+  const steerDraftRef = useRef('')
+
+  const cyclePending = () => {
+    const steer = cRefs.steerRef.current
+
+    if (steer === null) {
+      return false
+    }
+
+    steerDraftRef.current = cState.input
+    cActions.setSteerEdit(0)
+    cActions.setHistoryIdx(null)
+    cActions.setQueueEdit(null)
+    cActions.setInput(steer)
+
+    return true
+  }
+
   const cycleQueue = (dir: 1 | -1) => {
     const len = cRefs.queueRef.current.length
 
     if (!len) {
       return false
     }
+
+    // Queue and steer edits are mutually exclusive — moving into the queue
+    // leaves any active steer edit behind.
+    cActions.setSteerEdit(null)
 
     const index = cState.queueEditIdx === null ? (dir > 0 ? 0 : len - 1) : (cState.queueEditIdx + dir + len) % len
 
@@ -538,6 +562,15 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return cActions.clearIn()
     }
 
+    // Steer-edit cancel: restore the draft the user had before arrow-up pulled
+    // the pending steer into the input, and drop the edit marker.
+    if (key.escape && cState.steerEditIdx !== null) {
+      cActions.setInput(steerDraftRef.current)
+      cActions.setSteerEdit(null)
+
+      return
+    }
+
     if (key.escape && terminal.hasSelection) {
       return clearSelection()
     }
@@ -550,7 +583,8 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
         !cState.input || (cursor !== null && cState.input.lastIndexOf('\n', Math.max(0, cursor - 1)) < 0)
 
       if (noLineAbove) {
-        cycleQueue(1) || cycleHistory(-1)
+        // Pending steer is row 1 — arrow up reaches it before the queue.
+        cyclePending() || cycleQueue(1) || cycleHistory(-1)
 
         return
       }
@@ -584,6 +618,22 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       if (isMac) {
         return
       }
+    }
+
+    if (isCtrl(key, ch, 'x') && cState.steerEditIdx !== null) {
+      // Delete the pending steer: drop it from the composer AND tell the
+      // gateway to clear the agent slot, so the text is not injected on the
+      // next tool result behind the user's back.
+      cActions.clearSteer()
+      cActions.setSteerEdit(null)
+
+      const _sid = getUiState().sid
+
+      if (_sid) {
+        void gateway.rpc<{ status?: string }>('session.steer_clear', { session_id: _sid })
+      }
+
+      return cActions.clearIn()
     }
 
     if (isCtrl(key, ch, 'x') && handleInputSelectionClipboard(getInputSelection(), 'cut')) {

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -228,12 +228,36 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     }
   }
 
+  // Draft the input held when the user arrowed up into the pending steer, so
+  // Esc during a steer edit restores it instead of wiping the composer.
+  const steerDraftRef = useRef('')
+
+  const cyclePending = () => {
+    const steer = cRefs.steerRef.current
+
+    if (steer === null) {
+      return false
+    }
+
+    steerDraftRef.current = cState.input
+    cActions.setSteerEdit(0)
+    cActions.setHistoryIdx(null)
+    cActions.setQueueEdit(null)
+    cActions.setInput(steer)
+
+    return true
+  }
+
   const cycleQueue = (dir: 1 | -1) => {
     const len = cRefs.queueRef.current.length
 
     if (!len) {
       return false
     }
+
+    // Queue and steer edits are mutually exclusive — moving into the queue
+    // leaves any active steer edit behind.
+    cActions.setSteerEdit(null)
 
     const index = cState.queueEditIdx === null ? (dir > 0 ? 0 : len - 1) : (cState.queueEditIdx + dir + len) % len
 
@@ -525,6 +549,15 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return cActions.clearIn()
     }
 
+    // Steer-edit cancel: restore the draft the user had before arrow-up pulled
+    // the pending steer into the input, and drop the edit marker.
+    if (key.escape && cState.steerEditIdx !== null) {
+      cActions.setInput(steerDraftRef.current)
+      cActions.setSteerEdit(null)
+
+      return
+    }
+
     if (key.escape && terminal.hasSelection) {
       return clearSelection()
     }
@@ -537,7 +570,8 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
         !cState.input || (cursor !== null && cState.input.lastIndexOf('\n', Math.max(0, cursor - 1)) < 0)
 
       if (noLineAbove) {
-        cycleQueue(1) || cycleHistory(-1)
+        // Pending steer is row 1 — arrow up reaches it before the queue.
+        cyclePending() || cycleQueue(1) || cycleHistory(-1)
 
         return
       }
@@ -573,6 +607,22 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       if (isMac) {
         return
       }
+    }
+
+    if (isCtrl(key, ch, 'x') && cState.steerEditIdx !== null) {
+      // Delete the pending steer: drop it from the composer AND tell the
+      // gateway to clear the agent slot, so the text is not injected on the
+      // next tool result behind the user's back.
+      cActions.clearSteer()
+      cActions.setSteerEdit(null)
+
+      const _sid = getUiState().sid
+
+      if (_sid) {
+        void gateway.rpc<{ status?: string }>('session.steer_clear', { session_id: _sid })
+      }
+
+      return cActions.clearIn()
     }
 
     if (isCtrl(key, ch, 'x') && cState.queueEditIdx !== null) {

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -1151,8 +1151,10 @@ export function useMainApp(gw: GatewayClient) {
       input: composerState.input,
       inputBuf: composerState.inputBuf,
       pagerPageSize,
+      pendingSteer: composerState.pendingSteer,
       queueEditIdx: composerState.queueEditIdx,
       queuedDisplay: composerState.queuedDisplay,
+      steerEditIdx: composerState.steerEditIdx,
       submit,
       updateInput,
       voiceRecordKey

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -1145,8 +1145,10 @@ export function useMainApp(gw: GatewayClient) {
       input: composerState.input,
       inputBuf: composerState.inputBuf,
       pagerPageSize,
+      pendingSteer: composerState.pendingSteer,
       queueEditIdx: composerState.queueEditIdx,
       queuedDisplay: composerState.queuedDisplay,
+      steerEditIdx: composerState.steerEditIdx,
       submit,
       updateInput,
       voiceRecordKey

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -20,6 +20,15 @@ const DOUBLE_ENTER_MS = 450
 const spliceMatches = (text: string, matches: RegExpMatchArray[], results: string[]) =>
   matches.reduceRight((acc, m, i) => acc.slice(0, m.index!) + results[i] + acc.slice(m.index! + m[0].length), text)
 
+/**
+ * Whether a `session.steer` response means the steer was accepted. Both
+ * gateway steer paths (session.steer and the prompt.submit busy path) report
+ * 'steered' on success; 'queued' is the legacy value and means the same
+ * thing. Only 'rejected' (or a missing/errored response) is a failure.
+ */
+export const isSteerAccepted = (r: Pick<SessionSteerResponse, 'status'> | null | undefined): boolean =>
+  !!r && (r.status === 'steered' || r.status === 'queued')
+
 export const expandPasteTokens = (tokens: ComposerToken[]) =>
   expandTokens(tokens.filter(token => token.kind === 'paste'))
 
@@ -206,9 +215,19 @@ export function useSubmission(opts: UseSubmissionOptions) {
           .then(raw => {
             const r = asRpcResult<SessionSteerResponse>(raw)
 
-            if (r?.status !== 'queued') {
+            // Contract: both gateway steer paths (session.steer and the
+            // prompt.submit busy path) report 'steered' on success; 'queued'
+            // is the legacy value and means the same thing. Only 'rejected'
+            // (or a missing/errored response) falls back to the queue.
+            if (!isSteerAccepted(r)) {
               fallback('steer rejected — message queued for next turn')
+
+              return
             }
+
+            // Accepted: park the text in the pending-steer slot so the queue
+            // strip shows it first (tagged, editable, deletable).
+            composerActions.setSteer(item.text)
           })
           .catch(() => fallback('steer failed — message queued for next turn'))
 
@@ -278,7 +297,34 @@ export function useSubmission(opts: UseSubmissionOptions) {
       }
 
       const editIdx = composerRefs.queueEditRef.current
+      const steerEdit = composerRefs.steerEditRef.current
       composerActions.clearIn()
+
+      if (steerEdit !== null) {
+        // Editing the pending steer: swap the text in place and re-inject via
+        // session.steer so the agent slot carries the corrected wording. The
+        // steer row stays visible (tagged) until the next tool drain.
+        composerActions.replaceSteer(full)
+        composerActions.setSteerEdit(null)
+
+        if (!live.sid) {
+          return
+        }
+
+        gw.request<SessionSteerResponse>('session.steer', { session_id: live.sid, text: full })
+          .then(raw => {
+            const r = asRpcResult<SessionSteerResponse>(raw)
+
+            if (!r || r.status === 'rejected') {
+              // Rejected mid-edit: keep the row so the user sees the state
+              // instead of silently dropping the replacement.
+              sys('steer replace rejected — pending steer kept')
+            }
+          })
+          .catch(() => sys('steer replace failed — pending steer kept'))
+
+        return
+      }
 
       if (editIdx !== null) {
         const picked = composerActions.takeQueue(editIdx, full)

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -342,8 +342,10 @@ const ComposerPane = memo(function ComposerPane({
     >
       <QueuedMessages
         cols={composer.cols}
+        pendingSteer={composer.pendingSteer}
         queued={composer.queuedDisplay}
         queueEditIdx={composer.queueEditIdx}
+        steerEditIdx={composer.steerEditIdx}
         t={ui.theme}
       />
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -341,8 +341,10 @@ const ComposerPane = memo(function ComposerPane({
     >
       <QueuedMessages
         cols={composer.cols}
+        pendingSteer={composer.pendingSteer}
         queued={composer.queuedDisplay}
         queueEditIdx={composer.queueEditIdx}
+        steerEditIdx={composer.steerEditIdx}
         t={ui.theme}
       />
 

--- a/ui-tui/src/components/queuedMessages.tsx
+++ b/ui-tui/src/components/queuedMessages.tsx
@@ -5,29 +5,59 @@ import type { Theme } from '../theme.js'
 
 export const QUEUE_WINDOW = 3
 
-export function getQueueWindow(queueLen: number, queueEditIdx: number | null) {
-  const start =
-    queueEditIdx === null ? 0 : Math.max(0, Math.min(queueEditIdx - 1, Math.max(0, queueLen - QUEUE_WINDOW)))
+// Static braille frame for the pending-steer row. A live spinner would need a
+// mounted timer in a leaf that is otherwise pure; a fixed frame keeps the
+// strip deterministic (and testable) while still reading as "in flight" next
+// to the plain queue rows.
+export const STEER_BRAILLE = '⠋'
 
-  const end = Math.min(queueLen, start + QUEUE_WINDOW)
+/**
+ * Window over the queue rows. With a pending steer occupying row 1, the steer
+ * row is always visible and the queue rows get QUEUE_WINDOW - 1 slots below
+ * it, still centered on the row being edited.
+ */
+export function getQueueWindow(queueLen: number, queueEditIdx: number | null, hasSteer = false) {
+  const visible = hasSteer ? Math.max(1, QUEUE_WINDOW - 1) : QUEUE_WINDOW
+
+  const start =
+    queueEditIdx === null ? 0 : Math.max(0, Math.min(queueEditIdx - 1, Math.max(0, queueLen - visible)))
+
+  const end = Math.min(queueLen, start + visible)
 
   return { end, showLead: start > 0, showTail: end < queueLen, start }
 }
 
-export function QueuedMessages({ cols, queueEditIdx, queued, t }: QueuedMessagesProps) {
-  if (!queued.length) {
+export function QueuedMessages({ cols, pendingSteer = null, queueEditIdx, queued, steerEditIdx = null, t }: QueuedMessagesProps) {
+  const hasSteer = pendingSteer !== null
+  const total = queued.length + (hasSteer ? 1 : 0)
+
+  if (!total) {
     return null
   }
 
-  const q = getQueueWindow(queued.length, queueEditIdx)
+  const q = getQueueWindow(queued.length, queueEditIdx, hasSteer)
+
+  const hint =
+    steerEditIdx !== null
+      ? ' · editing 1 · Ctrl+X delete · Esc cancel'
+      : queueEditIdx !== null
+        ? ` · editing ${queueEditIdx + (hasSteer ? 2 : 1)} · Ctrl+X delete · Esc cancel`
+        : hasSteer
+          ? ' · ↑↓ edit · Ctrl+X delete · Esc cancel'
+          : ''
 
   return (
     <Box flexDirection="column" marginTop={1}>
       <Text color={t.color.muted} dimColor>
-        {`queued (${queued.length})${
-          queueEditIdx !== null ? ` · editing ${queueEditIdx + 1} · Ctrl+X delete · Esc cancel` : ''
-        }`}
+        {`${hasSteer ? 'pending' : 'queued'} (${total})${hint}`}
       </Text>
+
+      {hasSteer && (
+        <Text color={steerEditIdx !== null ? t.color.accent : t.color.muted} dimColor key="steer">
+          {steerEditIdx !== null ? '▸' : ' '} 1. {STEER_BRAILLE} [steer]{' '}
+          {compactPreview(pendingSteer!, Math.max(16, cols - 10))}
+        </Text>
+      )}
 
       {q.showLead && (
         <Text color={t.color.muted} dimColor>
@@ -42,7 +72,7 @@ export function QueuedMessages({ cols, queueEditIdx, queued, t }: QueuedMessages
 
         return (
           <Text color={active ? t.color.accent : t.color.muted} dimColor key={`${idx}-${item.slice(0, 16)}`}>
-            {active ? '▸' : ' '} {idx + 1}. {compactPreview(item, Math.max(16, cols - 10))}
+            {active ? '▸' : ' '} {idx + (hasSteer ? 2 : 1)}. {compactPreview(item, Math.max(16, cols - 10))}
           </Text>
         )
       })}
@@ -58,7 +88,11 @@ export function QueuedMessages({ cols, queueEditIdx, queued, t }: QueuedMessages
 
 interface QueuedMessagesProps {
   cols: number
+  /** Pending steer text accepted by the gateway; renders as the first row. */
+  pendingSteer?: null | string
   queueEditIdx: number | null
   queued: string[]
+  /** Non-null while the user is editing the steer row (arrowed up into it). */
+  steerEditIdx?: null | number
   t: Theme
 }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -325,7 +325,7 @@ export interface SessionInterruptResponse {
 }
 
 export interface SessionSteerResponse {
-  status?: 'queued' | 'rejected'
+  status?: 'steered' | 'queued' | 'rejected'
   text?: string
 }
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -315,7 +315,7 @@ export interface SessionInterruptResponse {
 }
 
 export interface SessionSteerResponse {
-  status?: 'queued' | 'rejected'
+  status?: 'steered' | 'queued' | 'rejected'
   text?: string
 }
 


### PR DESCRIPTION
## Summary

Fixes #68083 — pending steers now live in the queue strip instead of a scrolled ack line.

### Problem
`display.busy_input_mode: steer` (and `/steer`) accepted the text but then made it vanish: a successful `session.steer` was acknowledged with a one-line print above the composer, with no pending row, no edit path, and no way to cancel before the next tool-batch drain. Queue items had a real, revisit-able strip (`QueuedMessages` + ↑/↓ cycle); steers did not.

### Fix
**Composer pending model** — a successful `session.steer` now parks the text in a `pendingSteer` slot (mirrors the queue ref/state pattern) instead of dropping it.

**Pending strip** — `QueuedMessages` renders the steer as row 1: `⠋ [steer] …` (braille marker + durable tag), with follow-up queue rows below. Header becomes `pending (N) · ↑↓ edit · Ctrl+X delete · Esc cancel` when a steer is present, with the row being edited highlighted.

**Edit / delete / cancel** — arrow-up pulls the pending steer into the input (before the queue cycle); submit re-steers the replacement in place; Ctrl+X deletes the row *and* calls the new `session.steer_clear` RPC so the agent's stashed slot can't inject behind the user's back; Esc cancels the edit and restores the previous draft.

**Status contract fix** — both gateway steer paths (`session.steer` RPC and the `prompt.submit` busy path) now report `steered` on success. The client accepts `steered` and the legacy `queued`; it only falls back to the queue on `rejected` or error. Previously the split vocabulary meant a `steered` response was misread as failure.

**Resume support** — new `session.pending` RPC snapshots `{ steer, queue }` so a reconnect can rebuild the strip.

### Tests (same commit, per rule)
- `ui-tui/src/__tests__/pendingMessages.test.tsx` — renders the strip: steer-first ordering, `[steer]` tag, braille marker, edit hints, active-row cursor, legacy `queued (N)` behavior, empty state.
- `ui-tui/src/__tests__/useSubmission.test.ts` — pins the status-contract decision table (`steered`/`queued` accepted, `rejected`/missing rejected).
- `tests/test_tui_gateway_server.py` — updated `session.steer` assertion to `steered`, plus new tests for rejection, `session.steer_clear`, and `session.pending` snapshot.

Local: 14 new TS tests + 34 related TS tests pass; 7 gateway python tests pass; `tsc --noEmit` clean.

### Parity debt (not built here)
- **Classic CLI** still acks steers via `_cprint("⏩ Steered: …")` — it has no editable pending strip at all. A real CLI strip is a separate feature.
- Client doesn't yet consume `session.pending` on reconnect (would need a gateway-event/poll hook on resume).
- Steer edit re-runs `session.steer` rather than a dedicated replace RPC.
