### PR TITLE
test(stream-consumer): fix intermittent CI failure from monotonic-epoch assumption

### DIFF
--- a/tests/gateway/test_stream_consumer_fresh_final.py
+++ b/tests/gateway/test_stream_consumer_fresh_final.py
@@ -11,6 +11,7 @@ time instead of first-token time.
 from __future__ import annotations
 
 import asyncio
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -39,6 +40,20 @@ def _make_adapter(*, supports_delete: bool = True) -> MagicMock:
     return adapter
 
 
+# ``stream_consumer`` measures preview age with ``time.monotonic()``, whose
+# epoch is arbitrary (on Linux, boot). Assigning ``_message_created_ts = 0.0``
+# therefore does NOT mean "long ago" -- it means "monotonic() seconds ago",
+# which on a freshly-booted CI runner can be only a few seconds. That made
+# these tests pass on a long-uptime dev box and fail intermittently in CI.
+# Anchor to the same clock the production code reads instead.
+_LONG_AGO_SECONDS = 3600.0
+
+
+def _stale_ts() -> float:
+    """A ``_message_created_ts`` that is unambiguously old on any host."""
+    return time.monotonic() - _LONG_AGO_SECONDS
+
+
 class TestFreshFinalForLongLivedPreviews:
     """openclaw#72038 port — send fresh final when preview is old."""
 
@@ -53,7 +68,7 @@ class TestFreshFinalForLongLivedPreviews:
         )
         await consumer._send_or_edit("hello")
         # Pretend the preview has been visible for a long time.
-        consumer._message_created_ts = 0.0  # far in the past
+        consumer._message_created_ts = _stale_ts()  # far in the past
         await consumer._send_or_edit("hello world", finalize=True)
         # Should edit, not send a fresh message.
         assert adapter.send.call_count == 1  # only the initial send
@@ -74,7 +89,7 @@ class TestFreshFinalForLongLivedPreviews:
             config=StreamConsumerConfig(fresh_final_after_seconds=60.0),
         )
         await consumer._send_or_edit("hello")
-        consumer._message_created_ts = 0.0
+        consumer._message_created_ts = _stale_ts()
         await consumer._send_or_edit("hello world", finalize=True)
         assert adapter.send.call_count == 2
         adapter.edit_message.assert_not_called()
@@ -206,7 +221,7 @@ class TestCancelledBestEffortDeliveryFinalizes:
         consumer.on_delta("Reply with **bold** and `code` markers.")
         task = asyncio.create_task(consumer.run())
         await asyncio.sleep(0.05)
-        consumer._message_created_ts = 0.0  # force the preview stale
+        consumer._message_created_ts = _stale_ts()  # force the preview stale
         task.cancel()
         await asyncio.gather(task, return_exceptions=True)
 


### PR DESCRIPTION
## The failure

`test_fresh_final_without_delete_support_is_best_effort` fails intermittently in CI:

```
>       assert adapter.send.call_count == 2
E       AssertionError: assert 1 == 2
tests/gateway/test_stream_consumer_fresh_final.py:79: AssertionError
```

## Root cause

`gateway/stream_consumer.py:1718` measures preview age as:

```python
age = time.monotonic() - self._message_created_ts
```

`time.monotonic()` counts from an **arbitrary epoch** — on Linux, boot. The tests set `_message_created_ts = 0.0` intending "long ago", but that actually means **"`monotonic()` seconds ago"**. On a freshly-booted CI runner `monotonic()` can be a handful of seconds, so `age` lands under the 60s threshold, fresh-final never fires, only the initial send happens, and the count is 1 instead of 2.

That's exactly why it reproduces only in CI. On a dev box with hours of uptime `monotonic()` is large and the test always passes — locally it was **83344.6**, so `age` was ~83344 and the assertion held comfortably.

## The fix

Anchor to the same clock the production code reads:

```python
def _stale_ts() -> float:
    """A ``_message_created_ts`` that is unambiguously old on any host."""
    return time.monotonic() - _LONG_AGO_SECONDS
```

Applied to all three sites in the file. The third (`fresh_final_after_seconds=0.0`) was benign because the threshold check short-circuits, but it carried the same fragile assumption and would bite if that config ever changed.

**No assertion was weakened and no production code changed** — the production behaviour is correct. Only the test's notion of "old" was wrong.

## Verification

With `time.monotonic` patched to `12.0`, simulating a host booted 12 seconds ago:

| | result |
|---|---|
| old test code | **FAILED** at `test_stream_consumer_fresh_final.py:79` — the exact CI failure, reproduced deterministically |
| new test code | **1 passed** |

Unpatched, the full file is **10/10**.

The arithmetic, for the record:

```
old: age = monotonic() - 0.0            = 12.0   -> > 60?  False  (fresh-final skipped)
new: age = monotonic() - _stale_ts()    = 3600.0 -> > 60?  True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
