### PR TITLE
feat(desktop): add hermes-achievements as a native desktop plugin

### DIFF
--- a/apps/desktop/src/contrib/hermes-achievements-plugin.test.tsx
+++ b/apps/desktop/src/contrib/hermes-achievements-plugin.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Registration contract for the bundled hermes-achievements plugin — the
+ * wiring receipt: the plugin registers its page, sidebar nav, statusbar chip,
+ * and palette command through the SDK's contribution registry, scoped to its
+ * own namespace, and ships opt-in (`defaultEnabled: false`).
+ *
+ * Lives in `contrib/` (not the plugin dir) because the plugin fence lets
+ * plugin code import only the SDK — this test exercises the contract through
+ * the same host machinery the loader uses.
+ */
+
+import {
+  PALETTE_AREA,
+  ROUTES_AREA,
+  SIDEBAR_NAV_AREA,
+  STATUSBAR_AREAS
+} from '@hermes/plugin-sdk'
+import { describe, expect, it } from 'vitest'
+
+import plugin from '../plugins/hermes-achievements/plugin'
+
+import { createPluginContext } from './plugin'
+import { registry } from './registry'
+
+function register() {
+  const disposers: Array<() => void> = []
+  const ctx = createPluginContext(plugin.id, dispose => disposers.push(dispose))
+  plugin.register(ctx)
+
+  return disposers
+}
+
+describe('hermes-achievements plugin registration', () => {
+  it('ships opt-in (off until the user enables it in Settings ▸ Plugins)', () => {
+    expect(plugin.id).toBe('hermes-achievements')
+    expect(plugin.defaultEnabled).toBe(false)
+  })
+
+  it('registers the page, nav row, statusbar chip, and palette command', () => {
+    const disposers = register()
+
+    const areas = {
+      page: registry.getArea(ROUTES_AREA),
+      nav: registry.getArea(SIDEBAR_NAV_AREA),
+      statusbar: registry.getArea(STATUSBAR_AREAS.right),
+      palette: registry.getArea(PALETTE_AREA)
+    }
+
+    expect(areas.page.map(c => c.id)).toContain('hermes-achievements:page')
+    expect(areas.page.find(c => c.id === 'hermes-achievements:page')?.data).toMatchObject({ path: '/achievements' })
+
+    expect(areas.nav.map(c => c.id)).toContain('hermes-achievements:nav')
+    expect(areas.nav.find(c => c.id === 'hermes-achievements:nav')?.data).toMatchObject({ path: '/achievements' })
+
+    expect(areas.statusbar.map(c => c.id)).toContain('hermes-achievements:score')
+    expect(areas.palette.map(c => c.id)).toContain('hermes-achievements:open')
+
+    // The contribution batch, the i18n bundle, and the bindApi cleanup each
+    // tracked a disposer — deactivate must tear all of them down.
+    expect(disposers.length).toBe(3)
+  })
+
+  it('unregisters everything when the plugin deactivates', () => {
+    const disposers = register()
+    disposers.forEach(dispose => dispose())
+
+    expect(registry.getArea(ROUTES_AREA).map(c => c.id)).not.toContain('hermes-achievements:page')
+    expect(registry.getArea(SIDEBAR_NAV_AREA).map(c => c.id)).not.toContain('hermes-achievements:nav')
+    expect(registry.getArea(STATUSBAR_AREAS.right).map(c => c.id)).not.toContain('hermes-achievements:score')
+    expect(registry.getArea(PALETTE_AREA).map(c => c.id)).not.toContain('hermes-achievements:open')
+  })
+})

--- a/apps/desktop/src/plugins/README.md
+++ b/apps/desktop/src/plugins/README.md
@@ -4,7 +4,9 @@ Drop a `<name>/plugin.{ts,tsx}` here that default-exports a `HermesPlugin` and
 it registers automatically at boot (vite glob in `../contrib/plugins.ts`), with
 the same inventory + live enable/disable contract as runtime plugins.
 
-None ship in-tree today — reference/demo plugins (the counter example, the
+Real opt-in plugins ship in-tree: `kanban/` and `hermes-achievements/` — both
+`defaultEnabled: false`, so they inventory in Settings ▸ Plugins off until the
+user flips the switch. Reference/demo plugins (the counter example, the
 gateway-pill 1:1 rebuild, the runtime-loader hello world) live in the companion
 [`hermes-example-plugins`](https://github.com/NousResearch/hermes-example-plugins)
 repo so the shipped app stays uncluttered.

--- a/apps/desktop/src/plugins/hermes-achievements/api.test.ts
+++ b/apps/desktop/src/plugins/hermes-achievements/api.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { achievementsKey, bindApi, fetchAchievements, rescanAchievements } from './api'
+
+describe('achievements api', () => {
+  it('rejects until the rest door is bound', async () => {
+    const unsub = bindApi(vi.fn())
+    unsub()
+    await expect(fetchAchievements()).rejects.toThrow('not bound')
+  })
+
+  it('fetches the achievements payload through the bound door', async () => {
+    const rest = vi.fn().mockResolvedValue({ unlocked_count: 36, total_count: 60 })
+    bindApi(rest)
+
+    const data = await fetchAchievements()
+
+    expect(rest).toHaveBeenCalledWith('/achievements')
+    expect(data.unlocked_count).toBe(36)
+    expect(data.total_count).toBe(60)
+  })
+
+  it('posts a rescan through the bound door', async () => {
+    const rest = vi.fn().mockResolvedValue({ ok: true })
+    bindApi(rest)
+
+    await rescanAchievements()
+
+    expect(rest).toHaveBeenCalledWith('/rescan', { method: 'POST' })
+  })
+
+  it('uses a stable query key', () => {
+    expect(achievementsKey()).toEqual(['hermes-achievements', 'all'])
+  })
+})

--- a/apps/desktop/src/plugins/hermes-achievements/api.ts
+++ b/apps/desktop/src/plugins/hermes-achievements/api.ts
@@ -1,0 +1,49 @@
+/**
+ * Achievements data layer. Everything goes through `ctx.rest` — the plugin's
+ * own `/api/plugins/hermes-achievements/*` FastAPI router
+ * (`plugins/hermes-achievements/dashboard/plugin_api.py`), reused as-is via
+ * the desktop's namespace-scoped REST door. No new backend.
+ *
+ * Fetching, caching, polling, dedupe, and invalidation are React Query's job
+ * (the app's standard, via the SDK). This module owns the query keys and the
+ * REST calls.
+ */
+
+import { type PluginRestOptions, queryClient } from '@hermes/plugin-sdk'
+
+import type { AchievementFilter, AchievementsResponse } from './types'
+
+type Rest = <T>(path: string, opts?: PluginRestOptions) => Promise<T>
+
+let rest: null | Rest = null
+
+export const achievementsKey = (filter?: AchievementFilter) => ['hermes-achievements', filter ?? 'all'] as const
+
+/** Bind the plugin's REST door at register time and return a disposer the host
+ *  runs on unload/disable — so no stale reference survives a toggle. */
+export function bindApi(r: Rest): () => void {
+  rest = r
+
+  return () => {
+    rest = null
+  }
+}
+
+/** Fetch the full evaluated achievements payload. */
+export function fetchAchievements(): Promise<AchievementsResponse> {
+  if (!rest) {
+    return Promise.reject(new Error('achievements rest door not bound'))
+  }
+
+  return rest<AchievementsResponse>('/achievements')
+}
+
+/** Trigger a forced backend rescan, then invalidate the shared cache. */
+export async function rescanAchievements(): Promise<void> {
+  if (!rest) {
+    throw new Error('achievements rest door not bound')
+  }
+
+  await rest<{ ok: boolean }>('/rescan', { method: 'POST' })
+  await queryClient.invalidateQueries({ queryKey: ['hermes-achievements'] })
+}

--- a/apps/desktop/src/plugins/hermes-achievements/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-achievements/i18n.ts
@@ -1,0 +1,126 @@
+/**
+ * Plugin-scoped i18n for hermes-achievements — bundles shipped under the
+ * plugin id via ctx.i18n.register (#67303), never touching core en.ts.
+ * `useAchievementsI18n()` binds `t` to the message SHAPE so components keep
+ * typed `k.scoreUnlocked` / `k.nextTier(tier, n)` access (same pattern as
+ * kanban's `useKanban`).
+ */
+
+import { type PluginLocaleBundles, type PluginTranslate, usePluginI18n } from '@hermes/plugin-sdk'
+import { useMemo } from 'react'
+
+type AchievementsMessages = {
+  nav: string
+  openCommand: string
+  pageTitle: string
+  scoreUnlocked: string
+  discovered: string
+  secret: string
+  scanned: (when: string) => string
+  stale: string
+  rescan: string
+  scanning: string
+  retry: string
+  loadFailed: string
+  loadFailedHint: string
+  filterAll: string
+  filterUnlocked: string
+  filterDiscovered: string
+  filterSecret: string
+  emptyTitle: string
+  emptyBody: string
+  whatCounts: string
+  hideWhatCounts: string
+  evidenceFrom: (title: string) => string
+  nextTier: (tier: string, threshold: number) => string
+  maxTier: string
+  secretName: string
+  secretDescription: string
+  scoreTip: (unlocked: number, total: number) => string
+}
+
+const en: AchievementsMessages = {
+  nav: 'Achievements',
+  openCommand: 'Achievements: Open',
+  pageTitle: 'Achievements',
+  scoreUnlocked: 'unlocked',
+  discovered: 'discovered',
+  secret: 'secret',
+  scanned: when => `scanned ${when}`,
+  stale: 'stale',
+  rescan: 'Rescan',
+  scanning: 'Scanning…',
+  retry: 'Retry',
+  loadFailed: 'Could not load achievements',
+  loadFailedHint: 'is the achievements plugin enabled?',
+  filterAll: 'All',
+  filterUnlocked: 'Unlocked',
+  filterDiscovered: 'Discovered',
+  filterSecret: 'Secret',
+  emptyTitle: 'No achievements here',
+  emptyBody: 'Nothing in this state yet — keep using Hermes.',
+  whatCounts: 'What counts?',
+  hideWhatCounts: 'Hide what counts',
+  evidenceFrom: title => `evidence: ${title}`,
+  nextTier: (tier, threshold) => `next: ${tier} · ${threshold}`,
+  maxTier: 'max tier',
+  secretName: '???',
+  secretDescription: 'Secret achievement — hidden until the first matching signal appears.',
+  scoreTip: (unlocked, total) => `Achievements: ${unlocked}/${total} unlocked`
+}
+
+const ja: AchievementsMessages = {
+  nav: '実績',
+  openCommand: '実績: 開く',
+  pageTitle: '実績',
+  scoreUnlocked: '解除済み',
+  discovered: '発見済み',
+  secret: 'シークレット',
+  scanned: when => `スキャン ${when}`,
+  stale: '古い',
+  rescan: '再スキャン',
+  scanning: 'スキャン中…',
+  retry: '再試行',
+  loadFailed: '実績を読み込めませんでした',
+  loadFailedHint: '実績プラグインは有効ですか？',
+  filterAll: 'すべて',
+  filterUnlocked: '解除済み',
+  filterDiscovered: '発見済み',
+  filterSecret: 'シークレット',
+  emptyTitle: 'ここには実績がありません',
+  emptyBody: 'この状態のものはまだありません — Hermes を使い続けてください。',
+  whatCounts: '条件は？',
+  hideWhatCounts: '条件を隠す',
+  evidenceFrom: title => `証拠: ${title}`,
+  nextTier: (tier, threshold) => `次: ${tier} · ${threshold}`,
+  maxTier: '最大階級',
+  secretName: '???',
+  secretDescription: 'シークレット実績 — 最初のシグナルが検出されるまで非表示です。',
+  scoreTip: (unlocked, total) => `実績: ${unlocked}/${total} 解除済み`
+}
+
+export const ACHIEVEMENTS_LOCALES = { en, ja } satisfies PluginLocaleBundles
+
+type Bound<T> = { [K in keyof T]: T[K] extends (...args: infer A) => infer R ? (...args: A) => R : string }
+
+/** The full messages shape, bound to the active locale's translate fn. */
+export type AchievementsText = Bound<AchievementsMessages>
+
+function bind<T extends object>(t: PluginTranslate, template: T): Bound<T> {
+  const out = {} as Record<string, unknown>
+
+  for (const [key, value] of Object.entries(template)) {
+    out[key] =
+      typeof value === 'function'
+        ? (...args: unknown[]) => t(key, ...args)
+        : t(key)
+  }
+
+  return out as Bound<T>
+}
+
+export function useAchievementsI18n(): AchievementsText {
+  const t = usePluginI18n('hermes-achievements')
+
+  return useMemo(() => bind(t, en), [t])
+}

--- a/apps/desktop/src/plugins/hermes-achievements/page.tsx
+++ b/apps/desktop/src/plugins/hermes-achievements/page.tsx
@@ -1,0 +1,263 @@
+/**
+ * Achievements page — score header, filter tabs, and the achievement card
+ * grid. Read-only: the only mutation is the Rescan button, which forces the
+ * backend to re-evaluate session history.
+ */
+
+import {
+  Badge,
+  Button,
+  cn,
+  Codicon,
+  EmptyState,
+  ErrorState,
+  host,
+  relativeTime,
+  Skeleton,
+  useQuery
+} from '@hermes/plugin-sdk'
+import { useState } from 'react'
+
+import { achievementsKey, fetchAchievements, rescanAchievements } from './api'
+import { useAchievementsI18n } from './i18n'
+import { type Achievement, type AchievementFilter, TIER_ORDER } from './types'
+
+const FILTERS: AchievementFilter[] = ['all', 'unlocked', 'discovered', 'secret']
+
+function tierIndex(tier: string | null): number {
+  return tier ? TIER_ORDER.indexOf(tier as (typeof TIER_ORDER)[number]) : -1
+}
+
+function tierBadgeClass(tier: string | null): string {
+  // Tier is conveyed by label + a subtle theme-safe accent, never hardcoded
+  // colors. Higher tiers get a stronger visual weight via emphasis.
+  const i = tierIndex(tier)
+
+  if (i < 0) {return 'text-(--ui-text-quaternary)'}
+
+  if (i >= 4) {return 'text-(--ui-accent) font-semibold'}
+
+  if (i >= 3) {return 'text-(--ui-accent)'}
+
+  if (i >= 2) {return 'text-(--ui-text-primary)'}
+
+  return 'text-(--ui-text-secondary)'
+}
+
+function ScoreHeader({
+  data,
+  onRescan,
+  rescinding
+}: {
+  data: { unlocked_count: number; discovered_count: number; secret_count: number; total_count: number; generated_at: number; is_stale: boolean }
+  onRescan: () => void
+  rescinding: boolean
+}): React.JSX.Element {
+  const k = useAchievementsI18n()
+  const pct = data.total_count ? Math.round((data.unlocked_count / data.total_count) * 100) : 0
+
+  return (
+    <div className="border-b border-(--ui-stroke-secondary) px-6 py-5">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-baseline gap-3">
+            <span className="text-3xl font-semibold tabular-nums">
+              {data.unlocked_count}/{data.total_count}
+            </span>
+            <span className="text-sm text-(--ui-text-secondary)">
+              {k.scoreUnlocked} · {pct}%
+            </span>
+          </div>
+          <div className="mt-1 flex items-center gap-3 text-xs text-(--ui-text-tertiary)">
+            <span>{data.discovered_count} {k.discovered}</span>
+            <span>{data.secret_count} {k.secret}</span>
+            {data.generated_at > 0 && <span>{k.scanned(relativeTime(data.generated_at * 1000))}</span>}
+            {data.is_stale && <Badge variant="warn">{k.stale}</Badge>}
+          </div>
+        </div>
+        <Button disabled={rescinding} onClick={onRescan} size="sm" variant="secondary">
+          {rescinding ? k.scanning : k.rescan}
+        </Button>
+      </div>
+      <div className="mt-4 h-1.5 w-full overflow-hidden rounded-full bg-(--ui-bg-quaternary)">
+        <div
+          className="h-full rounded-full bg-(--ui-accent) transition-all"
+          style={{ width: `${Math.min(100, pct)}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+function AchievementCard({ item }: { item: Achievement }): React.JSX.Element {
+  const k = useAchievementsI18n()
+  const [open, setOpen] = useState(false)
+  const isSecret = item.state === 'secret'
+  const pct = item.progress_pct ?? 0
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col rounded-lg border p-4',
+        item.unlocked
+          ? 'border-(--ui-stroke-strong) bg-(--ui-bg-tertiary)'
+          : 'border-(--ui-stroke-secondary) bg-(--ui-bg-secondary)',
+        isSecret && 'opacity-70'
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Codicon
+            className={cn('shrink-0', item.unlocked ? 'text-(--ui-accent)' : 'text-(--ui-text-tertiary)')}
+            name="milestone"
+          />
+          <span className="truncate text-sm font-medium">{isSecret ? k.secretName : item.name}</span>
+        </div>
+        {item.tier ? (
+          <Badge className={cn('shrink-0 text-[0.6875rem]', tierBadgeClass(item.tier))} variant="outline">
+            {item.tier}
+          </Badge>
+        ) : item.unlocked ? (
+          <Badge className="shrink-0 text-[0.6875rem] text-(--ui-accent)" variant="outline">
+            Earned
+          </Badge>
+        ) : null}
+      </div>
+      <p className="mt-2 line-clamp-2 text-xs leading-relaxed text-(--ui-text-tertiary)">
+        {isSecret ? k.secretDescription : item.description}
+      </p>
+      <div className="mt-3">
+        <div className="flex items-center justify-between text-[0.6875rem] text-(--ui-text-tertiary)">
+          <span>
+            {item.unlocked
+              ? item.next_tier
+                ? k.nextTier(item.next_tier, item.next_threshold)
+                : k.maxTier
+              : item.next_tier
+                ? k.nextTier(item.next_tier, item.next_threshold)
+                : ''}
+          </span>
+          {!isSecret && <span className="tabular-nums">{pct}%</span>}
+        </div>
+        <div className="mt-1 h-1 w-full overflow-hidden rounded-full bg-(--ui-bg-quaternary)">
+          <div
+            className={cn('h-full rounded-full', item.unlocked ? 'bg-(--ui-accent)' : 'bg-(--ui-text-tertiary)')}
+            style={{ width: `${isSecret ? 0 : Math.min(100, pct)}%` }}
+          />
+        </div>
+      </div>
+      {item.criteria && (
+        <div className="mt-3">
+          <button
+            className="text-[0.6875rem] text-(--ui-text-tertiary) underline decoration-dotted underline-offset-2 hover:text-(--ui-text-primary)"
+            onClick={() => setOpen(o => !o)}
+            type="button"
+          >
+            {open ? k.hideWhatCounts : k.whatCounts}
+          </button>
+          {open && <p className="mt-1.5 text-[0.6875rem] leading-relaxed text-(--ui-text-tertiary)">{item.criteria}</p>}
+        </div>
+      )}
+      {item.evidence?.title && (
+        <p className="mt-2 truncate text-[0.6875rem] text-(--ui-text-quaternary)">{k.evidenceFrom(item.evidence.title)}</p>
+      )}
+    </div>
+  )
+}
+
+export function AchievementsPage(): React.JSX.Element {
+  const k = useAchievementsI18n()
+  const [filter, setFilter] = useState<AchievementFilter>('all')
+  const [rescinding, setRescinding] = useState(false)
+
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: achievementsKey(),
+    queryFn: fetchAchievements,
+    refetchInterval: 120_000
+  })
+
+  const rescan = async (): Promise<void> => {
+    setRescinding(true)
+
+    try {
+      await rescanAchievements()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      host.notify({ kind: 'error', message: `Achievements rescan failed: ${message}` })
+    } finally {
+      setRescinding(false)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="grid h-full grid-cols-1 gap-4 overflow-y-auto p-6 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 9 }, (_, i) => (
+          <Skeleton className="h-40 w-full rounded-lg" key={i} />
+        ))}
+      </div>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <ErrorState
+        description={`${error?.message ?? 'Unknown error'} — ${k.loadFailedHint}`}
+        title={k.loadFailed}
+      >
+        <Button onClick={() => refetch()} variant="secondary">
+          {k.retry}
+        </Button>
+      </ErrorState>
+    )
+  }
+
+  const items = data.achievements ?? []
+  const shown = items.filter(a => filter === 'all' || a.state === filter)
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <ScoreHeader data={data} onRescan={rescan} rescinding={rescinding} />
+      <div className="flex items-center gap-1 border-b border-(--ui-stroke-secondary) px-6 py-2">
+        {FILTERS.map(f => {
+          const count =
+            f === 'all'
+              ? data.total_count
+              : f === 'unlocked'
+                ? data.unlocked_count
+                : f === 'discovered'
+                  ? data.discovered_count
+                  : data.secret_count
+
+          const label =
+            f === 'all' ? k.filterAll : f === 'unlocked' ? k.filterUnlocked : f === 'discovered' ? k.filterDiscovered : k.filterSecret
+
+          return (
+            <button
+              className={cn(
+                'rounded-md px-2.5 py-1 text-xs capitalize transition-colors',
+                filter === f
+                  ? 'bg-(--ui-bg-quaternary) text-(--ui-text-primary)'
+                  : 'text-(--ui-text-tertiary) hover:text-(--ui-text-primary)'
+              )}
+              key={f}
+              onClick={() => setFilter(f)}
+              type="button"
+            >
+              {label} ({count})
+            </button>
+          )
+        })}
+      </div>
+      {shown.length === 0 ? (
+        <EmptyState description={k.emptyBody} title={k.emptyTitle} />
+      ) : (
+        <div className="grid flex-1 auto-rows-min grid-cols-1 gap-4 overflow-y-auto p-6 sm:grid-cols-2 lg:grid-cols-3">
+          {shown.map(a => (
+            <AchievementCard item={a} key={a.id} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/plugins/hermes-achievements/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-achievements/plugin.tsx
@@ -1,0 +1,108 @@
+/**
+ * Achievements — a first-class `/achievements` page + sidebar nav row + a live
+ * statusbar score chip + a ⌘K command, reusing the existing
+ * `plugins/hermes-achievements/dashboard/plugin_api.py` REST router through
+ * `ctx.rest` (namespace-scoped to `/api/plugins/hermes-achievements`). No new
+ * backend, no core edits.
+ *
+ * Ships OFF by default (`defaultEnabled: false`): it inventories in
+ * Settings ▸ Plugins and registers nothing until the user flips the switch.
+ */
+
+import {
+  cn,
+  Codicon,
+  type HermesPlugin,
+  host,
+  PALETTE_AREA,
+  type PaletteContribution,
+  type RouteContribution,
+  ROUTES_AREA,
+  SIDEBAR_NAV_AREA,
+  type SidebarNavContribution,
+  STATUSBAR_AREAS,
+  Tip,
+  useQuery
+} from '@hermes/plugin-sdk'
+
+import { achievementsKey, bindApi, fetchAchievements } from './api'
+import { ACHIEVEMENTS_LOCALES, useAchievementsI18n } from './i18n'
+import { AchievementsPage } from './page'
+
+// Live "36/60" pill — one glance at the score from anywhere, clicks through
+// to the page. Shares the page's query (one cache, one poll).
+function ScoreChip(): React.JSX.Element | null {
+  const k = useAchievementsI18n()
+
+  const { data } = useQuery({
+    queryKey: achievementsKey(),
+    queryFn: fetchAchievements,
+    refetchInterval: 120_000
+  })
+
+  if (!data?.unlocked_count) {
+    return null
+  }
+
+  return (
+    <Tip label={k.scoreTip(data.unlocked_count, data.total_count)}>
+      <button
+        className={cn(
+          'inline-flex h-full items-center gap-1 rounded-none px-1.5 text-[0.6875rem] tabular-nums transition-colors',
+          'text-(--ui-text-tertiary) hover:bg-(--chrome-action-hover) hover:text-foreground'
+        )}
+        onClick={() => host.navigate('/achievements')}
+        type="button"
+      >
+        <Codicon name="milestone" size="0.7rem" />
+        <span>
+          {data.unlocked_count}/{data.total_count}
+        </span>
+      </button>
+    </Tip>
+  )
+}
+
+const plugin: HermesPlugin = {
+  id: 'hermes-achievements',
+  name: 'Achievements',
+  defaultEnabled: false,
+  register(ctx) {
+    ctx.i18n.register(ACHIEVEMENTS_LOCALES)
+    ctx.onDispose(bindApi(ctx.rest))
+
+    ctx.registerMany([
+      {
+        id: 'page',
+        area: ROUTES_AREA,
+        data: { path: '/achievements' } satisfies RouteContribution,
+        title: 'Achievements',
+        render: () => <AchievementsPage />
+      },
+      {
+        id: 'nav',
+        area: SIDEBAR_NAV_AREA,
+        order: 55,
+        data: { codicon: 'milestone', label: 'Achievements', path: '/achievements' } satisfies SidebarNavContribution
+      },
+      {
+        id: 'score',
+        area: STATUSBAR_AREAS.right,
+        order: 90,
+        render: () => <ScoreChip />
+      },
+      {
+        id: 'open',
+        area: PALETTE_AREA,
+        data: {
+          id: 'hermes-achievements.open',
+          label: 'Achievements: Open',
+          keywords: ['achievements', 'badges', 'tiers', 'trophy'],
+          run: () => host.navigate('/achievements')
+        } satisfies PaletteContribution
+      }
+    ])
+  }
+}
+
+export default plugin

--- a/apps/desktop/src/plugins/hermes-achievements/types.ts
+++ b/apps/desktop/src/plugins/hermes-achievements/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Types for the hermes-achievements desktop plugin — mirrors the payloads the
+ * dashboard plugin API returns (plugins/hermes-achievements/dashboard/plugin_api.py).
+ */
+
+export type AchievementState = 'unlocked' | 'discovered' | 'secret'
+
+export interface AchievementEvidence {
+  session_id: string
+  title: string
+  value: number
+}
+
+export interface Achievement {
+  id: string
+  name: string
+  description: string
+  category: string
+  icon: string
+  kind: string
+  state: AchievementState
+  unlocked: boolean
+  discovered: boolean
+  tier: string | null
+  next_tier: string | null
+  next_threshold: number
+  progress: number
+  progress_pct: number
+  criteria?: string
+  unlocked_at?: number
+  evidence?: AchievementEvidence | null
+}
+
+export interface AchievementsResponse {
+  achievements: Achievement[]
+  unlocked_count: number
+  discovered_count: number
+  secret_count: number
+  total_count: number
+  error?: string | null
+  generated_at: number
+  is_stale: boolean
+  scan_meta?: Record<string, unknown>
+}
+
+export type AchievementFilter = 'all' | 'unlocked' | 'discovered' | 'secret'
+
+export const TIER_ORDER = ['Copper', 'Silver', 'Gold', 'Diamond', 'Olympian'] as const

--- a/contributors/emails/asimons81@gmail.com
+++ b/contributors/emails/asimons81@gmail.com
@@ -1,0 +1,2 @@
+asimons81
+# PR #77317 salvage (original author of the hermes-achievements desktop plugin)


### PR DESCRIPTION
## What does this PR do?

Adds the achievements system to the **desktop app** as a native bundled plugin — the same SDK-contract pattern as the in-tree kanban desktop plugin. The achievements backend (`plugins/hermes-achievements/dashboard/plugin_api.py`) already ships in-tree; this adds the desktop UI layer that consumes it through `ctx.rest` — no new backend, no core edits.

**Implementation credit:** this is @asimons81's work — the full visual implementation from [#77317](https://github.com/NousResearch/hermes-agent/pull/77317), preserved verbatim in commit `b523fcd5d6` with his git authorship (his original commit, cherry-picked byte-identical onto current `main`, plus his `Signed-off-by` chain recorded). This PR is the tested continuation of that PR: rebased onto current `main`, wiring verified, and a registration test added. It exists because the `#77317` fork branch was not writable from here; if #77317 lands first, close this one as superseded (and vice versa).

Contributions (all from #77317, unchanged):

- `/achievements` full page (`ROUTES_AREA`): score header (unlocked/total, discovered/secret counts, scan freshness + stale badge), filter tabs, achievement cards with tier badges, progress bars, "what counts" criteria, evidence session, and a **Rescan** button (POST `/rescan` + cache invalidation)
- Sidebar nav row (`SIDEBAR_NAV_AREA`)
- Live statusbar score chip (`STATUSBAR_AREAS.right`) — `36/60`, click-through
- ⌘K command (`PALETTE_AREA`)
- en/ja i18n bundles shipped via `ctx.i18n.register`, typed message-shape binding

Ships **off by default** (`defaultEnabled: false`) — inventories in Settings ▸ Plugins, matching kanban's opt-in contract.

Added on top (wiring/testing pass):

- `apps/desktop/src/contrib/hermes-achievements-plugin.test.tsx` — registration contract test: asserts the opt-in default, all four contribution surfaces with namespaced ids, and full teardown on deactivate. (Lives in `contrib/` because the plugin fence restricts `src/plugins/**` imports to the SDK.)
- `apps/desktop/src/plugins/README.md` — now lists `kanban/` and `hermes-achievements/` as the in-tree opt-in bundled plugins (the previous "None ship in-tree today" line was stale).

## Addressing existing review commentary

- **AI triage on #77317 (GottZ, twice):** "no registry or manifest wiring establishing that this native plugin is discovered by the desktop build." → The registry is the vite glob in `apps/desktop/src/contrib/plugins.ts` (`'../plugins/*/plugin.{ts,tsx}'`): a bundled plugin's drop-in folder IS the discovery, and `pluginActive(id, plugin.defaultEnabled ?? true)` gates it on the Settings ▸ Plugins inventory with the same live enable/disable contract as runtime plugins. The added registration test pins this wiring.
- **#77317 body:** correctly scopes itself as a *reference* to #49363 rather than closing it — kept exactly that way here. The generic desktop dashboard-plugin loader stays the separate work tracked by #46466.

## Related Issue

References #49363 (desktop dashboard-plugin parity) — this PR covers the achievements plugin specifically as a native SDK plugin; the generic loader remains #46466's scope and #49363 stays open for it.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/plugins/hermes-achievements/plugin.tsx` — plugin registration (page, nav, chip, palette) — @asimons81
- `apps/desktop/src/plugins/hermes-achievements/page.tsx` — achievements page UI — @asimons81
- `apps/desktop/src/plugins/hermes-achievements/api.ts` — `ctx.rest` data layer (fetch / rescan, React Query keys) — @asimons81
- `apps/desktop/src/plugins/hermes-achievements/types.ts` — payload types mirroring the backend — @asimons81
- `apps/desktop/src/plugins/hermes-achievements/i18n.ts` — en/ja bundles, typed shape binding — @asimons81
- `apps/desktop/src/plugins/hermes-achievements/api.test.ts` — 4 tests (bind/fetch/rescan/keys) — @asimons81
- `apps/desktop/src/contrib/hermes-achievements-plugin.test.tsx` — registration wiring tests (3)
- `apps/desktop/src/plugins/README.md` — bundled-plugin list doc fix

## How to Test

1. `npm run typecheck` and `npm run lint` in `apps/desktop` — clean
2. `npx vitest run src/plugins/hermes-achievements/ src/contrib/hermes-achievements-plugin.test.tsx` — 7 passing
3. Launch the desktop app; Settings ▸ Plugins → enable **Achievements**
4. Sidebar shows **Achievements**; click → page renders your real session score; bottom-right statusbar shows the `N/60` chip; ⌘K → "Achievements: Open"; Rescan forces a backend rescan

## Verification ledger (Windows host, against current main)

- `typecheck` (tsc × 3 configs): clean · `eslint` on changed files: clean · `git diff --check`: clean
- Achievements tests: 7/7 green (in the full suite and isolated)
- Full `test:ui` suite: 3360 passed; the 7 failures (messaging/gateway-settings/skills) are contention timeouts — all 13 pass in isolation on both this branch and clean main
- `test:desktop:platforms`: identical failure set on clean main and this branch (SSH/WSL host-environment tests, none touching plugin code) — pre-existing
- Packaged Windows build (`electron-builder`): success

## Platforms tested

- **Windows 10** — typecheck, lint, unit tests, full desktop test projects, and a packaged Electron build. No macOS/Linux run; changes are platform-agnostic (SDK contributions + REST), same as the kanban precedent.

## Why this matters to users

Before: desktop users who wanted to see their achievements had to open the web dashboard — the desktop app had no surface for the achievements backend that already ships in-tree. After: a native `/achievements` page, a live score chip in the statusbar, and a ⌘K command, all opt-in and disabled by default until a user enables the plugin in Settings ▸ Plugins — same contract as the kanban desktop plugin.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] All commits are DCO-signed; contributor attribution audit passes (`✅ All contributor emails on this branch are mapped.`)
