### PR TITLE
fix(photon): secure inbound attachment custody and ACKs

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -25,7 +25,6 @@ Outbound:
 from __future__ import annotations
 
 import asyncio
-import base64
 import json
 import logging
 import os
@@ -1190,10 +1189,11 @@ class PhotonAdapter(BasePlatformAdapter):
                           "targetText": "..." | null},
               "timestamp": "2026-05-14T19:06:32.000Z"
 
-        Attachment and voice content carry the bytes inline as base64 ``data``
-        (with ``encoding == "base64"``) when the sidecar could read them
-        within its size cap; otherwise only metadata is present and we surface
-        a marker.
+        Attachment and voice content carry metadata plus an opaque one-shot
+        ``handle`` when the sidecar could read their bytes into its bounded
+        in-memory store. Bytes are never embedded in this event or cached to
+        plaintext disk by this adapter. The handle remains in ``raw_message``
+        for the external secure attachment consumer.
             }
         """
         space = event.get("space") or {}
@@ -1219,8 +1219,8 @@ class PhotonAdapter(BasePlatformAdapter):
         except ValueError:
             timestamp = datetime.now(tz=timezone.utc)
 
-        # Media attachments (local cached paths) handed to the agent via the
-        # gateway's image-routing path, exactly like the BlueBubbles channel.
+        # Attachment bytes remain behind opaque sidecar handles. Downstream
+        # consumers can authorize the sender before redeeming a one-shot handle.
         media_urls: List[str] = []
         media_types: List[str] = []
 
@@ -1236,16 +1236,6 @@ class PhotonAdapter(BasePlatformAdapter):
             if not is_voice and (name.lower().endswith(".caf") or mime == "audio/x-caf"):
                 is_voice = True
             mtype = MessageType.VOICE if is_voice else _attachment_message_type(mime)
-            cached = _cache_inbound_attachment(
-                payload, name, mime, force_audio=is_voice
-            )
-            if cached:
-                return (
-                    "(voice)" if is_voice else "(attachment)",
-                    mtype,
-                    [cached],
-                    [mime or ("audio/mp4" if is_voice else "application/octet-stream")],
-                )
             label = "voice" if is_voice else "attachment"
             duration = payload.get("duration")
             duration_text = (
@@ -2629,83 +2619,6 @@ def _attachment_message_type(mime: str) -> MessageType:
     if mime.startswith("application/"):
         return MessageType.DOCUMENT
     return MessageType.DOCUMENT
-
-
-# MIME → file-extension maps for caching inbound attachment bytes. These mirror
-# the BlueBubbles iMessage channel so both adapters name cached media the same.
-_IMAGE_EXT_BY_MIME = {
-    "image/jpeg": ".jpg",
-    "image/png": ".png",
-    "image/gif": ".gif",
-    "image/webp": ".webp",
-    "image/heic": ".jpg",
-    "image/heif": ".jpg",
-    "image/tiff": ".jpg",
-}
-_AUDIO_EXT_BY_MIME = {
-    "audio/mp3": ".mp3",
-    "audio/mpeg": ".mp3",
-    "audio/ogg": ".ogg",
-    "audio/wav": ".wav",
-    "audio/x-caf": ".caf",
-    "audio/mp4": ".m4a",
-    "audio/aac": ".m4a",
-}
-
-
-def _cache_inbound_attachment(
-    content: Dict[str, Any],
-    name: str,
-    mime: str,
-    *,
-    force_audio: bool = False,
-) -> Optional[str]:
-    """Decode a base64-inlined inbound attachment and cache it locally.
-
-    The sidecar inlines the attachment bytes as ``content["data"]`` (base64).
-    We decode them and route to the shared media cache by MIME type, returning
-    the cached absolute path so the caller can populate ``media_urls`` (which
-    the gateway then hands to the model). Returns ``None`` when there are no
-    bytes (over the sidecar's inline cap or a failed read) or when caching
-    fails, so the caller can fall back to a text marker.
-    """
-    data_b64 = content.get("data")
-    if not data_b64:
-        return None
-    try:
-        raw = base64.b64decode(data_b64)
-    except (ValueError, TypeError) as exc:
-        logger.warning("[photon] failed to decode inbound attachment bytes: %s", exc)
-        return None
-
-    from gateway.platforms.base import (
-        cache_audio_from_bytes,
-        cache_document_from_bytes,
-        cache_image_from_bytes,
-    )
-
-    mime = (mime or "").lower()
-    # Prefer the real extension from the filename; fall back to the MIME map.
-    suffix = Path(name).suffix if name else ""
-    try:
-        if mime.startswith("image/"):
-            ext = suffix or _IMAGE_EXT_BY_MIME.get(mime, ".jpg")
-            try:
-                return cache_image_from_bytes(raw, ext)
-            except ValueError:
-                # Bytes don't look like a supported image (e.g. HEIC magic) —
-                # still deliver them as a document rather than dropping them.
-                return cache_document_from_bytes(raw, name)
-        if force_audio or mime.startswith("audio/"):
-            ext = suffix or _AUDIO_EXT_BY_MIME.get(
-                mime, ".m4a" if force_audio else ".mp3"
-            )
-            return cache_audio_from_bytes(raw, ext)
-        # Video, application/*, and everything else → document cache.
-        return cache_document_from_bytes(raw, name)
-    except Exception as exc:
-        logger.warning("[photon] failed to cache inbound attachment %s: %s", name, exc)
-        return None
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -26,6 +26,7 @@ Outbound:
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 import os
@@ -283,6 +284,29 @@ _DEFAULT_MENTION_PATTERNS = [
     r"(?<![\w@])@?hermes\s+agent\b[,:\-]?",
     r"(?<![\w@])@?hermes\b[,:\-]?",
 ]
+
+
+class PhotonAttachmentConsumerUnavailable(RuntimeError):
+    """A secure consumer did not accept an opaque attachment handle."""
+
+
+def _event_has_attachment_handle(event: Dict[str, Any]) -> bool:
+    def content_has_handle(content: Any) -> bool:
+        if not isinstance(content, dict):
+            return False
+        if content.get("type") in {"attachment", "voice"}:
+            return bool(
+                re.fullmatch(r"[a-f0-9]{48}", str(content.get("handle") or ""))
+            )
+        if content.get("type") == "group":
+            return any(
+                content_has_handle(item.get("content"))
+                for item in content.get("items") or []
+                if isinstance(item, dict)
+            )
+        return False
+
+    return content_has_handle(event.get("content"))
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -22,6 +22,7 @@ Outbound:
     spectrum-ts' ``attachment()`` / ``voice()`` content builders via the
     sidecar's ``/send-attachment`` endpoint.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -45,10 +46,12 @@ if TYPE_CHECKING:
     # site type-checks cleanly. The runtime fallback below keeps the optional
     # dependency truly optional (each use site is guarded by HTTPX_AVAILABLE).
     import httpx
+
     HTTPX_AVAILABLE = True
 else:
     try:
         import httpx
+
         HTTPX_AVAILABLE = True
     except ImportError:  # pragma: no cover - httpx is already a Hermes dep
         HTTPX_AVAILABLE = False
@@ -204,6 +207,9 @@ def _sidecar_pid_alive(pid: Any) -> bool:
 # reconnect can replay, so keep at least 1k ids for ~48h.
 _DEDUP_MAX_SIZE = 4000
 _DEDUP_WINDOW_SECONDS = 48 * 3600
+_DELIVERY_DEDUP_MAX_SIZE = 256
+_DELIVERY_DEDUP_WINDOW_SECONDS = 10 * 60
+_DELIVERY_ID_RE = re.compile(r"^[a-f0-9]{48}$")
 
 _FFFC_WAIT_SECONDS = 15.0  # Timeout for waiting on an attachment after a U+FFFC placeholder.
 
@@ -574,7 +580,9 @@ def _markdown_enabled() -> bool:
     text without a release.
     """
     return os.getenv("PHOTON_MARKDOWN", "true").strip().lower() not in {
-        "false", "0", "no",
+        "false",
+        "0",
+        "no",
     }
 
 
@@ -711,10 +719,7 @@ class PhotonAdapter(BasePlatformAdapter):
         # the spectrum-ts SDK authenticates with.
         stored_id, stored_sec = load_project_credentials()
         self._project_id: str = (
-            os.getenv("PHOTON_PROJECT_ID")
-            or extra.get("project_id")
-            or stored_id
-            or ""
+            os.getenv("PHOTON_PROJECT_ID") or extra.get("project_id") or stored_id or ""
         )
         self._project_secret: str = (
             _get_scoped_secret("PHOTON_PROJECT_SECRET")
@@ -803,6 +808,12 @@ class PhotonAdapter(BasePlatformAdapter):
         # Lightweight in-memory dedup. The gRPC stream is at-least-once, so we
         # may see the same messageId more than once (e.g. after a reconnect).
         self._seen_messages: Dict[str, float] = {}
+        # Successfully handled sidecar delivery tokens. This closes the
+        # accept-then-ACK network-failure window without invoking a secure
+        # consumer twice during an in-process reconnect replay.
+        self._handled_deliveries: Dict[str, float] = {}
+        self._accepted_handle_deliveries: Dict[str, float] = {}
+        self._delivery_processing_waiters: Dict[str, asyncio.Future] = {}
         # Ids of messages WE sent (bounded, insertion-order eviction). Inbound
         # reaction events are only routed to the agent when they target one of
         # these — a tapback on a human↔human message is not addressed to us.
@@ -817,8 +828,13 @@ class PhotonAdapter(BasePlatformAdapter):
         self._recent_richlinks_by_chat: Dict[str, float] = {}
         # Last time we sent a typing indicator per chat, for cooldown gating.
         self._typing_last_sent: Dict[str, float] = {}
-
         self._pending_fffc: Dict[str, tuple[float, Any]] = {}  # chat_key → (timestamp, asyncio.Task)
+        self._attachment_handle_consumer: Optional[Callable[[Dict[str, Any]], Any]] = (
+            None
+        )
+        self._attachment_sender_authorizer: Optional[
+            Callable[[Any, Dict[str, Any]], Any]
+        ] = None
 
         # Group-chat mention gating (parity with BlueBubbles). When enabled,
         # group messages are ignored unless they match a wake word; DMs are
@@ -827,13 +843,76 @@ class PhotonAdapter(BasePlatformAdapter):
         if _require_mention is None:
             _require_mention = os.getenv("PHOTON_REQUIRE_MENTION")
         self.require_mention = str(_require_mention).strip().lower() in {
-            "true", "1", "yes", "on",
+            "true",
+            "1",
+            "yes",
+            "on",
         }
         self._mention_patterns = self._compile_mention_patterns(
             extra["mention_patterns"]
             if "mention_patterns" in extra
             else os.getenv("PHOTON_MENTION_PATTERNS")
         )
+
+    def set_attachment_handle_consumer(
+        self,
+        consumer: Callable[[Dict[str, Any]], Any] | None,
+    ) -> None:
+        """Register the secure owner that redeems raw sidecar handles.
+
+        The callback must return ``True`` only after it has accepted ownership
+        of every handle in the raw event. Generic Hermes has no safe encrypted
+        media store, so handle-bearing events fail retryably until an embedding
+        runtime such as Keez installs this seam.
+        """
+        self._attachment_handle_consumer = consumer
+
+    def set_attachment_sender_authorizer(
+        self,
+        authorizer: Callable[[Any, Dict[str, Any]], Any] | None,
+    ) -> None:
+        """Register the sender-authorization gate paired with the consumer."""
+        self._attachment_sender_authorizer = authorizer
+
+    async def _require_attachment_handle_consumer(
+        self,
+        event: Dict[str, Any],
+        source: Any,
+    ) -> None:
+        if not _event_has_attachment_handle(event):
+            return
+        delivery_id = str(event.get("deliveryId") or "")
+        authorizer = self._attachment_sender_authorizer
+        consumer = self._attachment_handle_consumer
+        if authorizer is None or consumer is None:
+            raise PhotonAttachmentConsumerUnavailable(
+                "secure_attachment_consumer_unavailable"
+            )
+        try:
+            authorized = authorizer(source, event)
+            if inspect.isawaitable(authorized):
+                authorized = await authorized
+            if authorized is not True:
+                raise PhotonAttachmentConsumerUnavailable(
+                    "secure_attachment_sender_unauthorized"
+                )
+            if delivery_id and self._delivery_cache_has(
+                self._accepted_handle_deliveries, delivery_id
+            ):
+                return
+            accepted = consumer(event)
+            if inspect.isawaitable(accepted):
+                accepted = await accepted
+        except Exception as exc:
+            raise PhotonAttachmentConsumerUnavailable(
+                "secure_attachment_consumer_failed"
+            ) from exc
+        if accepted is not True:
+            raise PhotonAttachmentConsumerUnavailable(
+                "secure_attachment_consumer_rejected"
+            )
+        if delivery_id:
+            self._record_delivery_cache(self._accepted_handle_deliveries, delivery_id)
 
     # -- Group-mention gating (parity with BlueBubbles) -------------------
 
@@ -869,7 +948,7 @@ class PhotonAdapter(BasePlatformAdapter):
         for pattern in self._mention_patterns:
             match = pattern.match(text.lstrip())
             if match:
-                cleaned = text.lstrip()[match.end():].lstrip(" ,:-")
+                cleaned = text.lstrip()[match.end() :].lstrip(" ,:-")
                 return cleaned or text
         return text
 
@@ -877,9 +956,7 @@ class PhotonAdapter(BasePlatformAdapter):
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         if not HTTPX_AVAILABLE:
-            self._set_fatal_error(
-                "MISSING_DEP", "httpx not installed", retryable=False
-            )
+            self._set_fatal_error("MISSING_DEP", "httpx not installed", retryable=False)
             return False
         if not self._project_id or not self._project_secret:
             self._set_fatal_error(
@@ -917,9 +994,7 @@ class PhotonAdapter(BasePlatformAdapter):
 
         # Start consuming the inbound gRPC stream from the sidecar.
         self._inbound_running = True
-        self._inbound_task = asyncio.get_event_loop().create_task(
-            self._inbound_loop()
-        )
+        self._inbound_task = asyncio.get_event_loop().create_task(self._inbound_loop())
         self._sidecar_health_task = asyncio.get_event_loop().create_task(
             self._monitor_sidecar_health()
         )
@@ -937,7 +1012,8 @@ class PhotonAdapter(BasePlatformAdapter):
         self._mark_connected()
         logger.info(
             "[photon] connected — sidecar on %s:%d, streaming inbound over gRPC",
-            self._sidecar_bind, self._sidecar_port,
+            self._sidecar_bind,
+            self._sidecar_port,
         )
         return True
 
@@ -1041,7 +1117,10 @@ class PhotonAdapter(BasePlatformAdapter):
         while self._inbound_running:
             try:
                 async with client.stream(
-                    "GET", url, headers=headers, timeout=None,
+                    "GET",
+                    url,
+                    headers=headers,
+                    timeout=None,
                 ) as resp:
                     if resp.status_code != 200:
                         raise RuntimeError(f"/inbound returned {resp.status_code}")
@@ -1060,7 +1139,8 @@ class PhotonAdapter(BasePlatformAdapter):
                     break
                 logger.warning(
                     "[photon] inbound stream dropped (%s); reconnecting in %.1fs",
-                    e, backoff,
+                    e,
+                    backoff,
                 )
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, 30.0)
@@ -1137,12 +1217,85 @@ class PhotonAdapter(BasePlatformAdapter):
             logger.debug("[photon] skipping non-JSON inbound line")
             return
         msg_id = event.get("messageId")
-        if msg_id and self._is_duplicate(msg_id):
-            return
+        delivery_id = event.get("deliveryId")
+        has_handle = _event_has_attachment_handle(event)
         try:
-            await self._dispatch_inbound(event)
+            if has_handle and not _DELIVERY_ID_RE.fullmatch(str(delivery_id or "")):
+                raise PhotonAttachmentConsumerUnavailable(
+                    "secure_attachment_delivery_id_missing"
+                )
+            if delivery_id and self._delivery_was_handled(delivery_id):
+                await self._ack_inbound_delivery(delivery_id)
+                return
+            if msg_id and self._is_duplicate(msg_id):
+                if not delivery_id:
+                    return
+                # A new content-bound delivery token must pass the secure
+                # consumer; message-id dedup alone cannot prove acceptance.
+                self._seen_messages.pop(msg_id, None)
+            processing_waiter: asyncio.Future | None = None
+            if delivery_id:
+                processing_waiter = asyncio.get_running_loop().create_future()
+                self._delivery_processing_waiters[delivery_id] = processing_waiter
+            dispatched = await self._dispatch_inbound(event)
+            if processing_waiter is not None:
+                if dispatched:
+                    outcome = await processing_waiter
+                    if outcome != ProcessingOutcome.SUCCESS:
+                        raise RuntimeError("secure_attachment_dispatch_failed")
+                else:
+                    self._delivery_processing_waiters.pop(delivery_id, None)
+            if delivery_id:
+                self._record_handled_delivery(delivery_id)
+                await self._ack_inbound_delivery(delivery_id)
+        except PhotonAttachmentConsumerUnavailable:
+            if msg_id:
+                self._seen_messages.pop(msg_id, None)
+            self._set_fatal_error(
+                "ATTACHMENT_CONSUMER_UNAVAILABLE",
+                "Photon attachment requires a registered secure handle consumer",
+                retryable=True,
+            )
+            await self._notify_fatal_error()
+            raise
         except Exception:
+            if delivery_id:
+                waiter = self._delivery_processing_waiters.pop(delivery_id, None)
+                if waiter is not None and not waiter.done():
+                    waiter.cancel()
+                if msg_id:
+                    self._seen_messages.pop(msg_id, None)
+                raise
             logger.exception("[photon] inbound dispatch failed")
+
+    async def _ack_inbound_delivery(self, delivery_id: str) -> None:
+        await self._sidecar_call("/inbound-ack", {"deliveryId": delivery_id})
+
+    def _delivery_was_handled(self, delivery_id: str) -> bool:
+        return self._delivery_cache_has(self._handled_deliveries, delivery_id)
+
+    @staticmethod
+    def _delivery_cache_has(cache: Dict[str, float], delivery_id: str) -> bool:
+        now = time.time()
+        accepted_at = cache.get(delivery_id)
+        return (
+            accepted_at is not None
+            and now - accepted_at < _DELIVERY_DEDUP_WINDOW_SECONDS
+        )
+
+    def _record_handled_delivery(self, delivery_id: str) -> None:
+        self._record_delivery_cache(self._handled_deliveries, delivery_id)
+
+    @staticmethod
+    def _record_delivery_cache(cache: Dict[str, float], delivery_id: str) -> None:
+        now = time.time()
+        cache.pop(delivery_id, None)
+        cache[delivery_id] = now
+        for old_id, accepted_at in list(cache.items()):
+            if now - accepted_at >= _DELIVERY_DEDUP_WINDOW_SECONDS:
+                cache.pop(old_id, None)
+        while len(cache) > _DELIVERY_DEDUP_MAX_SIZE:
+            cache.pop(next(iter(cache)))
 
     def _is_duplicate(self, msg_id: str) -> bool:
         now = time.time()
@@ -1169,7 +1322,7 @@ class PhotonAdapter(BasePlatformAdapter):
                 "(message %s, chat %s)", message_id, chat_key,
             )
 
-    async def _dispatch_inbound(self, event: Dict[str, Any]) -> None:
+    async def _dispatch_inbound(self, event: Dict[str, Any]) -> bool:
         """Normalize a sidecar inbound event and dispatch it to the gateway.
 
         Event shape (from ``sidecar/index.mjs``)::
@@ -1203,7 +1356,7 @@ class PhotonAdapter(BasePlatformAdapter):
         space_id = space.get("id") or ""
         if not space_id:
             logger.warning("[photon] inbound missing space.id")
-            return
+            return False
 
         # iMessage spaces carry their type directly — no id string-sniffing.
         chat_type = "group" if space.get("type") == "group" else "dm"
@@ -1225,7 +1378,7 @@ class PhotonAdapter(BasePlatformAdapter):
         media_types: List[str] = []
 
         def _normalize_binary_payload(
-            payload: Dict[str, Any]
+            payload: Dict[str, Any],
         ) -> tuple[str, MessageType, List[str], List[str]]:
             is_voice = payload.get("type") == "voice"
             name = payload.get("name") or ("voice" if is_voice else "(unnamed)")
@@ -1239,9 +1392,7 @@ class PhotonAdapter(BasePlatformAdapter):
             label = "voice" if is_voice else "attachment"
             duration = payload.get("duration")
             duration_text = (
-                f", duration: {duration}s"
-                if isinstance(duration, (int, float))
-                else ""
+                f", duration: {duration}s" if isinstance(duration, (int, float)) else ""
             )
             return (
                 f"[Photon {label} received: {name} "
@@ -1262,10 +1413,8 @@ class PhotonAdapter(BasePlatformAdapter):
                 target_id and target_id in self._sent_message_ids
             )
             if not is_ours:
-                logger.debug(
-                    "[photon] ignoring reaction on a message we didn't send"
-                )
-                return
+                logger.debug("[photon] ignoring reaction on a message we didn't send")
+                return False
             emoji = content.get("emoji") or ""
             source = self.build_source(
                 chat_id=space_id,
@@ -1294,7 +1443,7 @@ class PhotonAdapter(BasePlatformAdapter):
                     timestamp=timestamp,
                 )
             )
-            return
+            return True
         # U+FFFC placeholder — wait for the real attachment instead of
         # dispatching. Detected before _record_last_inbound so the placeholder
         # is not recorded as the reaction target — the real attachment will be.
@@ -1308,7 +1457,7 @@ class PhotonAdapter(BasePlatformAdapter):
             )
             self._pending_fffc[chat_key] = (time.monotonic(), task)
             logger.debug("[photon] U+FFFC placeholder received — waiting for attachment")
-            return
+            return False
 
         # Cancel any pending U+FFFC timeout — the real message arrived.
         if ctype in {"attachment", "voice"}:
@@ -1325,7 +1474,7 @@ class PhotonAdapter(BasePlatformAdapter):
                 "[photon] suppressing rich-link preview attachment: %s",
                 _richlink_preview_label(content),
             )
-            return
+            return False
         # Anything past here is a real (reactable) message — remember it as
         # the chat's latest inbound so `add_reaction` can target it when the
         # caller doesn't pass an explicit message id. Recorded before the
@@ -1389,8 +1538,8 @@ class PhotonAdapter(BasePlatformAdapter):
                     text_parts.append(_format_richlink_content(item_content))
                     continue
                 if item_type in {"attachment", "voice"}:
-                    marker, item_mtype, item_urls, item_types = _normalize_binary_payload(
-                        item_content
+                    marker, item_mtype, item_urls, item_types = (
+                        _normalize_binary_payload(item_content)
                     )
                     if mtype == MessageType.TEXT:
                         mtype = item_mtype
@@ -1420,7 +1569,7 @@ class PhotonAdapter(BasePlatformAdapter):
                     "[photon] ignoring group message "
                     "(require_mention=true, no mention pattern matched)"
                 )
-                return
+                return False
             text = self._clean_mention_text(text)
 
         self._record_recent_richlink(space_id, _richlink_url_from_content(content) or text)
@@ -1442,7 +1591,9 @@ class PhotonAdapter(BasePlatformAdapter):
             media_urls=media_urls,
             media_types=media_types,
         )
+        await self._require_attachment_handle_consumer(event, source)
         await self.handle_message(message_event)
+        return True
 
     # -- Sidecar lifecycle -------------------------------------------------
 
@@ -1474,7 +1625,9 @@ class PhotonAdapter(BasePlatformAdapter):
     @staticmethod
     def _pid_alive(pid: int) -> bool:
         try:
-            os.kill(pid, 0)  # windows-footgun: ok — only called from _reap_stale_sidecar which win32-guards early
+            os.kill(
+                pid, 0
+            )  # windows-footgun: ok — only called from _reap_stale_sidecar which win32-guards early
             return True
         except OSError:
             return False
@@ -1523,7 +1676,8 @@ class PhotonAdapter(BasePlatformAdapter):
         for pid in stale:
             logger.warning(
                 "[photon] reaping orphaned sidecar (pid %d) on port %d",
-                pid, self._sidecar_port,
+                pid,
+                self._sidecar_port,
             )
             try:
                 os.kill(pid, signal.SIGTERM)
@@ -1535,7 +1689,9 @@ class PhotonAdapter(BasePlatformAdapter):
         for pid in stale:
             if self._pid_alive(pid):
                 try:
-                    os.kill(pid, signal.SIGKILL)  # windows-footgun: ok — unreachable on win32 (early return above)
+                    os.kill(
+                        pid, signal.SIGKILL
+                    )  # windows-footgun: ok — unreachable on win32 (early return above)
                 except OSError:
                     pass
         # Give the OS a beat to release the listening socket.
@@ -1696,7 +1852,9 @@ class PhotonAdapter(BasePlatformAdapter):
                 line = await loop.run_in_executor(None, stdout.readline)
                 if not line:
                     break
-                logger.info("[photon-sidecar] %s", line.decode("utf-8", "replace").rstrip())
+                logger.info(
+                    "[photon-sidecar] %s", line.decode("utf-8", "replace").rstrip()
+                )
         except Exception as e:  # pragma: no cover - defensive
             logger.warning("[photon-sidecar] supervisor exited: %s", e)
         if self._inbound_running:
@@ -1743,7 +1901,9 @@ class PhotonAdapter(BasePlatformAdapter):
             except subprocess.TimeoutExpired:
                 if sys.platform != "win32":
                     try:
-                        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)  # windows-footgun: ok
+                        os.killpg(
+                            os.getpgid(proc.pid), signal.SIGTERM
+                        )  # windows-footgun: ok
                     except (ProcessLookupError, PermissionError):
                         proc.terminate()
                 else:
@@ -2011,7 +2171,9 @@ class PhotonAdapter(BasePlatformAdapter):
             # Couldn't fetch the URL — fall back to sending it as text.
             return await super().send_image(chat_id, image_url, caption, reply_to)
         return await self._sidecar_send_attachment(
-            chat_id, local_path, caption=caption,
+            chat_id,
+            local_path,
+            caption=caption,
         )
 
     async def send_image_file(
@@ -2024,7 +2186,9 @@ class PhotonAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         return await self._sidecar_send_attachment(
-            chat_id, image_path, caption=caption,
+            chat_id,
+            image_path,
+            caption=caption,
         )
 
     async def send_voice(
@@ -2037,7 +2201,10 @@ class PhotonAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         return await self._sidecar_send_attachment(
-            chat_id, audio_path, caption=caption, kind="voice",
+            chat_id,
+            audio_path,
+            caption=caption,
+            kind="voice",
         )
 
     async def send_video(
@@ -2050,7 +2217,9 @@ class PhotonAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         return await self._sidecar_send_attachment(
-            chat_id, video_path, caption=caption,
+            chat_id,
+            video_path,
+            caption=caption,
         )
 
     async def send_document(
@@ -2064,7 +2233,10 @@ class PhotonAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         return await self._sidecar_send_attachment(
-            chat_id, file_path, name=file_name, caption=caption,
+            chat_id,
+            file_path,
+            name=file_name,
+            caption=caption,
         )
 
     async def send_animation(
@@ -2077,7 +2249,11 @@ class PhotonAdapter(BasePlatformAdapter):
     ) -> SendResult:
         # iMessage renders GIFs inline as ordinary image attachments.
         return await self.send_image(
-            chat_id, animation_url, caption, reply_to, metadata,
+            chat_id,
+            animation_url,
+            caption,
+            reply_to,
+            metadata,
         )
 
     async def send_poll(
@@ -2120,18 +2296,14 @@ class PhotonAdapter(BasePlatformAdapter):
             return
         self._typing_last_sent[chat_id] = now
         try:
-            await self._sidecar_call(
-                "/typing", {"spaceId": chat_id, "state": "start"}
-            )
+            await self._sidecar_call("/typing", {"spaceId": chat_id, "state": "start"})
         except Exception as e:
             logger.debug("[photon] send_typing failed: %s", e)
 
     async def stop_typing(self, chat_id: str) -> None:
         self._typing_last_sent.pop(chat_id, None)
         try:
-            await self._sidecar_call(
-                "/typing", {"spaceId": chat_id, "state": "stop"}
-            )
+            await self._sidecar_call("/typing", {"spaceId": chat_id, "state": "stop"})
         except Exception as e:
             logger.debug("[photon] stop_typing failed: %s", e)
 
@@ -2178,9 +2350,7 @@ class PhotonAdapter(BasePlatformAdapter):
             del last[key]  # refresh insertion order
         last[key] = message_id
         if len(last) > self._LAST_INBOUND_CHATS_MAX:
-            for old in list(last.keys())[
-                : len(last) - self._LAST_INBOUND_CHATS_MAX
-            ]:
+            for old in list(last.keys())[: len(last) - self._LAST_INBOUND_CHATS_MAX]:
                 del last[old]
 
     def _record_recent_richlink(self, chat_id: str, text: str) -> None:
@@ -2211,12 +2381,13 @@ class PhotonAdapter(BasePlatformAdapter):
 
     def _reactions_enabled(self) -> bool:
         return os.getenv("PHOTON_REACTIONS", "false").strip().lower() in {
-            "true", "1", "yes", "on",
+            "true",
+            "1",
+            "yes",
+            "on",
         }
 
-    async def _add_reaction(
-        self, chat_id: str, message_id: str, emoji: str
-    ) -> bool:
+    async def _add_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
         """Tapback ``emoji`` onto a message. Soft-fails (False), never raises."""
         try:
             await self._sidecar_call(
@@ -2237,7 +2408,8 @@ class PhotonAdapter(BasePlatformAdapter):
         """
         try:
             await self._sidecar_call(
-                "/unreact", {"spaceId": chat_id, "messageId": message_id},
+                "/unreact",
+                {"spaceId": chat_id, "messageId": message_id},
             )
             return True
         except Exception as e:
@@ -2316,6 +2488,19 @@ class PhotonAdapter(BasePlatformAdapter):
     # coherent. CANCELLED: leave the message unreacted.
     _OK_EMOJI = "\U0001f44d"
     _FAIL_EMOJI = "\U0001f44e"
+
+    async def on_processing_complete(
+        self, event: MessageEvent, outcome: ProcessingOutcome
+    ) -> None:
+        """Complete the reaction ACK and release a durable inbound waiter."""
+        try:
+            await super().on_processing_complete(event, outcome)
+        finally:
+            raw = event.raw_message if isinstance(event.raw_message, dict) else {}
+            delivery_id = str(raw.get("deliveryId") or "")
+            waiter = self._delivery_processing_waiters.pop(delivery_id, None)
+            if waiter is not None and not waiter.done():
+                waiter.set_result(outcome)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return whatever we know about a Spectrum space id.
@@ -2402,7 +2587,10 @@ class PhotonAdapter(BasePlatformAdapter):
                 delay = base_delay * (2 ** (attempt - 1))
                 logger.warning(
                     "[photon] Send failed (attempt %d/%d, retrying in %.1fs): %s",
-                    attempt, max_retries, delay, error_str,
+                    attempt,
+                    max_retries,
+                    delay,
+                    error_str,
                 )
                 await asyncio.sleep(delay)
                 result = await self.send(
@@ -2423,7 +2611,8 @@ class PhotonAdapter(BasePlatformAdapter):
             else:
                 logger.error(
                     "[photon] Failed to deliver response after %d retries: %s",
-                    max_retries, error_str,
+                    max_retries,
+                    error_str,
                 )
                 # Fall through to the plain-text fallback below. For URL-only
                 # responses this bypasses ``richlink()`` so a rich-link-specific
@@ -2440,7 +2629,9 @@ class PhotonAdapter(BasePlatformAdapter):
             markdown=False,
         )
         if not fallback_result.success:
-            logger.error("[photon] Plain-text retry also failed: %s", fallback_result.error)
+            logger.error(
+                "[photon] Plain-text retry also failed: %s", fallback_result.error
+            )
         return fallback_result
 
     async def _sidecar_send_richlink(self, space_id: str, url: str) -> SendResult:
@@ -2474,7 +2665,8 @@ class PhotonAdapter(BasePlatformAdapter):
         if len(text) > self.MAX_MESSAGE_LENGTH:
             logger.warning(
                 "[photon] truncating outbound from %d to %d chars",
-                len(text), self.MAX_MESSAGE_LENGTH,
+                len(text),
+                self.MAX_MESSAGE_LENGTH,
             )
             text = text[: self.MAX_MESSAGE_LENGTH]
         body: Dict[str, Any] = {"spaceId": space_id, "text": text}
@@ -2608,6 +2800,7 @@ class PhotonAdapter(BasePlatformAdapter):
 # ---------------------------------------------------------------------------
 # Helpers
 
+
 def _attachment_message_type(mime: str) -> MessageType:
     mime = (mime or "").lower()
     if mime.startswith("image/"):
@@ -2650,7 +2843,6 @@ def _standalone_error(resp: Any) -> Dict[str, Any]:
     else:
         error = str(data.get("error") or "sidecar reported failure")
     return {"error": error, "error_class": error_class, "retryable": retryable}
-
 
 async def _standalone_send(
     pconfig: PlatformConfig,
@@ -2740,7 +2932,9 @@ async def _standalone_send(
             import mimetypes
 
             for media_path, is_voice in media_files or []:
-                safe_path = BasePlatformAdapter.validate_media_delivery_path(str(media_path))
+                safe_path = BasePlatformAdapter.validate_media_delivery_path(
+                    str(media_path)
+                )
                 if not safe_path:
                     logger.warning("[photon] standalone send skipping unsafe path")
                     continue
@@ -2753,7 +2947,9 @@ async def _standalone_send(
                 if guessed:
                     att_body["mimeType"] = guessed
                 resp = await client.post(
-                    f"{base}/send-attachment", json=att_body, headers=headers,
+                    f"{base}/send-attachment",
+                    json=att_body,
+                    headers=headers,
                 )
                 if resp.status_code != 200:
                     return _standalone_error(resp)
@@ -2769,6 +2965,7 @@ async def _standalone_send(
 
 # ---------------------------------------------------------------------------
 # Plugin entry point
+
 
 def register(ctx) -> None:
     """Called by the Hermes plugin loader at startup."""

--- a/plugins/platforms/photon/sidecar/README.md
+++ b/plugins/platforms/photon/sidecar/README.md
@@ -23,6 +23,26 @@ npm install
 The Hermes plugin's `hermes photon setup` command runs `npm install`
 here automatically.
 
+## Inbound attachment handles
+
+Inbound attachment bytes never enter NDJSON and are never cached to plaintext
+disk by the Photon adapter. The normalized event contains the existing
+metadata plus a random 48-character opaque `handle`. The sidecar holds a copy
+of the bytes in memory with fixed limits: 20 MiB per item, 64 MiB total, 64
+items, and a five-minute TTL. Capacity and read failures emit metadata without
+a handle and never include provider error text.
+
+An authenticated `GET /attachment/<handle>` returns the raw bytes once with
+`Cache-Control: no-store` and `X-Content-Type-Options: nosniff`. The exact path
+accepts no query string or suffix. Consumption is atomic: concurrent or replay
+requests receive the same content-free 404 as expired and unknown handles.
+Buffers are zeroed after response completion, on expiry, and on shutdown.
+
+The Python adapter preserves the handle in `MessageEvent.raw_message` but does
+not fetch it or create a media cache file. A downstream secure consumer must
+authorize the sender and redeem the handle within the TTL before the attachment
+becomes model-ready.
+
 ## Run standalone
 
 For debugging:

--- a/plugins/platforms/photon/sidecar/README.md
+++ b/plugins/platforms/photon/sidecar/README.md
@@ -43,6 +43,13 @@ not fetch it or create a media cache file. A downstream secure consumer must
 authorize the sender and redeem the handle within the TTL before the attachment
 becomes model-ready.
 
+Handle-bearing events also carry a random `deliveryId`. The sidecar retains the
+event until the adapter posts `/inbound-ack` after sender authorization, secure
+handle acceptance, and successful message processing. A dropped connection
+replays the same delivery without redeeming the handle twice. The queue is
+bounded to 128 events with a five-minute TTL and wipes attachment buffers when
+an event expires or the process shuts down.
+
 ## Run standalone
 
 For debugging:

--- a/plugins/platforms/photon/sidecar/attachment-handles.mjs
+++ b/plugins/platforms/photon/sidecar/attachment-handles.mjs
@@ -1,0 +1,321 @@
+import crypto from "node:crypto";
+
+const HANDLE_RE = /^[a-f0-9]{48}$/;
+
+export class AttachmentHandleError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export class AttachmentHandleStore {
+  constructor({
+    maxItemBytes,
+    maxTotalBytes,
+    maxCount,
+    ttlMs,
+    now = Date.now,
+    randomBytes = crypto.randomBytes,
+    setTimer = setTimeout,
+    clearTimer = clearTimeout,
+  }) {
+    for (const [name, value] of Object.entries({
+      maxItemBytes,
+      maxTotalBytes,
+      maxCount,
+      ttlMs,
+    })) {
+      if (!Number.isSafeInteger(value) || value <= 0) {
+        throw new TypeError(`${name} must be a positive safe integer`);
+      }
+    }
+    if (maxItemBytes > maxTotalBytes) {
+      throw new TypeError("maxItemBytes cannot exceed maxTotalBytes");
+    }
+    this.maxItemBytes = maxItemBytes;
+    this.maxTotalBytes = maxTotalBytes;
+    this.maxCount = maxCount;
+    this.ttlMs = ttlMs;
+    this._now = now;
+    this._randomBytes = randomBytes;
+    this._setTimer = setTimer;
+    this._clearTimer = clearTimer;
+    this._entries = new Map();
+    this._totalBytes = 0;
+    this._expiryTimer = null;
+  }
+
+  _wipe(entry) {
+    entry.bytes.fill(0);
+    this._totalBytes -= entry.bytes.length;
+  }
+
+  _scheduleExpiry() {
+    if (this._expiryTimer !== null) {
+      this._clearTimer(this._expiryTimer);
+      this._expiryTimer = null;
+    }
+    let earliest = Infinity;
+    for (const entry of this._entries.values()) {
+      earliest = Math.min(earliest, entry.expiresAt);
+    }
+    if (earliest === Infinity) return;
+    this._expiryTimer = this._setTimer(
+      () => {
+        this._expiryTimer = null;
+        this.purgeExpired();
+      },
+      Math.max(1, earliest - this._now())
+    );
+    this._expiryTimer?.unref?.();
+  }
+
+  purgeExpired() {
+    const now = this._now();
+    for (const [handle, entry] of this._entries) {
+      if (entry.expiresAt <= now) {
+        this._entries.delete(handle);
+        this._wipe(entry);
+      }
+    }
+    this._scheduleExpiry();
+  }
+
+  assertCapacityFor(size) {
+    if (!Number.isSafeInteger(size) || size <= 0) {
+      throw new AttachmentHandleError(
+        "size_unavailable",
+        "attachment size is unavailable"
+      );
+    }
+    if (size > this.maxItemBytes) {
+      throw new AttachmentHandleError(
+        "item_too_large",
+        "attachment exceeds the per-item limit"
+      );
+    }
+    this.purgeExpired();
+    if (
+      this._entries.size >= this.maxCount ||
+      this._totalBytes + size > this.maxTotalBytes
+    ) {
+      throw new AttachmentHandleError(
+        "capacity_exceeded",
+        "attachment handle capacity is full"
+      );
+    }
+  }
+
+  availableBytes() {
+    this.purgeExpired();
+    if (this._entries.size >= this.maxCount) return 0;
+    return Math.min(
+      this.maxItemBytes,
+      this.maxTotalBytes - this._totalBytes
+    );
+  }
+
+  put(bytes, { mimeType = null } = {}) {
+    if (!Buffer.isBuffer(bytes)) {
+      throw new TypeError("attachment bytes must be a Buffer");
+    }
+    this.assertCapacityFor(bytes.length);
+    let handle;
+    do {
+      handle = this._randomBytes(24).toString("hex");
+    } while (this._entries.has(handle));
+    const owned = Buffer.from(bytes);
+    this._entries.set(handle, {
+      bytes: owned,
+      mimeType:
+        typeof mimeType === "string" && mimeType.length <= 255
+          ? mimeType
+          : null,
+      expiresAt: this._now() + this.ttlMs,
+    });
+    this._totalBytes += owned.length;
+    this._scheduleExpiry();
+    return { handle };
+  }
+
+  consume(handle) {
+    if (typeof handle !== "string" || !HANDLE_RE.test(handle)) {
+      throw new AttachmentHandleError(
+        "not_found",
+        "attachment handle not found"
+      );
+    }
+    this.purgeExpired();
+    const entry = this._entries.get(handle);
+    if (!entry) {
+      throw new AttachmentHandleError(
+        "not_found",
+        "attachment handle not found"
+      );
+    }
+    this._entries.delete(handle);
+    this._totalBytes -= entry.bytes.length;
+    this._scheduleExpiry();
+    return entry;
+  }
+
+  stats() {
+    this.purgeExpired();
+    return { count: this._entries.size, totalBytes: this._totalBytes };
+  }
+
+  close() {
+    if (this._expiryTimer !== null) {
+      this._clearTimer(this._expiryTimer);
+      this._expiryTimer = null;
+    }
+    for (const entry of this._entries.values()) this._wipe(entry);
+    this._entries.clear();
+  }
+}
+
+export async function normalizeInboundBinaryContent(
+  content,
+  store,
+  logError = (message) => console.error(message)
+) {
+  const meta = {
+    type: content.type,
+    id: content.id ?? null,
+    name: content.name ?? null,
+    mimeType: content.mimeType ?? null,
+    size: typeof content.size === "number" ? content.size : null,
+  };
+  if (content.type === "voice" && typeof content.duration === "number") {
+    meta.duration = content.duration;
+  }
+  try {
+    if (meta.size !== null) store.assertCapacityFor(meta.size);
+    const maxBytes = store.availableBytes();
+    if (maxBytes <= 0) {
+      throw new AttachmentHandleError(
+        "capacity_exceeded",
+        "attachment handle capacity is full"
+      );
+    }
+    const bytes = await readContentBytes(content, maxBytes);
+    const { handle } = store.put(bytes, { mimeType: meta.mimeType });
+    meta.size = bytes.length;
+    meta.handle = handle;
+  } catch (error) {
+    const code =
+      error instanceof AttachmentHandleError ? error.code : "read_failed";
+    logError(`photon-sidecar: attachment bytes unavailable (${code})`);
+  }
+  return meta;
+}
+
+async function readContentBytes(content, maxBytes) {
+  if (typeof content.stream === "function") {
+    const stream = await content.stream();
+    if (!stream || typeof stream.getReader !== "function") {
+      throw new AttachmentHandleError(
+        "stream_unavailable",
+        "attachment stream is unavailable"
+      );
+    }
+    const reader = stream.getReader();
+    const chunks = [];
+    let total = 0;
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const chunk = Buffer.from(value);
+        total += chunk.length;
+        if (total > maxBytes) {
+          try {
+            await reader.cancel();
+          } catch {
+            // The hard cap is authoritative even if provider cancellation
+            // itself reports a transport failure.
+          }
+          throw new AttachmentHandleError(
+            "item_too_large",
+            "attachment exceeds the available memory limit"
+          );
+        }
+        chunks.push(chunk);
+      }
+    } finally {
+      reader.releaseLock?.();
+    }
+    return Buffer.concat(chunks, total);
+  }
+  if (
+    typeof content.read !== "function" ||
+    !Number.isSafeInteger(content.size) ||
+    content.size <= 0
+  ) {
+    throw new AttachmentHandleError(
+      "size_unavailable",
+      "attachment has no bounded byte source"
+    );
+  }
+  const bytes = Buffer.from(await content.read());
+  if (bytes.length > maxBytes) {
+    throw new AttachmentHandleError(
+      "item_too_large",
+      "attachment exceeds the available memory limit"
+    );
+  }
+  return bytes;
+}
+
+export function parseAttachmentHandlePath(path) {
+  if (typeof path !== "string") return null;
+  const match = path.match(/^\/attachment\/([a-f0-9]{48})$/);
+  return match ? match[1] : null;
+}
+
+function safeMimeType(value) {
+  if (
+    typeof value === "string" &&
+    /^[A-Za-z0-9!#$&^_.+-]+\/[A-Za-z0-9!#$&^_.+-]+$/.test(value)
+  ) {
+    return value;
+  }
+  return "application/octet-stream";
+}
+
+export function serveAttachmentHandle(path, res, store) {
+  const handle = parseAttachmentHandlePath(path);
+  if (handle === null) return false;
+  let entry;
+  try {
+    entry = store.consume(handle);
+  } catch (error) {
+    if (!(error instanceof AttachmentHandleError)) throw error;
+    res.statusCode = 404;
+    res.setHeader("Content-Type", "application/json");
+    res.setHeader("Cache-Control", "no-store");
+    res.end(JSON.stringify({ ok: false, error: "attachment handle not found" }));
+    return true;
+  }
+  res.statusCode = 200;
+  res.setHeader("Content-Type", safeMimeType(entry.mimeType));
+  res.setHeader("Content-Length", String(entry.bytes.length));
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  let wiped = false;
+  const wipe = () => {
+    if (wiped) return;
+    wiped = true;
+    entry.bytes.fill(0);
+  };
+  res.once?.("close", wipe);
+  res.once?.("error", wipe);
+  try {
+    res.end(entry.bytes, wipe);
+  } catch (error) {
+    wipe();
+    throw error;
+  }
+  return true;
+}

--- a/plugins/platforms/photon/sidecar/attachment-handles.mjs
+++ b/plugins/platforms/photon/sidecar/attachment-handles.mjs
@@ -166,6 +166,7 @@ export class AttachmentHandleStore {
           : null,
       expiresAt: this._now() + this.ttlMs,
       state: "queued",
+      deliveryId: null,
       lease: null,
       wiped: false,
       aborted: false,
@@ -203,6 +204,49 @@ export class AttachmentHandleStore {
     entry.lease = null;
   }
 
+  bindHandles(handles, deliveryId) {
+    if (typeof deliveryId !== "string" || !DELIVERY_RE.test(deliveryId)) {
+      throw new AttachmentHandleError("invalid_binding", "invalid delivery binding");
+    }
+    if (!Array.isArray(handles) || handles.length === 0 || handles.length > this.maxCount) {
+      throw new AttachmentHandleError("binding_failed", "attachment binding failed");
+    }
+    this.purgeExpired();
+    const unique = new Set(handles);
+    if (unique.size !== handles.length) {
+      throw new AttachmentHandleError("binding_failed", "attachment binding failed");
+    }
+    const entries = [];
+    for (const handle of handles) {
+      if (typeof handle !== "string" || !HANDLE_RE.test(handle)) {
+        throw new AttachmentHandleError("binding_failed", "attachment binding failed");
+      }
+      const entry = this._entries.get(handle);
+      if (!entry || entry.deliveryId !== null) {
+        throw new AttachmentHandleError("binding_failed", "attachment binding failed");
+      }
+      entries.push(entry);
+    }
+    for (const entry of entries) entry.deliveryId = deliveryId;
+  }
+
+  bindEvent(event, deliveryId) {
+    const handles = [];
+    const stack = [event?.content];
+    while (stack.length > 0 && handles.length <= this.maxCount) {
+      const content = stack.pop();
+      if (!content || typeof content !== "object") continue;
+      if (content.type === "attachment" || content.type === "voice") {
+        if (HANDLE_RE.test(String(content.handle || ""))) handles.push(content.handle);
+      } else if (content.type === "group") {
+        for (const item of Array.isArray(content.items) ? content.items : []) {
+          stack.push(item?.content);
+        }
+      }
+    }
+    this.bindHandles(handles, deliveryId);
+  }
+
   lease(handle, deliveryId, { onExpire = null } = {}) {
     this._validateBinding(handle, deliveryId);
     this.purgeExpired();
@@ -212,6 +256,9 @@ export class AttachmentHandleStore {
         "not_found",
         "attachment handle not found"
       );
+    }
+    if (entry.deliveryId !== deliveryId) {
+      throw new AttachmentHandleError("binding_mismatch", "attachment delivery is not bound");
     }
     if (entry.lease && entry.lease.deliveryId !== deliveryId) {
       throw new AttachmentHandleError("binding_mismatch", "attachment lease is bound");
@@ -246,7 +293,7 @@ export class AttachmentHandleStore {
     }
     const entry = this._entries.get(handle);
     if (!entry) throw new AttachmentHandleError("not_found", "attachment handle not found");
-    if (entry.lease?.deliveryId !== deliveryId) {
+    if (entry.deliveryId !== deliveryId || entry.lease?.deliveryId !== deliveryId) {
       throw new AttachmentHandleError("binding_mismatch", "attachment lease binding mismatch");
     }
     while (this._consumed.size >= this.maxCount) {
@@ -266,7 +313,11 @@ export class AttachmentHandleStore {
     this.purgeExpired();
     const entry = this._entries.get(handle);
     if (!entry) throw new AttachmentHandleError("not_found", "attachment handle not found");
-    if (entry.lease?.deliveryId !== deliveryId || entry.lease?.leaseId !== leaseId) {
+    if (
+      entry.deliveryId !== deliveryId ||
+      entry.lease?.deliveryId !== deliveryId ||
+      entry.lease?.leaseId !== leaseId
+    ) {
       throw new AttachmentHandleError("binding_mismatch", "attachment lease binding mismatch");
     }
     this._abortLease(entry);

--- a/plugins/platforms/photon/sidecar/attachment-handles.mjs
+++ b/plugins/platforms/photon/sidecar/attachment-handles.mjs
@@ -1,6 +1,8 @@
 import crypto from "node:crypto";
 
 const HANDLE_RE = /^[a-f0-9]{48}$/;
+const DELIVERY_RE = /^[a-f0-9]{48}$/;
+const LEASE_RE = /^[a-f0-9]{48}$/;
 
 export class AttachmentHandleError extends Error {
   constructor(code, message) {
@@ -15,6 +17,7 @@ export class AttachmentHandleStore {
     maxTotalBytes,
     maxCount,
     ttlMs,
+    leaseTtlMs = ttlMs,
     now = Date.now,
     randomBytes = crypto.randomBytes,
     setTimer = setTimeout,
@@ -25,6 +28,7 @@ export class AttachmentHandleStore {
       maxTotalBytes,
       maxCount,
       ttlMs,
+      leaseTtlMs,
     })) {
       if (!Number.isSafeInteger(value) || value <= 0) {
         throw new TypeError(`${name} must be a positive safe integer`);
@@ -37,18 +41,38 @@ export class AttachmentHandleStore {
     this.maxTotalBytes = maxTotalBytes;
     this.maxCount = maxCount;
     this.ttlMs = ttlMs;
+    this.leaseTtlMs = leaseTtlMs;
     this._now = now;
     this._randomBytes = randomBytes;
     this._setTimer = setTimer;
     this._clearTimer = clearTimer;
     this._entries = new Map();
+    this._consumed = new Map();
     this._totalBytes = 0;
     this._expiryTimer = null;
   }
 
   _wipe(entry) {
+    if (entry.wiped) return;
+    entry.wiped = true;
     entry.bytes.fill(0);
     this._totalBytes -= entry.bytes.length;
+  }
+
+  _release(handle, entry, { abort = false } = {}) {
+    if (this._entries.get(handle) !== entry) return false;
+    this._entries.delete(handle);
+    if (abort && !entry.aborted) {
+      entry.aborted = true;
+      this._abortLease(entry);
+      try {
+        entry.onExpire?.();
+      } catch {
+        // Expiry and shutdown remain authoritative when socket teardown fails.
+      }
+    }
+    this._wipe(entry);
+    return true;
   }
 
   _scheduleExpiry() {
@@ -59,6 +83,10 @@ export class AttachmentHandleStore {
     let earliest = Infinity;
     for (const entry of this._entries.values()) {
       earliest = Math.min(earliest, entry.expiresAt);
+      if (entry.lease) earliest = Math.min(earliest, entry.lease.expiresAt);
+    }
+    for (const receipt of this._consumed.values()) {
+      earliest = Math.min(earliest, receipt.expiresAt);
     }
     if (earliest === Infinity) return;
     this._expiryTimer = this._setTimer(
@@ -75,9 +103,13 @@ export class AttachmentHandleStore {
     const now = this._now();
     for (const [handle, entry] of this._entries) {
       if (entry.expiresAt <= now) {
-        this._entries.delete(handle);
-        this._wipe(entry);
+        this._release(handle, entry, { abort: true });
+      } else if (entry.lease?.expiresAt <= now) {
+        this._abortLease(entry);
       }
+    }
+    for (const [handle, receipt] of this._consumed) {
+      if (receipt.expiresAt <= now) this._consumed.delete(handle);
     }
     this._scheduleExpiry();
   }
@@ -133,19 +165,46 @@ export class AttachmentHandleStore {
           ? mimeType
           : null,
       expiresAt: this._now() + this.ttlMs,
+      state: "queued",
+      lease: null,
+      wiped: false,
+      aborted: false,
+      onExpire: null,
     });
     this._totalBytes += owned.length;
     this._scheduleExpiry();
     return { handle };
   }
 
-  consume(handle) {
+  _validateBinding(handle, deliveryId, leaseId = null) {
     if (typeof handle !== "string" || !HANDLE_RE.test(handle)) {
       throw new AttachmentHandleError(
         "not_found",
         "attachment handle not found"
       );
     }
+    if (typeof deliveryId !== "string" || !DELIVERY_RE.test(deliveryId)) {
+      throw new AttachmentHandleError("invalid_binding", "invalid delivery binding");
+    }
+    if (leaseId !== null && (typeof leaseId !== "string" || !LEASE_RE.test(leaseId))) {
+      throw new AttachmentHandleError("invalid_binding", "invalid lease binding");
+    }
+  }
+
+  _abortLease(entry) {
+    if (!entry.lease) return;
+    for (const abort of entry.lease.aborters) {
+      try {
+        abort();
+      } catch {
+        // Lease expiry remains authoritative when socket teardown fails.
+      }
+    }
+    entry.lease = null;
+  }
+
+  lease(handle, deliveryId, { onExpire = null } = {}) {
+    this._validateBinding(handle, deliveryId);
     this.purgeExpired();
     const entry = this._entries.get(handle);
     if (!entry) {
@@ -154,10 +213,65 @@ export class AttachmentHandleStore {
         "attachment handle not found"
       );
     }
-    this._entries.delete(handle);
-    this._totalBytes -= entry.bytes.length;
+    if (entry.lease && entry.lease.deliveryId !== deliveryId) {
+      throw new AttachmentHandleError("binding_mismatch", "attachment lease is bound");
+    }
+    if (!entry.lease) {
+      entry.lease = {
+        deliveryId,
+        leaseId: this._randomBytes(24).toString("hex"),
+        expiresAt: Math.min(entry.expiresAt, this._now() + this.leaseTtlMs),
+        aborters: new Set(),
+      };
+    }
+    if (typeof onExpire === "function") entry.lease.aborters.add(onExpire);
     this._scheduleExpiry();
-    return entry;
+    return { entry, leaseId: entry.lease.leaseId };
+  }
+
+  detachLeaseResponse(handle, leaseId, aborter) {
+    const entry = this._entries.get(handle);
+    if (entry?.lease?.leaseId === leaseId) entry.lease.aborters.delete(aborter);
+  }
+
+  finalize(handle, deliveryId) {
+    this._validateBinding(handle, deliveryId);
+    this.purgeExpired();
+    const receipt = this._consumed.get(handle);
+    if (receipt) {
+      if (receipt.deliveryId === deliveryId) {
+        return "duplicate";
+      }
+      throw new AttachmentHandleError("not_found", "attachment handle not found");
+    }
+    const entry = this._entries.get(handle);
+    if (!entry) throw new AttachmentHandleError("not_found", "attachment handle not found");
+    if (entry.lease?.deliveryId !== deliveryId) {
+      throw new AttachmentHandleError("binding_mismatch", "attachment lease binding mismatch");
+    }
+    while (this._consumed.size >= this.maxCount) {
+      this._consumed.delete(this._consumed.keys().next().value);
+    }
+    this._consumed.set(handle, {
+      deliveryId,
+      expiresAt: this._now() + this.ttlMs,
+    });
+    this._release(handle, entry);
+    this._scheduleExpiry();
+    return "consumed";
+  }
+
+  releaseLease(handle, deliveryId, leaseId) {
+    this._validateBinding(handle, deliveryId, leaseId);
+    this.purgeExpired();
+    const entry = this._entries.get(handle);
+    if (!entry) throw new AttachmentHandleError("not_found", "attachment handle not found");
+    if (entry.lease?.deliveryId !== deliveryId || entry.lease?.leaseId !== leaseId) {
+      throw new AttachmentHandleError("binding_mismatch", "attachment lease binding mismatch");
+    }
+    this._abortLease(entry);
+    this._scheduleExpiry();
+    return "released";
   }
 
   stats() {
@@ -170,8 +284,10 @@ export class AttachmentHandleStore {
       this._clearTimer(this._expiryTimer);
       this._expiryTimer = null;
     }
-    for (const entry of this._entries.values()) this._wipe(entry);
-    this._entries.clear();
+    for (const [handle, entry] of this._entries) {
+      this._release(handle, entry, { abort: true });
+    }
+    this._consumed.clear();
   }
 }
 
@@ -274,6 +390,12 @@ export function parseAttachmentHandlePath(path) {
   return match ? match[1] : null;
 }
 
+export function parseAttachmentActionPath(path) {
+  if (typeof path !== "string") return null;
+  const match = path.match(/^\/attachment\/([a-f0-9]{48})\/(lease|consume|release)$/);
+  return match ? { handle: match[1], action: match[2] } : null;
+}
+
 function safeMimeType(value) {
   if (
     typeof value === "string" &&
@@ -284,38 +406,63 @@ function safeMimeType(value) {
   return "application/octet-stream";
 }
 
-export function serveAttachmentHandle(path, res, store) {
-  const handle = parseAttachmentHandlePath(path);
-  if (handle === null) return false;
-  let entry;
+export function serveAttachmentLease(path, body, res, store) {
+  const parsed = parseAttachmentActionPath(path);
+  if (parsed?.action !== "lease") return false;
+  const deliveryId = body?.deliveryId;
+  let leased;
+  const abort = () => res.destroy?.();
   try {
-    entry = store.consume(handle);
+    if (!body || Object.keys(body).length !== 1) throw new AttachmentHandleError("invalid_binding", "invalid delivery binding");
+    leased = store.lease(parsed.handle, deliveryId, { onExpire: abort });
   } catch (error) {
     if (!(error instanceof AttachmentHandleError)) throw error;
-    res.statusCode = 404;
+    res.statusCode = error.code === "invalid_binding" ? 400 : error.code === "binding_mismatch" ? 409 : 404;
     res.setHeader("Content-Type", "application/json");
     res.setHeader("Cache-Control", "no-store");
     res.end(JSON.stringify({ ok: false, error: "attachment handle not found" }));
     return true;
   }
+  const { entry, leaseId } = leased;
   res.statusCode = 200;
   res.setHeader("Content-Type", safeMimeType(entry.mimeType));
   res.setHeader("Content-Length", String(entry.bytes.length));
   res.setHeader("Cache-Control", "no-store");
   res.setHeader("X-Content-Type-Options", "nosniff");
-  let wiped = false;
-  const wipe = () => {
-    if (wiped) return;
-    wiped = true;
-    entry.bytes.fill(0);
-  };
-  res.once?.("close", wipe);
-  res.once?.("error", wipe);
+  res.setHeader("X-Hermes-Attachment-Lease-Id", leaseId);
+  const detach = () => store.detachLeaseResponse(parsed.handle, leaseId, abort);
+  res.once?.("close", detach);
+  res.once?.("error", detach);
   try {
-    res.end(entry.bytes, wipe);
+    res.end(entry.bytes, detach);
   } catch (error) {
-    wipe();
+    detach();
     throw error;
+  }
+  return true;
+}
+
+export function mutateAttachmentLease(path, body, res, store) {
+  const parsed = parseAttachmentActionPath(path);
+  if (!parsed || parsed.action === "lease") return false;
+  try {
+    const expectedKeys = parsed.action === "consume" ? "deliveryId" : "deliveryId,leaseId";
+    if (!body || Object.keys(body).sort().join(",") !== expectedKeys) {
+      throw new AttachmentHandleError("invalid_binding", "invalid lease binding");
+    }
+    const status = parsed.action === "consume"
+      ? store.finalize(parsed.handle, body.deliveryId)
+      : store.releaseLease(parsed.handle, body.deliveryId, body.leaseId);
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/json");
+    res.setHeader("Cache-Control", "no-store");
+    res.end(JSON.stringify({ ok: true, status }));
+  } catch (error) {
+    if (!(error instanceof AttachmentHandleError)) throw error;
+    res.statusCode = error.code === "invalid_binding" ? 400 : error.code === "binding_mismatch" ? 409 : 404;
+    res.setHeader("Content-Type", "application/json");
+    res.setHeader("Cache-Control", "no-store");
+    res.end(JSON.stringify({ ok: false, error: "attachment handle not found" }));
   }
   return true;
 }

--- a/plugins/platforms/photon/sidecar/attachment-handles.test.mjs
+++ b/plugins/platforms/photon/sidecar/attachment-handles.test.mjs
@@ -46,6 +46,7 @@ test("attachment bytes are represented by metadata and an opaque leased handle",
   assert.equal("data" in event, false);
   assert.equal("encoding" in event, false);
 
+  store.bindHandles([event.handle], DELIVERY_ID);
   const leased = store.lease(event.handle, DELIVERY_ID);
   assert.deepEqual([...leased.entry.bytes], [1, 2, 3, 4]);
   assert.equal(leased.entry.mimeType, "image/png");
@@ -173,6 +174,7 @@ test("unknown-size Spectrum streams are read incrementally within the hard cap",
 
   const event = await normalizeInboundBinaryContent(content, store);
   assert.equal(event.size, 4);
+  store.bindHandles([event.handle], DELIVERY_ID);
   assert.deepEqual([...store.lease(event.handle, DELIVERY_ID).entry.bytes], [1, 2, 3, 4]);
 });
 
@@ -226,6 +228,95 @@ test("attachment lease action path schema is exact", () => {
   }
 });
 
+test("wrong first lease cannot claim a handle before its delivery is bound", () => {
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 16,
+    maxTotalBytes: 16,
+    maxCount: 1,
+    ttlMs: 1_000,
+    setTimer: noTimer,
+  });
+  const { handle } = store.put(Buffer.from("private bytes"), {});
+  const wrong = "e".repeat(48);
+  assert.throws(
+    () => store.lease(handle, wrong),
+    (error) => error.code === "binding_mismatch"
+  );
+  store.bindHandles([handle], DELIVERY_ID);
+  assert.throws(
+    () => store.lease(handle, wrong),
+    (error) => error.code === "binding_mismatch"
+  );
+  assert.equal(store.lease(handle, DELIVERY_ID).entry.bytes.toString(), "private bytes");
+});
+
+test("mixed group handles are atomically pre-bound to one delivery", () => {
+  let counter = 1;
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 16,
+    maxTotalBytes: 32,
+    maxCount: 2,
+    ttlMs: 1_000,
+    setTimer: noTimer,
+    randomBytes: () => Buffer.alloc(24, counter++),
+  });
+  const first = store.put(Buffer.from("first"), {}).handle;
+  const second = store.put(Buffer.from("second"), {}).handle;
+  store.bindEvent({
+    content: {
+      type: "group",
+      items: [
+        { content: { type: "attachment", handle: first } },
+        { content: { type: "voice", handle: second } },
+      ],
+    },
+  }, DELIVERY_ID);
+  assert.equal(store.lease(first, DELIVERY_ID).entry.bytes.toString(), "first");
+  assert.equal(store.lease(second, DELIVERY_ID).entry.bytes.toString(), "second");
+});
+
+test("partial multi-handle bind failure rolls back every new binding", () => {
+  let counter = 1;
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 16,
+    maxTotalBytes: 32,
+    maxCount: 2,
+    ttlMs: 1_000,
+    setTimer: noTimer,
+    randomBytes: () => Buffer.alloc(24, counter++),
+  });
+  const first = store.put(Buffer.from("first"), {}).handle;
+  const second = store.put(Buffer.from("second"), {}).handle;
+  store.bindHandles([second], "e".repeat(48));
+  assert.throws(
+    () => store.bindHandles([first, second], DELIVERY_ID),
+    (error) => error.code === "binding_failed"
+  );
+  store.bindHandles([first], DELIVERY_ID);
+  assert.equal(store.lease(first, DELIVERY_ID).entry.bytes.toString(), "first");
+  assert.equal(store.lease(second, "e".repeat(48)).entry.bytes.toString(), "second");
+});
+
+test("missing handle in a multi-bind leaves existing handles unbound", () => {
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 16,
+    maxTotalBytes: 32,
+    maxCount: 2,
+    ttlMs: 1_000,
+    setTimer: noTimer,
+  });
+  const existing = store.put(Buffer.from("private bytes"), {}).handle;
+  assert.throws(
+    () => store.bindHandles([existing, "f".repeat(48)], DELIVERY_ID),
+    (error) => error.code === "binding_failed"
+  );
+  store.bindHandles([existing], DELIVERY_ID);
+  assert.equal(
+    store.lease(existing, DELIVERY_ID).entry.bytes.toString(),
+    "private bytes"
+  );
+});
+
 class FakeResponse extends EventEmitter {
   constructor() {
     super();
@@ -255,6 +346,7 @@ test("consumer crash after lease replays the same bytes and lease", () => {
   const { handle } = store.put(Buffer.from("private bytes"), {
     mimeType: "text/plain",
   });
+  store.bindHandles([handle], DELIVERY_ID);
   const first = new FakeResponse();
   assert.equal(
     serveAttachmentLease(`/attachment/${handle}/lease`, { deliveryId: DELIVERY_ID }, first, store),
@@ -290,6 +382,7 @@ test("expired attachment lease returns the stable content-free not-found envelop
     setTimer: noTimer,
   });
   const { handle } = store.put(Buffer.from("private bytes"), {});
+  store.bindHandles([handle], DELIVERY_ID);
   now += 11;
   const expired = new FakeResponse();
   serveAttachmentLease(`/attachment/${handle}/lease`, { deliveryId: DELIVERY_ID }, expired, store);
@@ -309,6 +402,7 @@ test("response faults retain charged bytes for an exact replay", () => {
     setTimer: noTimer,
   });
   const { handle } = store.put(Buffer.from("private bytes"), {});
+  store.bindHandles([handle], DELIVERY_ID);
   class FailingResponse extends FakeResponse {
     end(body) {
       this.reference = body;
@@ -342,6 +436,7 @@ test("stalled responses remain charged and are wiped by the transfer TTL", () =>
     clearTimer: () => {},
   });
   const { handle } = store.put(Buffer.from("private bytes"), {});
+  store.bindHandles([handle], DELIVERY_ID);
   class StalledResponse extends FakeResponse {
     end(body) {
       this.reference = body;
@@ -380,6 +475,7 @@ test("only exact binding finalizes and duplicate finalize is idempotent", () => 
     setTimer: noTimer,
   });
   const { handle } = store.put(Buffer.from("private bytes"), {});
+  store.bindHandles([handle], DELIVERY_ID);
   const lease = store.lease(handle, DELIVERY_ID);
   assert.throws(
     () => store.finalize(handle, "e".repeat(48)),
@@ -408,6 +504,7 @@ test("consumed idempotency receipts are strictly count bounded under flood", () 
   for (let index = 0; index < 8; index += 1) {
     const { handle } = store.put(Buffer.from(`secret-${index}`), {});
     const deliveryId = index.toString(16).padStart(48, "0");
+    store.bindHandles([handle], deliveryId);
     const lease = store.lease(handle, deliveryId);
     assert.equal(store.finalize(handle, deliveryId), "consumed");
     assert.ok(store._consumed.size <= 2);
@@ -425,6 +522,7 @@ test("release preserves bytes and permits a fresh lease for the same delivery", 
     setTimer: noTimer,
   });
   const { handle } = store.put(Buffer.from("private bytes"), {});
+  store.bindHandles([handle], DELIVERY_ID);
   const first = store.lease(handle, DELIVERY_ID);
   assert.equal(store.releaseLease(handle, DELIVERY_ID, first.leaseId), "released");
   assert.deepEqual(store.stats(), { count: 1, totalBytes: 13 });
@@ -442,6 +540,7 @@ test("consume and release HTTP mutations require exact bindings", () => {
     setTimer: noTimer,
   });
   const { handle } = store.put(Buffer.from("private bytes"), {});
+  store.bindHandles([handle], DELIVERY_ID);
   const lease = store.lease(handle, DELIVERY_ID);
   const consumed = new FakeResponse();
   assert.equal(mutateAttachmentLease(`/attachment/${handle}/consume`, {
@@ -465,6 +564,7 @@ test("completion close error and shutdown detach responses without consuming", (
       setTimer: noTimer,
     });
     const { handle } = store.put(Buffer.from("private bytes"), {});
+    store.bindHandles([handle], DELIVERY_ID);
     class ManualResponse extends FakeResponse {
       end(body, callback) {
         this.reference = body;

--- a/plugins/platforms/photon/sidecar/attachment-handles.test.mjs
+++ b/plugins/platforms/photon/sidecar/attachment-handles.test.mjs
@@ -1,0 +1,319 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+
+import {
+  AttachmentHandleError,
+  AttachmentHandleStore,
+  normalizeInboundBinaryContent,
+  parseAttachmentHandlePath,
+  serveAttachmentHandle,
+} from "./attachment-handles.mjs";
+
+const noTimer = () => ({ unref() {} });
+
+test("attachment bytes are represented by metadata and a one-shot opaque handle", async () => {
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 32,
+    maxTotalBytes: 64,
+    maxCount: 2,
+    ttlMs: 1_000,
+    setTimer: noTimer,
+  });
+  const event = await normalizeInboundBinaryContent(
+    {
+      type: "attachment",
+      id: "provider-1",
+      name: "photo.png",
+      mimeType: "image/png",
+      size: 4,
+      read: async () => Buffer.from([1, 2, 3, 4]),
+    },
+    store
+  );
+
+  assert.deepEqual(Object.keys(event).sort(), [
+    "handle",
+    "id",
+    "mimeType",
+    "name",
+    "size",
+    "type",
+  ]);
+  assert.match(event.handle, /^[a-f0-9]{48}$/);
+  assert.equal("data" in event, false);
+  assert.equal("encoding" in event, false);
+
+  const consumed = store.consume(event.handle);
+  assert.deepEqual([...consumed.bytes], [1, 2, 3, 4]);
+  assert.equal(consumed.mimeType, "image/png");
+  assert.throws(
+    () => store.consume(event.handle),
+    (error) =>
+      error instanceof AttachmentHandleError && error.code === "not_found"
+  );
+});
+
+test("store enforces item, count, and aggregate byte caps", () => {
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 4,
+    maxTotalBytes: 6,
+    maxCount: 2,
+    ttlMs: 1_000,
+    setTimer: noTimer,
+  });
+  store.put(Buffer.from("123"), { mimeType: "text/plain" });
+  store.put(Buffer.from("456"), { mimeType: "text/plain" });
+  assert.throws(
+    () => store.put(Buffer.from("7"), {}),
+    (error) => error.code === "capacity_exceeded"
+  );
+  assert.throws(
+    () => store.put(Buffer.from("12345"), {}),
+    (error) => error.code === "item_too_large"
+  );
+  assert.deepEqual(store.stats(), { count: 2, totalBytes: 6 });
+});
+
+test("expired handles are wiped and cannot be replayed", () => {
+  let now = 10_000;
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 8,
+    maxTotalBytes: 8,
+    maxCount: 1,
+    ttlMs: 50,
+    now: () => now,
+    setTimer: noTimer,
+  });
+  const { handle } = store.put(Buffer.from("secret"), {});
+  now += 51;
+  store.purgeExpired();
+  assert.deepEqual(store.stats(), { count: 0, totalBytes: 0 });
+  assert.throws(() => store.consume(handle), /not found/);
+});
+
+test("expiry timer purges bytes without a later request", () => {
+  let now = 20_000;
+  let expire = null;
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 8,
+    maxTotalBytes: 8,
+    maxCount: 1,
+    ttlMs: 25,
+    now: () => now,
+    setTimer: (callback) => {
+      expire = callback;
+      return { unref() {} };
+    },
+    clearTimer: () => {},
+  });
+  store.put(Buffer.from("secret"), {});
+  assert.equal(typeof expire, "function");
+  now += 26;
+  expire();
+  assert.deepEqual(store.stats(), { count: 0, totalBytes: 0 });
+});
+
+test("read failures and over-cap reads emit metadata without a handle", async () => {
+  const errors = [];
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 4,
+    maxTotalBytes: 8,
+    maxCount: 2,
+    ttlMs: 1_000,
+    setTimer: noTimer,
+  });
+  const failed = await normalizeInboundBinaryContent(
+    {
+      type: "attachment",
+      name: "failed.bin",
+      size: 4,
+      read: async () => {
+        throw new Error("private provider failure");
+      },
+    },
+    store,
+    (message) => errors.push(message)
+  );
+  const oversized = await normalizeInboundBinaryContent(
+    {
+      type: "attachment",
+      name: "large.bin",
+      size: 4,
+      read: async () => Buffer.from("12345"),
+    },
+    store,
+    (message) => errors.push(message)
+  );
+
+  assert.equal("handle" in failed, false);
+  assert.equal("handle" in oversized, false);
+  assert.equal(JSON.stringify(errors).includes("private provider failure"), false);
+  assert.deepEqual(store.stats(), { count: 0, totalBytes: 0 });
+});
+
+test("unknown-size Spectrum streams are read incrementally within the hard cap", async () => {
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 4,
+    maxTotalBytes: 4,
+    maxCount: 1,
+    ttlMs: 1_000,
+    setTimer: noTimer,
+  });
+  const content = {
+    type: "attachment",
+    name: "stream.bin",
+    stream: async () =>
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(Uint8Array.from([1, 2]));
+          controller.enqueue(Uint8Array.from([3, 4]));
+          controller.close();
+        },
+      }),
+  };
+
+  const event = await normalizeInboundBinaryContent(content, store);
+  assert.equal(event.size, 4);
+  assert.deepEqual([...store.consume(event.handle).bytes], [1, 2, 3, 4]);
+});
+
+test("unknown-size streams are cancelled when they cross the hard cap", async () => {
+  let cancelled = false;
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 3,
+    maxTotalBytes: 3,
+    maxCount: 1,
+    ttlMs: 1_000,
+    setTimer: noTimer,
+  });
+  const event = await normalizeInboundBinaryContent(
+    {
+      type: "attachment",
+      name: "large-stream.bin",
+      stream: async () =>
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(Uint8Array.from([1, 2]));
+            controller.enqueue(Uint8Array.from([3, 4]));
+          },
+          cancel() {
+            cancelled = true;
+          },
+        }),
+    },
+    store,
+    () => {}
+  );
+
+  assert.equal("handle" in event, false);
+  assert.equal(cancelled, true);
+  assert.deepEqual(store.stats(), { count: 0, totalBytes: 0 });
+});
+
+test("attachment GET path schema is exact", () => {
+  const handle = "a".repeat(48);
+  assert.equal(parseAttachmentHandlePath(`/attachment/${handle}`), handle);
+  for (const path of [
+    `/attachment/${handle}?again=1`,
+    `/attachment/${handle}/extra`,
+    `/attachment/${"a".repeat(47)}`,
+    `/attachments/${handle}`,
+    "/attachment/not-hex",
+  ]) {
+    assert.equal(parseAttachmentHandlePath(path), null);
+  }
+});
+
+class FakeResponse extends EventEmitter {
+  constructor() {
+    super();
+    this.headers = {};
+    this.statusCode = null;
+    this.body = null;
+  }
+
+  setHeader(name, value) {
+    this.headers[name] = value;
+  }
+
+  end(body, callback) {
+    this.body = Buffer.isBuffer(body) ? Buffer.from(body) : String(body ?? "");
+    callback?.();
+  }
+}
+
+test("raw attachment GET consumes once and replay is content-free", () => {
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 16,
+    maxTotalBytes: 16,
+    maxCount: 1,
+    ttlMs: 1_000,
+    setTimer: noTimer,
+  });
+  const { handle } = store.put(Buffer.from("private bytes"), {
+    mimeType: "text/plain",
+  });
+  const first = new FakeResponse();
+  assert.equal(
+    serveAttachmentHandle(`/attachment/${handle}`, first, store),
+    true
+  );
+  assert.equal(first.statusCode, 200);
+  assert.equal(first.headers["Content-Type"], "text/plain");
+  assert.equal(first.headers["Cache-Control"], "no-store");
+  assert.equal(first.body.toString(), "private bytes");
+
+  const replay = new FakeResponse();
+  assert.equal(
+    serveAttachmentHandle(`/attachment/${handle}`, replay, store),
+    true
+  );
+  assert.equal(replay.statusCode, 404);
+  assert.equal(replay.body.includes("private bytes"), false);
+});
+
+test("expired raw attachment GET returns the same stable not-found envelope", () => {
+  let now = 1_000;
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 16,
+    maxTotalBytes: 16,
+    maxCount: 1,
+    ttlMs: 10,
+    now: () => now,
+    setTimer: noTimer,
+  });
+  const { handle } = store.put(Buffer.from("private bytes"), {});
+  now += 11;
+  const expired = new FakeResponse();
+  serveAttachmentHandle(`/attachment/${handle}`, expired, store);
+  assert.equal(expired.statusCode, 404);
+  assert.deepEqual(JSON.parse(expired.body), {
+    ok: false,
+    error: "attachment handle not found",
+  });
+});
+
+test("response faults still wipe consumed bytes", () => {
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 16,
+    maxTotalBytes: 16,
+    maxCount: 1,
+    ttlMs: 1_000,
+    setTimer: noTimer,
+  });
+  const { handle } = store.put(Buffer.from("private bytes"), {});
+  class FailingResponse extends FakeResponse {
+    end(body) {
+      this.reference = body;
+      throw new Error("socket failed");
+    }
+  }
+  const response = new FailingResponse();
+  assert.throws(
+    () => serveAttachmentHandle(`/attachment/${handle}`, response, store),
+    /socket failed/
+  );
+  assert.equal(response.reference.every((value) => value === 0), true);
+  assert.deepEqual(store.stats(), { count: 0, totalBytes: 0 });
+});

--- a/plugins/platforms/photon/sidecar/attachment-handles.test.mjs
+++ b/plugins/platforms/photon/sidecar/attachment-handles.test.mjs
@@ -5,14 +5,16 @@ import test from "node:test";
 import {
   AttachmentHandleError,
   AttachmentHandleStore,
+  mutateAttachmentLease,
   normalizeInboundBinaryContent,
-  parseAttachmentHandlePath,
-  serveAttachmentHandle,
+  parseAttachmentActionPath,
+  serveAttachmentLease,
 } from "./attachment-handles.mjs";
 
 const noTimer = () => ({ unref() {} });
+const DELIVERY_ID = "d".repeat(48);
 
-test("attachment bytes are represented by metadata and a one-shot opaque handle", async () => {
+test("attachment bytes are represented by metadata and an opaque leased handle", async () => {
   const store = new AttachmentHandleStore({
     maxItemBytes: 32,
     maxTotalBytes: 64,
@@ -44,14 +46,10 @@ test("attachment bytes are represented by metadata and a one-shot opaque handle"
   assert.equal("data" in event, false);
   assert.equal("encoding" in event, false);
 
-  const consumed = store.consume(event.handle);
-  assert.deepEqual([...consumed.bytes], [1, 2, 3, 4]);
-  assert.equal(consumed.mimeType, "image/png");
-  assert.throws(
-    () => store.consume(event.handle),
-    (error) =>
-      error instanceof AttachmentHandleError && error.code === "not_found"
-  );
+  const leased = store.lease(event.handle, DELIVERY_ID);
+  assert.deepEqual([...leased.entry.bytes], [1, 2, 3, 4]);
+  assert.equal(leased.entry.mimeType, "image/png");
+  assert.equal(store.lease(event.handle, DELIVERY_ID).leaseId, leased.leaseId);
 });
 
 test("store enforces item, count, and aggregate byte caps", () => {
@@ -89,7 +87,7 @@ test("expired handles are wiped and cannot be replayed", () => {
   now += 51;
   store.purgeExpired();
   assert.deepEqual(store.stats(), { count: 0, totalBytes: 0 });
-  assert.throws(() => store.consume(handle), /not found/);
+  assert.throws(() => store.lease(handle, DELIVERY_ID), /not found/);
 });
 
 test("expiry timer purges bytes without a later request", () => {
@@ -175,7 +173,7 @@ test("unknown-size Spectrum streams are read incrementally within the hard cap",
 
   const event = await normalizeInboundBinaryContent(content, store);
   assert.equal(event.size, 4);
-  assert.deepEqual([...store.consume(event.handle).bytes], [1, 2, 3, 4]);
+  assert.deepEqual([...store.lease(event.handle, DELIVERY_ID).entry.bytes], [1, 2, 3, 4]);
 });
 
 test("unknown-size streams are cancelled when they cross the hard cap", async () => {
@@ -211,17 +209,20 @@ test("unknown-size streams are cancelled when they cross the hard cap", async ()
   assert.deepEqual(store.stats(), { count: 0, totalBytes: 0 });
 });
 
-test("attachment GET path schema is exact", () => {
+test("attachment lease action path schema is exact", () => {
   const handle = "a".repeat(48);
-  assert.equal(parseAttachmentHandlePath(`/attachment/${handle}`), handle);
+  assert.deepEqual(parseAttachmentActionPath(`/attachment/${handle}/lease`), {
+    handle,
+    action: "lease",
+  });
   for (const path of [
-    `/attachment/${handle}?again=1`,
+    `/attachment/${handle}/lease?again=1`,
     `/attachment/${handle}/extra`,
     `/attachment/${"a".repeat(47)}`,
     `/attachments/${handle}`,
     "/attachment/not-hex",
   ]) {
-    assert.equal(parseAttachmentHandlePath(path), null);
+    assert.equal(parseAttachmentActionPath(path), null);
   }
 });
 
@@ -243,7 +244,7 @@ class FakeResponse extends EventEmitter {
   }
 }
 
-test("raw attachment GET consumes once and replay is content-free", () => {
+test("consumer crash after lease replays the same bytes and lease", () => {
   const store = new AttachmentHandleStore({
     maxItemBytes: 16,
     maxTotalBytes: 16,
@@ -256,7 +257,7 @@ test("raw attachment GET consumes once and replay is content-free", () => {
   });
   const first = new FakeResponse();
   assert.equal(
-    serveAttachmentHandle(`/attachment/${handle}`, first, store),
+    serveAttachmentLease(`/attachment/${handle}/lease`, { deliveryId: DELIVERY_ID }, first, store),
     true
   );
   assert.equal(first.statusCode, 200);
@@ -264,16 +265,21 @@ test("raw attachment GET consumes once and replay is content-free", () => {
   assert.equal(first.headers["Cache-Control"], "no-store");
   assert.equal(first.body.toString(), "private bytes");
 
+  assert.deepEqual(store.stats(), { count: 1, totalBytes: 13 });
   const replay = new FakeResponse();
   assert.equal(
-    serveAttachmentHandle(`/attachment/${handle}`, replay, store),
+    serveAttachmentLease(`/attachment/${handle}/lease`, { deliveryId: DELIVERY_ID }, replay, store),
     true
   );
-  assert.equal(replay.statusCode, 404);
-  assert.equal(replay.body.includes("private bytes"), false);
+  assert.equal(replay.statusCode, 200);
+  assert.equal(replay.body.toString(), "private bytes");
+  assert.equal(
+    replay.headers["X-Hermes-Attachment-Lease-Id"],
+    first.headers["X-Hermes-Attachment-Lease-Id"]
+  );
 });
 
-test("expired raw attachment GET returns the same stable not-found envelope", () => {
+test("expired attachment lease returns the stable content-free not-found envelope", () => {
   let now = 1_000;
   const store = new AttachmentHandleStore({
     maxItemBytes: 16,
@@ -286,7 +292,7 @@ test("expired raw attachment GET returns the same stable not-found envelope", ()
   const { handle } = store.put(Buffer.from("private bytes"), {});
   now += 11;
   const expired = new FakeResponse();
-  serveAttachmentHandle(`/attachment/${handle}`, expired, store);
+  serveAttachmentLease(`/attachment/${handle}/lease`, { deliveryId: DELIVERY_ID }, expired, store);
   assert.equal(expired.statusCode, 404);
   assert.deepEqual(JSON.parse(expired.body), {
     ok: false,
@@ -294,7 +300,7 @@ test("expired raw attachment GET returns the same stable not-found envelope", ()
   });
 });
 
-test("response faults still wipe consumed bytes", () => {
+test("response faults retain charged bytes for an exact replay", () => {
   const store = new AttachmentHandleStore({
     maxItemBytes: 16,
     maxTotalBytes: 16,
@@ -311,9 +317,184 @@ test("response faults still wipe consumed bytes", () => {
   }
   const response = new FailingResponse();
   assert.throws(
-    () => serveAttachmentHandle(`/attachment/${handle}`, response, store),
+    () => serveAttachmentLease(`/attachment/${handle}/lease`, { deliveryId: DELIVERY_ID }, response, store),
     /socket failed/
   );
-  assert.equal(response.reference.every((value) => value === 0), true);
+  assert.equal(response.reference.toString(), "private bytes");
+  assert.deepEqual(store.stats(), { count: 1, totalBytes: 13 });
+  const replay = store.lease(handle, DELIVERY_ID);
+  assert.equal(replay.entry.bytes.toString(), "private bytes");
+});
+
+test("stalled responses remain charged and are wiped by the transfer TTL", () => {
+  let now = 30_000;
+  let expire = null;
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 16,
+    maxTotalBytes: 16,
+    maxCount: 1,
+    ttlMs: 50,
+    now: () => now,
+    setTimer: (callback) => {
+      expire = callback;
+      return { unref() {} };
+    },
+    clearTimer: () => {},
+  });
+  const { handle } = store.put(Buffer.from("private bytes"), {});
+  class StalledResponse extends FakeResponse {
+    end(body) {
+      this.reference = body;
+    }
+
+    destroy() {
+      this.destroyed = true;
+      this.emit("close");
+    }
+  }
+  const response = new StalledResponse();
+  serveAttachmentLease(`/attachment/${handle}/lease`, { deliveryId: DELIVERY_ID }, response, store);
+
+  assert.deepEqual(store.stats(), { count: 1, totalBytes: 13 });
+  assert.throws(
+    () => store.put(Buffer.from("x"), {}),
+    (error) => error.code === "capacity_exceeded"
+  );
+  now += 51;
+  expire();
   assert.deepEqual(store.stats(), { count: 0, totalBytes: 0 });
+  assert.equal(response.reference.every((value) => value === 0), true);
+  assert.equal(response.destroyed, true);
+
+  const replay = new FakeResponse();
+  serveAttachmentLease(`/attachment/${handle}/lease`, { deliveryId: DELIVERY_ID }, replay, store);
+  assert.equal(replay.statusCode, 404);
+});
+
+test("only exact binding finalizes and duplicate finalize is idempotent", () => {
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 16,
+    maxTotalBytes: 16,
+    maxCount: 1,
+    ttlMs: 1_000,
+    setTimer: noTimer,
+  });
+  const { handle } = store.put(Buffer.from("private bytes"), {});
+  const lease = store.lease(handle, DELIVERY_ID);
+  assert.throws(
+    () => store.finalize(handle, "e".repeat(48)),
+    (error) => error.code === "binding_mismatch"
+  );
+  assert.deepEqual(store.stats(), { count: 1, totalBytes: 13 });
+  assert.equal(store.finalize(handle, DELIVERY_ID), "consumed");
+  assert.deepEqual(store.stats(), { count: 0, totalBytes: 0 });
+  assert.equal(store.finalize(handle, DELIVERY_ID), "duplicate");
+  assert.throws(
+    () => store.finalize(handle, "e".repeat(48)),
+    (error) => error.code === "not_found"
+  );
+});
+
+test("consumed idempotency receipts are strictly count bounded under flood", () => {
+  let counter = 1;
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 16,
+    maxTotalBytes: 32,
+    maxCount: 2,
+    ttlMs: 1_000,
+    setTimer: noTimer,
+    randomBytes: () => Buffer.alloc(24, counter++),
+  });
+  for (let index = 0; index < 8; index += 1) {
+    const { handle } = store.put(Buffer.from(`secret-${index}`), {});
+    const deliveryId = index.toString(16).padStart(48, "0");
+    const lease = store.lease(handle, deliveryId);
+    assert.equal(store.finalize(handle, deliveryId), "consumed");
+    assert.ok(store._consumed.size <= 2);
+  }
+  assert.equal(store._consumed.size, 2);
+  assert.deepEqual(store.stats(), { count: 0, totalBytes: 0 });
+});
+
+test("release preserves bytes and permits a fresh lease for the same delivery", () => {
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 16,
+    maxTotalBytes: 16,
+    maxCount: 1,
+    ttlMs: 1_000,
+    setTimer: noTimer,
+  });
+  const { handle } = store.put(Buffer.from("private bytes"), {});
+  const first = store.lease(handle, DELIVERY_ID);
+  assert.equal(store.releaseLease(handle, DELIVERY_ID, first.leaseId), "released");
+  assert.deepEqual(store.stats(), { count: 1, totalBytes: 13 });
+  const retry = store.lease(handle, DELIVERY_ID);
+  assert.notEqual(retry.leaseId, first.leaseId);
+  assert.equal(retry.entry.bytes.toString(), "private bytes");
+});
+
+test("consume and release HTTP mutations require exact bindings", () => {
+  const store = new AttachmentHandleStore({
+    maxItemBytes: 16,
+    maxTotalBytes: 16,
+    maxCount: 1,
+    ttlMs: 1_000,
+    setTimer: noTimer,
+  });
+  const { handle } = store.put(Buffer.from("private bytes"), {});
+  const lease = store.lease(handle, DELIVERY_ID);
+  const consumed = new FakeResponse();
+  assert.equal(mutateAttachmentLease(`/attachment/${handle}/consume`, {
+    deliveryId: DELIVERY_ID,
+  }, consumed, store), true);
+  assert.deepEqual(JSON.parse(consumed.body), { ok: true, status: "consumed" });
+  const duplicate = new FakeResponse();
+  mutateAttachmentLease(`/attachment/${handle}/consume`, {
+    deliveryId: DELIVERY_ID,
+  }, duplicate, store);
+  assert.deepEqual(JSON.parse(duplicate.body), { ok: true, status: "duplicate" });
+});
+
+test("completion close error and shutdown detach responses without consuming", () => {
+  for (const releaseKind of ["completion", "close", "error", "shutdown"]) {
+    const store = new AttachmentHandleStore({
+      maxItemBytes: 16,
+      maxTotalBytes: 16,
+      maxCount: 1,
+      ttlMs: 1_000,
+      setTimer: noTimer,
+    });
+    const { handle } = store.put(Buffer.from("private bytes"), {});
+    class ManualResponse extends FakeResponse {
+      end(body, callback) {
+        this.reference = body;
+        this.completion = callback;
+      }
+
+      destroy() {
+        this.destroyed = true;
+        this.emit("close");
+      }
+    }
+    const response = new ManualResponse();
+    serveAttachmentLease(`/attachment/${handle}/lease`, { deliveryId: DELIVERY_ID }, response, store);
+    if (releaseKind === "completion") response.completion();
+    if (releaseKind === "close") response.emit("close");
+    if (releaseKind === "error") response.emit("error", new Error("socket"));
+    if (releaseKind === "shutdown") store.close();
+
+    response.completion();
+    response.emit("close");
+    if (releaseKind !== "error") response.emit("error", new Error("late"));
+    assert.deepEqual(
+      store.stats(),
+      releaseKind === "shutdown" ? { count: 0, totalBytes: 0 } : { count: 1, totalBytes: 13 }
+    );
+    assert.equal(
+      response.reference.every((value) => value === 0),
+      releaseKind === "shutdown"
+    );
+    assert.equal(Boolean(response.destroyed), releaseKind === "shutdown");
+    store.close();
+  }
 });

--- a/plugins/platforms/photon/sidecar/inbound-deliveries.mjs
+++ b/plugins/platforms/photon/sidecar/inbound-deliveries.mjs
@@ -1,0 +1,132 @@
+import crypto from "node:crypto";
+import { once } from "node:events";
+
+const DELIVERY_ID_RE = /^[a-f0-9]{48}$/;
+
+export function eventHasAttachmentHandle(event) {
+  function hasHandle(content) {
+    if (!content || typeof content !== "object") return false;
+    if (content.type === "attachment" || content.type === "voice") {
+      return DELIVERY_ID_RE.test(String(content.handle || ""));
+    }
+    if (content.type === "group") {
+      return (Array.isArray(content.items) ? content.items : []).some((item) =>
+        hasHandle(item?.content)
+      );
+    }
+    return false;
+  }
+  return hasHandle(event?.content);
+}
+
+export function parseDeliveryAck(body) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error("invalid_delivery_ack");
+  }
+  const keys = Object.keys(body);
+  if (keys.length !== 1 || keys[0] !== "deliveryId" ||
+      !DELIVERY_ID_RE.test(String(body.deliveryId || ""))) {
+    throw new Error("invalid_delivery_ack");
+  }
+  return body.deliveryId;
+}
+
+export async function deliverPendingEntry(entry, transport) {
+  for (;;) {
+    await transport.waitForConsumer();
+    const { res, version } = transport.currentConsumer();
+    if (!res) continue;
+    try {
+      const flushed = res.write(entry.line + "\n");
+      if (!flushed) {
+        const drain = once(res, "drain").then(() => "drained");
+        const changed = transport.waitForConsumerChange(version);
+        const outcome = await Promise.race([entry.settled, changed.promise, drain]);
+        changed.cancel();
+        if (outcome === "acked" || outcome === "expired" || outcome === "closed") {
+          return outcome;
+        }
+        if (outcome === "consumer_changed") continue;
+      }
+      const changed = transport.waitForConsumerChange(version);
+      const outcome = await Promise.race([entry.settled, changed.promise]);
+      changed.cancel();
+      if (outcome === "consumer_changed") continue;
+      return outcome;
+    } catch {
+      transport.clearConsumer(res);
+    }
+  }
+}
+
+export class InboundDeliveryQueue {
+  constructor({
+    maxBytes = 2 * 1024 * 1024,
+    ttlMs = 5 * 60 * 1000,
+    recentAckMax = 64,
+    randomBytes = crypto.randomBytes,
+    setTimer = setTimeout,
+    clearTimer = clearTimeout,
+  } = {}) {
+    this.maxBytes = maxBytes;
+    this.ttlMs = ttlMs;
+    this.recentAckMax = recentAckMax;
+    this.randomBytes = randomBytes;
+    this.setTimer = setTimer;
+    this.clearTimer = clearTimer;
+    this.pending = null;
+    this.totalBytes = 0;
+    this.recentAcks = new Map();
+  }
+
+  begin(event) {
+    if (this.pending) throw new Error("delivery_queue_full");
+    const deliveryId = this.randomBytes(24).toString("hex");
+    const line = JSON.stringify({ ...event, deliveryId });
+    const bytes = Buffer.byteLength(line);
+    if (bytes > this.maxBytes) throw new Error("delivery_too_large");
+    let settle;
+    const settled = new Promise((resolve) => { settle = resolve; });
+    const entry = { deliveryId, line, bytes, settled, settle, timer: null };
+    entry.timer = this.setTimer(() => this._release(entry, "expired"), this.ttlMs);
+    if (entry.timer && typeof entry.timer.unref === "function") entry.timer.unref();
+    this.pending = entry;
+    this.totalBytes = bytes;
+    return entry;
+  }
+
+  _rememberAck(deliveryId) {
+    this.recentAcks.delete(deliveryId);
+    this.recentAcks.set(deliveryId, true);
+    while (this.recentAcks.size > this.recentAckMax) {
+      this.recentAcks.delete(this.recentAcks.keys().next().value);
+    }
+  }
+
+  _release(entry, outcome) {
+    if (this.pending !== entry) return false;
+    this.clearTimer(entry.timer);
+    this.pending = null;
+    this.totalBytes = 0;
+    if (outcome === "acked") this._rememberAck(entry.deliveryId);
+    entry.settle(outcome);
+    return true;
+  }
+
+  ack(deliveryId) {
+    if (this.pending?.deliveryId === deliveryId) {
+      this._release(this.pending, "acked");
+      return "acked";
+    }
+    return this.recentAcks.has(deliveryId) ? "duplicate" : "not_found";
+  }
+
+  stats() {
+    return { count: this.pending ? 1 : 0, totalBytes: this.totalBytes };
+  }
+
+  close() {
+    if (this.pending) this._release(this.pending, "closed");
+    this.recentAcks.clear();
+  }
+}

--- a/plugins/platforms/photon/sidecar/inbound-deliveries.mjs
+++ b/plugins/platforms/photon/sidecar/inbound-deliveries.mjs
@@ -79,12 +79,13 @@ export class InboundDeliveryQueue {
     this.recentAcks = new Map();
   }
 
-  begin(event) {
+  begin(event, { bindDelivery = null } = {}) {
     if (this.pending) throw new Error("delivery_queue_full");
     const deliveryId = this.randomBytes(24).toString("hex");
     const line = JSON.stringify({ ...event, deliveryId });
     const bytes = Buffer.byteLength(line);
     if (bytes > this.maxBytes) throw new Error("delivery_too_large");
+    if (typeof bindDelivery === "function") bindDelivery(deliveryId);
     let settle;
     const settled = new Promise((resolve) => { settle = resolve; });
     const entry = { deliveryId, line, bytes, settled, settle, timer: null };

--- a/plugins/platforms/photon/sidecar/inbound-deliveries.test.mjs
+++ b/plugins/platforms/photon/sidecar/inbound-deliveries.test.mjs
@@ -38,6 +38,33 @@ test("attachment delivery is content-bound, opaque, and charged", () => {
   assert.deepEqual(queue.stats(), { count: 1, totalBytes: Buffer.byteLength(entry.line) });
 });
 
+test("delivery binding runs before an event becomes pending and fails atomically", () => {
+  const t = timers();
+  const queue = new InboundDeliveryQueue({
+    maxBytes: 4096,
+    ttlMs: 600000,
+    randomBytes: () => Buffer.alloc(24, 0xcd),
+    setTimer: t.setTimer,
+    clearTimer: t.clearTimer,
+  });
+  let bound = null;
+  const entry = queue.begin(
+    { content: { type: "attachment", handle: "a".repeat(48) } },
+    { bindDelivery: (deliveryId) => { bound = deliveryId; } }
+  );
+  assert.equal(bound, entry.deliveryId);
+  queue.ack(entry.deliveryId);
+
+  assert.throws(
+    () => queue.begin(
+      { content: { type: "attachment", handle: "b".repeat(48) } },
+      { bindDelivery: () => { throw new Error("binding_failed"); } }
+    ),
+    /binding_failed/
+  );
+  assert.deepEqual(queue.stats(), { count: 0, totalBytes: 0 });
+});
+
 test("one pending event and byte limit are hard bounds", () => {
   const t = timers();
   const queue = new InboundDeliveryQueue({

--- a/plugins/platforms/photon/sidecar/inbound-deliveries.test.mjs
+++ b/plugins/platforms/photon/sidecar/inbound-deliveries.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  deliverPendingEntry,
+  InboundDeliveryQueue,
+  eventHasAttachmentHandle,
+  parseDeliveryAck,
+} from "./inbound-deliveries.mjs";
+
+function timers() {
+  const slots = [];
+  return {
+    slots,
+    setTimer(fn) {
+      slots.push(fn);
+      return fn;
+    },
+    clearTimer() {},
+  };
+}
+
+test("attachment delivery is content-bound, opaque, and charged", () => {
+  const t = timers();
+  const queue = new InboundDeliveryQueue({
+    maxBytes: 4096,
+    ttlMs: 600000,
+    randomBytes: () => Buffer.alloc(24, 0xab),
+    setTimer: t.setTimer,
+    clearTimer: t.clearTimer,
+  });
+  const event = { messageId: "m1", content: { type: "attachment", handle: "a".repeat(48) } };
+  const entry = queue.begin(event);
+
+  assert.equal(entry.deliveryId, "ab".repeat(24));
+  assert.equal(event.deliveryId, undefined);
+  assert.equal(JSON.parse(entry.line).deliveryId, entry.deliveryId);
+  assert.deepEqual(queue.stats(), { count: 1, totalBytes: Buffer.byteLength(entry.line) });
+});
+
+test("one pending event and byte limit are hard bounds", () => {
+  const t = timers();
+  const queue = new InboundDeliveryQueue({
+    maxBytes: 128,
+    ttlMs: 600000,
+    setTimer: t.setTimer,
+    clearTimer: t.clearTimer,
+  });
+  assert.throws(() => queue.begin({ content: { text: "x".repeat(500) } }), /delivery_too_large/);
+  queue.begin({ content: { text: "ok" } });
+  assert.throws(() => queue.begin({ content: { text: "second" } }), /delivery_queue_full/);
+});
+
+test("ack is idempotent and releases capacity", async () => {
+  const t = timers();
+  const queue = new InboundDeliveryQueue({ ttlMs: 600000, setTimer: t.setTimer, clearTimer: t.clearTimer });
+  const entry = queue.begin({ content: { text: "ok" } });
+  assert.equal(queue.ack(entry.deliveryId), "acked");
+  assert.equal(await entry.settled, "acked");
+  assert.equal(queue.ack(entry.deliveryId), "duplicate");
+  assert.equal(queue.ack("f".repeat(48)), "not_found");
+  assert.deepEqual(queue.stats(), { count: 0, totalBytes: 0 });
+});
+
+test("ttl expiry releases capacity without retaining content", async () => {
+  const t = timers();
+  const queue = new InboundDeliveryQueue({ ttlMs: 600000, setTimer: t.setTimer, clearTimer: t.clearTimer });
+  const entry = queue.begin({ content: { text: "private-value" } });
+  t.slots[0]();
+  assert.equal(await entry.settled, "expired");
+  assert.deepEqual(queue.stats(), { count: 0, totalBytes: 0 });
+});
+
+test("handle detection includes mixed group children", () => {
+  assert.equal(eventHasAttachmentHandle({ content: { type: "text", text: "x" } }), false);
+  assert.equal(eventHasAttachmentHandle({ content: { type: "group", items: [
+    { content: { type: "text", text: "x" } },
+    { content: { type: "voice", handle: "c".repeat(48) } },
+  ] } }), true);
+});
+
+test("ack body is exact and token-shaped", () => {
+  assert.equal(parseDeliveryAck({ deliveryId: "d".repeat(48) }), "d".repeat(48));
+  assert.throws(() => parseDeliveryAck({ deliveryId: "d".repeat(48), extra: true }), /invalid_delivery_ack/);
+  assert.throws(() => parseDeliveryAck({ deliveryId: "nope" }), /invalid_delivery_ack/);
+});
+
+test("pending delivery replays the identical line after consumer reconnect", async () => {
+  const t = timers();
+  const queue = new InboundDeliveryQueue({ ttlMs: 600000, setTimer: t.setTimer, clearTimer: t.clearTimer });
+  const entry = queue.begin({ messageId: "ordered", content: { type: "attachment", handle: "e".repeat(48) } });
+  const first = { lines: [], write(line) { this.lines.push(line); return true; } };
+  const second = { lines: [], write(line) { this.lines.push(line); return true; } };
+  let res = first;
+  let version = 1;
+  let changedResolve;
+  const transport = {
+    async waitForConsumer() {},
+    currentConsumer: () => ({ res, version }),
+    waitForConsumerChange(expected) {
+      if (expected !== version) {
+        return { promise: Promise.resolve("consumer_changed"), cancel() {} };
+      }
+      let cancelled = false;
+      const promise = new Promise((resolve) => {
+        changedResolve = () => { if (!cancelled) resolve("consumer_changed"); };
+      });
+      return { promise, cancel() { cancelled = true; } };
+    },
+    clearConsumer() {},
+  };
+
+  const delivered = deliverPendingEntry(entry, transport);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(first.lines, [entry.line + "\n"]);
+  res = second;
+  version += 1;
+  changedResolve();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(second.lines, [entry.line + "\n"]);
+  queue.ack(entry.deliveryId);
+  assert.equal(await delivered, "acked");
+});

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -17,6 +17,7 @@
 // Protocol (all requests require `X-Hermes-Sidecar-Token: ${TOKEN}`):
 //   - GET  /inbound    -> 200 NDJSON stream; one JSON event per line, blank
 //                         lines are heartbeats. One consumer at a time.
+//   - GET  /attachment/<opaque-handle> -> one-shot raw attachment bytes
 //   - POST /healthz     -> {"ok": true}
 //   - POST /send        -> {"ok": true, "messageId": "..."}
 //       body: {"spaceId": "...", "text": "...",
@@ -72,6 +73,12 @@ import {
   shouldProbe,
   isZombieSuspect,
 } from "./stream-staleness.mjs";
+import {
+  AttachmentHandleStore,
+  normalizeInboundBinaryContent,
+  serveAttachmentHandle,
+} from "./attachment-handles.mjs";
+import fs from "node:fs";
 
 const projectId = process.env.PHOTON_PROJECT_ID;
 const projectSecret = process.env.PHOTON_PROJECT_SECRET;
@@ -82,13 +89,16 @@ const telemetry = /^(1|true|yes|on)$/i.test(
   (process.env.PHOTON_TELEMETRY || "").trim()
 );
 
-// Inbound binary content is read into memory and base64-inlined on the NDJSON
-// event so the Python adapter can cache the real bytes (and the agent can see
-// images / transcribe voice). Cap the size we inline — above it we forward
-// metadata only and the adapter surfaces a text marker, so one large clip can't
-// balloon a single NDJSON line. Override via PHOTON_MAX_INLINE_ATTACHMENT_BYTES.
-const MAX_INLINE_ATTACHMENT_BYTES =
-  Number(process.env.PHOTON_MAX_INLINE_ATTACHMENT_BYTES) || 20 * 1024 * 1024;
+const ATTACHMENT_MAX_ITEM_BYTES = 20 * 1024 * 1024;
+const ATTACHMENT_MAX_TOTAL_BYTES = 64 * 1024 * 1024;
+const ATTACHMENT_MAX_COUNT = 64;
+const ATTACHMENT_TTL_MS = 5 * 60 * 1000;
+const attachmentHandles = new AttachmentHandleStore({
+  maxItemBytes: ATTACHMENT_MAX_ITEM_BYTES,
+  maxTotalBytes: ATTACHMENT_MAX_TOTAL_BYTES,
+  maxCount: ATTACHMENT_MAX_COUNT,
+  ttlMs: ATTACHMENT_TTL_MS,
+});
 const DM_CHAT_GUID_RE = /^any;-;(\+\d{6,})$/;
 const E164_RE = /^\+\d{6,}$/;
 const MAX_KNOWN_SPACES = 2048;
@@ -429,57 +439,6 @@ async function deliver(line) {
   }
 }
 
-async function normalizeBinaryContent(content) {
-  const meta = {
-    type: content.type,
-    id: content.id ?? null,
-    name: content.name ?? null,
-    mimeType: content.mimeType ?? null,
-    size: typeof content.size === "number" ? content.size : null,
-  };
-  if (content.type === "voice" && typeof content.duration === "number") {
-    meta.duration = content.duration;
-  }
-
-  // Read the bytes eagerly and base64-inline them as `data` so the Python
-  // adapter can cache the real file (the agent then sees images and can run
-  // STT on voice notes). Spectrum content objects may not outlive this stream
-  // iteration, so a lazy/on-demand fetch isn't safe. Over-cap content (when
-  // size is known up front) is forwarded as metadata only and the adapter falls
-  // back to a text marker. A read failure must never break the inbound loop.
-  const label = `${content.type} ${meta.name ?? meta.id ?? "(unnamed)"}`;
-  if (meta.size !== null && meta.size > MAX_INLINE_ATTACHMENT_BYTES) {
-    console.error(
-      `photon-sidecar: ${label} (${meta.size} bytes) ` +
-        `exceeds inline cap ${MAX_INLINE_ATTACHMENT_BYTES}; forwarding metadata only`
-    );
-    return meta;
-  }
-  if (typeof content.read === "function") {
-    try {
-      const buf = await content.read();
-      // Guard the case where size was unknown but the bytes turn out to be
-      // over the cap.
-      if (buf && buf.length > MAX_INLINE_ATTACHMENT_BYTES) {
-        console.error(
-          `photon-sidecar: ${label} (${buf.length} bytes) ` +
-            `exceeds inline cap after read; forwarding metadata only`
-        );
-        return meta;
-      }
-      meta.data = Buffer.from(buf).toString("base64");
-      meta.encoding = "base64";
-    } catch (e) {
-      console.error(
-        `photon-sidecar: failed to read ${content.type} bytes ` +
-          "(forwarding metadata only): " +
-          (e && e.stack ? e.stack : String(e))
-      );
-    }
-  }
-  return meta;
-}
-
 // Best-effort text preview of a reaction's resolved target Message, so the
 // Python adapter can populate the gateway's `reply_to_text` (context: WHAT was
 // tapped back). The SDK only emits a reaction once it has resolved the full
@@ -533,7 +492,7 @@ async function normalizeContent(content) {
     return out;
   }
   if (content.type === "attachment" || content.type === "voice") {
-    return await normalizeBinaryContent(content);
+    return await normalizeInboundBinaryContent(content, attachmentHandles);
   }
   if (content.type === "group") {
     const items = [];
@@ -976,6 +935,12 @@ const server = http.createServer(async (req, res) => {
   if (req.method === "GET" && req.url === "/inbound") {
     return handleInbound(req, res);
   }
+  if (
+    req.method === "GET" &&
+    serveAttachmentHandle(req.url, res, attachmentHandles)
+  ) {
+    return;
+  }
   if (req.method !== "POST") {
     res.statusCode = 405;
     return res.end();
@@ -1202,6 +1167,7 @@ async function shutdown(signal) {
   // during one teardown.
   if (stopping) return;
   stopping = true;
+  attachmentHandles.close();
   console.error(`photon-sidecar: received ${signal}, stopping...`);
   try {
     await Promise.race([

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -20,7 +20,10 @@
 //   - POST /inbound-ack -> acknowledge one handle-bearing event only after its
 //                         secure bytes and durable job submission succeeded
 //       exact body: {"deliveryId": "<48 lowercase hex>"}
-//   - GET  /attachment/<opaque-handle> -> one-shot raw attachment bytes
+//   - POST /attachment/<opaque-handle>/lease -> replayable raw bytes bound to
+//                         an exact delivery; returns an opaque lease id header
+//   - POST /attachment/<opaque-handle>/(consume|release) -> finalize only
+//                         after durable consumer commit, or release for retry
 //   - POST /healthz     -> {"ok": true}
 //   - POST /send        -> {"ok": true, "messageId": "..."}
 //       body: {"spaceId": "...", "text": "...",
@@ -78,8 +81,9 @@ import {
 } from "./stream-staleness.mjs";
 import {
   AttachmentHandleStore,
+  mutateAttachmentLease,
   normalizeInboundBinaryContent,
-  serveAttachmentHandle,
+  serveAttachmentLease,
 } from "./attachment-handles.mjs";
 import {
   deliverPendingEntry,
@@ -992,12 +996,6 @@ const server = http.createServer(async (req, res) => {
   if (req.method === "GET" && req.url === "/inbound") {
     return handleInbound(req, res);
   }
-  if (
-    req.method === "GET" &&
-    serveAttachmentHandle(req.url, res, attachmentHandles)
-  ) {
-    return;
-  }
   if (req.method !== "POST") {
     res.statusCode = 405;
     return res.end();
@@ -1033,6 +1031,8 @@ const server = http.createServer(async (req, res) => {
       return;
     }
     const body = await readBody(req);
+    if (serveAttachmentLease(req.url, body, res, attachmentHandles)) return;
+    if (mutateAttachmentLease(req.url, body, res, attachmentHandles)) return;
     if (req.url === "/inbound-ack") {
       let deliveryId;
       try {

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -665,7 +665,10 @@ function inboundStreamErrorMessage(e) {
         const event = await normalizeEvent(space, message);
         if (!event) continue;
         if (eventHasAttachmentHandle(event)) {
-          const delivery = inboundDeliveries.begin(event);
+          const delivery = inboundDeliveries.begin(event, {
+            bindDelivery: (deliveryId) =>
+              attachmentHandles.bindEvent(event, deliveryId),
+          });
           const outcome = await deliverPendingEntry(delivery, {
             waitForConsumer,
             currentConsumer: () => ({ res: consumerRes, version: consumerVersion }),

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -17,6 +17,9 @@
 // Protocol (all requests require `X-Hermes-Sidecar-Token: ${TOKEN}`):
 //   - GET  /inbound    -> 200 NDJSON stream; one JSON event per line, blank
 //                         lines are heartbeats. One consumer at a time.
+//   - POST /inbound-ack -> acknowledge one handle-bearing event only after its
+//                         secure bytes and durable job submission succeeded
+//       exact body: {"deliveryId": "<48 lowercase hex>"}
 //   - GET  /attachment/<opaque-handle> -> one-shot raw attachment bytes
 //   - POST /healthz     -> {"ok": true}
 //   - POST /send        -> {"ok": true, "messageId": "..."}
@@ -78,6 +81,12 @@ import {
   normalizeInboundBinaryContent,
   serveAttachmentHandle,
 } from "./attachment-handles.mjs";
+import {
+  deliverPendingEntry,
+  InboundDeliveryQueue,
+  eventHasAttachmentHandle,
+  parseDeliveryAck,
+} from "./inbound-deliveries.mjs";
 import fs from "node:fs";
 
 const projectId = process.env.PHOTON_PROJECT_ID;
@@ -97,6 +106,10 @@ const attachmentHandles = new AttachmentHandleStore({
   maxItemBytes: ATTACHMENT_MAX_ITEM_BYTES,
   maxTotalBytes: ATTACHMENT_MAX_TOTAL_BYTES,
   maxCount: ATTACHMENT_MAX_COUNT,
+  ttlMs: ATTACHMENT_TTL_MS,
+});
+const inboundDeliveries = new InboundDeliveryQueue({
+  maxBytes: 2 * 1024 * 1024,
   ttlMs: ATTACHMENT_TTL_MS,
 });
 const DM_CHAT_GUID_RE = /^any;-;(\+\d{6,})$/;
@@ -357,6 +370,8 @@ const MESSAGE_EFFECTS = imessage?.effect?.message || {};
 // At most one Python consumer is attached at a time (the gateway adapter).
 let consumerRes = null;
 let consumerWaiters = [];
+let consumerVersion = 0;
+let consumerChangeWaiters = [];
 const knownSpaces = new Map();
 // Inbound Message objects by id, so /react can usually skip a
 // `space.getMessage` round trip when tapping back on a recent message.
@@ -412,13 +427,41 @@ function waitForConsumer() {
 
 function setConsumer(res) {
   consumerRes = res;
+  consumerVersion += 1;
+  const changeWaiters = consumerChangeWaiters;
+  consumerChangeWaiters = [];
+  for (const resolve of changeWaiters) resolve();
   const waiters = consumerWaiters;
   consumerWaiters = [];
   for (const resolve of waiters) resolve();
 }
 
 function clearConsumer(res) {
-  if (consumerRes === res) consumerRes = null;
+  if (consumerRes === res) {
+    consumerRes = null;
+    consumerVersion += 1;
+    const waiters = consumerChangeWaiters;
+    consumerChangeWaiters = [];
+    for (const resolve of waiters) resolve();
+  }
+}
+
+function waitForConsumerChange(version) {
+  if (consumerVersion !== version) {
+    return { promise: Promise.resolve("consumer_changed"), cancel() {} };
+  }
+  let waiter;
+  const promise = new Promise((resolve) => {
+    waiter = () => resolve("consumer_changed");
+    consumerChangeWaiters.push(waiter);
+  });
+  return {
+    promise,
+    cancel() {
+      const index = consumerChangeWaiters.indexOf(waiter);
+      if (index !== -1) consumerChangeWaiters.splice(index, 1);
+    },
+  };
 }
 
 // Write one NDJSON line to the active consumer. Blocks until a consumer is
@@ -617,7 +660,21 @@ function inboundStreamErrorMessage(e) {
         rememberKnownMessage(message);
         const event = await normalizeEvent(space, message);
         if (!event) continue;
-        await deliver(JSON.stringify(event));
+        if (eventHasAttachmentHandle(event)) {
+          const delivery = inboundDeliveries.begin(event);
+          const outcome = await deliverPendingEntry(delivery, {
+            waitForConsumer,
+            currentConsumer: () => ({ res: consumerRes, version: consumerVersion }),
+            waitForConsumerChange,
+            clearConsumer,
+          });
+          if (outcome !== "acked") {
+            exitForUpstream("inbound attachment acknowledgement unavailable");
+            await new Promise(() => {});
+          }
+        } else {
+          await deliver(JSON.stringify(event));
+        }
       }
       console.error("photon-sidecar: inbound stream ended — re-subscribing");
       markStreamRecovering("inbound stream ended");
@@ -976,6 +1033,21 @@ const server = http.createServer(async (req, res) => {
       return;
     }
     const body = await readBody(req);
+    if (req.url === "/inbound-ack") {
+      let deliveryId;
+      try {
+        deliveryId = parseDeliveryAck(body);
+      } catch {
+        return badRequest(res, "invalid_delivery_ack");
+      }
+      const status = inboundDeliveries.ack(deliveryId);
+      if (status === "not_found") {
+        res.statusCode = 404;
+        res.setHeader("Content-Type", "application/json");
+        return res.end(JSON.stringify({ ok: false, error: "delivery_not_found" }));
+      }
+      return ok(res, { deliveryId, status });
+    }
     if (req.url === "/send") {
       const { spaceId, text, format = "text" } = body || {};
       if (!spaceId || typeof text !== "string") {
@@ -1168,6 +1240,7 @@ async function shutdown(signal) {
   if (stopping) return;
   stopping = true;
   attachmentHandles.close();
+  inboundDeliveries.close();
   console.error(`photon-sidecar: received ${signal}, stopping...`);
   try {
     await Promise.race([

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -7,6 +7,7 @@
   "main": "index.mjs",
   "scripts": {
     "start": "node index.mjs",
+    "test": "node --test *.test.mjs",
     "postinstall": "node patch-spectrum-mixed-attachments.mjs"
   },
   "engines": {

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -4,6 +4,7 @@ These bypass the loopback HTTP stream — they call ``_dispatch_inbound`` /
 ``_on_inbound_line`` / ``_is_duplicate`` directly, exercising the
 sidecar-event parsing without spawning the Node sidecar or binding ports.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -13,8 +14,11 @@ from typing import Any, Dict, List
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent, MessageType
-from plugins.platforms.photon.adapter import PhotonAdapter
+from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+from plugins.platforms.photon.adapter import (
+    PhotonAdapter,
+    PhotonAttachmentConsumerUnavailable,
+)
 
 
 def _make_adapter(monkeypatch: pytest.MonkeyPatch) -> PhotonAdapter:
@@ -24,14 +28,23 @@ def _make_adapter(monkeypatch: pytest.MonkeyPatch) -> PhotonAdapter:
     return PhotonAdapter(cfg)
 
 
-def _capture(adapter: PhotonAdapter, monkeypatch: pytest.MonkeyPatch) -> List[MessageEvent]:
+def _capture(
+    adapter: PhotonAdapter, monkeypatch: pytest.MonkeyPatch
+) -> List[MessageEvent]:
     captured: List[MessageEvent] = []
 
     async def fake_handle(event: MessageEvent) -> None:
         captured.append(event)
+        if isinstance(event.raw_message, dict) and event.raw_message.get("deliveryId"):
+            await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
 
     monkeypatch.setattr(adapter, "handle_message", fake_handle)
     return captured
+
+
+def _accept_secure_handles(adapter: PhotonAdapter) -> None:
+    adapter.set_attachment_sender_authorizer(lambda _source, _event: True)
+    adapter.set_attachment_handle_consumer(lambda _event: True)
 
 
 def _dm_event(text: str, msg_id: str = "spc-msg-abc") -> Dict[str, Any]:
@@ -113,9 +126,11 @@ async def test_dispatch_attachment_without_bytes_surfaces_marker(
     adapter = _make_adapter(monkeypatch)
     captured = _capture(adapter, monkeypatch)
 
-    event = _attachment_event(
-        {"name": "IMG_4127.HEIC", "mimeType": "image/heic", "size": 12345}
-    )
+    event = _attachment_event({
+        "name": "IMG_4127.HEIC",
+        "mimeType": "image/heic",
+        "size": 12345,
+    })
     await adapter._dispatch_inbound(event)
     assert len(captured) == 1
     ev = captured[0]
@@ -135,14 +150,12 @@ async def test_dispatch_attachment_preserves_secure_handle_without_plaintext_cac
     captured = _capture(adapter, monkeypatch)
 
     handle = "a" * 48
-    event = _attachment_event(
-        {
-            "name": "photo.png",
-            "mimeType": "image/png",
-            "size": 67,
-            "handle": handle,
-        }
-    )
+    event = _attachment_event({
+        "name": "photo.png",
+        "mimeType": "image/png",
+        "size": 67,
+        "handle": handle,
+    })
     await adapter._dispatch_inbound(event)
 
     assert len(captured) == 1
@@ -161,21 +174,288 @@ async def test_dispatch_ignores_legacy_inline_base64(
     """A stale or compromised sidecar cannot revive plaintext disk caching."""
     adapter = _make_adapter(monkeypatch)
     captured = _capture(adapter, monkeypatch)
-    event = _attachment_event(
-        {
-            "name": "legacy.txt",
-            "mimeType": "text/plain",
-            "size": 6,
-            "data": "c2VjcmV0",
-            "encoding": "base64",
-        }
-    )
+    event = _attachment_event({
+        "name": "legacy.txt",
+        "mimeType": "text/plain",
+        "size": 6,
+        "data": "c2VjcmV0",
+        "encoding": "base64",
+    })
 
     await adapter._dispatch_inbound(event)
 
     assert captured[0].media_urls == []
     assert captured[0].media_types == []
     assert "Photon attachment received" in captured[0].text
+
+
+@pytest.mark.asyncio
+async def test_handle_without_secure_consumer_fails_retryably_instead_of_dispatching(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+    notified: list[bool] = []
+
+    async def notify() -> None:
+        notified.append(True)
+
+    monkeypatch.setattr(adapter, "_notify_fatal_error", notify)
+    event = _attachment_event(
+        {
+            "name": "photo.png",
+            "mimeType": "image/png",
+            "size": 67,
+            "handle": "e" * 48,
+        },
+        msg_id="secure-handle-no-consumer",
+    )
+    event["deliveryId"] = "9" * 48
+
+    with pytest.raises(PhotonAttachmentConsumerUnavailable):
+        await adapter._on_inbound_line(json.dumps(event))
+
+    assert captured == []
+    assert "secure-handle-no-consumer" not in adapter._seen_messages
+    assert adapter.fatal_error_code == "ATTACHMENT_CONSUMER_UNAVAILABLE"
+    assert adapter.fatal_error_retryable is True
+    assert "e" * 48 not in str(adapter.fatal_error_message)
+    assert notified == [True]
+
+
+@pytest.mark.asyncio
+async def test_registered_secure_consumer_receives_raw_handle_before_generic_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+    consumed: list[str] = []
+
+    async def consume(event: Dict[str, Any]) -> bool:
+        consumed.append(event["content"]["handle"])
+        return True
+
+    adapter.set_attachment_sender_authorizer(lambda _source, _event: True)
+    adapter.set_attachment_handle_consumer(consume)
+    event = _attachment_event(
+        {
+            "name": "photo.png",
+            "mimeType": "image/png",
+            "size": 67,
+            "handle": "f" * 48,
+        },
+        msg_id="secure-handle-consumed",
+    )
+    event["deliveryId"] = "8" * 48
+
+    async def ack(_path: str, _body: Dict[str, Any]) -> Dict[str, Any]:
+        return {"ok": True}
+
+    monkeypatch.setattr(adapter, "_sidecar_call", ack)
+
+    await adapter._on_inbound_line(json.dumps(event))
+
+    assert consumed == ["f" * 48]
+    assert len(captured) == 1
+    assert captured[0].media_urls == []
+    assert captured[0].raw_message["content"]["handle"] == "f" * 48
+
+
+@pytest.mark.asyncio
+async def test_group_attachment_without_mention_never_crosses_secure_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    adapter.require_mention = True
+    captured = _capture(adapter, monkeypatch)
+    calls: list[str] = []
+    adapter.set_attachment_sender_authorizer(
+        lambda _source, _event: calls.append("authorize") or True
+    )
+    adapter.set_attachment_handle_consumer(
+        lambda _event: calls.append("consume") or True
+    )
+    event = _attachment_event({"handle": "1" * 48}, "ignored-group-handle")
+    event["space"] = {"id": "group-1", "type": "group", "phone": None}
+
+    await adapter._dispatch_inbound(event)
+
+    assert calls == []
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_ignored_group_attachment_is_acked_without_secure_redemption(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    adapter.require_mention = True
+    calls: list[str] = []
+    adapter.set_attachment_sender_authorizer(
+        lambda _source, _event: calls.append("authorize") or True
+    )
+    adapter.set_attachment_handle_consumer(
+        lambda _event: calls.append("consume") or True
+    )
+
+    async def ack(path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        calls.append(f"ack:{path}:{body['deliveryId']}")
+        return {"ok": True}
+
+    monkeypatch.setattr(adapter, "_sidecar_call", ack)
+    event = _attachment_event({"handle": "a" * 48}, "ignored-group-ack")
+    event["space"] = {"id": "group-2", "type": "group", "phone": None}
+    event["deliveryId"] = "b" * 48
+
+    await adapter._on_inbound_line(json.dumps(event))
+
+    assert calls == [f"ack:/inbound-ack:{'b' * 48}"]
+
+
+@pytest.mark.asyncio
+async def test_attachment_authorizes_then_consumes_then_dispatches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    calls: list[str] = []
+
+    async def dispatch(_event: MessageEvent) -> None:
+        calls.append("dispatch")
+        await adapter.on_processing_complete(_event, ProcessingOutcome.SUCCESS)
+
+    monkeypatch.setattr(adapter, "handle_message", dispatch)
+    adapter.set_attachment_sender_authorizer(
+        lambda _source, _event: calls.append("authorize") or True
+    )
+    adapter.set_attachment_handle_consumer(
+        lambda _event: calls.append("consume") or True
+    )
+
+    await adapter._dispatch_inbound(_attachment_event({"handle": "2" * 48}))
+
+    assert calls == ["authorize", "consume", "dispatch"]
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_attachment_never_reaches_consumer_or_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    calls: list[str] = []
+    monkeypatch.setattr(
+        adapter,
+        "handle_message",
+        lambda _event: calls.append("dispatch"),
+    )
+    adapter.set_attachment_sender_authorizer(
+        lambda _source, _event: calls.append("authorize") or False
+    )
+    adapter.set_attachment_handle_consumer(
+        lambda _event: calls.append("consume") or True
+    )
+
+    with pytest.raises(PhotonAttachmentConsumerUnavailable):
+        await adapter._dispatch_inbound(_attachment_event({"handle": "3" * 48}))
+
+    assert calls == ["authorize"]
+
+
+@pytest.mark.asyncio
+async def test_delivery_ack_follows_secure_acceptance_and_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    calls: list[str] = []
+    adapter.set_attachment_sender_authorizer(
+        lambda _source, _event: calls.append("authorize") or True
+    )
+    adapter.set_attachment_handle_consumer(
+        lambda _event: calls.append("consume") or True
+    )
+
+    async def dispatch(_event: MessageEvent) -> None:
+        calls.append("dispatch")
+        await adapter.on_processing_complete(_event, ProcessingOutcome.SUCCESS)
+
+    async def sidecar_call(path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        calls.append(f"ack:{path}:{body['deliveryId']}")
+        return {"ok": True}
+
+    monkeypatch.setattr(adapter, "handle_message", dispatch)
+    monkeypatch.setattr(adapter, "_sidecar_call", sidecar_call)
+    event = _attachment_event({"handle": "4" * 48}, "acked-handle")
+    event["deliveryId"] = "5" * 48
+
+    await adapter._on_inbound_line(json.dumps(event))
+
+    assert calls == ["authorize", "consume", "dispatch", f"ack:/inbound-ack:{'5' * 48}"]
+
+
+@pytest.mark.asyncio
+async def test_ack_failure_replays_without_double_consuming(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    calls: list[str] = []
+    adapter.set_attachment_sender_authorizer(
+        lambda _source, _event: calls.append("authorize") or True
+    )
+    adapter.set_attachment_handle_consumer(
+        lambda _event: calls.append("consume") or True
+    )
+
+    async def dispatch(_event: MessageEvent) -> None:
+        calls.append("dispatch")
+        await adapter.on_processing_complete(_event, ProcessingOutcome.SUCCESS)
+
+    monkeypatch.setattr(adapter, "handle_message", dispatch)
+    attempts = 0
+
+    async def sidecar_call(_path: str, _body: Dict[str, Any]) -> Dict[str, Any]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("connection lost")
+        return {"ok": True}
+
+    monkeypatch.setattr(adapter, "_sidecar_call", sidecar_call)
+    event = _attachment_event({"handle": "6" * 48}, "replay-handle")
+    event["deliveryId"] = "7" * 48
+    line = json.dumps(event)
+
+    with pytest.raises(RuntimeError, match="connection lost"):
+        await adapter._on_inbound_line(line)
+    await adapter._on_inbound_line(line)
+
+    assert calls == ["authorize", "consume", "dispatch"]
+    assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_failed_background_processing_is_not_acked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    _accept_secure_handles(adapter)
+    sidecar_calls: list[str] = []
+
+    async def dispatch(event: MessageEvent) -> None:
+        await adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+    async def sidecar_call(path: str, _body: Dict[str, Any]) -> Dict[str, Any]:
+        sidecar_calls.append(path)
+        return {"ok": True}
+
+    monkeypatch.setattr(adapter, "handle_message", dispatch)
+    monkeypatch.setattr(adapter, "_sidecar_call", sidecar_call)
+    event = _attachment_event({"handle": "c" * 48}, "failed-background")
+    event["deliveryId"] = "e" * 48
+
+    with pytest.raises(RuntimeError, match="secure_attachment_dispatch_failed"):
+        await adapter._on_inbound_line(json.dumps(event))
+
+    assert "/inbound-ack" not in sidecar_calls
+    assert "failed-background" not in adapter._seen_messages
 
 
 @pytest.mark.asyncio
@@ -229,15 +509,13 @@ async def test_dispatch_voice_preserves_handle_without_plaintext_cache(
     adapter = _make_adapter(monkeypatch)
     captured = _capture(adapter, monkeypatch)
 
-    event = _voice_event(
-        {
-            "name": "note.ogg",
-            "mimeType": "audio/ogg",
-            "duration": 7,
-            "size": 36,
-            "handle": "c" * 48,
-        }
-    )
+    event = _voice_event({
+        "name": "note.ogg",
+        "mimeType": "audio/ogg",
+        "duration": 7,
+        "size": 36,
+        "handle": "c" * 48,
+    })
     await adapter._dispatch_inbound(event)
 
     assert len(captured) == 1
@@ -257,9 +535,12 @@ async def test_dispatch_voice_without_bytes_surfaces_marker(
     adapter = _make_adapter(monkeypatch)
     captured = _capture(adapter, monkeypatch)
 
-    event = _voice_event(
-        {"name": "note.m4a", "mimeType": "audio/mp4", "duration": 12, "size": 12345}
-    )
+    event = _voice_event({
+        "name": "note.m4a",
+        "mimeType": "audio/mp4",
+        "duration": 12,
+        "size": 12345,
+    })
     await adapter._dispatch_inbound(event)
 
     assert len(captured) == 1
@@ -280,14 +561,12 @@ async def test_dispatch_attachment_document_stays_behind_handle(
     adapter = _make_adapter(monkeypatch)
     captured = _capture(adapter, monkeypatch)
 
-    event = _attachment_event(
-        {
-            "name": "report.pdf",
-            "mimeType": "application/pdf",
-            "size": 29,
-            "handle": "d" * 48,
-        }
-    )
+    event = _attachment_event({
+        "name": "report.pdf",
+        "mimeType": "application/pdf",
+        "size": 29,
+        "handle": "d" * 48,
+    })
     await adapter._dispatch_inbound(event)
 
     assert len(captured) == 1
@@ -311,6 +590,17 @@ async def test_on_inbound_line_dispatches_and_dedups(
 
     assert len(captured) == 1
     assert captured[0].text == "ping"
+
+
+@pytest.mark.asyncio
+async def test_on_inbound_line_ignores_bad_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._on_inbound_line("{not json")
+    assert captured == []
 
 
 def test_is_duplicate_window(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -147,6 +147,7 @@ async def test_dispatch_attachment_preserves_secure_handle_without_plaintext_cac
 ) -> None:
     """The opaque handle stays in raw_message and never becomes a disk path."""
     adapter = _make_adapter(monkeypatch)
+    _accept_secure_handles(adapter)
     captured = _capture(adapter, monkeypatch)
 
     handle = "a" * 48
@@ -464,6 +465,7 @@ async def test_dispatch_group_preserves_text_and_attachment(
 ) -> None:
     """Spectrum group content from a mixed text+image iMessage must not drop text."""
     adapter = _make_adapter(monkeypatch)
+    _accept_secure_handles(adapter)
     captured = _capture(adapter, monkeypatch)
 
     event = _attachment_event(
@@ -507,6 +509,7 @@ async def test_dispatch_voice_preserves_handle_without_plaintext_cache(
 ) -> None:
     """Inbound voice bytes remain behind the one-shot sidecar handle."""
     adapter = _make_adapter(monkeypatch)
+    _accept_secure_handles(adapter)
     captured = _capture(adapter, monkeypatch)
 
     event = _voice_event({
@@ -559,6 +562,7 @@ async def test_dispatch_attachment_document_stays_behind_handle(
 ) -> None:
     """Non-image attachments retain type without writing a document cache."""
     adapter = _make_adapter(monkeypatch)
+    _accept_secure_handles(adapter)
     captured = _capture(adapter, monkeypatch)
 
     event = _attachment_event({
@@ -644,6 +648,7 @@ async def test_caf_attachment_named_promoted_to_voice(
 ) -> None:
     """A named .caf attachment is promoted to VOICE for STT routing."""
     adapter = _make_adapter(monkeypatch)
+    _accept_secure_handles(adapter)
     captured = _capture(adapter, monkeypatch)
 
     event = _caf_attachment_event(

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -7,9 +7,7 @@ sidecar-event parsing without spawning the Node sidecar or binding ports.
 from __future__ import annotations
 
 import asyncio
-import base64
 import json
-from pathlib import Path
 from typing import Any, Dict, List
 
 import pytest
@@ -67,11 +65,20 @@ async def test_dispatch_text_dm(monkeypatch: pytest.MonkeyPatch) -> None:
     assert src.user_id == "+15551234567"
 
 
-# A real 1x1 transparent PNG (passes base.py's _looks_like_image magic check).
-_PNG_1X1_B64 = (
-    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhf"
-    "DwAChwGA60e6kgAAAABJRU5ErkJggg=="
-)
+@pytest.mark.asyncio
+async def test_dispatch_group_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    event = {
+        "messageId": "spc-msg-grp",
+        "space": {"id": "group-guid-xyz", "type": "group", "phone": None},
+        "sender": {"id": "+15551234567"},
+        "content": {"type": "text", "text": "hi group"},
+        "timestamp": "2026-05-14T19:06:32.000Z",
+    }
+    await adapter._dispatch_inbound(event)
+    assert captured[0].source.chat_type == "group"
 
 
 def _attachment_event(
@@ -96,6 +103,199 @@ def _voice_event(
         "content": {"type": "voice", **content},
         "timestamp": "2026-05-14T19:06:32.000Z",
     }
+
+
+@pytest.mark.asyncio
+async def test_dispatch_attachment_without_bytes_surfaces_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No inline ``data`` (over cap / failed sidecar read) -> text marker, no media."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    event = _attachment_event(
+        {"name": "IMG_4127.HEIC", "mimeType": "image/heic", "size": 12345}
+    )
+    await adapter._dispatch_inbound(event)
+    assert len(captured) == 1
+    ev = captured[0]
+    assert "Photon attachment received" in ev.text
+    assert "IMG_4127.HEIC" in ev.text
+    assert ev.message_type == MessageType.PHOTO
+    assert ev.media_urls == []
+    assert ev.media_types == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_attachment_preserves_secure_handle_without_plaintext_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The opaque handle stays in raw_message and never becomes a disk path."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    handle = "a" * 48
+    event = _attachment_event(
+        {
+            "name": "photo.png",
+            "mimeType": "image/png",
+            "size": 67,
+            "handle": handle,
+        }
+    )
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 1
+    ev = captured[0]
+    assert ev.message_type == MessageType.PHOTO
+    assert ev.media_types == []
+    assert ev.media_urls == []
+    assert "Photon attachment received" in ev.text
+    assert ev.raw_message["content"]["handle"] == handle
+
+
+@pytest.mark.asyncio
+async def test_dispatch_ignores_legacy_inline_base64(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale or compromised sidecar cannot revive plaintext disk caching."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+    event = _attachment_event(
+        {
+            "name": "legacy.txt",
+            "mimeType": "text/plain",
+            "size": 6,
+            "data": "c2VjcmV0",
+            "encoding": "base64",
+        }
+    )
+
+    await adapter._dispatch_inbound(event)
+
+    assert captured[0].media_urls == []
+    assert captured[0].media_types == []
+    assert "Photon attachment received" in captured[0].text
+
+
+@pytest.mark.asyncio
+async def test_dispatch_group_preserves_text_and_attachment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Spectrum group content from a mixed text+image iMessage must not drop text."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    event = _attachment_event(
+        {},
+        msg_id="spc-msg-mixed",
+    )
+    event["content"] = {
+        "type": "group",
+        "items": [
+            {
+                "id": "p:0/spc-msg-mixed",
+                "content": {"type": "text", "text": "请分析这张图的重点"},
+            },
+            {
+                "id": "p:1/spc-msg-mixed",
+                "content": {
+                    "type": "attachment",
+                    "name": "photo.png",
+                    "mimeType": "image/png",
+                    "size": 67,
+                    "handle": "b" * 48,
+                },
+            },
+        ],
+    }
+
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 1
+    ev = captured[0]
+    assert ev.text.startswith("请分析这张图的重点")
+    assert "Photon attachment received" in ev.text
+    assert ev.message_type == MessageType.PHOTO
+    assert ev.media_types == []
+    assert ev.media_urls == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_voice_preserves_handle_without_plaintext_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inbound voice bytes remain behind the one-shot sidecar handle."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    event = _voice_event(
+        {
+            "name": "note.ogg",
+            "mimeType": "audio/ogg",
+            "duration": 7,
+            "size": 36,
+            "handle": "c" * 48,
+        }
+    )
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 1
+    ev = captured[0]
+    assert ev.message_type == MessageType.VOICE
+    assert ev.media_types == []
+    assert ev.media_urls == []
+    assert "Photon voice received" in ev.text
+    assert ev.raw_message["content"]["handle"] == "c" * 48
+
+
+@pytest.mark.asyncio
+async def test_dispatch_voice_without_bytes_surfaces_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Metadata-only voice still tells the agent a voice note arrived."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    event = _voice_event(
+        {"name": "note.m4a", "mimeType": "audio/mp4", "duration": 12, "size": 12345}
+    )
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 1
+    ev = captured[0]
+    assert "Photon voice received" in ev.text
+    assert "note.m4a" in ev.text
+    assert "duration: 12s" in ev.text
+    assert ev.message_type == MessageType.VOICE
+    assert ev.media_urls == []
+    assert ev.media_types == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_attachment_document_stays_behind_handle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-image attachments retain type without writing a document cache."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    event = _attachment_event(
+        {
+            "name": "report.pdf",
+            "mimeType": "application/pdf",
+            "size": 29,
+            "handle": "d" * 48,
+        }
+    )
+    await adapter._dispatch_inbound(event)
+
+    assert len(captured) == 1
+    ev = captured[0]
+    assert ev.message_type == MessageType.DOCUMENT
+    assert ev.media_types == []
+    assert ev.media_urls == []
+    assert "Photon attachment received" in ev.text
 
 
 @pytest.mark.asyncio
@@ -156,14 +356,12 @@ async def test_caf_attachment_named_promoted_to_voice(
     adapter = _make_adapter(monkeypatch)
     captured = _capture(adapter, monkeypatch)
 
-    raw = _CAF_BYTES
     event = _caf_attachment_event(
         {
             "name": "voice_note.caf",
             "mimeType": "audio/x-caf",
-            "size": len(raw),
-            "data": base64.b64encode(raw).decode("ascii"),
-            "encoding": "base64",
+            "size": len(_CAF_BYTES),
+            "handle": "e" * 48,
         }
     )
     await adapter._dispatch_inbound(event)
@@ -171,15 +369,10 @@ async def test_caf_attachment_named_promoted_to_voice(
     assert len(captured) == 1
     ev = captured[0]
     assert ev.message_type == MessageType.VOICE
-    assert ev.media_types == ["audio/x-caf"]
-    assert len(ev.media_urls) == 1
-    cached = Path(ev.media_urls[0])
-    try:
-        assert cached.is_file()
-        assert cached.read_bytes() == raw
-        assert ev.text == "(voice)"
-    finally:
-        cached.unlink(missing_ok=True)
+    assert ev.media_types == []
+    assert ev.media_urls == []
+    assert "Photon voice received" in ev.text
+    assert ev.raw_message["content"]["handle"] == "e" * 48
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Photon currently embeds inbound attachment bytes in NDJSON and the Python adapter writes them to a plaintext media cache before an embedding runtime can authorize the sender. This change replaces that handoff with bounded, opaque attachment handles and a durable accept/ACK protocol.

## Related Issue

No issue. Discovered while qualifying the v2026.8.3 Photon release for a production deployment.

## Type of Change

- [x] Bug fix
- [x] Security fix
- [x] Tests

## Changes Made

- Keep inbound bytes in a bounded in-memory sidecar store and expose token-gated lease, consume, and release operations.
- Pre-bind handles to a random delivery ID before an event can enter the pending queue.
- Require a downstream sender authorizer and secure handle consumer before generic gateway dispatch.
- ACK handle-bearing deliveries only after secure acceptance and successful processing.
- Replay the same delivery after disconnect or ACK loss without redeeming the handle twice.
- Fail retryably when no secure consumer is registered instead of falling back to plaintext caching.
- Bound storage to 20 MiB per item, 64 MiB total, 64 handles, 128 pending deliveries, and a five-minute TTL. Buffers are wiped on finalization, expiry, and shutdown.

This is complementary to #75673 and #75678. Those PRs cover read retries and split-event coalescing. This PR changes attachment custody and processing acknowledgement, so their adapter or sidecar changes may need a normal rebase if they merge first.

## How to Test

1. `HERMES_PYTHON=/path/to/python-with-pytest scripts/run_tests.sh tests/plugins/platforms/photon -q`
2. `npm test --prefix plugins/platforms/photon/sidecar`
3. `git diff --check upstream/main...HEAD`

Observed locally on macOS:

- 147 Photon Python tests passed.
- 29 sidecar Node tests passed.
- Diff check passed.

## Checklist

### Code

- [x] Read the contributing and agent guidance.
- [x] Commit messages use Conventional Commits.
- [x] Searched open Photon attachment PRs for duplicates.
- [x] PR contains only Photon attachment custody and ACK changes.
- [ ] Full repository pytest suite was not run; the complete Photon suite passed.
- [x] Added behavior-level Python and Node tests.
- [x] Tested on macOS.

### Documentation and Housekeeping

- [x] Updated the Photon sidecar documentation.
- [x] No config keys were added.
- [x] Considered cross-platform impact. The new store and protocol use portable Python and Node APIs.
- [x] No tool schemas changed.