### PR TITLE
fix(weixin): rate-limit circuit breaker makes the built-in retry/backoff unreachable

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1742,13 +1742,32 @@ class WeixinAdapter(BasePlatformAdapter):
             time.monotonic() + self._rate_limit_circuit_open_seconds,
         )
 
-    def _record_rate_limit_event(self) -> bool:
-        """Record a genuine iLink rate limit and return True if breaker opened."""
+    def _note_rate_limit_event(self) -> None:
+        """Record a genuine iLink rate limit within the sliding window.
+
+        Recording is deliberately separate from tripping the breaker: a single
+        transient 429-style reply should still be retried with backoff inside
+        the current send (see ``_send_text_chunk_locked``). The breaker is only
+        tripped once that retry budget is exhausted, so it protects *subsequent*
+        calls instead of aborting the current one.
+        """
         now = time.monotonic()
         window_start = now - self._rate_limit_circuit_window_seconds
         self._rate_limit_events = [ts for ts in self._rate_limit_events if ts >= window_start]
         self._rate_limit_events.append(now)
-        if len(self._rate_limit_events) >= self._rate_limit_circuit_threshold:
+
+    def _should_trip_rate_limit_circuit(self) -> bool:
+        return len(self._rate_limit_events) >= self._rate_limit_circuit_threshold
+
+    def _record_rate_limit_event(self) -> bool:
+        """Backwards-compatible helper: record an event and trip immediately.
+
+        Retained so external callers/subclasses keep working; the send path now
+        uses ``_note_rate_limit_event`` plus an explicit trip after the retry
+        budget is spent.
+        """
+        self._note_rate_limit_event()
+        if self._should_trip_rate_limit_circuit():
             self._open_rate_limit_circuit()
             return self._rate_limit_cooldown_remaining() > 0
         return False
@@ -1839,10 +1858,17 @@ class WeixinAdapter(BasePlatformAdapter):
                             last_error = RuntimeError(
                                 f"iLink sendmessage rate limited: ret={ret} errcode={errcode} errmsg={errmsg}"
                             )
-                            if self._record_rate_limit_event():
-                                last_error = self._rate_limit_error()
-                                break
+                            # Track the event for the cross-call breaker, but do not
+                            # abandon this send yet: a transient rate limit should
+                            # still consume the configured retry budget with backoff.
+                            self._note_rate_limit_event()
                             if attempt >= self._send_chunk_retries:
+                                # Retry budget exhausted and iLink is still limiting us:
+                                # trip the breaker so subsequent sends back off too.
+                                if self._should_trip_rate_limit_circuit():
+                                    self._open_rate_limit_circuit()
+                                    if self._rate_limit_cooldown_remaining() > 0:
+                                        last_error = self._rate_limit_error()
                                 break
                             wait = self._send_chunk_retry_delay_seconds * 3  # 3x backoff for rate limit
                             logger.warning(


### PR DESCRIPTION
## Summary

With the shipped defaults, a **single** transient iLink rate limit (`ret=-2`) trips the
circuit breaker and aborts the send immediately, so the per-chunk retry/backoff that the
same function already implements is dead code. Callers get a terminal error and typically
dead-letter the message, even though iLink recovers within seconds.

## The bug

Defaults (`gateway/platforms/weixin.py`):

| env var | default |
| --- | --- |
| `WEIXIN_SEND_CHUNK_RETRIES` | `4` |
| `WEIXIN_RATE_LIMIT_CIRCUIT_THRESHOLD` | **`1`** |
| `WEIXIN_RATE_LIMIT_CIRCUIT_OPEN_SECONDS` | `30.0` |

In `_send_text_chunk_locked`:

```python
if self._record_rate_limit_event():   # threshold == 1 → True on the very first -2
    last_error = self._rate_limit_error()
    break                             # ← leaves the retry loop immediately
if attempt >= self._send_chunk_retries:
    break
wait = self._send_chunk_retry_delay_seconds * 3   # 3x backoff for rate limit
await asyncio.sleep(wait)                          # ← never reached
continue                                           # ← never reached
```

`_record_rate_limit_event()` appends to the sliding window and returns
`len(events) >= threshold`. With `threshold=1` that is `True` on the first hit, so the
loop always breaks before the backoff path. `WEIXIN_SEND_CHUNK_RETRIES` and the `3x`
backoff cannot take effect unless an operator raises the threshold manually.

## Impact observed in production

On a self-hosted deployment that pushes scheduled reports through the Weixin adapter:

* **83 notifications dead-lettered**, including alerting and daily reports.
* Log breakdown: **263** `cooldown active` pre-flight rejections vs **54** real
  `ret=-2 errmsg="rate limited"` responses — i.e. ~83% of the failures never reached
  iLink at all; the breaker rejected them locally.
* Messages that *did* get through succeeded on **attempt 4 and attempt 5** (delivered
  21 min and 81 min after enqueue), which confirms the limit is transient and retrying
  is the correct response.

## The fix

Separate *recording* a rate-limit event from *tripping* the breaker:

* `_note_rate_limit_event()` — records into the sliding window only.
* `_should_trip_rate_limit_circuit()` — pure predicate.
* The send path now consumes its configured retry budget with the existing `3x` backoff
  and only trips the breaker once that budget is exhausted while iLink is still limiting.
  The breaker therefore protects *subsequent* calls rather than aborting the current one.
* `_record_rate_limit_event()` is kept as a thin backwards-compatible wrapper so external
  callers/subclasses are unaffected.

No config keys, defaults, or public behaviour change — the patch only makes the existing
retry logic reachable.

## Verification

Behaviour of the retry loop, before vs after (transient limit = first reply `-2`, then OK):

| scenario | before | after |
| --- | --- | --- |
| transient limit (recovers on 2nd try) | ✗ dead-lettered after **1** attempt | ✓ **delivered** on attempt 2 (3 s backoff) |
| recovers on 3rd try | ✗ dead-lettered after **1** attempt | ✓ **delivered** on attempt 3 |
| persistent limit | ✗ failed, breaker open | ✗ failed, breaker open (**unchanged protection**) |

The persistent-limit case still opens the breaker, so the protection this feature was
added for is preserved; the difference is that a genuine send is attempted first.

## Notes

* Discovered while debugging silent notification loss on a scheduled-push deployment.
* Happy to add a regression test around `_send_text_chunk_locked` if you'd like one in
  the PR — please point me at the preferred fixture style for platform adapters.