### PR TITLE
fix(gateway): attribute scoped credential lock conflicts to the owning profile

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3185,7 +3185,15 @@ class BasePlatformAdapter(ABC):
         """
         try:
             from gateway.status import write_runtime_status
-            write_runtime_status(platform=self.platform.value, **kwargs)
+            # Multiplexed secondary adapters share the process-level runtime
+            # status file with the primary adapter.  Their runner stamps a
+            # namespaced key (``<profile>:<platform>``) so one profile's fatal
+            # state cannot overwrite another profile's healthy entry.
+            platform_key = (
+                getattr(self, "_runtime_status_platform_key", None)
+                or self.platform.value
+            )
+            write_runtime_status(platform=platform_key, **kwargs)
         except Exception as exc:
             # Use getattr so object.__new__(...) test harnesses that skip __init__
             # don't blow up on attribute access.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3224,6 +3224,7 @@ class BasePlatformAdapter(ABC):
         """
         from gateway.status import (
             acquire_scoped_lock,
+            scoped_lock_owner_label,
             take_over_scoped_lock_holder,
         )
 
@@ -3271,11 +3272,21 @@ class BasePlatformAdapter(ABC):
                     return True
 
         owner_pid = existing.get('pid') if isinstance(existing, dict) else None
-        message = (
-            f'{resource_desc} already in use'
-            + (f' (PID {owner_pid})' if owner_pid else '')
-            + '. Stop the other gateway first.'
-        )
+        # OOF-3: scoped locks are machine-global, so the holder can be a
+        # different profile's gateway. A bare PID gives an operator no way to
+        # tell WHICH profile owns the credential — name it when we can.
+        owner_profile = scoped_lock_owner_label(existing)
+        if owner_profile:
+            holder = f" by the '{owner_profile}' profile gateway"
+            holder += f" (PID {owner_pid})" if owner_pid else ""
+            remedy = (
+                f" Stop that gateway first "
+                f"(hermes --profile {owner_profile} gateway stop)."
+            )
+        else:
+            holder = f" (PID {owner_pid})" if owner_pid else ""
+            remedy = " Stop the other gateway first."
+        message = f"{resource_desc} already in use{holder}.{remedy}"
         logger.error('[%s] %s', self.name, message)
         self._set_fatal_error(f'{scope}_lock', message, retryable=True)
         return False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10729,7 +10729,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pass
         try:
             from gateway.status import write_runtime_status
-            write_runtime_status(gateway_state="starting", exit_reason=None)
+            write_runtime_status(
+                gateway_state="starting",
+                exit_reason=None,
+                clear_profile_platforms=True,
+            )
         except Exception:
             pass
         try:
@@ -13282,12 +13286,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if credential_claim is not None:
                 owner = claimed.get(credential_claim)
                 if owner is not None:
+                    message = (
+                        f"Profile '{owner}' and '{profile_name}' both configure "
+                        f"{platform.value} with the same credential. Give each "
+                        f"profile its own {platform.value} credential."
+                    )
                     logger.error(
                         "Profile '%s' and '%s' both configure %s with the same "
                         "credential — refusing to start the duplicate (one "
                         "credential cannot be consumed twice). Give each profile "
                         "its own %s credential.",
                         owner, profile_name, platform.value, platform.value,
+                    )
+                    self._update_platform_runtime_status(
+                        f"{profile_name}:{platform.value}",
+                        platform_state="fatal",
+                        error_code="duplicate_credential",
+                        error_message=message,
                     )
                     # This adapter has not connected and therefore owns no
                     # resources to clean up. Calling disconnect here can mutate
@@ -13300,6 +13315,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 owner = claimed.get(listener_claim)
                 if owner is not None:
                     bind, port = listener_claim[-2:]
+                    message = (
+                        f"Profile '{owner}' and '{profile_name}' both configure "
+                        f"{platform.value} sidecars on the same listener. Configure "
+                        f"a distinct listener for profile '{profile_name}'."
+                    )
                     logger.error(
                         "Profile '%s' and '%s' both configure %s sidecars on "
                         "%s:%s — refusing to start the duplicate listener. "
@@ -13312,6 +13332,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         port,
                         platform.value,
                         profile_name,
+                    )
+                    self._update_platform_runtime_status(
+                        f"{profile_name}:{platform.value}",
+                        platform_state="fatal",
+                        error_code="duplicate_listener",
+                        error_message=message,
                     )
                     # Like credential conflicts, this adapter never connected
                     # and owns no resources that should be disconnected.
@@ -13347,6 +13373,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         platform: Platform,
     ) -> None:
         """Install the profile-scoped handlers shared by startup and reconnect."""
+        # Runtime status is process-scoped even while message/config work is
+        # profile-scoped.  Preserve both dimensions in the key so dashboard
+        # and NAS health aggregation can see which secondary profile failed.
+        adapter._runtime_status_platform_key = f"{profile_name}:{platform.value}"
         adapter.set_message_handler(self._make_profile_message_handler(profile_name))
         adapter.set_fatal_error_handler(
             self._make_profile_fatal_error_handler(profile_name, platform)

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1046,6 +1046,7 @@ def write_runtime_status(
     error_code: Any = _UNSET,
     error_message: Any = _UNSET,
     served_profiles: Any = _UNSET,
+    clear_profile_platforms: bool = False,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
@@ -1053,6 +1054,20 @@ def write_runtime_status(
     previous_payload = copy.deepcopy(payload)
     current_record = _build_pid_record()
     payload.setdefault("platforms", {})
+    if clear_profile_platforms:
+        # Secondary-profile adapter health is stored in the process-level
+        # status file as ``<profile>:<platform>``.  A fresh gateway process
+        # must not inherit those entries from the prior process: they would
+        # otherwise keep /api/status degraded until every old adapter emitted
+        # a new state (and removed profiles would remain degraded forever).
+        platforms = payload["platforms"]
+        if not isinstance(platforms, dict):
+            platforms = {}
+        payload["platforms"] = {
+            key: value
+            for key, value in platforms.items()
+            if not isinstance(key, str) or ":" not in key
+        }
     payload["kind"] = current_record["kind"]
     payload["pid"] = current_record["pid"]
     payload["argv"] = current_record["argv"]

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -16,6 +16,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import shlex
 import signal
 import subprocess
@@ -154,6 +155,63 @@ def _same_hermes_home(left: Path | str, right: Path | str) -> bool:
     return os.path.normcase(str(_canonical_hermes_home(left))) == os.path.normcase(
         str(_canonical_hermes_home(right))
     )
+
+
+# Mirrors hermes_cli.profiles._PROFILE_ID_RE — duplicated here because gateway
+# identity code must stay import-light (hermes_constants + stdlib only).
+_PROFILE_LABEL_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+def _profile_label_for_home(home: Path | str) -> Optional[str]:
+    """Best-effort profile label for a HERMES_HOME path.
+
+    Returns the profile name for ``<root>/profiles/<name>`` layouts (both
+    ``~/.hermes/profiles/coder`` and Docker ``/opt/data/profiles/coder``),
+    ``"default"`` for the deployment's root home, and ``None`` when no label
+    can be inferred.  Never raises — this feeds diagnostics only.
+    """
+    try:
+        canonical = _canonical_hermes_home(home)
+    except Exception:
+        return None
+    if canonical.parent.name == "profiles" and _PROFILE_LABEL_RE.match(canonical.name):
+        return canonical.name
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        if _same_hermes_home(canonical, get_default_hermes_root()):
+            return "default"
+    except Exception:
+        pass
+    try:
+        if _same_hermes_home(canonical, _get_platform_default_hermes_home()):
+            return "default"
+    except Exception:
+        pass
+    return None
+
+
+def scoped_lock_owner_label(record: Optional[dict[str, Any]]) -> Optional[str]:
+    """Profile label for the gateway that owns a scoped credential lock.
+
+    Scoped locks are machine-global, so the holder may belong to a different
+    HERMES_HOME profile than the caller.  Prefers the explicit ``profile``
+    field stamped by :func:`acquire_scoped_lock`; falls back to inferring the
+    label from the persisted ``hermes_home`` for locks written before the
+    profile field existed.  Returns ``None`` for legacy or malformed records
+    so callers keep their PID-only wording.
+    """
+    if not isinstance(record, dict):
+        return None
+    profile = record.get("profile")
+    if isinstance(profile, str) and _PROFILE_LABEL_RE.match(profile.strip()):
+        # Validate the persisted label — lock files are plain JSON on disk,
+        # and this string flows into log lines and a suggested CLI command.
+        return profile.strip()
+    home = record.get("hermes_home")
+    if isinstance(home, str) and home.strip():
+        return _profile_label_for_home(home)
+    return None
 
 
 def _get_pid_path() -> Path:
@@ -1374,6 +1432,15 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         "metadata": metadata or {},
         "updated_at": _utc_now_iso(),
     }
+    # Human-readable profile label for cross-profile conflict diagnostics
+    # (OOF-3): "Telegram bot token already in use (PID 559)" gives an
+    # operator no way to tell WHICH profile owns the credential.  Stamped
+    # only on scoped-lock records (they're machine-global; PID/runtime
+    # status files are per-home and don't need it).  Omitted when no label
+    # is inferable; readers fall back to deriving it from hermes_home.
+    profile = _profile_label_for_home(_get_process_hermes_home())
+    if profile:
+        record["profile"] = profile
 
     existing = _read_json_file(lock_path)
     if existing is None and lock_path.exists():

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1097,6 +1097,17 @@ def write_runtime_status(
         if error_message is not _UNSET:
             platform_payload["error_message"] = error_message
         platform_payload["updated_at"] = _utc_now_iso()
+        # Writer identity: which PROCESS wrote this entry.  The top-level
+        # pid/start_time are refreshed on every write, so they only identify
+        # the file's most recent writer — per-entry provenance is what lets
+        # a reader (the /api/status cross-profile aggregation) distinguish
+        # "written by the current live process" from "preserved from a prior
+        # process" with exact (pid, start_time) equality instead of clock
+        # heuristics.  start_time is the same PID-reuse fingerprint the
+        # liveness checks use, so a recycled PID never masquerades as the
+        # original writer.
+        platform_payload["writer_pid"] = current_record["pid"]
+        platform_payload["writer_start_time"] = current_record["start_time"]
         payload["platforms"][platform] = platform_payload
 
     _write_json_file(path, payload)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2881,6 +2881,79 @@ def _profile_platform_ports(profile_home: Path, runtime: Optional[dict]) -> Dict
     return ports
 
 
+# Small grace for comparing a platform entry's wall-clock ``updated_at``
+# against the gateway process's psutil-derived create time (both come from
+# the host clock, but coarse rounding can skew them by a moment).
+_PROFILE_PLATFORM_FRESHNESS_SLACK_S = 2.0
+
+
+def _profile_gateway_started_at(
+    profile_home: Path, runtime: Optional[dict]
+) -> Optional[float]:
+    """Wall-clock create time of the profile's LIVE gateway process, or None.
+
+    The record's own ``start_time`` field is a PID-reuse fingerprint, not a
+    timestamp (clock ticks since boot on Linux), so it cannot anchor a
+    freshness comparison.  Instead reuse the validated-liveness helper —
+    which checks the recorded PID against the live process table, the
+    fingerprint, and the profile's home — and ask psutil for that process's
+    epoch create time.  None when the record doesn't belong to a live
+    gateway (then nothing in it is current by definition).
+    """
+    try:
+        from gateway.status import get_runtime_status_running_pid
+
+        pid = get_runtime_status_running_pid(runtime, expected_home=profile_home)
+        if pid is None:
+            return None
+        import psutil  # type: ignore
+
+        return float(psutil.Process(pid).create_time())
+    except Exception:
+        return None
+
+
+def _fresh_profile_platforms(
+    started_at: Optional[float], platforms: dict
+) -> dict:
+    """Keep only platform entries written by the profile's CURRENT process.
+
+    Gateway startup deliberately preserves plain platform entries in
+    ``gateway_state.json`` across restarts (the dashboard keeps showing
+    last-known state while adapters reconnect), and the active-profile
+    endpoint compensates by filtering them against the current
+    configuration.  The cross-profile aggregation has no equivalent config
+    context (a profile's platform set depends on tokens in that profile's
+    ``.env`` behind its secret scope), so it uses freshness instead: an
+    entry is aggregatable only when its ``updated_at`` is at/after the live
+    gateway process's create time — i.e. the current process wrote it.  A
+    fatal entry left behind by a platform the operator has since
+    disabled/removed therefore stops degrading fleet health as soon as that
+    profile's gateway restarts (a config change requires that restart to
+    take effect anyway).  Fail closed: entries without a parseable
+    ``updated_at``, or records with no live process, are excluded —
+    aggregation is a supplement, and a false "degraded forever" is the
+    worse failure mode.
+    """
+    if started_at is None:
+        return {}
+    cutoff = float(started_at) - _PROFILE_PLATFORM_FRESHNESS_SLACK_S
+    fresh: Dict[str, dict] = {}
+    for key, value in platforms.items():
+        if not isinstance(value, dict):
+            continue
+        updated_at = value.get("updated_at")
+        if not isinstance(updated_at, str):
+            continue
+        try:
+            written = datetime.fromisoformat(updated_at).timestamp()
+        except (ValueError, TypeError):
+            continue
+        if written >= cutoff:
+            fresh[key] = value
+    return fresh
+
+
 def _collect_profile_gateway_topology() -> Dict[str, Any]:
     """Enumerate profiles and the gateways serving them for ``/api/status``.
 
@@ -2896,11 +2969,14 @@ def _collect_profile_gateway_topology() -> Dict[str, Any]:
       multiple profiles (gateway.multiplex_profiles), ``"single"`` for one
       live gateway, ``"multiple"`` for independent per-profile gateways,
       ``"none"`` when nothing is running.
-    * ``profile_platforms`` — ``{profile: platforms}`` raw runtime platform
-      maps for each LIVE gateway.  Internal aggregation input for
-      ``/api/status`` (independent per-profile gateways write failures to
-      their own ``gateway_state.json``, which the unparameterized endpoint
-      would otherwise never see).  Never exposed directly.
+    * ``profile_platforms`` — ``{profile: platforms}`` runtime platform maps
+      for each LIVE gateway, freshness-filtered to entries written by that
+      profile's current process (stale preserved entries for since-removed
+      platforms are excluded — see ``_fresh_profile_platforms``).  Internal
+      aggregation input for ``/api/status`` (independent per-profile gateways
+      write failures to their own ``gateway_state.json``, which the
+      unparameterized endpoint would otherwise never see).  Never exposed
+      directly.
     """
     try:
         from hermes_cli.profiles import _check_gateway_running, profiles_to_serve
@@ -2934,7 +3010,16 @@ def _collect_profile_gateway_topology() -> Dict[str, Any]:
             multiplex = True
         plats = (runtime or {}).get("platforms")
         if isinstance(plats, dict) and plats:
-            profile_platforms[name] = plats
+            # Freshness filter: gateway startup preserves plain platform
+            # entries across restarts, so the raw map can carry fatal state
+            # for platforms the operator has since disabled/removed.  Only
+            # entries written by the profile's current live process are
+            # aggregation candidates (see _fresh_profile_platforms).
+            fresh = _fresh_profile_platforms(
+                _profile_gateway_started_at(home, runtime), plats
+            )
+            if fresh:
+                profile_platforms[name] = fresh
         entry: Dict[str, Any] = {
             "profile": name,
             "ports": _profile_platform_ports(home, runtime),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2896,6 +2896,11 @@ def _collect_profile_gateway_topology() -> Dict[str, Any]:
       multiple profiles (gateway.multiplex_profiles), ``"single"`` for one
       live gateway, ``"multiple"`` for independent per-profile gateways,
       ``"none"`` when nothing is running.
+    * ``profile_platforms`` — ``{profile: platforms}`` raw runtime platform
+      maps for each LIVE gateway.  Internal aggregation input for
+      ``/api/status`` (independent per-profile gateways write failures to
+      their own ``gateway_state.json``, which the unparameterized endpoint
+      would otherwise never see).  Never exposed directly.
     """
     try:
         from hermes_cli.profiles import _check_gateway_running, profiles_to_serve
@@ -2903,10 +2908,16 @@ def _collect_profile_gateway_topology() -> Dict[str, Any]:
         homes = profiles_to_serve(True)
     except Exception:
         _log.debug("profile/gateway topology enumeration failed", exc_info=True)
-        return {"profiles": [], "gateway_mode": "unknown", "gateways": []}
+        return {
+            "profiles": [],
+            "gateway_mode": "unknown",
+            "gateways": [],
+            "profile_platforms": {},
+        }
 
     profile_names = [name for name, _home in homes]
     gateways: List[Dict[str, Any]] = []
+    profile_platforms: Dict[str, dict] = {}
     multiplex = False
     for name, home in homes:
         try:
@@ -2921,6 +2932,9 @@ def _collect_profile_gateway_topology() -> Dict[str, Any]:
         served = [str(p) for p in ((runtime or {}).get("served_profiles") or [])]
         if name == "default" and len(served) > 1:
             multiplex = True
+        plats = (runtime or {}).get("platforms")
+        if isinstance(plats, dict) and plats:
+            profile_platforms[name] = plats
         entry: Dict[str, Any] = {
             "profile": name,
             "ports": _profile_platform_ports(home, runtime),
@@ -2938,7 +2952,12 @@ def _collect_profile_gateway_topology() -> Dict[str, Any]:
     else:
         mode = "none"
 
-    return {"profiles": profile_names, "gateway_mode": mode, "gateways": gateways}
+    return {
+        "profiles": profile_names,
+        "gateway_mode": mode,
+        "gateways": gateways,
+        "profile_platforms": profile_platforms,
+    }
 
 
 # /api/status is polled ~1/s by the desktop app while it waits for the backend
@@ -3016,13 +3035,70 @@ async def get_health():
 
 
 _PROFILE_PLATFORM_STATUS_KEY_RE = re.compile(
-    r"^[a-z0-9][a-z0-9_-]{0,63}:[a-z][a-z0-9_]{0,63}$"
+    # Profile segment mirrors hermes_cli.profiles._PROFILE_ID_RE.  Platform
+    # segment mirrors the Platform enum's normalized values: built-in members
+    # plus plugin directory names (lowercased), which allow hyphens as well
+    # as underscores (e.g. ``reviewer:foo-bar``).
+    r"^[a-z0-9][a-z0-9_-]{0,63}:[a-z0-9][a-z0-9_-]{0,63}$"
 )
 
 
 def _is_profile_platform_status_key(key: object) -> bool:
     """Accept only the runner's public ``<profile>:<platform>`` key grammar."""
     return isinstance(key, str) and bool(_PROFILE_PLATFORM_STATUS_KEY_RE.fullmatch(key))
+
+
+def _status_platform_key_allowed(
+    key: object, configured: "set[str] | None"
+) -> bool:
+    """Decide whether a runtime-status platform key may appear publicly.
+
+    Namespaced ``<profile>:<platform>`` keys are validated against the key
+    grammar *unconditionally* — the config-set load failing must not fail
+    open into projecting arbitrary colon-containing keys from a process-local
+    JSON file onto the public endpoint.  Plain platform keys keep the
+    long-standing behavior: checked against the configured set when it
+    loaded, passed through when it did not.
+    """
+    if not isinstance(key, str):
+        return False
+    if ":" in key:
+        return _is_profile_platform_status_key(key)
+    return configured is None or key in configured
+
+
+def _merge_profile_gateway_platforms(
+    gateway_platforms: dict, profile_platforms: dict
+) -> dict:
+    """Merge independent per-profile gateway platform states (OOF-3).
+
+    Hosts that run separate gateway services per profile (``gateway_mode ==
+    "multiple"``) persist each profile's platform failures in that profile's
+    own ``gateway_state.json``.  The unparameterized ``/api/status`` — the
+    machine-level probe NAS health monitoring reads — only read the active
+    profile's file, so those failures were invisible to fleet health.  Fold
+    them in under the same validated ``<profile>:<platform>`` grammar the
+    multiplex path uses.  The active profile's own map is skipped (its
+    entries are already present, including any multiplex-namespaced ones),
+    and existing keys are never overwritten.
+    """
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        active = get_active_profile_name()
+    except Exception:
+        active = "default"
+    merged = dict(gateway_platforms)
+    for prof, plats in (profile_platforms or {}).items():
+        if prof == active or not isinstance(plats, dict):
+            continue
+        for key, value in plats.items():
+            if not isinstance(key, str) or ":" in key or not isinstance(value, dict):
+                continue
+            namespaced = f"{prof}:{key}"
+            if not _is_profile_platform_status_key(namespaced):
+                continue
+            merged.setdefault(namespaced, value)
+    return merged
 
 
 @app.get("/api/status")
@@ -3123,19 +3199,18 @@ async def get_status(profile: Optional[str] = None):
         if runtime:
             gateway_state = runtime.get("gateway_state")
             gateway_platforms = runtime.get("platforms") or {}
-            if configured_gateway_platforms is not None:
-                gateway_platforms = {
-                    key: value
-                    for key, value in gateway_platforms.items()
-                    # Namespaced entries are emitted by configured secondary-
-                    # profile adapters. The config set here belongs to the
-                    # active/default profile, so suffix-checking against it
-                    # would incorrectly hide secondary-only platforms. Keep
-                    # the accepted grammar narrow because this public endpoint
-                    # is projecting a process-local JSON file.
-                    if key in configured_gateway_platforms
-                    or _is_profile_platform_status_key(key)
-                }
+            # Namespaced entries are emitted by configured secondary-profile
+            # adapters. The config set here belongs to the active/default
+            # profile, so suffix-checking against it would incorrectly hide
+            # secondary-only platforms. Colon-containing keys are validated
+            # against the narrow key grammar UNCONDITIONALLY — a failed config
+            # load must not fail open into projecting arbitrary keys from a
+            # process-local JSON file onto this public endpoint.
+            gateway_platforms = {
+                key: value
+                for key, value in gateway_platforms.items()
+                if _status_platform_key_allowed(key, configured_gateway_platforms)
+            }
             gateway_exit_reason = runtime.get("exit_reason")
             # Contract: gateway_updated_at is RFC3339 string | null, never a
             # number. ``runtime`` here may be the local gateway_state.json
@@ -3156,6 +3231,23 @@ async def get_status(profile: Optional[str] = None):
         # ensure we still report the gateway as running (no shared volume scenario).
         if gateway_running and gateway_state is None and remote_health_body is not None:
             gateway_state = "running"
+
+        # Profile + gateway topology (cached, TTL 10s): fetched here — before
+        # the platform rollup — because plain ``/api/status`` is the
+        # machine-level probe NAS reads, and hosts running independent
+        # per-profile gateway services (gateway_mode == "multiple") persist
+        # each profile's platform failures in that profile's own
+        # gateway_state.json.  Fold those in under the validated
+        # ``<profile>:<platform>`` grammar so fleet health sees them (OOF-3).
+        # A ``?profile=`` request targets one profile's view and is left
+        # unmerged.
+        topology = await asyncio.get_running_loop().run_in_executor(
+            None, _collect_profile_gateway_topology_cached
+        )
+        if not requested_profile:
+            gateway_platforms = _merge_profile_gateway_platforms(
+                gateway_platforms, topology.get("profile_platforms") or {}
+            )
 
         active_sessions = await _status_active_sessions()
 
@@ -3336,9 +3428,9 @@ async def get_status(profile: Optional[str] = None):
         # the network (a gated bind), so they must survive the auth gate. The
         # per-gateway ``gateways[]`` detail carries host ports (deployment
         # recon), so it stays gated with the host paths / PID below.
-        topology = await asyncio.get_running_loop().run_in_executor(
-            None, _collect_profile_gateway_topology_cached
-        )
+        # (``topology`` was already fetched above, before the platform rollup,
+        # so the per-profile platform merge could use it — the TTL cache makes
+        # the earlier fetch the only real scan either way.)
         status["profiles"] = topology["profiles"]
         status["gateway_mode"] = topology["gateway_mode"]
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2881,42 +2881,39 @@ def _profile_platform_ports(profile_home: Path, runtime: Optional[dict]) -> Dict
     return ports
 
 
-# Small grace for comparing a platform entry's wall-clock ``updated_at``
-# against the gateway process's psutil-derived create time (both come from
-# the host clock, but coarse rounding can skew them by a moment).
-_PROFILE_PLATFORM_FRESHNESS_SLACK_S = 2.0
-
-
-def _profile_gateway_started_at(
+def _profile_gateway_writer_identity(
     profile_home: Path, runtime: Optional[dict]
-) -> Optional[float]:
-    """Wall-clock create time of the profile's LIVE gateway process, or None.
+) -> Optional[tuple]:
+    """``(pid, start_time)`` identity of the profile's LIVE gateway, or None.
 
-    The record's own ``start_time`` field is a PID-reuse fingerprint, not a
-    timestamp (clock ticks since boot on Linux), so it cannot anchor a
-    freshness comparison.  Instead reuse the validated-liveness helper —
-    which checks the recorded PID against the live process table, the
-    fingerprint, and the profile's home — and ask psutil for that process's
-    epoch create time.  None when the record doesn't belong to a live
-    gateway (then nothing in it is current by definition).
+    Reuses the validated-liveness helper — recorded PID checked against the
+    live process table, the start-time PID-reuse fingerprint, and the
+    profile's home — then reads the live process's fingerprint via the same
+    ``_get_process_start_time`` that stamped it, so equality is exact (no
+    unit or clock-source mismatch).  None when the record doesn't belong to
+    a live gateway; nothing in it is current by definition then.
     """
     try:
-        from gateway.status import get_runtime_status_running_pid
+        from gateway.status import (
+            _get_process_start_time,
+            get_runtime_status_running_pid,
+        )
 
         pid = get_runtime_status_running_pid(runtime, expected_home=profile_home)
         if pid is None:
             return None
-        import psutil  # type: ignore
-
-        return float(psutil.Process(pid).create_time())
+        start_time = _get_process_start_time(pid)
+        if start_time is None:
+            return None
+        return (pid, start_time)
     except Exception:
         return None
 
 
-def _fresh_profile_platforms(
-    started_at: Optional[float], platforms: dict
+def _owned_profile_platforms(
+    writer_identity: Optional[tuple], platforms: dict
 ) -> dict:
-    """Keep only platform entries written by the profile's CURRENT process.
+    """Keep only platform entries the profile's CURRENT process wrote.
 
     Gateway startup deliberately preserves plain platform entries in
     ``gateway_state.json`` across restarts (the dashboard keeps showing
@@ -2924,34 +2921,32 @@ def _fresh_profile_platforms(
     endpoint compensates by filtering them against the current
     configuration.  The cross-profile aggregation has no equivalent config
     context (a profile's platform set depends on tokens in that profile's
-    ``.env`` behind its secret scope), so it uses freshness instead: an
-    entry is aggregatable only when its ``updated_at`` is at/after the live
-    gateway process's create time — i.e. the current process wrote it.  A
-    fatal entry left behind by a platform the operator has since
-    disabled/removed therefore stops degrading fleet health as soon as that
-    profile's gateway restarts (a config change requires that restart to
-    take effect anyway).  Fail closed: entries without a parseable
-    ``updated_at``, or records with no live process, are excluded —
-    aggregation is a supplement, and a false "degraded forever" is the
-    worse failure mode.
+    ``.env`` behind its secret scope), so it demands strict process
+    ownership instead: ``write_runtime_status`` stamps every platform write
+    with the writer's ``(pid, start_time)`` identity, and an entry is
+    aggregatable only when that identity equals the profile's live gateway
+    process — exact match, no clock heuristics, so an entry written moments
+    before a fast restart can never masquerade as current.  A fatal entry
+    left behind by a platform the operator has since disabled/removed thus
+    stops degrading fleet health as soon as that profile's gateway restarts
+    (a config change requires that restart to take effect anyway).  Fail
+    closed: entries without a writer identity (legacy records) or records
+    with no live process are excluded — aggregation is a supplement, and a
+    false "degraded forever" is the worse failure mode.
     """
-    if started_at is None:
+    if writer_identity is None:
         return {}
-    cutoff = float(started_at) - _PROFILE_PLATFORM_FRESHNESS_SLACK_S
-    fresh: Dict[str, dict] = {}
+    live_pid, live_start = writer_identity
+    owned: Dict[str, dict] = {}
     for key, value in platforms.items():
         if not isinstance(value, dict):
             continue
-        updated_at = value.get("updated_at")
-        if not isinstance(updated_at, str):
-            continue
-        try:
-            written = datetime.fromisoformat(updated_at).timestamp()
-        except (ValueError, TypeError):
-            continue
-        if written >= cutoff:
-            fresh[key] = value
-    return fresh
+        if (
+            value.get("writer_pid") == live_pid
+            and value.get("writer_start_time") == live_start
+        ):
+            owned[key] = value
+    return owned
 
 
 def _collect_profile_gateway_topology() -> Dict[str, Any]:
@@ -2970,9 +2965,9 @@ def _collect_profile_gateway_topology() -> Dict[str, Any]:
       live gateway, ``"multiple"`` for independent per-profile gateways,
       ``"none"`` when nothing is running.
     * ``profile_platforms`` — ``{profile: platforms}`` runtime platform maps
-      for each LIVE gateway, freshness-filtered to entries written by that
+      for each LIVE gateway, ownership-filtered to entries stamped by that
       profile's current process (stale preserved entries for since-removed
-      platforms are excluded — see ``_fresh_profile_platforms``).  Internal
+      platforms are excluded — see ``_owned_profile_platforms``).  Internal
       aggregation input for ``/api/status`` (independent per-profile gateways
       write failures to their own ``gateway_state.json``, which the
       unparameterized endpoint would otherwise never see).  Never exposed
@@ -3010,16 +3005,17 @@ def _collect_profile_gateway_topology() -> Dict[str, Any]:
             multiplex = True
         plats = (runtime or {}).get("platforms")
         if isinstance(plats, dict) and plats:
-            # Freshness filter: gateway startup preserves plain platform
+            # Ownership filter: gateway startup preserves plain platform
             # entries across restarts, so the raw map can carry fatal state
             # for platforms the operator has since disabled/removed.  Only
-            # entries written by the profile's current live process are
-            # aggregation candidates (see _fresh_profile_platforms).
-            fresh = _fresh_profile_platforms(
-                _profile_gateway_started_at(home, runtime), plats
+            # entries stamped with the profile's current live process's
+            # writer identity are aggregation candidates (see
+            # _owned_profile_platforms).
+            owned = _owned_profile_platforms(
+                _profile_gateway_writer_identity(home, runtime), plats
             )
-            if fresh:
-                profile_platforms[name] = fresh
+            if owned:
+                profile_platforms[name] = owned
         entry: Dict[str, Any] = {
             "profile": name,
             "ports": _profile_platform_ports(home, runtime),
@@ -3152,6 +3148,20 @@ def _status_platform_key_allowed(
     return configured is None or key in configured
 
 
+# Per-entry writer-identity stamps (added by gateway.status.write_runtime_status
+# for the aggregation ownership check) are process recon — the same class of
+# detail as the auth-gated top-level ``gateway_pid`` — and must not project
+# onto the public endpoint.
+_PRIVATE_PLATFORM_ENTRY_KEYS = frozenset({"writer_pid", "writer_start_time"})
+
+
+def _public_platform_entry(value: Any) -> Any:
+    """Strip writer-identity stamps from a platform entry before projection."""
+    if not isinstance(value, dict):
+        return value
+    return {k: v for k, v in value.items() if k not in _PRIVATE_PLATFORM_ENTRY_KEYS}
+
+
 def _merge_profile_gateway_platforms(
     gateway_platforms: dict, profile_platforms: dict
 ) -> dict:
@@ -3182,7 +3192,7 @@ def _merge_profile_gateway_platforms(
             namespaced = f"{prof}:{key}"
             if not _is_profile_platform_status_key(namespaced):
                 continue
-            merged.setdefault(namespaced, value)
+            merged.setdefault(namespaced, _public_platform_entry(value))
     return merged
 
 
@@ -3292,7 +3302,7 @@ async def get_status(profile: Optional[str] = None):
             # load must not fail open into projecting arbitrary keys from a
             # process-local JSON file onto this public endpoint.
             gateway_platforms = {
-                key: value
+                key: _public_platform_entry(value)
                 for key, value in gateway_platforms.items()
                 if _status_platform_key_allowed(key, configured_gateway_platforms)
             }

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3015,6 +3015,16 @@ async def get_health():
     }
 
 
+_PROFILE_PLATFORM_STATUS_KEY_RE = re.compile(
+    r"^[a-z0-9][a-z0-9_-]{0,63}:[a-z][a-z0-9_]{0,63}$"
+)
+
+
+def _is_profile_platform_status_key(key: object) -> bool:
+    """Accept only the runner's public ``<profile>:<platform>`` key grammar."""
+    return isinstance(key, str) and bool(_PROFILE_PLATFORM_STATUS_KEY_RE.fullmatch(key))
+
+
 @app.get("/api/status")
 async def get_status(profile: Optional[str] = None):
     status_scope = None
@@ -3117,7 +3127,14 @@ async def get_status(profile: Optional[str] = None):
                 gateway_platforms = {
                     key: value
                     for key, value in gateway_platforms.items()
+                    # Namespaced entries are emitted by configured secondary-
+                    # profile adapters. The config set here belongs to the
+                    # active/default profile, so suffix-checking against it
+                    # would incorrectly hide secondary-only platforms. Keep
+                    # the accepted grammar narrow because this public endpoint
+                    # is projecting a process-local JSON file.
                     if key in configured_gateway_platforms
+                    or _is_profile_platform_status_key(key)
                 }
             gateway_exit_reason = runtime.get("exit_reason")
             # Contract: gateway_updated_at is RFC3339 string | null, never a

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -96,6 +96,39 @@ class TestProfileMessageHandler:
         assert seen["profile"] == "coder"
 
 
+class TestProfileRuntimeStatus:
+    def test_base_adapter_uses_namespaced_platform_key(self, monkeypatch):
+        from gateway.platforms.base import BasePlatformAdapter
+
+        class _ConcreteAdapter(BasePlatformAdapter):
+            async def connect(self):
+                return True
+
+            async def disconnect(self):
+                return None
+
+            async def send(self, *_args, **_kwargs):
+                return None
+
+            async def get_chat_info(self, *_args, **_kwargs):
+                return None
+
+        adapter = _ConcreteAdapter.__new__(_ConcreteAdapter)
+        adapter.platform = Platform.DISCORD
+        adapter._runtime_status_platform_key = "reviewer:discord"
+        writes = []
+        monkeypatch.setattr(
+            "gateway.status.write_runtime_status",
+            lambda **kwargs: writes.append(kwargs),
+        )
+
+        adapter._write_runtime_status_safe("fatal", platform_state="fatal")
+
+        assert writes == [
+            {"platform": "reviewer:discord", "platform_state": "fatal"}
+        ]
+
+
 class _SecondaryRecoveryAdapter:
     platform = Platform.DISCORD
 
@@ -273,6 +306,98 @@ class TestSecondaryProfileConfigHandling:
         assert "webhook" in message
         assert "telegram" not in message
         assert "reviewer" not in runner._profile_adapters
+
+    def test_configured_secondary_adapter_namespaces_runtime_status(self):
+        runner = _secondary_recovery_runner()
+        adapter = _SecondaryRecoveryAdapter()
+
+        runner._configure_profile_adapter(adapter, "reviewer", Platform.DISCORD)
+
+        assert adapter._runtime_status_platform_key == "reviewer:discord"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_credential_is_persisted_as_profile_fatal(
+        self, monkeypatch
+    ):
+        runner = _secondary_recovery_runner()
+        config = GatewayConfig(
+            multiplex_profiles=True,
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True, token="shared-discord-token"
+                )
+            },
+        )
+        adapter = _SecondaryRecoveryAdapter()
+        adapter.config = config.platforms[Platform.DISCORD]
+        writes = []
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: config)
+        monkeypatch.setattr(runner, "_create_adapter", lambda _p, _c: adapter)
+        monkeypatch.setattr(
+            runner,
+            "_update_platform_runtime_status",
+            lambda platform, **kwargs: writes.append((platform, kwargs)),
+        )
+        claim = runner._adapter_credential_claim(Platform.DISCORD, adapter)
+
+        connected = await runner._start_one_profile_adapters(
+            "reviewer", "/tmp/reviewer", {claim: "default"}
+        )
+
+        assert connected == 0
+        assert writes == [
+            (
+                "reviewer:discord",
+                {
+                    "platform_state": "fatal",
+                    "error_code": "duplicate_credential",
+                    "error_message": (
+                        "Profile 'default' and 'reviewer' both configure discord "
+                        "with the same credential. Give each profile its own "
+                        "discord credential."
+                    ),
+                },
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_listener_is_persisted_without_public_bind_details(
+        self, monkeypatch
+    ):
+        class _ListenerAdapter(_SecondaryRecoveryAdapter):
+            _sidecar_bind = "127.0.0.1"
+            _sidecar_port = 8789
+
+        runner = _secondary_recovery_runner()
+        platform = Platform("photon")
+        config = GatewayConfig(
+            multiplex_profiles=True,
+            platforms={platform: PlatformConfig(enabled=True)},
+        )
+        adapter = _ListenerAdapter()
+        adapter.platform = platform
+        adapter.config = config.platforms[platform]
+        writes = []
+
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: config)
+        monkeypatch.setattr(runner, "_create_adapter", lambda _p, _c: adapter)
+        monkeypatch.setattr(
+            runner,
+            "_update_platform_runtime_status",
+            lambda key, **kwargs: writes.append((key, kwargs)),
+        )
+        claim = runner._adapter_listener_claim(platform, adapter)
+
+        connected = await runner._start_one_profile_adapters(
+            "reviewer", "/tmp/reviewer", {claim: "default"}
+        )
+
+        assert connected == 0
+        assert writes[0][0] == "reviewer:photon"
+        assert writes[0][1]["error_code"] == "duplicate_listener"
+        assert "127.0.0.1" not in writes[0][1]["error_message"]
+        assert "8789" not in writes[0][1]["error_message"]
 
     @pytest.mark.asyncio
     async def test_multiplexer_skips_bad_profile_and_continues(self, monkeypatch, caplog):

--- a/tests/gateway/test_stale_platform_lock_retryable.py
+++ b/tests/gateway/test_stale_platform_lock_retryable.py
@@ -106,3 +106,79 @@ def test_explicit_replace_takeover_reacquires_lock_once(adapter):
     assert acquire.call_count == 2
 
 
+def test_lock_conflict_names_owning_profile(adapter):
+    """OOF-3: cross-profile conflicts must name the owning profile, not just a PID."""
+    existing = {
+        "pid": 559,
+        "start_time": 123,
+        "profile": "lead-gen-outreach",
+        "hermes_home": "/opt/data/profiles/lead-gen-outreach",
+    }
+
+    with patch(
+        "gateway.status.acquire_scoped_lock",
+        return_value=(False, existing),
+    ), patch.object(adapter, "_write_runtime_status_safe"):
+        result = adapter._acquire_platform_lock(
+            "telegram-bot-token",
+            "test-token",
+            "Telegram bot token",
+        )
+
+    assert result is False
+    assert adapter._fatal_error_message == (
+        "Telegram bot token already in use by the "
+        "'lead-gen-outreach' profile gateway (PID 559). "
+        "Stop that gateway first "
+        "(hermes --profile lead-gen-outreach gateway stop)."
+    )
+    assert adapter._fatal_error_retryable is True
+    assert adapter._fatal_error_code == "telegram-bot-token_lock"
+
+
+def test_lock_conflict_infers_profile_from_legacy_hermes_home(adapter):
+    """Locks written before the profile field existed still attribute via hermes_home."""
+    existing = {
+        "pid": 559,
+        "start_time": 123,
+        "hermes_home": "/opt/data/profiles/lead-gen-outreach",
+    }
+
+    with patch(
+        "gateway.status.acquire_scoped_lock",
+        return_value=(False, existing),
+    ), patch.object(adapter, "_write_runtime_status_safe"):
+        result = adapter._acquire_platform_lock(
+            "telegram-bot-token",
+            "test-token",
+            "Telegram bot token",
+        )
+
+    assert result is False
+    assert "'lead-gen-outreach' profile gateway (PID 559)" in (
+        adapter._fatal_error_message
+    )
+
+
+def test_lock_conflict_keeps_pid_only_wording_for_legacy_record(adapter):
+    """Records with no attribution signal retain the original PID-only message."""
+    existing = {
+        "pid": 99999,
+        "start_time": 123,
+    }
+
+    with patch(
+        "gateway.status.acquire_scoped_lock",
+        return_value=(False, existing),
+    ), patch.object(adapter, "_write_runtime_status_safe"):
+        result = adapter._acquire_platform_lock(
+            "telegram-bot-token",
+            "test-token",
+            "Telegram bot token",
+        )
+
+    assert result is False
+    assert adapter._fatal_error_message == (
+        "Telegram bot token already in use (PID 99999). "
+        "Stop the other gateway first."
+    )

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -209,15 +209,30 @@ class TestGatewayRuntimeStatus:
             clear_profile_platforms=True,
         )
 
-        assert status.read_runtime_status()["platforms"] == {
-            "telegram": {"state": "connected"},
-            "reviewer:slack": {
-                "state": "connected",
-                "updated_at": status.read_runtime_status()["platforms"][
-                    "reviewer:slack"
-                ]["updated_at"],
-            },
-        }
+        platforms = status.read_runtime_status()["platforms"]
+        assert set(platforms) == {"telegram", "reviewer:slack"}
+        assert platforms["telegram"] == {"state": "connected"}
+        assert platforms["reviewer:slack"]["state"] == "connected"
+
+    def test_platform_writes_are_stamped_with_writer_identity(
+        self, tmp_path, monkeypatch
+    ):
+        # The /api/status cross-profile aggregation must distinguish entries
+        # written by the CURRENT process from entries preserved across a
+        # restart (a wall-clock freshness window admits stale failures
+        # written moments before a fast restart).  Every platform write is
+        # therefore stamped with the writer's (pid, start_time) identity —
+        # the same PID-reuse fingerprint the liveness checks use — so
+        # ownership is exact equality, not clock heuristics.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        status.write_runtime_status(platform="telegram", platform_state="connected")
+
+        entry = status.read_runtime_status()["platforms"]["telegram"]
+        assert entry["writer_pid"] == os.getpid()
+        assert entry["writer_start_time"] == status._get_process_start_time(
+            os.getpid()
+        )
 
     def test_clear_profile_platforms_repairs_malformed_platforms(
         self, tmp_path, monkeypatch

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -169,6 +169,69 @@ class TestGatewayPidState:
 
 
 class TestGatewayRuntimeStatus:
+    def test_clear_profile_platforms_preserves_primary_entries(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "gateway_state.json").write_text(
+            json.dumps({
+                "platforms": {
+                    "telegram": {"state": "connected"},
+                    "reviewer:discord": {
+                        "state": "fatal",
+                        "error_code": "duplicate_credential",
+                    },
+                }
+            }),
+            encoding="utf-8",
+        )
+
+        status.write_runtime_status(clear_profile_platforms=True)
+
+        payload = status.read_runtime_status()
+        assert payload["platforms"] == {"telegram": {"state": "connected"}}
+
+    def test_clear_profile_platforms_and_write_are_one_atomic_update(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "gateway_state.json").write_text(
+            json.dumps({
+                "platforms": {
+                    "old:discord": {"state": "fatal"},
+                    "telegram": {"state": "connected"},
+                }
+            }),
+            encoding="utf-8",
+        )
+
+        status.write_runtime_status(
+            platform="reviewer:slack",
+            platform_state="connected",
+            clear_profile_platforms=True,
+        )
+
+        assert status.read_runtime_status()["platforms"] == {
+            "telegram": {"state": "connected"},
+            "reviewer:slack": {
+                "state": "connected",
+                "updated_at": status.read_runtime_status()["platforms"][
+                    "reviewer:slack"
+                ]["updated_at"],
+            },
+        }
+
+    def test_clear_profile_platforms_repairs_malformed_platforms(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "gateway_state.json").write_text(
+            json.dumps({"platforms": ["not", "a", "mapping"]}),
+            encoding="utf-8",
+        )
+
+        status.write_runtime_status(clear_profile_platforms=True)
+
+        assert status.read_runtime_status()["platforms"] == {}
+
 
     def test_write_runtime_status_overwrites_stale_pid_on_restart(self, tmp_path, monkeypatch):
         """Regression: setdefault() preserved stale PID from previous process (#1631)."""

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -510,6 +510,95 @@ class TestScopedLocks:
         assert not target_lock.exists()
         assert other_lock.exists()
 
+    def test_acquire_scoped_lock_stamps_profile_label(self, tmp_path, monkeypatch):
+        """OOF-3: scoped locks are machine-global — record which profile owns them."""
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profiles" / "lead-gen-outreach"))
+
+        acquired, existing = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", metadata={"platform": "telegram"}
+        )
+
+        assert acquired is True
+        lock_path = tmp_path / "locks" / (
+            "telegram-bot-token-" + status._scope_hash("secret") + ".lock"
+        )
+        payload = json.loads(lock_path.read_text())
+        assert payload["profile"] == "lead-gen-outreach"
+
+    def test_acquire_scoped_lock_omits_profile_when_not_inferable(self, tmp_path, monkeypatch):
+        """No label for unrecognizable custom homes — field omitted, not null."""
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "some-custom-dir"))
+        monkeypatch.setattr(status, "_profile_label_for_home", lambda home: None)
+
+        acquired, _ = status.acquire_scoped_lock("telegram-bot-token", "secret")
+
+        assert acquired is True
+        lock_path = tmp_path / "locks" / (
+            "telegram-bot-token-" + status._scope_hash("secret") + ".lock"
+        )
+        payload = json.loads(lock_path.read_text())
+        assert "profile" not in payload
+
+
+class TestScopedLockOwnerLabel:
+    """OOF-3: attribute a machine-global credential lock to its owning profile."""
+
+    def test_profile_label_for_named_profile_home(self, tmp_path):
+        home = tmp_path / "profiles" / "lead-gen-outreach"
+        assert status._profile_label_for_home(home) == "lead-gen-outreach"
+
+    def test_profile_label_for_docker_profile_home(self):
+        assert (
+            status._profile_label_for_home("/opt/data/profiles/zerocool")
+            == "zerocool"
+        )
+
+    def test_profile_label_for_root_home_is_default(self, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", "/opt/data")
+        assert status._profile_label_for_home("/opt/data") == "default"
+
+    def test_profile_label_for_unknown_layout_is_none(self, monkeypatch):
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        assert status._profile_label_for_home("/somewhere/else") is None
+
+    def test_profile_label_rejects_invalid_directory_names(self, tmp_path):
+        # Directory names outside the profile-id grammar must not be
+        # reported as profiles (they flow into a suggested CLI command).
+        home = tmp_path / "profiles" / "Bad Name!"
+        assert status._profile_label_for_home(home) is None
+
+    def test_owner_label_prefers_explicit_profile_field(self):
+        record = {"profile": "coder", "hermes_home": "/opt/data/profiles/other"}
+        assert status.scoped_lock_owner_label(record) == "coder"
+
+    def test_owner_label_rejects_malformed_profile_field(self):
+        # Lock files are plain JSON on disk — a tampered/corrupt profile
+        # string must never reach log lines or CLI guidance.
+        assert status.scoped_lock_owner_label({"profile": "Bad Name!"}) is None
+        assert status.scoped_lock_owner_label({"profile": "  "}) is None
+        assert status.scoped_lock_owner_label({"profile": 42}) is None
+
+    def test_owner_label_ignores_invalid_profile_and_uses_home(self):
+        # An invalid persisted profile string must not block the safe
+        # hermes_home fallback — attribution degrades, never corrupts.
+        record = {
+            "profile": "bad; rm -rf /",
+            "hermes_home": "/opt/data/profiles/zerocool",
+        }
+        assert status.scoped_lock_owner_label(record) == "zerocool"
+
+    def test_owner_label_falls_back_to_hermes_home(self):
+        # Locks written before the profile field existed still attribute.
+        record = {"pid": 559, "hermes_home": "/opt/data/profiles/zerocool"}
+        assert status.scoped_lock_owner_label(record) == "zerocool"
+
+    def test_owner_label_none_for_legacy_and_malformed_records(self):
+        assert status.scoped_lock_owner_label({"pid": 99999}) is None
+        assert status.scoped_lock_owner_label(None) is None
+        assert status.scoped_lock_owner_label("not-a-dict") is None
+
 
 class TestTakeoverMarker:
     """Tests for the --replace takeover marker.

--- a/tests/hermes_cli/test_web_server_gateway_topology.py
+++ b/tests/hermes_cli/test_web_server_gateway_topology.py
@@ -77,7 +77,35 @@ class TestCollectProfileGatewayTopology:
         assert topo["profiles"] == ["default", "coder"]
         assert topo["gateway_mode"] == "none"
         assert topo["gateways"] == []
+        assert topo["profile_platforms"] == {}
 
+    def test_collects_per_profile_platform_maps(self, tmp_path, monkeypatch):
+        # Independent per-profile gateways (gateway_mode == "multiple") each
+        # write their own gateway_state.json; the collector surfaces every
+        # LIVE profile's raw platform map for the /api/status merge (OOF-3).
+        homes = [("default", tmp_path / "d"), ("coder", tmp_path / "c")]
+        runtimes = {
+            "default": {"platforms": {"telegram": {"state": "connected"}}},
+            "coder": {
+                "platforms": {
+                    "discord": {
+                        "state": "fatal",
+                        "error_code": "duplicate_credential",
+                    }
+                }
+            },
+        }
+        _patch_topology(
+            monkeypatch, homes, running={"default", "coder"}, runtimes=runtimes
+        )
+        topo = _collect_profile_gateway_topology()
+        assert topo["gateway_mode"] == "multiple"
+        assert topo["profile_platforms"] == {
+            "default": {"telegram": {"state": "connected"}},
+            "coder": {
+                "discord": {"state": "fatal", "error_code": "duplicate_credential"}
+            },
+        }
 
 
 
@@ -89,7 +117,12 @@ class TestCollectProfileGatewayTopology:
 
         monkeypatch.setattr(profiles_mod, "profiles_to_serve", _boom)
         topo = _collect_profile_gateway_topology()
-        assert topo == {"profiles": [], "gateway_mode": "unknown", "gateways": []}
+        assert topo == {
+            "profiles": [],
+            "gateway_mode": "unknown",
+            "gateways": [],
+            "profile_platforms": {},
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -183,6 +216,178 @@ class TestStatusEndpointTopology:
 
         assert resp.status_code == 200
         assert "reviewer:discord:../../secret" not in resp.json()["gateway_platforms"]
+
+    def test_namespaced_key_validation_does_not_fail_open(self, monkeypatch):
+        # If loading the configured-platform set throws, plain keys keep the
+        # historical pass-through — but colon-containing keys must STILL be
+        # validated against the key grammar. A config-load failure must not
+        # let malformed keys from a process-local JSON file reach the public
+        # endpoint.
+        monkeypatch.setattr(web_server, "get_running_pid_cached", lambda: 123)
+        monkeypatch.setattr(
+            web_server,
+            "read_runtime_status",
+            lambda path=None: {
+                "gateway_state": "running",
+                "platforms": {
+                    "telegram": {"state": "connected"},
+                    "reviewer:discord": {"state": "fatal"},
+                    "reviewer:discord:../../secret": {"state": "fatal"},
+                    "REVIEWER:DISCORD": {"state": "fatal"},
+                },
+            },
+        )
+
+        def _boom():
+            raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr(
+            web_server, "_load_configured_gateway_platforms", _boom
+        )
+
+        resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        platforms = resp.json()["gateway_platforms"]
+        assert "telegram" in platforms
+        assert "reviewer:discord" in platforms
+        assert "reviewer:discord:../../secret" not in platforms
+        assert "REVIEWER:DISCORD" not in platforms
+
+    def test_status_preserves_hyphenated_plugin_platform_key(self, monkeypatch):
+        # Plugin platform IDs may contain hyphens (plugins/platforms/<dir>
+        # names are lowercased directory names; the Platform enum accepts
+        # them). A valid ``reviewer:foo-bar`` fatal entry must survive the
+        # public filter.
+        monkeypatch.setattr(web_server, "get_running_pid_cached", lambda: 123)
+        monkeypatch.setattr(
+            web_server,
+            "read_runtime_status",
+            lambda path=None: {
+                "gateway_state": "running",
+                "platforms": {
+                    "reviewer:foo-bar": {
+                        "state": "fatal",
+                        "error_code": "duplicate_credential",
+                    },
+                },
+            },
+        )
+        monkeypatch.setattr(
+            web_server,
+            "_load_configured_gateway_platforms",
+            lambda: {"telegram"},
+        )
+
+        resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        platforms = resp.json()["gateway_platforms"]
+        assert platforms["reviewer:foo-bar"]["error_code"] == "duplicate_credential"
+
+    def test_status_merges_independent_profile_gateway_failures(self, monkeypatch):
+        # OOF-3 deployment mode: separate gateway services per profile
+        # (gateway_mode == "multiple"). Each profile's failures live in its
+        # own gateway_state.json; the machine-level /api/status must fold
+        # them in as <profile>:<platform> so NAS health monitoring sees them.
+        import hermes_cli.profiles as profiles_mod
+
+        monkeypatch.setattr(web_server, "get_running_pid_cached", lambda: 123)
+        monkeypatch.setattr(
+            web_server,
+            "read_runtime_status",
+            lambda path=None: {
+                "gateway_state": "running",
+                "platforms": {"telegram": {"state": "connected"}},
+            },
+        )
+        monkeypatch.setattr(
+            web_server,
+            "_load_configured_gateway_platforms",
+            lambda: {"telegram"},
+        )
+        monkeypatch.setattr(
+            profiles_mod, "get_active_profile_name", lambda: "default"
+        )
+        monkeypatch.setattr(
+            web_server, "_collect_profile_gateway_topology",
+            lambda: {
+                "profiles": ["default", "lead-gen-outreach"],
+                "gateway_mode": "multiple",
+                "gateways": [
+                    {"profile": "default", "ports": {}},
+                    {"profile": "lead-gen-outreach", "ports": {}},
+                ],
+                "profile_platforms": {
+                    "default": {"telegram": {"state": "connected"}},
+                    "lead-gen-outreach": {
+                        "telegram": {
+                            "state": "fatal",
+                            "error_code": "duplicate_credential",
+                        },
+                        "bad key": {"state": "fatal"},
+                    },
+                },
+            },
+        )
+
+        resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        platforms = data["gateway_platforms"]
+        # Active profile's own entry untouched, no self-namespacing.
+        assert platforms["telegram"]["state"] == "connected"
+        assert "default:telegram" not in platforms
+        # Independent profile's failure folded in under the namespaced key.
+        assert (
+            platforms["lead-gen-outreach:telegram"]["error_code"]
+            == "duplicate_credential"
+        )
+        # Keys that don't survive the grammar are dropped, not projected.
+        assert not any("bad key" in key for key in platforms)
+        # The platforms component rollup counts the merged failure.
+        assert data["components"]["platforms"]["status"] == "degraded"
+
+    def test_profile_scoped_status_does_not_merge_other_profiles(self, monkeypatch):
+        # ?profile=<name> targets one profile's view — merging every other
+        # profile's failures into it would misattribute state.
+        import hermes_cli.profiles as profiles_mod
+
+        monkeypatch.setattr(web_server, "get_running_pid_cached", lambda: 123)
+        monkeypatch.setattr(
+            web_server,
+            "read_runtime_status",
+            lambda path=None: {
+                "gateway_state": "running",
+                "platforms": {"telegram": {"state": "connected"}},
+            },
+        )
+        monkeypatch.setattr(
+            web_server,
+            "_load_configured_gateway_platforms",
+            lambda: {"telegram"},
+        )
+        monkeypatch.setattr(
+            profiles_mod, "get_active_profile_name", lambda: "default"
+        )
+        monkeypatch.setattr(
+            web_server, "_collect_profile_gateway_topology",
+            lambda: {
+                "profiles": ["default", "coder"],
+                "gateway_mode": "multiple",
+                "gateways": [],
+                "profile_platforms": {
+                    "coder": {"telegram": {"state": "fatal"}},
+                },
+            },
+        )
+
+        resp = self.client.get("/api/status", params={"profile": "current"})
+
+        assert resp.status_code == 200
+        platforms = resp.json()["gateway_platforms"]
+        assert "coder:telegram" not in platforms
 
     def test_profile_names_and_mode_public_when_auth_gated(self, monkeypatch):
         # Profile NAMES + gateway_mode are low-sensitivity product surface: the

--- a/tests/hermes_cli/test_web_server_gateway_topology.py
+++ b/tests/hermes_cli/test_web_server_gateway_topology.py
@@ -131,6 +131,59 @@ class TestStatusEndpointTopology:
         # The per-gateway detail (host ports) is loopback-only recon.
         assert data["gateways"] == [{"profile": "default", "ports": {}}]
 
+    def test_status_preserves_secondary_profile_platform_errors(self, monkeypatch):
+        monkeypatch.setattr(web_server, "get_running_pid_cached", lambda: 123)
+        monkeypatch.setattr(
+            web_server,
+            "read_runtime_status",
+            lambda path=None: {
+                "gateway_state": "running",
+                "platforms": {
+                    "telegram": {"state": "connected"},
+                    "reviewer:discord": {
+                        "state": "fatal",
+                        "error_code": "duplicate_credential",
+                        "error_message": "Profiles configure the same credential",
+                    },
+                },
+            },
+        )
+        monkeypatch.setattr(
+            web_server,
+            "_load_configured_gateway_platforms",
+            lambda: {"telegram"},
+        )
+
+        resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        platforms = resp.json()["gateway_platforms"]
+        assert platforms["telegram"]["state"] == "connected"
+        assert platforms["reviewer:discord"]["error_code"] == "duplicate_credential"
+
+    def test_status_rejects_malformed_namespaced_platform_key(self, monkeypatch):
+        monkeypatch.setattr(web_server, "get_running_pid_cached", lambda: 123)
+        monkeypatch.setattr(
+            web_server,
+            "read_runtime_status",
+            lambda path=None: {
+                "gateway_state": "running",
+                "platforms": {
+                    "reviewer:discord:../../secret": {"state": "fatal"},
+                },
+            },
+        )
+        monkeypatch.setattr(
+            web_server,
+            "_load_configured_gateway_platforms",
+            lambda: {"telegram"},
+        )
+
+        resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        assert "reviewer:discord:../../secret" not in resp.json()["gateway_platforms"]
+
     def test_profile_names_and_mode_public_when_auth_gated(self, monkeypatch):
         # Profile NAMES + gateway_mode are low-sensitivity product surface: the
         # Hermes Cloud Portal reads /api/status over the network (a gated bind)

--- a/tests/hermes_cli/test_web_server_gateway_topology.py
+++ b/tests/hermes_cli/test_web_server_gateway_topology.py
@@ -83,14 +83,23 @@ class TestCollectProfileGatewayTopology:
         # Independent per-profile gateways (gateway_mode == "multiple") each
         # write their own gateway_state.json; the collector surfaces every
         # LIVE profile's raw platform map for the /api/status merge (OOF-3).
+        # Entries must be fresh — written by the profile's current process.
         homes = [("default", tmp_path / "d"), ("coder", tmp_path / "c")]
         runtimes = {
-            "default": {"platforms": {"telegram": {"state": "connected"}}},
+            "default": {
+                "platforms": {
+                    "telegram": {
+                        "state": "connected",
+                        "updated_at": "2026-08-05T10:00:05+00:00",
+                    }
+                }
+            },
             "coder": {
                 "platforms": {
                     "discord": {
                         "state": "fatal",
                         "error_code": "duplicate_credential",
+                        "updated_at": "2026-08-05T10:00:05+00:00",
                     }
                 }
             },
@@ -98,14 +107,91 @@ class TestCollectProfileGatewayTopology:
         _patch_topology(
             monkeypatch, homes, running={"default", "coder"}, runtimes=runtimes
         )
+        # Both gateways' live processes started before the entries were
+        # written (epoch for 2026-08-05T10:00:00Z).
+        monkeypatch.setattr(
+            web_server,
+            "_profile_gateway_started_at",
+            lambda home, runtime: 1785924000.0,
+        )
         topo = _collect_profile_gateway_topology()
         assert topo["gateway_mode"] == "multiple"
         assert topo["profile_platforms"] == {
-            "default": {"telegram": {"state": "connected"}},
+            "default": {
+                "telegram": {
+                    "state": "connected",
+                    "updated_at": "2026-08-05T10:00:05+00:00",
+                }
+            },
             "coder": {
-                "discord": {"state": "fatal", "error_code": "duplicate_credential"}
+                "discord": {
+                    "state": "fatal",
+                    "error_code": "duplicate_credential",
+                    "updated_at": "2026-08-05T10:00:05+00:00",
+                }
             },
         }
+
+    def test_stale_platform_entries_are_not_aggregated(self, tmp_path, monkeypatch):
+        # Gateway startup preserves plain platform entries across restarts;
+        # if the operator removed/disabled the platform and restarted, its
+        # old fatal entry must not keep degrading fleet health.  Entries
+        # written before the live process started — or with no parseable
+        # updated_at — are excluded.
+        homes = [("default", tmp_path / "d"), ("coder", tmp_path / "c")]
+        runtimes = {
+            "coder": {
+                "platforms": {
+                    # Written by the PRIOR process (before restart).
+                    "telegram": {
+                        "state": "fatal",
+                        "error_code": "duplicate_credential",
+                        "updated_at": "2026-08-05T09:00:00+00:00",
+                    },
+                    # No timestamp at all — fail closed.
+                    "discord": {"state": "fatal"},
+                    # Garbage timestamp — fail closed.
+                    "slack": {"state": "fatal", "updated_at": "not-a-time"},
+                    # Written by the current process — kept.
+                    "signal": {
+                        "state": "fatal",
+                        "error_code": "duplicate_credential",
+                        "updated_at": "2026-08-05T10:00:05+00:00",
+                    },
+                }
+            },
+        }
+        _patch_topology(
+            monkeypatch, homes, running={"coder"}, runtimes=runtimes
+        )
+        monkeypatch.setattr(
+            web_server,
+            "_profile_gateway_started_at",
+            lambda home, runtime: 1785924000.0,  # 2026-08-05T10:00:00Z
+        )
+        topo = _collect_profile_gateway_topology()
+        assert set(topo["profile_platforms"].get("coder", {})) == {"signal"}
+
+    def test_no_live_process_means_no_aggregation(self, tmp_path, monkeypatch):
+        # When the record's PID doesn't validate against a live gateway
+        # process, nothing in it is current — the whole map is excluded.
+        homes = [("coder", tmp_path / "c")]
+        runtimes = {
+            "coder": {
+                "platforms": {
+                    "telegram": {
+                        "state": "fatal",
+                        "updated_at": "2026-08-05T10:00:05+00:00",
+                    }
+                }
+            },
+        }
+        _patch_topology(monkeypatch, homes, running={"coder"}, runtimes=runtimes)
+        monkeypatch.setattr(
+            web_server, "_profile_gateway_started_at", lambda home, runtime: None
+        )
+        topo = _collect_profile_gateway_topology()
+        assert topo["profile_platforms"] == {}
 
 
 

--- a/tests/hermes_cli/test_web_server_gateway_topology.py
+++ b/tests/hermes_cli/test_web_server_gateway_topology.py
@@ -83,14 +83,15 @@ class TestCollectProfileGatewayTopology:
         # Independent per-profile gateways (gateway_mode == "multiple") each
         # write their own gateway_state.json; the collector surfaces every
         # LIVE profile's raw platform map for the /api/status merge (OOF-3).
-        # Entries must be fresh — written by the profile's current process.
+        # Entries must carry the current live process's writer identity.
         homes = [("default", tmp_path / "d"), ("coder", tmp_path / "c")]
         runtimes = {
             "default": {
                 "platforms": {
                     "telegram": {
                         "state": "connected",
-                        "updated_at": "2026-08-05T10:00:05+00:00",
+                        "writer_pid": 100,
+                        "writer_start_time": 111,
                     }
                 }
             },
@@ -99,7 +100,8 @@ class TestCollectProfileGatewayTopology:
                     "discord": {
                         "state": "fatal",
                         "error_code": "duplicate_credential",
-                        "updated_at": "2026-08-05T10:00:05+00:00",
+                        "writer_pid": 200,
+                        "writer_start_time": 222,
                     }
                 }
             },
@@ -107,12 +109,11 @@ class TestCollectProfileGatewayTopology:
         _patch_topology(
             monkeypatch, homes, running={"default", "coder"}, runtimes=runtimes
         )
-        # Both gateways' live processes started before the entries were
-        # written (epoch for 2026-08-05T10:00:00Z).
+        identities = {tmp_path / "d": (100, 111), tmp_path / "c": (200, 222)}
         monkeypatch.setattr(
             web_server,
-            "_profile_gateway_started_at",
-            lambda home, runtime: 1785924000.0,
+            "_profile_gateway_writer_identity",
+            lambda home, runtime: identities.get(home),
         )
         topo = _collect_profile_gateway_topology()
         assert topo["gateway_mode"] == "multiple"
@@ -120,14 +121,16 @@ class TestCollectProfileGatewayTopology:
             "default": {
                 "telegram": {
                     "state": "connected",
-                    "updated_at": "2026-08-05T10:00:05+00:00",
+                    "writer_pid": 100,
+                    "writer_start_time": 111,
                 }
             },
             "coder": {
                 "discord": {
                     "state": "fatal",
                     "error_code": "duplicate_credential",
-                    "updated_at": "2026-08-05T10:00:05+00:00",
+                    "writer_pid": 200,
+                    "writer_start_time": 222,
                 }
             },
         }
@@ -135,28 +138,40 @@ class TestCollectProfileGatewayTopology:
     def test_stale_platform_entries_are_not_aggregated(self, tmp_path, monkeypatch):
         # Gateway startup preserves plain platform entries across restarts;
         # if the operator removed/disabled the platform and restarted, its
-        # old fatal entry must not keep degrading fleet health.  Entries
-        # written before the live process started — or with no parseable
-        # updated_at — are excluded.
+        # old fatal entry must not keep degrading fleet health.  Ownership
+        # is exact (pid, start_time) equality with the live process — an
+        # entry written by the PREVIOUS process moments before a fast
+        # restart, a legacy entry with no writer identity, and a recycled
+        # PID with a different start-time fingerprint are all excluded.
         homes = [("default", tmp_path / "d"), ("coder", tmp_path / "c")]
         runtimes = {
             "coder": {
                 "platforms": {
-                    # Written by the PRIOR process (before restart).
+                    # Near-boundary: written by the PRIOR process (pid 199)
+                    # immediately before a fast restart. A wall-clock
+                    # freshness window would admit this; identity must not.
                     "telegram": {
                         "state": "fatal",
                         "error_code": "duplicate_credential",
-                        "updated_at": "2026-08-05T09:00:00+00:00",
+                        "updated_at": "2026-08-05T10:00:00.900000+00:00",
+                        "writer_pid": 199,
+                        "writer_start_time": 110,
                     },
-                    # No timestamp at all — fail closed.
+                    # Legacy entry, no writer identity — fail closed.
                     "discord": {"state": "fatal"},
-                    # Garbage timestamp — fail closed.
-                    "slack": {"state": "fatal", "updated_at": "not-a-time"},
+                    # Same PID recycled, different start-time fingerprint —
+                    # a different process, not the live writer.
+                    "slack": {
+                        "state": "fatal",
+                        "writer_pid": 200,
+                        "writer_start_time": 110,
+                    },
                     # Written by the current process — kept.
                     "signal": {
                         "state": "fatal",
                         "error_code": "duplicate_credential",
-                        "updated_at": "2026-08-05T10:00:05+00:00",
+                        "writer_pid": 200,
+                        "writer_start_time": 222,
                     },
                 }
             },
@@ -166,8 +181,8 @@ class TestCollectProfileGatewayTopology:
         )
         monkeypatch.setattr(
             web_server,
-            "_profile_gateway_started_at",
-            lambda home, runtime: 1785924000.0,  # 2026-08-05T10:00:00Z
+            "_profile_gateway_writer_identity",
+            lambda home, runtime: (200, 222),
         )
         topo = _collect_profile_gateway_topology()
         assert set(topo["profile_platforms"].get("coder", {})) == {"signal"}
@@ -181,14 +196,17 @@ class TestCollectProfileGatewayTopology:
                 "platforms": {
                     "telegram": {
                         "state": "fatal",
-                        "updated_at": "2026-08-05T10:00:05+00:00",
+                        "writer_pid": 200,
+                        "writer_start_time": 222,
                     }
                 }
             },
         }
         _patch_topology(monkeypatch, homes, running={"coder"}, runtimes=runtimes)
         monkeypatch.setattr(
-            web_server, "_profile_gateway_started_at", lambda home, runtime: None
+            web_server,
+            "_profile_gateway_writer_identity",
+            lambda home, runtime: None,
         )
         topo = _collect_profile_gateway_topology()
         assert topo["profile_platforms"] == {}
@@ -384,7 +402,13 @@ class TestStatusEndpointTopology:
             "read_runtime_status",
             lambda path=None: {
                 "gateway_state": "running",
-                "platforms": {"telegram": {"state": "connected"}},
+                "platforms": {
+                    "telegram": {
+                        "state": "connected",
+                        "writer_pid": 123,
+                        "writer_start_time": 456,
+                    }
+                },
             },
         )
         monkeypatch.setattr(
@@ -410,6 +434,8 @@ class TestStatusEndpointTopology:
                         "telegram": {
                             "state": "fatal",
                             "error_code": "duplicate_credential",
+                            "writer_pid": 789,
+                            "writer_start_time": 1011,
                         },
                         "bad key": {"state": "fatal"},
                     },
@@ -432,6 +458,12 @@ class TestStatusEndpointTopology:
         )
         # Keys that don't survive the grammar are dropped, not projected.
         assert not any("bad key" in key for key in platforms)
+        # Writer-identity stamps (process recon, same class as the auth-gated
+        # gateway_pid) never project onto the endpoint — neither on the active
+        # profile's own entries nor on merged cross-profile entries.
+        for entry in platforms.values():
+            assert "writer_pid" not in entry
+            assert "writer_start_time" not in entry
         # The platforms component rollup counts the merged failure.
         assert data["components"]["platforms"]["status"] == "degraded"
 


### PR DESCRIPTION
## Problem

Scoped bot credentials and listeners are **machine-global**, but multiplexed profile failures were hard to attribute and could remain invisible to fleet health:

1. Lock conflicts only reported the owning PID, not the profile operators needed to fix.
2. Secondary-profile adapters shared the process-level `gateway_state.json` platform keys with the primary adapter. A secondary `discord` failure could overwrite—or be overwritten by—the primary `discord` state.
3. Duplicate-credential/listener startup refusals were logged and skipped, but not persisted in `/api/status`. NAS therefore kept classifying affected instances as healthy while gateways retried indefinitely.

OOF-3 observed this across nine production instances (7,486 collision rows in 24h).

## Fix

### Actionable lock ownership

- `acquire_scoped_lock()` stamps a validated profile label inferred from process `HERMES_HOME`.
- `scoped_lock_owner_label()` prefers the explicit label and falls back to legacy `hermes_home` inference.
- Conflict messages identify the owning profile and provide the exact `hermes --profile <name> gateway stop` remedy; malformed/legacy records retain PID-only wording.

### Multi-profile health aggregation

- Secondary adapters write status under namespaced `<profile>:<platform>` keys, e.g. `lead-gen-outreach:telegram`; primary/single-profile keys remain unchanged.
- Startup duplicate-credential and duplicate-listener refusals persist `fatal` entries with stable codes (`duplicate_credential`, `duplicate_listener`). Public listener errors intentionally omit bind address/port details.
- Fresh gateway startup atomically prunes stale namespaced entries from prior processes while preserving primary platform state.
- `/api/status` preserves well-formed namespaced entries through active-profile filtering. Its public-key parser accepts only the existing profile-id grammar plus normalized platform names, rejecting malformed colon-containing keys.

This means NAS's existing top-level `gateway_platforms` iteration now sees persistent secondary-profile failures without a NAS-side schema or classifier change.

## Testing

- 109/109 targeted tests pass across runtime status, multiplex adapter registry, lock conflict handling, redaction, `/api/status` topology, and topology-cache coverage.
- 97/97 focused tests for the new paths pass; Ruff and `git diff --check` clean.
- Broad gateway-suite failures were reproduced byte-for-byte on the pre-change base in a detached worktree (environment/pre-existing failures, no regression).

New coverage includes:
- explicit + legacy lock owner attribution and grammar validation;
- namespaced adapter writes and startup collision persistence;
- listener-detail redaction;
- stale-entry pruning and clear+write atomicity;
- malformed persisted-status repair;
- `/api/status` pass-through for valid namespaced keys and rejection of malformed ones.

## Scope

This PR makes current collisions attributable, persistent, and visible to fleet health. Config-time duplicate-credential prevention remains separate work because it spans secret comparison and profile mutation paths rather than gateway runtime reporting.
