### PR TITLE
fix(security): redact dotted Alibaba token-plan keys (#78128)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -77,6 +77,7 @@ _REDACT_ENABLED = os.getenv("HERMES_REDACT_SECRETS", "true").lower() in {"1", "t
 
 # Known API key prefixes -- match the prefix + contiguous token chars
 _PREFIX_PATTERNS = [
+    r"sk-sp-[A-Za-z0-9_-]{10,}(?:\.[A-Za-z0-9_-]+)+",  # Alibaba Token Plan (dotted)
     r"sk-[A-Za-z0-9_-]{10,}",           # OpenAI / OpenRouter / Anthropic (sk-ant-*)
     r"ghp_[A-Za-z0-9]{10,}",            # GitHub PAT (classic)
     r"github_pat_[A-Za-z0-9_]{10,}",    # GitHub PAT (fine-grained)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -4,7 +4,13 @@ import logging
 
 import pytest
 
-from agent.redact import mask_secret, redact_cdp_url, redact_sensitive_text, RedactingFormatter
+from agent.redact import (
+    mask_secret,
+    redact_cdp_url,
+    redact_sensitive_text,
+    redact_terminal_output,
+    RedactingFormatter,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -16,6 +22,19 @@ def _ensure_redaction_enabled(monkeypatch):
 
 
 class TestKnownPrefixes:
+
+    def test_alibaba_token_plan_dotted_key(self):
+        token = "sk-sp-" + "f4k3t0k3n4t3std4t4" + ".part2xyz.part3tail"
+
+        terminal_result = redact_terminal_output(
+            f"ALIBABA_CODING_PLAN_API_KEY={token}",
+            command="grep API_KEY ~/.hermes/.env",
+        )
+        sentence_result = redact_sensitive_text(f"leaked key {token}.")
+
+        assert token not in terminal_result
+        assert ".part2xyz.part3" not in terminal_result
+        assert sentence_result.endswith("tail.")
 
 
 
@@ -1031,7 +1050,6 @@ class TestKeywordWordBoundary:
         text = "secrets: hunter2hunter2hunter2hh"
         result = redact_sensitive_text(text)
         assert "hunter2hunter2hunter2hh" not in result
-
 
 class TestMaskSecretControlStripping:
     """Issue #55319/#55321: mask_secret() must not emit control bytes


### PR DESCRIPTION
## What does this PR do?

Fixes the remaining secret-redaction gap for Alibaba Token Plan credentials.
These keys use the form `sk-sp-<segment>.<segment>...`, while the generic
`sk-` pattern stops at the first dot and leaves the remaining segments live.

Recent `main` changes now redact direct `cat ~/.hermes/.env` output as an env
dump, but the prefix bug remains on other code/file paths. On current `main`,
`grep API_KEY ~/.hermes/.env`, generic code output, and
`redact_sensitive_text()` still produce:

```text
sk-sp-...d4t4.part2xyz.part3tail
```

The dedicated pattern consumes one or more non-empty dotted segments before
the generic `sk-` alternative runs. It deliberately requires content after
each dot, so sentence-final punctuation is not swallowed.

## Related Issue

Fixes #78128

## Type of Change

- [x] Security fix

## Changes Made

- `agent/redact.py`: recognize complete dotted `sk-sp-` Token Plan keys.
- `tests/agent/test_redact.py`: cover the still-vulnerable `grep` terminal
  path, verify no middle segment survives, and preserve sentence punctuation.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_redact.py tests/agent/test_compaction_redaction_boundaries.py -q`.
2. Confirm: `106 passed`.
3. Run `uv run ruff check agent/redact.py tests/agent/test_redact.py`.
4. Confirm: `All checks passed!`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation update: N/A; behavior now matches the redaction contract
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: Python regex behavior is portable
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

Current `main` before this fix:

```text
grep_env 'ALIBABA_CODING_PLAN_API_KEY=sk-sp-...d4t4.part2xyz.part3tail'
sensitive_text 'leaked key sk-sp-...d4t4.part2xyz.part3tail.'
```

With this PR, both paths mask the complete credential while preserving
sentence punctuation.
