### PR TITLE
fix(config): redirect platforms.<name>.<display_setting> to display.platforms.<name>.<setting> (#71047)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4979,6 +4979,27 @@ def set_config_value(key: str, value: str, force: bool = False):
                     file=sys.stderr,
                 )
                 sys.exit(1)
+    # ── Per-platform display-setting redirect (#71047, Problem A) ─────────
+    # `platforms.<name>.<setting>` is silently ignored by the runtime: the
+    # connection config (gateway/config.py) reads only token/extra/overrides
+    # from the top-level `platforms.<name>` block, while per-platform *display*
+    # settings (streaming, show_reasoning, tool_progress, …) are resolved from
+    # `display.platforms.<name>.<setting>` (gateway/display_config.py). Without
+    # this redirect a write such as `hermes config set platforms.telegram.streaming
+    # false` lands on a key the gateway never reads, so the edit is invisible.
+    # Redirect ONLY known display settings (OVERRIDEABLE_KEYS), leaving real
+    # connection keys (token, extra, channel_overrides, …) untouched.
+    _plat_seg = key.split(".")
+    if len(_plat_seg) == 3 and _plat_seg[0] == "platforms":
+        try:
+            from gateway.display_config import OVERRIDEABLE_KEYS as _DISPLAY_KEYS
+        except Exception:
+            _DISPLAY_KEYS = frozenset()
+        if _plat_seg[2] in _DISPLAY_KEYS:
+            _display_key = f"display.platforms.{_plat_seg[1]}.{_plat_seg[2]}"
+            print(f"  (note: per-platform display setting — saved as {_display_key})")
+            key = _display_key
+
     _set_nested(user_config, key, value)
     # Normalize the api_base → base_url alias at set-time too (issue #8919),
     # so a fresh `hermes config set model.api_base ...` lands on the canonical

--- a/tests/hermes_cli/test_config_set_platforms_redirect.py
+++ b/tests/hermes_cli/test_config_set_platforms_redirect.py
@@ -1,0 +1,95 @@
+"""Regression tests for #71047 (Problem A): per-platform display settings.
+
+`hermes config set platforms.<name>.<display_setting> <value>` must write to
+`display.platforms.<name>.<display_setting>` — the path the gateway actually
+reads (gateway/display_config.py::resolve_display_setting). Writing to the
+top-level `platforms.<name>` block is silently ignored by the runtime, so the
+edit appeared to succeed while having no effect.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def _write_config(hermes_home: Path, data: dict) -> Path:
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(yaml.dump(data))
+    return config_path
+
+
+def _set(monkeypatch, hermes_home, key, value, force=False):
+    """Isolated call to set_config_value against a temp HERMES_HOME."""
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    # set_config_value resolves the home live via get_config_path()/get_hermes_home()
+    from hermes_cli.config import set_config_value
+    set_config_value(key, value, force=force)
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    # A config that already has a top-level platforms block (connection keys)
+    # AND a display.platforms block, mirroring the real-world report.
+    cfg = {
+        "model": {"default": "test-model", "provider": "openrouter"},
+        "platforms": {
+            "telegram": {"token": "secret-bot-token"},
+        },
+        "display": {
+            "skin": "default",
+            "platforms": {
+                "telegram": {"show_reasoning": True},
+            },
+        },
+    }
+    _write_config(home, cfg)
+    return home
+
+
+class TestPerPlatformDisplayRedirect:
+    def test_streaming_redirects_to_display_platforms(self, hermes_home, monkeypatch):
+        """platforms.telegram.streaming must land under display.platforms."""
+        _set(monkeypatch, hermes_home, "platforms.telegram.streaming", "false")
+
+        result = yaml.safe_load((hermes_home / "config.yaml").read_text())
+        # Redirected target exists and is correct
+        assert result["display"]["platforms"]["telegram"]["streaming"] is False
+        # Top-level platforms.telegram must NOT gain a streaming key
+        assert "streaming" not in result["platforms"]["telegram"]
+        # Connection key untouched
+        assert result["platforms"]["telegram"]["token"] == "secret-bot-token"
+
+    def test_show_reasoning_redirects(self, hermes_home, monkeypatch):
+        _set(monkeypatch, hermes_home, "platforms.telegram.show_reasoning", "false")
+        result = yaml.safe_load((hermes_home / "config.yaml").read_text())
+        assert result["display"]["platforms"]["telegram"]["show_reasoning"] is False
+
+    def test_tool_progress_redirects(self, hermes_home, monkeypatch):
+        # ``off`` is coerced to False by the bool-aware coercion in
+        # set_config_value; gateway/display_config._normalise turns False back
+        # into the canonical "off" string at read time, so the persisted value
+        # is the bool.
+        _set(monkeypatch, hermes_home, "platforms.discord.tool_progress", "off")
+        result = yaml.safe_load((hermes_home / "config.yaml").read_text())
+        assert result["display"]["platforms"]["discord"]["tool_progress"] is False
+
+    def test_connection_key_not_redirected(self, hermes_home, monkeypatch):
+        """A real connection key (token) stays in top-level platforms.<name>."""
+        _set(monkeypatch, hermes_home, "platforms.telegram.token", "new-token")
+        result = yaml.safe_load((hermes_home / "config.yaml").read_text())
+        assert result["platforms"]["telegram"]["token"] == "new-token"
+        # Nothing leaked into display.platforms.telegram.token
+        assert "token" not in result["display"]["platforms"]["telegram"]
+
+    def test_no_top_level_platforms_created_when_missing(self, tmp_path, monkeypatch):
+        """When there is no pre-existing top-level platforms block, a display
+        setting write must not invent one."""
+        home = tmp_path / ".hermes"
+        _write_config(home, {"model": {"default": "m"}})
+        _set(monkeypatch, home, "platforms.telegram.streaming", "true")
+        result = yaml.safe_load((home / "config.yaml").read_text())
+        assert result["display"]["platforms"]["telegram"]["streaming"] is True
+        assert "platforms" not in result  # no stray top-level platforms block


### PR DESCRIPTION
## Summary

Fixes **Problem A** of #71047: `hermes config set platforms.<name>.<display_setting> <value>` writes to a key the runtime never reads, so the edit appears to succeed while having no effect.

Root cause: the gateway reads per-platform **display** settings (streaming, show_reasoning, tool_progress, …) from `display.platforms.<name>.<setting>` (see `gateway/display_config.py::resolve_display_setting`), while the top-level `platforms.<name>` block holds only connection config (token, extra, channel_overrides). `set_config_value` wrote the dotted path verbatim, so `platforms.telegram.streaming` landed in the connection block and was silently ignored by the loader.

This mirrors the existing set-time alias/redirect pattern already in `set_config_value` (`model.api_base → model.base_url`, bare `model → model.default`).

## Fix

In `hermes_cli/config.py::set_config_value`, before the write, redirect a `platforms.<name>.<setting>` key to `display.platforms.<name>.<setting>` **only** when `<setting>` is a known per-platform display setting (`gateway.display_config.OVERRIDEABLE_KEYS`). Real connection keys (`token`, `extra`, `channel_overrides`, …) are left untouched. The `gateway.display_config` import is lazy/try-guarded to avoid a circular import (`gateway/config.py` already imports `hermes_cli.config`) and to keep the CLI working in minimal installs where `gateway` is not importable.

## Scope

This PR addresses **only Problem A** (the config-set duplicate/mis-targeted key). Problem B (Telegram streaming resend duplication) is a separate runtime issue and intentionally out of scope here, per the triage recommendation to keep the fix focused.

## Test plan

- Added `tests/hermes_cli/test_config_set_platforms_redirect.py`:
  - `platforms.telegram.streaming false` → `display.platforms.telegram.streaming: false` (bool-coerced), and no stray `streaming` key under the top-level `platforms.telegram` connection block.
  - `platforms.telegram.show_reasoning` / `platforms.discord.tool_progress` redirect correctly.
  - A real connection key (`platforms.telegram.token`) is **not** redirected.
  - When no top-level `platforms` block exists, the redirect does not invent one — it writes only `display.platforms...`.

```
hermes config set platforms.telegram.streaming false
# (note: per-platform display setting — saved as display.platforms.telegram.streaming)
✓ Set display.platforms.telegram.streaming = False in ~/.hermes/config.yaml
```

Closes #71047 (Problem A)
