### PR TITLE
fix(cli): recognize prefixed MCP toolsets

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2465,13 +2465,22 @@ def _get_platform_tools(
     # as an allowlist. Otherwise include every globally enabled MCP server.
     # Special sentinel: "no_mcp" in the toolset list disables all MCP servers.
     enabled_mcp_servers = enabled_mcp_server_names(config)
+    prefixed_mcp_servers = {
+        f"mcp-{name}": name for name in enabled_mcp_servers
+    }
+    mcp_server_entries = enabled_mcp_servers | set(prefixed_mcp_servers)
     # Allow "no_mcp" sentinel to opt out of all MCP servers for this platform
     if "no_mcp" in toolset_names:
         explicit_mcp_servers = set()
-        enabled_toolsets.update(explicit_passthrough - enabled_mcp_servers - {"no_mcp"})
+        enabled_toolsets.update(
+            explicit_passthrough - mcp_server_entries - {"no_mcp"}
+        )
     else:
-        explicit_mcp_servers = explicit_passthrough & enabled_mcp_servers
-        enabled_toolsets.update(explicit_passthrough - enabled_mcp_servers)
+        explicit_mcp_servers = {
+            prefixed_mcp_servers.get(name, name)
+            for name in explicit_passthrough & mcp_server_entries
+        }
+        enabled_toolsets.update(explicit_passthrough - mcp_server_entries)
     if include_default_mcp_servers:
         if explicit_mcp_servers or "no_mcp" in toolset_names:
             enabled_toolsets.update(explicit_mcp_servers)
@@ -2487,7 +2496,10 @@ def _get_platform_tools(
     agent_cfg = config.get("agent") or {}
     disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
     if disabled_toolsets:
-        disabled_set = {str(ts) for ts in disabled_toolsets}
+        disabled_set = {
+            prefixed_mcp_servers.get(str(ts), str(ts))
+            for ts in disabled_toolsets
+        }
         enabled_toolsets -= disabled_set
 
     # #38798: if this platform was explicitly configured but every toolset name
@@ -2503,7 +2515,10 @@ def _get_platform_tools(
         _named = [str(t) for t in _explicit if isinstance(t, str) and t]
         if (
             _named
-            and not any(validate_toolset(t) for t in _named)
+            and not any(
+                validate_toolset(t) or t in mcp_server_entries
+                for t in _named
+            )
             and platform not in _warned_invalid_platform_toolsets
         ):
             _warned_invalid_platform_toolsets.add(platform)

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -72,6 +72,39 @@ def test_partially_valid_platform_toolsets_no_runtime_warning(caplog):
     assert not any("#38798" in r.getMessage() for r in caplog.records)
 
 
+def test_prefixed_mcp_toolset_is_normalized_as_an_allowlist(caplog, monkeypatch):
+    import cli as cli_mod
+    import hermes_cli.tools_config as _tc
+
+    config = {
+        "platform_toolsets": {"cli": ["mcp-codegraph"]},
+        "mcp_servers": {
+            "codegraph": {"command": "codegraph"},
+            "other": {"command": "other"},
+        },
+    }
+    _tc._warned_invalid_platform_toolsets.discard("cli")
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
+        enabled = _get_platform_tools(config, "cli")
+
+    assert "codegraph" in enabled
+    assert "mcp-codegraph" not in enabled
+    assert "other" not in enabled
+    assert not any("#38798" in r.getMessage() for r in caplog.records)
+
+    messages = []
+    monkeypatch.setitem(cli_mod.CLI_CONFIG, "mcp_servers", config["mcp_servers"])
+    monkeypatch.setattr(
+        cli_mod.HermesCLI,
+        "_console_print",
+        lambda _self, message, *args, **kwargs: messages.append(message),
+    )
+    cli_mod.HermesCLI(toolsets=sorted(enabled), compact=True)
+
+    assert not any("Unknown toolsets" in message for message in messages)
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Recognize configured mcp-prefixed toolset names without widening the MCP allowlist.

## Related Issue

Fixes #78102

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Normalize enabled mcp-server aliases during platform resolution and cover startup warnings, allowlist behavior, and disabled toolsets.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_tools_config.py`
2. `ruff check hermes_cli/tools_config.py tests/hermes_cli/test_tools_config.py`
3. `python scripts/check-windows-footguns.py hermes_cli/tools_config.py tests/hermes_cli/test_tools_config.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable.
