### PR TITLE
fix(desktop): keep popped-out pet on-screen and never click-capturing when blank

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -217,6 +217,7 @@ import {
   MIN_WIDTH as WINDOW_MIN_WIDTH
 } from './window-state'
 import { hiddenWindowsChildOptions } from './windows-child-options'
+import { resolvePetOverlayBounds } from './pet-overlay'
 import {
   buildPathExtCandidates,
   chooseUpdaterArgs,
@@ -9031,6 +9032,49 @@ function closePetOverlay() {
   petOverlayWindow = null
 }
 
+// Re-home the popped-out pet after a display change: if the overlay still sits
+// on a connected display it stays put; otherwise it is re-centered on the main
+// window's display (see resolvePetOverlayBounds). The corrected spot is pushed
+// back to the renderer via the existing 'bounds' control channel, which it
+// persists for the next pop-out/restart.
+function rehomePetOverlay() {
+  if (!petOverlayWindow || petOverlayWindow.isDestroyed()) {
+    return
+  }
+
+  let anchor = null
+
+  try {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      anchor = mainWindow.getContentBounds()
+    }
+  } catch {
+    // Resolve falls back to the primary display when the anchor is unknown.
+  }
+
+  const current = petOverlayWindow.getBounds()
+  const resolved = resolvePetOverlayBounds(current, screen.getAllDisplays(), anchor)
+
+  if (!resolved) {
+    return
+  }
+
+  if (
+    resolved.x === current.x &&
+    resolved.y === current.y &&
+    resolved.width === current.width &&
+    resolved.height === current.height
+  ) {
+    return
+  }
+
+  petOverlayWindow.setBounds(resolved)
+
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('hermes:pet-overlay:control', { type: 'bounds', bounds: resolved })
+  }
+}
+
 // ── Quick Entry ─────────────────────────────────────────────────────────────
 //
 // A global shortcut summons a small frameless always-on-top composer from
@@ -9599,6 +9643,26 @@ ipcMain.handle('hermes:pet-overlay:open', async (_event, request) => {
     }
   } catch {
     // Fall back to raw bounds if the window geometry is unavailable.
+  }
+
+  // A remembered/dragged spot is only trusted while it still lands on a
+  // connected display — otherwise the transparent, non-activating overlay
+  // would open off-screen (e.g. saved on an external monitor that has since
+  // been unplugged) and the pet would be unfindable. Re-center on the main
+  // window's display instead, and echo the corrected bounds so the renderer
+  // persists the on-screen spot (self-healing).
+  if (screenBounds) {
+    let anchor = null
+
+    try {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        anchor = mainWindow.getContentBounds()
+      }
+    } catch {
+      // Resolve falls back to the primary display when the anchor is unknown.
+    }
+
+    screenBounds = resolvePetOverlayBounds(screenBounds, screen.getAllDisplays(), anchor) ?? screenBounds
   }
 
   openPetOverlay(screenBounds)
@@ -11844,6 +11908,18 @@ app.whenReady().then(() => {
 
     screen.on('display-removed', reposition)
   }
+
+  // The popped-out pet must never be stranded on a disconnected display: when
+  // the topology changes, pull an off-screen overlay back onto the display
+  // that holds the main window (and persist the corrected spot). Unlike the
+  // wake indicator this applies on every platform — the pet overlay exists
+  // everywhere, and rehomePetOverlay is a cheap no-op while the pet is in the
+  // window or still on-screen.
+  screen.on('display-added', rehomePetOverlay)
+
+  screen.on('display-metrics-changed', rehomePetOverlay)
+
+  screen.on('display-removed', rehomePetOverlay)
 
   createWindow()
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8899,6 +8899,12 @@ const wakeIndicatorController = createWakeIndicatorWindowController({
 // pushes pet state over IPC (hermes:pet-overlay:state); the overlay just renders
 // it. Control flows back (pop-in, composer submit) via hermes:pet-overlay:control.
 let petOverlayWindow = null
+// Set while a close is in flight: Electron's close() is async and can be
+// aborted on macOS, so the window may still be alive after closePetOverlay().
+// openPetOverlay must never reuse (or leave) a closing window — otherwise two
+// overlays can coexist and the orphaned one, rendering nothing, becomes an
+// invisible mouse-enabled transparent region that eats desktop clicks.
+let petOverlayClosing = false
 
 function petOverlayUrl() {
   if (DEV_SERVER) {
@@ -8961,6 +8967,17 @@ function spawnPetOverlayWindow(bounds) {
   win.setAlwaysOnTop(true, IS_MAC ? 'floating' : 'screen-saver')
   win.setHiddenInMissionControl?.(true)
 
+  // The overlay is a transparent rectangle; only the sprite pixels should be
+  // interactive. The renderer toggles click-through as the cursor enters/
+  // leaves the sprite (hermes:pet-overlay:ignore-mouse), but the window MUST
+  // start click-through from the main process: if the overlay page is slow to
+  // load, blank, or its renderer has died, a mouse-enabled transparent window
+  // sits over the desktop eating clicks (the invisible "dead zone" bug). The
+  // wake indicator already uses this spawn-time ignore pattern. forward:true
+  // keeps mousemove flowing to the page so the renderer can re-arm
+  // interactivity the moment the cursor touches a solid sprite pixel.
+  win.setIgnoreMouseEvents(true, { forward: true })
+
   try {
     // Electron docs: macOS may transform process type on each
     // setVisibleOnAllWorkspaces() call unless skipTransformProcessType=true,
@@ -8986,6 +9003,8 @@ function spawnPetOverlayWindow(bounds) {
   })
 
   win.on('closed', () => {
+    petOverlayClosing = false
+
     if (petOverlayWindow === win) {
       petOverlayWindow = null
     }
@@ -9004,7 +9023,7 @@ function spawnPetOverlayWindow(bounds) {
 }
 
 function openPetOverlay(bounds) {
-  if (petOverlayWindow && !petOverlayWindow.isDestroyed()) {
+  if (petOverlayWindow && !petOverlayWindow.isDestroyed() && !petOverlayClosing) {
     if (bounds) {
       petOverlayWindow.setBounds({
         x: Math.round(bounds.x),
@@ -9019,6 +9038,14 @@ function openPetOverlay(bounds) {
     return petOverlayWindow
   }
 
+  // A previous close was requested but never finished (close() can be aborted
+  // on macOS) — force the stale window down before spawning a replacement so
+  // two overlays can never coexist.
+  if (petOverlayWindow && !petOverlayWindow.isDestroyed()) {
+    petOverlayWindow.destroy()
+  }
+
+  petOverlayClosing = false
   petOverlayWindow = spawnPetOverlayWindow(bounds)
 
   return petOverlayWindow
@@ -9026,10 +9053,13 @@ function openPetOverlay(bounds) {
 
 function closePetOverlay() {
   if (petOverlayWindow && !petOverlayWindow.isDestroyed()) {
+    petOverlayClosing = true
     petOverlayWindow.close()
   }
 
-  petOverlayWindow = null
+  // The 'closed' handler nulls petOverlayWindow and clears the flag — do NOT
+  // null here: an open() racing a slow/aborted close would otherwise spawn a
+  // second overlay while the first is still on screen (see petOverlayClosing).
 }
 
 // Re-home the popped-out pet after a display change: if the overlay still sits
@@ -9038,7 +9068,7 @@ function closePetOverlay() {
 // back to the renderer via the existing 'bounds' control channel, which it
 // persists for the next pop-out/restart.
 function rehomePetOverlay() {
-  if (!petOverlayWindow || petOverlayWindow.isDestroyed()) {
+  if (!petOverlayWindow || petOverlayWindow.isDestroyed() || petOverlayClosing) {
     return
   }
 
@@ -9069,6 +9099,10 @@ function rehomePetOverlay() {
   }
 
   petOverlayWindow.setBounds(resolved)
+  // Re-assert click-through after a display-driven move so a re-home can never
+  // leave a mouse-enabled transparent region behind (same bug class as the
+  // spawn-time default above).
+  petOverlayWindow.setIgnoreMouseEvents(true, { forward: true })
 
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.webContents.send('hermes:pet-overlay:control', { type: 'bounds', bounds: resolved })

--- a/apps/desktop/electron/pet-overlay.test.ts
+++ b/apps/desktop/electron/pet-overlay.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for the pet-overlay geometry helpers. These cover the logic that
+ * protects the popped-out pet: a remembered spot on a since-unplugged monitor
+ * must never strand the overlay off-screen (the "pet vanished" bug), and a
+ * live re-home must leave an on-screen pet alone.
+ */
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { resolvePetOverlayBounds } from './pet-overlay'
+
+// A laptop panel left behind after a bigger external monitor is unplugged.
+const LAPTOP = [{ workArea: { x: 0, y: 0, width: 1366, height: 728 } }]
+// External monitor to the right of the laptop panel, now disconnected.
+const LAPTOP_PLUS_EXTERNAL = [
+  { workArea: { x: 0, y: 0, width: 1366, height: 728 } },
+  { workArea: { x: 1366, y: 0, width: 1920, height: 1040 } }
+]
+
+const ANCHOR_ON_LAPTOP = { x: 100, y: 80, width: 1200, height: 700 }
+const ANCHOR_ON_EXTERNAL = { x: 1400, y: 100, width: 1200, height: 700 }
+
+const PET_BOUNDS = { x: 200, y: 150, width: 300, height: 400 }
+
+// ─── sanity / garbage ──────────────────────────────────────────────────────
+
+test('resolvePetOverlayBounds returns null for missing or garbage input', () => {
+  assert.equal(resolvePetOverlayBounds(null, LAPTOP, ANCHOR_ON_LAPTOP), null)
+  assert.equal(resolvePetOverlayBounds(undefined, LAPTOP, ANCHOR_ON_LAPTOP), null)
+  assert.equal(
+    resolvePetOverlayBounds({ x: NaN, y: 0, width: 100, height: 100 }, LAPTOP, ANCHOR_ON_LAPTOP),
+    null
+  )
+  assert.equal(
+    resolvePetOverlayBounds({ x: 0, y: 0, width: 'wide', height: 100 }, LAPTOP, ANCHOR_ON_LAPTOP),
+    null
+  )
+})
+
+test('resolvePetOverlayBounds returns requested unchanged with no displays to validate against', () => {
+  assert.equal(resolvePetOverlayBounds(PET_BOUNDS, null, ANCHOR_ON_LAPTOP), PET_BOUNDS)
+  assert.equal(resolvePetOverlayBounds(PET_BOUNDS, [], ANCHOR_ON_LAPTOP), PET_BOUNDS)
+})
+
+// ─── on-screen trust ───────────────────────────────────────────────────────
+
+test('an on-screen saved spot is used as-is', () => {
+  assert.deepEqual(resolvePetOverlayBounds(PET_BOUNDS, LAPTOP, ANCHOR_ON_LAPTOP), PET_BOUNDS)
+})
+
+test('a spot on any connected display is used as-is, even if not the anchor display', () => {
+  const onExternal = { x: 1400, y: 200, width: 300, height: 400 }
+
+  assert.deepEqual(resolvePetOverlayBounds(onExternal, LAPTOP_PLUS_EXTERNAL, ANCHOR_ON_LAPTOP), onExternal)
+})
+
+test('a spot with only a sliver of overlap (below MIN_VISIBLE) is treated as off-screen', () => {
+  // 300px-wide window parked so only 30px of it is inside the laptop panel —
+  // less than the 48px MIN_VISIBLE the main window's restore path trusts.
+  const sliver = { x: -270, y: 150, width: 300, height: 400 }
+
+  const resolved = resolvePetOverlayBounds(sliver, LAPTOP, ANCHOR_ON_LAPTOP)
+
+  assert.notDeepEqual(resolved, sliver)
+  assert.equal(resolved.x, Math.round((1366 - 300) / 2))
+  assert.equal(resolved.y, Math.round((728 - 400) / 2))
+})
+
+// ─── off-screen re-home ────────────────────────────────────────────────────
+
+test('a spot remembered on a since-unplugged external monitor is re-centered on the anchor display', () => {
+  // Saved while the external was connected (x 1366+); only the laptop remains.
+  const stale = { x: 1500, y: 400, width: 300, height: 400 }
+
+  const resolved = resolvePetOverlayBounds(stale, LAPTOP, ANCHOR_ON_LAPTOP)
+
+  assert.deepEqual(resolved, {
+    x: Math.round((1366 - 300) / 2),
+    y: Math.round((728 - 400) / 2),
+    width: 300,
+    height: 400
+  })
+})
+
+test('re-home centers on the display holding the anchor (main window), not the primary', () => {
+  const stale = { x: -800, y: 400, width: 300, height: 400 }
+
+  const resolved = resolvePetOverlayBounds(stale, LAPTOP_PLUS_EXTERNAL, ANCHOR_ON_EXTERNAL)
+
+  assert.deepEqual(resolved, {
+    x: Math.round(1366 + (1920 - 300) / 2),
+    y: Math.round((1040 - 400) / 2),
+    width: 300,
+    height: 400
+  })
+})
+
+test('re-home falls back to the primary display when the anchor is missing', () => {
+  const stale = { x: 1500, y: 400, width: 300, height: 400 }
+
+  const resolved = resolvePetOverlayBounds(stale, LAPTOP, null)
+
+  assert.deepEqual(resolved, {
+    x: Math.round((1366 - 300) / 2),
+    y: Math.round((728 - 400) / 2),
+    width: 300,
+    height: 400
+  })
+})
+
+test('re-homed size is capped to the target work area', () => {
+  const huge = { x: 1500, y: 400, width: 2000, height: 1500 }
+
+  const resolved = resolvePetOverlayBounds(huge, LAPTOP, ANCHOR_ON_LAPTOP)
+
+  assert.deepEqual(resolved, {
+    x: 0,
+    y: 0,
+    width: 1366,
+    height: 728
+  })
+})
+
+// ─── live re-home (display unplugged while the pet is popped out) ──────────
+
+test('a still-on-screen pet is left exactly where it is', () => {
+  assert.deepEqual(resolvePetOverlayBounds(PET_BOUNDS, LAPTOP, ANCHOR_ON_LAPTOP), PET_BOUNDS)
+})
+
+test('a pet stranded by an unplugged display is pulled back onto the anchor display', () => {
+  const stranded = { x: 1500, y: 400, width: 300, height: 400 }
+
+  const resolved = resolvePetOverlayBounds(stranded, LAPTOP, ANCHOR_ON_LAPTOP)
+
+  assert.deepEqual(resolved, {
+    x: Math.round((1366 - 300) / 2),
+    y: Math.round((728 - 400) / 2),
+    width: 300,
+    height: 400
+  })
+})

--- a/apps/desktop/electron/pet-overlay.ts
+++ b/apps/desktop/electron/pet-overlay.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure geometry helpers for the popped-out pet overlay — deciding where its
+ * window may open and where it must be re-homed when the display topology
+ * changes. Side-effect-free so the on-screen validation is unit-testable
+ * without booting Electron; main.ts owns the live `screen` displays, the
+ * anchor window, and the overlay window itself.
+ *
+ * The bug this exists for: the renderer remembers the overlay's absolute
+ * screen position (localStorage hermes.desktop.pet-overlay-bounds.v1) and
+ * reuses it verbatim on the next pop-out / app restart. If that spot was on an
+ * external monitor that has since been unplugged, the overlay is created
+ * off-screen — and because it is a transparent, frameless, non-activating
+ * always-on-top panel hidden from Mission Control, an off-screen overlay is
+ * completely unfindable: the pet "vanishes." The main window's restore path
+ * already solves this class of problem (see window-state.ts `onScreen`); the
+ * overlay must apply the same rule, plus re-home itself while open.
+ */
+
+import { MIN_VISIBLE, onScreen } from './window-state'
+
+// Below this, a pet window is too small to be useful — mirrors the floor
+// enforced in main.ts's spawnPetOverlayWindow.
+const MIN_SIZE = 80
+
+/**
+ * Resolve where the pet-overlay window should open. Trusts `requested` screen
+ * bounds when they still intersect some connected display (the same
+ * ≥ MIN_VISIBLE overlap rule the main window's restore path uses), so a spot
+ * remembered on a since-unplugged monitor can never strand the pet off-screen.
+ *
+ * When the requested spot is off-screen the window is re-centered on the
+ * display holding `anchor` (the main window's content bounds — where the user
+ * actually is), falling back to the primary display when the anchor is
+ * missing. Size is capped to the target display's work area so a spot saved on
+ * a since-disconnected bigger monitor can't exceed any screen the user now
+ * has.
+ *
+ * Returns null for missing/garbage input (main falls back to its defaults);
+ * returns `requested` unchanged when there is nothing to validate against.
+ */
+export function resolvePetOverlayBounds(requested, displays, anchor) {
+  if (!requested) {
+    return null
+  }
+
+  const { x, y, width, height } = requested
+
+  if (![x, y, width, height].every(Number.isFinite)) {
+    return null
+  }
+
+  const list = Array.isArray(displays) ? displays : []
+
+  if (!list.length) {
+    return requested
+  }
+
+  if (onScreen({ x, y, width, height }, list)) {
+    return requested
+  }
+
+  const area = workAreaForAnchor(list, anchor)
+
+  if (!area) {
+    return requested
+  }
+
+  const cappedWidth = Math.max(MIN_SIZE, Math.min(Math.round(width), Math.round(area.width)))
+  const cappedHeight = Math.max(MIN_SIZE, Math.min(Math.round(height), Math.round(area.height)))
+
+  return {
+    x: Math.round(area.x + (area.width - cappedWidth) / 2),
+    y: Math.round(area.y + (area.height - cappedHeight) / 2),
+    width: cappedWidth,
+    height: cappedHeight
+  }
+}
+
+// The work area of the display whose bounds contain the anchor's center (the
+// display the main window sits on), or the first display when the anchor is
+// missing/unknown. Null when there are no usable displays at all.
+function workAreaForAnchor(displays, anchor) {
+  if (
+    anchor &&
+    Number.isFinite(anchor.x) &&
+    Number.isFinite(anchor.y) &&
+    Number.isFinite(anchor.width) &&
+    Number.isFinite(anchor.height)
+  ) {
+    const cx = anchor.x + anchor.width / 2
+    const cy = anchor.y + anchor.height / 2
+    const containing = displays.find(({ workArea: a }) => {
+      if (!a) {
+        return false
+      }
+
+      return cx >= a.x && cx < a.x + a.width && cy >= a.y && cy < a.y + a.height
+    })
+
+    if (containing?.workArea) {
+      return containing.workArea
+    }
+  }
+
+  return displays.find(({ workArea: a }) => a)?.workArea ?? null
+}


### PR DESCRIPTION
## What does this PR do?

Two fixes for the popped-out pet — the transparent, frameless, always-on-top overlay window that Shift-clicking the in-window pet opens. Both fix invisible-window failure modes: the pet either *vanishes* (opened off-screen) or *eats clicks* (a transparent mouse-enabled region sitting over the desktop).

### 1. Off-screen spawn after a monitor unplug (commit `34c975d57`)

The overlay restores and re-opens at the last remembered absolute screen position with **no validation against the currently connected displays**. When that spot was on an external monitor that has since been unplugged, the overlay is created off-screen. Because the overlay is a non-activating panel that is hidden from Mission Control and has no taskbar presence, an off-screen overlay is completely unfindable: the pet simply vanishes until the display is reconnected. The main window's restore path already guards against this (`window-state.ts` `onScreen`); the pet overlay was the one window that skipped the check.

- A remembered/dragged spot is only trusted while it still intersects a connected display's work area (the same ≥ `MIN_VISIBLE` 48px-overlap rule as the main window). Otherwise the overlay is re-centered on the display holding the main window — where the user actually is — and the corrected bounds are echoed back to the renderer, which persists them (self-healing: the stale stored spot is replaced on first use).
- On display topology changes (`display-added` / `display-metrics-changed` / `display-removed`), an open overlay stranded off-screen by an unplugged monitor is pulled back onto the main window's display, and the corrected position is persisted via the existing `bounds` control channel.
- Size is capped to the target work area, so a spot saved on a since-disconnected larger monitor can't exceed any screen the user now has.

### 2. Invisible click-capturing region ("dead zone") (commit `013c9f536`)

The overlay's click-through relied **entirely** on the renderer toggling `setIgnoreMouseEvents` as the cursor entered/left the sprite. If the overlay page is slow to load, blank, or its renderer has died, the window keeps the default mouse-enabled state — an invisible transparent region that captures clicks: clicks there never reach the app below and raise the Hermes window instead (symptom: a "dead zone" where the pet first appeared, even after dragging the pet away). A second overlay window could also appear when a macOS `close()` was slow/aborted while `petOverlayWindow` was already nulled (a subsequent open then spawned a replacement alongside the still-visible original).

- The overlay now spawns with `setIgnoreMouseEvents(true, { forward: true })` — the pattern the wake indicator already uses — so it can **never** capture clicks until the renderer explicitly re-arms interactivity over solid sprite pixels. `forward: true` keeps mousemove flowing to the page so the renderer re-arms the moment the cursor touches the pet.
- Click-through is re-asserted after display-driven re-home moves.
- A `petOverlayClosing` flag tracks close-in-flight: `openPetOverlay` never reuses a closing window and force-destroys a stale one before spawning a replacement, so two overlays can never coexist.

All geometry logic lives in a new side-effect-free module (`electron/pet-overlay.ts`) in the same style as `window-state.ts` / `quick-entry.ts`, so it is unit-testable without booting Electron.

## Related Issue

No existing issue filed — reported from a local install. Complementary to (not conflicting with) open PR #75307, which persists overlay bounds across restarts but does not validate them against connected displays.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/pet-overlay.ts` (new) — pure geometry helpers: `resolvePetOverlayBounds()` validates a requested spot against the current displays and re-centers on the anchor display's work area when off-screen.
- `apps/desktop/electron/pet-overlay.test.ts` (new) — 11 unit tests: garbage/null input, no-display fallback, on-screen trust, sub-`MIN_VISIBLE` sliver rejection, external-monitor-unplugged re-center, anchor-display preference over primary, primary fallback, work-area capping, and live re-home no-op vs. re-center.
- `apps/desktop/electron/main.ts` — validate + echo bounds in the `hermes:pet-overlay:open` handler; `rehomePetOverlay()` registered on `screen` `display-added` / `display-metrics-changed` / `display-removed` (all platforms — the pet overlay exists on Windows/Linux too; the wake indicator's macOS-only listener is unchanged); spawn the overlay click-through by default; re-assert click-through on re-home; `petOverlayClosing` open/close hardening so two overlays can never coexist.

## How to Test

1. `cd apps/desktop && npx vitest run electron/pet-overlay.test.ts electron/window-state.test.ts` — all pass.
2. Manual repro (macOS): with two displays connected, pop the pet out (Shift-click) and drag it onto the external monitor; quit Hermes; unplug the external monitor; relaunch → the pet must reappear on the remaining display (previously it opened off-screen and was unfindable).
3. Pop the pet out while the external monitor is unplugged → it must open near the main window instead of vanishing.
4. Unplug the external monitor while the pet is popped out on it → the pet is re-homed onto the remaining display.
5. Pop the pet out, drag it away, then kill the overlay page (DevTools → force-crash it): the original spot must pass clicks straight through to the app below — no dead zone, even with a dead overlay renderer.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] Commit messages follow Conventional Commits (`fix(desktop): keep popped-out pet on-screen after a monitor unplug`, `fix(desktop): never let a blank pet-overlay window capture clicks`)
- [x] Searched existing PRs — no duplicate; adjacent overlay work in #75307 is complementary (see Related Issue)
- [x] PR contains **only** changes related to this fix
- [ ] `pytest tests/ -q` — desktop-only change; the affected suites are the vitest runs above (full CI covers the rest)
- [x] Tests added for the fix
- [x] Tested on platform: macOS 12.7.3 (iMac) + macOS (M1 MacBook), Hermes desktop app

### Documentation & Housekeeping

- [x] Documentation — N/A (bug fix, no user-facing docs change)
- [x] `cli-config.yaml.example` — N/A (no config keys added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — display listeners intentionally registered on all platforms since the pet overlay exists on Windows/Linux too; macOS panel behavior verified
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

N/A — window-geometry bug; covered by unit tests and the manual repro steps above. (Diagnosis used CDP + CGWindowList on the affected machine: the ghost was a 500×500 normal-level blank overlay window at the pet's initial spot, while localStorage `hermes.desktop.pet-overlay-bounds.v1` held the real overlay bounds.)