### PR TITLE
fix: suppress macOS SSH warning when Remote Login is off

### DIFF
--- a/hermes_cli/security_audit_startup.py
+++ b/hermes_cli/security_audit_startup.py
@@ -11,7 +11,7 @@ Checks (each is independent and fail-safe — any internal error is swallowed
 and simply yields no finding):
 
 1. Running as root (POSIX uid 0).
-2. SSH daemon present with password authentication enabled.
+2. Active SSH daemon with password authentication enabled.
 3. Running inside a container with no persistent volume mount over the
    HERMES_HOME data dir (state is ephemeral — lost on container restart).
 4. A network-accessible gateway listener (dashboard / API server) with no
@@ -25,6 +25,8 @@ from __future__ import annotations
 import logging
 import os
 import re
+import subprocess
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -84,13 +86,47 @@ def _iter_sshd_config_lines() -> list[str]:
     return lines
 
 
+def _macos_sshd_service_active() -> Optional[bool]:
+    """Return whether macOS Remote Login's launchd service is active.
+
+    ``sshd_config`` exists on every macOS installation, including hosts where
+    Remote Login is disabled.  Treat an absent launchd service as explicitly
+    inactive so that the config's permissive default does not produce a false
+    exposure warning.  ``None`` preserves the conservative warning when the
+    service state cannot be inspected or on non-macOS platforms.
+    """
+    if sys.platform != "darwin":
+        return None
+    try:
+        result = subprocess.run(
+            ["/bin/launchctl", "print", "system/com.openssh.sshd"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode == 0:
+        return True
+    if result.returncode == 113:
+        # launchctl's stable status for an unknown service target. Other
+        # failures are inspection errors, not evidence that SSH is disabled.
+        return False
+    return None
+
+
 def _ssh_password_auth_enabled() -> Optional[str]:
     """Warn when an SSH daemon has password authentication enabled.
 
     Password auth on a public SSH daemon is the classic brute-force surface
     and pairs badly with a root-capable agent box. POSIX-only; returns None
-    when there's no sshd config to read (e.g. Windows, or SSH not installed).
+    when there's no sshd config to read (e.g. Windows, or SSH not installed),
+    or when macOS Remote Login is disabled.
     """
+    if _macos_sshd_service_active() is False:
+        return None
+
     lines = _iter_sshd_config_lines()
     if not lines:
         return None

--- a/tests/hermes_cli/test_security_audit_startup.py
+++ b/tests/hermes_cli/test_security_audit_startup.py
@@ -25,6 +25,120 @@ def _reset_audit_sentinel():
 # ── SSH password-auth check ─────────────────────────────────────────────────
 
 
+@pytest.mark.parametrize(
+    ("returncode", "expected"),
+    [(0, True), (113, False), (1, None)],
+)
+def test_macos_sshd_service_state_comes_from_launchctl(
+    monkeypatch, returncode, expected
+):
+    """launchd service presence is the macOS Remote Login signal."""
+    monkeypatch.setattr(audit.sys, "platform", "darwin")
+
+    class Result:
+        def __init__(self, code):
+            self.returncode = code
+
+    monkeypatch.setattr(
+        audit.subprocess,
+        "run",
+        lambda *args, **kwargs: Result(returncode),
+    )
+
+    assert audit._macos_sshd_service_active() is expected
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        OSError("launchctl unavailable"),
+        audit.subprocess.TimeoutExpired(cmd="launchctl", timeout=2),
+    ],
+)
+def test_macos_sshd_inspection_errors_are_unknown(monkeypatch, error):
+    """Inspection failures preserve the conservative warning path."""
+    monkeypatch.setattr(audit.sys, "platform", "darwin")
+
+    def fail_inspection(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(audit.subprocess, "run", fail_inspection)
+
+    assert audit._macos_sshd_service_active() is None
+
+
+def test_non_macos_skips_launchctl_and_preserves_warning(monkeypatch):
+    """Other POSIX platforms keep the original config-based behavior."""
+    monkeypatch.setattr(audit.sys, "platform", "linux")
+
+    def unexpected_launchctl(*args, **kwargs):
+        raise AssertionError("launchctl must not run outside macOS")
+
+    monkeypatch.setattr(audit.subprocess, "run", unexpected_launchctl)
+    monkeypatch.setattr(
+        audit,
+        "_iter_sshd_config_lines",
+        lambda: ["PasswordAuthentication yes"],
+    )
+
+    assert audit._macos_sshd_service_active() is None
+    assert audit._ssh_password_auth_enabled() is not None
+
+
+def test_macos_inactive_sshd_suppresses_password_auth_warning(monkeypatch):
+    """An installed config is not an exposed SSH service on macOS."""
+    monkeypatch.setattr(
+        audit,
+        "_iter_sshd_config_lines",
+        lambda: ["PasswordAuthentication yes"],
+    )
+    monkeypatch.setattr(
+        audit,
+        "_macos_sshd_service_active",
+        lambda: False,
+        raising=False,
+    )
+
+    assert audit._ssh_password_auth_enabled() is None
+
+
+def test_active_sshd_with_password_auth_still_warns(monkeypatch):
+    """Suppressing inactive macOS noise must not hide a real SSH exposure."""
+    monkeypatch.setattr(
+        audit,
+        "_iter_sshd_config_lines",
+        lambda: ["PasswordAuthentication yes"],
+    )
+    monkeypatch.setattr(
+        audit,
+        "_macos_sshd_service_active",
+        lambda: True,
+        raising=False,
+    )
+
+    finding = audit._ssh_password_auth_enabled()
+
+    assert finding is not None
+    assert "SSH password authentication is ENABLED" in finding
+
+
+def test_unknown_sshd_state_keeps_conservative_warning(monkeypatch):
+    """Inspection failures should not silently clear a possible exposure."""
+    monkeypatch.setattr(
+        audit,
+        "_iter_sshd_config_lines",
+        lambda: ["PasswordAuthentication yes"],
+    )
+    monkeypatch.setattr(
+        audit,
+        "_macos_sshd_service_active",
+        lambda: None,
+        raising=False,
+    )
+
+    assert audit._ssh_password_auth_enabled() is not None
+
+
 # ── container / volume-mount check ──────────────────────────────────────────
 
 
@@ -42,6 +156,7 @@ def _reset_audit_sentinel():
 
 def test_run_security_audit_aggregates(monkeypatch, tmp_path):
     monkeypatch.setattr(audit, "_is_root", lambda: True)
+    monkeypatch.setattr(audit, "_macos_sshd_service_active", lambda: True)
     monkeypatch.setattr(audit, "_iter_sshd_config_lines", lambda: ["PasswordAuthentication yes"])
     monkeypatch.setattr(audit, "_in_container", lambda: False)
     findings = audit.run_security_audit(hermes_home=tmp_path, config={})


### PR DESCRIPTION
## Summary
- query launchd before evaluating SSH password authentication on macOS
- suppress the warning only when `com.openssh.sshd` is definitively absent
- preserve conservative warnings for active or unknown service state and preserve non-macOS behavior

## Why
macOS ships an sshd configuration even when Remote Login is disabled. Treating config-file presence as an exposed daemon creates a startup false positive on otherwise quiet hosts.

The implementation treats launchctl status 0 as active, the observed service-not-found status 113 as inactive, and all other statuses/exceptions as unknown.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_security_audit_startup.py -q` — 12 passed
- `.venv/bin/python -m ruff check hermes_cli/security_audit_startup.py tests/hermes_cli/test_security_audit_startup.py` — passed
- `git diff --check` — passed
- live macOS probe: service inactive and SSH finding suppressed
- independent read-only review: no actionable findings