### PR TITLE
feat(desktop): send files and selected source lines to chat from righ…

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -19,8 +19,10 @@ import { FileDiffPanel } from '@/components/chat/diff-lines'
 import { chunkTextLines, useFixedRowWindow } from '@/components/chat/fixed-row-window'
 import { LazyShiki as ShikiHighlighter } from '@/components/chat/shiki-highlighter'
 import { PageLoader } from '@/components/page-loader'
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from '@/components/ui/context-menu'
 import { Tip } from '@/components/ui/tooltip'
 import { translateNow, useI18n } from '@/i18n'
+import { pathLabel } from '@/lib/chat-runtime'
 import {
   desktopFileDiff,
   desktopGitRoot,
@@ -35,6 +37,8 @@ import type { PreviewTarget } from '@/store/preview'
 import { setPreviewDirty } from '@/store/preview-edit'
 import { $currentCwd } from '@/store/session'
 import { notifyWorkspaceChanged } from '@/store/workspace-events'
+
+import { type SourceLineRange, sourceSelectionLineRange } from './source-selection'
 
 const SHIKI_THEME = { dark: 'github-dark-default', light: 'github-light-default' } as const
 const TEXT_PREVIEW_MAX_BYTES = 512 * 1024
@@ -459,6 +463,75 @@ export function SourceView({ filePath, language, text }: { filePath?: string; la
   const [selection, setSelection] = useState<LineSelection | null>(null)
   const inSelection = (line: number) => selection != null && line >= selection.start && line <= selection.end
 
+  // Text-drag selection → "send lines to chat". The selection is read the
+  // moment the context menu OPENS (a right-click keeps the browser selection;
+  // clicking a menu item later would collapse it), mapped to file line numbers
+  // via the chunked `.line` spans, and held until the menu closes.
+  const gridRef = useRef<HTMLDivElement | null>(null)
+  const [textSelRange, setTextSelRange] = useState<SourceLineRange | null>(null)
+
+  // Live "is something selected inside the grid" flag. Radix's trigger
+  // unconditionally preventDefaults the right-click once mounted, which would
+  // swallow the browser's native menu (Copy / Inspect) on a no-selection
+  // right-click. Feeding the flag to the trigger's `disabled` keeps the native
+  // menu whenever there is nothing to send — Radix skips preventDefault while
+  // disabled.
+  const [hasLiveSelection, setHasLiveSelection] = useState(false)
+
+  useEffect(() => {
+    const onChange = () => {
+      const grid = gridRef.current
+      const native = window.getSelection()
+      const range = native && native.rangeCount > 0 ? native.getRangeAt(0) : null
+      const next = Boolean(grid && range && !range.collapsed && grid.contains(range.commonAncestorContainer))
+
+      setHasLiveSelection(prev => (prev === next ? prev : next))
+    }
+
+    document.addEventListener('selectionchange', onChange)
+
+    return () => document.removeEventListener('selectionchange', onChange)
+  }, [])
+
+  const handleMenuOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setTextSelRange(null)
+
+      return
+    }
+
+    const grid = gridRef.current
+    const native = typeof window !== 'undefined' ? window.getSelection() : null
+    const range = native && native.rangeCount > 0 ? native.getRangeAt(0) : null
+
+    setTextSelRange(grid && range ? sourceSelectionLineRange(grid, range) : null)
+  }, [])
+
+  const sendTextSelectionToChat = useCallback(() => {
+    if (!filePath || !textSelRange) {
+      return
+    }
+
+    // droppedFileInlineRef quotes values containing ':' and resolves the path
+    // against cwd — the same ref a gutter drag / Ctrl+L produces. The display
+    // label shows just `name:range`; the full path rides the ref value.
+    const refText = droppedFileInlineRef(
+      { line: textSelRange.start, lineEnd: textSelRange.end > textSelRange.start ? textSelRange.end : undefined, path: filePath },
+      $currentCwd.get()
+    )
+
+    if (!refText) {
+      return
+    }
+
+    const rangeLabel = textSelRange.end > textSelRange.start ? `${textSelRange.start}-${textSelRange.end}` : `${textSelRange.start}`
+
+    requestComposerInsertRefs([{ kind: 'line', label: `${pathLabel(filePath)}:${rangeLabel}`, value: refText.replace(/^@line:/, '') }], {
+      target: 'active'
+    })
+    requestComposerFocus('active')
+  }, [filePath, textSelRange])
+
   const handleLineClick = (event: ReactMouseEvent, line: number) => {
     if (!filePath) {
       return
@@ -522,54 +595,69 @@ export function SourceView({ filePath, language, text }: { filePath?: string; la
   }, [filePath, selection])
 
   return (
-    <div className="h-full overflow-auto" onScroll={onScroll} ref={scrollerRef}>
-      <div className="grid min-w-max grid-cols-[auto_minmax(0,1fr)] font-mono text-[0.7rem] leading-relaxed">
-        {beforeRows > 0 && <div aria-hidden className="col-span-2" style={{ height: beforeRows * SOURCE_LINE_PX }} />}
-        {visibleChunks.map(chunk => (
-          <Fragment key={chunk.start}>
-            <div className="select-none text-right text-muted-foreground/55">
-              {chunk.lines.map((_lineText, offset) => {
-                const line = chunk.start + offset + 1
-                const selected = inSelection(line)
+    <ContextMenu onOpenChange={handleMenuOpenChange}>
+      <ContextMenuTrigger asChild disabled={!filePath || !hasLiveSelection}>
+        <div className="h-full overflow-auto" onScroll={onScroll} ref={scrollerRef}>
+          <div className="grid min-w-max grid-cols-[auto_minmax(0,1fr)] font-mono text-[0.7rem] leading-relaxed" ref={gridRef}>
+            {beforeRows > 0 && <div aria-hidden className="col-span-2" style={{ height: beforeRows * SOURCE_LINE_PX }} />}
+            {visibleChunks.map(chunk => (
+              <Fragment key={chunk.start}>
+                <div className="select-none text-right text-muted-foreground/55">
+                  {chunk.lines.map((_lineText, offset) => {
+                    const line = chunk.start + offset + 1
+                    const selected = inSelection(line)
 
-                return (
-                  <div
-                    className={cn(
-                      'h-5 w-9 pr-2 leading-5 tabular-nums transition-colors',
-                      filePath && 'cursor-pointer',
-                      selected
-                        ? 'bg-amber-200/45 text-amber-900 dark:bg-amber-300/20 dark:text-amber-100'
-                        : filePath && 'hover:text-foreground'
-                    )}
-                    draggable={Boolean(filePath)}
-                    key={line}
-                    onClick={event => handleLineClick(event, line)}
-                    onDragStart={event => handleDragStart(event, line)}
-                    title={filePath ? t.preview.sourceLineTitle : undefined}
+                    return (
+                      <div
+                        className={cn(
+                          'h-5 w-9 pr-2 leading-5 tabular-nums transition-colors',
+                          filePath && 'cursor-pointer',
+                          selected
+                            ? 'bg-amber-200/45 text-amber-900 dark:bg-amber-300/20 dark:text-amber-100'
+                            : filePath && 'hover:text-foreground'
+                        )}
+                        draggable={Boolean(filePath)}
+                        key={line}
+                        onClick={event => handleLineClick(event, line)}
+                        onDragStart={event => handleDragStart(event, line)}
+                        title={filePath ? t.preview.sourceLineTitle : undefined}
+                      >
+                        {line}
+                      </div>
+                    )
+                  })}
+                </div>
+                <div
+                  className="preview-source-code min-w-0 [&_pre]:m-0"
+                  data-chunk-start={chunk.start}
+                  data-selectable-text="true"
+                >
+                  <ShikiHighlighter
+                    addDefaultStyles={false}
+                    as="div"
+                    defaultColor="light-dark()"
+                    delay={80}
+                    language={language || 'text'}
+                    showLanguage={false}
+                    theme={SHIKI_THEME}
                   >
-                    {line}
-                  </div>
-                )
-              })}
-            </div>
-            <div className="preview-source-code min-w-0 [&_pre]:m-0" data-selectable-text="true">
-              <ShikiHighlighter
-                addDefaultStyles={false}
-                as="div"
-                defaultColor="light-dark()"
-                delay={80}
-                language={language || 'text'}
-                showLanguage={false}
-                theme={SHIKI_THEME}
-              >
-                {chunk.text}
-              </ShikiHighlighter>
-            </div>
-          </Fragment>
-        ))}
-        {afterRows > 0 && <div aria-hidden className="col-span-2" style={{ height: afterRows * SOURCE_LINE_PX }} />}
-      </div>
-    </div>
+                    {chunk.text}
+                  </ShikiHighlighter>
+                </div>
+              </Fragment>
+            ))}
+            {afterRows > 0 && <div aria-hidden className="col-span-2" style={{ height: afterRows * SOURCE_LINE_PX }} />}
+          </div>
+        </div>
+      </ContextMenuTrigger>
+      {filePath && textSelRange && (
+        <ContextMenuContent>
+          <ContextMenuItem onSelect={sendTextSelectionToChat}>
+            {t.preview.sendSelectionToChat(textSelRange.start, textSelRange.end > textSelRange.start ? textSelRange.end : undefined)}
+          </ContextMenuItem>
+        </ContextMenuContent>
+      )}
+    </ContextMenu>
   )
 }
 

--- a/apps/desktop/src/app/chat/right-rail/source-selection.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/source-selection.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { absoluteLineOf, sourceSelectionLineRange } from './source-selection'
+
+/** Build the DOM shape SourceView renders: chunk wrappers (0-based
+ *  data-chunk-start) each holding <code> with one <span class="line"> per line
+ *  of text (newlines live BETWEEN spans, as Shiki renders them). */
+function buildSourceView(chunkStarts: number[], linesPerChunk: number): HTMLElement {
+  const container = document.createElement('div')
+
+  for (const start of chunkStarts) {
+    const wrapper = document.createElement('div')
+
+    wrapper.className = 'preview-source-code'
+    wrapper.dataset.chunkStart = String(start)
+
+    const code = document.createElement('code')
+
+    for (let offset = 0; offset < linesPerChunk; offset += 1) {
+      const line = document.createElement('span')
+
+      line.className = 'line'
+      line.textContent = `line text ${start + offset + 1}`
+      code.appendChild(line)
+    }
+
+    wrapper.appendChild(code)
+    container.appendChild(wrapper)
+  }
+
+  document.body.appendChild(container)
+
+  return container
+}
+
+const firstTextNode = (el: Element) => el.firstChild as Text
+
+function selectFromTo(range: Range, from: { node: Node; offset: number }, to: { node: Node; offset: number }) {
+  range.setStart(from.node, from.offset)
+  range.setEnd(to.node, to.offset)
+}
+
+describe('sourceSelectionLineRange', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    // 2 chunks × 3 lines: lines 1–3 in chunk 0, lines 4–6 in chunk 3.
+    container = buildSourceView([0, 3], 3)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  const lineEl = (lineNumber: number) =>
+    container.querySelectorAll('.line')[lineNumber - 1] as HTMLElement
+
+  it('maps a same-line selection to that line', () => {
+    const range = document.createRange()
+    const text = firstTextNode(lineEl(2))
+
+    selectFromTo(range, { node: text, offset: 2 }, { node: text, offset: 5 })
+    expect(sourceSelectionLineRange(container, range)).toEqual({ end: 2, start: 2 })
+  })
+
+  it('maps a multi-line selection across a chunk boundary', () => {
+    const range = document.createRange()
+
+    selectFromTo(range, { node: firstTextNode(lineEl(2)), offset: 1 }, { node: firstTextNode(lineEl(5)), offset: 4 })
+    expect(sourceSelectionLineRange(container, range)).toEqual({ end: 5, start: 2 })
+  })
+
+  // No "dragged upward" case: Selection.getRangeAt() always hands back a
+  // start≤end range regardless of drag direction (the direction lives in
+  // anchor/focus), and constructing a reversed Range via setStart/setEnd
+  // collapses it per the DOM spec — so an inverted range can never arrive.
+
+  it('pulls the end back a line when the selection stops at a line start', () => {
+    const range = document.createRange()
+
+    // "Line 5" selected by dragging to the very start of line 6.
+    selectFromTo(range, { node: firstTextNode(lineEl(5)), offset: 0 }, { node: firstTextNode(lineEl(6)), offset: 0 })
+    expect(sourceSelectionLineRange(container, range)).toEqual({ end: 5, start: 5 })
+  })
+
+  it('returns null for a collapsed selection', () => {
+    const range = document.createRange()
+
+    selectFromTo(range, { node: firstTextNode(lineEl(1)), offset: 2 }, { node: firstTextNode(lineEl(1)), offset: 2 })
+    expect(sourceSelectionLineRange(container, range)).toBeNull()
+  })
+
+  it('returns null for a selection outside the container', () => {
+    const outside = document.createElement('p')
+
+    outside.textContent = 'not code'
+    document.body.appendChild(outside)
+
+    const range = document.createRange()
+    const text = outside.firstChild as Text
+
+    selectFromTo(range, { node: text, offset: 0 }, { node: text, offset: 3 })
+    expect(sourceSelectionLineRange(container, range)).toBeNull()
+  })
+})
+
+describe('absoluteLineOf', () => {
+  it('derives the 1-based file line from chunk offset', () => {
+    const container = buildSourceView([120], 4)
+    const lines = container.querySelectorAll('.line')
+
+    expect(absoluteLineOf(lines[0])).toBe(121)
+    expect(absoluteLineOf(lines[3])).toBe(124)
+    document.body.innerHTML = ''
+  })
+
+  it('returns null outside a chunked wrapper', () => {
+    const bare = document.createElement('span')
+
+    bare.className = 'line'
+    document.body.appendChild(bare)
+
+    expect(absoluteLineOf(bare)).toBeNull()
+    document.body.innerHTML = ''
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/source-selection.ts
+++ b/apps/desktop/src/app/chat/right-rail/source-selection.ts
@@ -1,0 +1,77 @@
+/**
+ * Map a mouse text-selection inside the windowed Shiki source view to file
+ * line numbers, for the "send selection to chat" context menu.
+ *
+ * Each 200-line chunk renders one `.preview-source-code` wrapper carrying its
+ * 0-based `data-chunk-start`; Shiki emits one `.line` span per line under a
+ * `<code>`. A boundary point (selection start/end) resolves to its `.line`,
+ * whose absolute line number is `chunkStart + indexOfLineWithinChunk + 1`.
+ */
+export interface SourceLineRange {
+  end: number
+  start: number
+}
+
+function lineElementFrom(node: Node): HTMLElement | null {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.parentElement?.closest('.line') ?? null
+  }
+
+  if (node instanceof Element) {
+    return node.closest('.line')
+  }
+
+  return null
+}
+
+/** 1-based file line number of a rendered `.line` span, or null when it sits
+ *  outside a chunked code wrapper. */
+export function absoluteLineOf(lineEl: Element): null | number {
+  const wrapper = lineEl.closest('[data-chunk-start]')
+  const code = lineEl.parentElement
+
+  if (!wrapper || !code) {
+    return null
+  }
+
+  const base = Number(wrapper.getAttribute('data-chunk-start'))
+  const index = Array.from(code.children).indexOf(lineEl)
+
+  if (!Number.isFinite(base) || index < 0) {
+    return null
+  }
+
+  return base + index + 1
+}
+
+/**
+ * Resolve the `[start, end]` file line range (1-based, inclusive) a DOM
+ * selection covers inside the source view's grid `container`. Returns null for
+ * a collapsed selection, one outside the container, or one whose boundaries
+ * don't land on a rendered line.
+ *
+ * A selection ending exactly at a line's start (caret parked there before any
+ * character) hasn't selected content on that line, so the end is pulled back
+ * one — dragging from line 5 to the very start of line 8 yields 5–7.
+ */
+export function sourceSelectionLineRange(container: HTMLElement, range: Range): null | SourceLineRange {
+  if (range.collapsed || !container.contains(range.commonAncestorContainer)) {
+    return null
+  }
+
+  const startLine = absoluteLineOf(lineElementFrom(range.startContainer) as Element)
+  const endLine = absoluteLineOf(lineElementFrom(range.endContainer) as Element)
+
+  if (startLine == null || endLine == null) {
+    return null
+  }
+
+  let start = Math.min(startLine, endLine)
+  let end = Math.max(startLine, endLine)
+
+  if (end > start && range.endOffset === 0 && range.endContainer.nodeType === Node.TEXT_NODE) {
+    end -= 1
+  }
+
+  return { end, start }
+}

--- a/apps/desktop/src/app/right-sidebar/file-actions.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/file-actions.test.tsx
@@ -1,0 +1,111 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { onComposerInsertRefsRequest } from '@/app/chat/composer/focus'
+
+import { FileEntryContextMenu } from './file-actions'
+
+afterEach(cleanup)
+
+interface Seen {
+  refs: unknown[]
+  target: string
+}
+
+async function openMenu(children: React.ReactNode) {
+  const utils = render(<>{children}</>)
+  const trigger = utils.container.firstElementChild as HTMLElement
+
+  await act(async () => {
+    fireEvent.contextMenu(trigger)
+  })
+
+  return utils
+}
+
+async function clickSend(seen: Seen[]) {
+  await act(async () => {
+    fireEvent.click(screen.getByText('Send to Chat'))
+  })
+
+  // The bus defers dispatch to a macrotask.
+  await waitFor(() => expect(seen.length).toBe(1))
+}
+
+describe('FileEntryContextMenu — Send to Chat', () => {
+  it('inserts an @file: ref that shows the name but carries the workspace-relative path', async () => {
+    const seen: Seen[] = []
+    const unsubscribe = onComposerInsertRefsRequest(({ refs, target }) => seen.push({ refs, target }))
+
+    try {
+      await openMenu(
+        <FileEntryContextMenu isDirectory={false} name="notes.md" path="/repo/src/notes.md" relativeTo="/repo">
+          <div>notes.md</div>
+        </FileEntryContextMenu>
+      )
+
+      await clickSend(seen)
+      expect(seen[0].target).toBe('main')
+      // Display label = basename; the value Hermes resolves stays the full
+      // workspace-relative path.
+      expect(seen[0].refs).toEqual([{ kind: 'file', label: 'notes.md', value: 'src/notes.md' }])
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('inserts an @folder: ref for directories', async () => {
+    const seen: Seen[] = []
+    const unsubscribe = onComposerInsertRefsRequest(({ refs, target }) => seen.push({ refs, target }))
+
+    try {
+      await openMenu(
+        <FileEntryContextMenu isDirectory name="src" path="/repo/src" relativeTo="/repo">
+          <div>src</div>
+        </FileEntryContextMenu>
+      )
+
+      await clickSend(seen)
+      expect(seen[0].target).toBe('main')
+      expect(seen[0].refs).toEqual([{ kind: 'folder', label: 'src', value: 'src' }])
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('falls back to the absolute path when outside the workspace', async () => {
+    const seen: Seen[] = []
+    const unsubscribe = onComposerInsertRefsRequest(({ refs }) => seen.push({ refs, target: '' }))
+
+    try {
+      await openMenu(
+        <FileEntryContextMenu isDirectory={false} name="photo.png" path="/elsewhere/photo.png" relativeTo="/repo">
+          <div>photo.png</div>
+        </FileEntryContextMenu>
+      )
+
+      await clickSend(seen)
+      expect(seen[0].refs).toEqual([{ kind: 'file', label: 'photo.png', value: '/elsewhere/photo.png' }])
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('sends the absolute path unchanged when there is no workspace root', async () => {
+    const seen: Seen[] = []
+    const unsubscribe = onComposerInsertRefsRequest(({ refs }) => seen.push({ refs, target: '' }))
+
+    try {
+      await openMenu(
+        <FileEntryContextMenu isDirectory={false} name="data.csv" path="/elsewhere/data.csv" relativeTo={null}>
+          <div>data.csv</div>
+        </FileEntryContextMenu>
+      )
+
+      await clickSend(seen)
+      expect(seen[0].refs).toEqual([{ kind: 'file', label: 'data.csv', value: '/elsewhere/data.csv' }])
+    } finally {
+      unsubscribe()
+    }
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/file-actions.tsx
+++ b/apps/desktop/src/app/right-sidebar/file-actions.tsx
@@ -1,6 +1,8 @@
 import { useStore } from '@nanostores/react'
 import { type KeyboardEvent as ReactKeyboardEvent, type ReactNode, useRef, useState } from 'react'
 
+import { requestComposerFocus, requestComposerInsertRefs } from '@/app/chat/composer/focus'
+import type { InlineRefInput } from '@/app/chat/composer/inline-refs'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import {
   ContextMenu,
@@ -62,6 +64,25 @@ export function FileEntryContextMenu({ children, isDirectory, name, path, relati
   const target: FileActionTarget = { isDirectory, name, path }
   const revealLabel = pickRevealLabel(m.revealFinder, m.revealExplorer, m.revealFileManager)
 
+  // Insert the entry's ADDRESS into the active chat as an inline
+  // `@file:`/`@folder:` ref — the gateway resolves the path itself; nothing is
+  // uploaded. Workspace-relative when possible, absolute otherwise (still
+  // resolvable). The chip SHOWS just the name (`label`) — the full path rides
+  // the ref value and the chip's hover title, so Hermes reads the real address.
+  const sendToChat = () => {
+    if (!path) {
+      return
+    }
+
+    const kind = isDirectory ? 'folder' : 'file'
+    const value = relativeTo ? toRelativePath(path, relativeTo) : path
+
+    const ref: InlineRefInput = { kind, label: name, value }
+
+    requestComposerInsertRefs([ref], { target: 'main' })
+    requestComposerFocus('main')
+  }
+
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
@@ -80,6 +101,7 @@ export function FileEntryContextMenu({ children, isDirectory, name, path, relati
             {m.copyRelativePath}
           </ContextMenuItem>
         )}
+        <ContextMenuItem onSelect={sendToChat}>{m.sendToChat}</ContextMenuItem>
         {localFs && (
           <>
             <ContextMenuSeparator />

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -46,6 +46,7 @@ export const ar = defineLocale({
     revealInSidebar: 'إظهار في شجرة الملفات',
     copyPath: 'نسخ المسار',
     copyRelativePath: 'نسخ المسار النسبي',
+    sendToChat: 'إرسال إلى المحادثة',
     rename: 'إعادة تسمية...',
     delete: 'حذف',
     renameTitle: 'إعادة تسمية',
@@ -2150,6 +2151,8 @@ export const ar = defineLocale({
     openInBrowser: 'فتح في المتصفح',
     linkHint: '⌘/Ctrl-نقر لجزء المعاينة',
     sourceLineTitle: 'انقر للتحديد · shift-نقر للتوسيع · اسحب إلى المُنشئ',
+    sendSelectionToChat: (start, end) =>
+      end && end > start ? `إرسال الأسطر ${start}–${end} إلى المحادثة` : `إرسال السطر ${start} إلى المحادثة`,
     source: 'المصدر',
     renderedPreview: 'المعاينة',
     diff: 'الفرق',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -52,6 +52,7 @@ export const en: Translations = {
     revealInSidebar: 'Reveal in filetree',
     copyPath: 'Copy Path',
     copyRelativePath: 'Copy Relative Path',
+    sendToChat: 'Send to Chat',
     rename: 'Rename…',
     delete: 'Delete',
     renameTitle: 'Rename',
@@ -2575,6 +2576,8 @@ export const en: Translations = {
     openInBrowser: 'Open in browser',
     linkHint: '⌘/Ctrl-click for preview pane',
     sourceLineTitle: 'Click to select · shift-click to extend · drag to composer',
+    sendSelectionToChat: (start, end) =>
+      end && end > start ? `Send lines ${start}–${end} to chat` : `Send line ${start} to chat`,
     source: 'SOURCE',
     renderedPreview: 'PREVIEW',
     diff: 'DIFF',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -52,6 +52,7 @@ export const ja = defineLocale({
     revealInSidebar: 'ファイルツリーで表示',
     copyPath: 'パスをコピー',
     copyRelativePath: '相対パスをコピー',
+    sendToChat: 'チャットに送信',
     rename: '名前を変更…',
     delete: '削除',
     renameTitle: '名前を変更',
@@ -2404,6 +2405,8 @@ export const ja = defineLocale({
     openInBrowser: 'ブラウザで開く',
     linkHint: '⌘/Ctrl+クリックでプレビューペイン',
     sourceLineTitle: 'クリックして選択 · Shift クリックで拡張 · コンポーザーにドラッグ',
+    sendSelectionToChat: (start, end) =>
+      end && end > start ? `${start}–${end} 行目をチャットに送信` : `${start} 行目をチャットに送信`,
     source: 'ソース',
     renderedPreview: 'プレビュー',
     diff: '差分',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -98,6 +98,9 @@ export interface Translations {
     revealInSidebar: string
     copyPath: string
     copyRelativePath: string
+    /** Insert the entry into the composer as an inline `@file:`/`@folder:`
+     *  path reference — no upload, just the address. */
+    sendToChat: string
     rename: string
     delete: string
     renameTitle: string
@@ -2178,6 +2181,8 @@ export interface Translations {
     openInBrowser: string
     linkHint: string
     sourceLineTitle: string
+    /** Context-menu action: send the text-selected line range to the chat. */
+    sendSelectionToChat: (start: number, end?: number) => string
     source: string
     renderedPreview: string
     diff: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -52,6 +52,7 @@ export const zhHant = defineLocale({
     revealInSidebar: '在檔案樹中顯示',
     copyPath: '複製路徑',
     copyRelativePath: '複製相對路徑',
+    sendToChat: '傳送至對話',
     rename: '重新命名…',
     delete: '刪除',
     renameTitle: '重新命名',
@@ -2327,6 +2328,8 @@ export const zhHant = defineLocale({
     openInBrowser: '在瀏覽器中開啟',
     linkHint: '⌘/Ctrl+點擊在預覽窗格開啟',
     sourceLineTitle: '點擊選取 · shift 點擊擴展 · 拖曳至輸入框',
+    sendSelectionToChat: (start, end) =>
+      end && end > start ? `將第 ${start}–${end} 行傳送至對話` : `將第 ${start} 行傳送至對話`,
     source: '原始碼',
     renderedPreview: '預覽',
     diff: '差異',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -52,6 +52,7 @@ export const zh: Translations = {
     revealInSidebar: '在文件树中显示',
     copyPath: '复制路径',
     copyRelativePath: '复制相对路径',
+    sendToChat: '发送到会话',
     rename: '重命名…',
     delete: '删除',
     renameTitle: '重命名',
@@ -2756,6 +2757,8 @@ export const zh: Translations = {
     openInBrowser: '在浏览器中打开',
     linkHint: '⌘/Ctrl+点击在预览面板打开',
     sourceLineTitle: '点击选择 · shift 点击扩展 · 拖到输入框',
+    sendSelectionToChat: (start, end) =>
+      end && end > start ? `将第 ${start}–${end} 行发送到会话` : `将第 ${start} 行发送到会话`,
     source: '源码',
     renderedPreview: '预览',
     diff: '差异',


### PR DESCRIPTION
…t-click

Two complementary context-send affordances, both pure path refs (nothing uploaded — the gateway resolves the address itself, same channel as in-app tree drags):

1. File tree context menu gains "Send to Chat": inserts an inline @file:/@folder: ref into the main composer. Workspace-relative when possible, absolute otherwise. The chip displays just the basename; the full path rides the ref value and the chip's hover title, so the agent still receives the real address. The shared refChipLabel is deliberately untouched — a global basename would de-duplicate same-named files in the @ completer.

2. Source preview (SourceView) gains drag-select → right-click → "Send lines N–M to chat": maps the text selection onto Shiki's per-line .line spans via per-chunk data-chunk-start anchors and inserts an @line:path:start-end ref — the same ref a gutter drag / Ctrl+L produces, with a name:range display label. The selection is captured when the menu opens (a right-click keeps it; clicking an item would collapse it). The Radix trigger is only armed while a live selection exists inside the grid, so a no-selection right-click keeps the browser's native menu (Radix unconditionally preventDefaults once mounted).

New modules: source-selection.ts (selection→line-range mapper) with 7 tests; file-actions.test.tsx (4 tests). i18n: fileMenu.sendToChat + preview.sendSelectionToChat in all 6 locales.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [x] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

