### PR TITLE
fix(cli): refresh context usage during tool loops

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3442,6 +3442,20 @@ def run_conversation(
                             f"{cached:,}/{prompt:,} tokens "
                             f"({hit_pct:.0f}% hit, {written:,} written)"
                         )
+
+                    # Let interactive surfaces repaint usage-dependent chrome
+                    # after all per-call context and session counters are current.
+                    # UI callbacks are best-effort and must never fail a turn.
+                    usage_updated_callback = getattr(
+                        agent, "_usage_updated_callback", None
+                    )
+                    if usage_updated_callback:
+                        try:
+                            usage_updated_callback()
+                        except Exception:
+                            logger.debug(
+                                "Usage-updated callback failed", exc_info=True
+                            )
                 
                 _retry.has_retried_429 = False  # Reset on success
                 # Note: don't clear the retry buffer here — an "API call

--- a/cli.py
+++ b/cli.py
@@ -4815,6 +4815,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._last_invalidate = now
             self._app.invalidate()
 
+    def _invalidate_usage_status(self) -> None:
+        """Repaint once after an API response updates token accounting."""
+        # Model responses are infrequent compared with streaming/spinner frames,
+        # so do not let one of those background paints swallow this state change.
+        self._invalidate(min_interval=0.0)
+
     def _paint_now(self) -> None:
         """Immediate, unthrottled repaint for user-blocking modal prompts.
 

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -531,6 +531,10 @@ class CLIAgentSetupMixin:
             # Route agent status output through prompt_toolkit so ANSI escape
             # sequences aren't garbled by patch_stdout's StdoutProxy (#2262).
             self.agent._print_fn = _cprint
+            # Refresh token/context status after every model response, including
+            # intermediate responses in tool loops. The dedicated helper forces
+            # this low-frequency repaint while preserving the resize guard.
+            self.agent._usage_updated_callback = self._invalidate_usage_status
             # Hydrate credits notices at session OPEN (parity with the TUI), so a
             # depletion / usage-band warning shows before the first message. The
             # notice_callback is bound above → _on_notice renders the line. Idempotent

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -170,6 +170,7 @@ def test_runtime_resolution_failure_is_not_sticky(monkeypatch):
     assert shell._init_agent() is True
     assert calls["count"] == 2
     assert shell.agent is not None
+    assert shell.agent._usage_updated_callback == shell._invalidate_usage_status
 
 
 

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -128,6 +128,16 @@ class TestCLIStatusBar:
 
 
 
+    def test_usage_status_repaint_bypasses_background_throttle(self):
+        cli_obj = _make_cli()
+        cli_obj._app = MagicMock()
+        cli_obj._last_invalidate = time.monotonic()
+        cli_obj._resize_recovery_pending = False
+
+        cli_obj._invalidate_usage_status()
+
+        cli_obj._app.invalidate.assert_called_once_with()
+
     def test_scheduled_unsuppress_debounces_resize_storm(self):
         """A fresh resize cancels the pending unsuppress and restarts it."""
         cli_obj = _make_cli()

--- a/tests/run_agent/test_context_token_tracking.py
+++ b/tests/run_agent/test_context_token_tracking.py
@@ -86,6 +86,49 @@ def test_anthropic_cache_read_and_creation_added(monkeypatch):
     assert agent.session_prompt_tokens == 17003
 
 
+def test_usage_updated_callback_runs_after_each_tool_loop_response(monkeypatch):
+    observed = []
+    responses = iter(
+        [
+            SimpleNamespace(
+                content=[
+                    SimpleNamespace(
+                        type="tool_use",
+                        id="call_1",
+                        name="t",
+                        input={},
+                    )
+                ],
+                stop_reason="tool_use",
+                usage=SimpleNamespace(input_tokens=400, output_tokens=20),
+                model="claude-sonnet-4-6",
+            ),
+            _anthropic_resp(600, 20),
+        ]
+    )
+    agent = _make_agent(
+        monkeypatch,
+        "anthropic_messages",
+        "anthropic",
+        lambda: next(responses),
+    )
+
+    def on_usage_updated():
+        observed.append(
+            (
+                agent.context_compressor.last_prompt_tokens,
+                agent.session_prompt_tokens,
+                agent.session_api_calls,
+            )
+        )
+
+    agent._usage_updated_callback = on_usage_updated
+
+    agent.run_conversation("hi")
+
+    assert observed == [(400, 400, 1), (600, 1000, 2)]
+
+
 def test_anthropic_no_cache_fields(monkeypatch):
     agent = _make_agent(monkeypatch, "anthropic_messages", "anthropic",
                         lambda: _anthropic_resp(500, 20))

--- a/tests/run_agent/test_context_token_tracking.py
+++ b/tests/run_agent/test_context_token_tracking.py
@@ -129,6 +129,27 @@ def test_usage_updated_callback_runs_after_each_tool_loop_response(monkeypatch):
     assert observed == [(400, 400, 1), (600, 1000, 2)]
 
 
+def test_usage_updated_callback_failure_does_not_abort_turn(monkeypatch):
+    calls = []
+    agent = _make_agent(
+        monkeypatch,
+        "anthropic_messages",
+        "anthropic",
+        lambda: _anthropic_resp(400, 20),
+    )
+
+    def on_usage_updated():
+        calls.append(agent.session_api_calls)
+        raise RuntimeError("repaint failed")
+
+    agent._usage_updated_callback = on_usage_updated
+
+    result = agent.run_conversation("hi")
+
+    assert calls == [1]
+    assert result["final_response"] == "ok"
+
+
 def test_anthropic_no_cache_fields(monkeypatch):
     agent = _make_agent(monkeypatch, "anthropic_messages", "anthropic",
                         lambda: _anthropic_resp(500, 20))


### PR DESCRIPTION
## What changed

The interactive CLI now repaints its status bar after each model response, once context and session token accounting are up to date. This keeps the context percentage moving between tool calls instead of waiting for unrelated UI activity.

The usage repaint skips the general 250 ms background throttle because model responses are infrequent, but it still respects the existing resize guard. The callback is also fail-open, so a UI problem cannot interrupt an agent turn.

## Tests

- `pytest -q tests/run_agent/test_context_token_tracking.py tests/run_agent/test_codex_app_server_integration.py tests/cli/test_cli_provider_resolution.py tests/cli/test_cli_status_bar.py`
- `ruff check` on the changed Python files

Addresses the interactive CLI portion of #77744.