### PR TITLE
feat(tools): add Blaxel cloud sandbox terminal backend

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -326,6 +326,24 @@ terminal:
 #   daytona_image: "nikolaik/python-nodejs:python3.11-nodejs20"
 #   container_disk: 10240          # Daytona max is 10GB per sandbox
 
+# -----------------------------------------------------------------------------
+# OPTION 7: Blaxel cloud execution
+# Commands run in Blaxel cloud sandboxes
+# Great for: Cloud sandboxes with a durable per-task volume
+# Requires: pip install 'hermes-agent[blaxel]', BL_WORKSPACE + BL_API_KEY env vars
+# -----------------------------------------------------------------------------
+# terminal:
+#   backend: "blaxel"
+#   cwd: "/blaxel"
+#   timeout: 180
+#   lifetime_seconds: 300
+#   blaxel_image: "blaxel/py-app:latest"   # base-image is Alpine/musl (no glibc)
+#   blaxel_ttl: "24h"
+#   container_memory: 4096         # MB
+#   container_persistent: true     # Mount a durable volume per task
+#   container_disk: 10240          # MB -- durable volume size, not container disk
+#   # container_cpu is ignored: Blaxel allocates CPU from the image profile
+
 #
 # --- Container resource limits (docker, singularity, modal, daytona -- ignored for local/ssh) ---
 # These settings apply to all container backends. They control the resources

--- a/hermes_cli/blaxel_auth.py
+++ b/hermes_cli/blaxel_auth.py
@@ -1,0 +1,126 @@
+"""Helpers for reporting Blaxel authentication state."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+_BLAXEL_CLI_CONFIG = Path.home() / ".blaxel" / "config.yaml"
+_CLI_CREDENTIAL_KEYS = ("apiKey", "access_token", "refresh_token")
+
+
+@dataclass(frozen=True)
+class BlaxelAuthStatus:
+    ok: bool
+    label: str
+    workspace: str
+    detail_lines: tuple[str, ...]
+
+
+def _read_cli_config() -> dict[str, Any]:
+    """Return the Blaxel CLI config, or an empty mapping when unreadable.
+
+    Never raises: a missing, unparseable, or permission-denied CLI config just
+    means "no CLI credentials", which is a normal state.
+    """
+    try:
+        import yaml
+    except ImportError:
+        return {}
+    try:
+        raw = _BLAXEL_CLI_CONFIG.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    try:
+        parsed = yaml.safe_load(raw) or {}
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _cli_workspace_names(config: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    entries = config.get("workspaces")
+    if not isinstance(entries, list):
+        return {}
+    found: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        if isinstance(entry, dict) and entry.get("name"):
+            found[str(entry["name"])] = entry
+    return found
+
+
+def _has_cli_credentials(entry: dict[str, Any]) -> bool:
+    credentials = entry.get("credentials")
+    if not isinstance(credentials, dict):
+        return False
+    return any(credentials.get(key) for key in _CLI_CREDENTIAL_KEYS)
+
+
+def resolve_blaxel_workspace() -> str:
+    """Return the workspace Blaxel will target, or an empty string.
+
+    ``BL_WORKSPACE`` wins. Otherwise fall back to the workspace the CLI has
+    selected, which is what the SDK itself resolves.
+    """
+    explicit = (os.getenv("BL_WORKSPACE") or "").strip()
+    if explicit:
+        return explicit
+    config = _read_cli_config()
+    context = config.get("context")
+    if isinstance(context, dict):
+        return str(context.get("workspace") or "").strip()
+    return ""
+
+
+def describe_blaxel_auth(workspace: Optional[str] = None) -> BlaxelAuthStatus:
+    """Return Blaxel auth status without exposing secret values.
+
+    Two supported paths, mirroring how the Blaxel SDK itself authenticates:
+
+    1. ``BL_API_KEY`` in the environment. This is the documented path for
+       deployments and any long-running non-interactive Hermes process.
+    2. Credentials already stored by ``bl login`` for the target workspace.
+       This covers ordinary local development, where requiring a separate API
+       key would reject a working setup.
+    """
+    resolved = (workspace or resolve_blaxel_workspace()).strip()
+    if not resolved:
+        return BlaxelAuthStatus(
+            ok=False,
+            label="no workspace resolved",
+            workspace="",
+            detail_lines=(
+                "Set BL_WORKSPACE, or select one with `bl login <workspace>`.",
+            ),
+        )
+
+    if os.getenv("BL_API_KEY"):
+        return BlaxelAuthStatus(
+            ok=True,
+            label="BL_API_KEY",
+            workspace=resolved,
+            detail_lines=(),
+        )
+
+    entry = _cli_workspace_names(_read_cli_config()).get(resolved)
+    if entry and _has_cli_credentials(entry):
+        return BlaxelAuthStatus(
+            ok=True,
+            label=f"Blaxel CLI credentials for {resolved}",
+            workspace=resolved,
+            detail_lines=(
+                "Set BL_API_KEY for deployments; CLI credentials can expire.",
+            ),
+        )
+
+    return BlaxelAuthStatus(
+        ok=False,
+        label="no credentials found",
+        workspace=resolved,
+        detail_lines=(
+            f"Run `bl login {resolved}`, or set BL_API_KEY.",
+        ),
+    )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -689,6 +689,10 @@ def get_container_exec_info() -> Optional[dict]:
 
 # Re-export from hermes_constants — canonical definition lives there.
 from hermes_constants import get_hermes_home, get_process_hermes_home  # noqa: F811,E402
+from hermes_constants import (  # noqa: E402
+    BLAXEL_DEFAULT_MEMORY_MB,
+    BLAXEL_DEFAULT_VOLUME_SIZE_MB,
+)
 from utils import atomic_replace, fast_safe_load
 
 def get_config_path() -> Path:
@@ -2827,6 +2831,51 @@ def _normalize_root_model_keys(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
+def _apply_backend_terminal_defaults(
+    config: Dict[str, Any],
+    user_config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Give the selected terminal backend its own resource defaults.
+
+    ``DEFAULT_CONFIG`` carries the shared container sizes (5120 MB / 51200 MB),
+    which are wrong for Blaxel: it wants 4096 MB of memory and treats
+    ``container_disk`` as a durable volume size. Without this, selecting the
+    backend in ``config.yaml`` yielded the shared defaults while the
+    ``TERMINAL_*`` env path yielded the Blaxel ones — the same value meaning two
+    different things depending on which path configured it.
+
+    Only untouched defaults are replaced. An explicit user value always wins.
+    """
+    terminal = config.get("terminal")
+    if not isinstance(terminal, dict):
+        return config
+
+    user_terminal = (user_config or {}).get("terminal")
+    if not isinstance(user_terminal, dict):
+        user_terminal = {}
+
+    backend = terminal.get("backend") or terminal.get("env_type")
+    if backend != "blaxel":
+        return config
+
+    shared_defaults = DEFAULT_CONFIG["terminal"]
+    backend_defaults = {
+        "container_memory": BLAXEL_DEFAULT_MEMORY_MB,
+        "container_disk": BLAXEL_DEFAULT_VOLUME_SIZE_MB,
+    }
+
+    terminal = dict(terminal)
+    for key, value in backend_defaults.items():
+        if key in user_terminal:
+            continue
+        if terminal.get(key) == shared_defaults.get(key):
+            terminal[key] = value
+
+    config = dict(config)
+    config["terminal"] = terminal
+    return config
+
+
 def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
     """Normalize legacy root-level max_turns into agent.max_turns.
 
@@ -3191,6 +3240,8 @@ TERMINAL_CONFIG_ENV_MAP = {
     "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
     "modal_image": "TERMINAL_MODAL_IMAGE",
     "daytona_image": "TERMINAL_DAYTONA_IMAGE",
+    "blaxel_image": "TERMINAL_BLAXEL_IMAGE",
+    "blaxel_ttl": "TERMINAL_BLAXEL_TTL",
     "vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
     "ssh_host": "TERMINAL_SSH_HOST",
     "ssh_user": "TERMINAL_SSH_USER",
@@ -3345,6 +3396,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                     user_config.pop("max_turns", None)
 
                 config = _deep_merge(config, user_config)
+                config = _apply_backend_terminal_defaults(config, user_config)
             except Exception as e:
                 # Last-known-good fallback (port of openai/codex#31188's
                 # invariant: a parse failure in a policy/config file must not

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -4,6 +4,8 @@ Pure-data leaf module: DEFAULT_CONFIG and OPTIONAL_ENV_VARS, extracted
 verbatim from hermes_cli/config.py. Must not import from hermes_cli.config.
 """
 
+from hermes_constants import BLAXEL_DEFAULT_IMAGE, BLAXEL_DEFAULT_TTL
+
 DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
@@ -318,6 +320,10 @@ DEFAULT_CONFIG = {
         # Vercel Sandbox runtime (vercel_sandbox backend only).
         # Supported: node24, node22, python3.13.
         "vercel_runtime": "node24",
+        # Blaxel sandbox settings (blaxel backend only). Region comes from
+        # BL_REGION so it sits with the other BL_* credentials.
+        "blaxel_image": BLAXEL_DEFAULT_IMAGE,
+        "blaxel_ttl": BLAXEL_DEFAULT_TTL,
         # Container resource limits (docker, singularity, modal, daytona, vercel_sandbox — ignored for local/ssh)
         "container_cpu": 1,
         "container_memory": 5120,       # MB (default 5GB)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -34,6 +34,7 @@ from hermes_cli.colors import Colors, color
 from hermes_cli.models import _HERMES_USER_AGENT
 from hermes_cli.vercel_auth import describe_vercel_auth
 from hermes_constants import OPENROUTER_MODELS_URL
+from hermes_constants import BLAXEL_SDK_INSTALL_COMMAND
 from utils import base_url_host_matches
 
 
@@ -1817,6 +1818,30 @@ def run_doctor(args):
                 "daytona SDK not installed",
                 "(pip install daytona)",
                 "Install daytona SDK: pip install daytona",
+                issues,
+            )
+
+    # Blaxel (if using blaxel backend)
+    if terminal_env == "blaxel":
+        from hermes_cli.blaxel_auth import describe_blaxel_auth
+
+        blaxel_auth = describe_blaxel_auth()
+        if blaxel_auth.ok:
+            check_ok("Blaxel auth", f"({blaxel_auth.label})")
+        else:
+            _fail_and_issue(
+                f"Blaxel auth unusable: {blaxel_auth.label}",
+                "(required for TERMINAL_ENV=blaxel)",
+                " ".join(blaxel_auth.detail_lines) or "Run `bl login <workspace>` or set BL_API_KEY",
+                issues,
+            )
+        if importlib.util.find_spec("blaxel") is not None:
+            check_ok("blaxel SDK", "(installed)")
+        else:
+            _fail_and_issue(
+                "blaxel SDK not installed",
+                f"({BLAXEL_SDK_INSTALL_COMMAND})",
+                f"Install blaxel SDK: {BLAXEL_SDK_INSTALL_COMMAND}",
                 issues,
             )
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -24,7 +24,15 @@ from typing import Optional, Dict, Any
 
 from hermes_cli.nous_subscription import get_nous_subscription_features
 from tools.tool_backend_helpers import managed_nous_tools_enabled
-from hermes_constants import get_optional_skills_dir
+from hermes_constants import (
+    BLAXEL_DEFAULT_IMAGE,
+    BLAXEL_DEFAULT_MEMORY_MB,
+    BLAXEL_DEFAULT_TTL,
+    BLAXEL_DEFAULT_VOLUME_SIZE_MB,
+    BLAXEL_SDK_DEPENDENCY,
+    BLAXEL_SDK_INSTALL_COMMAND,
+    get_optional_skills_dir,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -764,6 +772,56 @@ def _prompt_container_resources(config: dict):
         pass
 
 
+def _prompt_blaxel_sandbox_settings(config: dict):
+    """Prompt only for the Blaxel knobs that take effect.
+
+    Blaxel allocates CPU and container disk from the image profile, so this
+    deliberately does not reuse ``_prompt_container_resources``: asking for
+    values the backend ignores misleads the user. Durable volume size is its
+    own prompt and is never derived from memory.
+    """
+    terminal = config.setdefault("terminal", {})
+
+    print()
+    print_info("Blaxel settings:")
+    print_info("  CPU and container disk come from the image profile and are ignored here.")
+    print_info("  Credentials are read from BL_WORKSPACE and BL_API_KEY, never from config.yaml.")
+
+    current_image = terminal.get("blaxel_image") or BLAXEL_DEFAULT_IMAGE
+    image = prompt("  Sandbox image", current_image).strip() or current_image
+    terminal["blaxel_image"] = image
+    save_env_value("TERMINAL_BLAXEL_IMAGE", image)
+
+    current_memory = terminal.get("container_memory") or BLAXEL_DEFAULT_MEMORY_MB
+    memory_str = prompt("  Memory (MB)", str(current_memory))
+    try:
+        terminal["container_memory"] = int(memory_str)
+    except ValueError:
+        print_warning(f"Invalid memory '{memory_str}', keeping {current_memory}.")
+        terminal["container_memory"] = int(current_memory)
+
+    current_persist = terminal.get("container_persistent", True)
+    persist_label = "yes" if current_persist else "no"
+    persistent = prompt(
+        "  Keep a persistent volume per task? (yes/no)", persist_label
+    ).lower() in {"yes", "true", "y", "1"}
+    terminal["container_persistent"] = persistent
+
+    if persistent:
+        current_volume = terminal.get("container_disk") or BLAXEL_DEFAULT_VOLUME_SIZE_MB
+        volume_str = prompt("  Persistent volume size (MB)", str(current_volume))
+        try:
+            terminal["container_disk"] = int(volume_str)
+        except ValueError:
+            print_warning(f"Invalid volume size '{volume_str}', keeping {current_volume}.")
+            terminal["container_disk"] = int(current_volume)
+
+    current_ttl = terminal.get("blaxel_ttl") or BLAXEL_DEFAULT_TTL
+    ttl = prompt("  Sandbox TTL (e.g. 24h)", current_ttl).strip() or current_ttl
+    terminal["blaxel_ttl"] = ttl
+    save_env_value("TERMINAL_BLAXEL_TTL", ttl)
+
+
 def _prompt_vercel_sandbox_settings(config: dict):
     """Prompt for Vercel Sandbox settings without exposing unsupported disk sizing."""
     terminal = config.setdefault("terminal", {})
@@ -1340,11 +1398,18 @@ def setup_terminal_backend(config: dict):
         "SSH - run on a remote machine",
         "Daytona - persistent cloud development environment",
         "Vercel Sandbox - cloud microVM with snapshot filesystem persistence",
+        "Blaxel - cloud sandbox with an optional persistent volume",
     ]
-    idx_to_backend = {0: "local", 1: "docker", 2: "modal", 3: "ssh", 4: "daytona", 5: "vercel_sandbox"}
-    backend_to_idx = {"local": 0, "docker": 1, "modal": 2, "ssh": 3, "daytona": 4, "vercel_sandbox": 5}
+    idx_to_backend = {
+        0: "local", 1: "docker", 2: "modal", 3: "ssh", 4: "daytona",
+        5: "vercel_sandbox", 6: "blaxel",
+    }
+    backend_to_idx = {
+        "local": 0, "docker": 1, "modal": 2, "ssh": 3, "daytona": 4,
+        "vercel_sandbox": 5, "blaxel": 6,
+    }
 
-    next_idx = 6
+    next_idx = 7
     if is_linux:
         terminal_choices.append("Singularity/Apptainer - HPC-friendly container")
         idx_to_backend[next_idx] = "singularity"
@@ -1592,6 +1657,46 @@ def setup_terminal_backend(config: dict):
 
         _prompt_vercel_sandbox_settings(config)
 
+    elif selected_backend == "blaxel":
+        print_success("Terminal backend: Blaxel")
+        print_info("Cloud sandboxes with an optional persistent volume per task.")
+        print_info(f"Requires the optional SDK: {BLAXEL_SDK_INSTALL_COMMAND}")
+        print_info("Sign up at: https://blaxel.ai")
+
+        try:
+            __import__("blaxel")
+        except ImportError:
+            print_info("Installing blaxel SDK...")
+            import subprocess
+
+            # Managed uv first, same reasoning as the Vercel branch above.
+            from hermes_cli.managed_uv import ensure_uv
+
+            uv_bin = ensure_uv()
+            if uv_bin:
+                result = subprocess.run(
+                    [uv_bin, "pip", "install", "--python", sys.executable,
+                     BLAXEL_SDK_DEPENDENCY],
+                    capture_output=True,
+                    text=True,
+                )
+            else:
+                result = subprocess.run(
+                    [sys.executable, "-m", "pip", "install", BLAXEL_SDK_DEPENDENCY],
+                    capture_output=True,
+                    text=True,
+                )
+            if result.returncode == 0:
+                print_success("blaxel SDK installed")
+            else:
+                print_warning(
+                    f"Install failed — run manually: {BLAXEL_SDK_INSTALL_COMMAND}"
+                )
+                if result.stderr:
+                    print_info(f"  Error: {result.stderr.strip().splitlines()[-1]}")
+
+        _prompt_blaxel_sandbox_settings(config)
+
     elif selected_backend == "ssh":
         print_success("Terminal backend: SSH")
         print_info("Run commands on a remote machine via SSH.")
@@ -1647,6 +1752,10 @@ def setup_terminal_backend(config: dict):
         save_env_value("TERMINAL_MODAL_MODE", config["terminal"].get("modal_mode", "auto"))
     if selected_backend == "vercel_sandbox":
         save_env_value("TERMINAL_VERCEL_RUNTIME", config["terminal"].get("vercel_runtime", "node24"))
+    if selected_backend == "blaxel":
+        terminal_cfg = config["terminal"]
+        save_env_value("TERMINAL_CONTAINER_MEMORY", str(terminal_cfg.get("container_memory", BLAXEL_DEFAULT_MEMORY_MB)))
+        save_env_value("TERMINAL_CONTAINER_DISK", str(terminal_cfg.get("container_disk", BLAXEL_DEFAULT_VOLUME_SIZE_MB)))
     save_config(config)
     print()
     print_success(f"Terminal backend set to: {selected_backend}")

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -24,6 +24,7 @@ from hermes_cli.nous_account import (
 from hermes_cli.nous_subscription import get_nous_subscription_features
 from hermes_cli.runtime_provider import resolve_requested_provider
 from hermes_cli.vercel_auth import describe_vercel_auth
+from hermes_constants import BLAXEL_DEFAULT_IMAGE, BLAXEL_DEFAULT_TTL, BLAXEL_SDK_INSTALL_COMMAND
 from hermes_constants import OPENROUTER_MODELS_URL
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 
@@ -456,6 +457,39 @@ def show_status(args):
             print(f"  Auth detail:  {line}")
         print(f"  Persistence:  {'snapshot filesystem' if persist_enabled else 'ephemeral filesystem'}")
         print("  Processes:    live processes do not survive cleanup, snapshots, or sandbox recreation")
+    elif terminal_env == "blaxel":
+        blaxel_image = (
+            os.getenv("TERMINAL_BLAXEL_IMAGE")
+            or terminal_cfg.get("blaxel_image")
+            or BLAXEL_DEFAULT_IMAGE
+        )
+        ttl = (
+            os.getenv("TERMINAL_BLAXEL_TTL")
+            or terminal_cfg.get("blaxel_ttl")
+            or BLAXEL_DEFAULT_TTL
+        )
+        persist = os.getenv("TERMINAL_CONTAINER_PERSISTENT")
+        if persist is None:
+            persist_enabled = bool(terminal_cfg.get("container_persistent", True))
+        else:
+            persist_enabled = persist.lower() in {"1", "true", "yes", "on"}
+        sdk_ok = importlib.util.find_spec("blaxel") is not None
+        sdk_label = (
+            "installed" if sdk_ok
+            else f"missing (install: {BLAXEL_SDK_INSTALL_COMMAND})"
+        )
+        from hermes_cli.blaxel_auth import describe_blaxel_auth
+
+        blaxel_auth = describe_blaxel_auth()
+        print(f"  Blaxel Image: {blaxel_image}")
+        print(f"  TTL:          {ttl}")
+        print(f"  SDK:          {check_mark(sdk_ok)} {sdk_label}")
+        print(f"  Workspace:    {check_mark(bool(blaxel_auth.workspace))} "
+              f"{blaxel_auth.workspace or 'none resolved'}")
+        print(f"  Auth:         {check_mark(blaxel_auth.ok)} {blaxel_auth.label}")
+        for line in blaxel_auth.detail_lines:
+            print(f"  Auth detail:  {line}")
+        print(f"  Persistence:  {'persistent volume per task' if persist_enabled else 'ephemeral filesystem'}")
 
     sudo_password = os.getenv("SUDO_PASSWORD", "")
     print(f"  Sudo:         {check_mark(bool(sudo_password))} {'enabled' if sudo_password else 'disabled'}")

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -18,6 +18,25 @@ _HERMES_HOME_OVERRIDE: ContextVar[str | object] = ContextVar(
     "_HERMES_HOME_OVERRIDE", default=_UNSET
 )
 
+# ── Blaxel terminal backend defaults ──────────────────────────────────
+# Single source of truth for config loading, the setup wizard, doctor, and
+# runtime. Every Blaxel default is defined here exactly once so the wizard,
+# the env-var path, and the persisted config can never disagree.
+BLAXEL_DEFAULT_CWD = "/blaxel"
+# py-app, not base-image: base-image is Alpine/musl and has no glibc, so any
+# manylinux-only wheel an agent pip-installs in the sandbox fails to build.
+BLAXEL_DEFAULT_IMAGE = "blaxel/py-app:latest"
+BLAXEL_DEFAULT_MEMORY_MB = 4096
+BLAXEL_DEFAULT_TTL = "24h"
+# Durable volume size is its own knob. It is deliberately NOT derived from
+# container memory: raising memory must never silently grow paid storage.
+BLAXEL_DEFAULT_VOLUME_SIZE_MB = 10240
+# Declared once here and mirrored by the ``terminal.blaxel`` lazy-dep entry and
+# the ``blaxel`` extra in pyproject.toml, so the wizard, doctor, and the runtime
+# error message can never suggest a different install than the one that runs.
+BLAXEL_SDK_DEPENDENCY = "blaxel==0.2.55"
+BLAXEL_SDK_INSTALL_COMMAND = "pip install 'hermes-agent[blaxel]'"
+
 # ── TUI busy-indicator styles ─────────────────────────────────────────
 # Single source of truth shared by the CLI /indicator command, the TUI
 # gateway config handler, and the /help command registry. Keep in sync

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
+blaxel = ["blaxel==0.2.55"]
 hindsight = ["hindsight-client==0.6.1"]
 dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==1.28.1", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.14.1", "brotlicffi==1.2.0.1", "slack-bolt==1.29.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.1: CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -85,6 +85,39 @@ class TestLoadConfigDefaults:
             assert config["agent"]["max_turns"] == 42
             assert "max_turns" not in config
 
+    def test_blaxel_backend_gets_backend_specific_container_defaults(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text("terminal:\n  backend: blaxel\n")
+
+            config = load_config()
+            assert config["terminal"]["container_memory"] == 4096
+            assert config["terminal"]["container_disk"] == 10240
+
+    def test_blaxel_backend_never_overrides_explicit_container_values(self, tmp_path):
+        """An explicit user size must survive the backend-default pass."""
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text(
+                "terminal:\n"
+                "  backend: blaxel\n"
+                "  container_memory: 8192\n"
+                "  container_disk: 20480\n"
+            )
+
+            config = load_config()
+            assert config["terminal"]["container_memory"] == 8192
+            assert config["terminal"]["container_disk"] == 20480
+
+    def test_non_blaxel_backend_keeps_the_shared_container_defaults(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text("terminal:\n  backend: docker\n")
+
+            config = load_config()
+            assert config["terminal"]["container_memory"] == 5120
+            assert config["terminal"]["container_disk"] == 51200
+
 
 class TestLoadConfigParseFailure:
     """A YAML parse failure must NOT silently fall back to defaults.

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -250,3 +250,54 @@ def test_vercel_setup_prefills_project_and_team_from_link_file(tmp_path, monkeyp
     assert os.environ["VERCEL_TEAM_ID"] == "linked-team"
     assert defaults["    Vercel project ID"] == "linked-project"
     assert defaults["    Vercel team ID"] == "linked-team"
+
+
+def test_blaxel_setup_never_prompts_for_ignored_cpu_or_container_disk(tmp_path, monkeypatch):
+    """Blaxel must not reuse the shared container-resource prompt.
+
+    The review on #20809 flagged that routing Blaxel through
+    ``_prompt_container_resources`` asks for CPU and container disk, which the
+    backend ignores. This pins the Blaxel-specific prompt: the questions asked
+    are image, memory, persistence, volume size, and TTL — never CPU.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    for key in ("BL_WORKSPACE", "BL_API_KEY", "TERMINAL_BLAXEL_IMAGE", "TERMINAL_BLAXEL_TTL"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setitem(sys.modules, "blaxel", types.ModuleType("blaxel"))
+    config = load_config()
+
+    def fake_prompt_choice(question, choices, default=0):
+        if question == "Select terminal backend:":
+            return 6
+        raise AssertionError(f"Unexpected prompt_choice call: {question}")
+
+    asked: list[str] = []
+    answers = {
+        "Sandbox image": "blaxel/py-app:latest",
+        "Memory (MB)": "8192",
+        "Keep a persistent volume per task? (yes/no)": "yes",
+        "Persistent volume size (MB)": "20480",
+        "Sandbox TTL (e.g. 24h)": "12h",
+    }
+
+    def fake_prompt(question, default=None, *args, **kwargs):
+        label = question.strip()
+        asked.append(label)
+        return answers.get(label, default if default is not None else "")
+
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr("hermes_cli.setup.prompt", fake_prompt)
+
+    from hermes_cli.setup import setup_terminal_backend
+
+    setup_terminal_backend(config)
+
+    assert config["terminal"]["backend"] == "blaxel"
+    assert config["terminal"]["blaxel_image"] == "blaxel/py-app:latest"
+    assert config["terminal"]["container_memory"] == 8192
+    assert config["terminal"]["container_persistent"] is True
+    assert config["terminal"]["container_disk"] == 20480
+    assert config["terminal"]["blaxel_ttl"] == "12h"
+
+    joined = " | ".join(asked).lower()
+    assert "cpu" not in joined, f"Blaxel setup must not ask for CPU; asked: {asked}"

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -69,7 +69,7 @@ def test_lazy_installable_extras_excluded_from_all():
         "fal",
         "edge-tts", "tts-premium",
         "voice",  # faster-whisper / sounddevice / numpy
-        "modal", "daytona", "vercel",
+        "modal", "daytona", "vercel", "blaxel",
         "messaging", "slack", "matrix", "dingtalk", "feishu",
         "honcho", "hindsight",
         "supermemory", "mem0",

--- a/tests/tools/test_blaxel_environment.py
+++ b/tests/tools/test_blaxel_environment.py
@@ -1,0 +1,770 @@
+"""Unit tests for the Blaxel cloud sandbox environment backend."""
+
+import io
+import threading
+import re
+import tarfile
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build mock Blaxel SDK objects
+# ---------------------------------------------------------------------------
+
+
+def _make_exec_response(stdout="", stderr="", exit_code=0, logs=None, status="completed"):
+    return SimpleNamespace(
+        stdout=stdout,
+        stderr=stderr,
+        logs=logs if logs is not None else stdout,
+        exit_code=exit_code,
+        status=status,
+    )
+
+
+def _make_tar_bytes(files: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, content in files.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _make_sandbox():
+    sb = MagicMock()
+    sb.process.exec.return_value = _make_exec_response()
+    sb.fs.read_binary.return_value = _make_tar_bytes({})
+    return sb
+
+
+def _script_sandbox(sb, responses, *, home="/root"):
+    """Answer BaseEnvironment's bootstrap calls, then replay *responses*.
+
+    Bootstrap (the ``$HOME`` probe and ``init_session``'s snapshot setup) is
+    owned by BaseEnvironment and its call count is not this backend's contract.
+    Dispatching on the command text instead of queueing a fixed-length
+    ``side_effect`` keeps these tests pinned to Blaxel behavior, so a change to
+    the shared bootstrap cannot silently shift which response a command gets.
+    """
+    queued = list(responses)
+
+    def _dispatch(payload, *args, **kwargs):
+        command = ""
+        if isinstance(payload, dict):
+            command = str(payload.get("command") or "")
+        if "$HOME" in command or command.strip() in {"echo $HOME", "printf %s $HOME"}:
+            return _make_exec_response(stdout=home)
+        if _is_session_bootstrap(command):
+            return _make_exec_response(exit_code=0)
+        if queued:
+            return queued.pop(0)
+        return _make_exec_response()
+
+    sb.process.exec.side_effect = _dispatch
+    # BaseEnvironment reads the bootstrap's exit status through process.get.
+    # Left as a bare MagicMock, exit_code is not an int and init_session reads
+    # it as a failure. Tests that care about polling override this afterwards.
+    sb.process.get.return_value = SimpleNamespace(
+        status="completed", exit_code=0, stdout="", stderr="", logs="",
+    )
+    return sb
+
+
+_TRIVIAL_PROBES = frozenset({"true", ":", "bash -c true", "bash -c :"})
+
+
+def _is_session_bootstrap(command: str) -> bool:
+    """Recognize BaseEnvironment's session bootstrap and liveness probes.
+
+    Covers the snapshot bootstrap, the ``bash -c true`` login-shell check that
+    follows it, and the no-op readiness probes. None of these are commands the
+    caller asked for, so they must not consume a queued response.
+    """
+    stripped = command.strip()
+    if stripped in _TRIVIAL_PROBES:
+        return True
+    markers = ("__hermes_snap", "hermes-snap", "__hermes_fns", "__hermes_cwd")
+    return any(marker in command for marker in markers)
+
+
+def _patch_blaxel_imports(monkeypatch):
+    """Inject mock blaxel.core / blaxel.core.sandbox / blaxel.core.volume
+    modules so the BlaxelEnvironment import path works without the real
+    SDK installed."""
+    import sys
+    import types as _types
+
+    core_mod = _types.ModuleType("blaxel.core")
+    sandbox_mod = _types.ModuleType("blaxel.core.sandbox")
+    volume_mod = _types.ModuleType("blaxel.core.volume")
+
+    class _SandboxAPIError(Exception):
+        def __init__(self, msg="", status_code=None):
+            super().__init__(msg)
+            self.status_code = status_code
+
+    class _VolumeAPIError(Exception):
+        def __init__(self, msg="", status_code=None):
+            super().__init__(msg)
+            self.status_code = status_code
+
+    core_mod.SyncSandboxInstance = MagicMock()
+    core_mod.SyncVolumeInstance = MagicMock()
+    sandbox_mod.SandboxAPIError = _SandboxAPIError
+    volume_mod.VolumeAPIError = _VolumeAPIError
+
+    blaxel_mod = _types.ModuleType("blaxel")
+    blaxel_mod.core = core_mod
+
+    monkeypatch.setitem(sys.modules, "blaxel", blaxel_mod)
+    monkeypatch.setitem(sys.modules, "blaxel.core", core_mod)
+    monkeypatch.setitem(sys.modules, "blaxel.core.sandbox", sandbox_mod)
+    monkeypatch.setitem(sys.modules, "blaxel.core.volume", volume_mod)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *args, **kwargs: None)
+    return SimpleNamespace(
+        SyncSandboxInstance=core_mod.SyncSandboxInstance,
+        SyncVolumeInstance=core_mod.SyncVolumeInstance,
+        SandboxAPIError=_SandboxAPIError,
+        VolumeAPIError=_VolumeAPIError,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def blaxel_sdk(monkeypatch):
+    return _patch_blaxel_imports(monkeypatch)
+
+
+@pytest.fixture()
+def make_env(blaxel_sdk, monkeypatch, tmp_path):
+    """Factory that creates a BlaxelEnvironment with a mocked SDK."""
+    monkeypatch.setattr("tools.environments.base.is_interrupted", lambda: False)
+    monkeypatch.setattr("tools.credential_files.get_credential_file_mounts", lambda: [])
+    monkeypatch.setattr("tools.credential_files.get_skills_directory_mount", lambda **kw: None)
+    monkeypatch.setattr("tools.credential_files.iter_skills_files", lambda **kw: [])
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    # Default region — keep tests deterministic regardless of host env.
+    monkeypatch.setenv("BL_REGION", "us-pdx-1")
+    # Skip the readiness probe during unit tests; it consumes mock exec
+    # calls and is exercised by integration tests instead.
+    monkeypatch.setattr(
+        "tools.environments.blaxel.BlaxelEnvironment._wait_for_sandbox_ready",
+        lambda self, max_wait_seconds=60.0: None,
+    )
+
+    def _factory(
+        sandbox=None,
+        home_dir="/root",
+        persistent=True,
+        **kwargs,
+    ):
+        sandbox = sandbox or _make_sandbox()
+        sandbox.process.exec.return_value = _make_exec_response(stdout=home_dir)
+
+        blaxel_sdk.SyncSandboxInstance.create.return_value = sandbox
+
+        from tools.environments.blaxel import BlaxelEnvironment
+
+        env = BlaxelEnvironment(
+            image="blaxel/base-image:latest",
+            persistent_filesystem=persistent,
+            **kwargs,
+        )
+        env._mock_sdk = blaxel_sdk
+        return env
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# Constructor / cwd resolution
+# ---------------------------------------------------------------------------
+
+
+class TestCwdResolution:
+    """When no volume is mounted (non-persistent), cwd falls back to $HOME."""
+
+    def test_default_cwd_resolves_home(self, make_env):
+        env = make_env(persistent=False, home_dir="/home/blaxel")
+        assert env.cwd == "/home/blaxel"
+
+    def test_tilde_cwd_resolves_home(self, make_env):
+        env = make_env(persistent=False, cwd="~", home_dir="/home/blaxel")
+        assert env.cwd == "/home/blaxel"
+
+    def test_explicit_cwd_not_overridden(self, make_env):
+        env = make_env(persistent=False, cwd="/workspace", home_dir="/root")
+        assert env.cwd == "/workspace"
+
+    def test_home_detection_failure_keeps_default_cwd(self, make_env):
+        sb = _make_sandbox()
+        sb.process.exec.side_effect = RuntimeError("exec failed")
+        env = make_env(persistent=False, sandbox=sb)
+        # /root is the default home (set by self._remote_home before detection).
+        assert env.cwd == "/root"
+
+
+# ---------------------------------------------------------------------------
+# Sandbox persistence / reattach
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    def test_persistent_creates_sandbox_with_volume(self, make_env, blaxel_sdk):
+        env = make_env(persistent=True, task_id="mytask")
+        blaxel_sdk.SyncSandboxInstance.create.assert_called_once()
+        sandbox_config = blaxel_sdk.SyncSandboxInstance.create.call_args[0][0]
+        assert sandbox_config["name"] == "hermes-mytask"
+        assert sandbox_config["labels"] == {"hermes_task_id": "mytask"}
+        assert "volumes" in sandbox_config
+
+    def test_resource_names_are_sanitized_and_capped(self, make_env, blaxel_sdk):
+        task_id = "ABC/Some Very Long Task ID With Spaces and Symbols!" + ("x" * 80)
+        env = make_env(persistent=True, task_id=task_id)
+
+        sandbox_config = blaxel_sdk.SyncSandboxInstance.create.call_args[0][0]
+        volume_config = (
+            blaxel_sdk.SyncVolumeInstance.create_if_not_exists.call_args[0][0]
+        )
+        assert sandbox_config["name"].startswith("hermes-")
+        assert len(sandbox_config["name"]) <= 40
+        assert re.fullmatch(r"[a-z0-9-]+", sandbox_config["name"])
+        assert sandbox_config["name"] != f"hermes-{task_id}"
+        assert re.search(r"-[0-9a-f]{8}$", sandbox_config["name"])
+
+        assert volume_config["name"].startswith("hermes-")
+        assert volume_config["name"].endswith("-data")
+        assert len(volume_config["name"]) <= 40
+        assert re.fullmatch(r"[a-z0-9-]+", volume_config["name"])
+        assert re.search(r"-[0-9a-f]{8}-data$", volume_config["name"])
+
+        label_value = sandbox_config["labels"]["hermes_task_id"]
+        assert len(label_value) <= 63
+        assert re.fullmatch(r"[a-z0-9-]+", label_value)
+        assert label_value != task_id
+
+    def test_non_persistent_creates_sandbox_without_volume(
+        self, make_env, blaxel_sdk,
+    ):
+        env = make_env(persistent=False)
+        blaxel_sdk.SyncSandboxInstance.create.assert_called_once()
+        sandbox_config = blaxel_sdk.SyncSandboxInstance.create.call_args[0][0]
+        assert "volumes" not in sandbox_config
+
+    def test_name_conflict_reuses_healthy_existing(self, make_env, blaxel_sdk):
+        existing = _make_sandbox()
+        existing.process.exec.return_value = _make_exec_response(stdout="/root")
+        blaxel_sdk.SyncSandboxInstance.create.side_effect = (
+            blaxel_sdk.SandboxAPIError("ALREADY_EXISTS", status_code=409)
+        )
+        blaxel_sdk.SyncSandboxInstance.get.return_value = existing
+        from tools.environments.blaxel import BlaxelEnvironment
+        env = BlaxelEnvironment(
+            image="blaxel/base-image:latest",
+            persistent_filesystem=True,
+            task_id="conflict",
+        )
+        # The existing sandbox is responsive, so create() is NOT retried.
+        assert blaxel_sdk.SyncSandboxInstance.create.call_count == 1
+        blaxel_sdk.SyncSandboxInstance.delete.assert_not_called()
+        assert env._sandbox is existing
+
+    def test_name_conflict_recreates_when_existing_unresponsive(
+        self, make_env, blaxel_sdk, monkeypatch,
+    ):
+        # First create() raises 409, then the second create() succeeds.
+        fresh = _make_sandbox()
+        fresh.process.exec.return_value = _make_exec_response(stdout="/root")
+        blaxel_sdk.SyncSandboxInstance.create.side_effect = [
+            blaxel_sdk.SandboxAPIError("ALREADY_EXISTS", status_code=409),
+            fresh,
+        ]
+        # The "existing" one is unresponsive (its exec raises forever).
+        zombie = _make_sandbox()
+        zombie.process.exec.side_effect = RuntimeError("WORKLOAD_UNAVAILABLE")
+        blaxel_sdk.SyncSandboxInstance.get.return_value = zombie
+        # Skip the real time.sleep so the test stays fast.
+        monkeypatch.setattr("tools.environments.blaxel.time.sleep", lambda _s: None)
+        # Fast-forward _sandbox_is_responsive's deadline.
+        clock = {"t": 0.0}
+        def fake_monotonic():
+            clock["t"] += 100
+            return clock["t"]
+        monkeypatch.setattr(
+            "tools.environments.blaxel.time.monotonic", fake_monotonic,
+        )
+
+        from tools.environments.blaxel import BlaxelEnvironment
+        env = BlaxelEnvironment(
+            image="blaxel/base-image:latest",
+            persistent_filesystem=True,
+            task_id="zombie",
+        )
+        assert blaxel_sdk.SyncSandboxInstance.create.call_count == 2
+        blaxel_sdk.SyncSandboxInstance.delete.assert_called_with("hermes-zombie")
+        assert env._sandbox is fresh
+
+
+# ---------------------------------------------------------------------------
+# Volume-backed persistence
+# ---------------------------------------------------------------------------
+
+
+class TestVolume:
+    def test_persistent_creates_volume(self, make_env, blaxel_sdk):
+        env = make_env(persistent=True, task_id="mytask")
+        blaxel_sdk.SyncVolumeInstance.create_if_not_exists.assert_called_once()
+        vol_config = (
+            blaxel_sdk.SyncVolumeInstance.create_if_not_exists.call_args[0][0]
+        )
+        assert vol_config["name"] == "hermes-mytask-data"
+        assert vol_config["size"] == 10240
+        assert vol_config["region"] == "us-pdx-1"
+        assert vol_config["labels"] == {"hermes_task_id": "mytask"}
+        assert env._volume_name == "hermes-mytask-data"
+
+    def test_persistent_volume_size_uses_disk_not_memory(
+        self, make_env, blaxel_sdk,
+    ):
+        _env = make_env(persistent=True, task_id="mytask", memory=8192, disk=20480)
+        vol_config = (
+            blaxel_sdk.SyncVolumeInstance.create_if_not_exists.call_args[0][0]
+        )
+        sandbox_config = blaxel_sdk.SyncSandboxInstance.create.call_args[0][0]
+        assert vol_config["size"] == 20480
+        assert sandbox_config["memory"] == 8192
+
+    def test_persistent_mounts_volume_on_sandbox(self, make_env, blaxel_sdk):
+        env = make_env(persistent=True, task_id="mytask")
+        sandbox_config = blaxel_sdk.SyncSandboxInstance.create.call_args[0][0]
+        assert "volumes" in sandbox_config
+        assert sandbox_config["volumes"] == [{
+            "name": "hermes-mytask-data",
+            "mount_path": "/blaxel/persistent",
+            "read_only": False,
+        }]
+
+    def test_persistent_cwd_points_at_volume(self, make_env):
+        env = make_env(persistent=True, task_id="mytask")
+        assert env.cwd == "/blaxel/persistent"
+
+    def test_non_persistent_skips_volume(self, make_env, blaxel_sdk):
+        env = make_env(persistent=False)
+        blaxel_sdk.SyncVolumeInstance.create_if_not_exists.assert_not_called()
+        sandbox_config = blaxel_sdk.SyncSandboxInstance.create.call_args[0][0]
+        assert "volumes" not in sandbox_config
+        assert env._volume_name is None
+
+    def test_volume_creation_failure_raises_before_sandbox_create(
+        self, make_env, blaxel_sdk,
+    ):
+        blaxel_sdk.SyncVolumeInstance.create_if_not_exists.side_effect = (
+            blaxel_sdk.VolumeAPIError("quota exceeded", status_code=403)
+        )
+        with pytest.raises(RuntimeError, match="persistent filesystem requested"):
+            make_env(persistent=True, task_id="mytask")
+        blaxel_sdk.SyncSandboxInstance.create.assert_not_called()
+
+    def test_persistent_without_volume_sdk_raises(self, blaxel_sdk, monkeypatch):
+        import sys
+
+        monkeypatch.setattr("tools.environments.base.is_interrupted", lambda: False)
+        monkeypatch.setattr("tools.credential_files.get_credential_file_mounts", lambda: [])
+        monkeypatch.setattr("tools.credential_files.get_skills_directory_mount", lambda **kw: None)
+        monkeypatch.setattr("tools.credential_files.iter_skills_files", lambda **kw: [])
+        monkeypatch.setenv("BL_REGION", "us-pdx-1")
+        monkeypatch.delattr(sys.modules["blaxel.core"], "SyncVolumeInstance")
+
+        from tools.environments.blaxel import BlaxelEnvironment
+        with pytest.raises(RuntimeError, match="does not expose volume support"):
+            BlaxelEnvironment(
+                image="blaxel/base-image:latest",
+                persistent_filesystem=True,
+                task_id="mytask",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestCleanup:
+    def test_persistent_cleanup_deletes_sandbox_and_preserves_volume(self, make_env):
+        env = make_env(persistent=True)
+        sb = env._sandbox
+        volume_name = env._volume_name
+        env.cleanup()
+        sb.delete.assert_called_once()
+        assert volume_name is not None
+
+    def test_non_persistent_cleanup_deletes_sandbox(self, make_env):
+        env = make_env(persistent=False)
+        sb = env._sandbox
+        env.cleanup()
+        sb.delete.assert_called_once()
+
+    def test_cleanup_idempotent(self, make_env):
+        env = make_env(persistent=False)
+        env.cleanup()
+        env.cleanup()  # should not raise
+
+    def test_cleanup_swallows_404(self, make_env, blaxel_sdk):
+        env = make_env(persistent=False)
+        env._sandbox.delete.side_effect = blaxel_sdk.SandboxAPIError(
+            "gone", status_code=404,
+        )
+        env.cleanup()  # should not raise
+
+    def test_cleanup_swallows_generic_errors(self, make_env):
+        env = make_env(persistent=False)
+        env._sandbox.delete.side_effect = RuntimeError("boom")
+        env.cleanup()  # should not raise
+        assert env._sandbox is None
+
+    def test_cleanup_syncs_workspace_to_remote_sync_cache(
+        self, make_env, monkeypatch, tmp_path,
+    ):
+        hermes_home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        sb = _make_sandbox()
+        sb.fs.read_binary.return_value = _make_tar_bytes({
+            "result.txt": b"workspace-result",
+            "nested/output.log": b"nested-result",
+        })
+        env = make_env(persistent=False, sandbox=sb)
+        session_id = env._session_id
+
+        env.cleanup()
+
+        sync_root = hermes_home / "cache" / "remote-syncs" / session_id
+        assert (sync_root / "result.txt").read_bytes() == b"workspace-result"
+        assert (sync_root / "nested" / "output.log").read_bytes() == b"nested-result"
+
+        commands = [
+            call_args[0][0]["command"]
+            for call_args in sb.process.exec.call_args_list
+        ]
+        workspace_sync_commands = [
+            command for command in commands
+            if ".hermes_workspace_sync" in command
+        ]
+        assert workspace_sync_commands
+        assert "node_modules" in workspace_sync_commands[0]
+        assert ".hermes" in workspace_sync_commands[0]
+
+    def test_cleanup_sync_extracts_without_tar_filter_support(
+        self, make_env, monkeypatch, tmp_path,
+    ):
+        hermes_home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        sb = _make_sandbox()
+        sb.fs.read_binary.return_value = _make_tar_bytes({
+            "result.txt": b"workspace-result",
+        })
+        env = make_env(persistent=False, sandbox=sb)
+        session_id = env._session_id
+
+        original_extractall = tarfile.TarFile.extractall
+
+        def extractall_without_filter(
+            self, path=".", members=None, *, numeric_owner=False, filter=None,
+        ):
+            if filter is not None:
+                raise TypeError("extractall() got an unexpected keyword argument 'filter'")
+            return original_extractall(self, path, members, numeric_owner=numeric_owner)
+
+        monkeypatch.setattr(tarfile.TarFile, "extractall", extractall_without_filter)
+
+        env.cleanup()
+
+        sync_root = hermes_home / "cache" / "remote-syncs" / session_id
+        assert (sync_root / "result.txt").read_bytes() == b"workspace-result"
+
+
+class TestUploadGuards:
+    def test_bulk_download_uses_empty_remote_archive_for_missing_hermes(
+        self, make_env, tmp_path,
+    ):
+        sb = _make_sandbox()
+        env = make_env(persistent=False, sandbox=sb)
+        sb.process.exec.reset_mock()
+        sb.fs.read_binary.return_value = _make_tar_bytes({})
+        dest = tmp_path / "sync.tar"
+
+        env._blaxel_bulk_download(dest)
+
+        archive_command = sb.process.exec.call_args_list[0][0][0]["command"]
+        assert "[ -d /root/.hermes ]" in archive_command
+        assert "dd if=/dev/zero" in archive_command
+        with tarfile.open(dest) as tar:
+            assert tar.getmembers() == []
+
+    def test_bulk_download_tar_failure_writes_empty_archive(
+        self, make_env, tmp_path,
+    ):
+        sb = _make_sandbox()
+        env = make_env(persistent=False, sandbox=sb)
+        sb.process.exec.reset_mock()
+        sb.process.exec.side_effect = [
+            _make_exec_response(stderr="tar failed", exit_code=2),
+            _make_exec_response(),
+        ]
+        dest = tmp_path / "sync.tar"
+
+        env._blaxel_bulk_download(dest)
+
+        sb.fs.read_binary.assert_not_called()
+        with tarfile.open(dest) as tar:
+            assert tar.getmembers() == []
+
+    def test_bulk_upload_refuses_files_above_sync_limit(
+        self, make_env, monkeypatch, tmp_path,
+    ):
+        monkeypatch.setenv("TERMINAL_FILE_SYNC_MAX_MB", "1")
+        sb = _make_sandbox()
+        env = make_env(persistent=False, sandbox=sb)
+
+        small = tmp_path / "small.txt"
+        small.write_text("ok", encoding="utf-8")
+        large = tmp_path / "large.bin"
+        large.write_bytes(b"x" * (1024 * 1024 + 1))
+        exec_calls_before = sb.process.exec.call_count
+
+        with pytest.raises(RuntimeError, match="TERMINAL_FILE_SYNC_MAX_MB=1MB"):
+            env._blaxel_bulk_upload([
+                (str(small), "/root/small.txt"),
+                (str(large), "/root/large.bin"),
+            ])
+
+        assert sb.process.exec.call_count == exec_calls_before
+        sb.fs.write_binary.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Execute (short timeout — blocking path)
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteShort:
+    def test_basic_command(self, make_env):
+        sb = _make_sandbox()
+        _script_sandbox(sb, [_make_exec_response(stdout="hello", exit_code=0)])
+        env = make_env(persistent=False, sandbox=sb, timeout=30)
+
+        result = env.execute("echo hello")
+        assert "hello" in result["output"]
+        assert result["returncode"] == 0
+
+    def test_blocking_path_passes_timeout_in_ms(self, make_env):
+        """When timeout <= 50s, the SDK's blocking path is used with timeout in ms."""
+        sb = _make_sandbox()
+        _script_sandbox(sb, [_make_exec_response(stdout="ok", exit_code=0)])
+        env = make_env(persistent=False, sandbox=sb, timeout=42)
+
+        env.execute("echo hello")
+        last_call = sb.process.exec.call_args_list[-1]
+        config = last_call[0][0]
+        assert config["wait_for_completion"] is True
+        assert config["timeout"] == 42_000
+
+    def test_nonzero_exit_code(self, make_env):
+        sb = _make_sandbox()
+        _script_sandbox(sb, [_make_exec_response(stdout="not found", exit_code=127)])
+        env = make_env(persistent=False, sandbox=sb, timeout=30)
+
+        result = env.execute("bad_cmd")
+        assert result["returncode"] == 127
+
+
+# ---------------------------------------------------------------------------
+# Execute (long timeout — async polling path)
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteLong:
+    def test_long_timeout_uses_async_polling(self, make_env, monkeypatch):
+        sb = _make_sandbox()
+        _script_sandbox(sb, [_make_exec_response()])
+
+        # process.get returns "completed" on the first poll
+        sb.process.get.return_value = SimpleNamespace(
+            status="completed", exit_code=0, stdout="hello", stderr="", logs="hello",
+        )
+
+        # No real sleeps in tests
+        monkeypatch.setattr("tools.environments.blaxel.time.sleep", lambda _s: None)
+
+        env = make_env(persistent=False, sandbox=sb, timeout=120)
+        result = env.execute("sleep 1 && echo hello")
+
+        # The third exec call should have used wait_for_completion=False
+        async_call = sb.process.exec.call_args_list[-1]
+        assert async_call[0][0]["wait_for_completion"] is False
+        assert "name" in async_call[0][0]
+
+        assert result["returncode"] == 0
+        assert "hello" in result["output"]
+
+    def test_long_timeout_preserves_nonzero_exit_code(self, make_env, monkeypatch):
+        sb = _make_sandbox()
+        _script_sandbox(sb, [_make_exec_response()])
+        sb.process.get.return_value = SimpleNamespace(
+            status="completed", exit_code=7, stdout="bad", stderr="", logs="bad",
+        )
+        monkeypatch.setattr("tools.environments.blaxel.time.sleep", lambda _s: None)
+
+        env = make_env(persistent=False, sandbox=sb, timeout=120)
+        result = env.execute("exit 7")
+
+        assert result["returncode"] == 7
+        assert "bad" in result["output"]
+
+    def test_long_timeout_kills_on_timeout(self, make_env, monkeypatch):
+        sb = _make_sandbox()
+        _script_sandbox(sb, [_make_exec_response()])  # async start
+        # Always return "running" so the polling loop hits its deadline.
+        # Set after _script_sandbox so it wins over the completed default.
+        sb.process.get.return_value = SimpleNamespace(
+            status="running", exit_code=None, stdout="", stderr="", logs="",
+        )
+
+        # Build the environment on a REAL clock first. BaseEnvironment's session
+        # bootstrap runs during construction; under the jumping clock below it
+        # times out and issues its own kill, which then races the assertion and
+        # makes this test flake between 1 and 2 recorded kills.
+        env = make_env(persistent=False, sandbox=sb, timeout=120)
+        sb.process.kill.reset_mock()
+
+        # Fake monotonic clock that jumps forward past the deadline
+        clock = {"t": 0.0}
+
+        def fake_monotonic():
+            clock["t"] += 100
+            return clock["t"]
+
+        monkeypatch.setattr("tools.environments.blaxel.time.monotonic", fake_monotonic)
+        monkeypatch.setattr("tools.environments.blaxel.time.sleep", lambda _s: None)
+
+        result = env.execute("sleep 9999")
+
+        sb.process.kill.assert_called_once()
+        assert result["returncode"] == 124
+
+
+# ---------------------------------------------------------------------------
+# Resource handling
+# ---------------------------------------------------------------------------
+
+
+class TestResourceHandling:
+    @staticmethod
+    def _last_sandbox_config(blaxel_sdk):
+        for mock_method in (
+            blaxel_sdk.SyncSandboxInstance.create_if_not_exists,
+            blaxel_sdk.SyncSandboxInstance.create,
+        ):
+            if mock_method.call_args is not None:
+                return mock_method.call_args[0][0]
+        raise AssertionError("Sandbox creation was never called")
+
+    def test_memory_passed_to_create(self, make_env, blaxel_sdk):
+        env = make_env(memory=4096)
+        config = self._last_sandbox_config(blaxel_sdk)
+        assert config["memory"] == 4096
+
+    def test_region_uses_env_var(self, make_env, blaxel_sdk, monkeypatch):
+        monkeypatch.setenv("BL_REGION", "eu-lon-1")
+        env = make_env()
+        config = self._last_sandbox_config(blaxel_sdk)
+        assert config["region"] == "eu-lon-1"
+
+    def test_region_defaults_when_env_unset(self, make_env, blaxel_sdk, monkeypatch):
+        monkeypatch.delenv("BL_REGION", raising=False)
+        env = make_env()
+        config = self._last_sandbox_config(blaxel_sdk)
+        assert config["region"] == "us-pdx-1"
+
+    def test_ttl_passed_to_create(self, make_env, blaxel_sdk):
+        env = make_env(ttl="1h")
+        config = self._last_sandbox_config(blaxel_sdk)
+        assert config["ttl"] == "1h"
+
+    def test_lazy_dep_registration(self):
+        from hermes_constants import BLAXEL_SDK_DEPENDENCY
+        from tools.lazy_deps import LAZY_DEPS
+
+        assert LAZY_DEPS["terminal.blaxel"] == (BLAXEL_SDK_DEPENDENCY,)
+
+    def test_wait_for_sandbox_ready_raises_on_timeout(
+        self, blaxel_sdk, monkeypatch,
+    ):
+        monkeypatch.setattr("tools.environments.base.is_interrupted", lambda: False)
+        monkeypatch.setattr("tools.credential_files.get_credential_file_mounts", lambda: [])
+        monkeypatch.setattr("tools.credential_files.get_skills_directory_mount", lambda **kw: None)
+        monkeypatch.setattr("tools.credential_files.iter_skills_files", lambda **kw: [])
+        monkeypatch.setenv("BL_REGION", "us-pdx-1")
+
+        sb = _make_sandbox()
+        sb.process.exec.side_effect = RuntimeError("WORKLOAD_UNAVAILABLE")
+        blaxel_sdk.SyncSandboxInstance.create.return_value = sb
+
+        clock = {"t": 0.0}
+
+        def fake_monotonic():
+            clock["t"] += 100
+            return clock["t"]
+
+        monkeypatch.setattr("tools.environments.blaxel.time.monotonic", fake_monotonic)
+        monkeypatch.setattr("tools.environments.blaxel.time.sleep", lambda _s: None)
+
+        from tools.environments.blaxel import BlaxelEnvironment
+        with pytest.raises(RuntimeError, match="did not become ready"):
+            BlaxelEnvironment(
+                image="blaxel/base-image:latest",
+                persistent_filesystem=False,
+                task_id="timeout",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Interrupt
+# ---------------------------------------------------------------------------
+
+
+class TestInterrupt:
+    def test_interrupt_kills_process_and_returns_130(self, make_env, monkeypatch):
+        sb = _make_sandbox()
+        event = threading.Event()
+        calls = {"n": 0}
+
+        def exec_side_effect(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return _make_exec_response(stdout="/root")
+            if calls["n"] == 2:
+                return _make_exec_response(exit_code=0)
+            event.wait(timeout=5)
+            return _make_exec_response(stdout="done", exit_code=0)
+
+        sb.process.exec.side_effect = exec_side_effect
+        env = make_env(persistent=False, sandbox=sb, timeout=30)
+
+        monkeypatch.setattr(
+            "tools.environments.base.is_interrupted", lambda: True
+        )
+        try:
+            result = env.execute("sleep 10")
+            assert result["returncode"] == 130
+            sb.process.kill.assert_called()
+        finally:
+            event.set()

--- a/tests/tools/test_container_cwd_sanitize.py
+++ b/tests/tools/test_container_cwd_sanitize.py
@@ -33,7 +33,7 @@ class TestIsUnusableContainerCwd:
 
     def test_container_backends_set(self):
         assert tt._CONTAINER_BACKENDS == frozenset(
-            {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
+            {"docker", "singularity", "modal", "daytona", "vercel_sandbox", "blaxel"}
         )
 
 

--- a/tests/tools/test_terminal_requirements.py
+++ b/tests/tools/test_terminal_requirements.py
@@ -23,6 +23,11 @@ def _clear_terminal_env(monkeypatch):
         "TERMINAL_SSH_USER",
         "TERMINAL_TIMEOUT",
         "TERMINAL_VERCEL_RUNTIME",
+        "TERMINAL_BLAXEL_IMAGE",
+        "TERMINAL_BLAXEL_TTL",
+        "BL_WORKSPACE",
+        "BL_API_KEY",
+        "BL_REGION",
         "MODAL_TOKEN_ID",
         "MODAL_TOKEN_SECRET",
         "VERCEL_OIDC_TOKEN",
@@ -206,3 +211,172 @@ def test_vercel_backend_rejects_malformed_disk_without_raising(monkeypatch, capl
         "Invalid value for TERMINAL_CONTAINER_DISK" in record.getMessage()
         for record in caplog.records
     )
+
+
+# ---------------------------------------------------------------------------
+# Blaxel backend
+# ---------------------------------------------------------------------------
+
+
+def _isolate_blaxel_cli_config(monkeypatch, tmp_path, workspaces=None):
+    """Point the Blaxel CLI-config reader at a temp file.
+
+    Without this, these tests read the developer's real ~/.blaxel/config.yaml
+    and pass or fail depending on whose machine they run on.
+    """
+    import yaml
+
+    from hermes_cli import blaxel_auth
+
+    path = tmp_path / "blaxel-config.yaml"
+    if workspaces is None:
+        path.write_text("{}", encoding="utf-8")
+    else:
+        path.write_text(yaml.safe_dump(workspaces), encoding="utf-8")
+    monkeypatch.setattr(blaxel_auth, "_BLAXEL_CLI_CONFIG", path)
+    return path
+
+
+def test_blaxel_backend_without_any_workspace_logs_specific_error(
+    monkeypatch, tmp_path, caplog
+):
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "blaxel")
+    _isolate_blaxel_cli_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(terminal_tool_module.importlib.util, "find_spec", lambda _name: object())
+
+    with caplog.at_level(logging.ERROR):
+        ok = terminal_tool_module.check_terminal_requirements()
+
+    assert ok is False
+    assert any("no workspace resolved" in r.getMessage() for r in caplog.records)
+
+
+def test_blaxel_backend_with_workspace_but_no_credentials_logs_specific_error(
+    monkeypatch, tmp_path, caplog
+):
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "blaxel")
+    monkeypatch.setenv("BL_WORKSPACE", "ws")
+    _isolate_blaxel_cli_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(terminal_tool_module.importlib.util, "find_spec", lambda _name: object())
+
+    with caplog.at_level(logging.ERROR):
+        ok = terminal_tool_module.check_terminal_requirements()
+
+    assert ok is False
+    assert any("no credentials found" in r.getMessage() for r in caplog.records)
+
+
+def test_blaxel_backend_accepts_cli_login_without_an_api_key(monkeypatch, tmp_path):
+    """`bl login` is the documented path; requiring BL_API_KEY would reject it.
+
+    The Blaxel SDK authenticates from the CLI's stored credentials, so the
+    requirements gate must not be stricter than the SDK.
+    """
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "blaxel")
+    monkeypatch.setenv("BL_WORKSPACE", "ws")
+    _isolate_blaxel_cli_config(
+        monkeypatch,
+        tmp_path,
+        {"workspaces": [{"name": "ws", "credentials": {"access_token": "tok"}}]},
+    )
+    monkeypatch.setattr(terminal_tool_module.importlib.util, "find_spec", lambda _name: object())
+
+    assert terminal_tool_module.check_terminal_requirements() is True
+
+
+def test_blaxel_backend_falls_back_to_the_cli_selected_workspace(monkeypatch, tmp_path):
+    """No BL_WORKSPACE: use whatever workspace the CLI has selected."""
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "blaxel")
+    _isolate_blaxel_cli_config(
+        monkeypatch,
+        tmp_path,
+        {
+            "context": {"workspace": "ws"},
+            "workspaces": [{"name": "ws", "credentials": {"apiKey": "k"}}],
+        },
+    )
+    monkeypatch.setattr(terminal_tool_module.importlib.util, "find_spec", lambda _name: object())
+
+    assert terminal_tool_module.check_terminal_requirements() is True
+
+
+def test_blaxel_backend_without_sdk_reports_the_documented_install(
+    monkeypatch, tmp_path, caplog
+):
+    """The failure message must match the install the extra actually provides."""
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "blaxel")
+    monkeypatch.setenv("BL_WORKSPACE", "ws")
+    monkeypatch.setenv("BL_API_KEY", "key")
+    _isolate_blaxel_cli_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(terminal_tool_module.importlib.util, "find_spec", lambda _name: None)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *a, **k: None)
+
+    with caplog.at_level(logging.ERROR):
+        ok = terminal_tool_module.check_terminal_requirements()
+
+    assert ok is False
+    assert any(
+        "hermes-agent[blaxel]" in r.getMessage() for r in caplog.records
+    ), "install guidance must point at the extra, not a bare SDK pin"
+
+
+def test_blaxel_backend_with_credentials_and_sdk_passes(monkeypatch, tmp_path):
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "blaxel")
+    monkeypatch.setenv("BL_WORKSPACE", "ws")
+    monkeypatch.setenv("BL_API_KEY", "key")
+    _isolate_blaxel_cli_config(monkeypatch, tmp_path)
+    monkeypatch.setattr(terminal_tool_module.importlib.util, "find_spec", lambda _name: object())
+
+    assert terminal_tool_module.check_terminal_requirements() is True
+
+
+def test_blaxel_defaults_do_not_inherit_the_shared_container_sizes(monkeypatch):
+    """Blaxel memory/volume defaults must come from one place only.
+
+    Guards the drift the review flagged on #20809: the env path defaulted to
+    4096 MB while the persisted config defaulted to 5120 MB.
+    """
+    from hermes_constants import (
+        BLAXEL_DEFAULT_CWD,
+        BLAXEL_DEFAULT_MEMORY_MB,
+        BLAXEL_DEFAULT_VOLUME_SIZE_MB,
+    )
+
+    _clear_terminal_env(monkeypatch)
+    monkeypatch.setenv("TERMINAL_ENV", "blaxel")
+    monkeypatch.setattr(terminal_tool_module, "_terminal_config_bridge_attempted", True)
+
+    config = terminal_tool_module._get_env_config()
+
+    assert config["env_type"] == "blaxel"
+    assert config["cwd"] == BLAXEL_DEFAULT_CWD
+    assert config["container_memory"] == BLAXEL_DEFAULT_MEMORY_MB
+    assert config["container_disk"] == BLAXEL_DEFAULT_VOLUME_SIZE_MB
+
+
+def test_blaxel_sdk_pin_matches_across_every_declaration_site():
+    """The pin is declared in three files; a mismatch is a silent install bug.
+
+    This mirrors the sibling-site contract style already used elsewhere in the
+    suite rather than sharing a constant, because lazy_deps and pyproject are
+    intentionally literal.
+    """
+    import re
+    from pathlib import Path
+
+    from hermes_constants import BLAXEL_SDK_DEPENDENCY
+    from tools.lazy_deps import LAZY_DEPS
+
+    root = Path(__file__).resolve().parents[2]
+    pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+    extra = re.search(r'^blaxel = \["([^"]+)"\]', pyproject, re.MULTILINE)
+
+    assert extra, "pyproject.toml must declare a [blaxel] extra"
+    assert LAZY_DEPS["terminal.blaxel"] == (BLAXEL_SDK_DEPENDENCY,)
+    assert extra.group(1) == BLAXEL_SDK_DEPENDENCY

--- a/tools/environments/blaxel.py
+++ b/tools/environments/blaxel.py
@@ -1,0 +1,793 @@
+"""Blaxel cloud sandbox execution environment.
+
+Uses the Blaxel Python SDK (``blaxel.core.SyncSandboxInstance``) to run
+commands in cloud sandboxes. Supports persistent sandboxes: when enabled,
+a task-scoped Blaxel volume is created (or reused)
+and mounted at ``/blaxel/persistent`` on the sandbox. The volume survives
+sandbox deletion / TTL expiry, so the agent's working files remain
+durable across sessions even if the sandbox itself goes away.
+"""
+
+import logging
+import os
+import hashlib
+import re
+import shlex
+import shutil
+import tarfile
+import tempfile
+import threading
+import time
+import uuid
+from pathlib import Path
+
+from hermes_constants import (
+    BLAXEL_DEFAULT_CWD,
+    BLAXEL_DEFAULT_MEMORY_MB,
+    BLAXEL_DEFAULT_TTL,
+    BLAXEL_DEFAULT_VOLUME_SIZE_MB,
+    get_hermes_home,
+)
+from tools.environments.base import (
+    BaseEnvironment,
+    _ThreadedProcessHandle,
+)
+from tools.environments.file_sync import (
+    FileSyncManager,
+    iter_sync_files,
+    quoted_mkdir_command,
+    quoted_rm_command,
+    unique_parent_dirs,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Blaxel platform caps a single blocking ``process.exec`` at 60s. Anything
+# beyond that is run with ``wait_for_completion=False`` and polled via
+# ``process.get()`` / ``process.logs()`` so longer Hermes timeouts work.
+_BLAXEL_BLOCKING_EXEC_CAP_SECONDS = 50
+_BLAXEL_POLL_INTERVAL_SECONDS = 1.0
+
+# Mount point inside the sandbox where the persistent Blaxel volume lives.
+# When ``persistent_filesystem=True``, this directory is durable across
+# sandbox recreation; everything else in the sandbox is ephemeral.
+_BLAXEL_VOLUME_MOUNT_PATH = "/blaxel/persistent"
+_BLAXEL_RESOURCE_MAX_LENGTH = 40
+_BLAXEL_LABEL_MAX_LENGTH = 63
+_BLAXEL_HASH_LENGTH = 8
+_BLAXEL_DEFAULT_REGION = "us-pdx-1"
+_WORKSPACE_SYNC_MAX_MB = 100
+_WORKSPACE_SYNC_EXCLUDES = (
+    ".git",
+    ".hermes",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+)
+
+
+def _safe_blaxel_component(value: str, max_length: int) -> str:
+    """Return a DNS-label-safe, deterministic Blaxel name component."""
+    raw = str(value or "default")
+    slug = re.sub(r"[^a-z0-9-]+", "-", raw.lower()).strip("-")
+    slug = re.sub(r"-{2,}", "-", slug) or "default"
+    if len(slug) <= max_length:
+        return slug
+
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:_BLAXEL_HASH_LENGTH]
+    keep = max(1, max_length - _BLAXEL_HASH_LENGTH - 1)
+    prefix = slug[:keep].rstrip("-") or slug[:keep]
+    return f"{prefix}-{digest}"
+
+
+def _blaxel_resource_name(prefix: str, task_id: str, suffix: str = "") -> str:
+    """Build a Blaxel resource name capped for downstream platform labels."""
+    component_max = _BLAXEL_RESOURCE_MAX_LENGTH - len(prefix) - len(suffix) - 1
+    if component_max < _BLAXEL_HASH_LENGTH + 2:
+        raise ValueError("Blaxel resource prefix/suffix leaves no room for task id")
+    component = _safe_blaxel_component(task_id, component_max)
+    return f"{prefix}-{component}{suffix}"
+
+
+def _blaxel_label_value(task_id: str) -> str:
+    return _safe_blaxel_component(task_id, _BLAXEL_LABEL_MAX_LENGTH)
+
+
+def _workspace_sync_max_bytes() -> int:
+    raw = os.getenv("TERMINAL_FILE_SYNC_MAX_MB", str(_WORKSPACE_SYNC_MAX_MB))
+    try:
+        mb = int(raw)
+    except ValueError:
+        mb = _WORKSPACE_SYNC_MAX_MB
+    return max(1, mb) * 1024 * 1024
+
+
+def _numeric_equal(value: object, expected: float) -> bool:
+    try:
+        return float(value) == expected
+    except (TypeError, ValueError):
+        return False
+
+
+def _guard_blaxel_upload_size(host_path: str, remote_path: str) -> None:
+    max_bytes = _workspace_sync_max_bytes()
+    try:
+        size = Path(host_path).stat().st_size
+    except OSError:
+        return
+    if size <= max_bytes:
+        return
+
+    max_mb = max_bytes // (1024 * 1024)
+    message = (
+        f"Blaxel upload refused for {remote_path}: {size} bytes exceeds "
+        f"TERMINAL_FILE_SYNC_MAX_MB={max_mb}MB"
+    )
+    logger.warning(message)
+    raise RuntimeError(message)
+
+
+def _path_is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _extract_data_tar(tar: tarfile.TarFile, dest: Path) -> None:
+    """Extract tar data members safely on Python versions without filters."""
+    dest = dest.resolve()
+    dest.mkdir(parents=True, exist_ok=True)
+
+    try:
+        tar.extractall(dest, filter="data")
+        return
+    except TypeError as e:
+        if "filter" not in str(e):
+            raise
+
+    for member in tar.getmembers():
+        target = (dest / member.name).resolve()
+        if target != dest and not _path_is_relative_to(target, dest):
+            raise tarfile.TarError(f"refusing to extract unsafe tar member {member.name!r}")
+        if member.isdir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        if not member.isfile():
+            continue
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        source = tar.extractfile(member)
+        if source is None:
+            continue
+        with source, open(target, "wb") as f:
+            shutil.copyfileobj(source, f)
+        os.chmod(target, member.mode & 0o777)
+
+
+def _write_empty_tar(path: Path) -> None:
+    with tarfile.open(path, "w"):
+        pass
+
+
+def _ensure_blaxel_sdk() -> None:
+    """Lazy-install blaxel SDK on demand. Idempotent once installed."""
+    try:
+        from tools.lazy_deps import ensure as _lazy_ensure
+        _lazy_ensure("terminal.blaxel", prompt=False)
+    except ImportError:
+        pass
+    except Exception as e:
+        raise ImportError(str(e))
+
+
+class BlaxelEnvironment(BaseEnvironment):
+    """Blaxel cloud sandbox execution backend.
+
+    Spawn-per-call via _ThreadedProcessHandle wrapping blocking SDK calls.
+    cancel_fn wired to ``process.kill(name)`` (or sandbox.delete() as a last
+    resort) for interrupt support.
+    """
+
+    _stdin_mode = "heredoc"
+
+    def __init__(
+        self,
+        image: str,
+        cwd: str = BLAXEL_DEFAULT_CWD,
+        timeout: int = 60,
+        cpu: int | float = 1,
+        memory: int = BLAXEL_DEFAULT_MEMORY_MB,
+        disk: int = BLAXEL_DEFAULT_VOLUME_SIZE_MB,
+        persistent_filesystem: bool = True,
+        task_id: str = "default",
+        ttl: str = BLAXEL_DEFAULT_TTL,
+    ):
+        requested_cwd = cwd
+        super().__init__(cwd=cwd, timeout=timeout)
+
+        _ensure_blaxel_sdk()
+
+        # Lazy import: keep blaxel SDK optional until backend is selected.
+        from blaxel.core import SyncSandboxInstance
+        try:
+            from blaxel.core.sandbox import SandboxAPIError
+        except Exception:
+            SandboxAPIError = Exception
+        try:
+            from blaxel.core import SyncVolumeInstance
+            from blaxel.core.volume import VolumeAPIError
+        except Exception:
+            SyncVolumeInstance = None
+            VolumeAPIError = Exception
+
+        self._SyncSandboxInstance = SyncSandboxInstance
+        self._SandboxAPIError = SandboxAPIError
+        self._SyncVolumeInstance = SyncVolumeInstance
+        self._VolumeAPIError = VolumeAPIError
+        self._persistent = persistent_filesystem
+        self._task_id = task_id
+        self._lock = threading.Lock()
+        self._sandbox = None
+        self._volume_name: str | None = None
+
+        sandbox_name = _blaxel_resource_name("hermes", task_id)
+        self._sandbox_name = sandbox_name
+        task_label = _blaxel_label_value(task_id)
+
+        bl_region = os.getenv("BL_REGION", "").strip() or _BLAXEL_DEFAULT_REGION
+
+        # Blaxel sandbox config — see blaxel.core.SandboxCreateConfiguration.
+        # Resources: memory in MB. CPU and sandbox disk are not first-class
+        # on Blaxel sandboxes today (the platform allocates them per image
+        # profile), so we pass only ``memory`` to the sandbox. When persistent
+        # mode is enabled, ``disk`` is used below as the Blaxel volume size.
+        # Region is read by the SDK from the BL_REGION env var; we don't
+        # surface it as a Hermes-level knob.
+        sandbox_config: dict[str, object] = {
+            "name": sandbox_name,
+            "image": image,
+            "memory": int(memory),
+            "ttl": ttl,
+            "region": bl_region,
+            "labels": {"hermes_task_id": task_label},
+        }
+
+        if cpu not in (None, "") and not _numeric_equal(cpu, 1.0):
+            logger.info("Blaxel: ignoring cpu=%s (allocated by image profile)", cpu)
+        if (
+            disk not in (None, "")
+            and int(disk) != BLAXEL_DEFAULT_VOLUME_SIZE_MB
+            and not self._persistent
+        ):
+            logger.info("Blaxel: ignoring disk=%s (allocated by image profile)", disk)
+
+        # When persistent, ensure a Blaxel volume exists and mount it.
+        # Blaxel sandboxes can disappear (TTL, platform churn); only volumes
+        # are truly durable, so all real persistence lives there.
+        if self._persistent:
+            if SyncVolumeInstance is None:
+                raise RuntimeError(
+                    "Blaxel persistent filesystem requested, but the installed "
+                    "blaxel SDK does not expose volume support. Set "
+                    "terminal.container_persistent=false or install a newer SDK."
+                )
+            volume_name = _blaxel_resource_name("hermes", task_id, "-data")
+            self._volume_name = volume_name
+            volume_size_mb = max(1024, int(disk))
+            try:
+                SyncVolumeInstance.create_if_not_exists({
+                    "name": volume_name,
+                    "size": volume_size_mb,
+                    "region": bl_region,
+                    "labels": {"hermes_task_id": task_label},
+                })
+                logger.info("Blaxel: ensured volume %s (%d MB, region=%s)",
+                            volume_name, volume_size_mb, bl_region)
+                sandbox_config["volumes"] = [{
+                    "name": volume_name,
+                    "mount_path": _BLAXEL_VOLUME_MOUNT_PATH,
+                    "read_only": False,
+                }]
+            except Exception as e:
+                logger.warning(
+                    "Blaxel: could not ensure volume %s (%s)",
+                    volume_name, e,
+                )
+                self._volume_name = None
+                raise RuntimeError(
+                    "Blaxel persistent filesystem requested, but volume "
+                    f"{volume_name!r} could not be created or reused: {e}. "
+                    "Set terminal.container_persistent=false to use an "
+                    "ephemeral sandbox."
+                ) from e
+
+        self._sandbox = self._create_or_recreate_sandbox(sandbox_config)
+        logger.info(
+            "Blaxel: sandbox %s ready for task %s (volume %s)",
+            sandbox_name, task_id, self._volume_name or "<none>",
+        )
+
+        self._wait_for_sandbox_ready()
+
+        # When the persistent volume is mounted, point cwd at it so the
+        # agent's working files end up on durable storage. Otherwise fall
+        # back to $HOME.
+        self._remote_home = "/root"
+        try:
+            response = self._sandbox.process.exec({
+                "command": "echo $HOME",
+                "wait_for_completion": True,
+                "timeout": 10_000,
+            })
+            home = (
+                getattr(response, "stdout", None)
+                or getattr(response, "logs", None)
+                or ""
+            ).strip()
+            if home:
+                self._remote_home = home
+        except Exception:
+            pass
+
+        if requested_cwd in ("~", "/blaxel"):
+            if self._volume_name:
+                self.cwd = _BLAXEL_VOLUME_MOUNT_PATH
+                # Make sure the mount point exists and is the cwd target.
+                try:
+                    self._sandbox.process.exec({
+                        "command": f"mkdir -p {_BLAXEL_VOLUME_MOUNT_PATH}",
+                        "wait_for_completion": True,
+                        "timeout": 10_000,
+                    })
+                except Exception:
+                    pass
+            else:
+                self.cwd = self._remote_home
+        logger.info("Blaxel: resolved home to %s, cwd to %s",
+                    self._remote_home, self.cwd)
+
+        self._sync_manager = FileSyncManager(
+            get_files_fn=lambda: iter_sync_files(f"{self._remote_home}/.hermes"),
+            upload_fn=self._blaxel_upload,
+            delete_fn=self._blaxel_delete,
+            bulk_upload_fn=self._blaxel_bulk_upload,
+            bulk_download_fn=self._blaxel_bulk_download,
+        )
+        self._sync_manager.sync(force=True)
+        self.init_session()
+
+    # ------------------------------------------------------------------
+    # File sync transport
+    # ------------------------------------------------------------------
+
+    def _create_or_recreate_sandbox(self, sandbox_config: dict):
+        """Create a sandbox by name; if the name conflicts with a stale
+        (terminated) sandbox, delete it and create fresh.
+
+        This replaces ``create_if_not_exists``, which can reattach to a
+        sandbox the platform is already tearing down — leading to all
+        subsequent ``process.exec`` calls returning ``WORKLOAD_UNAVAILABLE``.
+        """
+        SyncSandboxInstance = self._SyncSandboxInstance
+        try:
+            return SyncSandboxInstance.create(sandbox_config)
+        except self._SandboxAPIError as e:
+            status = getattr(e, "status_code", None)
+            # 409 from the SDK or controlplane means the sandbox name is taken.
+            # The HTTP error envelope sometimes embeds a 409 in the message
+            # body even when ``status_code`` is None on the SDK error.
+            is_conflict = status == 409 or "409" in str(e) or "ALREADY_EXISTS" in str(e)
+            if not is_conflict:
+                raise
+
+        # Name conflict: probe the existing one, reuse if healthy, recreate
+        # otherwise.
+        existing = None
+        try:
+            existing = SyncSandboxInstance.get(sandbox_config["name"])
+        except Exception:
+            existing = None
+
+        if existing is not None and self._sandbox_is_responsive(existing):
+            logger.info(
+                "Blaxel: reusing existing healthy sandbox %s",
+                sandbox_config["name"],
+            )
+            return existing
+
+        # Stale handle — delete it and try again. Best-effort delete.
+        logger.info(
+            "Blaxel: existing sandbox %s is unresponsive, recreating",
+            sandbox_config["name"],
+        )
+        try:
+            SyncSandboxInstance.delete(sandbox_config["name"])
+        except Exception as e:
+            logger.debug("Blaxel: stale sandbox delete failed: %s", e)
+        # Wait briefly for the volume to detach before retrying.
+        time.sleep(3.0)
+        return SyncSandboxInstance.create(sandbox_config)
+
+    def _sandbox_is_responsive(self, sandbox, max_wait_seconds: float = 15.0) -> bool:
+        """Return True if a no-op ``process.exec`` returns within the budget."""
+        delay = 0.5
+        deadline = time.monotonic() + max_wait_seconds
+        while time.monotonic() < deadline:
+            try:
+                sandbox.process.exec({
+                    "command": ":",
+                    "wait_for_completion": True,
+                    "timeout": 5_000,
+                })
+                return True
+            except Exception:
+                time.sleep(delay)
+                delay = min(delay * 2, 4.0)
+        return False
+
+    def _wait_for_sandbox_ready(self, max_wait_seconds: float = 60.0) -> None:
+        """Poll the sandbox until ``process.exec`` succeeds.
+
+        Right after ``create``/``create_if_not_exists`` the sandbox can
+        return ``WORKLOAD_UNAVAILABLE`` (HTTP 404) for a few seconds while
+        the workload is still scheduling. The platform docs explicitly say
+        "Retry with exponential backoff: 500ms → 30s" — so we do.
+        """
+        delay = 0.5
+        deadline = time.monotonic() + max_wait_seconds
+        last_err: Exception | None = None
+        while time.monotonic() < deadline:
+            try:
+                self._sandbox.process.exec({
+                    "command": ":",  # no-op
+                    "wait_for_completion": True,
+                    "timeout": 5_000,
+                })
+                return
+            except Exception as e:
+                last_err = e
+                time.sleep(delay)
+                delay = min(delay * 2, 8.0)
+        raise RuntimeError(
+            "Blaxel sandbox "
+            f"{self._sandbox_name} did not become ready within "
+            f"{max_wait_seconds:.0f}s (last error: {last_err})"
+        )
+
+    def _blaxel_upload(self, host_path: str, remote_path: str) -> None:
+        """Upload one file after guarding the SDK's bytes-only write path."""
+        _guard_blaxel_upload_size(host_path, remote_path)
+        parent = str(Path(remote_path).parent)
+        self._sandbox.process.exec({
+            "command": f"mkdir -p {shlex.quote(parent)}",
+            "wait_for_completion": True,
+            "timeout": 10_000,
+        })
+        with open(host_path, "rb") as f:
+            self._sandbox.fs.write_binary(remote_path, f.read())
+
+    def _blaxel_bulk_upload(self, files: list[tuple[str, str]]) -> None:
+        """Upload many files. Blaxel SDK has no batched upload endpoint,
+        so we mkdir parents in one shell call and then write files one by
+        one — the SDK still parallelizes large-file part uploads internally.
+        """
+        if not files:
+            return
+        for host_path, remote_path in files:
+            _guard_blaxel_upload_size(host_path, remote_path)
+
+        parents = unique_parent_dirs(files)
+        if parents:
+            self._sandbox.process.exec({
+                "command": quoted_mkdir_command(parents),
+                "wait_for_completion": True,
+                "timeout": 30_000,
+            })
+
+        for host_path, remote_path in files:
+            with open(host_path, "rb") as f:
+                self._sandbox.fs.write_binary(remote_path, f.read())
+
+    def _blaxel_bulk_download(self, dest: Path) -> None:
+        """Download remote .hermes/ as a tar archive."""
+        rel_base = f"{self._remote_home}/.hermes".lstrip("/")
+        remote_tar = f"/tmp/.hermes_sync.{os.getpid()}.tar"
+        try:
+            command = (
+                f"rm -f {shlex.quote(remote_tar)} && "
+                f"if [ -d {shlex.quote('/' + rel_base)} ]; then "
+                f"tar cf {shlex.quote(remote_tar)} -C / {shlex.quote(rel_base)}; "
+                f"else dd if=/dev/zero of={shlex.quote(remote_tar)} "
+                f"bs=10240 count=1 >/dev/null 2>&1; fi"
+            )
+            try:
+                response = self._sandbox.process.exec({
+                    "command": command,
+                    "wait_for_completion": True,
+                    "timeout": 60_000,
+                })
+            except Exception as e:
+                logger.warning("Blaxel: remote .hermes archive command failed: %s", e)
+                _write_empty_tar(dest)
+                return
+            exit_code = getattr(response, "exit_code", None) or 0
+            if exit_code:
+                output = (
+                    getattr(response, "stdout", None)
+                    or getattr(response, "stderr", None)
+                    or getattr(response, "logs", None)
+                    or ""
+                )
+                logger.warning(
+                    "Blaxel: remote .hermes archive command failed (%s): %s",
+                    exit_code,
+                    output,
+                )
+                _write_empty_tar(dest)
+                return
+            try:
+                data = self._sandbox.fs.read_binary(remote_tar)
+            except Exception as e:
+                logger.warning("Blaxel: remote .hermes archive unavailable: %s", e)
+                _write_empty_tar(dest)
+                return
+            with open(dest, "wb") as f:
+                f.write(data)
+        finally:
+            try:
+                self._sandbox.process.exec({
+                    "command": f"rm -f {shlex.quote(remote_tar)}",
+                    "wait_for_completion": True,
+                    "timeout": 10_000,
+                })
+            except Exception:
+                pass
+
+    def _blaxel_workspace_bulk_download(self, dest: Path) -> None:
+        """Download the remote working tree as a tar archive.
+
+        The managed .hermes credential/cache tree is intentionally excluded
+        here and handled by FileSyncManager. This archive is for user-visible
+        files created during the sandbox run.
+        """
+        remote_base = (self.cwd or self._remote_home or "/").rstrip("/") or "/"
+        remote_tar = f"/tmp/.hermes_workspace_sync.{os.getpid()}.tar"
+        remote_list = f"/tmp/.hermes_workspace_sync.{os.getpid()}.list"
+        max_bytes = _workspace_sync_max_bytes()
+        prune_parts = []
+        for name in _WORKSPACE_SYNC_EXCLUDES:
+            prune_parts.append(f"-path {shlex.quote('./' + name)}")
+            prune_parts.append(f"-path {shlex.quote('./' + name + '/*')}")
+        prune_expr = " -o ".join(prune_parts)
+        find_cmd = (
+            f"find . \\( {prune_expr} \\) -prune -o "
+            f"-type f -size -{max_bytes}c -print"
+        )
+        command = (
+            f"rm -f {shlex.quote(remote_tar)} {shlex.quote(remote_list)} && "
+            f"cd {shlex.quote(remote_base)} && "
+            f"{find_cmd} > {shlex.quote(remote_list)} && "
+            f"if [ -s {shlex.quote(remote_list)} ]; then "
+            f"tar -cf {shlex.quote(remote_tar)} -T {shlex.quote(remote_list)}; "
+            f"else dd if=/dev/zero of={shlex.quote(remote_tar)} "
+            f"bs=10240 count=1 >/dev/null 2>&1; fi"
+        )
+        try:
+            response = self._sandbox.process.exec({
+                "command": command,
+                "wait_for_completion": True,
+                "timeout": 60_000,
+            })
+            exit_code = getattr(response, "exit_code", None) or 0
+            if exit_code:
+                output = (
+                    getattr(response, "stdout", None)
+                    or getattr(response, "stderr", None)
+                    or getattr(response, "logs", None)
+                    or ""
+                )
+                raise RuntimeError(
+                    f"workspace archive command failed ({exit_code}): {output}"
+                )
+            data = self._sandbox.fs.read_binary(remote_tar)
+            with open(dest, "wb") as f:
+                f.write(data)
+        finally:
+            try:
+                self._sandbox.process.exec({
+                    "command": (
+                        f"rm -f {shlex.quote(remote_tar)} "
+                        f"{shlex.quote(remote_list)}"
+                    ),
+                    "wait_for_completion": True,
+                    "timeout": 10_000,
+                })
+            except Exception:
+                pass
+
+    def _sync_workspace_back(self) -> None:
+        """Persist user-created sandbox files to host remote-sync cache."""
+        dest = get_hermes_home() / "cache" / "remote-syncs" / self._session_id
+        dest.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(suffix=".tar") as tf:
+            self._blaxel_workspace_bulk_download(Path(tf.name))
+            try:
+                with tarfile.open(tf.name) as tar:
+                    _extract_data_tar(tar, dest)
+            except tarfile.ReadError:
+                logger.debug("Blaxel: workspace sync archive was empty or invalid")
+                return
+        logger.info("Blaxel: synced workspace files to %s", dest)
+
+    def _blaxel_delete(self, remote_paths: list[str]) -> None:
+        """Batch-delete remote files via SDK exec."""
+        self._sandbox.process.exec({
+            "command": quoted_rm_command(remote_paths),
+            "wait_for_completion": True,
+            "timeout": 30_000,
+        })
+
+    # ------------------------------------------------------------------
+    # Sandbox lifecycle
+    # ------------------------------------------------------------------
+
+    def _before_execute(self) -> None:
+        """Sync files before each command. Blaxel sandboxes auto-resume
+        from standby on the first request, so we don't need an explicit
+        start/refresh step here."""
+        self._sync_manager.sync()
+
+    def _run_bash(self, cmd_string: str, *, login: bool = False,
+                  timeout: int = 120,
+                  stdin_data: str | None = None):
+        """Return a _ThreadedProcessHandle wrapping a blocking Blaxel SDK call."""
+        sandbox = self._sandbox
+
+        if login:
+            shell_cmd = f"bash -l -c {shlex.quote(cmd_string)}"
+        else:
+            shell_cmd = f"bash -c {shlex.quote(cmd_string)}"
+
+        process_name = f"hermes-{uuid.uuid4().hex[:12]}"
+        killed = threading.Event()
+
+        def kill_remote_process():
+            if killed.is_set():
+                return
+            killed.set()
+            try:
+                sandbox.process.kill(process_name)
+            except Exception:
+                pass
+
+        def exec_fn() -> tuple[str, int]:
+            return self._exec_with_timeout(
+                shell_cmd,
+                process_name,
+                timeout,
+                kill_fn=kill_remote_process,
+            )
+
+        return _ThreadedProcessHandle(exec_fn, cancel_fn=kill_remote_process)
+
+    def _exec_with_timeout(
+        self,
+        shell_cmd: str,
+        process_name: str,
+        timeout: int,
+        kill_fn=None,
+    ) -> tuple[str, int]:
+        """Run *shell_cmd* with a Hermes-style timeout.
+
+        For short timeouts (<= 50s) we use the SDK's blocking ``wait_for_completion``
+        path. For longer timeouts we run async and poll, since Blaxel caps a
+        single blocking exec at 60s.
+        """
+        sandbox = self._sandbox
+        if timeout <= _BLAXEL_BLOCKING_EXEC_CAP_SECONDS:
+            response = sandbox.process.exec({
+                "command": shell_cmd,
+                "name": process_name,
+                "wait_for_completion": True,
+                "timeout": int(timeout * 1000),
+            })
+            return self._collect_output(response, process_name)
+
+        sandbox.process.exec({
+            "command": shell_cmd,
+            "name": process_name,
+            "wait_for_completion": False,
+        })
+
+        deadline = time.monotonic() + timeout
+        last_status = None
+        while time.monotonic() < deadline:
+            try:
+                proc_info = sandbox.process.get(process_name)
+            except Exception as e:
+                logger.debug("Blaxel: process.get(%s) failed: %s",
+                             process_name, e)
+                time.sleep(_BLAXEL_POLL_INTERVAL_SECONDS)
+                continue
+            last_status = getattr(proc_info, "status", None)
+            if last_status and str(last_status) not in ("running", "ProcessResponseStatus.RUNNING"):
+                exit_code = getattr(proc_info, "exit_code", None)
+                if exit_code is None:
+                    exit_code = 0
+                return self._collect_output(proc_info, process_name, exit_code=exit_code)
+            time.sleep(_BLAXEL_POLL_INTERVAL_SECONDS)
+
+        if kill_fn is not None:
+            kill_fn()
+        else:
+            try:
+                sandbox.process.kill(process_name)
+            except Exception:
+                pass
+        return ("", 124)
+
+    def _collect_output(self, response, process_name: str,
+                        exit_code: int | None = None) -> tuple[str, int]:
+        """Pull stdout/stderr from a ProcessResponse, falling back to
+        ``process.logs()`` when the response object only has a name."""
+        stdout = getattr(response, "stdout", "") or ""
+        stderr = getattr(response, "stderr", "") or ""
+        logs = getattr(response, "logs", "") or ""
+        rc = exit_code if exit_code is not None else (
+            getattr(response, "exit_code", None) or 0
+        )
+
+        output = ""
+        if stdout or stderr:
+            output = stdout
+            if stderr:
+                output = (output + "\n" + stderr) if output else stderr
+        elif logs:
+            output = logs
+        else:
+            try:
+                output = self._sandbox.process.logs(process_name, "all") or ""
+            except Exception:
+                output = ""
+        return (output, int(rc))
+
+    def cleanup(self):
+        with self._lock:
+            if self._sandbox is None:
+                return
+
+            try:
+                self._sync_workspace_back()
+            except Exception as e:
+                logger.warning("Blaxel: workspace sync_back failed: %s", e)
+
+            if self._sync_manager:
+                logger.info("Blaxel: syncing files from sandbox...")
+                try:
+                    self._sync_manager.sync_back()
+                except Exception as e:
+                    logger.warning("Blaxel: sync_back failed: %s", e)
+
+            try:
+                self._sandbox.delete()
+                if self._persistent:
+                    logger.info(
+                        "Blaxel: deleted sandbox %s%s",
+                        self._sandbox_name,
+                        f" (volume {self._volume_name} preserved)"
+                        if self._volume_name else
+                        " (no persistent volume mounted)",
+                    )
+                else:
+                    logger.info("Blaxel: deleted sandbox %s", self._sandbox_name)
+            except self._SandboxAPIError as e:
+                if getattr(e, "status_code", None) == 404:
+                    logger.info("Blaxel: sandbox %s already gone", self._sandbox_name)
+                else:
+                    logger.warning("Blaxel: cleanup failed: %s", e)
+            except Exception as e:
+                logger.warning("Blaxel: cleanup failed: %s", e)
+            self._sandbox = None

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -256,6 +256,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "terminal.modal": ("modal==1.3.4",),
     "terminal.daytona": ("daytona==0.155.0",),
     "terminal.vercel": ("vercel==0.7.2",),
+    "terminal.blaxel": ("blaxel==0.2.55",),
 
     # ─── Skills ────────────────────────────────────────────────────────────
     "skill.google_workspace": (

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -12,9 +12,10 @@ Environment Selection (via TERMINAL_ENV environment variable):
 - "docker": Execute in Docker containers (isolated, requires Docker)
 - "modal": Execute in Modal cloud sandboxes (direct Modal or managed gateway)
 - "vercel_sandbox": Execute in Vercel Sandbox cloud sandboxes
+- "blaxel": Execute in Blaxel cloud sandboxes
 
 Features:
-- Multiple execution backends (local, docker, modal, vercel_sandbox)
+- Multiple execution backends (local, docker, modal, vercel_sandbox, blaxel)
 - Background task support
 - VM/container lifecycle management
 - Automatic cleanup after inactivity
@@ -49,6 +50,13 @@ import subprocess
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
+from hermes_constants import (
+    BLAXEL_DEFAULT_CWD,
+    BLAXEL_DEFAULT_MEMORY_MB,
+    BLAXEL_DEFAULT_TTL,
+    BLAXEL_DEFAULT_VOLUME_SIZE_MB,
+    BLAXEL_SDK_INSTALL_COMMAND,
+)
 from utils import env_var_enabled
 
 logger = logging.getLogger(__name__)
@@ -187,6 +195,49 @@ def _check_vercel_sandbox_requirements(config: dict[str, Any]) -> bool:
         "development only."
     )
     return False
+
+
+def _check_blaxel_requirements(config: dict[str, Any]) -> bool:
+    """Validate Blaxel terminal backend requirements.
+
+    Accepts either supported credential path — ``BL_API_KEY`` for deployments,
+    or credentials already stored by ``bl login`` for local development. The
+    Blaxel SDK honors both, so requiring the API key would reject a setup that
+    works.
+    """
+    from hermes_cli.blaxel_auth import describe_blaxel_auth
+
+    auth = describe_blaxel_auth()
+    if not auth.ok:
+        logger.error(
+            "Blaxel backend selected but authentication is not usable (%s). %s",
+            auth.label,
+            " ".join(auth.detail_lines),
+        )
+        return False
+
+    if importlib.util.find_spec("blaxel") is not None:
+        return True
+
+    try:
+        from tools.lazy_deps import ensure as _lazy_ensure
+        _lazy_ensure("terminal.blaxel", prompt=False)
+    except ImportError:
+        pass
+    except Exception as e:
+        logger.error("blaxel is required for the Blaxel terminal backend: %s", e)
+        return False
+
+    # A just-installed distribution is invisible to find_spec until the import
+    # system's directory caches are dropped.
+    importlib.invalidate_caches()
+    if importlib.util.find_spec("blaxel") is None:
+        logger.error(
+            "blaxel is required for the Blaxel terminal backend: %s",
+            BLAXEL_SDK_INSTALL_COMMAND,
+        )
+        return False
+    return True
 
 
 # Cache for disk usage warning to avoid full rglob scan on every call.
@@ -1364,7 +1415,7 @@ def _safe_getcwd() -> str:
 # cwd looks when it leaks toward a Linux container's ``-w`` flag.
 _HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")
 
-_CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
+_CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox", "blaxel"})
 
 
 def _is_ssh_remote_tilde_cwd(backend: str, cwd: str) -> bool:
@@ -1466,7 +1517,7 @@ def _get_env_config() -> Dict[str, Any]:
     env_type = os.getenv("TERMINAL_ENV", "local")
     
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
-    container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
+    container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox", "blaxel"}
     docker_backend = env_type == "docker"
 
     # Docker/container-only env vars may be bridged from config.yaml even when
@@ -1481,6 +1532,17 @@ def _get_env_config() -> Dict[str, Any]:
         container_cpu = 1.0
         container_memory = 5120
         container_disk = 51200
+
+    if env_type == "blaxel":
+        # Blaxel's durable volume is billed storage, not container scratch, so
+        # it must not inherit the shared 51200 default. Re-resolved here rather
+        # than folded into the block above so no other backend is touched.
+        container_memory = _parse_env_var(
+            "TERMINAL_CONTAINER_MEMORY", str(BLAXEL_DEFAULT_MEMORY_MB)
+        )
+        container_disk = _parse_env_var(
+            "TERMINAL_CONTAINER_DISK", str(BLAXEL_DEFAULT_VOLUME_SIZE_MB)
+        )
 
     if docker_backend:
         docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON")
@@ -1504,6 +1566,8 @@ def _get_env_config() -> Dict[str, Any]:
         default_cwd = "~"
     elif env_type == "vercel_sandbox":
         default_cwd = _VERCEL_SANDBOX_DEFAULT_CWD
+    elif env_type == "blaxel":
+        default_cwd = BLAXEL_DEFAULT_CWD
     else:
         default_cwd = "/root"
 
@@ -1609,7 +1673,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     
     Args:
         env_type: One of "local", "docker", "singularity", "modal",
-            "daytona", "vercel_sandbox", "ssh"
+            "daytona", "vercel_sandbox", "blaxel", "ssh"
         image: Docker/Singularity/Modal image name (ignored for local/ssh/vercel)
         cwd: Working directory
         timeout: Default command timeout
@@ -1748,6 +1812,22 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             task_id=task_id,
         )
 
+    elif env_type == "blaxel":
+        # Lazy import so the blaxel SDK is only required when the backend is
+        # actually selected.
+        from tools.environments.blaxel import BlaxelEnvironment as _BlaxelEnvironment
+        return _BlaxelEnvironment(
+            image=image,
+            cwd=cwd,
+            timeout=timeout,
+            cpu=cpu,
+            memory=memory,
+            disk=disk,
+            persistent_filesystem=persistent,
+            task_id=task_id,
+            ttl=cc.get("blaxel_ttl") or BLAXEL_DEFAULT_TTL,
+        )
+
     elif env_type == "ssh":
         if not ssh_config or not ssh_config.get("host") or not ssh_config.get("user"):
             raise ValueError("SSH environment requires ssh_host and ssh_user to be configured")
@@ -1763,7 +1843,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     else:
         raise ValueError(
             f"Unknown environment type: {env_type}. Use 'local', 'docker', "
-            f"'singularity', 'modal', 'daytona', 'vercel_sandbox', or 'ssh'"
+            f"'singularity', 'modal', 'daytona', 'vercel_sandbox', 'blaxel', or 'ssh'"
         )
 
 
@@ -2433,7 +2513,7 @@ def terminal_tool(
                             }
 
                         container_config = None
-                        if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
+                        if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox", "blaxel"}:
                             container_config = {
                                 "container_cpu": config.get("container_cpu", 1),
                                 "container_memory": config.get("container_memory", 5120),
@@ -2441,6 +2521,7 @@ def terminal_tool(
                                 "container_persistent": config.get("container_persistent", True),
                                 "modal_mode": config.get("modal_mode", "auto"),
                                 "vercel_runtime": config.get("vercel_runtime", ""),
+                                "blaxel_ttl": config.get("blaxel_ttl", ""),
                                 "docker_volumes": config.get("docker_volumes", []),
                                 "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
                                 "docker_forward_env": config.get("docker_forward_env", []),
@@ -3267,6 +3348,9 @@ def check_terminal_requirements() -> bool:
         elif env_type == "vercel_sandbox":
             return _check_vercel_sandbox_requirements(config)
 
+        elif env_type == "blaxel":
+            return _check_blaxel_requirements(config)
+
         elif env_type == "daytona":
             from daytona import Daytona  # noqa: F401 — SDK presence check
             from agent.secret_scope import get_secret
@@ -3275,7 +3359,7 @@ def check_terminal_requirements() -> bool:
         else:
             logger.error(
                 "Unknown TERMINAL_ENV '%s'. Use one of: local, docker, singularity, "
-                "modal, daytona, vercel_sandbox, ssh.",
+                "modal, daytona, vercel_sandbox, blaxel, ssh.",
                 env_type,
             )
             return False
@@ -3318,7 +3402,7 @@ if __name__ == "__main__":
     print(
         "  TERMINAL_ENV: "
         f"{os.getenv('TERMINAL_ENV', 'local')} "
-        "(local/docker/singularity/modal/daytona/vercel_sandbox/ssh)"
+        "(local/docker/singularity/modal/daytona/vercel_sandbox/blaxel/ssh)"
     )
     print(f"  TERMINAL_DOCKER_IMAGE: {os.getenv('TERMINAL_DOCKER_IMAGE', default_img)}")
     print(f"  TERMINAL_SINGULARITY_IMAGE: {os.getenv('TERMINAL_SINGULARITY_IMAGE', f'docker://{default_img}')}")

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-20T16:38:42.729819205Z"
+exclude-newer = "2026-07-21T01:42:54.483828Z"
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -518,6 +518,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7f/45/8ae61209bb9015f516102fa559a2914178da1d5868428bd86a1b4421141d/base58-2.1.1.tar.gz", hash = "sha256:c5d0cb3f5b6e81e8e35da5754388ddcc6d0d14b6c6a132cb93d69ed580a7278c", size = 6528, upload-time = "2021-10-30T22:12:17.858Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/45/ec96b29162a402fc4c1c5512d114d7b3787b9d1c2ec241d9568b4816ee23/base58-2.1.1-py3-none-any.whl", hash = "sha256:11a36f4d3ce51dfc1043f3218591ac4eb1ceb172919cebe05b52a5bcc8d245c2", size = 5621, upload-time = "2021-10-30T22:12:16.658Z" },
+]
+
+[[package]]
+name = "blaxel"
+version = "0.2.55"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "dockerfile-parse" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "pyjwt" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tomli" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/bd/9b389c9b2dcc49d4189354ad1b3148464101fabd2aa787542a67e9701373/blaxel-0.2.55.tar.gz", hash = "sha256:94fc21f6ccbc09dec578e7a5fead9ccefd68f93083c9cde9b778a321d8844ccf", size = 430721, upload-time = "2026-06-10T19:24:40.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/3c/8fa0c08c9488a4a937522c2f6d2c56bb55099d316cbb6dbe7a8561c568ff/blaxel-0.2.55-py3-none-any.whl", hash = "sha256:ff10277b86bead0598ebfe1b7720dc4323aec5228000b85ccec183b20371e157", size = 642648, upload-time = "2026-06-10T19:24:39.351Z" },
 ]
 
 [[package]]
@@ -1110,6 +1132,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dockerfile-parse"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1626,6 +1657,9 @@ azure-identity = [
 bedrock = [
     { name = "boto3" },
 ]
+blaxel = [
+    { name = "blaxel" },
+]
 cli = [
     { name = "simple-term-menu" },
 ]
@@ -1814,6 +1848,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = "==0.87.0" },
     { name = "asyncpg", marker = "extra == 'matrix'", specifier = "==0.31.0" },
     { name = "azure-identity", marker = "extra == 'azure-identity'", specifier = "==1.25.3" },
+    { name = "blaxel", marker = "extra == 'blaxel'", specifier = "==0.2.55" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = "==1.42.89" },
     { name = "brotlicffi", marker = "extra == 'messaging'", specifier = "==1.2.0.1" },
     { name = "certifi", specifier = "==2026.5.20" },
@@ -1936,7 +1971,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "blaxel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -4409,6 +4444,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -242,6 +242,11 @@ These variables configure the [Tool Gateway](/user-guide/features/tool-gateway) 
 | `TERMINAL_MODAL_IMAGE` | Modal container image |
 | `TERMINAL_DAYTONA_IMAGE` | Daytona sandbox image |
 | `TERMINAL_VERCEL_RUNTIME` | Vercel Sandbox runtime (`node24`, `node22`, `python3.13`) |
+| `TERMINAL_BLAXEL_IMAGE` | Blaxel sandbox image |
+| `TERMINAL_BLAXEL_TTL` | Blaxel sandbox time-to-live (e.g. `24h`) |
+| `BL_WORKSPACE` | Blaxel workspace (required for `TERMINAL_ENV=blaxel`) |
+| `BL_API_KEY` | Blaxel API key (required for `TERMINAL_ENV=blaxel`) |
+| `BL_REGION` | Blaxel region (default `us-pdx-1`) |
 | `TERMINAL_TIMEOUT` | Command timeout in seconds |
 | `TERMINAL_LIFETIME_SECONDS` | Max lifetime for terminal sessions in seconds |
 | `TERMINAL_CWD` | Deprecated direct override for gateway/cron terminal sessions. Prefer `terminal.cwd` in `config.yaml`; CLI still uses the launch directory. |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -120,7 +120,7 @@ Hermes supports seven terminal backends. Each determines where the agent's shell
 
 ```yaml
 terminal:
-  backend: local    # local | docker | ssh | modal | daytona | vercel_sandbox | singularity
+  backend: local    # local | docker | ssh | modal | daytona | vercel_sandbox | blaxel | singularity
   cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
   font_family: ""   # Desktop terminal font; e.g. "MesloLGS NF"
   timeout: 180      # Per-command timeout in seconds
@@ -145,6 +145,7 @@ For cloud sandboxes such as Modal, Daytona, and Vercel Sandbox, `container_persi
 | **modal** | Modal cloud sandbox | Full (cloud VM) | Ephemeral cloud compute, evals |
 | **daytona** | Daytona workspace | Full (cloud container) | Managed cloud dev environments |
 | **vercel_sandbox** | Vercel Sandbox | Full (cloud microVM) | Cloud execution with snapshot-backed filesystem persistence |
+| **blaxel** | Blaxel cloud sandbox | Full (cloud sandbox) | Cloud execution with an optional persistent volume per task |
 | **singularity** | Singularity/Apptainer container | Namespaces (--containall) | HPC clusters, shared machines |
 
 ### Local Backend
@@ -424,6 +425,39 @@ OIDC tokens are short-lived and should not be used as the documented deployment 
 **Background commands:** `terminal(background=true)` uses Hermes' generic non-local background process flow. You can spawn, poll, wait, view logs, and kill processes through the normal process tool while the sandbox is alive. Hermes does not provide native Vercel detached-process recovery after cleanup or restart.
 
 **Disk sizing:** Vercel Sandbox does not currently support Hermes' `container_disk` resource knob. Leave `container_disk` unset or at the shared default `51200`; non-default values fail diagnostics and backend creation instead of being silently ignored.
+
+### Blaxel Backend
+
+Runs commands in a [Blaxel](https://blaxel.ai) cloud sandbox. Hermes uses the normal terminal and file tool surfaces; there are no Blaxel-specific model-facing tools.
+
+```yaml
+terminal:
+  backend: blaxel
+  blaxel_image: blaxel/py-app:latest   # sandbox image
+  blaxel_ttl: 24h                      # sandbox time-to-live
+  cwd: /blaxel                         # default workspace root
+  container_persistent: true           # Mount a durable volume per task
+  container_memory: 4096               # MB
+  container_disk: 10240                # MB, durable volume size (not container disk)
+```
+
+**Required install:** Install the optional SDK extra:
+
+```bash
+pip install 'hermes-agent[blaxel]'
+```
+
+**Required authentication:** Set `BL_WORKSPACE` and `BL_API_KEY`. Keep `BL_API_KEY` in your environment or `.env`, never in `config.yaml`. Set `BL_REGION` to pick a region; it defaults to `us-pdx-1`.
+
+**Image:** `blaxel_image` defaults to `blaxel/py-app:latest`. Avoid `blaxel/base-image:latest` for general agent work: it is Alpine/musl and has no glibc, so any manylinux-only Python wheel the agent installs in the sandbox fails to build.
+
+**Ignored resource knobs:** Blaxel allocates CPU and container disk from the image profile. `container_cpu` is ignored, and a non-default value is logged rather than applied. `container_disk` is repurposed as the durable volume size and is only used when `container_persistent: true`.
+
+**Persistence:** When `container_persistent: true`, Hermes mounts one durable Blaxel volume per task. The volume name is derived from the task id, then sanitized and length-capped, so the name in the Blaxel console is not always a literal `hermes-<task_id>-data`. Deleting the sandbox preserves the volume. Note that a single delete leaves a `TERMINATED` sandbox record in Blaxel; that record is expected and does not mean cleanup failed.
+
+**Background commands:** `terminal(background=true)` uses Hermes' generic non-local background process flow. Processes are tracked while the sandbox is alive and do not survive cleanup or sandbox recreation.
+
+**File sync limit:** Per-file uploads above `TERMINAL_FILE_SYNC_MAX_MB` (default 100 MB) are refused with a clear error rather than buffered into memory.
 
 ### Singularity/Apptainer Backend
 


### PR DESCRIPTION
## What

I'm on the team at Blaxel. This is first-party support for our cloud sandbox platform, so the integration is maintained by the people who run the service it talks to. SDK changes and issues against this backend land with us.

Adds Blaxel as a terminal backend alongside Modal, Daytona, and Vercel Sandbox. Commands run in a remote Linux sandbox with an optional durable volume, so a session's files survive a sandbox restart.

Select it with `TERMINAL_ENV=blaxel` or option 6 in `hermes setup`.

## Scope

Nothing outside the Blaxel path changes. The PR deletes 15 lines outside the lockfile: 14 are backend enumerations that had to grow to admit a ninth backend, and 1 is an import line.

Blaxel's memory and volume defaults live in their own `env_type == "blaxel"` block rather than editing the shared `5120`/`51200` defaults, because its durable volume is billed storage, not container scratch. Verified with a clean `HERMES_HOME`:

| backend | memory | disk |
|---|---|---|
| local, docker, singularity, modal, daytona, vercel_sandbox, ssh | 5120 | 51200 |
| blaxel | 4096 | 10240 |

## How to test

No Blaxel account needed. The tests are hermetic: they don't read `~/.blaxel/config.yaml` and pass with the SDK not installed.

```
scripts/run_tests.sh --files 'tests/tools/test_blaxel_environment.py:tests/tools/test_terminal_requirements.py:tests/hermes_cli/test_config.py'
```

With an account:

```
pip install 'hermes-agent[blaxel]'
bl login                  # or export BL_API_KEY=...
export TERMINAL_ENV=blaxel
hermes doctor             # reports workspace + which credential path is in use
hermes
```

## Verification

Ran against a real workspace, which caught two things mocks did not:

- Auth accepts either `BL_API_KEY` or credentials from `bl login`. The SDK honors both, so requiring the API key would have rejected a working local setup. `hermes_cli/blaxel_auth.py` mirrors the existing `vercel_auth.py`.
- Default image is `blaxel/py-app:latest`, not `blaxel/base-image`. The latter is Alpine/musl and externally managed, so an agent's `pip install` of a manylinux-only wheel fails inside the sandbox.

End-to-end in a live workspace: sandbox create, `/blaxel` cwd, echo / pwd / uname / file write / file read / python3 / non-zero exit, session snapshot, and cleanup leaving no orphaned sandboxes or volumes.

Full suite via `scripts/run_tests.sh`: no new failures against the same commit on `main`. Developed on macOS 15 (arm64), Python 3.11. The backend only runs commands inside a remote Linux sandbox, so there is no host-specific process or PTY handling.

## Dependency

`blaxel==0.2.55` as an optional `blaxel` extra plus a `tools/lazy_deps.py` entry, matching `modal`/`daytona`/`vercel`. Not in `[all]`. A test asserts the pin is identical across all three declaration sites so they cannot drift. `uv.lock` updated for the new extra.

## Related

Supersedes #20809, an earlier version of this from a colleague's fork. It can be closed; I don't have write access on that fork.
