### PR TITLE
fix(file-tools): sensitive-path write guard silently no-ops on Windows

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,10 +6,13 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+
+import pytest
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
     PATCH_SCHEMA,
+    _check_sensitive_path,
 )
 
 
@@ -994,3 +997,59 @@ class TestNotFoundCache:
         assert _check_not_found_cache("read", "/tmp/never-exists-notify", tid) is None, (
             "notify_other_tool_call must clear cached misses"
         )
+
+
+class TestSensitivePathGuardIsSeparatorAgnostic:
+    r"""The sensitive-path guard must hold on Windows, not just POSIX.
+
+    ``_SENSITIVE_PATH_PREFIXES`` / ``_SENSITIVE_EXACT_PATHS`` are written in
+    POSIX form, but ``_check_sensitive_path`` builds its comparison strings
+    with ``os.path.normpath`` and ``_resolve_path_for_task``. On Windows both
+    route through ``ntpath``, which rewrites ``/etc/resolv.conf`` to
+    ``\etc\resolv.conf`` — so every ``startswith`` missed and the guard
+    returned None for every sensitive path.
+
+    That is not cosmetic: a task running on a Windows host whose file_ops
+    backend is a Linux container (see ``_file_ops_uses_host_paths``) targets a
+    real ``/etc``, so the write guard was fully bypassed there.
+    """
+
+    @pytest.mark.parametrize(
+        "sensitive",
+        [
+            "/etc/resolv.conf",
+            "/boot/grub/grub.cfg",
+            "/usr/lib/systemd/system/evil.service",
+            "/private/var/db/something",
+            "/var/run/docker.sock",
+        ],
+    )
+    def test_sensitive_paths_are_blocked(self, sensitive):
+        assert _check_sensitive_path(sensitive) is not None, (
+            f"{sensitive} must be refused on every platform"
+        )
+
+    @pytest.mark.parametrize(
+        "ordinary",
+        [
+            "/home/me/project/main.py",
+            "./relative/file.txt",
+            "docs/readme.md",
+        ],
+    )
+    def test_ordinary_paths_are_not_blocked(self, ordinary):
+        assert _check_sensitive_path(ordinary) is None, (
+            f"{ordinary} is an ordinary path and must stay writable"
+        )
+
+    def test_posix_does_not_rewrite_backslashes(self):
+        r"""On POSIX a backslash is a legal filename character.
+
+        The separator normalisation must be Windows-only, otherwise a file
+        genuinely named ``foo\bar.txt`` would be reinterpreted as a path.
+        """
+        import os
+
+        if os.sep != "/":
+            pytest.skip("POSIX-only: asserts backslashes are left untouched")
+        assert _check_sensitive_path("/home/me/weird\name.txt") is None

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -8,7 +8,7 @@ import os
 import posixpath
 import sys
 import threading
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePath, PurePosixPath
 
 from agent.file_safety import get_read_block_error
 from tools.binary_extensions import has_binary_extension
@@ -672,6 +672,24 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
+def _posix_form(path: str) -> str:
+    """Return *path* with native separators flipped to ``/``.
+
+    ``_SENSITIVE_PATH_PREFIXES`` / ``_SENSITIVE_EXACT_PATHS`` are written in
+    POSIX form, but on Windows both ``os.path.normpath`` and
+    ``_resolve_path_for_task`` (which goes through ``ntpath``) rewrite
+    ``/etc/resolv.conf`` to ``\\etc\\resolv.conf`` — so every ``startswith``
+    below silently missed and the guard no-opped on a Windows host, including
+    for tasks whose file_ops backend is a Linux container where ``/etc/...``
+    really is the system path. Comparing in POSIX form makes the guard
+    separator-agnostic. Never rewrite on POSIX, where ``\\`` is a legal
+    character in a filename.
+    """
+    if os.sep == "/":
+        return path
+    return PurePath(path).as_posix()
+
+
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
@@ -679,14 +697,16 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
     except (OSError, ValueError):
         resolved = filepath
     normalized = os.path.normpath(_expand_tilde(filepath))
+    resolved_posix = _posix_form(resolved)
+    normalized_posix = _posix_form(normalized)
     _err = (
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
     for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix) or normalized.startswith(prefix):
+        if resolved_posix.startswith(prefix) or normalized_posix.startswith(prefix):
             return _err
-    if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
+    if resolved_posix in _SENSITIVE_EXACT_PATHS or normalized_posix in _SENSITIVE_EXACT_PATHS:
         return _err
     # Prevent agents from modifying the Hermes config file directly.
     # approvals.mode and other security settings live here; a malicious or


### PR DESCRIPTION
## The bug

`_check_sensitive_path()` compares against POSIX-form constants — `_SENSITIVE_PATH_PREFIXES` (`/etc/`, `/boot/`, `/usr/lib/systemd/`, `/private/...`) and `_SENSITIVE_EXACT_PATHS` (`/var/run/docker.sock`) — but builds its comparison strings with `os.path.normpath()` and `_resolve_path_for_task()`. On Windows both route through `ntpath`, which rewrites `/etc/resolv.conf` into `\etc\resolv.conf`.

Every `startswith(prefix)` and set-membership test therefore missed, and the guard returned `None` for **every** sensitive path on a Windows host.

Measured against unmodified `main`, on Windows:

```
_check_sensitive_path('/etc/resolv.conf')                  -> None   (allowed)
_check_sensitive_path('/boot/grub/grub.cfg')               -> None   (allowed)
_check_sensitive_path('/var/run/docker.sock')              -> None   (allowed)
_check_sensitive_path('/usr/lib/systemd/system/x.service') -> None   (allowed)
```

## Why it matters

Not cosmetic. A task running on a Windows host whose file_ops backend is a Linux container (see `_file_ops_uses_host_paths`) targets a **real** `/etc` — so the write guard was fully bypassed in exactly the configuration where it does the most work.

## The fix

Adds `_posix_form()`, which flips native separators to `/` before comparison.

It is deliberately a **no-op on POSIX**: a backslash is a legal filename character there, so rewriting would reinterpret a file genuinely named `foo\bar.txt` as a path. A test pins that non-rewriting behaviour.

## Scope note

Per SECURITY.md §2.4 this guard is an in-process heuristic, not a security boundary, and §3.2 places heuristic bypasses out of scope for the private-disclosure channel. Hence a normal PR rather than an advisory. It's still documented behaviour that doesn't work on one supported platform.

## Verification

`tests/tools/test_file_tools.py` on a Windows host:

| | failed | passed |
|---|---|---|
| before | 6 | 41 |
| after | **2** | **53** |

**Newly broken: none** — the set-diff of failure names between baseline and fix is empty.

The fix repairs four tests that were each independently asserting this guard works:
`test_system_path_still_blocked`, `test_macos_private_var_carveouts`, `test_patch_move_to_sensitive_dst_blocked`, `test_patch_update_no_space_after_asterisks_blocked`.

The two still-failing tests (`test_writes_content`, `test_replace_mode_calls_patch_replace`) were already failing on unmodified `main` and are unrelated to this guard.

New coverage (`TestSensitivePathGuardIsSeparatorAgnostic`) **fails 5/8 when the fix is reverted** and passes 8/8 with it, so it pins the behaviour rather than passing vacuously. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
