### PR TITLE
fix(kanban): count dry-run spawns toward global cap

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8519,6 +8519,7 @@ def _dispatch_once_locked(
             continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
+            spawned += 1
             # Increment per-profile counter even in dry_run so the cap
             # check sees the would-be spawn on subsequent iterations.
             # Without this, dry_run reports every task as spawnable and
@@ -8619,6 +8620,7 @@ def _dispatch_once_locked(
             continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
+            spawned += 1
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -16,9 +16,9 @@ import pytest
 
 @pytest.fixture()
 def isolated_kanban_home_with_profiles(monkeypatch):
-    """Spin up a fresh HERMES_HOME with kanban DB + alpha/beta profiles."""
+    """Spin up a fresh HERMES_HOME with the profiles used by these tests."""
     test_home = tempfile.mkdtemp(prefix="kanban_per_profile_cap_test_")
-    for prof in ("alpha", "beta", "default"):
+    for prof in ("alpha", "beta", "default", "coordinator"):
         os.makedirs(os.path.join(test_home, "profiles", prof), exist_ok=True)
     monkeypatch.setenv("HERMES_HOME", test_home)
     for mod in list(sys.modules.keys()):
@@ -98,3 +98,52 @@ def test_capped_tasks_dispatched_on_subsequent_tick(isolated_kanban_home_with_pr
     assert res2.spawned[0][0] != spawned_id  # different task this time
 
 
+def test_dry_run_respects_global_cap_with_running_task(
+    isolated_kanban_home_with_profiles,
+):
+    kb = isolated_kanban_home_with_profiles
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        running_id = kb.create_task(
+            conn, title="coordinator", assignee="coordinator",
+        )
+        conn.execute(
+            "UPDATE tasks SET status = 'running' WHERE id = ?",
+            (running_id,),
+        )
+        ready_id = kb.create_task(conn, title="ready", assignee="alpha")
+        review_ids = []
+        for i in range(3):
+            review_id = kb.create_task(
+                conn,
+                title=f"review-{i}",
+                assignee="beta",
+                priority=3 - i,
+            )
+            conn.execute(
+                "UPDATE tasks SET status = 'review' WHERE id = ?",
+                (review_id,),
+            )
+            review_ids.append(review_id)
+
+    dispatch_options = {
+        "max_in_progress": 3,
+        "max_in_progress_per_profile": 3,
+    }
+    with kb.connect_closing() as conn:
+        predicted = kb.dispatch_once(conn, dry_run=True, **dispatch_options)
+        running = conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+        ).fetchone()[0]
+        actual = kb.dispatch_once(
+            conn, spawn_fn=_fake_spawn, dry_run=False, **dispatch_options,
+        )
+
+    assert running == 1
+    assert [(task_id, assignee) for task_id, assignee, _ in predicted.spawned] == [
+        (task_id, assignee) for task_id, assignee, _ in actual.spawned
+    ]
+    assert [task_id for task_id, _, _ in predicted.spawned] == [
+        ready_id,
+        review_ids[0],
+    ]


### PR DESCRIPTION
## What does this PR do?

Count predicted dry-run spawns toward the global concurrency cap.

## Related Issue

Fixes #78117

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Increment the dry-run counter and verify parity with real dispatch when one slot is already occupied.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_kanban_per_profile_cap.py`
2. `ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_per_profile_cap.py`
3. `python scripts/check-windows-footguns.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_per_profile_cap.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable.
