### PR TITLE
fix(gateway/weixin): stop rate-limit circuit breaker infinite retry loop

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1207,6 +1207,15 @@ class WeixinAdapter(BasePlatformAdapter):
             extra.get("rate_limit_circuit_open_seconds")
             or os.getenv("WEIXIN_RATE_LIMIT_CIRCUIT_OPEN_SECONDS", "30.0")
         )
+        self._rate_limit_circuit_backoff_factor = float(
+            extra.get("rate_limit_circuit_backoff_factor")
+            or os.getenv("WEIXIN_RATE_LIMIT_CIRCUIT_BACKOFF_FACTOR", "2.0")
+        )
+        self._rate_limit_circuit_max_open_seconds = float(
+            extra.get("rate_limit_circuit_max_open_seconds")
+            or os.getenv("WEIXIN_RATE_LIMIT_CIRCUIT_MAX_OPEN_SECONDS", "600.0")
+        )
+        self._rate_limit_backoff_multiplier = 1.0
         self._rate_limit_circuit_until = 0.0
         self._rate_limit_events: List[float] = []
         self._dm_policy = str(extra.get("dm_policy") or os.getenv("WEIXIN_DM_POLICY", "pairing")).strip().lower()
@@ -1719,13 +1728,33 @@ class WeixinAdapter(BasePlatformAdapter):
     def _open_rate_limit_circuit(self) -> None:
         if self._rate_limit_circuit_open_seconds <= 0:
             return
+        open_seconds = min(
+            self._rate_limit_circuit_max_open_seconds,
+            self._rate_limit_circuit_open_seconds * self._rate_limit_backoff_multiplier,
+        )
         self._rate_limit_circuit_until = max(
             self._rate_limit_circuit_until,
-            time.monotonic() + self._rate_limit_circuit_open_seconds,
+            time.monotonic() + open_seconds,
+        )
+        # Exponential backoff: each consecutive open doubles the cooldown
+        # (1x, 2x, 4x, ...) up to the configured cap. Without this, a
+        # persistent rate limit re-opens the breaker for the same flat
+        # window on every retry, so the cooldown never ends (Issue #77836).
+        self._rate_limit_backoff_multiplier = min(
+            self._rate_limit_circuit_max_open_seconds / self._rate_limit_circuit_open_seconds,
+            self._rate_limit_backoff_multiplier * self._rate_limit_circuit_backoff_factor,
         )
 
     def _record_rate_limit_event(self) -> bool:
-        """Record a genuine iLink rate limit and return True if breaker opened."""
+        """Record a genuine iLink rate limit and return True if breaker opened.
+
+        While the breaker is already open the response is NOT recorded:
+        re-recording on every retry would re-open the breaker and reset the
+        cooldown to the full window each time, making the cooldown
+        effectively infinite (Issue #77836).
+        """
+        if self._rate_limit_cooldown_remaining() > 0:
+            return False
         now = time.monotonic()
         window_start = now - self._rate_limit_circuit_window_seconds
         self._rate_limit_events = [ts for ts in self._rate_limit_events if ts >= window_start]
@@ -1738,6 +1767,7 @@ class WeixinAdapter(BasePlatformAdapter):
     def _reset_rate_limit_circuit(self) -> None:
         self._rate_limit_events.clear()
         self._rate_limit_circuit_until = 0.0
+        self._rate_limit_backoff_multiplier = 1.0
 
     async def _send_text_chunk(
         self,
@@ -1808,6 +1838,14 @@ class WeixinAdapter(BasePlatformAdapter):
                                 self.name, _safe_id(chat_id),
                             )
                             continue
+                        # Stale session (-2 + "unknown error") or -14 that could
+                        # not be salvaged by a tokenless retry — treat as session
+                        # expiry, never as a rate limit (Issue #77836).
+                        if is_session_expired:
+                            errmsg = resp.get("errmsg") or resp.get("msg") or "session expired"
+                            raise RuntimeError(
+                                f"iLink sendmessage session expired: ret={ret} errcode={errcode} errmsg={errmsg}"
+                            )
                         # Rate limit (-2) — backoff and retry
                         is_rate_limited = (
                             ret == RATE_LIMIT_ERRCODE
@@ -1821,6 +1859,12 @@ class WeixinAdapter(BasePlatformAdapter):
                             last_error = RuntimeError(
                                 f"iLink sendmessage rate limited: ret={ret} errcode={errcode} errmsg={errmsg}"
                             )
+                            if self._rate_limit_cooldown_remaining() > 0:
+                                # Breaker already open — do not record a fresh
+                                # event (that would re-open it and reset the
+                                # cooldown, looping forever). Fail fast instead.
+                                last_error = self._rate_limit_error()
+                                break
                             if self._record_rate_limit_event():
                                 last_error = self._rate_limit_error()
                                 break

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -270,6 +270,92 @@ class TestWeixinChunkDelivery:
         assert send_message_mock.await_count == 2
         assert sleep_mock.await_count == 1
 
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_open_circuit_uses_exponential_backoff(self, send_message_mock, sleep_mock):
+        """Regression test for #77836: each consecutive rate-limit re-open must
+        double the cooldown (1x, 2x, 4x ...) up to the configured cap instead of
+        resetting to the same flat window on every retry."""
+        adapter = self._connected_adapter()
+        adapter._send_chunk_retries = 0
+        adapter._send_chunk_retry_delay_seconds = 0
+        adapter._rate_limit_circuit_threshold = 1
+        adapter._rate_limit_circuit_window_seconds = 60
+        adapter._rate_limit_circuit_open_seconds = 60
+        adapter._rate_limit_circuit_backoff_factor = 2.0
+        adapter._rate_limit_circuit_max_open_seconds = 600
+
+        send_message_mock.return_value = {
+            "ret": weixin.RATE_LIMIT_ERRCODE,
+            "errcode": weixin.RATE_LIMIT_ERRCODE,
+            "errmsg": "frequency limit",
+        }
+
+        expected = [60.0, 120.0, 240.0, 480.0, 600.0, 600.0]
+        for idx, want in enumerate(expected):
+            result = asyncio.run(adapter.send("wxid_test123", "msg"))
+            assert result.success is False
+            assert "cooldown" in (result.error or "")
+            remaining = adapter._rate_limit_cooldown_remaining()
+            assert remaining > 0, f"iteration {idx}: circuit should be open"
+            assert abs(remaining - want) < 1.5, (
+                f"iteration {idx}: expected ~{want:.0f}s cooldown, got {remaining:.1f}s"
+            )
+            # Simulate the cooldown expiring before the gateway retries the message.
+            adapter._rate_limit_circuit_until = 0.0
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_no_event_recorded_while_circuit_open(self, send_message_mock, sleep_mock):
+        """Regression test for #77836: sends during the cooldown window must fail
+        fast without recording new events or extending the cooldown."""
+        adapter = self._connected_adapter()
+        adapter._send_chunk_retries = 3
+        adapter._send_chunk_retry_delay_seconds = 0
+        adapter._rate_limit_circuit_threshold = 1
+        adapter._rate_limit_circuit_open_seconds = 60
+
+        # Open the circuit as if a previous send had tripped it.
+        adapter._open_rate_limit_circuit()
+        until_before = adapter._rate_limit_circuit_until
+        events_before = list(adapter._rate_limit_events)
+
+        result = asyncio.run(adapter.send("wxid_test123", "blocked"))
+
+        assert result.success is False
+        assert "cooldown" in (result.error or "")
+        assert send_message_mock.await_count == 0
+        assert adapter._rate_limit_circuit_until == until_before
+        assert adapter._rate_limit_events == events_before
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_stale_session_minus_2_does_not_open_circuit(self, send_message_mock, sleep_mock):
+        """Regression test for #77836: errcode=-2 with 'unknown error' is a
+        stale-session signal and must never trip the rate-limit circuit breaker."""
+        adapter = self._connected_adapter()
+        adapter._send_chunk_retries = 1
+        adapter._send_chunk_retry_delay_seconds = 0
+        adapter._rate_limit_circuit_threshold = 1
+        adapter._rate_limit_circuit_open_seconds = 60
+
+        send_message_mock.return_value = {
+            "ret": weixin.RATE_LIMIT_ERRCODE,
+            "errcode": weixin.RATE_LIMIT_ERRCODE,
+            "errmsg": "unknown error",
+        }
+
+        result = asyncio.run(adapter.send("wxid_test123", "hello"))
+
+        assert result.success is False
+        assert "cooldown" not in (result.error or "")
+        assert "session expired" in (result.error or "")
+        # Tokenless retry happens once; neither attempt trips the breaker.
+        assert send_message_mock.await_count == 2
+        assert adapter._rate_limit_cooldown_remaining() == 0.0
+        assert adapter._rate_limit_events == []
+        assert adapter._rate_limit_backoff_multiplier == 1.0
+
 
 class TestWeixinOutboundMedia:
 


### PR DESCRIPTION
## Summary

Fixes the Weixin (iLink) rate-limit circuit breaker infinite retry loop described in #77836. When iLink keeps returning `errcode=-2`, every retry recorded a fresh rate-limit event and re-opened the breaker for the same flat `WEIXIN_RATE_LIMIT_CIRCUIT_OPEN_SECONDS` window, so the cooldown never actually elapsed (production logs showed "cooldown active for 30.0s" for 13+ minutes).

## Root Cause

In `gateway/platforms/weixin.py`, the send path (`_send_text_chunk_locked`) has three compounding problems:

1. **Flat cooldown, reset on every retry** — `_open_rate_limit_circuit()` always set `_rate_limit_circuit_until = now + 30.0s`. After the cooldown expired, the gateway retried the message, iLink returned `-2` again, a **new** event was recorded, and the breaker re-opened for another flat 30s. With `WEIXIN_RATE_LIMIT_CIRCUIT_THRESHOLD=1` this repeats indefinitely — the cooldown is effectively infinite while iLink keeps returning `-2`.
2. **No guard against re-recording while open** — `_record_rate_limit_event()` appended a new event on every `-2` response, even when the breaker was already open, feeding the re-open loop.
3. **Stale session misclassified as rate limit** — `errcode=-2` with `errmsg="unknown error"` is a stale-session signal (`_is_stale_session_ret`), not a genuine rate limit. The session-expired check ran first but only handled the "retry once without `context_token`" path; when that tokenless retry also returned `-2`/"unknown error" (or there was no token), the response fell through to the rate-limit branch and tripped the circuit breaker — turning a session problem into an endless rate-limit cooldown.

## Change

All changes are in `gateway/platforms/weixin.py`:

1. **Exponential backoff** — `_open_rate_limit_circuit()` now opens for `open_seconds × multiplier` and doubles the multiplier per consecutive open (1x, 2x, 4x, …), capped by a new `WEIXIN_RATE_LIMIT_CIRCUIT_MAX_OPEN_SECONDS` (default 600s, env/extra-configurable via `rate_limit_circuit_max_open_seconds`; factor configurable via `WEIXIN_RATE_LIMIT_CIRCUIT_BACKOFF_FACTOR`, default 2.0). A persistent rate limit now backs off: 30s → 60s → 120s → … instead of looping at 30s forever.
2. **No re-record while the breaker is open** — `_record_rate_limit_event()` returns early (and the send path breaks fast) when `_rate_limit_cooldown_remaining() > 0`, so an open breaker is never re-opened by a retry and the cooldown is never reset mid-window.
3. **Stale session handled before the circuit breaker** — after the tokenless retry is exhausted, `is_session_expired` (including `_is_stale_session_ret`: `-2` + "unknown error") raises a descriptive "session expired" error instead of falling into the rate-limit branch. The circuit breaker now only sees genuine rate limits.
4. `_reset_rate_limit_circuit()` also resets the backoff multiplier, so a successful send restores the base cooldown.

## Verification

- Added 3 regression tests in `tests/gateway/test_weixin.py`:
  - `test_open_circuit_uses_exponential_backoff` — cooldown grows 60 → 120 → 240 → 480 → capped at 600 across consecutive re-opens (previously flat 60 every time).
  - `test_no_event_recorded_while_circuit_open` — a send during the cooldown window fails fast: zero HTTP calls, no new events recorded, cooldown not extended.
  - `test_stale_session_minus_2_does_not_open_circuit` — `-2`/"unknown error" raises a session-expired error, never opens the breaker (events list empty, cooldown 0, backoff multiplier untouched).
- `tests/gateway/test_weixin.py`: 33 passed (30 pre-existing + 3 new).
- Full `tests/gateway` suite: 4535 passed; the 7 failures (`test_wecom_callback.py`, `test_session_store_prune.py`) are pre-existing and reproduce on a clean checkout of `main` (unrelated to this change).
- `ruff check` clean on both modified files.

Closes #77836
