### PR TITLE
fix(gateway): keep launchd stdio logs on boot volume (#78129)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4090,9 +4090,9 @@ def generate_launchd_plist() -> str:
     # to launchd's WorkingDirectory as to systemd's).
     working_dir = _stable_service_working_dir()
     hermes_home = str(get_hermes_home().resolve())
-    log_dir = get_hermes_home() / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
     label = get_launchd_label()
+    log_dir = Path.home() / "Library" / "Logs" / label
+    log_dir.mkdir(parents=True, exist_ok=True)
     profile_arg = _profile_arg(hermes_home)
     # Build a sane PATH for the launchd plist.  launchd provides only a
     # minimal default (/usr/bin:/bin:/usr/sbin:/sbin) which misses Homebrew,
@@ -4177,10 +4177,10 @@ def generate_launchd_plist() -> str:
     <integer>25</integer>
 
     <key>StandardOutPath</key>
-    <string>{log_dir}/gateway.log</string>
+    <string>{log_dir}/gateway.stdout.log</string>
     
     <key>StandardErrorPath</key>
-    <string>{log_dir}/gateway.error.log</string>
+    <string>{log_dir}/gateway.stderr.log</string>
 </dict>
 </plist>
 """

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -232,6 +232,26 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in plist
         assert str(profile_node_bin) not in plist
 
+    def test_launchd_stdio_uses_user_library_logs_not_hermes_home(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        user_home = tmp_path / "user"
+        hermes_home = tmp_path / "external-volume" / "hermes"
+        user_home.mkdir()
+        hermes_home.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        log_dir = user_home / "Library" / "Logs" / gateway_cli.get_launchd_label()
+        assert f"<string>{log_dir}/gateway.stdout.log</string>" in plist
+        assert f"<string>{log_dir}/gateway.stderr.log</string>" in plist
+        assert str(hermes_home / "logs") not in plist
+        assert log_dir.is_dir()
+
 
 
 class TestGatewayStopCleanup:
@@ -1964,7 +1984,6 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is True
         assert attempts["bootstrap"] >= 2  # the timeout was retried, not raised
-
     def test_registered_but_not_running_is_not_success(self, monkeypatch):
         """A definition with no PID must not end the loop.
 
@@ -1995,4 +2014,3 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is False
         assert list_calls["n"] >= 1
-


### PR DESCRIPTION
## What does this PR do?

Moves launchd's stdout and stderr redirection away from `HERMES_HOME` and into
the macOS-standard user log location:

```text
~/Library/Logs/<launchd-label>/gateway.stdout.log
~/Library/Logs/<launchd-label>/gateway.stderr.log
```

launchd opens `StandardOutPath` and `StandardErrorPath` before executing the
gateway. When `HERMES_HOME` is on a non-boot volume, that pre-exec open can fail
with `EX_CONFIG 78` even though the gateway itself can access the volume.
Keeping launchd-owned stdio on the user's boot-volume home avoids that failure.

Hermes' application-managed `HERMES_HOME/logs/gateway.log` is unchanged.

## Related Issue

Addresses #78129

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: generate per-label launchd stdio paths under
  `~/Library/Logs` and create that directory before installing the plist.
- `tests/hermes_cli/test_gateway_service.py`: verify a custom external
  `HERMES_HOME` never appears in the plist's stdio paths.

## Why this approach

- Uses the platform-standard user log directory instead of adding mount-device
  detection and fallback branches.
- Retains per-profile isolation through the existing launchd label.
- Leaves systemd services and Hermes' own structured logs untouched.

## Explicit boundaries

- This PR does not add a generic post-start liveness check. That is independent
  defense-in-depth work described in #78129.
- PR #32795 is adjacent but distinct: it preserves explicitly customized paths
  from an existing plist, while this PR fixes the generated default used for a
  fresh install.

## How to Test

1. Run:
   `python -m pytest -q tests/hermes_cli/test_gateway_service.py`
2. Confirm: `71 passed`.
3. Run:
   `python -m pytest -q tests/gateway/test_status.py::TestLaunchdPlistRespawnGovernance`
4. Confirm: `1 passed`.
5. Run:
   `python -m ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
6. Confirm: `All checks passed!`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation update: N/A; application log locations are unchanged
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: change is launchd-only
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

The staged-file Windows footgun scan reported six existing unencoded
`write_text()` calls in `test_gateway_service.py`; none are in this diff.
