### PR TITLE
fix(deps): patch npm audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7417,9 +7417,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13746,9 +13746,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16621,9 +16621,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17774,7 +17774,7 @@
         "ink-text-input": "6.0.0",
         "nanostores": "1.4.0",
         "react": "19.2.7",
-        "undici": "6.27.0",
+        "undici": "6.28.0",
         "unicode-animations": "1.0.3"
       },
       "devDependencies": {
@@ -17800,9 +17800,9 @@
       }
     },
     "ui-tui/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lodash": "4.18.1",
     "yauzl": "^3.3.1",
     "protobufjs": "^8.7.1",
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9"
   },
   "engines": {
     "node": ">=22.22.0",

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -25,7 +25,7 @@
     "ink-text-input": "6.0.0",
     "nanostores": "1.4.0",
     "react": "19.2.7",
-    "undici": "6.27.0",
+    "undici": "6.28.0",
     "unicode-animations": "1.0.3"
   },
   "overrides": {


### PR DESCRIPTION
## What does this PR do?

Patches the exact vulnerable npm dependency versions reported across the root, Web, and TUI audit scopes without using broad `npm audit fix` churn.

The TUI directly uses Undici's WebSocket path. No use of the affected retry, cache, cookie, or blob-body APIs was found. This keeps the remediation to patch releases and exact lockfile records.

## Related Issue

N/A — dependency advisory remediation discovered through `hermes doctor` and scoped `npm audit` output.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `package.json`: bump the root `brace-expansion` override from `5.0.8` to `5.0.9`.
- `ui-tui/package.json`: bump the direct `undici` dependency from `6.27.0` to `6.28.0`.
- `package-lock.json`: update the corresponding Undici 6.x and 7.x resolutions to `6.28.0` and `7.29.0` with their registry integrity values.
- No unrelated dependency or lockfile churn.

Resolved advisory records:

- GHSA-rgw5-rvv9-x895
- GHSA-4cwx-7wf7-3272
- GHSA-8xcm-r25x-g524
- GHSA-m8rv-5g2x-5cg5
- GHSA-v3r7-h72x-cjcm
- GHSA-jr45-8vmc-qm54

## How to Test

1. Run `npm ci --ignore-scripts`.
2. Run `npm audit --workspaces=false`, `npm audit --workspace web`, and `npm audit --workspace ui-tui`; each should report zero vulnerabilities.
3. Run TUI, Web, and Desktop typechecks/builds plus `npm test --workspace ui-tui -- src/__tests__/gatewayClient.test.ts`.

Observed verification:

- all three audit scopes: 0 vulnerabilities
- TUI, Web, and Desktop typechecks/builds: passed
- focused TUI gateway-client tests: 13/13 passed
- `git diff --check`: passed
- clean rebase onto current `main`

The broad TUI/Desktop suites have existing Windows-only POSIX/path/permissions/symlink/SSH-harness failures. Exact-base comparison reproduced the same 8 TUI and 17 Desktop failures, with zero new candidate failures.

The preferred Python CI-parity wrapper also completed on Windows but is not green on this platform: 464 failures across 179 files plus one collection error. The failures are outside the three changed npm files and include POSIX signals/devices, MSYS/native path conversion, symlink privileges, file permissions, shell/tool availability, and optional-dependency environment assumptions. The PR leaves the all-pass checkbox below unchecked; upstream Linux CI remains authoritative for that suite.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — `scripts/run_tests.sh` completed in an isolated `.[all,dev]` environment, but the current Windows baseline is not green (details above)
- [ ] I've added tests for my changes — N/A: dependency patch only; existing audit, lock consistency, typecheck, build, and gateway-client tests cover the affected surface
- [x] I've tested on my platform: Windows 10, Node v22.23.1, npm 10.9.8, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A; no user-facing behavior changed
- [x] I've updated `cli-config.yaml.example` — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact — dependency-only patch; Windows validation and exact-base comparisons completed
- [x] I've updated tool descriptions/schemas — N/A; no tool behavior changed

## Screenshots / Logs

```text
package-lock.json   | 26 +++++++++++++-------------
package.json        |  2 +-
ui-tui/package.json |  2 +-
3 files changed, 15 insertions(+), 15 deletions(-)
```
