### PR TITLE
fix(disk-cleanup): don't raise on oversized or permission-blocked path args

### DIFF
--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -71,11 +71,19 @@ def _drain(task_id: str, session_id: str) -> Set[str]:
 
 def _attempt_track(path_str: str, task_id: str, session_id: str) -> None:
     """Best-effort auto-track. Never raises."""
+    # Reject absurd inputs before touching the filesystem: a garbage path arg
+    # (e.g. a multi-line blob from a confused model) can exceed NAME_MAX and
+    # make even stat() raise ENAMETOOLONG. Cheap guard, avoids the syscall.
+    if not isinstance(path_str, str) or not path_str or len(path_str) > 1024:
+        return
     try:
         p = Path(path_str).expanduser()
-    except Exception:
-        return
-    if not p.exists():
+        # exists()/resolve() can raise OSError for over-long components
+        # (ENAMETOOLONG) or permission-blocked parents (EACCES/EPERM) —
+        # e.g. /var/db/ConfigurationProfiles/Store on macOS. Swallow all.
+        if not p.exists():
+            return
+    except (OSError, ValueError, RuntimeError):
         return
     category = dg.guess_category(p)
     if category is None:

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -327,6 +327,46 @@ class TestPostToolCallHook:
         assert not tracked_file.exists() or tracked_file.read_text().strip() == "[]"
 
 
+    def test_oversized_path_arg_does_not_raise(self, _isolate_env):
+        """Regression: a garbage multi-line ``path`` arg must not blow up the
+        post_tool_call hook with ENAMETOOLONG (Errno 63).
+
+        During provider outages the model can emit a blob (file listings,
+        newline-separated paths) as the ``path`` argument. The component
+        exceeds NAME_MAX, so even ``Path.exists()`` raises ``OSError`` — which
+        previously escaped the hook and spammed the error log.
+        """
+        pi = _load_plugin_init()
+        blob = "/Slang.doc\n---\n" + "\n".join(
+            f"/Users/hermes/Desktop/node_modules/pkg_{i}/deep/deep/deep/x" for i in range(60)
+        )
+        # Must not raise.
+        pi._on_post_tool_call(
+            tool_name="write_file",
+            args={"path": blob, "content": "x"},
+            result="OK",
+            task_id="t5", session_id="s5",
+        )
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        assert not tracked_file.exists() or tracked_file.read_text().strip() == "[]"
+
+
+    def test_permission_blocked_path_does_not_raise(self, _isolate_env):
+        """Regression: paths whose stat() is blocked by macOS TCC/sandbox
+        (EACCES/EPERM, e.g. /var/db/ConfigurationProfiles/Store) must not
+        escape the hook either."""
+        pi = _load_plugin_init()
+        # Must not raise — even when the path is not tracked.
+        pi._on_post_tool_call(
+            tool_name="write_file",
+            args={"path": "/var/db/ConfigurationProfiles/Store", "content": "x"},
+            result="OK",
+            task_id="t6", session_id="s6",
+        )
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        assert not tracked_file.exists() or tracked_file.read_text().strip() == "[]"
+
+
 class TestOnSessionEndHook:
     def test_runs_quick_when_test_files_tracked(self, _isolate_env):
         pi = _load_plugin_init()


### PR DESCRIPTION
## Bug Description

The `disk-cleanup` plugin's `post_tool_call` hook (`_attempt_track`) can throw, despite its "Never raises" contract, spamming the gateway error log:

```
WARNING hermes_cli.plugins: Hook 'post_tool_call' callback _on_post_tool_call raised:
[Errno 63] File name too long: '/Slang.doc\n---\n/Users/hermes/Desktop\n/Users/hermes/Desktop/victorramon-site/node_modules\n...'
```

and variants:

```
[Errno 13] Permission denied: '/Users/gamingtriad/.hermes/:'
[Errno 1] Operation not permitted: '/var/db/ConfigurationProfiles/Store'
```

Observed during a provider outage (DeepSeek 503 storm) when the model emitted a garbage multi-line blob as the `path` argument to `write_file`/`patch`.

## Root Cause

`_attempt_track()` wraps only `Path(path_str).expanduser()` in its try/except; the very next line, `p.exists()`, is **outside** the guard. `Path.exists()` performs a `stat()`:

- A path arg whose component exceeds `NAME_MAX` (255 bytes) — e.g. a multi-line file-listing blob passed as `path` — raises `OSError` `ENAMETOOLONG` (Errno 63).
- Paths blocked by macOS TCC/sandbox permissions (e.g. `/var/db/ConfigurationProfiles/Store`) raise `EACCES`/`EPERM` (Errno 13/1).

Any of these escape the hook and break the "never raises" promise, flooding the log with tracebacks on every offending tool call.

## Fix

- **Input guard**: reject non-str, empty, or `>1024`-char `path_str` before any filesystem touch — a cheap way to skip absurd blobs without even calling `stat()`.
- **Guard the syscall**: move `p.exists()` inside the `try`, catching `(OSError, ValueError, RuntimeError)` so the hook genuinely never raises.

## How to Verify

1. Run `pytest tests/plugins/test_disk_cleanup_plugin.py` — 29 tests pass (27 existing + 2 new).
2. New `test_oversized_path_arg_does_not_raise`: feeds a multi-line path blob to `_on_post_tool_call` (the exact Errno-63 pattern from production logs) and asserts no raise.
3. New `test_permission_blocked_path_does_not_raise`: feeds `/var/db/ConfigurationProfiles/Store` (Errno-13 pattern) and asserts no raise.
4. Normal tracking still works: `test_write_file_test_pattern_tracked` and `test_terminal_command_picks_up_paths` pass unchanged.

## Test Plan

- [x] Added regression tests for both failure classes (ENAMETOOLONG blob, EACCES path)
- [x] Existing tests still pass (29 passed in 0.57s)
- [x] Manual verification: replayed both failing inputs from the production log against the patched `_attempt_track` — swallowed cleanly, no raise

## Risk Assessment

Low — the change only broadens the exceptions swallowed inside a best-effort auto-track hook (it already documented "Never raises" as its contract). Legitimate tracked paths under `HERMES_HOME`/`/tmp/hermes-*` are unaffected; the 1024-char guard only rejects inputs that could never be valid tracked files.
