### PR TITLE
fix(tools): pass BUZZ_* platform credentials to terminal children

### DIFF
--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -186,6 +186,33 @@ class TestExecuteCodeIntegration:
 
         assert "SERVICE_TOKEN" not in child_env
 
+    def test_execute_code_strips_buzz_vars(self):
+        """BUZZ_* credentials must stay out of the execute_code child even
+        though they pass through to terminal children (issue #78026): the
+        carve-out is terminal-only.
+
+        - BUZZ_PRIVATE_KEY matches the KEY secret substring.
+        - BUZZ_AUTH_TAG matches the AUTH secret substring.
+        - BUZZ_RELAY_URL matches no secret substring but is not on the safe
+          prefix allowlist, so it is dropped too.
+        """
+        from tools.code_execution_tool import _scrub_child_env
+
+        buzz_vars = {
+            "BUZZ_PRIVATE_KEY": "nsec1fake",
+            "BUZZ_AUTH_TAG": '["tag","data","kind","sig"]',
+            "BUZZ_RELAY_URL": "https://mycommunity.communities.buzz.xyz",
+            "PATH": "/usr/bin",
+            "HOME": "/home/user",
+        }
+        child_env = _scrub_child_env(buzz_vars)
+
+        assert "BUZZ_PRIVATE_KEY" not in child_env
+        assert "BUZZ_AUTH_TAG" not in child_env
+        assert "BUZZ_RELAY_URL" not in child_env
+        assert child_env["PATH"] == "/usr/bin"
+        assert child_env["HOME"] == "/home/user"
+
 
 class TestTerminalIntegration:
     """Verify that the passthrough is checked in terminal's env sanitizers."""
@@ -316,6 +343,33 @@ class TestTerminalIntegration:
             result = _sanitize_subprocess_env({var: "secret", "PATH": "/usr/bin"})
             assert var not in result
             assert "PATH" in result
+
+    def test_passthrough_cannot_register_buzz_vars(self):
+        """GHSA-rhgp-j443-p4rf seal stays intact for the BUZZ_* first-party
+        platform credentials: even though they pass through to terminal
+        children by default (issue #78026), env_passthrough registration must
+        still refuse them — the carve-out opens NO registration path, so a
+        skill cannot expand BUZZ_* exposure to execute_code."""
+        from tools.environments.local import _sanitize_subprocess_env
+
+        for var in (
+            "BUZZ_PRIVATE_KEY",
+            "BUZZ_AUTH_TAG",
+            "BUZZ_RELAY_URL",
+        ):
+            register_env_passthrough([var])
+            assert not is_env_passthrough(var), (
+                f"{var} should be refused passthrough registration"
+            )
+            # Terminal sanitizer still passes BUZZ_* through to terminal
+            # children by the first-party carve-out...
+            result = _sanitize_subprocess_env({var: "value", "PATH": "/usr/bin"})
+            assert result.get(var) == "value"
+            # ...but the execute_code child never sees them.
+            from tools.code_execution_tool import _scrub_child_env
+
+            child_env = _scrub_child_env({var: "value", "PATH": "/usr/bin"})
+            assert var not in child_env
 
     def test_passthrough_allows_auxiliary_non_secret_routing(self):
         """AUXILIARY_*_PROVIDER / _MODEL and GATEWAY_RELAY routing hints are not

--- a/tests/tools/test_hermes_subprocess_env.py
+++ b/tests/tools/test_hermes_subprocess_env.py
@@ -62,6 +62,19 @@ class TestStripByDefault:
         for var in _TIER1_SAMPLE:
             assert var not in result, f"{var} leaked (Tier-1) with inherit_credentials=False"
 
+    def test_buzz_platform_vars_stripped_by_default(self):
+        """BUZZ_* first-party platform credentials must NOT reach the
+        non-terminal spawn surface (browser / TUI host / copilot-executor),
+        even though they pass through to terminal children (issue #78026)."""
+        buzz_sample = {
+            "BUZZ_PRIVATE_KEY": "nsec1fake",
+            "BUZZ_AUTH_TAG": '["tag","data","kind","sig"]',
+            "BUZZ_RELAY_URL": "https://mycommunity.communities.buzz.xyz",
+        }
+        result = _build(buzz_sample)
+        for var in buzz_sample:
+            assert var not in result, f"{var} leaked via hermes_subprocess_env"
+
 
     def test_pythonutf8_set(self):
         result = _build()

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -10,6 +10,7 @@ See: https://github.com/NousResearch/hermes-agent/issues/1264
 
 import os
 import threading
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -239,6 +240,183 @@ class TestProviderEnvBlocklist:
         assert "OPENAI_BASE_URL" not in result_env
         assert "MY_CUSTOM_VAR" in result_env
         assert result_env["MY_CUSTOM_VAR"] == "keep-this"
+
+
+class TestTerminalFirstPartyPlatformEnv:
+    """BUZZ_* first-party platform credentials must reach terminal children.
+
+    Issue #78026: Buzz platform agents could not use the ``buzz`` CLI from the
+    terminal tool because BUZZ_PRIVATE_KEY / BUZZ_AUTH_TAG / BUZZ_RELAY_URL
+    (and the other BUZZ_* vars) are stripped by _HERMES_PROVIDER_ENV_BLOCKLIST
+    and env_passthrough refuses to re-allow them (GHSA-rhgp-j443-p4rf).
+
+    The carve-out is TERMINAL-ONLY: foreground (_make_run_env) and
+    background/PTY (_sanitize_subprocess_env) children get the BUZZ_* vars;
+    execute_code, hermes_subprocess_env, docker, and env_passthrough
+    registration stay sealed. The blocklist itself is NOT modified.
+    """
+
+    def test_make_run_env_preserves_buzz_vars(self):
+        """Foreground terminal children get the BUZZ_* credentials."""
+        from tools.environments.local import _make_run_env
+
+        buzz_vars = {
+            "BUZZ_PRIVATE_KEY": "nsec1faketestkey",
+            "BUZZ_AUTH_TAG": '["tag","data","kind","sig"]',
+            "BUZZ_RELAY_URL": "https://mycommunity.communities.buzz.xyz",
+        }
+        with patch.dict(os.environ, {**buzz_vars, "PATH": "/usr/bin:/bin"}, clear=True):
+            run_env = _make_run_env({})
+
+        for var, value in buzz_vars.items():
+            assert run_env.get(var) == value, (
+                f"{var} missing from foreground terminal env (issue #78026)"
+            )
+
+    def test_sanitize_subprocess_env_preserves_buzz_vars(self):
+        """Background/PTY terminal children get the BUZZ_* credentials."""
+        from tools.environments.local import _sanitize_subprocess_env
+
+        buzz_vars = {
+            "BUZZ_PRIVATE_KEY": "nsec1faketestkey",
+            "BUZZ_AUTH_TAG": '["tag","data","kind","sig"]',
+            "BUZZ_RELAY_URL": "https://mycommunity.communities.buzz.xyz",
+        }
+        result = _sanitize_subprocess_env({**buzz_vars, "HOME": "/home/user"})
+
+        for var, value in buzz_vars.items():
+            assert result.get(var) == value, (
+                f"{var} missing from background/PTY terminal env (issue #78026)"
+            )
+
+    def test_buzz_vars_stay_in_blocklist(self):
+        """The carve-out is a scrub-path exemption, NOT a blocklist removal —
+        BUZZ_* must remain blocked for every non-terminal surface (execute_code,
+        hermes_subprocess_env, env_passthrough registration)."""
+        assert {"BUZZ_PRIVATE_KEY", "BUZZ_AUTH_TAG", "BUZZ_RELAY_URL"} <= \
+            _HERMES_PROVIDER_ENV_BLOCKLIST
+
+    def test_buzz_vars_use_plain_value_under_multiplex_without_scope(self, monkeypatch):
+        """First-party platform vars are the process's own env values: with
+        multiplex active and NO profile secret scope installed, the terminal
+        scrub paths must forward the plain env value — NOT raise
+        UnscopedSecretError (the fail-closed regression where the webhook-
+        filter script runner crashed instead of running without the var)."""
+        from agent import secret_scope as ss
+        from tools.environments.local import _make_run_env, _sanitize_subprocess_env
+
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec-plain-value")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+        ss.set_multiplex_active(True)
+        try:
+            run_env = _make_run_env({})
+            sanitized = _sanitize_subprocess_env(
+                {"BUZZ_PRIVATE_KEY": "nsec-plain-value", "HOME": "/home/user"}
+            )
+        finally:
+            ss.set_multiplex_active(False)
+
+        assert run_env["BUZZ_PRIVATE_KEY"] == "nsec-plain-value"
+        assert sanitized["BUZZ_PRIVATE_KEY"] == "nsec-plain-value"
+
+    def test_buzz_vars_are_not_scope_resolved(self, monkeypatch):
+        """First-party matches bypass the profile secret scope: a scope value
+        for BUZZ_PRIVATE_KEY must NOT override the process env value — only
+        skill/config passthrough names are scope-resolved."""
+        from agent import secret_scope as ss
+        from tools.environments.local import _make_run_env, _sanitize_subprocess_env
+
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec-process-env")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"BUZZ_PRIVATE_KEY": "nsec-scoped"})
+        try:
+            run_env = _make_run_env({})
+            sanitized = _sanitize_subprocess_env(
+                {"BUZZ_PRIVATE_KEY": "nsec-process-env", "HOME": "/home/user"}
+            )
+        finally:
+            ss.reset_secret_scope(token)
+            ss.set_multiplex_active(False)
+
+        assert run_env["BUZZ_PRIVATE_KEY"] == "nsec-process-env"
+        assert sanitized["BUZZ_PRIVATE_KEY"] == "nsec-process-env"
+
+
+class TestTerminalFirstPartySnapshotIsolation:
+    """BUZZ_* first-party vars must not persist in the shared terminal
+    snapshot — a cross-profile leak under a multiplexed gateway.
+
+    The terminal login-shell snapshot (init_session ``export -p`` dump and the
+    per-command re-dump) captures the child env, which now includes
+    BUZZ_PRIVATE_KEY. The exclusion set is derived from get_all_passthrough()
+    plus backend-specific additions — and BUZZ_* can never be in it, because
+    env_passthrough refuses blocklisted names (GHSA-rhgp-j443-p4rf). Without
+    an exclusion, profile A's BUZZ_PRIVATE_KEY lands in hermes-snap-<id>.sh
+    and profile B's later command on the same collapsed LocalEnvironment
+    sources it. Fix: LocalEnvironment treats first-party terminal env names
+    like profile-scoped passthrough names — excluded from the dump and
+    save/restored per command.
+    """
+
+    def test_snapshot_exclusion_set_includes_first_party_names(self, monkeypatch):
+        """Under multiplex, BUZZ_* names present in the env are added to the
+        snapshot exclusion set, so the dump excludes them and _wrap_command
+        save/restores them per command."""
+        from agent import secret_scope as ss
+        from tools.environments.local import LocalEnvironment
+
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec-profile-a")
+        env = LocalEnvironment.__new__(LocalEnvironment)
+        env.env = {}
+        env._snapshot_passthrough_names = set()
+        ss.set_multiplex_active(True)
+        try:
+            excluded = env._snapshot_excluded_passthrough_names()
+        finally:
+            ss.set_multiplex_active(False)
+
+        assert "BUZZ_PRIVATE_KEY" in excluded
+        # The set is monotonic for the environment lifetime: the name stays
+        # excluded (and unset-guarded per command) even once it leaves the env.
+        assert "BUZZ_PRIVATE_KEY" in env._snapshot_passthrough_names
+
+    def test_buzz_secret_never_reaches_second_profile_via_snapshot(self, monkeypatch, tmp_path):
+        """Multiplex regression, end-to-end with real bash: (a) the snapshot
+        file never contains profile A's BUZZ_PRIVATE_KEY, and (b) profile B
+        sharing the same LocalEnvironment does not see profile A's
+        BUZZ_PRIVATE_KEY in its terminal env."""
+        import shutil
+        if not shutil.which("bash"):
+            pytest.skip("bash required")
+
+        from agent import secret_scope as ss
+        from tools.environments.local import LocalEnvironment
+
+        monkeypatch.setenv("BUZZ_PRIVATE_KEY", "nsec-profile-a")
+        ss.set_multiplex_active(True)
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+        try:
+            # Profile A's command re-dumps the snapshot; the exclusion must
+            # keep BUZZ_PRIVATE_KEY out of BOTH the initial dump and the
+            # per-command re-dump.
+            env.execute("true")
+
+            snap = Path(env._snapshot_path)
+            assert snap.exists()
+            snap_text = snap.read_text(encoding="utf-8", errors="replace")
+            assert "nsec-profile-a" not in snap_text
+            assert "BUZZ_PRIVATE_KEY" not in snap_text
+
+            # Profile B: no BUZZ_PRIVATE_KEY in its env, same LocalEnvironment
+            # (same snapshot file). It must not see profile A's value.
+            monkeypatch.delenv("BUZZ_PRIVATE_KEY")
+            result = env.execute("printf '%s' \"${BUZZ_PRIVATE_KEY-unset}\"")
+            assert "nsec-profile-a" not in result["output"]
+            assert "unset" in result["output"]
+        finally:
+            env.cleanup()
+            ss.set_multiplex_active(False)
 
 
 class TestForceEnvOptIn:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -336,6 +336,53 @@ def _build_provider_env_blocklist() -> frozenset:
 
 _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 
+# First-party platform credentials the agent's own platform adapters need in
+# terminal children (e.g. the ``BUZZ_*`` vars for the Buzz messaging
+# platform, which drive the platform-mandated ``buzz`` CLI: BUZZ_PRIVATE_KEY,
+# BUZZ_AUTH_TAG, BUZZ_RELAY_URL, and the other BUZZ_* names). These are the
+# agent's OWN credentials — a Buzz community agent is expected to operate the
+# ``buzz`` CLI — so they are carved out of the terminal scrub.
+#
+# Scope is TERMINAL ONLY: the foreground ``_make_run_env`` and background/PTY
+# ``_sanitize_subprocess_env`` paths pass them through. ``_sanitize_subprocess_env``
+# is also consumed by search workers (e.g. the ddgs web-search subprocess),
+# the computer-use driver binary, and user-script runners (bang ``!``
+# commands, quick commands, cron scripts, webhook-filter scripts), so those
+# children receive the vars too — matching the approved background/PTY scope.
+# Every other surface stays sealed — execute_code scrubbing,
+# :func:`hermes_subprocess_env` (browser / TUI host / copilot-executor
+# spawns), docker children, and ``env_passthrough`` registration (skills/config
+# still cannot register these names). The GHSA-rhgp-j443-p4rf seal is
+# preserved because no registration path is opened; this is a scrub-path
+# exemption, not an allowlist addition.
+#
+# First-party matches use the merged env value directly — they are the
+# process's own env values and are never scope-resolved (a profile secret
+# scope under multiplex would otherwise raise UnscopedSecretError at
+# passthrough-resolution call sites); only skill/config passthrough names
+# resolve through the profile secret scope. The snapshot mechanism treats
+# these names like profile-scoped passthrough names (see
+# ``LocalEnvironment._additional_profile_scoped_passthrough_names``) so they
+# never persist in the shared terminal snapshot across profiles.
+#
+# Prefix-based on purpose: future ``BUZZ_*`` names added by the platform's
+# plugin.yaml (or a user's own credentials file) are covered without another
+# code change. Contrast with CLAUDE_CODE_OAUTH_TOKEN above, which is discarded
+# from the blocklist entirely because it is NOT a Hermes credential; these ARE
+# Hermes-managed first-party platform credentials, so they stay IN the
+# blocklist for every non-terminal surface.
+#
+# See issue #78026 (Buzz agents could not use ``buzz`` from the terminal tool).
+_TERMINAL_FIRST_PARTY_ENV_PREFIXES = ("BUZZ_",)
+
+
+def _is_terminal_first_party_env(name: str) -> bool:
+    """Return True if ``name`` is a first-party platform credential that must
+    reach terminal children (the ``BUZZ_*`` set; see
+    ``_TERMINAL_FIRST_PARTY_ENV_PREFIXES``)."""
+    return name.startswith(_TERMINAL_FIRST_PARTY_ENV_PREFIXES)
+
+
 # Active-virtualenv markers that must NOT leak into terminal subprocesses.
 # The gateway runs inside its own venv, so its process environment carries
 # VIRTUAL_ENV (and possibly CONDA_PREFIX). If those leak into commands the
@@ -471,10 +518,17 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
             continue
         if _is_hermes_internal_secret(key):
             continue
+        first_party = _is_terminal_first_party_env(key)
         passthrough = _is_passthrough(key)
-        if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+        if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not (passthrough or first_party):
             continue
-        resolved = _resolve_passthrough_value(key, value) if passthrough else value
+        # First-party platform vars are the process's own env values: use them
+        # directly, never scope-resolve (multiplex with no scope would raise
+        # UnscopedSecretError — a regression where the script previously ran
+        # without the var). Only skill/config passthrough names resolve.
+        resolved = value
+        if passthrough and not first_party:
+            resolved = _resolve_passthrough_value(key, value)
         if resolved is not None:
             sanitized[key] = resolved
 
@@ -487,10 +541,13 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         elif _is_hermes_internal_secret(key):
             continue
         else:
+            first_party = _is_terminal_first_party_env(key)
             passthrough = _is_passthrough(key)
-            if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+            if key in _HERMES_PROVIDER_ENV_BLOCKLIST and not (passthrough or first_party):
                 continue
-            resolved = _resolve_passthrough_value(key, value) if passthrough else value
+            resolved = value
+            if passthrough and not first_party:
+                resolved = _resolve_passthrough_value(key, value)
             if resolved is not None:
                 sanitized[key] = resolved
 
@@ -1287,10 +1344,15 @@ def _make_run_env(env: dict) -> dict:
         elif _is_hermes_internal_secret(k):
             continue
         else:
+            first_party = _is_terminal_first_party_env(k)
             passthrough = _is_passthrough(k)
-            if k in _HERMES_PROVIDER_ENV_BLOCKLIST and not passthrough:
+            if k in _HERMES_PROVIDER_ENV_BLOCKLIST and not (passthrough or first_party):
                 continue
-            value = _resolve_passthrough_value(k, v) if passthrough else v
+            # First-party vars use the merged env value directly (see
+            # _sanitize_subprocess_env); only passthrough names resolve.
+            value = v
+            if passthrough and not first_party:
+                value = _resolve_passthrough_value(k, v)
             if value is not None:
                 run_env[k] = value
     path_key = _path_env_key(run_env)
@@ -1420,6 +1482,36 @@ class LocalEnvironment(BaseEnvironment):
     """
 
     _profile_scoped_passthrough = True
+
+    def _additional_profile_scoped_passthrough_names(self) -> tuple[str, ...]:
+        """Return first-party terminal env names (``BUZZ_*``) present in the
+        current env, so they are excluded from the shared session snapshot.
+
+        The login-shell snapshot (``init_session`` ``export -p`` dump and the
+        per-command re-dump) captures the child env, which now includes the
+        ``BUZZ_*`` vars the terminal carve-out passes through. The exclusion
+        set is derived from ``get_all_passthrough()`` plus backend-specific
+        additions — and ``BUZZ_*`` can NEVER be in it, because env_passthrough
+        refuses blocklisted names (GHSA-rhgp-j443-p4rf). Under a multiplexed
+        gateway, profile A's BUZZ_PRIVATE_KEY would land in
+        ``hermes-snap-<id>.sh`` and a later command from profile B sharing
+        this collapsed LocalEnvironment would ``source`` it: a cross-profile
+        nsec leak that defeats profile isolation.
+
+        Treating these names like profile-scoped passthrough names keeps them
+        out of the dump and save/restores the current profile's value (or
+        unsets the name) per command in ``_wrap_command``. The set is monotonic
+        for the environment lifetime: once a name is seen it stays excluded,
+        so a later profile that lacks the var still gets the unset-guard.
+        """
+        merged = dict(os.environ | self.env)
+        return tuple(
+            sorted(
+                name
+                for name in merged
+                if isinstance(name, str) and _is_terminal_first_party_env(name)
+            )
+        )
 
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         cwd = _resolve_local_initial_cwd(cwd)

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -117,6 +117,7 @@ Check status with `hermes gateway status` — Buzz connection state is reported 
 
 ## Notes and limitations
 
+- **`BUZZ_*` env vars are available in terminal tool children** — the agent can invoke the `buzz` CLI directly (e.g. `buzz messages send ...`) because `BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`, `BUZZ_RELAY_URL`, and the other `BUZZ_*` variables are passed through to terminal subprocesses. (`execute_code` and other non-terminal spawns remain sealed.)
 - **Inbound is polled, not streamed.** The `buzz` CLI is request/response, so the adapter polls `buzz messages get` per watched channel every `poll_interval` seconds (default 4). Expect up to one interval of latency on inbound messages. A future optimization is a websocket transport (the Buzz repo ships `buzz-ws-client` for true streaming).
 - On (re)connect the adapter seeds its high-water mark from the newest events, so channel history is never replayed into the agent.
 - New DM conversations are discovered automatically (every few poll sweeps).

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -506,6 +506,8 @@ If you add names to `terminal.docker_forward_env`, those variables are intention
 
 Both `execute_code` and `terminal` strip sensitive environment variables from child processes to prevent credential exfiltration by LLM-generated code. However, skills that declare `required_environment_variables` legitimately need access to those vars.
 
+First-party platform credentials — the `BUZZ_*` variables used by the Buzz messaging platform — are passed through to `terminal` children (foreground and background/PTY spawns) by default so a Buzz platform agent can invoke its platform-mandated CLI (e.g. `buzz`) from the terminal tool. Because `_sanitize_subprocess_env` also feeds search workers (e.g. the ddgs web-search subprocess), the computer-use driver binary, and user-script runners (bang `!` commands, quick commands, cron scripts, webhook-filter scripts), those children receive the variables too. This carve-out is **terminal-only**: it does not apply to `execute_code`, browser/TUI-host spawns (`hermes_subprocess_env`), Docker/Modal children, or `env_passthrough` registration, which remain sealed.
+
 ### How It Works
 
 Two mechanisms allow specific variables through the sandbox filters:


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where Buzz platform agents cannot use the `buzz` CLI from their terminal tool. The `BUZZ_*` credentials (`BUZZ_PRIVATE_KEY`, `BUZZ_AUTH_TAG`, `BUZZ_RELAY_URL`, and the other `BUZZ_*` names) are added to `_HERMES_PROVIDER_ENV_BLOCKLIST` from the buzz plugin.yaml (they land in `OPTIONAL_ENV_VARS` with category `messaging`), so the terminal scrub paths drop them, and `env_passthrough` refuses to re-allow anything on the blocklist (the GHSA-rhgp-j443-p4rf seal). The only previous escape hatch was the undocumented `_HERMES_FORCE_` prefix wrapper.

In the reported `hermes acp` scenario the Buzz adapter's `register()` is never invoked (platform adapters are deferred loaders there), so an adapter-registration fix would not work — the fix lives in the scrub paths themselves.

**Fix:** a terminal-only, first-party carve-out. `BUZZ_*` vars pass through to foreground (`_make_run_env`) and background/PTY (`_sanitize_subprocess_env`) terminal children, using the process env value directly (never scope-resolved). Everything else stays sealed and unchanged: the blocklist itself, the `env_passthrough` refusal, execute_code scrubbing, `hermes_subprocess_env` (browser/TUI-host/copilot-executor spawns), and docker children. The GHSA-rhgp-j443-p4rf seal is preserved because no registration path is opened — skills/config still cannot register these names.

Review hardening: first-party names are also excluded from the terminal login-snapshot dump and save/restored per command, so a profile's Buzz identity cannot leak cross-profile through the shared snapshot under a multiplexed gateway.

## Related Issue

Fixes #78026

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/local.py` — `_TERMINAL_FIRST_PARTY_ENV_PREFIXES = ("BUZZ_",)` + `_is_terminal_first_party_env()` with documented rationale; carve-out wired into `_make_run_env` and both `_sanitize_subprocess_env` loops (plain env value, never scope-resolved); `LocalEnvironment._additional_profile_scoped_passthrough_names()` override excludes present first-party names from the terminal login-snapshot dump and save/restores them per command.
- `tests/tools/test_local_env_blocklist.py` — terminal flow-through tests for all three vars, blocklist-membership invariant, plain-value tests (no `UnscopedSecretError` without a scope; scope does not override the process env), and a multiplex snapshot-isolation regression test using a real bash login snapshot.
- `tests/tools/test_env_passthrough.py` — execute_code still strips all three `BUZZ_*` vars; `register_env_passthrough()` still refuses them.
- `tests/tools/test_hermes_subprocess_env.py` — `hermes_subprocess_env(inherit_credentials=False)` still strips `BUZZ_*` (Tier 2).
- `website/docs/user-guide/security.md` — documents the terminal-only carve-out, its `_sanitize_subprocess_env` consumers, and the surfaces that remain sealed.
- `website/docs/user-guide/messaging/buzz.md` — notes `BUZZ_*` vars are available in terminal tool children.

## How to Test

1. Run the affected test files: `scripts/run_tests.sh tests/tools/test_local_env_blocklist.py tests/tools/test_env_passthrough.py tests/tools/test_hermes_subprocess_env.py tests/tools/test_base_environment.py tests/tools/test_docker_environment.py` — 164 passed / 0 failed locally.
2. Set `BUZZ_PRIVATE_KEY` / `BUZZ_RELAY_URL` in the environment of a Buzz-platform agent and invoke `buzz` from the terminal tool — it should no longer exit 3 with `auth error: BUZZ_PRIVATE_KEY is required`.
3. Regression: `BUZZ_*` should still be stripped from execute_code children, `hermes_subprocess_env` spawns, and docker children (covered by the new tests).

Note: the full `scripts/run_tests.sh` suite (17k tests) was not run locally; CI runs it on this PR. Full-suite checklist item below is intentionally unchecked pending CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (ran targeted affected files: 164 passed; full suite left to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Test run (hermetic runner, TZ=UTC):

```
=== Summary: 5 files, 164 tests passed, 0 failed (100% complete) in 4.9s (20 workers) ===
  tests/tools/test_hermes_subprocess_env.py (17✓)
  tests/tools/test_env_passthrough.py (25✓)
  tests/tools/test_docker_environment.py (51✓)
  tests/tools/test_local_env_blocklist.py (50✓)
  tests/tools/test_base_environment.py (21✓)
```

Ruff: `All checks passed!` on all changed Python files.
