### PR TITLE
fix(gateway): fix and verify launchd startup with external homes

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3697,6 +3697,17 @@ def get_launchd_label() -> str:
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 
+def _launchd_stdio_log_dir() -> Path:
+    """Return a boot-volume log directory for launchd's pre-exec redirects."""
+    return _launchd_user_home() / "Library" / "Logs" / get_launchd_label()
+
+
+def _ensure_launchd_stdio_log_dir() -> Path:
+    log_dir = _launchd_stdio_log_dir()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return log_dir
+
+
 # Cached launchd domain result — probing is cheap but should only run once per
 # process invocation (each ``hermes gateway start/stop/status`` call).
 _resolved_launchd_domain: str | None = None
@@ -3774,6 +3785,7 @@ def _launchd_domain() -> str:
 # 3/113 ("Could not find service") all mean the job isn't currently loaded in
 # the target domain, so start/restart should re-bootstrap the plist and retry.
 _LAUNCHD_JOB_UNLOADED_EXIT_CODES = frozenset({3, 113, 125})
+_LAUNCHD_READY_TIMEOUT_SECONDS = 60.0
 
 # launchctl returns 5 ("Input/output error") or a persistent 125 in two very
 # different situations, so exit 5 is NOT on its own proof the domain is broken:
@@ -3852,6 +3864,64 @@ def _launchctl_bootstrap(
             check=True,
             timeout=timeout,
         )
+
+
+def _wait_for_launchd_gateway_ready(
+    *, timeout: float | None = None
+) -> tuple[int | None, str | None]:
+    """Wait for launchd and Hermes runtime state to agree on a ready PID."""
+    wait_seconds = max(
+        0.0,
+        _LAUNCHD_READY_TIMEOUT_SECONDS if timeout is None else float(timeout),
+    )
+    deadline = time.monotonic() + wait_seconds
+    label = get_launchd_label()
+
+    while True:
+        try:
+            result = subprocess.run(
+                ["launchctl", "list", label],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            result = None
+
+        pid = None
+        if result is not None and result.returncode == 0:
+            pid = _parse_launchd_pid_from_list_output(result.stdout or "")
+        if pid is not None:
+            runtime_state = _gateway_runtime_status_for_pid(pid)
+            gateway_state = (runtime_state or {}).get("gateway_state")
+            if gateway_state == "running":
+                return pid, None
+            if gateway_state == "startup_failed":
+                reason = (runtime_state or {}).get("exit_reason") or "startup failed"
+                return None, str(reason)
+
+        if time.monotonic() >= deadline:
+            return None, None
+        time.sleep(min(0.5, max(0.0, deadline - time.monotonic())))
+
+
+def _require_launchd_gateway_ready() -> int:
+    pid, failure_reason = _wait_for_launchd_gateway_ready()
+    if pid is not None:
+        return pid
+
+    if failure_reason:
+        print_error(f"Gateway startup failed: {failure_reason}")
+    else:
+        print_error(
+            "Gateway did not become ready within "
+            f"{_LAUNCHD_READY_TIMEOUT_SECONDS:g}s."
+        )
+    print(f"  Inspect: launchctl print {_launchd_domain()}/{get_launchd_label()}")
+    print(f"  launchd stderr: {_launchd_stdio_log_dir() / 'gateway.stderr.log'}")
+    sys.exit(1)
 
 
 def _launchd_reload_log_path() -> Path:
@@ -4058,8 +4128,7 @@ def generate_launchd_plist() -> str:
     working_dir = _stable_service_working_dir()
     hermes_home = str(get_hermes_home().resolve())
     label = get_launchd_label()
-    log_dir = Path.home() / "Library" / "Logs" / label
-    log_dir.mkdir(parents=True, exist_ok=True)
+    log_dir = _launchd_stdio_log_dir()
     profile_arg = _profile_arg(hermes_home)
     # Build a sane PATH for the launchd plist.  launchd provides only a
     # minimal default (/usr/bin:/bin:/usr/sbin:/sbin) which misses Homebrew,
@@ -4181,6 +4250,7 @@ def refresh_launchd_plist_if_needed() -> bool:
     if _refuse_temp_home_service_write(new_plist, "launchd plist"):
         return False
 
+    _ensure_launchd_stdio_log_dir()
     plist_path.write_text(new_plist, encoding="utf-8")
     label = get_launchd_label()
     domain = _launchd_domain()
@@ -4349,6 +4419,7 @@ def launchd_install(force: bool = False):
     new_plist = generate_launchd_plist()
     if _refuse_temp_home_service_write(new_plist, "launchd plist"):
         return
+    _ensure_launchd_stdio_log_dir()
     print(f"Installing launchd service to: {plist_path}")
     plist_path.write_text(new_plist, encoding="utf-8")
 
@@ -4363,7 +4434,8 @@ def launchd_install(force: bool = False):
         return
 
     print()
-    print("✓ Service installed and loaded!")
+    pid = _require_launchd_gateway_ready()
+    print(f"✓ Service installed and loaded (PID {pid})!")
     _clear_launchd_unsupported_marker()
     print()
     print("Next steps:")
@@ -4392,6 +4464,7 @@ def launchd_uninstall():
 def launchd_start():
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
+    _ensure_launchd_stdio_log_dir()
 
     # Self-heal if the plist is missing entirely (e.g., manual cleanup, failed upgrade)
     if not plist_path.exists():
@@ -4413,7 +4486,8 @@ def launchd_start():
                 raise
             _launchd_fallback_to_detached(f"launchctl exit {e.returncode}")
             return
-        print("✓ Service started")
+        pid = _require_launchd_gateway_ready()
+        print(f"✓ Service started (PID {pid})")
         _clear_launchd_unsupported_marker()
         return
 
@@ -4443,7 +4517,8 @@ def launchd_start():
                 raise
             _launchd_fallback_to_detached(f"launchctl exit {e2.returncode}")
             return
-    print("✓ Service started")
+    pid = _require_launchd_gateway_ready()
+    print(f"✓ Service started (PID {pid})")
     _clear_launchd_unsupported_marker()
 
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4057,9 +4057,9 @@ def generate_launchd_plist() -> str:
     # to launchd's WorkingDirectory as to systemd's).
     working_dir = _stable_service_working_dir()
     hermes_home = str(get_hermes_home().resolve())
-    log_dir = get_hermes_home() / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
     label = get_launchd_label()
+    log_dir = Path.home() / "Library" / "Logs" / label
+    log_dir.mkdir(parents=True, exist_ok=True)
     profile_arg = _profile_arg(hermes_home)
     # Build a sane PATH for the launchd plist.  launchd provides only a
     # minimal default (/usr/bin:/bin:/usr/sbin:/sbin) which misses Homebrew,
@@ -4144,10 +4144,10 @@ def generate_launchd_plist() -> str:
     <integer>25</integer>
 
     <key>StandardOutPath</key>
-    <string>{log_dir}/gateway.log</string>
+    <string>{log_dir}/gateway.stdout.log</string>
     
     <key>StandardErrorPath</key>
-    <string>{log_dir}/gateway.error.log</string>
+    <string>{log_dir}/gateway.stderr.log</string>
 </dict>
 </plist>
 """

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -232,6 +232,26 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in plist
         assert str(profile_node_bin) not in plist
 
+    def test_launchd_stdio_uses_user_library_logs_not_hermes_home(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        user_home = tmp_path / "user"
+        hermes_home = tmp_path / "external-volume" / "hermes"
+        user_home.mkdir()
+        hermes_home.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        log_dir = user_home / "Library" / "Logs" / gateway_cli.get_launchd_label()
+        assert f"<string>{log_dir}/gateway.stdout.log</string>" in plist
+        assert f"<string>{log_dir}/gateway.stderr.log</string>" in plist
+        assert str(hermes_home / "logs") not in plist
+        assert log_dir.is_dir()
+
 
 
 class TestGatewayStopCleanup:
@@ -1759,4 +1779,3 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is True
         assert attempts["bootstrap"] >= 2  # the timeout was retried, not raised
-

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,6 +1,7 @@
 """Tests for gateway service management helpers."""
 
 import os
+import plistlib
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -232,25 +233,23 @@ class TestGeneratedSystemdUnits:
         assert str(local_bin) in plist
         assert str(profile_node_bin) not in plist
 
-    def test_launchd_stdio_uses_user_library_logs_not_hermes_home(
-        self,
-        tmp_path,
-        monkeypatch,
+    def test_launchd_stdio_logs_stay_on_the_user_boot_volume(
+        self, tmp_path, monkeypatch
     ):
-        user_home = tmp_path / "user"
-        hermes_home = tmp_path / "external-volume" / "hermes"
-        user_home.mkdir()
+        user_home = tmp_path / "Users" / "alice"
+        hermes_home = tmp_path / "Volumes" / "Vault" / "hermes"
+        user_home.mkdir(parents=True)
         hermes_home.mkdir(parents=True)
-        monkeypatch.setenv("HOME", str(user_home))
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: user_home)
         monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: hermes_home)
 
-        plist = gateway_cli.generate_launchd_plist()
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode())
+        expected_dir = user_home / "Library" / "Logs" / gateway_cli.get_launchd_label()
 
-        log_dir = user_home / "Library" / "Logs" / gateway_cli.get_launchd_label()
-        assert f"<string>{log_dir}/gateway.stdout.log</string>" in plist
-        assert f"<string>{log_dir}/gateway.stderr.log</string>" in plist
-        assert str(hermes_home / "logs") not in plist
-        assert log_dir.is_dir()
+        assert Path(plist["StandardOutPath"]).parent == expected_dir
+        assert Path(plist["StandardErrorPath"]).parent == expected_dir
+        assert not Path(plist["StandardOutPath"]).is_relative_to(hermes_home)
+        assert not Path(plist["StandardErrorPath"]).is_relative_to(hermes_home)
 
 
 
@@ -285,6 +284,117 @@ class TestGatewayStopCleanup:
 
 class TestLaunchdServiceRecovery:
 
+    def test_launchd_start_waits_for_matching_runtime_ready_pid(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+        runtime_probes = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(
+            gateway_cli, "refresh_launchd_plist_if_needed", lambda: False
+        )
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "list"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout='{\n\t"PID" = 4321;\n}',
+                    stderr="",
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_gateway_runtime_status_for_pid",
+            lambda pid: runtime_probes.append(pid)
+            or {"pid": pid, "gateway_state": "running"},
+        )
+
+        gateway_cli.launchd_start()
+
+        assert runtime_probes == [4321]
+        assert "Service started (PID 4321)" in capsys.readouterr().out
+
+    def test_launchd_start_fails_when_launchd_never_spawns_a_pid(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(
+            gateway_cli, "refresh_launchd_plist_if_needed", lambda: False
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_LAUNCHD_READY_TIMEOUT_SECONDS",
+            0.0,
+            raising=False,
+        )
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "list"]:
+                return SimpleNamespace(returncode=0, stdout="{}", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(SystemExit) as exc_info:
+            gateway_cli.launchd_start()
+
+        assert exc_info.value.code == 1
+        output = capsys.readouterr().out
+        assert "Service started" not in output
+        assert "did not become ready" in output
+        assert "gateway.stderr.log" in output
+
+    def test_launchd_install_creates_stdio_log_dir_and_waits_for_ready_pid(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        plist_path = tmp_path / "LaunchAgents" / "ai.hermes.gateway.plist"
+        user_home = tmp_path / "Users" / "alice"
+        runtime_probes = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: user_home)
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "generate_launchd_plist", lambda: "<plist/>")
+        monkeypatch.setattr(gateway_cli, "_launchctl_bootstrap", lambda *a, **k: None)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "list"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout='{\n\t"PID" = 9876;\n}',
+                    stderr="",
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_gateway_runtime_status_for_pid",
+            lambda pid: runtime_probes.append(pid)
+            or {"pid": pid, "gateway_state": "running"},
+        )
+
+        gateway_cli.launchd_install()
+
+        expected_log_dir = user_home / "Library" / "Logs" / "ai.hermes.gateway"
+        assert expected_log_dir.is_dir()
+        assert runtime_probes == [9876]
+        assert "Service installed and loaded (PID 9876)" in capsys.readouterr().out
+
 
     def test_refresh_defers_reload_when_running_inside_gateway_tree(self, tmp_path, monkeypatch):
         """#43842: when the refresh runs inside the gateway's own process tree,
@@ -294,6 +404,7 @@ class TestLaunchdServiceRecovery:
         plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
 
         monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
         monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: False)
         monkeypatch.setattr(
             gateway_cli,


### PR DESCRIPTION
## What does this PR do?

Fixes both launchd failure modes reported in #78129:

1. launchd-owned stdout/stderr now live under the real macOS user's boot-volume log directory:

   ```text
   ~/Library/Logs/<launchd-label>/gateway.stdout.log
   ~/Library/Logs/<launchd-label>/gateway.stderr.log
   ```

   This prevents launchd's pre-exec redirect open from failing with `EX_CONFIG 78` when `HERMES_HOME` is on a non-boot volume. Hermes' application-managed logs under `HERMES_HOME/logs` are unchanged.

2. `hermes gateway install` and `hermes gateway start` no longer report success merely because `bootstrap` or `kickstart` returned zero. They wait up to 60 seconds for launchd to expose a PID and for that same PID's Hermes runtime state to become `running`.

This builds on #78141. Its `deb3c4eaa` commit is retained as the first commit so RerankerGuo's authorship is preserved; the follow-up commit adds readiness verification and tightens profile/user-home handling.

## Related Issue

Fixes #78129

Builds on #78141

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Why this is the right fix

- `StandardOutPath` and `StandardErrorPath` are launchd infrastructure, so they use the platform-standard user log location instead of following potentially external Hermes state.
- The directory is derived from `_launchd_user_home()`, not the possibly profile-overridden `HOME`, and remains isolated by the existing profile-scoped launchd label.
- Plist generation stays side-effect free. Service install/start/refresh paths create the directory immediately before launchd may need it.
- Readiness requires agreement between launchd's current PID and Hermes' runtime record. A stale `gateway_state.json` from an old PID cannot produce a false success.
- A `startup_failed` state exits immediately; a timeout exits non-zero and prints both `launchctl print` and the launchd stderr path.
- `launchd_restart()` is intentionally unchanged because restart readiness is already covered by #56908.

## Changes Made

- `hermes_cli/gateway.py`
  - Generate profile-scoped launchd stdio paths under the real user's `Library/Logs`.
  - Create the stdio directory on launchd install/start/refresh paths.
  - Poll `launchctl list <label>` and require matching Hermes runtime readiness.
  - Return a non-zero exit with actionable diagnostics when startup never becomes ready.
- `tests/hermes_cli/test_gateway_service.py`
  - Cover external `HERMES_HOME` plist generation.
  - Cover successful start readiness and matching PID checks.
  - Cover the no-PID false-success regression.
  - Cover first-install directory creation and readiness.

## How to Test

1. Configure `HERMES_HOME` on a non-boot volume.
2. Run `hermes gateway install` or `hermes gateway start`.
3. Confirm the generated plist points stdio at `~/Library/Logs/<label>/`, while Hermes application logs remain under `HERMES_HOME/logs`.
4. Confirm success is printed only after launchd's PID has a matching `gateway_state=running` runtime record.
5. For a pre-exec failure, confirm the command exits non-zero and prints the `launchctl print` command plus `gateway.stderr.log` path.

## Validation

Parent-commit reproduction tests:

- External-home plist test failed because stdio still pointed into `HERMES_HOME/logs`.
- Start did not probe the launchd PID/runtime state and printed success with no PID.
- Start returned success when launchd never spawned a PID.
- Install did not create the new stdio directory or wait for runtime readiness.

Post-fix checks on macOS 26.5.2:

```text
.venv/bin/pytest -q -p no:cacheprovider tests/hermes_cli/test_gateway_service.py
74 passed

pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_restart_loop.py tests/gateway/test_status.py -k 'launchd or launchctl'
24 passed, 124 deselected

.venv/bin/ruff check --no-cache hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py
All checks passed!

git diff upstream/main...HEAD --check
passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and built on #78141 rather than discarding its contribution
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5.2 (targeted command-path tests)

### Documentation & Housekeeping

- [x] Documentation update: N/A; Hermes application log locations are unchanged
- [x] `cli-config.yaml.example` update: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A; no architecture or workflow changed
- [x] Cross-platform impact considered: changes are isolated to launchd/macOS code paths
- [x] Tool descriptions/schemas update: N/A

## Remaining Risk

A live launchd E2E run with `HERMES_HOME` on a physically separate volume was not performed locally. The path failure is covered by plist regression tests and the issue's controlled reproduction; launchd/runtime convergence is covered with command-path tests.
