### PR TITLE
fix(cron): skip binary content returned by remote script readers

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -258,7 +258,10 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:
         descriptor = os.open(path, flags)
-    except OSError:
+    except (OSError, ValueError):
+        # OSError: unreadable paths. ValueError: embedded NUL byte in a junk
+        # path tokenized out of binary content — a guarded read must never
+        # crash the guard (#76762).
         return None, False
     try:
         metadata = os.fstat(descriptor)
@@ -327,6 +330,14 @@ def _contains_unsafe_gateway_action(
         if script_text is None and read_remote_script is not None:
             # Local path missing; try the remote backend if one is available.
             script_text = read_remote_script(str(script_path))
+            # A backend may return raw binary content — e.g. an interpreter
+            # larger than the local read limit fetched back through a remote
+            # shell ("cat"). Mirror the local binary skip above: a NUL byte
+            # means this is not a shell script, and scanning decoded machine
+            # code feeds junk paths into the recursion and false-positives
+            # (or crashes on) any innocent command (#76510).
+            if script_text and "\x00" in script_text:
+                script_text = None
         if not script_text:
             continue
         # Relative references inside a script resolve against that script's

--- a/tests/cron/test_lifecycle_guard_binary_false_positive.py
+++ b/tests/cron/test_lifecycle_guard_binary_false_positive.py
@@ -1,0 +1,146 @@
+"""Regression tests: gateway lifecycle guard must not false-positive (or
+crash) on large binaries referenced by absolute path (#76510).
+
+The guard reads "referenced scripts" for gateway-lifecycle commands. When a
+command executes a large binary by path (e.g. ``/.../venv/bin/python``), two
+failure modes existed:
+
+1. Local read path (fixed in #76762): the bounded first-chunk read detects
+   NUL bytes and skips the binary.
+2. Remote-reader path (this fix): ``tools/terminal_tool.py`` falls back to a
+   backend shell read (``env.execute("cat ...")``) when the local read is
+   skipped for size, handing the guard the ENTIRE binary as text. Scanning
+   decoded machine code feeds junk path tokens into the recursion, which
+   crashed the guard with ``ValueError: embedded null byte`` from
+   ``os.open`` and fail-closed blocked innocent commands.
+
+The security boundary must be immune to what the reader callback returns:
+NUL-byte content is never a shell script, so it is skipped exactly like the
+local binary skip.
+"""
+
+import os
+
+import pytest
+
+from cron.lifecycle_guard import (
+    _read_referenced_script,
+    contains_gateway_lifecycle_command_or_referenced_script,
+)
+
+
+def _make_large_binary(path, size=1_200_000):
+    """Write a file larger than the 1MB read limit with binary content.
+
+    The content mimics what naive tokenization of a real ELF interpreter
+    produces: NUL-laden tokens that contain "/" (so the guard treats them
+    as referenced-script paths) — the shape that crashed the guard with
+    ``ValueError: embedded null byte`` in production (#76510).
+    """
+    with open(path, "wb") as fh:
+        fh.write(b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 8)
+        # Tokens: "\x00/junk\x00path\x00" carries "/" + NUL bytes, so it is
+        # yielded as a script path and makes os.open raise ValueError.
+        chunk = b"\x00/junk\x00path\x00 hermes\x00gateway\x00stop\x00" * 64
+        while fh.tell() < size:
+            fh.write(chunk)
+
+
+class TestRemoteReaderBinarySkip:
+    """Binary content returned by the remote reader must be skipped."""
+
+    def test_large_binary_via_remote_reader_not_blocked(self, tmp_path):
+        """#76510: absolute-path binary > 1MB whose content comes back
+        through the remote reader must not block and must not raise."""
+        binary = tmp_path / "python"
+        _make_large_binary(binary)
+        raw = binary.read_bytes().decode("utf-8", errors="replace")
+
+        def reader(script_path):
+            # Mirrors terminal_tool._read_script_in_env's backend fallback:
+            # the whole file content comes back as text.
+            return raw if os.path.basename(script_path) == "python" else None
+
+        command = f"{binary} --version"
+        # Pre-fix this raised ValueError("embedded null byte") or returned
+        # True at the recursion-depth limit; either way the command was
+        # unusable inside the gateway.
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                command, cwd=str(tmp_path), read_remote_script=reader
+            )
+            is False
+        )
+
+    def test_remote_reader_text_script_still_scanned(self, tmp_path):
+        """The NUL skip must not weaken the guard: text content from the
+        remote reader is still scanned for lifecycle commands."""
+        missing = tmp_path / "helper.sh"  # not on disk -> reader fallback
+
+        def reader(script_path):
+            return "hermes gateway restart" if "helper.sh" in script_path else None
+
+        command = f"bash {missing}"
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                command, cwd=str(tmp_path), read_remote_script=reader
+            )
+            is True
+        )
+
+    def test_remote_reader_benign_text_not_blocked(self, tmp_path):
+        """Benign text scripts from the remote reader stay allowed."""
+        missing = tmp_path / "deploy.sh"
+
+        def reader(script_path):
+            return "echo deploying && systemctl restart nginx" if "deploy.sh" in script_path else None
+
+        command = f"bash {missing}"
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                command, cwd=str(tmp_path), read_remote_script=reader
+            )
+            is False
+        )
+
+
+class TestReadReferencedScriptHardening:
+    """The bounded local reader itself must never crash the guard."""
+
+    def test_oversized_binary_local_read_skipped(self, tmp_path):
+        """#76762 regression guard: >1MB binary is skipped, not unsafe."""
+        binary = tmp_path / "interpreter"
+        _make_large_binary(binary)
+        text, unsafe = _read_referenced_script(binary)
+        assert text is None
+        assert unsafe is False
+
+    def test_null_byte_path_does_not_raise(self, tmp_path):
+        """Junk tokens tokenized out of binary content can contain NUL
+        bytes; os.open raises ValueError on them. The reader must treat
+        that as 'nothing to scan', never crash."""
+        text, unsafe = _read_referenced_script(tmp_path / "junk\x00.sh")
+        assert text is None
+        assert unsafe is False
+
+
+class TestDirectLifecycleCommandsStillBlocked:
+    """Security invariants must hold alongside the false-positive fix."""
+
+    def test_direct_restart_still_blocked(self):
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                "hermes gateway restart", cwd="/tmp"
+            )
+            is True
+        )
+
+    def test_local_script_with_restart_still_blocked(self, tmp_path):
+        script = tmp_path / "cycle.sh"
+        script.write_text("#!/bin/sh\nhermes gateway restart\n")
+        assert (
+            contains_gateway_lifecycle_command_or_referenced_script(
+                f"bash {script}", cwd=str(tmp_path)
+            )
+            is True
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes a false-positive block (and an uncaught crash) in the gateway lifecycle guard when a terminal command executes a **large binary by absolute path** from inside the gateway (`_HERMES_GATEWAY=1`).

When a referenced file exceeds the 1MB local read limit (`_MAX_REFERENCED_SCRIPT_BYTES`), the terminal tool's reader falls back to a backend shell read (`cat ...`) and hands the guard the **entire binary as text**. The guard then scanned that decoded machine code: junk tokens tokenized out of it (which contain `/` and NUL bytes) were fed into the referenced-script recursion, causing:

1. **Uncaught crash**: `ValueError: embedded null byte` from `os.open` on junk path tokens.
2. **Fail-closed block**: innocent commands like `/.../venv/bin/python --version` return "Blocked: command or referenced script cannot restart or stop the gateway..." even though they are harmless.

This is the residual half of the fix from #76762: that patch added the NUL-byte binary skip to the **local** read path (`_read_referenced_script`), but the **remote-reader** content path was left unguarded, and the `os.open` there only caught `OSError`, not `ValueError`.

The fix treats NUL-byte content returned by the remote reader exactly like the existing local binary skip — a binary is never a referenced *shell script* — and catches `ValueError` on `os.open` for junk paths. The security boundary must be immune to whatever the reader callback returns (local, SSH, Modal, or any other backend).

## Related Issue

Fixes #76510

(Follow-up hardening to #76762; that issue fixed the local read path but left the remote-reader content path and the `os.open` crash.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/lifecycle_guard.py`:
  - `_contains_unsafe_gateway_action`: skip NUL-byte content returned by `read_remote_script` (mirrors the local binary skip from #76762).
  - `_read_referenced_script`: catch `ValueError` alongside `OSError` on `os.open` (embedded NUL byte in junk paths tokenized from binary content).
- `tests/cron/test_lifecycle_guard_binary_false_positive.py`: new regression tests (red on `main`, green with this patch).

## How to Test

1. **Regression tests** (fail on unpatched `main` with `ValueError: embedded null byte`, pass with this patch):
   ```bash
   pytest tests/cron/test_lifecycle_guard_binary_false_positive.py -v
   ```
2. **Live reproduction** (inside a running gateway, `_HERMES_GATEWAY=1`):
   ```
   /home/<user>/.hermes/hermes-agent/venv/bin/python --version
   ```
   Before: `Blocked: command or referenced script cannot restart or stop the gateway...` (or a `ValueError` traceback). After: runs normally.
3. **Security invariants preserved** (covered by tests): direct `hermes gateway restart` and genuine shell scripts containing it are still blocked, both from the local reader and via the remote reader.

Verified with the full cron + gateway suite: `pytest tests/cron/ tests/hermes_cli/test_gateway_restart_loop.py tests/hermes_cli/test_gateway_service.py tests/tools/test_terminal_none_command_guard.py` → 551 passed.

Full suite (`pytest tests/ -q --ignore=tests/docker`): 1897 passed. One pre-existing, order-dependent failure in `tests/agent/test_file_safety.py::TestCacheFileReadBlocking::test_hub_index_cache_blocked` — verified to fail **identically on unmodified `main`** in the same run order (passes in isolation); unrelated to this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (CachyOS BORE kernel), Python 3.11.15, gateway as systemd user service

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring comments explain the NUL-skip and reference both issues
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the fix is pure-Python on the guard's reader boundary, no platform-specific syscalls; the NUL-byte check works identically on Windows/macOS
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema changes)

## Screenshots / Logs

**Red on `main`** (unpatched guard):
```
FAILED tests/cron/test_lifecycle_guard_binary_false_positive.py::TestRemoteReaderBinarySkip::test_large_binary_via_remote_reader_not_blocked
FAILED tests/cron/test_lifecycle_guard_binary_false_positive.py::TestReadReferencedScriptHardening::test_null_byte_path_does_not_raise
E   ValueError: embedded null byte
cron/lifecycle_guard.py:260: ValueError
2 failed, 5 passed
```

**Green with this patch**:
```
7 passed in 0.13s
```

**Production scenario** (21MB venv interpreter returned by the backend reader):
```
Reader liefert 21479135 chars Binary-Muell
1) Produktionsszenario: venv/bin/python --version  -> PASS
2) Sicherheits-Invariante: echtes Restart-Script via Reader  -> BLOCKED
3) Direktes Lifecycle-Kommando wird weiterhin geblockt  -> BLOCKED
```
