### PR TITLE
fix(update): classify long gateway command lines in desktop preflight

### DIFF
--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -126,6 +126,29 @@ def _is_pausable_gateway(cmdline: str) -> bool:
     return looks_like_gateway_command_line(cmdline)
 
 
+def _is_pausable_gateway_process(pid: int, captured_cmdline: str) -> bool:
+    """Classify a holder using its live argv when the capture is incomplete.
+
+    ``_detect_venv_python_processes`` caps captured command lines at 120
+    characters for display. Managed-runtime interpreter paths can exceed that
+    limit before the trailing ``gateway run`` tokens, so the captured prefix
+    alone is not sufficient for the Desktop preflight exemption. Re-read the
+    argv only for classification and keep the captured prefix for output.
+
+    If the process exits or cannot be inspected, fail closed by retaining the
+    captured-prefix verdict: the holder remains a blocker.
+    """
+    if _is_pausable_gateway(captured_cmdline):
+        return True
+    try:
+        import psutil  # noqa: PLC0415
+
+        live_cmdline = " ".join(psutil.Process(int(pid)).cmdline())
+    except Exception:
+        return False
+    return bool(live_cmdline) and _is_pausable_gateway(live_cmdline)
+
+
 def main() -> None:
     """Entry point.  Prints one JSON doc to stdout.  Exits 0 for valid scan."""
     try:
@@ -140,6 +163,11 @@ def main() -> None:
     except Exception as exc:
         _emit_probe_fail(f"scan aborted: {exc}")
 
+    pausable_gateway_pids = {
+        pid
+        for pid, _name, cmdline in matches
+        if _is_pausable_gateway_process(pid, cmdline)
+    }
     processes = [
         {
             "pid": pid,
@@ -147,16 +175,15 @@ def main() -> None:
             "cmdline": _redact_sensitive_cmdline(cmdline),
         }
         for pid, name, cmdline in matches
-        if not _is_pausable_gateway(cmdline)
+        if pid not in pausable_gateway_pids
     ]
-    exempted = sum(1 for _pid, _name, cmdline in matches if _is_pausable_gateway(cmdline))
     data = {
         "ok": True,
         "blocked": bool(processes),
         "processes": processes,
         # Diagnostic only: gateway processes present but not counted as
         # blockers because the downstream updater pauses them itself.
-        "pausable_gateways": exempted,
+        "pausable_gateways": len(pausable_gateway_pids),
     }
     print(json.dumps(data))
     sys.exit(0)

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -212,3 +212,38 @@ def test_main_desktop_serve_backend_still_blocks(monkeypatch, capsys):
     assert data["blocked"] is True
     assert [p["pid"] for p in data["processes"]] == [78]
     assert data["pausable_gateways"] == 0
+
+
+def test_main_classifies_gateway_from_live_cmdline_when_capture_is_truncated(
+    monkeypatch, capsys
+):
+    """Long managed-runtime paths must not hide the trailing gateway command."""
+    executable = (
+        "C:/Users/u/.hermes/hermes-agent/.hermes-runtime/python/"
+        "generation-1785179197-21284-2ba3099e/"
+        "cpython-3.11-windows-x86_64-none/python.exe"
+    )
+    argv = [executable, "-m", "hermes_cli.main", "gateway", "run"]
+    full_cmdline = " ".join(argv)
+    captured = full_cmdline[:120]
+    assert "gateway" not in captured
+
+    process = types.SimpleNamespace(cmdline=lambda: argv)
+    fake_psutil = types.SimpleNamespace(Process=lambda pid: process)
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+    import hermes_cli.main as cli_main
+
+    monkeypatch.setattr(
+        cli_main,
+        "_detect_venv_python_processes",
+        lambda: [(42, "python.exe", captured)],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    data = json.loads(capsys.readouterr().out)
+
+    assert excinfo.value.code == 0
+    assert data["blocked"] is False
+    assert data["processes"] == []
+    assert data["pausable_gateways"] == 1


### PR DESCRIPTION
## What does this PR do?

Fix the Windows Desktop update preflight incorrectly reporting a running Hermes
gateway as a non-pausable venv blocker when the gateway uses a long managed
runtime path.

`_detect_venv_python_processes()` intentionally caps captured command lines at
120 characters for display. A `.hermes-runtime` interpreter path can exceed
that limit before the trailing `-m hermes_cli.main gateway run` tokens. The
preflight therefore classified only the truncated prefix, failed to recognize
the process as a pausable gateway, and aborted the update before the CLI
updater could pause it.

The preflight now re-reads the process's live, complete argv only for gateway
classification. It keeps using the captured 120-character prefix for JSON and
diagnostic output. If the process exits or cannot be inspected, classification
fails closed and the holder remains a blocker.

## Related Issue

Fixes #78089.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `_is_pausable_gateway_process()` in
  `hermes_cli/_scan_venv_blockers.py` to classify a holder from its complete
  live argv when the captured prefix is insufficient.
- Preserve the existing bounded/redacted command line in preflight output.
- Preserve fail-closed behavior when process inspection fails.
- Classify each holder once and reuse the result for blocker output and the
  `pausable_gateways` count.
- Add a regression test using a managed-runtime path long enough to hide the
  trailing gateway command beyond character 120.

## Duplicate Check

Searched open and closed issues and PRs using the issue number, exact symbols,
the 120-character truncation, `venv-blocked`, and pausable-gateway terminology.
No PR addresses this root cause.

- #75881 introduced the pausable-gateway exemption that this fix makes reliable
  for long runtime paths.
- #78012 hardens probe error handling and per-process failures.
- #74599 improves Windows process-scan performance and updater handoff.
- #77418 handles gateways that respawn later during dependency synchronization.

Those changes are related but do not restore the full argv before the Desktop
preflight classifies the gateway.

## How to Test

1. Run the focused updater suites:

   ```bash
   scripts/run_tests.sh \
     tests/hermes_cli/test_scan_venv_blockers.py \
     tests/hermes_cli/test_update_venv_health.py \
     tests/hermes_cli/test_update_concurrent_quarantine.py
   ```

2. Confirm all 40 tests pass.
3. Run lint and the Windows compatibility scan:

   ```bash
   ruff check hermes_cli/_scan_venv_blockers.py \
     tests/hermes_cli/test_scan_venv_blockers.py
   python scripts/check-windows-footguns.py \
     hermes_cli/_scan_venv_blockers.py \
     tests/hermes_cli/test_scan_venv_blockers.py
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is covered by the helper docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
Before fix: 23 passed, 1 failed
After fix:  24 passed, 0 failed
Expanded updater suites: 40 passed, 0 failed
Ruff: All checks passed!
Windows footgun scan: No Windows footguns found (2 files scanned)
```
