### PR TITLE
fix(a2a): close forwarded-session DB connections on errors

### DIFF
--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -43,6 +43,7 @@ import urllib.request
 from collections import deque
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FuturesTimeout
+from contextlib import closing
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Dict, Optional
 
@@ -807,13 +808,12 @@ class A2AAdapter(BasePlatformAdapter):
         if not db or not os.path.exists(db):
             return ""
         try:
-            con = sqlite3.connect(db, timeout=5)
-            row = con.execute(
-                "SELECT id FROM sessions WHERE title = ? ORDER BY started_at DESC LIMIT 1",
-                (title,),
-            ).fetchone()
-            con.close()
-            return str(row[0]) if row else ""
+            with closing(sqlite3.connect(db, timeout=5)) as con:
+                row = con.execute(
+                    "SELECT id FROM sessions WHERE title = ? ORDER BY started_at DESC LIMIT 1",
+                    (title,),
+                ).fetchone()
+                return str(row[0]) if row else ""
         except Exception:
             logger.debug("A2A: could not lookup forwarded session", exc_info=True)
             return ""
@@ -823,13 +823,12 @@ class A2AAdapter(BasePlatformAdapter):
         if not db or not os.path.exists(db):
             return ""
         try:
-            con = sqlite3.connect(db, timeout=5)
-            row = con.execute(
-                "SELECT id FROM sessions WHERE source = 'a2a' AND started_at >= ? ORDER BY started_at DESC LIMIT 1",
-                (started_after - 2.0,),
-            ).fetchone()
-            con.close()
-            return str(row[0]) if row else ""
+            with closing(sqlite3.connect(db, timeout=5)) as con:
+                row = con.execute(
+                    "SELECT id FROM sessions WHERE source = 'a2a' AND started_at >= ? ORDER BY started_at DESC LIMIT 1",
+                    (started_after - 2.0,),
+                ).fetchone()
+                return str(row[0]) if row else ""
         except Exception:
             logger.debug("A2A: could not find latest forwarded session", exc_info=True)
             return ""
@@ -839,10 +838,9 @@ class A2AAdapter(BasePlatformAdapter):
         if not db or not os.path.exists(db) or not session_id:
             return
         try:
-            con = sqlite3.connect(db, timeout=5)
-            con.execute("UPDATE sessions SET title = ? WHERE id = ?", (title, session_id))
-            con.commit()
-            con.close()
+            with closing(sqlite3.connect(db, timeout=5)) as con:
+                con.execute("UPDATE sessions SET title = ? WHERE id = ?", (title, session_id))
+                con.commit()
         except Exception:
             logger.debug("A2A: could not title forwarded session", exc_info=True)
 

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -1570,6 +1570,49 @@ class TestV1SpecRegressionFixes:
         assert "one" in adapter._agents
         assert "two" not in adapter._agents
 
+    @pytest.mark.parametrize(
+        ("helper_name", "helper_args"),
+        [
+            ("_lookup_forward_session", ("dev", "session-title")),
+            ("_latest_a2a_session", ("dev", 0.0)),
+            ("_title_forward_session", ("dev", "session-id", "session-title")),
+        ],
+    )
+    def test_profile_session_helpers_close_connection_on_query_error(
+        self,
+        helper_name,
+        helper_args,
+        monkeypatch,
+        tmp_path,
+    ):
+        from plugins.platforms.a2a import adapter as adapter_module
+        from gateway.config import PlatformConfig
+
+        class FailingConnection:
+            closed = False
+
+            def execute(self, *_args, **_kwargs):
+                raise RuntimeError("query failed")
+
+            def close(self):
+                self.closed = True
+
+        db_path = tmp_path / "state.db"
+        db_path.touch()
+        connection = FailingConnection()
+        monkeypatch.setattr(
+            adapter_module.sqlite3,
+            "connect",
+            lambda *_args, **_kwargs: connection,
+        )
+
+        adapter = adapter_module.A2AAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_profile_state_db", lambda _profile: str(db_path))
+
+        getattr(adapter, helper_name)(*helper_args)
+
+        assert connection.closed is True
+
     def test_forward_to_profile_first_contact_creates_then_resumes_fake_hermes(self, monkeypatch, tmp_path):
         from plugins.platforms.a2a.adapter import A2AAdapter
         from gateway.config import PlatformConfig


### PR DESCRIPTION
## What does this PR do?

The A2A adapter's forwarded-session lookup and title helpers opened SQLite
connections that were closed only on the success path. If a query or commit
raised, the helpers caught the error and returned, leaving the connection open.
Repeated transient `state.db` failures in a long-running multi-agent gateway
could therefore accumulate file descriptors.

This change scopes each connection with `contextlib.closing`, so it is released
on successful returns and on every exception path without changing the helpers'
existing best-effort behavior.

## Related Issue

N/A - found during a resource-lifecycle audit of the A2A profile forwarding
path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/a2a/adapter.py`: close forwarded-session SQLite
  connections deterministically in all three lookup/title helpers.
- `tests/plugins/test_a2a_plugin.py`: add parameterized regression coverage
  proving each helper closes its connection when a query fails.

## How to Test

1. Run:
   `python -m pytest -q tests/plugins/test_a2a_plugin.py tests/plugins/test_a2a_phase23.py`
2. Confirm: `154 passed, 17 deselected`.
3. Run:
   `python -m ruff check plugins/platforms/a2a/adapter.py tests/plugins/test_a2a_plugin.py`
4. Confirm: `All checks passed!`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing behavior or configuration changed
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: `contextlib.closing` and SQLite are portable
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

Focused regression before the fix: `3 failed`.

Focused regression after the fix: `3 passed`.

Full A2A plugin suites: `154 passed, 17 deselected`.
