### PR TITLE
feat(cli): add substring fallback to slash command autocomplete

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -2096,58 +2096,59 @@ class SlashCommandCompleter(Completer):
 
         word = text[1:]
 
+        # Two-pass matching: prefix matches first (preserving source
+        # ordering), then substring matches as a fallback.  This lets
+        # ``/pdf`` match ``nano-pdf`` or ``/ocr`` match
+        # ``ocr-and-documents`` while keeping prefix matches at the top
+        # of the dropdown.  See issue #33822.
+        prefix_matches: list = []
+        substring_matches: list = []
+
+        def _stage(cmd_name: str, display: str, meta: str) -> None:
+            """Stage a completion into the prefix or substring bucket."""
+            if cmd_name.startswith(word):
+                prefix_matches.append(Completion(
+                    self._completion_text(cmd_name, word),
+                    start_position=-len(word),
+                    display=display,
+                    display_meta=meta,
+                ))
+            elif word and word in cmd_name:
+                substring_matches.append(Completion(
+                    self._completion_text(cmd_name, word),
+                    start_position=-len(word),
+                    display=display,
+                    display_meta=meta,
+                ))
+
         for cmd, desc in COMMANDS.items():
             if not self._command_allowed(cmd):
                 continue
-            cmd_name = cmd[1:]
-            if cmd_name.startswith(word):
-                yield Completion(
-                    self._completion_text(cmd_name, word),
-                    start_position=-len(word),
-                    display=cmd,
-                    display_meta=desc,
-                )
+            _stage(cmd[1:], cmd, desc)
 
         for cmd, info in self._iter_skill_bundles().items():
-            cmd_name = cmd[1:]
-            if cmd_name.startswith(word):
-                description = str(info.get("description", "Skill bundle"))
-                short_desc = description[:50] + ("..." if len(description) > 50 else "")
-                skill_count = len(info.get("skills", []))
-                yield Completion(
-                    self._completion_text(cmd_name, word),
-                    start_position=-len(word),
-                    display=cmd,
-                    display_meta=f"▣ {short_desc} ({skill_count} skills)",
-                )
+            description = str(info.get("description", "Skill bundle"))
+            short_desc = description[:50] + ("..." if len(description) > 50 else "")
+            skill_count = len(info.get("skills", []))
+            _stage(cmd[1:], cmd, f"▣ {short_desc} ({skill_count} skills)")
 
         for cmd, info in self._iter_skill_commands().items():
-            cmd_name = cmd[1:]
-            if cmd_name.startswith(word):
-                description = str(info.get("description", "Skill command"))
-                short_desc = description[:50] + ("..." if len(description) > 50 else "")
-                yield Completion(
-                    self._completion_text(cmd_name, word),
-                    start_position=-len(word),
-                    display=cmd,
-                    display_meta=f"⚡ {short_desc}",
-                )
+            description = str(info.get("description", "Skill command"))
+            short_desc = description[:50] + ("..." if len(description) > 50 else "")
+            _stage(cmd[1:], cmd, f"⚡ {short_desc}")
 
         # Plugin-registered slash commands
         try:
             from hermes_cli.plugins import get_plugin_commands
             for cmd_name, cmd_info in get_plugin_commands().items():
-                if cmd_name.startswith(word):
-                    desc = str(cmd_info.get("description", "Plugin command"))
-                    short_desc = desc[:50] + ("..." if len(desc) > 50 else "")
-                    yield Completion(
-                        self._completion_text(cmd_name, word),
-                        start_position=-len(word),
-                        display=f"/{cmd_name}",
-                        display_meta=f"🔌 {short_desc}",
-                    )
+                desc = str(cmd_info.get("description", "Plugin command"))
+                short_desc = desc[:50] + ("..." if len(desc) > 50 else "")
+                _stage(cmd_name, f"/{cmd_name}", f"🔌 {short_desc}")
         except Exception:
             pass
+
+        yield from prefix_matches
+        yield from substring_matches
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -343,6 +343,85 @@ class TestSlashCommandCompleter:
         assert "help" in texts
 
 
+# ── Two-pass prefix-then-substring matching ────────────────────────────
+
+
+class TestSubstringFallbackCompletion:
+    """Prefix matches come first, then substring matches as fallback.
+
+    See issue #33822 — typing ``/pdf`` should match ``nano-pdf`` even
+    though it doesn't start with ``pdf``.
+    """
+
+    def test_substring_match_when_no_prefix(self):
+        """``/pdf`` matches ``nano-pdf`` via substring fallback."""
+        completer = SlashCommandCompleter(
+            skill_commands_provider=lambda: {
+                "/nano-pdf": {"description": "Nano PDF skill"},
+            }
+        )
+        completions = _completions(completer, "/pdf")
+        texts = [c.text for c in completions]
+        assert "nano-pdf" in texts
+
+    def test_prefix_match_when_substring_also_matches(self):
+        """``/ocr`` matches ``ocr-and-documents`` via prefix (not substring)."""
+        completer = SlashCommandCompleter(
+            skill_commands_provider=lambda: {
+                "/ocr-and-documents": {"description": "OCR skill"},
+            }
+        )
+        completions = _completions(completer, "/ocr")
+        assert len(completions) == 1
+        assert completions[0].text == "ocr-and-documents"
+
+    def test_prefix_ranked_before_substring(self):
+        """When both prefix and substring candidates exist, prefix wins."""
+        completer = SlashCommandCompleter(
+            skill_commands_provider=lambda: {
+                "/pdf-tool": {"description": "PDF tool (prefix match)"},
+                "/nano-pdf": {"description": "Nano PDF (substring match)"},
+            }
+        )
+        completions = _completions(completer, "/pdf")
+        texts = [c.text for c in completions]
+        # prefix match must come before substring match
+        assert texts.index("pdf-tool") < texts.index("nano-pdf")
+
+    def test_empty_word_does_not_trigger_substring(self):
+        """Empty query (bare ``/``) must not match everything as substring."""
+        completer = SlashCommandCompleter(
+            skill_commands_provider=lambda: {
+                "/skill-a": {"description": "A"},
+            }
+        )
+        completions = _completions(completer, "/")
+        texts = {c.text for c in completions}
+        # skill-a should appear (prefix match on empty string), but
+        # nothing should match via "empty string is substring of everything"
+        assert "skill-a" in texts
+
+    def test_substring_match_for_skill_bundle(self):
+        """Substring fallback also applies to skill bundles."""
+        completer = SlashCommandCompleter(
+            skill_bundles_provider=lambda: {
+                "/my-bundle": {"description": "My bundle", "skills": ["a", "b"]},
+            }
+        )
+        completions = _completions(completer, "/bundle")
+        texts = [c.text for c in completions]
+        assert "my-bundle" in texts
+
+    def test_substring_match_for_builtin_command(self):
+        """Substring fallback also applies to built-in slash commands."""
+        completer = SlashCommandCompleter()
+        # /skills contains "kill" as a substring — previously only prefix
+        # matched, so /ski would work but /kill would not
+        completions = _completions(completer, "/kill")
+        texts = {c.text for c in completions}
+        assert "skills" in texts
+
+
 
 
 # ── Stacked slash-skill completion ──────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Adds substring matching as a fallback to slash command autocomplete. Previously, completion matched by prefix only (`startswith`), so typing `/pdf` would NOT match `nano-pdf`, `/ocr` would NOT match `ocr-and-documents`, etc. This was frustrating when you remember what a skill does but not its exact name prefix.

The `@` file completion already had fuzzy matching (`_fuzzy_file_completions`); this brings the same flexibility to slash commands.

## Related Issue

Closes #33822

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/commands.py` — `SlashCommandCompleter.get_completions()`: replaced four separate `startswith` checks with a two-pass `_stage()` helper that buckets candidates into prefix matches first, then substring matches as fallback. Applied to all four completion sources: builtin commands, skill bundles, skill commands, plugin commands.
- `tests/hermes_cli/test_commands.py` — Added `TestSubstringFallbackCompletion` with 6 tests covering prefix priority, substring fallback, ranking order, empty-query guard, skill bundles, and builtin commands.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_commands.py -v
```

Manual verification in `hermes` CLI:

| User types | Before | After |
|---|---|---|
| `/pdf` | no match | `nano-pdf` (substring) |
| `/ocr` | `ocr-and-documents` (prefix) | `ocr-and-documents` (unchanged, prefix still wins) |
| `/kill` | no match | `skills` (substring) |
| `/doc` | `docx` (prefix) | `docx` (unchanged, prefix still wins) |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(cli):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (58 tests in test_commands.py, 75 across test_commands + test_path_completion + test_complete_path_at_filter — all pass)
- [x] I've added tests for my changes (6 new tests in `TestSubstringFallbackCompletion`)
- [x] I've tested on my platform: macOS 15.7.3

### Documentation & Housekeeping

- [x] N/A — no config keys, no architecture changes, no tool behavior changes

## Relationship to #33831

PR #33831 addresses the same issue (#33822) but was flagged by the sweeper review for two problems:

1. **No prefix-first ordering** — the single-pass `startswith(word) or query in name` predicate yields prefix and substring matches interleaved in source order, not the fallback/priority policy requested in the issue.
2. **No tests** — no test coverage for the new substring behavior.

This PR implements the two-stage prefix-then-substring policy from the issue and adds focused tests. The `_stage()` helper also eliminates the four-way code duplication that #33831 carried forward.
