### PR TITLE
fix(agent): filter ephemeral scaffolding from trajectory conversion

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -38,6 +38,7 @@ from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_res
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import STATUS_EXHAUSTED, credential_pool_matches_provider
 from agent.error_classifier import FailoverReason
+from run_agent import _is_ephemeral_scaffolding
 from agent.turn_context import drop_stale_api_content
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
 
@@ -163,7 +164,13 @@ def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_que
     
     while i < len(messages):
         msg = messages[i]
-        
+
+        # Skip ephemeral scaffolding (synthetic nudges, prefill sentinels, etc.)
+        # so they don't leak into saved trajectories as training data.
+        if _is_ephemeral_scaffolding(msg):
+            i += 1
+            continue
+
         if msg["role"] == "assistant":
             # Check if this message has tool calls
             if "tool_calls" in msg and msg["tool_calls"]:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -27,6 +27,7 @@ from agent.credential_pool import (
 )
 from agent.error_classifier import FailoverReason
 from agent.turn_context import drop_stale_api_content
+from agent.session_persistence import _is_ephemeral_scaffolding
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
 logger = logging.getLogger(__name__)
 
@@ -168,6 +169,13 @@ def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_que
     i = 1
     while i < len(messages):
         msg = messages[i]
+
+        # Skip ephemeral scaffolding (synthetic nudges, prefill sentinels, etc.)
+        # so they don't leak into saved trajectories as training data.
+        if _is_ephemeral_scaffolding(msg):
+            i += 1
+            continue
+
         if msg["role"] == "assistant":
             if msg.get("tool_calls"):
                 trajectory.append({"from": "gpt", "value": _trajectory_tool_call_turn(msg)})


### PR DESCRIPTION
## Problem

`convert_to_trajectory_format()` in `agent/agent_runtime_helpers.py` processes ALL messages in the conversation history when converting to trajectory format for saving. This includes synthetic nudges (internal recovery instructions) that carry ephemeral flags:

- `_verification_stop_synthetic` — "issue the actual tool call now" nudge from verify-on-stop
- `_pre_verify_synthetic` — nudge from pre_verify hook
- `_dropped_toolcall_nudge` — re-prompt for dropped tool calls
- `_kanban_stop_synthetic` — kanban worker stop-guard
- `_empty_recovery_synthetic` / `_empty_terminal_sentinel` — empty response recovery

These internal retry instructions leak into saved trajectories (`save_trajectories=True`) as if they were real user messages, polluting training data.

## Fix

Add `_is_ephemeral_scaffolding()` check at the top of the trajectory conversion loop. Any message carrying an ephemeral flag is skipped, mirroring the existing DB flush filter in `run_agent.py` (`_flush_messages_to_session_db` already strips these via `_is_ephemeral_scaffolding`).

## Test plan

- [x] `py_compile` — OK
- [x] `pytest tests/agent/test_verification_stop.py tests/agent/test_verification_stop_caching.py tests/run_agent/test_verification_continuation_budget.py tests/test_trajectory_compressor.py tests/test_trajectory_compressor_async.py` — 52 passed

## Related

- The `_EPHEMERAL_SCAFFOLDING_FLAGS` list and `_is_ephemeral_scaffolding()` function are defined in `run_agent.py` and already used by the DB flush path
- This PR extends the same filter to the trajectory conversion path