### PR TITLE
feat(buzz): retain approved unmentioned channel context

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -25,6 +25,7 @@ Configuration in config.yaml::
             cli_path: ""               # path to the buzz binary (default: PATH, then ~/bin/buzz)
             credentials_file: ""       # JSON file holding the nsec (fallback for BUZZ_PRIVATE_KEY)
             allowed_users: []          # empty = allow all; entries are hex pubkeys or npubs
+            observe_unmentioned_group_messages: false  # store approved channel chatter as context
 
 Or via environment variables (overrides config.yaml):
     BUZZ_RELAY_URL, BUZZ_CHANNELS, BUZZ_HOME_CHANNEL, BUZZ_POLL_INTERVAL,
@@ -37,6 +38,7 @@ environment and is never logged.
 """
 
 import asyncio
+import dataclasses
 import json
 import logging
 import os
@@ -44,7 +46,7 @@ import re
 import shutil
 import time
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlsplit, urlunsplit
@@ -391,6 +393,15 @@ class BuzzAdapter(BasePlatformAdapter):
         else:
             _rm_cfg = _rm_raw
         self.require_mention = str(_rm_cfg).strip().lower() not in ("false", "0", "no", "off")
+
+        # Mention-gated channel messages may be stored as context for a later
+        # addressed request. This is opt-in and is protected by the explicit
+        # adapter allow-list checked in _observe_unmentioned_group_message().
+        _observe_raw = os.getenv("BUZZ_OBSERVE_UNMENTIONED_GROUP_MESSAGES")
+        _observe_cfg = extra.get("observe_unmentioned_group_messages", False)
+        self.observe_unmentioned_group_messages = str(
+            _observe_cfg if _observe_raw is None else _observe_raw
+        ).strip().lower() in ("true", "1", "yes", "on")
 
         # Inbound transport: "auto" (WebSocket with poll fallback, default),
         # "websocket" (require WS; fail connect when it can't authenticate),
@@ -1030,16 +1041,18 @@ class BuzzAdapter(BasePlatformAdapter):
         self._maybe_latch_dm(channel_id, state, event)
 
         is_dm = state["chat_type"] == "dm"
-        # In shared channels, respond only when addressed — unless
-        # require_mention is disabled, in which case respond to every message.
-        # DMs always dispatch.
-        if not is_dm and self.require_mention and not self._is_mentioned(content):
-            return
-
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
         # BUZZ_ALLOW_ALL_USERS centrally as well; empty list = no filter here).
         if self._allowed_pubkeys and pubkey not in self._allowed_pubkeys:
             logger.debug("Buzz: ignoring message from unauthorized pubkey %s…", pubkey[:8])
+            return
+
+        # In shared channels, respond only when addressed — unless
+        # require_mention is disabled, in which case respond to every message.
+        # DMs always dispatch. Opt-in observation records only explicitly
+        # allow-listed channel senders as context for a later mention.
+        if not is_dm and self.require_mention and not self._is_mentioned(content):
+            self._observe_unmentioned_group_message(channel_id, pubkey, content, event_id, created_at)
             return
 
         # Strip a leading @mention so slash commands (@Chip /whoami ->
@@ -1210,6 +1223,42 @@ class BuzzAdapter(BasePlatformAdapter):
             state["seen"][event_id] = None
             self._trim_seen(state)
 
+    def _observe_unmentioned_group_message(
+        self, channel_id: str, pubkey: str, content: str, event_id: str, created_at: int
+    ) -> None:
+        """Persist an approved, mention-gated channel message as context only.
+
+        The shared source lets a later mention from any approved member use the
+        same channel history. Requiring both an opt-in and a non-empty adapter
+        allow-list prevents unrestricted community traffic entering a prompt.
+        """
+        if not self.observe_unmentioned_group_messages or not self._allowed_pubkeys:
+            return
+        store = getattr(self, "_session_store", None)
+        if store is None:
+            return
+        try:
+            source = self.build_source(
+                chat_id=channel_id,
+                chat_name=self._channel_names.get(channel_id, channel_id),
+                chat_type="group",
+                user_id=pubkey,
+                user_name=self._user_names.get(pubkey, pubkey[:16]),
+            )
+            shared_source = dataclasses.replace(source, user_id=None, user_name=None, user_id_alt=None)
+            session_entry = store.get_or_create_session(shared_source)
+            store.append_to_transcript(session_entry.session_id, {
+                "role": "user",
+                "content": f"[{pubkey[:16]}|{pubkey}]\n{content}",
+                "timestamp": datetime.fromtimestamp(created_at, tz=timezone.utc).isoformat()
+                if created_at else datetime.now(tz=timezone.utc).isoformat(),
+                "message_id": event_id,
+                "observed": True,
+            })
+            logger.debug("Buzz: observed unmentioned channel message %s", event_id[:12])
+        except Exception:
+            logger.warning("Buzz: failed to observe unmentioned channel message", exc_info=True)
+
     async def _dispatch_message(
         self,
         text: str,
@@ -1316,6 +1365,8 @@ def _apply_yaml_config(yaml_cfg: dict, buzz_cfg: dict) -> Optional[dict]:
         os.environ["BUZZ_ALLOW_ALL_USERS"] = str(extra["allow_all_users"]).lower()
     if "require_mention" in extra and not os.getenv("BUZZ_REQUIRE_MENTION"):
         os.environ["BUZZ_REQUIRE_MENTION"] = str(extra["require_mention"]).lower()
+    if "observe_unmentioned_group_messages" in extra and not os.getenv("BUZZ_OBSERVE_UNMENTIONED_GROUP_MESSAGES"):
+        os.environ["BUZZ_OBSERVE_UNMENTIONED_GROUP_MESSAGES"] = str(extra["observe_unmentioned_group_messages"]).lower()
     return None
 
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -45,6 +45,7 @@ _ENV_VARS = (
     "BUZZ_POLL_INTERVAL",
     "BUZZ_CLI_PATH",
     "BUZZ_CREDENTIALS_FILE",
+    "BUZZ_OBSERVE_UNMENTIONED_GROUP_MESSAGES",
 )
 
 
@@ -249,6 +250,34 @@ class TestMentionGating:
         adapter._allowed_pubkeys = {"b" * 64}
         await self._poll_with(adapter, _event("e1", content="@Chip hello", created_at=10))
         assert adapter._dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_observes_unmentioned_allowlisted_channel_message(self, adapter):
+        adapter.observe_unmentioned_group_messages = True
+        adapter._allowed_pubkeys = {OTHER_PUBKEY}
+        store = MagicMock()
+        store.get_or_create_session.return_value = MagicMock(session_id="shared-channel-session")
+        adapter.set_session_store(store)
+
+        await self._poll_with(adapter, _event("e1", content="project context", created_at=10))
+
+        assert adapter._dispatched == []
+        source = store.get_or_create_session.call_args.args[0]
+        assert source.user_id is None
+        entry = store.append_to_transcript.call_args.args[1]
+        assert entry["observed"] is True
+        assert entry["message_id"] == "e1"
+        assert entry["content"] == f"[{OTHER_PUBKEY[:16]}|{OTHER_PUBKEY}]\nproject context"
+
+    @pytest.mark.asyncio
+    async def test_does_not_observe_without_explicit_allowlist(self, adapter):
+        adapter.observe_unmentioned_group_messages = True
+        store = MagicMock()
+        adapter.set_session_store(store)
+
+        await self._poll_with(adapter, _event("e1", content="untrusted context", created_at=10))
+
+        store.get_or_create_session.assert_not_called()
 
 
 # ── DM classification via p-tags (issue #68871) ──────────────────────────

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -34,6 +34,7 @@ gateway:
         cli_path: ""               # buzz binary (default: PATH, then ~/bin/buzz)
         credentials_file: ""       # JSON file with the nsec (BUZZ_PRIVATE_KEY fallback)
         allowed_users: []          # empty = allow all; hex pubkeys or npubs
+        observe_unmentioned_group_messages: false # opt-in context for allowed channel members
 ```
 
 Plus, in `~/.hermes/.env`:
@@ -55,6 +56,7 @@ BUZZ_PRIVATE_KEY=nsec1...
 | `BUZZ_POLL_INTERVAL` | — | Seconds between inbound poll sweeps (default: 4) |
 | `BUZZ_CLI_PATH` | — | Path to the `buzz` binary (default: `buzz` on PATH, then `~/bin/buzz`) |
 | `BUZZ_CREDENTIALS_FILE` | — | JSON credentials file holding the nsec, used when `BUZZ_PRIVATE_KEY` is unset |
+| `BUZZ_OBSERVE_UNMENTIONED_GROUP_MESSAGES` | — | Opt in to retaining unmentioned, allow-listed channel messages as context |
 
 ## Recommended default settings
 
@@ -100,6 +102,7 @@ gateway:
 - In shared channels the agent only responds when **addressed** — by `@name`, its npub, or its hex pubkey. Everything else is ignored.
 - Direct messages always reach the agent, no mention needed.
 - The agent's own messages are never dispatched back to it (self-echo suppression by pubkey), and every event is de-duplicated by event id against a per-channel high-water mark.
+- To let a later mention refer to ordinary channel discussion, set `observe_unmentioned_group_messages: true`. This is intentionally restricted to channels with a non-empty `allowed_users` list; each observed message is stored as context only and never triggers an agent response. This prevents unrestricted community traffic from silently entering a prompt.
 
 ## Access control
 


### PR DESCRIPTION
## Summary
- adds an opt-in Buzz setting to retain unmentioned, mention-gated channel messages as context for a later addressed request;
- stores that context under a chat-shared source, with sender attribution and `observed: true`, without dispatching an agent turn;
- documents the configuration and adds regression tests for the allow-listed and no-allow-list paths.

## Security and design
Observed text can become prompt context, so this is intentionally narrower than the existing normal message path: it requires both `observe_unmentioned_group_messages: true` and a non-empty `allowed_users` adapter allow-list. Messages from non-allow-listed senders remain ignored before any transcript write.

I considered fetching arbitrary thread/DM history from the Buzz CLI. I did not choose that approach because the checked-in adapter has no verified history API contract for those operations, whereas the session store already supports the platform-agnostic `observed` context convention used by Telegram. The selected implementation is a small, opt-in improvement to the channel-context portion of #77985 without claiming to complete the separate thread/DM-history work.

Related: #77985

## Validation
- `uv run --no-project --with pytest --with pytest-asyncio --with pyyaml --with httpx python -m pytest tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py -q` — 29 passed
- `uv run --no-project --with ruff ruff check plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_adapter.py` — passed
- `python3 -m py_compile plugins/platforms/buzz/adapter.py` — passed
- `git diff --check` — passed

## Automation disclosure
This contribution was authored and validated by an automated agent acting for `@kushin25`; the account holder retains responsibility for the contribution.
