### PR TITLE
fix(cron): skip non-script files in lifecycle guard script walk

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -177,6 +177,32 @@ def _resolve_terminal_script_path(candidate: str, cwd: Optional[str]) -> Path:
     return path
 
 
+def _looks_like_shell_script(path: Path) -> bool:
+    """True if *path* is plausibly a shell script (extension or shebang).
+
+    Absolute-path binaries (e.g. ``/usr/bin/python3``) are not scripts;
+    scanning their bytes is wasted work and risks false positives on binary
+    content (#76762). Extension-matched files always count; otherwise only
+    regular files whose first two bytes are a ``#!`` shebang do. Non-regular
+    or unreadable files fall through to the legacy scan so
+    ``_read_referenced_script`` keeps its fails-closed behaviour.
+    """
+    if path.suffix.lower() in {".sh", ".bash", ".zsh"}:
+        return True
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
+        descriptor = os.open(path, flags)
+    except OSError:
+        return True
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            return True
+        return os.read(descriptor, 2) == b"#!"
+    finally:
+        os.close(descriptor)
+
+
 def _iter_referenced_shell_scripts(
     command: str,
     *,
@@ -226,7 +252,9 @@ def _iter_referenced_shell_scripts(
         # (#77131). Skip pure-separator tokens.
         if executable.strip("/"):
             if "/" in executable or executable.endswith((".sh", ".bash", ".zsh")):
-                yield _resolve_terminal_script_path(executable, cwd)
+                candidate = _resolve_terminal_script_path(executable, cwd)
+                if _looks_like_shell_script(candidate):
+                    yield candidate
 
 
 def _iter_shell_command_payloads(command: str) -> Iterator[str]:

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -695,6 +695,28 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_absolute_path_extensionless_non_script_is_not_walked(self, tmp_path):
+        """#76762 follow-up: an absolute path to a non-script file (no .sh
+        extension, no shebang) is not treated as a referenced shell script,
+        so its bytes are never read and scanned.
+
+        Before this fix the walker yielded every path containing ``/``,
+        reading and re-tokenizing arbitrary files (logs, data, binaries) —
+        wasted I/O and a false-positive source.
+        """
+        from cron.lifecycle_guard import _iter_referenced_shell_scripts
+
+        non_script = tmp_path / "notes.txt"
+        non_script.write_text("hermes gateway stop\n")
+        walked = list(_iter_referenced_shell_scripts(str(non_script)))
+        assert walked == []
+
+        shebang = tmp_path / "tool"  # extensionless, but a real script
+        shebang.write_text("#!/bin/bash\necho hi\n")
+        shebang.chmod(0o700)
+        walked = list(_iter_referenced_shell_scripts(str(shebang)))
+        assert walked == [shebang]
+
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:
         a .sh script that itself invokes a lifecycle command is caught."""


### PR DESCRIPTION
## Summary

Follow-up to #76762 / #77332. The lifecycle guard's referenced-script walk
(`_iter_referenced_shell_scripts`) yields **every** token containing `/` as
a "referenced shell script", then reads and scans its bytes. For absolute
paths to non-scripts (binaries like `/usr/bin/python3`, logs, data files)
this is wasted I/O and a false-positive source — and it was the original
crash vector behind #76762.

This PR narrows the walk to files that actually look like shell scripts:
- extension match (`.sh` / `.bash` / `.zsh`), or
- a regular file with a `#!` shebang

Non-regular/unreadable paths fall through to the legacy scan so the
existing fails-closed behaviour (`_read_referenced_script`) is preserved.

## Changes

- `cron/lifecycle_guard.py`: add `_looks_like_shell_script()` and apply it
  in `_iter_referenced_shell_scripts`
- `tests/hermes_cli/test_gateway_restart_loop.py`: new test
  `test_absolute_path_extensionless_non_script_is_not_walked` asserting a
  `.txt` file is not walked while an extensionless shebang script still is

## Test

```
83 passed in 1.02s   (tests/hermes_cli/test_gateway_restart_loop.py)
```

Closes #76762 (completes the second proposed fix from the issue)
