### PR TITLE
fix(install): fall back to GitHub when the uv installer host is blocked

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -1242,6 +1242,16 @@ def repair_vulnerable_runtime(
 # ---------------------------------------------------------------------------
 
 
+_UV_INSTALLER_URLS_POSIX = (
+    "https://astral.sh/uv/install.sh",
+    "https://github.com/astral-sh/uv/releases/latest/download/uv-installer.sh",
+)
+_UV_INSTALLER_URLS_WINDOWS = (
+    "https://astral.sh/uv/install.ps1",
+    "https://github.com/astral-sh/uv/releases/latest/download/uv-installer.ps1",
+)
+
+
 def _install_uv(target: Path) -> None:
     """Bootstrap uv into *target* using the official standalone installer.
 
@@ -1266,16 +1276,23 @@ def _install_uv(target: Path) -> None:
 
 
 def _install_uv_posix(env: dict[str, str]) -> None:
-    """Download + sh the POSIX installer (two-stage to avoid curl|sh pitfalls)."""
+    """Download + sh the POSIX installer from either official source."""
     with tempfile.NamedTemporaryFile(suffix=".sh", delete=False) as f:
         installer_path = f.name
 
     try:
-        subprocess.run(
-            ["curl", "-LsSf", "https://astral.sh/uv/install.sh", "-o", installer_path],
-            check=True,
-            capture_output=True,
-        )
+        for installer_url in _UV_INSTALLER_URLS_POSIX:
+            try:
+                subprocess.run(
+                    ["curl", "-LsSf", installer_url, "-o", installer_path],
+                    check=True,
+                    capture_output=True,
+                )
+            except subprocess.CalledProcessError:
+                if installer_url == _UV_INSTALLER_URLS_POSIX[-1]:
+                    raise
+            else:
+                break
         subprocess.run(
             ["sh", installer_path],
             env=env,
@@ -1290,14 +1307,21 @@ def _install_uv_posix(env: dict[str, str]) -> None:
 
 
 def _install_uv_windows(env: dict[str, str]) -> None:
-    """Invoke the PowerShell installer."""
-    cmd = "irm https://astral.sh/uv/install.ps1 | iex"
-    subprocess.run(
-        ["powershell", "-ExecutionPolicy", "Bypass", "-c", cmd],
-        env=env,
-        check=True,
-        capture_output=True,
-    )
+    """Invoke the PowerShell installer from either official source."""
+    for installer_url in _UV_INSTALLER_URLS_WINDOWS:
+        cmd = f"$ErrorActionPreference = 'Stop'; irm {installer_url} | iex"
+        try:
+            subprocess.run(
+                ["powershell", "-ExecutionPolicy", "Bypass", "-c", cmd],
+                env=env,
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError:
+            if installer_url == _UV_INSTALLER_URLS_WINDOWS[-1]:
+                raise
+        else:
+            return
 
 
 def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> bool:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -482,7 +482,13 @@ function Install-Uv {
         # than a bare `powershell`, which isn't guaranteed to be on PATH under
         # PowerShell 7 / pwsh-only setups.
         $psHostExe = Get-PowerShellHostExe
-        & $psHostExe -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex" 2>&1 | Out-Null
+        & $psHostExe -ExecutionPolicy ByPass -c "`$ErrorActionPreference = 'Stop'; irm https://astral.sh/uv/install.ps1 | iex" 2>&1 | Out-Null
+        if (-not (Test-Path $managedUv)) {
+            # Some corporate proxies block astral.sh while allowing the
+            # identical official installer asset hosted on uv's GitHub release.
+            Write-Warn "Primary uv installer source failed; retrying from GitHub..."
+            & $psHostExe -ExecutionPolicy ByPass -c "`$ErrorActionPreference = 'Stop'; irm https://github.com/astral-sh/uv/releases/latest/download/uv-installer.ps1 | iex" 2>&1 | Out-Null
+        }
         $ErrorActionPreference = $prevEAP
 
         if (Test-Path $managedUv) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -572,11 +572,22 @@ install_uv() {
     # Two-stage: download the installer, then run it.  Piping
     # `curl | sh` masks curl failures (sh exits 0 on empty stdin)
     # and conflates network errors with installer errors.
-    local _uv_install_log _uv_installer
+    local _uv_install_log _uv_installer _uv_installer_url
+    local _uv_installer_downloaded=0
     _uv_install_log="$(mktemp 2>/dev/null || echo "/tmp/hermes-uv-install.$$.log")"
     _uv_installer="$(mktemp 2>/dev/null || echo "/tmp/hermes-uv-installer.$$.sh")"
-    if ! curl -LsSf https://astral.sh/uv/install.sh -o "$_uv_installer" 2>"$_uv_install_log"; then
-        log_error "Failed to download uv installer from https://astral.sh/uv/install.sh"
+    for _uv_installer_url in \
+        "https://astral.sh/uv/install.sh" \
+        "https://github.com/astral-sh/uv/releases/latest/download/uv-installer.sh"
+    do
+        if curl -LsSf "$_uv_installer_url" -o "$_uv_installer" 2>>"$_uv_install_log"; then
+            _uv_installer_downloaded=1
+            break
+        fi
+        log_warn "Could not download uv installer from $_uv_installer_url; trying fallback..."
+    done
+    if [ "$_uv_installer_downloaded" -ne 1 ]; then
+        log_error "Failed to download uv installer from official sources"
         log_info "curl output:"
         sed 's/^/    /' "$_uv_install_log" >&2
         log_info "Install manually: https://docs.astral.sh/uv/getting-started/installation/"

--- a/tests/test_uv_installer_source_fallback.py
+++ b/tests/test_uv_installer_source_fallback.py
@@ -1,0 +1,91 @@
+"""Installer entry points must tolerate either official uv script host failing."""
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+PRIMARY_PS1 = "https://astral.sh/uv/install.ps1"
+FALLBACK_PS1 = (
+    "https://github.com/astral-sh/uv/releases/latest/download/uv-installer.ps1"
+)
+PRIMARY_SH = "https://astral.sh/uv/install.sh"
+FALLBACK_SH = (
+    "https://github.com/astral-sh/uv/releases/latest/download/uv-installer.sh"
+)
+
+
+def test_managed_uv_posix_retries_official_github_source(monkeypatch):
+    import hermes_cli.managed_uv as managed_uv
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[0] == "curl" and "astral.sh" in cmd[2]:
+            raise subprocess.CalledProcessError(22, cmd)
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(managed_uv.subprocess, "run", fake_run)
+
+    managed_uv._install_uv_posix({})
+
+    download_urls = [cmd[2] for cmd in calls if cmd[0] == "curl"]
+    assert download_urls == [PRIMARY_SH, FALLBACK_SH]
+    assert calls[-1][0] == "sh"
+
+
+def test_managed_uv_windows_retries_official_github_source(monkeypatch):
+    import hermes_cli.managed_uv as managed_uv
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if "astral.sh" in cmd[-1]:
+            raise subprocess.CalledProcessError(1, cmd)
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(managed_uv.subprocess, "run", fake_run)
+
+    managed_uv._install_uv_windows({})
+
+    commands = [cmd[-1] for cmd in calls]
+    assert commands == [
+        f"$ErrorActionPreference = 'Stop'; irm {PRIMARY_PS1} | iex",
+        f"$ErrorActionPreference = 'Stop'; irm {FALLBACK_PS1} | iex",
+    ]
+
+
+def test_windows_installer_retries_github_when_primary_did_not_install_uv():
+    source = INSTALL_PS1.read_text(encoding="utf-8")
+    install_uv = source.split("function Install-Uv", 1)[1].split(
+        "function Sync-EnvPath", 1
+    )[0]
+
+    assert PRIMARY_PS1 in install_uv
+    assert FALLBACK_PS1 in install_uv
+    assert install_uv.index(PRIMARY_PS1) < install_uv.index(FALLBACK_PS1)
+    assert "if (-not (Test-Path $managedUv))" in install_uv
+    invocation_lines = [
+        line
+        for line in install_uv.splitlines()
+        if "uv/install.ps1 | iex" in line or "uv-installer.ps1 | iex" in line
+    ]
+    assert len(invocation_lines) == 2
+    assert all("$ErrorActionPreference = 'Stop';" in line for line in invocation_lines)
+
+
+def test_posix_installer_tries_both_official_sources_before_failing():
+    source = INSTALL_SH.read_text(encoding="utf-8")
+    install_uv = source.split("install_uv()", 1)[1].split("check_python()", 1)[0]
+
+    assert PRIMARY_SH in install_uv
+    assert FALLBACK_SH in install_uv
+    assert install_uv.index(PRIMARY_SH) < install_uv.index(FALLBACK_SH)
+    assert "for _uv_installer_url in" in install_uv
+    assert 'curl -LsSf "$_uv_installer_url"' in install_uv


### PR DESCRIPTION
## Summary

Fix uv installation on networks where `astral.sh` is blocked by retrying the official installer from GitHub Releases.

Fixes #69216.

## Root cause

Hermes fetched the uv installer script exclusively from `astral.sh`. On corporate or filtered networks where that host is unavailable, `uv.exe` was never installed and setup could not continue.

The uv project also publishes the same official installer through GitHub Releases, but Hermes did not use it as a fallback.

## Changes

- Retry the official GitHub release installer when the primary source fails.
- Cover all three affected paths:
  - Windows PowerShell installer
  - POSIX shell installer
  - Managed uv bootstrap used by Hermes updates
- Make PowerShell download errors terminating so the fallback actually runs.
- Preserve the existing managed installation location and two-stage POSIX download behavior.
- Add regression tests for source ordering and fallback behavior.

## Duplicate check

Checked open and closed issues and PRs by issue number, installer URLs, `astral.sh`, and fallback-related terms immediately before opening this PR.

- #69366 only exposes suppressed installer errors; it does not provide another download source.
- #69374 attempted to locate uv in alternate directories and was closed because that premise did not match the reported failure.
- No open or closed PR implements the official GitHub installer-source fallback.

## Validation

- 19 targeted tests passed
- PowerShell AST parsing passed
- `bash -n scripts/install.sh` passed
- Ruff passed
- Windows footgun checks passed
- Both primary and fallback `.ps1` and `.sh` URLs returned HTTP 200
