### PR TITLE
fix(desktop): preserve fenced text diagrams

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -70,6 +70,67 @@ describe('preprocessMarkdown', () => {
     expect(output).toContain('const value = 1;')
   })
 
+  it('keeps ASCII diagrams in text fences preformatted', () => {
+    const input = [
+      '```text',
+      'You',
+      ' │',
+      ' ├─ Hermes Desktop',
+      ' ├─ Terminal',
+      ' ├─ Telegram',
+      ' └─ WhatsApp',
+      '        │',
+      '        ▼',
+      ' Hermes Agent runtime',
+      '        │',
+      '        ├─ Instructions and personality',
+      '        ├─ Current conversation',
+      '        ├─ Memory and relevant skills',
+      '        ├─ Available tools',
+      '        └─ Safety rules',
+      '        │',
+      '        ▼',
+      ' AI model',
+      '        │',
+      '        ├─ Respond directly',
+      '        └─ Request a tool',
+      '               │',
+      '               ▼',
+      '       File, terminal, web,',
+      '       browser, calendar, etc.',
+      '```'
+    ].join('\n')
+
+    expect(preprocessMarkdown(input)).toBe(input)
+  })
+
+  it('keeps plain-ASCII tree diagrams in text fences preformatted', () => {
+    const input = [
+      '```text',
+      'User',
+      '+----- Desktop',
+      '+- Terminal',
+      '`----- WhatsApp',
+      'Runtime',
+      'Model',
+      '```'
+    ].join('\n')
+
+    expect(preprocessMarkdown(input)).toBe(input)
+  })
+
+  it('keeps CRLF diagram fences followed by a final newline', () => {
+    const lines = ['```text', 'User', '+----- Desktop', '`----- Terminal', 'Runtime', '```', '']
+
+    expect(preprocessMarkdown(lines.join('\r\n'))).toBe(lines.join('\n'))
+  })
+
+  it('keeps CRLF diagram fences followed by prose', () => {
+    const lines = ['```text', 'User', '+----- Desktop', '`----- Terminal', 'Runtime', '```', '', 'After the diagram.']
+
+    expect(preprocessMarkdown(lines.join('\r\n'))).toBe(lines.join('\n'))
+  })
+
   it('keeps dangling real code fences during streaming', () => {
     const input = ['```ts', 'const value = 1;'].join('\n')
     const output = preprocessMarkdown(input)

--- a/apps/desktop/src/lib/markdown-code.test.ts
+++ b/apps/desktop/src/lib/markdown-code.test.ts
@@ -20,4 +20,38 @@ describe('isLikelyProseCodeBlock', () => {
   it('keeps real code blocks', () => {
     expect(isLikelyProseCodeBlock('ts', 'const value = { bunny: true };\nreturn value')).toBe(false)
   })
+
+  it('keeps diagram-like text blocks preformatted', () => {
+    const diagram = ['User', ' │', ' ├─ Desktop', ' └─ Terminal', ' │', ' ▼', 'Runtime', ' │', ' ▼', 'Model'].join(
+      '\n'
+    )
+
+    expect(isLikelyProseCodeBlock('text', diagram)).toBe(false)
+  })
+
+  it('keeps labeled plain-ASCII branches preformatted without standalone connector rows', () => {
+    const diagram = ['User', '+- Desktop', '`- Terminal', 'Runtime', '+--> Tools', 'Model'].join('\n')
+
+    expect(isLikelyProseCodeBlock('text', diagram)).toBe(false)
+  })
+
+  it('keeps arbitrary-length plain-ASCII branches preformatted', () => {
+    const diagram = ['User', '+----- Desktop', '`----- Terminal', 'Runtime', 'Model'].join('\n')
+
+    expect(isLikelyProseCodeBlock('text', diagram)).toBe(false)
+  })
+
+  it('does not mistake inline Unicode arrows in prose for diagram rows', () => {
+    const prose = ['The request moves from client → server.', 'The response moves from server → client.', 'Both remain prose.'].join(
+      '\n'
+    )
+
+    expect(isLikelyProseCodeBlock('heads', prose)).toBe(true)
+  })
+
+  it('recognizes CRLF-terminated ASCII connector rows', () => {
+    const diagram = ['User', '+- Desktop', '`- Terminal', 'Runtime'].join('\r\n')
+
+    expect(isLikelyProseCodeBlock('text', diagram)).toBe(false)
+  })
 })

--- a/apps/desktop/src/lib/markdown-code.ts
+++ b/apps/desktop/src/lib/markdown-code.ts
@@ -38,6 +38,7 @@ const COMMON_CODE_LANGUAGES = new Set([
 interface CodeSignals {
   bulletLines: number
   codeSignals: number
+  diagramLines: number
   hasMarkdown: boolean
   proseLines: number
   trimmed: string
@@ -259,6 +260,19 @@ function codeSignalCount(body: string): number {
   return CODE_SIGNAL_RE.reduce((total, pattern) => total + (body.match(pattern)?.length ?? 0), 0)
 }
 
+// Fenced diagrams are layout-sensitive even when their labels look like prose.
+// Count structural rows so the prose-fence recovery heuristic never unwraps
+// them into normal Markdown (which collapses their newlines and spacing).
+const UNICODE_DIAGRAM_LINE_RE = /^\s*[\u2190-\u21ff\u2500-\u257f\u25b2-\u25c0]/u
+const ASCII_DIAGRAM_LINE_RE = /^\s*(?:[|+\\/<>^v][|+\-=`\\/<>^v ]*|[+|`\\][-=>|+`\\]+\s+\S.*)$/iu
+
+function diagramLineCount(body: string): number {
+  return body
+    .split('\n')
+    .map(line => line.replace(/\r$/, ''))
+    .filter(line => UNICODE_DIAGRAM_LINE_RE.test(line) || ASCII_DIAGRAM_LINE_RE.test(line)).length
+}
+
 function codeSignals(body: string): CodeSignals {
   const trimmed = body.trim()
   const markdownSignals = (trimmed.match(/\*\*[^*]+\*\*/g) || []).length + (trimmed.match(/`[^`\n]+`/g) || []).length
@@ -266,6 +280,7 @@ function codeSignals(body: string): CodeSignals {
   return {
     bulletLines: (trimmed.match(/^\s*[-*]\s+\S+/gm) || []).length,
     codeSignals: codeSignalCount(trimmed),
+    diagramLines: diagramLineCount(trimmed),
     hasMarkdown: markdownSignals > 0,
     proseLines: proseLineCount(trimmed),
     trimmed,
@@ -287,6 +302,10 @@ export function isLikelyProseFence(info: string, body: string): boolean {
   const signals = codeSignals(body)
 
   if (!signals.trimmed) {
+    return false
+  }
+
+  if (signals.diagramLines >= 2) {
     return false
   }
 
@@ -312,7 +331,7 @@ export function isLikelyProseCodeBlock(language: string | undefined, code: strin
   const cleanLanguage = sanitizeLanguageTag(language || '')
   const signals = codeSignals(code || '')
 
-  if (!signals.trimmed || signals.codeSignals >= 3) {
+  if (!signals.trimmed || signals.codeSignals >= 3 || signals.diagramLines >= 2) {
     return false
   }
 

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -478,7 +478,8 @@ function normalizeFenceBlocks(text: string): string {
 }
 
 export function preprocessMarkdown(text: string): string {
-  const cleaned = text.replace(REASONING_BLOCK_RE, '').replace(PREVIEW_MARKER_RE, '')
+  const normalizedLineEndings = text.replace(/\r\n?/g, '\n')
+  const cleaned = normalizedLineEndings.replace(REASONING_BLOCK_RE, '').replace(PREVIEW_MARKER_RE, '')
   const scrubbed = scrubBacktickNoise(cleaned)
   const normalizedFences = normalizeFenceBlocks(scrubbed)
   const strippedEmptyFences = stripEmptyFenceBlocks(normalizedFences)


### PR DESCRIPTION
## Summary
- preserve fenced ASCII and Unicode diagrams instead of unwrapping them as prose
- require structural diagram rows to reduce ordinary-prose false positives
- normalize CRLF before fence scrubbing so Windows-style fenced diagrams survive end to end
- add classifier and preprocessing regression coverage for short/long branches, inline arrows, CRLF final newlines, and following prose

## Verification
- [x] 3,019 Desktop UI tests passed
- [x] 46 focused Markdown tests passed
- [x] TypeScript typecheck passed
- [x] ESLint passed
- [x] production renderer build passed (4,677 modules)
- [x] `git diff --check` passed
- [x] fail-closed independent review passed with no security concerns or logic errors