### PR TITLE
feat(providers): add AgentRouter as a model provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,19 @@
 # UPSTAGE_BASE_URL=https://api.upstage.ai/v1
 
 # =============================================================================
+# LLM PROVIDER (AgentRouter)
+# =============================================================================
+# AgentRouter relays several model families behind one key.
+# Two providers share this key:
+#   agentrouter            → OpenAI-compatible route (gpt-5.5, gpt-5.6, glm-5.2)
+#   agentrouter-anthropic  → Anthropic Messages route (claude-opus-4-6/4-7/4-8)
+# Get your key at: https://agentrouter.org/console/token
+# AGENTROUTER_API_KEY=your_key_here
+# Optional base URL overrides (note: the Anthropic route takes no /v1 suffix):
+# AGENTROUTER_BASE_URL=https://agentrouter.org/v1
+# AGENTROUTER_ANTHROPIC_BASE_URL=https://agentrouter.org
+
+# =============================================================================
 # TOOL API KEYS
 # =============================================================================
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -596,8 +596,8 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
     Some third-party /anthropic endpoints implement Anthropic's Messages API but
     require Authorization: Bearer instead of Anthropic's native x-api-key header.
     MiniMax's global and China Anthropic-compatible endpoints, Azure AI
-    Foundry's Anthropic-style endpoint, Palantir Foundry's LLM proxy, and Nous
-    Portal's Messages route follow this pattern.
+    Foundry's Anthropic-style endpoint, Palantir Foundry's LLM proxy, Nous
+    Portal's Messages route, and AgentRouter's relay follow this pattern.
     """
     if _is_nous_portal_endpoint(base_url):
         return True
@@ -613,6 +613,14 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
         # Hostname match (not substring) so e.g. evil.com/palantirfoundry
         # paths don't trigger Bearer auth.
         or base_url_host_matches(normalized, "palantirfoundry.com")
+        # AgentRouter's Anthropic-compatible relay (https://agentrouter.org,
+        # no /v1 and no /anthropic suffix) documents its key as an
+        # ANTHROPIC_AUTH_TOKEN, i.e. Authorization: Bearer. Its ``ak-…`` keys
+        # carry no sk-ant-api prefix, so without this they'd fall through to
+        # OAuth-shape detection and then to x-api-key, which the relay 401s on.
+        # Hostname match so lookalike paths (evil.test/agentrouter.org/…)
+        # don't opt into Bearer auth.
+        or base_url_host_matches(normalized, "agentrouter.org")
     )
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -290,6 +290,26 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("GMI_API_KEY",),
         base_url_env_var="GMI_BASE_URL",
     ),
+    # AgentRouter exposes two wire protocols on one host and one API key.
+    # They are separate providers because the base URL and transport differ:
+    # /v1 is OpenAI-compatible (GPT, GLM), the bare host is Anthropic Messages
+    # (Claude Opus). See plugins/model-providers/agentrouter/.
+    "agentrouter": ProviderConfig(
+        id="agentrouter",
+        name="AgentRouter",
+        auth_type="api_key",
+        inference_base_url="https://agentrouter.org/v1",
+        api_key_env_vars=("AGENTROUTER_API_KEY",),
+        base_url_env_var="AGENTROUTER_BASE_URL",
+    ),
+    "agentrouter-anthropic": ProviderConfig(
+        id="agentrouter-anthropic",
+        name="AgentRouter (Claude)",
+        auth_type="api_key",
+        inference_base_url="https://agentrouter.org",
+        api_key_env_vars=("AGENTROUTER_API_KEY",),
+        base_url_env_var="AGENTROUTER_ANTHROPIC_BASE_URL",
+    ),
     "minimax": ProviderConfig(
         id="minimax",
         name="MiniMax",
@@ -1968,6 +1988,8 @@ def resolve_provider(
         "step": "stepfun", "stepfun-coding-plan": "stepfun",
         "arcee-ai": "arcee", "arceeai": "arcee",
         "gmi-cloud": "gmi", "gmicloud": "gmi",
+        "agent-router": "agentrouter", "agentrouter-openai": "agentrouter",
+        "agentrouter-claude": "agentrouter-anthropic",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
         "minimax-portal": "minimax-oauth", "minimax-global": "minimax-oauth", "minimax_oauth": "minimax-oauth",
         "alibaba_coding": "alibaba-coding-plan", "alibaba-coding": "alibaba-coding-plan",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -117,6 +117,25 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://api.stepfun.ai/step_plan/v1",
         base_url_env_var="STEPFUN_BASE_URL",
     ),
+    # AgentRouter relays several upstream vendors behind one key, so it is an
+    # aggregator on both routes. The Anthropic route's base URL deliberately
+    # omits ``/v1`` — the Anthropic SDK appends ``/v1/messages`` itself — which
+    # also means host_mandated_api_mode() can't infer the wire from the URL;
+    # these overlays are what pin the transport.
+    "agentrouter": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        extra_env_vars=("AGENTROUTER_API_KEY",),
+        base_url_override="https://agentrouter.org/v1",
+        base_url_env_var="AGENTROUTER_BASE_URL",
+    ),
+    "agentrouter-anthropic": HermesOverlay(
+        transport="anthropic_messages",
+        is_aggregator=True,
+        extra_env_vars=("AGENTROUTER_API_KEY",),
+        base_url_override="https://agentrouter.org",
+        base_url_env_var="AGENTROUTER_ANTHROPIC_BASE_URL",
+    ),
     "minimax": HermesOverlay(
         transport="anthropic_messages",
         base_url_env_var="MINIMAX_BASE_URL",
@@ -304,6 +323,11 @@ ALIASES: Dict[str, str] = {
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
 
+    # agentrouter (two wires, one host — see HERMES_OVERLAYS above)
+    "agent-router": "agentrouter",
+    "agentrouter-openai": "agentrouter",
+    "agentrouter-claude": "agentrouter-anthropic",
+
     # anthropic
     "claude": "anthropic",
     "claude-code": "anthropic",
@@ -408,6 +432,8 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",
     "upstage": "Upstage Solar",
+    "agentrouter": "AgentRouter",
+    "agentrouter-anthropic": "AgentRouter (Claude)",
     "tencent-tokenhub": "Tencent TokenHub",
     "lmstudio": "LM Studio",
     "local": "Local endpoint",

--- a/plugins/model-providers/agentrouter/__init__.py
+++ b/plugins/model-providers/agentrouter/__init__.py
@@ -1,0 +1,79 @@
+"""AgentRouter provider profiles (OpenAI-compatible + Anthropic Messages).
+
+AgentRouter (https://agentrouter.org) is a relay that fronts several upstream
+model families behind one API key. It exposes *two* wire protocols on the same
+host, and the vendor docs are explicit that they are not interchangeable:
+
+  - ``https://agentrouter.org/v1``  — OpenAI-compatible Chat Completions.
+    Serves the GPT and GLM families (``gpt-5.6``, ``gpt-5.5``, ``glm-5.2``).
+  - ``https://agentrouter.org``     — Anthropic Messages (note: no ``/v1``
+    path segment; the SDK appends ``/v1/messages`` itself). Serves the Claude
+    Opus family (``claude-opus-4-6``, ``claude-opus-4-7``, ``claude-opus-4-8``).
+
+Both routes authenticate with the same ``AGENTROUTER_API_KEY`` (``ak-…``) sent
+as ``Authorization: Bearer``. The Messages route therefore needs Bearer rather
+than Anthropic's native ``x-api-key`` — wired in
+``agent.anthropic_adapter._requires_bearer_auth``.
+
+Hence two profiles from one plugin (same pattern as the MiniMax plugin): pick
+``agentrouter`` for GPT/GLM, ``agentrouter-anthropic`` for Claude. The model
+catalog is fetched live from ``/v1/models`` for both (it requires auth, so the
+``fallback_models`` below cover the offline picker).
+
+Docs: https://agentrouter.org/docs/index.html
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+# Both routes share one host. The catalog only exists on the OpenAI-compatible
+# path, so the Anthropic profile points ``models_url`` at it explicitly rather
+# than letting the default ``{base_url}/models`` resolve to the bare host.
+_MODELS_URL = "https://agentrouter.org/v1/models"
+
+agentrouter = ProviderProfile(
+    name="agentrouter",
+    aliases=("agent-router", "agentrouter-openai"),
+    display_name="AgentRouter",
+    description="AgentRouter — OpenAI-compatible relay (GPT, GLM)",
+    signup_url="https://agentrouter.org/console/token",
+    env_vars=("AGENTROUTER_API_KEY", "AGENTROUTER_BASE_URL"),
+    base_url="https://agentrouter.org/v1",
+    models_url=_MODELS_URL,
+    auth_type="api_key",
+    # default_aux_model left empty → auxiliary side tasks reuse the main model.
+    # AgentRouter publishes no cheap/small model to pin one to.
+    # entry [0] is the setup default; gpt-5.5 is the default AgentRouter's own
+    # docs configure for every client they document.
+    fallback_models=(
+        "gpt-5.5",
+        "gpt-5.6",
+        "glm-5.2",
+    ),
+)
+
+agentrouter_anthropic = ProviderProfile(
+    name="agentrouter-anthropic",
+    aliases=("agentrouter-claude",),
+    api_mode="anthropic_messages",
+    display_name="AgentRouter (Claude)",
+    description="AgentRouter — Anthropic Messages relay (Claude Opus)",
+    signup_url="https://agentrouter.org/console/token",
+    env_vars=("AGENTROUTER_API_KEY", "AGENTROUTER_ANTHROPIC_BASE_URL"),
+    # No ``/v1`` — the Anthropic SDK appends ``/v1/messages`` to this base.
+    base_url="https://agentrouter.org",
+    models_url=_MODELS_URL,
+    auth_type="api_key",
+    supports_vision=True,
+    fallback_models=(
+        "claude-opus-4-6",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+    ),
+)
+
+# Register the OpenAI-compatible profile first so the shared ``agentrouter.org``
+# hostname reverse-maps to ``agentrouter`` in agent/model_metadata.py (first
+# writer wins there). Context windows resolve from the model id either way.
+register_provider(agentrouter)
+register_provider(agentrouter_anthropic)

--- a/plugins/model-providers/agentrouter/plugin.yaml
+++ b/plugins/model-providers/agentrouter/plugin.yaml
@@ -1,0 +1,5 @@
+name: agentrouter-provider
+kind: model-provider
+version: 1.0.0
+description: AgentRouter relay (OpenAI-compatible + Anthropic Messages routes)
+author: Nous Research

--- a/tests/hermes_cli/test_agentrouter_provider.py
+++ b/tests/hermes_cli/test_agentrouter_provider.py
@@ -1,0 +1,160 @@
+"""Tests for AgentRouter first-class provider wiring.
+
+AgentRouter is unusual among Hermes providers: one host, one API key, two wire
+protocols. ``https://agentrouter.org/v1`` speaks OpenAI Chat Completions and
+``https://agentrouter.org`` speaks Anthropic Messages. Neither URL carries the
+``/anthropic`` suffix that ``host_mandated_api_mode`` keys off, so the transport
+is pinned entirely by the HERMES_OVERLAYS entries checked here — get those wrong
+and Claude traffic silently goes out on the OpenAI wire (or vice versa).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+
+if "dotenv" not in sys.modules:
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = fake_dotenv
+
+
+class TestAgentRouterResolver:
+    """resolve_provider_full must recognise both routes.
+
+    When it returns None, an explicit ``provider: agentrouter`` in config.yaml
+    is discarded and resolution falls through to env auto-detect.
+    """
+
+    def test_resolves_openai_route(self):
+        from hermes_cli.providers import resolve_provider_full
+
+        pdef = resolve_provider_full("agentrouter", {}, [])
+        assert pdef is not None
+        assert pdef.id == "agentrouter"
+        assert pdef.base_url == "https://agentrouter.org/v1"
+        assert "AGENTROUTER_API_KEY" in pdef.api_key_env_vars
+
+    def test_resolves_anthropic_route(self):
+        from hermes_cli.providers import resolve_provider_full
+
+        pdef = resolve_provider_full("agentrouter-anthropic", {}, [])
+        assert pdef is not None
+        assert pdef.id == "agentrouter-anthropic"
+        assert pdef.base_url == "https://agentrouter.org"
+        assert "AGENTROUTER_API_KEY" in pdef.api_key_env_vars
+
+
+class TestAgentRouterOverlays:
+    def test_openai_overlay(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+
+        overlay = HERMES_OVERLAYS["agentrouter"]
+        assert overlay.transport == "openai_chat"
+        assert overlay.extra_env_vars == ("AGENTROUTER_API_KEY",)
+        assert overlay.base_url_override == "https://agentrouter.org/v1"
+        assert overlay.base_url_env_var == "AGENTROUTER_BASE_URL"
+        assert overlay.is_aggregator
+
+    def test_anthropic_overlay(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+
+        overlay = HERMES_OVERLAYS["agentrouter-anthropic"]
+        assert overlay.transport == "anthropic_messages"
+        assert overlay.base_url_override == "https://agentrouter.org"
+        assert overlay.base_url_env_var == "AGENTROUTER_ANTHROPIC_BASE_URL"
+        assert overlay.is_aggregator
+
+    def test_labels(self):
+        from hermes_cli.providers import get_label
+
+        assert get_label("agentrouter") == "AgentRouter"
+        assert get_label("agentrouter-anthropic") == "AgentRouter (Claude)"
+
+
+class TestAgentRouterApiMode:
+    """The Claude route must land on anthropic_messages.
+
+    ``https://agentrouter.org`` matches none of host_mandated_api_mode's URL
+    heuristics (no api.anthropic.com host, no /anthropic suffix), so without the
+    overlay this would default to chat_completions.
+    """
+
+    def test_anthropic_route_selects_messages_transport(self):
+        from hermes_cli.providers import determine_api_mode
+
+        mode = determine_api_mode(
+            "agentrouter-anthropic",
+            base_url="https://agentrouter.org",
+            model="claude-opus-4-6",
+        )
+        assert mode == "anthropic_messages"
+
+    def test_openai_route_stays_on_chat_completions(self):
+        from hermes_cli.providers import determine_api_mode
+
+        mode = determine_api_mode(
+            "agentrouter",
+            base_url="https://agentrouter.org/v1",
+            model="gpt-5.5",
+        )
+        assert mode == "chat_completions"
+
+
+class TestAgentRouterAliases:
+    def test_auth_resolver_aliases(self):
+        from hermes_cli.auth import resolve_provider
+
+        assert resolve_provider("agent-router") == "agentrouter"
+        assert resolve_provider("agentrouter-openai") == "agentrouter"
+        assert resolve_provider("agentrouter-claude") == "agentrouter-anthropic"
+
+    def test_provider_registry_entries(self):
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        assert PROVIDER_REGISTRY["agentrouter"].auth_type == "api_key"
+        assert (
+            PROVIDER_REGISTRY["agentrouter"].inference_base_url
+            == "https://agentrouter.org/v1"
+        )
+        # Both routes authenticate with the same key.
+        assert PROVIDER_REGISTRY["agentrouter-anthropic"].api_key_env_vars == (
+            "AGENTROUTER_API_KEY",
+        )
+        assert (
+            PROVIDER_REGISTRY["agentrouter-anthropic"].inference_base_url
+            == "https://agentrouter.org"
+        )
+
+
+class TestAgentRouterEnvCatalog:
+    """The dashboard Providers page lists OPTIONAL_ENV_VARS keys whose category
+    is "provider". Without these entries AGENTROUTER_API_KEY never reaches the
+    frontend and AgentRouter stays invisible there, even though EnvPage.tsx has
+    a matching PROVIDER_GROUPS prefix.
+    """
+
+    def test_optional_env_vars_include_agentrouter(self):
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        assert "AGENTROUTER_API_KEY" in OPTIONAL_ENV_VARS
+        assert OPTIONAL_ENV_VARS["AGENTROUTER_API_KEY"]["category"] == "provider"
+        assert OPTIONAL_ENV_VARS["AGENTROUTER_API_KEY"]["password"] is True
+
+        assert "AGENTROUTER_BASE_URL" in OPTIONAL_ENV_VARS
+        assert OPTIONAL_ENV_VARS["AGENTROUTER_BASE_URL"]["category"] == "provider"
+        assert OPTIONAL_ENV_VARS["AGENTROUTER_BASE_URL"]["password"] is False
+
+
+class TestAgentRouterInPicker:
+    """CANONICAL_PROVIDERS auto-extends from the plugin registry; both routes
+    are api-key providers so both must show up in `hermes model`.
+    """
+
+    def test_both_routes_are_listed(self):
+        from hermes_cli.models import CANONICAL_PROVIDERS
+
+        slugs = {p.slug for p in CANONICAL_PROVIDERS}
+        assert "agentrouter" in slugs
+        assert "agentrouter-anthropic" in slugs

--- a/tests/plugins/model_providers/test_agentrouter_profile.py
+++ b/tests/plugins/model_providers/test_agentrouter_profile.py
@@ -1,0 +1,141 @@
+"""Unit tests for the AgentRouter provider profiles.
+
+AgentRouter registers two profiles from one plugin because it serves two wire
+protocols on the same host:
+
+  - ``agentrouter``            → OpenAI-compatible Chat Completions at /v1
+  - ``agentrouter-anthropic``  → Anthropic Messages at the bare host (no /v1)
+
+The invariants below are the ones downstream layers (auth, models, doctor,
+runtime_provider, transport, anthropic_adapter) actually read.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def openai_profile():
+    """Resolve the OpenAI-compatible AgentRouter profile via the registry.
+
+    Importing ``model_tools`` triggers plugin discovery. Going through
+    ``get_provider_profile`` keeps the test honest about the real registration
+    path (name + alias resolution) rather than importing the plugin directly.
+    """
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("agentrouter")
+    assert profile is not None, "agentrouter provider profile must be registered"
+    return profile
+
+
+@pytest.fixture
+def anthropic_profile():
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("agentrouter-anthropic")
+    assert profile is not None, (
+        "agentrouter-anthropic provider profile must be registered"
+    )
+    return profile
+
+
+class TestOpenAICompatibleProfile:
+    def test_identity_and_endpoint(self, openai_profile):
+        assert openai_profile.name == "agentrouter"
+        assert openai_profile.api_mode == "chat_completions"
+        assert openai_profile.auth_type == "api_key"
+        assert openai_profile.base_url == "https://agentrouter.org/v1"
+        assert openai_profile.get_hostname() == "agentrouter.org"
+
+    def test_env_vars(self, openai_profile):
+        # API key first, optional base-url override second (priority order).
+        assert openai_profile.env_vars == (
+            "AGENTROUTER_API_KEY",
+            "AGENTROUTER_BASE_URL",
+        )
+
+    def test_aliases_resolve_to_same_object(self, openai_profile):
+        import providers
+
+        for alias in ("agent-router", "agentrouter-openai"):
+            assert providers.get_provider_profile(alias) is openai_profile
+
+    def test_fallback_catalog_is_the_documented_openai_family(self, openai_profile):
+        # The live /v1/models catalog needs auth, so the offline picker falls
+        # back to this list. entry[0] is the setup default.
+        assert openai_profile.fallback_models[0] == "gpt-5.5"
+        assert set(openai_profile.fallback_models) == {"gpt-5.5", "gpt-5.6", "glm-5.2"}
+
+    def test_no_pinned_aux_model(self, openai_profile):
+        # AgentRouter publishes no cheap/small model, so auxiliary tasks
+        # (compression, titles, vision) must reuse the main model.
+        assert openai_profile.default_aux_model == ""
+
+
+class TestAnthropicMessagesProfile:
+    def test_identity_and_endpoint(self, anthropic_profile):
+        assert anthropic_profile.name == "agentrouter-anthropic"
+        assert anthropic_profile.api_mode == "anthropic_messages"
+        assert anthropic_profile.auth_type == "api_key"
+        # No /v1 — the Anthropic SDK appends /v1/messages to this base.
+        assert anthropic_profile.base_url == "https://agentrouter.org"
+        assert anthropic_profile.get_hostname() == "agentrouter.org"
+
+    def test_alias_resolves(self, anthropic_profile):
+        import providers
+
+        assert providers.get_provider_profile("agentrouter-claude") is anthropic_profile
+
+    def test_shares_the_openai_api_key(self, anthropic_profile):
+        assert anthropic_profile.env_vars[0] == "AGENTROUTER_API_KEY"
+
+    def test_models_url_points_at_the_v1_catalog(self, anthropic_profile):
+        # The bare Anthropic host has no /models route; without the explicit
+        # models_url the default {base_url}/models probe (and the doctor health
+        # check that reuses it) would hit https://agentrouter.org/models.
+        assert anthropic_profile.models_url == "https://agentrouter.org/v1/models"
+
+    def test_fallback_catalog_is_the_documented_claude_family(self, anthropic_profile):
+        assert anthropic_profile.fallback_models[0] == "claude-opus-4-6"
+        assert set(anthropic_profile.fallback_models) == {
+            "claude-opus-4-6",
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+        }
+
+    def test_is_a_distinct_profile_from_the_openai_route(
+        self, anthropic_profile, openai_profile
+    ):
+        assert anthropic_profile is not openai_profile
+
+
+class TestAnthropicBearerAuth:
+    """AgentRouter keys are ``ak-…`` and must go out as Authorization: Bearer.
+
+    Without the ``_requires_bearer_auth`` entry the adapter would fall through
+    to OAuth-shape detection and then to Anthropic's native ``x-api-key``,
+    which the relay rejects with 401.
+    """
+
+    def test_relay_host_requires_bearer(self):
+        from agent.anthropic_adapter import _requires_bearer_auth
+
+        assert _requires_bearer_auth("https://agentrouter.org") is True
+        assert _requires_bearer_auth("https://agentrouter.org/") is True
+
+    def test_native_anthropic_still_uses_x_api_key(self):
+        from agent.anthropic_adapter import _requires_bearer_auth
+
+        assert _requires_bearer_auth("https://api.anthropic.com") is False
+
+    def test_lookalike_hosts_do_not_opt_into_bearer(self):
+        from agent.anthropic_adapter import _requires_bearer_auth
+
+        # Hostname match, never bare substring: neither a suffix-spoof host nor
+        # a path segment may borrow AgentRouter's auth scheme.
+        assert _requires_bearer_auth("https://agentrouter.org.attacker.test") is False
+        assert _requires_bearer_auth("https://proxy.test/agentrouter.org/v1") is False

--- a/web/src/pages/EnvPage.tsx
+++ b/web/src/pages/EnvPage.tsx
@@ -66,6 +66,7 @@ const PROVIDER_GROUPS: { prefix: string; name: string; priority: number }[] = [
   { prefix: "OPENROUTER_", name: "OpenRouter", priority: 12 },
   { prefix: "XIAOMI_", name: "Xiaomi MiMo", priority: 13 },
   { prefix: "UPSTAGE_", name: "Upstage Solar", priority: 14 },
+  { prefix: "AGENTROUTER_", name: "AgentRouter", priority: 15 },
 ];
 
 function getProviderGroup(key: string): string {

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -23,6 +23,8 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Fireworks AI** | `FIREWORKS_API_KEY` in `~/.hermes/.env` (provider: `fireworks`; aliases: `fireworks-ai`, `fw`) |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
 | **AI Gateway** | `AI_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `ai-gateway`) |
+| **AgentRouter** | `AGENTROUTER_API_KEY` in `~/.hermes/.env` (provider: `agentrouter`, OpenAI-compatible route: GPT / GLM; aliases: `agent-router`, `agentrouter-openai`) |
+| **AgentRouter (Claude)** | `AGENTROUTER_API_KEY` in `~/.hermes/.env` (provider: `agentrouter-anthropic`, Anthropic Messages route: Claude Opus; alias: `agentrouter-claude`) |
 | **z.ai / GLM** | `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`) |
 | **Kimi / Moonshot** | `KIMI_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding`) |
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |
@@ -539,6 +541,40 @@ model:
 ```
 
 The base URL can be overridden with `STEPFUN_BASE_URL` (default: `https://api.stepfun.com/v1`).
+
+### AgentRouter
+
+[AgentRouter](https://agentrouter.org) relays several upstream model families behind a single API key. Grab a key from the [token console](https://agentrouter.org/console/token) and put it in `~/.hermes/.env`:
+
+```bash
+AGENTROUTER_API_KEY=ak-your-key-here
+```
+
+AgentRouter exposes **two wire protocols on the same host**, and they are not interchangeable — which family you want decides which provider you pick:
+
+| Provider | Endpoint | Models |
+|----------|----------|--------|
+| `agentrouter` | `https://agentrouter.org/v1` (OpenAI-compatible) | `gpt-5.5`, `gpt-5.6`, `glm-5.2` |
+| `agentrouter-anthropic` | `https://agentrouter.org` (Anthropic Messages) | `claude-opus-4-6`, `claude-opus-4-7`, `claude-opus-4-8` |
+
+```bash
+# GPT / GLM over the OpenAI-compatible route
+hermes chat --provider agentrouter --model gpt-5.5
+
+# Claude Opus over the Anthropic Messages route
+hermes chat --provider agentrouter-anthropic --model claude-opus-4-6
+```
+
+Or set one permanently in `config.yaml`:
+```yaml
+model:
+  provider: "agentrouter-anthropic"
+  default: "claude-opus-4-6"
+```
+
+Both routes authenticate with the same `AGENTROUTER_API_KEY`, sent as `Authorization: Bearer`. Aliases: `agent-router` / `agentrouter-openai` → `agentrouter`, `agentrouter-claude` → `agentrouter-anthropic`.
+
+Base URLs can be overridden with `AGENTROUTER_BASE_URL` and `AGENTROUTER_ANTHROPIC_BASE_URL`. Note that the Anthropic route deliberately carries **no** `/v1` suffix — the Anthropic SDK appends `/v1/messages` itself, so adding it yourself produces a 404.
 
 ### Hugging Face Inference Providers
 


### PR DESCRIPTION
## What

Adds [AgentRouter](https://agentrouter.org) as a bundled model-provider plugin. AgentRouter is a relay that fronts several upstream model families behind a single API key.

It's unusual among Hermes providers in that it serves **two wire protocols on the same host**, and [its docs](https://agentrouter.org/docs/index.html) are explicit that they are not interchangeable. So it registers two profiles from one plugin — the same pattern the MiniMax plugin already uses:

| Provider | Endpoint | Models |
|----------|----------|--------|
| `agentrouter` | `https://agentrouter.org/v1` (OpenAI-compatible) | `gpt-5.5`, `gpt-5.6`, `glm-5.2` |
| `agentrouter-anthropic` | `https://agentrouter.org` (Anthropic Messages) | `claude-opus-4-6`, `claude-opus-4-7`, `claude-opus-4-8` |

Both authenticate with the same `AGENTROUTER_API_KEY` (`ak-…`), sent as `Authorization: Bearer`. The Anthropic base URL deliberately carries no `/v1` — the Anthropic SDK appends `/v1/messages` itself.

```bash
hermes chat --provider agentrouter --model gpt-5.5
hermes chat --provider agentrouter-anthropic --model claude-opus-4-6
```

## Two things worth reviewing

**Transport pinning.** Neither base URL carries the `/anthropic` suffix or `api.anthropic.com` host that `host_mandated_api_mode()` keys off, so URL detection finds nothing. The `HERMES_OVERLAYS` entries are the only thing pinning the wire — without them the Claude route would silently default to `chat_completions`. Covered by tests.

**Bearer auth on the Messages route** (`agent/anthropic_adapter.py`). AgentRouter documents its key as an `ANTHROPIC_AUTH_TOKEN`. Its `ak-…` keys carry no `sk-ant-api` prefix, so without an entry in `_requires_bearer_auth` they'd fall through to OAuth-shape detection and then to Anthropic's native `x-api-key`, which the relay 401s on. Matched on hostname rather than substring, so lookalike hosts (`agentrouter.org.attacker.test`) and path-segment spoofs (`proxy.test/agentrouter.org/v1`) can't opt into Bearer — there's a test for that.

## Changes

- `plugins/model-providers/agentrouter/` — both profiles + `plugin.yaml`. `models_url` pins the catalog probe to `/v1/models` on both routes since the bare Anthropic host exposes none; `default_aux_model` left empty so auxiliary tasks reuse the main model (AgentRouter publishes no cheap/small model to pin one to).
- `hermes_cli/providers.py` — `HERMES_OVERLAYS`, labels, aliases.
- `hermes_cli/auth.py` — `PROVIDER_REGISTRY` entries + aliases, so `hermes doctor` / `resolve_provider` recognise both routes at validation time.
- `agent/anthropic_adapter.py` — one entry in `_requires_bearer_auth`.
- `.env.example`, `website/docs/integrations/providers.md`, `web/src/pages/EnvPage.tsx`.

`hermes_cli/models.py` needs no edit — `CANONICAL_PROVIDERS` auto-extends from the plugin registry for api-key profiles.

## Testing

```
pytest tests/providers tests/plugins/model_providers \
       tests/hermes_cli/test_agentrouter_provider.py \
       tests/agent/test_anthropic_adapter.py \
       tests/hermes_cli/test_api_key_providers.py \
       tests/hermes_cli/test_runtime_provider_resolution.py
```
712 passed; `ruff` clean. New tests cover profile registration/identity/endpoints/aliases/catalogs, Bearer-auth selection plus lookalike-host rejection, resolver + overlay + `api_mode` wiring for both routes, env catalog, and picker presence.

Also verified by hand that `resolve_runtime_provider()` returns the right `base_url` and `api_mode` for both routes and that both show up in `CANONICAL_PROVIDERS`.

**Not exercised: live inference.** I don't have an AgentRouter account, so the endpoints, model IDs, and the Bearer requirement all come from the vendor docs rather than a real request. Happy to adjust if a maintainer with a key finds any of it off — the model lists in particular are only the offline fallback, since the live `/v1/models` catalog supersedes them whenever a key is present.

Platforms tested: Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
