### PR TITLE
fix(stt): reject structured transcription errors (#78098)

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -13,6 +13,8 @@ import types
 import wave
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
+from types import SimpleNamespace
+
 
 import pytest
 
@@ -205,6 +207,31 @@ class TestTranscribeGroq:
 # ============================================================================
 # _transcribe_openai — additional tests
 # ============================================================================
+
+def test_openai_transcription_error_object_is_not_returned_as_text(
+    monkeypatch,
+    sample_wav,
+):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    mock_client = MagicMock()
+    mock_client.audio.transcriptions.create.return_value = SimpleNamespace(
+        text=None,
+        error="Transcription failed",
+    )
+
+    with (
+        patch("tools.transcription_tools._HAS_OPENAI", True),
+        patch("openai.OpenAI", return_value=mock_client),
+    ):
+        from tools.transcription_tools import _transcribe_openai
+
+        result = _transcribe_openai(sample_wav, "gpt-4o-transcribe")
+
+    assert result["success"] is False
+    assert result["transcript"] == ""
+    assert "Transcription failed" in result["error"]
+    assert "text=None" not in result["error"]
+
 
 class TestTranscribeLocalCommand:
     def test_command_provider_uses_sanitized_child_env(self, monkeypatch):
@@ -928,6 +955,19 @@ class TestExtractTranscriptText:
 
         assert result == "The user literally said <asr_text> while reading markup."
 
+    def test_rejects_structured_error_instead_of_stringifying_repr(self):
+        from tools.transcription_tools import _extract_transcript_text
+
+        transcription = SimpleNamespace(
+            text=None,
+            logprobs=None,
+            usage=None,
+            error="Transcription failed",
+        )
+
+        with pytest.raises(ValueError, match="Transcription failed"):
+            _extract_transcript_text(transcription)
+
 
 # Shell safety — shlex.split on auto-detected templates
 # ============================================================================
@@ -1159,7 +1199,7 @@ class TestTranscribeCredentialReadGuard:
         from agent.file_safety import get_read_block_error
 
         env_file = tmp_path / ".env"
-        env_file.write_text("OPENAI_API_KEY=sk-secret\n")
+        env_file.write_text("OPENAI_API_KEY=sk-secret\n", encoding="utf-8")
 
         expected = get_read_block_error(str(env_file))
         assert expected, "test setup: a .env file should be read-blocked"

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2988,19 +2988,32 @@ def _resolve_openai_audio_client_config() -> tuple[str, str]:
 def _extract_transcript_text(transcription: Any) -> str:
     """Normalize text and JSON transcription responses to a plain string."""
     text: Optional[str] = None
+    structured_response = False
 
     if isinstance(transcription, str):
         text = transcription.strip()
 
     if text is None and hasattr(transcription, "text"):
+        structured_response = True
         value = getattr(transcription, "text")
         if isinstance(value, str):
             text = value.strip()
 
     if text is None and isinstance(transcription, dict):
+        structured_response = True
         value = transcription.get("text")
         if isinstance(value, str):
             text = value.strip()
+
+    if text is None and structured_response:
+        error = (
+            transcription.get("error")
+            if isinstance(transcription, dict)
+            else getattr(transcription, "error", None)
+        )
+        if error:
+            raise ValueError(str(error))
+        return ""
 
     if text is None:
         text = str(transcription).strip()


### PR DESCRIPTION
## What does this PR do?

Fixes #78098 by preventing structured STT error objects from becoming user
message text.

An OpenAI-compatible transcription response can be a structured object with
`text=None` and an explicit provider error. Current `main` falls through to
`str(transcription)`, treats the Python representation as a successful
transcript, and sends it as the user's message.

Structured responses now:

- raise their explicit provider error through the existing transcription
  failure path; or
- return an empty transcript when they contain neither text nor an error.

Plain strings and unknown scalar response types preserve existing behavior.

## Current-main reproduction

Verified against `origin/main` at `87fd0ed25` using the same two regression
tests added by this PR:

```text
scripts/run_tests.sh tests/tools/test_transcription_tools.py \
  -k 'openai_transcription_error_object_is_not_returned_as_text or rejects_structured_error_instead_of_stringifying_repr' -q

# current main production code: 2 failed
# this PR: 2 passed
```

On current `main`, `_transcribe_openai()` reports `success=True`, and
`_extract_transcript_text()` does not raise for the structured provider error.

## End-to-end validation

Independent native validation on this PR traced the reported object through
`_extract_transcript_text` -> `_transcribe_openai` -> the web transcription
endpoint -> Desktop conversation mode. The PR converts that path to the
existing HTTP 400/error-toast flow while preserving successful plain-string,
object-with-text, dict-with-text, and silent-empty responses.

## Verification

```text
scripts/run_tests.sh tests/tools/test_transcription_tools.py \
  -k 'openai_transcription_error_object_is_not_returned_as_text or rejects_structured_error_instead_of_stringifying_repr or ExtractTranscriptText' -q
# 4 passed

uv run ruff check tools/transcription_tools.py tests/tools/test_transcription_tools.py
# All checks passed

.venv/bin/python scripts/check-windows-footguns.py --diff origin/main
# No Windows footguns found

git diff --check
# passed
```

The complete transcription test file reports 51 passed and one unrelated
faster-whisper configuration assertion failure. That exact failure reproduces
on current `main` (`compute_type` is `int8`, while the stale assertion expects
`float32`).

## Scope

- No Desktop-side change is required.
- No provider routing or model selection behavior changes.
- No change to valid transcript normalization.
