### PR TITLE
fix(update): stop truncating venv blocker cmdline before gateway exemption

### DIFF
--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -144,7 +144,7 @@ def main() -> None:
         {
             "pid": pid,
             "name": name,
-            "cmdline": _redact_sensitive_cmdline(cmdline),
+            "cmdline": _redact_sensitive_cmdline(cmdline)[:120],
         }
         for pid, name, cmdline in matches
         if not _is_pausable_gateway(cmdline)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2911,7 +2911,7 @@ def _detect_venv_python_processes(
         if not is_holder:
             continue
         name = info.get("name") or Path(exe).name
-        matches.append((int(pid), str(name), cmdline_raw[:120]))
+        matches.append((int(pid), str(name), cmdline_raw))
     return matches
 
 def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> str:
@@ -2921,12 +2921,13 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
     ]
     for pid, name, cmdline in matches[:6]:
         hint = ""
-        low = cmdline.lower()
+        display_cmdline = cmdline[:120] if len(cmdline) > 120 else cmdline
+        low = display_cmdline.lower()
         if "serve" in low or "dashboard" in low:
             hint = "  ← Hermes Desktop backend (close the desktop app)"
         elif "gateway" in low:
             hint = "  ← gateway"
-        lines.append(f"  PID {pid}  {name}  {cmdline}{hint}")
+        lines.append(f"  PID {pid}  {name}  {display_cmdline}{hint}")
     if len(matches) > 6:
         lines.append(f"  ... and {len(matches) - 6} more")
     lines.append("")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3027,9 +3027,8 @@ def _leftover_pausable_gateway_pids(
     to exempt them (``_is_pausable_gateway``), so the preflight's exemption
     and this guard's tolerance cannot drift apart — matcher drift between
     two views of the same process table is what produced the launcher/worker
-    dead-end fixed above. The scan captures only a 120-char cmdline prefix,
-    so the live argv is re-read where psutil allows; an unreadable argv
-    falls back to the captured prefix.
+    dead-end fixed above. The detector preserves the full command line so
+    classification does not depend on a second process-table read.
 
     Returns ``None`` when any holder is not a pausable gateway — an operator
     REPL, a stray script, or the Desktop backend has no pause machinery
@@ -3037,20 +3036,9 @@ def _leftover_pausable_gateway_pids(
     """
     from hermes_cli._scan_venv_blockers import _is_pausable_gateway
 
-    try:
-        import psutil  # type: ignore
-    except Exception:
-        psutil = None
-
     pids: list[int] = []
     for pid, _name, cmdline in matches:
-        argv = cmdline
-        if psutil is not None:
-            try:
-                argv = " ".join(psutil.Process(int(pid)).cmdline()) or cmdline
-            except Exception:
-                pass
-        if not _is_pausable_gateway(argv):
+        if not _is_pausable_gateway(cmdline):
             return None
         pids.append(int(pid))
     return pids

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -212,3 +212,32 @@ def test_main_desktop_serve_backend_still_blocks(monkeypatch, capsys):
     assert data["blocked"] is True
     assert [p["pid"] for p in data["processes"]] == [78]
     assert data["pausable_gateways"] == 0
+
+
+def test_main_exempts_gateway_beyond_legacy_cmdline_limit(monkeypatch, capsys):
+    cmdline = (
+        "C:\\" + "deep-path\\" * 14
+        + "venv\\Scripts\\python.exe -m hermes_cli.main gateway run --replace"
+    )
+    assert cmdline.index("gateway run") > 120
+
+    code, data = _run_main_with_detector(
+        monkeypatch, capsys, [(91, "python.exe", cmdline)]
+    )
+
+    assert code == 0
+    assert data["blocked"] is False
+    assert data["processes"] == []
+    assert data["pausable_gateways"] == 1
+
+
+def test_main_truncates_reported_cmdline_at_json_boundary(monkeypatch, capsys):
+    cmdline = "python.exe -m hermes_cli.main serve " + "x" * 160
+
+    code, data = _run_main_with_detector(
+        monkeypatch, capsys, [(92, "python.exe", cmdline)]
+    )
+
+    assert code == 0
+    assert data["blocked"] is True
+    assert data["processes"][0]["cmdline"] == cmdline[:120]

--- a/tests/hermes_cli/test_update_concurrent_quarantine.py
+++ b/tests/hermes_cli/test_update_concurrent_quarantine.py
@@ -443,66 +443,38 @@ GATEWAY_ARGV = [
 ]
 
 
-def _fake_psutil_cmdlines(argv_by_pid):
-    """psutil stand-in serving live argv per pid; unknown pids raise."""
-
-    class FakeProc:
-        def __init__(self, pid):
-            if pid not in argv_by_pid:
-                raise ValueError(f"no such pid {pid}")
-            self._argv = argv_by_pid[pid]
-
-        def cmdline(self):
-            return self._argv
-
-    return types.SimpleNamespace(Process=FakeProc)
-
-
-def test_leftover_holders_that_are_all_gateways_are_nominated(monkeypatch):
+def test_leftover_holders_that_are_all_gateways_are_nominated():
     """Respawned/unmapped gateway holders get stopped, not dead-ended on."""
-    monkeypatch.setitem(
-        sys.modules,
-        "psutil",
-        _fake_psutil_cmdlines({300: GATEWAY_ARGV, 301: GATEWAY_ARGV}),
-    )
+    gateway_cmdline = " ".join(GATEWAY_ARGV)
     matches = [
-        (300, "python.exe", "truncated..."),
-        (301, "python.exe", "truncated..."),
+        (300, "python.exe", gateway_cmdline),
+        (301, "python.exe", gateway_cmdline),
     ]
 
     assert cli_main._leftover_pausable_gateway_pids(matches) == [300, 301]
 
 
-def test_one_non_gateway_holder_keeps_the_hard_refusal(monkeypatch):
+def test_one_non_gateway_holder_keeps_the_hard_refusal():
     """A REPL/backend holder means the guard must abort exactly as before."""
-    monkeypatch.setitem(
-        sys.modules,
-        "psutil",
-        _fake_psutil_cmdlines(
-            {300: GATEWAY_ARGV, 400: [r"C:\x\venv\Scripts\python.exe", "-i"]}
-        ),
-    )
-    matches = [(300, "python.exe", "..."), (400, "python.exe", "...")]
+    matches = [
+        (300, "python.exe", " ".join(GATEWAY_ARGV)),
+        (400, "python.exe", r"C:\x\venv\Scripts\python.exe -i"),
+    ]
 
     assert cli_main._leftover_pausable_gateway_pids(matches) is None
 
 
-def test_unreadable_argv_falls_back_to_the_captured_prefix(monkeypatch):
-    """psutil failure degrades to the scan's captured cmdline, not a crash.
-
-    The captured prefix decides: a gateway invocation still qualifies, and
-    anything else still refuses.
-    """
-    monkeypatch.setitem(sys.modules, "psutil", _fake_psutil_cmdlines({}))
-    gateway_prefix = r"venv\Scripts\python.exe -m hermes_cli.main gateway run"
+def test_leftover_holders_use_the_captured_cmdline():
+    """The detector's complete command line is the classification source."""
+    gateway_cmdline = r"venv\Scripts\python.exe -m hermes_cli.main gateway run"
 
     assert cli_main._leftover_pausable_gateway_pids(
-        [(300, "python.exe", gateway_prefix)]
+        [(300, "python.exe", gateway_cmdline)]
     ) == [300]
     assert (
         cli_main._leftover_pausable_gateway_pids(
             [
-                (300, "python.exe", gateway_prefix),
+                (300, "python.exe", gateway_cmdline),
                 (400, "python.exe", "python.exe -i"),
             ]
         )
@@ -522,7 +494,6 @@ def test_unreadable_argv_falls_back_to_the_captured_prefix(monkeypatch):
 # ---------------------------------------------------------------------------
 # cmd_update integration — concurrent-instance gate
 # ---------------------------------------------------------------------------
-
 
 
 

--- a/tests/hermes_cli/test_update_venv_health.py
+++ b/tests/hermes_cli/test_update_venv_health.py
@@ -86,6 +86,28 @@ def test_detect_venv_python_excludes_self_and_ancestors(_winp, tmp_path):
         assert cli_main._detect_venv_python_processes() == []
 
 
+@patch.object(cli_main, "_is_windows", return_value=True)
+def test_detect_venv_python_preserves_long_gateway_cmdline(_winp, tmp_path):
+    project_root = tmp_path / ("deep-path-" * 14)
+    venv_py = str(project_root / "venv" / "Scripts" / "python.exe")
+    argv = [venv_py, "-m", "hermes_cli.main", "gateway", "run", "--replace"]
+    cmdline = " ".join(argv)
+    assert cmdline.index("gateway run") > 120
+
+    me = MagicMock()
+    me.parents.return_value = []
+    fake_psutil = types.SimpleNamespace(
+        process_iter=lambda attrs: iter([_proc(4242, venv_py, "python.exe", argv)]),
+        Process=lambda *a, **k: me,
+    )
+    with patch.object(cli_main, "PROJECT_ROOT", project_root), patch.dict(
+        sys.modules, {"psutil": fake_psutil}
+    ):
+        assert cli_main._detect_venv_python_processes() == [
+            (4242, "python.exe", cmdline)
+        ]
+
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`_detect_venv_python_processes()` truncated every cmdline to 120 chars before storing it in the match tuple. The pausable-gateway exemption in `_scan_venv_blockers` then operated on that already-truncated string. For desktop-runtime gateways whose full cmdline exceeds 120 chars (e.g. 186 chars on the reporter's machine), the trailing `gateway run` tokens were cut off and `looks_like_gateway_command_line()` returned `False` — so the Desktop UI preflight aborted with "venv-blocked" before the CLI updater got to pause the gateway.

## Root cause

`_detect_venv_python_processes()` at `update_cmd.py:2914` stored `cmdline_raw[:120]` in the match tuple. `_scan_venv_blockers.py:150` then applied `_is_pausable_gateway()` to that truncated string, defeating the exemption added by #75881.

## Fix

Move the 120-char truncation from the match tuple to the display helper `_format_venv_python_holders_message()`, so:

- `_scan_venv_blockers` `_is_pausable_gateway()` sees the full cmdline — exemption works
- `_leftover_pausable_gateway_pids()` sees the full cmdline as fallback (it already re-reads via psutil, now consistent)
- Display message still shows a compact 120-char cmdline

## Related

- Fixes #78089
- Builds on #75881 (pausable-gateway exemption)
- #74386, #74326, #74783 — original three-layer gateway/update coordination issues