### PR TITLE
fix(desktop): preserve session history after interrupted API calls

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2140,6 +2140,9 @@ class AIAgent:
             # at the end of the scan (see append_messages_batch).
             _batch_rows: List[Dict[str, Any]] = []
             _batch_msgs: List[Dict] = []
+            # Stamp live dicts only after the batch commit succeeds. Timestamp
+            # means first successful durable write, not a failed attempt.
+            _pending_live_timestamps: List[tuple[Dict[str, Any], float]] = []
             for _msg_idx in range(_scan_start, len(messages)):
                 msg = messages[_msg_idx]
                 if not isinstance(msg, dict):
@@ -2216,7 +2219,7 @@ class AIAgent:
                         _row_timestamp = _ov_timestamp
                 if _row_timestamp is None:
                     _row_timestamp = time.time()
-                    msg["timestamp"] = _row_timestamp
+                    _pending_live_timestamps.append((msg, _row_timestamp))
                 # Store the sidecar only when it actually differs.
                 if _row_api_content == content:
                     _row_api_content = None
@@ -2324,6 +2327,8 @@ class AIAgent:
                     )
                     or 300.0,
                 )
+                for _msg, _ts in _pending_live_timestamps:
+                    _msg["timestamp"] = _ts
                 for _written in _batch_msgs:
                     _written[_DB_PERSISTED_MARKER] = True
             # The intrinsic markers are now the sole source of truth. Reset the

--- a/run_agent.py
+++ b/run_agent.py
@@ -2214,6 +2214,9 @@ class AIAgent:
                         content = _ov_content
                     if _ov_timestamp is not None:
                         _row_timestamp = _ov_timestamp
+                if _row_timestamp is None:
+                    _row_timestamp = time.time()
+                    msg["timestamp"] = _row_timestamp
                 # Store the sidecar only when it actually differs.
                 if _row_api_content == content:
                     _row_api_content = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -2210,6 +2210,14 @@ class AIAgent:
                         elif isinstance(p, dict) and p.get("type") in {"image", "image_url", "input_image"}:
                             _txt.append("[screenshot]")
                     content = "\n".join(_txt) if _txt else None
+                # Keep the timestamp assigned to this first durable write on
+                # the live dict as well. A later rewind/regenerate may
+                # rewrite the in-memory transcript through replace_messages();
+                # without it every otherwise-surviving row is stamped with the
+                # rewrite batch's time instead of its original event time.
+                if _row_timestamp is None:
+                    _row_timestamp = time.time()
+                    msg["timestamp"] = _row_timestamp
                 tool_calls_data = None
                 if hasattr(msg, "tool_calls") and isinstance(msg.tool_calls, list) and msg.tool_calls:
                     tool_calls_data = [

--- a/tests/agent/test_cursor_optimizations_parity.py
+++ b/tests/agent/test_cursor_optimizations_parity.py
@@ -137,9 +137,11 @@ def test_parity_token_memo():
         print(f"  n={n}: OK (equal across 3 iterations + compression + in-place edit + odd types)")
 
 
-def test_parity_persist_bounded_scan():
+def test_parity_persist_bounded_scan(monkeypatch):
     print("=== parity: _flush_messages_to_session_db bounded scan ===")
     import run_agent as ra
+
+    monkeypatch.setattr(ra.time, "time", lambda: 1_700_000_000.0)
 
     class FakeDB:
         def __init__(self):
@@ -268,8 +270,12 @@ def bench():
 
 
 if __name__ == "__main__":
+    class _MonkeyPatch:
+        def setattr(self, target, name, value, raising=True):
+            setattr(target, name, value)
+
     test_parity_sanitize_cursor()
     test_parity_token_memo()
-    test_parity_persist_bounded_scan()
+    test_parity_persist_bounded_scan(_MonkeyPatch())
     bench()
     print("ALL PARITY CHECKS PASSED")

--- a/tests/run_agent/test_session_flush_timestamps.py
+++ b/tests/run_agent/test_session_flush_timestamps.py
@@ -1,0 +1,46 @@
+"""Regression coverage for timestamps assigned during append-only persistence."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from run_agent import AIAgent
+
+
+class _RecordingSessionDB:
+    def __init__(self):
+        self.batches: list[list[dict]] = []
+
+    def append_messages_batch(self, *, session_id, messages, **_kwargs):
+        self.batches.append(list(messages))
+
+
+def test_flush_stamps_live_message_with_the_durable_write_timestamp():
+    """A later transcript rewrite must retain the original event timestamp.
+
+    Current main assigns a timestamp to the SessionDB row when the live dict
+    has none, but leaves the live dict unstamped. A later replace_messages()
+    then batch-restamps surviving rows.
+    """
+    db = _RecordingSessionDB()
+    agent = SimpleNamespace(
+        _persist_disabled=False,
+        _session_db=db,
+        _session_db_created=True,
+        _persist_user_message_idx=None,
+        _persist_user_message_override=None,
+        _persist_user_message_timestamp=None,
+        _flushed_db_message_session_id=None,
+        _last_flushed_db_idx=0,
+        _flushed_db_message_ids=set(),
+        _db_flush_scan_prefix=None,
+        _active_compression_lock_holder=None,
+        session_id="session",
+    )
+    messages = [{"role": "user", "content": "keep this timestamp"}]
+
+    assert AIAgent._flush_messages_to_session_db_unlocked(agent, messages) is True
+
+    assert isinstance(messages[0]["timestamp"], float)
+    assert len(db.batches) == 1
+    assert db.batches[0][0]["timestamp"] == messages[0]["timestamp"]

--- a/tests/run_agent/test_session_flush_timestamps.py
+++ b/tests/run_agent/test_session_flush_timestamps.py
@@ -16,11 +16,10 @@ class _RecordingSessionDB:
 
 
 def test_flush_stamps_live_message_with_the_durable_write_timestamp():
-    """A later transcript rewrite must retain the original event timestamp.
+    """A later transcript rewrite must retain the original durable-write timestamp.
 
-    Current main assigns a timestamp to the SessionDB row when the live dict
-    has none, but leaves the live dict unstamped. A later replace_messages()
-    then batch-restamps surviving rows.
+    Timestamp is first successful durable write. SessionDB used to assign a
+    time to the row while leaving the live dict unstamped.
     """
     db = _RecordingSessionDB()
     agent = SimpleNamespace(
@@ -43,4 +42,37 @@ def test_flush_stamps_live_message_with_the_durable_write_timestamp():
 
     assert isinstance(messages[0]["timestamp"], float)
     assert len(db.batches) == 1
+    assert db.batches[0][0]["timestamp"] == messages[0]["timestamp"]
+
+
+def test_flush_does_not_stamp_live_dict_until_batch_commit_succeeds():
+    """Timestamp means first successful durable write, not a failed attempt."""
+
+    class _FailingSessionDB:
+        def append_messages_batch(self, *, session_id, messages, **_kwargs):
+            raise RuntimeError("disk full")
+
+    messages = [{"role": "user", "content": "unstamped until commit"}]
+    agent = SimpleNamespace(
+        _persist_disabled=False,
+        _session_db=_FailingSessionDB(),
+        _session_db_created=True,
+        _persist_user_message_idx=None,
+        _persist_user_message_override=None,
+        _persist_user_message_timestamp=None,
+        _flushed_db_message_session_id=None,
+        _last_flushed_db_idx=0,
+        _flushed_db_message_ids=set(),
+        _db_flush_scan_prefix=None,
+        _active_compression_lock_holder=None,
+        session_id="session",
+    )
+
+    assert AIAgent._flush_messages_to_session_db_unlocked(agent, messages) is False
+    assert "timestamp" not in messages[0]
+
+    db = _RecordingSessionDB()
+    agent._session_db = db
+    assert AIAgent._flush_messages_to_session_db_unlocked(agent, messages) is True
+    assert isinstance(messages[0]["timestamp"], float)
     assert db.batches[0][0]["timestamp"] == messages[0]["timestamp"]

--- a/tests/run_agent/test_session_flush_timestamps.py
+++ b/tests/run_agent/test_session_flush_timestamps.py
@@ -1,0 +1,39 @@
+"""Regression coverage for timestamps assigned during append-only persistence."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from run_agent import AIAgent
+
+
+class _RecordingSessionDB:
+    def __init__(self):
+        self.writes: list[dict] = []
+
+    def append_message(self, **kwargs):
+        self.writes.append(kwargs)
+
+
+def test_flush_stamps_live_message_with_the_durable_write_timestamp():
+    """A later transcript rewrite must retain the original event timestamp."""
+    db = _RecordingSessionDB()
+    agent = SimpleNamespace(
+        _persist_disabled=False,
+        _session_db=db,
+        _session_db_created=True,
+        _persist_user_message_idx=None,
+        _persist_user_message_override=None,
+        _persist_user_message_timestamp=None,
+        _flushed_db_message_session_id=None,
+        _last_flushed_db_idx=0,
+        _flushed_db_message_ids=set(),
+        _db_flush_scan_prefix=None,
+        session_id="session",
+    )
+    messages = [{"role": "user", "content": "keep this timestamp"}]
+
+    assert AIAgent._flush_messages_to_session_db_unlocked(agent, messages) is True
+
+    assert isinstance(messages[0]["timestamp"], float)
+    assert db.writes[0]["timestamp"] == messages[0]["timestamp"]

--- a/tests/run_agent/test_session_flush_timestamps.py
+++ b/tests/run_agent/test_session_flush_timestamps.py
@@ -9,10 +9,10 @@ from run_agent import AIAgent
 
 class _RecordingSessionDB:
     def __init__(self):
-        self.writes: list[dict] = []
+        self.batches: list[list[dict]] = []
 
-    def append_message(self, **kwargs):
-        self.writes.append(kwargs)
+    def append_messages_batch(self, *, session_id, messages, compression_lock_holder=None):
+        self.batches.append(list(messages))
 
 
 def test_flush_stamps_live_message_with_the_durable_write_timestamp():
@@ -29,6 +29,7 @@ def test_flush_stamps_live_message_with_the_durable_write_timestamp():
         _last_flushed_db_idx=0,
         _flushed_db_message_ids=set(),
         _db_flush_scan_prefix=None,
+        _active_compression_lock_holder=None,
         session_id="session",
     )
     messages = [{"role": "user", "content": "keep this timestamp"}]
@@ -36,4 +37,5 @@ def test_flush_stamps_live_message_with_the_durable_write_timestamp():
     assert AIAgent._flush_messages_to_session_db_unlocked(agent, messages) is True
 
     assert isinstance(messages[0]["timestamp"], float)
-    assert db.writes[0]["timestamp"] == messages[0]["timestamp"]
+    assert len(db.batches) == 1
+    assert db.batches[0][0]["timestamp"] == messages[0]["timestamp"]

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -430,6 +430,21 @@ def test_merge_interrupted_history_matrix():
     assert {"role": "user", "content": "OTHER"} not in merged
     assert {"role": "assistant", "content": "obsolete"} not in merged
 
+    # Divergent prefix with the current user buried before a stale assistant.
+    buried = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "OTHER"},
+        {"role": "user", "content": "retry me"},
+        {"role": "assistant", "content": "partial stale"},
+    ]
+    merged = server._merge_interrupted_api_history(
+        live, buried, turn_start_history=turn_start, current_prompt="retry me"
+    )
+    assert merged[:3] == live
+    assert merged[-1]["content"] == "retry me"
+    assert {"role": "assistant", "content": "partial stale"} not in merged
+
     # Transformed current-turn user (context-reference / HUD note wrap).
     wrapped = [
         {"role": "user", "content": "a"},

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -430,6 +430,33 @@ def test_merge_interrupted_history_matrix():
     assert {"role": "user", "content": "OTHER"} not in merged
     assert {"role": "assistant", "content": "obsolete"} not in merged
 
+    # Transformed current-turn user (context-reference / HUD note wrap).
+    wrapped = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "[file.md]\n\nretry me"},
+    ]
+    merged = server._merge_interrupted_api_history(
+        live, wrapped, turn_start_history=turn_start, current_prompt="retry me"
+    )
+    assert merged[:3] == live
+    assert merged[-1]["content"] == "[file.md]\n\nretry me"
+
+    # Multimodal current-turn user tail after a truncated snapshot.
+    multimodal_user = {
+        "role": "user",
+        "content": [{"type": "text", "text": "retry me"}, {"type": "image_url", "image_url": {"url": "x"}}],
+    }
+    returned_mm = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        multimodal_user,
+    ]
+    merged = server._merge_interrupted_api_history(
+        live, returned_mm, turn_start_history=turn_start, current_prompt="retry me"
+    )
+    assert merged[-1] is multimodal_user
+
     # G: new current-turn compaction rewrite is accepted.
     compacted = [
         {

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -289,3 +289,185 @@ def test_next_turn_replaces_retained_error_snapshot(emits, turn_env):
     completes = _events(emits, "message.complete")
     assert len(completes) == 1
     assert completes[0]["status"] == "complete"
+
+
+# ── interrupted_during_api_call must not clobber newer live history (#78010)
+
+
+def _history_rows(count: int, *, start: int = 0):
+    return [
+        {
+            "role": "user" if index % 2 == 0 else "assistant",
+            "content": f"message {index}",
+            "timestamp": float(index),
+        }
+        for index in range(start, start + count)
+    ]
+
+
+def test_interrupted_api_call_does_not_overwrite_newer_live_history(emits, turn_env):
+    """RED on current main: result['messages'] replaces live history in place.
+
+    The reported class: turn starts at 144 rows, the interrupted result
+    returns a stale 113-row prefix plus the current user tail, and the
+    gateway used to assign that list onto session['history'].
+    """
+    live_history = _history_rows(144)
+
+    def _interrupted(_prompt, conversation_history=None, **_kwargs):
+        stale_prefix = [
+            {
+                "role": row["role"],
+                "content": row["content"],
+                "timestamp": row["timestamp"],
+            }
+            for row in (conversation_history or [])[:113]
+        ]
+        return {
+            "final_response": "",
+            "interrupted": True,
+            "turn_exit_reason": "interrupted_during_api_call",
+            "messages": [*stale_prefix, {"role": "user", "content": "retry me"}],
+        }
+
+    agent = types.SimpleNamespace(
+        session_id="session-key",
+        run_conversation=_interrupted,
+        clear_interrupt=lambda: None,
+    )
+    session = _session(agent=agent, running=True, history=live_history)
+    server._start_inflight_turn(session, "retry me")
+
+    server._run_prompt_submit("rid", "sid", session, "retry me")
+
+    assert session["history"][:144] == live_history
+    assert session["history"][-1]["content"] == "retry me"
+    assert len(session["history"]) == 145
+    assert [row["content"] for row in session["history"][:144]] == [
+        f"message {index}" for index in range(144)
+    ]
+
+
+def test_merge_interrupted_history_matrix():
+    from agent.context_compressor import COMPRESSED_SUMMARY_METADATA_KEY, LEGACY_SUMMARY_PREFIX
+
+    live = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"},
+    ]
+    turn_start = list(live)
+
+    # A/D: copied stale prefix + current user tail.
+    returned_copied = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "retry me"},
+    ]
+    merged = server._merge_interrupted_api_history(
+        live,
+        returned_copied,
+        turn_start_history=turn_start,
+        current_prompt="retry me",
+    )
+    assert merged[:3] == live
+    assert merged[-1]["content"] == "retry me"
+    assert len(merged) == 4
+
+    # B: returned is a strict prefix of live — keep live.
+    strict_prefix = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+    ]
+    assert (
+        server._merge_interrupted_api_history(
+            live, strict_prefix, turn_start_history=turn_start
+        )
+        == live
+    )
+
+    # C: returned extends the full live prefix.
+    extended = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"},
+        {"role": "assistant", "content": "d"},
+    ]
+    assert (
+        server._merge_interrupted_api_history(
+            live, extended, turn_start_history=turn_start
+        )
+        == extended
+    )
+
+    # E: tool-call identity is part of the fingerprint.
+    live_tool = [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "c1", "name": "web"}]},
+        {"role": "tool", "content": "ok", "tool_call_id": "c1", "name": "web"},
+    ]
+    returned_other_tool = [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "c2", "name": "web"}]},
+        {"role": "tool", "content": "ok", "tool_call_id": "c2", "name": "web"},
+    ]
+    assert (
+        server._merge_interrupted_api_history(
+            live_tool, returned_other_tool, turn_start_history=live_tool
+        )
+        == live_tool
+    )
+
+    # F: divergent stale snapshot must not append obsolete pre-turn rows.
+    diverged = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "OTHER"},
+        {"role": "assistant", "content": "obsolete"},
+    ]
+    merged = server._merge_interrupted_api_history(
+        live, diverged, turn_start_history=turn_start, current_prompt="c"
+    )
+    assert merged == live
+    assert {"role": "user", "content": "OTHER"} not in merged
+    assert {"role": "assistant", "content": "obsolete"} not in merged
+
+    # G: new current-turn compaction rewrite is accepted.
+    compacted = [
+        {
+            "role": "user",
+            "content": f"{LEGACY_SUMMARY_PREFIX} new rewrite of a/b/c",
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        }
+    ]
+    assert server._interrupted_result_allows_rewrite(live, compacted, {"compressed": True})
+    assert (
+        server._merge_interrupted_api_history(
+            live, compacted, turn_start_history=turn_start, allow_rewrite=True
+        )
+        == compacted
+    )
+
+    # H: old summary already represented in live (marker stripped) is not a rewrite.
+    live_with_summary = [
+        {"role": "user", "content": f"{LEGACY_SUMMARY_PREFIX} earlier turns"},
+        {"role": "user", "content": "later ask"},
+        {"role": "assistant", "content": "later answer"},
+    ]
+    stale_marked = [
+        {
+            "role": "user",
+            "content": f"{LEGACY_SUMMARY_PREFIX} earlier turns",
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        }
+    ]
+    assert not server._interrupted_result_allows_rewrite(
+        live_with_summary, stale_marked, {"compressed": True}
+    )
+    assert (
+        server._merge_interrupted_api_history(
+            live_with_summary,
+            stale_marked,
+            turn_start_history=live_with_summary,
+            allow_rewrite=False,
+        )
+        == live_with_summary
+    )

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -465,7 +465,9 @@ def test_merge_interrupted_history_matrix():
             COMPRESSED_SUMMARY_METADATA_KEY: True,
         }
     ]
-    assert server._interrupted_result_allows_rewrite(live, compacted, {"compressed": True})
+    assert server._interrupted_result_allows_rewrite(
+        live, compacted, {"compressed": True}, turn_start_history=turn_start
+    )
     assert (
         server._merge_interrupted_api_history(
             live, compacted, turn_start_history=turn_start, allow_rewrite=True
@@ -487,7 +489,8 @@ def test_merge_interrupted_history_matrix():
         }
     ]
     assert not server._interrupted_result_allows_rewrite(
-        live_with_summary, stale_marked, {"compressed": True}
+        live_with_summary, stale_marked, {"compressed": True},
+        turn_start_history=live_with_summary,
     )
     assert (
         server._merge_interrupted_api_history(
@@ -497,4 +500,66 @@ def test_merge_interrupted_history_matrix():
             allow_rewrite=False,
         )
         == live_with_summary
+    )
+
+    # Repeated current prompt must survive even if an earlier turn used the same text.
+    for prompt in ("continue", "yes", "no", "try again"):
+        turn = [
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": "old"},
+        ]
+        returned = [
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": "old"},
+            {"role": "user", "content": prompt},
+        ]
+        merged = server._merge_interrupted_api_history(
+            turn, returned, turn_start_history=turn, current_prompt=prompt
+        )
+        assert [row["content"] for row in merged] == [prompt, "old", prompt]
+        assert len(merged) == 3
+
+    # Repeated structured tool shape in a previous turn must not erase this turn's copy.
+    tool_turn = [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "c1", "name": "web"}]},
+        {"role": "tool", "content": "ok", "tool_call_id": "c1", "name": "web"},
+    ]
+    tool_returned = [
+        *tool_turn,
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "c1", "name": "web"}]},
+    ]
+    merged = server._merge_interrupted_api_history(
+        tool_turn, tool_returned, turn_start_history=tool_turn
+    )
+    assert len(merged) == 3
+    assert merged[-1]["tool_calls"] == [{"id": "c1", "name": "web"}]
+
+    # Older summary A must not authorize rewrite after live moved to summary B.
+    live_newer = [
+        {
+            "role": "user",
+            "content": f"{LEGACY_SUMMARY_PREFIX} summary B",
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        },
+        {"role": "user", "content": "later"},
+    ]
+    stale_older = [
+        {
+            "role": "user",
+            "content": f"{LEGACY_SUMMARY_PREFIX} summary A",
+            COMPRESSED_SUMMARY_METADATA_KEY: True,
+        },
+        {"role": "user", "content": "later"},
+    ]
+    assert not server._interrupted_result_allows_rewrite(
+        live_newer, stale_older, {"compressed": True}, turn_start_history=live_newer
+    )
+    assert (
+        server._merge_interrupted_api_history(
+            live_newer,
+            stale_older,
+            turn_start_history=live_newer,
+            allow_rewrite=False,
+        )
+        == live_newer
     )

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -445,6 +445,20 @@ def test_merge_interrupted_history_matrix():
     assert merged[-1]["content"] == "retry me"
     assert {"role": "assistant", "content": "partial stale"} not in merged
 
+    # Short prompt "no" must not match an unrelated user row containing those letters.
+    noisy = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "another note"},
+        {"role": "assistant", "content": "obsolete"},
+    ]
+    assert (
+        server._merge_interrupted_api_history(
+            live, noisy, turn_start_history=turn_start, current_prompt="no"
+        )
+        == live
+    )
+
     # Transformed current-turn user (context-reference / HUD note wrap).
     wrapped = [
         {"role": "user", "content": "a"},

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -152,13 +152,20 @@ def test_interrupted_api_result_cannot_restore_stale_history_snapshot(emits, tur
     ]
 
     def _interrupted(_prompt, conversation_history=None, **_kwargs):
-        # Simulate a result assembled from a stale turn-start snapshot. The
-        # shared objects model run_conversation's shallow history copy.
+        # Equivalent but copied dictionaries — fingerprint merge, not ``is``.
+        stale_prefix = [
+            {
+                "role": row["role"],
+                "content": row["content"],
+                "timestamp": row["timestamp"],
+            }
+            for row in (conversation_history or [])[:113]
+        ]
         return {
             "final_response": "",
             "interrupted": True,
             "turn_exit_reason": "interrupted_during_api_call",
-            "messages": [*(conversation_history or [])[:113], {"role": "user", "content": "retry me"}],
+            "messages": [*stale_prefix, {"role": "user", "content": "retry me"}],
         }
 
     agent = types.SimpleNamespace(
@@ -175,6 +182,64 @@ def test_interrupted_api_result_cannot_restore_stale_history_snapshot(emits, tur
     assert session["history"][-1]["content"] == "retry me"
     assert len(session["history"]) == 145
     assert _events(emits, "message.complete")[0]["status"] == "interrupted"
+
+
+def test_merge_interrupted_api_history_fingerprint_cases():
+    live = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"},
+    ]
+
+    # Equivalent but copied dictionaries sharing a stale prefix + new tail.
+    returned_copied = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "retry"},
+    ]
+    merged = server._merge_interrupted_api_history(live, returned_copied)
+    assert merged[:3] == live
+    assert merged[-1]["content"] == "retry"
+
+    # Returned is a strict prefix of live with no new tail — keep live.
+    strict_prefix = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+    ]
+    assert server._merge_interrupted_api_history(live, strict_prefix) == live
+
+    # Full live prefix plus a new tail — accept returned.
+    extended = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "c"},
+        {"role": "assistant", "content": "d"},
+    ]
+    assert server._merge_interrupted_api_history(live, extended) == extended
+
+    # Mismatch after several shared messages — keep live, append returned tail.
+    diverged = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+        {"role": "user", "content": "OTHER"},
+        {"role": "assistant", "content": "tail"},
+    ]
+    merged = server._merge_interrupted_api_history(live, diverged)
+    assert merged[:3] == live
+    assert merged[3:] == diverged[2:]
+
+    # Legitimate compacted rewrite marker — accept returned shorter history.
+    compacted = [{"role": "user", "content": "summary of prior turns"}]
+    assert (
+        server._merge_interrupted_api_history(
+            live, compacted, allow_rewrite=True
+        )
+        == compacted
+    )
+
+    # No shared prefix and no rewrite marker — prefer longer live transcript.
+    unrelated = [{"role": "user", "content": "brand new"}]
+    assert server._merge_interrupted_api_history(live, unrelated) == live
 
 
 # ── Returned-error path (run_conversation returns an error result) ────

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -135,6 +135,48 @@ def test_healthy_snapshot_carries_no_error_keys():
     assert snapshot == {"assistant": "hello", "streaming": True, "user": "hi"}
 
 
+def test_interrupted_api_result_cannot_restore_stale_history_snapshot(emits, turn_env):
+    """An interrupted turn must preserve newer live history before retry/rewind.
+
+    A stale result formerly replaced ``session["history"]`` directly. The
+    desktop's subsequent regenerate then persisted that shortened snapshot with
+    ``replace_messages()``, making the missing rows permanent.
+    """
+    live_history = [
+        {
+            "role": "user" if index % 2 == 0 else "assistant",
+            "content": f"message {index}",
+            "timestamp": float(index),
+        }
+        for index in range(144)
+    ]
+
+    def _interrupted(_prompt, conversation_history=None, **_kwargs):
+        # Simulate a result assembled from a stale turn-start snapshot. The
+        # shared objects model run_conversation's shallow history copy.
+        return {
+            "final_response": "",
+            "interrupted": True,
+            "turn_exit_reason": "interrupted_during_api_call",
+            "messages": [*(conversation_history or [])[:113], {"role": "user", "content": "retry me"}],
+        }
+
+    agent = types.SimpleNamespace(
+        session_id="session-key",
+        run_conversation=_interrupted,
+        clear_interrupt=lambda: None,
+    )
+    session = _session(agent=agent, running=True, history=live_history)
+    server._start_inflight_turn(session, "retry me")
+
+    server._run_prompt_submit("rid", "sid", session, "retry me")
+
+    assert session["history"][:144] == live_history
+    assert session["history"][-1]["content"] == "retry me"
+    assert len(session["history"]) == 145
+    assert _events(emits, "message.complete")[0]["status"] == "interrupted"
+
+
 # ── Returned-error path (run_conversation returns an error result) ────
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7891,12 +7891,26 @@ def _message_text(msg: Any) -> str:
 def _is_current_turn_user_row(msg: Any, current_prompt: str | None) -> bool:
     if not isinstance(msg, dict) or msg.get("role") != "user":
         return False
+    if _is_compaction_summary_message(msg):
+        return False
     if not current_prompt:
-        return True
+        return False
     text = _message_text(msg)
-    if current_prompt == text or current_prompt in text or (text and text in current_prompt):
+    if text == current_prompt:
         return True
-    return isinstance(msg.get("content"), list)
+    if text.endswith(current_prompt) and (
+        len(text) == len(current_prompt) or text[-(len(current_prompt) + 1)] in "\n "
+    ):
+        return True
+    content = msg.get("content")
+    if isinstance(content, list):
+        for part in content:
+            if not isinstance(part, dict) or part.get("type") != "text":
+                continue
+            part_text = str(part.get("text") or "")
+            if part_text == current_prompt or current_prompt in part_text.splitlines():
+                return True
+    return False
 
 
 def _append_turn_local_tail(live: list, turn_start: list, tail: list) -> list:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7837,22 +7837,39 @@ def _interrupted_result_allows_rewrite(
     live_history: list,
     returned_history: list,
     result: dict,
+    *,
+    turn_start_history: list | None = None,
 ) -> bool:
-    """True only for a NEW current-turn compaction, not a stale old summary."""
-    new_summaries = [
-        msg
-        for msg in returned_history
-        if _is_compaction_summary_message(msg)
-        and not _live_already_represents_summary(live_history, msg)
-    ]
-    if new_summaries:
-        return True
+    """True only with positive current-turn compaction evidence.
+
+    A summary absent from live history is not enough: an older generation
+    (summary A) is also absent after a newer one (summary B) replaced it.
+    """
     flagged = bool(
         result.get("compressed")
         or result.get("context_compressed")
         or result.get("history_rewrite")
     )
-    return flagged and not any(_is_compaction_summary_message(msg) for msg in returned_history)
+    if not flagged:
+        return False
+
+    live = list(live_history or [])
+    returned = list(returned_history or [])
+    turn_start = list(turn_start_history) if turn_start_history is not None else live
+    returned_summaries = [msg for msg in returned if _is_compaction_summary_message(msg)]
+    if not returned_summaries:
+        return False
+    if all(_live_already_represents_summary(live, msg) for msg in returned_summaries):
+        return False
+    live_summaries = [msg for msg in live if _is_compaction_summary_message(msg)]
+    if live_summaries and not any(
+        _live_already_represents_summary(live, msg) for msg in returned_summaries
+    ):
+        # Live already moved to a different compression generation.
+        return False
+    return not any(
+        _live_already_represents_summary(turn_start, msg) for msg in returned_summaries
+    )
 
 
 def _message_text(msg: Any) -> str:
@@ -7871,10 +7888,8 @@ def _message_text(msg: Any) -> str:
     return ""
 
 
-def _is_current_turn_user_row(msg: Any, current_prompt: str | None, known_fps: set) -> bool:
+def _is_current_turn_user_row(msg: Any, current_prompt: str | None) -> bool:
     if not isinstance(msg, dict) or msg.get("role") != "user":
-        return False
-    if _message_fingerprint(msg) in known_fps:
         return False
     if not current_prompt:
         return True
@@ -7882,6 +7897,16 @@ def _is_current_turn_user_row(msg: Any, current_prompt: str | None, known_fps: s
     if current_prompt == text or current_prompt in text or (text and text in current_prompt):
         return True
     return isinstance(msg.get("content"), list)
+
+
+def _append_turn_local_tail(live: list, turn_start: list, tail: list) -> list:
+    """Append this-turn rows positionally. Repeated historical text still counts."""
+    shared_live_turn = _common_history_prefix_len(live, turn_start)
+    if shared_live_turn == len(turn_start) and len(live) >= len(turn_start):
+        live_tail = live[len(turn_start) :]
+        already = _common_history_prefix_len(live_tail, tail)
+        return [*live, *tail[already:]]
+    return [*live, *tail]
 
 
 def _merge_interrupted_api_history(
@@ -7892,7 +7917,11 @@ def _merge_interrupted_api_history(
     allow_rewrite: bool = False,
     current_prompt: str | None = None,
 ) -> list:
-    """Keep newer live rows when an interrupted turn returns a stale snapshot."""
+    """Keep newer live rows when an interrupted turn returns a stale snapshot.
+
+    Reconciliation is positional/turn-relative: a current-turn ``continue`` is
+    not dropped just because an earlier turn used the same text.
+    """
     live = list(live_history or [])
     returned = list(returned_history or [])
     if not returned:
@@ -7908,26 +7937,22 @@ def _merge_interrupted_api_history(
     if shared_live == len(live):
         return returned
 
-    live_fps = {_message_fingerprint(msg) for msg in live}
-    turn_start = list(turn_start_history) if turn_start_history is not None else None
-    if turn_start is not None:
+    turn_start = list(turn_start_history) if turn_start_history is not None else []
+    if turn_start:
         shared_turn = _common_history_prefix_len(turn_start, returned)
         if shared_turn == len(turn_start):
-            tail = [
-                msg
-                for msg in returned[shared_turn:]
-                if _message_fingerprint(msg) not in live_fps
-            ]
-            return [*live, *tail]
-        turn_fps = {_message_fingerprint(msg) for msg in turn_start}
-        known = live_fps | turn_fps
+            return _append_turn_local_tail(live, turn_start, returned[shared_turn:])
         last = returned[shared_turn:][-1] if shared_turn < len(returned) else None
-        if last is not None and _is_current_turn_user_row(last, current_prompt, known):
+        if last is not None and _is_current_turn_user_row(last, current_prompt):
+            if live and _message_fingerprint(live[-1]) == _message_fingerprint(last):
+                return live
             return [*live, last]
         return live
 
     last = returned[-1] if returned else None
-    if last is not None and _is_current_turn_user_row(last, current_prompt, live_fps):
+    if last is not None and _is_current_turn_user_row(last, current_prompt):
+        if live and _message_fingerprint(live[-1]) == _message_fingerprint(last):
+            return live
         return [*live, last]
     return live
 
@@ -11146,6 +11171,7 @@ def _run_prompt_submit(
                                     live_history,
                                     result["messages"],
                                     result,
+                                    turn_start_history=history,
                                 )
                                 session["history"] = _merge_interrupted_api_history(
                                     live_history,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7942,8 +7942,11 @@ def _merge_interrupted_api_history(
         shared_turn = _common_history_prefix_len(turn_start, returned)
         if shared_turn == len(turn_start):
             return _append_turn_local_tail(live, turn_start, returned[shared_turn:])
-        last = returned[shared_turn:][-1] if shared_turn < len(returned) else None
-        if last is not None and _is_current_turn_user_row(last, current_prompt):
+        last = None
+        for msg in returned[shared_turn:]:
+            if _is_current_turn_user_row(msg, current_prompt):
+                last = msg
+        if last is not None:
             if live and _message_fingerprint(live[-1]) == _message_fingerprint(last):
                 return live
             return [*live, last]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7855,6 +7855,35 @@ def _interrupted_result_allows_rewrite(
     return flagged and not any(_is_compaction_summary_message(msg) for msg in returned_history)
 
 
+def _message_text(msg: Any) -> str:
+    if not isinstance(msg, dict):
+        return ""
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            str(part.get("text") or "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        ]
+        return "\n".join(parts)
+    return ""
+
+
+def _is_current_turn_user_row(msg: Any, current_prompt: str | None, known_fps: set) -> bool:
+    if not isinstance(msg, dict) or msg.get("role") != "user":
+        return False
+    if _message_fingerprint(msg) in known_fps:
+        return False
+    if not current_prompt:
+        return True
+    text = _message_text(msg)
+    if current_prompt == text or current_prompt in text or (text and text in current_prompt):
+        return True
+    return isinstance(msg.get("content"), list)
+
+
 def _merge_interrupted_api_history(
     live_history: list,
     returned_history: list,
@@ -7879,27 +7908,26 @@ def _merge_interrupted_api_history(
     if shared_live == len(live):
         return returned
 
+    live_fps = {_message_fingerprint(msg) for msg in live}
     turn_start = list(turn_start_history) if turn_start_history is not None else None
     if turn_start is not None:
         shared_turn = _common_history_prefix_len(turn_start, returned)
         if shared_turn == len(turn_start):
-            existing = {_message_fingerprint(msg) for msg in live}
             tail = [
                 msg
                 for msg in returned[shared_turn:]
-                if _message_fingerprint(msg) not in existing
+                if _message_fingerprint(msg) not in live_fps
             ]
             return [*live, *tail]
+        turn_fps = {_message_fingerprint(msg) for msg in turn_start}
+        known = live_fps | turn_fps
+        last = returned[shared_turn:][-1] if shared_turn < len(returned) else None
+        if last is not None and _is_current_turn_user_row(last, current_prompt, known):
+            return [*live, last]
+        return live
 
-    live_fps = {_message_fingerprint(msg) for msg in live}
     last = returned[-1] if returned else None
-    if (
-        current_prompt
-        and isinstance(last, dict)
-        and last.get("role") == "user"
-        and last.get("content") == current_prompt
-        and _message_fingerprint(last) not in live_fps
-    ):
+    if last is not None and _is_current_turn_user_row(last, current_prompt, live_fps):
         return [*live, last]
     return live
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7773,6 +7773,137 @@ def _clear_inflight_turn(session: dict) -> None:
     session["inflight_turn"] = None
 
 
+def _message_fingerprint(msg: Any) -> tuple[Any, ...]:
+    """Stable transcript-row identity for interrupt merges (not object id)."""
+    if not isinstance(msg, dict):
+        return ("__non_dict__", type(msg).__name__, repr(msg))
+
+    content = msg.get("content")
+    if content is not None and not isinstance(content, str):
+        try:
+            content = json.dumps(content, sort_keys=True, default=str)
+        except TypeError:
+            content = repr(content)
+
+    tool_calls = msg.get("tool_calls")
+    if tool_calls is not None and not isinstance(tool_calls, str):
+        try:
+            tool_calls = json.dumps(tool_calls, sort_keys=True, default=str)
+        except TypeError:
+            tool_calls = repr(tool_calls)
+
+    return (
+        msg.get("role"),
+        content,
+        msg.get("tool_call_id"),
+        msg.get("name"),
+        tool_calls,
+    )
+
+
+def _common_history_prefix_len(left: list, right: list) -> int:
+    shared = 0
+    limit = min(len(left), len(right))
+    while (
+        shared < limit
+        and _message_fingerprint(left[shared]) == _message_fingerprint(right[shared])
+    ):
+        shared += 1
+    return shared
+
+
+def _is_compaction_summary_message(msg: Any) -> bool:
+    from agent.context_compressor import is_compaction_summary_message
+
+    return bool(is_compaction_summary_message(msg))
+
+
+def _live_already_represents_summary(live_history: list, summary_msg: Any) -> bool:
+    summary_fp = _message_fingerprint(summary_msg)
+    summary_content = summary_msg.get("content") if isinstance(summary_msg, dict) else None
+    for msg in live_history:
+        if _message_fingerprint(msg) == summary_fp:
+            return True
+        if (
+            _is_compaction_summary_message(msg)
+            and isinstance(msg, dict)
+            and msg.get("content") == summary_content
+        ):
+            return True
+    return False
+
+
+def _interrupted_result_allows_rewrite(
+    live_history: list,
+    returned_history: list,
+    result: dict,
+) -> bool:
+    """True only for a NEW current-turn compaction, not a stale old summary."""
+    new_summaries = [
+        msg
+        for msg in returned_history
+        if _is_compaction_summary_message(msg)
+        and not _live_already_represents_summary(live_history, msg)
+    ]
+    if new_summaries:
+        return True
+    flagged = bool(
+        result.get("compressed")
+        or result.get("context_compressed")
+        or result.get("history_rewrite")
+    )
+    return flagged and not any(_is_compaction_summary_message(msg) for msg in returned_history)
+
+
+def _merge_interrupted_api_history(
+    live_history: list,
+    returned_history: list,
+    *,
+    turn_start_history: list | None = None,
+    allow_rewrite: bool = False,
+    current_prompt: str | None = None,
+) -> list:
+    """Keep newer live rows when an interrupted turn returns a stale snapshot."""
+    live = list(live_history or [])
+    returned = list(returned_history or [])
+    if not returned:
+        return live
+    if not live:
+        return returned
+    if allow_rewrite:
+        return returned
+
+    shared_live = _common_history_prefix_len(live, returned)
+    if shared_live == len(returned) and len(returned) <= len(live):
+        return live
+    if shared_live == len(live):
+        return returned
+
+    turn_start = list(turn_start_history) if turn_start_history is not None else None
+    if turn_start is not None:
+        shared_turn = _common_history_prefix_len(turn_start, returned)
+        if shared_turn == len(turn_start):
+            existing = {_message_fingerprint(msg) for msg in live}
+            tail = [
+                msg
+                for msg in returned[shared_turn:]
+                if _message_fingerprint(msg) not in existing
+            ]
+            return [*live, *tail]
+
+    live_fps = {_message_fingerprint(msg) for msg in live}
+    last = returned[-1] if returned else None
+    if (
+        current_prompt
+        and isinstance(last, dict)
+        and last.get("role") == "user"
+        and last.get("content") == current_prompt
+        and _message_fingerprint(last) not in live_fps
+    ):
+        return [*live, last]
+    return live
+
+
 def _fail_inflight_turn(session: dict, error: Any) -> None:
     """Mark the in-flight turn terminal-error but keep it replayable.
 
@@ -10981,7 +11112,22 @@ def _run_prompt_submit(
                     with session["history_lock"]:
                         current_version = int(session.get("history_version", 0))
                         if current_version == history_version:
-                            session["history"] = result["messages"]
+                            if result.get("turn_exit_reason") == "interrupted_during_api_call":
+                                live_history = session.get("history") or []
+                                allow_rewrite = _interrupted_result_allows_rewrite(
+                                    live_history,
+                                    result["messages"],
+                                    result,
+                                )
+                                session["history"] = _merge_interrupted_api_history(
+                                    live_history,
+                                    result["messages"],
+                                    turn_start_history=history,
+                                    allow_rewrite=allow_rewrite,
+                                    current_prompt=text if isinstance(text, str) else None,
+                                )
+                            else:
+                                session["history"] = result["messages"]
                             session["history_version"] = history_version + 1
                         else:
                             # History mutated externally during the turn.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7123,6 +7123,35 @@ def _clear_inflight_turn(session: dict) -> None:
     session["inflight_turn"] = None
 
 
+def _merge_interrupted_api_history(
+    live_history: list[dict], returned_history: list[dict]
+) -> list[dict]:
+    """Keep a live transcript from being rolled back by an interrupted turn.
+
+    ``run_conversation`` normally returns the turn-start history plus its new
+    tail, sharing the original message dicts by identity.  An API-call
+    interruption can instead return an older snapshot.  Replacing the gateway's
+    live history with that prefix silently drops the newer rows.  Preserve the
+    live prefix and append only the returned turn tail in that case.
+
+    An identity mismatch at the first row indicates a legitimate rewrite such
+    as compaction, not a stale prefix, so leave that canonical result intact.
+    """
+    if not returned_history:
+        return live_history
+    if not live_history:
+        return returned_history
+
+    shared = 0
+    limit = min(len(live_history), len(returned_history))
+    while shared < limit and live_history[shared] is returned_history[shared]:
+        shared += 1
+
+    if shared == 0 or shared == len(live_history):
+        return returned_history
+    return [*live_history, *returned_history[shared:]]
+
+
 def _fail_inflight_turn(session: dict, error: Any) -> None:
     """Mark the in-flight turn terminal-error but keep it replayable.
 
@@ -9716,7 +9745,17 @@ def _run_prompt_submit(
                     with session["history_lock"]:
                         current_version = int(session.get("history_version", 0))
                         if current_version == history_version:
-                            session["history"] = result["messages"]
+                            if result.get("turn_exit_reason") == "interrupted_during_api_call":
+                                # The agent did not receive a response, so its
+                                # returned history must not roll back durable
+                                # gateway state if it was built from an older
+                                # turn snapshot. Preserve the live prefix and
+                                # only accept this interrupted turn's new tail.
+                                session["history"] = _merge_interrupted_api_history(
+                                    history, result["messages"]
+                                )
+                            else:
+                                session["history"] = result["messages"]
                             session["history_version"] = history_version + 1
                         else:
                             # History mutated externally during the turn.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7123,33 +7123,85 @@ def _clear_inflight_turn(session: dict) -> None:
     session["inflight_turn"] = None
 
 
+def _message_fingerprint(msg: Any) -> tuple[Any, ...]:
+    """Stable message identity for interrupt-merge comparisons.
+
+    Object identity (``is``) is too fragile: serialization, sanitization, DB
+    round-trips, and shallow copies all produce equivalent dicts that must
+    still count as the same transcript row.
+    """
+    if not isinstance(msg, dict):
+        return ("__non_dict__", type(msg).__name__, repr(msg))
+
+    content = msg.get("content")
+    if content is not None and not isinstance(content, str):
+        try:
+            content = json.dumps(content, sort_keys=True, default=str)
+        except TypeError:
+            content = repr(content)
+
+    tool_calls = msg.get("tool_calls")
+    if tool_calls is not None and not isinstance(tool_calls, str):
+        try:
+            tool_calls = json.dumps(tool_calls, sort_keys=True, default=str)
+        except TypeError:
+            tool_calls = repr(tool_calls)
+
+    return (
+        msg.get("role"),
+        content,
+        msg.get("tool_call_id"),
+        msg.get("name"),
+        tool_calls,
+    )
+
+
 def _merge_interrupted_api_history(
-    live_history: list[dict], returned_history: list[dict]
+    live_history: list[dict],
+    returned_history: list[dict],
+    *,
+    allow_rewrite: bool = False,
 ) -> list[dict]:
     """Keep a live transcript from being rolled back by an interrupted turn.
 
     ``run_conversation`` normally returns the turn-start history plus its new
-    tail, sharing the original message dicts by identity.  An API-call
-    interruption can instead return an older snapshot.  Replacing the gateway's
-    live history with that prefix silently drops the newer rows.  Preserve the
-    live prefix and append only the returned turn tail in that case.
-
-    An identity mismatch at the first row indicates a legitimate rewrite such
-    as compaction, not a stale prefix, so leave that canonical result intact.
+    tail.  An API-call interruption can instead return an older snapshot.
+    Replacing the gateway's live history with that prefix silently drops the
+    newer rows.  Preserve the live prefix and append only the returned turn
+    tail unless the result explicitly marks a compaction/rewrite.
     """
     if not returned_history:
-        return live_history
+        return list(live_history)
     if not live_history:
-        return returned_history
+        return list(returned_history)
+    if allow_rewrite:
+        return list(returned_history)
 
     shared = 0
     limit = min(len(live_history), len(returned_history))
-    while shared < limit and live_history[shared] is returned_history[shared]:
+    while (
+        shared < limit
+        and _message_fingerprint(live_history[shared])
+        == _message_fingerprint(returned_history[shared])
+    ):
         shared += 1
 
-    if shared == 0 or shared == len(live_history):
-        return returned_history
-    return [*live_history, *returned_history[shared:]]
+    # Returned is a strict prefix of (or equal to) live with no new tail.
+    if shared == len(returned_history) and len(returned_history) <= len(live_history):
+        return list(live_history)
+
+    # Returned extends the full live prefix — accept it.
+    if shared == len(live_history):
+        return list(returned_history)
+
+    # Shared some prefix, then diverged or returned a shorter stale view.
+    if shared > 0:
+        return [*live_history, *returned_history[shared:]]
+
+    # No shared prefix and no rewrite marker — prefer the longer live transcript.
+    if len(live_history) >= len(returned_history):
+        return list(live_history)
+    return list(returned_history)
 
 
 def _fail_inflight_turn(session: dict, error: Any) -> None:
@@ -9746,13 +9798,20 @@ def _run_prompt_submit(
                         current_version = int(session.get("history_version", 0))
                         if current_version == history_version:
                             if result.get("turn_exit_reason") == "interrupted_during_api_call":
-                                # The agent did not receive a response, so its
-                                # returned history must not roll back durable
-                                # gateway state if it was built from an older
-                                # turn snapshot. Preserve the live prefix and
-                                # only accept this interrupted turn's new tail.
+                                # Merge against the live session history (not
+                                # the turn-start snapshot) so concurrent
+                                # appends that forgot to bump history_version
+                                # still cannot be clobbered by a stale result.
+                                # Fingerprint equality, not object identity.
+                                allow_rewrite = bool(
+                                    result.get("compressed")
+                                    or result.get("context_compressed")
+                                    or result.get("history_rewrite")
+                                )
                                 session["history"] = _merge_interrupted_api_history(
-                                    history, result["messages"]
+                                    session.get("history") or [],
+                                    result["messages"],
+                                    allow_rewrite=allow_rewrite,
                                 )
                             else:
                                 session["history"] = result["messages"]


### PR DESCRIPTION
## Summary
- Prevent `interrupted_during_api_call` results from replacing newer live gateway history with a stale turn snapshot (`session["history"] = result["messages"]` on the equal `history_version` path).
- Fresh replay onto current `upstream/main` `74f99af470`. Merge is positional / turn-relative against the turn-start snapshot — a current-turn `continue` is not dropped just because an earlier turn used the same text.
- Divergent stale remainder is not appended. A current-turn user row is kept only on exact / delimited-suffix / multimodal text-part identity, not substring match.
- Compaction rewrite requires positive current-turn evidence (`compressed` / `history_rewrite` plus a summary new vs turn-start). An older summary A cannot replace live summary B.
- First-write timestamps are stamped on the live dict only after a successful `append_messages_batch` (first durable write, not a failed attempt).

Fixes #78010

## Related, not closed
- #81951 is a sibling class (cross-process warm-cache truncation; UI full, model request truncated). Its closer is #82090. This PR does **not** claim to close #81951.

## Test plan
- [x] `python -m pytest tests/tui_gateway/test_failed_turn_retention.py tests/run_agent/test_session_flush_timestamps.py -q` — 12 passed on current main
- [x] Adjacent: model-switch marker, auto-continue, personality, CLI interrupt-history, finalize persist — 47 passed
- [ ] Manual: long desktop session → interrupt mid API call → regenerate/retry → confirm history length and timestamps are preserved (`needs-repro`; deterministic overwrite path is the load-bearing proof)