### PR TITLE
fix(provider): pass reasoning_effort to DashScope coding-plan endpoint (#77818)

### DIFF
--- a/plugins/model-providers/alibaba-coding-plan/__init__.py
+++ b/plugins/model-providers/alibaba-coding-plan/__init__.py
@@ -4,10 +4,48 @@ Separate from the standard `alibaba` profile because it hits a different
 endpoint (coding-intl.dashscope.aliyuncs.com) with a dedicated API key tier.
 """
 
+from typing import Any
+
 from providers import register_provider
 from providers.base import ProviderProfile
 
-alibaba_coding_plan = ProviderProfile(
+
+class AlibabaCodingPlanProfile(ProviderProfile):
+    """Alibaba Cloud Coding Plan — top-level reasoning_effort passthrough.
+
+    Qwen3 thinking models on DashScope support ``reasoning_effort`` as a
+    top-level request parameter (xhigh / medium / low; server default:
+    xhigh).  Without this override the field is silently omitted and the
+    endpoint always applies its server-side default, making it impossible
+    for users to lower thinking depth (#77818).
+    """
+
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, **context: Any
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        top_level: dict[str, Any] = {}
+
+        if not isinstance(reasoning_config, dict):
+            return {}, top_level
+
+        effort = (reasoning_config.get("effort") or "").strip().lower()
+        if not effort:
+            return {}, top_level
+
+        # Map Hermes effort levels to DashScope-supported values.
+        # DashScope Qwen3 accepts: xhigh, medium, low.
+        if effort in {"xhigh", "max", "ultra"}:
+            top_level["reasoning_effort"] = "xhigh"
+        elif effort in {"low", "medium", "high"}:
+            top_level["reasoning_effort"] = effort
+        # "none" / "minimal" → omit so the model applies its default
+        # (users who set effort=none likely want thinking off, but
+        # DashScope doesn't support that — omit to avoid 400 errors).
+
+        return {}, top_level
+
+
+alibaba_coding_plan = AlibabaCodingPlanProfile(
     name="alibaba-coding-plan",
     aliases=("alibaba_coding", "alibaba-coding", "dashscope-coding"),
     display_name="Alibaba Cloud (Coding Plan)",


### PR DESCRIPTION
## Summary

Fixes #77818. The `alibaba-coding-plan` provider profile did not override `build_api_kwargs_extras`, so `reasoning_effort` was silently omitted from every request to the DashScope coding-plan endpoint.

## Root Cause

Qwen3 thinking models on DashScope support `reasoning_effort` as a top-level request parameter (`xhigh` / `medium` / `low`; server default: `xhigh`). Without a provider-specific override, the base `ProviderProfile.build_api_kwargs_extras` returns `({}, {})`, and the field never reaches the wire. Users cannot lower thinking depth to save tokens or latency.

## Fix

Add `AlibabaCodingPlanProfile` (subclass of `ProviderProfile`) that overrides `build_api_kwargs_extras` to map Hermes effort levels to the DashScope wire format:

| Hermes effort | Wire value |
|---|---|
| `xhigh`, `max`, `ultra` | `xhigh` |
| `low`, `medium`, `high` | passthrough |
| `none`, `minimal`, empty | omitted (server default) |

This follows the same pattern used by `DeepSeekProfile`, `ZAIProfile`, and `KimiCodingProfile`.

## Changes

- `plugins/model-providers/alibaba-coding-plan/__init__.py`: Replace bare `ProviderProfile` registration with `AlibabaCodingPlanProfile` subclass that passes `reasoning_effort` through to the DashScope API.

## Testing

```python
from plugins.model_providers.alibaba_coding_plan import alibaba_coding_plan

# With effort set
_, top = alibaba_coding_plan.build_api_kwargs_extras(
    reasoning_config={"enabled": True, "effort": "medium"}
)
assert top == {"reasoning_effort": "medium"}

# With xhigh/max mapped
_, top = alibaba_coding_plan.build_api_kwargs_extras(
    reasoning_config={"enabled": True, "effort": "max"}
)
assert top == {"reasoning_effort": "xhigh"}

# Without config — no field emitted
_, top = alibaba_coding_plan.build_api_kwargs_extras(reasoning_config=None)
assert top == {}
```
