### PR TITLE
feat(tools): add delegate_completion, a name-only one-shot completion tool

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1823,7 +1823,9 @@ DEFAULT_CONFIG = {
             # NOTE: no reasoning_effort here by design — see moa_reference above.
         },
     },
-    
+
+    "delegate_completion_tasks": [],
+
     "display": {
         "compact": False,
         "personality": "",

--- a/tools/delegate_completion_tool.py
+++ b/tools/delegate_completion_tool.py
@@ -1,0 +1,99 @@
+from tools.registry import registry, tool_error, tool_result
+
+DELEGATE_COMPLETION_SCHEMA = {
+    "name": "delegate_completion",
+    "description": (
+        "One-shot LLM completion for a named, operator-configured task. "
+        "Pass only `task` (must be one of the pre-approved task names below) "
+        "and `prompt` (what to send). The provider and model for each task "
+        "are fixed by the operator in config.yaml — this tool has no "
+        "provider/model/base_url parameter and never accepts one. "
+        "(task enum rebuilt at every get_definitions() call from "
+        "config.yaml's delegate_completion_tasks block.)"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task": {
+                "type": "string",
+                "enum": [],
+                "description": "Name of a pre-configured task. (rebuilt at get_definitions() time)",
+            },
+            "prompt": {
+                "type": "string",
+                "description": "The content to send to the model for this task.",
+            },
+        },
+        "required": ["task", "prompt"],
+    },
+}
+
+_INTERNAL_ONLY_TASK_NAMES = {"approval", "mcp"}
+
+
+def _delegate_completion_allowlist() -> list:
+    from hermes_cli.config import load_config
+    config = load_config()
+    names = config.get("delegate_completion_tasks", []) or []
+    auxiliary = config.get("auxiliary", {}) or {}
+    return [
+        n for n in names
+        if isinstance(n, str) and n.strip()
+        and n not in _INTERNAL_ONLY_TASK_NAMES
+        and n in auxiliary
+    ]
+
+
+def check_delegate_completion_requirements() -> bool:
+    return len(_delegate_completion_allowlist()) > 0
+
+
+def _build_delegate_completion_schema_overrides() -> dict:
+    allowed = _delegate_completion_allowlist()
+    overrides_params = {**DELEGATE_COMPLETION_SCHEMA["parameters"]}
+    overrides_params["properties"] = {
+        k: dict(v) for k, v in DELEGATE_COMPLETION_SCHEMA["parameters"]["properties"].items()
+    }
+    overrides_params["properties"]["task"]["enum"] = allowed
+    overrides_params["properties"]["task"]["description"] = (
+        f"Name of a pre-configured task. Must be one of: {', '.join(allowed)}"
+        if allowed else "No delegate_completion_tasks configured — this tool is currently unusable."
+    )
+    return {"parameters": overrides_params}
+
+
+def delegate_completion(task: str, prompt: str, **kw) -> str:
+    from agent.auxiliary_client import call_llm, extract_content_or_reasoning
+
+    allowed = _delegate_completion_allowlist()
+    if not isinstance(task, str) or task not in allowed:
+        return tool_error(
+            f"Unknown task '{task}'. Must be one of: {', '.join(allowed) or '(none configured)'}"
+        )
+    if not isinstance(prompt, str) or not prompt.strip():
+        return tool_error("prompt is required")
+
+    try:
+        response = call_llm(
+            task=task,
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except Exception as e:
+        return tool_error(f"delegate_completion task '{task}' failed: {e}")
+
+    text = extract_content_or_reasoning(response)
+    return tool_result(task=task, content=text)
+
+
+registry.register(
+    name="delegate_completion",
+    toolset="delegate_completion",
+    schema=DELEGATE_COMPLETION_SCHEMA,
+    handler=lambda args, **kw: delegate_completion(
+        task=args.get("task"),
+        prompt=args.get("prompt"),
+    ),
+    check_fn=check_delegate_completion_requirements,
+    emoji="🤖",
+    dynamic_schema_overrides=_build_delegate_completion_schema_overrides,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -62,7 +62,7 @@ _HERMES_CORE_TOOLS = [
     # Clarifying questions
     "clarify",
     # Code execution + delegation
-    "execute_code", "delegate_task",
+    "execute_code", "delegate_task", "delegate_completion",
     # Cronjob management
     "cronjob",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
@@ -249,6 +249,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "delegate_completion": {
+        "description": "One-shot LLM completion for a named, operator-configured task (no provider/model choice)",
+        "tools": ["delegate_completion"],
+        "includes": []
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 
@@ -359,7 +365,7 @@ TOOLSETS = {
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             "todo", "memory",
             "session_search", "clarify",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "delegate_completion",
         ],
         "includes": [],
         # Posture toolset: selected per-session by agent/coding_context.py,
@@ -391,7 +397,7 @@ TOOLSETS = {
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             "todo", "memory",
             "session_search",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "delegate_completion",
         ],
         "includes": []
     },
@@ -419,7 +425,7 @@ TOOLSETS = {
             # Session history search
             "session_search",
             # Code execution + delegation
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "delegate_completion",
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)


### PR DESCRIPTION
## Summary

Adds `delegate_completion`, a lightweight one-shot completion tool for pure text-transform work, avoiding `delegate_task`'s full agent-loop overhead (system prompt, tool schemas, multi-turn iteration) for tasks that don't need any of that — the exact gap described in #59070.

## Why this should land where #59214 / #59557 didn't

Both prior attempts at this tool exposed `provider`/`model` as agent-callable tool parameters and were rejected under the `delegation-model-routing` policy (#59557 closed explicitly on this; #59214 still open but flagged with the same objection).

This implementation follows the shape the close message on #59557 explicitly invited:

> "keep any backend choice user-configured in config.yaml and avoid model-controlled provider/model parameters"

- The tool schema has **only** `task` (a name) and `prompt` — no `provider`, `model`, or `base_url` field anywhere.
- `task` must be present in an opt-in `delegate_completion_tasks:` allowlist in `config.yaml`, **and** must also exist as a real `auxiliary.*` entry — the backend for every task name is fixed entirely by the operator, never chosen or discoverable-by-guessing by the model.
- The allowlist check happens in the tool itself, before `call_llm` is ever invoked — it does not rely on `call_llm`'s own lenient `{}`-on-unknown-task fallback-to-auto behavior, so a misconfigured or unlisted name fails clearly instead of silently routing somewhere unintended.
- Internal-only auxiliary tasks (`approval`, `mcp`) are hard-blocked from being aliased through this tool even if an operator lists them, since they have fixed calling contracts elsewhere in the codebase that a raw `prompt` string would bypass.
- The tool is hidden from the schema entirely (`check_fn`) when no tasks are configured — no dead/always-erroring tool exposed by default.

## Changes

- `tools/delegate_completion_tool.py` (new) — schema, handler, dynamic enum/description overrides, registration.
- `toolsets.py` — added to `_HERMES_CORE_TOOLS` (covers CLI/messaging platforms) and to the `coding`, `hermes-acp`, and `hermes-api-server` toolsets, which enumerate `delegate_task` independently rather than including the shared core list.
- `hermes_cli/config.py` — new `delegate_completion_tasks: []` default config key.

## Testing

- Verified against a live Ollama Cloud-backed task end-to-end (real completion returned, not mocked).
- Verified the allowlist correctly rejects: an unconfigured task name, a task name with no matching `auxiliary.*` entry, and non-string `task`/`prompt` arguments (returns `tool_error`, no unhandled exception).
- Verified `check_fn` correctly hides the tool when `delegate_completion_tasks` is empty/unset.

Closes #59070.