### PR TITLE
fix(relay): recover corrupted session stacks after failed turn cleanup

### DIFF
--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -342,6 +342,47 @@ class RelayRuntime:
                 "; ".join(failures),
             )
 
+    def discard_session_tree(self, session_id: str) -> None:
+        """Forget a corrupted session stack without attempting more pops.
+
+        Relay scopes are strictly LIFO.  Once a turn pop is rejected, trying
+        to guess and close unknown nested scopes can corrupt the stack further.
+        Remove the affected session and its delegated children instead; the
+        next turn will create a fresh context while Hermes conversation state
+        remains untouched.
+        """
+        root_id = str(session_id or "")
+        if not root_id:
+            return
+
+        with self._sessions_lock:
+            discarded_ids = {root_id}
+            while True:
+                children = {
+                    child_id
+                    for child_id, parent_id in self._subagent_parents.items()
+                    if parent_id in discarded_ids
+                }
+                new_children = children - discarded_ids
+                if not new_children:
+                    break
+                discarded_ids.update(new_children)
+
+            discarded = [
+                session
+                for current_id in discarded_ids
+                if (session := self._sessions.pop(current_id, None)) is not None
+            ]
+            for current_id in discarded_ids:
+                self._subagent_parents.pop(current_id, None)
+                self._subagent_parent_handles.pop(current_id, None)
+
+        for session in discarded:
+            with session.lock:
+                session.closing = True
+                session.handle = None
+                session.context = None
+
     def shutdown(self) -> None:
         """Close all core-owned Relay session scopes."""
         with self._sessions_lock:
@@ -655,6 +696,7 @@ class RelaySessionCoordinator:
                             logger.warning(
                                 "Hermes Relay turn finalization failed", exc_info=True
                             )
+                            lease.host.discard_session_tree(lease.session.session_id)
             finally:
                 try:
                     # Delegated agents own one turn. Close their conversation

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -792,6 +792,69 @@ def test_sync_session_runner_releases_lock_before_callback(direct_runtime):
     assert contender.is_alive() is False
 
 
+def test_turn_pop_failure_discards_corrupted_session_for_next_turn(
+    direct_runtime,
+    monkeypatch,
+):
+    coordinator = relay_runtime.SESSION_COORDINATOR
+    profile_key = relay_runtime.current_profile_key()
+    lease = coordinator.acquire_conversation(
+        profile_key=profile_key,
+        session_id="corrupted-session",
+        platform="cli",
+    )
+    corrupted_session = lease.session
+    assert corrupted_session is not None
+    turn = coordinator.begin_turn(
+        lease,
+        turn_id="interrupted-turn",
+        task_id="interrupted-task",
+    )
+    assert turn.handle is not None
+    runtime = lease.host
+    delegated_session = runtime.register_subagent({
+        "parent_session_id": "corrupted-session",
+        "child_session_id": "interrupted-child",
+    })
+    assert delegated_session is not None
+
+    original_pop = direct_runtime.scope.pop
+
+    def reject_turn_pop(handle, **kwargs):
+        if handle == turn.handle:
+            raise RuntimeError("scope handle is not at the top of the stack")
+        return original_pop(handle, **kwargs)
+
+    monkeypatch.setattr(direct_runtime.scope, "pop", reject_turn_pop)
+
+    coordinator.end_turn(turn, outcome="cancelled")
+
+    assert runtime.get_session("corrupted-session") is None
+    assert runtime.get_session("interrupted-child") is None
+    assert corrupted_session.closing is True
+    assert corrupted_session.handle is None
+    assert corrupted_session.context is None
+    assert delegated_session.closing is True
+    assert delegated_session.handle is None
+    assert delegated_session.context is None
+
+    replacement_lease = coordinator.acquire_conversation(
+        profile_key=profile_key,
+        session_id="corrupted-session",
+        platform="cli",
+    )
+    assert replacement_lease.session is not None
+    assert replacement_lease.session is not corrupted_session
+    assert replacement_lease.session.handle is not None
+
+    coordinator.release_conversation(lease)
+    coordinator.release_conversation(replacement_lease)
+    coordinator.finalize_conversation(
+        profile_key=profile_key,
+        session_id="corrupted-session",
+    )
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Recover Relay sessions after turn finalization encounters a corrupted LIFO
scope stack.

Interrupted tool calls, provider failures, and incomplete delegated-agent
cleanup can leave an unknown nested scope above the turn scope. Relay then
rejects finalization with:

```text
RuntimeError: scope handle is not at the top of the stack
```

`end_turn()` caught and logged this exception, but retained the corrupted
`RelaySession` in the runtime registry. Every subsequent turn reused the same
broken context, causing repeated finalization failures and sessions that
appeared to hang until the gateway was restarted.

Trying additional scope pops is unsafe because Hermes does not own or know the
handle currently at the top of the native stack. This change instead discards
the affected runtime session and its delegated child sessions. The next turn
creates a clean Relay context while preserving the Hermes conversation and
persisted session state.

This complements #74864, which prevents one known concurrent-turn cause of
scope corruption. This PR handles recovery after corruption has already
occurred, including interruption and provider/delegation cleanup paths.

## Related Issue

Fixes #78068.

Also mitigates #78060.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `RelayRuntime.discard_session_tree()` to atomically remove a corrupted
  session and its delegated descendants without attempting further scope pops.
- Clear discarded sessions' handles and contexts so stale leases fail closed.
- Invoke recovery when the turn-scope pop fails during `end_turn()`.
- Add a regression test that injects the native non-LIFO error, verifies parent
  and delegated-child invalidation, and verifies the next acquire creates a
  fresh Relay session.

## How to Test

1. Run the focused Relay suites:

   ```bash
   scripts/run_tests.sh \
     tests/agent/test_relay_llm.py \
     tests/agent/test_relay_tools.py \
     tests/agent/test_auxiliary_relay.py \
     tests/hermes_cli/test_relay_shared_metrics_runtime.py
   ```

2. Confirm the runtime suite reports `15 passed` and the command exits with
   status 0.
3. Run lint on the changed files:

   ```bash
   ruff check agent/relay_runtime.py \
     tests/hermes_cli/test_relay_shared_metrics_runtime.py
   ```

4. Confirm Ruff reports `All checks passed!`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
Runtime suite: 15 passed
Focused test command exit code: 0
Ruff: All checks passed!
Windows footgun scan: No Windows footguns found (2 files scanned)
```
