### PR TITLE
feat(terminal): interpret signal-termination exit codes (port from kilocode#12698)

### DIFF
--- a/tests/tools/test_terminal_signal_exit.py
+++ b/tests/tools/test_terminal_signal_exit.py
@@ -1,0 +1,95 @@
+"""Tests for signal-termination exit code interpretation.
+
+Ported from Kilo-Org/kilocode#12698 ("settle signal-terminated shell
+commands as 128 + signum"): the model must see a human-readable note for
+signal deaths instead of a bare exit_code=-9 / 137 it burns turns
+mis-diagnosing.
+"""
+
+import pytest
+
+from tools.terminal_tool import _interpret_exit_code, _interpret_signal_exit
+
+
+class TestInterpretSignalExit:
+    # ---- negative codes: subprocess -signum semantics (definite) ----
+
+    @pytest.mark.parametrize("code,expect", [
+        (-9, "SIGKILL"),
+        (-11, "SIGSEGV"),
+        (-15, "SIGTERM"),
+        (-6, "SIGABRT"),
+        (-8, "SIGFPE"),
+        (-13, "SIGPIPE"),
+    ])
+    def test_negative_known_signals(self, code, expect):
+        note = _interpret_signal_exit(code)
+        assert note is not None
+        assert expect in note
+        assert "terminated by" in note.lower()
+
+    def test_negative_oom_mentions_oom(self):
+        note = _interpret_signal_exit(-9)
+        assert "OOM" in note
+
+    def test_negative_unknown_signal_still_reports(self):
+        # signum without a curated note still yields a generic note.
+        note = _interpret_signal_exit(-31)
+        assert note is not None
+        assert "31" in note
+
+    # ---- 128+signum band: shell convention (hedged) ----
+
+    @pytest.mark.parametrize("code,expect", [
+        (137, "SIGKILL"),
+        (139, "SIGSEGV"),
+        (143, "SIGTERM"),
+        (134, "SIGABRT"),
+        (141, "SIGPIPE"),
+    ])
+    def test_shell_band_known_signals(self, code, expect):
+        note = _interpret_signal_exit(code)
+        assert note is not None
+        assert expect in note
+        # Hedged: a program can legitimately exit with these codes.
+        assert "usually" in note
+
+    def test_shell_band_uncurated_signum_returns_none(self):
+        # 128+signum for a signum outside the curated table must stay
+        # silent — we never guess on ambiguous application exit codes.
+        assert _interpret_signal_exit(128 + 40) is None
+
+    # ---- exclusions ----
+
+    def test_sigint_130_excluded(self):
+        # rc=130 has bespoke interrupt-marker handling in the executor.
+        assert _interpret_signal_exit(130) is None
+        assert _interpret_signal_exit(-2) is None
+
+    @pytest.mark.parametrize("code", [0, 1, 2, 42, 100, 127, 128])
+    def test_normal_codes_return_none(self, code):
+        assert _interpret_signal_exit(code) is None
+
+
+class TestSignalExitWiring:
+    """_interpret_exit_code surfaces signal notes and keeps old semantics."""
+
+    def test_signal_note_via_interpret_exit_code(self):
+        note = _interpret_exit_code("python3 crash.py", -11)
+        assert note is not None and "SIGSEGV" in note
+
+    def test_shell_band_via_interpret_exit_code(self):
+        note = _interpret_exit_code("./run_build.sh", 137)
+        assert note is not None and "SIGKILL" in note
+
+    def test_signal_note_wins_over_command_semantics(self):
+        # A grep killed by SIGKILL must report the signal, not "no matches".
+        note = _interpret_exit_code("grep foo huge.log", 137)
+        assert "SIGKILL" in note
+
+    def test_grep_exit_1_unchanged(self):
+        note = _interpret_exit_code("grep foo bar.txt", 1)
+        assert note is not None and "no matches" in note.lower()
+
+    def test_success_unchanged(self):
+        assert _interpret_exit_code("ls", 0) is None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2291,6 +2291,61 @@ atexit.register(_atexit_cleanup)
 # wastes a turn investigating something that just means "no matches".
 # This lookup adds a human-readable note so the agent can move on.
 
+# Signal-death notes for the lethal signals seen in practice. Keyed by
+# signum; used for both the ``-signum`` (subprocess) and ``128+signum``
+# (shell) encodings. Curated rather than exhaustive so we never mislabel a
+# legitimate application exit code (e.g. 130/SIGINT is handled by the
+# executor's interrupt-marker path and excluded here).
+_SIGNAL_EXIT_NOTES: dict[int, str] = {
+    3:  "SIGQUIT (quit from keyboard)",
+    4:  "SIGILL (illegal instruction — corrupt binary or wrong architecture)",
+    6:  "SIGABRT (abort — assertion failure, fatal runtime error, or glibc abort)",
+    7:  "SIGBUS (bus error — misaligned or unmapped memory access)",
+    8:  "SIGFPE (fatal arithmetic error, e.g. integer division by zero)",
+    9:  "SIGKILL — often the kernel OOM killer on memory exhaustion, "
+        "or an explicit kill -9",
+    11: "SIGSEGV (segmentation fault — the program crashed)",
+    13: "SIGPIPE (wrote to a closed pipe — e.g. output piped to a reader that exited)",
+    15: "SIGTERM (terminated — kill/timeout or shutdown requested it to stop)",
+    24: "SIGXCPU (CPU time limit exceeded)",
+    25: "SIGXFSZ (file size limit exceeded)",
+}
+
+
+def _interpret_signal_exit(exit_code: int) -> str | None:
+    """Map signal-termination exit codes to a human-readable note.
+
+    Returns None when ``exit_code`` does not look like a signal death.
+    Negative codes are Python ``subprocess`` semantics (definite); codes in
+    the 128+signum band are the shell convention (very likely but not
+    guaranteed, so those notes hedge with "usually").
+    """
+    if exit_code < 0:
+        signum = -exit_code
+        if signum == 2:  # SIGINT — executor's interrupt-marker path owns it
+            return None
+        note = _SIGNAL_EXIT_NOTES.get(signum)
+        if note:
+            return f"Command terminated by signal {signum}: {note}"
+        try:
+            import signal as _signal
+            name = _signal.Signals(signum).name
+        except (ValueError, ImportError):
+            name = f"signal {signum}"
+        return f"Command terminated by {name} (signal {signum})"
+
+    if exit_code > 128:
+        signum = exit_code - 128
+        note = _SIGNAL_EXIT_NOTES.get(signum)
+        if note:
+            return (
+                f"Exit code {exit_code} usually means the command was "
+                f"terminated by signal {signum}: {note}"
+            )
+
+    return None
+
+
 def _interpret_exit_code(command: str, exit_code: int) -> str | None:
     """Return a human-readable note when a non-zero exit code is non-erroneous.
 
@@ -2300,6 +2355,21 @@ def _interpret_exit_code(command: str, exit_code: int) -> str | None:
     """
     if exit_code == 0:
         return None
+
+    # Signal terminations (ported from Kilo-Org/kilocode#12698, adapted to
+    # Python semantics). Two shapes reach the model:
+    #   * negative codes — subprocess.Popen reports a signal-killed process
+    #     as ``-signum`` (definite signal death), and
+    #   * 128+signum — the conventional shell encoding when bash reports a
+    #     signal-killed child (heuristic: a program *can* ``exit 139``, so
+    #     these notes say "usually").
+    # Without a note the model sees a bare ``exit_code=-9`` or ``137`` and
+    # burns turns re-running or mis-diagnosing (137 = OOM kill is the big
+    # one). 130/SIGINT is deliberately absent: the executor has bespoke
+    # interrupt-marker handling for rc=130.
+    signal_note = _interpret_signal_exit(exit_code)
+    if signal_note is not None:
+        return signal_note
 
     # Extract the last command in a pipeline/chain — that determines the
     # exit code.  Handles  `cmd1 && cmd2`, `cmd1 | cmd2`, `cmd1; cmd2`.

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2022,6 +2022,61 @@ atexit.register(_atexit_cleanup)
 # wastes a turn investigating something that just means "no matches".
 # This lookup adds a human-readable note so the agent can move on.
 
+# Signal-death notes for the lethal signals seen in practice. Keyed by
+# signum; used for both the ``-signum`` (subprocess) and ``128+signum``
+# (shell) encodings. Curated rather than exhaustive so we never mislabel a
+# legitimate application exit code (e.g. 130/SIGINT is handled by the
+# executor's interrupt-marker path and excluded here).
+_SIGNAL_EXIT_NOTES: dict[int, str] = {
+    3:  "SIGQUIT (quit from keyboard)",
+    4:  "SIGILL (illegal instruction — corrupt binary or wrong architecture)",
+    6:  "SIGABRT (abort — assertion failure, fatal runtime error, or glibc abort)",
+    7:  "SIGBUS (bus error — misaligned or unmapped memory access)",
+    8:  "SIGFPE (fatal arithmetic error, e.g. integer division by zero)",
+    9:  "SIGKILL — often the kernel OOM killer on memory exhaustion, "
+        "or an explicit kill -9",
+    11: "SIGSEGV (segmentation fault — the program crashed)",
+    13: "SIGPIPE (wrote to a closed pipe — e.g. output piped to a reader that exited)",
+    15: "SIGTERM (terminated — kill/timeout or shutdown requested it to stop)",
+    24: "SIGXCPU (CPU time limit exceeded)",
+    25: "SIGXFSZ (file size limit exceeded)",
+}
+
+
+def _interpret_signal_exit(exit_code: int) -> str | None:
+    """Map signal-termination exit codes to a human-readable note.
+
+    Returns None when ``exit_code`` does not look like a signal death.
+    Negative codes are Python ``subprocess`` semantics (definite); codes in
+    the 128+signum band are the shell convention (very likely but not
+    guaranteed, so those notes hedge with "usually").
+    """
+    if exit_code < 0:
+        signum = -exit_code
+        if signum == 2:  # SIGINT — executor's interrupt-marker path owns it
+            return None
+        note = _SIGNAL_EXIT_NOTES.get(signum)
+        if note:
+            return f"Command terminated by signal {signum}: {note}"
+        try:
+            import signal as _signal
+            name = _signal.Signals(signum).name
+        except (ValueError, ImportError):
+            name = f"signal {signum}"
+        return f"Command terminated by {name} (signal {signum})"
+
+    if exit_code > 128:
+        signum = exit_code - 128
+        note = _SIGNAL_EXIT_NOTES.get(signum)
+        if note:
+            return (
+                f"Exit code {exit_code} usually means the command was "
+                f"terminated by signal {signum}: {note}"
+            )
+
+    return None
+
+
 def _interpret_exit_code(command: str, exit_code: int) -> str | None:
     """Return a human-readable note when a non-zero exit code is non-erroneous.
 
@@ -2031,6 +2086,21 @@ def _interpret_exit_code(command: str, exit_code: int) -> str | None:
     """
     if exit_code == 0:
         return None
+
+    # Signal terminations (ported from Kilo-Org/kilocode#12698, adapted to
+    # Python semantics). Two shapes reach the model:
+    #   * negative codes — subprocess.Popen reports a signal-killed process
+    #     as ``-signum`` (definite signal death), and
+    #   * 128+signum — the conventional shell encoding when bash reports a
+    #     signal-killed child (heuristic: a program *can* ``exit 139``, so
+    #     these notes say "usually").
+    # Without a note the model sees a bare ``exit_code=-9`` or ``137`` and
+    # burns turns re-running or mis-diagnosing (137 = OOM kill is the big
+    # one). 130/SIGINT is deliberately absent: the executor has bespoke
+    # interrupt-marker handling for rc=130.
+    signal_note = _interpret_signal_exit(exit_code)
+    if signal_note is not None:
+        return signal_note
 
     # Extract the last command in a pipeline/chain — that determines the
     # exit code.  Handles  `cmd1 && cmd2`, `cmd1 | cmd2`, `cmd1; cmd2`.


### PR DESCRIPTION
## Summary
The terminal tool now tells the model *why* a command died when it was killed by a signal — `exit_code=137` gets an `exit_code_meaning` note naming SIGKILL and the likely OOM cause instead of leaving the model to burn turns re-running and mis-diagnosing.

Ported from [Kilo-Org/kilocode#12698](https://github.com/Kilo-Org/kilocode/pull/12698) ("settle signal-terminated shell commands as 128 + signum"). Kilo's bug was a hang because their spawner produced *no* numeric code on signal death; Hermes already produces numeric codes (Python `subprocess` `-signum`, or the shell's `128+signum`), so the adaptation targets the remaining gap: the model can't read them.

## Changes
- `tools/terminal_tool.py`: new `_interpret_signal_exit()` wired into `_interpret_exit_code()` ahead of the per-command semantics table.
  - Negative codes (definite signal death from `subprocess`) → "Command terminated by signal N: …" for a curated table (SIGKILL/SIGSEGV/SIGTERM/SIGABRT/SIGBUS/SIGFPE/SIGPIPE/SIGQUIT/SIGILL/SIGXCPU/SIGXFSZ), generic fallback for uncurated signums.
  - `128+signum` band (shell convention, ambiguous — a program *can* `exit 139`) → hedged "usually means…" note, curated signals only; uncurated codes stay silent so legitimate application exit codes are never mislabeled.
  - SIGINT excluded on both paths — rc=130 already has bespoke interrupt-marker handling in the executor.
- `tests/tools/test_terminal_signal_exit.py`: 26 tests covering both encodings, exclusions, hedging, and precedence over the command-semantics table (a SIGKILLed grep reports the signal, not "no matches").

## Validation
| | Before | After |
|---|---|---|
| `python3` SIGSEGV (real process, E2E) | `exit_code: 139`, no note | `exit_code_meaning: Exit code 139 usually means … SIGSEGV (segmentation fault…)` |
| `bash -c 'kill -9 $$'` (E2E) | `exit_code: 137`, no note | `… SIGKILL — often the kernel OOM killer …` |
| `grep` no-match / diff / existing semantics | unchanged | unchanged (56/56 targeted tests pass) |

E2E was run through the real `terminal_tool()` with an isolated temp `HERMES_HOME` and genuinely signal-killed processes, not mocks.

## Architectural notes
- Kilo's change sits in their process spawner (Effect/Node); Hermes' equivalent gap was presentation, so the port lands in the existing exit-code semantics tier (`_interpret_exit_code`) — zero new tool surface, no behavior change for non-signal exits.
- Notes ride the existing `exit_code_meaning` field the model already knows from grep/diff semantics.

## Infographic

![Signal-aware terminal exit codes](https://v3b.fal.media/files/b/0aa4eb11/usZax2HMUvRMgeHxz5i2-_yuEkxVN8.png)
