### PR TITLE
fix: preserve one-shot logging

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -190,13 +190,6 @@ def run_oneshot(
 
     Returns the exit code.  The caller owns process termination.
     """
-    # Silence every stdlib logger for the duration.  AIAgent, tools, and
-    # provider adapters all log to stderr through the root logger; file
-    # handlers added by setup_logging() keep working (they're attached to
-    # the root logger's handler list, not affected by level), but no
-    # bytes reach the terminal.
-    logging.disable(logging.CRITICAL)
-
     # --provider without --model is ambiguous: carrying the user's configured
     # model across to a different provider is usually wrong (that provider may
     # not host it), and silently picking the provider's catalog default hides

--- a/tests/agent/test_anthropic_output_field_leak.py
+++ b/tests/agent/test_anthropic_output_field_leak.py
@@ -10,9 +10,6 @@ Fix: whitelist input-permitted fields per block type at three points —
 normalize_response capture, _sanitize_replay_block (ordered-blocks replay), and
 _convert_content_part_to_anthropic (content-list replay).
 """
-import sys, os
-sys.path.insert(0, os.path.expanduser("~/.hermes/hermes-agent"))
-
 import pytest
 from agent.anthropic_adapter import (
     _sanitize_replay_block,

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -1,4 +1,5 @@
 from argparse import Namespace
+import logging
 import os
 from pathlib import Path
 import subprocess
@@ -130,6 +131,55 @@ def test_oneshot_subprocess_exits_without_teardown_abort():
     # Don't demand byte-empty stderr — an import-time warning from the heavy
     # CLI import chain shouldn't fail this. What matters is no crash traceback.
     assert b"Traceback" not in result.stderr
+
+
+def test_oneshot_declares_stateless_delivery_during_agent_run(monkeypatch, capsys):
+    import hermes_cli.oneshot as oneshot
+    from gateway.session_context import async_delivery_supported, reset_session_vars
+
+    observed = []
+
+    def fake_run(*_args, **_kwargs):
+        observed.append(async_delivery_supported())
+        return "ok", {"final_response": "ok"}
+
+    reset_session_vars()
+    try:
+        monkeypatch.setattr(oneshot, "_run_agent", fake_run)
+        assert oneshot.run_oneshot("hello") == 0
+    finally:
+        reset_session_vars()
+
+    assert observed == [False]
+    assert capsys.readouterr().out == "ok\n"
+
+
+def test_oneshot_keeps_file_logging_enabled(monkeypatch, tmp_path, capsys):
+    import hermes_cli.oneshot as oneshot
+
+    log_path = tmp_path / "agent.log"
+    handler = logging.FileHandler(log_path, encoding="utf-8")
+    logger = logging.getLogger("tests.oneshot.file_logging")
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    previous_disable = logging.root.manager.disable
+
+    def fake_run(*_args, **_kwargs):
+        logger.info("one-shot agent activity")
+        return "ok", {"final_response": "ok"}
+
+    logging.disable(logging.NOTSET)
+    try:
+        monkeypatch.setattr(oneshot, "_run_agent", fake_run)
+        assert oneshot.run_oneshot("hello") == 0
+    finally:
+        handler.close()
+        logger.removeHandler(handler)
+        logging.disable(previous_disable)
+
+    assert log_path.read_text(encoding="utf-8") == "one-shot agent activity\n"
+    assert capsys.readouterr().out == "ok\n"
 
 
 
@@ -282,7 +332,6 @@ def test_make_tui_argv_dev_prebuilds_hermes_ink(monkeypatch, main_mod, tmp_path)
     assert argv == [str(tsx), "src/entry.tsx"]
     assert cwd == tui_dir
     assert calls == [(["/usr/bin/npm", "run", "build"], str(ink_dir))]
-
 
 
 


### PR DESCRIPTION
## Problem

One-shot `hermes -z` runs globally disabled Python logging. This hid `agent.log` and `errors.log` activity while long-running delegated work continued, making stalled task runners appear frozen after plugin discovery. A separate regression test also forced imports from `~/.hermes/hermes-agent`, so clean-worktree tests could silently exercise stale installed code.

## Changes

- Keep stdlib logging enabled during one-shot runs while retaining the existing stdout/stderr redirection.
- Cover file logging during one-shot execution.
- Pin one-shot stateless delivery so background delegation stays synchronous and drains before exit.
- Remove the hard-coded installed-checkout path from the Anthropic replay regression test.

## Validation

- `ruff check` on the three changed files
- `git diff --check`
- canonical focused suite: 32 passed
- canonical full suite: 25,254 passed; 56 pre-existing environment/platform failures across 19 files (optional lazy dependencies and Linux-only behavior on macOS)

No runtime rollout, gateway restart, or Dependabot PR processing is included.