### PR TITLE
fix(gateway): retry startup home-channel notification on send_path_degraded

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21040,15 +21040,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if home.scope_id:
                         metadata["scope_id"] = home.scope_id
                 send_metadata = _non_conversational_metadata(metadata, platform=platform)
-                if send_metadata is not None or transport.is_relay:
-                    result = await transport.send(
-                        platform,
-                        str(home.chat_id),
-                        message,
-                        metadata=send_metadata,
-                    )
-                else:
-                    result = await transport.adapter.send(str(home.chat_id), message)
+
+                async def _do_send() -> object:
+                    if send_metadata is not None or transport.is_relay:
+                        return await transport.send(
+                            platform,
+                            str(home.chat_id),
+                            message,
+                            metadata=send_metadata,
+                        )
+                    return await transport.adapter.send(str(home.chat_id), message)
+
+                result = await _do_send()
+                # The Telegram adapter marks its send path as degraded
+                # (`_send_path_degraded`) until the first successful getUpdates
+                # after connecting. The startup notification can race ahead of
+                # that and get dropped with `send_path_degraded` (retryable).
+                # Wait briefly for polling to confirm, then retry once.
+                if (
+                    result is not None
+                    and getattr(result, "success", True) is False
+                    and getattr(result, "error", "") == "send_path_degraded"
+                ):
+                    await asyncio.sleep(3.0)
+                    result = await _do_send()
                 if result is not None and getattr(result, "success", True) is False:
                     logger.warning(
                         "Home-channel startup notification failed for %s:%s: %s",


### PR DESCRIPTION
## Summary
Fixes the race where the gateway's startup "back online" notification to the Telegram home channel is dropped after a (re)start.

The Telegram adapter sets `_send_path_degraded = True` when polling begins (`plugins/platforms/telegram/adapter.py:2046`) and only clears it in `_record_polling_progress()` after the first successful `getUpdates` (`adapter.py:2060`). `_send_home_channel_startup_notifications()` (`gateway/run.py`) fires during startup and calls `adapter.send(...)`, which returns `SendResult(success=False, error="send_path_degraded", retryable=True)` while the flag is still `True` — so the one-shot notification is logged as failed and never delivered. Normal inbound/outbound traffic works fine immediately afterward (polling is actually healthy).

## Fix
In `_send_home_channel_startup_notifications`, if the send returns `send_path_degraded` (retryable), `await asyncio.sleep(3.0)` for polling to confirm, then retry the send once. No change to the Telegram adapter or polling logic — only the caller retries the best-effort notification.

## Repro
- Hermes Agent v0.19.0 (a991dfc2)
- Telegram polling mode, home channel `5343292981`
- gateway.log timeline:
  ```
  09:14:15 ✓ telegram connected (polling starts)
  09:14:16 WARNING Home-channel startup notification failed ... send_path_degraded
  09:14:30 inbound Ping -> delivered OK
  ```
- Tracked in #66589 (still OPEN) — this PR adds the fix.

## Test plan
- [ ] Restart gateway with Telegram home channel; confirm "♻️ Gateway online" notification is now received.
- [ ] Confirm no regression to normal message delivery.
- [ ] Confirm non-degraded sends are unaffected (only the retry path added).

Closes #66589