### PR TITLE
fix(sessions): add 'hermes sessions set-endpoint' to re-point pinned session endpoints (#77831)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12290,6 +12290,42 @@ def main():
         help="Maximum sessions to examine (default: 200)",
     )
 
+    sessions_set_endpoint = sessions_subparsers.add_parser(
+        "set-endpoint",
+        help="Re-point a session to a new provider endpoint (rewrites the stored model_config + billing route)",
+        description=(
+            "Sessions pin their provider endpoint in the durable session row "
+            "(model_config JSON + billing_provider/billing_base_url columns); "
+            "the runtime resolves it from that snapshot on every resume, so a "
+            "moved model server keeps stranding open sessions even across "
+            "restarts. This rewrites the row to target the new URL: model_config "
+            "provider/base_url plus the billing_* columns, preserving every "
+            "other stored knob. The provider id is validated so the rewritten "
+            "row is immediately routable."
+        ),
+    )
+    sessions_set_endpoint.add_argument(
+        "session_id",
+        metavar="ID",
+        help="Session ID (or unique prefix) to re-point",
+    )
+    sessions_set_endpoint.add_argument(
+        "url",
+        metavar="URL",
+        help="New endpoint base URL (http/https, e.g. http://203.0.113.7:8355/v1)",
+    )
+    sessions_set_endpoint.add_argument(
+        "--provider",
+        metavar="PROVIDER",
+        default=None,
+        help=(
+            "Provider id to store: a built-in provider, bare 'custom', or a "
+            "configured custom:<name>. Defaults to the configured entry that "
+            "owns URL, the session's existing provider when still routable, "
+            "or bare 'custom'."
+        ),
+    )
+
     sessions_browse = sessions_subparsers.add_parser(
         "browse",
         help="Interactive session picker — browse, search, and resume sessions",

--- a/hermes_cli/session_endpoint.py
+++ b/hermes_cli/session_endpoint.py
@@ -1,0 +1,171 @@
+"""Helpers for ``hermes sessions set-endpoint`` (issue #77831).
+
+Sessions pin their provider endpoint in the durable session row
+(``sessions.model_config`` JSON plus the ``billing_provider`` /
+``billing_base_url`` / ``billing_mode`` columns). The runtime resolves the
+endpoint from that per-session snapshot on every resume — not from live
+``config.yaml`` — so a moved model server keeps stranding open sessions even
+across restarts, and there is no supported way to re-point one (only manual
+``state.db`` editing).
+
+These helpers back the ``hermes sessions set-endpoint <id> <url>`` command:
+
+* :func:`normalize_endpoint_url` validates the new endpoint URL.
+* :func:`resolve_endpoint_provider_id` resolves the provider id to persist so
+  the rewritten row is immediately routable — never a ``custom:<name>`` slug
+  with no matching config entry, which the runtime refuses with a hard
+  ``Unknown provider 'custom:<...>'`` error (the secondary footgun reported
+  in the issue).
+* :func:`billing_provider_id` maps the persisted provider id to the
+  ``sessions.billing_provider`` bucket the runtime itself writes for custom
+  endpoints (the bare class ``"custom"``).
+
+Config-backed lookups are imported lazily inside the functions (the
+hermes_cli convention) so tests can patch the module of origin.
+"""
+
+from typing import Optional, Tuple
+from urllib.parse import urlsplit
+
+
+def normalize_endpoint_url(raw: str) -> str:
+    """Validate an endpoint base URL and return it in canonical form.
+
+    Accepts ``http``/``https`` URLs with a host. Returns the URL with a
+    single trailing slash stripped (``http://host:8355/v1/`` →
+    ``http://host:8355/v1``), matching the convention the runtime stores in
+    ``model_config.base_url`` / ``billing_base_url``.
+
+    Raises ``ValueError`` with a user-facing message otherwise.
+    """
+    value = (raw or "").strip()
+    if not value:
+        raise ValueError("endpoint URL is empty")
+    try:
+        parts = urlsplit(value)
+    except ValueError as exc:
+        raise ValueError(f"invalid endpoint URL {value!r}: {exc}") from exc
+    scheme = (parts.scheme or "").lower()
+    if scheme not in ("http", "https"):
+        raise ValueError(
+            f"invalid endpoint URL {value!r}: scheme must be http or https"
+        )
+    if not parts.hostname:
+        raise ValueError(f"invalid endpoint URL {value!r}: missing host")
+    # ``parts.port`` raises for out-of-range ports (e.g. :99999) — surface it.
+    try:
+        parts.port
+    except ValueError as exc:
+        raise ValueError(f"invalid endpoint URL {value!r}: {exc}") from exc
+    return value.rstrip("/")
+
+
+def _configured_custom_entry(provider_id: str):
+    """Return the configured ``providers:`` / ``custom_providers:`` entry that
+    carries ``provider_id`` (a ``custom:<name>`` slug), or None."""
+    from hermes_cli.runtime_provider import _get_named_custom_provider
+
+    return _get_named_custom_provider(provider_id)
+
+
+def _canonical_builtin(provider_id: str) -> Optional[str]:
+    """Canonical id for a built-in provider / alias, else None."""
+    from hermes_cli.auth import AuthError, resolve_provider
+
+    try:
+        canonical = resolve_provider(provider_id)
+    except AuthError:
+        return None
+    if canonical and canonical != "auto":
+        return canonical
+    return None
+
+
+def _validate_requested_provider(provider_id: str) -> str:
+    """Validate an explicit ``--provider`` value; returns the id to persist."""
+    norm = (provider_id or "").strip()
+    if not norm:
+        raise ValueError("--provider value is empty")
+    lower = norm.lower()
+    if lower == "custom":
+        return "custom"
+    if lower == "auto":
+        raise ValueError(
+            f"Unknown provider '{norm}': 'auto' is not a routable provider id. "
+            "Use a built-in provider, bare 'custom', or a configured custom:<name>."
+        )
+    if lower.startswith("custom:"):
+        if _configured_custom_entry(norm) is not None:
+            return norm
+        raise ValueError(
+            f"Unknown provider '{norm}': no providers:/custom_providers: entry "
+            "matches this custom:<name>. Use the entry's slug, a built-in "
+            "provider, or bare 'custom'."
+        )
+    canonical = _canonical_builtin(norm)
+    if canonical:
+        return canonical
+    raise ValueError(
+        f"Unknown provider '{norm}'. Check 'hermes model' for available "
+        "providers, or use bare 'custom' for a generic endpoint."
+    )
+
+
+def resolve_endpoint_provider_id(
+    base_url: str,
+    existing_provider: Optional[str] = None,
+    requested_provider: Optional[str] = None,
+) -> Tuple[str, str]:
+    """Resolve the provider id to persist for a session re-pointed to ``base_url``.
+
+    Returns ``(provider_id, source)`` where source is one of:
+
+    * ``"requested"`` — caller-supplied ``--provider`` (validated routable).
+    * ``"config-entry"`` — the ``custom:<name>`` slug of the configured
+      entry whose base_url matches the new endpoint (the issue's own
+      workaround shape: keep the live ``providers.<name>`` form).
+    * ``"existing"`` — the session's stored provider id, kept when it is
+      still routable (built-in, bare ``custom``, or a configured entry).
+    * ``"custom-fallback"`` — bare ``custom`` (the endpoint URL drives
+      routing), used when nothing else names a routable identity.
+
+    Raises ``ValueError`` when ``requested_provider`` is not routable.
+    """
+    if requested_provider:
+        return _validate_requested_provider(requested_provider), "requested"
+
+    from hermes_cli.runtime_provider import find_custom_provider_identity
+
+    try:
+        entry_slug = find_custom_provider_identity(base_url)
+    except Exception:
+        entry_slug = None
+    if entry_slug:
+        return entry_slug, "config-entry"
+
+    existing = (existing_provider or "").strip()
+    if existing:
+        lower = existing.lower()
+        if lower == "custom":
+            return "custom", "existing"
+        if lower.startswith("custom:"):
+            if _configured_custom_entry(existing) is not None:
+                return existing, "existing"
+        elif _canonical_builtin(existing):
+            return existing, "existing"
+
+    return "custom", "custom-fallback"
+
+
+def billing_provider_id(provider_id: str) -> str:
+    """Map the persisted provider id to the ``sessions.billing_provider`` value.
+
+    Custom endpoints (bare ``custom`` or any ``custom:<name>`` slug) are
+    billed under the bare class ``"custom"`` — the same value the runtime's
+    own billing-route persistence (``update_session_billing_route``) writes
+    for them. Built-in providers keep their canonical id.
+    """
+    lower = (provider_id or "").strip().lower()
+    if lower == "custom" or lower.startswith("custom:"):
+        return "custom"
+    return provider_id

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -1153,6 +1153,95 @@ def cmd_sessions(args, sessions_parser=None):
             size_mb = os.path.getsize(db_path) / (1024 * 1024)
             print(f"Database size: {size_mb:.1f} MB")
 
+    elif action == "set-endpoint":
+        # Re-point a session to a new provider endpoint (issue #77831).
+        # Sessions pin their endpoint in the durable row (model_config +
+        # billing_* columns); the runtime resolves from that snapshot on every
+        # resume, so a moved server strands open sessions even across
+        # restarts. This rewrites the row so the next resume targets the new
+        # URL, deriving a routable provider id (never a custom:<name> slug
+        # with no matching config entry).
+        from hermes_cli.session_endpoint import (
+            billing_provider_id,
+            normalize_endpoint_url,
+            resolve_endpoint_provider_id,
+        )
+
+        resolved_session_id = db.resolve_session_id(args.session_id)
+        if not resolved_session_id:
+            print(f"Session '{args.session_id}' not found.")
+            return
+        try:
+            new_url = normalize_endpoint_url(args.url)
+        except ValueError as exc:
+            print(f"Error: {exc}")
+            return
+        row = db.get_session(resolved_session_id)
+        if not row:
+            print(f"Session '{args.session_id}' not found.")
+            return
+
+        raw_mc = row.get("model_config")
+        model_config: dict = {}
+        if isinstance(raw_mc, dict):
+            model_config = dict(raw_mc)
+        elif isinstance(raw_mc, str) and raw_mc.strip():
+            try:
+                parsed = _json.loads(raw_mc)
+                if isinstance(parsed, dict):
+                    model_config = parsed
+            except Exception:
+                pass
+
+        old_provider = str(
+            model_config.get("provider") or row.get("billing_provider") or ""
+        ).strip()
+        old_base_url = str(
+            model_config.get("base_url") or row.get("billing_base_url") or ""
+        ).strip()
+
+        try:
+            new_provider, source = resolve_endpoint_provider_id(
+                new_url,
+                existing_provider=old_provider,
+                requested_provider=getattr(args, "provider", None),
+            )
+        except ValueError as exc:
+            print(f"Error: {exc}")
+            return
+
+        model_config["provider"] = new_provider
+        model_config["base_url"] = new_url
+        db.update_session_meta(
+            resolved_session_id, _json.dumps(model_config, ensure_ascii=False)
+        )
+        db.update_session_billing_route(
+            resolved_session_id,
+            provider=billing_provider_id(new_provider),
+            base_url=new_url,
+        )
+
+        print(f"Session '{resolved_session_id}' re-pointed to {new_url}.")
+        if old_provider != new_provider:
+            print(f"  provider: {new_provider} (was {old_provider or '(none)'})")
+        else:
+            print(f"  provider: {new_provider}")
+        if old_base_url != new_url:
+            print(f"  base_url: {new_url} (was {old_base_url or '(none)'})")
+        else:
+            print(f"  base_url: {new_url}")
+        if source == "custom-fallback":
+            print(
+                "  note: no configured provider owns this URL — stored bare "
+                "'custom' (the endpoint URL drives routing)."
+            )
+        elif source == "config-entry":
+            print(
+                f"  note: provider id derived from the configured entry that "
+                f"serves this URL ({new_provider})."
+            )
+        print("  The next resumed turn in this session uses the new endpoint.")
+
     else:
         sessions_parser.print_help()
 

--- a/tests/hermes_cli/test_session_endpoint.py
+++ b/tests/hermes_cli/test_session_endpoint.py
@@ -1,0 +1,195 @@
+"""Unit tests for hermes_cli/session_endpoint.py (issue #77831)."""
+
+import pytest
+
+from hermes_cli.session_endpoint import (
+    billing_provider_id,
+    normalize_endpoint_url,
+    resolve_endpoint_provider_id,
+)
+
+
+# ── normalize_endpoint_url ────────────────────────────────────────────────
+
+
+class TestNormalizeEndpointUrl:
+    def test_accepts_http_url_with_path(self):
+        assert (
+            normalize_endpoint_url("http://203.0.113.7:8355/v1")
+            == "http://203.0.113.7:8355/v1"
+        )
+
+    def test_strips_single_trailing_slash(self):
+        assert (
+            normalize_endpoint_url("https://model-host.local:8355/v1/")
+            == "https://model-host.local:8355/v1"
+        )
+        assert (
+            normalize_endpoint_url("http://localhost:11434") == "http://localhost:11434"
+        )
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValueError, match="empty"):
+            normalize_endpoint_url("")
+        with pytest.raises(ValueError, match="empty"):
+            normalize_endpoint_url("   ")
+
+    def test_rejects_non_http_scheme(self):
+        with pytest.raises(ValueError, match="scheme must be http or https"):
+            normalize_endpoint_url("ftp://host/v1")
+        with pytest.raises(ValueError, match="scheme must be http or https"):
+            normalize_endpoint_url("model-host.local:8355")
+
+    def test_rejects_missing_host(self):
+        with pytest.raises(ValueError, match="missing host"):
+            normalize_endpoint_url("http://")
+        with pytest.raises(ValueError, match="missing host"):
+            normalize_endpoint_url("http:///v1")
+
+    def test_rejects_out_of_range_port(self):
+        with pytest.raises(ValueError, match="invalid endpoint URL"):
+            normalize_endpoint_url("http://host:99999/v1")
+
+
+# ── resolve_endpoint_provider_id ──────────────────────────────────────────
+
+
+def _no_entry(provider_id):
+    return None
+
+
+def _entry(provider_id):
+    return {"name": provider_id.split(":", 1)[1], "base_url": "http://x/v1"}
+
+
+@pytest.fixture
+def patch_rt(monkeypatch):
+    """Patch the lazy-imported runtime_provider lookups (module of origin)."""
+    import hermes_cli.runtime_provider as rt_mod
+
+    monkeypatch.setattr(rt_mod, "find_custom_provider_identity", lambda url: None)
+    monkeypatch.setattr(rt_mod, "_get_named_custom_provider", _no_entry)
+    return rt_mod
+
+
+class TestRequestedProvider:
+    def test_bare_custom(self, patch_rt):
+        assert resolve_endpoint_provider_id(
+            "http://203.0.113.7:8355/v1", requested_provider="custom"
+        ) == ("custom", "requested")
+
+    def test_builtin(self, patch_rt):
+        assert resolve_endpoint_provider_id(
+            "http://203.0.113.7:8355/v1", requested_provider="openrouter"
+        ) == ("openrouter", "requested")
+
+    def test_configured_custom_entry(self, patch_rt, monkeypatch):
+        import hermes_cli.runtime_provider as rt_mod
+
+        monkeypatch.setattr(rt_mod, "_get_named_custom_provider", _entry)
+        assert resolve_endpoint_provider_id(
+            "http://203.0.113.7:8355/v1", requested_provider="custom:local"
+        ) == ("custom:local", "requested")
+
+    def test_unknown_custom_entry_rejected(self, patch_rt):
+        with pytest.raises(ValueError, match="Unknown provider 'custom:nope'"):
+            resolve_endpoint_provider_id(
+                "http://203.0.113.7:8355/v1", requested_provider="custom:nope"
+            )
+
+    def test_auto_rejected(self, patch_rt):
+        with pytest.raises(ValueError, match="not a routable provider id"):
+            resolve_endpoint_provider_id(
+                "http://203.0.113.7:8355/v1", requested_provider="auto"
+            )
+
+    def test_unknown_builtin_rejected(self, patch_rt, monkeypatch):
+        import hermes_cli.auth as auth_mod
+
+        def _boom(_):
+            raise auth_mod.AuthError("Unknown provider 'nope'.")
+
+        monkeypatch.setattr(auth_mod, "resolve_provider", _boom)
+        with pytest.raises(ValueError, match="Unknown provider 'nope'"):
+            resolve_endpoint_provider_id(
+                "http://203.0.113.7:8355/v1", requested_provider="nope"
+            )
+
+
+class TestAutoDerive:
+    def test_config_entry_owns_url(self, patch_rt, monkeypatch):
+        import hermes_cli.runtime_provider as rt_mod
+
+        monkeypatch.setattr(
+            rt_mod, "find_custom_provider_identity", lambda url: "custom:local"
+        )
+        assert resolve_endpoint_provider_id(
+            "http://203.0.113.7:8355/v1",
+            existing_provider="custom:model-host.local:8355",
+        ) == ("custom:local", "config-entry")
+
+    def test_keeps_bare_custom(self, patch_rt):
+        assert resolve_endpoint_provider_id(
+            "http://203.0.113.7:8355/v1", existing_provider="custom"
+        ) == ("custom", "existing")
+
+    def test_keeps_builtin(self, patch_rt, monkeypatch):
+        import hermes_cli.auth as auth_mod
+
+        monkeypatch.setattr(auth_mod, "resolve_provider", lambda pid: "anthropic")
+        assert resolve_endpoint_provider_id(
+            "https://api.anthropic.com",
+            existing_provider="anthropic",
+        ) == ("anthropic", "existing")
+
+    def test_keeps_configured_custom_slug(self, patch_rt, monkeypatch):
+        import hermes_cli.runtime_provider as rt_mod
+
+        monkeypatch.setattr(rt_mod, "_get_named_custom_provider", _entry)
+        assert resolve_endpoint_provider_id(
+            "http://203.0.113.7:8355/v1",
+            existing_provider="custom:local",
+        ) == ("custom:local", "existing")
+
+    def test_falls_back_to_bare_custom_for_orphan_slug(self, patch_rt):
+        # The issue's footgun: a custom:<endpoint> slug with no config entry
+        # must NOT be persisted (the runtime refuses it with
+        # "Unknown provider 'custom:<endpoint>'").
+        assert resolve_endpoint_provider_id(
+            "http://203.0.113.7:8355/v1",
+            existing_provider="custom:model-host.local:8355",
+        ) == ("custom", "custom-fallback")
+
+    def test_falls_back_with_no_existing_provider(self, patch_rt):
+        assert resolve_endpoint_provider_id(
+            "http://203.0.113.7:8355/v1", existing_provider=None
+        ) == ("custom", "custom-fallback")
+
+    def test_find_error_is_tolerated(self, patch_rt, monkeypatch):
+        import hermes_cli.runtime_provider as rt_mod
+
+        monkeypatch.setattr(
+            rt_mod,
+            "find_custom_provider_identity",
+            lambda url: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        assert resolve_endpoint_provider_id(
+            "http://203.0.113.7:8355/v1",
+            existing_provider="custom:model-host.local:8355",
+        ) == ("custom", "custom-fallback")
+
+
+# ── billing_provider_id ───────────────────────────────────────────────────
+
+
+class TestBillingProviderId:
+    def test_bare_custom(self):
+        assert billing_provider_id("custom") == "custom"
+
+    def test_custom_slug_billed_under_bare_class(self):
+        assert billing_provider_id("custom:local") == "custom"
+        assert billing_provider_id("custom:model-host.local:8355") == "custom"
+
+    def test_builtin_kept(self):
+        assert billing_provider_id("anthropic") == "anthropic"
+        assert billing_provider_id("openrouter") == "openrouter"

--- a/tests/hermes_cli/test_sessions_set_endpoint_cli.py
+++ b/tests/hermes_cli/test_sessions_set_endpoint_cli.py
@@ -1,0 +1,200 @@
+"""CLI tests for ``hermes sessions set-endpoint`` (issue #77831).
+
+Follows the FakeDB pattern of tests/hermes_cli/test_sessions_delete.py:
+monkeypatch ``hermes_state.SessionDB`` with a fake, drive ``main()`` via
+``sys.argv``, and assert on captured writes + stdout.
+"""
+
+import json
+import sys
+
+import pytest
+
+
+SESSION_ID = "20260315_092437_c9a6ff"
+OLD_URL = "http://model-host.local:8355/v1"
+NEW_URL = "http://203.0.113.7:8355/v1"
+
+
+def _run(monkeypatch, capsys, argv_tail, row, **rt_patches):
+    """Run `hermes sessions set-endpoint <argv_tail>` against a FakeDB."""
+    import hermes_cli.main as main_mod
+    import hermes_cli.runtime_provider as rt_mod
+    import hermes_state
+
+    captured = {"meta": None, "billing": None, "closed": False}
+
+    class FakeDB:
+        def resolve_session_id(self, session_id):
+            captured["resolved_from"] = session_id
+            return SESSION_ID if session_id.startswith("20260315") else None
+
+        def get_session(self, session_id):
+            return dict(row)
+
+        def update_session_meta(self, session_id, model_config_json, model=None):
+            captured["meta"] = (session_id, model_config_json)
+
+        def update_session_billing_route(
+            self, session_id, *, provider, base_url, billing_mode=None
+        ):
+            captured["billing"] = (session_id, provider, base_url, billing_mode)
+
+        def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    # Config-backed lookups are imported lazily inside the helper — patch the
+    # module of origin.
+    monkeypatch.setattr(
+        rt_mod,
+        "find_custom_provider_identity",
+        rt_patches.get("find", lambda url: None),
+    )
+    monkeypatch.setattr(
+        rt_mod, "_get_named_custom_provider", rt_patches.get("entry", lambda pid: None)
+    )
+    monkeypatch.setattr(sys, "argv", ["hermes", "sessions", "set-endpoint", *argv_tail])
+
+    main_mod.main()
+    return captured, capsys.readouterr().out
+
+
+def _stuck_row():
+    """The issue's repro row: session pinned to the dead endpoint."""
+    return {
+        "id": SESSION_ID,
+        "model_config": json.dumps({
+            "provider": "custom:model-host.local:8355",
+            "base_url": OLD_URL,
+            "model": "qwen3",
+        }),
+        "billing_provider": "custom",
+        "billing_base_url": OLD_URL,
+        "billing_mode": "chat_completions",
+    }
+
+
+def test_set_endpoint_rewrites_row_and_billing(monkeypatch, capsys):
+    captured, output = _run(monkeypatch, capsys, [SESSION_ID, NEW_URL], _stuck_row())
+
+    assert f"Session '{SESSION_ID}' re-pointed to {NEW_URL}." in output
+    assert "stored bare 'custom'" in output
+
+    # model_config: provider/base_url rewritten, other knobs preserved.
+    sid, meta_json = captured["meta"]
+    assert sid == SESSION_ID
+    meta = json.loads(meta_json)
+    assert meta["provider"] == "custom"
+    assert meta["base_url"] == NEW_URL
+    assert meta["model"] == "qwen3"
+
+    # billing route rewritten; billing_mode preserved (None -> COALESCE).
+    bsid, provider, base_url, billing_mode = captured["billing"]
+    assert bsid == SESSION_ID
+    assert provider == "custom"
+    assert base_url == NEW_URL
+    assert billing_mode is None
+    assert captured["closed"] is True
+
+
+def test_set_endpoint_uses_configured_entry_slug(monkeypatch, capsys):
+    captured, output = _run(
+        monkeypatch,
+        capsys,
+        [SESSION_ID, NEW_URL],
+        _stuck_row(),
+        find=lambda url: "custom:local",
+    )
+
+    assert "derived from the configured entry" in output
+    assert "  provider: custom:local (was custom:model-host.local:8355)" in output
+    meta = json.loads(captured["meta"][1])
+    assert meta["provider"] == "custom:local"
+    assert meta["base_url"] == NEW_URL
+    # custom:* slugs bill under the bare class.
+    assert captured["billing"][1] == "custom"
+    assert captured["billing"][2] == NEW_URL
+
+
+def test_set_endpoint_keeps_builtin_provider(monkeypatch, capsys):
+    row = dict(_stuck_row())
+    row["model_config"] = json.dumps({
+        "provider": "anthropic",
+        "base_url": "https://api.anthropic.com",
+    })
+    captured, output = _run(
+        monkeypatch,
+        capsys,
+        [SESSION_ID, NEW_URL],
+        row,
+    )
+
+    assert "  provider: anthropic" in output
+    meta = json.loads(captured["meta"][1])
+    assert meta["provider"] == "anthropic"
+    assert meta["base_url"] == NEW_URL
+    assert captured["billing"][1] == "anthropic"
+
+
+def test_set_endpoint_explicit_provider(monkeypatch, capsys):
+    captured, output = _run(
+        monkeypatch,
+        capsys,
+        [SESSION_ID, NEW_URL, "--provider", "custom:local"],
+        _stuck_row(),
+        entry=lambda pid: {"name": "local", "base_url": NEW_URL},
+    )
+
+    assert "re-pointed to" in output
+    meta = json.loads(captured["meta"][1])
+    assert meta["provider"] == "custom:local"
+    assert meta["base_url"] == NEW_URL
+    assert captured["billing"][1] == "custom"
+
+
+def test_set_endpoint_unknown_provider_rejected(monkeypatch, capsys):
+    captured, output = _run(
+        monkeypatch,
+        capsys,
+        [SESSION_ID, NEW_URL, "--provider", "custom:nope"],
+        _stuck_row(),
+    )
+
+    assert "Error: Unknown provider 'custom:nope'" in output
+    assert captured["meta"] is None
+    assert captured["billing"] is None
+
+
+def test_set_endpoint_session_not_found(monkeypatch, capsys):
+    captured, output = _run(monkeypatch, capsys, ["nope", NEW_URL], _stuck_row())
+
+    assert "Session 'nope' not found." in output
+    assert captured["meta"] is None
+    assert captured["billing"] is None
+
+
+def test_set_endpoint_invalid_url(monkeypatch, capsys):
+    captured, output = _run(
+        monkeypatch, capsys, [SESSION_ID, "ftp://host/v1"], _stuck_row()
+    )
+
+    assert "Error: invalid endpoint URL 'ftp://host/v1'" in output
+    assert captured["meta"] is None
+    assert captured["billing"] is None
+
+
+def test_set_endpoint_unique_prefix_resolution(monkeypatch, capsys):
+    captured, output = _run(monkeypatch, capsys, ["20260315", NEW_URL], _stuck_row())
+
+    assert captured["resolved_from"] == "20260315"
+    assert f"Session '{SESSION_ID}' re-pointed to {NEW_URL}." in output
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hermes_home(monkeypatch, tmp_path):
+    """Keep real config out of the lookups (conftest-level safety net)."""
+    import os
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    os.environ.pop("HERMES_INFERENCE_PROVIDER", None)

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -435,6 +435,38 @@ hermes sessions rename 20250305_091523_a1b2c3d4 debugging auth flow
 
 If the title is already in use by another session, an error is shown.
 
+### Re-point a Session's Endpoint
+
+Sessions pin their provider endpoint in the durable session row
+(`sessions.model_config` JSON plus the `billing_provider` /
+`billing_base_url` / `billing_mode` columns). The runtime resolves the
+endpoint from that snapshot on every resume — not from live `config.yaml` —
+so when a model server's address changes (e.g. an in-house server reachable
+via `model-host.local:8355` on one network and `203.0.113.7:8355` on
+another), an already-open session keeps retrying the dead address, even
+across restarts. New sessions pick up the new endpoint; existing ones need
+re-pointing:
+
+```bash
+# Re-point a session to a new endpoint (rewrites model_config + billing route)
+hermes sessions set-endpoint 20250305_091523_a1b2c3d4 http://203.0.113.7:8355/v1
+
+# Unique prefixes work too
+hermes sessions set-endpoint 20250305_091523 http://203.0.113.7:8355/v1
+
+# Force a specific provider id (built-in, bare 'custom', or configured custom:<name>)
+hermes sessions set-endpoint 20250305_091523_a1b2c3d4 http://203.0.113.7:8355/v1 --provider custom:local
+```
+
+The provider id is validated so the rewritten row is immediately routable.
+Without `--provider`, the command stores the configured `custom:<name>` entry
+that owns the new URL, keeps the session's existing provider when it is still
+routable (built-in or configured entry), or falls back to bare `custom` (the
+endpoint URL drives routing). It never writes a `custom:<name>` slug with no
+matching config entry — the runtime refuses those with
+`Unknown provider 'custom:<...>'`. The next resumed turn in the session uses
+the new endpoint.
+
 ### Prune Old Sessions
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a supported re-pointing path for sessions whose provider endpoint is pinned in the durable session row: `hermes sessions set-endpoint <session-id> <url> [--provider <provider-id>]`.

Sessions pin their provider endpoint persistently in `state.db` (`sessions.model_config` JSON with `provider` + `base_url`, plus the `billing_provider` / `billing_base_url` / `billing_mode` columns). The runtime resolves the endpoint from that per-session snapshot on every resume — not from live `config.yaml` — so when a model server's address changes, an already-open session keeps retrying the dead address, **and this survives restarts** (unlike #67821). Until now the only fix was manual `state.db` editing.

## Root Cause

- Session identity owns the endpoint: `sessions.model_config` + `billing_*` are the source of truth for resolution, read back on every resume; `config.yaml` only defaults sessions born after a change.
- The stored snapshot is decoupled from the configured endpoint and survives restarts, so no event ever repairs it.
- No supported re-pointing path existed: `hermes sessions` had no set-endpoint / set-model-config subcommand.
- Secondary footgun: hand-rewriting the row with a compound id (`custom:<endpoint>`) that has no matching `custom_providers:`/`providers:` entry produces a hard `Unknown provider 'custom:<endpoint>'` error.

## Change

New `hermes sessions set-endpoint <id> <url>` subcommand (6 files, +723/−0):

- **`hermes_cli/session_endpoint.py`** (new): pure helper module —
  - `normalize_endpoint_url()` validates the URL (http/https scheme, host present, port in range, trailing slash stripped) and
  - `resolve_endpoint_provider_id()` resolves/validates the provider id to persist, and `billing_provider_id()` maps custom ids to the bare `"custom"` billing bucket the runtime itself writes.
- **`hermes_cli/sessions_cmd.py`**: dispatch branch that reads the row, rewrites `model_config` (provider + base_url, preserving every other knob), and persists the billing route via the existing `SessionDB.update_session_meta()` / `update_session_billing_route()`.
- **`hermes_cli/main.py`**: `set-endpoint` subparser (`ID`, `URL`, optional `--provider`).
- **Provider id validation** (the footgun fix): `--provider` accepts a built-in provider, bare `custom`, or a configured `custom:<name>` entry; when omitted, the command stores the configured entry that owns the new URL, keeps the session's existing provider when still routable, or falls back to bare `custom` — it never writes a `custom:<name>` slug with no matching config entry.
- **Docs**: new "Re-point a Session's Endpoint" section in `website/docs/user-guide/sessions.md`.
- **Tests**: `tests/hermes_cli/test_session_endpoint.py` (helper units, FakeDB-free) and `tests/hermes_cli/test_sessions_set_endpoint_cli.py` (CLI via the existing FakeDB pattern) — 30 new tests.

## Verification

- 30 new tests pass (`test_session_endpoint.py` + `test_sessions_set_endpoint_cli.py`); existing sessions CLI suites (`test_sessions_delete.py`, `test_sessions_export_md_cli.py`, `test_sessions_size_delta_label.py`) still pass.
- End-to-end smoke against a real throwaway `state.db`: seeded a session pinned to `http://model-host.local:8355/v1` (issue repro shape), ran `hermes sessions set-endpoint <id> http://203.0.113.7:8355/v1`, and verified the row is rewritten — `model_config.provider` → `custom`, `model_config.base_url` → new URL, `billing_provider` → `custom`, `billing_base_url` → new URL, model preserved.
- `ruff check` clean on all touched files; added regions are `ruff format`-clean (format-diff identical to base — pre-existing format debt untouched).
- No competing PR exists for #77831 (checked via `gh search prs` and the issue body/comments).

## Notes / Out of Scope

The issue also suggests (1) a GUI affordance in Desktop Settings, (2) an "unavailable modal" recovery action, and (3) optionally falling back to the configured endpoint when `billing_base_url` no longer resolves. This PR delivers the CLI re-pointing path (item 2 of the issue's Suggested Fix, and the minimal acceptable scope) plus the provider-id validation that removes the hand-repair footgun; the GUI/modal/fallback items remain follow-ups.

Closes #77831
