### PR TITLE
fix(slack): inject text-level marker when bot is explicitly @mentioned

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6278,6 +6278,17 @@ class SlackAdapter(BasePlatformAdapter):
             text, chat_id=channel_id, team_id=team_id
         )
 
+        # When the bot was explicitly @mentioned, prepend a text-level marker
+        # so the agent knows this message was directed at it.  The identity
+        # prompt injected via channel_prompt (_build_identity_prompt) tells the
+        # model "treat every delivered turn as intentionally routed to you",
+        # but models may still emit NO_REPLY when the mention is stripped from
+        # the visible text.  A text-level marker is harder to ignore.
+        # Commands skip this — they are already recognized as addressed input.
+        if is_mentioned and not is_command_text:
+            _directed = "(directed at you)"
+            text = f"{_directed} {text}" if text else _directed
+
         msg_event = MessageEvent(
             text=(command_probe_text if is_command_text else text),
             message_type=msg_type,


### PR DESCRIPTION
## Summary

When a Slack user @mentions the bot, the raw `<@BOT_UID>` token is stripped from the text before it reaches the agent ([adapter.py:5723](https://github.com/NousResearch/hermes-agent/blob/main/plugins/platforms/slack/adapter.py#L5723)). The identity prompt injected via `channel_prompt` (`_build_identity_prompt`) tells the model "treat every delivered turn as intentionally routed to you", but models may still emit `NO_REPLY` when the visible text contains no indication that the message was addressed to them.

This causes the gateway to suppress the response — the user sees the bot enter its "thinking" state but receives no answer.

## Root Cause

The mention stripping at line 5723:
```python
text = text.replace(f"<@{bot_uid}>", "").strip()
```

removes all textual evidence that the message was directed at the bot. The `_build_identity_prompt` compensates via `channel_prompt`, but this ephemeral system-prompt instruction is not always strong enough to override the model's NO_REPLY training for unaddressed messages.

## Fix

Prepend `(directed at you)` to the normalised user text when `is_mentioned` is True and the message is not a slash command:

```python
if is_mentioned and not is_command_text:
    _directed = "(directed at you)"
    text = f"{_directed} {text}" if text else _directed
```

The marker is injected after `_humanize_user_mentions` (so it doesn't interfere with `<@UID>` to `@DisplayName` rendering) and before the `MessageEvent` construction. Commands skip the marker because they are already recognised as addressed input.

## Changes

- `plugins/platforms/slack/adapter.py`: Add text-level `(directed at you)` marker when bot is explicitly @mentioned

## Test Plan

- [ ] Manual test: @mention the bot in a Slack channel with `require_mention` enabled — verify the agent responds instead of returning NO_REPLY
- [ ] Verify slash commands still work: `@bot /help` should not get the marker
- [ ] Verify non-mentioned messages are unaffected

Fixes #78106