### PR TITLE
fix(kanban): emit lifecycle observers after commit

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -101,6 +101,44 @@ _log = logging.getLogger(__name__)
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
+KANBAN_EVENT_SCHEMA_VERSION = "hermes.kanban.event.v1"
+FAILURE_COUNT_MAX = 1000
+KANBAN_EVENT_KINDS: frozenset[str] = frozenset({
+    "created", "linked", "unlinked", "decomposed",
+    "assigned", "model_override_set", "reasoning_effort_set", "commented",
+    "attached", "attachment_removed", "edited", "specified", "reprioritized",
+    "promoted", "promoted_manual", "claimed", "claim_rejected",
+    "claim_extended", "reclaimed", "scheduled", "unblocked", "heartbeat",
+    "spawned", "reclaim_deferred", "respawn_guarded", "completed",
+    "dependency_wait", "blocked", "block_loop_detected", "archived", "status",
+    "stale", "timed_out", "protocol_violation", "rate_limited", "crashed",
+    "spawn_failed", "gave_up", "completion_blocked_hallucination",
+    "suspected_hallucinated_references", "tip_scratch_workspace",
+})
+
+
+@dataclass(frozen=True)
+class _KanbanEventNotification:
+    task_id: str
+    kind: str
+    core_event_seq: int
+    created_at_epoch_s: int
+    run_id: Optional[int]
+    status_to: Optional[str]
+    failure_count: Optional[int]
+
+
+@dataclass
+class _KanbanEventTxnFrame:
+    connection: sqlite3.Connection
+    board: Optional[str]
+    profile_name: str
+    notifications: list[_KanbanEventNotification] = field(default_factory=list)
+
+
+_KANBAN_EVENT_TXN_FRAME: ContextVar[Optional[_KanbanEventTxnFrame]] = ContextVar(
+    "hermes_kanban_event_txn_frame", default=None
+)
 
 # Typed block reasons. Distinguishes the two fundamentally different things a
 # worker (or human) means by "blocked", so each can be routed differently
@@ -208,6 +246,42 @@ def _fire_kanban_lifecycle_hook(event: str, task_id: str, **fields: Any) -> None
         invoke_hook(event, task_id=task_id, profile_name=profile_name, **fields)
     except Exception as exc:  # pragma: no cover - defensive
         _log.debug("kanban lifecycle hook %s failed: %s", event, exc)
+
+
+def _active_profile_name() -> str:
+    """Resolve the active profile using the existing lifecycle convention."""
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return get_active_profile_name()
+    except Exception:
+        return "default"
+
+
+def _fire_kanban_event_hook(
+    frame: _KanbanEventTxnFrame, notification: _KanbanEventNotification
+) -> None:
+    """Dispatch one content-free generic event, fully best-effort."""
+    fields: dict[str, Any] = {
+        "task_id": notification.task_id,
+        "kind": notification.kind,
+        "core_event_seq": notification.core_event_seq,
+        "created_at_epoch_s": notification.created_at_epoch_s,
+        "run_id": notification.run_id,
+        "board": frame.board,
+        "profile_name": frame.profile_name,
+        "kanban_event_schema_version": KANBAN_EVENT_SCHEMA_VERSION,
+    }
+    if notification.status_to is not None:
+        fields["status_to"] = notification.status_to
+    if notification.failure_count is not None:
+        fields["failure_count"] = notification.failure_count
+    try:
+        from hermes_cli.lifecycle import invoke_hook
+
+        invoke_hook("kanban_task_event", **fields)
+    except Exception as exc:  # pragma: no cover - defensive
+        _log.debug("kanban generic event hook failed: %s", exc)
 
 
 # A running task's claim is valid for 15 minutes by default; after that the
@@ -2799,43 +2873,49 @@ def _execute_boundary_with_retry(conn: sqlite3.Connection, sql: str) -> None:
 
 @contextlib.contextmanager
 def write_txn(conn: sqlite3.Connection):
-    """Context manager for an IMMEDIATE write transaction.
+    """Context manager for one non-reentrant IMMEDIATE write transaction.
 
-    Use for any multi-statement write (creating a task + link, claiming a
-    task + recording an event, etc.).  A claim CAS inside this context is
-    atomic -- at most one concurrent writer can succeed.
-
-    The explicit ROLLBACK on exception is wrapped in try/except so that
-    a SQLite auto-rollback (which leaves no active transaction) does not
-    shadow the original exception with a spurious rollback error.
+    Generic event notifications are transaction-owned and flush synchronously,
+    in insertion order, only after COMMIT and the post-commit file invariant
+    both succeed. The frame is detached before callbacks, so callback-origin
+    writes use an independent transaction.
     """
     _assert_not_delegated_child_mutation()
+    if _KANBAN_EVENT_TXN_FRAME.get() is not None:
+        raise sqlite3.OperationalError("cannot start a transaction within a transaction")
     _execute_boundary_with_retry(conn, "BEGIN IMMEDIATE")
+    frame = _KanbanEventTxnFrame(
+        connection=conn,
+        board=get_current_board(),
+        profile_name=_active_profile_name(),
+    )
+    token = _KANBAN_EVENT_TXN_FRAME.set(frame)
     try:
         yield conn
     except Exception:
         try:
             conn.execute("ROLLBACK")
         except sqlite3.OperationalError:
-            # SQLite has already auto-rolled-back the transaction (typical
-            # under EIO, lock contention, or corruption). Nothing to undo;
-            # do not let this secondary failure shadow the real one.
+            # SQLite may already have auto-rolled back; preserve the real error.
             pass
         raise
     else:
         try:
             _execute_boundary_with_retry(conn, "COMMIT")
         except Exception:
-            # COMMIT exhausted retries with the txn still open; roll back so the
-            # connection isn't poisoned for the next BEGIN IMMEDIATE.
             try:
                 conn.execute("ROLLBACK")
             except sqlite3.OperationalError:
                 pass
             raise
-        # Post-commit file-length check: header page_count must match actual file pages.
-        # A discrepancy means a torn-extend — raise now rather than silently corrupt.
+        # Existing success boundary: committed rows are not notified if this
+        # post-commit integrity check fails.
         _check_file_length_invariant(conn)
+    finally:
+        _KANBAN_EVENT_TXN_FRAME.reset(token)
+
+    for notification in frame.notifications:
+        _fire_kanban_event_hook(frame, notification)
 
 
 # ---------------------------------------------------------------------------
@@ -3269,6 +3349,7 @@ def create_task(
                         "model_override": model_override,
                         "provider_override": provider_override,
                     },
+                    status_to=task_status,
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
@@ -3544,14 +3625,18 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
         parent_status = conn.execute(
             "SELECT status FROM tasks WHERE id = ?", (parent_id,)
         ).fetchone()["status"]
+        linked_status_to = None
         if parent_status != "done":
-            conn.execute(
+            demoted = conn.execute(
                 "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
                 (child_id,),
             )
+            if demoted.rowcount == 1:
+                linked_status_to = "todo"
         _append_event(
             conn, child_id, "linked",
             {"parent": parent_id, "child": child_id},
+            status_to=linked_status_to,
         )
         _inherit_notify_subs(conn, child_id, (parent_id,))
 
@@ -3958,21 +4043,45 @@ def _append_event(
     payload: Optional[dict] = None,
     *,
     run_id: Optional[int] = None,
-) -> None:
-    """Record an event row.  Called from within an already-open txn.
+    status_to: Optional[str] = None,
+    failure_count: Optional[int] = None,
+) -> int:
+    """Insert an event and queue its content-free post-commit notification."""
+    frame = _KANBAN_EVENT_TXN_FRAME.get()
+    if frame is None or frame.connection is not conn:
+        raise RuntimeError("_append_event requires the active write_txn connection")
+    if status_to is not None and status_to not in VALID_STATUSES:
+        raise ValueError(f"invalid event status_to: {status_to!r}")
 
-    ``run_id`` is optional: pass the current run id so UIs can group
-    events by attempt. For events that aren't scoped to a single run
-    (task created/edited/archived, dependency promotion) leave it None
-    and the row carries NULL.
-    """
     now = int(time.time())
     pl = json.dumps(payload, ensure_ascii=False) if payload else None
-    conn.execute(
+    cursor = conn.execute(
         "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
         "VALUES (?, ?, ?, ?, ?)",
         (task_id, run_id, kind, pl, now),
     )
+    if cursor.lastrowid is None:  # pragma: no cover - SQLite INSERT invariant
+        raise RuntimeError("task event insert returned no row id")
+    event_id = int(cursor.lastrowid)
+    queued_failure_count: Optional[int] = None
+    if (
+        isinstance(failure_count, int)
+        and not isinstance(failure_count, bool)
+        and 0 <= failure_count <= FAILURE_COUNT_MAX
+    ):
+        queued_failure_count = failure_count
+    frame.notifications.append(
+        _KanbanEventNotification(
+            task_id=task_id,
+            kind=kind,
+            core_event_seq=event_id,
+            created_at_epoch_s=now,
+            run_id=run_id,
+            status_to=status_to,
+            failure_count=queued_failure_count,
+        )
+    )
+    return event_id
 
 
 def _end_run(
@@ -4214,7 +4323,7 @@ def recompute_ready(
                         "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = 'todo'",
                         (task_id,),
                     )
-                _append_event(conn, task_id, "promoted", None)
+                _append_event(conn, task_id, "promoted", None, status_to="ready")
                 promoted += 1
     return promoted
 
@@ -4262,6 +4371,7 @@ def claim_task(
             _append_event(
                 conn, task_id, "claim_rejected",
                 {"reason": "parents_not_done"},
+                status_to="todo",
             )
             return None
         # Defensive: if a prior run somehow leaked (invariant violation from
@@ -4333,6 +4443,7 @@ def claim_task(
             conn, task_id, "claimed",
             {"lock": lock, "expires": expires, "run_id": run_id},
             run_id=run_id,
+            status_to="running",
         )
         claimed = get_task(conn, task_id)
     _fire_kanban_lifecycle_hook(
@@ -4416,6 +4527,7 @@ def claim_review_task(
             {"lock": lock, "expires": expires, "run_id": run_id,
              "source_status": "review"},
             run_id=run_id,
+            status_to="running",
         )
         return get_task(conn, task_id)
 
@@ -4592,6 +4704,7 @@ def release_stale_claims(
                 conn, row["id"], "reclaimed",
                 payload,
                 run_id=run_id,
+                status_to="ready",
             )
             reclaimed += 1
     return reclaimed
@@ -4657,6 +4770,7 @@ def reclaim_task(
             conn, task_id, "reclaimed",
             payload,
             run_id=run_id,
+            status_to="ready",
         )
     # Operator intervention — they've looked at the task, so the
     # consecutive-failures counter is now stale. Give the next retry
@@ -5000,6 +5114,7 @@ def complete_task(
             conn, task_id, "completed",
             completed_payload,
             run_id=run_id,
+            status_to="done",
         )
     # Prose-scan the summary + result for t_<hex> references that do
     # not resolve. Advisory — does not block the completion. Runs in
@@ -5687,6 +5802,7 @@ def block_task(
             _append_event(
                 conn, task_id, "dependency_wait",
                 {"reason": reason, "kind": kind}, run_id=run_id,
+                status_to="todo",
             )
             blocked_task = get_task(conn, task_id)
         _fire_kanban_lifecycle_hook(
@@ -5762,6 +5878,7 @@ def block_task(
                     "limit": BLOCK_RECURRENCE_LIMIT,
                 },
                 run_id=run_id,
+                status_to="triage",
             )
         else:
             if expected_run_id is None:
@@ -5814,6 +5931,7 @@ def block_task(
                 conn, task_id, "blocked",
                 {"reason": reason, "kind": kind, "recurrences": recurrences},
                 run_id=run_id,
+                status_to="blocked",
             )
         _blocked_task = get_task(conn, task_id)
     _fire_kanban_lifecycle_hook(
@@ -5893,6 +6011,7 @@ def promote_task(
             task_id,
             "promoted_manual",
             {"actor": actor, "reason": reason, "forced": force},
+            status_to="ready",
         )
 
     return True, None
@@ -5960,6 +6079,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         _append_event(
             conn, task_id, "unblocked",
             {"status": new_status} if new_status != "ready" else None,
+            status_to=new_status,
         )
         return True
 
@@ -6045,6 +6165,7 @@ def specify_triage_task(
             task_id,
             "specified",
             {"changed_fields": changed_fields} if changed_fields else None,
+            status_to="todo",
         )
     # Outside the write_txn above, so we don't nest BEGIN IMMEDIATE — the
     # ready-promotion pass opens its own IMMEDIATE txn. This runs the same
@@ -6214,6 +6335,7 @@ def decompose_triage_task(
             _append_event(
                 conn, new_id, "created",
                 {"by": author or "decomposer", "from_decompose_of": task_id},
+                status_to="todo",
             )
             _inherit_notify_subs(conn, new_id, (task_id,), created_at=now)
             child_ids.append(new_id)
@@ -6276,6 +6398,7 @@ def decompose_triage_task(
                 "child_ids": child_ids,
                 "root_assignee": root_assignee,
             },
+            status_to="todo",
         )
 
     # Outside the write_txn: promote parent-free children to 'ready'
@@ -6306,7 +6429,10 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
         )
-        _append_event(conn, task_id, "archived", None, run_id=run_id)
+        _append_event(
+            conn, task_id, "archived", None,
+            run_id=run_id, status_to="archived",
+        )
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.
@@ -6728,7 +6854,10 @@ def schedule_task(
                 outcome="scheduled",
                 summary=reason,
             )
-        _append_event(conn, task_id, "scheduled", {"reason": reason}, run_id=run_id)
+        _append_event(
+            conn, task_id, "scheduled", {"reason": reason},
+            run_id=run_id, status_to="scheduled",
+        )
         return True
 
 
@@ -7279,6 +7408,7 @@ def enforce_max_runtime(
                 )
                 _append_event(
                     conn, tid, "timed_out", payload, run_id=run_id,
+                    status_to="ready",
                 )
                 timed_out.append(tid)
         # Increment the unified failure counter. Outside the write_txn
@@ -7417,6 +7547,7 @@ def detect_stale_running(
             )
             _append_event(
                 conn, tid, "stale", payload, run_id=run_id,
+                status_to="ready",
             )
             reclaimed.append(tid)
 
@@ -7661,6 +7792,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     conn, row["id"], event_kind,
                     event_payload,
                     run_id=run_id,
+                    status_to="ready",
                 )
                 if rate_limited_exit:
                     # Stamp the failure-error column so ``check_respawn_guard``
@@ -7910,6 +8042,8 @@ def _record_task_failure(
                 payload.update(event_payload_extra)
             _append_event(
                 conn, task_id, "gave_up", payload, run_id=run_id,
+                failure_count=failures,
+                status_to="blocked",
             )
             blocked = True
         else:
@@ -7943,6 +8077,8 @@ def _record_task_failure(
                     conn, task_id, outcome,
                     {"error": error[:500], "failures": failures},
                     run_id=run_id,
+                    failure_count=failures,
+                    status_to="ready",
                 )
             # Timeout/crash path's caller already emitted its own event.
     return blocked

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5654,27 +5654,11 @@ def block_task(
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
         )
-    recurrences = 0
-    with write_txn(conn):
-        cur_row = conn.execute(
-            "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
-            (task_id,),
-        ).fetchone()
-        if cur_row is None:
-            return False
-        prev_kind = cur_row["block_kind"] if "block_kind" in cur_row.keys() else None
-        prev_recurrences = (
-            int(cur_row["block_recurrences"])
-            if "block_recurrences" in cur_row.keys()
-            and cur_row["block_recurrences"] is not None
-            else 0
-        )
 
-        # Dependency blocks never enter the human ``blocked`` bucket — they
-        # wait in ``todo`` and let ``recompute_ready`` gate on parents. Routing
-        # here (rather than ``blocked``) is what keeps a cron from ever seeing
-        # a dependency-wait as something to "unblock".
-        if kind == "dependency":
+    # Dependency blocks have their own routing path so the lifecycle hook can
+    # run only after write_txn has committed and completed its invariant check.
+    if kind == "dependency":
+        with write_txn(conn):
             cur = conn.execute(
                 """
                 UPDATE tasks
@@ -5704,16 +5688,32 @@ def block_task(
                 conn, task_id, "dependency_wait",
                 {"reason": reason, "kind": kind}, run_id=run_id,
             )
-            _blocked_task = get_task(conn, task_id)
-            _fire_kanban_lifecycle_hook(
-                "kanban_task_blocked",
-                task_id,
-                board=get_current_board(),
-                assignee=_blocked_task.assignee if _blocked_task else None,
-                run_id=run_id,
-                reason=reason,
-            )
-            return True
+            blocked_task = get_task(conn, task_id)
+        _fire_kanban_lifecycle_hook(
+            "kanban_task_blocked",
+            task_id,
+            board=get_current_board(),
+            assignee=blocked_task.assignee if blocked_task else None,
+            run_id=run_id,
+            reason=reason,
+        )
+        return True
+
+    recurrences = 0
+    with write_txn(conn):
+        cur_row = conn.execute(
+            "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if cur_row is None:
+            return False
+        prev_kind = cur_row["block_kind"] if "block_kind" in cur_row.keys() else None
+        prev_recurrences = (
+            int(cur_row["block_recurrences"])
+            if "block_recurrences" in cur_row.keys()
+            and cur_row["block_recurrences"] is not None
+            else 0
+        )
 
         # Truly-blocked kinds. Increment the unblock-loop counter when this is a
         # re-block for the SAME reason after a prior unblock. block_task only

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -212,6 +212,10 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+    # Generic per-row Kanban observer. Fired synchronously by write_txn only
+    # after COMMIT and the post-commit file invariant succeed. The envelope is
+    # content-free; return values are ignored and failures cannot affect state.
+    "kanban_task_event",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -964,11 +964,11 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     "UPDATE tasks SET priority = ? WHERE id = ?",
                     (int(payload.priority), task_id),
                 )
-                conn.execute(
-                    "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                    "VALUES (?, 'reprioritized', ?, ?)",
-                    (task_id, json.dumps({"priority": int(payload.priority)}),
-                     int(time.time())),
+                kanban_db._append_event(
+                    conn,
+                    task_id,
+                    "reprioritized",
+                    {"priority": int(payload.priority)},
                 )
 
         # --- title / body -------------------------------------------------
@@ -987,11 +987,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 conn.execute(
                     f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?", vals,
                 )
-                conn.execute(
-                    "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                    "VALUES (?, 'edited', NULL, ?)",
-                    (task_id, int(time.time())),
-                )
+                kanban_db._append_event(conn, task_id, "edited")
 
         updated = kanban_db.get_task(conn, task_id)
         return {"task": _task_dict(updated) if updated else None}
@@ -1099,10 +1095,13 @@ def _set_status_direct(
                 outcome="reclaimed", status="reclaimed",
                 summary=f"status changed to {new_status} (dashboard/direct)",
             )
-        conn.execute(
-            "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
-            "VALUES (?, ?, 'status', ?, ?)",
-            (task_id, run_id, json.dumps({"status": new_status}), int(time.time())),
+        kanban_db._append_event(
+            conn,
+            task_id,
+            "status",
+            {"status": new_status},
+            run_id=run_id,
+            status_to=new_status,
         )
         if reopening_satisfied_parent:
             # A parent leaving done/archived invalidates any direct child that
@@ -1120,20 +1119,16 @@ def _set_status_direct(
                     (child_id,),
                 )
                 if demoted.rowcount == 1:
-                    conn.execute(
-                        "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                        "VALUES (?, 'status', ?, ?)",
-                        (
-                            child_id,
-                            json.dumps(
-                                {
-                                    "status": "todo",
-                                    "reason": "parent_reopened",
-                                    "parent": task_id,
-                                }
-                            ),
-                            int(time.time()),
-                        ),
+                    kanban_db._append_event(
+                        conn,
+                        child_id,
+                        "status",
+                        {
+                            "status": "todo",
+                            "reason": "parent_reopened",
+                            "parent": task_id,
+                        },
+                        status_to="todo",
                     )
     # If we re-opened something, children may have gone stale.
     if new_status in {"done", "ready"}:
@@ -1310,11 +1305,11 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             "UPDATE tasks SET priority = ? WHERE id = ?",
                             (int(payload.priority), tid),
                         )
-                        conn.execute(
-                            "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                            "VALUES (?, 'reprioritized', ?, ?)",
-                            (tid, json.dumps({"priority": int(payload.priority)}),
-                             int(time.time())),
+                        kanban_db._append_event(
+                            conn,
+                            tid,
+                            "reprioritized",
+                            {"priority": int(payload.priority)},
                         )
                 if payload.clear_model_override or payload.model_override is not None:
                     new_model = (

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -312,7 +312,8 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         tid = kb.create_task(conn, title="cycle test", assignee="worker")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
         # First crash — fired by the dispatcher when the worker PID dies.
-        kb._append_event(conn, tid, kind="crashed")
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind="crashed")
     finally:
         conn.close()
 
@@ -337,7 +338,8 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         # Second crash — same task, same dispatcher (or a respawn). Append
         # another event to simulate the dispatcher firing crashed a second
         # time during retry.
-        kb._append_event(conn, tid, kind="crashed")
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, kind="crashed")
     finally:
         conn.close()
 
@@ -488,11 +490,12 @@ def test_notifier_delivers_block_loop_detected_triage_ping(tmp_path, monkeypatch
     try:
         tid = kb.create_task(conn, title="loops forever", assignee="worker")
         kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
-        kb._append_event(
-            conn, tid, "block_loop_detected",
-            {"reason": "needs credentials", "kind": "needs_input",
-             "recurrences": 2, "limit": kb.BLOCK_RECURRENCE_LIMIT},
-        )
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn, tid, "block_loop_detected",
+                {"reason": "needs credentials", "kind": "needs_input",
+                 "recurrences": 2, "limit": kb.BLOCK_RECURRENCE_LIMIT},
+            )
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_generic_event_hook.py
+++ b/tests/hermes_cli/test_kanban_generic_event_hook.py
@@ -1,0 +1,446 @@
+"""C-1 generic per-row Kanban event observer contract."""
+
+from __future__ import annotations
+
+import ast
+import json
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.plugins import VALID_HOOKS, get_plugin_manager
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def generic_hooks():
+    manager = get_plugin_manager()
+    seen: list[dict] = []
+    saved = {name: list(callbacks) for name, callbacks in manager._hooks.items()}
+    manager._hooks.setdefault("kanban_task_event", []).append(
+        lambda **kwargs: seen.append(kwargs)
+    )
+    try:
+        yield seen
+    finally:
+        manager._hooks = saved
+
+
+def test_generic_hook_is_registered_without_replacing_legacy_hooks():
+    assert "kanban_task_event" in VALID_HOOKS
+    assert {
+        "kanban_task_claimed",
+        "kanban_task_completed",
+        "kanban_task_blocked",
+    } <= VALID_HOOKS
+
+
+def test_one_committed_row_matches_exact_database_scalars(
+    kanban_home, generic_hooks, monkeypatch
+):
+    monkeypatch.setattr(kb.time, "time", lambda: 1_700_000_123)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(
+            conn, title="event", assignee="worker", initial_status="running"
+        )
+        row = conn.execute(
+            "SELECT id, task_id, run_id, kind, created_at FROM task_events "
+            "WHERE task_id = ? ORDER BY id",
+            (task_id,),
+        ).fetchone()
+
+    assert len(generic_hooks) == 1
+    event = generic_hooks[0]
+    assert event == {
+        "task_id": row["task_id"],
+        "kind": row["kind"],
+        "core_event_seq": row["id"],
+        "created_at_epoch_s": row["created_at"],
+        "run_id": row["run_id"],
+        "board": "default",
+        "profile_name": "default",
+        # create_task normalizes unsupported direct-running creation to ready.
+        "status_to": "ready",
+        "kanban_event_schema_version": "hermes.kanban.event.v1",
+        "telemetry_schema_version": event["telemetry_schema_version"],
+    }
+
+
+def test_multirow_flush_is_post_commit_ordered_and_off_lock(
+    kanban_home, generic_hooks
+):
+    manager = get_plugin_manager()
+    callback_writes: list[str] = []
+
+    def observe_and_write(*, kind, **_kwargs):
+        assert origin.in_transaction is False
+        if not kind.startswith("synthetic-"):
+            return
+        with kb.connect_closing() as observer:
+            callback_writes.append(
+                kb.create_task(observer, title=f"callback-{kind}", assignee="observer")
+            )
+
+    manager._hooks["kanban_task_event"].insert(0, observe_and_write)
+    with kb.connect_closing() as origin:
+        task_id = kb.create_task(origin, title="first", assignee="worker")
+        generic_hooks.clear()
+        callback_writes.clear()
+        with kb.write_txn(origin):
+            kb._append_event(origin, task_id, "synthetic-first")
+            kb._append_event(origin, task_id, "synthetic-second")
+
+    assert [
+        event["kind"]
+        for event in generic_hooks
+        if event["kind"].startswith("synthetic-")
+    ] == [
+        "synthetic-first",
+        "synthetic-second",
+    ]
+    assert len(callback_writes) == 2
+
+
+def test_body_rollback_commit_failure_and_invariant_failure_suppress_and_reset(
+    kanban_home, generic_hooks, monkeypatch
+):
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="failure paths", assignee="worker")
+        generic_hooks.clear()
+        with pytest.raises(RuntimeError, match="body"):
+            with kb.write_txn(conn):
+                kb._append_event(conn, task_id, "rollback-event")
+                raise RuntimeError("body")
+        assert generic_hooks == []
+
+        real_boundary = kb._execute_boundary_with_retry
+
+        def fail_commit(candidate, sql):
+            if sql == "COMMIT":
+                raise sqlite3.OperationalError("forced commit")
+            return real_boundary(candidate, sql)
+
+        monkeypatch.setattr(kb, "_execute_boundary_with_retry", fail_commit)
+        with pytest.raises(sqlite3.OperationalError, match="forced commit"):
+            with kb.write_txn(conn):
+                kb._append_event(conn, task_id, "commit-event")
+        assert generic_hooks == []
+        monkeypatch.setattr(kb, "_execute_boundary_with_retry", real_boundary)
+
+        monkeypatch.setattr(
+            kb,
+            "_check_file_length_invariant",
+            lambda _conn: (_ for _ in ()).throw(RuntimeError("invariant")),
+        )
+        with pytest.raises(RuntimeError, match="invariant"):
+            with kb.write_txn(conn):
+                kb._append_event(conn, task_id, "invariant-event")
+        assert generic_hooks == []
+
+    # Frame state was cleared despite each failure path.
+    monkeypatch.setattr(kb, "_check_file_length_invariant", lambda _conn: None)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="after", assignee="worker")
+    assert generic_hooks[-1]["task_id"] == task_id
+
+
+def test_append_without_frame_fails_before_insert(kanban_home):
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="owner", assignee="worker")
+        before = len(kb.list_events(conn, task_id))
+        with pytest.raises(RuntimeError, match="active write_txn"):
+            kb._append_event(conn, task_id, "escaped")
+        assert len(kb.list_events(conn, task_id)) == before
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (0, 0),
+        (7, 7),
+        (kb.FAILURE_COUNT_MAX, kb.FAILURE_COUNT_MAX),
+        (True, None),
+        ("7", None),
+        (7.0, None),
+        (-1, None),
+        (1001, None),
+        (None, None),
+    ],
+)
+def test_failure_count_is_strict_bounded_scalar(
+    kanban_home, generic_hooks, value, expected
+):
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="failure", assignee="worker")
+        generic_hooks.clear()
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn,
+                task_id,
+                "synthetic-failure",
+                {"failures": value, "error": "must-not-leak"},
+                failure_count=value,
+            )
+
+    event = generic_hooks[0]
+    if expected is None:
+        assert "failure_count" not in event
+    else:
+        assert event["failure_count"] == expected
+    assert not ({"payload", "reason", "error", "summary", "title", "body"} & event.keys())
+
+
+def test_failure_writer_queues_its_local_count(kanban_home, generic_hooks):
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="real failure", assignee="worker")
+        assert kb.claim_task(conn, task_id, claimer="worker") is not None
+        generic_hooks.clear()
+
+        blocked = kb._record_spawn_failure(
+            conn, task_id, "must-not-leak", failure_limit=2
+        )
+
+    assert blocked is False
+    assert len(generic_hooks) == 1
+    assert generic_hooks[0]["kind"] == "spawn_failed"
+    assert generic_hooks[0]["failure_count"] == 1
+    assert "error" not in generic_hooks[0]
+
+
+def test_unknown_kind_dispatches_and_observer_failures_are_isolated(
+    kanban_home, generic_hooks
+):
+    manager = get_plugin_manager()
+    manager._hooks["kanban_task_event"].insert(
+        0, lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("observer"))
+    )
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="unknown", assignee="worker")
+        generic_hooks.clear()
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn, task_id, "future-unknown", {"failures": 7}
+            )
+        assert kb.list_events(conn, task_id)[-1].kind == "future-unknown"
+
+    assert generic_hooks[0]["kind"] == "future-unknown"
+    assert "failure_count" not in generic_hooks[0]
+    assert "future-unknown" not in kb.KANBAN_EVENT_KINDS
+
+
+def test_synchronous_observer_latency_is_on_originating_return_path(
+    kanban_home, generic_hooks
+):
+    manager = get_plugin_manager()
+    delay_s = 0.03
+    manager._hooks["kanban_task_event"].insert(
+        0, lambda **_kwargs: time.sleep(delay_s)
+    )
+
+    started = time.monotonic()
+    with kb.connect_closing() as conn:
+        kb.create_task(conn, title="latency", assignee="worker")
+    elapsed = time.monotonic() - started
+
+    assert elapsed >= delay_s
+    assert len(generic_hooks) == 1
+
+
+def test_dispatcher_and_worker_manual_origins_emit_in_their_own_processes(
+    kanban_home, generic_hooks
+):
+    child_result = kanban_home.parent / "dispatcher-events.json"
+    child_code = """
+import json
+import os
+import sys
+os.environ["HERMES_HOME"] = sys.argv[1]
+from hermes_cli import kanban_db as kb
+from hermes_cli.plugins import get_plugin_manager
+seen = []
+get_plugin_manager()._hooks.setdefault("kanban_task_event", []).append(
+    lambda **kwargs: seen.append(kwargs)
+)
+with kb.connect_closing() as conn:
+    task_id = kb.create_task(conn, title="cross-process", assignee="worker")
+    assert kb.claim_task(conn, task_id, claimer="dispatcher") is not None
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    json.dump({"pid": os.getpid(), "task_id": task_id, "events": seen}, handle)
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", child_code, str(kanban_home), str(child_result)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.stderr == ""
+    dispatcher = json.loads(child_result.read_text())
+    assert [event["kind"] for event in dispatcher["events"]] == ["created", "claimed"]
+    assert generic_hooks == []
+
+    with kb.connect_closing() as conn:
+        assert kb.block_task(
+            conn, dispatcher["task_id"], reason="manual worker boundary"
+        ) is True
+
+    assert [event["kind"] for event in generic_hooks] == ["blocked"]
+
+
+def test_status_to_is_not_changed_by_reentrant_post_commit_mutation(
+    kanban_home, generic_hooks
+):
+    manager = get_plugin_manager()
+    mutated = False
+
+    def mutate_after_created(*, task_id, kind, **_kwargs):
+        nonlocal mutated
+        if kind != "created" or mutated:
+            return
+        mutated = True
+        with kb.connect_closing() as observer:
+            with kb.write_txn(observer):
+                observer.execute(
+                    "UPDATE tasks SET status = 'todo' WHERE id = ?", (task_id,)
+                )
+                kb._append_event(
+                    observer, task_id, "status", {"status": "todo"},
+                    status_to="todo",
+                )
+
+    manager._hooks["kanban_task_event"].insert(0, mutate_after_created)
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="capture", assignee="worker")
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "todo"
+
+    created = next(event for event in generic_hooks if event["kind"] == "created")
+    assert created["status_to"] == "ready"
+
+
+def test_source_inventory_declares_kinds_and_exact_status_matrix():
+    source_path = Path(kb.__file__)
+    tree = ast.parse(source_path.read_text())
+    calls: list[tuple[str, str | None]] = []
+    dynamic_kinds: set[str] = set()
+    failure_count_calls: set[tuple[str, str]] = set()
+
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_append_event"
+            and len(node.args) >= 3
+        ):
+            continue
+        kind_node = node.args[2]
+        status_to = next(
+            (ast.unparse(kw.value) for kw in node.keywords if kw.arg == "status_to"),
+            None,
+        )
+        failure_count = next(
+            (
+                ast.unparse(kw.value)
+                for kw in node.keywords
+                if kw.arg == "failure_count"
+            ),
+            None,
+        )
+        if failure_count is not None:
+            failure_count_calls.add((ast.unparse(kind_node), failure_count))
+        if isinstance(kind_node, ast.Constant) and isinstance(kind_node.value, str):
+            calls.append((kind_node.value, status_to))
+        else:
+            dynamic_kinds.add(ast.unparse(kind_node))
+
+    literal_kinds = {kind for kind, _status in calls}
+    assert literal_kinds <= kb.KANBAN_EVENT_KINDS
+    assert dynamic_kinds == {"event_kind", "outcome"}
+    assert failure_count_calls == {
+        ("'gave_up'", "failures"),
+        ("outcome", "failures"),
+    }
+    assert kb.KANBAN_EVENT_KINDS - literal_kinds == {
+        "crashed", "protocol_violation", "rate_limited", "spawn_failed",
+        "reprioritized", "status",
+    }
+
+    actual: dict[str, set[str | None]] = {}
+    for kind, status_to in calls:
+        actual.setdefault(kind, set()).add(status_to)
+    assert actual["created"] == {"task_status", "'todo'"}
+    assert actual["linked"] == {"linked_status_to", None}
+    expected_statuses = {
+        "promoted": "'ready'",
+        "promoted_manual": "'ready'",
+        "claimed": "'running'",
+        "claim_rejected": "'todo'",
+        "reclaimed": "'ready'",
+        "completed": "'done'",
+        "dependency_wait": "'todo'",
+        "blocked": "'blocked'",
+        "block_loop_detected": "'triage'",
+        "unblocked": "new_status",
+        "specified": "'todo'",
+        "decomposed": "'todo'",
+        "scheduled": "'scheduled'",
+        "gave_up": "'blocked'",
+        "archived": "'archived'",
+        "stale": "'ready'",
+        "timed_out": "'ready'",
+    }
+    for kind, status_to in expected_statuses.items():
+        assert actual[kind] == {status_to}
+
+    for non_transition in (
+        "assigned", "commented", "heartbeat", "spawned", "attached",
+        "attachment_removed", "claim_extended", "reclaim_deferred",
+    ):
+        assert actual[non_transition] == {None}
+
+
+def test_all_production_task_event_inserts_use_shared_append_seam():
+    repo = Path(__file__).resolve().parents[2]
+    direct_insert_files = []
+    for path in repo.rglob("*.py"):
+        if "tests" in path.parts:
+            continue
+        text = path.read_text(errors="replace")
+        if "INSERT INTO task_events" in text:
+            direct_insert_files.append(path.relative_to(repo).as_posix())
+    assert direct_insert_files == ["hermes_cli/kanban_db.py"]
+
+    dashboard = (
+        repo / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    ).read_text()
+    assert "INSERT INTO task_events" not in dashboard
+    assert dashboard.count("kanban_db._append_event(") == 5
+
+
+def test_public_plugin_docs_describe_generic_event_contract():
+    repo = Path(__file__).resolve().parents[2]
+    developer_guide = (
+        repo / "website" / "docs" / "developer-guide" / "plugins" / "index.md"
+    ).read_text()
+    kanban_guide = (
+        repo / "website" / "docs" / "user-guide" / "features" / "kanban.md"
+    ).read_text()
+    for document in (developer_guide, kanban_guide):
+        assert "kanban_task_event" in document
+        assert "core_event_seq" in document
+        assert "at most once" in document
+        assert "synchronous" in document

--- a/tests/hermes_cli/test_kanban_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_lifecycle_hooks.py
@@ -8,6 +8,7 @@ and that a misbehaving hook callback never breaks the transition.
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -46,6 +47,234 @@ def captured_hooks(monkeypatch):
         mgr._hooks = saved
 
 
+def test_dependency_block_hook_waits_for_full_transaction_boundary(
+    kanban_home, monkeypatch
+):
+    """Dependency hooks observe committed state and not invariant-failed writes."""
+    mgr = get_plugin_manager()
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+    observed: list[tuple[bool, str, list[str], str]] = []
+
+    def _observe_committed_state(*, task_id, **_kwargs):
+        origin_in_transaction = conn.in_transaction
+        with kb.connect_closing() as observer:
+            task = kb.get_task(observer, task_id)
+            assert task is not None
+            kinds = [event.kind for event in kb.list_events(observer, task_id)]
+            callback_task_id = kb.create_task(
+                observer, title="callback writer", assignee="observer"
+            )
+        observed.append(
+            (origin_in_transaction, task.status, kinds, callback_task_id)
+        )
+
+    try:
+        conn = kb.connect()
+        try:
+            first = kb.create_task(conn, title="first", assignee="worker")
+            assert kb.claim_task(conn, first) is not None
+            mgr._hooks.setdefault("kanban_task_blocked", []).append(
+                _observe_committed_state
+            )
+
+            assert kb.block_task(
+                conn,
+                first,
+                reason="waiting for parent",
+                kind="dependency",
+            ) is True
+            assert len(observed) == 1
+            in_txn, status, kinds, callback_task_id = observed[0]
+            assert in_txn is False
+            assert status == "todo"
+            assert kinds == ["created", "claimed", "dependency_wait"]
+            assert kb.get_task(conn, callback_task_id) is not None
+
+            second = kb.create_task(conn, title="second", assignee="worker")
+            assert kb.claim_task(conn, second) is not None
+
+            def _invariant_failed(_conn):
+                raise RuntimeError("forced post-commit invariant failure")
+
+            monkeypatch.setattr(kb, "_check_file_length_invariant", _invariant_failed)
+            with pytest.raises(RuntimeError, match="forced post-commit invariant failure"):
+                kb.block_task(
+                    conn,
+                    second,
+                    reason="waiting for parent",
+                    kind="dependency",
+                )
+
+            assert len(observed) == 1
+        finally:
+            conn.close()
+    finally:
+        mgr._hooks = saved
+
+
+def test_dependency_block_failures_suppress_hook_and_transition(
+    kanban_home, monkeypatch
+):
+    """Body and terminal commit failures roll back without dispatch."""
+    mgr = get_plugin_manager()
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+    fired: list[dict] = []
+    real_get_task = kb.get_task
+    real_boundary = kb._execute_boundary_with_retry
+
+    try:
+        with kb.connect_closing() as conn:
+            body_task = kb.create_task(conn, title="body failure", assignee="worker")
+            commit_task = kb.create_task(conn, title="commit failure", assignee="worker")
+            assert kb.claim_task(conn, body_task) is not None
+            assert kb.claim_task(conn, commit_task) is not None
+            mgr._hooks.setdefault("kanban_task_blocked", []).append(
+                lambda **kwargs: fired.append(kwargs)
+            )
+
+            def _fail_after_append(candidate_conn, task_id):
+                if candidate_conn is conn and task_id == body_task:
+                    raise RuntimeError("forced body failure")
+                return real_get_task(candidate_conn, task_id)
+
+            monkeypatch.setattr(kb, "get_task", _fail_after_append)
+            with pytest.raises(RuntimeError, match="forced body failure"):
+                kb.block_task(
+                    conn, body_task, reason="body", kind="dependency"
+                )
+            monkeypatch.setattr(kb, "get_task", real_get_task)
+
+            assert fired == []
+            body_after = real_get_task(conn, body_task)
+            assert body_after is not None
+            assert body_after.status == "running"
+            assert "dependency_wait" not in {
+                event.kind for event in kb.list_events(conn, body_task)
+            }
+
+            def _fail_commit(candidate_conn, sql):
+                if candidate_conn is conn and sql == "COMMIT":
+                    raise sqlite3.OperationalError("forced terminal commit failure")
+                return real_boundary(candidate_conn, sql)
+
+            monkeypatch.setattr(kb, "_execute_boundary_with_retry", _fail_commit)
+            with pytest.raises(
+                sqlite3.OperationalError, match="forced terminal commit failure"
+            ):
+                kb.block_task(
+                    conn, commit_task, reason="commit", kind="dependency"
+                )
+
+            assert fired == []
+            assert conn.in_transaction is False
+            commit_after = real_get_task(conn, commit_task)
+            assert commit_after is not None
+            assert commit_after.status == "running"
+            assert "dependency_wait" not in {
+                event.kind for event in kb.list_events(conn, commit_task)
+            }
+    finally:
+        mgr._hooks = saved
+
+
+def test_dependency_block_payload_and_observer_failure_isolation(kanban_home):
+    """Dependency callback kwargs stay stable and observers remain fail-open."""
+    mgr = get_plugin_manager()
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+    seen: list[dict] = []
+
+    def _boom(**_kwargs):
+        raise RuntimeError("observer exploded")
+
+    try:
+        with kb.connect_closing() as conn:
+            task_id = kb.create_task(conn, title="payload", assignee="worker")
+            claimed = kb.claim_task(conn, task_id)
+            assert claimed is not None
+            mgr._hooks.setdefault("kanban_task_blocked", []).extend(
+                [_boom, lambda **kwargs: seen.append(kwargs)]
+            )
+
+            assert kb.block_task(
+                conn,
+                task_id,
+                reason="waiting",
+                kind="dependency",
+                expected_run_id=claimed.current_run_id,
+            ) is True
+
+            task = kb.get_task(conn, task_id)
+            assert task is not None
+            assert task.status == "todo"
+            assert [event.kind for event in kb.list_events(conn, task_id)][-1] == (
+                "dependency_wait"
+            )
+
+        assert len(seen) == 1
+        assert seen[0]["task_id"] == task_id
+        assert seen[0]["assignee"] == "worker"
+        assert seen[0]["run_id"] == claimed.current_run_id
+        assert seen[0]["reason"] == "waiting"
+        assert isinstance(seen[0]["board"], str)
+        assert isinstance(seen[0]["profile_name"], str)
+    finally:
+        mgr._hooks = saved
+
+
+def test_sibling_lifecycle_hooks_remain_post_commit(kanban_home):
+    """Claim, complete, hard-block, and loop paths retain post-commit timing."""
+    mgr = get_plugin_manager()
+    saved = {k: list(v) for k, v in mgr._hooks.items()}
+    observed: list[tuple[str, bool, str, str]] = []
+
+    try:
+        with kb.connect_closing() as conn:
+            def _observe(hook_name):
+                def _callback(*, task_id, **_kwargs):
+                    in_transaction = conn.in_transaction
+                    with kb.connect_closing() as observer:
+                        task = kb.get_task(observer, task_id)
+                        assert task is not None
+                        last_kind = kb.list_events(observer, task_id)[-1].kind
+                    observed.append(
+                        (hook_name, in_transaction, task.status, last_kind)
+                    )
+                return _callback
+
+            for hook_name in (
+                "kanban_task_claimed",
+                "kanban_task_completed",
+                "kanban_task_blocked",
+            ):
+                mgr._hooks.setdefault(hook_name, []).append(_observe(hook_name))
+
+            loop_task = kb.create_task(conn, title="loop", assignee="worker")
+            assert kb.claim_task(conn, loop_task) is not None
+            assert kb.block_task(
+                conn, loop_task, reason="same", kind="capability"
+            ) is True
+            assert kb.unblock_task(conn, loop_task) is True
+            assert kb.claim_task(conn, loop_task) is not None
+            assert kb.block_task(
+                conn, loop_task, reason="same", kind="capability"
+            ) is True
+
+            complete_task = kb.create_task(
+                conn, title="complete", assignee="worker"
+            )
+            assert kb.claim_task(conn, complete_task) is not None
+            assert kb.complete_task(conn, complete_task, summary="done") is True
+
+        assert observed == [
+            ("kanban_task_claimed", False, "running", "claimed"),
+            ("kanban_task_blocked", False, "blocked", "blocked"),
+            ("kanban_task_claimed", False, "running", "claimed"),
+            ("kanban_task_blocked", False, "triage", "block_loop_detected"),
+            ("kanban_task_claimed", False, "running", "claimed"),
+            ("kanban_task_completed", False, "done", "completed"),
+        ]
+    finally:
+        mgr._hooks = saved
 
 
 def test_claim_fires_hook(kanban_home, captured_hooks):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -19,6 +19,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from hermes_cli import kanban_db as kb
+from hermes_cli.plugins import get_plugin_manager
 
 
 # ---------------------------------------------------------------------------
@@ -58,6 +59,20 @@ def client(kanban_home):
     app = FastAPI()
     app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
     return TestClient(app)
+
+
+@pytest.fixture
+def generic_events():
+    manager = get_plugin_manager()
+    seen: list[dict] = []
+    saved = {name: list(callbacks) for name, callbacks in manager._hooks.items()}
+    manager._hooks.setdefault("kanban_task_event", []).append(
+        lambda **kwargs: seen.append(kwargs)
+    )
+    try:
+        yield seen
+    finally:
+        manager._hooks = saved
 
 
 # ---------------------------------------------------------------------------
@@ -113,6 +128,94 @@ def test_create_task_appears_on_board(client):
     assert ready["tasks"][0]["id"] == task_id
     assert "acme" in data["tenants"]
     assert "researcher" in data["assignees"]
+
+
+def test_dashboard_event_writers_share_generic_post_commit_contract(
+    client, generic_events
+):
+    first = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "first"}
+    ).json()["task"]
+    second = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "second"}
+    ).json()["task"]
+    generic_events.clear()
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{first['id']}",
+        json={"priority": 7, "title": "first edited"},
+    )
+    assert response.status_code == 200, response.text
+    response = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [first["id"], second["id"]], "priority": 9},
+    )
+    assert response.status_code == 200, response.text
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{first['id']}", json={"status": "todo"}
+    )
+    assert response.status_code == 200, response.text
+
+    assert [event["kind"] for event in generic_events] == [
+        "reprioritized",
+        "edited",
+        "reprioritized",
+        "reprioritized",
+        "status",
+    ]
+    assert [event["task_id"] for event in generic_events] == [
+        first["id"], first["id"], first["id"], second["id"], first["id"],
+    ]
+    assert generic_events[-1]["status_to"] == "todo"
+    assert all("payload" not in event for event in generic_events)
+
+    with kb.connect_closing() as conn:
+        rows = conn.execute(
+            "SELECT id, task_id, kind, created_at FROM task_events "
+            "WHERE id IN ({}) ORDER BY id".format(
+                ",".join("?" for _ in generic_events)
+            ),
+            [event["core_event_seq"] for event in generic_events],
+        ).fetchall()
+    assert [
+        (row["id"], row["task_id"], row["kind"], row["created_at"])
+        for row in rows
+    ] == [
+        (
+            event["core_event_seq"], event["task_id"], event["kind"],
+            event["created_at_epoch_s"],
+        )
+        for event in generic_events
+    ]
+
+
+def test_dashboard_reopened_parent_demotion_captures_child_destination(
+    client, generic_events
+):
+    parent = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "parent"}
+    ).json()["task"]
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}", json={"status": "done"}
+    )
+    assert response.status_code == 200, response.text
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "child", "parents": [parent["id"]]},
+    ).json()["task"]
+    assert child["status"] == "ready"
+    generic_events.clear()
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{parent['id']}", json={"status": "todo"}
+    )
+    assert response.status_code == 200, response.text
+
+    status_events = [event for event in generic_events if event["kind"] == "status"]
+    assert [(event["task_id"], event["status_to"]) for event in status_events] == [
+        (parent["id"], "todo"),
+        (child["id"], "todo"),
+    ]
 
 
 def test_patch_board_sets_project_directory(client, tmp_path):

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -614,12 +614,15 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | `kanban_task_claimed` | A kanban task is claimed (dispatcher process, before the worker spawns) | `task_id: str, board: str \| None, assignee: str \| None, run_id: int \| None, profile_name: str` | ignored |
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
 | `kanban_task_blocked` | A kanban task is blocked (worker process) | `task_id, board, assignee, run_id, profile_name, reason: str \| None` | ignored |
+| `kanban_task_event` | Every committed Kanban event row (originating dispatcher, worker/manual, or dashboard process) | `task_id, kind, core_event_seq: int, created_at_epoch_s: int, run_id: int \| None, board: str \| None, profile_name: str, status_to?: str, failure_count?: int, kanban_event_schema_version: str` | ignored |
 
 Most hooks are fire-and-forget observers — their return values are ignored. The exceptions are `pre_llm_call`, which can inject context into the conversation, and `pre_tool_call`, which can return a block/approve directive.
 
 All callbacks should accept `**kwargs` for forward compatibility. If a hook callback crashes, it's logged and skipped. Other hooks and the agent continue normally.
 
 The kanban lifecycle hooks fire **after** the board DB change commits, so a callback always sees durable state and can never hold the SQLite write lock. Because kanban workers run as separate `hermes -p <profile> chat -q` subprocesses, `kanban_task_claimed` fires in the **dispatcher** process while `kanban_task_completed` / `kanban_task_blocked` fire in the **worker** process — hook in the dispatcher to observe every transition centrally, or in the worker for per-task in-session context.
+
+`kanban_task_event` is the content-free generic row observer. It fires synchronously after commit and the board file-integrity check, in insertion order within one transaction, and outside the SQLite write lock. Delivery is process-local, best effort, and at most once: there is no replay or durable outbox, sequence gaps do not prove callback loss, and a slow callback delays the originating CLI, worker, dispatcher, or dashboard return path. The callback receives row identity and bounded transition scalars only—never the event payload, task prose, reason, error, filename, PID, or actor metadata.
 
 ### `pre_llm_call` context injection
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -477,6 +477,8 @@ The dispatcher spawns the worker with the pinned model (`--provider <name>` is p
 
 Board transitions fire [plugin hooks](/user-guide/features/hooks#plugin-hooks): `kanban_task_claimed`, `kanban_task_completed`, and `kanban_task_blocked`, each carrying `task_id` and `profile_name`. Hooks fire **after** the board DB change commits, so callbacks always see durable state. Note the process split: `kanban_task_claimed` fires in the **dispatcher** process, while `kanban_task_completed`/`kanban_task_blocked` fire in the **worker** process — register the hook in the dispatcher profile to observe every transition centrally.
 
+Plugins can also register `kanban_task_event`, a content-free observer for each committed event row. Its envelope includes `task_id`, `kind`, board-local `core_event_seq`, the committed timestamp and run ID, board/profile identifiers, and—when known—bounded `status_to` and `failure_count` scalars. Callbacks run synchronously after commit and outside the SQLite write lock, in insertion order within one transaction. Delivery is process-local, best effort, and at most once; there is no replay or global arrival-order guarantee, and slow callbacks delay the originating dispatcher, worker/manual, or dashboard return path.
+
 ```python
 def register(ctx):
     def on_blocked(task_id=None, profile_name=None, **kw):


### PR DESCRIPTION
## Summary

This PR makes two additive Kanban lifecycle changes:

1. Dispatches the existing `kanban_task_blocked` dependency-block hook synchronously **after commit**, rather than while the SQLite write transaction is active.
2. Adds an observer-only `kanban_task_event` hook that emits one content-free notification for each committed `task_events` row.

## R-1: dependency-block hook timing

- Preserves the existing hook name and kwargs.
- Moves dependency-block notification outside the write transaction and SQLite lock.
- Suppresses notification on rollback, commit failure, or file-invariant failure.
- Keeps observer failures isolated from the committed Kanban mutation.

## C-1: generic committed-event observer

- Registers additive hook `kanban_task_event`.
- Uses a transaction-owned `ContextVar` frame to capture notifications in insertion order.
- Flushes synchronously after commit, frame detachment, invariant checks, and lock release.
- Emits a closed, content-free scalar envelope:
  - `kanban_event_schema_version`
  - `kind`
  - `core_event_seq`
  - `created_at_epoch_s`
  - `run_id`
  - `board`
  - `profile_name`
  - optional `status_to`
  - optional bounded `failure_count`
- Does not expose payload, reason, error, summary, title, body, or arbitrary metadata.
- Routes all production `task_events` writers, including dashboard mutations, through `_append_event()`.
- Provides process-local, synchronous, ordered-per-transaction, at-most-once observation with no replay guarantee.

## Compatibility and failure semantics

- Existing lifecycle hooks remain unchanged apart from corrected post-commit timing for dependency blocking.
- Observer exceptions are logged and isolated.
- Rollback and failed commits produce no generic callbacks.
- Slow observers delay the originating path but do not run under the SQLite write lock.
- Child-process dispatchers remain process-local; callbacks do not cross process boundaries.

## Verification

- Focused generic-hook suite: **22 passed**
- Related Kanban matrix: **116 passed across 8 files**
- Ruff: passed
- Python `compileall`: passed
- `git diff --check`: passed
- Production writer inventory and declared-kind/status-destination guards: passed
- Broad parallel comparison against pinned base `d0b87dad77944c669b453385bb797d53fa33c4f7`:
  - candidate: **24,305 passed, 63 failed**
  - baseline: **24,275 passed, 65 failed**
  - final candidate-only failing files: **none**
  - remaining failures are baseline/environment-sensitive optional-dependency tests

### Current-upstream compatibility

The prospective GitHub merge was reproduced locally against upstream `main` at `91937a6dc3ffbbe2f3be91a500f0ecf962c4cf53`:

- merge applied without conflicts, including the overlapping `hermes_cli/kanban_db.py` change from `58286878e`
- related Kanban matrix: **116 passed across 8 files**
- Ruff, Python `compileall`, and `git diff --check`: passed
- the published branch was not rebased or rewritten

## Scope

This PR does not deploy or enable a plugin, alter profile configuration, migrate persisted schemas, add replay, or change asynchronous execution behavior.
