### PR TITLE
Nit: Fix Docker migration for unversioned configs

### DIFF
--- a/scripts/docker_config_migrate.py
+++ b/scripts/docker_config_migrate.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Iterable
 
 from hermes_cli.config import (
+    _raw_config_has_explicit_version,
     check_config_version,
     get_config_path,
     get_env_path,
@@ -63,11 +64,13 @@ def main() -> int:
     if current_ver >= latest_ver:
         return 0
 
-    # Below the auto-migration support floor: migrate_config() refuses (and
-    # leaves the file untouched), so don't run the backup/verify dance that
-    # would raise "did not advance config version" and block the boot.
-    # Warn-and-continue matches the CLI's fail-safe posture.
-    if current_ver < SUPPORT_FLOOR_VERSION:
+    # Below the auto-migration support floor, only explicitly versioned legacy
+    # configs are refused. Unversioned configs are fresh/minimal and must reach
+    # migrate_config(), which stamps them with the current schema version.
+    # Otherwise, don't run the backup/verify dance that would raise "did not
+    # advance config version" and block the boot. Warn-and-continue matches the
+    # CLI's fail-safe posture.
+    if current_ver < SUPPORT_FLOOR_VERSION and _raw_config_has_explicit_version():
         print(
             f"[config-migrate] WARNING: {support_floor_message()}",
             file=sys.stderr,

--- a/tests/tools/test_docker_config_migrate.py
+++ b/tests/tools/test_docker_config_migrate.py
@@ -42,6 +42,23 @@ def _run_migration(hermes_home: Path, **env_overrides: str) -> subprocess.Comple
     )
 
 
+def test_docker_config_migrate_stamps_unversioned_config(tmp_path: Path) -> None:
+    """Unversioned fresh configs follow the canonical migration path."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump({"model": {"default": "m", "provider": "openrouter"}}),
+        encoding="utf-8",
+    )
+
+    proc = _run_migration(tmp_path)
+
+    assert proc.returncode == 0, proc.stderr
+    assert "can no longer be auto-migrated" not in proc.stderr
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+    assert raw["model"] == {"default": "m", "provider": "openrouter"}
+
+
 def test_docker_config_migrate_backs_up_and_migrates_legacy_config(tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
     env_path = tmp_path / ".env"
@@ -89,21 +106,6 @@ def test_docker_config_migrate_skips_below_floor_config_untouched(tmp_path: Path
             }
         )
     )
-    config_path.write_text(original, encoding="utf-8")
-
-    proc = _run_migration(tmp_path)
-
-    assert proc.returncode == 0, proc.stderr
-    assert "Migrating config schema" not in proc.stdout
-    assert "can no longer be auto-migrated" in proc.stderr
-    assert config_path.read_text(encoding="utf-8") == original
-    assert not list(tmp_path.glob("*.bak-*"))
-
-
-def test_docker_config_migrate_skips_unversioned_config_untouched(tmp_path: Path) -> None:
-    """Unversioned configs coerce to version 0 — below the floor, so refused."""
-    config_path = tmp_path / "config.yaml"
-    original = yaml.safe_dump({"model": {"default": "m", "provider": "openrouter"}})
     config_path.write_text(original, encoding="utf-8")
 
     proc = _run_migration(tmp_path)


### PR DESCRIPTION
## Root cause

On a fresh Docker volume, `cli-config.yaml.example` is seeded without `_config_version`. Docker's migration wrapper interpreted the missing value as version `0` and applied the legacy-config support-floor guard before the canonical migrator ran.

The canonical migration path intentionally treats an unversioned configuration as fresh or minimal, migrates it, and stamps the current schema version.

## Docker impact

Fresh Docker deployments logged an unsupported-legacy-config warning on first boot even though the configuration was new. Startup continued, but the warning incorrectly told users to regenerate or manually repair their configuration.

## Fix

Apply the Docker support-floor guard only when the configuration carries an explicitly old schema version. Unversioned fresh configurations now proceed through the canonical migration path; explicitly old configurations remain safely refused.

## Testing

- `venv/bin/python3 -m pytest tests/tools/test_docker_config_migrate.py`
  - 8 passed
