### PR TITLE
fix(guard): never crash or false-positive on binary/executable paths

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -171,7 +171,19 @@ def contains_launchctl_submit_command(command: str) -> bool:
 
 
 def _resolve_terminal_script_path(candidate: str, cwd: Optional[str]) -> Path:
-    path = Path(candidate).expanduser()
+    try:
+        # Reject NUL bytes before pathlib touches them: expanduser() raises
+        # either ValueError ("embedded null byte") or RuntimeError ("Could
+        # not determine home directory", #77906) depending on what the
+        # tokenized garbage looks like. Guard must never crash on either.
+        if "\x00" in candidate:
+            return Path("/nonexistent-guard-skip") if cwd else Path.cwd()
+        path = Path(candidate).expanduser()
+    except (OSError, ValueError, RuntimeError):
+        # OSError: unreadable/long paths. ValueError/RuntimeError: NUL byte
+        # or unresolvable ~ in a path tokenized from a binary's decoded
+        # contents. Never let a guarded path crash the guard (#77906).
+        return Path("/nonexistent-guard-skip") if cwd else Path.cwd()
     if not path.is_absolute():
         path = Path(cwd or Path.cwd()) / path
     return path
@@ -258,7 +270,12 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError, RuntimeError):
+        # OSError: unreadable/long paths. ValueError: embedded NUL byte in
+        # the path (from a binary's decoded contents tokenized as a script
+        # path). Either way the file is not a readable shell script — treat
+        # as "nothing to scan" (#77906). A guarded path must never crash
+        # the guard.
         return None, False
     try:
         metadata = os.fstat(descriptor)
@@ -268,7 +285,9 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         # chunk tells us if this is a binary (NUL bytes) that should be
         # skipped as "nothing to scan" rather than failing closed (#76762).
         data = os.read(descriptor, _MAX_REFERENCED_SCRIPT_BYTES + 1)
-    except OSError:
+    except (OSError, ValueError, RuntimeError):
+        # ValueError: embedded NUL byte in path — same class as os.open
+        # above (#77906); never let a guarded path crash the guard.
         return None, False
     finally:
         os.close(descriptor)
@@ -374,7 +393,12 @@ def _resolve_script_path(script_path: str) -> Path:
     """
     from hermes_constants import get_hermes_home
 
-    raw = Path(script_path).expanduser()
+    try:
+        raw = Path(script_path).expanduser()
+    except (OSError, ValueError):
+        # ValueError: embedded NUL byte in the path (#77906). Never let a
+        # guarded path crash the guard — treat as unreadable (empty).
+        return get_hermes_home() / "scripts" / "_guard_skip_unreadable"
     if raw.is_absolute():
         return raw
     return get_hermes_home() / "scripts" / raw

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2545,6 +2545,15 @@ def terminal_tool(
                         if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= 1024 * 1024:
                             data = local_path.read_bytes()
                             if len(data) <= 1024 * 1024:
+                                # Binary (ELF/Mach-O/PE) contains NUL bytes —
+                                # decoding it as text feeds machine-code junk
+                                # into the lifecycle scan, producing false
+                                # positives like "gateway restart" found in
+                                # the binary's string table (#77906). Treat
+                                # binaries as "nothing to scan", matching
+                                # _read_referenced_script's NUL check.
+                                if b"\x00" in data:
+                                    return None
                                 return data.decode("utf-8", errors="replace")
                 except Exception:
                     pass
@@ -2552,7 +2561,12 @@ def terminal_tool(
                 try:
                     result = env.execute(f"cat {shlex.quote(script_path)}")
                     if result.get("returncode", -1) == 0:
-                        return result.get("output", "")
+                        output = result.get("output", "")
+                        # Same binary guard as the local branch: NUL bytes
+                        # mean the file is a binary, not a script (#77906).
+                        if "\x00" in output:
+                            return None
+                        return output
                 except Exception:
                     pass
                 return None


### PR DESCRIPTION
## What happened

After the last Hermes update, the terminal guard started refusing to run the most basic commands. On any machine where scripts are invoked via a full path to the interpreter (venv, uv, Homebrew, `~/.hermes/bin`), the terminal just breaks out of nowhere.

Here's what actually happened:

- You run `/venv/bin/python -c "print(1)"` — and get `ValueError: embedded null byte`. The command doesn't even start, the terminal just dies.
- You type `sh ~/scripts/restart.sh` — `RuntimeError: Could not determine home directory`.
- A plain interpreter call by full path — "Blocked: command or referenced script cannot restart or stop the gateway."

Yes, you read that right: the guard decided that `python -c "print(1)"` is an attempt to restart the gateway.

## Why

When scanning a command, the guard sees a full path to a binary (`venv/bin/python`) and tries to read it as a shell script. A Python binary is a Mach-O file full of NUL bytes, and that breaks things in two places:

1. **`cron/lifecycle_guard.py`** — `os.open()` / `os.read()` / `expanduser()` crash on paths with NUL bytes (or on `~` when there's no `HOME` in the launchd environment). Only `OSError` was caught, but it's `ValueError` and `RuntimeError` that get raised — unhandled exceptions kill the guard on every command that mentions a full-path binary.
2. **`tools/terminal_tool.py`** — any file up to 1 MB gets decoded as UTF-8 with `errors="replace"`, binaries included. Machine code turns into garbage "text" containing the words `gateway`, `restart`, `hermes` — and the guard produces a false "cannot restart or stop the gateway" block.

## Who's affected

Anyone who runs tools by full path: venv, uv tool bins, Homebrew, `~/.hermes/bin`. In practice — nearly everyone working with virtual environments, especially after a gateway restart.

## The fix

Don't let the guard crash on binaries: reject NUL bytes before touching the filesystem and catch `(OSError, ValueError, RuntimeError)` everywhere paths are handled.

Verified on a live machine (macOS, gateway under launchd without `HOME`):

| Command | Before | After |
|---|---|---|
| `/venv/bin/python -c "print(1)"` | `ValueError: embedded null byte` | works |
| `sh ~/scripts/restart.sh` (no HOME) | `RuntimeError` | works |
| `python /tmp/foo\x00bar.py` (NUL in token) | crash | no crash |
| `ls -la /tmp` | works | works |
| actual `hermes gateway restart` | blocked (correct) | still blocked (correct) |

Real lifecycle commands (`hermes gateway restart`, `launchctl submit`) are still blocked exactly as before — this fix doesn't weaken anything.
